### PR TITLE
Support AgentRequest metadata and sampling overrides

### DIFF
--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -1991,6 +1991,16 @@ struct RequestSubmitArgs {
     session_id: Option<String>,
     #[arg(long)]
     behavior_id: Option<String>,
+    #[arg(long)]
+    temperature: Option<f64>,
+    #[arg(long)]
+    top_p: Option<f64>,
+    #[arg(long)]
+    top_k: Option<i64>,
+    #[arg(long)]
+    max_tokens: Option<i64>,
+    #[arg(long)]
+    metadata: Option<String>,
     #[arg(long = "output-file")]
     output_file: Option<PathBuf>,
     #[arg(long, default_value_t = false)]
@@ -3026,6 +3036,13 @@ async fn request_submit(args: RequestSubmitArgs) -> Result<()> {
         &content,
         args.session_id.as_deref(),
         args.behavior_id.as_deref(),
+        RequestSubmitOptions {
+            temperature: args.temperature,
+            top_p: args.top_p,
+            top_k: args.top_k,
+            max_tokens: args.max_tokens,
+            metadata: args.metadata.clone(),
+        },
     )
     .await?;
     let request_summary = json!({
@@ -3033,6 +3050,11 @@ async fn request_submit(args: RequestSubmitArgs) -> Result<()> {
         "session_id": submitted.session_id,
         "agent_did": submitted.agent_did,
         "behavior_id": submitted.behavior_id,
+        "temperature": submitted.temperature,
+        "top_p": submitted.top_p,
+        "top_k": submitted.top_k,
+        "max_tokens": submitted.max_tokens,
+        "metadata": submitted.metadata,
     });
     if args.no_wait {
         print_json(&request_summary)?;
@@ -3085,6 +3107,11 @@ async fn request_show(args: RequestShowArgs) -> Result<()> {
                 failure_reason
                 retry_count
                 max_retries
+                temperature
+                top_p
+                top_k
+                max_tokens
+                metadata
                 created_at
                 claimed_at
                 deadline
@@ -5536,6 +5563,20 @@ struct SubmittedRequest {
     session_id: String,
     agent_did: String,
     behavior_id: Option<String>,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    max_tokens: Option<i64>,
+    metadata: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct RequestSubmitOptions {
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    max_tokens: Option<i64>,
+    metadata: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -5562,6 +5603,7 @@ async fn create_agent_request(
     content: &str,
     session_id: Option<&str>,
     behavior_id: Option<&str>,
+    options: RequestSubmitOptions,
 ) -> Result<SubmittedRequest> {
     let request_id = uuid::Uuid::new_v4().to_string();
     let session_id = session_id
@@ -5579,6 +5621,25 @@ async fn create_agent_request(
             )
         })
         .unwrap_or_default();
+    let request_override_fields = vec![
+        optional_f64_field("temperature", options.temperature),
+        optional_f64_field("top_p", options.top_p),
+        optional_i64_field("top_k", options.top_k),
+        optional_i64_field("max_tokens", options.max_tokens),
+        options
+            .metadata
+            .as_ref()
+            .map(|metadata| format!(r#"metadata: "{}""#, escape_graphql_string(metadata))),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(",\n                ");
+    let request_override_fields = if request_override_fields.is_empty() {
+        String::new()
+    } else {
+        format!("{request_override_fields},\n                ")
+    };
     let mutation = format!(
         r#"mutation {{
             create_AgentRequest(input: {{
@@ -5590,7 +5651,7 @@ async fn create_agent_request(
                 retry_root_request: "{request_id}",
                 superseded_by_request: "",
                 content: "{content}",
-                status: "pending",
+                {request_override_fields}status: "pending",
                 lifecycle_state: "pending",
                 backend_id: "",
                 execution_origin: "interactive",
@@ -5605,6 +5666,7 @@ async fn create_agent_request(
         behavior_field = behavior_field,
         session_id = escape_graphql_string(&session_id),
         content = escape_graphql_string(content),
+        request_override_fields = request_override_fields,
     );
     post_graphql(graphql, &mutation).await?;
 
@@ -5616,6 +5678,11 @@ async fn create_agent_request(
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned),
+        temperature: options.temperature,
+        top_p: options.top_p,
+        top_k: options.top_k,
+        max_tokens: options.max_tokens,
+        metadata: options.metadata,
     })
 }
 
@@ -5629,8 +5696,15 @@ async fn submit_chat_turn(
     poll_secs: u64,
 ) -> Result<(SubmittedRequest, Value)> {
     let existing_tool_calls = load_existing_tool_call_keys(graphql, session_id).await?;
-    let submitted =
-        create_agent_request(graphql, agent_did, content, Some(session_id), behavior_id).await?;
+    let submitted = create_agent_request(
+        graphql,
+        agent_did,
+        content,
+        Some(session_id),
+        behavior_id,
+        RequestSubmitOptions::default(),
+    )
+    .await?;
     let response = stream_turn_progress(
         graphql,
         &submitted,
@@ -5651,8 +5725,15 @@ async fn submit_chat_turn_json(
     timeout_secs: u64,
     poll_secs: u64,
 ) -> Result<Value> {
-    let submitted =
-        create_agent_request(graphql, agent_did, content, Some(session_id), behavior_id).await?;
+    let submitted = create_agent_request(
+        graphql,
+        agent_did,
+        content,
+        Some(session_id),
+        behavior_id,
+        RequestSubmitOptions::default(),
+    )
+    .await?;
     let response =
         wait_for_terminal_response(graphql, &submitted.request_id, timeout_secs, poll_secs)
             .await

--- a/crates/defra-agent-cli/src/tui.rs
+++ b/crates/defra-agent-cli/src/tui.rs
@@ -291,6 +291,7 @@ impl App {
             &content,
             Some(&self.session_id),
             self.behavior_id.as_deref(),
+            crate::RequestSubmitOptions::default(),
         )
         .await?;
         self.active_request = Some(submitted);

--- a/crates/defra-agent/schemas/README.md
+++ b/crates/defra-agent/schemas/README.md
@@ -68,7 +68,7 @@ These documents record user requests, assistant output, and conversation history
 
 | Collection | Key fields | References | Written by | Read by |
 |------------|------------|------------|------------|---------|
-| `AgentRequest` | `request_id`, `agent_did`, `behavior_id`, `session_id`, `status`, `lifecycle_state`, `backend_id`, `failure_reason` | belongs to an agent/session/behavior | `chat`, `request submit`, lifecycle transitions | router, CLI inspection, recovery |
+| `AgentRequest` | `request_id`, `agent_did`, `behavior_id`, `session_id`, sampling overrides, `metadata`, `status`, `lifecycle_state`, `backend_id`, `failure_reason` | belongs to an agent/session/behavior | `chat`, `request submit`, lifecycle transitions | router, CLI inspection, recovery |
 | `InferenceCall` | `call_id`, `request_id`, `backend_id`, `call_kind`, `call_state`, queue/timing/token fields | belongs to a request/backend | admission controller at terminal call state | benchmarking, RL reward shaping, debugging |
 | `AgentResponse` | `request_id`, `agent_did`, `behavior_id`, `session_id`, `status`, `content`, `reasoning`, `error_message`, `progress_seq` | latest response for a request | streaming/runtime code | `chat`, `response show`, `response wait`, TUI |
 | `AgentSession` | `session_id`, `behavior_id`, `status`, `started`, `ended` | ties a sequence of requests to one behavior | session manager | `chat`, inspection, recovery |

--- a/crates/defra-agent/schemas/agent/agent_request.graphql
+++ b/crates/defra-agent/schemas/agent/agent_request.graphql
@@ -7,6 +7,11 @@ type AgentRequest @branchable {
     retry_root_request: String
     superseded_by_request: String
     content: String
+    temperature: Float
+    top_p: Float
+    top_k: Int
+    max_tokens: Int
+    metadata: String
     status: String @index
     lifecycle_state: String @index
     backend_id: String @index

--- a/crates/defra-agent/src/admission/mod.rs
+++ b/crates/defra-agent/src/admission/mod.rs
@@ -1270,6 +1270,11 @@ mod tests {
             behavior_id: Some("default".to_string()),
             session_id: format!("session-{request_id}"),
             content: "hello".to_string(),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            metadata: None,
             created_at: "2026-04-15T00:00:00Z".to_string(),
         }
     }

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -7,7 +7,7 @@ use tokio::sync::watch;
 
 use crate::compaction::CompactionStrategy;
 use crate::config::{
-    BehaviorConfig, DEFAULT_COMPACTION_THRESHOLD, DEFAULT_CONTEXT_WINDOW,
+    BehaviorConfig, SamplingConfig, DEFAULT_COMPACTION_THRESHOLD, DEFAULT_CONTEXT_WINDOW,
     DEFAULT_DEADLINE_DURATION_SECS, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_MAX_TURNS,
     DEFAULT_MODEL_NAME, DEFAULT_STREAM_BATCH_MS,
 };
@@ -202,6 +202,9 @@ pub(crate) fn behavior_config_from_documents(
         .and_then(|profile| profile.deadline_duration_secs)
         .and_then(|value| u64::try_from(value).ok())
         .unwrap_or(DEFAULT_DEADLINE_DURATION_SECS);
+    let profile_max_tokens = inference_profile
+        .and_then(|profile| profile.max_output_tokens)
+        .and_then(|value| u64::try_from(value).ok());
 
     Ok(BehaviorConfig {
         name: behavior.behavior_id.clone(),
@@ -239,6 +242,12 @@ pub(crate) fn behavior_config_from_documents(
         compaction_strategy,
         stream_batch_ms,
         deadline_duration: Duration::from_secs(deadline_duration_secs),
+        sampling: SamplingConfig {
+            temperature: inference_profile.and_then(|profile| profile.temperature),
+            top_p: None,
+            top_k: None,
+            max_tokens: profile_max_tokens,
+        },
     })
 }
 

--- a/crates/defra-agent/src/agent/builder.rs
+++ b/crates/defra-agent/src/agent/builder.rs
@@ -12,7 +12,7 @@ use crate::backend_provider::BackendProviderKind;
 use crate::backend_registry::lookup_backend;
 use crate::compaction::CompactionStrategy;
 use crate::config::{
-    BehaviorConfig, DEFAULT_COMPACTION_THRESHOLD, DEFAULT_CONTEXT_WINDOW,
+    BehaviorConfig, SamplingConfig, DEFAULT_COMPACTION_THRESHOLD, DEFAULT_CONTEXT_WINDOW,
     DEFAULT_DEADLINE_DURATION_SECS, DEFAULT_MAX_OUTPUT_TOKENS, DEFAULT_MAX_TURNS,
     DEFAULT_MODEL_NAME, DEFAULT_STREAM_BATCH_MS,
 };
@@ -338,6 +338,7 @@ pub(crate) struct PendingBehaviorConfig {
     compaction_strategy: CompactionStrategy,
     stream_batch_ms: u64,
     deadline_duration: Duration,
+    sampling: SamplingConfig,
 }
 
 impl PendingBehaviorConfig {
@@ -359,6 +360,7 @@ impl PendingBehaviorConfig {
             compaction_strategy: CompactionStrategy::StripThenSummarize,
             stream_batch_ms: DEFAULT_STREAM_BATCH_MS,
             deadline_duration: Duration::from_secs(DEFAULT_DEADLINE_DURATION_SECS),
+            sampling: SamplingConfig::default(),
         }
     }
 
@@ -440,6 +442,7 @@ impl PendingBehaviorConfig {
             compaction_strategy: self.compaction_strategy,
             stream_batch_ms: self.stream_batch_ms,
             deadline_duration: self.deadline_duration,
+            sampling: self.sampling,
         })
     }
 }

--- a/crates/defra-agent/src/agent/daemon/inference.rs
+++ b/crates/defra-agent/src/agent/daemon/inference.rs
@@ -7,6 +7,7 @@ use tracing::Instrument;
 
 use super::{BehaviorDaemon, HandleRequestOutcome};
 use crate::admission::{self, CallKind};
+use crate::completion_factory::agent_with_request_sampling;
 use crate::config::DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS;
 use crate::error::classify_completion_error;
 use crate::hook::DefraSessionHook;
@@ -67,14 +68,14 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 .await?;
                 let persistence_hook = hook.clone();
 
+                let agent = agent_with_request_sampling(&self.agent, &self.behavior, request);
                 let mut stream =
                     admission::scope_call(CallKind::Inference, attempt_index as i64, async {
                         tokio::select! {
                             _ = shutdown.changed() => {
                                 Err(anyhow!("shutdown requested before inference stream started"))
                             }
-                            stream = self
-                                .agent
+                            stream = agent
                                 .stream_prompt(&request.content)
                                 .with_history(history.to_vec())
                                 .with_hook(hook) => Ok::<_, anyhow::Error>(stream)

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -321,6 +321,7 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
         compaction_strategy: crate::compaction::CompactionStrategy::StripThenSummarize,
         stream_batch_ms: crate::config::DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(crate::config::DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: crate::config::SamplingConfig::default(),
     });
     let updated_behavior = Arc::new(BehaviorConfig {
         name: "general".to_string(),
@@ -353,6 +354,7 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
         compaction_strategy: crate::compaction::CompactionStrategy::StripThenSummarize,
         stream_batch_ms: crate::config::DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(crate::config::DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: crate::config::SamplingConfig::default(),
     });
 
     let initial_snapshot =

--- a/crates/defra-agent/src/agent/runtime/tests.rs
+++ b/crates/defra-agent/src/agent/runtime/tests.rs
@@ -30,6 +30,11 @@ fn request(behavior_id: Option<&str>, session_id: &str) -> AgentRequest {
         behavior_id: behavior_id.map(ToOwned::to_owned),
         session_id: session_id.to_string(),
         content: "hello".to_string(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-04-09T00:00:00Z".to_string(),
     }
 }
@@ -646,6 +651,11 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
             behavior_id: None,
             session_id: "session-router".to_string(),
             content: "hello".to_string(),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            metadata: None,
             created_at: "2026-04-09T00:00:00Z".to_string(),
         }))
         .await

--- a/crates/defra-agent/src/agent/stream_processor/tests.rs
+++ b/crates/defra-agent/src/agent/stream_processor/tests.rs
@@ -89,6 +89,11 @@ async fn persist_partial_turn_saves_reasoning_and_text_to_history() {
         behavior_id: Some("general".to_string()),
         session_id: session_id.clone(),
         content: "Inspect the repo".to_string(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: chrono::Utc::now().to_rfc3339(),
     };
     let mut lifecycle = RequestLifecycle::new_with_agent_did(

--- a/crates/defra-agent/src/completion_factory.rs
+++ b/crates/defra-agent/src/completion_factory.rs
@@ -6,7 +6,8 @@ use rig::tool::ToolDyn;
 
 use crate::admission::{AdmissionRegistry, AdmittedCompletionClient};
 use crate::backend_provider::BackendProviderKind;
-use crate::config::BehaviorConfig;
+use crate::config::{BehaviorConfig, SamplingConfig};
+use crate::watcher::AgentRequest;
 
 pub(crate) fn build_agent<C>(
     client: &C,
@@ -76,11 +77,80 @@ where
         builder = builder.tool_choice(ToolChoice::Auto);
     }
 
-    if let Some(additional_params) = provider_additional_params(behavior.backend_provider_kind) {
+    if let Some(temperature) = behavior.sampling.temperature {
+        builder = builder.temperature(temperature);
+    }
+
+    if let Some(max_tokens) = behavior.sampling.max_tokens {
+        builder = builder.max_tokens(max_tokens);
+    }
+
+    if let Some(additional_params) = merge_optional_params(
+        provider_additional_params(behavior.backend_provider_kind),
+        behavior.sampling.additional_params(),
+    ) {
         builder = builder.additional_params(additional_params);
     }
 
     builder
+}
+
+pub(crate) fn agent_with_request_sampling<M>(
+    agent: &Agent<M>,
+    behavior: &BehaviorConfig,
+    request: &AgentRequest,
+) -> Agent<M>
+where
+    M: CompletionModel,
+{
+    let sampling = sampling_for_request(behavior.sampling, request);
+    let mut agent = agent.clone();
+    agent.temperature = sampling.temperature;
+    agent.max_tokens = sampling.max_tokens;
+    if let Some(additional_params) = sampling.additional_params() {
+        agent.additional_params =
+            merge_optional_params(agent.additional_params.take(), Some(additional_params));
+    }
+    agent
+}
+
+fn sampling_for_request(defaults: SamplingConfig, request: &AgentRequest) -> SamplingConfig {
+    SamplingConfig {
+        temperature: request.temperature.or(defaults.temperature),
+        top_p: request.top_p.or(defaults.top_p),
+        top_k: request.top_k.or(defaults.top_k),
+        max_tokens: request
+            .max_tokens
+            .and_then(|value| u64::try_from(value).ok())
+            .or(defaults.max_tokens),
+    }
+}
+
+fn merge_optional_params(
+    left: Option<serde_json::Value>,
+    right: Option<serde_json::Value>,
+) -> Option<serde_json::Value> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(merge_json_values(left, right)),
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    }
+}
+
+fn merge_json_values(left: serde_json::Value, right: serde_json::Value) -> serde_json::Value {
+    match (left, right) {
+        (serde_json::Value::Object(mut left), serde_json::Value::Object(right)) => {
+            for (key, right_value) in right {
+                let value = left
+                    .remove(&key)
+                    .map(|left_value| merge_json_values(left_value, right_value.clone()))
+                    .unwrap_or(right_value);
+                left.insert(key, value);
+            }
+            serde_json::Value::Object(left)
+        }
+        (_, right) => right,
+    }
 }
 
 fn provider_additional_params(kind: BackendProviderKind) -> Option<serde_json::Value> {
@@ -109,5 +179,58 @@ mod tests {
     #[test]
     fn openai_compatible_has_no_provider_specific_additional_params() {
         assert!(provider_additional_params(BackendProviderKind::OpenAiCompatible).is_none());
+    }
+
+    #[test]
+    fn sampling_additional_params_merge_with_provider_params() {
+        let sampling = SamplingConfig {
+            temperature: Some(0.1),
+            top_p: Some(0.95),
+            top_k: Some(40),
+            max_tokens: Some(1024),
+        };
+
+        let value = merge_optional_params(
+            provider_additional_params(BackendProviderKind::OpenRouter),
+            sampling.additional_params(),
+        )
+        .expect("sampling params should be present");
+
+        assert_eq!(value["provider"]["require_parameters"], true);
+        assert_eq!(value["top_p"], 0.95);
+        assert_eq!(value["top_k"], 40);
+        assert_eq!(value["max_tokens"], 1024);
+        assert!(value.get("temperature").is_none());
+    }
+
+    #[test]
+    fn request_sampling_overrides_behavior_defaults() {
+        let defaults = SamplingConfig {
+            temperature: Some(0.7),
+            top_p: Some(0.9),
+            top_k: Some(20),
+            max_tokens: Some(2048),
+        };
+        let request = AgentRequest {
+            doc_id: String::new(),
+            request_id: String::new(),
+            agent_did: String::new(),
+            behavior_id: None,
+            session_id: String::new(),
+            content: String::new(),
+            temperature: Some(0.0),
+            top_p: None,
+            top_k: Some(40),
+            max_tokens: Some(512),
+            metadata: Some(r#"{"run_id":"foo"}"#.to_string()),
+            created_at: String::new(),
+        };
+
+        let sampling = sampling_for_request(defaults, &request);
+
+        assert_eq!(sampling.temperature, Some(0.0));
+        assert_eq!(sampling.top_p, Some(0.9));
+        assert_eq!(sampling.top_k, Some(40));
+        assert_eq!(sampling.max_tokens, Some(512));
     }
 }

--- a/crates/defra-agent/src/config.rs
+++ b/crates/defra-agent/src/config.rs
@@ -37,6 +37,39 @@ pub struct BehaviorConfig {
     pub compaction_strategy: CompactionStrategy,
     pub stream_batch_ms: u64,
     pub deadline_duration: Duration,
+    pub sampling: SamplingConfig,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct SamplingConfig {
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<i64>,
+    pub max_tokens: Option<u64>,
+}
+
+impl SamplingConfig {
+    pub fn is_empty(self) -> bool {
+        self.temperature.is_none()
+            && self.top_p.is_none()
+            && self.top_k.is_none()
+            && self.max_tokens.is_none()
+    }
+
+    pub fn additional_params(self) -> Option<serde_json::Value> {
+        let mut params = serde_json::Map::new();
+        if let Some(top_p) = self.top_p {
+            params.insert("top_p".to_string(), serde_json::json!(top_p));
+        }
+        if let Some(top_k) = self.top_k {
+            params.insert("top_k".to_string(), serde_json::json!(top_k));
+        }
+        if let Some(max_tokens) = self.max_tokens {
+            params.insert("max_tokens".to_string(), serde_json::json!(max_tokens));
+        }
+
+        (!params.is_empty()).then(|| serde_json::Value::Object(params))
+    }
 }
 
 impl std::fmt::Debug for BehaviorConfig {
@@ -62,6 +95,7 @@ impl std::fmt::Debug for BehaviorConfig {
             .field("compaction_strategy", &self.compaction_strategy)
             .field("stream_batch_ms", &self.stream_batch_ms)
             .field("deadline_duration", &self.deadline_duration)
+            .field("sampling", &self.sampling)
             .finish()
     }
 }

--- a/crates/defra-agent/src/lifecycle/materialize.rs
+++ b/crates/defra-agent/src/lifecycle/materialize.rs
@@ -202,6 +202,11 @@ impl RequestLifecycle {
             behavior_id: Some(behavior_id.clone()),
             session_id: session_id.clone(),
             content: content.to_string(),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            metadata: None,
             created_at,
         };
 

--- a/crates/defra-agent/src/scheduler/tests.rs
+++ b/crates/defra-agent/src/scheduler/tests.rs
@@ -482,6 +482,7 @@ async fn scheduled_execution_succeeds_without_external_ops_service() {
         compaction_strategy: CompactionStrategy::StripThenSummarize,
         stream_batch_ms: DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: crate::config::SamplingConfig::default(),
     };
 
     let tool_surface = behavior.tools.resolve(node.as_ref()).await.unwrap();
@@ -646,6 +647,7 @@ async fn scheduled_execution_updates_live_task_runtime_fields() {
         compaction_strategy: CompactionStrategy::StripThenSummarize,
         stream_batch_ms: DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: crate::config::SamplingConfig::default(),
     };
 
     let tool_surface = behavior.tools.resolve(node.as_ref()).await.unwrap();
@@ -790,6 +792,7 @@ async fn scheduler_tick_shutdown_is_prompt_while_task_waits_for_backend_capacity
         compaction_strategy: CompactionStrategy::StripThenSummarize,
         stream_batch_ms: DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: crate::config::SamplingConfig::default(),
     });
     let tool_surface = Arc::new(behavior.tools.resolve(node.as_ref()).await.unwrap());
     insert_due_task(

--- a/crates/defra-agent/src/watcher.rs
+++ b/crates/defra-agent/src/watcher.rs
@@ -23,6 +23,11 @@ pub struct AgentRequest {
     pub behavior_id: Option<String>,
     pub session_id: String,
     pub content: String,
+    pub temperature: Option<f64>,
+    pub top_p: Option<f64>,
+    pub top_k: Option<i64>,
+    pub max_tokens: Option<i64>,
+    pub metadata: Option<String>,
     pub created_at: String,
 }
 

--- a/crates/defra-agent/src/watcher/query.rs
+++ b/crates/defra-agent/src/watcher/query.rs
@@ -18,6 +18,11 @@ impl DefraWatcher {
                     behavior_id
                     session_id
                     content
+                    temperature
+                    top_p
+                    top_k
+                    max_tokens
+                    metadata
                     created_at
                 }}
             }}"#,
@@ -44,6 +49,11 @@ impl DefraWatcher {
                 behavior_id: normalize_optional_string(row.behavior_id),
                 session_id: row.session_id,
                 content: row.content,
+                temperature: row.temperature,
+                top_p: row.top_p,
+                top_k: row.top_k,
+                max_tokens: row.max_tokens,
+                metadata: row.metadata,
                 created_at: row.created_at,
             })),
             None => Ok(None),
@@ -66,6 +76,11 @@ impl DefraWatcher {
                     behavior_id
                     session_id
                     content
+                    temperature
+                    top_p
+                    top_k
+                    max_tokens
+                    metadata
                     created_at
                 }}
             }}"#,
@@ -92,6 +107,11 @@ impl DefraWatcher {
                 behavior_id: normalize_optional_string(row.behavior_id),
                 session_id: row.session_id,
                 content: row.content,
+                temperature: row.temperature,
+                top_p: row.top_p,
+                top_k: row.top_k,
+                max_tokens: row.max_tokens,
+                metadata: row.metadata,
                 created_at: row.created_at,
             })
             .collect())
@@ -112,6 +132,11 @@ struct AgentRequestRow {
     behavior_id: Option<String>,
     session_id: String,
     content: String,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    max_tokens: Option<i64>,
+    metadata: Option<String>,
     created_at: String,
 }
 
@@ -124,5 +149,10 @@ struct PendingAgentRequestRow {
     behavior_id: Option<String>,
     session_id: String,
     content: String,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    max_tokens: Option<i64>,
+    metadata: Option<String>,
     created_at: String,
 }

--- a/crates/defra-agent/src/watcher/tests.rs
+++ b/crates/defra-agent/src/watcher/tests.rs
@@ -14,6 +14,11 @@ fn agent_request_clone() {
         behavior_id: Some("general".into()),
         session_id: "sess-1".into(),
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-03-12T00:00:00Z".into(),
     };
     let cloned = req.clone();
@@ -63,6 +68,11 @@ fn request(request_id: &str, session_id: &str) -> AgentRequest {
         behavior_id: Some("general".into()),
         session_id: session_id.to_string(),
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-03-12T00:00:00Z".into(),
     }
 }

--- a/crates/defra-agent/tests/backend_auth.rs
+++ b/crates/defra-agent/tests/backend_auth.rs
@@ -256,6 +256,7 @@ fn test_behavior(
         compaction_strategy: CompactionStrategy::StripThenSummarize,
         stream_batch_ms: defra_agent::config::DEFAULT_STREAM_BATCH_MS,
         deadline_duration: Duration::from_secs(defra_agent::config::DEFAULT_DEADLINE_DURATION_SECS),
+        sampling: defra_agent::config::SamplingConfig::default(),
     }
 }
 

--- a/crates/defra-agent/tests/lifecycle_regression.rs
+++ b/crates/defra-agent/tests/lifecycle_regression.rs
@@ -1,5 +1,5 @@
 use defra_agent::lifecycle::ClaimOutcome;
-use defra_agent::watcher::AgentRequest;
+use defra_agent::watcher::{AgentRequest, DefraWatcher};
 use defra_agent::RequestLifecycle;
 use serde::Deserialize;
 
@@ -38,6 +38,76 @@ struct BehaviorRow {
 }
 
 #[tokio::test]
+async fn pending_request_hydrates_sampling_fields_and_metadata() {
+    let db = test_db("request-sampling-metadata").await;
+    let request_id = "req-sampling-metadata";
+    let session_id = "session-sampling-metadata";
+    let metadata = r#" { "run_id": "foo" } "#;
+    let escaped_metadata = defra_agent::graphql::escape_graphql_string(metadata);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{AGENT_DID}",
+                behavior_id: "{AGENT_NAME}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "visible prompt",
+                temperature: 0.0,
+                top_p: 0.95,
+                top_k: 40,
+                max_tokens: 512,
+                metadata: "{escaped_metadata}",
+                status: "pending",
+                lifecycle_state: "pending",
+                backend_id: "",
+                execution_origin: "interactive",
+                created_at: "2026-03-23T00:00:00Z",
+                retry_count: 0,
+                max_retries: 3
+            }}) {{ _docID }}
+        }}"#,
+    );
+    let resp = db.node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create request failed: {:?}",
+        resp.errors
+    );
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                _docID
+            }}
+        }}"#,
+    );
+    let resp = db.node.execute(&query).await;
+    assert!(
+        !resp.has_errors(),
+        "query request failed: {:?}",
+        resp.errors
+    );
+    let doc_id = first_row::<support::DocIdRow>(&resp, "AgentRequest").doc_id;
+
+    let watcher = DefraWatcher::new(db.node.clone(), AGENT_DID);
+    let request = watcher
+        .try_fetch_request(&doc_id)
+        .await
+        .unwrap()
+        .expect("pending request");
+
+    assert_eq!(request.temperature, Some(0.0));
+    assert_eq!(request.top_p, Some(0.95));
+    assert_eq!(request.top_k, Some(40));
+    assert_eq!(request.max_tokens, Some(512));
+    assert_eq!(request.metadata.as_deref(), Some(metadata));
+    assert_eq!(request.content, "visible prompt");
+    assert!(!request.content.contains("run_id"));
+}
+
+#[tokio::test]
 async fn claim_rejects_when_another_non_terminal_request_exists() {
     let db = test_db("lifecycle-dedup").await;
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -54,6 +124,11 @@ async fn claim_rejects_when_another_non_terminal_request_exists() {
         behavior_id: Some(AGENT_NAME.into()),
         session_id,
         content: "second".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: later,
     };
 
@@ -105,6 +180,11 @@ async fn claim_suppresses_later_pending_duplicates() {
         behavior_id: Some(AGENT_NAME.into()),
         session_id: session_id.clone(),
         content: "first".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-03-23T00:00:00Z".into(),
     };
 
@@ -183,6 +263,11 @@ async fn claim_preserves_explicit_behavior_id() {
         behavior_id: Some("code".into()),
         session_id: session_id.into(),
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: created_at.into(),
     };
 
@@ -440,6 +525,11 @@ async fn complete_does_not_overwrite_conversation_for_newer_request() {
         behavior_id: Some(AGENT_NAME.into()),
         session_id: session_id.into(),
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-03-23T00:00:00Z".into(),
     };
     let mut lifecycle = RequestLifecycle::new(db.node.clone(), AGENT_NAME, first_request, 300);
@@ -487,6 +577,11 @@ async fn advance_increments_progress_seq() {
         behavior_id: Some(AGENT_NAME.into()),
         session_id: "session-1".into(),
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at: "2026-03-23T00:00:00Z".into(),
     };
 

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -229,6 +229,11 @@ pub fn build_request(
         behavior_id: Some(AGENT_NAME.into()),
         session_id,
         content: "hello".into(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
         created_at,
     }
 }


### PR DESCRIPTION
## Summary
- add optional AgentRequest metadata and sampling override fields
- hydrate request fields into watcher/runtime requests and keep metadata out of prompt content
- apply per-request sampling over behavior InferenceProfile defaults when building Rig calls
- expose request submit/show CLI support for the new fields

Fixes #23

## Tests
- cargo check -p defra-agent -p defra-agent-cli
- cargo test -p defra-agent completion_factory -- --nocapture
- cargo test -p defra-agent pending_request_hydrates_sampling_fields_and_metadata -- --nocapture
- cargo test -p defra-agent-cli --test cli_e2e -- --nocapture --test-threads=1