### PR TITLE
Fix ToolServiceRegistry schema and apply semantics

### DIFF
--- a/crates/defra-agent-cli/src/desired_state.rs
+++ b/crates/defra-agent-cli/src/desired_state.rs
@@ -135,8 +135,10 @@ pub(crate) struct DesiredInferenceProfile {
     pub(crate) deadline_duration_secs: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(deny_unknown_fields)]
+const DEFAULT_TOOL_SERVICE_MCP_PATH: &str = "/mcp";
+const TOOL_SERVICE_ADDRESS_FIELDS: &[&str] = &["hostname", "tailscale_ip", "lan_ip"];
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub(crate) struct DesiredToolServiceRegistry {
     pub(crate) service_id: String,
     pub(crate) display_name: Option<String>,
@@ -146,6 +148,38 @@ pub(crate) struct DesiredToolServiceRegistry {
     pub(crate) lan_ip: Option<String>,
     pub(crate) mcp_port: Option<i64>,
     pub(crate) mcp_path: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for DesiredToolServiceRegistry {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(deny_unknown_fields)]
+        struct Wire {
+            service_id: String,
+            display_name: Option<String>,
+            description: Option<String>,
+            hostname: Option<String>,
+            tailscale_ip: Option<String>,
+            lan_ip: Option<String>,
+            mcp_port: Option<i64>,
+            mcp_path: Option<String>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        Ok(Self {
+            service_id: wire.service_id,
+            display_name: wire.display_name,
+            description: wire.description,
+            hostname: Some(normalize_tool_service_string(wire.hostname)),
+            tailscale_ip: Some(normalize_tool_service_string(wire.tailscale_ip)),
+            lan_ip: Some(normalize_tool_service_string(wire.lan_ip)),
+            mcp_port: wire.mcp_port,
+            mcp_path: Some(normalize_tool_service_mcp_path(wire.mcp_path)),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -765,6 +799,84 @@ fn non_empty(value: &Option<String>) -> Option<&str> {
         .filter(|value| !value.is_empty())
 }
 
+fn normalize_tool_service_string(value: Option<String>) -> String {
+    value.unwrap_or_default().trim().to_string()
+}
+
+fn normalize_tool_service_mcp_path(value: Option<String>) -> String {
+    let trimmed = value.as_deref().unwrap_or_default().trim();
+    if trimmed.is_empty() {
+        DEFAULT_TOOL_SERVICE_MCP_PATH.to_string()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+fn optional_string_from_value(field: &str, value: Option<&Value>) -> Result<Option<String>> {
+    match value {
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(Value::Null) | None => Ok(None),
+        Some(value) => Err(anyhow!(
+            "ToolServiceRegistry field {field} must be a string or null, got {value}"
+        )),
+    }
+}
+
+fn optional_i64_from_value(field: &str, value: Option<&Value>) -> Result<Option<i64>> {
+    match value {
+        Some(Value::Number(value)) => value
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| anyhow!("ToolServiceRegistry field {field} must be an integer")),
+        Some(Value::Null) | None => Ok(None),
+        Some(value) => Err(anyhow!(
+            "ToolServiceRegistry field {field} must be an integer or null, got {value}"
+        )),
+    }
+}
+
+fn tool_service_registry_from_live_value(value: &Value) -> Result<DesiredToolServiceRegistry> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow!("expected ToolServiceRegistry live row to be an object"))?;
+    let service_id = object
+        .get("service_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("ToolServiceRegistry live row is missing service_id"))?
+        .to_string();
+
+    Ok(DesiredToolServiceRegistry {
+        service_id,
+        display_name: optional_string_from_value("display_name", object.get("display_name"))?,
+        description: optional_string_from_value("description", object.get("description"))?,
+        hostname: optional_string_from_value("hostname", object.get("hostname"))?,
+        tailscale_ip: optional_string_from_value("tailscale_ip", object.get("tailscale_ip"))?,
+        lan_ip: optional_string_from_value("lan_ip", object.get("lan_ip"))?,
+        mcp_port: optional_i64_from_value("mcp_port", object.get("mcp_port"))?,
+        mcp_path: optional_string_from_value("mcp_path", object.get("mcp_path"))?,
+    })
+}
+
+pub(crate) fn normalize_tool_service_registry_storage_fields(
+    object: &mut Map<String, Value>,
+) -> Result<()> {
+    for field in TOOL_SERVICE_ADDRESS_FIELDS {
+        let normalized =
+            normalize_tool_service_string(optional_string_from_value(field, object.get(*field))?);
+        object.insert((*field).to_string(), Value::String(normalized));
+    }
+
+    let mcp_path = normalize_tool_service_mcp_path(optional_string_from_value(
+        "mcp_path",
+        object.get("mcp_path"),
+    )?);
+    object.insert("mcp_path".to_string(), Value::String(mcp_path));
+
+    Ok(())
+}
+
 pub(crate) fn manifest_from_export_bundle(
     bundle: &super::ConfigExportBundle,
 ) -> Result<DesiredStateManifest> {
@@ -870,21 +982,7 @@ pub(crate) fn manifest_from_export_bundle(
         tool_service_registries: bundle
             .tool_service_registries
             .iter()
-            .map(|value| {
-                desired_from_value(
-                    value,
-                    &[
-                        "service_id",
-                        "display_name",
-                        "description",
-                        "hostname",
-                        "tailscale_ip",
-                        "lan_ip",
-                        "mcp_port",
-                        "mcp_path",
-                    ],
-                )
-            })
+            .map(tool_service_registry_from_live_value)
             .collect::<Result<Vec<_>>>()?,
         scheduled_tasks: bundle
             .scheduled_tasks
@@ -1232,6 +1330,71 @@ where
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn desired_tool_service_registry_normalizes_address_storage_fields() {
+        let service: DesiredToolServiceRegistry = serde_json::from_value(json!({
+            "service_id": "observability-mcp",
+            "display_name": "Observability",
+            "description": null,
+            "hostname": null,
+            "tailscale_ip": " 100.64.0.10 ",
+            "lan_ip": null,
+            "mcp_port": 9201,
+            "mcp_path": "mcp"
+        }))
+        .expect("desired tool service should deserialize");
+
+        assert_eq!(service.hostname.as_deref(), Some(""));
+        assert_eq!(service.tailscale_ip.as_deref(), Some("100.64.0.10"));
+        assert_eq!(service.lan_ip.as_deref(), Some(""));
+        assert_eq!(service.mcp_path.as_deref(), Some("/mcp"));
+    }
+
+    #[test]
+    fn live_tool_service_registry_preserves_null_storage_for_diff() {
+        let service = tool_service_registry_from_live_value(&json!({
+            "service_id": "observability-mcp",
+            "hostname": null,
+            "tailscale_ip": null,
+            "lan_ip": null,
+            "mcp_port": 9201,
+            "mcp_path": null
+        }))
+        .expect("live tool service should parse");
+
+        assert_eq!(service.hostname, None);
+        assert_eq!(service.tailscale_ip, None);
+        assert_eq!(service.lan_ip, None);
+        assert_eq!(service.mcp_path, None);
+    }
+
+    #[test]
+    fn diff_marks_live_null_tool_service_storage_for_update() {
+        let desired: DesiredToolServiceRegistry = serde_json::from_value(json!({
+            "service_id": "observability-mcp",
+            "hostname": "studio-1",
+            "mcp_port": 9201
+        }))
+        .expect("desired tool service should deserialize");
+        let live = tool_service_registry_from_live_value(&json!({
+            "service_id": "observability-mcp",
+            "hostname": "studio-1",
+            "tailscale_ip": null,
+            "lan_ip": null,
+            "mcp_port": 9201,
+            "mcp_path": null
+        }))
+        .expect("live tool service should parse");
+
+        let diff = diff_collection(
+            vec![(desired.service_id.clone(), &desired)],
+            vec![(live.service_id.clone(), &live)],
+        );
+
+        assert_eq!(diff.update, vec!["observability-mcp"]);
+        assert!(diff.unchanged.is_empty());
+    }
 
     #[test]
     fn deprecated_backend_capability_fields_are_ignored_for_diff_equality() {

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -4167,6 +4167,7 @@ async fn build_config_export_bundle(
     )
     .await?;
     sort_document_rows(&mut tool_service_registry_rows, "service_id");
+    normalize_tool_service_registry_export_rows(&mut tool_service_registry_rows)?;
     let mut scheduled_task_rows = graphql_rows_or_empty_if_collection_missing(
         access,
         "ScheduledTask",
@@ -4435,6 +4436,16 @@ fn sort_document_rows(rows: &mut [Value], key: &str) {
     });
 }
 
+fn normalize_tool_service_registry_export_rows(rows: &mut [Value]) -> Result<()> {
+    for row in rows {
+        let object = row
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("ToolServiceRegistry export row must be an object"))?;
+        desired_state::normalize_tool_service_registry_storage_fields(object)?;
+    }
+    Ok(())
+}
+
 fn collect_string_field_values(rows: &[Value], field: &str) -> Vec<String> {
     let mut values = rows
         .iter()
@@ -4633,6 +4644,7 @@ fn sanitize_import_document(collection_name: &str, doc: &Value, for_update: bool
             for field in ["tools", "version", "updated_at"] {
                 object.remove(field);
             }
+            desired_state::normalize_tool_service_registry_storage_fields(&mut object)?;
             if for_update {
                 object.insert("updated_at".to_string(), Value::Null);
             }
@@ -6735,30 +6747,36 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_tool_service_registry_preserves_null_address_fields_for_diff_convergence() {
-        // apply/diff compare live rows against the desired manifest. If sanitize
-        // rewrites null address fields to empty strings on the live side but the
-        // manifest serializes None as JSON null, the diff sees a false delta and
-        // `config apply` reports "did not converge". Null-tolerance is handled at
-        // the parser layer (see registry::null_as_empty_string), so sanitize keeps
-        // these fields unchanged.
+    fn sanitize_tool_service_registry_normalizes_address_fields_for_storage() {
         let input = json!({
             "service_id": "observability-mcp",
             "hostname": null,
-            "tailscale_ip": "100.69.4.79",
+            "tailscale_ip": " 100.69.4.79 ",
             "lan_ip": null,
             "mcp_port": 9201,
-            "mcp_path": null
+            "mcp_path": "mcp"
         });
         let out = sanitize_import_document("ToolServiceRegistry", &input, false).unwrap();
         let obj = out.as_object().unwrap();
-        assert!(obj.get("hostname").unwrap().is_null());
-        assert!(obj.get("lan_ip").unwrap().is_null());
-        assert!(obj.get("mcp_path").unwrap().is_null());
+        assert_eq!(obj.get("hostname").and_then(|v| v.as_str()), Some(""));
+        assert_eq!(obj.get("lan_ip").and_then(|v| v.as_str()), Some(""));
         assert_eq!(
             obj.get("tailscale_ip").and_then(|v| v.as_str()),
             Some("100.69.4.79")
         );
+        assert_eq!(obj.get("mcp_path").and_then(|v| v.as_str()), Some("/mcp"));
+    }
+
+    #[test]
+    fn sanitize_tool_service_registry_defaults_mcp_path() {
+        let input = json!({
+            "service_id": "observability-mcp",
+            "hostname": "studio-1",
+            "mcp_port": 9201
+        });
+        let out = sanitize_import_document("ToolServiceRegistry", &input, false).unwrap();
+        let obj = out.as_object().unwrap();
+        assert_eq!(obj.get("mcp_path").and_then(|v| v.as_str()), Some("/mcp"));
     }
 
     #[test]

--- a/crates/defra-agent/schemas/README.md
+++ b/crates/defra-agent/schemas/README.md
@@ -91,7 +91,16 @@ legacy name fallback anymore.
 
 | Collection | Key fields | Meaning | Written by | Read by |
 |------------|------------|---------|------------|---------|
-| `ToolServiceRegistry` | `service_id`, `hostname`, `mcp_port`, `tools`, `status`, `updated_at` | registry entries for discoverable MCP-style tool services | service registry writers | meta-tools and discovery flows |
+| `ToolServiceRegistry` | `service_id`, `hostname`, `tailscale_ip`, `lan_ip`, `mcp_port`, `mcp_path`, `status`, `version`, `updated_at` | registry entries for discoverable MCP-style tool services | desired-state apply, service registry writers | meta-tools and discovery flows |
+
+`ToolServiceRegistry` desired-state owns the identity and endpoint fields:
+`service_id`, `display_name`, `description`, `hostname`, `tailscale_ip`,
+`lan_ip`, `mcp_port`, and `mcp_path`. Desired-state apply normalizes missing or
+null address fields to empty strings, defaults missing or empty `mcp_path` to
+`/mcp`, and creates rows with `status: "online"` so they are discoverable.
+`version` and `updated_at` are runtime-owned and may be null on rows created by
+apply. Tool lists are discovered from the MCP service at runtime; the schema does
+not expose a persisted `tools` relation.
 
 ## Operational Relationships
 

--- a/crates/defra-agent/schemas/services/tool_service_registry.graphql
+++ b/crates/defra-agent/schemas/services/tool_service_registry.graphql
@@ -1,8 +1,3 @@
-type ToolServiceEntry {
-    name: String
-    description: String
-}
-
 type ToolServiceRegistry {
     service_id: String @index(unique: true)
     display_name: String
@@ -12,7 +7,6 @@ type ToolServiceRegistry {
     lan_ip: String
     mcp_port: Int
     mcp_path: String
-    tools: [ToolServiceEntry]
     status: String @index
     version: String
     updated_at: DateTime @index(direction: DESC)

--- a/crates/defra-agent/tests/document_config_bootstrap.rs
+++ b/crates/defra-agent/tests/document_config_bootstrap.rs
@@ -159,6 +159,36 @@ async fn upsert_helpers_roundtrip_behavior_and_profile() {
     assert_eq!(profile.deadline_duration_secs, Some(120));
 }
 
+#[tokio::test]
+async fn tool_service_registry_schema_does_not_expose_broken_tools_relation() {
+    let db = test_db("tool-service-registry-tools-relation").await;
+    let response = db
+        .node
+        .execute(
+            r#"{
+                ToolServiceRegistry {
+                    service_id
+                    tools { name }
+                }
+            }"#,
+        )
+        .await;
+
+    assert!(
+        response.has_errors(),
+        "querying the removed tools relation should fail validation"
+    );
+    let errors = format!("{:?}", response.errors);
+    assert!(
+        errors.contains("tools"),
+        "expected validation error to mention tools field, got {errors}"
+    );
+    assert!(
+        !errors.contains("TypeJoinMany"),
+        "schema should not expose a tools relation that fails during join planning: {errors}"
+    );
+}
+
 async fn insert_principal(
     node: &defra_agent::defra_node::EmbeddedNode,
     agent_did: &str,


### PR DESCRIPTION
## Summary
- Remove the persisted `ToolServiceRegistry.tools` relation from the checked-in schema so new schema installs no longer expose the broken `TypeJoinMany` path.
- Normalize ToolServiceRegistry desired-state/apply storage: missing or null address fields become empty strings, missing or empty `mcp_path` becomes `/mcp`, and runtime-owned fields stay out of desired diffs.
- Preserve raw live nulls during desired-state diffing so `config apply` rewrites older rows and converges, while export/import round trips emit normalized rows.
- Document the desired-state/runtime-owned ToolServiceRegistry contract.

## Issue Links
- Fixes #28, assuming there are no existing stores that need the old `ToolServiceRegistry` collection definition migrated in place. DefraDB schema migration/patch tooling is tracked separately in sourcenetwork/defradb.rs#859 for future hardening.
- Fixes #29.

## Tests
- `cargo test -p defra-agent-cli tool_service_registry -- --nocapture`
- `cargo test -p defra-agent-cli diff_marks_live_null_tool_service_storage_for_update -- --nocapture`
- `cargo test -p defra-agent --test document_config_bootstrap tool_service_registry_schema_does_not_expose_broken_tools_relation -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_e2e config_apply_reconciles_tool_services_and_scheduled_tasks_end_to_end -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_e2e config_export_import_round_trips_tool_services_and_scheduled_tasks -- --nocapture`
- `cargo test -p defra-agent-cli`
- `cargo test -p defra-agent --test document_config_bootstrap`
- `cargo test -p defra-agent --lib --tests`
- `cargo check --workspace`
- `git diff --check`