### PR TITLE
Add desktop local bootstrap init

### DIFF
--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -6,10 +6,11 @@ on:
       inference_endpoint:
         description: OpenAI-compatible base URL, including /v1
         required: true
-        default: http://100.73.235.38:8000/v1
+        default: http://workstation-1:8000/v1
       model_name:
         description: Model name served by the endpoint
         required: true
+        default: MiniMax-M2.7-NVFP4
 
 env:
   CARGO_INCREMENTAL: "0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1927,7 +1927,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2442,7 +2442,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -3205,7 +3205,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3350,7 +3350,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -3628,7 +3628,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3643,7 +3643,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "anyhow",
@@ -3692,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3714,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3728,7 +3728,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "async-lock",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "async-trait",
@@ -3781,7 +3781,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "anyhow",
  "document",
@@ -3855,6 +3855,7 @@ dependencies = [
  "crossterm 0.29.0",
  "defra-agent",
  "defra-node",
+ "defra-p2p-adapter",
  "hostname",
  "opentelemetry 0.31.0",
  "opentelemetry-otlp 0.31.1",
@@ -3879,16 +3880,19 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "clap",
  "crypto",
  "defra-agent",
  "defra-agent-protocol",
  "defra-node",
+ "defra-p2p-adapter",
  "dirs",
  "eframe",
  "egui",
  "egui_commonmark",
  "identity",
  "p2p",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "syntect",
@@ -3910,7 +3914,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3933,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "async-stream",
@@ -3964,7 +3968,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "anyhow",
@@ -3975,6 +3979,7 @@ dependencies = [
  "db-merge",
  "defra-core",
  "defra-http",
+ "defra-p2p-adapter",
  "events",
  "identity",
  "lens",
@@ -3993,9 +3998,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defra-p2p-adapter"
+version = "0.5.0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
+dependencies = [
+ "acp",
+ "async-trait",
+ "blockstore",
+ "bytes",
+ "cid 0.10.1",
+ "db",
+ "db-merge",
+ "defra-core",
+ "defra-http",
+ "document",
+ "events",
+ "hex",
+ "lens",
+ "libp2p",
+ "p2p",
+ "serde",
+ "serde_bytes",
+ "serde_ipld_dagcbor",
+ "serde_json",
+ "storage",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "serde",
 ]
@@ -4279,7 +4313,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4831,7 +4865,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6348,7 +6382,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7268,7 +7302,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9595,7 +9629,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "anyhow",
@@ -10670,7 +10704,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10705,7 +10739,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10722,7 +10756,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "async-lock",
@@ -10753,7 +10787,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11905,7 +11939,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12675,7 +12709,7 @@ checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12819,7 +12853,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16206,7 +16240,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=52b2b86c#52b2b86c6687585280d37dbcca1d3d1be8190a05"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8ad38101#8ad38101f27ae90983adb70546f30c3c6be74836"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,20 +17,21 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "52b2b86c" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "52b2b86c" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
 dirs = "5"
 eframe = "0.34.1"
 egui = "0.34.1"
 egui_commonmark = { version = "0.23.0", features = ["better_syntax_highlighting"] }
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "52b2b86c" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "52b2b86c" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "52b2b86c" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8ad38101" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -130,9 +130,6 @@ The server reads the initialized home directory, starts the local node, and prin
 - `graphql`
 - `default_behavior_id`
 - `tool_ceiling`
-
-If you start the runtime with P2P enabled, the readiness JSON also includes:
-
 - `p2p_transport`
 - `p2p_peer_id`
 - `p2p_listen_addresses`
@@ -147,13 +144,12 @@ The runtime HTTP port also exposes a stable machine-readable operations surface:
 
 `server` stays in the foreground until you stop it with `Ctrl-C`. By default it keeps logs quiet and prints the readiness JSON plus a short status line. If you want debug output, set `RUST_LOG=info` or a more specific filter before starting it.
 
-The default behavior stays local-only. If you do not pass any P2P flags, `p2p_transport` stays `none`.
+The standard server path always starts the IROH P2P transport for local desktop pairing. It binds to localhost on an ephemeral P2P port by default, with relay and discovery disabled.
 
-To enable operator-facing P2P bring-up with iroh:
+To pin the local P2P socket for demos:
 
 ```bash
 $AGENT server \
-  --p2p-transport iroh \
   --p2p-bind-addr 127.0.0.1 \
   --p2p-port 4017 \
   --p2p-relay-mode disabled \
@@ -221,8 +217,8 @@ After that, the agent can use read-only file tools on new requests. This change 
 To bring up two runtimes and connect them through the operator CLI:
 
 ```bash
-$AGENT server --home /tmp/amy --p2p-transport iroh --p2p-bind-addr 127.0.0.1 --p2p-port 4017
-$AGENT server --home /tmp/coding --p2p-transport iroh --p2p-bind-addr 127.0.0.1 --p2p-port 4018
+$AGENT server --home /tmp/amy --p2p-bind-addr 127.0.0.1 --p2p-port 4017
+$AGENT server --home /tmp/coding --p2p-bind-addr 127.0.0.1 --p2p-port 4018
 ```
 
 Read Amy's startup JSON or `/tmp/amy/runtime.json` and take one of the values from `p2p_listen_addresses`.
@@ -324,8 +320,8 @@ cd crates/defra-agent/proofs && lake build
 There is also an ignored live smoke test for the real binary flow against an external inference endpoint:
 
 ```bash
-export DEFRA_AGENT_CLI_E2E_MODEL_ENDPOINT=http://100.73.235.38:8000/v1
-export DEFRA_AGENT_CLI_E2E_MODEL_NAME=your-model-name
+export DEFRA_AGENT_CLI_E2E_MODEL_ENDPOINT=http://workstation-1:8000/v1
+export DEFRA_AGENT_CLI_E2E_MODEL_NAME=MiniMax-M2.7-NVFP4
 # export DEFRA_AGENT_CLI_E2E_API_KEY=...   # if your endpoint requires auth
 
 cargo test -p defra-agent-cli \

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -18,6 +18,7 @@ clap.workspace = true
 crossterm = "0.29"
 defra-agent = { path = "../defra-agent" }
 defra-node.workspace = true
+defra-p2p-adapter.workspace = true
 hostname.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -92,12 +92,13 @@ Examples:
   defra-agent reset
   defra-agent reset --home /path/to/home";
 const SERVER_AFTER_HELP: &str = "\
-`server` reads the initialized home directory, starts the embedded DefraDB runtime, and serves GraphQL locally.
+`server` reads the initialized home directory, starts the embedded DefraDB runtime, serves GraphQL locally, and starts IROH P2P for desktop pairing.
 
 Common flow:
   defra-agent init
   defra-agent server
-  defra-agent server --p2p-transport iroh --p2p-port 4017
+  defra-agent-desktop init
+  defra-agent-desktop
   defra-agent chat";
 const CHAT_AFTER_HELP: &str = "\
 Examples:
@@ -436,17 +437,15 @@ struct ServeArgs {
         help = "Root directory for readonly/readwrite tool ceilings. Readonly defaults to the current working directory when unset"
     )]
     tool_root: Option<PathBuf>,
-    #[arg(long, value_enum, default_value_t = P2pTransportArg::None)]
-    p2p_transport: P2pTransportArg,
     #[arg(long)]
     p2p_bind_addr: Option<IpAddr>,
     #[arg(long)]
     p2p_port: Option<u16>,
     #[arg(long)]
     p2p_secret_key_path: Option<PathBuf>,
-    #[arg(long, value_enum, default_value_t = P2pRelayModeArg::Default)]
+    #[arg(long, value_enum, default_value_t = P2pRelayModeArg::Disabled)]
     p2p_relay_mode: P2pRelayModeArg,
-    #[arg(long, value_enum, default_value_t = P2pDiscoveryArg::N0)]
+    #[arg(long, value_enum, default_value_t = P2pDiscoveryArg::Disabled)]
     p2p_discovery: P2pDiscoveryArg,
 }
 
@@ -2808,7 +2807,7 @@ async fn serve(args: ServeArgs) -> Result<()> {
         }
     }
 
-    let p2p_status = load_local_server_p2p_status(node.as_ref(), args.p2p_transport).await?;
+    let p2p_status = load_local_server_p2p_status(node.as_ref(), P2pTransportArg::Iroh).await?;
     write_runtime_state(
         &home_dir,
         &StoredRuntimeState {
@@ -2857,7 +2856,7 @@ async fn serve(args: ServeArgs) -> Result<()> {
     });
     print_json(&output)?;
     eprintln!(
-        "defra-agent server is running. Press Ctrl-C to stop. Run `defra-agent chat` in another terminal."
+        "defra-agent server is running with IROH P2P. Press Ctrl-C to stop. Run `defra-agent-desktop init` or `defra-agent chat` in another terminal."
     );
 
     run_handle
@@ -2866,7 +2865,7 @@ async fn serve(args: ServeArgs) -> Result<()> {
 }
 
 fn default_p2p_transport() -> String {
-    P2pTransportArg::None.as_str().to_string()
+    P2pTransportArg::Iroh.as_str().to_string()
 }
 
 fn default_p2p_secret_key_path(home_dir: &Path) -> PathBuf {
@@ -2877,47 +2876,35 @@ fn resolve_server_p2p_config(
     home_dir: &Path,
     args: &ServeArgs,
 ) -> Result<Option<defra_node::P2PConfig>> {
-    match args.p2p_transport {
-        P2pTransportArg::None => {
-            if args.p2p_bind_addr.is_some()
-                || args.p2p_port.is_some()
-                || args.p2p_secret_key_path.is_some()
-                || args.p2p_relay_mode != P2pRelayModeArg::Default
-                || args.p2p_discovery != P2pDiscoveryArg::N0
-            {
-                anyhow::bail!("P2P-specific flags require `--p2p-transport iroh`");
-            }
-            Ok(None)
-        }
-        P2pTransportArg::Iroh => {
-            let secret_key_path = args
-                .p2p_secret_key_path
-                .clone()
-                .unwrap_or_else(|| default_p2p_secret_key_path(home_dir));
-            if let Some(parent) = secret_key_path.parent() {
-                fs::create_dir_all(parent)
-                    .with_context(|| format!("creating P2P key directory {}", parent.display()))?;
-            }
-            Ok(Some(defra_node::P2PConfig {
-                port: args.p2p_port.unwrap_or(0),
-                bind_addr: args.p2p_bind_addr,
-                relay_mode: match args.p2p_relay_mode {
-                    P2pRelayModeArg::Default => p2p::iroh::IrohRelayModeConfig::Default,
-                    P2pRelayModeArg::Disabled => p2p::iroh::IrohRelayModeConfig::Disabled,
-                },
-                discovery: match args.p2p_discovery {
-                    P2pDiscoveryArg::N0 => p2p::iroh::IrohDiscoveryConfig::N0,
-                    P2pDiscoveryArg::Disabled => p2p::iroh::IrohDiscoveryConfig::Disabled,
-                },
-                secret_key_path: Some(secret_key_path),
-                load_persisted_collections: true,
-                max_concurrent_dag_fetches: DEFAULT_P2P_MAX_CONCURRENT_DAG_FETCHES,
-                max_concurrent_push_tasks: DEFAULT_P2P_MAX_CONCURRENT_PUSH_TASKS,
-                rate_limit_burst: DEFAULT_P2P_RATE_LIMIT_BURST,
-                rate_limit_rate: DEFAULT_P2P_RATE_LIMIT_RATE,
-            }))
-        }
+    let secret_key_path = args
+        .p2p_secret_key_path
+        .clone()
+        .unwrap_or_else(|| default_p2p_secret_key_path(home_dir));
+    if let Some(parent) = secret_key_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("creating P2P key directory {}", parent.display()))?;
     }
+    Ok(Some(defra_node::P2PConfig {
+        port: args.p2p_port.unwrap_or(0),
+        bind_addr: Some(
+            args.p2p_bind_addr
+                .unwrap_or(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+        ),
+        relay_mode: match args.p2p_relay_mode {
+            P2pRelayModeArg::Default => p2p::iroh::IrohRelayModeConfig::Default,
+            P2pRelayModeArg::Disabled => p2p::iroh::IrohRelayModeConfig::Disabled,
+        },
+        discovery: match args.p2p_discovery {
+            P2pDiscoveryArg::N0 => p2p::iroh::IrohDiscoveryConfig::N0,
+            P2pDiscoveryArg::Disabled => p2p::iroh::IrohDiscoveryConfig::Disabled,
+        },
+        secret_key_path: Some(secret_key_path),
+        load_persisted_collections: true,
+        max_concurrent_dag_fetches: DEFAULT_P2P_MAX_CONCURRENT_DAG_FETCHES,
+        max_concurrent_push_tasks: DEFAULT_P2P_MAX_CONCURRENT_PUSH_TASKS,
+        rate_limit_burst: DEFAULT_P2P_RATE_LIMIT_BURST,
+        rate_limit_rate: DEFAULT_P2P_RATE_LIMIT_RATE,
+    }))
 }
 
 async fn load_local_server_p2p_status(
@@ -2938,7 +2925,10 @@ async fn load_local_server_p2p_status(
                     "P2P transport was requested but is not available on the embedded node"
                 )
             })?;
-            let peer_id = p2p.local_peer_id().await;
+            let peer_id = p2p
+                .local_peer_id()
+                .await
+                .context("loading local P2P peer id from the embedded node")?;
             let listen_addresses = wait_for_p2p_listen_addresses(p2p).await?;
             let connected_peers = p2p
                 .connected_peers()
@@ -2955,10 +2945,15 @@ async fn load_local_server_p2p_status(
     }
 }
 
-async fn wait_for_p2p_listen_addresses(p2p: &dyn defra_node::P2POps) -> Result<Vec<String>> {
+async fn wait_for_p2p_listen_addresses(
+    p2p: &dyn defra_p2p_adapter::P2POperations,
+) -> Result<Vec<String>> {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     loop {
-        let listen_addresses = p2p.listen_addresses().await;
+        let listen_addresses = p2p
+            .listen_addresses()
+            .await
+            .context("loading local P2P listen addresses from the embedded node")?;
         if !listen_addresses.is_empty() {
             return Ok(listen_addresses);
         }
@@ -4532,7 +4527,7 @@ fn persisted_p2p_status(runtime_state: Option<&StoredRuntimeState>) -> Value {
         }),
         None => json!({
             "enabled": false,
-            "p2p_transport": default_p2p_transport(),
+            "p2p_transport": P2pTransportArg::None.as_str(),
             "p2p_peer_id": Value::Null,
             "p2p_listen_addresses": [],
             "p2p_connected_peers": [],

--- a/crates/defra-agent-cli/tests/cli_e2e.rs
+++ b/crates/defra-agent-cli/tests/cli_e2e.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::io::{BufRead, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
@@ -13,7 +13,8 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 use uuid::Uuid;
 
-const DEFAULT_MODEL_ENDPOINT: &str = "http://100.73.235.38:8000/v1";
+const DEFAULT_MODEL_ENDPOINT: &str = "http://workstation-1:8000/v1";
+const DEFAULT_MODEL_NAME: &str = "MiniMax-M2.7-NVFP4";
 
 struct ServeProcess {
     child: Child,
@@ -3529,8 +3530,6 @@ async fn server_startup_with_iroh_p2p_reports_runtime_connectivity() -> Result<(
         &home_dir,
         port,
         &[
-            "--p2p-transport",
-            "iroh",
             "--p2p-bind-addr",
             "127.0.0.1",
             "--p2p-port",
@@ -3588,7 +3587,7 @@ async fn server_startup_with_iroh_p2p_reports_runtime_connectivity() -> Result<(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn server_startup_defaults_to_local_only_when_p2p_disabled() -> Result<()> {
+async fn server_startup_defaults_to_iroh_p2p_for_desktop_pairing() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
@@ -3617,29 +3616,29 @@ async fn server_startup_defaults_to_local_only_when_p2p_disabled() -> Result<()>
 
     assert_eq!(
         readiness.get("p2p_transport").and_then(Value::as_str),
-        Some("none")
+        Some("iroh")
     );
-    assert!(readiness.get("p2p_peer_id").is_none_or(Value::is_null));
-    assert_eq!(
-        readiness
-            .get("p2p_listen_addresses")
-            .and_then(Value::as_array)
-            .map(Vec::len),
-        Some(0)
-    );
+    assert!(readiness
+        .get("p2p_peer_id")
+        .and_then(Value::as_str)
+        .is_some_and(|value| !value.is_empty()));
+    assert!(readiness
+        .get("p2p_listen_addresses")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| !rows.is_empty()));
 
     let runtime_state = read_runtime_state_json(&home_dir)?;
     assert_eq!(
         runtime_state.get("p2p_transport").and_then(Value::as_str),
-        Some("none")
+        Some("iroh")
     );
-    assert!(runtime_state.get("p2p_peer_id").is_none_or(Value::is_null));
     assert_eq!(
-        runtime_state
-            .get("p2p_listen_addresses")
-            .and_then(Value::as_array)
-            .map(Vec::len),
-        Some(0)
+        runtime_state.get("p2p_peer_id"),
+        readiness.get("p2p_peer_id")
+    );
+    assert_eq!(
+        runtime_state.get("p2p_listen_addresses"),
+        readiness.get("p2p_listen_addresses")
     );
 
     Ok(())
@@ -3809,8 +3808,6 @@ async fn status_includes_p2p_runtime_info() -> Result<()> {
         &home_dir,
         port,
         &[
-            "--p2p-transport",
-            "iroh",
             "--p2p-bind-addr",
             "127.0.0.1",
             "--p2p-port",
@@ -3878,8 +3875,6 @@ async fn diagnose_with_explicit_graphql_does_not_reuse_unrelated_local_p2p_state
         &home_dir,
         port,
         &[
-            "--p2p-transport",
-            "iroh",
             "--p2p-bind-addr",
             "127.0.0.1",
             "--p2p-port",
@@ -3950,8 +3945,6 @@ async fn p2p_connects_two_local_servers_via_operator_commands() -> Result<()> {
         &home_a,
         port_a,
         &[
-            "--p2p-transport",
-            "iroh",
             "--p2p-bind-addr",
             "127.0.0.1",
             "--p2p-port",
@@ -3967,8 +3960,6 @@ async fn p2p_connects_two_local_servers_via_operator_commands() -> Result<()> {
         &home_b,
         port_b,
         &[
-            "--p2p-transport",
-            "iroh",
             "--p2p-bind-addr",
             "127.0.0.1",
             "--p2p-port",
@@ -4011,11 +4002,17 @@ async fn p2p_connects_two_local_servers_via_operator_commands() -> Result<()> {
     assert!(status_b
         .get("p2p_connected_peers")
         .and_then(Value::as_array)
-        .is_some_and(|rows| rows.iter().any(|row| row.as_str() == Some(peer_id_a))));
+        .is_some_and(|rows| rows
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|row| row.contains(peer_id_a))));
     assert!(status_a
         .get("p2p_connected_peers")
         .and_then(Value::as_array)
-        .is_some_and(|rows| rows.iter().any(|row| row.as_str() == Some(peer_id_b))));
+        .is_some_and(|rows| rows
+            .iter()
+            .filter_map(Value::as_str)
+            .any(|row| row.contains(peer_id_b))));
 
     let peers_b = run_cli_json(&home_b, &["p2p", "peers"])?;
     assert_eq!(peers_b.get("count").and_then(Value::as_u64), Some(1));
@@ -4058,18 +4055,28 @@ async fn p2p_connects_two_local_servers_via_operator_commands() -> Result<()> {
         Some(true)
     );
     for path in [
-        "/checks/p2p/collections/error",
-        "/checks/p2p/replicators/error",
-        "/checks/p2p/documents/error",
+        "/checks/p2p/info/ok",
+        "/checks/p2p/peers/ok",
+        "/checks/p2p/collections/ok",
+        "/checks/p2p/replicators/ok",
+        "/checks/p2p/documents/ok",
     ] {
         assert!(
             diagnose_b
                 .pointer(path)
-                .and_then(Value::as_str)
-                .is_some_and(|error| error.contains("not supported")),
-            "expected unsupported diagnostic at {path}: {diagnose_b}"
+                .and_then(Value::as_bool)
+                .is_some_and(|ok| ok),
+            "expected successful diagnostic at {path}: {diagnose_b}"
         );
     }
+    assert!(diagnose_b
+        .pointer("/checks/p2p/collections/value")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| !rows.is_empty()));
+    assert!(diagnose_b
+        .pointer("/checks/p2p/replicators/value")
+        .and_then(Value::as_array)
+        .is_some_and(|rows| !rows.is_empty()));
 
     Ok(())
 }
@@ -4846,8 +4853,12 @@ async fn reconciled_runtime_sends_generation_two_tools_and_completes_tool_loop()
 async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_tools() -> Result<()>
 {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
-    let home_dir = tempdir.path().join("home");
+    let home_dir = tempdir.path().join("agent-home");
+    let desktop_home = tempdir.path().join("desktop-home");
     fs::create_dir_all(&home_dir)?;
+    let home_arg = home_dir
+        .to_str()
+        .ok_or_else(|| anyhow!("demo home path is not UTF-8"))?;
 
     let files_dir = home_dir.join("demo-files");
     fs::create_dir_all(&files_dir)?;
@@ -4866,28 +4877,20 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
     let graphql = graphql_url(port);
     let agent_name = format!("cli-live-demo-{}", Uuid::new_v4().simple());
     let agent_did = format!("did:defra-agent:{agent_name}");
-    let live_api_key_available =
-        std::env::var("DEFRA_AGENT_CLI_E2E_API_KEY").is_ok_and(|value| !value.trim().is_empty());
 
-    let mut init_args = vec![
+    let init_args = vec![
+        "--home".to_string(),
+        home_arg.to_string(),
         "--agent-name".to_string(),
         agent_name.clone(),
+        "--model-name".to_string(),
+        DEFAULT_MODEL_NAME.to_string(),
         "--max-concurrent".to_string(),
         "2".to_string(),
         "--max-queue-depth".to_string(),
         "4".to_string(),
+        DEFAULT_MODEL_ENDPOINT.to_string(),
     ];
-    if live_api_key_available {
-        init_args.push("--api-key-env-var".to_string());
-        init_args.push("DEFRA_AGENT_CLI_E2E_API_KEY".to_string());
-    }
-    if let Ok(model_name) = std::env::var("DEFRA_AGENT_CLI_E2E_MODEL_NAME") {
-        init_args.push("--model-name".to_string());
-        init_args.push(model_name);
-    }
-    if let Ok(model_endpoint) = std::env::var("DEFRA_AGENT_CLI_E2E_MODEL_ENDPOINT") {
-        init_args.push(model_endpoint);
-    }
     let init_arg_refs = init_args.iter().map(String::as_str).collect::<Vec<_>>();
     let init = run_init_json(&home_dir, &init_arg_refs)?;
     let backend_id = init
@@ -4921,11 +4924,61 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         .ok_or_else(|| anyhow!("init output missing tool_selection_id: {init}"))?
         .to_string();
 
-    let mut serve = spawn_server(&home_dir, port)?;
+    let (mut serve, readiness) =
+        spawn_server_with_ready_json(&home_dir, port, &["--home", home_arg], &[])?;
     wait_for_port(port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+    assert_eq!(
+        readiness.get("p2p_transport").and_then(Value::as_str),
+        Some("iroh")
+    );
 
-    let mut backend_args = vec![
+    let desktop_init = run_desktop_init_json(&home_dir, &desktop_home, "Standard Onboarding Demo")?;
+    assert_eq!(
+        desktop_init.get("status").and_then(Value::as_str),
+        Some("initialized")
+    );
+    assert_eq!(
+        desktop_init.get("source").and_then(Value::as_str),
+        Some("local-standard")
+    );
+    assert_eq!(
+        desktop_init.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        desktop_init.get("graphql").and_then(Value::as_str),
+        Some(graphql.as_str())
+    );
+    assert_eq!(
+        desktop_init.get("p2p_transport").and_then(Value::as_str),
+        Some("iroh")
+    );
+    let peer_directory_path = desktop_home.join("peers.json");
+    let peer_directory: Value = serde_json::from_slice(
+        &fs::read(&peer_directory_path)
+            .with_context(|| format!("reading {}", peer_directory_path.display()))?,
+    )
+    .with_context(|| format!("decoding {}", peer_directory_path.display()))?;
+    let peer = peer_directory
+        .get("peers")
+        .and_then(Value::as_array)
+        .and_then(|peers| peers.first())
+        .ok_or_else(|| anyhow!("desktop init did not persist a peer: {peer_directory}"))?;
+    assert_eq!(
+        peer.get("source").and_then(Value::as_str),
+        Some("local-standard")
+    );
+    assert_eq!(
+        peer.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        peer.get("graphql").and_then(Value::as_str),
+        Some(graphql.as_str())
+    );
+
+    let backend_args = vec![
         "config",
         "backend",
         "set",
@@ -4944,10 +4997,6 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         "--max-queue-depth",
         "4",
     ];
-    if live_api_key_available {
-        backend_args.push("--api-key-env-var");
-        backend_args.push("DEFRA_AGENT_CLI_E2E_API_KEY");
-    }
     run_cli_json(&home_dir, &backend_args)?;
 
     run_cli_json(
@@ -5011,6 +5060,8 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         &home_dir,
         &[
             "chat",
+            "--home",
+            home_arg,
             "--session-id",
             &session_id,
             "--output-format",
@@ -5040,6 +5091,8 @@ async fn standard_onboarding_live_demo_runs_real_conversation_with_filesystem_to
         &home_dir,
         &[
             "chat",
+            "--home",
+            home_arg,
             "--session-id",
             &session_id,
             "--output-format",
@@ -5132,7 +5185,7 @@ async fn cli_flow_runs_real_tool_loop_against_live_endpoint() -> Result<()> {
     let model_endpoint = std::env::var("DEFRA_AGENT_CLI_E2E_MODEL_ENDPOINT")
         .unwrap_or_else(|_| DEFAULT_MODEL_ENDPOINT.to_string());
     let model_name = std::env::var("DEFRA_AGENT_CLI_E2E_MODEL_NAME")
-        .context("set DEFRA_AGENT_CLI_E2E_MODEL_NAME for the live CLI e2e test")?;
+        .unwrap_or_else(|_| DEFAULT_MODEL_NAME.to_string());
     let mut init_args = vec![
         "--agent-name".to_string(),
         agent_name.clone(),
@@ -5301,6 +5354,62 @@ async fn cli_flow_runs_real_tool_loop_against_live_endpoint() -> Result<()> {
 
 fn cli_bin() -> &'static str {
     env!("CARGO_BIN_EXE_defra-agent")
+}
+
+fn desktop_bin() -> Result<PathBuf> {
+    let cli_path = Path::new(cli_bin());
+    let binary_name = format!("defra-agent-desktop{}", std::env::consts::EXE_SUFFIX);
+    let desktop_path = cli_path
+        .parent()
+        .ok_or_else(|| anyhow!("unable to resolve defra-agent binary directory"))?
+        .join(binary_name);
+    if desktop_path.exists() {
+        return Ok(desktop_path);
+    }
+
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .ok_or_else(|| anyhow!("unable to resolve workspace root from CARGO_MANIFEST_DIR"))?;
+    let status = Command::new("cargo")
+        .current_dir(workspace_root)
+        .args([
+            "build",
+            "-p",
+            "defra-agent-desktop",
+            "--bin",
+            "defra-agent-desktop",
+        ])
+        .status()
+        .context("building defra-agent-desktop binary for demo e2e")?;
+    if !status.success() {
+        bail!("cargo build -p defra-agent-desktop --bin defra-agent-desktop failed");
+    }
+    Ok(desktop_path)
+}
+
+fn run_desktop_init_json(agent_home: &Path, desktop_home: &Path, label: &str) -> Result<Value> {
+    let output = Command::new(desktop_bin()?)
+        .env("RUST_LOG", "error")
+        .arg("init")
+        .arg("--agent-home")
+        .arg(agent_home)
+        .arg("--desktop-home")
+        .arg(desktop_home)
+        .arg("--label")
+        .arg(label)
+        .arg("--json")
+        .output()
+        .context("running defra-agent-desktop init")?;
+    if !output.status.success() {
+        bail!(
+            "defra-agent-desktop init failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    serde_json::from_slice(&output.stdout).context("parsing JSON from defra-agent-desktop init")
 }
 
 fn allocate_port() -> Result<u16> {
@@ -6210,7 +6319,11 @@ async fn wait_for_connected_peer(
         if status
             .get("p2p_connected_peers")
             .and_then(Value::as_array)
-            .is_some_and(|rows| rows.iter().any(|row| row.as_str() == Some(peer_id)))
+            .is_some_and(|rows| {
+                rows.iter()
+                    .filter_map(Value::as_str)
+                    .any(|row| row.contains(peer_id))
+            })
         {
             return Ok(status);
         }

--- a/crates/defra-agent-cli/tests/cli_e2e.rs
+++ b/crates/defra-agent-cli/tests/cli_e2e.rs
@@ -3592,11 +3592,11 @@ async fn server_startup_defaults_to_iroh_p2p_for_desktop_pairing() -> Result<()>
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
 
-    let model_name = format!("mock-local-only-model-{}", Uuid::new_v4().simple());
+    let model_name = format!("mock-default-iroh-model-{}", Uuid::new_v4().simple());
     let mock_endpoint = MockModelEndpoint::start(&model_name)?;
 
     let port = allocate_port()?;
-    let agent_name = format!("cli-local-only-{}", Uuid::new_v4().simple());
+    let agent_name = format!("cli-default-iroh-{}", Uuid::new_v4().simple());
     let agent_did = format!("did:defra-agent:{agent_name}");
     let graphql = graphql_url(port);
 
@@ -5363,9 +5363,6 @@ fn desktop_bin() -> Result<PathBuf> {
         .parent()
         .ok_or_else(|| anyhow!("unable to resolve defra-agent binary directory"))?
         .join(binary_name);
-    if desktop_path.exists() {
-        return Ok(desktop_path);
-    }
 
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/crates/defra-agent-desktop/Cargo.toml
+++ b/crates/defra-agent-desktop/Cargo.toml
@@ -9,15 +9,18 @@ description = "Native egui desktop dashboard for defra-agent"
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
+clap.workspace = true
 crypto.workspace = true
 defra-agent-protocol.workspace = true
 defra-node = { workspace = true, features = ["p2p"] }
+defra-p2p-adapter.workspace = true
 dirs.workspace = true
 eframe.workspace = true
 egui.workspace = true
 egui_commonmark.workspace = true
 identity.workspace = true
 p2p.workspace = true
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 syntect.workspace = true

--- a/crates/defra-agent-desktop/src/app/tests/support.rs
+++ b/crates/defra-agent-desktop/src/app/tests/support.rs
@@ -708,7 +708,7 @@ async fn configure_live_test_replicators(
 async fn wait_for_connectable_iroh_addr(core: &ClientCore, label: &str) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
-        let addrs = core.p2p().listen_addresses().await;
+        let addrs = core.p2p().listen_addresses().await?;
         if let Some(addr) = addrs
             .iter()
             .find(|addr| addr.contains("/p2p/") || addr.starts_with("endpoint"))
@@ -778,7 +778,11 @@ async fn set_replicator_with_retry(
 ) -> Result<()> {
     let deadline = Instant::now() + Duration::from_secs(60);
     loop {
-        match core.p2p().set_replicator(addr, collections.clone()).await {
+        match core
+            .p2p()
+            .add_replicator(collections.clone(), Some(addr), Vec::new(), None)
+            .await
+        {
             Ok(()) => return Ok(()),
             Err(error) => {
                 if Instant::now() >= deadline {

--- a/crates/defra-agent-desktop/src/client/core.rs
+++ b/crates/defra-agent-desktop/src/client/core.rs
@@ -7,7 +7,8 @@ use defra_agent_protocol::row::{
     AgentBehaviorRow, AgentRequestRow, InferenceBackendRow, InferenceProfileRow, ScheduledTaskRow,
     ToolSelectionRow,
 };
-use defra_node::{EmbeddedNode, NodeBuilder, P2PConfig, P2POps};
+use defra_node::{EmbeddedNode, NodeBuilder, P2PConfig};
+use defra_p2p_adapter::P2POperations as P2POps;
 use p2p::iroh::{IrohDiscoveryConfig, IrohRelayModeConfig};
 use tokio::sync::{Mutex, RwLock};
 
@@ -20,6 +21,7 @@ use super::query::load_full_snapshot;
 use super::schema::{
     ensure_runtime_schemas, subscribe_all_collections, subscribed_collection_names,
 };
+use crate::local_runtime;
 
 #[derive(Debug, Clone)]
 pub struct ClientCoreOptions {
@@ -136,8 +138,16 @@ impl ClientCore {
         let p2p = node
             .p2p_arc()
             .context("desktop node started without P2P support")?;
-        let local_peer_id = p2p.local_peer_id().await;
-        let listen_addresses = p2p.listen_addresses().await;
+        let local_peer_id = p2p
+            .local_peer_id()
+            .await
+            .map_err(anyhow::Error::msg)
+            .context("reading desktop P2P peer id")?;
+        let listen_addresses = p2p
+            .listen_addresses()
+            .await
+            .map_err(anyhow::Error::msg)
+            .context("reading desktop P2P listen addresses")?;
 
         let (peer_statuses, peer_errors) =
             bootstrap_saved_peers(&p2p, peer_directory.records(), &options).await;
@@ -383,12 +393,14 @@ impl ClientCore {
         let (connected, warning) = match self.p2p.connect_peer(&record.addr).await {
             Ok(()) => match self
                 .p2p
-                .set_replicator(
-                    &record.addr,
+                .add_replicator(
                     subscribed_collection_names()
                         .into_iter()
                         .map(str::to_owned)
                         .collect(),
+                    Some(&record.addr),
+                    Vec::new(),
+                    None,
                 )
                 .await
             {
@@ -648,12 +660,14 @@ async fn bootstrap_saved_peers(
 
                 if options.install_replicators_on_bootstrap {
                     if let Err(error) = p2p
-                        .set_replicator(
-                            &record.addr,
+                        .add_replicator(
                             subscribed_collection_names()
                                 .into_iter()
                                 .map(str::to_owned)
                                 .collect(),
+                            Some(&record.addr),
+                            Vec::new(),
+                            None,
                         )
                         .await
                     {
@@ -663,6 +677,20 @@ async fn bootstrap_saved_peers(
                         );
                         status.last_error = Some(message.clone());
                         errors.push(message);
+                    }
+                }
+
+                if let Some(graphql) = record.graphql.as_deref() {
+                    match configure_local_runtime_pairing(p2p, graphql).await {
+                        Ok(()) => {}
+                        Err(error) => {
+                            let message = format!(
+                                "peer {} local runtime pairing failed: {}",
+                                record.label, error
+                            );
+                            status.last_error = Some(message.clone());
+                            errors.push(message);
+                        }
                     }
                 }
             }
@@ -677,6 +705,26 @@ async fn bootstrap_saved_peers(
     }
 
     (statuses, errors)
+}
+
+async fn configure_local_runtime_pairing(p2p: &Arc<dyn P2POps>, graphql: &str) -> Result<()> {
+    let desktop_listen_address = p2p
+        .listen_addresses()
+        .await
+        .map_err(anyhow::Error::msg)
+        .context("reading desktop P2P listen addresses for local runtime pairing")?
+        .into_iter()
+        .find(|addr| !addr.trim().is_empty())
+        .context("desktop node has no IROH listen address for local runtime pairing")?;
+    local_runtime::complete_runtime_pairing(
+        graphql,
+        &desktop_listen_address,
+        subscribed_collection_names()
+            .into_iter()
+            .map(str::to_owned)
+            .collect(),
+    )
+    .await
 }
 
 fn normalize_required<'a>(field: &str, value: &'a str) -> Result<&'a str> {

--- a/crates/defra-agent-desktop/src/client/peer_directory.rs
+++ b/crates/defra-agent-desktop/src/client/peer_directory.rs
@@ -11,6 +11,10 @@ pub struct PeerRecord {
     pub label: String,
     pub addr: String,
     pub agent_did: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub graphql: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -27,9 +31,23 @@ impl PeerRecord {
             label: label.into(),
             addr: addr.into(),
             agent_did: agent_did.into(),
+            source: None,
+            graphql: None,
             created_at: now.clone(),
             updated_at: now,
         }
+    }
+
+    pub fn local_standard(
+        label: impl Into<String>,
+        addr: impl Into<String>,
+        agent_did: impl Into<String>,
+        graphql: impl Into<String>,
+    ) -> Self {
+        let mut record = Self::new(label, addr, agent_did);
+        record.source = Some("local-standard".to_string());
+        record.graphql = Some(graphql.into());
+        record
     }
 }
 
@@ -96,6 +114,34 @@ impl PeerDirectory {
         record.label = label.to_string();
         record.addr = addr.to_string();
         record.agent_did = agent_did.to_string();
+
+        self.upsert(record.clone()).await?;
+        Ok(record)
+    }
+
+    pub async fn upsert_local_standard_peer(
+        &mut self,
+        label: &str,
+        addr: &str,
+        agent_did: &str,
+        graphql: &str,
+    ) -> Result<PeerRecord> {
+        let label = normalize_non_empty("label", label)?;
+        let addr = normalize_non_empty("addr", addr)?;
+        let agent_did = normalize_non_empty("agent_did", agent_did)?;
+        let graphql = normalize_non_empty("graphql", graphql)?;
+
+        let mut record = self
+            .peers
+            .iter()
+            .find(|existing| existing.source.as_deref() == Some("local-standard"))
+            .cloned()
+            .unwrap_or_else(|| PeerRecord::local_standard(label, addr, agent_did, graphql));
+        record.label = label.to_string();
+        record.addr = addr.to_string();
+        record.agent_did = agent_did.to_string();
+        record.source = Some("local-standard".to_string());
+        record.graphql = Some(graphql.to_string());
 
         self.upsert(record.clone()).await?;
         Ok(record)
@@ -249,5 +295,48 @@ mod tests {
         assert_eq!(first.peer_id, second.peer_id);
         assert_eq!(directory.records().len(), 1);
         assert_eq!(directory.records()[0].label, "Workshop Bay Updated");
+    }
+
+    #[tokio::test]
+    async fn upsert_local_standard_peer_tracks_graphql_and_source() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let path = tempdir.path().join("peers.json");
+        let mut directory = PeerDirectory::load(&path).await.unwrap();
+
+        let first = directory
+            .upsert_local_standard_peer(
+                "Local Agent",
+                "iroh://first",
+                "did:defra-agent:default",
+                "http://127.0.0.1:9191/api/v0/graphql",
+            )
+            .await
+            .unwrap();
+        let second = directory
+            .upsert_local_standard_peer(
+                "Local Agent Updated",
+                "iroh://second",
+                "did:defra-agent:default",
+                "http://127.0.0.1:9192/api/v0/graphql",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first.peer_id, second.peer_id);
+        assert_eq!(directory.records().len(), 1);
+        assert_eq!(
+            directory.records()[0].source.as_deref(),
+            Some("local-standard")
+        );
+        assert_eq!(
+            directory.records()[0].graphql.as_deref(),
+            Some("http://127.0.0.1:9192/api/v0/graphql")
+        );
+
+        let reloaded = PeerDirectory::load(&path).await.unwrap();
+        assert_eq!(
+            reloaded.records()[0].graphql.as_deref(),
+            Some("http://127.0.0.1:9192/api/v0/graphql")
+        );
     }
 }

--- a/crates/defra-agent-desktop/src/client/schema.rs
+++ b/crates/defra-agent-desktop/src/client/schema.rs
@@ -37,7 +37,7 @@ pub async fn subscribe_all_collections(node: &EmbeddedNode) -> Result<()> {
     let p2p = node.p2p().context("desktop node missing P2P support")?;
 
     for name in subscribed_collection_names() {
-        match p2p.subscribe_collection(name).await {
+        match p2p.add_collections(vec![name.to_owned()]).await {
             Ok(()) => {}
             Err(error) => {
                 if error.to_string().contains("already") {

--- a/crates/defra-agent-desktop/src/lib.rs
+++ b/crates/defra-agent-desktop/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub(crate) mod audit;
 pub mod client;
+pub mod local_runtime;
 pub mod state;
 pub mod telemetry;
 pub mod theme;

--- a/crates/defra-agent-desktop/src/local_runtime.rs
+++ b/crates/defra-agent-desktop/src/local_runtime.rs
@@ -1,0 +1,283 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::client::{DesktopPaths, PeerDirectory};
+
+const INIT_CONFIG_FILE_NAME: &str = "init.json";
+const RUNTIME_STATE_FILE_NAME: &str = "runtime.json";
+const LOCAL_STANDARD_SOURCE: &str = "local-standard";
+
+#[derive(Debug, Clone)]
+pub struct DesktopInitOptions {
+    pub agent_home: PathBuf,
+    pub desktop_paths: DesktopPaths,
+    pub label: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DesktopInitSummary {
+    pub status: &'static str,
+    pub source: &'static str,
+    pub agent_home: String,
+    pub desktop_home: String,
+    pub peer_directory: String,
+    pub label: String,
+    pub agent_name: String,
+    pub agent_did: String,
+    pub graphql: String,
+    pub p2p_transport: String,
+    pub p2p_peer_id: String,
+    pub p2p_listen_address: String,
+    pub peer_record_id: String,
+    pub next_steps: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredInitConfig {
+    agent_name: String,
+    agent_did: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct StoredRuntimeState {
+    graphql: String,
+    agent_name: String,
+    agent_did: String,
+    #[serde(default)]
+    p2p_transport: String,
+    #[serde(default)]
+    p2p_peer_id: Option<String>,
+    #[serde(default)]
+    p2p_listen_addresses: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NodeIdentityResponse {
+    #[serde(default)]
+    peer_id: Option<String>,
+}
+
+pub fn default_agent_home() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("unable to resolve home directory")?;
+    Ok(home.join(".defra-agent"))
+}
+
+pub async fn init_standard_local_runtime(
+    options: DesktopInitOptions,
+) -> Result<DesktopInitSummary> {
+    options.desktop_paths.ensure_root_dirs().await?;
+    let init = read_json::<StoredInitConfig>(&options.agent_home.join(INIT_CONFIG_FILE_NAME))?;
+    let runtime =
+        read_json::<StoredRuntimeState>(&options.agent_home.join(RUNTIME_STATE_FILE_NAME))
+            .with_context(|| {
+                format!(
+            "no running local defra-agent runtime found at {}; run `defra-agent server` first",
+            options.agent_home.join(RUNTIME_STATE_FILE_NAME).display()
+        )
+            })?;
+
+    if runtime.p2p_transport != "iroh" {
+        anyhow::bail!(
+            "local runtime uses p2p_transport={}; desktop pairing requires iroh. Restart with `defra-agent server` from a current build.",
+            if runtime.p2p_transport.is_empty() {
+                "<empty>"
+            } else {
+                runtime.p2p_transport.as_str()
+            }
+        );
+    }
+    if runtime.agent_did != init.agent_did {
+        anyhow::bail!(
+            "runtime agent DID {} does not match initialized agent DID {}",
+            runtime.agent_did,
+            init.agent_did
+        );
+    }
+    if runtime.agent_name != init.agent_name {
+        anyhow::bail!(
+            "runtime agent name {} does not match initialized agent name {}",
+            runtime.agent_name,
+            init.agent_name
+        );
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("building local runtime HTTP client")?;
+    let api_base = p2p_api_base(&runtime.graphql)?;
+    let identity: NodeIdentityResponse =
+        http_get_json(&client, &format!("{api_base}/node/identity")).await?;
+    let live_listen_addresses: Vec<String> =
+        http_get_json(&client, &format!("{api_base}/p2p/info")).await?;
+    let p2p_peer_id = identity
+        .peer_id
+        .or_else(|| runtime.p2p_peer_id.clone())
+        .filter(|value| !value.trim().is_empty())
+        .context("local runtime is reachable but did not report a P2P peer id")?;
+    let p2p_listen_address = live_listen_addresses
+        .into_iter()
+        .chain(runtime.p2p_listen_addresses.iter().cloned())
+        .find(|value| !value.trim().is_empty())
+        .context("local runtime is reachable but did not report a P2P listen address")?;
+
+    let mut peer_directory =
+        PeerDirectory::load(options.desktop_paths.peer_directory_path()).await?;
+    let peer = peer_directory
+        .upsert_local_standard_peer(
+            &options.label,
+            &p2p_listen_address,
+            &runtime.agent_did,
+            &runtime.graphql,
+        )
+        .await?;
+
+    Ok(DesktopInitSummary {
+        status: "initialized",
+        source: LOCAL_STANDARD_SOURCE,
+        agent_home: options.agent_home.display().to_string(),
+        desktop_home: options.desktop_paths.root().display().to_string(),
+        peer_directory: options
+            .desktop_paths
+            .peer_directory_path()
+            .display()
+            .to_string(),
+        label: peer.label,
+        agent_name: runtime.agent_name,
+        agent_did: runtime.agent_did,
+        graphql: runtime.graphql,
+        p2p_transport: "iroh".to_string(),
+        p2p_peer_id,
+        p2p_listen_address,
+        peer_record_id: peer.peer_id,
+        next_steps: vec!["defra-agent-desktop".to_string()],
+    })
+}
+
+pub fn render_human_summary(summary: &DesktopInitSummary) -> String {
+    format!(
+        "\
+defra-agent-desktop init complete
+Discovered local defra-agent runtime: {agent_home}
+GraphQL reachable: {graphql}
+Agent DID: {agent_did}
+P2P transport: {p2p_transport}
+P2P peer ID: {p2p_peer_id}
+P2P listen address: {p2p_listen_address}
+Saved desktop deployment: {label}
+Desktop data dir: {desktop_home}
+Peer directory: {peer_directory}
+
+Next:
+  defra-agent-desktop
+",
+        agent_home = summary.agent_home,
+        graphql = summary.graphql,
+        agent_did = summary.agent_did,
+        p2p_transport = summary.p2p_transport,
+        p2p_peer_id = summary.p2p_peer_id,
+        p2p_listen_address = summary.p2p_listen_address,
+        label = summary.label,
+        desktop_home = summary.desktop_home,
+        peer_directory = summary.peer_directory,
+    )
+}
+
+pub(crate) async fn complete_runtime_pairing(
+    graphql: &str,
+    desktop_listen_address: &str,
+    collections: Vec<String>,
+) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .context("building local runtime pairing HTTP client")?;
+    let api_base = p2p_api_base(graphql)?;
+    http_post_json(
+        &client,
+        &format!("{api_base}/p2p/connect"),
+        &vec![desktop_listen_address.to_string()],
+    )
+    .await?;
+    http_post_json(
+        &client,
+        &format!("{api_base}/p2p/collections"),
+        &collections,
+    )
+    .await?;
+    http_post_json(
+        &client,
+        &format!("{api_base}/p2p/replicators"),
+        &P2pReplicatorRequest {
+            addresses: vec![desktop_listen_address.to_string()],
+            collections,
+        },
+    )
+    .await
+}
+
+fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    serde_json::from_slice(&bytes).with_context(|| format!("decoding {}", path.display()))
+}
+
+fn p2p_api_base(graphql: &str) -> Result<String> {
+    graphql
+        .trim()
+        .strip_suffix("/graphql")
+        .map(ToOwned::to_owned)
+        .with_context(|| format!("expected GraphQL endpoint ending in /graphql, got {graphql}"))
+}
+
+async fn http_get_json<T: for<'de> Deserialize<'de>>(
+    client: &reqwest::Client,
+    url: &str,
+) -> Result<T> {
+    let response = client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("sending GET request to {url}"))?;
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .with_context(|| format!("reading GET response body from {url}"))?;
+    if !status.is_success() {
+        anyhow::bail!(
+            "GET {url} failed with {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    serde_json::from_slice(&body).with_context(|| format!("decoding JSON response from {url}"))
+}
+
+async fn http_post_json<B: Serialize>(client: &reqwest::Client, url: &str, body: &B) -> Result<()> {
+    let response = client
+        .post(url)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("sending POST request to {url}"))?;
+    let status = response.status();
+    let bytes = response
+        .bytes()
+        .await
+        .with_context(|| format!("reading POST response body from {url}"))?;
+    if !status.is_success() {
+        anyhow::bail!(
+            "POST {url} failed with {status}: {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct P2pReplicatorRequest {
+    collections: Vec<String>,
+    addresses: Vec<String>,
+}

--- a/crates/defra-agent-desktop/src/main.rs
+++ b/crates/defra-agent-desktop/src/main.rs
@@ -1,18 +1,91 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
+use clap::{Parser, Subcommand};
 use defra_agent_desktop::app::DesktopApp;
+use defra_agent_desktop::client::DesktopPaths;
+use defra_agent_desktop::local_runtime::{
+    default_agent_home, init_standard_local_runtime, render_human_summary, DesktopInitOptions,
+};
 use defra_agent_desktop::telemetry::global_log_layer;
 use eframe::egui;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-fn main() -> eframe::Result<()> {
+#[derive(Debug, Parser)]
+#[command(
+    name = "defra-agent-desktop",
+    about = "Native desktop dashboard for local and peered defra-agent runtimes"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    #[command(about = "Discover and save the standard local defra-agent runtime")]
+    Init(InitArgs),
+}
+
+#[derive(Debug, clap::Args)]
+struct InitArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    agent_home: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Desktop data directory. Defaults to the platform-local desktop data dir"
+    )]
+    desktop_home: Option<PathBuf>,
+    #[arg(long, default_value = "Local Agent", help = "Saved deployment label")]
+    label: String,
+    #[arg(long, help = "Print machine-readable JSON instead of human output")]
+    json: bool,
+}
+
+fn main() -> anyhow::Result<()> {
     init_tracing();
+    let cli = Cli::parse();
+    if let Some(command) = cli.command {
+        return run_command(command);
+    }
+
+    launch_desktop()
+}
+
+fn run_command(command: Command) -> anyhow::Result<()> {
+    match command {
+        Command::Init(args) => {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|error| anyhow::anyhow!(error))?;
+            let agent_home = args.agent_home.unwrap_or(default_agent_home()?);
+            let desktop_paths = match args.desktop_home {
+                Some(root) => DesktopPaths::from_root(root),
+                None => DesktopPaths::discover()?,
+            };
+            let summary = runtime.block_on(init_standard_local_runtime(DesktopInitOptions {
+                agent_home,
+                desktop_paths,
+                label: args.label,
+            }))?;
+            if args.json {
+                println!("{}", serde_json::to_string_pretty(&summary)?);
+            } else {
+                print!("{}", render_human_summary(&summary));
+            }
+            Ok(())
+        }
+    }
+}
+
+fn launch_desktop() -> anyhow::Result<()> {
     let runtime = Arc::new(
         tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .thread_name("desktop-client")
             .build()
-            .map_err(|error| eframe::Error::AppCreation(Box::new(error)))?,
+            .map_err(|error| anyhow::anyhow!(error))?,
     );
 
     let options = eframe::NativeOptions {
@@ -28,6 +101,7 @@ fn main() -> eframe::Result<()> {
         options,
         Box::new(move |cc| Ok(Box::new(DesktopApp::new(cc, Arc::clone(&runtime))))),
     )
+    .map_err(|error| anyhow::anyhow!("{error}"))
 }
 
 fn init_tracing() {

--- a/crates/defra-agent-desktop/tests/client_core.rs
+++ b/crates/defra-agent-desktop/tests/client_core.rs
@@ -85,7 +85,7 @@ async fn two_client_cores_connect_over_iroh() -> Result<()> {
 async fn wait_for_connectable_iroh_addr(core: &ClientCore) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        let addrs = core.p2p().listen_addresses().await;
+        let addrs = core.p2p().listen_addresses().await?;
         if let Some(addr) = addrs
             .into_iter()
             .find(|addr| addr.contains("/p2p/") || addr.starts_with("endpoint"))

--- a/crates/defra-agent-desktop/tests/submission_api.rs
+++ b/crates/defra-agent-desktop/tests/submission_api.rs
@@ -267,7 +267,7 @@ where
 async fn wait_for_connectable_iroh_addr(core: &ClientCore) -> Result<String> {
     let deadline = Instant::now() + Duration::from_secs(10);
     loop {
-        let addrs = core.p2p().listen_addresses().await;
+        let addrs = core.p2p().listen_addresses().await?;
         if let Some(addr) = addrs
             .into_iter()
             .find(|addr| addr.contains("/p2p/") || addr.starts_with("endpoint"))

--- a/docs/superpowers/plans/2026-04-15-defra-agent-desktop-local-bootstrap.md
+++ b/docs/superpowers/plans/2026-04-15-defra-agent-desktop-local-bootstrap.md
@@ -1,0 +1,87 @@
+# defra-agent desktop local bootstrap plan
+
+## Goal
+
+Make the standard laptop demo path explicit and low-flag:
+
+```bash
+defra-agent init
+defra-agent server
+defra-agent-desktop init
+defra-agent-desktop
+```
+
+The server path is IROH P2P. The desktop init path discovers the standard
+local runtime, verifies it is usable, saves it as a desktop deployment, and
+sets up the app to complete local pairing on launch.
+
+## Principles
+
+- IROH is the only supported transport for the desktop/local-agent path.
+- The happy path should not require users to paste P2P flags.
+- Init commands should be explicit about what they changed and what to run next.
+- Runtime-owned state stays in `~/.defra-agent`; desktop-owned state stays in
+  the desktop data directory.
+- The first implementation uses the P2P HTTP endpoints directly for the
+  desktop-to-runtime pairing calls. The app depends on `defradb.rs` after
+  `sourcenetwork/defradb.rs#864`, so the local code uses the shared
+  `P2POperations` surface for embedded-node calls.
+
+## Task Breakdown
+
+1. Standardize local server P2P defaults.
+   - Make `defra-agent server` start with IROH enabled by default.
+   - Default to localhost bind, ephemeral P2P port, relay disabled, and
+     discovery disabled for local laptop safety.
+   - Keep readiness JSON explicit: GraphQL URL, agent DID, P2P peer ID, and
+     listen addresses.
+   - Update CLI tests so the no-flag server path asserts IROH readiness.
+
+2. Add `defra-agent-desktop init`.
+   - Add a headless subcommand to the desktop binary.
+   - Read the standard agent home, `init.json`, and `runtime.json`.
+   - Verify the runtime GraphQL endpoint is reachable.
+   - Require `p2p_transport = "iroh"` and at least one listen address.
+   - Save a local deployment record into the desktop peer directory.
+   - Print a human-readable summary of what was discovered and written.
+
+3. Extend desktop peer metadata.
+   - Add optional `source` and `graphql` fields to saved peer records.
+   - Mark standard local discovery records as `source = "local-standard"`.
+   - Preserve backward compatibility for existing `peers.json` files.
+
+4. Complete local pairing on desktop app launch.
+   - When a saved peer has a local runtime GraphQL endpoint, connect the runtime
+     back to the current desktop IROH listen address.
+   - Configure runtime-side collection subscriptions and runtime-to-desktop
+     replicators for the protocol collections.
+   - Keep this logic isolated behind a small local-runtime bootstrap helper.
+
+5. Make inference and behavior editing demoable from the UI.
+   - Ensure the standard initialized backend and behavior appear in Operator.
+   - Support changing endpoint, model, profile, and behavior prompt from the UI.
+   - Ensure new chat submissions use the edited runtime documents.
+
+6. Seed optional behavior presets.
+   - Add a small set of standard behaviors for demos, such as `General`,
+     `Repo Reader`, and `Planner`.
+   - Keep the default principal behavior stable.
+   - Decide whether presets belong in `defra-agent init` or a later
+     `config preset apply` command before broadening the surface.
+
+7. Add end-to-end bootstrap coverage.
+   - Exercise `defra-agent init -> defra-agent server -> defra-agent-desktop init`.
+   - Use an explicit `--home`/`--agent-home` pair so the demo is easy to run in
+     an isolated temp directory.
+   - Default the live demo endpoint to `http://workstation-1:8000/v1` and the
+     model to the endpoint-reported `MiniMax-M2.7-NVFP4`.
+   - Launch a desktop client against the saved local peer.
+   - Submit a request from the desktop path and assert the response is visible.
+
+## First PR Slice
+
+This PR should cover tasks 1-4 and the focused tests needed to prove the
+standard local bootstrap path. It also adds the first demo e2e for
+`defra-agent init --home -> defra-agent server --home -> defra-agent-desktop init --agent-home`
+against the live workstation inference endpoint. Behavior presets and richer UI
+editing coverage remain follow-up work.


### PR DESCRIPTION
## Summary
- make `defra-agent server` start the local IROH P2P path by default and remove the public `--p2p-transport` selector
- add `defra-agent-desktop init` with `--agent-home`, `--desktop-home`, JSON output, local runtime discovery, and peer-directory persistence
- complete local runtime pairing on desktop client bootstrap for saved local-standard peers
- update to `defradb.rs` `8ad38101` including PR 864 and move embedded P2P calls to the shared `P2POperations` surface
- expand e2e coverage for explicit `--home` plus `defra-agent-desktop init --agent-home` against `http://workstation-1:8000/v1` model `MiniMax-M2.7-NVFP4`

## Tests
- `cargo fmt --all --check`
- `cargo check -p defra-agent-cli -p defra-agent-desktop`
- `cargo test -p defra-agent-cli --test cli_e2e p2p -- --nocapture`
- `cargo test -p defra-agent-desktop upsert_local_standard_peer_tracks_graphql_and_source -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_e2e standard_onboarding_live_demo_runs_real_conversation_with_filesystem_tools -- --ignored --nocapture`