### PR TITLE
proofs: strengthen T2 to pre-trace seriality

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Triggers.lean
+++ b/crates/defra-agent/proofs/Proofs/Triggers.lean
@@ -276,6 +276,34 @@ theorem dispatch_manual_lineage_id_is_none
     that happen to share the same document id. -/
 abbrev TriggerKey := String × TriggerKind
 
+namespace FireIntent
+
+/--
+Boundary predicate saying that any fire intent targeting tuple `t` must use
+`.serial` concurrency.
+
+Intents that do not target `t` are unconstrained; the implication only becomes
+load-bearing when both the trigger id and kind match `t`.
+-/
+def SerialForKey (t : TriggerKey) (intent : FireIntent) : Prop :=
+  intent.triggerId = some t.1 → intent.triggerKind = t.2 → intent.concurrency = .serial
+
+instance (t : TriggerKey) (intent : FireIntent) : Decidable (FireIntent.SerialForKey t intent) := by
+  unfold FireIntent.SerialForKey
+  infer_instance
+
+/-- A `SerialForKey` intent targeting `t` must use `.serial` concurrency. -/
+theorem serialForKey_target_is_serial
+    {t : TriggerKey}
+    {intent : FireIntent}
+    (h_serial : intent.SerialForKey t)
+    (h_triggerId : intent.triggerId = some t.1)
+    (h_kind : intent.triggerKind = t.2) :
+    intent.concurrency = .serial :=
+  h_serial h_triggerId h_kind
+
+end FireIntent
+
 /-- Spec-layer projection of an AgentRequest sufficient to state the
     trigger-engine theorems. The real `AgentRequest` carries far more
     state; here we only track the fields the trigger engine reasons
@@ -421,6 +449,8 @@ predicate on fire intents.
 
 This lets the proofs layer keep `Reachable` as the raw operational relation
 while moving the real theorem surface onto a boundary-tightened trace relation.
+The `terminate` constructor carries no extra boundary premise because it
+consumes no new `FireIntent`; it only evolves an already-materialized request.
 -/
 inductive ReachableUnder (P : FireIntent → Prop) : SystemState → Prop where
   | empty : ReachableUnder P SystemState.empty
@@ -435,6 +465,13 @@ inductive ReachableUnder (P : FireIntent → Prop) : SystemState → Prop where
 /-- Spec-facing strengthened reachability with the manual-intent boundary enforced. -/
 abbrev WellFormedReachable : SystemState → Prop :=
   ReachableUnder FireIntent.WellFormed
+
+/--
+Spec-facing strengthened reachability where the trace boundary is both
+well-formed for manual fires and serial for a distinguished trigger key `t`.
+-/
+abbrev SeriallyReachable (t : TriggerKey) : SystemState → Prop :=
+  ReachableUnder (fun intent => intent.WellFormed ∧ intent.SerialForKey t)
 
 /-- Any strengthened reachable state is reachable in the raw operational semantics. -/
 theorem ReachableUnder.toReachable
@@ -686,6 +723,92 @@ private theorem dispatchStep_preserves_causedBy_and_concurrency
           split <;> rfl
 
 /--
+If `dispatch` materializes a seed with a concrete trigger id, that id and
+trigger kind came from the fire intent that dispatched it.
+-/
+private theorem dispatch_seed_some_triggerId_matches_intent
+    (snap : TriggerSnapshot) (intent : FireIntent) (seed : RequestSeed)
+    {tid : String}
+    (h_dispatch : dispatch snap intent = some seed)
+    (h_seedId : seed.causedByTriggerId = some tid) :
+    intent.triggerId = some tid ∧ intent.triggerKind = seed.causedByTriggerKind := by
+  unfold dispatch at h_dispatch
+  cases h_kind : intent.triggerKind with
+  | schedule =>
+    rw [h_kind] at h_dispatch
+    cases h_triggerId : intent.triggerId with
+    | none =>
+      rw [h_triggerId] at h_dispatch
+      simp at h_dispatch
+    | some intentTid =>
+      rw [h_triggerId] at h_dispatch
+      simp only at h_dispatch
+      cases h_found : dispatchEnabledForSchedule snap intentTid with
+      | none =>
+        rw [h_found] at h_dispatch
+        simp at h_dispatch
+      | some _ =>
+        rw [h_found] at h_dispatch
+        simp only at h_dispatch
+        injection h_dispatch with h_seed_eq
+        subst h_seed_eq
+        simp at h_seedId
+        obtain rfl := h_seedId
+        exact ⟨rfl, rfl⟩
+  | event =>
+    rw [h_kind] at h_dispatch
+    cases h_triggerId : intent.triggerId with
+    | none =>
+      rw [h_triggerId] at h_dispatch
+      simp at h_dispatch
+    | some intentTid =>
+      rw [h_triggerId] at h_dispatch
+      simp only at h_dispatch
+      cases h_found : dispatchEnabledForEvent snap intentTid with
+      | none =>
+        rw [h_found] at h_dispatch
+        simp at h_dispatch
+      | some _ =>
+        rw [h_found] at h_dispatch
+        simp only at h_dispatch
+        injection h_dispatch with h_seed_eq
+        subst h_seed_eq
+        simp at h_seedId
+        obtain rfl := h_seedId
+        exact ⟨rfl, rfl⟩
+  | manual =>
+    rw [h_kind] at h_dispatch
+    simp only at h_dispatch
+    injection h_dispatch with h_seed_eq
+    subst h_seed_eq
+    simp at h_seedId
+
+/--
+If a materialized seed carries trigger tuple `t`, then the dispatching intent
+targeted `t` as well.
+-/
+private theorem dispatch_key_matches_intent_target
+    (snap : TriggerSnapshot) (intent : FireIntent) (seed : RequestSeed) (t : TriggerKey)
+    (h_dispatch : dispatch snap intent = some seed)
+    (h_key :
+      (match seed.causedByTriggerId with
+      | none => none
+      | some tid => some (tid, seed.causedByTriggerKind)) = some t) :
+    intent.triggerId = some t.1 ∧ intent.triggerKind = t.2 := by
+  cases h_seedId : seed.causedByTriggerId with
+  | none =>
+    simp [h_seedId] at h_key
+  | some tid =>
+    have h_tuple : (tid, seed.causedByTriggerKind) = t := by
+      simpa [h_seedId] using h_key
+    have ⟨h_triggerId, h_kind⟩ :=
+      dispatch_seed_some_triggerId_matches_intent snap intent seed h_dispatch h_seedId
+    cases t with
+    | mk tid' kind' =>
+      cases h_tuple
+      simpa using And.intro h_triggerId h_kind
+
+/--
 Post-hypothesis pre-state preservation for dispatchStep.
 
 If the post-step state satisfies "every request for tuple `t` is serial",
@@ -705,6 +828,164 @@ theorem dispatchStep_hypothesis_preservation
   have h_causedBy' : r'.causedBy = some t := h_cb.trans h_causedBy
   have h_serial' := h_hyp_post r' h_mem' h_causedBy'
   exact h_conc ▸ h_serial'
+
+/--
+Generic helper for mapped request lists whose update function preserves the
+`causedBy` and `concurrency` fields.
+-/
+private theorem map_member_has_preimage_preserving_causedBy_and_concurrency
+    (s : SystemState)
+    (f : AgentRequest → AgentRequest)
+    (h_preserve : ∀ r, (f r).causedBy = r.causedBy ∧ (f r).concurrency = r.concurrency)
+    (r : AgentRequest) :
+    r ∈ s.requests.map f →
+    ∃ r0 ∈ s.requests, r.causedBy = r0.causedBy ∧ r.concurrency = r0.concurrency := by
+  intro h_mem
+  rcases List.mem_map.mp h_mem with ⟨r0, h_mem0, h_eq⟩
+  refine ⟨r0, h_mem0, ?_, ?_⟩
+  · cases h_eq
+    exact (h_preserve r0).1
+  · cases h_eq
+    exact (h_preserve r0).2
+
+/--
+Trace-boundary preservation for the current T2 seriality hypothesis.
+
+If every pre-state request for tuple `t` is serial, and the incoming intent is
+serial whenever it targets `t`, then every post-state request for `t` is serial
+after one `dispatchStep`.
+-/
+private theorem dispatchStep_preserves_target_seriality
+    (s : SystemState) (snap : TriggerSnapshot) (intent : FireIntent) (t : TriggerKey)
+    (h_before : ∀ r ∈ s.requests, r.causedBy = some t → r.concurrency = .serial)
+    (h_serial : intent.SerialForKey t) :
+    ∀ r ∈ (dispatchStep s snap intent).requests,
+      r.causedBy = some t →
+      r.concurrency = .serial := by
+  intro r h_mem h_causedBy
+  unfold dispatchStep at h_mem
+  cases h_disp : dispatch snap intent with
+  | none =>
+    rw [h_disp] at h_mem
+    exact h_before r h_mem h_causedBy
+  | some seed =>
+    cases h_conc : intent.concurrency with
+    | parallel =>
+      rw [h_disp, h_conc] at h_mem
+      rcases List.mem_append.mp h_mem with h_old | h_new
+      · exact h_before r h_old h_causedBy
+      · have h_new_req :
+          r =
+            { id := s!"dispatched-{s.requests.length}"
+            , causedBy :=
+                match seed.causedByTriggerId with
+                | none => none
+                | some tid => some (tid, seed.causedByTriggerKind)
+            , concurrency := .parallel
+            , isTerminal := false
+            , executionOrigin :=
+                match seed.causedByTriggerKind with
+                | .manual => .interactive
+                | .schedule | .event => .scheduled } := by
+          simpa using h_new
+        cases h_new_req
+        have ⟨h_triggerId, h_kind⟩ :=
+          dispatch_key_matches_intent_target snap intent seed t h_disp h_causedBy
+        have h_intent_serial :=
+          FireIntent.serialForKey_target_is_serial h_serial h_triggerId h_kind
+        rw [h_conc] at h_intent_serial
+        cases h_intent_serial
+    | serial =>
+      cases h_key : seed.causedByTriggerId with
+      | none =>
+        simp [h_disp, h_conc, h_key] at h_mem
+        rcases h_mem with h_old | h_new
+        · exact h_before r h_old h_causedBy
+        · cases h_new
+          simp at h_causedBy
+      | some tid =>
+        simp [h_disp, h_conc, h_key] at h_mem
+        by_cases h_any :
+            ∃ x ∈ s.requests, x.causedBy = some (tid, seed.causedByTriggerKind) ∧ x.isTerminal = false
+        · rw [if_pos h_any] at h_mem
+          exact h_before r h_mem h_causedBy
+        · rw [if_neg h_any] at h_mem
+          rcases List.mem_append.mp h_mem with h_old | h_new
+          · exact h_before r h_old h_causedBy
+          · have h_new_req :
+              r =
+                { id := s!"dispatched-{s.requests.length}"
+                , causedBy := some (tid, seed.causedByTriggerKind)
+                , concurrency := .serial
+                , isTerminal := false
+                , executionOrigin :=
+                    match seed.causedByTriggerKind with
+                    | .manual => .interactive
+                    | .schedule | .event => .scheduled } := by
+              simpa using h_new
+            cases h_new_req
+            simp
+    | latestOnly =>
+      cases h_key : seed.causedByTriggerId with
+      | none =>
+        simp [h_disp, h_conc, h_key] at h_mem
+        rcases h_mem with h_old | h_new
+        · exact h_before r h_old h_causedBy
+        · cases h_new
+          simp at h_causedBy
+      | some tid =>
+        simp [h_disp, h_conc, h_key] at h_mem
+        rcases h_mem with h_superseded | h_new
+        ·
+          have h_map_mem :
+              r ∈
+                s.requests.map (fun r =>
+                  if r.causedBy = some (tid, seed.causedByTriggerKind) ∧ r.isTerminal = false then
+                    { r with isTerminal := true }
+                  else r) := by
+            simpa using h_superseded
+          obtain ⟨r0, h_mem0, h_cb, h_conc'⟩ :=
+            map_member_has_preimage_preserving_causedBy_and_concurrency s
+              (fun r =>
+                if r.causedBy = some (tid, seed.causedByTriggerKind) ∧ r.isTerminal = false then
+                  { r with isTerminal := true }
+                else r)
+              (by
+                intro r0
+                by_cases h_cond :
+                    r0.causedBy = some (tid, seed.causedByTriggerKind) ∧ r0.isTerminal = false <;>
+                  simp [h_cond])
+              r
+              h_map_mem
+          have h_cb' : r0.causedBy = some t := by
+            rw [← h_cb]
+            exact h_causedBy
+          have h_serial0 := h_before r0 h_mem0 h_cb'
+          rw [h_conc']
+          exact h_serial0
+        · have h_new_req :
+            r =
+              { id := s!"dispatched-{s.requests.length}"
+              , causedBy := some (tid, seed.causedByTriggerKind)
+              , concurrency := .latestOnly
+              , isTerminal := false
+              , executionOrigin :=
+                  match seed.causedByTriggerKind with
+                  | .manual => .interactive
+                  | .schedule | .event => .scheduled } := by
+            simpa using h_new
+          cases h_new_req
+          have h_key_match :
+              (match seed.causedByTriggerId with
+              | none => none
+              | some tid' => some (tid', seed.causedByTriggerKind)) = some t := by
+            simpa [h_key] using h_causedBy
+          have ⟨h_triggerId, h_kind⟩ :=
+            dispatch_key_matches_intent_target snap intent seed t h_disp h_key_match
+          have h_intent_serial :=
+            FireIntent.serialForKey_target_is_serial h_serial h_triggerId h_kind
+          rw [h_conc] at h_intent_serial
+          cases h_intent_serial
 
 /--
 Helper: if `l.any p = false`, then `(l.filter p).length = 0`.
@@ -1090,6 +1371,55 @@ private theorem lifecycleTerminateStep_preserves_causedBy_and_concurrency
   · split <;> rfl
 
 /--
+Lifecycle terminal transitions preserve the seriality hypothesis for requests
+already keyed to `t`, because they do not alter `causedBy` or `concurrency`.
+-/
+private theorem lifecycleTerminateStep_preserves_target_seriality
+    (s : SystemState) (reqId : String) (t : TriggerKey)
+    (h_before : ∀ r ∈ s.requests, r.causedBy = some t → r.concurrency = .serial) :
+    ∀ r ∈ (lifecycleTerminateStep s reqId).requests,
+      r.causedBy = some t →
+      r.concurrency = .serial := by
+  intro r h_mem h_causedBy
+  obtain ⟨r0, h_mem0, h_cb, h_conc⟩ :=
+    map_member_has_preimage_preserving_causedBy_and_concurrency s
+      (fun r =>
+        if (r.id == reqId) && !r.isTerminal then
+          { r with isTerminal := true }
+        else r)
+      (by
+        intro r0
+        by_cases h_cond : ((r0.id == reqId) && !r0.isTerminal) = true <;>
+          simp [h_cond])
+      r
+      (by simpa [lifecycleTerminateStep] using h_mem)
+  have h_cb' : r0.causedBy = some t := by
+    rw [← h_cb]
+    exact h_causedBy
+  have h_serial0 := h_before r0 h_mem0 h_cb'
+  rw [h_conc]
+  exact h_serial0
+
+/--
+Any request for tuple `t` in a `SeriallyReachable t` state is serial.
+
+This is the pre-trace bridge from the strengthened trace boundary back to T2's
+original post-state hypothesis shape.
+-/
+private theorem seriallyReachable_requests_for_key_are_serial
+    (s : SystemState) (t : TriggerKey)
+    (h_reach : SeriallyReachable t s) :
+    ∀ r ∈ s.requests, r.causedBy = some t → r.concurrency = .serial := by
+  induction h_reach with
+  | empty =>
+    intro r h_mem h_causedBy
+    simp [SystemState.empty] at h_mem
+  | step s snap intent h_boundary h_prev ih =>
+    exact dispatchStep_preserves_target_seriality s snap intent t ih h_boundary.2
+  | terminate s reqId h_prev ih =>
+    exact lifecycleTerminateStep_preserves_target_seriality s reqId t ih
+
+/--
 T2 (serial at-most-one): any reachable system state has at most one
 non-terminal request per trigger tuple, provided every request for that
 tuple in the state uses `.serial` concurrency.
@@ -1166,6 +1496,23 @@ theorem T2_serial_at_most_one_wellFormed
     (∀ r ∈ s.requests, r.causedBy = some t → r.concurrency = .serial) →
     s.nonTerminalCountFor t ≤ 1 :=
   T2_serial_at_most_one_under FireIntent.WellFormed s t h_reach
+
+/--
+Stronger pre-trace form of T2: if the trigger trace is well-formed and every
+intent targeting `t` is serial at the boundary, then the reachable state has
+at most one non-terminal request for `t`.
+-/
+theorem T2_serial_at_most_one_pretrace
+    (s : SystemState)
+    (t : TriggerKey)
+    (h_reach : SeriallyReachable t s) :
+    s.nonTerminalCountFor t ≤ 1 :=
+  T2_serial_at_most_one_under
+    (fun intent => intent.WellFormed ∧ intent.SerialForKey t)
+    s
+    t
+    h_reach
+    (seriallyReachable_requests_for_key_are_serial s t h_reach)
 
 /-- Terminal predicate matching the `superseded` state. Kept as a Bool
     field on `AgentRequest` so the trigger layer can reason without


### PR DESCRIPTION
## Summary
- add `FireIntent.SerialForKey` and `SeriallyReachable` on top of `ReachableUnder`
- prove the strengthened trace boundary implies T2's existing post-state seriality hypothesis
- add the stronger pre-trace theorem `T2_serial_at_most_one_pretrace`

## Testing
- cd crates/defra-agent/proofs && lake build

Closes #71
Refs #77
