### PR TITLE
style: run cargo fmt --all

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -631,7 +631,11 @@ pub(crate) struct ConfigExportArgs {
         help = "Directory to write the manifest root into (author format for `config validate`, `diff`, and `apply`)"
     )]
     pub(crate) root: PathBuf,
-    #[arg(long, default_value_t = false, help = "Overwrite the root dir if it is non-empty")]
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Overwrite the root dir if it is non-empty"
+    )]
     pub(crate) force: bool,
     #[arg(long)]
     pub(crate) home: Option<PathBuf>,

--- a/crates/defra-agent-cli/src/commands/config/task_run.rs
+++ b/crates/defra-agent-cli/src/commands/config/task_run.rs
@@ -31,8 +31,8 @@ const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 
 pub(super) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
     // 1. Parse --args as a JSON object.
-    let args_value: Value = serde_json::from_str(&args.args)
-        .map_err(|e| anyhow!("--args is not valid JSON: {e}"))?;
+    let args_value: Value =
+        serde_json::from_str(&args.args).map_err(|e| anyhow!("--args is not valid JSON: {e}"))?;
     if !args_value.is_object() {
         anyhow::bail!("--args must be a JSON object (got: {args_value})");
     }
@@ -250,9 +250,7 @@ async fn lookup_doc_id_by_request_id(
     let response = access.execute(&query).await?;
     if let Some(errs) = response.get("errors").and_then(|v| v.as_array()) {
         if !errs.is_empty() {
-            anyhow::bail!(
-                "lookup AgentRequest by request_id {request_id} failed: {errs:?}"
-            );
+            anyhow::bail!("lookup AgentRequest by request_id {request_id} failed: {errs:?}");
         }
     }
     Ok(response

--- a/crates/defra-agent-cli/src/config_writes/event_trigger.rs
+++ b/crates/defra-agent-cli/src/config_writes/event_trigger.rs
@@ -55,8 +55,7 @@ pub(crate) async fn write_event_trigger_document(
     match crate::extract_mutation_doc_id(&response, "EventTrigger") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current =
-                select_matching_event_trigger_row(access, trigger_id, update_doc).await?;
+            let current = select_matching_event_trigger_row(access, trigger_id, update_doc).await?;
             if let Some(row) = current {
                 let current_doc_id = row
                     .get("_docID")

--- a/crates/defra-agent-cli/src/desired_state/load.rs
+++ b/crates/defra-agent-cli/src/desired_state/load.rs
@@ -44,8 +44,7 @@ pub(crate) fn load_manifest_root(
         load_per_doc_collection(root, Collection::InferenceProfile, &mut errors);
     let tool_service_registries: Vec<DesiredToolServiceRegistry> =
         load_per_doc_collection(root, Collection::ToolServiceRegistry, &mut errors);
-    let mut tasks: Vec<DesiredTask> =
-        load_per_doc_collection(root, Collection::Task, &mut errors);
+    let mut tasks: Vec<DesiredTask> = load_per_doc_collection(root, Collection::Task, &mut errors);
     let schedules: Vec<DesiredSchedule> =
         load_per_doc_collection(root, Collection::Schedule, &mut errors);
     let event_triggers: Vec<DesiredEventTrigger> =
@@ -101,7 +100,11 @@ pub(crate) fn load_manifest_root(
     (
         manifest,
         DesiredStateValidationReport {
-            status: if errors.is_empty() { "validated" } else { "invalid" },
+            status: if errors.is_empty() {
+                "validated"
+            } else {
+                "invalid"
+            },
             ok: errors.is_empty(),
             root: root_display,
             agent_did,
@@ -111,10 +114,7 @@ pub(crate) fn load_manifest_root(
     )
 }
 
-fn empty_report(
-    root_display: String,
-    errors: Vec<String>,
-) -> DesiredStateValidationReport {
+fn empty_report(root_display: String, errors: Vec<String>) -> DesiredStateValidationReport {
     DesiredStateValidationReport {
         status: "invalid",
         ok: false,
@@ -135,10 +135,7 @@ fn empty_report(
     }
 }
 
-fn load_agent_principal(
-    root: &Path,
-    errors: &mut Vec<String>,
-) -> Option<DesiredAgentPrincipal> {
+fn load_agent_principal(root: &Path, errors: &mut Vec<String>) -> Option<DesiredAgentPrincipal> {
     let file_name = Collection::AgentPrincipal
         .file_name()
         .expect("AgentPrincipal has a top-level file");
@@ -310,13 +307,12 @@ where
 /// is `..` (ParentDir), a root separator, or an absolute prefix is rejected
 /// with an error. This prevents `./../secret.md` and similar tricks from
 /// reading files outside the document directory.
-pub(crate) fn hydrate_sidecar(
-    value: &mut Option<String>,
-    json_dir: &Path,
-) -> Result<(), String> {
+pub(crate) fn hydrate_sidecar(value: &mut Option<String>, json_dir: &Path) -> Result<(), String> {
     use std::path::Component;
 
-    let Some(current) = value.as_deref() else { return Ok(()) };
+    let Some(current) = value.as_deref() else {
+        return Ok(());
+    };
     if !current.starts_with("./") {
         return Ok(());
     }
@@ -354,9 +350,8 @@ pub(crate) fn hydrate_sidecar(
             format!("reading {} failed: {error}", sidecar_path.display())
         }
     })?;
-    let body = String::from_utf8(bytes).map_err(|_| {
-        format!("sidecar is not valid UTF-8: {}", sidecar_path.display())
-    })?;
+    let body = String::from_utf8(bytes)
+        .map_err(|_| format!("sidecar is not valid UTF-8: {}", sidecar_path.display()))?;
     *value = Some(body);
     Ok(())
 }

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -392,28 +392,44 @@ pub(crate) trait HasUniqueId {
 }
 
 impl HasUniqueId for DesiredAgentBehavior {
-    fn unique_id(&self) -> &str { &self.behavior_id }
+    fn unique_id(&self) -> &str {
+        &self.behavior_id
+    }
 }
 impl HasUniqueId for DesiredToolSelection {
-    fn unique_id(&self) -> &str { &self.selection_id }
+    fn unique_id(&self) -> &str {
+        &self.selection_id
+    }
 }
 impl HasUniqueId for DesiredInferenceBackend {
-    fn unique_id(&self) -> &str { &self.backend_id }
+    fn unique_id(&self) -> &str {
+        &self.backend_id
+    }
 }
 impl HasUniqueId for DesiredInferenceProfile {
-    fn unique_id(&self) -> &str { &self.profile_id }
+    fn unique_id(&self) -> &str {
+        &self.profile_id
+    }
 }
 impl HasUniqueId for DesiredToolServiceRegistry {
-    fn unique_id(&self) -> &str { &self.service_id }
+    fn unique_id(&self) -> &str {
+        &self.service_id
+    }
 }
 impl HasUniqueId for DesiredTask {
-    fn unique_id(&self) -> &str { &self.task_id }
+    fn unique_id(&self) -> &str {
+        &self.task_id
+    }
 }
 impl HasUniqueId for DesiredSchedule {
-    fn unique_id(&self) -> &str { &self.schedule_id }
+    fn unique_id(&self) -> &str {
+        &self.schedule_id
+    }
 }
 impl HasUniqueId for DesiredEventTrigger {
-    fn unique_id(&self) -> &str { &self.trigger_id }
+    fn unique_id(&self) -> &str {
+        &self.trigger_id
+    }
 }
 
 #[cfg(test)]

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -214,15 +214,18 @@ fn round_trip_load_write_load_is_identity() {
     assert_eq!(loaded.tool_selections, original.tool_selections);
     assert_eq!(loaded.inference_backends, original.inference_backends);
     assert_eq!(loaded.inference_profiles, original.inference_profiles);
-    assert_eq!(loaded.tool_service_registries, original.tool_service_registries);
+    assert_eq!(
+        loaded.tool_service_registries,
+        original.tool_service_registries
+    );
     assert_eq!(loaded.tasks, original.tasks);
     assert_eq!(loaded.schedules, original.schedules);
 }
 
 mod load_manifest_root {
+    use crate::desired_state::load::load_manifest_root;
     use std::fs;
     use tempfile::tempdir;
-    use crate::desired_state::load::load_manifest_root;
 
     /// Write a minimal but fully valid manifest root: one principal with a
     /// `default_behavior_id` pointing to the single behavior in `agent-behaviors/default/`.
@@ -378,13 +381,20 @@ mod load_manifest_root {
         .unwrap();
 
         let (manifest, report) = load_manifest_root(tmp.path());
-        assert!(report.ok, "expected valid manifest, got {:?}", report.errors);
+        assert!(
+            report.ok,
+            "expected valid manifest, got {:?}",
+            report.errors
+        );
         let manifest = manifest.expect("manifest should load");
 
         assert_eq!(report.counts.event_triggers, 1);
         assert_eq!(manifest.event_triggers.len(), 1);
         assert_eq!(manifest.event_triggers[0].trigger_id, "new-customer-greet");
-        assert_eq!(manifest.event_triggers[0].source_collection, "CustomerSignup");
+        assert_eq!(
+            manifest.event_triggers[0].source_collection,
+            "CustomerSignup"
+        );
         assert_eq!(manifest.event_triggers[0].event_kind, "created");
         assert!(manifest.event_triggers[0].enabled);
     }
@@ -423,7 +433,11 @@ mod load_manifest_root {
         .unwrap();
 
         let (_, report) = load_manifest_root(tmp.path());
-        assert!(report.ok, "expected valid manifest, got {:?}", report.errors);
+        assert!(
+            report.ok,
+            "expected valid manifest, got {:?}",
+            report.errors
+        );
     }
 }
 
@@ -818,9 +832,10 @@ fn sample_event_trigger_for(trigger_id: &str, task_id: &str) -> DesiredEventTrig
 #[test]
 fn validate_rejects_event_trigger_referencing_unknown_task() {
     let mut manifest = manifest_with_default_behavior();
-    manifest
-        .event_triggers
-        .push(sample_event_trigger_for("new-customer-greet", "missing-task"));
+    manifest.event_triggers.push(sample_event_trigger_for(
+        "new-customer-greet",
+        "missing-task",
+    ));
 
     let errors = validation_errors(&manifest);
     assert!(
@@ -856,15 +871,15 @@ fn validate_rejects_event_trigger_template_referencing_args_scope() {
     let mut task = sample_task("summarize-inbox");
     task.prompt_template = "{{ args.foo }}".to_string();
     manifest.tasks.push(task);
-    manifest
-        .event_triggers
-        .push(sample_event_trigger_for("new-customer-greet", "summarize-inbox"));
+    manifest.event_triggers.push(sample_event_trigger_for(
+        "new-customer-greet",
+        "summarize-inbox",
+    ));
 
     let errors = validation_errors(&manifest);
     assert!(
         errors.iter().any(|message| {
-            message.contains("new-customer-greet")
-                && message.contains("forbidden scope: args")
+            message.contains("new-customer-greet") && message.contains("forbidden scope: args")
         }),
         "expected event-trigger forbidden-args rejection, got {errors:?}"
     );
@@ -876,9 +891,10 @@ fn validate_accepts_event_trigger_template_using_event_and_doc_scopes() {
     let mut task = sample_task("summarize-inbox");
     task.prompt_template = "{{ event.fired_at }} {{ doc.name }}".to_string();
     manifest.tasks.push(task);
-    manifest
-        .event_triggers
-        .push(sample_event_trigger_for("new-customer-greet", "summarize-inbox"));
+    manifest.event_triggers.push(sample_event_trigger_for(
+        "new-customer-greet",
+        "summarize-inbox",
+    ));
 
     let errors = validation_errors(&manifest);
     assert!(
@@ -893,12 +909,14 @@ fn validate_accepts_event_trigger_template_using_event_and_doc_scopes() {
 fn validate_rejects_duplicate_event_trigger_id() {
     let mut manifest = manifest_with_default_behavior();
     manifest.tasks.push(sample_task("summarize-inbox"));
-    manifest
-        .event_triggers
-        .push(sample_event_trigger_for("new-customer-greet", "summarize-inbox"));
-    manifest
-        .event_triggers
-        .push(sample_event_trigger_for("new-customer-greet", "summarize-inbox"));
+    manifest.event_triggers.push(sample_event_trigger_for(
+        "new-customer-greet",
+        "summarize-inbox",
+    ));
+    manifest.event_triggers.push(sample_event_trigger_for(
+        "new-customer-greet",
+        "summarize-inbox",
+    ));
 
     let errors = validation_errors(&manifest);
     assert!(
@@ -974,8 +992,8 @@ fn export_bundle_round_trip_preserves_tasks_and_schedules() {
 
 #[test]
 fn hydrate_sidecar_replaces_dot_slash_path_with_file_contents() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     fs::write(dir.path().join("prompt.md"), "You are a helpful agent.").unwrap();
@@ -987,8 +1005,8 @@ fn hydrate_sidecar_replaces_dot_slash_path_with_file_contents() {
 
 #[test]
 fn hydrate_sidecar_leaves_literal_string_untouched() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     let mut value = Some("You are a helpful agent.".to_string());
@@ -998,8 +1016,8 @@ fn hydrate_sidecar_leaves_literal_string_untouched() {
 
 #[test]
 fn hydrate_sidecar_ignores_absolute_path() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     let mut value = Some("/etc/hosts".to_string());
@@ -1009,8 +1027,8 @@ fn hydrate_sidecar_ignores_absolute_path() {
 
 #[test]
 fn hydrate_sidecar_ignores_parent_relative_path() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     let mut value = Some("../elsewhere.md".to_string());
@@ -1020,8 +1038,8 @@ fn hydrate_sidecar_ignores_parent_relative_path() {
 
 #[test]
 fn hydrate_sidecar_rejects_parent_component_in_rel_path() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     // Create a sibling file OUTSIDE the doc directory.
     let tmp = tempdir().unwrap();
@@ -1037,8 +1055,8 @@ fn hydrate_sidecar_rejects_parent_component_in_rel_path() {
 
 #[test]
 fn hydrate_sidecar_rejects_nested_parent_component() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let tmp = tempdir().unwrap();
     let json_dir = tmp.path().join("a").join("b");
@@ -1053,8 +1071,8 @@ fn hydrate_sidecar_rejects_nested_parent_component() {
 
 #[test]
 fn hydrate_sidecar_errors_when_file_missing() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     let mut value = Some("./missing.md".to_string());
@@ -1065,8 +1083,8 @@ fn hydrate_sidecar_errors_when_file_missing() {
 
 #[test]
 fn hydrate_sidecar_errors_on_non_utf8() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     fs::write(dir.path().join("bad.md"), [0xff, 0xfe, 0xfd]).unwrap();
@@ -1077,8 +1095,8 @@ fn hydrate_sidecar_errors_on_non_utf8() {
 
 #[test]
 fn hydrate_sidecar_is_noop_on_none() {
-    use tempfile::tempdir;
     use super::load::hydrate_sidecar;
+    use tempfile::tempdir;
 
     let dir = tempdir().unwrap();
     let mut value: Option<String> = None;
@@ -1087,11 +1105,11 @@ fn hydrate_sidecar_is_noop_on_none() {
 }
 
 mod load_per_doc_collection {
-    use std::fs;
-    use tempfile::tempdir;
     use crate::desired_state::load::load_per_doc_collection;
     use crate::desired_state::{DesiredAgentBehavior, HasUniqueId};
     use defra_agent::Collection;
+    use std::fs;
+    use tempfile::tempdir;
 
     fn write_behavior_dir(root: &std::path::Path, handle: &str, behavior_id: &str) {
         let dir = root.join("agent-behaviors").join(handle);
@@ -1101,7 +1119,11 @@ mod load_per_doc_collection {
             "agent_did": "did:key:example",
             "enabled": true,
         });
-        fs::write(dir.join("object.json"), serde_json::to_vec_pretty(&body).unwrap()).unwrap();
+        fs::write(
+            dir.join("object.json"),
+            serde_json::to_vec_pretty(&body).unwrap(),
+        )
+        .unwrap();
     }
 
     #[test]
@@ -1137,7 +1159,11 @@ mod load_per_doc_collection {
         let _: Vec<DesiredAgentBehavior> =
             load_per_doc_collection(tmp.path(), Collection::AgentBehavior, &mut errors);
         assert_eq!(errors.len(), 1);
-        assert!(errors[0].contains("is missing object.json"), "got: {:?}", errors);
+        assert!(
+            errors[0].contains("is missing object.json"),
+            "got: {:?}",
+            errors
+        );
     }
 
     #[test]
@@ -1148,7 +1174,11 @@ mod load_per_doc_collection {
         let _: Vec<DesiredAgentBehavior> =
             load_per_doc_collection(tmp.path(), Collection::AgentBehavior, &mut errors);
         assert_eq!(errors.len(), 1);
-        assert!(errors[0].contains("does not match behavior_id"), "got: {:?}", errors);
+        assert!(
+            errors[0].contains("does not match behavior_id"),
+            "got: {:?}",
+            errors
+        );
         assert!(errors[0].contains("on-disk-name"));
         assert!(errors[0].contains("id-inside-json"));
     }
@@ -1177,12 +1207,18 @@ mod load_per_doc_collection {
         let tmp = tempdir().unwrap();
         write_behavior_dir(tmp.path(), "default", "default");
         fs::write(
-            tmp.path().join("agent-behaviors").join("default").join("README.md"),
+            tmp.path()
+                .join("agent-behaviors")
+                .join("default")
+                .join("README.md"),
             "notes",
         )
         .unwrap();
         fs::write(
-            tmp.path().join("agent-behaviors").join("default").join(".DS_Store"),
+            tmp.path()
+                .join("agent-behaviors")
+                .join("default")
+                .join(".DS_Store"),
             "",
         )
         .unwrap();
@@ -1213,8 +1249,8 @@ pub(super) mod write_manifest_root {
     use tempfile::tempdir;
 
     use crate::desired_state::{
-        write_manifest_root, DesiredAgentBehavior, DesiredAgentPrincipal,
-        DesiredStateManifest, DesiredTask,
+        write_manifest_root, DesiredAgentBehavior, DesiredAgentPrincipal, DesiredStateManifest,
+        DesiredTask,
     };
 
     pub(in crate::desired_state::tests) fn minimal_manifest() -> DesiredStateManifest {
@@ -1267,7 +1303,10 @@ pub(super) mod write_manifest_root {
         assert!(behavior_object.is_file());
         let behavior_sidecar = tmp.path().join("agent-behaviors/default/system_prompt.md");
         assert!(behavior_sidecar.is_file());
-        assert_eq!(fs::read_to_string(&behavior_sidecar).unwrap(), "You are helpful.");
+        assert_eq!(
+            fs::read_to_string(&behavior_sidecar).unwrap(),
+            "You are helpful."
+        );
         let behavior_body: serde_json::Value =
             serde_json::from_slice(&fs::read(&behavior_object).unwrap()).unwrap();
         assert_eq!(
@@ -1279,7 +1318,10 @@ pub(super) mod write_manifest_root {
         assert!(task_object.is_file());
         let task_sidecar = tmp.path().join("tasks/seed-health/prompt.md");
         assert!(task_sidecar.is_file());
-        assert_eq!(fs::read_to_string(&task_sidecar).unwrap(), "Check the fleet.");
+        assert_eq!(
+            fs::read_to_string(&task_sidecar).unwrap(),
+            "Check the fleet."
+        );
         let task_body: serde_json::Value =
             serde_json::from_slice(&fs::read(&task_object).unwrap()).unwrap();
         assert_eq!(
@@ -1408,7 +1450,10 @@ pub(super) mod write_manifest_root {
         // Old behavior dir is gone.
         assert!(!tmp.path().join("agent-behaviors/old-name").exists());
         // New content is present.
-        assert!(tmp.path().join("agent-behaviors/default/object.json").is_file());
+        assert!(tmp
+            .path()
+            .join("agent-behaviors/default/object.json")
+            .is_file());
     }
 }
 
@@ -1430,7 +1475,10 @@ mod write_manifest_root_safe_id {
 
     #[test]
     fn rejects_null_byte() {
-        assert!(check_filesystem_safe_id("a\0b").is_err(), "should reject null byte");
+        assert!(
+            check_filesystem_safe_id("a\0b").is_err(),
+            "should reject null byte"
+        );
     }
 
     #[test]
@@ -1439,9 +1487,7 @@ mod write_manifest_root_safe_id {
             check_filesystem_safe_id("did:defra-agent:example:default").is_ok(),
             "colons are legal on POSIX"
         );
-        assert!(
-            check_filesystem_safe_id("did:key:abc:default:tools").is_ok()
-        );
+        assert!(check_filesystem_safe_id("did:key:abc:default:tools").is_ok());
     }
 
     #[test]

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -476,9 +476,7 @@ pub(crate) async fn validate_manifest_against_live(
         // `__type(name: "Missing")` returns `{ "data": { "__type": null } }`
         // — not a GraphQL error. Detect it explicitly so we can produce a
         // friendly message instead of silently passing.
-        let type_node = response
-            .get("data")
-            .and_then(|d| d.get("__type"));
+        let type_node = response.get("data").and_then(|d| d.get("__type"));
         let fields = type_node
             .filter(|v| !v.is_null())
             .and_then(|t| t.get("fields"))

--- a/crates/defra-agent-cli/src/desired_state/write.rs
+++ b/crates/defra-agent-cli/src/desired_state/write.rs
@@ -16,9 +16,7 @@ use super::{DesiredStateManifest, HasUniqueId};
 /// init-generated IDs.
 pub(crate) fn check_filesystem_safe_id(id: &str) -> Result<(), String> {
     if id.is_empty() {
-        return Err(
-            "unique id is empty; choose a filesystem-safe id".to_string(),
-        );
+        return Err("unique id is empty; choose a filesystem-safe id".to_string());
     }
     if id == "." || id == ".." {
         return Err(format!(
@@ -47,18 +45,13 @@ pub(crate) fn check_filesystem_safe_id(id: &str) -> Result<(), String> {
 /// when `force=true`) is never called on a manifest that would produce a
 /// partial write.
 fn validate_handles(manifest: &DesiredStateManifest) -> Result<(), String> {
-    fn validate_vec<T: HasUniqueId>(
-        docs: &[T],
-        collection_name: &str,
-    ) -> Result<(), String> {
+    fn validate_vec<T: HasUniqueId>(docs: &[T], collection_name: &str) -> Result<(), String> {
         let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
         for doc in docs {
             let id = doc.unique_id();
             check_filesystem_safe_id(id)?;
             if !seen.insert(id) {
-                return Err(format!(
-                    "duplicate {collection_name} id '{id}' in manifest"
-                ));
+                return Err(format!("duplicate {collection_name} id '{id}' in manifest"));
             }
         }
         Ok(())
@@ -132,18 +125,8 @@ pub(crate) fn write_manifest_root(
         &manifest.tool_service_registries,
         no_sidecar,
     )?;
-    write_per_doc_collection(
-        root,
-        Collection::Task,
-        &manifest.tasks,
-        spill_task_sidecar,
-    )?;
-    write_per_doc_collection(
-        root,
-        Collection::Schedule,
-        &manifest.schedules,
-        no_sidecar,
-    )?;
+    write_per_doc_collection(root, Collection::Task, &manifest.tasks, spill_task_sidecar)?;
+    write_per_doc_collection(root, Collection::Schedule, &manifest.schedules, no_sidecar)?;
     write_per_doc_collection(
         root,
         Collection::EventTrigger,
@@ -156,8 +139,7 @@ pub(crate) fn write_manifest_root(
 
 fn prepare_root(root: &Path, force: bool) -> Result<(), String> {
     if !root.exists() {
-        fs::create_dir_all(root)
-            .map_err(|e| format!("creating {} failed: {e}", root.display()))?;
+        fs::create_dir_all(root).map_err(|e| format!("creating {} failed: {e}", root.display()))?;
         return Ok(());
     }
     let is_empty = fs::read_dir(root)
@@ -186,10 +168,8 @@ fn prepare_root(root: &Path, force: bool) -> Result<(), String> {
             root.display()
         ));
     }
-    fs::remove_dir_all(root)
-        .map_err(|e| format!("clearing {} failed: {e}", root.display()))?;
-    fs::create_dir_all(root)
-        .map_err(|e| format!("creating {} failed: {e}", root.display()))?;
+    fs::remove_dir_all(root).map_err(|e| format!("clearing {} failed: {e}", root.display()))?;
+    fs::create_dir_all(root).map_err(|e| format!("creating {} failed: {e}", root.display()))?;
     Ok(())
 }
 
@@ -275,7 +255,10 @@ fn spill_string_field(
             doc_dir.join(sidecar_name).display()
         )
     })?;
-    object.insert(field.to_string(), Value::String(format!("./{sidecar_name}")));
+    object.insert(
+        field.to_string(),
+        Value::String(format!("./{sidecar_name}")),
+    );
     Ok(())
 }
 

--- a/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
@@ -41,7 +41,10 @@ async fn config_apply_reconciles_tool_services_tasks_and_schedules_end_to_end() 
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", &root.to_string_lossy()])?;
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
     let principal = read_json_file(&root.join("agent-principal.json"))?;
     let behavior_id = principal
         .get("default_behavior_id")
@@ -622,7 +625,10 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", &root.to_string_lossy()])?;
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
     let principal = read_json_file(&root.join("agent-principal.json"))?;
     let behavior_id = principal
         .get("default_behavior_id")
@@ -632,7 +638,10 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     let task_id = format!("greet-signup-{}", Uuid::new_v4().simple());
     let trigger_id = format!("on-signup-created-{}", Uuid::new_v4().simple());
     let task_path = root.join("tasks").join(&task_id).join("object.json");
-    let trigger_path = root.join("event_triggers").join(&trigger_id).join("object.json");
+    let trigger_path = root
+        .join("event_triggers")
+        .join(&trigger_id)
+        .join("object.json");
 
     // Use InferenceBackend as the source collection — it's registered on
     // every defra-agent server, so the apply-time live validation (filter
@@ -755,9 +764,7 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
         Some(task_id.as_str())
     );
     assert_eq!(
-        trigger_row
-            .get("source_collection")
-            .and_then(Value::as_str),
+        trigger_row.get("source_collection").and_then(Value::as_str),
         Some("InferenceBackend")
     );
     assert_eq!(
@@ -874,9 +881,7 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     .await?;
     let trigger_after_noop_row = first_graphql_row(&trigger_after_noop, "EventTrigger")?;
     assert_eq!(
-        trigger_after_noop_row
-            .get("_docID")
-            .and_then(Value::as_str),
+        trigger_after_noop_row.get("_docID").and_then(Value::as_str),
         Some(initial_trigger_doc_id.as_str()),
         "EventTrigger docID must be stable across noop apply"
     );
@@ -908,9 +913,8 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     // Stay within a valid GraphQL filter literal so the apply-time live
     // validation still passes. `provider_kind` is a real field on
     // InferenceBackend.
-    trigger_manifest["filter"] = Value::String(
-        "{ enabled: { _eq: true }, provider_kind: { _eq: \"openai\" } }".to_string(),
-    );
+    trigger_manifest["filter"] =
+        Value::String("{ enabled: { _eq: true }, provider_kind: { _eq: \"openai\" } }".to_string());
     trigger_manifest["enabled"] = Value::from(false);
     trigger_manifest["concurrency"] = Value::String("latest_only".to_string());
     write_json_file(&trigger_path, &trigger_manifest)?;
@@ -948,7 +952,9 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
     .await?;
     let trigger_after_update_row = first_graphql_row(&trigger_after_update, "EventTrigger")?;
     assert_eq!(
-        trigger_after_update_row.get("filter").and_then(Value::as_str),
+        trigger_after_update_row
+            .get("filter")
+            .and_then(Value::as_str),
         Some("{ enabled: { _eq: true }, provider_kind: { _eq: \"openai\" } }"),
         "apply must update filter"
     );
@@ -1024,9 +1030,7 @@ struct LiveValidationFixture {
     _tempdir: tempfile::TempDir,
 }
 
-async fn prepare_live_validation_fixture(
-    suffix: &str,
-) -> Result<LiveValidationFixture> {
+async fn prepare_live_validation_fixture(suffix: &str) -> Result<LiveValidationFixture> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     let root = tempdir.path().join("infra").join("agents").join("default");
@@ -1049,7 +1053,10 @@ async fn prepare_live_validation_fixture(
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", &root.to_string_lossy()])?;
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
     let principal = read_json_file(&root.join("agent-principal.json"))?;
     let behavior_id = principal
         .get("default_behavior_id")
@@ -1059,7 +1066,10 @@ async fn prepare_live_validation_fixture(
     let task_id = format!("greet-{suffix}");
     let trigger_id = format!("on-created-{suffix}");
     let task_path = root.join("tasks").join(&task_id).join("object.json");
-    let trigger_path = root.join("event_triggers").join(&trigger_id).join("object.json");
+    let trigger_path = root
+        .join("event_triggers")
+        .join(&trigger_id)
+        .join("object.json");
 
     // Seed the Task + Trigger with a VALID baseline. Individual tests
     // overwrite fields to exercise specific failure modes.
@@ -1127,7 +1137,10 @@ async fn apply_rejects_event_trigger_with_malformed_filter() -> Result<()> {
         .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
     let stderr = run_cli_failure_stderr(&fx.home_dir, &["config", "apply", "--root", root_str])?;
     assert!(
-        stderr.contains(&format!("event_trigger {} filter syntax error", fx.trigger_id)),
+        stderr.contains(&format!(
+            "event_trigger {} filter syntax error",
+            fx.trigger_id
+        )),
         "expected filter syntax error for trigger {} in stderr, got: {stderr}",
         fx.trigger_id,
     );
@@ -1145,8 +1158,7 @@ async fn apply_rejects_event_trigger_template_referencing_unknown_doc_field() ->
     // on InferenceBackend. Keep the trigger's filter valid so the failure
     // is unambiguously the template check.
     let mut task_manifest = read_json_file(&fx.task_path)?;
-    task_manifest["prompt_template"] =
-        Value::String("Greet {{ doc.nonexistent }}.".to_string());
+    task_manifest["prompt_template"] = Value::String("Greet {{ doc.nonexistent }}.".to_string());
     write_json_file(&fx.task_path, &task_manifest)?;
 
     let root_str = fx
@@ -1196,4 +1208,3 @@ async fn apply_accepts_event_trigger_with_valid_filter_and_doc_paths() -> Result
     );
     Ok(())
 }
-

--- a/crates/defra-agent-cli/tests/cli_config_apply_graphql.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_graphql.rs
@@ -36,7 +36,15 @@ async fn config_apply_updates_backend_from_fresh_init_home_over_graphql() -> Res
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", root.to_str().expect("utf-8 root")])?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
 
     let backends_dir = root.join("inference-backends");
     let backend_entry = fs::read_dir(&backends_dir)

--- a/crates/defra-agent-cli/tests/cli_config_apply_local.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_local.rs
@@ -29,7 +29,15 @@ async fn config_apply_updates_backend_from_fresh_init_home_locally() -> Result<(
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", root.to_str().expect("utf-8 root")])?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
 
     let backends_dir = root.join("inference-backends");
     let backend_entry = fs::read_dir(&backends_dir)

--- a/crates/defra-agent-cli/tests/cli_config_apply_running.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_running.rs
@@ -33,7 +33,15 @@ async fn config_apply_reconciles_running_runtime_without_restart() -> Result<()>
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", root.to_str().expect("utf-8 root")])?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
 
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;

--- a/crates/defra-agent-cli/tests/cli_config_diff.rs
+++ b/crates/defra-agent-cli/tests/cli_config_diff.rs
@@ -30,7 +30,15 @@ async fn config_diff_reports_no_changes_for_matching_live_state() -> Result<()> 
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", root.to_str().expect("utf-8 root")])?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
 
     let output = run_cli_json(
         &home_dir,
@@ -104,7 +112,15 @@ async fn config_diff_reports_updates_for_changed_backend_manifest() -> Result<()
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", root.to_str().expect("utf-8 root")])?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
 
     let backends_dir = root.join("inference-backends");
     let backend_entry = fs::read_dir(&backends_dir)

--- a/crates/defra-agent-cli/tests/cli_config_export_import.rs
+++ b/crates/defra-agent-cli/tests/cli_config_export_import.rs
@@ -429,8 +429,7 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
         );
     } else {
         assert_eq!(
-            prompt_template,
-            "Audit the fleet state and summarize drift.",
+            prompt_template, "Audit the fleet state and summarize drift.",
             "inline prompt_template should match original"
         );
     }

--- a/crates/defra-agent-cli/tests/cli_config_task_run.rs
+++ b/crates/defra-agent-cli/tests/cli_config_task_run.rs
@@ -42,7 +42,10 @@ async fn config_task_run_creates_manual_agent_request() -> Result<()> {
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", &root.to_string_lossy()])?;
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
     let principal = read_json_file(&root.join("agent-principal.json"))?;
     let behavior_id = principal
         .get("default_behavior_id")
@@ -105,7 +108,10 @@ async fn config_task_run_creates_manual_agent_request() -> Result<()> {
             &graphql,
         ],
     )?;
-    assert_eq!(fire.get("task_id").and_then(Value::as_str), Some(task_id.as_str()));
+    assert_eq!(
+        fire.get("task_id").and_then(Value::as_str),
+        Some(task_id.as_str())
+    );
     assert_eq!(fire.get("status").and_then(Value::as_str), Some("pending"));
     assert_eq!(
         fire.get("behavior_id").and_then(Value::as_str),
@@ -150,7 +156,10 @@ async fn config_task_run_creates_manual_agent_request() -> Result<()> {
     )
     .await?;
     let row = first_graphql_row(&response, "AgentRequest")?;
-    assert_eq!(row.get("agent_did").and_then(Value::as_str), Some(agent_did.as_str()));
+    assert_eq!(
+        row.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
     assert_eq!(
         row.get("behavior_id").and_then(Value::as_str),
         Some(behavior_id.as_str())
@@ -204,7 +213,10 @@ async fn config_task_run_rejects_disabled_task() -> Result<()> {
         ],
     )?;
 
-    run_cli_text(&home_dir, &["config", "export", "--root", &root.to_string_lossy()])?;
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
     let principal = read_json_file(&root.join("agent-principal.json"))?;
     let behavior_id = principal
         .get("default_behavior_id")

--- a/crates/defra-agent-cli/tests/cli_config_validate.rs
+++ b/crates/defra-agent-cli/tests/cli_config_validate.rs
@@ -30,7 +30,9 @@ async fn config_validate_accepts_normalized_manifest_root() -> Result<()> {
         }),
     )?;
     {
-        let dir = root.join("agent-behaviors").join(default_behavior_id.as_str());
+        let dir = root
+            .join("agent-behaviors")
+            .join(default_behavior_id.as_str());
         fs::create_dir_all(&dir)?;
         write_json_file(
             &dir.join("object.json"),
@@ -50,7 +52,9 @@ async fn config_validate_accepts_normalized_manifest_root() -> Result<()> {
         )?;
     }
     {
-        let dir = root.join("tool-selections").join(tool_selection_id.as_str());
+        let dir = root
+            .join("tool-selections")
+            .join(tool_selection_id.as_str());
         fs::create_dir_all(&dir)?;
         write_json_file(
             &dir.join("object.json"),
@@ -250,7 +254,9 @@ async fn config_validate_accepts_tool_services_dir_and_tasks_dir() -> Result<()>
         }),
     )?;
     {
-        let dir = root.join("agent-behaviors").join(default_behavior_id.as_str());
+        let dir = root
+            .join("agent-behaviors")
+            .join(default_behavior_id.as_str());
         fs::create_dir_all(&dir)?;
         write_json_file(
             &dir.join("object.json"),
@@ -270,7 +276,9 @@ async fn config_validate_accepts_tool_services_dir_and_tasks_dir() -> Result<()>
         )?;
     }
     {
-        let dir = root.join("tool-selections").join(tool_selection_id.as_str());
+        let dir = root
+            .join("tool-selections")
+            .join(tool_selection_id.as_str());
         fs::create_dir_all(&dir)?;
         write_json_file(
             &dir.join("object.json"),

--- a/crates/defra-agent-cli/tests/support/fs.rs
+++ b/crates/defra-agent-cli/tests/support/fs.rs
@@ -195,8 +195,7 @@ fn write_per_doc_collection(
             .and_then(Value::as_str)
             .ok_or_else(|| anyhow!("row missing {unique_field}: {row}"))?;
         let dir = root.join(dir_name).join(handle);
-        fs::create_dir_all(&dir)
-            .with_context(|| format!("creating {}", dir.display()))?;
+        fs::create_dir_all(&dir).with_context(|| format!("creating {}", dir.display()))?;
         write_json_file(&dir.join("object.json"), &object)?;
     }
     Ok(())

--- a/crates/defra-agent-cli/tests/support/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mod.rs
@@ -6,8 +6,8 @@ pub mod process;
 pub mod waits;
 
 pub use fs::{
-    assert_runtime_init_state, project_object_fields, read_captured_log,
-    read_json_file, read_runtime_state_json, write_json_file, write_manifest_root_from_export,
+    assert_runtime_init_state, project_object_fields, read_captured_log, read_json_file,
+    read_runtime_state_json, write_json_file, write_manifest_root_from_export,
 };
 pub use graphql::{doc_id_for_selection, escape_graphql_string, first_graphql_row, graphql_query};
 pub use mocks::{

--- a/crates/defra-agent-desktop/src/client/mutations/manage/task.rs
+++ b/crates/defra-agent-desktop/src/client/mutations/manage/task.rs
@@ -274,15 +274,7 @@ pub async fn fire_task_now(
         bail!("AgentBehavior {behavior_id} is disabled");
     }
 
-    write_manual_agent_request(
-        node,
-        agent_did,
-        behavior_id,
-        task_id,
-        prompt_template,
-        args,
-    )
-    .await
+    write_manual_agent_request(node, agent_did, behavior_id, task_id, prompt_template, args).await
 }
 
 /// Fire a schedule's task immediately.
@@ -299,10 +291,7 @@ pub async fn fire_task_now(
 /// caught up yet). The `SELECT` mirrors every field on
 /// `defra_agent_protocol::row::TaskRow` so `serde_json::from_value`
 /// does not fail on a missing column.
-pub async fn fire_schedule_now(
-    node: &EmbeddedNode,
-    schedule_row: &ScheduleRow,
-) -> Result<String> {
+pub async fn fire_schedule_now(node: &EmbeddedNode, schedule_row: &ScheduleRow) -> Result<String> {
     let task_id = schedule_row
         .task_id
         .as_deref()
@@ -310,12 +299,7 @@ pub async fn fire_schedule_now(
             let trimmed = value.trim();
             (!trimmed.is_empty()).then_some(trimmed)
         })
-        .ok_or_else(|| {
-            anyhow!(
-                "schedule {} has no task_id",
-                schedule_row.schedule_id
-            )
-        })?;
+        .ok_or_else(|| anyhow!("schedule {} has no task_id", schedule_row.schedule_id))?;
     let task_query = format!(
         r#"query {{
             Task(filter: {{ task_id: {{ _eq: "{id}" }} }}, limit: 1) {{
@@ -387,10 +371,7 @@ pub async fn upsert_event_trigger(node: &EmbeddedNode, row: &EventTriggerRow) ->
             r#"trigger_id: "{}""#,
             escape_graphql_string(trigger_id)
         )),
-        Some(format!(
-            r#"task_id: "{}""#,
-            escape_graphql_string(task_id)
-        )),
+        Some(format!(r#"task_id: "{}""#, escape_graphql_string(task_id))),
         Some(graphql_string_field(
             "source_collection",
             row.source_collection.as_deref(),
@@ -415,10 +396,7 @@ pub async fn upsert_event_trigger(node: &EmbeddedNode, row: &EventTriggerRow) ->
         )),
     ];
     let update_fields = [
-        Some(format!(
-            r#"task_id: "{}""#,
-            escape_graphql_string(task_id)
-        )),
+        Some(format!(r#"task_id: "{}""#, escape_graphql_string(task_id))),
         Some(graphql_string_field(
             "source_collection",
             row.source_collection.as_deref(),
@@ -433,10 +411,7 @@ pub async fn upsert_event_trigger(node: &EmbeddedNode, row: &EventTriggerRow) ->
             "concurrency",
             row.concurrency.as_deref(),
         )),
-        Some(format!(
-            r#"updated_at: "{}""#,
-            escape_graphql_string(&now)
-        )),
+        Some(format!(r#"updated_at: "{}""#, escape_graphql_string(&now))),
     ];
 
     let mutation = format!(

--- a/crates/defra-agent-desktop/src/manage/documents.rs
+++ b/crates/defra-agent-desktop/src/manage/documents.rs
@@ -562,15 +562,17 @@ pub fn entity_summaries(
                     .tasks
                     .iter()
                     .filter(|task| {
-                        task.behavior_id
-                            .as_deref()
-                            .is_some_and(|behavior_id| {
-                                store.behavior_row(agent_did, behavior_id).is_some()
-                            })
+                        task.behavior_id.as_deref().is_some_and(|behavior_id| {
+                            store.behavior_row(agent_did, behavior_id).is_some()
+                        })
                     })
                     .map(|task| task.task_id.clone())
                     .collect(),
-                None => store.tasks.iter().map(|task| task.task_id.clone()).collect(),
+                None => store
+                    .tasks
+                    .iter()
+                    .map(|task| task.task_id.clone())
+                    .collect(),
             };
 
             let mut rows: Vec<_> = store

--- a/crates/defra-agent-desktop/src/manage/rows.rs
+++ b/crates/defra-agent-desktop/src/manage/rows.rs
@@ -5,8 +5,8 @@ use defra_agent_protocol::row::{
 };
 
 use crate::state::{
-    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft, TaskDraft,
-    ToolSelectionDraft,
+    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft,
+    TaskDraft, ToolSelectionDraft,
 };
 
 use super::{

--- a/crates/defra-agent-desktop/src/state/activity.rs
+++ b/crates/defra-agent-desktop/src/state/activity.rs
@@ -26,9 +26,16 @@ pub enum PendingChatAction {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PendingManageAction {
-    SelectDeployment { peer_id: String, agent_did: String },
-    SelectSection { section: super::ManageSection },
-    SelectEntity { entity_id: String },
+    SelectDeployment {
+        peer_id: String,
+        agent_did: String,
+    },
+    SelectSection {
+        section: super::ManageSection,
+    },
+    SelectEntity {
+        entity_id: String,
+    },
     StartNewDocument,
     DiscardDraft,
     ApplyDraft,

--- a/crates/defra-agent-desktop/src/views/chat/transcript/messages.rs
+++ b/crates/defra-agent-desktop/src/views/chat/transcript/messages.rs
@@ -114,7 +114,10 @@ fn turn_block(
 
 fn render_lineage_badge(ui: &mut Ui, badge: LineageBadge<'_>) {
     let response = ui.add(egui::Label::new(
-        RichText::new(badge.label).monospace().small().color(badge.color),
+        RichText::new(badge.label)
+            .monospace()
+            .small()
+            .color(badge.color),
     ));
     if let Some(tooltip) = badge.tooltip {
         response.on_hover_text(tooltip);

--- a/crates/defra-agent-desktop/src/views/manage/editors/mod.rs
+++ b/crates/defra-agent-desktop/src/views/manage/editors/mod.rs
@@ -5,8 +5,8 @@ use eframe::egui::{self, RichText, TextEdit, Ui};
 use crate::audit;
 use crate::client::ClientStore;
 use crate::state::{
-    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft, TaskDraft,
-    ToolSelectionDraft,
+    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft,
+    TaskDraft, ToolSelectionDraft,
 };
 use crate::theme;
 

--- a/crates/defra-agent-desktop/src/views/manage/editors/render.rs
+++ b/crates/defra-agent-desktop/src/views/manage/editors/render.rs
@@ -2,8 +2,8 @@ use eframe::egui::Ui;
 
 use crate::client::ClientStore;
 use crate::state::{
-    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft, TaskDraft,
-    ToolSelectionDraft,
+    BackendDraft, BehaviorDraft, EventTriggerDraft, InferenceProfileDraft, ScheduleDraft,
+    TaskDraft, ToolSelectionDraft,
 };
 
 use super::{
@@ -107,7 +107,12 @@ pub(super) fn render_task_editor(ui: &mut Ui, draft: &mut TaskDraft, store: &Cli
         "Last Status",
         runs.last_status.as_deref().unwrap_or("(none)"),
     );
-    read_only_multiline(ui, "Last Error", runs.last_error.as_deref().unwrap_or(""), 3);
+    read_only_multiline(
+        ui,
+        "Last Error",
+        runs.last_error.as_deref().unwrap_or(""),
+        3,
+    );
     read_only_field(
         ui,
         "Triggers Referenced",

--- a/crates/defra-agent-desktop/src/views/manage/mod.rs
+++ b/crates/defra-agent-desktop/src/views/manage/mod.rs
@@ -562,9 +562,11 @@ fn render_fire_task_modal(ui: &mut Ui, state: &mut ShellState) {
         .resizable(true)
         .default_width(420.0)
         .show(ui.ctx(), |ui| {
-            let draft = state.manage.fire_task_draft.as_mut().expect(
-                "fire_task_modal invoked with a present draft; guard checked above",
-            );
+            let draft = state
+                .manage
+                .fire_task_draft
+                .as_mut()
+                .expect("fire_task_modal invoked with a present draft; guard checked above");
             ui.label("Args (JSON object):");
             ui.add(
                 egui::TextEdit::multiline(&mut draft.args_text)
@@ -649,9 +651,7 @@ mod tests {
         // state would hit `task ... disappeared from store` in the
         // controller.
         assert!(!task_run_now_enabled(
-            /* client_online */ true,
-            /* task_enabled */ true,
-            "task-new",
+            /* client_online */ true, /* task_enabled */ true, "task-new",
             /* persisted_row_exists */ false,
         ));
     }

--- a/crates/defra-agent/src/agent/document_view/snapshot.rs
+++ b/crates/defra-agent/src/agent/document_view/snapshot.rs
@@ -310,14 +310,14 @@ fn resolve_event_triggers(
         let trigger = &trigger_record.value;
         let trigger_id = trigger.trigger_id.clone();
 
-        let concurrency =
-            match ConcurrencyMode::parse(trigger.concurrency.as_deref().unwrap_or("")) {
-                Some(mode) => mode,
-                None => {
-                    unavailable_event_triggers.insert(trigger_id);
-                    continue;
-                }
-            };
+        let concurrency = match ConcurrencyMode::parse(trigger.concurrency.as_deref().unwrap_or(""))
+        {
+            Some(mode) => mode,
+            None => {
+                unavailable_event_triggers.insert(trigger_id);
+                continue;
+            }
+        };
 
         if trigger.enabled != Some(true) {
             unavailable_event_triggers.insert(trigger_id);

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -158,20 +158,18 @@ pub(in crate::agent) async fn run_agent(
                 trigger_engine_materializer_snapshot_rx,
             ),
         );
-        let schedule_source: Box<dyn crate::trigger_engine::TriggerSource> = Box::new(
-            crate::trigger_engine::schedule_source::ScheduleSource::new(
+        let schedule_source: Box<dyn crate::trigger_engine::TriggerSource> =
+            Box::new(crate::trigger_engine::schedule_source::ScheduleSource::new(
                 trigger_engine_schedule_snapshot_rx,
                 trigger_engine_node.clone(),
                 trigger_engine_cancel.clone(),
-            ),
-        );
-        let event_source: Box<dyn crate::trigger_engine::TriggerSource> = Box::new(
-            crate::trigger_engine::event_source::EventSource::new(
+            ));
+        let event_source: Box<dyn crate::trigger_engine::TriggerSource> =
+            Box::new(crate::trigger_engine::event_source::EventSource::new(
                 trigger_engine_event_snapshot_rx,
                 trigger_engine_node,
                 trigger_engine_cancel.clone(),
-            ),
-        );
+            ));
         let manual_source_box: Box<dyn crate::trigger_engine::TriggerSource> =
             Box::new(manual_source);
         let sources: Vec<Box<dyn crate::trigger_engine::TriggerSource>> =

--- a/crates/defra-agent/src/collection.rs
+++ b/crates/defra-agent/src/collection.rs
@@ -141,7 +141,11 @@ mod tests {
     fn all_collections_have_distinct_file_or_dir_names() {
         let names: BTreeSet<&str> = Collection::ALL
             .iter()
-            .map(|c| c.file_name().or(c.dir_name()).expect("every variant has one"))
+            .map(|c| {
+                c.file_name()
+                    .or(c.dir_name())
+                    .expect("every variant has one")
+            })
             .collect();
         assert_eq!(names.len(), Collection::ALL.len());
     }

--- a/crates/defra-agent/src/document_config/event_trigger.rs
+++ b/crates/defra-agent/src/document_config/event_trigger.rs
@@ -105,10 +105,7 @@ pub(crate) async fn update_event_trigger_runtime_fields(
     // fields are never overwritten.
     let mut entries: Vec<String> = Vec::new();
     if let Some(v) = updates.last_attempt_at.as_ref() {
-        entries.push(format!(
-            "last_attempt_at: \"{}\"",
-            escape_graphql_string(v)
-        ));
+        entries.push(format!("last_attempt_at: \"{}\"", escape_graphql_string(v)));
     }
     if let Some(v) = updates.last_fired_source_doc_id.as_ref() {
         entries.push(format!(
@@ -117,16 +114,10 @@ pub(crate) async fn update_event_trigger_runtime_fields(
         ));
     }
     if let Some(v) = updates.last_status.as_ref() {
-        entries.push(format!(
-            "last_status: \"{}\"",
-            escape_graphql_string(v)
-        ));
+        entries.push(format!("last_status: \"{}\"", escape_graphql_string(v)));
     }
     if let Some(v) = updates.last_error.as_ref() {
-        entries.push(format!(
-            "last_error: \"{}\"",
-            escape_graphql_string(v)
-        ));
+        entries.push(format!("last_error: \"{}\"", escape_graphql_string(v)));
     }
     if let Some(delta) = updates.fire_count_delta {
         let new_fire_count = current_fire_count.saturating_add(delta);

--- a/crates/defra-agent/src/document_config/mod.rs
+++ b/crates/defra-agent/src/document_config/mod.rs
@@ -35,8 +35,8 @@ pub use tool_selection::{load_tool_selection, upsert_tool_selection, ToolSelecti
 
 #[allow(unused_imports)]
 pub(crate) use event_trigger::{
-    list_event_trigger_records, load_event_trigger_by_doc_id,
-    update_event_trigger_runtime_fields, EventTrigger, EventTriggerRuntimeUpdate,
+    list_event_trigger_records, load_event_trigger_by_doc_id, update_event_trigger_runtime_fields,
+    EventTrigger, EventTriggerRuntimeUpdate,
 };
 #[allow(unused_imports)]
 pub(crate) use schedule::{

--- a/crates/defra-agent/src/lifecycle/manual.rs
+++ b/crates/defra-agent/src/lifecycle/manual.rs
@@ -198,7 +198,11 @@ mod tests {
             }}"#
         );
         let response = node.execute(&query).await;
-        assert!(!response.has_errors(), "query failed: {:?}", response.errors);
+        assert!(
+            !response.has_errors(),
+            "query failed: {:?}",
+            response.errors
+        );
 
         let rows = response
             .data

--- a/crates/defra-agent/src/runtime_snapshot.rs
+++ b/crates/defra-agent/src/runtime_snapshot.rs
@@ -396,8 +396,10 @@ fn configuration_fingerprint(
         fingerprint.push('\n');
     }
 
-    let mut unavailable_event_trigger_ids =
-        unavailable_event_triggers.iter().cloned().collect::<Vec<_>>();
+    let mut unavailable_event_trigger_ids = unavailable_event_triggers
+        .iter()
+        .cloned()
+        .collect::<Vec<_>>();
     unavailable_event_trigger_ids.sort();
     for trigger_id in unavailable_event_trigger_ids {
         fingerprint.push_str("unavailable_event_trigger:");

--- a/crates/defra-agent/src/template/mod.rs
+++ b/crates/defra-agent/src/template/mod.rs
@@ -51,10 +51,7 @@ impl VariableRef {
 /// The input template is rejected if it exceeds [`MAX_TEMPLATE_BYTES`]; the
 /// rendered output is rejected if it exceeds [`MAX_RENDERED_BYTES`]. Both
 /// caps keep trigger evaluation bounded regardless of event payload size.
-pub fn render_template(
-    template: &str,
-    scope: &TemplateScope,
-) -> Result<String, TemplateError> {
+pub fn render_template(template: &str, scope: &TemplateScope) -> Result<String, TemplateError> {
     if template.len() > MAX_TEMPLATE_BYTES {
         return Err(TemplateError::Parse(format!(
             "template exceeds {} bytes",

--- a/crates/defra-agent/src/trigger_engine/event_source.rs
+++ b/crates/defra-agent/src/trigger_engine/event_source.rs
@@ -394,10 +394,7 @@ impl EventSource {
     /// should be treated as a "created" fire under v1 semantics. Subsequent
     /// observations (updates / deletes / replays) return `false`.
     fn is_first_seen(&mut self, collection: &str, doc_id: &str) -> bool {
-        let set = self
-            .seen_docs
-            .entry(collection.to_string())
-            .or_default();
+        let set = self.seen_docs.entry(collection.to_string()).or_default();
         set.insert(doc_id.to_string())
     }
 
@@ -592,8 +589,7 @@ impl EventSource {
         result: crate::trigger_engine::FireResult,
     ) {
         tokio::spawn(async move {
-            let now = chrono::Utc::now().to_rfc3339_opts(
-                chrono::SecondsFormat::Secs, true);
+            let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
             let (status, error_value, fire_delta) = match &result {
                 crate::trigger_engine::FireResult::Fired { .. } => ("fired", None, Some(1)),
                 crate::trigger_engine::FireResult::Skipped { reason } => {
@@ -749,8 +745,7 @@ impl EventSource {
 impl TriggerSource for EventSource {
     fn next_fire(
         &mut self,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FireIntent>> + Send + '_>>
-    {
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FireIntent>> + Send + '_>> {
         Box::pin(async move {
             // Outer loop: reconcile-on-generation-bump, then race subscription
             // vs. snapshot-change vs. cancel. `None` here means "source is

--- a/crates/defra-agent/src/trigger_engine/manual_source.rs
+++ b/crates/defra-agent/src/trigger_engine/manual_source.rs
@@ -41,10 +41,7 @@ pub(crate) struct ManualTriggerHandle {
 impl ManualSource {
     pub(crate) fn new(cancel: CancellationToken) -> (Self, ManualTriggerHandle) {
         let (tx, rx) = mpsc::channel(MANUAL_CHANNEL_CAPACITY);
-        (
-            Self { rx, cancel },
-            ManualTriggerHandle { tx },
-        )
+        (Self { rx, cancel }, ManualTriggerHandle { tx })
     }
 }
 
@@ -77,8 +74,7 @@ impl ManualTriggerHandle {
             })?;
 
         let (result_tx, result_rx) = oneshot::channel();
-        let now =
-            chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
         let intent = FireIntent {
             trigger_id: None,
@@ -108,9 +104,7 @@ impl ManualTriggerHandle {
 }
 
 impl TriggerSource for ManualSource {
-    fn next_fire(
-        &mut self,
-    ) -> Pin<Box<dyn Future<Output = Option<FireIntent>> + Send + '_>> {
+    fn next_fire(&mut self) -> Pin<Box<dyn Future<Output = Option<FireIntent>> + Send + '_>> {
         Box::pin(async move {
             tokio::select! {
                 _ = self.cancel.cancelled() => None,

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -1356,10 +1356,8 @@ async fn event_source_next_fire_emits_intent_on_matching_real_event() {
         output_schema_ref: None,
     };
     let trigger = resolved_event_trigger("trigger-webhook", "WebhookEvent", task.clone());
-    let snapshot = snapshot_with_event_triggers(
-        1,
-        HashMap::from([("trigger-webhook".to_string(), trigger)]),
-    );
+    let snapshot =
+        snapshot_with_event_triggers(1, HashMap::from([("trigger-webhook".to_string(), trigger)]));
     let (_tx, rx) = watch::channel(snapshot.clone());
 
     let cancel = CancellationToken::new();
@@ -1426,9 +1424,7 @@ async fn event_source_next_fire_emits_intent_on_matching_real_event() {
     assert_eq!(ev["trigger_kind"].as_str(), Some("event"));
     assert_eq!(ev["source_collection"].as_str(), Some("WebhookEvent"));
     assert!(
-        ev["source_doc_id"]
-            .as_str()
-            .is_some_and(|s| !s.is_empty()),
+        ev["source_doc_id"].as_str().is_some_and(|s| !s.is_empty()),
         "source_doc_id should be a non-empty string from the persisted doc, got {:?}",
         ev["source_doc_id"]
     );
@@ -1601,10 +1597,8 @@ async fn event_source_hydrates_doc_vars_from_source_doc_fields() {
     // No filter on the trigger — every create fires, and the fire must
     // carry the full doc projection.
     let trigger = resolved_event_trigger("trigger-hydrate", "WebhookEvent", task.clone());
-    let snapshot = snapshot_with_event_triggers(
-        1,
-        HashMap::from([("trigger-hydrate".to_string(), trigger)]),
-    );
+    let snapshot =
+        snapshot_with_event_triggers(1, HashMap::from([("trigger-hydrate".to_string(), trigger)]));
     let (_tx, rx) = watch::channel(snapshot.clone());
 
     let cancel = CancellationToken::new();
@@ -1742,10 +1736,8 @@ async fn event_source_on_result_writes_runtime_fields_on_fired() {
         output_schema_ref: None,
     };
     let trigger = resolved_event_trigger("trigger-fired", "WebhookEvent", task.clone());
-    let snapshot = snapshot_with_event_triggers(
-        1,
-        HashMap::from([("trigger-fired".to_string(), trigger)]),
-    );
+    let snapshot =
+        snapshot_with_event_triggers(1, HashMap::from([("trigger-fired".to_string(), trigger)]));
     let (_tx, rx) = watch::channel(snapshot.clone());
 
     let cancel = CancellationToken::new();
@@ -2006,11 +1998,7 @@ async fn event_source_on_result_writes_runtime_fields_on_skipped_or_errored() {
 /// Build a `ResolvedTask` for unit tests that exercise the manual-fire path.
 /// Mirrors `resolved_task` but takes an explicit `task_id` / `behavior_id`
 /// so callers can assert the `task_id` round-tripped through the intent.
-fn resolved_task_for_test(
-    task_id: &str,
-    behavior_id: &str,
-    prompt_template: &str,
-) -> ResolvedTask {
+fn resolved_task_for_test(task_id: &str, behavior_id: &str, prompt_template: &str) -> ResolvedTask {
     ResolvedTask {
         task_id: task_id.to_string(),
         behavior_id: behavior_id.to_string(),
@@ -2072,11 +2060,8 @@ async fn manual_source_run_task_now_yields_intent_with_args_vars() {
 
 #[tokio::test]
 async fn manual_source_run_task_now_rejects_unknown_task() {
-    let snapshot = snapshot_with_active_task(resolved_task_for_test(
-        "other-task",
-        "behavior-1",
-        "x",
-    ));
+    let snapshot =
+        snapshot_with_active_task(resolved_task_for_test("other-task", "behavior-1", "x"));
     let (_source, handle) = ManualSource::new(CancellationToken::new());
     let err = handle
         .run_task_now(snapshot.as_ref(), "missing", serde_json::json!({}))
@@ -2096,12 +2081,9 @@ async fn manual_source_next_fire_returns_none_after_cancel() {
     // Cancel immediately.
     cancel.cancel();
 
-    let result = tokio::time::timeout(
-        std::time::Duration::from_millis(200),
-        source.next_fire(),
-    )
-    .await
-    .expect("timed out waiting for cancelled next_fire");
+    let result = tokio::time::timeout(std::time::Duration::from_millis(200), source.next_fire())
+        .await
+        .expect("timed out waiting for cancelled next_fire");
     assert!(result.is_none());
 }
 
@@ -2219,9 +2201,7 @@ async fn dispatch_manual_intent_renders_with_args_and_materializes() {
             request_id, "req-0",
             "spy materializer hands back sequentially-numbered ids starting at req-0"
         ),
-        other => panic!(
-            "expected Fired for Manual intent (bypasses enabled-gate), got {other:?}"
-        ),
+        other => panic!("expected Fired for Manual intent (bypasses enabled-gate), got {other:?}"),
     }
 
     let calls = materializer.calls();
@@ -2472,8 +2452,7 @@ async fn event_source_fans_out_one_event_across_multiple_matching_triggers() {
 
     let task = resolved_task("ignored");
     // Two triggers on the same collection. lex order: trigger-alpha < trigger-beta.
-    let trigger_alpha =
-        resolved_event_trigger("trigger-alpha", "WebhookEvent", task.clone());
+    let trigger_alpha = resolved_event_trigger("trigger-alpha", "WebhookEvent", task.clone());
     let trigger_beta = resolved_event_trigger("trigger-beta", "WebhookEvent", task);
     let snapshot = snapshot_with_event_triggers(
         1,
@@ -2623,8 +2602,7 @@ async fn event_source_tries_all_triggers_when_first_filter_misses() {
 
     // And crucially, there must be no second intent — trigger-a did NOT
     // match the filter, so it must not have emitted.
-    let maybe_extra =
-        tokio::time::timeout(Duration::from_millis(300), source.next_fire()).await;
+    let maybe_extra = tokio::time::timeout(Duration::from_millis(300), source.next_fire()).await;
     assert!(
         maybe_extra.is_err(),
         "trigger-a emitted a FireIntent despite its filter miss",

--- a/crates/defra-agent/tests/event_trigger_e2e.rs
+++ b/crates/defra-agent/tests/event_trigger_e2e.rs
@@ -34,9 +34,7 @@ use std::time::Duration;
 
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
-use defra_agent::{
-    AgentIdentity, DefraAgent, DocumentRuntimeOptions, ToolCeiling,
-};
+use defra_agent::{AgentIdentity, DefraAgent, DocumentRuntimeOptions, ToolCeiling};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -454,7 +452,11 @@ async fn event_trigger_fires_on_source_doc_create_end_to_end() {
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     };
-    assert_eq!(fired.fire_count, Some(1), "fire_count must be 1 after one fire: {fired:?}");
+    assert_eq!(
+        fired.fire_count,
+        Some(1),
+        "fire_count must be 1 after one fire: {fired:?}"
+    );
     assert_eq!(
         fired.last_fired_source_doc_id.as_deref(),
         Some(source_doc_id.as_str()),

--- a/crates/defra-agent/tests/manual_run_conformance.rs
+++ b/crates/defra-agent/tests/manual_run_conformance.rs
@@ -47,10 +47,7 @@ use support::{test_db, AGENT_DID, AGENT_NAME};
 /// Fetch the full row shape the helper writes so tests can inspect lineage,
 /// execution origin, lifecycle state, and the rendered content without
 /// reconstructing the filter in every case.
-async fn fetch_manual_row(
-    node: &defra_agent::defra_node::EmbeddedNode,
-    doc_id: &str,
-) -> Value {
+async fn fetch_manual_row(node: &defra_agent::defra_node::EmbeddedNode, doc_id: &str) -> Value {
     let escaped = escape_graphql_string(doc_id);
     let query = format!(
         r#"{{

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -743,7 +743,11 @@ async fn serial_skip_event_does_not_create_request() {
         ) { _docID }
     }"#;
     let gate = db.node.execute(gating_query).await;
-    assert!(!gate.has_errors(), "gating query errored: {:?}", gate.errors);
+    assert!(
+        !gate.has_errors(),
+        "gating query errored: {:?}",
+        gate.errors
+    );
     let gate_rows = gate
         .data
         .as_ref()
@@ -850,7 +854,11 @@ async fn latest_only_event_transition_to_superseded() {
         ) { _docID }
     }"#;
     let resp = db.node.execute(supersede).await;
-    assert!(!resp.has_errors(), "supersede mutation errored: {:?}", resp.errors);
+    assert!(
+        !resp.has_errors(),
+        "supersede mutation errored: {:?}",
+        resp.errors
+    );
     let updated_rows = resp
         .data
         .as_ref()
@@ -2063,7 +2071,9 @@ async fn manual_run_preserves_lineage_through_claim_transition() {
         }
     );
     assert_eq!(
-        fetch_request_snapshot(&db.node, &doc_id).await.lifecycle_state,
+        fetch_request_snapshot(&db.node, &doc_id)
+            .await
+            .lifecycle_state,
         "pending"
     );
 
@@ -2085,7 +2095,11 @@ async fn manual_run_preserves_lineage_through_claim_transition() {
         }}"#
     );
     let resp = db.node.execute(&query).await;
-    assert!(!resp.has_errors(), "AgentRequest query failed: {:?}", resp.errors);
+    assert!(
+        !resp.has_errors(),
+        "AgentRequest query failed: {:?}",
+        resp.errors
+    );
     let row = resp
         .data
         .as_ref()

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -99,12 +99,7 @@ async fn register_audit_event_schema(node: &EmbeddedNode) {
         .expect("add_schema for AuditEvent");
 }
 
-async fn create_task(
-    node: &EmbeddedNode,
-    task_id: &str,
-    behavior_id: &str,
-    prompt_template: &str,
-) {
+async fn create_task(node: &EmbeddedNode, task_id: &str, behavior_id: &str, prompt_template: &str) {
     let escaped_task_id = escape_graphql_string(task_id);
     let escaped_behavior_id = escape_graphql_string(behavior_id);
     let escaped_prompt_template = escape_graphql_string(prompt_template);
@@ -208,10 +203,7 @@ async fn update_event_trigger_source_collection(
         .map(str::to_owned);
 
     let last_attempt_entry = match last_attempt_at.as_deref() {
-        Some(v) => format!(
-            ", last_attempt_at: \"{}\"",
-            escape_graphql_string(v)
-        ),
+        Some(v) => format!(", last_attempt_at: \"{}\"", escape_graphql_string(v)),
         None => String::new(),
     };
     let mutation = format!(
@@ -466,10 +458,7 @@ async fn supersede_nonterminal_requests_for_trigger(
         .unwrap_or(0)
 }
 
-async fn fetch_request_state(
-    node: &EmbeddedNode,
-    request_id: &str,
-) -> Option<(String, String)> {
+async fn fetch_request_state(node: &EmbeddedNode, request_id: &str) -> Option<(String, String)> {
     let escaped_request_id = escape_graphql_string(request_id);
     let query = format!(
         r#"{{
@@ -614,14 +603,10 @@ async fn wait_for_request_count(
             return;
         }
         if count > expected {
-            panic!(
-                "over-fire for trigger_id={trigger_id}: expected {expected}, got {count}"
-            );
+            panic!("over-fire for trigger_id={trigger_id}: expected {expected}, got {count}");
         }
         if tokio::time::Instant::now() >= deadline {
-            panic!(
-                "timed out waiting for request_count({trigger_id}) == {expected}; got {count}"
-            );
+            panic!("timed out waiting for request_count({trigger_id}) == {expected}; got {count}");
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
@@ -631,11 +616,7 @@ async fn wait_for_request_count(
 /// Used by the "does not fire" cases. This is necessarily a negative
 /// assertion with a timeout — the engine is event-driven, so we sleep long
 /// enough that if it *were* going to fire it would have done so already.
-async fn assert_no_request_within(
-    node: &EmbeddedNode,
-    trigger_id: &str,
-    settle: Duration,
-) {
+async fn assert_no_request_within(node: &EmbeddedNode, trigger_id: &str, settle: Duration) {
     tokio::time::sleep(settle).await;
     let count = count_agent_requests_for_trigger(node, trigger_id, "event").await;
     assert_eq!(
@@ -742,7 +723,12 @@ async fn does_not_fire_when_source_doc_fails_filter() {
     let db = test_db("trigger-conformance-filter-miss").await;
     register_webhook_event_schema(db.node.as_ref()).await;
 
-    let agent = boot_agent(&db, "trigger-conformance-filter-miss", "backend-filter-miss").await;
+    let agent = boot_agent(
+        &db,
+        "trigger-conformance-filter-miss",
+        "backend-filter-miss",
+    )
+    .await;
     let initial_gen = fetch_runtime_snapshot(db.node.as_ref(), &agent.agent_did)
         .await
         .unwrap()
@@ -825,12 +811,7 @@ async fn enabled_false_does_not_fire() {
     tokio::time::sleep(Duration::from_secs(7)).await;
 
     let _ = write_webhook_event(db.node.as_ref(), "ext-disabled", "any").await;
-    assert_no_request_within(
-        db.node.as_ref(),
-        "trigger-disabled",
-        Duration::from_secs(2),
-    )
-    .await;
+    assert_no_request_within(db.node.as_ref(), "trigger-disabled", Duration::from_secs(2)).await;
 
     let row = fetch_event_trigger_row(db.node.as_ref(), "trigger-disabled")
         .await
@@ -1024,20 +1005,12 @@ async fn subscription_reconciles_on_generation_bump() {
 
     // Step 4: WebhookEvent creates after the flip must NOT produce a new
     // fire — WebhookEvent is no longer in the desired collection set.
-    let before_flip = count_agent_requests_for_trigger(
-        db.node.as_ref(),
-        "trigger-reconcile",
-        "event",
-    )
-    .await;
+    let before_flip =
+        count_agent_requests_for_trigger(db.node.as_ref(), "trigger-reconcile", "event").await;
     let _ = write_webhook_event(db.node.as_ref(), "post-flip-webhook", "any").await;
     tokio::time::sleep(Duration::from_secs(2)).await;
-    let after_webhook = count_agent_requests_for_trigger(
-        db.node.as_ref(),
-        "trigger-reconcile",
-        "event",
-    )
-    .await;
+    let after_webhook =
+        count_agent_requests_for_trigger(db.node.as_ref(), "trigger-reconcile", "event").await;
     assert_eq!(
         after_webhook, before_flip,
         "post-flip WebhookEvent must not fire trigger-reconcile \
@@ -1073,33 +1046,20 @@ async fn serial_skips_when_prior_non_terminal() {
     .unwrap();
 
     assert!(
-        has_nonterminal_request_for_trigger(
-            db.node.as_ref(),
-            "trigger-event-serial",
-            "event",
-        )
-        .await,
+        has_nonterminal_request_for_trigger(db.node.as_ref(), "trigger-event-serial", "event",)
+            .await,
         "gating query must see the in-flight event-kind request"
     );
     assert_eq!(
-        count_agent_requests_for_trigger(
-            db.node.as_ref(),
-            "trigger-event-serial",
-            "event",
-        )
-        .await,
+        count_agent_requests_for_trigger(db.node.as_ref(), "trigger-event-serial", "event",).await,
         1,
         "seeded count should be 1"
     );
 
     // The engine's FireResult::Skipped decision: no materialize call, so no
     // additional AgentRequest for the lineage tuple.
-    let after = count_agent_requests_for_trigger(
-        db.node.as_ref(),
-        "trigger-event-serial",
-        "event",
-    )
-    .await;
+    let after =
+        count_agent_requests_for_trigger(db.node.as_ref(), "trigger-event-serial", "event").await;
     assert_eq!(
         after, 1,
         "serial skip must not produce a second AgentRequest for the event-kind tuple"
@@ -1173,21 +1133,12 @@ async fn latest_only_supersedes_prior_fire() {
         "new fire must have a fresh request_id"
     );
     assert_eq!(
-        count_agent_requests_for_trigger(
-            db.node.as_ref(),
-            "trigger-event-latest",
-            "event",
-        )
-        .await,
+        count_agent_requests_for_trigger(db.node.as_ref(), "trigger-event-latest", "event",).await,
         2
     );
     assert!(
-        has_nonterminal_request_for_trigger(
-            db.node.as_ref(),
-            "trigger-event-latest",
-            "event",
-        )
-        .await,
+        has_nonterminal_request_for_trigger(db.node.as_ref(), "trigger-event-latest", "event",)
+            .await,
         "after materialize, the new claimed request must be visible to the gating query"
     );
 }
@@ -1266,7 +1217,12 @@ async fn two_triggers_same_source_collection_each_evaluate_filter_independently(
     let db = test_db("trigger-conformance-two-filters").await;
     register_webhook_event_schema(db.node.as_ref()).await;
 
-    let agent = boot_agent(&db, "trigger-conformance-two-filters", "backend-two-filters").await;
+    let agent = boot_agent(
+        &db,
+        "trigger-conformance-two-filters",
+        "backend-two-filters",
+    )
+    .await;
     let initial_gen = fetch_runtime_snapshot(db.node.as_ref(), &agent.agent_did)
         .await
         .unwrap()
@@ -1325,12 +1281,7 @@ async fn two_triggers_same_source_collection_each_evaluate_filter_independently(
     )
     .await;
     // B does not fire within the settle window.
-    assert_no_request_within(
-        db.node.as_ref(),
-        "trigger-two-b",
-        Duration::from_secs(2),
-    )
-    .await;
+    assert_no_request_within(db.node.as_ref(), "trigger-two-b", Duration::from_secs(2)).await;
 
     // Runtime-writeback sanity.
     let a = wait_for_last_status(


### PR DESCRIPTION
## Summary
- run `cargo fmt --all` across the workspace
- clear the recurring repo-wide formatting drift that has been failing `rust-and-cli`

## Testing
- cargo fmt --all --check
