### PR TITLE
Refactor desired-state collection plumbing

### DIFF
--- a/crates/defra-agent-cli/src/commands/chat/streaming.rs
+++ b/crates/defra-agent-cli/src/commands/chat/streaming.rs
@@ -148,10 +148,7 @@ pub(super) async fn stream_turn_progress(
             .and_then(Value::as_array)
             .and_then(|rows| rows.first())
             .cloned();
-        if let Some(progress) = response_row
-            .as_ref()
-            .and_then(|row| decode_chat_turn_progress(row))
-        {
+        if let Some(progress) = response_row.as_ref().and_then(decode_chat_turn_progress) {
             if progress.progress_seq > latest_progress_seq
                 || progress.content != latest_content
                 || progress.reasoning != latest_reasoning

--- a/crates/defra-agent-cli/src/commands/config/behavior.rs
+++ b/crates/defra-agent-cli/src/commands/config/behavior.rs
@@ -13,7 +13,7 @@ pub(super) async fn behavior_set(args: BehaviorUpsertArgs) -> Result<()> {
         .unwrap_or_else(|| default_behavior_id_for_agent(&args.agent_did));
     let system_prompt = match args.system_prompt_file {
         Some(ref path) => Some(
-            std::fs::read_to_string(&path)
+            std::fs::read_to_string(path)
                 .with_context(|| format!("reading system prompt from {}", path.display()))?,
         ),
         None => None,

--- a/crates/defra-agent-cli/src/commands/p2p/collections.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/collections.rs
@@ -215,7 +215,6 @@ pub(super) async fn p2p_collections_sync_versions(args: P2pSyncVersionsArgs) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared::{P2pCollectionSubscriptionRow, P2pReplicatorRow};
     use std::collections::BTreeMap;
 
     #[test]

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -16,6 +16,18 @@ use crate::{
     extract_mutation_doc_id, graphql_input_literal, CONFIG_EXPORT_FORMAT, CONFIG_EXPORT_FORMAT_V1,
 };
 
+const CONFIG_APPLY_ORDER: [Collection; 9] = [
+    Collection::InferenceBackend,
+    Collection::InferenceProfile,
+    Collection::ToolServiceRegistry,
+    Collection::ToolSelection,
+    Collection::AgentBehavior,
+    Collection::Task,
+    Collection::Schedule,
+    Collection::EventTrigger,
+    Collection::AgentPrincipal,
+];
+
 pub(crate) fn read_config_import_bundle(
     path: Option<&std::path::Path>,
 ) -> Result<ConfigExportBundle> {
@@ -190,31 +202,11 @@ pub(crate) async fn apply_import_collection(
 pub(crate) fn diff_has_pending_apply(
     counts: &desired_state::DesiredStateDiffCollectionsCounts,
 ) -> bool {
-    [
-        &counts.agent_principal,
-        &counts.agent_behaviors,
-        &counts.tool_selections,
-        &counts.inference_backends,
-        &counts.inference_profiles,
-        &counts.tool_service_registries,
-        &counts.tasks,
-        &counts.schedules,
-        &counts.event_triggers,
-    ]
-    .iter()
-    .any(|count| count.create > 0 || count.update > 0)
+    counts.has_pending_apply()
 }
 
 pub(crate) fn config_apply_counts_changed(counts: &ConfigApplyCounts) -> bool {
-    counts.agent_principal > 0
-        || counts.agent_behaviors > 0
-        || counts.tool_selections > 0
-        || counts.inference_backends > 0
-        || counts.inference_profiles > 0
-        || counts.tool_service_registries > 0
-        || counts.tasks > 0
-        || counts.schedules > 0
-        || counts.event_triggers > 0
+    counts.changed()
 }
 
 pub(crate) fn select_apply_principal_docs(
@@ -235,131 +227,41 @@ pub(crate) async fn apply_desired_state_changes(
     planned: &desired_state::DesiredStateDiffReport,
 ) -> Result<ConfigApplyCounts> {
     let desired_bundle = desired_bundle.as_bundle();
-    let backend_docs = select_apply_collection_docs(
-        &desired_bundle.inference_backends,
-        Collection::InferenceBackend.unique_field(),
-        Collection::InferenceBackend.graphql_type(),
-        &planned.collections.inference_backends,
-    )?;
-    let profile_docs = select_apply_collection_docs(
-        &desired_bundle.inference_profiles,
-        Collection::InferenceProfile.unique_field(),
-        Collection::InferenceProfile.graphql_type(),
-        &planned.collections.inference_profiles,
-    )?;
-    let tool_selection_docs = select_apply_collection_docs(
-        &desired_bundle.tool_selections,
-        Collection::ToolSelection.unique_field(),
-        Collection::ToolSelection.graphql_type(),
-        &planned.collections.tool_selections,
-    )?;
-    let tool_service_registry_docs = select_apply_collection_docs(
-        &desired_bundle.tool_service_registries,
-        Collection::ToolServiceRegistry.unique_field(),
-        Collection::ToolServiceRegistry.graphql_type(),
-        &planned.collections.tool_service_registries,
-    )?;
-    let behavior_docs = select_apply_collection_docs(
-        &desired_bundle.agent_behaviors,
-        Collection::AgentBehavior.unique_field(),
-        Collection::AgentBehavior.graphql_type(),
-        &planned.collections.agent_behaviors,
-    )?;
-    let task_docs = select_apply_collection_docs(
-        &desired_bundle.tasks,
-        Collection::Task.unique_field(),
-        Collection::Task.graphql_type(),
-        &planned.collections.tasks,
-    )?;
-    let schedule_docs = select_apply_collection_docs(
-        &desired_bundle.schedules,
-        Collection::Schedule.unique_field(),
-        Collection::Schedule.graphql_type(),
-        &planned.collections.schedules,
-    )?;
-    let event_trigger_docs = select_apply_collection_docs(
-        &desired_bundle.event_triggers,
-        Collection::EventTrigger.unique_field(),
-        Collection::EventTrigger.graphql_type(),
-        &planned.collections.event_triggers,
-    )?;
-    let principal_docs = select_apply_principal_docs(
-        desired_bundle.agent_principal.as_ref(),
-        &planned.collections.agent_principal,
-    )?;
+    let mut counts = ConfigApplyCounts::default();
 
-    Ok(ConfigApplyCounts {
-        inference_backends: apply_import_collection(
+    for collection in CONFIG_APPLY_ORDER {
+        let docs = select_apply_docs_for_collection(desired_bundle, planned, collection)?;
+        let applied = apply_import_collection(
             access,
-            Collection::InferenceBackend.graphql_type(),
-            Collection::InferenceBackend.unique_field(),
-            &backend_docs,
+            collection.graphql_type(),
+            collection.unique_field(),
+            &docs,
             true,
         )
-        .await?,
-        inference_profiles: apply_import_collection(
-            access,
-            Collection::InferenceProfile.graphql_type(),
-            Collection::InferenceProfile.unique_field(),
-            &profile_docs,
-            true,
-        )
-        .await?,
-        tool_service_registries: apply_import_collection(
-            access,
-            Collection::ToolServiceRegistry.graphql_type(),
-            Collection::ToolServiceRegistry.unique_field(),
-            &tool_service_registry_docs,
-            true,
-        )
-        .await?,
-        tool_selections: apply_import_collection(
-            access,
-            Collection::ToolSelection.graphql_type(),
-            Collection::ToolSelection.unique_field(),
-            &tool_selection_docs,
-            true,
-        )
-        .await?,
-        agent_behaviors: apply_import_collection(
-            access,
-            Collection::AgentBehavior.graphql_type(),
-            Collection::AgentBehavior.unique_field(),
-            &behavior_docs,
-            true,
-        )
-        .await?,
-        tasks: apply_import_collection(
-            access,
-            Collection::Task.graphql_type(),
-            Collection::Task.unique_field(),
-            &task_docs,
-            true,
-        )
-        .await?,
-        schedules: apply_import_collection(
-            access,
-            Collection::Schedule.graphql_type(),
-            Collection::Schedule.unique_field(),
-            &schedule_docs,
-            true,
-        )
-        .await?,
-        event_triggers: apply_import_collection(
-            access,
-            Collection::EventTrigger.graphql_type(),
-            Collection::EventTrigger.unique_field(),
-            &event_trigger_docs,
-            true,
-        )
-        .await?,
-        agent_principal: apply_import_collection(
-            access,
-            Collection::AgentPrincipal.graphql_type(),
-            Collection::AgentPrincipal.unique_field(),
-            &principal_docs,
-            true,
-        )
-        .await?,
-    })
+        .await?;
+        counts.set(collection, applied);
+    }
+
+    Ok(counts)
+}
+
+fn select_apply_docs_for_collection(
+    desired_bundle: &ConfigExportBundle,
+    planned: &desired_state::DesiredStateDiffReport,
+    collection: Collection,
+) -> Result<Vec<Value>> {
+    let diff = planned.collections.get(collection);
+    if collection == Collection::AgentPrincipal {
+        return select_apply_principal_docs(desired_bundle.agent_principal.as_ref(), diff);
+    }
+
+    let docs = desired_bundle
+        .docs_for_collection(collection)
+        .expect("non-principal desired-state collection has document slice");
+    select_apply_collection_docs(
+        docs,
+        collection.unique_field(),
+        collection.graphql_type(),
+        diff,
+    )
 }

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -19,6 +19,7 @@ use anyhow::Result;
 use defra_agent::defra_node::EmbeddedNode;
 use serde_json::{json, Value};
 
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum ConfigAccess {
     Graphql(String),
     Local(EmbeddedNode),

--- a/crates/defra-agent-cli/src/desired_state/diff.rs
+++ b/crates/defra-agent-cli/src/desired_state/diff.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use super::{
     DesiredAgentPrincipal, DesiredStateCollectionDiff, DesiredStateDiffCollections,
-    DesiredStateDiffCollectionsCounts, DesiredStateDiffReport, DesiredStateManifest,
+    DesiredStateDiffReport, DesiredStateManifest, HasUniqueId,
 };
 
 pub(crate) fn diff_manifests(
@@ -18,119 +18,29 @@ pub(crate) fn diff_manifests(
         Some(&desired.agent_principal),
         live_principal,
     );
-    let agent_behaviors = diff_collection(
-        desired
-            .agent_behaviors
-            .iter()
-            .map(|value| (value.behavior_id.clone(), value))
-            .collect(),
-        live.agent_behaviors
-            .iter()
-            .map(|value| (value.behavior_id.clone(), value))
-            .collect(),
-    );
-    let tool_selections = diff_collection(
-        desired
-            .tool_selections
-            .iter()
-            .map(|value| (value.selection_id.clone(), value))
-            .collect(),
-        live.tool_selections
-            .iter()
-            .map(|value| (value.selection_id.clone(), value))
-            .collect(),
-    );
-    let inference_backends = diff_collection(
-        desired
-            .inference_backends
-            .iter()
-            .map(|value| (value.backend_id.clone(), value))
-            .collect(),
-        live.inference_backends
-            .iter()
-            .map(|value| (value.backend_id.clone(), value))
-            .collect(),
-    );
-    let inference_profiles = diff_collection(
-        desired
-            .inference_profiles
-            .iter()
-            .map(|value| (value.profile_id.clone(), value))
-            .collect(),
-        live.inference_profiles
-            .iter()
-            .map(|value| (value.profile_id.clone(), value))
-            .collect(),
-    );
-    let tool_service_registries = diff_collection(
-        desired
-            .tool_service_registries
-            .iter()
-            .map(|value| (value.service_id.clone(), value))
-            .collect(),
-        live.tool_service_registries
-            .iter()
-            .map(|value| (value.service_id.clone(), value))
-            .collect(),
-    );
-    let tasks = diff_collection(
-        desired
-            .tasks
-            .iter()
-            .map(|value| (value.task_id.clone(), value))
-            .collect(),
-        live.tasks
-            .iter()
-            .map(|value| (value.task_id.clone(), value))
-            .collect(),
-    );
-    let schedules = diff_collection(
-        desired
-            .schedules
-            .iter()
-            .map(|value| (value.schedule_id.clone(), value))
-            .collect(),
-        live.schedules
-            .iter()
-            .map(|value| (value.schedule_id.clone(), value))
-            .collect(),
-    );
-    let event_triggers = diff_collection(
-        desired
-            .event_triggers
-            .iter()
-            .map(|value| (value.trigger_id.clone(), value))
-            .collect(),
-        live.event_triggers
-            .iter()
-            .map(|value| (value.trigger_id.clone(), value))
-            .collect(),
-    );
-
-    let counts = DesiredStateDiffCollectionsCounts {
-        agent_principal: agent_principal.counts(),
-        agent_behaviors: agent_behaviors.counts(),
-        tool_selections: tool_selections.counts(),
-        inference_backends: inference_backends.counts(),
-        inference_profiles: inference_profiles.counts(),
-        tool_service_registries: tool_service_registries.counts(),
-        tasks: tasks.counts(),
-        schedules: schedules.counts(),
-        event_triggers: event_triggers.counts(),
+    let collections = DesiredStateDiffCollections {
+        agent_principal,
+        agent_behaviors: diff_manifest_collection(&desired.agent_behaviors, &live.agent_behaviors),
+        tool_selections: diff_manifest_collection(&desired.tool_selections, &live.tool_selections),
+        inference_backends: diff_manifest_collection(
+            &desired.inference_backends,
+            &live.inference_backends,
+        ),
+        inference_profiles: diff_manifest_collection(
+            &desired.inference_profiles,
+            &live.inference_profiles,
+        ),
+        tool_service_registries: diff_manifest_collection(
+            &desired.tool_service_registries,
+            &live.tool_service_registries,
+        ),
+        tasks: diff_manifest_collection(&desired.tasks, &live.tasks),
+        schedules: diff_manifest_collection(&desired.schedules, &live.schedules),
+        event_triggers: diff_manifest_collection(&desired.event_triggers, &live.event_triggers),
     };
-    let ok = [
-        &counts.agent_principal,
-        &counts.agent_behaviors,
-        &counts.tool_selections,
-        &counts.inference_backends,
-        &counts.inference_profiles,
-        &counts.tool_service_registries,
-        &counts.tasks,
-        &counts.schedules,
-        &counts.event_triggers,
-    ]
-    .iter()
-    .all(|count| count.create == 0 && count.update == 0 && count.live_only == 0);
+
+    let counts = collections.counts();
+    let ok = counts.is_exact_match();
 
     DesiredStateDiffReport {
         status: "diffed",
@@ -139,17 +49,7 @@ pub(crate) fn diff_manifests(
         access_mode: access_mode.to_string(),
         agent_did: desired.agent_principal.agent_did.clone(),
         counts,
-        collections: DesiredStateDiffCollections {
-            agent_principal,
-            agent_behaviors,
-            tool_selections,
-            inference_backends,
-            inference_profiles,
-            tool_service_registries,
-            tasks,
-            schedules,
-            event_triggers,
-        },
+        collections,
     }
 }
 
@@ -244,4 +144,19 @@ where
         unchanged,
         live_only,
     }
+}
+
+fn diff_manifest_collection<T>(desired: &[T], live: &[T]) -> DesiredStateCollectionDiff
+where
+    T: HasUniqueId + PartialEq,
+{
+    diff_collection(
+        desired
+            .iter()
+            .map(|value| (value.unique_id().to_string(), value))
+            .collect(),
+        live.iter()
+            .map(|value| (value.unique_id().to_string(), value))
+            .collect(),
+    )
 }

--- a/crates/defra-agent-cli/src/desired_state/load.rs
+++ b/crates/defra-agent-cli/src/desired_state/load.rs
@@ -120,17 +120,7 @@ fn empty_report(root_display: String, errors: Vec<String>) -> DesiredStateValida
         ok: false,
         root: root_display,
         agent_did: None,
-        counts: DesiredStateCounts {
-            agent_principal: 0,
-            agent_behaviors: 0,
-            tool_selections: 0,
-            inference_backends: 0,
-            inference_profiles: 0,
-            tool_service_registries: 0,
-            tasks: 0,
-            schedules: 0,
-            event_triggers: 0,
-        },
+        counts: DesiredStateCounts::empty(),
         errors,
     }
 }

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use write::write_manifest_root;
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize};
 
-use defra_agent::BackendProviderKind;
+use defra_agent::{BackendProviderKind, Collection};
 
 pub(crate) const DEFAULT_TOOL_SERVICE_MCP_PATH: &str = "/mcp";
 pub(crate) const TOOL_SERVICE_ADDRESS_FIELDS: &[&str] = &["hostname", "tailscale_ip", "lan_ip"];
@@ -280,6 +280,36 @@ pub(crate) struct DesiredStateDiffCollections {
     pub(crate) event_triggers: DesiredStateCollectionDiff,
 }
 
+impl DesiredStateDiffCollections {
+    pub(crate) fn get(&self, collection: Collection) -> &DesiredStateCollectionDiff {
+        match collection {
+            Collection::AgentPrincipal => &self.agent_principal,
+            Collection::AgentBehavior => &self.agent_behaviors,
+            Collection::ToolSelection => &self.tool_selections,
+            Collection::InferenceBackend => &self.inference_backends,
+            Collection::InferenceProfile => &self.inference_profiles,
+            Collection::ToolServiceRegistry => &self.tool_service_registries,
+            Collection::Task => &self.tasks,
+            Collection::Schedule => &self.schedules,
+            Collection::EventTrigger => &self.event_triggers,
+        }
+    }
+
+    pub(crate) fn counts(&self) -> DesiredStateDiffCollectionsCounts {
+        DesiredStateDiffCollectionsCounts {
+            agent_principal: self.agent_principal.counts(),
+            agent_behaviors: self.agent_behaviors.counts(),
+            tool_selections: self.tool_selections.counts(),
+            inference_backends: self.inference_backends.counts(),
+            inference_profiles: self.inference_profiles.counts(),
+            tool_service_registries: self.tool_service_registries.counts(),
+            tasks: self.tasks.counts(),
+            schedules: self.schedules.counts(),
+            event_triggers: self.event_triggers.counts(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct DesiredStateDiffCollectionsCounts {
     pub(crate) agent_principal: DesiredStateDiffCounts,
@@ -291,6 +321,39 @@ pub(crate) struct DesiredStateDiffCollectionsCounts {
     pub(crate) tasks: DesiredStateDiffCounts,
     pub(crate) schedules: DesiredStateDiffCounts,
     pub(crate) event_triggers: DesiredStateDiffCounts,
+}
+
+impl DesiredStateDiffCollectionsCounts {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &DesiredStateDiffCounts> {
+        Collection::ALL
+            .iter()
+            .copied()
+            .map(|collection| self.get(collection))
+    }
+
+    pub(crate) fn get(&self, collection: Collection) -> &DesiredStateDiffCounts {
+        match collection {
+            Collection::AgentPrincipal => &self.agent_principal,
+            Collection::AgentBehavior => &self.agent_behaviors,
+            Collection::ToolSelection => &self.tool_selections,
+            Collection::InferenceBackend => &self.inference_backends,
+            Collection::InferenceProfile => &self.inference_profiles,
+            Collection::ToolServiceRegistry => &self.tool_service_registries,
+            Collection::Task => &self.tasks,
+            Collection::Schedule => &self.schedules,
+            Collection::EventTrigger => &self.event_triggers,
+        }
+    }
+
+    pub(crate) fn is_exact_match(&self) -> bool {
+        self.iter()
+            .all(|count| count.create == 0 && count.update == 0 && count.live_only == 0)
+    }
+
+    pub(crate) fn has_pending_apply(&self) -> bool {
+        self.iter()
+            .any(|count| count.create > 0 || count.update > 0)
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -315,6 +378,22 @@ pub(crate) struct DesiredStateCounts {
     pub(crate) tasks: usize,
     pub(crate) schedules: usize,
     pub(crate) event_triggers: usize,
+}
+
+impl DesiredStateCounts {
+    pub(crate) fn empty() -> Self {
+        Self {
+            agent_principal: 0,
+            agent_behaviors: 0,
+            tool_selections: 0,
+            inference_backends: 0,
+            inference_profiles: 0,
+            tool_service_registries: 0,
+            tasks: 0,
+            schedules: 0,
+            event_triggers: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -419,6 +419,7 @@ mod tests {
     use super::*;
     use serde_json::Value;
 
+    #[test]
     fn sanitize_inference_backend_drops_deprecated_capability_fields() {
         let input = serde_json::json!({
             "backend_id": "local",

--- a/crates/defra-agent-cli/src/shared.rs
+++ b/crates/defra-agent-cli/src/shared.rs
@@ -1,4 +1,4 @@
-use defra_agent::BackendProviderKind;
+use defra_agent::{BackendProviderKind, Collection};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -168,7 +168,23 @@ pub(crate) struct ConfigExportBundle {
     pub(crate) event_triggers: Vec<Value>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+impl ConfigExportBundle {
+    pub(crate) fn docs_for_collection(&self, collection: Collection) -> Option<&[Value]> {
+        match collection {
+            Collection::AgentPrincipal => None,
+            Collection::AgentBehavior => Some(&self.agent_behaviors),
+            Collection::ToolSelection => Some(&self.tool_selections),
+            Collection::InferenceBackend => Some(&self.inference_backends),
+            Collection::InferenceProfile => Some(&self.inference_profiles),
+            Collection::ToolServiceRegistry => Some(&self.tool_service_registries),
+            Collection::Task => Some(&self.tasks),
+            Collection::Schedule => Some(&self.schedules),
+            Collection::EventTrigger => Some(&self.event_triggers),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
 pub(crate) struct ConfigApplyCounts {
     pub(crate) agent_principal: usize,
     pub(crate) agent_behaviors: usize,
@@ -179,6 +195,39 @@ pub(crate) struct ConfigApplyCounts {
     pub(crate) tasks: usize,
     pub(crate) schedules: usize,
     pub(crate) event_triggers: usize,
+}
+
+impl ConfigApplyCounts {
+    pub(crate) fn set(&mut self, collection: Collection, count: usize) {
+        match collection {
+            Collection::AgentPrincipal => self.agent_principal = count,
+            Collection::AgentBehavior => self.agent_behaviors = count,
+            Collection::ToolSelection => self.tool_selections = count,
+            Collection::InferenceBackend => self.inference_backends = count,
+            Collection::InferenceProfile => self.inference_profiles = count,
+            Collection::ToolServiceRegistry => self.tool_service_registries = count,
+            Collection::Task => self.tasks = count,
+            Collection::Schedule => self.schedules = count,
+            Collection::EventTrigger => self.event_triggers = count,
+        }
+    }
+
+    pub(crate) fn changed(&self) -> bool {
+        Collection::ALL.iter().copied().any(|collection| {
+            let count = match collection {
+                Collection::AgentPrincipal => self.agent_principal,
+                Collection::AgentBehavior => self.agent_behaviors,
+                Collection::ToolSelection => self.tool_selections,
+                Collection::InferenceBackend => self.inference_backends,
+                Collection::InferenceProfile => self.inference_profiles,
+                Collection::ToolServiceRegistry => self.tool_service_registries,
+                Collection::Task => self.tasks,
+                Collection::Schedule => self.schedules,
+                Collection::EventTrigger => self.event_triggers,
+            };
+            count > 0
+        })
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
@@ -1018,7 +1018,6 @@ async fn config_apply_reconciles_event_triggers_end_to_end() -> Result<()> {
 struct LiveValidationFixture {
     home_dir: std::path::PathBuf,
     root: std::path::PathBuf,
-    task_id: String,
     trigger_id: String,
     task_path: std::path::PathBuf,
     trigger_path: std::path::PathBuf,
@@ -1109,7 +1108,6 @@ async fn prepare_live_validation_fixture(suffix: &str) -> Result<LiveValidationF
     Ok(LiveValidationFixture {
         home_dir,
         root,
-        task_id,
         trigger_id,
         task_path,
         trigger_path,

--- a/crates/defra-agent-cli/tests/cli_config_apply_order.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_order.rs
@@ -1,45 +1,40 @@
-/// Anchors the write order in `apply_desired_state_changes` to the topological
-/// rank declared by `Collection::apply_order`.
+/// Anchors the desired-state write order to the topological rank declared by
+/// `Collection::apply_order`.
 ///
 /// This is a source-grep test: it reads the source of `config_import.rs` at
-/// compile time and asserts that the `apply_import_collection` assignments
-/// inside the `Ok(ConfigApplyCounts { ... })` literal appear in the expected
-/// order.  No live DefraDB node is required.
+/// compile time and asserts that the centralized `CONFIG_APPLY_ORDER` table
+/// appears in the expected order. No live DefraDB node is required.
 #[test]
 fn apply_desired_state_changes_order_matches_collection_apply_order() {
     let src = include_str!("../src/config_import.rs");
-    let body_start = src.find("Ok(ConfigApplyCounts {").unwrap();
-    let body_end = src[body_start..].find("})").unwrap() + body_start;
+    let body_start = src.find("const CONFIG_APPLY_ORDER").unwrap();
+    let body_end = src[body_start..].find("];").unwrap() + body_start;
     let body = &src[body_start..body_end];
 
-    // Extract assignment keys in source order.
-    let re = regex::Regex::new(
-        r"(?m)^\s*(agent_principal|agent_behaviors|tool_selections|inference_backends|inference_profiles|tool_service_registries|tasks|schedules|event_triggers):\s*apply_import_collection",
-    )
-    .unwrap();
+    let re = regex::Regex::new(r"Collection::([A-Za-z]+)").unwrap();
     let found: Vec<&str> = re
         .captures_iter(body)
         .map(|c| c.get(1).unwrap().as_str())
         .collect();
 
-    // Expected order = Collection::ALL sorted by (apply_order, graphql_type):
+    // Expected order preserves the existing manual order within each apply rank:
     //   rank 0: InferenceBackend, InferenceProfile, ToolServiceRegistry, ToolSelection
     //   rank 1: AgentBehavior
     //   rank 2: Task, Schedule
-    //   rank 3: AgentPrincipal, EventTrigger
+    //   rank 3: EventTrigger, AgentPrincipal
     let expected = vec![
-        "inference_backends",
-        "inference_profiles",
-        "tool_service_registries",
-        "tool_selections",
-        "agent_behaviors",
-        "tasks",
-        "schedules",
-        "event_triggers",
-        "agent_principal",
+        "InferenceBackend",
+        "InferenceProfile",
+        "ToolServiceRegistry",
+        "ToolSelection",
+        "AgentBehavior",
+        "Task",
+        "Schedule",
+        "EventTrigger",
+        "AgentPrincipal",
     ];
     assert_eq!(
         found, expected,
-        "apply_desired_state_changes write order does not match Collection::apply_order ranks"
+        "CONFIG_APPLY_ORDER does not match Collection::apply_order ranks"
     );
 }

--- a/crates/defra-agent-cli/tests/cli_config_backend.rs
+++ b/crates/defra-agent-cli/tests/cli_config_backend.rs
@@ -4,7 +4,7 @@ use support::*;
 use std::fs;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde_json::Value;
 use uuid::Uuid;
 

--- a/crates/defra-agent-cli/tests/cli_config_diff.rs
+++ b/crates/defra-agent-cli/tests/cli_config_diff.rs
@@ -2,7 +2,6 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;

--- a/crates/defra-agent-cli/tests/cli_config_validate.rs
+++ b/crates/defra-agent-cli/tests/cli_config_validate.rs
@@ -2,7 +2,6 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde_json::Value;

--- a/crates/defra-agent-cli/tests/cli_help.rs
+++ b/crates/defra-agent-cli/tests/cli_help.rs
@@ -1,12 +1,8 @@
 mod support;
 use support::*;
 
+use anyhow::{Context, Result};
 use std::fs;
-use std::time::Duration;
-
-use anyhow::{anyhow, Context, Result};
-use serde_json::Value;
-use uuid::Uuid;
 
 #[test]
 fn top_level_help_shows_quickstart_workflow() -> Result<()> {

--- a/crates/defra-agent-cli/tests/cli_status.rs
+++ b/crates/defra-agent-cli/tests/cli_status.rs
@@ -4,7 +4,7 @@ use support::*;
 use std::fs;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use serde_json::Value;
 use uuid::Uuid;
 

--- a/crates/defra-agent-cli/tests/support/fs.rs
+++ b/crates/defra-agent-cli/tests/support/fs.rs
@@ -224,6 +224,7 @@ pub fn read_runtime_state_json(home_dir: &Path) -> Result<Value> {
     serde_json::from_slice(&bytes).with_context(|| format!("decoding {}", path.display()))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn assert_runtime_init_state(
     graphql: &str,
     agent_did: &str,

--- a/crates/defra-agent-cli/tests/support/mocks/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/mod.rs
@@ -45,8 +45,10 @@ pub fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequestData> {
                     break;
                 }
             }
-        } else if buffer.len() >= header_end.expect("header_end should be set") + content_length {
-            break;
+        } else if let Some(end) = header_end {
+            if buffer.len() >= end + content_length {
+                break;
+            }
         }
     }
 

--- a/crates/defra-agent-cli/tests/support/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code, unused_imports)]
+
 pub mod fs;
 pub mod graphql;
 pub mod mocks;

--- a/crates/defra-agent/src/admission/client.rs
+++ b/crates/defra-agent/src/admission/client.rs
@@ -151,6 +151,7 @@ where
 pub(crate) enum CallKind {
     Inference,
     Compaction,
+    #[allow(dead_code)]
     Scheduled,
 }
 

--- a/crates/defra-agent/src/admission/registry.rs
+++ b/crates/defra-agent/src/admission/registry.rs
@@ -145,6 +145,7 @@ impl AdmissionRegistry {
     }
 
     #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) async fn acquire_for_test(
         &self,
         request_id: impl Into<String>,

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -59,6 +59,7 @@ pub trait ProcessLifecycleObserver: Send + Sync {
     fn on_process_state_change(&self, state: ProcessLifecycleState);
 }
 
+#[derive(Default)]
 pub struct DocumentRuntimeOptions {
     pub tool_ceiling: ToolCeiling,
     pub mcp_pool: McpPool,
@@ -67,20 +68,6 @@ pub struct DocumentRuntimeOptions {
     pub retry_policy: RetryPolicy,
     pub hook_failure_policy: FailurePolicy,
     pub process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
-}
-
-impl Default for DocumentRuntimeOptions {
-    fn default() -> Self {
-        Self {
-            tool_ceiling: ToolCeiling::meta_only(),
-            mcp_pool: McpPool::default(),
-            local_hostname: None,
-            local_subnet: None,
-            retry_policy: RetryPolicy::default(),
-            hook_failure_policy: FailurePolicy::default(),
-            process_state_observer: None,
-        }
-    }
 }
 
 #[derive(Clone)]

--- a/crates/defra-agent/src/agent/builder.rs
+++ b/crates/defra-agent/src/agent/builder.rs
@@ -30,6 +30,7 @@ use crate::tool_surface::{
 #[cfg(test)]
 const TEST_DEFAULT_BACKEND_ENDPOINT: &str = "http://localhost:8000/v1";
 
+#[derive(Default)]
 pub struct DefraAgentBuilder {
     node: Option<Arc<EmbeddedNode>>,
     identity: Option<Arc<dyn AgentIdentity>>,
@@ -42,24 +43,6 @@ pub struct DefraAgentBuilder {
     hook_failure_policy: FailurePolicy,
     process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
     behaviors: Vec<PendingBehaviorConfig>,
-}
-
-impl Default for DefraAgentBuilder {
-    fn default() -> Self {
-        Self {
-            node: None,
-            identity: None,
-            default_behavior_id: None,
-            tool_ceiling: ToolCeiling::meta_only(),
-            mcp_pool: McpPool::default(),
-            local_hostname: None,
-            local_subnet: None,
-            retry_policy: RetryPolicy::default(),
-            hook_failure_policy: FailurePolicy::default(),
-            process_state_observer: None,
-            behaviors: Vec::new(),
-        }
-    }
 }
 
 impl DefraAgentBuilder {
@@ -411,6 +394,7 @@ impl PendingBehaviorConfig {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_with_resolved_backend(
         self,
         identity: Arc<dyn AgentIdentity>,

--- a/crates/defra-agent/src/agent/runtime/context.rs
+++ b/crates/defra-agent/src/agent/runtime/context.rs
@@ -138,6 +138,7 @@ impl RuntimeContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn run_behavior_with_client<C>(
         &self,
         behavior: Arc<crate::config::BehaviorConfig>,

--- a/crates/defra-agent/src/compaction/tests.rs
+++ b/crates/defra-agent/src/compaction/tests.rs
@@ -10,7 +10,6 @@ use rig::completion::{
 use rig::one_or_many::OneOrMany;
 use rig::streaming::StreamingCompletionResponse;
 
-use super::summary::compaction_prompt;
 use super::*;
 use crate::ensure_schemas;
 use crate::prompt::{LayeredPromptBuilder, PromptBuilder};

--- a/crates/defra-agent/src/config.rs
+++ b/crates/defra-agent/src/config.rs
@@ -68,7 +68,7 @@ impl SamplingConfig {
             params.insert("max_tokens".to_string(), serde_json::json!(max_tokens));
         }
 
-        (!params.is_empty()).then(|| serde_json::Value::Object(params))
+        (!params.is_empty()).then_some(serde_json::Value::Object(params))
     }
 }
 

--- a/crates/defra-agent/src/runtime_snapshot.rs
+++ b/crates/defra-agent/src/runtime_snapshot.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use tokio::sync::{mpsc, watch};
+use tokio::sync::mpsc;
+#[cfg(test)]
+use tokio::sync::watch;
 
 use crate::admission::BackendAdmissionConfig;
 use crate::config::BehaviorConfig;
@@ -21,6 +23,7 @@ pub(crate) struct ResolvedTask {
     pub(crate) task_id: String,
     pub(crate) behavior_id: String,
     pub(crate) prompt_template: String,
+    #[allow(dead_code)]
     pub(crate) output_schema_ref: Option<String>,
 }
 
@@ -33,9 +36,11 @@ pub(crate) struct ResolvedTask {
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedSchedule {
     pub(crate) schedule_id: String,
+    #[allow(dead_code)]
     pub(crate) task_id: String,
     pub(crate) task: ResolvedTask,
     pub(crate) interval_secs: i64,
+    #[allow(dead_code)]
     pub(crate) enabled: bool,
     pub(crate) concurrency: ConcurrencyMode,
 }
@@ -76,6 +81,7 @@ impl ConcurrencyMode {
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedEventTrigger {
     pub(crate) trigger_id: String,
+    #[allow(dead_code)]
     pub(crate) task_id: String,
     pub(crate) task: ResolvedTask,
     pub(crate) source_collection: String,
@@ -83,6 +89,7 @@ pub(crate) struct ResolvedEventTrigger {
     /// `"deleted"` support.
     pub(crate) event_kind: String,
     pub(crate) filter: Option<String>,
+    #[allow(dead_code)]
     pub(crate) enabled: bool,
     pub(crate) concurrency: ConcurrencyMode,
 }
@@ -250,6 +257,8 @@ impl ActiveRuntimeSnapshot {
         &self.active_tasks
     }
 
+    #[cfg(test)]
+    #[allow(dead_code)]
     pub(crate) fn tool_surface(&self, behavior_id: &str) -> Option<&Arc<ToolSurface>> {
         self.tool_surfaces.get(behavior_id)
     }
@@ -276,6 +285,7 @@ impl ActiveRuntimeSnapshot {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn refresh_active_snapshot(
     active_snapshot: &mut Arc<ActiveRuntimeSnapshot>,
     active_snapshot_rx: &mut watch::Receiver<Arc<ActiveRuntimeSnapshot>>,

--- a/crates/defra-agent/src/session/conversation.rs
+++ b/crates/defra-agent/src/session/conversation.rs
@@ -25,6 +25,7 @@ pub(crate) async fn upsert_conversation_from_request(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn upsert_conversation_from_request_with_identity(
     node: &EmbeddedNode,
     session_id: &str,

--- a/crates/defra-agent/src/toolset/shared/filesystem.rs
+++ b/crates/defra-agent/src/toolset/shared/filesystem.rs
@@ -280,6 +280,7 @@ fn collect_glob_matches_inner(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_grep_matches_inner(
     context: &ToolContext,
     traversal_root: &Path,

--- a/crates/defra-agent/src/trigger_engine/event_source.rs
+++ b/crates/defra-agent/src/trigger_engine/event_source.rs
@@ -591,7 +591,14 @@ impl EventSource {
         tokio::spawn(async move {
             let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
             let (status, error_value, fire_delta) = match &result {
-                crate::trigger_engine::FireResult::Fired { .. } => ("fired", None, Some(1)),
+                crate::trigger_engine::FireResult::Fired { request_id } => {
+                    tracing::debug!(
+                        trigger_id = %trigger_id,
+                        request_id = %request_id,
+                        "event trigger fire materialized request"
+                    );
+                    ("fired", None, Some(1))
+                }
                 crate::trigger_engine::FireResult::Skipped { reason } => {
                     ("skipped", Some(reason.clone()), None)
                 }

--- a/crates/defra-agent/src/trigger_engine/mod.rs
+++ b/crates/defra-agent/src/trigger_engine/mod.rs
@@ -21,6 +21,10 @@ pub(crate) mod schedule_source;
 #[cfg(test)]
 mod tests;
 
+type TriggerLockKey = (String, TriggerKind);
+type TriggerLock = Arc<Mutex<()>>;
+type TriggerLockMap = HashMap<TriggerLockKey, TriggerLock>;
+
 /// Kind of trigger that produced a fire intent.
 ///
 /// Schedule and Event triggers both drive the engine from stored trigger
@@ -87,35 +91,6 @@ pub(crate) enum FireResult {
     Errored { error: String },
 }
 
-/// Persisted-status projection of a `FireResult`.
-///
-/// `FireResult` carries the per-outcome payload (request id / reason / error);
-/// `FireAttemptStatus` is the compact enum form that lands in the
-/// `last_status` field on `Schedule` and `EventTrigger` documents via the
-/// source's `on_result` callback. Keeping the two apart lets the engine stay
-/// free of persistence-layer wording.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum FireAttemptStatus {
-    Fired,
-    Skipped,
-    Errored,
-}
-
-impl FireAttemptStatus {
-    /// String form matching the GraphQL-persisted `last_status` values.
-    ///
-    /// Note: `Errored` serializes to `"error"` (not `"errored"`) to match the
-    /// existing schema vocabulary on `Schedule.last_status` /
-    /// `EventTrigger.last_status`.
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            FireAttemptStatus::Fired => "fired",
-            FireAttemptStatus::Skipped => "skipped",
-            FireAttemptStatus::Errored => "error",
-        }
-    }
-}
-
 /// Stream of fire intents produced by a source (e.g. the schedule clock, an
 /// event-queue poller, a manual-fire inbox).
 ///
@@ -178,7 +153,7 @@ pub(crate) struct TriggerEngine {
     #[allow(dead_code)]
     materializer: Arc<dyn MaterializerHandle>,
     #[allow(dead_code)]
-    per_trigger_locks: Mutex<HashMap<(String, TriggerKind), Arc<Mutex<()>>>>,
+    per_trigger_locks: Mutex<TriggerLockMap>,
 }
 
 impl TriggerEngine {

--- a/crates/defra-agent/src/trigger_engine/schedule_source.rs
+++ b/crates/defra-agent/src/trigger_engine/schedule_source.rs
@@ -195,13 +195,20 @@ impl TriggerSource for ScheduleSource {
                         args_vars: None,
                         on_result: Box::new(move |result| {
                             let updates = match &result {
-                                FireResult::Fired { .. } => ScheduleRuntimeUpdate {
-                                    next_run_at: Some(advanced_next_run_at_str.clone()),
-                                    last_attempt_at: Some(last_attempt_at.clone()),
-                                    last_status: Some("fired".to_string()),
-                                    last_error: None,
-                                    fire_count_delta: Some(1),
-                                },
+                                FireResult::Fired { request_id } => {
+                                    tracing::debug!(
+                                        schedule_id = %schedule_id_for_callback,
+                                        request_id = %request_id,
+                                        "schedule fire materialized request"
+                                    );
+                                    ScheduleRuntimeUpdate {
+                                        next_run_at: Some(advanced_next_run_at_str.clone()),
+                                        last_attempt_at: Some(last_attempt_at.clone()),
+                                        last_status: Some("fired".to_string()),
+                                        last_error: None,
+                                        fire_count_delta: Some(1),
+                                    }
+                                }
                                 FireResult::Skipped { .. } => ScheduleRuntimeUpdate {
                                     // Skipped still advances `next_run_at` so
                                     // a serial-gated fire doesn't hammer the

--- a/crates/defra-agent/tests/apply_property.rs
+++ b/crates/defra-agent/tests/apply_property.rs
@@ -192,7 +192,7 @@ proptest! {
         let steps = diff(&m, &l).into_steps();
         let mut acc = l.clone();
         for s in &steps {
-            acc = apply_all(&acc, &[s.clone()]);
+            acc = apply_all(&acc, std::slice::from_ref(s));
             for payload in acc.desired.values() {
                 for r in references_of(payload) {
                     prop_assert!(
@@ -248,7 +248,7 @@ proptest! {
         let steps = diff(&m, &l).into_steps();
         let mut acc = l.clone();
         for s in &steps {
-            acc = apply_all(&acc, &[s.clone()]);
+            acc = apply_all(&acc, std::slice::from_ref(s));
             for (d, payload) in &acc.desired {
                 for r in references_of(payload) {
                     prop_assert!(
@@ -277,8 +277,8 @@ proptest! {
         let steps = diff(&m, &l).into_steps();
         let mut acc = l.clone();
         for s in &steps {
-            acc = apply_all(&acc, &[s.clone()]);
-            for (_d, payload) in &acc.desired {
+            acc = apply_all(&acc, std::slice::from_ref(s));
+            for payload in acc.desired.values() {
                 for r in references_of(payload) {
                     prop_assert!(
                         acc.desired.contains_key(&r),

--- a/crates/defra-agent/tests/schedule_conformance.rs
+++ b/crates/defra-agent/tests/schedule_conformance.rs
@@ -163,7 +163,7 @@ async fn set_schedule_enabled(
 /// successful fire: advances `next_run_at` by `interval_secs`, writes
 /// `last_attempt_at`, sets `last_status = "fired"`, and bumps `fire_count` by
 /// 1. Apply-owned fields (`enabled`, `interval_secs`, `task_id`,
-/// `concurrency`) must NOT be touched.
+///    `concurrency`) must NOT be touched.
 async fn schedule_writeback_fired(
     node: &defra_agent::defra_node::EmbeddedNode,
     schedule_id: &str,

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -405,18 +405,17 @@ async fn serial_skip_does_not_create_request() {
 
     // Run the exact query `ProductionMaterializer` uses to gate the fire.
     // Expect `true` — a non-terminal request for this tuple exists.
-    let gating_query = format!(
-        r#"query {{
+    let gating_query = r#"query {
             AgentRequest(
-                filter: {{
-                    caused_by_trigger_id: {{ _eq: "sched-serial" }},
-                    caused_by_trigger_kind: {{ _eq: "schedule" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
-                }},
+                filter: {
+                    caused_by_trigger_id: { _eq: "sched-serial" },
+                    caused_by_trigger_kind: { _eq: "schedule" },
+                    lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                },
                 limit: 1
-            ) {{ _docID }}
-        }}"#
-    );
+            ) { _docID }
+        }"#
+    .to_string();
     let gate = db.node.execute(&gating_query).await;
     assert!(
         !gate.has_errors(),
@@ -515,21 +514,20 @@ async fn latest_only_transition_to_superseded() {
 
     // Run the engine's supersede mutation verbatim (the shape in
     // `production_materializer::supersede_nonterminal_requests_for_trigger`).
-    let supersede = format!(
-        r#"mutation {{
+    let supersede = r#"mutation {
             update_AgentRequest(
-                filter: {{
-                    caused_by_trigger_id: {{ _eq: "sched-latest" }},
-                    caused_by_trigger_kind: {{ _eq: "schedule" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
-                }},
-                input: {{
+                filter: {
+                    caused_by_trigger_id: { _eq: "sched-latest" },
+                    caused_by_trigger_kind: { _eq: "schedule" },
+                    lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                },
+                input: {
                     status: "superseded",
                     lifecycle_state: "superseded"
-                }}
-            ) {{ _docID }}
-        }}"#
-    );
+                }
+            ) { _docID }
+        }"#
+    .to_string();
     let resp = db.node.execute(&supersede).await;
     assert!(
         !resp.has_errors(),
@@ -582,16 +580,15 @@ async fn fire_errored_does_not_create_request() {
 
     // The persistence boundary: no materialize call means no AgentRequest
     // row with the lineage tuple. Query the engine's tuple filter to confirm.
-    let query = format!(
-        r#"query {{
+    let query = r#"query {
             AgentRequest(
-                filter: {{
-                    caused_by_trigger_id: {{ _eq: "sched-render-err" }},
-                    caused_by_trigger_kind: {{ _eq: "schedule" }}
-                }}
-            ) {{ _docID }}
-        }}"#
-    );
+                filter: {
+                    caused_by_trigger_id: { _eq: "sched-render-err" },
+                    caused_by_trigger_kind: { _eq: "schedule" }
+                }
+            ) { _docID }
+        }"#
+    .to_string();
     let resp = db.node.execute(&query).await;
     assert!(!resp.has_errors(), "tuple query errored: {:?}", resp.errors);
     let rows = resp

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -454,6 +454,7 @@ pub async fn create_agent_message(
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn create_agent_tool_call(
     node: &EmbeddedNode,
     session_id: &str,

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -257,8 +257,8 @@ async fn write_dynamic_event(
         .as_ref()
         .unwrap_or_else(|| panic!("add_{collection} response missing data"));
     let field = data
-        .get(&format!("add_{collection}"))
-        .or_else(|| data.get(&format!("create_{collection}")))
+        .get(format!("add_{collection}"))
+        .or_else(|| data.get(format!("create_{collection}")))
         .unwrap_or_else(|| panic!("add_/create_{collection} key missing; data={data:?}"));
     field
         .get("_docID")
@@ -1193,7 +1193,7 @@ async fn template_render_failure_records_error_status() {
     )
     .await;
     assert!(
-        errored.last_error.as_deref().unwrap_or("").len() > 0,
+        !errored.last_error.as_deref().unwrap_or("").is_empty(),
         "last_error must carry a render-failure reason: {errored:?}"
     );
     assert_eq!(


### PR DESCRIPTION
## Summary
- centralize desired-state diff count aggregation and pending-apply checks
- replace per-collection diff projection boilerplate with a shared `HasUniqueId` helper
- consolidate config apply document selection/count assignment behind `Collection` helpers while preserving existing apply order
- clean Rust fmt/clippy/build warning output across the affected Rust and CLI test targets

Closes #55

## Tests
- `cargo fmt --all --check`
- `cargo clippy -p defra-agent -p defra-agent-cli --all-targets -- -D warnings`
- `cargo test -p defra-agent --lib --tests`
- `cargo test -p defra-agent-cli -- --nocapture --test-threads=1`