### PR TITLE
Add macOS Secure Enclave agent identities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Rewrite Git SSH dependencies to HTTPS
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf ssh://git@github.com/
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
 
       - name: Rewrite Git SSH dependencies to HTTPS
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
         run: |
-          git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
         run: |
-          git config --global url."https://${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
+          git config --global url."https://x-access-token:${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -29,8 +29,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Rewrite Git SSH dependencies to HTTPS
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
         run: |
-          git config --global url."https://github.com/".insteadOf ssh://git@github.com/
+          git config --global url."https://${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
         run: |
-          git config --global url."https://${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
+          git config --global url."https://x-access-token:${PRIVATE_REPO_PAT}@github.com/sourcenetwork/".insteadOf "ssh://git@github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3102,7 +3102,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3437,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-lock",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-trait",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "anyhow",
  "document",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-stream",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "serde",
 ]
@@ -4190,7 +4190,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6192,7 +6192,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7114,7 +7114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-lock",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11675,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12496,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12631,7 +12631,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16181,7 +16181,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3102,7 +3102,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3437,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "anyhow",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-lock",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-trait",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "anyhow",
  "document",
@@ -3630,6 +3630,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rig-core",
  "rmcp",
+ "security-framework 3.7.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -3748,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3771,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-stream",
@@ -3802,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "anyhow",
@@ -3834,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-trait",
@@ -3863,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "serde",
 ]
@@ -4189,7 +4190,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4559,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6191,7 +6192,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7113,7 +7114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7306,6 +7307,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-websocket",
  "libp2p-yamux",
  "multiaddr",
  "pin-project",
@@ -7739,6 +7741,27 @@ dependencies = [
  "tokio",
  "tracing",
  "void",
+]
+
+[[package]]
+name = "libp2p-websocket"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b953b6803a1f3161a989538974d72511c4e48a4af355337b6fb90723c56c05"
+dependencies = [
+ "either",
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot 0.12.5",
+ "pin-project-lite",
+ "rw-stream-sink",
+ "soketto",
+ "thiserror 1.0.69",
+ "tracing",
+ "url",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -9291,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "anyhow",
@@ -10449,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10484,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10501,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "async-lock",
@@ -10532,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11652,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12424,6 +12447,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "soketto"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e859df029d160cb88608f5d7df7fb4753fd20fdfb4de5644f3d8b8440841721"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1",
+]
+
+[[package]]
 name = "sorted-index-buffer"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12458,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12593,7 +12631,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16143,7 +16181,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=b1e6c2cfd2a38231e128716e5d13e482dbfacd92#b1e6c2cfd2a38231e128716e5d13e482dbfacd92"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3000,7 +3000,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3102,7 +3102,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3422,7 +3422,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3437,7 +3437,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -3486,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3508,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3522,7 +3522,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-lock",
@@ -3560,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-trait",
@@ -3575,7 +3575,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "anyhow",
  "document",
@@ -3749,7 +3749,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3772,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-stream",
@@ -3803,7 +3803,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-trait",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "serde",
 ]
@@ -4190,7 +4190,7 @@ checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4560,7 +4560,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6192,7 +6192,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7114,7 +7114,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -9314,7 +9314,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "anyhow",
@@ -10472,7 +10472,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10507,7 +10507,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10524,7 +10524,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "async-lock",
@@ -10555,7 +10555,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11675,7 +11675,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12496,7 +12496,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12631,7 +12631,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16181,7 +16181,7 @@ checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=624476fd5bb4914ffe016979c773adf90af78567#624476fd5bb4914ffe016979c773adf90af78567"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=25b935b763d7c935ec686a5a43a7affd0e2451fa#25b935b763d7c935ec686a5a43a7affd0e2451fa"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "b1e6c2cfd2a38231e128716e5d13e482dbfacd92" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "624476fd5bb4914ffe016979c773adf90af78567" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "25b935b763d7c935ec686a5a43a7affd0e2451fa" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -104,6 +104,24 @@ pub(crate) struct ProvisionArgs {
         help = "Create a local file-key identity when the home is uninitialized. Production hosts should bootstrap identity first."
     )]
     pub(crate) bootstrap_file_identity: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Create/load a macOS Secure Enclave identity when the home is uninitialized."
+    )]
+    pub(crate) bootstrap_macos_secure_enclave: bool,
+    #[arg(
+        long,
+        value_name = "LABEL",
+        help = "Keychain label for the macOS Secure Enclave identity."
+    )]
+    pub(crate) secure_enclave_label: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum IdentityBackendArg {
+    File,
+    MacosSecureEnclave,
 }
 
 #[derive(clap::Args)]
@@ -134,6 +152,19 @@ pub(crate) struct InitArgs {
     pub(crate) agent_name: String,
     #[arg(long)]
     pub(crate) key_path: Option<PathBuf>,
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = IdentityBackendArg::File,
+        help = "Local identity backend for init metadata."
+    )]
+    pub(crate) identity_backend: IdentityBackendArg,
+    #[arg(
+        long,
+        value_name = "LABEL",
+        help = "Keychain label for --identity-backend macos-secure-enclave."
+    )]
+    pub(crate) secure_enclave_label: Option<String>,
     #[arg(
         long = "inference-url",
         alias = "inference-endpoint",

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -11,8 +11,9 @@ use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::{
     default_behavior_id_for_agent, default_inference_profile_id_for_behavior,
     default_tool_selection_id_for_behavior, ensure_config_bootstrap_schemas, load_agent_behavior,
-    load_agent_principal, upsert_agent_principal, upsert_inference_profile, AgentBehavior,
-    AgentIdentity, InferenceProfile, KeyIdentity, ToolSelectionDocument,
+    load_agent_principal, load_or_create_macos_secure_enclave_identity, upsert_agent_principal,
+    upsert_inference_profile, AgentBehavior, AgentIdentity, InferenceProfile, KeyIdentity,
+    ToolSelectionDocument,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -65,20 +66,17 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
     fs::create_dir_all(&data_dir)
         .with_context(|| format!("creating data directory {}", data_dir.display()))?;
 
-    let key_path = args
-        .key_path
-        .clone()
-        .unwrap_or_else(|| default_key_path(&home_dir, &args.agent_name));
-    if let Some(parent) = key_path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("creating key directory {}", parent.display()))?;
-    }
-
     if args.identity_only {
+        let key_path = args
+            .key_path
+            .clone()
+            .unwrap_or_else(|| default_key_path(&home_dir, &args.agent_name));
         let summary = write_identity_only_home_metadata(IdentityOnlyHomeOptions {
             home: &home_dir,
             agent_name: &args.agent_name,
-            key_path: &key_path,
+            key_path: Some(&key_path),
+            identity_backend: args.identity_backend,
+            secure_enclave_label: args.secure_enclave_label.as_deref(),
             write_tools: args.write_tools,
             tool_root: args.tool_root.as_deref(),
             reset: args.reset,
@@ -97,6 +95,8 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
             "identity": {
                 "agent_did": summary.agent_did,
                 "key_path": summary.key_path,
+                "identity_backend": summary.identity_backend,
+                "secure_enclave_label": summary.secure_enclave_label,
                 "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
             },
             "next_steps": [
@@ -109,29 +109,39 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         return Ok(());
     }
 
-    let identity = Arc::new(
-        KeyIdentity::load_or_create(&key_path, None)
-            .context("creating or loading agent identity key")?,
-    );
-    identity
+    let initialized_identity = load_or_create_home_identity(HomeIdentityOptions {
+        home: &home_dir,
+        agent_name: &args.agent_name,
+        key_path: args.key_path.as_deref(),
+        identity_backend: args.identity_backend,
+        secure_enclave_label: args.secure_enclave_label.as_deref(),
+    })?;
+    initialized_identity
+        .identity
         .sign(b"defra-agent init identity")
         .await
         .context("creating or loading agent identity key")?;
 
-    let node = EmbeddedNode::builder()
-        .data_path(&data_dir)
+    let mut node_builder = EmbeddedNode::builder().data_path(&data_dir);
+    if let Some(node_identity_did) = initialized_identity.node_identity_did.as_ref() {
+        node_builder = node_builder.with_node_identity_did(node_identity_did.clone());
+    }
+    let node = node_builder
         .build()
         .await
         .context("building embedded defra node for init")?;
     ensure_config_bootstrap_schemas(&node).await?;
 
     let access = ConfigAccess::Local(node);
-    let summary = initialize_runtime_home(&access, &args, identity.did()).await?;
+    let summary =
+        initialize_runtime_home(&access, &args, initialized_identity.identity.did()).await?;
     let stored = StoredInitConfig {
         home: home_dir.to_string_lossy().to_string(),
         agent_name: args.agent_name.clone(),
-        agent_did: identity.did().to_string(),
-        key_path: Some(key_path.to_string_lossy().to_string()),
+        agent_did: initialized_identity.identity.did().to_string(),
+        key_path: initialized_identity.key_path.clone(),
+        identity_backend: initialized_identity.identity_backend.clone(),
+        secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
         tool_ceiling: summary.tool_ceiling,
         tool_root: summary.tool_root.clone(),
     };
@@ -146,8 +156,10 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         "status": "initialized",
         "home": home_dir,
         "agent_name": args.agent_name,
-        "agent_did": identity.did(),
-        "key_path": key_path,
+        "agent_did": initialized_identity.identity.did(),
+        "key_path": initialized_identity.key_path,
+        "identity_backend": initialized_identity.identity_backend,
+        "secure_enclave_label": initialized_identity.secure_enclave_label,
         "default_behavior_id": summary.default_behavior_id,
         "tool_selection_id": summary.tool_selection_id,
         "inference_profile_id": summary.inference_profile_id,
@@ -155,8 +167,10 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         "tool_root": summary.tool_root,
         "runtime_state_reset": runtime_state_reset,
         "identity": {
-            "agent_did": identity.did(),
+            "agent_did": initialized_identity.identity.did(),
             "key_path": stored.key_path,
+            "identity_backend": stored.identity_backend,
+            "secure_enclave_label": stored.secure_enclave_label,
             "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
         },
         "next_steps": init_next_steps(&summary),
@@ -170,10 +184,28 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
 pub(crate) struct IdentityOnlyHomeOptions<'a> {
     pub(crate) home: &'a Path,
     pub(crate) agent_name: &'a str,
-    pub(crate) key_path: &'a Path,
+    pub(crate) key_path: Option<&'a Path>,
+    pub(crate) identity_backend: IdentityBackendArg,
+    pub(crate) secure_enclave_label: Option<&'a str>,
     pub(crate) write_tools: bool,
     pub(crate) tool_root: Option<&'a Path>,
     pub(crate) reset: bool,
+}
+
+struct HomeIdentityOptions<'a> {
+    home: &'a Path,
+    agent_name: &'a str,
+    key_path: Option<&'a Path>,
+    identity_backend: IdentityBackendArg,
+    secure_enclave_label: Option<&'a str>,
+}
+
+struct HomeIdentity {
+    identity: Arc<dyn AgentIdentity>,
+    key_path: Option<String>,
+    identity_backend: Option<String>,
+    secure_enclave_label: Option<String>,
+    node_identity_did: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -182,6 +214,8 @@ pub(crate) struct IdentityOnlyHomeSummary {
     pub(crate) agent_name: String,
     pub(crate) agent_did: String,
     pub(crate) key_path: Option<String>,
+    pub(crate) identity_backend: Option<String>,
+    pub(crate) secure_enclave_label: Option<String>,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,
     pub(crate) runtime_state_reset: bool,
@@ -193,16 +227,16 @@ pub(crate) async fn write_identity_only_home_metadata(
     let data_dir = default_data_dir(options.home);
     fs::create_dir_all(&data_dir)
         .with_context(|| format!("creating data directory {}", data_dir.display()))?;
-    if let Some(parent) = options.key_path.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("creating key directory {}", parent.display()))?;
-    }
 
-    let identity = Arc::new(
-        KeyIdentity::load_or_create(options.key_path, None)
-            .context("creating or loading agent identity key")?,
-    );
-    identity
+    let initialized_identity = load_or_create_home_identity(HomeIdentityOptions {
+        home: options.home,
+        agent_name: options.agent_name,
+        key_path: options.key_path,
+        identity_backend: options.identity_backend,
+        secure_enclave_label: options.secure_enclave_label,
+    })?;
+    initialized_identity
+        .identity
         .sign(b"defra-agent init identity")
         .await
         .context("creating or loading agent identity key")?;
@@ -217,12 +251,13 @@ pub(crate) async fn write_identity_only_home_metadata(
             .to_string_lossy()
             .to_string(),
     );
-    let key_path = Some(options.key_path.to_string_lossy().to_string());
     let stored = StoredInitConfig {
         home: options.home.to_string_lossy().to_string(),
         agent_name: options.agent_name.to_string(),
-        agent_did: identity.did().to_string(),
-        key_path: key_path.clone(),
+        agent_did: initialized_identity.identity.did().to_string(),
+        key_path: initialized_identity.key_path.clone(),
+        identity_backend: initialized_identity.identity_backend.clone(),
+        secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
         tool_ceiling,
         tool_root: tool_root.clone(),
     };
@@ -236,12 +271,68 @@ pub(crate) async fn write_identity_only_home_metadata(
     Ok(IdentityOnlyHomeSummary {
         home: options.home.to_string_lossy().to_string(),
         agent_name: options.agent_name.to_string(),
-        agent_did: identity.did().to_string(),
-        key_path,
+        agent_did: initialized_identity.identity.did().to_string(),
+        key_path: initialized_identity.key_path,
+        identity_backend: initialized_identity.identity_backend,
+        secure_enclave_label: initialized_identity.secure_enclave_label,
         tool_ceiling,
         tool_root,
         runtime_state_reset,
     })
+}
+
+fn load_or_create_home_identity(options: HomeIdentityOptions<'_>) -> Result<HomeIdentity> {
+    match options.identity_backend {
+        IdentityBackendArg::File => {
+            let key_path = options
+                .key_path
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| default_key_path(options.home, options.agent_name));
+            if let Some(parent) = key_path.parent() {
+                fs::create_dir_all(parent)
+                    .with_context(|| format!("creating key directory {}", parent.display()))?;
+            }
+            let identity = Arc::new(
+                KeyIdentity::load_or_create(&key_path, None)
+                    .context("creating or loading agent identity key")?,
+            );
+            Ok(HomeIdentity {
+                identity,
+                key_path: Some(key_path.to_string_lossy().to_string()),
+                identity_backend: None,
+                secure_enclave_label: None,
+                node_identity_did: None,
+            })
+        }
+        IdentityBackendArg::MacosSecureEnclave => {
+            if options.key_path.is_some() {
+                anyhow::bail!(
+                    "--key-path cannot be used with --identity-backend macos-secure-enclave"
+                );
+            }
+            let label = options
+                .secure_enclave_label
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--secure-enclave-label is required with --identity-backend macos-secure-enclave"
+                    )
+                })?;
+            let identity = Arc::new(
+                load_or_create_macos_secure_enclave_identity(label, None)
+                    .with_context(|| format!("loading macOS Secure Enclave identity {label}"))?,
+            );
+            let did = identity.did().to_string();
+            Ok(HomeIdentity {
+                identity,
+                key_path: None,
+                identity_backend: Some("macos-secure-enclave".to_string()),
+                secure_enclave_label: Some(label.to_string()),
+                node_identity_did: Some(did),
+            })
+        }
+    }
 }
 
 async fn initialize_runtime_home(

--- a/crates/defra-agent-cli/src/commands/provision.rs
+++ b/crates/defra-agent-cli/src/commands/provision.rs
@@ -18,8 +18,14 @@ use crate::{
 pub(crate) async fn provision(args: ProvisionArgs) -> Result<()> {
     let home_dir = resolve_home_dir(args.home.as_deref());
     let agent_name = resolve_provision_agent_name(&args);
-    let identity =
-        ensure_home_identity(&home_dir, &agent_name, args.bootstrap_file_identity).await?;
+    let identity = ensure_home_identity(
+        &home_dir,
+        &agent_name,
+        args.bootstrap_file_identity,
+        args.bootstrap_macos_secure_enclave,
+        args.secure_enclave_label.as_deref(),
+    )
+    .await?;
 
     let (access, _) = resolve_config_access(Some(&home_dir), None, true).await?;
     let bound = binding::load_bound_manifest(binding::ManifestBindingOptions {
@@ -75,6 +81,8 @@ struct ProvisionIdentityReport {
     agent_name: String,
     agent_did: String,
     key_path: Option<String>,
+    identity_backend: Option<String>,
+    secure_enclave_label: Option<String>,
 }
 
 fn resolve_provision_agent_name(args: &ProvisionArgs) -> String {
@@ -99,7 +107,15 @@ async fn ensure_home_identity(
     home_dir: &Path,
     agent_name: &str,
     bootstrap_file_identity: bool,
+    bootstrap_macos_secure_enclave: bool,
+    secure_enclave_label: Option<&str>,
 ) -> Result<ProvisionIdentityReport> {
+    if bootstrap_file_identity && bootstrap_macos_secure_enclave {
+        anyhow::bail!(
+            "--bootstrap-file-identity and --bootstrap-macos-secure-enclave are mutually exclusive"
+        );
+    }
+
     if let Some(init_config) = read_init_config(home_dir)? {
         let agent_did = init_config.agent_did.trim().to_string();
         if !agent_did.is_empty() && !agent_did.starts_with("did:defra-agent:") {
@@ -108,11 +124,13 @@ async fn ensure_home_identity(
                 agent_name: init_config.agent_name,
                 agent_did,
                 key_path: init_config.key_path,
+                identity_backend: init_config.identity_backend,
+                secure_enclave_label: init_config.secure_enclave_label,
             });
         }
     }
 
-    if !bootstrap_file_identity {
+    if !bootstrap_file_identity && !bootstrap_macos_secure_enclave {
         anyhow::bail!(
             "initialized home identity is required before provisioning {}; run `defra-agent init --identity-only --home {}` for file-key development, or bootstrap the host identity backend first",
             home_dir.display(),
@@ -120,11 +138,21 @@ async fn ensure_home_identity(
         );
     }
 
-    let key_path = default_key_path(home_dir, agent_name);
+    let key_path = if bootstrap_macos_secure_enclave {
+        None
+    } else {
+        Some(default_key_path(home_dir, agent_name))
+    };
     let initialized = write_identity_only_home_metadata(IdentityOnlyHomeOptions {
         home: home_dir,
         agent_name,
-        key_path: &key_path,
+        key_path: key_path.as_deref(),
+        identity_backend: if bootstrap_macos_secure_enclave {
+            IdentityBackendArg::MacosSecureEnclave
+        } else {
+            IdentityBackendArg::File
+        },
+        secure_enclave_label,
         write_tools: false,
         tool_root: None,
         reset: false,
@@ -140,6 +168,8 @@ fn report_from_initialized_identity(summary: IdentityOnlyHomeSummary) -> Provisi
         agent_name: summary.agent_name,
         agent_did: summary.agent_did,
         key_path: summary.key_path,
+        identity_backend: summary.identity_backend,
+        secure_enclave_label: summary.secure_enclave_label,
     }
 }
 

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::{
-    ensure_runtime_schemas, AgentIdentity, DefraAgent, DocumentRuntimeOptions, KeyIdentity,
-    McpPool, ProcessLifecycleObserver, ProcessLifecycleState, ToolCeiling,
+    ensure_runtime_schemas, load_macos_secure_enclave_identity, AgentIdentity, DefraAgent,
+    DocumentRuntimeOptions, KeyIdentity, McpPool, ProcessLifecycleObserver, ProcessLifecycleState,
+    ToolCeiling,
 };
 use serde_json::{json, Value};
 use tokio::sync::watch;
@@ -65,7 +66,9 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
         .clone()
         .or_else(|| init_config.as_ref().map(|config| config.agent_name.clone()))
         .unwrap_or_else(|| DEFAULT_AGENT_NAME.to_string());
-    let identity = resolve_server_identity(&args, init_config.as_ref(), &home_dir, &agent_name)?;
+    let server_identity =
+        resolve_server_identity(&args, init_config.as_ref(), &home_dir, &agent_name)?;
+    let identity = server_identity.identity;
     let effective_tool_ceiling = args
         .tool_ceiling
         .or_else(|| init_config.as_ref().map(|config| config.tool_ceiling))
@@ -107,6 +110,9 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
         defra_node::HttpConfig::with_addr(http_addr)
             .with_extra_routes(runtime_contract_router(graphql_url.clone())),
     );
+    if let Some(node_identity_did) = server_identity.node_identity_did.as_ref() {
+        node_builder = node_builder.with_node_identity_did(node_identity_did.clone());
+    }
     if let Some(config) = p2p_config {
         node_builder = node_builder.with_p2p(config);
     }
@@ -240,12 +246,17 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
         .context("joining defra-agent runtime task")?
 }
 
+struct ServerIdentity {
+    identity: Arc<dyn AgentIdentity>,
+    node_identity_did: Option<String>,
+}
+
 fn resolve_server_identity(
     args: &ServeArgs,
     init_config: Option<&StoredInitConfig>,
     home_dir: &Path,
     agent_name: &str,
-) -> Result<Arc<dyn AgentIdentity>> {
+) -> Result<ServerIdentity> {
     if let Some(config) = init_config {
         let agent_did = config.agent_did.trim();
         if is_real_agent_did(agent_did)
@@ -256,11 +267,7 @@ fn resolve_server_identity(
                 .map(str::trim)
                 .is_none_or(str::is_empty)
         {
-            anyhow::bail!(
-                "initialized home {} has agent DID {} but no key_path. Standalone `defra-agent server` cannot load a non-file identity from init.json yet; start this runtime from a host process that registers the signer in-process, or bootstrap a file-key identity for standalone development.",
-                home_dir.display(),
-                agent_did
-            );
+            return resolve_no_key_server_identity(config, home_dir);
         }
     }
 
@@ -275,7 +282,56 @@ fn resolve_server_identity(
             .context("creating or loading agent identity key")?,
     );
     ensure_identity_matches_init_config(init_config, identity.did())?;
-    Ok(identity)
+    Ok(ServerIdentity {
+        identity,
+        node_identity_did: None,
+    })
+}
+
+fn resolve_no_key_server_identity(
+    config: &StoredInitConfig,
+    home_dir: &Path,
+) -> Result<ServerIdentity> {
+    let backend = config
+        .identity_backend
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "initialized home {} has agent DID {} but no key_path or identity_backend",
+                home_dir.display(),
+                config.agent_did
+            )
+        })?;
+    match backend {
+        "macos-secure-enclave" => {
+            let label = config
+                .secure_enclave_label
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "initialized home {} uses macos-secure-enclave but has no secure_enclave_label",
+                        home_dir.display()
+                    )
+                })?;
+            let identity = Arc::new(
+                load_macos_secure_enclave_identity(label, None)
+                    .with_context(|| format!("loading macOS Secure Enclave identity {label}"))?,
+            );
+            ensure_identity_matches_init_config(Some(config), identity.did())?;
+            Ok(ServerIdentity {
+                node_identity_did: Some(identity.did().to_string()),
+                identity,
+            })
+        }
+        other => anyhow::bail!(
+            "initialized home {} uses unsupported identity_backend {other:?} without key_path",
+            home_dir.display()
+        ),
+    }
 }
 
 fn default_p2p_transport() -> String {

--- a/crates/defra-agent-cli/src/http/prometheus.rs
+++ b/crates/defra-agent-cli/src/http/prometheus.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
 use crate::post_graphql;
@@ -42,9 +42,16 @@ pub(crate) struct MetricsBackendRow {
     pub(crate) max_concurrent: i64,
     #[serde(default)]
     pub(crate) max_queue_depth: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "null_string_as_unknown")]
     pub(crate) probe_status: String,
     pub(crate) last_probe: Option<String>,
+}
+
+fn null_string_as_unknown<'de, D>(deserializer: D) -> std::result::Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_else(|| "unknown".to_string()))
 }
 
 pub(crate) async fn render_prometheus_metrics(graphql: &str) -> Result<String> {
@@ -320,4 +327,27 @@ fn rfc3339_timestamp_seconds(value: &str) -> Option<i64> {
     chrono::DateTime::parse_from_rfc3339(value)
         .ok()
         .map(|timestamp| timestamp.timestamp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metrics_query_data_treats_null_probe_status_as_unknown() {
+        let data: MetricsQueryData = serde_json::from_value(serde_json::json!({
+            "AgentRuntime": [],
+            "InferenceBackend": [{
+                "backend_id": "workstation-1",
+                "enabled": true,
+                "max_concurrent": 2,
+                "max_queue_depth": 8,
+                "probe_status": null,
+                "last_probe": null
+            }]
+        }))
+        .expect("metrics query data should decode null probe_status");
+
+        assert_eq!(data.inference_backends[0].probe_status, "unknown");
+    }
 }

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -81,6 +81,7 @@ Examples:
   defra-agent init --backend-preset openai --model-name MODEL
   defra-agent init --inference-url $INFERENCE_ENDPOINT --model-name MODEL --write-tools
   defra-agent init --identity-only
+  defra-agent init --identity-only --identity-backend macos-secure-enclave --secure-enclave-label LABEL
 
 Next:
   ollama pull gemma4-26b-a4b
@@ -95,9 +96,10 @@ Examples:
   defra-agent provision --home /path/to/home --root infra/agents/HOST/AGENT
   defra-agent provision --root infra/agents/mini-1/mini-1-steward
   defra-agent provision --root infra/agents/dev/dev-agent --bootstrap-file-identity
+  defra-agent provision --root infra/agents/mini-1/mini-1-steward --bootstrap-macos-secure-enclave --secure-enclave-label LABEL
 
 Production low-level flow:
-  bootstrap the host identity backend so init.json contains the real agent DID
+  defra-agent init --identity-only --identity-backend macos-secure-enclave --secure-enclave-label LABEL
   defra-agent config apply --root <root> --home <home> --bind-agent-did home
   defra-agent config diff --root <root> --home <home> --bind-agent-did home
 
@@ -118,8 +120,8 @@ Common flow:
   defra-agent chat
 
 Identity note:
-  Standalone server startup currently requires a loadable file key.
-  Homes with a real agent DID and no key_path must be started by a host identity backend that registers the signer in-process before constructing the runtime.";
+  Standalone server startup supports file keys and macOS Secure Enclave homes initialized with identity_backend=macos-secure-enclave.
+  Homes with a real agent DID and no key_path must include a supported identity_backend and label in init.json.";
 const CHAT_AFTER_HELP: &str = "\
 Examples:
   defra-agent chat

--- a/crates/defra-agent-cli/src/shared.rs
+++ b/crates/defra-agent-cli/src/shared.rs
@@ -54,6 +54,10 @@ pub(crate) struct StoredInitConfig {
     pub(crate) agent_name: String,
     pub(crate) agent_did: String,
     pub(crate) key_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) identity_backend: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) secure_enclave_label: Option<String>,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,
 }

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -188,16 +188,8 @@ async fn server_rejects_real_initialized_did_without_key_path() -> Result<()> {
         ],
     )?;
     assert!(
-        stderr.contains("no key_path"),
-        "expected no-key-path error, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("cannot load a non-file identity"),
-        "expected non-file identity load error, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("registers the signer in-process"),
-        "expected host-process signer hint, got:\n{stderr}"
+        stderr.contains("no key_path or identity_backend"),
+        "expected no-key-path/backend error, got:\n{stderr}"
     );
     assert!(
         !agent_home.join("keys").exists(),

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -37,6 +37,9 @@ reqwest.workspace = true
 rmcp = { version = "1.2.0", features = ["client", "transport-streamable-http-client-reqwest", "reqwest"] }
 tokio-util = "0.7"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
+
 [dev-dependencies]
 tempfile = "3"
 proptest = "1"

--- a/crates/defra-agent/src/identity.rs
+++ b/crates/defra-agent/src/identity.rs
@@ -210,6 +210,11 @@ fn register_public_key(did: &str, key_type: crypto::KeyType, public_key: Vec<u8>
 }
 
 #[cfg(target_os = "macos")]
+const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+#[cfg(target_os = "macos")]
+const ERR_SEC_MISSING_ENTITLEMENT: i32 = -34018;
+
+#[cfg(target_os = "macos")]
 fn register_macos_secure_enclave_identity(
     label: &str,
     create_if_missing: bool,
@@ -300,11 +305,23 @@ fn find_macos_secure_enclave_key(label: &str) -> Result<Option<security_framewor
     search
         .key_class(KeyClass::private())
         .label(label)
+        .ignore_legacy_keychains()
         .load_refs(true)
         .limit(2);
-    let keys = search.search().with_context(|| {
-        format!("searching keychain for macOS Secure Enclave key label {label}")
-    })?;
+    let keys = match search.search() {
+        Ok(keys) => keys,
+        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => {
+            return Ok(None);
+        }
+        Err(error) if error.code() == ERR_SEC_MISSING_ENTITLEMENT => {
+            return Err(missing_secure_enclave_entitlement_error(label));
+        }
+        Err(error) => {
+            return Err(anyhow::Error::from(error)).with_context(|| {
+                format!("searching keychain for macOS Secure Enclave key label {label}")
+            });
+        }
+    };
     let mut matches = keys.into_iter().filter_map(|item| match item {
         SearchResult::Ref(Reference::Key(key)) => Some(key),
         _ => None,
@@ -318,19 +335,37 @@ fn find_macos_secure_enclave_key(label: &str) -> Result<Option<security_framewor
 
 #[cfg(target_os = "macos")]
 fn create_macos_secure_enclave_key(label: &str) -> Result<security_framework::key::SecKey> {
+    use security_framework::access_control::SecAccessControl;
     use security_framework::item::Location;
     use security_framework::key::{GenerateKeyOptions, KeyType, SecKey, Token};
+    use security_framework::passwords_options::AccessControlOptions;
 
+    let access_control =
+        SecAccessControl::create_with_flags(AccessControlOptions::PRIVATE_KEY_USAGE.bits())
+            .context("creating Secure Enclave key access control")?;
     let mut options = GenerateKeyOptions::default();
     options
         .set_key_type(KeyType::ec())
         .set_size_in_bits(256)
         .set_label(label)
+        .set_access_control(access_control)
         .set_token(Token::SecureEnclave)
         .set_location(Location::DataProtectionKeychain);
-    SecKey::new(&options)
-        .map_err(|error| anyhow!("{error}"))
-        .with_context(|| format!("creating macOS Secure Enclave key label {label}"))
+    match SecKey::new(&options) {
+        Ok(key) => Ok(key),
+        Err(error) if error.code() == ERR_SEC_MISSING_ENTITLEMENT as isize => {
+            Err(missing_secure_enclave_entitlement_error(label))
+        }
+        Err(error) => Err(anyhow!("{error}"))
+            .with_context(|| format!("creating macOS Secure Enclave key label {label}")),
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn missing_secure_enclave_entitlement_error(label: &str) -> anyhow::Error {
+    anyhow!(
+        "macOS Secure Enclave key label {label} requires a codesigned binary with Data Protection keychain access-group entitlements"
+    )
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/defra-agent/src/identity.rs
+++ b/crates/defra-agent/src/identity.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, OnceLock, RwLock};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use crypto::Key;
-use defra_core::signing::{SigningConfig, SigningKeyType};
+use defra_core::signing::{RemoteSigner, SigningConfig, SigningKeyType};
 use identity::{FullIdentity as _, Identity as _, RawIdentity};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -124,6 +124,20 @@ impl RegisteredIdentity {
     }
 }
 
+pub fn load_or_create_macos_secure_enclave_identity(
+    label: &str,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    register_macos_secure_enclave_identity(label, true, service_account)
+}
+
+pub fn load_macos_secure_enclave_identity(
+    label: &str,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    register_macos_secure_enclave_identity(label, false, service_account)
+}
+
 impl std::fmt::Debug for RegisteredIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RegisteredIdentity")
@@ -193,6 +207,157 @@ fn register_public_key(did: &str, key_type: crypto::KeyType, public_key: Vec<u8>
                 bytes: public_key,
             },
         );
+}
+
+#[cfg(target_os = "macos")]
+fn register_macos_secure_enclave_identity(
+    label: &str,
+    create_if_missing: bool,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    let signer = MacosSecureEnclaveSigner::load(label, create_if_missing)?;
+    let did = signer.did.clone();
+    let public_key_bytes = signer.public_key_bytes.clone();
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Secp256r1,
+            private_key_bytes: Vec::new(),
+            public_key_bytes: public_key_bytes.clone(),
+            public_key_hex: lowercase_hex(&public_key_bytes),
+            remote_signer: Some(Arc::new(signer)),
+            signing_authorization: None,
+        },
+    );
+    RegisteredIdentity::from_registered_did(did, service_account)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn register_macos_secure_enclave_identity(
+    _label: &str,
+    _create_if_missing: bool,
+    _service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    anyhow::bail!("macos-secure-enclave identity backend is only available on macOS")
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Debug)]
+struct MacosSecureEnclaveSigner {
+    label: String,
+    key: security_framework::key::SecKey,
+    did: String,
+    public_key_bytes: Vec<u8>,
+}
+
+#[cfg(target_os = "macos")]
+impl MacosSecureEnclaveSigner {
+    fn load(label: &str, create_if_missing: bool) -> Result<Self> {
+        let key = match find_macos_secure_enclave_key(label)? {
+            Some(key) => key,
+            None if create_if_missing => create_macos_secure_enclave_key(label)?,
+            None => anyhow::bail!("macOS Secure Enclave key not found for label {label}"),
+        };
+        let public_key_bytes = public_key_bytes_for_sec_key(&key)
+            .with_context(|| format!("loading public key for Secure Enclave key {label}"))?;
+        let did = did_for_secp256r1_public_key(&public_key_bytes)
+            .with_context(|| format!("deriving DID for Secure Enclave key {label}"))?;
+        Ok(Self {
+            label: label.to_string(),
+            key,
+            did,
+            public_key_bytes,
+        })
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl RemoteSigner for MacosSecureEnclaveSigner {
+    fn sign_sync(
+        &self,
+        data: &[u8],
+        _authorization: Option<&defra_core::signing::SigningAuthorization>,
+    ) -> std::result::Result<Vec<u8>, String> {
+        self.key
+            .create_signature(
+                security_framework::key::Algorithm::ECDSASignatureMessageX962SHA256,
+                data,
+            )
+            .map_err(|error| {
+                format!(
+                    "Secure Enclave signing failed for label {}: {error}",
+                    self.label
+                )
+            })
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn find_macos_secure_enclave_key(label: &str) -> Result<Option<security_framework::key::SecKey>> {
+    use security_framework::item::{ItemSearchOptions, KeyClass, Reference, SearchResult};
+
+    let mut search = ItemSearchOptions::new();
+    search
+        .key_class(KeyClass::private())
+        .label(label)
+        .load_refs(true)
+        .limit(2);
+    let keys = search.search().with_context(|| {
+        format!("searching keychain for macOS Secure Enclave key label {label}")
+    })?;
+    let mut matches = keys.into_iter().filter_map(|item| match item {
+        SearchResult::Ref(Reference::Key(key)) => Some(key),
+        _ => None,
+    });
+    let first = matches.next();
+    if matches.next().is_some() {
+        anyhow::bail!("multiple keychain private keys found for label {label}");
+    }
+    Ok(first)
+}
+
+#[cfg(target_os = "macos")]
+fn create_macos_secure_enclave_key(label: &str) -> Result<security_framework::key::SecKey> {
+    use security_framework::item::Location;
+    use security_framework::key::{GenerateKeyOptions, KeyType, SecKey, Token};
+
+    let mut options = GenerateKeyOptions::default();
+    options
+        .set_key_type(KeyType::ec())
+        .set_size_in_bits(256)
+        .set_label(label)
+        .set_token(Token::SecureEnclave)
+        .set_location(Location::DataProtectionKeychain);
+    SecKey::new(&options)
+        .map_err(|error| anyhow!("{error}"))
+        .with_context(|| format!("creating macOS Secure Enclave key label {label}"))
+}
+
+#[cfg(target_os = "macos")]
+fn public_key_bytes_for_sec_key(key: &security_framework::key::SecKey) -> Result<Vec<u8>> {
+    let public_key = key
+        .public_key()
+        .ok_or_else(|| anyhow!("Secure Enclave key has no public key"))?;
+    let data = public_key
+        .external_representation()
+        .ok_or_else(|| anyhow!("Secure Enclave public key is not exportable"))?;
+    Ok(data.to_vec())
+}
+
+fn did_for_secp256r1_public_key(public_key_bytes: &[u8]) -> Result<String> {
+    let public_key = crypto::public_key_from_bytes(crypto::KeyType::Secp256r1, public_key_bytes)
+        .map_err(anyhow::Error::from)?;
+    public_key.did().map_err(anyhow::Error::from)
+}
+
+fn lowercase_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
 }
 
 fn known_public_key_for_did(did: &str) -> Result<KnownPublicKey> {

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -61,7 +61,10 @@ pub use document_config::{
 };
 pub use health_checker::{spawn_health_checker, HealthStatus, ServiceHealth, ServiceHealthMap};
 pub use hook::{DefraSessionHook, FailurePolicy, HookStats};
-pub use identity::{AgentIdentity, KeyIdentity, RegisteredIdentity, ServiceAccount};
+pub use identity::{
+    load_macos_secure_enclave_identity, load_or_create_macos_secure_enclave_identity,
+    AgentIdentity, KeyIdentity, RegisteredIdentity, ServiceAccount,
+};
 pub use interrupt::{fetch_interrupt_requested_at, interrupt_request};
 pub use lifecycle::{write_manual_agent_request, RecoveryReport, RequestLifecycle};
 pub use mcp_pool::McpPool;


### PR DESCRIPTION
## Summary
- add macOS Secure Enclave-backed registered identities for defra-agent runtimes
- persist `identity_backend` and `secure_enclave_label` in `init.json` for no-key homes
- teach init/provision/server to bootstrap and load macOS Secure Enclave identities, then pass the registered DID into the embedded DefraDB node
- keep file-key development behavior intact and fail closed for unsupported no-key homes
- harden macOS keychain handling so missing labels can create keys and missing Data Protection keychain entitlements produce an actionable error
- make runtime `/healthz` and `/metrics` tolerate `null` backend `probe_status` from portable manifests as `unknown`

## Dependency
- `defra-node` registered node identity support merged in sourcenetwork/defradb.rs#927.
- `Cargo.toml` now follows DefraDB `main`; `Cargo.lock` resolves that dependency set to merge commit `25b935b763d7c935ec686a5a43a7affd0e2451fa`.

## Local smoke
- `provision --bootstrap-macos-secure-enclave` against `infra/agents/amygdalabook/amygdalabook-steward` reaches macOS keychain setup, then fails closed under the unsigned local debug binary with: `requires a codesigned binary with Data Protection keychain access-group entitlements`.
- The same manifest provisions with `--bootstrap-file-identity`, starts `defra-agent server`, returns `/healthz` 200 with degraded backend status, and renders `/metrics` with backend `probe_status="unknown"`.

## Tests
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo check --locked -p defra-agent-cli -p defra-agent`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p defra-agent --lib --tests`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p defra-agent-cli --test cli_init --test cli_provision --test cli_server --test cli_help`
- `cargo test -p defra-agent-cli http::prometheus::tests::metrics_query_data_treats_null_probe_status_as_unknown`
- `cargo fmt --all --check`
- `git diff --check`
