### PR TITLE
Add macOS keychain agent identity backend

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -112,6 +112,18 @@ pub(crate) struct ProvisionArgs {
     pub(crate) bootstrap_macos_secure_enclave: bool,
     #[arg(
         long,
+        default_value_t = false,
+        help = "Create/load a macOS login-keychain software identity when the home is uninitialized."
+    )]
+    pub(crate) bootstrap_macos_keychain: bool,
+    #[arg(
+        long,
+        value_name = "LABEL",
+        help = "Keychain label for the macOS keychain identity."
+    )]
+    pub(crate) keychain_label: Option<String>,
+    #[arg(
+        long,
         value_name = "LABEL",
         help = "Keychain label for the macOS Secure Enclave identity."
     )]
@@ -121,6 +133,7 @@ pub(crate) struct ProvisionArgs {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
 pub(crate) enum IdentityBackendArg {
     File,
+    MacosKeychain,
     MacosSecureEnclave,
 }
 
@@ -159,6 +172,12 @@ pub(crate) struct InitArgs {
         help = "Local identity backend for init metadata."
     )]
     pub(crate) identity_backend: IdentityBackendArg,
+    #[arg(
+        long,
+        value_name = "LABEL",
+        help = "Keychain label for --identity-backend macos-keychain."
+    )]
+    pub(crate) keychain_label: Option<String>,
     #[arg(
         long,
         value_name = "LABEL",

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -10,9 +10,9 @@ use defra_agent::config::{
 use defra_agent::{
     default_behavior_id_for_agent, default_inference_profile_id_for_behavior,
     default_tool_selection_id_for_behavior, ensure_config_bootstrap_schemas, load_agent_behavior,
-    load_agent_principal, load_or_create_macos_secure_enclave_identity, upsert_agent_principal,
-    upsert_inference_profile, AgentBehavior, AgentIdentity, InferenceProfile, KeyIdentity,
-    ToolSelectionDocument,
+    load_agent_principal, load_or_create_macos_keychain_identity,
+    load_or_create_macos_secure_enclave_identity, upsert_agent_principal, upsert_inference_profile,
+    AgentBehavior, AgentIdentity, InferenceProfile, KeyIdentity, ToolSelectionDocument,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -66,15 +66,20 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         .with_context(|| format!("creating data directory {}", data_dir.display()))?;
 
     if args.identity_only {
-        let key_path = args
-            .key_path
-            .clone()
-            .unwrap_or_else(|| default_key_path(&home_dir, &args.agent_name));
+        if args.identity_backend != IdentityBackendArg::File && args.key_path.is_some() {
+            anyhow::bail!("--key-path cannot be used with non-file identity backends");
+        }
+        let key_path = (args.identity_backend == IdentityBackendArg::File).then(|| {
+            args.key_path
+                .clone()
+                .unwrap_or_else(|| default_key_path(&home_dir, &args.agent_name))
+        });
         let summary = write_identity_only_home_metadata(IdentityOnlyHomeOptions {
             home: &home_dir,
             agent_name: &args.agent_name,
-            key_path: Some(&key_path),
+            key_path: key_path.as_deref(),
             identity_backend: args.identity_backend,
+            keychain_label: args.keychain_label.as_deref(),
             secure_enclave_label: args.secure_enclave_label.as_deref(),
             write_tools: args.write_tools,
             tool_root: args.tool_root.as_deref(),
@@ -95,6 +100,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
                 "agent_did": summary.agent_did,
                 "key_path": summary.key_path,
                 "identity_backend": summary.identity_backend,
+                "keychain_label": summary.keychain_label,
                 "secure_enclave_label": summary.secure_enclave_label,
                 "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
             },
@@ -113,6 +119,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         agent_name: &args.agent_name,
         key_path: args.key_path.as_deref(),
         identity_backend: args.identity_backend,
+        keychain_label: args.keychain_label.as_deref(),
         secure_enclave_label: args.secure_enclave_label.as_deref(),
     })?;
     initialized_identity
@@ -140,6 +147,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         agent_did: initialized_identity.identity.did().to_string(),
         key_path: initialized_identity.key_path.clone(),
         identity_backend: initialized_identity.identity_backend.clone(),
+        keychain_label: initialized_identity.keychain_label.clone(),
         secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
         tool_ceiling: summary.tool_ceiling,
         tool_root: summary.tool_root.clone(),
@@ -158,6 +166,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         "agent_did": initialized_identity.identity.did(),
         "key_path": initialized_identity.key_path,
         "identity_backend": initialized_identity.identity_backend,
+        "keychain_label": initialized_identity.keychain_label,
         "secure_enclave_label": initialized_identity.secure_enclave_label,
         "default_behavior_id": summary.default_behavior_id,
         "tool_selection_id": summary.tool_selection_id,
@@ -169,6 +178,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
             "agent_did": initialized_identity.identity.did(),
             "key_path": stored.key_path,
             "identity_backend": stored.identity_backend,
+            "keychain_label": stored.keychain_label,
             "secure_enclave_label": stored.secure_enclave_label,
             "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
         },
@@ -185,6 +195,7 @@ pub(crate) struct IdentityOnlyHomeOptions<'a> {
     pub(crate) agent_name: &'a str,
     pub(crate) key_path: Option<&'a Path>,
     pub(crate) identity_backend: IdentityBackendArg,
+    pub(crate) keychain_label: Option<&'a str>,
     pub(crate) secure_enclave_label: Option<&'a str>,
     pub(crate) write_tools: bool,
     pub(crate) tool_root: Option<&'a Path>,
@@ -196,6 +207,7 @@ struct HomeIdentityOptions<'a> {
     agent_name: &'a str,
     key_path: Option<&'a Path>,
     identity_backend: IdentityBackendArg,
+    keychain_label: Option<&'a str>,
     secure_enclave_label: Option<&'a str>,
 }
 
@@ -203,6 +215,7 @@ struct HomeIdentity {
     identity: Arc<dyn AgentIdentity>,
     key_path: Option<String>,
     identity_backend: Option<String>,
+    keychain_label: Option<String>,
     secure_enclave_label: Option<String>,
     node_identity_did: Option<String>,
 }
@@ -214,6 +227,7 @@ pub(crate) struct IdentityOnlyHomeSummary {
     pub(crate) agent_did: String,
     pub(crate) key_path: Option<String>,
     pub(crate) identity_backend: Option<String>,
+    pub(crate) keychain_label: Option<String>,
     pub(crate) secure_enclave_label: Option<String>,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,
@@ -232,6 +246,7 @@ pub(crate) async fn write_identity_only_home_metadata(
         agent_name: options.agent_name,
         key_path: options.key_path,
         identity_backend: options.identity_backend,
+        keychain_label: options.keychain_label,
         secure_enclave_label: options.secure_enclave_label,
     })?;
     initialized_identity
@@ -256,6 +271,7 @@ pub(crate) async fn write_identity_only_home_metadata(
         agent_did: initialized_identity.identity.did().to_string(),
         key_path: initialized_identity.key_path.clone(),
         identity_backend: initialized_identity.identity_backend.clone(),
+        keychain_label: initialized_identity.keychain_label.clone(),
         secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
         tool_ceiling,
         tool_root: tool_root.clone(),
@@ -273,6 +289,7 @@ pub(crate) async fn write_identity_only_home_metadata(
         agent_did: initialized_identity.identity.did().to_string(),
         key_path: initialized_identity.key_path,
         identity_backend: initialized_identity.identity_backend,
+        keychain_label: initialized_identity.keychain_label,
         secure_enclave_label: initialized_identity.secure_enclave_label,
         tool_ceiling,
         tool_root,
@@ -299,8 +316,36 @@ fn load_or_create_home_identity(options: HomeIdentityOptions<'_>) -> Result<Home
                 identity,
                 key_path: Some(key_path.to_string_lossy().to_string()),
                 identity_backend: None,
+                keychain_label: None,
                 secure_enclave_label: None,
                 node_identity_did: None,
+            })
+        }
+        IdentityBackendArg::MacosKeychain => {
+            if options.key_path.is_some() {
+                anyhow::bail!("--key-path cannot be used with --identity-backend macos-keychain");
+            }
+            let label = options
+                .keychain_label
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--keychain-label is required with --identity-backend macos-keychain"
+                    )
+                })?;
+            let identity = Arc::new(
+                load_or_create_macos_keychain_identity(label, None)
+                    .with_context(|| format!("loading macOS keychain identity {label}"))?,
+            );
+            let did = identity.did().to_string();
+            Ok(HomeIdentity {
+                identity,
+                key_path: None,
+                identity_backend: Some("macos-keychain".to_string()),
+                keychain_label: Some(label.to_string()),
+                secure_enclave_label: None,
+                node_identity_did: Some(did),
             })
         }
         IdentityBackendArg::MacosSecureEnclave => {
@@ -327,6 +372,7 @@ fn load_or_create_home_identity(options: HomeIdentityOptions<'_>) -> Result<Home
                 identity,
                 key_path: None,
                 identity_backend: Some("macos-secure-enclave".to_string()),
+                keychain_label: None,
                 secure_enclave_label: Some(label.to_string()),
                 node_identity_did: Some(did),
             })

--- a/crates/defra-agent-cli/src/commands/provision.rs
+++ b/crates/defra-agent-cli/src/commands/provision.rs
@@ -22,7 +22,9 @@ pub(crate) async fn provision(args: ProvisionArgs) -> Result<()> {
         &home_dir,
         &agent_name,
         args.bootstrap_file_identity,
+        args.bootstrap_macos_keychain,
         args.bootstrap_macos_secure_enclave,
+        args.keychain_label.as_deref(),
         args.secure_enclave_label.as_deref(),
     )
     .await?;
@@ -82,6 +84,7 @@ struct ProvisionIdentityReport {
     agent_did: String,
     key_path: Option<String>,
     identity_backend: Option<String>,
+    keychain_label: Option<String>,
     secure_enclave_label: Option<String>,
 }
 
@@ -107,13 +110,21 @@ async fn ensure_home_identity(
     home_dir: &Path,
     agent_name: &str,
     bootstrap_file_identity: bool,
+    bootstrap_macos_keychain: bool,
     bootstrap_macos_secure_enclave: bool,
+    keychain_label: Option<&str>,
     secure_enclave_label: Option<&str>,
 ) -> Result<ProvisionIdentityReport> {
-    if bootstrap_file_identity && bootstrap_macos_secure_enclave {
-        anyhow::bail!(
-            "--bootstrap-file-identity and --bootstrap-macos-secure-enclave are mutually exclusive"
-        );
+    let bootstrap_count = [
+        bootstrap_file_identity,
+        bootstrap_macos_keychain,
+        bootstrap_macos_secure_enclave,
+    ]
+    .into_iter()
+    .filter(|value| *value)
+    .count();
+    if bootstrap_count > 1 {
+        anyhow::bail!("bootstrap identity flags are mutually exclusive");
     }
 
     if let Some(init_config) = read_init_config(home_dir)? {
@@ -125,12 +136,13 @@ async fn ensure_home_identity(
                 agent_did,
                 key_path: init_config.key_path,
                 identity_backend: init_config.identity_backend,
+                keychain_label: init_config.keychain_label,
                 secure_enclave_label: init_config.secure_enclave_label,
             });
         }
     }
 
-    if !bootstrap_file_identity && !bootstrap_macos_secure_enclave {
+    if !bootstrap_file_identity && !bootstrap_macos_keychain && !bootstrap_macos_secure_enclave {
         anyhow::bail!(
             "initialized home identity is required before provisioning {}; run `defra-agent init --identity-only --home {}` for file-key development, or bootstrap the host identity backend first",
             home_dir.display(),
@@ -138,7 +150,7 @@ async fn ensure_home_identity(
         );
     }
 
-    let key_path = if bootstrap_macos_secure_enclave {
+    let key_path = if bootstrap_macos_keychain || bootstrap_macos_secure_enclave {
         None
     } else {
         Some(default_key_path(home_dir, agent_name))
@@ -149,9 +161,12 @@ async fn ensure_home_identity(
         key_path: key_path.as_deref(),
         identity_backend: if bootstrap_macos_secure_enclave {
             IdentityBackendArg::MacosSecureEnclave
+        } else if bootstrap_macos_keychain {
+            IdentityBackendArg::MacosKeychain
         } else {
             IdentityBackendArg::File
         },
+        keychain_label,
         secure_enclave_label,
         write_tools: false,
         tool_root: None,
@@ -169,6 +184,7 @@ fn report_from_initialized_identity(summary: IdentityOnlyHomeSummary) -> Provisi
         agent_did: summary.agent_did,
         key_path: summary.key_path,
         identity_backend: summary.identity_backend,
+        keychain_label: summary.keychain_label,
         secure_enclave_label: summary.secure_enclave_label,
     }
 }

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::{
-    ensure_runtime_schemas, load_macos_secure_enclave_identity, AgentIdentity, DefraAgent,
-    DocumentRuntimeOptions, KeyIdentity, McpPool, ProcessLifecycleObserver, ProcessLifecycleState,
-    ToolCeiling,
+    ensure_runtime_schemas, load_macos_keychain_identity, load_macos_secure_enclave_identity,
+    AgentIdentity, DefraAgent, DocumentRuntimeOptions, KeyIdentity, McpPool,
+    ProcessLifecycleObserver, ProcessLifecycleState, ToolCeiling,
 };
 use serde_json::{json, Value};
 use tokio::sync::watch;
@@ -305,6 +305,28 @@ fn resolve_no_key_server_identity(
             )
         })?;
     match backend {
+        "macos-keychain" => {
+            let label = config
+                .keychain_label
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "initialized home {} uses macos-keychain but has no keychain_label",
+                        home_dir.display()
+                    )
+                })?;
+            let identity = Arc::new(
+                load_macos_keychain_identity(label, None)
+                    .with_context(|| format!("loading macOS keychain identity {label}"))?,
+            );
+            ensure_identity_matches_init_config(Some(config), identity.did())?;
+            Ok(ServerIdentity {
+                node_identity_did: Some(identity.did().to_string()),
+                identity,
+            })
+        }
         "macos-secure-enclave" => {
             let label = config
                 .secure_enclave_label

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -81,6 +81,7 @@ Examples:
   defra-agent init --backend-preset openai --model-name MODEL
   defra-agent init --inference-url $INFERENCE_ENDPOINT --model-name MODEL --write-tools
   defra-agent init --identity-only
+  defra-agent init --identity-only --identity-backend macos-keychain --keychain-label LABEL
   defra-agent init --identity-only --identity-backend macos-secure-enclave --secure-enclave-label LABEL
 
 Next:
@@ -96,9 +97,11 @@ Examples:
   defra-agent provision --home /path/to/home --root infra/agents/HOST/AGENT
   defra-agent provision --root infra/agents/mini-1/mini-1-steward
   defra-agent provision --root infra/agents/dev/dev-agent --bootstrap-file-identity
+  defra-agent provision --root infra/agents/mini-1/mini-1-steward --bootstrap-macos-keychain --keychain-label LABEL
   defra-agent provision --root infra/agents/mini-1/mini-1-steward --bootstrap-macos-secure-enclave --secure-enclave-label LABEL
 
 Production low-level flow:
+  defra-agent init --identity-only --identity-backend macos-keychain --keychain-label LABEL
   defra-agent init --identity-only --identity-backend macos-secure-enclave --secure-enclave-label LABEL
   defra-agent config apply --root <root> --home <home> --bind-agent-did home
   defra-agent config diff --root <root> --home <home> --bind-agent-did home
@@ -120,7 +123,7 @@ Common flow:
   defra-agent chat
 
 Identity note:
-  Standalone server startup supports file keys and macOS Secure Enclave homes initialized with identity_backend=macos-secure-enclave.
+  Standalone server startup supports file keys, macOS keychain software-key homes initialized with identity_backend=macos-keychain, and macOS Secure Enclave homes initialized with identity_backend=macos-secure-enclave.
   Homes with a real agent DID and no key_path must include a supported identity_backend and label in init.json.";
 const CHAT_AFTER_HELP: &str = "\
 Examples:

--- a/crates/defra-agent-cli/src/shared.rs
+++ b/crates/defra-agent-cli/src/shared.rs
@@ -57,6 +57,8 @@ pub(crate) struct StoredInitConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) identity_backend: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) keychain_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) secure_enclave_label: Option<String>,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -210,6 +210,50 @@ async fn server_rejects_real_initialized_did_without_key_path() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_rejects_macos_keychain_identity_without_label() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_env = tempdir.path().join("home-env");
+    let agent_home = home_env.join(".defra-agent");
+    fs::create_dir_all(&agent_home)?;
+
+    let agent_did = format!("did:key:z{}", Uuid::new_v4().simple());
+    write_json_file(
+        &agent_home.join("init.json"),
+        &serde_json::json!({
+            "home": agent_home.to_string_lossy(),
+            "agent_name": "mini-1-steward",
+            "agent_did": agent_did,
+            "key_path": null,
+            "identity_backend": "macos-keychain",
+            "tool_ceiling": "Readonly",
+            "tool_root": tempdir.path().to_string_lossy()
+        }),
+    )?;
+
+    let port = allocate_port()?;
+    let stderr = run_cli_failure_stderr(
+        &home_env,
+        &[
+            "server",
+            "--home",
+            agent_home.to_str().expect("utf-8 home"),
+            "--http-port",
+            &port.to_string(),
+        ],
+    )?;
+    assert!(
+        stderr.contains("macos-keychain"),
+        "expected macos-keychain error, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("no keychain_label"),
+        "expected missing keychain label error, got:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn server_rejects_real_initialized_did_with_missing_key_file_without_creating_it(
 ) -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;

--- a/crates/defra-agent/src/identity.rs
+++ b/crates/defra-agent/src/identity.rs
@@ -138,6 +138,20 @@ pub fn load_macos_secure_enclave_identity(
     register_macos_secure_enclave_identity(label, false, service_account)
 }
 
+pub fn load_or_create_macos_keychain_identity(
+    label: &str,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    register_macos_keychain_identity(label, true, service_account)
+}
+
+pub fn load_macos_keychain_identity(
+    label: &str,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    register_macos_keychain_identity(label, false, service_account)
+}
+
 impl std::fmt::Debug for RegisteredIdentity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RegisteredIdentity")
@@ -245,6 +259,72 @@ fn register_macos_secure_enclave_identity(
 ) -> Result<RegisteredIdentity> {
     anyhow::bail!("macos-secure-enclave identity backend is only available on macOS")
 }
+
+#[cfg(target_os = "macos")]
+fn register_macos_keychain_identity(
+    label: &str,
+    create_if_missing: bool,
+    service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    let identity = load_or_create_macos_keychain_raw_identity(label, create_if_missing)?;
+    let did = identity.did().map_err(anyhow::Error::from)?.to_string();
+    let public_key_bytes = identity.public_key_bytes();
+    defra_core::signing::store_identity(
+        &did,
+        SigningConfig {
+            key_type: SigningKeyType::Ed25519,
+            private_key_bytes: SigningConfig::private_key_bytes_from_vec(
+                identity.private_key_bytes(),
+            ),
+            public_key_bytes: public_key_bytes.clone(),
+            public_key_hex: lowercase_hex(&public_key_bytes),
+            remote_signer: None,
+            signing_authorization: None,
+        },
+    );
+    RegisteredIdentity::from_registered_did(did, service_account)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn register_macos_keychain_identity(
+    _label: &str,
+    _create_if_missing: bool,
+    _service_account: Option<ServiceAccount>,
+) -> Result<RegisteredIdentity> {
+    anyhow::bail!("macos-keychain identity backend is only available on macOS")
+}
+
+#[cfg(target_os = "macos")]
+fn load_or_create_macos_keychain_raw_identity(
+    label: &str,
+    create_if_missing: bool,
+) -> Result<RawIdentity> {
+    let keychain = security_framework::os::macos::keychain::SecKeychain::default()
+        .context("loading default macOS keychain")?;
+    match keychain.find_generic_password(MACOS_KEYCHAIN_SERVICE, label) {
+        Ok((password, _)) => RawIdentity::from_bytes(crypto::KeyType::Ed25519, password.as_ref())
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("loading macOS keychain identity {label}")),
+        Err(error) if error.code() == ERR_SEC_ITEM_NOT_FOUND => {
+            if !create_if_missing {
+                anyhow::bail!("macOS keychain identity not found for label {label}");
+            }
+            let private_key = crypto::generate_ed25519().map_err(anyhow::Error::from)?;
+            let bytes = private_key.raw();
+            keychain
+                .set_generic_password(MACOS_KEYCHAIN_SERVICE, label, &bytes)
+                .with_context(|| format!("storing macOS keychain identity {label}"))?;
+            RawIdentity::from_private_key(private_key)
+                .map_err(anyhow::Error::from)
+                .with_context(|| format!("constructing macOS keychain identity {label}"))
+        }
+        Err(error) => Err(anyhow::Error::from(error))
+            .with_context(|| format!("reading macOS keychain identity {label}")),
+    }
+}
+
+#[cfg(target_os = "macos")]
+const MACOS_KEYCHAIN_SERVICE: &str = "defra-agent.identity";
 
 #[cfg(target_os = "macos")]
 #[derive(Debug)]

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -62,7 +62,8 @@ pub use document_config::{
 pub use health_checker::{spawn_health_checker, HealthStatus, ServiceHealth, ServiceHealthMap};
 pub use hook::{DefraSessionHook, FailurePolicy, HookStats};
 pub use identity::{
-    load_macos_secure_enclave_identity, load_or_create_macos_secure_enclave_identity,
+    load_macos_keychain_identity, load_macos_secure_enclave_identity,
+    load_or_create_macos_keychain_identity, load_or_create_macos_secure_enclave_identity,
     AgentIdentity, KeyIdentity, RegisteredIdentity, ServiceAccount,
 };
 pub use interrupt::{fetch_interrupt_requested_at, interrupt_request};


### PR DESCRIPTION
## Summary
- add a macOS login-keychain software-key identity backend for defra-agent homes
- thread `identity_backend=macos-keychain` and `keychain_label` through init, provision, and server startup
- keep Secure Enclave behavior separate; no-key homes now support fileless macOS keychain identities via the existing DefraDB registered identity path

## Verification
- `cargo test -p defra-agent-cli --test cli_server server_rejects_macos_keychain_identity_without_label`
- `cargo test -p defra-agent-cli --test cli_provision --test cli_init --test cli_help`
- `cargo test -p defra-agent identity::tests`
- `cargo check -p defra-agent-cli -p defra-agent`
- `git diff --check`
- mini-1 smoke: provisioned a scratch macOS keychain home with current post-RocksDB binary, bootstrapped a temporary LaunchAgent in `gui/501`, verified `/version`, `/healthz`, RocksDB startup logs, and ready runtime state

## Notes
- No defradb.rs change is required for this path; it uses the registered identity hooks already merged upstream.
- For unsigned local binaries, create the keychain item after deploying the binary. Replacing an unsigned binary after keychain creation can force a macOS access prompt. Stable signing should avoid that for production artifacts.