### PR TITLE
Restore CLI version metadata command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3609,7 +3609,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum 0.8.9",
@@ -3674,7 +3674,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop-tauri"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3734,7 +3734,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-protocol"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sourcenetwork/defra-agent"

--- a/crates/defra-agent-cli/build.rs
+++ b/crates/defra-agent-cli/build.rs
@@ -5,6 +5,7 @@ use std::process::Command;
 fn main() {
     println!("cargo:rerun-if-env-changed=DEFRA_AGENT_BUILD_GIT_SHA");
     println!("cargo:rerun-if-env-changed=DEFRA_AGENT_BUILD_GIT_REF");
+    println!("cargo:rerun-if-env-changed=DEFRA_AGENT_BUILD_GIT_TAG");
 
     if let Some(head_path) = git_path("HEAD") {
         println!("cargo:rerun-if-changed={head_path}");
@@ -36,6 +37,14 @@ fn main() {
         println!("cargo:rustc-env=DEFRA_AGENT_BUILD_GIT_REF={value}");
     }
 
+    if let Some(value) = env::var("DEFRA_AGENT_BUILD_GIT_TAG")
+        .ok()
+        .filter(|value| !value.is_empty())
+        .or_else(|| git_output(&["describe", "--tags", "--exact-match", "HEAD"]))
+    {
+        println!("cargo:rustc-env=DEFRA_AGENT_BUILD_GIT_TAG={value}");
+    }
+
     if let Some(value) = git_output(&["status", "--porcelain", "--untracked-files=no"]) {
         println!(
             "cargo:rustc-env=DEFRA_AGENT_BUILD_GIT_DIRTY={}",
@@ -49,10 +58,17 @@ fn main() {
     if let Ok(profile) = env::var("PROFILE") {
         println!("cargo:rustc-env=DEFRA_AGENT_BUILD_PROFILE={profile}");
     }
+    if let Some(rustc) = command_output(Command::new("rustc").arg("--version")) {
+        println!("cargo:rustc-env=DEFRA_AGENT_BUILD_RUSTC={rustc}");
+    }
 }
 
 fn git_output(args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).output().ok()?;
+    command_output(Command::new("git").args(args))
+}
+
+fn command_output(command: &mut Command) -> Option<String> {
+    let output = command.output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -30,6 +30,8 @@ pub(crate) struct Cli {
 
 #[derive(Subcommand)]
 pub(crate) enum Command {
+    #[command(about = "Print build and release metadata")]
+    Version,
     #[command(about = "Initialize a local agent home directory", after_help = INIT_AFTER_HELP)]
     Init(InitArgs),
     #[command(

--- a/crates/defra-agent-cli/src/http/version.rs
+++ b/crates/defra-agent-cli/src/http/version.rs
@@ -17,6 +17,7 @@ pub(crate) struct VersionResponse {
 pub(super) struct BuildMetadata {
     pub(super) git_sha: Option<&'static str>,
     pub(super) git_ref: Option<&'static str>,
+    pub(super) git_tag: Option<&'static str>,
     pub(super) git_dirty: Option<bool>,
     pub(super) target: Option<&'static str>,
     pub(super) profile: Option<&'static str>,
@@ -44,6 +45,7 @@ pub(crate) fn version_response() -> VersionResponse {
         build: BuildMetadata {
             git_sha: option_env!("DEFRA_AGENT_BUILD_GIT_SHA"),
             git_ref: option_env!("DEFRA_AGENT_BUILD_GIT_REF"),
+            git_tag: option_env!("DEFRA_AGENT_BUILD_GIT_TAG"),
             git_dirty: option_env!("DEFRA_AGENT_BUILD_GIT_DIRTY").and_then(|value| match value {
                 "true" => Some(true),
                 "false" => Some(false),
@@ -53,4 +55,25 @@ pub(crate) fn version_response() -> VersionResponse {
             profile: option_env!("DEFRA_AGENT_BUILD_PROFILE"),
         },
     }
+}
+
+pub(crate) fn version_text() -> String {
+    let version = version_response();
+    let mut revision = version.build.git_sha.unwrap_or("unknown").to_string();
+    if version.build.git_dirty == Some(true) {
+        revision.push_str("-dirty");
+    }
+    if let Some(tag) = version.build.git_tag {
+        revision.push_str(", tag ");
+        revision.push_str(tag);
+    }
+
+    format!(
+        "{} {} ({revision})\nbuilt {} for {}\n{}\n",
+        version.binary,
+        version.version,
+        version.build.profile.unwrap_or("unknown"),
+        version.build.target.unwrap_or("unknown"),
+        option_env!("DEFRA_AGENT_BUILD_RUSTC").unwrap_or("rustc unknown")
+    )
 }

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -262,6 +262,10 @@ async fn main() -> Result<()> {
     let telemetry = telemetry::init(DEFAULT_LOG_FILTER)?;
     let cli = Cli::parse();
     let result = match cli.command {
+        Command::Version => {
+            print!("{}", http::version::version_text());
+            Ok(())
+        }
         Command::Init(args) => commands::init::init(args).await,
         Command::Provision(args) => commands::provision::provision(args).await,
         Command::Reset(args) => commands::reset::reset(args).await,


### PR DESCRIPTION
## Summary
- restore the top-level `defra-agent version` command consumed by amygdala-deploy local artifact resolution
- include exact release tag metadata when the binary is built from a tag
- bump the workspace package version to 0.1.1 for the follow-up release

## Tests
- cargo test -p defra-agent-cli --test cli_help --test cli_server
- cargo run -p defra-agent-cli -- version
- git diff --check
