### PR TITLE
Continue desktop UI polish and status discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,6 +3719,7 @@ dependencies = [
  "defra-agent",
  "defra-agent-desktop-core",
  "defra-agent-protocol",
+ "reqwest 0.12.28",
  "rig-core",
  "serde",
  "serde_json",

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ chrono.workspace = true
 defra-agent = { path = "../../../crates/defra-agent" }
 defra-agent-desktop-core.workspace = true
 defra-agent-protocol = { path = "../../../crates/defra-agent-protocol" }
+reqwest.workspace = true
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 serde.workspace = true

--- a/apps/desktop-tauri/src-tauri/src/bridge/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/mod.rs
@@ -28,8 +28,8 @@ use self::types::{
     AgentConfigSaveRequest, BackendSaveRequest, BehaviorSaveRequest, ChatSendRequest,
     ChatSendResult, ClientUpdateEvent, ConversationRenameRequest, DesktopBootstrapSummary,
     DesktopClientSnapshot, DesktopInitRequest, DesktopSessionSnapshot, EventTriggerSaveRequest,
-    InferenceProfileSaveRequest, PeerAddRequest, ScheduleRunRequest, ScheduleSaveRequest,
-    TaskRunRequest, TaskRunResult, TaskSaveRequest, ToolSelectionSaveRequest,
+    InferenceProfileSaveRequest, PeerAddRequest, PeerStatusFetchRequest, ScheduleRunRequest,
+    ScheduleSaveRequest, TaskRunRequest, TaskRunResult, TaskSaveRequest, ToolSelectionSaveRequest,
     ToolServiceSaveRequest, ToolServiceTestRequest, ToolServiceTestResult, ToolServiceToolView,
 };
 
@@ -69,6 +69,26 @@ fn require_trimmed(name: &str, value: impl AsRef<str>) -> Result<String, String>
     } else {
         Ok(value)
     }
+}
+
+fn peer_status_url(server_address: &str) -> Result<String, String> {
+    let trimmed = require_trimmed("server_address", server_address)?;
+    let with_scheme = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed
+    } else {
+        format!("http://{trimmed}")
+    };
+    let mut url = reqwest::Url::parse(&with_scheme)
+        .map_err(|error| format!("server_address is not a valid URL: {error}"))?;
+    let path = url.path().trim_end_matches('/');
+    if path.is_empty() || path == "/" || path == "/api/v0" || path == "/api/v0/graphql" {
+        url.set_path("/status");
+    } else if !path.ends_with("/status") {
+        url.set_path(&format!("{path}/status"));
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string())
 }
 
 fn validate_event_kind(event_kind: &str) -> Result<(), String> {
@@ -265,6 +285,31 @@ fn desktop_peer_add(
             .await
             .map_err(|error| error.to_string())?;
         emit_config_update_and_snapshot(&app, &core).await
+    })
+}
+
+#[tauri::command]
+fn desktop_peer_status_fetch(request: PeerStatusFetchRequest) -> Result<serde_json::Value, String> {
+    let url = peer_status_url(&request.server_address)?;
+    tauri::async_runtime::block_on(async move {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|error| format!("building status HTTP client failed: {error}"))?;
+        let response = client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|error| format!("fetching {url} failed: {error}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(format!("GET {url} returned {status}: {body}"));
+        }
+        response
+            .json::<serde_json::Value>()
+            .await
+            .map_err(|error| format!("decoding {url} response failed: {error}"))
     })
 }
 
@@ -1035,6 +1080,7 @@ pub fn run() {
             desktop_client_start,
             desktop_client_shutdown,
             desktop_peer_add,
+            desktop_peer_status_fetch,
             desktop_p2p_repair,
             desktop_client_snapshot,
             desktop_session_snapshot,
@@ -1055,4 +1101,22 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::peer_status_url;
+
+    #[test]
+    fn peer_status_url_accepts_bare_host_and_graphql_endpoint() {
+        assert_eq!(
+            peer_status_url("127.0.0.1:9181").expect("bare host should normalize"),
+            "http://127.0.0.1:9181/status"
+        );
+        assert_eq!(
+            peer_status_url("http://127.0.0.1:9181/api/v0/graphql")
+                .expect("graphql endpoint should normalize"),
+            "http://127.0.0.1:9181/status"
+        );
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/bridge/types.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types.rs
@@ -23,6 +23,12 @@ pub(crate) struct PeerAddRequest {
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct PeerStatusFetchRequest {
+    pub server_address: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ChatSendRequest {
     pub agent_did: String,
     pub behavior_id: Option<String>,

--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -45,6 +45,7 @@ function App() {
           repairingP2P={shell.repairingP2P}
           starting={shell.starting}
           onAddPeer={shell.onAddPeer}
+          onFetchPeerStatus={shell.onFetchPeerStatus}
           onOpenChat={openChat}
           onOpenConfig={openConfig}
           onRepairP2P={shell.onRepairP2P}

--- a/apps/desktop-tauri/src/components/ConfigWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ConfigWorkspace.tsx
@@ -257,6 +257,40 @@ export function ConfigWorkspace({
     );
   }
 
+  function selectConfigBehavior(behaviorId: string) {
+    setSelectedConfigBehaviorId(behaviorId);
+    const behavior = selectedDeployment?.behaviors.find(
+      (candidate) => candidate.behaviorId === behaviorId,
+    );
+    if (!behavior || !selectedDeployment) {
+      return;
+    }
+    if (
+      behavior.backendId &&
+      selectedDeployment.inferenceBackends.some(
+        (backend) => backend.backendId === behavior.backendId,
+      )
+    ) {
+      setSelectedBackendId(behavior.backendId);
+    }
+    if (
+      behavior.inferenceProfileId &&
+      selectedDeployment.inferenceProfiles.some(
+        (profile) => profile.profileId === behavior.inferenceProfileId,
+      )
+    ) {
+      setSelectedProfileId(behavior.inferenceProfileId);
+    }
+    if (
+      behavior.toolSelectionId &&
+      selectedDeployment.toolSelections.some(
+        (selection) => selection.selectionId === behavior.toolSelectionId,
+      )
+    ) {
+      setSelectedToolSelectionId(behavior.toolSelectionId);
+    }
+  }
+
   return (
     <section className="config-workspace config-workspace-full">
       <header className="config-header">
@@ -353,7 +387,7 @@ export function ConfigWorkspace({
           onSaveAgentConfig={onSaveAgentConfig}
           onSaveBehaviorConfig={onSaveBehaviorConfig}
           onSavedStatusChange={setSavedStatus}
-          onSelectBehavior={setSelectedConfigBehaviorId}
+          onSelectBehavior={selectConfigBehavior}
         />
       ) : null}
 

--- a/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
@@ -152,7 +152,13 @@ export function BackendConfigEditor({
           <span>Backend ID</span>
           <input
             data-testid="backend-id"
-            onChange={(event) => setBackendId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!backend) {
+                setBackendId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(backend)}
+            title={backend ? "Backend IDs cannot be renamed after creation." : undefined}
             value={backendId}
           />
         </label>

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -10,7 +10,7 @@ import type {
   InferenceProfileView,
   ToolSelectionView,
 } from "../../lib/types";
-import { ConfigDocumentList, PencilIcon, PlusIcon } from "./ConfigChrome";
+import { ConfigDocumentList, PlusIcon } from "./ConfigChrome";
 import {
   boolText,
   isOptionalFloat,
@@ -135,7 +135,6 @@ export function BehaviorConfigEditor({
   onSaveBehaviorConfig,
 }: BehaviorConfigEditorProps) {
   const [behaviorId, setBehaviorId] = useState("");
-  const [editingBehaviorId, setEditingBehaviorId] = useState(false);
   const [systemPrompt, setSystemPrompt] = useState("");
   const [backendId, setBackendId] = useState("");
   const [profileId, setProfileId] = useState("");
@@ -158,7 +157,6 @@ export function BehaviorConfigEditor({
       nextProfileId = selectedProfileId;
     }
     setBehaviorId(behavior?.behaviorId ?? "");
-    setEditingBehaviorId(!behavior);
     setSystemPrompt(behavior?.systemPrompt ?? "");
     setBackendId(behavior?.backendId ?? "");
     setProfileId(nextProfileId);
@@ -227,7 +225,7 @@ export function BehaviorConfigEditor({
         <div>
           <p className="eyebrow">Behavior</p>
           <div className="behavior-key-row">
-            {editingBehaviorId ? (
+            {!behavior ? (
               <input
                 className="behavior-key-input"
                 data-testid="behavior-id"
@@ -237,18 +235,6 @@ export function BehaviorConfigEditor({
             ) : (
               <h3>{behaviorId || "New Behavior"}</h3>
             )}
-            {!editingBehaviorId ? (
-              <button
-                aria-label="Edit behavior key"
-                className="ghost-button config-icon-button"
-                data-testid="behavior-edit-key"
-                onClick={() => setEditingBehaviorId(true)}
-                title="Edit behavior key"
-                type="button"
-              >
-                <PencilIcon />
-              </button>
-            ) : null}
           </div>
         </div>
         {savedStatus === `behavior:${behaviorId.trim()}` ? (

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -18,6 +18,9 @@ import {
   parseOptionalFloat,
 } from "./formUtils";
 
+const DEFAULT_COMPACTION_STRATEGY = "StripThenSummarize";
+const DEFAULT_COMPACTION_THRESHOLD = "0.75";
+
 export type BehaviorConfigPanelProps = {
   deployment: DeploymentView;
   selectedBehavior: BehaviorView | null;
@@ -138,9 +141,10 @@ export function BehaviorConfigEditor({
   const [profileId, setProfileId] = useState("");
   const [toolSelectionId, setToolSelectionId] = useState("");
   const [compactionStrategy, setCompactionStrategy] =
-    useState("StripThenSummarize");
-  const [compactionThreshold, setCompactionThreshold] = useState("0.95");
-  const [compactionEnabled, setCompactionEnabled] = useState(true);
+    useState(DEFAULT_COMPACTION_STRATEGY);
+  const [compactionThreshold, setCompactionThreshold] = useState(
+    DEFAULT_COMPACTION_THRESHOLD,
+  );
   const [enabled, setEnabled] = useState(true);
   const [defaultForAgent, setDefaultForAgent] = useState(false);
 
@@ -159,15 +163,11 @@ export function BehaviorConfigEditor({
     setBackendId(behavior?.backendId ?? "");
     setProfileId(nextProfileId);
     setToolSelectionId(behavior?.toolSelectionId ?? "");
-    setCompactionStrategy(behavior?.compactionStrategy ?? "StripThenSummarize");
+    setCompactionStrategy(behavior?.compactionStrategy ?? DEFAULT_COMPACTION_STRATEGY);
     setCompactionThreshold(
       behavior?.compactionThreshold != null
         ? String(behavior.compactionThreshold)
-        : "0.95",
-    );
-    setCompactionEnabled(
-      !behavior ||
-        Boolean(behavior.compactionStrategy || behavior.compactionThreshold != null),
+        : DEFAULT_COMPACTION_THRESHOLD,
     );
     setEnabled(behavior?.enabled ?? true);
     setDefaultForAgent(behavior?.isDefault ?? false);
@@ -190,7 +190,6 @@ export function BehaviorConfigEditor({
     ),
   );
   const compactionThresholdValid =
-    !compactionEnabled ||
     isOptionalFloat(compactionThreshold, {
       min: 0,
       max: 1,
@@ -207,12 +206,8 @@ export function BehaviorConfigEditor({
       backendId: optionalString(backendId),
       inferenceProfileId: profileId.trim(),
       toolSelectionId: optionalString(toolSelectionId),
-      compactionStrategy: compactionEnabled
-        ? optionalString(compactionStrategy)
-        : null,
-      compactionThreshold: compactionEnabled
-        ? parseOptionalFloat(compactionThreshold)
-        : null,
+      compactionStrategy: optionalString(compactionStrategy),
+      compactionThreshold: parseOptionalFloat(compactionThreshold),
       enabled,
     });
     if (defaultForAgent && nextId !== currentDefaultBehaviorId) {
@@ -369,28 +364,12 @@ export function BehaviorConfigEditor({
         </label>
       </div>
 
-      <section
-        className={
-          compactionEnabled
-            ? "behavior-compaction-box"
-            : "behavior-compaction-box disabled"
-        }
-      >
-        <label className="checkbox behavior-compaction-toggle">
-          <input
-            checked={compactionEnabled}
-            data-testid="behavior-compaction-enabled"
-            onChange={(event) => setCompactionEnabled(event.currentTarget.checked)}
-            type="checkbox"
-          />
-          <span>Enable compaction</span>
-        </label>
+      <section className="behavior-compaction-box">
         <div className="grid-2">
           <label className="field">
             <span>Strategy</span>
             <select
               data-testid="behavior-compaction-strategy"
-              disabled={!compactionEnabled}
               onChange={(event) => setCompactionStrategy(event.currentTarget.value)}
               value={compactionStrategy}
             >
@@ -403,7 +382,6 @@ export function BehaviorConfigEditor({
             <span>Threshold</span>
             <input
               data-testid="behavior-compaction-threshold"
-              disabled={!compactionEnabled}
               max="1"
               min="0"
               onChange={(event) =>

--- a/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
@@ -145,7 +145,17 @@ export function EventTriggerConfigEditor({
           <span>Trigger ID</span>
           <input
             data-testid="event-trigger-id"
-            onChange={(event) => setTriggerId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!eventTrigger) {
+                setTriggerId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(eventTrigger)}
+            title={
+              eventTrigger
+                ? "Event trigger IDs cannot be renamed after creation."
+                : undefined
+            }
             value={triggerId}
           />
         </label>

--- a/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
@@ -162,7 +162,13 @@ export function InferenceProfileConfigEditor({
           <span>Profile document ID</span>
           <input
             data-testid="profile-id"
-            onChange={(event) => setProfileId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!profile) {
+                setProfileId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(profile)}
+            title={profile ? "Profile IDs cannot be renamed after creation." : undefined}
             value={profileId}
           />
         </label>

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -157,7 +157,13 @@ export function ScheduleConfigEditor({
           <span>Schedule ID</span>
           <input
             data-testid="schedule-id"
-            onChange={(event) => setScheduleId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!schedule) {
+                setScheduleId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(schedule)}
+            title={schedule ? "Schedule IDs cannot be renamed after creation." : undefined}
             value={scheduleId}
           />
         </label>
@@ -264,7 +270,7 @@ export function ScheduleConfigEditor({
           <button
             className="ghost-button"
             data-testid="schedule-run"
-            disabled={runningTask || !scheduleId.trim()}
+            disabled={runningTask || !schedule || !scheduleId.trim()}
             onClick={() => void runSelectedSchedule()}
             type="button"
           >

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -158,7 +158,13 @@ export function TaskConfigEditor({
           <span>Task ID</span>
           <input
             data-testid="task-id"
-            onChange={(event) => setTaskId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!task) {
+                setTaskId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(task)}
+            title={task ? "Task IDs cannot be renamed after creation." : undefined}
             value={taskId}
           />
         </label>
@@ -314,7 +320,7 @@ export function TaskConfigEditor({
           <button
             className="ghost-button"
             data-testid="task-run"
-            disabled={runningTask || !taskId.trim() || !runArgsValid}
+            disabled={runningTask || !task || !taskId.trim() || !runArgsValid}
             onClick={() => void runSelectedTask()}
             type="button"
           >

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -208,7 +208,17 @@ export function ToolSelectionConfigEditor({
           <span>Selection ID</span>
           <input
             data-testid="tool-selection-id"
-            onChange={(event) => setSelectionId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!toolSelection) {
+                setSelectionId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(toolSelection)}
+            title={
+              toolSelection
+                ? "Tool selection IDs cannot be renamed after creation."
+                : undefined
+            }
             value={selectionId}
           />
         </label>

--- a/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
@@ -193,7 +193,17 @@ export function ToolServiceConfigEditor({
           <span>Service ID</span>
           <input
             data-testid="tool-service-id"
-            onChange={(event) => setServiceId(event.currentTarget.value)}
+            onChange={(event) => {
+              if (!toolService) {
+                setServiceId(event.currentTarget.value);
+              }
+            }}
+            readOnly={Boolean(toolService)}
+            title={
+              toolService
+                ? "Tool service IDs cannot be renamed after creation."
+                : undefined
+            }
             value={serviceId}
           />
         </label>

--- a/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
@@ -21,6 +21,7 @@ type FleetDashboardProps = {
   repairingP2P: boolean;
   starting: boolean;
   onAddPeer: (request: PeerAddRequest) => Promise<unknown>;
+  onFetchPeerStatus: (serverAddress: string) => Promise<unknown>;
   onOpenChat: (agentDid: string) => void;
   onOpenConfig: (agentDid: string) => void;
   onRepairP2P: () => Promise<unknown>;
@@ -51,6 +52,7 @@ export function FleetDashboard({
   repairingP2P,
   starting,
   onAddPeer,
+  onFetchPeerStatus,
   onOpenChat,
   onOpenConfig,
   onRepairP2P,
@@ -60,13 +62,12 @@ export function FleetDashboard({
   const [localError, setLocalError] = useState<string | null>(null);
   const hasDeployments = deployments.length > 0;
 
-  async function submitPeer(event: FormEvent) {
-    event.preventDefault();
+  async function submitPeer(request: PeerAddRequest) {
     setLocalError(null);
     try {
       await onAddPeer({
-        ...peerForm,
-        agentDid: validateAgentDid(peerForm.agentDid),
+        ...request,
+        agentDid: validateAgentDid(request.agentDid),
       });
       setPeerForm(DEFAULT_PEER_FORM);
       setShowAddPeer(false);
@@ -92,6 +93,7 @@ export function FleetDashboard({
             localError={localError}
             peerForm={peerForm}
             onPeerFormChange={setPeerForm}
+            onFetchPeerStatus={onFetchPeerStatus}
             onSubmit={submitPeer}
           />
         </div>
@@ -122,6 +124,7 @@ export function FleetDashboard({
             localError={localError}
             peerForm={peerForm}
             onPeerFormChange={setPeerForm}
+            onFetchPeerStatus={onFetchPeerStatus}
             onSubmit={submitPeer}
           />
         </section>
@@ -180,7 +183,8 @@ type AddPeerFormProps = {
   localError: string | null;
   peerForm: PeerAddRequest;
   onPeerFormChange: (value: PeerAddRequest) => void;
-  onSubmit: (event: FormEvent) => void;
+  onFetchPeerStatus: (serverAddress: string) => Promise<unknown>;
+  onSubmit: (request: PeerAddRequest) => Promise<void>;
 };
 
 function AddPeerForm({
@@ -189,10 +193,19 @@ function AddPeerForm({
   localError,
   peerForm,
   onPeerFormChange,
+  onFetchPeerStatus,
   onSubmit,
 }: AddPeerFormProps) {
   const [connectionJson, setConnectionJson] = useState("");
   const [importStatus, setImportStatus] = useState<string | null>(null);
+  const [serverAddress, setServerAddress] = useState("");
+  const [fetchingStatus, setFetchingStatus] = useState(false);
+  const manualPeerReady =
+    Boolean(peerForm.label.trim()) &&
+    Boolean(peerForm.agentDid.trim()) &&
+    Boolean(peerForm.addr.trim());
+  const serverAddressReady = Boolean(serverAddress.trim());
+  const busy = disabled || addingPeer || fetchingStatus;
 
   function updateConnectionJson(value: string) {
     setConnectionJson(value);
@@ -209,14 +222,79 @@ function AddPeerForm({
     }
   }
 
+  async function fetchServerStatus() {
+    const trimmed = serverAddress.trim();
+    if (!trimmed) {
+      throw new Error("Server address is required");
+    }
+
+    setFetchingStatus(true);
+    setImportStatus(null);
+    try {
+      const status = await onFetchPeerStatus(trimmed);
+      const request = parsePeerConnectionJson(JSON.stringify(status));
+      onPeerFormChange(request);
+      setImportStatus("Fetched /status");
+      return request;
+    } catch (error) {
+      setImportStatus(String(error));
+      throw error;
+    } finally {
+      setFetchingStatus(false);
+    }
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    try {
+      const request = manualPeerReady ? peerForm : await fetchServerStatus();
+      await onSubmit(request);
+    } catch {
+      // Field-level and parent errors are rendered in the form.
+    }
+  }
+
+  async function handleFetchClick() {
+    try {
+      await fetchServerStatus();
+    } catch {
+      // The status line renders the discovery error.
+    }
+  }
+
   return (
-    <form className="fleet-add-form" onSubmit={onSubmit}>
+    <form
+      className="fleet-add-form"
+      onSubmit={(event) => void handleSubmit(event)}
+    >
+      <div className="fleet-discovery-row">
+        <label className="field">
+          <span>Server address</span>
+          <input
+            className="mono"
+            data-testid="fleet-add-server-address"
+            disabled={busy}
+            onChange={(event) => setServerAddress(event.currentTarget.value)}
+            placeholder="http://127.0.0.1:9181"
+            value={serverAddress}
+          />
+        </label>
+        <button
+          className="ghost-button"
+          data-testid="fleet-fetch-status"
+          disabled={busy || !serverAddressReady}
+          onClick={() => void handleFetchClick()}
+          type="button"
+        >
+          {fetchingStatus ? "Fetching..." : "Fetch /status"}
+        </button>
+      </div>
       <label className="field fleet-import-field">
         <span>Connection JSON</span>
         <textarea
           className="mono"
           data-testid="fleet-add-connection-json"
-          disabled={disabled || addingPeer}
+          disabled={busy}
           onChange={(event) => updateConnectionJson(event.currentTarget.value)}
           placeholder='{"label":"api-gateway","agentDid":"did:key:z6Mk...","addr":"/ip4/100.73.235.38/tcp/9161/p2p/12D3Koo..."}'
           value={connectionJson}
@@ -229,7 +307,7 @@ function AddPeerForm({
         <span>Agent label</span>
         <input
           data-testid="fleet-add-label"
-          disabled={disabled || addingPeer}
+          disabled={busy}
           onChange={(event) =>
             onPeerFormChange({ ...peerForm, label: event.currentTarget.value })
           }
@@ -242,7 +320,7 @@ function AddPeerForm({
         <input
           className="mono"
           data-testid="fleet-add-agent-did"
-          disabled={disabled || addingPeer}
+          disabled={busy}
           onChange={(event) =>
             onPeerFormChange({
               ...peerForm,
@@ -258,7 +336,7 @@ function AddPeerForm({
         <input
           className="mono"
           data-testid="fleet-add-addr"
-          disabled={disabled || addingPeer}
+          disabled={busy}
           onChange={(event) =>
             onPeerFormChange({ ...peerForm, addr: event.currentTarget.value })
           }
@@ -274,14 +352,15 @@ function AddPeerForm({
           disabled={
             disabled ||
             addingPeer ||
-            !peerForm.label.trim() ||
-            !peerForm.agentDid.trim() ||
-            !peerForm.addr.trim()
+            fetchingStatus ||
+            (!manualPeerReady && !serverAddressReady)
           }
           type="submit"
         >
-          {addingPeer
-            ? "Adding..."
+          {fetchingStatus
+            ? "Fetching..."
+            : addingPeer
+              ? "Adding..."
             : disabled
               ? "Preparing..."
               : "Add Agent Connection"}

--- a/apps/desktop-tauri/src/hooks/useDesktopShell.ts
+++ b/apps/desktop-tauri/src/hooks/useDesktopShell.ts
@@ -3,6 +3,7 @@ import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import {
   addPeer,
   fetchDesktopSnapshot,
+  fetchPeerStatus,
   fetchSessionSnapshot,
   renameConversation,
   repairP2P,
@@ -396,6 +397,16 @@ export function useDesktopShell() {
     }
   }
 
+  async function onFetchPeerStatus(serverAddress: string) {
+    setError(null);
+    try {
+      return await fetchPeerStatus(serverAddress);
+    } catch (err) {
+      setError(String(err));
+      throw err;
+    }
+  }
+
   async function onRepairP2P() {
     setRepairingP2P(true);
     setError(null);
@@ -690,6 +701,7 @@ export function useDesktopShell() {
     setDraft,
     refreshSnapshot,
     onAddPeer,
+    onFetchPeerStatus,
     onRepairP2P,
     onSendMessage,
     onRenameConversationTitle,

--- a/apps/desktop-tauri/src/lib/desktop-api.ts
+++ b/apps/desktop-tauri/src/lib/desktop-api.ts
@@ -61,6 +61,7 @@ export type DesktopApiAdapter = {
   startDesktopClient: () => Promise<DesktopClientSnapshot>;
   shutdownDesktopClient: () => Promise<DesktopClientSnapshot>;
   addPeer: (request: PeerAddRequest) => Promise<DesktopClientSnapshot>;
+  fetchPeerStatus: (serverAddress: string) => Promise<unknown>;
   repairP2P: () => Promise<DesktopClientSnapshot>;
   fetchSessionSnapshot: (
     sessionId: string,
@@ -123,6 +124,11 @@ const defaultDesktopApiAdapter: DesktopApiAdapter = {
   },
   addPeer(request) {
     return invokeDesktop<DesktopClientSnapshot>("desktop_peer_add", { request });
+  },
+  fetchPeerStatus(serverAddress) {
+    return invokeDesktop<unknown>("desktop_peer_status_fetch", {
+      request: { serverAddress },
+    });
   },
   repairP2P() {
     return invokeDesktop<DesktopClientSnapshot>("desktop_p2p_repair");
@@ -223,6 +229,10 @@ export async function shutdownDesktopClient() {
 
 export async function addPeer(request: PeerAddRequest) {
   return desktopApiAdapter().addPeer(request);
+}
+
+export async function fetchPeerStatus(serverAddress: string) {
+  return desktopApiAdapter().fetchPeerStatus(serverAddress);
 }
 
 export async function repairP2P() {

--- a/apps/desktop-tauri/src/styles/config.css
+++ b/apps/desktop-tauri/src/styles/config.css
@@ -364,13 +364,23 @@
   }
 
   .config-document-list-body .list-item:hover {
-    background: rgb(var(--source-green-rgb) / 0.07);
+    background: rgb(255 255 255 / 0.035);
   }
 
   .config-document-list-body .list-item.selected {
     border-color: var(--border-subtle);
-    background: rgb(var(--source-green-rgb) / 0.13);
-    box-shadow: inset 2px 0 0 var(--color-accent);
+    background: rgb(0 0 0 / 0.32);
+    box-shadow:
+      inset 3px 0 0 rgb(var(--source-green-rgb) / 0.72),
+      inset 0 0 0 1px rgb(255 255 255 / 0.035);
+  }
+
+  .config-document-list-body .list-item-meta {
+    color: var(--color-text-muted);
+  }
+
+  .config-document-list-body .list-item.selected .list-item-meta {
+    color: var(--color-text-soft);
   }
 
   .config-document-list-body > .muted {

--- a/apps/desktop-tauri/src/styles/config.css
+++ b/apps/desktop-tauri/src/styles/config.css
@@ -323,21 +323,6 @@
     background: var(--color-surface-strong);
   }
 
-  .behavior-compaction-box.disabled {
-    opacity: 0.56;
-  }
-
-  .behavior-compaction-box.disabled select,
-  .behavior-compaction-box.disabled input:not([type="checkbox"]) {
-    cursor: default;
-  }
-
-  .behavior-compaction-toggle {
-    border: 0;
-    padding: 0;
-    background: transparent;
-  }
-
   .behavior-system-prompt {
     min-height: 320px;
   }

--- a/apps/desktop-tauri/src/styles/config.css
+++ b/apps/desktop-tauri/src/styles/config.css
@@ -476,6 +476,13 @@
     padding: var(--space-4) var(--space-5);
   }
 
+  .config-workspace .field > input[readonly] {
+    border-color: var(--border-subtle);
+    background: rgb(0 0 0 / 0.48);
+    color: var(--color-text-muted);
+    cursor: default;
+  }
+
   .config-workspace .field > input:focus,
   .config-workspace .field > select:focus,
   .config-workspace .field > textarea:focus,

--- a/apps/desktop-tauri/src/styles/fleet.css
+++ b/apps/desktop-tauri/src/styles/fleet.css
@@ -71,6 +71,14 @@
     align-items: end;
   }
 
+  .fleet-discovery-row {
+    grid-column: 1 / -1;
+    display: grid;
+    grid-template-columns: minmax(260px, 1fr) auto;
+    gap: var(--space-5);
+    align-items: end;
+  }
+
   .fleet-add-form > .field {
     min-width: 0;
   }
@@ -109,6 +117,10 @@
 
   .fleet-empty-card .fleet-add-form {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .fleet-empty-card .fleet-discovery-row {
+    grid-template-columns: minmax(0, 1fr) auto;
   }
 
   .fleet-empty-card .fleet-add-actions {

--- a/apps/desktop-tauri/src/styles/sidebar.css
+++ b/apps/desktop-tauri/src/styles/sidebar.css
@@ -84,13 +84,15 @@
   }
 
   .sidebar .list-item:hover {
-    background: rgb(var(--source-green-rgb) / 0.07);
+    background: rgb(255 255 255 / 0.035);
   }
 
   .sidebar .list-item.selected {
     border-color: var(--border-subtle);
-    background: rgb(var(--source-green-rgb) / 0.13);
-    box-shadow: inset 3px 0 0 var(--color-accent);
+    background: rgb(0 0 0 / 0.32);
+    box-shadow:
+      inset 3px 0 0 rgb(var(--source-green-rgb) / 0.72),
+      inset 0 0 0 1px rgb(255 255 255 / 0.035);
   }
 
   .sidebar .list-item-title {
@@ -98,9 +100,13 @@
   }
 
   .sidebar .list-item-meta {
-    color: var(--color-accent-muted);
+    color: var(--color-text-muted);
     font-size: 10px;
     letter-spacing: 0.12em;
+  }
+
+  .sidebar .list-item.selected .list-item-meta {
+    color: var(--color-text-soft);
   }
 
   .peer-item-card {

--- a/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
+++ b/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
@@ -105,4 +105,51 @@ describe("BehaviorConfigEditor", () => {
     expect(onSaveAgentConfig).not.toHaveBeenCalled();
     expect(onSaved).toHaveBeenCalledWith("did:key:z6MkAgent:default");
   });
+
+  it("makes the behavior-to-agent default dependency explicit", async () => {
+    const opsBehavior = {
+      ...behavior,
+      behaviorId: "did:key:z6MkAgent:ops",
+      displayName: "Ops",
+      isDefault: false,
+    };
+    const onSaveAgentConfig = vi.fn<
+      [(request: AgentConfigSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    const onSaveBehaviorConfig = vi.fn<
+      [(request: BehaviorSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <BehaviorConfigEditor
+        agentDid="did:key:z6MkAgent"
+        agentDisplayName="Local Agent"
+        agentEnabled
+        behavior={opsBehavior}
+        currentDefaultBehaviorId={behavior.behaviorId}
+        inferenceBackends={inferenceBackends}
+        inferenceProfiles={inferenceProfiles}
+        savedStatus={null}
+        saving={false}
+        toolSelections={toolSelections}
+        onCreateBackend={vi.fn()}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={onSaveAgentConfig}
+        onSaveBehaviorConfig={onSaveBehaviorConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("behavior-default-for-agent"));
+    fireEvent.click(screen.getByTestId("behavior-save"));
+
+    await waitFor(() => expect(onSaveBehaviorConfig).toHaveBeenCalledTimes(1));
+    expect(onSaveAgentConfig).toHaveBeenCalledWith({
+      agentDid: "did:key:z6MkAgent",
+      displayName: "Local Agent",
+      defaultBehaviorId: "did:key:z6MkAgent:ops",
+      enabled: true,
+    });
+  });
 });

--- a/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
+++ b/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
@@ -83,6 +83,8 @@ describe("BehaviorConfigEditor", () => {
     );
 
     expect(screen.queryByTestId("behavior-compaction-enabled")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("behavior-id")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("behavior-edit-key")).not.toBeInTheDocument();
     expect(screen.getByTestId("behavior-compaction-strategy")).toHaveValue(
       "StripThenSummarize",
     );

--- a/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
+++ b/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BehaviorConfigEditor } from "../src/components/config/BehaviorConfigPanel";
+import type {
+  AgentConfigSaveRequest,
+  BehaviorSaveRequest,
+  BehaviorView,
+  InferenceBackendView,
+  InferenceProfileView,
+  ToolSelectionView,
+} from "../src/lib/types";
+
+const behavior: BehaviorView = {
+  behaviorId: "did:key:z6MkAgent:default",
+  displayName: "Default",
+  systemPrompt: "You are the default agent.",
+  backendId: "default-backend",
+  modelName: "default-model",
+  toolSelectionId: "default-tools",
+  inferenceProfileId: "default-profile",
+  compactionStrategy: null,
+  compactionThreshold: null,
+  enabled: true,
+  isDefault: true,
+};
+
+const inferenceBackends: InferenceBackendView[] = [
+  {
+    backendId: "default-backend",
+    name: "Default Backend",
+    providerKind: "openai",
+    endpoint: "http://127.0.0.1:8000/v1",
+    apiKeyConfigured: false,
+    maxConcurrent: 2,
+    maxQueueDepth: 100,
+    enabled: true,
+    models: ["default-model"],
+  },
+];
+
+const inferenceProfiles: InferenceProfileView[] = [
+  {
+    profileId: "default-profile",
+    displayName: "Default Profile",
+  },
+];
+
+const toolSelections: ToolSelectionView[] = [
+  {
+    selectionId: "default-tools",
+    displayName: "Default Tools",
+  },
+];
+
+describe("BehaviorConfigEditor", () => {
+  it("saves explicit compaction defaults onto the selected behavior", async () => {
+    const onSaveAgentConfig = vi.fn<[(request: AgentConfigSaveRequest) => Promise<unknown>]>();
+    const onSaveBehaviorConfig = vi.fn<
+      [(request: BehaviorSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    const onSaved = vi.fn();
+
+    render(
+      <BehaviorConfigEditor
+        agentDid="did:key:z6MkAgent"
+        agentDisplayName="Local Agent"
+        agentEnabled
+        behavior={behavior}
+        currentDefaultBehaviorId={behavior.behaviorId}
+        inferenceBackends={inferenceBackends}
+        inferenceProfiles={inferenceProfiles}
+        savedStatus={null}
+        saving={false}
+        toolSelections={toolSelections}
+        onCreateBackend={vi.fn()}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={onSaveAgentConfig}
+        onSaveBehaviorConfig={onSaveBehaviorConfig}
+        onSaved={onSaved}
+      />,
+    );
+
+    expect(screen.queryByTestId("behavior-compaction-enabled")).not.toBeInTheDocument();
+    expect(screen.getByTestId("behavior-compaction-strategy")).toHaveValue(
+      "StripThenSummarize",
+    );
+    expect(screen.getByTestId("behavior-compaction-threshold")).toHaveValue(0.75);
+
+    fireEvent.click(screen.getByTestId("behavior-save"));
+
+    await waitFor(() => {
+      expect(onSaveBehaviorConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentDid: "did:key:z6MkAgent",
+          behaviorId: "did:key:z6MkAgent:default",
+          compactionStrategy: "StripThenSummarize",
+          compactionThreshold: 0.75,
+        }),
+      );
+    });
+    expect(onSaveAgentConfig).not.toHaveBeenCalled();
+    expect(onSaved).toHaveBeenCalledWith("did:key:z6MkAgent:default");
+  });
+});

--- a/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
@@ -1,0 +1,448 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackendConfigEditor } from "../src/components/config/BackendConfigPanel";
+import { EventTriggerConfigEditor } from "../src/components/config/EventTriggerConfigPanel";
+import { InferenceProfileConfigEditor } from "../src/components/config/InferenceProfileConfigPanel";
+import { ScheduleConfigEditor } from "../src/components/config/ScheduleConfigPanel";
+import { TaskConfigEditor } from "../src/components/config/TaskConfigPanel";
+import { ToolSelectionConfigEditor } from "../src/components/config/ToolSelectionConfigPanel";
+import { ToolServiceConfigEditor } from "../src/components/config/ToolServiceConfigPanel";
+import type {
+  BackendSaveRequest,
+  EventTriggerSaveRequest,
+  InferenceBackendView,
+  InferenceProfileSaveRequest,
+  InferenceProfileView,
+  ScheduleSaveRequest,
+  ScheduleView,
+  TaskRunResult,
+  TaskSaveRequest,
+  TaskView,
+  ToolSelectionSaveRequest,
+  ToolSelectionView,
+  ToolServiceRegistryView,
+  ToolServiceSaveRequest,
+  ToolServiceTestRequest,
+  ToolServiceTestResult,
+} from "../src/lib/types";
+
+const backend: InferenceBackendView = {
+  backendId: "default-backend",
+  name: "Default Backend",
+  providerKind: "openai",
+  endpoint: "http://127.0.0.1:8000/v1",
+  apiKeyConfigured: false,
+  maxConcurrent: 2,
+  maxQueueDepth: 20,
+  enabled: true,
+  models: ["baa-ai/model"],
+};
+
+const profile: InferenceProfileView = {
+  profileId: "default-profile",
+  displayName: "Default Profile",
+  contextWindow: 131072,
+  maxOutputTokens: 32768,
+  temperature: 0,
+};
+
+const toolSelection: ToolSelectionView = {
+  selectionId: "default-tools",
+  agentDid: "did:key:z6MkAgent",
+  displayName: "Default Tools",
+  enableFileTools: true,
+  fileToolsMode: "ReadOnly",
+  fileToolRoot: "/tmp/work",
+  enableBash: true,
+  bashMode: "ReadOnly",
+  cliToolNames: ["grep"],
+  enableMetaTools: true,
+  delegateTo: ["mcp-local"],
+};
+
+const toolService: ToolServiceRegistryView = {
+  serviceId: "mcp-local",
+  displayName: "Local MCP",
+  description: "Local tools",
+  hostname: "localhost",
+  mcpPort: 7331,
+  mcpPath: "/mcp",
+  status: "online",
+};
+
+const task: TaskView = {
+  taskId: "task-a",
+  name: "Task A",
+  description: "Runs task A",
+  behaviorId: "default",
+  promptTemplate: "Run task A",
+  enabled: true,
+  outputSchemaRef: null,
+  recentRuns: {
+    totalFires: 0,
+    scheduleCount: 0,
+    eventTriggerCount: 0,
+  },
+  runHistory: [],
+};
+
+const schedule: ScheduleView = {
+  scheduleId: "timer-a",
+  taskId: "task-a",
+  intervalSecs: 60,
+  enabled: true,
+  concurrency: "serial",
+  fireCount: 0,
+};
+
+const runResult: TaskRunResult = {
+  requestDocId: "bae-run",
+  requestId: "run-1",
+  sessionId: "session-1",
+  agentDid: "did:key:z6MkAgent",
+  behaviorId: "default",
+  status: "submitted",
+  lifecycleState: "queued",
+};
+
+describe("config panel action buttons", () => {
+  it("keeps persisted document IDs immutable when saving existing rows", async () => {
+    const onSaveBackendConfig = vi.fn<
+      [(request: BackendSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <BackendConfigEditor
+        backend={backend}
+        savedStatus={null}
+        saving={false}
+        onSaveBackendConfig={onSaveBackendConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("backend-id"), {
+      target: { value: "renamed-backend" },
+    });
+    fireEvent.click(screen.getByTestId("backend-save"));
+    await waitFor(() =>
+      expect(onSaveBackendConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ backendId: "default-backend" }),
+      ),
+    );
+    expect(screen.getByTestId("backend-id")).toHaveAttribute("readonly");
+
+    const onSaveProfileConfig = vi.fn<
+      [(request: InferenceProfileSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <InferenceProfileConfigEditor
+        profile={profile}
+        savedStatus={null}
+        saving={false}
+        onSaveInferenceProfileConfig={onSaveProfileConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("profile-id"), {
+      target: { value: "renamed-profile" },
+    });
+    fireEvent.click(screen.getByTestId("profile-save"));
+    await waitFor(() =>
+      expect(onSaveProfileConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ profileId: "default-profile" }),
+      ),
+    );
+    expect(screen.getByTestId("profile-id")).toHaveAttribute("readonly");
+
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={toolSelection}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("tool-selection-id"), {
+      target: { value: "renamed-tools" },
+    });
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ selectionId: "default-tools" }),
+      ),
+    );
+    expect(screen.getByTestId("tool-selection-id")).toHaveAttribute("readonly");
+
+    const onSaveToolServiceConfig = vi.fn<
+      [(request: ToolServiceSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <ToolServiceConfigEditor
+        savedStatus={null}
+        saving={false}
+        toolService={toolService}
+        onSaveToolServiceConfig={onSaveToolServiceConfig}
+        onSaved={vi.fn()}
+        onTestToolService={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("tool-service-id"), {
+      target: { value: "renamed-service" },
+    });
+    fireEvent.click(screen.getByTestId("tool-service-save"));
+    await waitFor(() =>
+      expect(onSaveToolServiceConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceId: "mcp-local" }),
+      ),
+    );
+    expect(screen.getByTestId("tool-service-id")).toHaveAttribute("readonly");
+
+    const onSaveTaskConfig = vi.fn<
+      [(request: TaskSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <TaskConfigEditor
+        behaviors={[
+          {
+            behaviorId: "default",
+            displayName: "Default",
+            enabled: true,
+            isDefault: true,
+          },
+        ]}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={null}
+        task={task}
+        onRunTask={vi.fn()}
+        onSaveTaskConfig={onSaveTaskConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("task-id"), {
+      target: { value: "renamed-task" },
+    });
+    fireEvent.click(screen.getByTestId("task-save"));
+    await waitFor(() =>
+      expect(onSaveTaskConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: "task-a" }),
+      ),
+    );
+    expect(screen.getByTestId("task-id")).toHaveAttribute("readonly");
+
+    const onSaveScheduleConfig = vi.fn<
+      [(request: ScheduleSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <ScheduleConfigEditor
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        schedule={schedule}
+        selectedTask={task}
+        tasks={[task]}
+        onRunSchedule={vi.fn()}
+        onSaveScheduleConfig={onSaveScheduleConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("schedule-id"), {
+      target: { value: "renamed-schedule" },
+    });
+    fireEvent.click(screen.getByTestId("schedule-save"));
+    await waitFor(() =>
+      expect(onSaveScheduleConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ scheduleId: "timer-a" }),
+      ),
+    );
+    expect(screen.getByTestId("schedule-id")).toHaveAttribute("readonly");
+
+    const onSaveEventTriggerConfig = vi.fn<
+      [(request: EventTriggerSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    render(
+      <EventTriggerConfigEditor
+        eventTrigger={{
+          triggerId: "event-a",
+          taskId: "task-a",
+          sourceCollection: "AgentRequest",
+          eventKind: "created",
+          enabled: true,
+          concurrency: "serial",
+          fireCount: 0,
+        }}
+        savedStatus={null}
+        saving={false}
+        selectedTask={task}
+        tasks={[task]}
+        onSaveEventTriggerConfig={onSaveEventTriggerConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("event-trigger-id"), {
+      target: { value: "renamed-event" },
+    });
+    fireEvent.click(screen.getByTestId("event-trigger-save"));
+    await waitFor(() =>
+      expect(onSaveEventTriggerConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ triggerId: "event-a" }),
+      ),
+    );
+    expect(screen.getByTestId("event-trigger-id")).toHaveAttribute("readonly");
+  });
+
+  it("keeps manual run buttons disabled for drafts and invalid args", async () => {
+    const onRunTask = vi.fn<[(request: { taskId: string; args?: unknown }) => Promise<TaskRunResult>]>(
+      () => Promise.resolve(runResult),
+    );
+    const draftTask = render(
+      <TaskConfigEditor
+        behaviors={[]}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={null}
+        task={null}
+        onRunTask={onRunTask}
+        onSaveTaskConfig={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("task-id"), {
+      target: { value: "draft-task" },
+    });
+    expect(screen.getByTestId("task-run")).toBeDisabled();
+    draftTask.unmount();
+
+    render(
+      <TaskConfigEditor
+        behaviors={[
+          {
+            behaviorId: "default",
+            displayName: "Default",
+            enabled: true,
+            isDefault: true,
+          },
+        ]}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={null}
+        task={task}
+        onRunTask={onRunTask}
+        onSaveTaskConfig={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("task-run-args"), {
+      target: { value: "{bad json" },
+    });
+    expect(screen.getByTestId("task-run")).toBeDisabled();
+
+    fireEvent.change(screen.getByTestId("task-run-args"), {
+      target: { value: '{"foo":"bar"}' },
+    });
+    fireEvent.click(screen.getByTestId("task-run"));
+    await waitFor(() =>
+      expect(onRunTask).toHaveBeenCalledWith({
+        taskId: "task-a",
+        args: { foo: "bar" },
+      }),
+    );
+  });
+
+  it("keeps timer run disabled for drafts and runs existing timers", async () => {
+    const onRunSchedule = vi.fn<[(request: { scheduleId: string }) => Promise<TaskRunResult>]>(
+      () => Promise.resolve(runResult),
+    );
+    const draftSchedule = render(
+      <ScheduleConfigEditor
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        schedule={null}
+        selectedTask={task}
+        tasks={[task]}
+        onRunSchedule={onRunSchedule}
+        onSaveScheduleConfig={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.change(screen.getByTestId("schedule-id"), {
+      target: { value: "draft-timer" },
+    });
+    expect(screen.getByTestId("schedule-run")).toBeDisabled();
+    draftSchedule.unmount();
+
+    render(
+      <ScheduleConfigEditor
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        schedule={schedule}
+        selectedTask={task}
+        tasks={[task]}
+        onRunSchedule={onRunSchedule}
+        onSaveScheduleConfig={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("schedule-run"));
+    await waitFor(() =>
+      expect(onRunSchedule).toHaveBeenCalledWith({ scheduleId: "timer-a" }),
+    );
+  });
+
+  it("surfaces tool service test success and errors from the test button", async () => {
+    const result: ToolServiceTestResult = {
+      serviceId: "mcp-local",
+      endpoint: "http://localhost:7331/mcp",
+      status: "ok",
+      toolCount: 1,
+      tools: [{ name: "list_files", description: "List files" }],
+    };
+    const onTestToolService = vi.fn<
+      [(request: ToolServiceTestRequest) => Promise<ToolServiceTestResult>]
+    >(() => Promise.resolve(result));
+
+    render(
+      <ToolServiceConfigEditor
+        savedStatus={null}
+        saving={false}
+        toolService={toolService}
+        onSaveToolServiceConfig={vi.fn()}
+        onSaved={vi.fn()}
+        onTestToolService={onTestToolService}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("tool-service-test"));
+    await waitFor(() =>
+      expect(onTestToolService).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceId: "mcp-local",
+          hostname: "localhost",
+          mcpPort: 7331,
+          mcpPath: "/mcp",
+        }),
+      ),
+    );
+    expect(await screen.findByTestId("tool-service-test-result")).toHaveTextContent(
+      "list_files",
+    );
+
+    onTestToolService.mockRejectedValueOnce(new Error("connection refused"));
+    fireEvent.click(screen.getByTestId("tool-service-test"));
+    expect(await screen.findByTestId("tool-service-test-error")).toHaveTextContent(
+      "connection refused",
+    );
+  });
+});

--- a/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
@@ -445,4 +445,76 @@ describe("config panel action buttons", () => {
       "connection refused",
     );
   });
+
+  it("makes tool service delegates explicit in tool selections", async () => {
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={{
+          ...toolSelection,
+          enableMetaTools: false,
+          delegateTo: [],
+        }}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-delegate-mcp-local")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("tool-enable-meta-tools"));
+    expect(screen.getByTestId("tool-delegate-mcp-local")).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId("tool-delegate-mcp-local"));
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableMetaTools: true,
+          delegateTo: ["mcp-local"],
+        }),
+      ),
+    );
+  });
+
+  it("applies the server tool ceiling when saving tool selections", async () => {
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="MetaOnly"
+        toolRoot="/tmp/work"
+        toolSelection={toolSelection}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-enable-file-tools")).toBeDisabled();
+    expect(screen.getByTestId("tool-enable-bash")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableFileTools: false,
+          enableBash: false,
+        }),
+      ),
+    );
+  });
 });

--- a/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
@@ -1,0 +1,599 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+
+import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
+import {
+  AgentConfigEditor,
+  BackendConfigPanel,
+  BehaviorConfigPanel,
+  EventTriggerConfigPanel,
+  InferenceProfileConfigPanel,
+  ScheduleConfigPanel,
+  TaskConfigPanel,
+  ToolSelectionConfigPanel,
+  ToolServiceConfigPanel,
+} from "../src/components/config";
+import type {
+  AgentConfigSaveRequest,
+  BackendSaveRequest,
+  BootstrapSummary,
+  DeploymentView,
+  EventTriggerSaveRequest,
+  InferenceProfileSaveRequest,
+  ScheduleSaveRequest,
+  TaskRunResult,
+  TaskSaveRequest,
+  ToolSelectionSaveRequest,
+  ToolServiceSaveRequest,
+  ToolServiceTestRequest,
+  ToolServiceTestResult,
+} from "../src/lib/types";
+
+const runResult: TaskRunResult = {
+  requestDocId: "bae-run",
+  requestId: "run-1",
+  sessionId: "session-1",
+  agentDid: "did:key:z6MkAgent",
+  behaviorId: "default",
+  status: "submitted",
+  lifecycleState: "queued",
+};
+
+const deployment: DeploymentView = {
+  peerId: "peer-1",
+  label: "Local Agent",
+  agentDid: "did:key:z6MkAgent",
+  addr: "iroh://local",
+  source: "local",
+  graphql: null,
+  dialSucceeded: true,
+  defaultBehaviorId: "default",
+  agentPrincipal: {
+    agentDid: "did:key:z6MkAgent",
+    displayName: "Local Agent",
+    defaultBehaviorId: "default",
+    enabled: true,
+  },
+  runtime: null,
+  behaviors: [
+    {
+      behaviorId: "default",
+      displayName: "Default",
+      systemPrompt: "You are the default behavior.",
+      backendId: "backend-a",
+      inferenceProfileId: "profile-a",
+      toolSelectionId: "tools-a",
+      enabled: true,
+      isDefault: true,
+    },
+    {
+      behaviorId: "ops",
+      displayName: "Ops",
+      systemPrompt: "You are the ops behavior.",
+      backendId: "backend-a",
+      inferenceProfileId: "profile-a",
+      toolSelectionId: "tools-a",
+      enabled: true,
+      isDefault: false,
+    },
+  ],
+  inferenceBackends: [
+    {
+      backendId: "backend-a",
+      name: "Backend A",
+      providerKind: "openai",
+      endpoint: "http://127.0.0.1:8000/v1",
+      apiKeyConfigured: false,
+      enabled: true,
+      models: ["model-a"],
+    },
+  ],
+  inferenceProfiles: [
+    {
+      profileId: "profile-a",
+      displayName: "Profile A",
+      contextWindow: 131072,
+    },
+  ],
+  toolSelections: [
+    {
+      selectionId: "tools-a",
+      agentDid: "did:key:z6MkAgent",
+      displayName: "Tools A",
+      enableFileTools: true,
+      fileToolsMode: "ReadOnly",
+      enableBash: true,
+      bashMode: "ReadOnly",
+      cliToolNames: ["grep"],
+      enableMetaTools: true,
+      delegateTo: ["service-a"],
+    },
+  ],
+  toolServiceRegistries: [
+    {
+      serviceId: "service-a",
+      displayName: "Service A",
+      hostname: "localhost",
+      mcpPort: 7331,
+      mcpPath: "/mcp",
+      status: "online",
+    },
+  ],
+  tasks: [
+    {
+      taskId: "task-a",
+      name: "Task A",
+      behaviorId: "default",
+      promptTemplate: "Run task A",
+      enabled: true,
+      recentRuns: {
+        totalFires: 0,
+        scheduleCount: 1,
+        eventTriggerCount: 1,
+      },
+      runHistory: [],
+    },
+  ],
+  schedules: [
+    {
+      scheduleId: "timer-a",
+      taskId: "task-a",
+      intervalSecs: 60,
+      enabled: true,
+      concurrency: "serial",
+      fireCount: 0,
+    },
+  ],
+  eventTriggers: [
+    {
+      triggerId: "event-a",
+      taskId: "task-a",
+      sourceCollection: "AgentRequest",
+      eventKind: "created",
+      enabled: true,
+      concurrency: "serial",
+      fireCount: 0,
+    },
+  ],
+  conversations: [],
+};
+
+const bootstrap: BootstrapSummary = {
+  dataDir: "/tmp/defra-agent",
+  agentDid: "did:key:z6MkAgent",
+  localPeerId: "peer-1",
+  initAgentName: "Local Agent",
+  initToolCeiling: "Readwrite",
+  initToolRoot: "/tmp/work",
+  defaultPeerAddr: "iroh://local",
+};
+
+type ListCase = {
+  createTestId: string;
+  rowTestId: string;
+  selectId: string;
+  renderPanel: (onCreate: () => void, onSelect: (id: string) => void) => ReactElement;
+};
+
+const listCases: ListCase[] = [
+  {
+    createTestId: "behavior-new",
+    rowTestId: "config-behavior-ops",
+    selectId: "ops",
+    renderPanel: (onCreate, onSelect) => (
+      <BehaviorConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={deployment.behaviors[0]}
+        onCreateBackend={vi.fn()}
+        onCreateBehavior={onCreate}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={vi.fn()}
+        onSaveBehaviorConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectBehavior={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "backend-new",
+    rowTestId: "config-backend-backend-a",
+    selectId: "backend-a",
+    renderPanel: (onCreate, onSelect) => (
+      <BackendConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedBackendId={deployment.inferenceBackends[0].backendId}
+        onCreateBackend={onCreate}
+        onSaveBackendConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectBackend={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "profile-new",
+    rowTestId: "config-profile-profile-a",
+    selectId: "profile-a",
+    renderPanel: (onCreate, onSelect) => (
+      <InferenceProfileConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedProfileId={deployment.inferenceProfiles[0].profileId}
+        onCreateProfile={onCreate}
+        onSaveInferenceProfileConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectProfile={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "tool-selection-new",
+    rowTestId: "config-tool-selection-tools-a",
+    selectId: "tools-a",
+    renderPanel: (onCreate, onSelect) => (
+      <ToolSelectionConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedToolSelectionId={deployment.toolSelections[0].selectionId}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        onCreateToolSelection={onCreate}
+        onSaveToolSelectionConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectToolSelection={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "tool-service-new",
+    rowTestId: "config-tool-service-service-a",
+    selectId: "service-a",
+    renderPanel: (onCreate, onSelect) => (
+      <ToolServiceConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedToolServiceId={deployment.toolServiceRegistries[0].serviceId}
+        onCreateToolService={onCreate}
+        onSaveToolServiceConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectToolService={onSelect}
+        onTestToolService={vi.fn()}
+      />
+    ),
+  },
+  {
+    createTestId: "task-new",
+    rowTestId: "config-task-task-a",
+    selectId: "task-a",
+    renderPanel: (onCreate, onSelect) => (
+      <TaskConfigPanel
+        deployment={deployment}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={deployment.behaviors[0]}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateTask={onCreate}
+        onRunTask={vi.fn()}
+        onSaveTaskConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectTask={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "schedule-new",
+    rowTestId: "config-schedule-timer-a",
+    selectId: "timer-a",
+    renderPanel: (onCreate, onSelect) => (
+      <ScheduleConfigPanel
+        deployment={deployment}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedScheduleId={deployment.schedules[0].scheduleId}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateSchedule={onCreate}
+        onRunSchedule={vi.fn()}
+        onSaveScheduleConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectSchedule={onSelect}
+      />
+    ),
+  },
+  {
+    createTestId: "event-trigger-new",
+    rowTestId: "config-event-trigger-event-a",
+    selectId: "event-a",
+    renderPanel: (onCreate, onSelect) => (
+      <EventTriggerConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedEventTriggerId={deployment.eventTriggers[0].triggerId}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateEventTrigger={onCreate}
+        onSaveEventTriggerConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectEventTrigger={onSelect}
+      />
+    ),
+  },
+];
+
+function workspaceHandlers() {
+  return {
+    onBack: vi.fn(),
+    onSaveAgentConfig: vi.fn<[(request: AgentConfigSaveRequest) => Promise<unknown>]>(
+      () => Promise.resolve(),
+    ),
+    onSaveBackendConfig: vi.fn<[(request: BackendSaveRequest) => Promise<unknown>]>(
+      () => Promise.resolve(),
+    ),
+    onSaveInferenceProfileConfig: vi.fn<
+      [(request: InferenceProfileSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
+    onSaveToolSelectionConfig: vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
+    onSaveToolServiceConfig: vi.fn<
+      [(request: ToolServiceSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
+    onTestToolService: vi.fn<
+      [(request: ToolServiceTestRequest) => Promise<ToolServiceTestResult>]
+    >(() =>
+      Promise.resolve({
+        serviceId: "service-a",
+        endpoint: "http://localhost:7331/mcp",
+        status: "ok",
+        toolCount: 0,
+        tools: [],
+      }),
+    ),
+    onSaveBehaviorConfig: vi.fn(),
+    onSaveTaskConfig: vi.fn<[(request: TaskSaveRequest) => Promise<unknown>]>(
+      () => Promise.resolve(),
+    ),
+    onSaveScheduleConfig: vi.fn<
+      [(request: ScheduleSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
+    onRunSchedule: vi.fn<[(request: { scheduleId: string }) => Promise<TaskRunResult>]>(
+      () => Promise.resolve(runResult),
+    ),
+    onSaveEventTriggerConfig: vi.fn<
+      [(request: EventTriggerSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
+    onRunTask: vi.fn<
+      [(request: { taskId: string; args?: unknown }) => Promise<TaskRunResult>]
+    >(() => Promise.resolve(runResult)),
+  };
+}
+
+describe("config panel wiring", () => {
+  it.each(listCases)(
+    "wires Add New and list selection for $createTestId",
+    ({ createTestId, rowTestId, selectId, renderPanel }) => {
+      const onCreate = vi.fn();
+      const onSelect = vi.fn();
+
+      render(renderPanel(onCreate, onSelect));
+
+      fireEvent.click(screen.getByTestId(createTestId));
+      expect(onCreate).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(screen.getByTestId(rowTestId));
+      expect(onSelect).toHaveBeenCalledWith(selectId);
+    },
+  );
+
+  it("wires behavior linked-document create buttons", () => {
+    const onCreateBackend = vi.fn();
+    const onCreateProfile = vi.fn();
+    const onCreateToolSelection = vi.fn();
+
+    render(
+      <BehaviorConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={deployment.behaviors[0]}
+        onCreateBackend={onCreateBackend}
+        onCreateBehavior={vi.fn()}
+        onCreateProfile={onCreateProfile}
+        onCreateToolSelection={onCreateToolSelection}
+        onSaveAgentConfig={vi.fn()}
+        onSaveBehaviorConfig={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSelectBehavior={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("behavior-create-backend"));
+    fireEvent.click(screen.getByTestId("behavior-create-profile"));
+    fireEvent.click(screen.getByTestId("behavior-create-tool-selection"));
+
+    expect(onCreateBackend).toHaveBeenCalledTimes(1);
+    expect(onCreateProfile).toHaveBeenCalledTimes(1);
+    expect(onCreateToolSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires agent edit, cancel, and save buttons", async () => {
+    const onSaveAgentConfig = vi.fn<
+      [(request: AgentConfigSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    const onSaved = vi.fn();
+
+    render(
+      <AgentConfigEditor
+        agent={deployment.agentPrincipal}
+        behaviors={deployment.behaviors}
+        bootstrap={bootstrap}
+        savedStatus={null}
+        saving={false}
+        onSaveAgentConfig={onSaveAgentConfig}
+        onSaved={onSaved}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.change(screen.getByTestId("agent-display-name"), {
+      target: { value: "Edited Agent" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByTestId("agent-display-name")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Local Agent" })).toBeInTheDocument();
+    expect(onSaveAgentConfig).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.change(screen.getByTestId("agent-display-name"), {
+      target: { value: "Edited Agent" },
+    });
+    fireEvent.click(screen.getByTestId("agent-save"));
+
+    await waitFor(() =>
+      expect(onSaveAgentConfig).toHaveBeenCalledWith({
+        agentDid: "did:key:z6MkAgent",
+        displayName: "Edited Agent",
+        defaultBehaviorId: "default",
+        enabled: true,
+      }),
+    );
+    expect(onSaved).toHaveBeenCalledWith("did:key:z6MkAgent");
+  });
+
+  it("wires workspace back buttons and tab buttons", () => {
+    const emptyHandlers = workspaceHandlers();
+    const emptyRender = render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={null}
+        {...emptyHandlers}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Back to Chat" }));
+    expect(emptyHandlers.onBack).toHaveBeenCalledTimes(1);
+    emptyRender.unmount();
+
+    const handlers = workspaceHandlers();
+    const { unmount } = render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("config-back-tab"));
+    expect(handlers.onBack).toHaveBeenCalledTimes(1);
+
+    const tabExpectations: Array<[string, () => void]> = [
+      [
+        "config-tab-agent",
+        () => expect(screen.getByTestId("agent-edit-display-name")).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-behavior",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Agent Behaviors" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-backends",
+        () =>
+          expect(screen.getByRole("heading", { name: "Backends" })).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-profiles",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Inference Profiles" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-toolSelections",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Tool Selections" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-metaTools",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "HTTP MCP Services" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-tasks",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Task Prompts" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-timerTriggers",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Timer Triggers" }),
+          ).toBeInTheDocument(),
+      ],
+      [
+        "config-tab-eventTriggers",
+        () =>
+          expect(
+            screen.getByRole("heading", { name: "Event Triggers" }),
+          ).toBeInTheDocument(),
+      ],
+    ];
+
+    for (const [tabId, assertActivePanel] of tabExpectations) {
+      fireEvent.click(screen.getByTestId(tabId));
+      assertActivePanel();
+    }
+
+    unmount();
+  });
+
+  it("wires workspace behavior shortcuts into new config drafts", () => {
+    const handlers = workspaceHandlers();
+    render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("behavior-create-backend"));
+    expect(screen.getByTestId("backend-id")).not.toHaveAttribute("readonly");
+    expect(screen.getByTestId("backend-id")).toHaveValue("");
+
+    fireEvent.click(screen.getByTestId("config-tab-behavior"));
+    fireEvent.click(screen.getByTestId("behavior-create-profile"));
+    expect(screen.getByTestId("profile-id")).not.toHaveAttribute("readonly");
+    expect(screen.getByTestId("profile-id")).toHaveValue("");
+
+    fireEvent.click(screen.getByTestId("config-tab-behavior"));
+    fireEvent.click(screen.getByTestId("behavior-create-tool-selection"));
+    expect(screen.getByTestId("tool-selection-id")).not.toHaveAttribute("readonly");
+    expect(screen.getByTestId("tool-selection-id")).toHaveValue("");
+  });
+});

--- a/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 
 import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
 import {
+  AgentConfigPanel,
   AgentConfigEditor,
   BackendConfigPanel,
   BehaviorConfigPanel,
@@ -17,6 +18,7 @@ import {
 import type {
   AgentConfigSaveRequest,
   BackendSaveRequest,
+  BehaviorSaveRequest,
   BootstrapSummary,
   DeploymentView,
   EventTriggerSaveRequest,
@@ -358,7 +360,9 @@ function workspaceHandlers() {
         tools: [],
       }),
     ),
-    onSaveBehaviorConfig: vi.fn(),
+    onSaveBehaviorConfig: vi.fn<
+      [(request: BehaviorSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve()),
     onSaveTaskConfig: vi.fn<[(request: TaskSaveRequest) => Promise<unknown>]>(
       () => Promise.resolve(),
     ),
@@ -376,6 +380,179 @@ function workspaceHandlers() {
     >(() => Promise.resolve(runResult)),
   };
 }
+
+type SaveBoundaryCase = {
+  name: string;
+  saveTestId: string;
+  selectedId: string;
+  savedStatus: string;
+  renderPanel: (
+    onSave: (request: unknown) => Promise<unknown>,
+    onSelect: (id: string) => void,
+    onSavedStatusChange: (value: string) => void,
+  ) => ReactElement;
+};
+
+const saveBoundaryCases: SaveBoundaryCase[] = [
+  {
+    name: "behavior",
+    saveTestId: "behavior-save",
+    selectedId: "default",
+    savedStatus: "behavior:default",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <BehaviorConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={deployment.behaviors[0]}
+        onCreateBackend={vi.fn()}
+        onCreateBehavior={vi.fn()}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={vi.fn()}
+        onSaveBehaviorConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectBehavior={onSelect}
+      />
+    ),
+  },
+  {
+    name: "backend",
+    saveTestId: "backend-save",
+    selectedId: "backend-a",
+    savedStatus: "backend:backend-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <BackendConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedBackendId={deployment.inferenceBackends[0].backendId}
+        onCreateBackend={vi.fn()}
+        onSaveBackendConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectBackend={onSelect}
+      />
+    ),
+  },
+  {
+    name: "profile",
+    saveTestId: "profile-save",
+    selectedId: "profile-a",
+    savedStatus: "profile:profile-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <InferenceProfileConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedProfileId={deployment.inferenceProfiles[0].profileId}
+        onCreateProfile={vi.fn()}
+        onSaveInferenceProfileConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectProfile={onSelect}
+      />
+    ),
+  },
+  {
+    name: "tool selection",
+    saveTestId: "tool-selection-save",
+    selectedId: "tools-a",
+    savedStatus: "tool:tools-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <ToolSelectionConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedToolSelectionId={deployment.toolSelections[0].selectionId}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        onCreateToolSelection={vi.fn()}
+        onSaveToolSelectionConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectToolSelection={onSelect}
+      />
+    ),
+  },
+  {
+    name: "tool service",
+    saveTestId: "tool-service-save",
+    selectedId: "service-a",
+    savedStatus: "tool-service:service-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <ToolServiceConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedToolServiceId={deployment.toolServiceRegistries[0].serviceId}
+        onCreateToolService={vi.fn()}
+        onSaveToolServiceConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectToolService={onSelect}
+        onTestToolService={vi.fn()}
+      />
+    ),
+  },
+  {
+    name: "task",
+    saveTestId: "task-save",
+    selectedId: "task-a",
+    savedStatus: "task:task-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <TaskConfigPanel
+        deployment={deployment}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedBehavior={deployment.behaviors[0]}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateTask={vi.fn()}
+        onRunTask={vi.fn()}
+        onSaveTaskConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectTask={onSelect}
+      />
+    ),
+  },
+  {
+    name: "schedule",
+    saveTestId: "schedule-save",
+    selectedId: "timer-a",
+    savedStatus: "schedule:timer-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <ScheduleConfigPanel
+        deployment={deployment}
+        runningTask={false}
+        savedStatus={null}
+        saving={false}
+        selectedScheduleId={deployment.schedules[0].scheduleId}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateSchedule={vi.fn()}
+        onRunSchedule={vi.fn()}
+        onSaveScheduleConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectSchedule={onSelect}
+      />
+    ),
+  },
+  {
+    name: "event trigger",
+    saveTestId: "event-trigger-save",
+    selectedId: "event-a",
+    savedStatus: "event-trigger:event-a",
+    renderPanel: (onSave, onSelect, onSavedStatusChange) => (
+      <EventTriggerConfigPanel
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        selectedEventTriggerId={deployment.eventTriggers[0].triggerId}
+        selectedTaskId={deployment.tasks[0].taskId}
+        onCreateEventTrigger={vi.fn()}
+        onSaveEventTriggerConfig={(request) => onSave(request)}
+        onSavedStatusChange={onSavedStatusChange}
+        onSelectEventTrigger={onSelect}
+      />
+    ),
+  },
+];
 
 describe("config panel wiring", () => {
   it.each(listCases)(
@@ -423,6 +600,46 @@ describe("config panel wiring", () => {
     expect(onCreateBackend).toHaveBeenCalledTimes(1);
     expect(onCreateProfile).toHaveBeenCalledTimes(1);
     expect(onCreateToolSelection).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(saveBoundaryCases)(
+    "wires save completion across the $name panel boundary",
+    async ({ saveTestId, selectedId, savedStatus, renderPanel }) => {
+      const onSave = vi.fn(async (_request: unknown) => undefined);
+      const onSelect = vi.fn();
+      const onSavedStatusChange = vi.fn();
+
+      render(renderPanel(onSave, onSelect, onSavedStatusChange));
+      fireEvent.click(screen.getByTestId(saveTestId));
+
+      await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
+      expect(onSelect).toHaveBeenCalledWith(selectedId);
+      expect(onSavedStatusChange).toHaveBeenCalledWith(savedStatus);
+    },
+  );
+
+  it("wires save completion across the agent panel boundary", async () => {
+    const onSaveAgentConfig = vi.fn<
+      [(request: AgentConfigSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+    const onSavedStatusChange = vi.fn();
+
+    render(
+      <AgentConfigPanel
+        bootstrap={bootstrap}
+        deployment={deployment}
+        savedStatus={null}
+        saving={false}
+        onSaveAgentConfig={onSaveAgentConfig}
+        onSavedStatusChange={onSavedStatusChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.click(screen.getByTestId("agent-save"));
+
+    await waitFor(() => expect(onSaveAgentConfig).toHaveBeenCalledTimes(1));
+    expect(onSavedStatusChange).toHaveBeenCalledWith("agent:did:key:z6MkAgent");
   });
 
   it("wires agent edit, cancel, and save buttons", async () => {
@@ -595,5 +812,91 @@ describe("config panel wiring", () => {
     fireEvent.click(screen.getByTestId("behavior-create-tool-selection"));
     expect(screen.getByTestId("tool-selection-id")).not.toHaveAttribute("readonly");
     expect(screen.getByTestId("tool-selection-id")).toHaveValue("");
+  });
+
+  it("routes workspace save buttons to the active panel handlers", async () => {
+    const handlers = workspaceHandlers();
+    render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("behavior-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveBehaviorConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ behaviorId: "default" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-agent"));
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.click(screen.getByTestId("agent-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveAgentConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ agentDid: "did:key:z6MkAgent" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-backends"));
+    fireEvent.click(screen.getByTestId("backend-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveBackendConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ backendId: "backend-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-profiles"));
+    fireEvent.click(screen.getByTestId("profile-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveInferenceProfileConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ profileId: "profile-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-toolSelections"));
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ selectionId: "tools-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-metaTools"));
+    fireEvent.click(screen.getByTestId("tool-service-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveToolServiceConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ serviceId: "service-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-tasks"));
+    fireEvent.click(screen.getByTestId("task-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveTaskConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ taskId: "task-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-timerTriggers"));
+    fireEvent.click(screen.getByTestId("schedule-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveScheduleConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ scheduleId: "timer-a" }),
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-eventTriggers"));
+    fireEvent.click(screen.getByTestId("event-trigger-save"));
+    await waitFor(() =>
+      expect(handlers.onSaveEventTriggerConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ triggerId: "event-a" }),
+      ),
+    );
   });
 });

--- a/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-wiring.test.tsx
@@ -73,9 +73,9 @@ const deployment: DeploymentView = {
       behaviorId: "ops",
       displayName: "Ops",
       systemPrompt: "You are the ops behavior.",
-      backendId: "backend-a",
-      inferenceProfileId: "profile-a",
-      toolSelectionId: "tools-a",
+      backendId: "backend-b",
+      inferenceProfileId: "profile-b",
+      toolSelectionId: "tools-b",
       enabled: true,
       isDefault: false,
     },
@@ -90,12 +90,26 @@ const deployment: DeploymentView = {
       enabled: true,
       models: ["model-a"],
     },
+    {
+      backendId: "backend-b",
+      name: "Backend B",
+      providerKind: "openai",
+      endpoint: "http://127.0.0.1:9000/v1",
+      apiKeyConfigured: false,
+      enabled: true,
+      models: ["model-b"],
+    },
   ],
   inferenceProfiles: [
     {
       profileId: "profile-a",
       displayName: "Profile A",
       contextWindow: 131072,
+    },
+    {
+      profileId: "profile-b",
+      displayName: "Profile B",
+      contextWindow: 65536,
     },
   ],
   toolSelections: [
@@ -110,6 +124,18 @@ const deployment: DeploymentView = {
       cliToolNames: ["grep"],
       enableMetaTools: true,
       delegateTo: ["service-a"],
+    },
+    {
+      selectionId: "tools-b",
+      agentDid: "did:key:z6MkAgent",
+      displayName: "Tools B",
+      enableFileTools: false,
+      fileToolsMode: "ReadOnly",
+      enableBash: false,
+      bashMode: "ReadOnly",
+      cliToolNames: [],
+      enableMetaTools: false,
+      delegateTo: [],
     },
   ],
   toolServiceRegistries: [
@@ -133,6 +159,19 @@ const deployment: DeploymentView = {
         totalFires: 0,
         scheduleCount: 1,
         eventTriggerCount: 1,
+      },
+      runHistory: [],
+    },
+    {
+      taskId: "task-b",
+      name: "Task B",
+      behaviorId: "ops",
+      promptTemplate: "Run task B",
+      enabled: true,
+      recentRuns: {
+        totalFires: 0,
+        scheduleCount: 0,
+        eventTriggerCount: 0,
       },
       runHistory: [],
     },
@@ -812,6 +851,60 @@ describe("config panel wiring", () => {
     fireEvent.click(screen.getByTestId("behavior-create-tool-selection"));
     expect(screen.getByTestId("tool-selection-id")).not.toHaveAttribute("readonly");
     expect(screen.getByTestId("tool-selection-id")).toHaveValue("");
+  });
+
+  it("makes selected behavior dependencies explicit across linked panes", () => {
+    const handlers = workspaceHandlers();
+    render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("config-behavior-ops"));
+
+    fireEvent.click(screen.getByTestId("config-tab-backends"));
+    expect(screen.getByTestId("backend-id")).toHaveValue("backend-b");
+
+    fireEvent.click(screen.getByTestId("config-tab-profiles"));
+    expect(screen.getByTestId("profile-id")).toHaveValue("profile-b");
+
+    fireEvent.click(screen.getByTestId("config-tab-toolSelections"));
+    expect(screen.getByTestId("tool-selection-id")).toHaveValue("tools-b");
+
+    fireEvent.click(screen.getByTestId("config-tab-tasks"));
+    fireEvent.click(screen.getByTestId("task-new"));
+    expect(screen.getByTestId("task-behavior-id")).toHaveValue("ops");
+  });
+
+  it("uses the selected task when creating timer and event trigger drafts", () => {
+    const handlers = workspaceHandlers();
+    render(
+      <ConfigWorkspace
+        bootstrap={bootstrap}
+        runningTask={false}
+        saving={false}
+        selectedBehaviorId="default"
+        selectedDeployment={deployment}
+        {...handlers}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("config-tab-tasks"));
+    fireEvent.click(screen.getByTestId("config-task-task-b"));
+
+    fireEvent.click(screen.getByTestId("config-tab-timerTriggers"));
+    fireEvent.click(screen.getByTestId("schedule-new"));
+    expect(screen.getByTestId("schedule-task-id")).toHaveValue("task-b");
+
+    fireEvent.click(screen.getByTestId("config-tab-eventTriggers"));
+    fireEvent.click(screen.getByTestId("event-trigger-new"));
+    expect(screen.getByTestId("event-trigger-task-id")).toHaveValue("task-b");
   });
 
   it("routes workspace save buttons to the active panel handlers", async () => {

--- a/apps/desktop-tauri/tests/fleet-dashboard.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-dashboard.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FleetDashboard } from "../src/components/fleet/FleetDashboard";
+
+describe("FleetDashboard add connection flow", () => {
+  it("discovers peer connection details from a server /status address", async () => {
+    const onFetchPeerStatus = vi.fn(async () => ({
+      agent_name: "worker-a",
+      agent_did: "did:key:z6MkWorkerA",
+      p2p: {
+        p2p_shareable_address:
+          "/ip4/100.73.235.39/tcp/9161/p2p/12D3KooWorker",
+      },
+    }));
+    const onAddPeer = vi.fn(async () => undefined);
+
+    render(
+      <FleetDashboard
+        addingPeer={false}
+        bootstrap={null}
+        deployments={[]}
+        loading={false}
+        p2pHealth={null}
+        repairingP2P={false}
+        starting={false}
+        onAddPeer={onAddPeer}
+        onFetchPeerStatus={onFetchPeerStatus}
+        onOpenChat={vi.fn()}
+        onOpenConfig={vi.fn()}
+        onRepairP2P={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
+      target: { value: "http://127.0.0.1:9181" },
+    });
+    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+
+    await waitFor(() => {
+      expect(onFetchPeerStatus).toHaveBeenCalledWith("http://127.0.0.1:9181");
+      expect(onAddPeer).toHaveBeenCalledWith({
+        label: "worker-a",
+        agentDid: "did:key:z6MkWorkerA",
+        addr: "/ip4/100.73.235.39/tcp/9161/p2p/12D3KooWorker",
+      });
+    });
+  });
+
+  it("lets users preview discovered /status details before adding", async () => {
+    const onFetchPeerStatus = vi.fn(async () => ({
+      agent_name: "api-gateway",
+      agent_did: "did:key:z6MkGateway",
+      p2p_shareable_address: "iroh://gateway",
+    }));
+
+    render(
+      <FleetDashboard
+        addingPeer={false}
+        bootstrap={null}
+        deployments={[]}
+        loading={false}
+        p2pHealth={null}
+        repairingP2P={false}
+        starting={false}
+        onAddPeer={vi.fn()}
+        onFetchPeerStatus={onFetchPeerStatus}
+        onOpenChat={vi.fn()}
+        onOpenConfig={vi.fn()}
+        onRepairP2P={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
+      target: { value: "127.0.0.1:9181" },
+    });
+    fireEvent.click(screen.getByTestId("fleet-fetch-status"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("fleet-add-label")).toHaveValue("api-gateway");
+      expect(screen.getByTestId("fleet-add-agent-did")).toHaveValue(
+        "did:key:z6MkGateway",
+      );
+      expect(screen.getByTestId("fleet-add-addr")).toHaveValue("iroh://gateway");
+    });
+  });
+});

--- a/apps/desktop-tauri/tests/live-bridge-runner.ts
+++ b/apps/desktop-tauri/tests/live-bridge-runner.ts
@@ -345,6 +345,13 @@ export class LiveBridgeRunner implements TauriDriverBridge {
         this.postJson<DesktopClientSnapshot>("/desktop/client/shutdown", {}),
       addPeer: async (request) =>
         this.postJson<DesktopClientSnapshot>("/desktop/peer/add", request),
+      fetchPeerStatus: async (serverAddress) => {
+        const response = await this.fetchWithTimeout(
+          normalizePeerStatusUrl(serverAddress),
+          {},
+        );
+        return this.decodeJson<unknown>(response);
+      },
       repairP2P: async () =>
         this.postJson<DesktopClientSnapshot>("/desktop/p2p/repair", {}),
       fetchSessionSnapshot: async (sessionId, requestId) =>
@@ -725,4 +732,27 @@ function appendRunnerArg(
     return;
   }
   args.push(flag, trimmed);
+}
+
+function normalizePeerStatusUrl(serverAddress: string) {
+  const trimmed = serverAddress.trim();
+  const url = new URL(
+    trimmed.startsWith("http://") || trimmed.startsWith("https://")
+      ? trimmed
+      : `http://${trimmed}`,
+  );
+  const path = url.pathname.replace(/\/+$/, "");
+  if (
+    path === "" ||
+    path === "/" ||
+    path === "/api/v0" ||
+    path === "/api/v0/graphql"
+  ) {
+    url.pathname = "/status";
+  } else if (!path.endsWith("/status")) {
+    url.pathname = `${path}/status`;
+  }
+  url.search = "";
+  url.hash = "";
+  return url.toString();
 }

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -107,8 +107,11 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
 
     let p2p_config = resolve_server_p2p_config(&home_dir, &args)?;
     let mut node_builder = crate::persistent_node_builder(&data_dir).with_http(
-        defra_node::HttpConfig::with_addr(http_addr)
-            .with_extra_routes(runtime_contract_router(graphql_url.clone())),
+        defra_node::HttpConfig::with_addr(http_addr).with_extra_routes(runtime_contract_router(
+            graphql_url.clone(),
+            agent_name.clone(),
+            identity.did().to_string(),
+        )),
     );
     if let Some(node_identity_did) = server_identity.node_identity_did.as_ref() {
         node_builder = node_builder.with_node_identity_did(node_identity_did.clone());

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -7,6 +7,7 @@ use axum::{
     routing::get,
     Router,
 };
+use serde_json::{json, Value};
 
 use crate::http::healthz::render_healthz_payload;
 use crate::http::prometheus::{load_metrics_query_data, render_prometheus_metrics};
@@ -17,13 +18,21 @@ const PROMETHEUS_CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8"
 #[derive(Clone)]
 pub(crate) struct RuntimeHttpState {
     pub(crate) graphql: String,
+    pub(crate) agent_name: String,
+    pub(crate) agent_did: String,
     pub(crate) started_at: String,
     pub(crate) started_instant: Instant,
 }
 
-pub(crate) fn runtime_contract_router(graphql: String) -> Router {
+pub(crate) fn runtime_contract_router(
+    graphql: String,
+    agent_name: String,
+    agent_did: String,
+) -> Router {
     let state = RuntimeHttpState {
         graphql,
+        agent_name,
+        agent_did,
         started_at: chrono::Utc::now().to_rfc3339(),
         started_instant: Instant::now(),
     };
@@ -32,6 +41,7 @@ pub(crate) fn runtime_contract_router(graphql: String) -> Router {
         .route("/metrics", get(metrics_handler))
         .route("/version", get(version_handler))
         .route("/healthz", get(healthz_handler))
+        .route("/status", get(status_handler))
         .with_state(state)
 }
 
@@ -67,4 +77,55 @@ async fn healthz_handler(State(state): State<RuntimeHttpState>) -> Response {
             (StatusCode::SERVICE_UNAVAILABLE, axum::Json(health)).into_response()
         }
     }
+}
+
+async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
+    let p2p = crate::commands::p2p::load_live_http_p2p_status(None, &state.graphql).await;
+    let mut body = match load_metrics_query_data(&state.graphql).await {
+        Ok(data) => {
+            let health = render_healthz_payload(&state, Some(&data), None);
+            let runtime = data
+                .agent_runtimes
+                .iter()
+                .find(|runtime| runtime.agent_did == state.agent_did)
+                .or_else(|| data.agent_runtimes.first());
+            json!({
+                "status": health.get("status").cloned().unwrap_or(Value::String("unknown".to_string())),
+                "ok": health.get("ok").cloned().unwrap_or(Value::Bool(false)),
+                "service": "defra-agent",
+                "version": version_response().version,
+                "started_at": state.started_at,
+                "uptime_seconds": state.started_instant.elapsed().as_secs(),
+                "graphql": state.graphql,
+                "agent_name": state.agent_name,
+                "agent_did": state.agent_did,
+                "runtime": runtime,
+                "runtimes": data.agent_runtimes,
+                "backends": data.inference_backends,
+                "p2p": p2p.clone(),
+            })
+        }
+        Err(error) => json!({
+            "status": "unhealthy",
+            "ok": false,
+            "service": "defra-agent",
+            "version": version_response().version,
+            "started_at": state.started_at,
+            "uptime_seconds": state.started_instant.elapsed().as_secs(),
+            "graphql": state.graphql,
+            "agent_name": state.agent_name,
+            "agent_did": state.agent_did,
+            "runtime": Value::Null,
+            "runtimes": [],
+            "backends": [],
+            "p2p": p2p.clone(),
+            "error": error.to_string(),
+        }),
+    };
+
+    if let Some(map) = body.as_object_mut() {
+        crate::commands::p2p::flatten_p2p_fields(map, &p2p);
+    }
+
+    (StatusCode::OK, axum::Json(body)).into_response()
 }

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -118,6 +118,39 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         "expected runtime row for {agent_did} in /healthz body: {health}"
     );
 
+    let status_response = client
+        .get(format!("http://127.0.0.1:{port}/status"))
+        .send()
+        .await
+        .context("fetching /status")?;
+    assert!(
+        status_response.status().is_success(),
+        "unexpected /status response: {status_response:?}"
+    );
+    let status: Value = status_response
+        .json()
+        .await
+        .context("reading /status body")?;
+    assert_eq!(
+        status.get("agent_name").and_then(Value::as_str),
+        Some(agent_name.as_str())
+    );
+    assert_eq!(
+        status.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        status.get("graphql").and_then(Value::as_str),
+        Some(graphql.as_str())
+    );
+    assert!(
+        status
+            .get("p2p_listen_addresses")
+            .and_then(Value::as_array)
+            .is_some_and(|rows| !rows.is_empty()),
+        "expected /status to include P2P listen addresses: {status}"
+    );
+
     let response = client
         .get(format!("http://127.0.0.1:{port}/metrics"))
         .send()


### PR DESCRIPTION
## Summary
- align fleet/chat/config UI styling and config panel wiring
- add address-only add-agent flow that fetches server /status through the native desktop bridge
- expose /status on the defra-agent server with agent identity and P2P fields

## Tests
- npm test
- npm run build
- cargo fmt --check && git diff --check
- cargo test -p defra-agent-desktop-tauri peer_status_url --lib
- cargo test -p defra-agent-cli server_exposes_prometheus_metrics_endpoint --test cli_server