### PR TITLE
Sign macOS binary with imported identity fingerprint

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -198,17 +198,24 @@ jobs:
 
           identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
           printf '%s\n' "${identity_output}"
-          if ! grep -Fq "${MACOS_CODESIGN_IDENTITY}" <<< "${identity_output}"; then
+          identity_line="$(grep -F "${MACOS_CODESIGN_IDENTITY}" <<< "${identity_output}" | head -n 1 || true)"
+          if [[ -z "${identity_line}" ]]; then
             echo "::error::Configured MACOS_CODESIGN_IDENTITY was not found in the imported signing keychain."
             exit 1
           fi
+          signing_identity="$(awk '{ print $2 }' <<< "${identity_line}")"
+          if [[ -z "${signing_identity}" ]]; then
+            echo "::error::Could not extract signing identity fingerprint from imported keychain identity."
+            exit 1
+          fi
+          echo "Using imported signing identity fingerprint ${signing_identity}."
 
           sign_with_timestamp_arg() {
             local timestamp_arg="$1"
             codesign \
               --force \
               --keychain "${keychain_path}" \
-              --sign "${MACOS_CODESIGN_IDENTITY}" \
+              --sign "${signing_identity}" \
               --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
               "${timestamp_arg}" \
               "${binary_path}"


### PR DESCRIPTION
## Summary
- keep signing in the same step as temporary keychain import
- match the configured signing identity against security find-identity output
- pass the imported identity fingerprint to codesign with the temp keychain path

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'\n- git diff --check -- .github/workflows/release-macos.yml