### PR TITLE
Use standard macOS signing keychain setup

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -164,7 +164,8 @@ jobs:
           fi
 
           binary_path="target/release/defra-agent"
-          keychain_path="${RUNNER_TEMP}/defra-agent-signing.keychain-db"
+          keychain_name="defra-agent-signing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          keychain_path="${keychain_name}.keychain"
           keychain_password="${MACOS_CODESIGN_KEYCHAIN_PASSWORD:-$(uuidgen)}"
           cert_path="${RUNNER_TEMP}/defra-agent-codesign.p12"
           original_keychains_path="${RUNNER_TEMP}/defra-agent-original-keychains.txt"
@@ -182,18 +183,22 @@ jobs:
           security unlock-keychain -p "${keychain_password}" "${keychain_path}"
           security import "${cert_path}" \
             -k "${keychain_path}" \
+            -f pkcs12 \
             -P "${MACOS_CODESIGN_CERT_PASSWORD}" \
             -T /usr/bin/codesign \
-            -T /usr/bin/security
+            -T /usr/bin/security \
+            -T /usr/bin/pkgbuild \
+            -T /usr/bin/productbuild \
+            -T /usr/bin/productsign
 
           keychains=()
           while IFS= read -r keychain; do
             [[ -n "${keychain}" ]] && keychains+=("${keychain}")
           done < <(sed -e 's/^[[:space:]]*"//' -e 's/"$//' "${original_keychains_path}")
 
-          security list-keychains -d user -s "${keychain_path}" "${keychains[@]}"
+          security list-keychains -d user -s "${keychain_path}" login.keychain "${keychains[@]}"
           security default-keychain -d user -s "${keychain_path}"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${keychain_password}" "${keychain_path}"
+          security set-key-partition-list -S apple-tool:,apple: -k "${keychain_password}" "${keychain_path}"
           security unlock-keychain -p "${keychain_password}" "${keychain_path}"
 
           identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
@@ -214,7 +219,6 @@ jobs:
             local timestamp_arg="$1"
             codesign \
               --force \
-              --keychain "${keychain_path}" \
               --sign "${signing_identity}" \
               --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
               "${timestamp_arg}" \


### PR DESCRIPTION
## Summary
- switch release signing to a named temporary user keychain instead of a RUNNER_TEMP keychain-db path
- import the p12 explicitly as pkcs12 and add the same tool ACLs used by Apple import-codesign-certs
- put the temp keychain on the user search list and let codesign resolve the parsed fingerprint normally

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'
- git diff --check -- .github/workflows/release-macos.yml
