### PR TITLE
Use persistent Studio signing keychain

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -93,9 +93,8 @@ jobs:
       - name: Validate release signing mode
         env:
           DRY_RUN_UNSIGNED_INPUT: ${{ inputs.dry_run_unsigned }}
-          MACOS_CODESIGN_CERT_P12_BASE64: ${{ secrets.MACOS_CODESIGN_CERT_P12_BASE64 }}
-          MACOS_CODESIGN_CERT_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERT_PASSWORD }}
           MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          MACOS_CODESIGN_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CODESIGN_KEYCHAIN_PASSWORD }}
         run: |
           set -euo pipefail
 
@@ -120,9 +119,8 @@ jobs:
           fi
 
           missing=()
-          [[ -n "${MACOS_CODESIGN_CERT_P12_BASE64}" ]] || missing+=("MACOS_CODESIGN_CERT_P12_BASE64")
-          [[ -n "${MACOS_CODESIGN_CERT_PASSWORD}" ]] || missing+=("MACOS_CODESIGN_CERT_PASSWORD")
           [[ -n "${MACOS_CODESIGN_IDENTITY}" ]] || missing+=("MACOS_CODESIGN_IDENTITY")
+          [[ -n "${MACOS_CODESIGN_KEYCHAIN_PASSWORD}" ]] || missing+=("MACOS_CODESIGN_KEYCHAIN_PASSWORD")
 
           if [[ "${signing_enabled}" == "true" && "${#missing[@]}" -gt 0 ]]; then
             printf "::error::Missing required macOS signing secret(s): %s\n" "${missing[*]}"
@@ -134,6 +132,77 @@ jobs:
           fi
 
           echo "SIGNING_ENABLED=${signing_enabled}" >> "${GITHUB_ENV}"
+
+      - name: Preflight native signing keychain
+        env:
+          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
+          MACOS_CODESIGN_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CODESIGN_KEYCHAIN_PASSWORD }}
+          MACOS_CODESIGN_KEYCHAIN_PATH_VAR: ${{ vars.MACOS_CODESIGN_KEYCHAIN_PATH }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${SIGNING_ENABLED}" != "true" ]]; then
+            echo "Skipping native signing keychain preflight for unsigned manual dry-run."
+            exit 0
+          fi
+
+          keychain_path="${MACOS_CODESIGN_KEYCHAIN_PATH_VAR:-${HOME}/Library/Keychains/defra-agent-signing.keychain-db}"
+          keychain_password="${MACOS_CODESIGN_KEYCHAIN_PASSWORD}"
+          login_keychain="${HOME}/Library/Keychains/login.keychain-db"
+          original_keychains_path="${RUNNER_TEMP}/defra-agent-original-keychains.txt"
+          original_default_keychain_path="${RUNNER_TEMP}/defra-agent-original-default-keychain.txt"
+
+          if [[ ! -f "${keychain_path}" ]]; then
+            echo "::error::Native macOS signing keychain not found at ${keychain_path}."
+            exit 1
+          fi
+
+          echo "SIGNING_KEYCHAIN=${keychain_path}" >> "${GITHUB_ENV}"
+          security list-keychains -d user > "${original_keychains_path}"
+          security default-keychain -d user > "${original_default_keychain_path}" || true
+          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+
+          keychains=()
+          while IFS= read -r keychain; do
+            [[ -n "${keychain}" ]] && keychains+=("${keychain}")
+          done < <(sed -e 's/^[[:space:]]*"//' -e 's/"$//' "${original_keychains_path}")
+
+          security list-keychains -d user -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
+          security list-keychains -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
+          security default-keychain -d user -s "${keychain_path}"
+          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
+
+          identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
+          printf '%s\n' "${identity_output}"
+          identity_line="$(grep -F "${MACOS_CODESIGN_IDENTITY}" <<< "${identity_output}" | head -n 1 || true)"
+          if [[ -z "${identity_line}" ]]; then
+            echo "::error::Configured MACOS_CODESIGN_IDENTITY was not found in ${keychain_path}."
+            exit 1
+          fi
+          signing_identity="$(awk '{ print $2 }' <<< "${identity_line}")"
+          if [[ -z "${signing_identity}" ]]; then
+            echo "::error::Could not extract signing identity fingerprint from native keychain identity."
+            exit 1
+          fi
+          echo "SIGNING_IDENTITY=${signing_identity}" >> "${GITHUB_ENV}"
+
+          smoke_bin="${RUNNER_TEMP}/defra-agent-codesign-smoke"
+          cp /bin/echo "${smoke_bin}"
+          codesign --remove-signature "${smoke_bin}" 2>/dev/null || true
+          codesign \
+            --force \
+            --sign "${signing_identity}" \
+            --keychain "${keychain_path}" \
+            --identifier "${MACOS_CODESIGN_IDENTIFIER}.smoke" \
+            --timestamp=none \
+            "${smoke_bin}"
+          codesign --verify --strict --verbose=2 "${smoke_bin}"
+          designated_requirement="$(codesign -d -r- "${smoke_bin}" 2>&1)"
+          printf '%s\n' "${designated_requirement}"
+          if grep -q 'designated => cdhash' <<< "${designated_requirement}"; then
+            echo "::error::Native signing smoke test produced an ad-hoc cdhash designated requirement."
+            exit 1
+          fi
 
       - name: Build release binary
         run: |
@@ -147,11 +216,8 @@ jobs:
           cargo build -p defra-agent-cli --release
           file target/release/defra-agent
 
-      - name: Import signing certificate and sign binary
+      - name: Sign binary with native macOS identity
         env:
-          MACOS_CODESIGN_CERT_P12_BASE64: ${{ secrets.MACOS_CODESIGN_CERT_P12_BASE64 }}
-          MACOS_CODESIGN_CERT_PASSWORD: ${{ secrets.MACOS_CODESIGN_CERT_PASSWORD }}
-          MACOS_CODESIGN_IDENTITY: ${{ secrets.MACOS_CODESIGN_IDENTITY }}
           MACOS_CODESIGN_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CODESIGN_KEYCHAIN_PASSWORD }}
           TIMESTAMP_MODE_INPUT: ${{ inputs.codesign_timestamp }}
           TIMESTAMP_MODE_VAR: ${{ vars.MACOS_CODESIGN_TIMESTAMP_MODE }}
@@ -164,94 +230,26 @@ jobs:
           fi
 
           binary_path="target/release/defra-agent"
-          keychain_name="defra-agent-signing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          keychain_path="${HOME}/Library/Keychains/${keychain_name}.keychain-db"
-          keychain_password="${MACOS_CODESIGN_KEYCHAIN_PASSWORD:-$(uuidgen)}"
-          cert_path="${RUNNER_TEMP}/defra-agent-codesign.p12"
-          original_keychains_path="${RUNNER_TEMP}/defra-agent-original-keychains.txt"
-          original_default_keychain_path="${RUNNER_TEMP}/defra-agent-original-default-keychain.txt"
-          login_keychain="${HOME}/Library/Keychains/login.keychain-db"
+          keychain_path="${SIGNING_KEYCHAIN}"
+          signing_identity="${SIGNING_IDENTITY}"
           timestamp_mode="${TIMESTAMP_MODE_INPUT:-${TIMESTAMP_MODE_VAR:-auto}}"
 
-          trap 'rm -f "${cert_path}"' EXIT
-          echo "SIGNING_KEYCHAIN=${keychain_path}" >> "${GITHUB_ENV}"
-          printf '%s' "${MACOS_CODESIGN_CERT_P12_BASE64}" | base64 -D > "${cert_path}"
-
-          security list-keychains -d user > "${original_keychains_path}"
-          security default-keychain -d user > "${original_default_keychain_path}" || true
-          security create-keychain -p "${keychain_password}" "${keychain_path}"
-          security set-keychain-settings -lut 21600 "${keychain_path}"
-          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
-          security import "${cert_path}" \
-            -k "${keychain_path}" \
-            -A \
-            -t cert \
-            -f pkcs12 \
-            -P "${MACOS_CODESIGN_CERT_PASSWORD}" \
-            -T /usr/bin/codesign \
-            -T /usr/bin/security \
-            -T /usr/bin/pkgbuild \
-            -T /usr/bin/productbuild \
-            -T /usr/bin/productsign
-
-          keychains=()
-          while IFS= read -r keychain; do
-            [[ -n "${keychain}" ]] && keychains+=("${keychain}")
-          done < <(sed -e 's/^[[:space:]]*"//' -e 's/"$//' "${original_keychains_path}")
-
-          security list-keychains -d user -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
-          security list-keychains -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
-          security default-keychain -d user -s "${keychain_path}"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${keychain_password}" "${keychain_path}"
-          security unlock-keychain -p "${keychain_password}" "${keychain_path}"
-          echo "Active user keychain search list:"
-          security list-keychains -d user
-          echo "Active default keychain:"
-          security default-keychain -d user
-
-          identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
-          printf '%s\n' "${identity_output}"
-          echo "Codesigning identities visible through the active search list:"
-          security find-identity -v -p codesigning
-          identity_line="$(grep -F "${MACOS_CODESIGN_IDENTITY}" <<< "${identity_output}" | head -n 1 || true)"
-          if [[ -z "${identity_line}" ]]; then
-            echo "::error::Configured MACOS_CODESIGN_IDENTITY was not found in the imported signing keychain."
+          if [[ -z "${keychain_path}" || -z "${signing_identity}" ]]; then
+            echo "::error::Native signing keychain preflight did not provide SIGNING_KEYCHAIN/SIGNING_IDENTITY."
             exit 1
           fi
-          signing_identity="$(awk '{ print $2 }' <<< "${identity_line}")"
-          if [[ -z "${signing_identity}" ]]; then
-            echo "::error::Could not extract signing identity fingerprint from imported keychain identity."
-            exit 1
-          fi
-          echo "Using imported signing identity fingerprint ${signing_identity}."
-
-          identity_candidates=("${MACOS_CODESIGN_IDENTITY}")
-          if [[ "${signing_identity}" != "${MACOS_CODESIGN_IDENTITY}" ]]; then
-            identity_candidates+=("${signing_identity}")
-          fi
+          security unlock-keychain -p "${MACOS_CODESIGN_KEYCHAIN_PASSWORD}" "${keychain_path}"
+          echo "Signing with native macOS identity fingerprint ${signing_identity} from ${keychain_path}."
 
           sign_with_timestamp_arg() {
             local timestamp_arg="$1"
-            local identity_candidate
-            local status=1
-
-            for identity_candidate in "${identity_candidates[@]}"; do
-              if codesign \
-                --force \
-                --sign "${identity_candidate}" \
-                --keychain "${keychain_path}" \
-                --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
-                "${timestamp_arg}" \
-                "${binary_path}"; then
-                return 0
-              else
-                status=$?
-              fi
-
-              echo "::warning::codesign could not use one imported identity candidate; trying the next candidate if available."
-            done
-
-            return "${status}"
+            codesign \
+              --force \
+              --sign "${signing_identity}" \
+              --keychain "${keychain_path}" \
+              --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
+              "${timestamp_arg}" \
+              "${binary_path}"
           }
 
           codesign --remove-signature "${binary_path}" 2>/dev/null || true
@@ -367,7 +365,7 @@ jobs:
             gh release create "${GITHUB_REF_NAME}" --verify-tag --title "${GITHUB_REF_NAME}" --notes "Signed defra-agent macOS release artifact."
           gh release upload "${GITHUB_REF_NAME}" "${TARBALL}" "${CHECKSUM_FILE}" --clobber
 
-      - name: Delete temporary keychain
+      - name: Restore keychain search list
         if: always()
         env:
           PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
@@ -375,7 +373,6 @@ jobs:
           set -euo pipefail
           git config --global --remove-section "url.https://x-access-token:${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
           git config --global --remove-section "url.https://${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
-          keychain_path="${SIGNING_KEYCHAIN:-${RUNNER_TEMP}/defra-agent-signing.keychain-db}"
           original_keychains_path="${RUNNER_TEMP}/defra-agent-original-keychains.txt"
           original_default_keychain_path="${RUNNER_TEMP}/defra-agent-original-default-keychain.txt"
 
@@ -396,8 +393,4 @@ jobs:
             if [[ -n "${default_keychain}" ]]; then
               security default-keychain -d user -s "${default_keychain}" || true
             fi
-          fi
-
-          if [[ -f "${keychain_path}" ]]; then
-            security delete-keychain "${keychain_path}" || true
           fi

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -32,7 +32,9 @@ The macOS release workflow:
 - runs on a self-hosted Mac Studio runner labeled `self-hosted`, `macOS`,
   `ARM64`, and `studio`;
 - builds `defra-agent-cli` in release mode, producing `target/release/defra-agent`;
-- imports a signing certificate into a temporary keychain;
+- unlocks the runner's persistent signing keychain;
+- makes that keychain visible to non-interactive `codesign` jobs;
+- smoke-signs a test binary before the Rust build starts;
 - signs with `--identifier org.sourcenetwork.defra-agent`;
 - verifies with `codesign --verify --strict --verbose=2`;
 - prints the designated requirement with `codesign -d -r-`;
@@ -57,31 +59,31 @@ Set these repository or environment secrets before running the release workflow:
 
 ```text
 PRIVATE_REPO_PAT
-MACOS_CODESIGN_CERT_P12_BASE64
-MACOS_CODESIGN_CERT_PASSWORD
 MACOS_CODESIGN_IDENTITY
+MACOS_CODESIGN_KEYCHAIN_PASSWORD
 ```
 
 `PRIVATE_REPO_PAT` is the same private dependency fetch token used by CI. The
 workflow disables checkout's persisted `GITHUB_TOKEN` credentials and uses this
 PAT for Source Network git dependencies, matching the Backbone CI pattern.
 
-Optional:
-
-```text
-MACOS_CODESIGN_KEYCHAIN_PASSWORD
-```
-
 `MACOS_CODESIGN_IDENTITY` can be the identity name shown by
 `security find-identity -v -p codesigning`, or the certificate SHA-1 hash from
 that output.
 
+`MACOS_CODESIGN_KEYCHAIN_PASSWORD` must unlock the persistent signing keychain on
+each Studio runner.
+
 The workflow also honors optional repository variables:
 
 ```text
+MACOS_CODESIGN_KEYCHAIN_PATH=/Users/admin/Library/Keychains/defra-agent-signing.keychain-db
 MACOS_CODESIGN_TIMESTAMP_MODE=auto|enabled|none
 MACOS_CODESIGN_SPCTL_REQUIRED=true|false
 ```
+
+`MACOS_CODESIGN_KEYCHAIN_PATH` defaults to
+`$HOME/Library/Keychains/defra-agent-signing.keychain-db`.
 
 Use `enabled` for Developer ID release signing when timestamping must succeed.
 Use `none` for self-signed or internal identities that cannot use Apple's
@@ -92,7 +94,7 @@ with `--timestamp=none` if timestamping is unavailable.
 not pass Gatekeeper assessment. Set `MACOS_CODESIGN_SPCTL_REQUIRED=true` only for
 Developer ID releases where Gatekeeper assessment is expected to pass.
 
-## Creating and exporting a certificate
+## Studio signing keychain
 
 Preferred production path: use an Apple Developer ID Application certificate
 owned by Source Network.
@@ -101,7 +103,20 @@ Internal path: use a stable self-signed code-signing certificate that is kept an
 reused for all steward releases. Replacing the certificate changes the
 designated requirement and may require another keychain approval/migration.
 
-To create or export the identity on macOS:
+Each self-hosted Studio runner must have the signing identity installed in a
+persistent keychain that CI can unlock over SSH and from the GitHub Actions
+runner session. The release workflow defaults to:
+
+```text
+/Users/admin/Library/Keychains/defra-agent-signing.keychain-db
+```
+
+The current release identity is a Developer ID Application identity. The workflow
+finds it in the signing keychain, extracts the SHA-1 fingerprint, smoke-signs a
+copy of `/bin/echo`, and refuses to continue if the designated requirement is an
+ad-hoc `cdhash`.
+
+To create or rotate the identity on a Studio:
 
 1. Open Keychain Access.
 2. For Developer ID, import the Apple-issued certificate and private key into the
@@ -110,21 +125,22 @@ To create or export the identity on macOS:
    code-signing certificate in the login keychain.
 4. In Keychain Access, export the signing identity as a `.p12` file and set an
    export password.
-5. Find the identity value:
+5. Create or unlock the persistent CI signing keychain.
+6. Import the `.p12` into that keychain.
+7. Allow `codesign` and `security` to use the private key from non-interactive
+   runner jobs.
+8. Store the keychain password in `MACOS_CODESIGN_KEYCHAIN_PASSWORD`.
+9. Find the identity value:
 
 ```sh
 security find-identity -v -p codesigning
 ```
 
-6. Base64-encode the exported `.p12` for GitHub:
+10. Store the identity name or SHA-1 hash in `MACOS_CODESIGN_IDENTITY`.
 
-```sh
-base64 -i defra-agent-codesign.p12 | pbcopy
-```
-
-7. Store the copied value in `MACOS_CODESIGN_CERT_P12_BASE64`, the export
-   password in `MACOS_CODESIGN_CERT_PASSWORD`, and the identity name or SHA-1
-   hash in `MACOS_CODESIGN_IDENTITY`.
+The exported `.p12` is only needed for runner provisioning or certificate
+rotation. The release workflow does not import a `.p12` at runtime; tagged
+release artifacts must be signed by the native Studio keychain path.
 
 ## Local verification
 


### PR DESCRIPTION
## Summary
- switch macOS release signing from runtime .p12 import to the persistent Studio signing keychain
- preflight the native keychain with a smoke codesign before the Rust release build
- update signing docs for Studio provisioning and required secrets

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'
- git diff --check -- .github/workflows/release-macos.yml docs/macos-signing.md