### PR TITLE
Sign through active Studio keychain

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -176,6 +176,8 @@ jobs:
 
           identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
           printf '%s\n' "${identity_output}"
+          active_identity_output="$(security find-identity -v -p codesigning)"
+          printf '%s\n' "${active_identity_output}"
           identity_line="$(grep -F "${MACOS_CODESIGN_IDENTITY}" <<< "${identity_output}" | head -n 1 || true)"
           if [[ -z "${identity_line}" ]]; then
             echo "::error::Configured MACOS_CODESIGN_IDENTITY was not found in ${keychain_path}."
@@ -200,7 +202,6 @@ jobs:
           codesign \
             --force \
             --sign "${signing_identity_name}" \
-            --keychain "${keychain_path}" \
             --identifier "${MACOS_CODESIGN_IDENTIFIER}.smoke" \
             --timestamp=none \
             "${smoke_bin}"
@@ -254,7 +255,6 @@ jobs:
             codesign \
               --force \
               --sign "${signing_identity}" \
-              --keychain "${keychain_path}" \
               --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
               "${timestamp_arg}" \
               "${binary_path}"

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -113,8 +113,9 @@ runner session. The release workflow defaults to:
 
 The current release identity is a Developer ID Application identity. The workflow
 finds it in the signing keychain, refreshes private-key access for `codesign`,
-smoke-signs a copy of `/bin/echo`, and refuses to continue if the designated
-requirement is an ad-hoc `cdhash`.
+puts the keychain first in the active search list, smoke-signs a copy of
+`/bin/echo`, and refuses to continue if the designated requirement is an ad-hoc
+`cdhash`.
 
 To create or rotate the identity on a Studio:
 


### PR DESCRIPTION
## Summary
- stop passing the persistent keychain directly to codesign after making it active/default
- print identities from the active search list during release preflight
- keep the smoke-sign gate before the release build

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'
- git diff --check -- .github/workflows/release-macos.yml docs/macos-signing.md