### PR TITLE
Set Studio signing runner session

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -170,7 +170,7 @@ jobs:
           security list-keychains -d user -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
           security list-keychains -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
           security default-keychain -d user -s "${keychain_path}"
-          security default-keychain -s "${keychain_path}"
+          security default-keychain -s "${keychain_path}" || true
           security unlock-keychain -p "${keychain_password}" "${keychain_path}"
           security set-keychain-settings -lut 21600 "${keychain_path}"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${keychain_password}" "${keychain_path}"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -170,9 +170,18 @@ jobs:
           security list-keychains -d user -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
           security list-keychains -s "${keychain_path}" "${login_keychain}" "${keychains[@]}"
           security default-keychain -d user -s "${keychain_path}"
+          security default-keychain -s "${keychain_path}"
           security unlock-keychain -p "${keychain_password}" "${keychain_path}"
           security set-keychain-settings -lut 21600 "${keychain_path}"
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${keychain_password}" "${keychain_path}"
+          echo "Active user keychain search list:"
+          security list-keychains -d user
+          echo "Active default keychain search list:"
+          security list-keychains
+          echo "Active user default keychain:"
+          security default-keychain -d user
+          echo "Active default keychain:"
+          security default-keychain
 
           identity_output="$(security find-identity -v -p codesigning "${keychain_path}")"
           printf '%s\n' "${identity_output}"
@@ -400,5 +409,6 @@ jobs:
             default_keychain="$(sed -e 's/^[[:space:]]*"//' -e 's/"$//' "${original_default_keychain_path}")"
             if [[ -n "${default_keychain}" ]]; then
               security default-keychain -d user -s "${default_keychain}" || true
+              security default-keychain -s "${default_keychain}" || true
             fi
           fi

--- a/docs/macos-signing.md
+++ b/docs/macos-signing.md
@@ -117,6 +117,16 @@ puts the keychain first in the active search list, smoke-signs a copy of
 `/bin/echo`, and refuses to continue if the designated requirement is an ad-hoc
 `cdhash`.
 
+The defra-agent Studio runner is launched by
+`/Library/LaunchDaemons/com.github.actions.runner.defra-agent.plist`. That
+LaunchDaemon must set `SessionCreate=true`; otherwise the job can update the
+user keychain search list while the default keychain domain seen by `codesign`
+still contains only the System keychain. Use:
+
+```sh
+scripts/enable-defra-agent-runner-session.sh
+```
+
 To create or rotate the identity on a Studio:
 
 1. Open Keychain Access.

--- a/scripts/enable-defra-agent-runner-session.sh
+++ b/scripts/enable-defra-agent-runner-session.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plist="${1:-/Library/LaunchDaemons/com.github.actions.runner.defra-agent.plist}"
+
+if [[ ! -f "${plist}" ]]; then
+  echo "Runner LaunchDaemon plist not found: ${plist}" >&2
+  exit 1
+fi
+
+label="$(/usr/libexec/PlistBuddy -c 'Print :Label' "${plist}")"
+
+if /usr/libexec/PlistBuddy -c 'Print :SessionCreate' "${plist}" >/dev/null 2>&1; then
+  sudo /usr/libexec/PlistBuddy -c 'Set :SessionCreate true' "${plist}"
+else
+  sudo /usr/libexec/PlistBuddy -c 'Add :SessionCreate bool true' "${plist}"
+fi
+
+sudo plutil -lint "${plist}"
+sudo launchctl bootout system "${plist}" 2>/dev/null || true
+sudo launchctl bootstrap system "${plist}"
+sudo launchctl kickstart -k "system/${label}" 2>/dev/null || true
+sudo launchctl print "system/${label}" | sed -n '1,80p'


### PR DESCRIPTION
## Summary
- set the signing keychain as both user and active default before release signing
- keep release signing through the active Studio keychain after preflight smoke signing
- add a helper script and docs for enabling SessionCreate on the defra-agent Studio LaunchDaemon

## Validation
- manual release workflow on this branch: https://github.com/sourcenetwork/defra-agent/actions/runs/25139302864
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'
- bash -n scripts/enable-defra-agent-runner-session.sh
- git diff --check -- .github/workflows/release-macos.yml docs/macos-signing.md scripts/enable-defra-agent-runner-session.sh