### PR TITLE
Write release checksums with relative artifact names

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -348,7 +348,10 @@ jobs:
           chmod 0755 "${package_root}/defra-agent"
 
           tar -C "${package_parent}" -czf "${tarball}" "${artifact_basename}"
-          shasum -a 256 "${tarball}" > "${checksum_file}"
+          (
+            cd "${dist_dir}"
+            shasum -a 256 "${artifact_basename}.tar.gz" > "${artifact_basename}.tar.gz.sha256"
+          )
 
           echo "tarball=${tarball}" >> "${GITHUB_OUTPUT}"
           echo "checksum_file=${checksum_file}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Summary
- write macOS release checksum files from inside the dist directory so they contain the artifact basename
- keeps local verification with `shasum -a 256 -c defra-agent-aarch64-apple-darwin.tar.gz.sha256` working after download

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-macos.yml`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-macos.yml"); puts "yaml ok"'`
- `git diff --check -- .github/workflows/release-macos.yml`
- downloaded v0.1.1 assets and verified checksum plus codesign locally