### PR TITLE
Batch fork copy mutations

### DIFF
--- a/crates/defra-agent/src/session/fork.rs
+++ b/crates/defra-agent/src/session/fork.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use defra_node::EmbeddedNode;
 
 use super::query::load_conversation_document;
-use super::retry::execute_mutation_with_retry;
+use super::retry::{execute_batch_mutation_with_retry, execute_mutation_with_retry};
 use crate::graphql::escape_graphql_string;
 
 #[derive(Debug, Clone)]
@@ -287,9 +287,9 @@ async fn copy_messages(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    let mut count = 0u32;
     let child_session_escaped = escape_graphql_string(child_session_id);
-    for row in &rows {
+    let mut mutation_fields = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
         let sequence = row
             .get("sequence")
             .and_then(|v| v.as_u64())
@@ -298,9 +298,8 @@ async fn copy_messages(
         let content = row.get("content").and_then(|v| v.as_str()).unwrap_or("");
         let timestamp = row.get("timestamp").and_then(|v| v.as_str()).unwrap_or("");
         let message_key = format!("{child_session_escaped}:{sequence}");
-        let mutation = format!(
-            r#"mutation {{
-                create_AgentMessage(input: {{
+        mutation_fields.push(format!(
+            r#"message_{index}: create_AgentMessage(input: {{
                     message_key: "{message_key}",
                     session_id: "{child_session_escaped}",
                     sequence: {sequence},
@@ -308,15 +307,14 @@ async fn copy_messages(
                     content: "{content_escaped}",
                     timestamp: "{timestamp_escaped}"
                 }}) {{ _docID }}
-            }}"#,
+            "#,
             role_escaped = escape_graphql_string(role),
             content_escaped = escape_graphql_string(content),
             timestamp_escaped = escape_graphql_string(timestamp),
-        );
-        execute_mutation_with_retry(node, &mutation, "fork::copy_message").await?;
-        count += 1;
+        ));
     }
-    Ok(count)
+    execute_batch_mutation_with_retry(node, &mutation_fields, "fork::copy_messages").await?;
+    Ok(mutation_fields.len() as u32)
 }
 
 async fn copy_tool_calls(
@@ -350,9 +348,9 @@ async fn copy_tool_calls(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    let mut count = 0u32;
     let child_session_escaped = escape_graphql_string(child_session_id);
-    for row in &rows {
+    let mut mutation_fields = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
         let message_sequence = row
             .get("message_sequence")
             .and_then(|v| v.as_u64())
@@ -372,9 +370,8 @@ async fn copy_tool_calls(
             .unwrap_or("");
         let tool_call_id_escaped = escape_graphql_string(tool_call_id);
         let tool_call_key = format!("{child_session_escaped}:{tool_call_id_escaped}");
-        let mutation = format!(
-            r#"mutation {{
-                create_AgentToolCall(input: {{
+        mutation_fields.push(format!(
+            r#"tool_call_{index}: create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
                     session_id: "{child_session_escaped}",
                     message_sequence: {message_sequence},
@@ -386,18 +383,17 @@ async fn copy_tool_calls(
                     started_at: "{started_at_escaped}",
                     completed_at: "{completed_at_escaped}"
                 }}) {{ _docID }}
-            }}"#,
+            "#,
             tool_name_escaped = escape_graphql_string(tool_name),
             args_escaped = escape_graphql_string(args),
             result_escaped = escape_graphql_string(result),
             status_escaped = escape_graphql_string(status),
             started_at_escaped = escape_graphql_string(started_at),
             completed_at_escaped = escape_graphql_string(completed_at),
-        );
-        execute_mutation_with_retry(node, &mutation, "fork::copy_tool_call").await?;
-        count += 1;
+        ));
     }
-    Ok(count)
+    execute_batch_mutation_with_retry(node, &mutation_fields, "fork::copy_tool_calls").await?;
+    Ok(mutation_fields.len() as u32)
 }
 
 async fn copy_tool_results(
@@ -431,10 +427,10 @@ async fn copy_tool_results(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    let mut count = 0u32;
     let child_session_escaped = escape_graphql_string(child_session_id);
     let child_agent_did_escaped = escape_graphql_string(child_agent_did);
-    for row in &rows {
+    let mut mutation_fields = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
         let tool_name = row.get("tool_name").and_then(|v| v.as_str()).unwrap_or("");
         let tool_input = row.get("tool_input").and_then(|v| v.as_str()).unwrap_or("");
         let output_text = row
@@ -454,9 +450,8 @@ async fn copy_tool_results(
             .and_then(|v| v.as_str())
             .unwrap_or("");
         let created_at = row.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
-        let mutation = format!(
-            r#"mutation {{
-                create_AgentToolResult(input: {{
+        mutation_fields.push(format!(
+            r#"tool_result_{index}: create_AgentToolResult(input: {{
                     agent_did: "{child_agent_did_escaped}",
                     session_id: "{child_session_escaped}",
                     tool_name: "{tool_name_escaped}",
@@ -467,18 +462,17 @@ async fn copy_tool_results(
                     conversation_doc_id: "{conversation_doc_id_escaped}",
                     created_at: "{created_at_escaped}"
                 }}) {{ _docID }}
-            }}"#,
+            "#,
             tool_name_escaped = escape_graphql_string(tool_name),
             tool_input_escaped = escape_graphql_string(tool_input),
             output_text_escaped = escape_graphql_string(output_text),
             truncation_metadata_escaped = escape_graphql_string(truncation_metadata),
             conversation_doc_id_escaped = escape_graphql_string(conversation_doc_id),
             created_at_escaped = escape_graphql_string(created_at),
-        );
-        execute_mutation_with_retry(node, &mutation, "fork::copy_tool_result").await?;
-        count += 1;
+        ));
     }
-    Ok(count)
+    execute_batch_mutation_with_retry(node, &mutation_fields, "fork::copy_tool_results").await?;
+    Ok(mutation_fields.len() as u32)
 }
 
 async fn copy_compaction_entries(
@@ -513,9 +507,9 @@ async fn copy_compaction_entries(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    let mut count = 0u32;
     let child_session_escaped = escape_graphql_string(child_session_id);
-    for row in &rows {
+    let mut mutation_fields = Vec::with_capacity(rows.len());
+    for (index, row) in rows.iter().enumerate() {
         let sequence = row
             .get("sequence")
             .and_then(|v| v.as_u64())
@@ -543,9 +537,8 @@ async fn copy_compaction_entries(
             .unwrap_or(0);
         let created_at = row.get("created_at").and_then(|v| v.as_str()).unwrap_or("");
         let compaction_key = format!("{child_session_escaped}:{sequence}");
-        let mutation = format!(
-            r#"mutation {{
-                create_CompactionEntry(input: {{
+        mutation_fields.push(format!(
+            r#"compaction_{index}: create_CompactionEntry(input: {{
                     compaction_key: "{compaction_key}",
                     session_id: "{child_session_escaped}",
                     sequence: {sequence},
@@ -557,16 +550,16 @@ async fn copy_compaction_entries(
                     compacted_tokens: {compacted_tokens},
                     created_at: "{created_at_escaped}"
                 }}) {{ _docID }}
-            }}"#,
+            "#,
             summary_escaped = escape_graphql_string(summary),
             files_read_escaped = escape_graphql_string(files_read),
             files_modified_escaped = escape_graphql_string(files_modified),
             created_at_escaped = escape_graphql_string(created_at),
-        );
-        execute_mutation_with_retry(node, &mutation, "fork::copy_compaction_entry").await?;
-        count += 1;
+        ));
     }
-    Ok(count)
+    execute_batch_mutation_with_retry(node, &mutation_fields, "fork::copy_compaction_entries")
+        .await?;
+    Ok(mutation_fields.len() as u32)
 }
 
 async fn create_child_session_and_conversation(

--- a/crates/defra-agent/src/session/retry.rs
+++ b/crates/defra-agent/src/session/retry.rs
@@ -1,5 +1,7 @@
 use super::*;
 
+const DEFAULT_BATCH_MUTATION_SIZE: usize = 50;
+
 pub(crate) async fn execute_mutation_with_retry(
     node: &EmbeddedNode,
     mutation: &str,
@@ -42,6 +44,27 @@ pub(crate) async fn execute_mutation_with_retry(
         "{operation} failed after {MAX_MUTATION_RETRIES} retries: {:?}",
         resp.errors
     )
+}
+
+pub(crate) async fn execute_batch_mutation_with_retry(
+    node: &EmbeddedNode,
+    mutation_fields: &[String],
+    operation: &str,
+) -> Result<()> {
+    if mutation_fields.is_empty() {
+        return Ok(());
+    }
+
+    for fields in mutation_fields.chunks(DEFAULT_BATCH_MUTATION_SIZE) {
+        let mutation = build_batch_mutation(fields);
+        execute_mutation_with_retry(node, &mutation, operation).await?;
+    }
+
+    Ok(())
+}
+
+fn build_batch_mutation(fields: &[String]) -> String {
+    format!("mutation {{\n{}\n}}", fields.join("\n"))
 }
 
 pub(super) async fn retry_operation<F, Fut, T>(operation: &str, f: F) -> Result<T>
@@ -127,4 +150,25 @@ pub async fn count_active_sessions(node: &EmbeddedNode) -> Result<usize> {
         .and_then(|value| value.as_array())
         .map(|rows| rows.len())
         .unwrap_or(0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_batch_mutation;
+
+    #[test]
+    fn build_batch_mutation_wraps_alias_fields() {
+        let fields = vec![
+            r#"msg_0: create_AgentMessage(input: { message_key: "s:1" }) { _docID }"#.to_string(),
+            r#"msg_1: create_AgentMessage(input: { message_key: "s:2" }) { _docID }"#.to_string(),
+        ];
+
+        assert_eq!(
+            build_batch_mutation(&fields),
+            r#"mutation {
+msg_0: create_AgentMessage(input: { message_key: "s:1" }) { _docID }
+msg_1: create_AgentMessage(input: { message_key: "s:2" }) { _docID }
+}"#
+        );
+    }
 }

--- a/crates/defra-agent/tests/fork_invariants.rs
+++ b/crates/defra-agent/tests/fork_invariants.rs
@@ -386,6 +386,129 @@ async fn fork_copies_compaction_entries_strictly_before_cut_ts() {
 }
 
 #[tokio::test]
+async fn fork_batches_multiple_rows_for_all_copy_collections() {
+    let db = test_db("fork-batch-copy-all").await;
+
+    let parent_session = "parent-batch-copy";
+    create_agent_session(&db.node, parent_session, AGENT_NAME, "2026-04-21T10:00:00Z").await;
+    create_agent_conversation(&db.node, parent_session, AGENT_NAME, "2026-04-21T10:00:00Z").await;
+    create_agent_behavior(&db.node, AGENT_NAME, AGENT_DID).await;
+
+    for (sequence, role, content, timestamp) in [
+        (1, "user", "u1", "2026-04-21T10:00:00Z"),
+        (2, "assistant", "a1", "2026-04-21T10:00:01Z"),
+        (3, "tool", "tool output", "2026-04-21T10:00:02Z"),
+        (4, "user", "u2", "2026-04-21T10:00:04Z"),
+    ] {
+        create_agent_message(&db.node, parent_session, sequence, role, content, timestamp).await;
+    }
+
+    for i in 1..=3 {
+        let tool_call_id = format!("tc-{i}");
+        let args = format!(r#"{{"index":{i}}}"#);
+        let result = format!("tool-call-result-{i}");
+        let timestamp = format!("2026-04-21T10:00:0{i}Z");
+        create_agent_tool_call(
+            &db.node,
+            parent_session,
+            i,
+            &tool_call_id,
+            "read_file",
+            &args,
+            &result,
+            "completed",
+            &timestamp,
+            &timestamp,
+        )
+        .await;
+
+        let tool_input = format!(r#"{{"path":"file-{i}.txt"}}"#);
+        let output_text = format!("tool-result-{i}");
+        create_agent_tool_result(
+            &db.node,
+            parent_session,
+            "read_file",
+            &tool_input,
+            &output_text,
+            &timestamp,
+        )
+        .await;
+
+        create_compaction_entry(
+            &db.node,
+            parent_session,
+            i,
+            &format!("summary-{i}"),
+            i,
+            &timestamp,
+        )
+        .await;
+    }
+
+    let outcome = fork(
+        &db.node,
+        ForkParams {
+            source_session_id: parent_session,
+            fork_at_user_turn: 1,
+            caller_agent_did: AGENT_DID,
+            target_behavior_id: None,
+        },
+    )
+    .await
+    .expect("fork succeeds");
+
+    assert_eq!(outcome.copied_messages, 3);
+    assert_eq!(outcome.copied_tool_calls, 3);
+    assert_eq!(outcome.copied_tool_results, 3);
+    assert_eq!(outcome.copied_compaction_entries, 3);
+
+    let child_messages = fetch_message_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert_eq!(child_messages.len(), 3);
+    assert_eq!(
+        child_messages
+            .iter()
+            .map(|message| message.content.as_str())
+            .collect::<Vec<_>>(),
+        vec!["u1", "a1", "tool output"]
+    );
+
+    let child_tool_calls =
+        fetch_tool_call_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert_eq!(child_tool_calls.len(), 3);
+    assert_eq!(
+        child_tool_calls
+            .iter()
+            .map(|tool_call| tool_call.tool_call_id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["tc-1", "tc-2", "tc-3"]
+    );
+
+    let child_tool_results =
+        fetch_tool_result_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert_eq!(child_tool_results.len(), 3);
+    assert_eq!(
+        child_tool_results
+            .iter()
+            .map(|tool_result| tool_result.output_text.as_str())
+            .collect::<Vec<_>>(),
+        vec!["tool-result-1", "tool-result-2", "tool-result-3"]
+    );
+
+    let child_compactions =
+        fetch_compaction_entry_snapshots_for_session(&db.node, &outcome.session_id).await;
+    assert_eq!(child_compactions.len(), 3);
+    for (index, compaction) in child_compactions.iter().enumerate() {
+        let sequence = (index + 1) as u32;
+        assert_eq!(compaction.sequence, sequence);
+        assert_eq!(compaction.summary, format!("summary-{sequence}"));
+        assert_eq!(
+            compaction.compaction_key,
+            format!("{}:{sequence}", outcome.session_id)
+        );
+    }
+}
+
+#[tokio::test]
 async fn fork_rejects_source_with_non_terminal_request() {
     let db = test_db("fork-busy-source").await;
 


### PR DESCRIPTION
## Summary
- add a bounded aliased GraphQL batch mutation helper on top of the existing mutation retry path
- use it for fork copy creates across AgentMessage, AgentToolCall, AgentToolResult, and CompactionEntry
- add multi-row fork invariant coverage that exercises batched creates for every copied collection

## Verification
- cargo fmt
- cargo test -p defra-agent build_batch_mutation_wraps_alias_fields
- cargo test -p defra-agent --test fork_invariants
- cargo clippy -p defra-agent --tests -- -A clippy::needless_borrow -A clippy::needless_borrows_for_generic_args -D warnings

Plain `cargo clippy -p defra-agent --tests -- -D warnings` currently fails on two pre-existing identity.rs needless-borrow lints unrelated to this patch.

## Scope
This is phase 1 for #83. Fork is not the highest-frequency path, but it is the lowest-risk place to prove the bounded alias helper against real embedded GraphQL writes and existing invariants. The next phase should target higher-frequency config/import/apply and lifecycle/recovery paths.

Refs #83