### PR TITLE
Batch config import mutations

### DIFF
--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::Read;
 
 use anyhow::{Context, Result};
@@ -8,13 +9,17 @@ use serde_json::Value;
 use crate::config_bundle::{sanitize_import_document, select_apply_collection_docs};
 use crate::config_writes::{
     write_event_trigger_document, write_schedule_document, write_task_document, ConfigAccess,
+    ExistingDocumentRef,
 };
 use crate::desired_state;
 use crate::desired_state::DesiredApplyBundle;
 use crate::shared::{ConfigApplyCounts, ConfigExportBundle};
 use crate::{
-    extract_mutation_doc_id, graphql_input_literal, CONFIG_EXPORT_FORMAT, CONFIG_EXPORT_FORMAT_V1,
+    extract_mutation_doc_id, graphql_input_literal, graphql_string_list_literal,
+    CONFIG_EXPORT_FORMAT, CONFIG_EXPORT_FORMAT_V1,
 };
+
+const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 
 const CONFIG_APPLY_ORDER: [Collection; 9] = [
     Collection::InferenceBackend,
@@ -27,6 +32,19 @@ const CONFIG_APPLY_ORDER: [Collection; 9] = [
     Collection::EventTrigger,
     Collection::AgentPrincipal,
 ];
+
+#[derive(Debug, Clone)]
+struct PreparedImportDocument {
+    unique_value: String,
+    add_doc: Value,
+    update_doc: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+struct AliasedMutationField {
+    alias: String,
+    field: String,
+}
 
 pub(crate) fn read_config_import_bundle(
     path: Option<&std::path::Path>,
@@ -83,120 +101,453 @@ pub(crate) async fn apply_import_collection(
     docs: &[Value],
     override_existing: bool,
 ) -> Result<usize> {
-    for doc in docs {
-        let unique_value = doc
-            .get(unique_field)
-            .and_then(Value::as_str)
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .ok_or_else(|| {
-                anyhow::anyhow!(
-                    "{} import document is missing {}: {}",
-                    collection_name,
-                    unique_field,
-                    doc
-                )
-            })?;
-        let add_doc = sanitize_import_document(collection_name, doc, false)?;
-        if override_existing && collection_name == "Task" {
-            let update_doc = sanitize_import_document(collection_name, doc, true)?;
-            let doc_id = write_task_document(access, unique_value, &add_doc, &update_doc)
-                .await
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "importing {collection_name} {} failed: {error}",
-                        unique_value
-                    )
-                })?;
-            if doc_id.trim().is_empty() {
-                anyhow::bail!(
-                    "importing {collection_name} {} returned an empty _docID",
-                    unique_value
-                );
-            }
-            continue;
-        }
-        if override_existing && collection_name == "Schedule" {
-            let update_doc = sanitize_import_document(collection_name, doc, true)?;
-            let doc_id = write_schedule_document(access, unique_value, &add_doc, &update_doc)
-                .await
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "importing {collection_name} {} failed: {error}",
-                        unique_value
-                    )
-                })?;
-            if doc_id.trim().is_empty() {
-                anyhow::bail!(
-                    "importing {collection_name} {} returned an empty _docID",
-                    unique_value
-                );
-            }
-            continue;
-        }
-        if override_existing && collection_name == "EventTrigger" {
-            let update_doc = sanitize_import_document(collection_name, doc, true)?;
-            let doc_id = write_event_trigger_document(access, unique_value, &add_doc, &update_doc)
-                .await
-                .map_err(|error| {
-                    anyhow::anyhow!(
-                        "importing {collection_name} {} failed: {error}",
-                        unique_value
-                    )
-                })?;
-            if doc_id.trim().is_empty() {
-                anyhow::bail!(
-                    "importing {collection_name} {} returned an empty _docID",
-                    unique_value
-                );
-            }
-            continue;
-        }
+    let prepared =
+        prepare_import_documents(collection_name, unique_field, docs, override_existing)?;
+    if prepared.is_empty() {
+        return Ok(0);
+    }
 
-        let add_literal = graphql_input_literal(&add_doc)?;
-        let mutation = if override_existing {
-            let update_doc = sanitize_import_document(collection_name, doc, true)?;
-            let update_literal = graphql_input_literal(&update_doc)?;
-            format!(
-                r#"mutation {{
-                    upsert_{collection_name}(
-                        filter: {{ {unique_field}: {{ _eq: "{unique_value}" }} }},
-                        add: {add_literal},
-                        update: {update_literal}
-                    ) {{ _docID }}
-                }}"#,
-                collection_name = collection_name,
-                unique_field = unique_field,
-                unique_value = escape_graphql_string(unique_value),
-                add_literal = add_literal,
-                update_literal = update_literal,
-            )
-        } else {
-            format!(
-                r#"mutation {{
-                    create_{collection_name}(input: {add_literal}) {{ _docID }}
-                }}"#,
-                collection_name = collection_name,
-                add_literal = add_literal,
-            )
-        };
-        let response = access.execute(&mutation).await.map_err(|error| {
-            if override_existing {
-                anyhow::anyhow!(
-                    "importing {collection_name} {} failed: {error}",
-                    unique_value
-                )
-            } else {
-                anyhow::anyhow!(
-                    "importing {collection_name} {} failed: {error}\nNext:\n  1. If the document already exists, rerun with `defra-agent config import --override`\n  2. Or remove the existing document and retry",
-                    unique_value
-                )
-            }
-        })?;
-        let _ = extract_mutation_doc_id(&response, collection_name)?;
+    if override_existing && uses_custom_apply_writer(collection_name) {
+        apply_custom_override_collection_batched(access, collection_name, unique_field, &prepared)
+            .await?;
+    } else {
+        apply_generic_import_collection_batched(
+            access,
+            collection_name,
+            unique_field,
+            &prepared,
+            override_existing,
+        )
+        .await?;
     }
 
     Ok(docs.len())
+}
+
+fn prepare_import_documents(
+    collection_name: &str,
+    unique_field: &str,
+    docs: &[Value],
+    override_existing: bool,
+) -> Result<Vec<PreparedImportDocument>> {
+    docs.iter()
+        .map(|doc| {
+            let unique_value = doc
+                .get(unique_field)
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{} import document is missing {}: {}",
+                        collection_name,
+                        unique_field,
+                        doc
+                    )
+                })?
+                .to_string();
+            let add_doc = sanitize_import_document(collection_name, doc, false)?;
+            let update_doc = if override_existing {
+                Some(sanitize_import_document(collection_name, doc, true)?)
+            } else {
+                None
+            };
+            Ok(PreparedImportDocument {
+                unique_value,
+                add_doc,
+                update_doc,
+            })
+        })
+        .collect()
+}
+
+fn uses_custom_apply_writer(collection_name: &str) -> bool {
+    matches!(collection_name, "Task" | "Schedule" | "EventTrigger")
+}
+
+async fn apply_generic_import_collection_batched(
+    access: &ConfigAccess,
+    collection_name: &str,
+    unique_field: &str,
+    docs: &[PreparedImportDocument],
+    override_existing: bool,
+) -> Result<()> {
+    let fields = docs
+        .iter()
+        .enumerate()
+        .map(|(index, doc)| {
+            generic_import_mutation_field(
+                index,
+                collection_name,
+                unique_field,
+                doc,
+                override_existing,
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    match execute_aliased_mutation_batches(access, collection_name, &fields).await {
+        Ok(()) => Ok(()),
+        Err(_) if override_existing => {
+            for doc in docs {
+                apply_generic_import_document(
+                    access,
+                    collection_name,
+                    unique_field,
+                    doc,
+                    override_existing,
+                )
+                .await?;
+            }
+            Ok(())
+        }
+        Err(error) => Err(anyhow::anyhow!(
+            "importing {collection_name} batch failed: {error}\nNext:\n  1. If a document already exists, rerun with `defra-agent config import --override`\n  2. Or remove the existing document and retry"
+        )),
+    }
+}
+
+fn generic_import_mutation_field(
+    index: usize,
+    collection_name: &str,
+    unique_field: &str,
+    doc: &PreparedImportDocument,
+    override_existing: bool,
+) -> Result<AliasedMutationField> {
+    let alias = format!("doc_{index}");
+    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let field = if override_existing {
+        let update_literal =
+            graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("missing update document for {collection_name}")
+            })?)?;
+        format!(
+            r#"{alias}: upsert_{collection_name}(
+                filter: {{ {unique_field}: {{ _eq: "{unique_value}" }} }},
+                add: {add_literal},
+                update: {update_literal}
+            ) {{ _docID }}"#,
+            unique_value = escape_graphql_string(&doc.unique_value),
+        )
+    } else {
+        format!(r#"{alias}: create_{collection_name}(input: {add_literal}) {{ _docID }}"#)
+    };
+    Ok(AliasedMutationField { alias, field })
+}
+
+async fn apply_generic_import_document(
+    access: &ConfigAccess,
+    collection_name: &str,
+    unique_field: &str,
+    doc: &PreparedImportDocument,
+    override_existing: bool,
+) -> Result<()> {
+    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let mutation = if override_existing {
+        let update_literal =
+            graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("missing update document for {collection_name}")
+            })?)?;
+        format!(
+            r#"mutation {{
+                upsert_{collection_name}(
+                    filter: {{ {unique_field}: {{ _eq: "{unique_value}" }} }},
+                    add: {add_literal},
+                    update: {update_literal}
+                ) {{ _docID }}
+            }}"#,
+            unique_value = escape_graphql_string(&doc.unique_value),
+        )
+    } else {
+        format!(r#"mutation {{ create_{collection_name}(input: {add_literal}) {{ _docID }} }}"#)
+    };
+    let response = access.execute(&mutation).await.map_err(|error| {
+        if override_existing {
+            anyhow::anyhow!(
+                "importing {collection_name} {} failed: {error}",
+                doc.unique_value
+            )
+        } else {
+            anyhow::anyhow!(
+                "importing {collection_name} {} failed: {error}\nNext:\n  1. If the document already exists, rerun with `defra-agent config import --override`\n  2. Or remove the existing document and retry",
+                doc.unique_value
+            )
+        }
+    })?;
+    let _ = extract_mutation_doc_id(&response, collection_name)?;
+    Ok(())
+}
+
+async fn apply_custom_override_collection_batched(
+    access: &ConfigAccess,
+    collection_name: &str,
+    unique_field: &str,
+    docs: &[PreparedImportDocument],
+) -> Result<()> {
+    if has_duplicate_unique_values(docs) {
+        return apply_custom_override_documents_individually(access, collection_name, docs).await;
+    }
+
+    let existing_by_unique = match query_existing_documents_by_unique_values(
+        access,
+        collection_name,
+        unique_field,
+        docs,
+    )
+    .await
+    {
+        Ok(existing_by_unique) => existing_by_unique,
+        Err(_) => {
+            return apply_custom_override_documents_individually(access, collection_name, docs)
+                .await;
+        }
+    };
+    let fields = docs
+        .iter()
+        .enumerate()
+        .map(|(index, doc)| {
+            custom_override_mutation_field(
+                index,
+                collection_name,
+                unique_field,
+                doc,
+                existing_by_unique
+                    .get(&doc.unique_value)
+                    .map(Vec::as_slice)
+                    .unwrap_or(&[]),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    match execute_aliased_mutation_batches(access, collection_name, &fields).await {
+        Ok(()) => Ok(()),
+        Err(_) => apply_custom_override_documents_individually(access, collection_name, docs).await,
+    }
+}
+
+fn has_duplicate_unique_values(docs: &[PreparedImportDocument]) -> bool {
+    let mut seen = std::collections::BTreeSet::new();
+    docs.iter()
+        .any(|doc| !seen.insert(doc.unique_value.as_str()))
+}
+
+async fn query_existing_documents_by_unique_values(
+    access: &ConfigAccess,
+    collection_name: &str,
+    unique_field: &str,
+    docs: &[PreparedImportDocument],
+) -> Result<BTreeMap<String, Vec<ExistingDocumentRef>>> {
+    let unique_values = docs
+        .iter()
+        .map(|doc| doc.unique_value.clone())
+        .collect::<Vec<_>>();
+    let limit = unique_values.len().saturating_mul(16).max(16);
+    let unique_values_literal = graphql_string_list_literal(&unique_values);
+    let query = format!(
+        r#"{{
+            {collection_name}(
+                showDeleted: true,
+                filter: {{ {unique_field}: {{ _in: {unique_values_literal} }} }},
+                limit: {limit}
+            ) {{
+                _docID
+                _deleted
+                {unique_field}
+            }}
+        }}"#,
+    );
+    let response = access.execute(&query).await?;
+    let rows = response
+        .get("data")
+        .and_then(|data| data.get(collection_name))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut by_unique: BTreeMap<String, Vec<ExistingDocumentRef>> = BTreeMap::new();
+    for row in rows {
+        let unique_value = row
+            .get(unique_field)
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                anyhow::anyhow!("{collection_name} lookup row missing {unique_field}: {row}")
+            })?
+            .to_string();
+        let doc_ref = ExistingDocumentRef {
+            doc_id: row
+                .get("_docID")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "{collection_name} lookup row missing _docID for {unique_field}={unique_value}: {row}"
+                    )
+                })?
+                .to_string(),
+            deleted: row
+                .get("_deleted")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+        };
+        by_unique.entry(unique_value).or_default().push(doc_ref);
+    }
+
+    Ok(by_unique)
+}
+
+fn custom_override_mutation_field(
+    index: usize,
+    collection_name: &str,
+    unique_field: &str,
+    doc: &PreparedImportDocument,
+    existing_rows: &[ExistingDocumentRef],
+) -> Result<AliasedMutationField> {
+    let alias = format!("doc_{index}");
+    let existing = select_existing_import_document(
+        collection_name,
+        unique_field,
+        &doc.unique_value,
+        existing_rows,
+    )?;
+    let field = if existing.as_ref().is_some_and(|existing| !existing.deleted) {
+        let update_literal =
+            graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
+                anyhow::anyhow!("missing update document for {collection_name}")
+            })?)?;
+        let doc_id = existing
+            .as_ref()
+            .expect("existing checked above")
+            .doc_id
+            .as_str();
+        format!(
+            r#"{alias}: update_{collection_name}(docID: "{doc_id}", input: {update_literal}) {{ _docID }}"#,
+            doc_id = escape_graphql_string(doc_id),
+        )
+    } else {
+        let add_literal = graphql_input_literal(&doc.add_doc)?;
+        format!(r#"{alias}: create_{collection_name}(input: {add_literal}) {{ _docID }}"#)
+    };
+
+    Ok(AliasedMutationField { alias, field })
+}
+
+fn select_existing_import_document(
+    collection_name: &str,
+    unique_field: &str,
+    unique_value: &str,
+    rows: &[ExistingDocumentRef],
+) -> Result<Option<ExistingDocumentRef>> {
+    let live_rows = rows.iter().filter(|row| !row.deleted).collect::<Vec<_>>();
+    if live_rows.len() > 1 {
+        anyhow::bail!(
+            "multiple live {collection_name} documents share {unique_field}={unique_value}"
+        );
+    }
+    if let Some(row) = live_rows.first() {
+        return Ok(Some((*row).clone()));
+    }
+
+    let deleted_rows = rows.iter().filter(|row| row.deleted).collect::<Vec<_>>();
+    if deleted_rows.len() > 1 {
+        anyhow::bail!(
+            "multiple deleted {collection_name} tombstones share {unique_field}={unique_value}"
+        );
+    }
+
+    Ok(deleted_rows.first().map(|row| (*row).clone()))
+}
+
+async fn apply_custom_override_documents_individually(
+    access: &ConfigAccess,
+    collection_name: &str,
+    docs: &[PreparedImportDocument],
+) -> Result<()> {
+    for doc in docs {
+        let update_doc = doc
+            .update_doc
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("missing update document for {collection_name}"))?;
+        let doc_id = match collection_name {
+            "Task" => {
+                write_task_document(access, &doc.unique_value, &doc.add_doc, update_doc).await
+            }
+            "Schedule" => {
+                write_schedule_document(access, &doc.unique_value, &doc.add_doc, update_doc).await
+            }
+            "EventTrigger" => {
+                write_event_trigger_document(access, &doc.unique_value, &doc.add_doc, update_doc)
+                    .await
+            }
+            _ => unreachable!("custom apply writer only supports selected collections"),
+        }
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "importing {collection_name} {} failed: {error}",
+                doc.unique_value
+            )
+        })?;
+        if doc_id.trim().is_empty() {
+            anyhow::bail!(
+                "importing {collection_name} {} returned an empty _docID",
+                doc.unique_value
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn execute_aliased_mutation_batches(
+    access: &ConfigAccess,
+    collection_name: &str,
+    fields: &[AliasedMutationField],
+) -> Result<()> {
+    for chunk in fields.chunks(CONFIG_IMPORT_BATCH_SIZE) {
+        let mutation = build_aliased_mutation(chunk);
+        let response = access.execute(&mutation).await?;
+        for field in chunk {
+            let _ = extract_aliased_mutation_doc_id(&response, &field.alias, collection_name)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn build_aliased_mutation(fields: &[AliasedMutationField]) -> String {
+    let body = fields
+        .iter()
+        .map(|field| field.field.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!("mutation {{\n{body}\n}}")
+}
+
+fn extract_aliased_mutation_doc_id(
+    response: &Value,
+    alias: &str,
+    collection_name: &str,
+) -> Result<String> {
+    let data = response
+        .get("data")
+        .ok_or_else(|| anyhow::anyhow!("graphql response missing data: {response}"))?;
+    if let Some(doc_id) = data
+        .get(alias)
+        .and_then(|value| value.get("_docID"))
+        .and_then(Value::as_str)
+    {
+        return Ok(doc_id.to_string());
+    }
+    if let Some(doc_id) = data
+        .get(alias)
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("_docID"))
+        .and_then(Value::as_str)
+    {
+        return Ok(doc_id.to_string());
+    }
+    anyhow::bail!(
+        "graphql mutation alias {alias} returned no _docID for {collection_name}: {response}"
+    );
 }
 
 pub(crate) fn diff_has_pending_apply(
@@ -264,4 +615,121 @@ fn select_apply_docs_for_collection(
         collection.graphql_type(),
         diff,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn build_aliased_mutation_wraps_all_fields() {
+        let fields = vec![
+            AliasedMutationField {
+                alias: "doc_0".to_string(),
+                field: r#"doc_0: create_Task(input: { task_id: "a" }) { _docID }"#.to_string(),
+            },
+            AliasedMutationField {
+                alias: "doc_1".to_string(),
+                field: r#"doc_1: create_Task(input: { task_id: "b" }) { _docID }"#.to_string(),
+            },
+        ];
+
+        assert_eq!(
+            build_aliased_mutation(&fields),
+            r#"mutation {
+doc_0: create_Task(input: { task_id: "a" }) { _docID }
+doc_1: create_Task(input: { task_id: "b" }) { _docID }
+}"#
+        );
+    }
+
+    #[test]
+    fn extract_aliased_mutation_doc_id_accepts_object_and_array_shapes() {
+        let response = json!({
+            "data": {
+                "doc_0": { "_docID": "doc-a" },
+                "doc_1": [{ "_docID": "doc-b" }]
+            }
+        });
+
+        assert_eq!(
+            extract_aliased_mutation_doc_id(&response, "doc_0", "Task").unwrap(),
+            "doc-a"
+        );
+        assert_eq!(
+            extract_aliased_mutation_doc_id(&response, "doc_1", "Task").unwrap(),
+            "doc-b"
+        );
+    }
+
+    #[test]
+    fn has_duplicate_unique_values_detects_repeated_import_ids() {
+        let docs = vec![
+            PreparedImportDocument {
+                unique_value: "task-a".to_string(),
+                add_doc: json!({ "task_id": "task-a" }),
+                update_doc: Some(json!({ "task_id": "task-a" })),
+            },
+            PreparedImportDocument {
+                unique_value: "task-b".to_string(),
+                add_doc: json!({ "task_id": "task-b" }),
+                update_doc: Some(json!({ "task_id": "task-b" })),
+            },
+            PreparedImportDocument {
+                unique_value: "task-a".to_string(),
+                add_doc: json!({ "task_id": "task-a", "enabled": true }),
+                update_doc: Some(json!({ "enabled": true })),
+            },
+        ];
+
+        assert!(has_duplicate_unique_values(&docs));
+    }
+
+    #[test]
+    fn custom_override_mutation_field_updates_live_doc_by_doc_id() {
+        let doc = PreparedImportDocument {
+            unique_value: "task-a".to_string(),
+            add_doc: json!({ "task_id": "task-a", "enabled": true }),
+            update_doc: Some(json!({ "enabled": false })),
+        };
+        let existing = vec![ExistingDocumentRef {
+            doc_id: "doc-live".to_string(),
+            deleted: false,
+        }];
+
+        let field = custom_override_mutation_field(0, "Task", "task_id", &doc, &existing).unwrap();
+
+        assert_eq!(field.alias, "doc_0");
+        assert!(
+            field
+                .field
+                .contains(r#"doc_0: update_Task(docID: "doc-live""#),
+            "expected update field, got {}",
+            field.field
+        );
+        assert!(field.field.contains("enabled: false"));
+    }
+
+    #[test]
+    fn custom_override_mutation_field_recreates_deleted_doc() {
+        let doc = PreparedImportDocument {
+            unique_value: "task-a".to_string(),
+            add_doc: json!({ "task_id": "task-a", "enabled": true }),
+            update_doc: Some(json!({ "enabled": false })),
+        };
+        let existing = vec![ExistingDocumentRef {
+            doc_id: "doc-deleted".to_string(),
+            deleted: true,
+        }];
+
+        let field = custom_override_mutation_field(0, "Task", "task_id", &doc, &existing).unwrap();
+
+        assert_eq!(field.alias, "doc_0");
+        assert!(
+            field.field.contains("doc_0: create_Task(input:"),
+            "expected create field, got {}",
+            field.field
+        );
+    }
 }

--- a/crates/defra-agent-cli/tests/cli_config_export_import.rs
+++ b/crates/defra-agent-cli/tests/cli_config_export_import.rs
@@ -208,6 +208,8 @@ async fn config_import_round_trips_and_requires_override() -> Result<()> {
     let agent_did = format!("did:key:z{}", Uuid::new_v4().simple());
     let default_behavior_id = "default".to_string();
     let tool_selection_id = format!("{default_behavior_id}-tools");
+    let profile_id_a = format!("{default_behavior_id}-profile-a");
+    let profile_id_b = format!("{default_behavior_id}-profile-b");
     let backend_id = format!("{agent_name}-backend");
     let export_path = tempdir.path().join("agent-config.json");
 
@@ -248,7 +250,28 @@ async fn config_import_round_trips_and_requires_override() -> Result<()> {
             "enabled": true,
             "models": ["mock-model"]
         }],
-        "inference_profiles": [],
+        "inference_profiles": [
+            {
+                "profile_id": profile_id_a,
+                "display_name": "Fast",
+                "context_window": 8192,
+                "max_output_tokens": 1024,
+                "max_turns": 16,
+                "temperature": 0.0,
+                "stream_batch_ms": 40,
+                "deadline_duration_secs": 300
+            },
+            {
+                "profile_id": profile_id_b,
+                "display_name": "Deep",
+                "context_window": 16384,
+                "max_output_tokens": 2048,
+                "max_turns": 32,
+                "temperature": 0.2,
+                "stream_batch_ms": 80,
+                "deadline_duration_secs": 600
+            }
+        ],
         "tool_service_registries": [],
         "tasks": [],
         "schedules": []
@@ -280,6 +303,12 @@ async fn config_import_round_trips_and_requires_override() -> Result<()> {
             .pointer("/counts/agent_behaviors")
             .and_then(Value::as_u64),
         Some(1)
+    );
+    assert_eq!(
+        imported
+            .pointer("/counts/inference_profiles")
+            .and_then(Value::as_u64),
+        Some(2)
     );
 
     // A second import without --override must fail with guidance.
@@ -337,6 +366,8 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
     let service_id = format!("ops-mcp-{}", Uuid::new_v4().simple());
     let task_id = format!("nightly-audit-{}", Uuid::new_v4().simple());
     let schedule_id = format!("{task_id}-hourly");
+    let second_task_id = format!("weekly-audit-{}", Uuid::new_v4().simple());
+    let second_schedule_id = format!("{second_task_id}-daily");
 
     // Set up the source DB via `config apply --root` using simple, safe IDs.
     let (agent_did, behavior_id, _selection_id, _backend_id) = write_simple_manifest_root(
@@ -381,6 +412,22 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
         )?;
     }
     {
+        let dir = initial_root.join("tasks").join(&second_task_id);
+        fs::create_dir_all(&dir)?;
+        write_json_file(
+            &dir.join("object.json"),
+            &serde_json::json!({
+                "task_id": second_task_id,
+                "name": "Weekly Audit",
+                "description": null,
+                "behavior_id": behavior_id,
+                "prompt_template": "Summarize weekly infrastructure changes.",
+                "enabled": true,
+                "output_schema_ref": null
+            }),
+        )?;
+    }
+    {
         let dir = initial_root.join("schedules").join(&schedule_id);
         fs::create_dir_all(&dir)?;
         write_json_file(
@@ -391,6 +438,20 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
                 "interval_secs": 3600,
                 "enabled": false,
                 "concurrency": "serial"
+            }),
+        )?;
+    }
+    {
+        let dir = initial_root.join("schedules").join(&second_schedule_id);
+        fs::create_dir_all(&dir)?;
+        write_json_file(
+            &dir.join("object.json"),
+            &serde_json::json!({
+                "schedule_id": second_schedule_id,
+                "task_id": second_task_id,
+                "interval_secs": 86400,
+                "enabled": true,
+                "concurrency": "parallel"
             }),
         )?;
     }
@@ -410,13 +471,13 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
     );
     assert_eq!(
         applied.pointer("/applied/tasks").and_then(Value::as_u64),
-        Some(1)
+        Some(2)
     );
     assert_eq!(
         applied
             .pointer("/applied/schedules")
             .and_then(Value::as_u64),
-        Some(1)
+        Some(2)
     );
 
     // Export the source DB to a new manifest root.
@@ -497,6 +558,17 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
         Some(schedule_id.as_str()),
         "expected schedule {schedule_id} in export root"
     );
+    assert_eq!(
+        schedules
+            .iter()
+            .find(|s| {
+                s.get("schedule_id").and_then(Value::as_str) == Some(second_schedule_id.as_str())
+            })
+            .and_then(|s| s.get("schedule_id"))
+            .and_then(Value::as_str),
+        Some(second_schedule_id.as_str()),
+        "expected schedule {second_schedule_id} in export root"
+    );
 
     // Apply the exported root to a fresh target DB and verify convergence.
     let reapplied = run_config_apply(&target_home, &export_root)?;
@@ -513,13 +585,13 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
     );
     assert_eq!(
         reapplied.pointer("/applied/tasks").and_then(Value::as_u64),
-        Some(1)
+        Some(2)
     );
     assert_eq!(
         reapplied
             .pointer("/applied/schedules")
             .and_then(Value::as_u64),
-        Some(1)
+        Some(2)
     );
 
     // Re-export from the target and verify the data survived the apply.
@@ -540,6 +612,15 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
         Some(task_id.as_str()),
         "expected task {task_id} in re-exported root"
     );
+    assert_eq!(
+        reexported_tasks
+            .iter()
+            .find(|t| { t.get("task_id").and_then(Value::as_str) == Some(second_task_id.as_str()) })
+            .and_then(|t| t.get("task_id"))
+            .and_then(Value::as_str),
+        Some(second_task_id.as_str()),
+        "expected task {second_task_id} in re-exported root"
+    );
 
     let reexported_schedules = read_per_doc_collection(&reapply_root, "schedules")?;
     assert_eq!(
@@ -550,6 +631,17 @@ async fn config_export_apply_round_trips_with_extra_collections() -> Result<()> 
             .and_then(Value::as_str),
         Some(schedule_id.as_str()),
         "expected schedule {schedule_id} in re-exported root"
+    );
+    assert_eq!(
+        reexported_schedules
+            .iter()
+            .find(|s| {
+                s.get("schedule_id").and_then(Value::as_str) == Some(second_schedule_id.as_str())
+            })
+            .and_then(|s| s.get("schedule_id"))
+            .and_then(Value::as_str),
+        Some(second_schedule_id.as_str()),
+        "expected schedule {second_schedule_id} in re-exported root"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- batch generic config import/apply create and upsert mutations with bounded GraphQL alias groups
- batch Task/Schedule/EventTrigger override apply by prefetching existing rows, then emitting aliased create/update mutations while preserving the per-document fallback path
- expand config export/import tests to exercise multi-document generic import and multi-task/multi-schedule apply round trips

## Notes
- Duplicate Task/Schedule/EventTrigger IDs intentionally fall back to the old sequential writer path so precomputed batch create/update decisions do not change behavior.
- Plain `cargo clippy -p defra-agent-cli --tests -- -D warnings` still trips the existing `defra-agent/src/identity.rs` lints unrelated to this branch, so the final clippy run uses the same explicit allowances as the first batching PR.

## Verification
- `cargo fmt`
- `cargo test -p defra-agent-cli config_import::tests`
- `cargo test -p defra-agent-cli --test cli_config_export_import`
- `cargo test -p defra-agent-cli --test cli_config_apply_e2e`
- `cargo test -p defra-agent-cli --test cli_config_apply_local`
- `cargo test -p defra-agent-cli --test cli_config_apply_graphql`
- `cargo clippy -p defra-agent-cli --tests -- -A clippy::needless_borrow -A clippy::needless_borrows_for_generic_args -D warnings`

Part of #83.
