### PR TITLE
Coalesce desktop chat submit mutations

### DIFF
--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/conversation.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/conversation.rs
@@ -112,21 +112,40 @@ pub(super) async fn upsert_session(
     behavior_id: &Option<String>,
 ) -> Result<()> {
     let now = Utc::now().to_rfc3339();
+    let field = build_upsert_session_field(
+        "upsert_AgentSession",
+        store,
+        session_id,
+        agent_name,
+        behavior_id,
+        &now,
+    );
+    let mutation = format!("mutation {{\n{field}\n}}");
+    execute_mutation(node, &mutation, "upsert_session").await
+}
+
+pub(super) fn build_upsert_session_field(
+    alias: &str,
+    store: &ClientStore,
+    session_id: &str,
+    agent_name: &str,
+    behavior_id: &Option<String>,
+    now: &str,
+) -> String {
     let existing = store
         .sessions
         .iter()
         .find(|row| row.session_id == session_id);
     let started = existing
         .and_then(|row| normalize_optional_string(row.started.as_deref()))
-        .unwrap_or(now.as_str());
+        .unwrap_or(now);
 
     let escaped_session_id = escape_graphql_string(session_id);
     let escaped_agent_name = escape_graphql_string(agent_name);
     let escaped_behavior_id = escape_graphql_string(behavior_id.as_deref().unwrap_or(""));
     let escaped_started = escape_graphql_string(started);
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentSession(
+    format!(
+        r#"{alias}: upsert_AgentSession(
                 filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
                 add: {{
                     session_id: "{escaped_session_id}",
@@ -142,9 +161,8 @@ pub(super) async fn upsert_session(
                     status: "active"
                 }}
             ) {{ _docID }}
-        }}"#
-    );
-    execute_mutation(node, &mutation, "upsert_session").await
+        "#
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -160,6 +178,35 @@ pub(super) async fn upsert_conversation(
     status: &str,
 ) -> Result<()> {
     let now = Utc::now().to_rfc3339();
+    let field = build_upsert_conversation_field(
+        "upsert_AgentConversation",
+        store,
+        session_id,
+        agent_did,
+        agent_name,
+        behavior_id,
+        latest_request_id,
+        content,
+        status,
+        &now,
+    );
+    let mutation = format!("mutation {{\n{field}\n}}");
+    execute_mutation(node, &mutation, "upsert_conversation").await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_upsert_conversation_field(
+    alias: &str,
+    store: &ClientStore,
+    session_id: &str,
+    agent_did: &str,
+    agent_name: &str,
+    behavior_id: &Option<String>,
+    latest_request_id: &str,
+    content: &str,
+    status: &str,
+    now: &str,
+) -> String {
     let existing = store
         .conversations
         .iter()
@@ -188,7 +235,7 @@ pub(super) async fn upsert_conversation(
     };
     let created_at = existing
         .and_then(|row| normalize_optional_string(row.created_at.as_deref()))
-        .unwrap_or(now.as_str());
+        .unwrap_or(now);
     let latest_request_id = normalize_optional_string(Some(latest_request_id))
         .or_else(|| {
             existing.and_then(|row| normalize_optional_string(row.latest_request_id.as_deref()))
@@ -205,9 +252,8 @@ pub(super) async fn upsert_conversation(
     let escaped_status = escape_graphql_string(status);
     let escaped_created_at = escape_graphql_string(created_at);
     let escaped_latest_request_id = escape_graphql_string(latest_request_id);
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentConversation(
+    format!(
+        r#"{alias}: upsert_AgentConversation(
                 filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
                 add: {{
                     session_id: "{escaped_session_id}",
@@ -235,9 +281,8 @@ pub(super) async fn upsert_conversation(
                     latest_request_id: "{escaped_latest_request_id}"
                 }}
             ) {{ _docID }}
-        }}"#
-    );
-    execute_mutation(node, &mutation, "upsert_conversation").await
+        "#
+    )
 }
 
 fn derive_conversation_preview(content: &str) -> String {

--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
@@ -10,7 +10,7 @@ use super::super::graphql::{
     escape_graphql_string, execute_mutation, normalize_optional_string, normalize_required,
 };
 use super::binding::resolve_agent_binding;
-use super::conversation::{upsert_conversation, upsert_session};
+use super::conversation::{build_upsert_conversation_field, build_upsert_session_field};
 
 const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 
@@ -62,15 +62,6 @@ pub async fn submit_request(
     let created_at = Utc::now().to_rfc3339();
     let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(session_id))?;
 
-    upsert_session(
-        node,
-        store,
-        session_id,
-        &binding.agent_name,
-        &binding.behavior_id,
-    )
-    .await?;
-
     // Thread retry linkage: carry parent's retry root forward, else this row is
     // the root of its own retry chain.
     let (retry_parent_request, retry_root_request) =
@@ -83,85 +74,30 @@ pub async fn submit_request(
             (String::new(), request_id.clone())
         };
 
-    let escaped_request_id = escape_graphql_string(&request_id);
-    let escaped_agent_did = escape_graphql_string(agent_did);
-    let escaped_behavior_id = escape_graphql_string(binding.behavior_id.as_deref().unwrap_or(""));
-    let escaped_session_id = escape_graphql_string(session_id);
-    let escaped_content = escape_graphql_string(content);
-    let escaped_created_at = escape_graphql_string(&created_at);
-    let escaped_retry_parent = escape_graphql_string(&retry_parent_request);
-    let escaped_retry_root = escape_graphql_string(&retry_root_request);
-
-    let valid_until_field = match options.valid_until {
-        Some(valid_until) => {
-            let escaped = escape_graphql_string(&valid_until.to_rfc3339());
-            format!(
-                r#",
-                valid_until: "{escaped}""#,
-            )
-        }
-        None => String::new(),
-    };
-
-    // Only emit sampling override + metadata fields when the caller actually
-    // set them. Omitting a field leaves the schema default (null) in place;
-    // emitting `null` explicitly also works but leaving the field out keeps
-    // the mutation shape identical to what previously-submitted rows used
-    // before the override plumbing landed.
-    let override_fields = {
-        let mut parts: Vec<String> = Vec::new();
-        if let Some(temperature) = options.temperature {
-            parts.push(format!("temperature: {temperature}"));
-        }
-        if let Some(top_p) = options.top_p {
-            parts.push(format!("top_p: {top_p}"));
-        }
-        if let Some(top_k) = options.top_k {
-            parts.push(format!("top_k: {top_k}"));
-        }
-        if let Some(max_tokens) = options.max_tokens {
-            parts.push(format!("max_tokens: {max_tokens}"));
-        }
-        if let Some(metadata) = options.metadata.as_deref() {
-            parts.push(format!(
-                r#"metadata: "{}""#,
-                escape_graphql_string(metadata)
-            ));
-        }
-        if parts.is_empty() {
-            String::new()
-        } else {
-            format!(",\n                {}", parts.join(",\n                "))
-        }
-    };
-
-    let mutation = format!(
-        r#"mutation {{
-            add_AgentRequest(input: {{
-                request_id: "{escaped_request_id}",
-                agent_did: "{escaped_agent_did}",
-                behavior_id: "{escaped_behavior_id}",
-                session_id: "{escaped_session_id}",
-                retry_parent_request: "{escaped_retry_parent}",
-                retry_root_request: "{escaped_retry_root}",
-                superseded_by_request: "",
-                content: "{escaped_content}",
-                status: "pending",
-                lifecycle_state: "pending",
-                backend_id: "",
-                execution_origin: "interactive",
-                failure_reason: "",
-                created_at: "{escaped_created_at}",
-                retry_count: 0,
-                max_retries: {max_retries}{valid_until_field}{override_fields}
-            }}) {{ _docID }}
-        }}"#,
-        max_retries = DEFAULT_REQUEST_MAX_RETRIES,
+    let session_field = build_upsert_session_field(
+        "session",
+        store,
+        session_id,
+        &binding.agent_name,
+        &binding.behavior_id,
+        &created_at,
     );
-    execute_mutation(node, &mutation, "submit_request").await?;
-
-    upsert_conversation(
-        node,
+    let request_field = build_add_agent_request_field(
+        "request",
+        &request_id,
+        agent_did,
+        binding.behavior_id.as_deref().unwrap_or(""),
+        session_id,
+        &retry_parent_request,
+        &retry_root_request,
+        content,
+        &created_at,
+        0,
+        i64::from(DEFAULT_REQUEST_MAX_RETRIES),
+        &submit_request_extra_fields(&options),
+    );
+    let conversation_field = build_upsert_conversation_field(
+        "conversation",
         store,
         session_id,
         agent_did,
@@ -170,8 +106,11 @@ pub async fn submit_request(
         &request_id,
         content,
         "active",
-    )
-    .await?;
+        &created_at,
+    );
+    let mutation =
+        build_coalesced_submit_mutation(&[session_field, request_field, conversation_field]);
+    execute_mutation(node, &mutation, "submit_request").await?;
 
     Ok(SubmittedRequest {
         request_id,
@@ -219,33 +158,132 @@ pub async fn retry_request(
     let created_at = Utc::now().to_rfc3339();
     let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(session_id))?;
 
-    upsert_session(
-        node,
+    let session_field = build_upsert_session_field(
+        "session",
         store,
         session_id,
         &binding.agent_name,
         &binding.behavior_id,
-    )
-    .await?;
+        &created_at,
+    );
+    let request_field = build_add_agent_request_field(
+        "request",
+        &request_id,
+        agent_did,
+        binding.behavior_id.as_deref().unwrap_or(""),
+        session_id,
+        parent_request_id,
+        retry_root_request,
+        content,
+        &created_at,
+        retry_count,
+        max_retries,
+        "",
+    );
+    let conversation_field = build_upsert_conversation_field(
+        "conversation",
+        store,
+        session_id,
+        agent_did,
+        &binding.agent_name,
+        &binding.behavior_id,
+        &request_id,
+        content,
+        "active",
+        &created_at,
+    );
+    let mutation =
+        build_coalesced_submit_mutation(&[session_field, request_field, conversation_field]);
+    execute_mutation(node, &mutation, "retry_request").await?;
 
-    let escaped_request_id = escape_graphql_string(&request_id);
-    let escaped_parent_request_id = escape_graphql_string(parent_request_id);
-    let escaped_retry_root_request = escape_graphql_string(retry_root_request);
+    Ok(SubmittedRequest {
+        request_id,
+        session_id: session_id.to_string(),
+        agent_did: agent_did.to_string(),
+        behavior_id: binding.behavior_id,
+    })
+}
+
+fn submit_request_extra_fields(options: &SubmitRequestOptions) -> String {
+    let valid_until_field = match options.valid_until.as_ref() {
+        Some(valid_until) => {
+            let escaped = escape_graphql_string(&valid_until.to_rfc3339());
+            format!(
+                r#",
+                valid_until: "{escaped}""#,
+            )
+        }
+        None => String::new(),
+    };
+
+    // Only emit sampling override + metadata fields when the caller actually
+    // set them. Omitting a field leaves the schema default (null) in place;
+    // emitting `null` explicitly also works but leaving the field out keeps
+    // the mutation shape identical to what previously-submitted rows used
+    // before the override plumbing landed.
+    let mut override_parts: Vec<String> = Vec::new();
+    if let Some(temperature) = options.temperature {
+        override_parts.push(format!("temperature: {temperature}"));
+    }
+    if let Some(top_p) = options.top_p {
+        override_parts.push(format!("top_p: {top_p}"));
+    }
+    if let Some(top_k) = options.top_k {
+        override_parts.push(format!("top_k: {top_k}"));
+    }
+    if let Some(max_tokens) = options.max_tokens {
+        override_parts.push(format!("max_tokens: {max_tokens}"));
+    }
+    if let Some(metadata) = options.metadata.as_deref() {
+        override_parts.push(format!(
+            r#"metadata: "{}""#,
+            escape_graphql_string(metadata)
+        ));
+    }
+    let override_fields = if override_parts.is_empty() {
+        String::new()
+    } else {
+        format!(
+            ",\n                {}",
+            override_parts.join(",\n                ")
+        )
+    };
+
+    format!("{valid_until_field}{override_fields}")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_add_agent_request_field(
+    alias: &str,
+    request_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    session_id: &str,
+    retry_parent_request: &str,
+    retry_root_request: &str,
+    content: &str,
+    created_at: &str,
+    retry_count: i64,
+    max_retries: i64,
+    extra_fields: &str,
+) -> String {
+    let escaped_request_id = escape_graphql_string(request_id);
     let escaped_agent_did = escape_graphql_string(agent_did);
-    let escaped_behavior_id = escape_graphql_string(binding.behavior_id.as_deref().unwrap_or(""));
+    let escaped_behavior_id = escape_graphql_string(behavior_id);
     let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_retry_parent = escape_graphql_string(retry_parent_request);
+    let escaped_retry_root = escape_graphql_string(retry_root_request);
     let escaped_content = escape_graphql_string(content);
-    let escaped_created_at = escape_graphql_string(&created_at);
+    let escaped_created_at = escape_graphql_string(created_at);
 
-    let mutation = format!(
-        r#"mutation {{
-            add_AgentRequest(input: {{
+    format!(
+        r#"{alias}: add_AgentRequest(input: {{
                 request_id: "{escaped_request_id}",
                 agent_did: "{escaped_agent_did}",
                 behavior_id: "{escaped_behavior_id}",
                 session_id: "{escaped_session_id}",
-                retry_parent_request: "{escaped_parent_request_id}",
-                retry_root_request: "{escaped_retry_root_request}",
+                retry_parent_request: "{escaped_retry_parent}",
+                retry_root_request: "{escaped_retry_root}",
                 superseded_by_request: "",
                 content: "{escaped_content}",
                 status: "pending",
@@ -255,31 +293,17 @@ pub async fn retry_request(
                 failure_reason: "",
                 created_at: "{escaped_created_at}",
                 retry_count: {retry_count},
-                max_retries: {max_retries}
+                max_retries: {max_retries}{extra_fields}
             }}) {{ _docID }}
-        }}"#
-    );
-    execute_mutation(node, &mutation, "retry_request").await?;
-
-    upsert_conversation(
-        node,
-        store,
-        session_id,
-        agent_did,
-        &binding.agent_name,
-        &binding.behavior_id,
-        &request_id,
-        content,
-        "active",
+        "#
     )
-    .await?;
+}
 
-    Ok(SubmittedRequest {
-        request_id,
-        session_id: session_id.to_string(),
-        agent_did: agent_did.to_string(),
-        behavior_id: binding.behavior_id,
-    })
+fn build_coalesced_submit_mutation(fields: &[String; 3]) -> String {
+    format!(
+        "mutation {{\n{}\n{}\n{}\n}}",
+        fields[0], fields[1], fields[2]
+    )
 }
 
 /// Resend a stale-terminal request by reading its inputs and submitting a

--- a/crates/defra-agent-desktop-core/src/client/store/mod.rs
+++ b/crates/defra-agent-desktop-core/src/client/store/mod.rs
@@ -127,9 +127,7 @@ impl ClientStore {
             .iter()
             .find(|row| {
                 row.session_id == session_id
-                    && agent_did.map_or(true, |agent_did| {
-                        row.agent_did.as_deref() == Some(agent_did)
-                    })
+                    && agent_did.is_none_or(|agent_did| row.agent_did.as_deref() == Some(agent_did))
             })
             .and_then(|row| clean_string(row.behavior_id.as_deref()))
             .or_else(|| {
@@ -194,7 +192,7 @@ impl ClientStore {
             .filter(|row| {
                 row.task_id
                     .as_deref()
-                    .is_some_and(|task_id| task_ids.iter().any(|candidate| *candidate == task_id))
+                    .is_some_and(|task_id| task_ids.contains(&task_id))
             })
             .collect()
     }
@@ -212,7 +210,7 @@ impl ClientStore {
             .filter(|row| {
                 row.task_id
                     .as_deref()
-                    .is_some_and(|task_id| task_ids.iter().any(|candidate| *candidate == task_id))
+                    .is_some_and(|task_id| task_ids.contains(&task_id))
             })
             .collect()
     }

--- a/crates/defra-agent-desktop-core/tests/submission_api.rs
+++ b/crates/defra-agent-desktop-core/tests/submission_api.rs
@@ -200,6 +200,98 @@ async fn submit_request_writes_request_and_updates_conversation_summary() -> Res
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let core = ClientCore::start_with_paths_and_options(
+        DesktopPaths::from_root(tempdir.path()),
+        ClientCoreOptions::local_only(),
+    )
+    .await?;
+
+    let created = core
+        .create_conversation("did:defra:amy", Some("amy-code"))
+        .await?;
+    let original = core
+        .submit_request(&created.session_id, "did:defra:amy", "first attempt", None)
+        .await?;
+    let parent = core
+        .store()
+        .snapshot()
+        .requests
+        .iter()
+        .find(|row| row.request_id == original.request_id)
+        .cloned()
+        .context("expected submitted parent request in desktop store")?;
+
+    let retried = core.retry_request(&parent).await?;
+
+    let request: RequestRow = query_single(
+        core.node(),
+        &format!(
+            r#"{{
+                AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    request_id
+                    agent_did
+                    behavior_id
+                    session_id
+                    content
+                    status
+                    lifecycle_state
+                    execution_origin
+                    retry_root_request
+                    retry_parent_request
+                    retry_count
+                    max_retries
+                }}
+            }}"#,
+            retried.request_id
+        ),
+        "AgentRequest",
+    )
+    .await?;
+    assert_eq!(request.request_id, retried.request_id);
+    assert_eq!(request.agent_did, "did:defra:amy");
+    assert_eq!(request.behavior_id, "amy-code");
+    assert_eq!(request.session_id, created.session_id);
+    assert_eq!(request.content, "first attempt");
+    assert_eq!(request.status, "pending");
+    assert_eq!(request.lifecycle_state, "pending");
+    assert_eq!(request.execution_origin, "interactive");
+    assert_eq!(request.retry_parent_request, original.request_id);
+    assert_eq!(request.retry_root_request, original.request_id);
+    assert_eq!(request.retry_count, 1);
+    assert_eq!(request.max_retries, 3);
+
+    let conversation: ConversationRow = query_single(
+        core.node(),
+        &format!(
+            r#"{{
+                AgentConversation(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    session_id
+                    agent_name
+                    agent_did
+                    behavior_id
+                    title
+                    preview_text
+                    status
+                    latest_request_id
+                }}
+            }}"#,
+            created.session_id
+        ),
+        "AgentConversation",
+    )
+    .await?;
+    assert_eq!(conversation.preview_text, "first attempt");
+    assert_eq!(conversation.status, "active");
+    assert_eq!(conversation.latest_request_id, retried.request_id);
+    assert_eq!(core.store().focused_request_id(), Some(retried.request_id));
+
+    core.shutdown().await?;
+    Ok(())
+}
+
 /// Regression test for the "resend drops overrides" bug. Previously,
 /// `fetch_request_view` only queried `session_id`, `agent_did`, `behavior_id`,
 /// `content`, `lifecycle_state`, `failure_reason` — so `resend_request`


### PR DESCRIPTION
## Summary
- coalesce desktop `submit_request` and `retry_request` writes into one aliased GraphQL mutation for session upsert, request add, and conversation upsert
- factor existing session/conversation mutation bodies into aliasable field builders while preserving the standalone create-conversation helpers
- add direct retry-chain coverage and clean up a few desktop-store clippy nits surfaced by package clippy

## Follow-up
- Read batching remains the next important phase for #83, especially config export/diff and schedule-source scans.

## Verification
- `cargo fmt`
- `cargo test -p defra-agent-desktop-core --test submission_api`
- `cargo test -p defra-agent-desktop-core --test client_store`
- `cargo clippy -p defra-agent-desktop-core --tests -- -A clippy::needless_borrow -A clippy::needless_borrows_for_generic_args -D warnings`

Plain clippy without the two allowances still fails on pre-existing `defra-agent/src/identity.rs` lints, same as the previous batching PRs.

Part of #83.
