### PR TITLE
Improve desktop remote agent management

### DIFF
--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -11,6 +11,7 @@
     "test:live:behavior-config": "node ./tests/run-live-test.mjs -t \"edits behavior config\"",
     "test:live:config": "node ./tests/run-live-test.mjs -t \"configures backend profile tools behavior task\"",
     "test:live:chat": "node ./tests/run-live-test.mjs -t \"drives three real UI turns\"",
+    "smoke:remote-fleet": "node ./scripts/remote-fleet-smoke.mjs",
     "preview": "vite preview",
     "tauri": "tauri"
   },

--- a/apps/desktop-tauri/scripts/remote-fleet-smoke.mjs
+++ b/apps/desktop-tauri/scripts/remote-fleet-smoke.mjs
@@ -1,0 +1,767 @@
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const DEFAULT_PEERS = [
+  ["studio-1", "http://100.69.4.79:9491"],
+  ["studio-2", "http://100.76.203.120:9491"],
+  ["mini-1", "http://100.102.157.108:9191"],
+  ["mini-2", "http://100.107.77.21:9191"],
+];
+
+const READY_TIMEOUT_MS = 120_000;
+const FETCH_TIMEOUT_MS = 75_000;
+const SYNC_TIMEOUT_MS = 45_000;
+const CHAT_TIMEOUT_MS = 90_000;
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, "../../..");
+
+const argv = [...process.argv.slice(2)];
+const shouldSendChat = takeBooleanFlag(argv, "--send");
+const keepRunner = takeBooleanFlag(argv, "--keep-runner");
+const jsonOutput = takeBooleanFlag(argv, "--json");
+const peerOverrides = takeRepeatedFlag(argv, "--peer");
+
+if (argv.length > 0) {
+  throw new Error(`unknown argument(s): ${argv.join(" ")}`);
+}
+
+const peers = peerOverrides.length > 0 ? peerOverrides.map(parsePeerArg) : DEFAULT_PEERS;
+
+const runnerLogs = [];
+
+main().catch((error) => {
+  console.error(error.stack || error.message || String(error));
+  process.exit(1);
+});
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  log(`remote fleet smoke starting (${shouldSendChat ? "sync + chat" : "sync only"})`);
+
+  const resolvedPeers = [];
+  for (const [label, serverAddress] of peers) {
+    const peer = await resolvePeer(label, serverAddress);
+    resolvedPeers.push(peer);
+    log(
+      `${label}: status ok, did=${peer.agentDid}, graphql=${peer.graphql}, addr=${shorten(peer.addr, 90)}`,
+    );
+  }
+
+  const runner = await startBridgeRunner();
+  const results = [];
+  try {
+    log(`bridge runner ready at ${runner.baseUrl}`);
+    for (const peer of resolvedPeers) {
+      const result = await smokePeer(runner.baseUrl, peer);
+      results.push(result);
+      const counts = result.syncedCounts;
+      log(
+        `${peer.label}: synced behaviors=${counts.behaviors} tasks=${counts.tasks} conversations=${counts.conversations} backends=${counts.inferenceBackends}`,
+      );
+      if (result.chat) {
+        log(
+          `${peer.label}: chat request=${result.chat.requestId} local=${result.chat.localAccepted} remote=${result.chat.remoteVisible}`,
+        );
+      }
+    }
+  } finally {
+    if (keepRunner) {
+      log(`leaving bridge runner alive at ${runner.baseUrl}`);
+    } else {
+      await stopBridgeRunner(runner.process);
+    }
+  }
+
+  const runnerErrors = runnerLogs.filter((line) =>
+    /\b(ERROR|panic|panicked)\b|Block merge failed/i.test(line),
+  );
+  const failed = results.flatMap((result) => result.failures);
+  if (runnerErrors.length > 0) {
+    failed.push(`bridge runner emitted ${runnerErrors.length} error log line(s)`);
+  }
+
+  const summary = {
+    startedAt,
+    completedAt: new Date().toISOString(),
+    mode: shouldSendChat ? "sync+chat" : "sync",
+    peers: results,
+    runnerErrors: runnerErrors.slice(-20),
+    ok: failed.length === 0,
+    failures: failed,
+  };
+
+  if (jsonOutput) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    printSummary(summary);
+  }
+
+  if (!summary.ok) {
+    process.exit(1);
+  }
+}
+
+async function smokePeer(baseUrl, peer) {
+  const failures = [];
+  const addSnapshot = await postJson(`${baseUrl}/desktop/peer/add`, {
+    label: peer.label,
+    agentDid: peer.agentDid,
+    addr: peer.addr,
+    graphql: peer.graphql,
+  });
+
+  let deployment = findDeployment(addSnapshot, peer.agentDid);
+  if (!deployment) {
+    deployment = await waitForDeployment(baseUrl, peer.agentDid, SYNC_TIMEOUT_MS);
+  }
+
+  if (!deployment) {
+    return {
+      label: peer.label,
+      agentDid: peer.agentDid,
+      graphql: peer.graphql,
+      syncedCounts: emptyCounts(),
+      chat: null,
+      failures: [`${peer.label}: deployment did not appear after peer add`],
+    };
+  }
+
+  const counts = deploymentCounts(deployment);
+  if (counts.behaviors < 1) {
+    failures.push(`${peer.label}: no behaviors synced`);
+  }
+  if (counts.tasks < 1) {
+    failures.push(`${peer.label}: no tasks synced`);
+  }
+  if (counts.inferenceBackends < 1) {
+    failures.push(`${peer.label}: no inference backends synced`);
+  }
+
+  let chat = null;
+  if (shouldSendChat) {
+    chat = await smokeChat(baseUrl, peer, deployment);
+    if (!chat.localAccepted) {
+      failures.push(`${peer.label}: desktop did not accept chat send`);
+    }
+    if (!chat.remoteVisible) {
+      failures.push(
+        `${peer.label}: remote GraphQL did not show new AgentRequest ${chat.requestId}`,
+      );
+    }
+  }
+
+  return {
+    label: peer.label,
+    agentDid: peer.agentDid,
+    graphql: peer.graphql,
+    displayName: deployment.agentPrincipal?.displayName ?? deployment.label,
+    syncedCounts: counts,
+    chat,
+    failures,
+  };
+}
+
+async function smokeChat(baseUrl, peer, deployment) {
+  const behaviorId =
+    deployment.defaultBehaviorId ||
+    deployment.behaviors?.find((behavior) => behavior.isDefault)?.behaviorId ||
+    deployment.behaviors?.[0]?.behaviorId ||
+    null;
+  const content = [
+    "Desktop remote smoke test.",
+    `Peer: ${peer.label}.`,
+    `Timestamp: ${new Date().toISOString()}.`,
+    "Please reply with exactly one short sentence.",
+  ].join(" ");
+
+  try {
+    const sent = await postJson(`${baseUrl}/desktop/chat/send`, {
+      agentDid: peer.agentDid,
+      behaviorId,
+      sessionId: null,
+      content,
+    });
+    const localSession = await waitForLocalSession(
+      baseUrl,
+      peer.agentDid,
+      sent.sessionId,
+      sent.requestId,
+      CHAT_TIMEOUT_MS,
+    );
+    const remote = await waitForRemoteRequest(
+      peer.graphql,
+      sent.sessionId,
+      sent.requestId,
+      CHAT_TIMEOUT_MS,
+    );
+    return {
+      localAccepted: Boolean(sent.sessionId && sent.requestId),
+      sessionId: sent.sessionId,
+      requestId: sent.requestId,
+      behaviorId: sent.behaviorId ?? behaviorId,
+      localTurnState: localSession?.turnState ?? null,
+      localTimelineItems: localSession?.timelineItems?.length ?? 0,
+      remoteVisible: Boolean(remote?.request),
+      remoteLifecycleState: remote?.request?.lifecycle_state ?? null,
+      remoteStatus: remote?.request?.status ?? null,
+      remoteResponseStatus: remote?.response?.status ?? null,
+      remoteResponseError: remote?.response?.error_message ?? null,
+    };
+  } catch (error) {
+    return {
+      localAccepted: false,
+      sessionId: null,
+      requestId: null,
+      behaviorId,
+      localTurnState: null,
+      localTimelineItems: 0,
+      remoteVisible: false,
+      remoteLifecycleState: null,
+      remoteStatus: null,
+      remoteResponseStatus: null,
+      remoteResponseError: String(error.message || error),
+    };
+  }
+}
+
+async function resolvePeer(label, serverAddress) {
+  const statusUrl = normalizeStatusUrl(serverAddress);
+  const status = await getJson(statusUrl);
+  const agentDid = stringValue(status.agent_did || status.agentDid);
+  if (!agentDid) {
+    throw new Error(`${label}: status response is missing agent_did`);
+  }
+  const graphql = normalizeGraphqlUrl(status, statusUrl);
+  const addr = selectPeerAddr(status, statusUrl);
+  if (!graphql) {
+    throw new Error(`${label}: status response is missing GraphQL endpoint`);
+  }
+  if (!addr) {
+    throw new Error(`${label}: status response is missing P2P address`);
+  }
+  return {
+    label,
+    serverAddress,
+    statusUrl,
+    agentDid,
+    agentName: stringValue(status.agent_name || status.agentName) || label,
+    graphql,
+    addr,
+  };
+}
+
+function normalizeStatusUrl(serverAddress) {
+  const trimmed = serverAddress.trim();
+  const url = new URL(
+    trimmed.startsWith("http://") || trimmed.startsWith("https://")
+      ? trimmed
+      : `http://${trimmed}`,
+  );
+  const path = url.pathname.replace(/\/+$/, "");
+  if (
+    path === "" ||
+    path === "/" ||
+    path === "/api/v0" ||
+    path === "/api/v0/graphql"
+  ) {
+    url.pathname = "/status";
+  } else if (!path.endsWith("/status")) {
+    url.pathname = `${path}/status`;
+  }
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function normalizeGraphqlUrl(status, statusUrl) {
+  const raw = stringValue(
+    status.desktop_graphql ||
+      status.desktopGraphql ||
+      status.graphql ||
+      status.graphql_url ||
+      status.graphqlUrl,
+  );
+  const statusEndpoint = new URL(statusUrl);
+  if (!raw) {
+    const fallback = new URL(statusEndpoint.toString());
+    fallback.pathname = "/api/v0/graphql";
+    fallback.search = "";
+    fallback.hash = "";
+    return fallback.toString();
+  }
+
+  const graphql = new URL(raw, statusEndpoint);
+  if (
+    graphql.hostname === "127.0.0.1" ||
+    graphql.hostname === "localhost" ||
+    graphql.hostname === "0.0.0.0" ||
+    graphql.hostname === "::1"
+  ) {
+    graphql.protocol = statusEndpoint.protocol;
+    graphql.hostname = statusEndpoint.hostname;
+    graphql.port = statusEndpoint.port;
+  }
+  if (graphql.pathname === "/" || graphql.pathname === "") {
+    graphql.pathname = "/api/v0/graphql";
+  }
+  graphql.search = "";
+  graphql.hash = "";
+  return graphql.toString();
+}
+
+function selectPeerAddr(status, statusUrl) {
+  const statusHost = new URL(statusUrl).hostname;
+  const p2p = status.p2p ?? {};
+  const addrs = [
+    ...arrayValue(p2p.p2p_listen_addresses),
+    ...arrayValue(p2p.listen_addresses),
+    ...arrayValue(status.p2p_listen_addresses),
+    ...arrayValue(status.listen_addresses),
+  ].filter((value) => typeof value === "string" && value.trim() !== "");
+  return (
+    addrs.find((addr) => addr.includes(statusHost)) ||
+    stringValue(p2p.p2p_shareable_address) ||
+    stringValue(status.p2p_shareable_address) ||
+    addrs[0] ||
+    ""
+  );
+}
+
+async function startBridgeRunner() {
+  const env = {
+    ...process.env,
+    CARGO_NET_GIT_FETCH_WITH_CLI:
+      process.env.CARGO_NET_GIT_FETCH_WITH_CLI ?? "true",
+  };
+  const child = spawn(
+    "cargo",
+    [
+      "run",
+      "-p",
+      "defra-agent-desktop-tauri",
+      "--bin",
+      "bridge_runner",
+      "--quiet",
+      "--",
+      "--desktop-only",
+    ],
+    {
+      cwd: repoRoot,
+      env,
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  child.stdout.setEncoding("utf8");
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk) => collectRunnerLog(chunk));
+
+  let ready;
+  try {
+    ready = await waitForReadyMessage(child, READY_TIMEOUT_MS);
+  } catch (error) {
+    await stopBridgeRunner(child);
+    throw error;
+  }
+  return {
+    process: child,
+    baseUrl: ready.baseUrl,
+    ready,
+  };
+}
+
+async function waitForReadyMessage(child, timeoutMs) {
+  let stdoutBuffer = "";
+  let stdout = "";
+  let stderr = "";
+
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `bridge runner did not become ready within ${timeoutMs}ms\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      );
+    }, timeoutMs);
+
+    const onStdout = (chunk) => {
+      stdoutBuffer += chunk.toString();
+      let newlineIndex = stdoutBuffer.indexOf("\n");
+      while (newlineIndex !== -1) {
+        const line = stdoutBuffer.slice(0, newlineIndex).trim();
+        stdoutBuffer = stdoutBuffer.slice(newlineIndex + 1);
+        stdout += `${line}\n`;
+        collectRunnerLog(line);
+        try {
+          const message = JSON.parse(line);
+          if (message.kind === "ready" && message.baseUrl) {
+            cleanup();
+            resolvePromise(message);
+            return;
+          }
+        } catch {
+          // Logs can appear before the ready JSON.
+        }
+        newlineIndex = stdoutBuffer.indexOf("\n");
+      }
+    };
+
+    const onStderr = (chunk) => {
+      stderr += chunk.toString();
+    };
+
+    const onExit = (code) => {
+      cleanup();
+      rejectPromise(
+        new Error(
+          `bridge runner exited before ready (code=${code ?? "null"})\nstdout:\n${stdout}${stdoutBuffer}\nstderr:\n${stderr}`,
+        ),
+      );
+    };
+
+    const cleanup = () => {
+      clearTimeout(timeout);
+      child.stdout.off("data", onStdout);
+      child.stderr.off("data", onStderr);
+      child.off("exit", onExit);
+    };
+
+    child.stdout.on("data", onStdout);
+    child.stderr.on("data", onStderr);
+    child.on("exit", onExit);
+  });
+}
+
+function collectRunnerLog(chunk) {
+  const lines = String(chunk)
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+  for (const line of lines) {
+    runnerLogs.push(line);
+    if (runnerLogs.length > 500) {
+      runnerLogs.shift();
+    }
+  }
+}
+
+async function stopBridgeRunner(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+  child.stdin.end();
+  await new Promise((resolvePromise) => {
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      resolvePromise();
+    }, 10_000);
+    child.once("exit", () => {
+      clearTimeout(timeout);
+      resolvePromise();
+    });
+  });
+}
+
+async function waitForDeployment(baseUrl, agentDid, timeoutMs) {
+  return await waitFor(
+    async () => {
+      const snapshot = await getJson(`${baseUrl}/desktop/client/snapshot`);
+      const deployment = findDeployment(snapshot, agentDid);
+      if (deployment) {
+        return deployment;
+      }
+      return null;
+    },
+    timeoutMs,
+    1_500,
+  );
+}
+
+async function waitForLocalSession(baseUrl, agentDid, sessionId, requestId, timeoutMs) {
+  return await waitFor(
+    async () => {
+      const snapshot = await postJson(`${baseUrl}/desktop/session/snapshot`, {
+        agentDid,
+        sessionId,
+        requestId,
+      });
+      if (snapshot?.sessionId === sessionId) {
+        return snapshot;
+      }
+      return null;
+    },
+    timeoutMs,
+    1_500,
+  );
+}
+
+async function waitForRemoteRequest(graphql, sessionId, requestId, timeoutMs) {
+  return await waitFor(
+    async () => {
+      const data = await queryRemoteChat(graphql, sessionId, requestId);
+      if (data.request) {
+        return data;
+      }
+      return null;
+    },
+    timeoutMs,
+    2_000,
+  );
+}
+
+async function queryRemoteChat(graphql, sessionId, requestId) {
+  const query = `query RemoteChatSmoke {
+    AgentRequest(filter: { request_id: { _eq: "${escapeGraphql(requestId)}" } }, limit: 1) {
+      request_id
+      agent_did
+      behavior_id
+      session_id
+      status
+      lifecycle_state
+      failure_reason
+      created_at
+      claimed_at
+      execution_origin
+    }
+    AgentConversation(filter: { session_id: { _eq: "${escapeGraphql(sessionId)}" } }, limit: 1) {
+      session_id
+      agent_did
+      behavior_id
+      title
+      status
+      latest_request_id
+      updated_at
+    }
+    AgentResponse(filter: { request_id: { _eq: "${escapeGraphql(requestId)}" } }, limit: 1) {
+      request_id
+      status
+      error_message
+      completed_at
+      materialized_at
+    }
+  }`;
+  const response = await postJson(graphql, { query });
+  const errors = response.errors;
+  if (Array.isArray(errors) && errors.length > 0) {
+    throw new Error(`remote GraphQL returned errors: ${JSON.stringify(errors)}`);
+  }
+  return {
+    request: response.data?.AgentRequest?.[0] ?? null,
+    conversation: response.data?.AgentConversation?.[0] ?? null,
+    response: response.data?.AgentResponse?.[0] ?? null,
+  };
+}
+
+async function waitFor(probe, timeoutMs, intervalMs) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = null;
+  while (Date.now() < deadline) {
+    try {
+      const value = await probe();
+      if (value) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+    await sleep(intervalMs);
+  }
+  if (lastError) {
+    throw lastError;
+  }
+  return null;
+}
+
+async function getJson(url) {
+  return await fetchJson(url, { method: "GET" });
+}
+
+async function postJson(url, body) {
+  return await fetchJson(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchJson(url, init) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    let response;
+    try {
+      response = await fetch(url, { ...init, signal: controller.signal });
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new Error(`${init.method ?? "GET"} ${url} timed out after ${FETCH_TIMEOUT_MS}ms`);
+      }
+      throw error;
+    }
+    const text = await response.text();
+    let json = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch (error) {
+      throw new Error(`failed to parse JSON from ${url}: ${text.slice(0, 300)}`);
+    }
+    if (!response.ok) {
+      throw new Error(
+        `${init.method ?? "GET"} ${url} failed with ${response.status}: ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function findDeployment(snapshot, agentDid) {
+  return (
+    snapshot?.client?.deployments?.find((deployment) => deployment.agentDid === agentDid) ??
+    null
+  );
+}
+
+function deploymentCounts(deployment) {
+  return {
+    behaviors: deployment.behaviors?.length ?? 0,
+    tasks: deployment.tasks?.length ?? 0,
+    conversations: deployment.conversations?.length ?? 0,
+    inferenceBackends: deployment.inferenceBackends?.length ?? 0,
+    inferenceProfiles: deployment.inferenceProfiles?.length ?? 0,
+    toolSelections: deployment.toolSelections?.length ?? 0,
+    toolServiceRegistries: deployment.toolServiceRegistries?.length ?? 0,
+    schedules: deployment.schedules?.length ?? 0,
+    eventTriggers: deployment.eventTriggers?.length ?? 0,
+  };
+}
+
+function emptyCounts() {
+  return {
+    behaviors: 0,
+    tasks: 0,
+    conversations: 0,
+    inferenceBackends: 0,
+    inferenceProfiles: 0,
+    toolSelections: 0,
+    toolServiceRegistries: 0,
+    schedules: 0,
+    eventTriggers: 0,
+  };
+}
+
+function printSummary(summary) {
+  console.log("");
+  console.log("Remote fleet smoke summary");
+  console.log(`Mode: ${summary.mode}`);
+  for (const peer of summary.peers) {
+    const counts = peer.syncedCounts;
+    console.log(
+      [
+        `${summary.okForPeer?.[peer.label] ?? (peer.failures.length === 0 ? "PASS" : "FAIL")} ${peer.label}`,
+        `behaviors=${counts.behaviors}`,
+        `tasks=${counts.tasks}`,
+        `conversations=${counts.conversations}`,
+        `backends=${counts.inferenceBackends}`,
+        `profiles=${counts.inferenceProfiles}`,
+      ].join(" "),
+    );
+    if (peer.chat) {
+      console.log(
+        `  chat request=${peer.chat.requestId ?? "n/a"} local=${peer.chat.localAccepted} remote=${peer.chat.remoteVisible} state=${peer.chat.remoteLifecycleState ?? peer.chat.localTurnState ?? "n/a"}`,
+      );
+    }
+    for (const failure of peer.failures) {
+      console.log(`  - ${failure}`);
+    }
+  }
+  if (summary.runnerErrors.length > 0) {
+    console.log("");
+    console.log("Bridge runner error logs:");
+    for (const line of summary.runnerErrors) {
+      console.log(`  ${line}`);
+    }
+  }
+  if (summary.failures.length === 0) {
+    console.log("");
+    console.log("All checks passed.");
+  } else {
+    console.log("");
+    console.log("Failures:");
+    for (const failure of summary.failures) {
+      console.log(`  - ${failure}`);
+    }
+  }
+}
+
+function takeBooleanFlag(args, name) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return false;
+  }
+  args.splice(index, 1);
+  return true;
+}
+
+function takeRepeatedFlag(args, name) {
+  const values = [];
+  for (let index = 0; index < args.length; ) {
+    const value = args[index];
+    if (value === name) {
+      const next = args[index + 1];
+      if (!next || next.startsWith("--")) {
+        throw new Error(`missing value for ${name}`);
+      }
+      values.push(next);
+      args.splice(index, 2);
+      continue;
+    }
+    if (value.startsWith(`${name}=`)) {
+      values.push(value.slice(name.length + 1));
+      args.splice(index, 1);
+      continue;
+    }
+    index += 1;
+  }
+  return values;
+}
+
+function parsePeerArg(value) {
+  const [label, ...addressParts] = value.split("=");
+  const address = addressParts.join("=");
+  if (!label || !address) {
+    throw new Error(`invalid --peer value "${value}", expected label=http://host:port`);
+  }
+  return [label, address];
+}
+
+function stringValue(value) {
+  return typeof value === "string" && value.trim() !== "" ? value.trim() : "";
+}
+
+function arrayValue(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function escapeGraphql(value) {
+  return String(value).replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function shorten(value, maxLength) {
+  if (!value || value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 1)}...`;
+}
+
+function sleep(ms) {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}
+
+function log(message) {
+  if (!jsonOutput) {
+    console.log(`[remote-smoke] ${message}`);
+  }
+}

--- a/apps/desktop-tauri/src-tauri/src/bin/bridge_runner.rs
+++ b/apps/desktop-tauri/src-tauri/src/bin/bridge_runner.rs
@@ -39,6 +39,8 @@ use live_fixture::{LiveBackendOverride, LiveBridgeFixture};
 #[derive(Debug, Parser)]
 struct RunnerArgs {
     #[arg(long)]
+    desktop_only: bool,
+    #[arg(long)]
     inference_url: Option<String>,
     #[arg(long)]
     model_name: Option<String>,
@@ -62,15 +64,20 @@ struct ReadyMessage {
 
 fn main() -> Result<()> {
     let args = RunnerArgs::parse();
-    let backend_override = LiveBackendOverride {
-        inference_url: args.inference_url,
-        model_name: args.model_name,
-        provider: args.provider,
-        api_key: args.api_key,
-        api_key_env_var: args.api_key_env_var,
+    let fixture = if args.desktop_only {
+        std::panic::catch_unwind(LiveBridgeFixture::start_desktop_only)
+            .map_err(|_| anyhow!("bridge runner panicked during desktop-only startup"))??
+    } else {
+        let backend_override = LiveBackendOverride {
+            inference_url: args.inference_url,
+            model_name: args.model_name,
+            provider: args.provider,
+            api_key: args.api_key,
+            api_key_env_var: args.api_key_env_var,
+        };
+        std::panic::catch_unwind(|| LiveBridgeFixture::start(Some(backend_override)))
+            .map_err(|_| anyhow!("bridge runner panicked during startup"))??
     };
-    let fixture = std::panic::catch_unwind(|| LiveBridgeFixture::start(Some(backend_override)))
-        .map_err(|_| anyhow!("bridge runner panicked during startup"))??;
     let server = BridgeRunnerServer::start(Arc::clone(&fixture))?;
     let ready = ReadyMessage {
         kind: "ready",

--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/chat.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/chat.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Result};
 use defra_agent_desktop_core::client::ClientCore;
 use defra_agent_protocol::client_protocol::ClientTurnState;
+use uuid::Uuid;
 
 use super::super::types::{ChatSendRequest, ChatSendResult, ConversationRenameRequest};
 
@@ -46,13 +47,15 @@ pub(crate) async fn send_chat_message(
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned);
 
-    let session_id = match request
+    let requested_session_id = request
         .session_id
         .as_deref()
         .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
+        .filter(|value| !value.is_empty());
+    let remote_graphql = core.graphql_for_agent(&agent_did).await;
+    let session_id = match requested_session_id {
         Some(session_id) => session_id.to_string(),
+        None if remote_graphql.is_some() => Uuid::new_v4().to_string(),
         None => {
             core.create_conversation(&agent_did, behavior_id.as_deref())
                 .await?
@@ -70,9 +73,23 @@ pub(crate) async fn send_chat_message(
         }
     }
 
-    let submitted = core
-        .submit_request(&session_id, &agent_did, &content, behavior_id.as_deref())
-        .await?;
+    let submitted = match remote_graphql {
+        Some(graphql) => {
+            core.submit_remote_graphql_request_with_options(
+                &graphql,
+                &session_id,
+                &agent_did,
+                &content,
+                behavior_id.as_deref(),
+                Default::default(),
+            )
+            .await?
+        }
+        None => {
+            core.submit_request(&session_id, &agent_did, &content, behavior_id.as_deref())
+                .await?
+        }
+    };
 
     Ok(ChatSendResult {
         session_id,

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/session.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/session.rs
@@ -112,6 +112,8 @@ pub(crate) fn build_session_snapshot_from_store_for_agent(
             turn_state,
             Some(defra_agent_protocol::client_protocol::ClientTurnState::WaitingForClaim)
                 | Some(defra_agent_protocol::client_protocol::ClientTurnState::Streaming)
+                | Some(defra_agent_protocol::client_protocol::ClientTurnState::Failed)
+                | Some(defra_agent_protocol::client_protocol::ClientTurnState::Interrupted)
         ) && response.materialized_message_sequence.is_none()
             && (response
                 .content

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
@@ -124,6 +124,94 @@ fn session_snapshot_orders_pending_turn_before_orphan_tool_groups_and_live_overl
 }
 
 #[test]
+fn session_snapshot_keeps_failed_unmaterialized_response_overlay() {
+    let store = ClientStore::from_rows(ClientStoreRows {
+        conversations: vec![AgentConversationRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Amy".to_string()),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            title: Some("conversation".to_string()),
+            title_source: Some("generated".to_string()),
+            preview_text: Some("turn one".to_string()),
+            status: Some("active".to_string()),
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            updated_at: Some("2026-04-21T12:15:00Z".to_string()),
+            latest_request_id: Some("req-1".to_string()),
+        }],
+        requests: vec![AgentRequestRow {
+            request_id: "req-1".to_string(),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            session_id: Some("session-1".to_string()),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("turn one".to_string()),
+            status: Some("error".to_string()),
+            lifecycle_state: Some("failed".to_string()),
+            backend_id: None,
+            execution_origin: Some("interactive".to_string()),
+            failure_reason: Some("request deadline exceeded".to_string()),
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            claimed_at: Some("2026-04-21T12:00:01Z".to_string()),
+            deadline: Some("2026-04-21T12:15:00Z".to_string()),
+            retry_count: Some(0),
+            max_retries: Some(3),
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        }],
+        messages: vec![AgentMessageRow {
+            message_key: "msg-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            sequence: Some(1),
+            role: Some("user".to_string()),
+            content: Some(user_message_json("turn one")),
+            timestamp: Some("2026-04-21T12:00:00Z".to_string()),
+        }],
+        responses: vec![AgentResponseRow {
+            response_key: "resp-1".to_string(),
+            request_id: Some("req-1".to_string()),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            session_id: Some("session-1".to_string()),
+            content: Some("partial answer before timeout".to_string()),
+            reasoning: None,
+            status: Some("error".to_string()),
+            error_message: Some("request deadline exceeded".to_string()),
+            token_count: Some(12),
+            progress_seq: Some(3),
+            materialized_message_sequence: None,
+            materialized_at: None,
+            created_at: Some("2026-04-21T12:00:02Z".to_string()),
+            completed_at: Some("2026-04-21T12:15:00Z".to_string()),
+            interrupted_at: None,
+        }],
+        ..ClientStoreRows::default()
+    });
+
+    let snapshot = build_session_snapshot_from_store(&store, "session-1", Some("req-1"))
+        .expect("session snapshot");
+
+    assert_eq!(snapshot.turn_state.as_deref(), Some("failed"));
+    assert_eq!(
+        snapshot
+            .active_response_overlay
+            .as_ref()
+            .and_then(|overlay| overlay.content.as_deref()),
+        Some("partial answer before timeout")
+    );
+
+    let live_content = snapshot.timeline_items.iter().find_map(|item| match item {
+        RenderedTimelineItem::LiveAssistant { content, .. } => content.as_deref(),
+        _ => None,
+    });
+    assert_eq!(live_content, Some("partial answer before timeout"));
+}
+
+#[test]
 fn session_snapshot_keeps_full_live_overlay_when_only_prior_turn_shares_prefix() {
     let store = ClientStore::from_rows(ClientStoreRows {
         conversations: vec![AgentConversationRow {

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/config.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/config.rs
@@ -1,6 +1,5 @@
 use tauri::{AppHandle, State};
 
-use super::emit_config_update_and_snapshot;
 use super::super::commands::{
     save_agent_config, save_backend_config, save_behavior_config, save_inference_profile_config,
     save_tool_selection_config, save_tool_service_config, test_tool_service_config,
@@ -11,6 +10,7 @@ use super::super::types::{
     InferenceProfileSaveRequest, ToolSelectionSaveRequest, ToolServiceSaveRequest,
     ToolServiceTestRequest, ToolServiceTestResult,
 };
+use super::emit_config_update_and_snapshot;
 
 #[tauri::command]
 pub(crate) fn desktop_agent_config_save(

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/peers.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/peers.rs
@@ -3,10 +3,10 @@ use std::time::Duration;
 use defra_agent_desktop_core::local_runtime::fetch_runtime_connection_payload;
 use tauri::{AppHandle, State};
 
-use super::emit_config_update_and_snapshot;
 use super::super::commands::{add_peer, repair_p2p};
 use super::super::state::{current_core, DesktopAppState};
 use super::super::types::{DesktopClientSnapshot, PeerAddRequest, PeerStatusFetchRequest};
+use super::emit_config_update_and_snapshot;
 
 #[tauri::command]
 pub(crate) fn desktop_peer_add(

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/tasks.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/tasks.rs
@@ -1,6 +1,5 @@
 use tauri::{AppHandle, Emitter, State};
 
-use super::emit_config_update_and_snapshot;
 use super::super::commands::{
     run_schedule_config, run_task_config, save_event_trigger_config, save_schedule_config,
     save_task_config,
@@ -10,6 +9,7 @@ use super::super::types::{
     ClientUpdateEvent, DesktopClientSnapshot, EventTriggerSaveRequest, ScheduleRunRequest,
     ScheduleSaveRequest, TaskRunRequest, TaskRunResult, TaskSaveRequest,
 };
+use super::emit_config_update_and_snapshot;
 
 #[tauri::command]
 pub(crate) fn desktop_task_save(

--- a/apps/desktop-tauri/src-tauri/src/runner/live_fixture.rs
+++ b/apps/desktop-tauri/src-tauri/src/runner/live_fixture.rs
@@ -248,13 +248,106 @@ impl LiveBridgeFixture {
         }))
     }
 
+    pub(crate) fn start_desktop_only() -> Result<Arc<Self>> {
+        init_live_runner_tracing();
+
+        let runtime = live_runtime()?;
+        let tempdir = tempfile::tempdir()?;
+        let remote_paths = DesktopPaths::from_root(tempdir.path().join("remote-empty"));
+        let desktop_paths = DesktopPaths::from_root(tempdir.path().join("desktop"));
+        let agent_home = tempdir.path().join("agent-home");
+        std::fs::create_dir_all(&agent_home)?;
+
+        let remote_core = Arc::new(runtime.block_on(ClientCore::start_with_paths_and_options(
+            remote_paths,
+            live_core_options(),
+        ))?);
+        let desktop_core = Arc::new(runtime.block_on(ClientCore::start_with_paths_and_options(
+            desktop_paths.clone(),
+            live_core_options(),
+        ))?);
+        let p2p_listen_address = desktop_core
+            .listen_addresses()
+            .first()
+            .cloned()
+            .unwrap_or_default();
+
+        let init_summary = DesktopInitSummary {
+            status: "initialized",
+            source: "bridge-runner-desktop-only",
+            status_endpoint: None,
+            agent_home: agent_home.display().to_string(),
+            desktop_home: desktop_paths.root().display().to_string(),
+            peer_directory: desktop_paths.peer_directory_path().display().to_string(),
+            label: "Desktop Only".to_string(),
+            agent_name: String::new(),
+            agent_did: String::new(),
+            graphql: String::new(),
+            p2p_transport: "iroh".to_string(),
+            p2p_peer_id: desktop_core.local_peer_id().to_string(),
+            p2p_listen_address,
+            peer_record_id: String::new(),
+            next_steps: vec![],
+        };
+
+        tracing::info!("desktop-only bridge fixture ready");
+
+        let update_version = Arc::new(AtomicU64::new(1));
+        let update_task = {
+            let desktop_core = Arc::clone(&desktop_core);
+            let update_version = Arc::clone(&update_version);
+            runtime.spawn(async move {
+                let mut store_updates = desktop_core.store_updates();
+                let mut health_updates = desktop_core.p2p_health_updates();
+                loop {
+                    tokio::select! {
+                        changed = store_updates.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
+                            update_version.fetch_add(1, Ordering::SeqCst);
+                        }
+                        changed = health_updates.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
+                            update_version.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                }
+            })
+        };
+
+        Ok(Arc::new(Self {
+            runtime,
+            _tempdir: tempdir,
+            desktop_paths,
+            agent_home,
+            desktop_core,
+            remote_core,
+            deployment_label: "Desktop Only".to_string(),
+            agent_did: String::new(),
+            tool_root: PathBuf::new(),
+            init_summary,
+            bootstrap_saved_peers: Vec::new(),
+            update_version,
+            update_task: Mutex::new(Some(update_task)),
+            running_agent: Mutex::new(None),
+            shutdown_started: AtomicBool::new(false),
+        }))
+    }
+
     pub(crate) async fn build_bootstrap_summary(&self) -> DesktopBootstrapSummary {
         DesktopBootstrapSummary {
             default_agent_home: self.agent_home.display().to_string(),
-            init_agent_name: Some(DEFAULT_AGENT_NAME.to_string()),
-            init_agent_did: Some(self.init_summary.agent_did.clone()),
+            init_agent_name: non_empty_clone(&self.init_summary.agent_name),
+            init_agent_did: non_empty_clone(&self.init_summary.agent_did),
             init_tool_ceiling: Some("Readwrite".to_string()),
-            init_tool_root: Some(self.tool_root.display().to_string()),
+            init_tool_root: self
+                .tool_root
+                .to_str()
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
             desktop_home: self.desktop_paths.root().display().to_string(),
             peer_directory_path: self
                 .desktop_paths
@@ -269,6 +362,10 @@ impl LiveBridgeFixture {
             saved_peers: self.bootstrap_saved_peers.clone(),
         }
     }
+}
+
+fn non_empty_clone(value: &str) -> Option<String> {
+    (!value.trim().is_empty()).then(|| value.to_string())
 }
 
 fn live_runtime() -> Result<Arc<Runtime>> {

--- a/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
@@ -1,6 +1,10 @@
 import { isTerminalTurnState } from "../../lib/chat-shell";
 import type { BootstrapSummary, DeploymentView, P2PHealth } from "../../lib/types";
-import { displayAgentIdentity, displayBehaviorLabel } from "../../lib/types";
+import {
+  displayAgentIdentity,
+  displayBehaviorLabel,
+  displayGraphqlEndpoint,
+} from "../../lib/types";
 import { ChatIcon, ConfigIcon, RepairIcon, ToolIconGlyph } from "./FleetIcons";
 import { deploymentStatus, formatRelativeTime, inferenceBackendTitle, toolCeilingIcons, type ToolIcon } from "./fleetMetrics";
 
@@ -45,6 +49,7 @@ export function FleetRow({
     bootstrap?.initToolCeiling,
   );
   const agentIdentity = displayAgentIdentity(deployment.agentDid);
+  const graphqlEndpoint = displayGraphqlEndpoint(deployment.graphql);
   const defaultBehaviorLabel = displayBehaviorLabel(
     deployment.defaultBehaviorId ?? deployment.agentPrincipal.defaultBehaviorId,
   );
@@ -77,6 +82,14 @@ export function FleetRow({
                 .filter(Boolean)
                 .join(" | ")}
             </span>
+            {graphqlEndpoint ? (
+              <span
+                className="fleet-agent-endpoint mono"
+                title={`GraphQL endpoint: ${deployment.graphql ?? ""}`}
+              >
+                GraphQL {graphqlEndpoint}
+              </span>
+            ) : null}
           </div>
         </div>
       </td>

--- a/apps/desktop-tauri/src/components/sidebar-widgets/ConnectedPeerSection.tsx
+++ b/apps/desktop-tauri/src/components/sidebar-widgets/ConnectedPeerSection.tsx
@@ -1,5 +1,5 @@
 import type { DeploymentView } from "../../lib/types";
-import { displayAgentIdentity } from "../../lib/types";
+import { displayAgentIdentity, displayGraphqlEndpoint } from "../../lib/types";
 
 export type ConnectedPeerSectionProps = {
   deployments: DeploymentView[];
@@ -18,6 +18,7 @@ export function ConnectedPeerSection({
     deployments.find((deployment) => deployment.agentDid === selectedAgentDid) ??
     null;
   const agentIdentity = displayAgentIdentity(selectedDeployment?.agentDid);
+  const graphqlEndpoint = displayGraphqlEndpoint(selectedDeployment?.graphql);
 
   return (
     <section className="sidebar-section connected-peer-section">
@@ -37,8 +38,14 @@ export function ConnectedPeerSection({
         {agentIdentity ? (
           <span className="connected-peer-identity">{agentIdentity}</span>
         ) : null}
-        {selectedDeployment?.graphql ? (
-          <span className="connected-peer-endpoint">{selectedDeployment.graphql}</span>
+        {graphqlEndpoint ? (
+          <span
+            className="connected-peer-detail"
+            title={`GraphQL endpoint: ${selectedDeployment?.graphql ?? ""}`}
+          >
+            <span className="connected-peer-detail-label">GraphQL</span>
+            <span className="connected-peer-endpoint">{graphqlEndpoint}</span>
+          </span>
         ) : null}
 
         <div className="connected-peer-actions">

--- a/apps/desktop-tauri/src/hooks/desktopShellChatActions.ts
+++ b/apps/desktop-tauri/src/hooks/desktopShellChatActions.ts
@@ -10,7 +10,9 @@ import type { DeploymentView, DesktopSessionSnapshot } from "../lib/types";
 type ChatActionParams = {
   draft: string;
   newConversationAgentRef: MutableRefObject<string | null>;
-  refreshSession: (nextSessionId: string | null) => Promise<void>;
+  refreshSession: (
+    nextSessionId: string | null,
+  ) => Promise<DesktopSessionSnapshot | null>;
   refreshSnapshot: () => Promise<void>;
   selectedBehaviorId: string | null;
   selectedDeployment: DeploymentView | null;
@@ -77,8 +79,6 @@ export function createDesktopShellChatActions({
         sessionId: result.sessionId,
         requestId: result.requestId,
       });
-      await refreshSnapshot();
-      await refreshSession(result.sessionId);
     } catch (err) {
       setLocalWorkflow({ kind: "ready" });
       setError(String(err));

--- a/apps/desktop-tauri/src/hooks/desktopShellEffects.ts
+++ b/apps/desktop-tauri/src/hooks/desktopShellEffects.ts
@@ -4,6 +4,7 @@ import type { ChatWorkflowState } from "../lib/chat-shell";
 import type {
   DeploymentView,
   DesktopClientSnapshot,
+  DesktopSessionSnapshot,
   P2PHealth,
 } from "../lib/types";
 import {
@@ -21,7 +22,7 @@ type DesktopShellEffectsArgs = {
   lastP2PAutoRestartAt: MutableRefObject<number | null>;
   localWorkflow: ChatWorkflowState;
   newConversationAgentRef: MutableRefObject<string | null>;
-  refreshSession: (sessionId: string | null) => Promise<void>;
+  refreshSession: (sessionId: string | null) => Promise<DesktopSessionSnapshot | null>;
   refreshSnapshot: () => Promise<void>;
   restartDesktopClient: (reason: string) => Promise<void>;
   runtimeHealth: P2PHealth | null;
@@ -41,6 +42,15 @@ type DesktopShellEffectsArgs = {
   stopping: boolean;
   onStartClient: () => Promise<void>;
 };
+
+function isTerminalTurnState(turnState?: string | null) {
+  return (
+    turnState === "completed" ||
+    turnState === "failed" ||
+    turnState === "superseded" ||
+    turnState === "interrupted"
+  );
+}
 
 export function useDesktopShellEffects({
   autoRestartInFlight,
@@ -144,8 +154,17 @@ export function useDesktopShellEffects({
     let disposed = false;
     let unlisten: (() => void) | undefined;
 
-    void listenToDesktopClientUpdates(async () => {
+    void listenToDesktopClientUpdates(async (event) => {
       if (disposed) {
+        return;
+      }
+      if (event.reason === "store" && selectedAgentDid) {
+        if (selectedSessionId) {
+          const nextSession = await refreshSession(selectedSessionId);
+          if (isTerminalTurnState(nextSession?.turnState)) {
+            await refreshSnapshot();
+          }
+        }
         return;
       }
       await refreshSnapshot();
@@ -164,7 +183,7 @@ export function useDesktopShellEffects({
       disposed = true;
       unlisten?.();
     };
-  }, [selectedSessionId, selectedTrackedRequestId]);
+  }, [selectedAgentDid, selectedSessionId, selectedTrackedRequestId]);
 
   useEffect(() => {
     if (!deployments.length) {
@@ -206,9 +225,11 @@ export function useDesktopShellEffects({
 
     if (
       selectedSessionId &&
-      selectedDeployment.conversations.some(
+      (selectedDeployment.conversations.some(
         (conversation) => conversation.sessionId === selectedSessionId,
-      )
+      ) ||
+        (localWorkflow.kind === "awaitingObservation" &&
+          localWorkflow.sessionId === selectedSessionId))
     ) {
       newConversationAgentRef.current = null;
       return;
@@ -223,6 +244,7 @@ export function useDesktopShellEffects({
 
     setSelectedSessionId(selectedDeployment.conversations[0]?.sessionId ?? null);
   }, [
+    localWorkflow,
     newConversationAgentRef,
     selectedBehaviorId,
     selectedDeployment,

--- a/apps/desktop-tauri/src/hooks/desktopShellTaskActions.ts
+++ b/apps/desktop-tauri/src/hooks/desktopShellTaskActions.ts
@@ -9,6 +9,7 @@ import {
 } from "../lib/desktop-api";
 import type {
   DesktopClientSnapshot,
+  DesktopSessionSnapshot,
   EventTriggerSaveRequest,
   ScheduleRunRequest,
   ScheduleSaveRequest,
@@ -18,7 +19,9 @@ import type {
 } from "../lib/types";
 
 type TaskActionParams = {
-  refreshSession: (nextSessionId: string | null) => Promise<void>;
+  refreshSession: (
+    nextSessionId: string | null,
+  ) => Promise<DesktopSessionSnapshot | null>;
   refreshSnapshot: () => Promise<void>;
   setError: Dispatch<SetStateAction<string | null>>;
   setRunningTask: Dispatch<SetStateAction<boolean>>;

--- a/apps/desktop-tauri/src/hooks/useDesktopShell.ts
+++ b/apps/desktop-tauri/src/hooks/useDesktopShell.ts
@@ -36,6 +36,9 @@ export function useDesktopShell() {
   const lastP2PAutoRestartAt = useRef<number | null>(null);
   const lastObservedP2PHealth = useRef<P2PHealth | null>(null);
   const selectedSessionIdRef = useRef<string | null>(null);
+  const selectedAgentDidRef = useRef<string | null>(null);
+  const selectedTrackedRequestIdRef = useRef<string | null>(null);
+  const sessionRefreshSeq = useRef(0);
   const newConversationAgentRef = useRef<string | null>(null);
   const [snapshot, setSnapshot] = useState<DesktopClientSnapshot | null>(null);
   const [session, setSession] = useState<DesktopSessionSnapshot | null>(null);
@@ -93,6 +96,9 @@ export function useDesktopShell() {
     selectedSessionId,
     shellProjection.workflow,
   );
+  selectedAgentDidRef.current = selectedAgentDid;
+  selectedSessionIdRef.current = selectedSessionId;
+  selectedTrackedRequestIdRef.current = selectedTrackedRequestId;
 
   async function refreshSnapshot() {
     setLoading(true);
@@ -107,21 +113,34 @@ export function useDesktopShell() {
     }
   }
 
-  async function refreshSession(nextSessionId: string | null) {
+  async function refreshSession(
+    nextSessionId: string | null,
+  ): Promise<DesktopSessionSnapshot | null> {
+    const refreshSeq = sessionRefreshSeq.current + 1;
+    sessionRefreshSeq.current = refreshSeq;
+
     if (!nextSessionId) {
-      setSession(null);
-      return;
+      if (sessionRefreshSeq.current === refreshSeq) {
+        setSession(null);
+      }
+      return null;
     }
 
     try {
       const next = await fetchSessionSnapshot(
         nextSessionId,
-        selectedAgentDid,
-        trackedRequestIdForSession(nextSessionId, shellProjection.workflow),
+        selectedAgentDidRef.current,
+        selectedTrackedRequestIdRef.current,
       );
-      setSession(next);
+      if (sessionRefreshSeq.current === refreshSeq) {
+        setSession(next);
+      }
+      return next;
     } catch (err) {
-      setError(String(err));
+      if (sessionRefreshSeq.current === refreshSeq) {
+        setError(String(err));
+      }
+      return null;
     }
   }
 

--- a/apps/desktop-tauri/src/lib/desktop-events.ts
+++ b/apps/desktop-tauri/src/lib/desktop-events.ts
@@ -1,6 +1,11 @@
 import { listen } from "@tauri-apps/api/event";
 
-export type DesktopClientUpdatedHandler = () => void | Promise<void>;
+export type DesktopClientUpdatedEvent = {
+  reason?: string | null;
+};
+export type DesktopClientUpdatedHandler = (
+  event: DesktopClientUpdatedEvent,
+) => void | Promise<void>;
 export type DesktopClientUpdatedUnlisten = () => void;
 export type DesktopClientUpdatedListenerFactory = (
   handler: DesktopClientUpdatedHandler,
@@ -9,9 +14,12 @@ export type DesktopClientUpdatedListenerFactory = (
 async function defaultDesktopClientUpdatedListenerFactory(
   handler: DesktopClientUpdatedHandler,
 ) {
-  const unlisten = await listen("desktop://client-updated", () => {
-    void handler();
-  });
+  const unlisten = await listen<DesktopClientUpdatedEvent>(
+    "desktop://client-updated",
+    (event) => {
+      void handler(event.payload ?? {});
+    },
+  );
   return () => {
     unlisten();
   };

--- a/apps/desktop-tauri/src/lib/types.ts
+++ b/apps/desktop-tauri/src/lib/types.ts
@@ -27,6 +27,7 @@ export {
   displayAgentIdentity,
   displayBehaviorLabel,
   displayConversationTitle,
+  displayGraphqlEndpoint,
   formatBytes,
 } from "./types/display";
 export type {

--- a/apps/desktop-tauri/src/lib/types/display.ts
+++ b/apps/desktop-tauri/src/lib/types/display.ts
@@ -17,6 +17,19 @@ export function displayConversationTitle(value?: string | null) {
   return trimmed && trimmed.length > 0 ? trimmed : "untitled";
 }
 
+export function displayGraphqlEndpoint(value?: string | null) {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const url = new URL(trimmed);
+    return `${url.host}${url.pathname.replace(/\/$/, "")}`;
+  } catch {
+    return trimmed;
+  }
+}
+
 export function formatBytes(value: number) {
   if (value < 1024) {
     return `${value} B`;

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -75,6 +75,10 @@
     white-space: nowrap;
   }
 
+  .fleet-agent-endpoint {
+    color: var(--color-accent);
+  }
+
   .fleet-agent-name {
     width: fit-content;
     max-width: 100%;

--- a/apps/desktop-tauri/src/styles/sidebar/connected-peer.css
+++ b/apps/desktop-tauri/src/styles/sidebar/connected-peer.css
@@ -39,7 +39,7 @@
   }
 
   .connected-peer-identity,
-  .connected-peer-endpoint {
+  .connected-peer-detail {
     min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -49,6 +49,31 @@
   }
 
   .connected-peer-identity {
+    font-family:
+      "SF Mono",
+      "JetBrains Mono",
+      ui-monospace,
+      monospace;
+  }
+
+  .connected-peer-detail {
+    display: inline-flex;
+    gap: var(--space-2);
+    align-items: baseline;
+  }
+
+  .connected-peer-detail-label {
+    flex: 0 0 auto;
+    color: var(--color-accent);
+    font-size: 10px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .connected-peer-endpoint {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-family:
       "SF Mono",
       "JetBrains Mono",

--- a/crates/defra-agent-cli/src/commands/request.rs
+++ b/crates/defra-agent-cli/src/commands/request.rs
@@ -203,7 +203,7 @@ async fn request_resend(args: RequestResendArgs) -> Result<()> {
         &graphql,
         &stale.agent_did,
         &stale.content,
-        Some(stale.session_id.as_str()),
+        None,
         stale.behavior_id.as_deref(),
         RequestSubmitOptions {
             // Preserve sampling overrides + metadata from the original row.

--- a/crates/defra-agent-cli/src/request_helpers.rs
+++ b/crates/defra-agent-cli/src/request_helpers.rs
@@ -418,7 +418,6 @@ pub(crate) fn parse_valid_until_flag(raw: Option<&str>) -> Result<Option<DateTim
 /// dropping them would silently change model behavior on retry.
 #[derive(Debug, Clone)]
 pub(crate) struct StaleRequestView {
-    pub(crate) session_id: String,
     pub(crate) agent_did: String,
     pub(crate) behavior_id: Option<String>,
     pub(crate) content: String,
@@ -442,7 +441,6 @@ pub(crate) async fn fetch_request_view(
                 filter: {{ request_id: {{ _eq: "{request_id}" }} }},
                 limit: 1
             ) {{
-                session_id
                 agent_did
                 behavior_id
                 content
@@ -480,7 +478,6 @@ pub(crate) async fn fetch_request_view(
     let as_optional_f64 = |key: &str| row.get(key).and_then(|v| v.as_f64());
     let as_optional_i64 = |key: &str| row.get(key).and_then(|v| v.as_i64());
     Ok(StaleRequestView {
-        session_id: as_string("session_id"),
         agent_did: as_string("agent_did"),
         behavior_id: as_optional("behavior_id"),
         content: as_string("content"),

--- a/crates/defra-agent-desktop-core/src/client/core.rs
+++ b/crates/defra-agent-desktop-core/src/client/core.rs
@@ -23,7 +23,7 @@ use super::observe::{ObservedStore, ObserverHandle};
 use super::paths::DesktopPaths;
 use super::peer_directory::{PeerDirectory, PeerRecord};
 use super::principal_identity::PrincipalIdentity;
-use super::query::load_full_snapshot_with_peer_records;
+use super::query::{load_full_snapshot, load_full_snapshot_from_graphql};
 
 const BOOTSTRAP_OPERATION_TIMEOUT: Duration = Duration::from_secs(20);
 const PEER_ADD_OPERATION_TIMEOUT: Duration = Duration::from_secs(5);
@@ -273,15 +273,60 @@ impl ClientCore {
     }
 
     pub async fn refresh_store(&self) -> Result<u64> {
-        let records = self.peer_directory.read().await.records().to_vec();
-        let snapshot = load_full_snapshot_with_peer_records(self.node.as_ref(), &records).await?;
+        let snapshot = load_full_snapshot(self.node.as_ref()).await?;
         let rows = snapshot.row_count();
-        let version = self.store.replace_snapshot(snapshot);
+        let version = self.store.merge_snapshot(snapshot);
         tracing::debug!(
             target: "defra_agent_desktop_core::replication",
             version,
             rows,
-            "desktop replica snapshot refreshed"
+            "desktop local replica snapshot refreshed"
+        );
+        Ok(version)
+    }
+
+    pub async fn refresh_remote_agent(&self, agent_did: &str) -> Result<Option<u64>> {
+        let agent_did = agent_did.trim();
+        if agent_did.is_empty() {
+            return Ok(None);
+        }
+
+        let record = {
+            let peer_directory = self.peer_directory.read().await;
+            peer_directory
+                .records()
+                .iter()
+                .find(|record| record.agent_did == agent_did)
+                .cloned()
+        };
+        let Some(record) = record else {
+            return Ok(None);
+        };
+
+        self.refresh_remote_peer_record(&record).await.map(Some)
+    }
+
+    pub async fn refresh_remote_peer_record(&self, record: &PeerRecord) -> Result<u64> {
+        let graphql = record
+            .graphql
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("peer {} has no GraphQL endpoint", record.label))?;
+
+        let mut snapshot = load_full_snapshot_from_graphql(graphql).await?;
+        snapshot.stamp_source_agent_did(&record.agent_did);
+        let rows = snapshot.row_count();
+        let version = self.store.merge_snapshot(snapshot);
+        tracing::info!(
+            target: "defra_agent_desktop_core::replication",
+            peer_id = %record.peer_id,
+            label = %record.label,
+            agent_did = %record.agent_did,
+            graphql,
+            version,
+            rows,
+            "desktop remote peer snapshot merged"
         );
         Ok(version)
     }

--- a/crates/defra-agent-desktop-core/src/client/core/writes.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/writes.rs
@@ -1,3 +1,8 @@
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
 use anyhow::{Context, Result};
 use defra_agent_protocol::row::{
     AgentBehaviorRow, AgentPrincipalRow, AgentRequestRow, EventTriggerRow, InferenceBackendRow,
@@ -7,13 +12,38 @@ use defra_agent_protocol::row::{
 use super::super::mutations::{
     self, CreatedConversation, PeerMutationResult, SubmitRequestOptions, SubmittedRequest,
 };
+use super::super::peer_directory::PeerRecord;
+use super::super::query::load_chat_patch_from_graphql;
 use super::super::schema::subscribed_collection_names;
+use super::super::store::ClientStore;
 use super::bootstrap::{
     add_replicator_with_retry_until, branchable_pair_sync_enabled, connect_peer_with_retry_until,
     normalize_required, p2p_pairing_enabled_for_graphql, sync_branchable_collections_with_retry,
     BRANCHABLE_PAIR_SYNC_ENV, REMOTE_P2P_PAIRING_ENV,
 };
 use super::{ClientCore, ClientPeerStatus, PEER_ADD_OPERATION_TIMEOUT};
+
+const REMOTE_REQUEST_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+const REMOTE_REQUEST_REFRESH_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+fn is_terminal_lifecycle_state(value: Option<&str>) -> bool {
+    matches!(
+        value,
+        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
+    )
+}
+
+fn chat_patch_signature(patch: &ClientStore) -> (usize, usize, u64) {
+    let rows = patch.row_count();
+    match serde_json::to_vec(&patch.to_rows()) {
+        Ok(bytes) => {
+            let mut hasher = DefaultHasher::new();
+            bytes.hash(&mut hasher);
+            (rows, bytes.len(), hasher.finish())
+        }
+        Err(_) => (rows, 0, 0),
+    }
+}
 
 impl ClientCore {
     pub async fn create_conversation(
@@ -98,6 +128,191 @@ impl ClientCore {
             }
             Err(error) => Err(self.record_mutation_error("submit request", error)),
         }
+    }
+
+    pub async fn submit_remote_graphql_request_with_options(
+        &self,
+        graphql: &str,
+        session_id: &str,
+        agent_did: &str,
+        content: &str,
+        behavior_id: Option<&str>,
+        options: SubmitRequestOptions,
+    ) -> Result<SubmittedRequest> {
+        let snapshot = self.store.snapshot();
+        let peer_record = self.peer_record_for_agent(agent_did).await;
+        match mutations::submit_request_to_graphql(
+            graphql,
+            snapshot.as_ref(),
+            session_id,
+            agent_did,
+            content,
+            behavior_id,
+            options,
+        )
+        .await
+        {
+            Ok(result) => {
+                self.store
+                    .set_focused_request_id(Some(result.request_id.clone()));
+                self.spawn_remote_request_refresh(
+                    graphql.to_string(),
+                    agent_did.to_string(),
+                    result.request_id.clone(),
+                    session_id.to_string(),
+                    peer_record.clone(),
+                );
+                self.clear_mutation_error();
+                tracing::info!(
+                    target: "defra_agent_desktop_core::writes",
+                    action = "chat_submit_remote_graphql",
+                    row_id = %result.request_id,
+                    agent_did,
+                    session_id,
+                    peer_id = %peer_record.as_ref().map(|record| record.peer_id.as_str()).unwrap_or(""),
+                    peer_label = %peer_record.as_ref().map(|record| record.label.as_str()).unwrap_or(""),
+                    peer_addr = %peer_record.as_ref().map(|record| record.addr.as_str()).unwrap_or(""),
+                    graphql,
+                    "desktop remote write saved"
+                );
+                Ok(result)
+            }
+            Err(error) => Err(self.record_mutation_error("submit remote GraphQL request", error)),
+        }
+    }
+
+    fn spawn_remote_request_refresh(
+        &self,
+        graphql: String,
+        agent_did: String,
+        request_id: String,
+        session_id: String,
+        peer_record: Option<PeerRecord>,
+    ) {
+        let store = Arc::clone(&self.store);
+
+        tokio::spawn(async move {
+            let peer_id = peer_record
+                .as_ref()
+                .map(|record| record.peer_id.clone())
+                .unwrap_or_default();
+            let peer_label = peer_record
+                .as_ref()
+                .map(|record| record.label.clone())
+                .unwrap_or_default();
+            let peer_addr = peer_record
+                .as_ref()
+                .map(|record| record.addr.clone())
+                .unwrap_or_default();
+            let started = Instant::now();
+            let mut last_patch_signature: Option<(usize, usize, u64)> = None;
+            loop {
+                if started.elapsed() >= REMOTE_REQUEST_REFRESH_TIMEOUT {
+                    tracing::warn!(
+                        target: "defra_agent_desktop_core::writes",
+                        request_id = %request_id,
+                        agent_did = %agent_did,
+                        session_id = %session_id,
+                        peer_id = %peer_id,
+                        peer_label = %peer_label,
+                        peer_addr = %peer_addr,
+                        graphql = %graphql,
+                        "desktop remote request refresh timed out before terminal state"
+                    );
+                    break;
+                }
+
+                tokio::time::sleep(REMOTE_REQUEST_REFRESH_INTERVAL).await;
+                match load_chat_patch_from_graphql(&graphql, &request_id).await {
+                    Ok(mut patch) => {
+                        patch.stamp_source_agent_did(&agent_did);
+                        let terminal = patch.request_row(&request_id).is_some_and(|row| {
+                            is_terminal_lifecycle_state(row.lifecycle_state.as_deref())
+                        });
+                        let patch_signature = chat_patch_signature(&patch);
+                        let (rows, bytes, _hash) = patch_signature;
+
+                        if !terminal && last_patch_signature == Some(patch_signature) {
+                            tracing::debug!(
+                                target: "defra_agent_desktop_core::writes",
+                                request_id = %request_id,
+                                agent_did = %agent_did,
+                                session_id = %session_id,
+                                peer_id = %peer_id,
+                                peer_label = %peer_label,
+                                peer_addr = %peer_addr,
+                                graphql = %graphql,
+                                rows,
+                                bytes,
+                                "desktop remote request patch unchanged"
+                            );
+                            continue;
+                        }
+
+                        last_patch_signature = Some(patch_signature);
+                        let version = store.merge_chat_patch(patch);
+                        tracing::info!(
+                            target: "defra_agent_desktop_core::writes",
+                            request_id = %request_id,
+                            agent_did = %agent_did,
+                            session_id = %session_id,
+                            peer_id = %peer_id,
+                            peer_label = %peer_label,
+                            peer_addr = %peer_addr,
+                            graphql = %graphql,
+                            version,
+                            rows,
+                            bytes,
+                            terminal,
+                            "desktop remote request patch merged"
+                        );
+                        if terminal {
+                            break;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            target: "defra_agent_desktop_core::writes",
+                            request_id = %request_id,
+                            agent_did = %agent_did,
+                            session_id = %session_id,
+                            peer_id = %peer_id,
+                            peer_label = %peer_label,
+                            peer_addr = %peer_addr,
+                            graphql = %graphql,
+                            error = %error,
+                            "desktop could not load remote request patch"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    pub async fn graphql_for_agent(&self, agent_did: &str) -> Option<String> {
+        self.peer_record_for_agent(agent_did)
+            .await
+            .and_then(|record| {
+                record
+                    .graphql
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+            })
+    }
+
+    pub async fn peer_record_for_agent(&self, agent_did: &str) -> Option<PeerRecord> {
+        let agent_did = agent_did.trim();
+        if agent_did.is_empty() {
+            return None;
+        }
+        let peer_directory = self.peer_directory.read().await;
+        peer_directory
+            .records()
+            .iter()
+            .find(|record| record.agent_did == agent_did)
+            .cloned()
     }
 
     pub async fn rename_conversation(&self, session_id: &str, title: &str) -> Result<()> {
@@ -325,7 +540,16 @@ impl ClientCore {
                     "skipping automatic reverse P2P pairing for GraphQL-managed peer"
                 );
             }
-            if let Err(error) = self.refresh_store().await {
+            let refresh_result = if record
+                .graphql
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            {
+                self.refresh_remote_peer_record(&record).await.map(|_| ())
+            } else {
+                self.refresh_store().await.map(|_| ())
+            };
+            if let Err(error) = refresh_result {
                 append_warning(
                     &mut warning,
                     format!("deployment saved but remote snapshot refresh failed: {error}"),
@@ -411,9 +635,25 @@ impl ClientCore {
     }
 
     pub async fn save_behavior(&self, row: &AgentBehaviorRow) -> Result<()> {
-        match mutations::upsert_agent_behavior(self.node.as_ref(), row).await {
+        let remote_graphql = match row.agent_did.as_deref() {
+            Some(agent_did) => self.graphql_for_agent(agent_did).await,
+            None => None,
+        };
+        let result = match remote_graphql.as_deref() {
+            Some(graphql) => mutations::upsert_agent_behavior_to_graphql(graphql, row).await,
+            None => mutations::upsert_agent_behavior(self.node.as_ref(), row).await,
+        };
+        match result {
             Ok(()) => {
-                self.refresh_store().await?;
+                if let Some(agent_did) = row.agent_did.as_deref() {
+                    if remote_graphql.is_some() {
+                        self.refresh_remote_agent(agent_did).await?;
+                    } else {
+                        self.refresh_store().await?;
+                    }
+                } else {
+                    self.refresh_store().await?;
+                }
                 self.clear_mutation_error();
                 tracing::info!(
                     target: "defra_agent_desktop_core::writes",
@@ -428,9 +668,18 @@ impl ClientCore {
     }
 
     pub async fn save_agent_principal(&self, row: &AgentPrincipalRow) -> Result<()> {
-        match mutations::upsert_agent_principal(self.node.as_ref(), row).await {
+        let remote_graphql = self.graphql_for_agent(&row.agent_did).await;
+        let result = match remote_graphql.as_deref() {
+            Some(graphql) => mutations::upsert_agent_principal_to_graphql(graphql, row).await,
+            None => mutations::upsert_agent_principal(self.node.as_ref(), row).await,
+        };
+        match result {
             Ok(()) => {
-                self.refresh_store().await?;
+                if remote_graphql.is_some() {
+                    self.refresh_remote_agent(&row.agent_did).await?;
+                } else {
+                    self.refresh_store().await?;
+                }
                 self.clear_mutation_error();
                 tracing::info!(
                     target: "defra_agent_desktop_core::writes",
@@ -462,9 +711,25 @@ impl ClientCore {
     }
 
     pub async fn save_tool_selection(&self, row: &ToolSelectionRow) -> Result<()> {
-        match mutations::upsert_tool_selection(self.node.as_ref(), row).await {
+        let remote_graphql = match row.agent_did.as_deref() {
+            Some(agent_did) => self.graphql_for_agent(agent_did).await,
+            None => None,
+        };
+        let result = match remote_graphql.as_deref() {
+            Some(graphql) => mutations::upsert_tool_selection_to_graphql(graphql, row).await,
+            None => mutations::upsert_tool_selection(self.node.as_ref(), row).await,
+        };
+        match result {
             Ok(()) => {
-                self.refresh_store().await?;
+                if let Some(agent_did) = row.agent_did.as_deref() {
+                    if remote_graphql.is_some() {
+                        self.refresh_remote_agent(agent_did).await?;
+                    } else {
+                        self.refresh_store().await?;
+                    }
+                } else {
+                    self.refresh_store().await?;
+                }
                 self.clear_mutation_error();
                 tracing::info!(
                     target: "defra_agent_desktop_core::writes",

--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/mod.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/mod.rs
@@ -10,7 +10,8 @@ pub use conversation::{create_conversation, rename_conversation, CreatedConversa
 // the conformance test; desktop code only uses `interrupt_request`.
 pub use defra_agent::interrupt_request;
 pub use request::{
-    resend_request, retry_request, submit_request, SubmitRequestOptions, SubmittedRequest,
+    resend_request, retry_request, submit_request, submit_request_to_graphql, SubmitRequestOptions,
+    SubmittedRequest,
 };
 
 #[cfg(test)]

--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use defra_agent_protocol::row::AgentRequestRow;
 use defra_node::EmbeddedNode;
@@ -7,7 +7,8 @@ use uuid::Uuid;
 use crate::client::store::ClientStore;
 
 use super::super::graphql::{
-    escape_graphql_string, execute_mutation, normalize_optional_string, normalize_required,
+    escape_graphql_string, execute_mutation, execute_remote_mutation, normalize_optional_string,
+    normalize_required,
 };
 use super::binding::resolve_agent_binding;
 use super::conversation::{build_upsert_conversation_field, build_upsert_session_field};
@@ -120,13 +121,79 @@ pub async fn submit_request(
     })
 }
 
+pub async fn submit_request_to_graphql(
+    graphql: &str,
+    store: &ClientStore,
+    session_id: &str,
+    agent_did: &str,
+    content: &str,
+    behavior_id: Option<&str>,
+    options: SubmitRequestOptions,
+) -> Result<SubmittedRequest> {
+    let graphql = normalize_required("graphql", graphql)?;
+    let session_id = normalize_required("session_id", session_id)?;
+    let agent_did = normalize_required("agent_did", agent_did)?;
+    let content = normalize_required("content", content)?;
+    if options.retry_parent_request.is_some() {
+        bail!("remote GraphQL chat submission does not yet support retry threading");
+    }
+
+    let request_id = Uuid::new_v4().to_string();
+    let created_at = Utc::now().to_rfc3339();
+    let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(session_id))?;
+    let session_field = build_upsert_session_field(
+        "session",
+        store,
+        session_id,
+        &binding.agent_name,
+        &binding.behavior_id,
+        &created_at,
+    );
+    let request_field = build_add_agent_request_field(
+        "request",
+        &request_id,
+        agent_did,
+        binding.behavior_id.as_deref().unwrap_or(""),
+        session_id,
+        "",
+        &request_id,
+        content,
+        &created_at,
+        0,
+        i64::from(DEFAULT_REQUEST_MAX_RETRIES),
+        &submit_request_extra_fields(&options),
+    );
+    let conversation_field = build_upsert_conversation_field(
+        "conversation",
+        store,
+        session_id,
+        agent_did,
+        &binding.agent_name,
+        &binding.behavior_id,
+        &request_id,
+        content,
+        "active",
+        &created_at,
+    );
+    let mutation =
+        build_coalesced_submit_mutation(&[session_field, request_field, conversation_field]);
+    execute_remote_mutation(graphql, &mutation, "submit_request").await?;
+
+    Ok(SubmittedRequest {
+        request_id,
+        session_id: session_id.to_string(),
+        agent_did: agent_did.to_string(),
+        behavior_id: binding.behavior_id,
+    })
+}
+
 pub async fn retry_request(
     node: &EmbeddedNode,
     store: &ClientStore,
     parent: &AgentRequestRow,
 ) -> Result<SubmittedRequest> {
     let parent_request_id = normalize_required("request_id", &parent.request_id)?;
-    let session_id = normalize_required(
+    let parent_session_id = normalize_required(
         "session_id",
         parent
             .session_id
@@ -155,13 +222,14 @@ pub async fn retry_request(
         .max_retries
         .unwrap_or(i64::from(DEFAULT_REQUEST_MAX_RETRIES));
     let request_id = Uuid::new_v4().to_string();
+    let session_id = Uuid::new_v4().to_string();
     let created_at = Utc::now().to_rfc3339();
-    let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(session_id))?;
+    let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(parent_session_id))?;
 
     let session_field = build_upsert_session_field(
         "session",
         store,
-        session_id,
+        &session_id,
         &binding.agent_name,
         &binding.behavior_id,
         &created_at,
@@ -171,7 +239,7 @@ pub async fn retry_request(
         &request_id,
         agent_did,
         binding.behavior_id.as_deref().unwrap_or(""),
-        session_id,
+        &session_id,
         parent_request_id,
         retry_root_request,
         content,
@@ -183,7 +251,7 @@ pub async fn retry_request(
     let conversation_field = build_upsert_conversation_field(
         "conversation",
         store,
-        session_id,
+        &session_id,
         agent_did,
         &binding.agent_name,
         &binding.behavior_id,
@@ -198,7 +266,7 @@ pub async fn retry_request(
 
     Ok(SubmittedRequest {
         request_id,
-        session_id: session_id.to_string(),
+        session_id,
         agent_did: agent_did.to_string(),
         behavior_id: binding.behavior_id,
     })
@@ -323,10 +391,11 @@ pub async fn resend_request(
             stale.failure_reason
         );
     }
+    let retry_session_id = Uuid::new_v4().to_string();
     submit_request(
         node,
         store,
-        &stale.session_id,
+        &retry_session_id,
         &stale.agent_did,
         &stale.content,
         stale.behavior_id.as_deref(),
@@ -348,7 +417,6 @@ pub async fn resend_request(
 /// Minimal projection of an AgentRequest used by resend to copy over inputs.
 /// Carries sampling overrides + metadata so resend preserves submitter intent.
 struct StaleRequestView {
-    session_id: String,
     agent_did: String,
     behavior_id: Option<String>,
     content: String,
@@ -369,7 +437,6 @@ async fn fetch_request_view(node: &EmbeddedNode, request_id: &str) -> Result<Sta
                 filter: {{ request_id: {{ _eq: "{escaped}" }} }},
                 limit: 1
             ) {{
-                session_id
                 agent_did
                 behavior_id
                 content
@@ -395,11 +462,6 @@ async fn fetch_request_view(node: &EmbeddedNode, request_id: &str) -> Result<Sta
         .and_then(|arr| arr.first())
         .ok_or_else(|| anyhow::anyhow!("request {request_id} not found"))?;
     Ok(StaleRequestView {
-        session_id: row
-            .get("session_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string(),
         agent_did: row
             .get("agent_did")
             .and_then(|v| v.as_str())

--- a/crates/defra-agent-desktop-core/src/client/mutations/graphql.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/graphql.rs
@@ -1,5 +1,9 @@
 use anyhow::{bail, Context, Result};
 use defra_node::EmbeddedNode;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+const REMOTE_MUTATION_HTTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
 
 pub(super) async fn execute_mutation(
     node: &EmbeddedNode,
@@ -19,6 +23,49 @@ pub(super) async fn execute_mutation(
         );
     }
     Ok(())
+}
+
+pub(super) async fn execute_remote_mutation(
+    graphql: &str,
+    mutation: &str,
+    operation: &str,
+) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(REMOTE_MUTATION_HTTP_TIMEOUT)
+        .build()
+        .context("building remote GraphQL mutation HTTP client")?;
+    let response = client
+        .post(graphql)
+        .json(&json!({ "query": mutation }))
+        .send()
+        .await
+        .with_context(|| format!("sending {operation} mutation to {graphql}"))?;
+    let status = response.status();
+    let body = response
+        .bytes()
+        .await
+        .with_context(|| format!("reading {operation} mutation response from {graphql}"))?;
+    if !status.is_success() {
+        bail!(
+            "{operation} mutation to {graphql} failed with {status}: {}",
+            String::from_utf8_lossy(&body)
+        );
+    }
+    let response: RemoteGraphqlMutationResponse = serde_json::from_slice(&body)
+        .with_context(|| format!("decoding {operation} mutation response from {graphql}"))?;
+    if let Some(errors) = response.errors {
+        if !errors.is_empty() {
+            bail!("{operation} mutation to {graphql} returned errors: {errors:?}");
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct RemoteGraphqlMutationResponse {
+    #[allow(dead_code)]
+    data: Option<Value>,
+    errors: Option<Vec<Value>>,
 }
 
 pub(super) fn join_fields(fields: &[Option<String>]) -> String {

--- a/crates/defra-agent-desktop-core/src/client/mutations/manage/behavior.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/manage/behavior.rs
@@ -4,11 +4,22 @@ use defra_agent_protocol::row::AgentBehaviorRow;
 use defra_node::EmbeddedNode;
 
 use super::super::graphql::{
-    escape_graphql_string, execute_mutation, graphql_optional_bool_field,
+    escape_graphql_string, execute_mutation, execute_remote_mutation, graphql_optional_bool_field,
     graphql_optional_float_field, graphql_string_field, join_fields, normalize_required,
 };
 
 pub async fn upsert_agent_behavior(node: &EmbeddedNode, row: &AgentBehaviorRow) -> Result<()> {
+    let mutation = build_upsert_agent_behavior_mutation(row)?;
+    execute_mutation(node, &mutation, "upsert_agent_behavior").await
+}
+
+pub async fn upsert_agent_behavior_to_graphql(graphql: &str, row: &AgentBehaviorRow) -> Result<()> {
+    let graphql = normalize_required("graphql", graphql)?;
+    let mutation = build_upsert_agent_behavior_mutation(row)?;
+    execute_remote_mutation(graphql, &mutation, "upsert_agent_behavior").await
+}
+
+fn build_upsert_agent_behavior_mutation(row: &AgentBehaviorRow) -> Result<String> {
     let behavior_id = normalize_required("behavior_id", &row.behavior_id)?;
     let agent_did = normalize_required(
         "agent_did",
@@ -109,7 +120,7 @@ pub async fn upsert_agent_behavior(node: &EmbeddedNode, row: &AgentBehaviorRow) 
         Some(graphql_optional_bool_field("enabled", row.enabled)),
     ];
 
-    let mutation = format!(
+    Ok(format!(
         r#"mutation {{
             upsert_AgentBehavior(
                 filter: {{ behavior_id: {{ _eq: "{behavior_id}" }} }},
@@ -124,6 +135,5 @@ pub async fn upsert_agent_behavior(node: &EmbeddedNode, row: &AgentBehaviorRow) 
         behavior_id = escape_graphql_string(behavior_id),
         add_fields = join_fields(&add_fields),
         update_fields = join_fields(&update_fields),
-    );
-    execute_mutation(node, &mutation, "upsert_agent_behavior").await
+    ))
 }

--- a/crates/defra-agent-desktop-core/src/client/mutations/manage/mod.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/manage/mod.rs
@@ -5,11 +5,13 @@ mod profile;
 mod task;
 mod tools;
 
-pub use behavior::upsert_agent_behavior;
+pub use behavior::{upsert_agent_behavior, upsert_agent_behavior_to_graphql};
 pub use inference::upsert_inference_backend;
-pub use principal::upsert_agent_principal;
+pub use principal::{upsert_agent_principal, upsert_agent_principal_to_graphql};
 pub use profile::upsert_inference_profile;
 pub use task::{
     fire_schedule_now, fire_task_now, upsert_event_trigger, upsert_schedule, upsert_task,
 };
-pub use tools::{upsert_tool_selection, upsert_tool_service_registry};
+pub use tools::{
+    upsert_tool_selection, upsert_tool_selection_to_graphql, upsert_tool_service_registry,
+};

--- a/crates/defra-agent-desktop-core/src/client/mutations/manage/principal.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/manage/principal.rs
@@ -4,11 +4,25 @@ use defra_agent_protocol::row::AgentPrincipalRow;
 use defra_node::EmbeddedNode;
 
 use super::super::graphql::{
-    escape_graphql_string, execute_mutation, graphql_optional_bool_field, graphql_string_field,
-    join_fields, normalize_required,
+    escape_graphql_string, execute_mutation, execute_remote_mutation, graphql_optional_bool_field,
+    graphql_string_field, join_fields, normalize_required,
 };
 
 pub async fn upsert_agent_principal(node: &EmbeddedNode, row: &AgentPrincipalRow) -> Result<()> {
+    let mutation = build_upsert_agent_principal_mutation(row)?;
+    execute_mutation(node, &mutation, "upsert_agent_principal").await
+}
+
+pub async fn upsert_agent_principal_to_graphql(
+    graphql: &str,
+    row: &AgentPrincipalRow,
+) -> Result<()> {
+    let graphql = normalize_required("graphql", graphql)?;
+    let mutation = build_upsert_agent_principal_mutation(row)?;
+    execute_remote_mutation(graphql, &mutation, "upsert_agent_principal").await
+}
+
+fn build_upsert_agent_principal_mutation(row: &AgentPrincipalRow) -> Result<String> {
     let agent_did = normalize_required("agent_did", &row.agent_did)?;
     let created_at = row
         .created_at
@@ -52,7 +66,7 @@ pub async fn upsert_agent_principal(node: &EmbeddedNode, row: &AgentPrincipalRow
         Some(graphql_optional_bool_field("enabled", row.enabled)),
     ];
 
-    let mutation = format!(
+    Ok(format!(
         r#"mutation {{
             upsert_AgentPrincipal(
                 filter: {{ agent_did: {{ _eq: "{agent_did}" }} }},
@@ -67,6 +81,5 @@ pub async fn upsert_agent_principal(node: &EmbeddedNode, row: &AgentPrincipalRow
         agent_did = escape_graphql_string(agent_did),
         add_fields = join_fields(&add_fields),
         update_fields = join_fields(&update_fields),
-    );
-    execute_mutation(node, &mutation, "upsert_agent_principal").await
+    ))
 }

--- a/crates/defra-agent-desktop-core/src/client/mutations/manage/tools.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/manage/tools.rs
@@ -3,12 +3,23 @@ use defra_agent_protocol::row::{ToolSelectionRow, ToolServiceRegistryRow};
 use defra_node::EmbeddedNode;
 
 use super::super::graphql::{
-    escape_graphql_string, execute_mutation, graphql_optional_bool_field,
+    escape_graphql_string, execute_mutation, execute_remote_mutation, graphql_optional_bool_field,
     graphql_optional_int_field, graphql_string_field, graphql_string_list_field, join_fields,
     normalize_required,
 };
 
 pub async fn upsert_tool_selection(node: &EmbeddedNode, row: &ToolSelectionRow) -> Result<()> {
+    let mutation = build_upsert_tool_selection_mutation(row)?;
+    execute_mutation(node, &mutation, "upsert_tool_selection").await
+}
+
+pub async fn upsert_tool_selection_to_graphql(graphql: &str, row: &ToolSelectionRow) -> Result<()> {
+    let graphql = normalize_required("graphql", graphql)?;
+    let mutation = build_upsert_tool_selection_mutation(row)?;
+    execute_remote_mutation(graphql, &mutation, "upsert_tool_selection").await
+}
+
+fn build_upsert_tool_selection_mutation(row: &ToolSelectionRow) -> Result<String> {
     let selection_id = normalize_required("selection_id", &row.selection_id)?;
     let agent_did = normalize_required(
         "agent_did",
@@ -88,7 +99,7 @@ pub async fn upsert_tool_selection(node: &EmbeddedNode, row: &ToolSelectionRow) 
         Some(graphql_string_list_field("delegate_to", &row.delegate_to)),
     ];
 
-    let mutation = format!(
+    Ok(format!(
         r#"mutation {{
             upsert_ToolSelection(
                 filter: {{ selection_id: {{ _eq: "{selection_id}" }} }},
@@ -103,8 +114,7 @@ pub async fn upsert_tool_selection(node: &EmbeddedNode, row: &ToolSelectionRow) 
         selection_id = escape_graphql_string(selection_id),
         add_fields = join_fields(&add_fields),
         update_fields = join_fields(&update_fields),
-    );
-    execute_mutation(node, &mutation, "upsert_tool_selection").await
+    ))
 }
 
 pub async fn upsert_tool_service_registry(

--- a/crates/defra-agent-desktop-core/src/client/mutations/mod.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/mod.rs
@@ -5,11 +5,13 @@ mod setup;
 
 pub use chat::{
     create_conversation, interrupt_request, rename_conversation, resend_request, retry_request,
-    submit_request, CreatedConversation, SubmitRequestOptions, SubmittedRequest,
+    submit_request, submit_request_to_graphql, CreatedConversation, SubmitRequestOptions,
+    SubmittedRequest,
 };
 pub use manage::{
-    fire_schedule_now, fire_task_now, upsert_agent_behavior, upsert_agent_principal,
-    upsert_event_trigger, upsert_inference_backend, upsert_inference_profile, upsert_schedule,
-    upsert_task, upsert_tool_selection, upsert_tool_service_registry,
+    fire_schedule_now, fire_task_now, upsert_agent_behavior, upsert_agent_behavior_to_graphql,
+    upsert_agent_principal, upsert_agent_principal_to_graphql, upsert_event_trigger,
+    upsert_inference_backend, upsert_inference_profile, upsert_schedule, upsert_task,
+    upsert_tool_selection, upsert_tool_selection_to_graphql, upsert_tool_service_registry,
 };
 pub use setup::PeerMutationResult;

--- a/crates/defra-agent-desktop-core/src/client/observe.rs
+++ b/crates/defra-agent-desktop-core/src/client/observe.rs
@@ -5,7 +5,7 @@ use defra_node::{EmbeddedNode, EventName};
 use tokio::sync::{watch, RwLock as AsyncRwLock};
 
 use super::peer_directory::PeerDirectory;
-use super::query::load_full_snapshot_with_peer_records;
+use super::query::load_full_snapshot;
 use super::store::{ClientStore, SharedClientStore};
 
 const OBSERVER_DEBOUNCE: Duration = Duration::from_millis(150);
@@ -59,6 +59,26 @@ impl ObservedStore {
         self.version_tx.send_replace(next_version);
         next_version
     }
+
+    pub fn merge_chat_patch(&self, patch: ClientStore) -> u64 {
+        let mut snapshot = self.snapshot.write().expect("store snapshot lock poisoned");
+        let next_snapshot = snapshot.merge_chat_patch(patch);
+        *snapshot = Arc::new(next_snapshot);
+
+        let next_version = self.version_tx.borrow().saturating_add(1);
+        self.version_tx.send_replace(next_version);
+        next_version
+    }
+
+    pub fn merge_snapshot(&self, incoming: ClientStore) -> u64 {
+        let mut snapshot = self.snapshot.write().expect("store snapshot lock poisoned");
+        let next_snapshot = snapshot.merge_snapshot(incoming);
+        *snapshot = Arc::new(next_snapshot);
+
+        let next_version = self.version_tx.borrow().saturating_add(1);
+        self.version_tx.send_replace(next_version);
+        next_version
+    }
 }
 
 pub struct ObserverHandle {
@@ -76,7 +96,7 @@ impl ObserverHandle {
 pub fn spawn_observer(
     node: Arc<EmbeddedNode>,
     store: Arc<ObservedStore>,
-    peer_directory: Arc<AsyncRwLock<PeerDirectory>>,
+    _peer_directory: Arc<AsyncRwLock<PeerDirectory>>,
 ) -> ObserverHandle {
     let (stop_tx, mut stop_rx) = watch::channel(false);
     let task = tokio::spawn(async move {
@@ -108,10 +128,9 @@ pub fn spawn_observer(
                 tracing::warn!(dropped, "desktop observation subscription dropped messages");
             }
 
-            let records = peer_directory.read().await.records().to_vec();
-            match load_full_snapshot_with_peer_records(node.as_ref(), &records).await {
+            match load_full_snapshot(node.as_ref()).await {
                 Ok(snapshot) => {
-                    let version = store.replace_snapshot(snapshot);
+                    let version = store.merge_snapshot(snapshot);
                     tracing::trace!(version, "desktop observation snapshot refreshed");
                 }
                 Err(error) => {

--- a/crates/defra-agent-desktop-core/src/client/query.rs
+++ b/crates/defra-agent-desktop-core/src/client/query.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Context, Result};
+use defra_agent_protocol::graphql::escape_graphql_string;
 use defra_agent_protocol::row::{
     AgentBehaviorRow, AgentConversationRow, AgentMessageRow, AgentPrincipalRow, AgentRequestRow,
     AgentResponseRow, AgentRuntimeRow, AgentSessionRow, AgentToolCallRow, AgentToolResultRow,
@@ -296,6 +297,57 @@ pub async fn load_full_snapshot_from_graphql(graphql: &str) -> Result<ClientStor
     }))
 }
 
+pub async fn load_chat_patch_from_graphql(graphql: &str, request_id: &str) -> Result<ClientStore> {
+    let request_id = request_id.trim();
+    if request_id.is_empty() {
+        return Ok(ClientStore::default());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(REMOTE_SNAPSHOT_HTTP_TIMEOUT)
+        .build()
+        .context("building remote GraphQL chat patch HTTP client")?;
+    let lookup_query = remote_request_lookup_query(request_id);
+    let lookup_data = execute_remote_graphql_query(
+        &client,
+        graphql,
+        &lookup_query,
+        "remote GraphQL request lookup",
+    )
+    .await?;
+    let request_rows: Vec<AgentRequestRow> = parse_remote_rows(&lookup_data, "AgentRequest")?;
+    let Some(session_id) = request_rows
+        .first()
+        .and_then(|row| row.session_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        return Ok(ClientStore::from_rows(ClientStoreRows {
+            requests: request_rows,
+            responses: parse_remote_rows(&lookup_data, "AgentResponse")?,
+            ..ClientStoreRows::default()
+        }));
+    };
+
+    let patch_query = remote_chat_patch_query(&session_id);
+    let data =
+        execute_remote_graphql_query(&client, graphql, &patch_query, "remote GraphQL chat patch")
+            .await?;
+
+    Ok(ClientStore::from_rows(ClientStoreRows {
+        conversations: parse_remote_rows(&data, "AgentConversation")?,
+        requests: parse_remote_rows(&data, "AgentRequest")?,
+        responses: parse_remote_rows(&data, "AgentResponse")?,
+        messages: parse_remote_rows(&data, "AgentMessage")?,
+        sessions: parse_remote_rows(&data, "AgentSession")?,
+        tool_calls: parse_remote_rows(&data, "AgentToolCall")?,
+        tool_results: parse_remote_rows(&data, "AgentToolResult")?,
+        compaction_entries: parse_remote_rows(&data, "CompactionEntry")?,
+        ..ClientStoreRows::default()
+    }))
+}
+
 async fn load_rows<T>(node: &EmbeddedNode, root: &str, query: &str) -> Result<Vec<T>>
 where
     T: DeserializeOwned,
@@ -352,36 +404,45 @@ struct RemoteGraphqlResponse {
 }
 
 async fn execute_remote_snapshot_query(client: &reqwest::Client, graphql: &str) -> Result<Value> {
+    execute_remote_graphql_query(client, graphql, REMOTE_SNAPSHOT_QUERY, "snapshot").await
+}
+
+async fn execute_remote_graphql_query(
+    client: &reqwest::Client,
+    graphql: &str,
+    query: &str,
+    operation: &str,
+) -> Result<Value> {
     let response = client
         .post(graphql)
-        .json(&json!({ "query": REMOTE_SNAPSHOT_QUERY }))
+        .json(&json!({ "query": query }))
         .send()
         .await
-        .with_context(|| format!("sending remote GraphQL snapshot query to {graphql}"))?;
+        .with_context(|| format!("sending {operation} query to {graphql}"))?;
     let status = response.status();
     let body = response
         .bytes()
         .await
-        .with_context(|| format!("reading remote GraphQL snapshot response from {graphql}"))?;
+        .with_context(|| format!("reading {operation} response from {graphql}"))?;
     if !status.is_success() {
         bail!(
-            "remote GraphQL snapshot query to {graphql} failed with {status}: {}",
+            "{operation} query to {graphql} failed with {status}: {}",
             String::from_utf8_lossy(&body)
         );
     }
 
     let response: RemoteGraphqlResponse = serde_json::from_slice(&body)
-        .with_context(|| format!("decoding remote GraphQL snapshot response from {graphql}"))?;
+        .with_context(|| format!("decoding {operation} response from {graphql}"))?;
     if let Some(errors) = response
         .errors
         .as_ref()
         .filter(|errors| !errors_is_empty(errors))
     {
-        bail!("remote GraphQL snapshot query returned errors: {errors}");
+        bail!("{operation} query returned errors: {errors}");
     }
     response
         .data
-        .context("remote GraphQL snapshot query returned no data")
+        .context(format!("{operation} query returned no data"))
 }
 
 fn parse_remote_rows<T>(data: &Value, root: &str) -> Result<Vec<T>>
@@ -491,6 +552,36 @@ fn append_rows(target: &mut ClientStoreRows, mut incoming: ClientStoreRows) {
     target
         .tool_service_registry_source_agent_dids
         .append(&mut incoming.tool_service_registry_source_agent_dids);
+}
+
+fn remote_request_lookup_query(request_id: &str) -> String {
+    let request_id = escape_graphql_string(request_id);
+    format!(
+        r#"
+query DesktopRemoteRequestLookup {{
+  AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{ request_id agent_did behavior_id session_id retry_parent_request retry_root_request superseded_by_request content status lifecycle_state backend_id execution_origin caused_by_trigger_id caused_by_trigger_kind failure_reason created_at claimed_at deadline retry_count max_retries interrupt_requested_at valid_until }}
+  AgentResponse(filter: {{ request_id: {{ _eq: "{request_id}" }} }}) {{ response_key request_id agent_did behavior_id session_id content reasoning status error_message token_count progress_seq materialized_message_sequence materialized_at created_at completed_at interrupted_at }}
+}}
+"#
+    )
+}
+
+fn remote_chat_patch_query(session_id: &str) -> String {
+    let session_id = escape_graphql_string(session_id);
+    format!(
+        r#"
+query DesktopRemoteChatPatch {{
+  AgentConversation(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ session_id agent_name agent_did behavior_id title title_source preview_text status created_at updated_at latest_request_id }}
+  AgentRequest(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ request_id agent_did behavior_id session_id retry_parent_request retry_root_request superseded_by_request content status lifecycle_state backend_id execution_origin caused_by_trigger_id caused_by_trigger_kind failure_reason created_at claimed_at deadline retry_count max_retries interrupt_requested_at valid_until }}
+  AgentResponse(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ response_key request_id agent_did behavior_id session_id content reasoning status error_message token_count progress_seq materialized_message_sequence materialized_at created_at completed_at interrupted_at }}
+  AgentMessage(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ message_key session_id sequence role content timestamp }}
+  AgentSession(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ session_id agent_name behavior_id started ended status }}
+  AgentToolCall(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ tool_call_key session_id message_sequence tool_name tool_call_id args result status started_at completed_at }}
+  AgentToolResult(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ agent_did session_id tool_name tool_input output_text truncated truncation_metadata conversation_doc_id created_at discarded_because_interrupted }}
+  CompactionEntry(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{ compaction_key session_id sequence summary files_read files_modified messages_compacted original_tokens compacted_tokens created_at }}
+}}
+"#
+    )
 }
 
 const REMOTE_SNAPSHOT_QUERY: &str = r#"

--- a/crates/defra-agent-desktop-core/src/client/store/mod.rs
+++ b/crates/defra-agent-desktop-core/src/client/store/mod.rs
@@ -133,6 +133,166 @@ impl Default for ClientStore {
 }
 
 impl ClientStore {
+    pub fn merge_snapshot(&self, snapshot: ClientStore) -> Self {
+        let mut rows = self.to_rows();
+        let incoming = snapshot.to_rows();
+
+        upsert_rows_by_key(
+            &mut rows.agent_principals,
+            incoming.agent_principals,
+            |row| row.agent_did.clone(),
+        );
+        upsert_rows_by_key(&mut rows.behaviors, incoming.behaviors, behavior_merge_key);
+        upsert_rows_by_key(&mut rows.runtimes, incoming.runtimes, |row| {
+            row.agent_did.clone()
+        });
+        upsert_rows_by_key(
+            &mut rows.conversations,
+            incoming.conversations,
+            conversation_merge_key,
+        );
+        upsert_rows_by_key(&mut rows.requests, incoming.requests, request_merge_key);
+        upsert_rows_by_key(&mut rows.responses, incoming.responses, response_merge_key);
+        upsert_rows_with_sources_by_key(
+            &mut rows.messages,
+            &mut rows.message_source_agent_dids,
+            incoming.messages,
+            incoming.message_source_agent_dids,
+            message_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.sessions,
+            &mut rows.session_source_agent_dids,
+            incoming.sessions,
+            incoming.session_source_agent_dids,
+            session_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tool_calls,
+            &mut rows.tool_call_source_agent_dids,
+            incoming.tool_calls,
+            incoming.tool_call_source_agent_dids,
+            tool_call_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tool_results,
+            &mut rows.tool_result_source_agent_dids,
+            incoming.tool_results,
+            incoming.tool_result_source_agent_dids,
+            tool_result_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.compaction_entries,
+            &mut rows.compaction_entry_source_agent_dids,
+            incoming.compaction_entries,
+            incoming.compaction_entry_source_agent_dids,
+            compaction_entry_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tasks,
+            &mut rows.task_source_agent_dids,
+            incoming.tasks,
+            incoming.task_source_agent_dids,
+            task_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.schedules,
+            &mut rows.schedule_source_agent_dids,
+            incoming.schedules,
+            incoming.schedule_source_agent_dids,
+            schedule_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.event_triggers,
+            &mut rows.event_trigger_source_agent_dids,
+            incoming.event_triggers,
+            incoming.event_trigger_source_agent_dids,
+            event_trigger_merge_key,
+        );
+        upsert_rows_by_key(
+            &mut rows.tool_selections,
+            incoming.tool_selections,
+            tool_selection_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.inference_backends,
+            &mut rows.inference_backend_source_agent_dids,
+            incoming.inference_backends,
+            incoming.inference_backend_source_agent_dids,
+            inference_backend_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.inference_profiles,
+            &mut rows.inference_profile_source_agent_dids,
+            incoming.inference_profiles,
+            incoming.inference_profile_source_agent_dids,
+            inference_profile_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tool_service_registries,
+            &mut rows.tool_service_registry_source_agent_dids,
+            incoming.tool_service_registries,
+            incoming.tool_service_registry_source_agent_dids,
+            tool_service_registry_merge_key,
+        );
+
+        ClientStore::from_rows(rows)
+    }
+
+    pub fn merge_chat_patch(&self, patch: ClientStore) -> Self {
+        let mut rows = self.to_rows();
+        let patch_rows = patch.to_rows();
+
+        upsert_rows_by_key(
+            &mut rows.conversations,
+            patch_rows.conversations,
+            conversation_merge_key,
+        );
+        upsert_rows_by_key(&mut rows.requests, patch_rows.requests, request_merge_key);
+        upsert_rows_by_key(
+            &mut rows.responses,
+            patch_rows.responses,
+            response_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.messages,
+            &mut rows.message_source_agent_dids,
+            patch_rows.messages,
+            patch_rows.message_source_agent_dids,
+            message_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.sessions,
+            &mut rows.session_source_agent_dids,
+            patch_rows.sessions,
+            patch_rows.session_source_agent_dids,
+            session_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tool_calls,
+            &mut rows.tool_call_source_agent_dids,
+            patch_rows.tool_calls,
+            patch_rows.tool_call_source_agent_dids,
+            tool_call_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.tool_results,
+            &mut rows.tool_result_source_agent_dids,
+            patch_rows.tool_results,
+            patch_rows.tool_result_source_agent_dids,
+            tool_result_merge_key,
+        );
+        upsert_rows_with_sources_by_key(
+            &mut rows.compaction_entries,
+            &mut rows.compaction_entry_source_agent_dids,
+            patch_rows.compaction_entries,
+            patch_rows.compaction_entry_source_agent_dids,
+            compaction_entry_merge_key,
+        );
+
+        ClientStore::from_rows(rows)
+    }
+
     pub fn stamp_source_agent_did(&mut self, agent_did: &str) {
         let source = Some(agent_did.to_string());
         self.message_source_agent_dids = vec![source.clone(); self.messages.len()];
@@ -603,6 +763,200 @@ fn source_agent_matches(sources: &[Option<String>], row_index: usize, agent_did:
         .get(row_index)
         .and_then(|source| source.as_deref())
         .map_or(true, |source_agent_did| source_agent_did == agent_did)
+}
+
+fn upsert_rows_by_key<T>(target: &mut Vec<T>, incoming: Vec<T>, key_fn: impl Fn(&T) -> String) {
+    let mut indexes = target
+        .iter()
+        .enumerate()
+        .map(|(index, row)| (key_fn(row), index))
+        .collect::<HashMap<_, _>>();
+
+    for row in incoming {
+        let key = key_fn(&row);
+        if let Some(index) = indexes.get(&key).copied() {
+            target[index] = row;
+        } else {
+            indexes.insert(key, target.len());
+            target.push(row);
+        }
+    }
+}
+
+fn upsert_rows_with_sources_by_key<T>(
+    target: &mut Vec<T>,
+    target_sources: &mut Vec<Option<String>>,
+    incoming: Vec<T>,
+    incoming_sources: Vec<Option<String>>,
+    key_fn: impl Fn(&T, Option<&str>) -> String,
+) {
+    normalize_sources(target_sources, target.len());
+    let mut incoming_sources = incoming_sources;
+    normalize_sources(&mut incoming_sources, incoming.len());
+
+    let mut indexes = target
+        .iter()
+        .enumerate()
+        .map(|(index, row)| {
+            let source = target_sources.get(index).and_then(|value| value.as_deref());
+            (key_fn(row, source), index)
+        })
+        .collect::<HashMap<_, _>>();
+
+    for (row, source) in incoming.into_iter().zip(incoming_sources.into_iter()) {
+        let key = key_fn(&row, source.as_deref());
+        if let Some(index) = indexes.get(&key).copied() {
+            target[index] = row;
+            target_sources[index] = source;
+        } else {
+            indexes.insert(key, target.len());
+            target.push(row);
+            target_sources.push(source);
+        }
+    }
+}
+
+fn normalize_sources(sources: &mut Vec<Option<String>>, row_count: usize) {
+    sources.truncate(row_count);
+    sources.resize_with(row_count, || None);
+}
+
+fn conversation_merge_key(row: &AgentConversationRow) -> String {
+    format!(
+        "{}\0{}",
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.session_id
+    )
+}
+
+fn behavior_merge_key(row: &AgentBehaviorRow) -> String {
+    format!(
+        "{}\0{}",
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.behavior_id
+    )
+}
+
+fn request_merge_key(row: &AgentRequestRow) -> String {
+    format!(
+        "{}\0{}",
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.request_id
+    )
+}
+
+fn response_merge_key(row: &AgentResponseRow) -> String {
+    format!(
+        "{}\0{}",
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.response_key
+    )
+}
+
+fn message_merge_key(row: &AgentMessageRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.message_key
+    )
+}
+
+fn session_merge_key(row: &AgentSessionRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.session_id
+    )
+}
+
+fn tool_call_merge_key(row: &AgentToolCallRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.tool_call_key
+    )
+}
+
+fn tool_result_merge_key(row: &AgentToolResultRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}\0{}\0{}\0{}\0{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.session_id.as_deref().unwrap_or_default(),
+        row.tool_name.as_deref().unwrap_or_default(),
+        row.tool_input.as_deref().unwrap_or_default(),
+        row.conversation_doc_id.as_deref().unwrap_or_default(),
+        row.created_at.as_deref().unwrap_or_default()
+    )
+}
+
+fn compaction_entry_merge_key(row: &CompactionEntryRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.compaction_key
+    )
+}
+
+fn task_merge_key(row: &TaskRow, source_agent_did: Option<&str>) -> String {
+    format!("{}\0{}", source_agent_did.unwrap_or_default(), row.task_id)
+}
+
+fn schedule_merge_key(row: &ScheduleRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.schedule_id
+    )
+}
+
+fn event_trigger_merge_key(row: &EventTriggerRow, source_agent_did: Option<&str>) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.trigger_id
+    )
+}
+
+fn tool_selection_merge_key(row: &ToolSelectionRow) -> String {
+    format!(
+        "{}\0{}",
+        row.agent_did.as_deref().unwrap_or_default(),
+        row.selection_id
+    )
+}
+
+fn inference_backend_merge_key(
+    row: &InferenceBackendRow,
+    source_agent_did: Option<&str>,
+) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.backend_id
+    )
+}
+
+fn inference_profile_merge_key(
+    row: &InferenceProfileRow,
+    source_agent_did: Option<&str>,
+) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.profile_id
+    )
+}
+
+fn tool_service_registry_merge_key(
+    row: &ToolServiceRegistryRow,
+    source_agent_did: Option<&str>,
+) -> String {
+    format!(
+        "{}\0{}",
+        source_agent_did.unwrap_or_default(),
+        row.service_id
+    )
 }
 
 #[cfg(test)]

--- a/crates/defra-agent-desktop-core/tests/client_store.rs
+++ b/crates/defra-agent-desktop-core/tests/client_store.rs
@@ -6,7 +6,8 @@ use defra_agent_desktop_core::client::{
 };
 use defra_agent_protocol::client_protocol::ClientTurnState;
 use defra_agent_protocol::row::{
-    AgentConversationRow, AgentPrincipalRow, AgentRequestRow, AgentResponseRow, AgentRuntimeRow,
+    AgentConversationRow, AgentMessageRow, AgentPrincipalRow, AgentRequestRow, AgentResponseRow,
+    AgentRuntimeRow, AgentSessionRow,
 };
 use tokio::time::{sleep, timeout};
 
@@ -275,6 +276,146 @@ fn focused_request_id_defaults_to_none() {
     let (observed_store, _rx) =
         defra_agent_desktop_core::client::ObservedStore::new(ClientStore::default());
     assert!(observed_store.focused_request_id().is_none());
+}
+
+#[test]
+fn chat_patch_merge_updates_one_agent_without_dropping_other_agent_rows() {
+    let base = ClientStore::from_rows(ClientStoreRows {
+        conversations: vec![
+            AgentConversationRow {
+                session_id: "session-1".to_string(),
+                agent_name: Some("Amy".to_string()),
+                agent_did: Some("did:defra:amy".to_string()),
+                behavior_id: Some("amy-default".to_string()),
+                title: Some("Old title".to_string()),
+                title_source: None,
+                preview_text: None,
+                status: None,
+                created_at: Some("2026-04-14T00:00:00Z".to_string()),
+                updated_at: Some("2026-04-14T00:01:00Z".to_string()),
+                latest_request_id: Some("req-1".to_string()),
+            },
+            AgentConversationRow {
+                session_id: "session-1".to_string(),
+                agent_name: Some("Bea".to_string()),
+                agent_did: Some("did:defra:bea".to_string()),
+                behavior_id: Some("bea-default".to_string()),
+                title: Some("Other agent".to_string()),
+                title_source: None,
+                preview_text: None,
+                status: None,
+                created_at: Some("2026-04-14T00:00:00Z".to_string()),
+                updated_at: Some("2026-04-14T00:02:00Z".to_string()),
+                latest_request_id: Some("bea-req-1".to_string()),
+            },
+        ],
+        messages: vec![AgentMessageRow {
+            message_key: "session-1:1".to_string(),
+            session_id: Some("session-1".to_string()),
+            sequence: Some(1),
+            role: Some("user".to_string()),
+            content: Some("old".to_string()),
+            timestamp: Some("2026-04-14T00:01:00Z".to_string()),
+        }],
+        message_source_agent_dids: vec![Some("did:defra:amy".to_string())],
+        sessions: vec![AgentSessionRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Bea".to_string()),
+            behavior_id: Some("bea-default".to_string()),
+            started: Some("2026-04-14T00:00:00Z".to_string()),
+            ended: None,
+            status: Some("active".to_string()),
+        }],
+        session_source_agent_dids: vec![Some("did:defra:bea".to_string())],
+        ..ClientStoreRows::default()
+    });
+
+    let mut patch = ClientStore::from_rows(ClientStoreRows {
+        conversations: vec![AgentConversationRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Amy".to_string()),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            title: Some("Updated title".to_string()),
+            title_source: None,
+            preview_text: Some("new preview".to_string()),
+            status: None,
+            created_at: Some("2026-04-14T00:00:00Z".to_string()),
+            updated_at: Some("2026-04-14T00:03:00Z".to_string()),
+            latest_request_id: Some("req-2".to_string()),
+        }],
+        requests: vec![AgentRequestRow {
+            request_id: "req-2".to_string(),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            session_id: Some("session-1".to_string()),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("hello".to_string()),
+            status: Some("completed".to_string()),
+            lifecycle_state: Some("completed".to_string()),
+            backend_id: None,
+            execution_origin: None,
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            failure_reason: None,
+            created_at: Some("2026-04-14T00:02:00Z".to_string()),
+            claimed_at: None,
+            deadline: None,
+            retry_count: None,
+            max_retries: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        }],
+        messages: vec![AgentMessageRow {
+            message_key: "session-1:1".to_string(),
+            session_id: Some("session-1".to_string()),
+            sequence: Some(1),
+            role: Some("user".to_string()),
+            content: Some("new".to_string()),
+            timestamp: Some("2026-04-14T00:02:00Z".to_string()),
+        }],
+        sessions: vec![AgentSessionRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            started: Some("2026-04-14T00:00:00Z".to_string()),
+            ended: None,
+            status: Some("active".to_string()),
+        }],
+        ..ClientStoreRows::default()
+    });
+    patch.stamp_source_agent_did("did:defra:amy");
+
+    let merged = base.merge_chat_patch(patch);
+
+    assert_eq!(merged.conversations.len(), 2);
+    assert_eq!(
+        merged
+            .conversation_rows("did:defra:amy")
+            .first()
+            .and_then(|row| row.title.as_deref()),
+        Some("Updated title")
+    );
+    assert_eq!(
+        merged
+            .conversation_rows("did:defra:bea")
+            .first()
+            .and_then(|row| row.title.as_deref()),
+        Some("Other agent")
+    );
+    assert_eq!(merged.messages.len(), 1);
+    assert_eq!(merged.messages[0].content.as_deref(), Some("new"));
+    assert_eq!(merged.sessions.len(), 2);
+    assert!(merged
+        .session_source_agent_dids
+        .iter()
+        .any(|source| source.as_deref() == Some("did:defra:amy")));
+    assert!(merged
+        .session_source_agent_dids
+        .iter()
+        .any(|source| source.as_deref() == Some("did:defra:bea")));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/defra-agent-desktop-core/tests/submission_api.rs
+++ b/crates/defra-agent-desktop-core/tests/submission_api.rs
@@ -253,7 +253,8 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
     assert_eq!(request.request_id, retried.request_id);
     assert_eq!(request.agent_did, "did:defra:amy");
     assert_eq!(request.behavior_id, "amy-code");
-    assert_eq!(request.session_id, created.session_id);
+    assert_eq!(request.session_id, retried.session_id);
+    assert_ne!(request.session_id, created.session_id);
     assert_eq!(request.content, "first attempt");
     assert_eq!(request.status, "pending");
     assert_eq!(request.lifecycle_state, "pending");
@@ -263,7 +264,7 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
     assert_eq!(request.retry_count, 1);
     assert_eq!(request.max_retries, 3);
 
-    let conversation: ConversationRow = query_single(
+    let original_conversation: ConversationRow = query_single(
         core.node(),
         &format!(
             r#"{{
@@ -283,9 +284,34 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
         "AgentConversation",
     )
     .await?;
-    assert_eq!(conversation.preview_text, "first attempt");
-    assert_eq!(conversation.status, "active");
-    assert_eq!(conversation.latest_request_id, retried.request_id);
+    assert_eq!(original_conversation.preview_text, "first attempt");
+    assert_eq!(original_conversation.status, "active");
+    assert_eq!(original_conversation.latest_request_id, original.request_id);
+
+    let retry_conversation: ConversationRow = query_single(
+        core.node(),
+        &format!(
+            r#"{{
+                AgentConversation(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    session_id
+                    agent_name
+                    agent_did
+                    behavior_id
+                    title
+                    preview_text
+                    status
+                    latest_request_id
+                }}
+            }}"#,
+            retried.session_id
+        ),
+        "AgentConversation",
+    )
+    .await?;
+    assert_eq!(retry_conversation.session_id, retried.session_id);
+    assert_eq!(retry_conversation.preview_text, "first attempt");
+    assert_eq!(retry_conversation.status, "active");
+    assert_eq!(retry_conversation.latest_request_id, retried.request_id);
     assert_eq!(core.store().focused_request_id(), Some(retried.request_id));
 
     core.shutdown().await?;
@@ -293,10 +319,10 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
 }
 
 /// Regression test for the "resend drops overrides" bug. Previously,
-/// `fetch_request_view` only queried `session_id`, `agent_did`, `behavior_id`,
-/// `content`, `lifecycle_state`, `failure_reason` — so `resend_request`
-/// silently rebuilt the new row without the original sampling overrides or
-/// metadata. Resend must preserve submitter intent across the retry chain.
+/// `fetch_request_view` only queried routing/content state fields, so
+/// `resend_request` silently rebuilt the new row without the original sampling
+/// overrides or metadata. Resend must preserve submitter intent across the
+/// retry chain.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn resend_preserves_request_overrides_and_metadata() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
@@ -358,6 +384,7 @@ async fn resend_preserves_request_overrides_and_metadata() -> Result<()> {
             r#"{{
                 AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, limit: 1) {{
                     request_id
+                    session_id
                     retry_parent_request
                     retry_root_request
                     temperature
@@ -373,6 +400,8 @@ async fn resend_preserves_request_overrides_and_metadata() -> Result<()> {
     )
     .await?;
     assert_eq!(new_row.request_id, resent.request_id);
+    assert_eq!(new_row.session_id, resent.session_id);
+    assert_ne!(new_row.session_id, original.session_id);
     assert_eq!(new_row.retry_parent_request, original.request_id);
     // Root should chain back to the original (this was the root of its own chain).
     assert_eq!(new_row.retry_root_request, original.request_id);
@@ -389,6 +418,7 @@ async fn resend_preserves_request_overrides_and_metadata() -> Result<()> {
 #[derive(Debug, Deserialize)]
 struct RequestWithOverridesRow {
     request_id: String,
+    session_id: String,
     retry_parent_request: String,
     retry_root_request: String,
     temperature: Option<f64>,

--- a/crates/defra-agent/src/agent/stream_processor.rs
+++ b/crates/defra-agent/src/agent/stream_processor.rs
@@ -103,8 +103,8 @@ impl<'a> StreamProcessor<'a> {
                 Ok(StreamAction::Continue)
             }
             Ok(MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
-                tool_result: _tool_result,
-                ..
+                tool_result,
+                internal_call_id,
             })) => {
                 let _ = self.stream_writer.flush_pending(self.doc_id).await?;
                 self.lifecycle.advance().await?;
@@ -117,6 +117,12 @@ impl<'a> StreamProcessor<'a> {
                         "persist streamed assistant turn",
                     )?;
                 }
+                self.persistence_hook.apply_persistence_policy(
+                    self.persistence_hook
+                        .persist_stream_tool_result_message(&tool_result, &internal_call_id)
+                        .await,
+                    "persist streamed tool result",
+                )?;
                 Ok(StreamAction::Continue)
             }
             Ok(MultiTurnStreamItem::FinalResponse(response)) => {

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -30,14 +31,77 @@ struct HookCounters {
     successes: AtomicU64,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TranscriptTurnState {
+    Idle,
+    AssistantBuilding { sequence: u32 },
+    AssistantPersisted { sequence: u32 },
+}
+
 struct SessionState {
     session_id: Option<String>,
     current_request_id: Option<String>,
     agent_name: String,
     sequence: u32,
-    assistant_turn_sequence: Option<u32>,
-    assistant_turn_saved: bool,
+    transcript_turn: TranscriptTurnState,
+    persisted_tool_result_ids: HashSet<String>,
     initialized: bool,
+}
+
+impl SessionState {
+    fn reset_after_user_message(&mut self) {
+        self.transcript_turn = TranscriptTurnState::Idle;
+    }
+
+    fn begin_or_continue_assistant_turn(&mut self) -> u32 {
+        match self.transcript_turn {
+            TranscriptTurnState::AssistantBuilding { sequence } => sequence,
+            TranscriptTurnState::Idle | TranscriptTurnState::AssistantPersisted { .. } => {
+                self.sequence += 1;
+                let sequence = self.sequence;
+                self.transcript_turn = TranscriptTurnState::AssistantBuilding { sequence };
+                sequence
+            }
+        }
+    }
+
+    fn persist_assistant_turn(&mut self) -> anyhow::Result<u32> {
+        let sequence = match self.transcript_turn {
+            TranscriptTurnState::AssistantBuilding { sequence } => sequence,
+            TranscriptTurnState::Idle => {
+                self.sequence += 1;
+                self.sequence
+            }
+            TranscriptTurnState::AssistantPersisted { sequence } => {
+                anyhow::bail!("assistant turn for sequence {sequence} already persisted");
+            }
+        };
+        self.transcript_turn = TranscriptTurnState::AssistantPersisted { sequence };
+        Ok(sequence)
+    }
+
+    fn mark_tool_result_seen_for_persisted_turn(&mut self, internal_call_id: &str) -> bool {
+        matches!(
+            self.transcript_turn,
+            TranscriptTurnState::AssistantPersisted { .. }
+        ) && self
+            .persisted_tool_result_ids
+            .insert(internal_call_id.to_string())
+    }
+
+    fn mark_stream_tool_result_seen(&mut self, internal_call_id: &str) -> anyhow::Result<bool> {
+        if !matches!(
+            self.transcript_turn,
+            TranscriptTurnState::AssistantPersisted { .. }
+        ) {
+            anyhow::bail!(
+                "cannot persist streamed tool result before its assistant turn is persisted"
+            );
+        }
+        Ok(self
+            .persisted_tool_result_ids
+            .insert(internal_call_id.to_string()))
+    }
 }
 
 #[derive(Clone)]
@@ -76,8 +140,8 @@ impl DefraSessionHook {
                 current_request_id: None,
                 agent_name: agent_name.to_string(),
                 sequence: 0,
-                assistant_turn_sequence: None,
-                assistant_turn_saved: false,
+                transcript_turn: TranscriptTurnState::Idle,
+                persisted_tool_result_ids: HashSet::new(),
                 initialized: false,
             })),
         }
@@ -107,8 +171,8 @@ impl DefraSessionHook {
                 current_request_id: None,
                 agent_name: agent_name.to_string(),
                 sequence: max_seq,
-                assistant_turn_sequence: None,
-                assistant_turn_saved: false,
+                transcript_turn: TranscriptTurnState::Idle,
+                persisted_tool_result_ids: HashSet::new(),
                 initialized: true,
             })),
         })

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -22,27 +22,11 @@ impl DefraSessionHook {
                 Message::User { .. } => {
                     state.sequence += 1;
                     let sequence = state.sequence;
-                    state.assistant_turn_sequence = None;
-                    state.assistant_turn_saved = false;
+                    state.reset_after_user_message();
                     (session_id, sequence, "user")
                 }
                 Message::Assistant { .. } => {
-                    let sequence = match state.assistant_turn_sequence {
-                        Some(sequence) if !state.assistant_turn_saved => sequence,
-                        Some(sequence) => {
-                            anyhow::bail!(
-                                "assistant turn for sequence {} already persisted",
-                                sequence
-                            );
-                        }
-                        None => {
-                            state.sequence += 1;
-                            let sequence = state.sequence;
-                            state.assistant_turn_sequence = Some(sequence);
-                            sequence
-                        }
-                    };
-                    state.assistant_turn_saved = true;
+                    let sequence = state.persist_assistant_turn()?;
                     (session_id, sequence, "assistant")
                 }
                 Message::System { .. } => {
@@ -59,6 +43,7 @@ impl DefraSessionHook {
     pub async fn persist_stream_tool_result_message(
         &self,
         tool_result: &ToolResult,
+        internal_call_id: &str,
     ) -> anyhow::Result<()> {
         let session_id = self
             .state
@@ -68,20 +53,28 @@ impl DefraSessionHook {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
 
-        let tool_call_id = &tool_result.id;
-        let stored_result = session::load_tool_call_result(&self.node, &session_id, tool_call_id)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::warn!(
-                    error = %e,
-                    tool_call_id = %tool_call_id,
-                    "failed to load stored tool result, falling back to stream payload"
-                );
-                let raw = render_tool_result_text(tool_result);
-                let (text, _, _) =
-                    truncate_text(&raw, TruncationMode::Head, &self.truncation_limits);
-                text
-            });
+        let should_persist = {
+            let mut state = self.state.lock().await;
+            state.mark_stream_tool_result_seen(internal_call_id)?
+        };
+        if !should_persist {
+            return Ok(());
+        }
+
+        let stored_result =
+            session::load_tool_call_result(&self.node, &session_id, internal_call_id)
+                .await
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        error = %e,
+                        tool_call_id = %internal_call_id,
+                        "failed to load stored tool result, falling back to stream payload"
+                    );
+                    let raw = render_tool_result_text(tool_result);
+                    let (text, _, _) =
+                        truncate_text(&raw, TruncationMode::Head, &self.truncation_limits);
+                    text
+                });
 
         let persisted_result = ToolResult {
             id: tool_result.id.clone(),
@@ -105,16 +98,7 @@ impl DefraSessionHook {
             .clone()
             .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
 
-        let sequence = match state.assistant_turn_sequence {
-            Some(sequence) => sequence,
-            None => {
-                state.sequence += 1;
-                let sequence = state.sequence;
-                state.assistant_turn_sequence = Some(sequence);
-                state.assistant_turn_saved = false;
-                sequence
-            }
-        };
+        let sequence = state.begin_or_continue_assistant_turn();
 
         Ok((session_id, sequence))
     }
@@ -131,8 +115,7 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 state.initialized = true;
             }
 
-            state.assistant_turn_sequence = None;
-            state.assistant_turn_saved = false;
+            state.reset_after_user_message();
             drop(state);
 
             self.persist_message(prompt).await?;
@@ -223,12 +206,14 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
     ) -> HookAction {
         let persist_result: anyhow::Result<()> = async {
             let (session_id, should_persist_message) = {
-                let state = self.state.lock().await;
+                let mut state = self.state.lock().await;
                 let session_id = state
                     .session_id
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
-                (session_id, state.assistant_turn_saved)
+                let should_persist_message =
+                    state.mark_tool_result_seen_for_persisted_turn(internal_call_id);
+                (session_id, should_persist_message)
             };
 
             let truncator =

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -55,6 +55,44 @@ fn user_text_message(text: &str) -> Message {
     }
 }
 
+fn session_state_for_test() -> SessionState {
+    SessionState {
+        session_id: Some("session-1".to_string()),
+        current_request_id: None,
+        agent_name: "agent".to_string(),
+        sequence: 0,
+        transcript_turn: TranscriptTurnState::Idle,
+        persisted_tool_result_ids: std::collections::HashSet::new(),
+        initialized: true,
+    }
+}
+
+#[test]
+fn transcript_turn_state_allocates_new_assistant_after_saved_turn() {
+    let mut state = session_state_for_test();
+
+    assert_eq!(state.begin_or_continue_assistant_turn(), 1);
+    assert_eq!(state.begin_or_continue_assistant_turn(), 1);
+    assert_eq!(state.persist_assistant_turn().unwrap(), 1);
+    assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
+    assert!(!state.mark_stream_tool_result_seen("call-1").unwrap());
+
+    state.reset_after_user_message();
+    assert_eq!(state.begin_or_continue_assistant_turn(), 2);
+    assert_eq!(state.persist_assistant_turn().unwrap(), 2);
+}
+
+#[test]
+fn transcript_turn_state_rejects_stream_result_before_assistant_is_saved() {
+    let mut state = session_state_for_test();
+
+    assert!(state.mark_stream_tool_result_seen("call-1").is_err());
+    assert_eq!(state.begin_or_continue_assistant_turn(), 1);
+    assert!(state.mark_stream_tool_result_seen("call-1").is_err());
+    assert_eq!(state.persist_assistant_turn().unwrap(), 1);
+    assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
+}
+
 async fn create_streaming_response(
     node: &defra_node::EmbeddedNode,
     request_id: &str,
@@ -164,13 +202,16 @@ async fn streaming_turn_persists_full_assistant_history_in_sequence() {
         .await
         .unwrap();
 
-    hook.persist_stream_tool_result_message(&ToolResult {
-        id: "internal-1".to_string(),
-        call_id: Some("call-1".to_string()),
-        content: OneOrMany::one(ToolResultContent::Text(Text {
-            text: "ephemeral stream payload".to_string(),
-        })),
-    })
+    hook.persist_stream_tool_result_message(
+        &ToolResult {
+            id: "internal-1".to_string(),
+            call_id: Some("call-1".to_string()),
+            content: OneOrMany::one(ToolResultContent::Text(Text {
+                text: "ephemeral stream payload".to_string(),
+            })),
+        },
+        "internal-1",
+    )
     .await
     .unwrap();
 
@@ -259,6 +300,166 @@ async fn streaming_turn_persists_full_assistant_history_in_sequence() {
         row.get("status").and_then(|value| value.as_str()),
         Some("completed")
     );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn tool_call_after_saved_assistant_starts_new_turn_without_orphan_result() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-tool-turn-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    let user_prompt = user_text_message("Inspect mini-1");
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook, &user_prompt, &[]).await,
+        HookAction::Continue
+    ));
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook, "first", None, "internal-1", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+    hook.persist_message(&Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+            id: "call-1".to_string(),
+            call_id: None,
+            function: ToolFunction {
+                name: "first".to_string(),
+                arguments: json!({}),
+            },
+            signature: None,
+            additional_params: None,
+        })),
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook, "second", None, "internal-2", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_result(
+            &hook,
+            "second",
+            Some("call-2".to_string()),
+            "internal-2",
+            "{}",
+            "second result",
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    let session_id = hook.session_id().await.expect("session id");
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        history.len(),
+        2,
+        "tool result must not be persisted before its assistant turn"
+    );
+
+    let resp = node
+        .execute(&format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{
+                        session_id: {{ _eq: "{session_id}" }},
+                        tool_call_id: {{ _eq: "internal-2" }}
+                    }},
+                    limit: 1
+                ) {{ message_sequence result status }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "query tool call failed: {:?}",
+        resp.errors
+    );
+    let row = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| value.as_array())
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("tool call row");
+    assert_eq!(
+        row.get("message_sequence").and_then(|value| value.as_u64()),
+        Some(3)
+    );
+    assert_eq!(
+        row.get("result").and_then(|value| value.as_str()),
+        Some("second result")
+    );
+    assert_eq!(
+        row.get("status").and_then(|value| value.as_str()),
+        Some("completed")
+    );
+
+    hook.persist_message(&Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+            id: "call-2".to_string(),
+            call_id: None,
+            function: ToolFunction {
+                name: "second".to_string(),
+                arguments: json!({}),
+            },
+            signature: None,
+            additional_params: None,
+        })),
+    })
+    .await
+    .unwrap();
+    hook.persist_stream_tool_result_message(
+        &ToolResult {
+            id: "call-2".to_string(),
+            call_id: None,
+            content: OneOrMany::one(ToolResultContent::Text(Text {
+                text: "stream fallback".to_string(),
+            })),
+        },
+        "internal-2",
+    )
+    .await
+    .unwrap();
+
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    assert_eq!(history.len(), 4);
+    assert!(matches!(
+        &history[2],
+        Message::Assistant { content, .. }
+            if matches!(content.first_ref(), AssistantContent::ToolCall(tool_call)
+                if tool_call.id == "call-2")
+    ));
+    assert!(matches!(
+        &history[3],
+        Message::User { content }
+            if matches!(content.first_ref(), UserContent::ToolResult(tool_result)
+                if tool_result.id == "call-2"
+                    && matches!(tool_result.content.first_ref(), ToolResultContent::Text(Text { text }) if text == "second result"))
+    ));
 
     let _ = std::fs::remove_dir_all(&data_path);
 }


### PR DESCRIPTION
## Summary
- add remote GraphQL chat submission refresh with targeted incremental patch merging
- preserve remote configuration/state without destructive desktop rewrites and scope snapshots by agent
- improve desktop chat/session refresh behavior for remote peers, including stalled/failed stream visibility
- add remote fleet smoke automation for the four deployed agents

## Verification
- npm test -- --run
- npm run build
- cargo check -p defra-agent-desktop-core
- cargo check -p defra-agent-desktop-tauri
- cargo test -p defra-agent-desktop-tauri
- git diff --check