### PR TITLE
Add tool-call trace export

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -13,6 +13,7 @@ use crate::{
     CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP, INIT_AFTER_HELP,
     P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
     RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP,
+    TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -58,6 +59,14 @@ pub(crate) enum Command {
     Show {
         #[command(subcommand)]
         command: ShowCommand,
+    },
+    #[command(
+        about = "Export persisted tool-call traces for measurement",
+        after_help = TRACE_AFTER_HELP
+    )]
+    Trace {
+        #[command(subcommand)]
+        command: TraceCommand,
     },
     #[command(about = "Show the current local runtime status", after_help = STATUS_AFTER_HELP)]
     Status(StatusArgs),
@@ -460,6 +469,36 @@ pub(crate) struct RuntimeShowArgs {
     pub(crate) graphql: Option<String>,
     #[arg(long)]
     pub(crate) agent_did: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum TraceCommand {
+    #[command(name = "export", about = "Export Amy-style tool-call JSONL")]
+    Export(TraceExportArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct TraceExportArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint to read instead of local home state")]
+    pub(crate) graphql: Option<String>,
+    #[arg(long, help = "Restrict export to one session_id")]
+    pub(crate) session_id: Option<String>,
+    #[arg(long, help = "Restrict export to one inferred request_id")]
+    pub(crate) request_id: Option<String>,
+    #[arg(long, help = "Run id to stamp on exported JSONL records")]
+    pub(crate) run_id: Option<String>,
+    #[arg(long, help = "Case id to stamp on exported JSONL records")]
+    pub(crate) case_id: Option<String>,
+    #[arg(
+        long,
+        default_value_t = 500,
+        help = "Maximum recent AgentToolCall rows to export"
+    )]
+    pub(crate) limit: usize,
+    #[arg(long = "output-file", help = "Write JSONL to a file instead of stdout")]
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 #[derive(Subcommand)]

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub(crate) mod serve;
 pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod status;
+pub(crate) mod trace;

--- a/crates/defra-agent-cli/src/commands/trace.rs
+++ b/crates/defra-agent-cli/src/commands/trace.rs
@@ -1,0 +1,905 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+
+use anyhow::{Context, Result};
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::trace_export::{
+    analyze_request_failure, analyze_tool_call, extract_raw_tool_call_json, latency_ms,
+    raw_message_json, AmyToolCallTraceRecord,
+};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::cli::args::{TraceCommand, TraceExportArgs};
+use crate::config_writes::ConfigAccess;
+use crate::{graphql_rows_or_empty_if_collection_missing, graphql_string_list_literal};
+
+pub(crate) async fn dispatch(command: TraceCommand) -> Result<()> {
+    match command {
+        TraceCommand::Export(args) => trace_export(args).await,
+    }
+}
+
+async fn trace_export(args: TraceExportArgs) -> Result<()> {
+    let (access, _home_dir) =
+        crate::resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let requested_request = match args.request_id.as_deref() {
+        Some(request_id) => Some(load_request_by_id(&access, request_id).await?),
+        None => None,
+    };
+    if let (Some(session_id), Some(request)) = (args.session_id.as_deref(), &requested_request) {
+        if request.session_id.as_deref() != Some(session_id) {
+            anyhow::bail!(
+                "--session-id {session_id} does not match request {} session_id={}",
+                request.request_id,
+                request.session_id.as_deref().unwrap_or("")
+            );
+        }
+    }
+
+    let session_filter = args.session_id.as_deref().or_else(|| {
+        requested_request
+            .as_ref()
+            .and_then(|request| request.session_id.as_deref())
+    });
+    let tool_calls = load_tool_calls(&access, args.limit, session_filter).await?;
+    if tool_calls.is_empty() {
+        write_jsonl(args.output_file.as_deref(), &[])?;
+        return Ok(());
+    }
+
+    let session_ids = unique_tool_call_session_ids(&tool_calls);
+    let messages = load_messages_for_tool_calls(&access, &tool_calls).await?;
+    let mut requests = load_requests_for_sessions(&access, &session_ids).await?;
+    if let Some(request) = requested_request {
+        if !requests
+            .iter()
+            .any(|row| row.request_id == request.request_id)
+        {
+            requests.push(request);
+        }
+    }
+    let responses = load_responses_for_sessions(&access, &session_ids).await?;
+    let sessions = load_sessions(&access, &session_ids).await?;
+    let conversations = load_conversations(&access, &session_ids).await?;
+    let behaviors = load_behaviors(&access, &requests, &sessions, &conversations).await?;
+
+    let records = build_records(
+        &tool_calls,
+        &messages,
+        &requests,
+        &responses,
+        &sessions,
+        &conversations,
+        &behaviors,
+        &args,
+    );
+    let records = match args.request_id.as_deref() {
+        Some(request_id) => records
+            .into_iter()
+            .filter(|record| record.request_id.as_deref() == Some(request_id))
+            .collect::<Vec<_>>(),
+        None => records,
+    };
+
+    write_jsonl(args.output_file.as_deref(), &records)
+}
+
+fn build_records(
+    tool_calls: &[ToolCallRow],
+    messages: &HashMap<(String, i64), MessageRow>,
+    requests: &[RequestRow],
+    responses: &[ResponseRow],
+    sessions: &HashMap<String, SessionRow>,
+    conversations: &HashMap<String, ConversationRow>,
+    behaviors: &HashMap<String, BehaviorRow>,
+    args: &TraceExportArgs,
+) -> Vec<AmyToolCallTraceRecord> {
+    let requests_by_session = rows_by_session(requests);
+    let responses_by_session = rows_by_session(responses);
+    let responses_by_request = responses
+        .iter()
+        .map(|row| (row.request_id.clone(), row))
+        .collect::<HashMap<_, _>>();
+
+    tool_calls
+        .iter()
+        .map(|tool_call| {
+            let session_requests = requests_by_session
+                .get(tool_call.session_id.as_str())
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let session_responses = responses_by_session
+                .get(tool_call.session_id.as_str())
+                .map(Vec::as_slice)
+                .unwrap_or(&[]);
+            let request =
+                infer_request_for_tool_call(tool_call, session_requests, session_responses);
+            let response = request.and_then(|request| {
+                responses_by_request
+                    .get(request.request_id.as_str())
+                    .copied()
+            });
+            let request_failure = combined_request_failure_text(request, response);
+            let request_failure_class = analyze_request_failure(request_failure.as_deref());
+            let analysis = analyze_tool_call(
+                &tool_call.tool_name,
+                &tool_call.args,
+                &tool_call.result,
+                &tool_call.status,
+            );
+            let message = tool_call
+                .message_sequence
+                .and_then(|sequence| messages.get(&(tool_call.session_id.clone(), sequence)));
+            let raw_assistant_message = message.map(|message| raw_message_json(&message.content));
+            let raw_tool_call_json = message.and_then(|message| {
+                extract_raw_tool_call_json(
+                    &message.role,
+                    &message.content,
+                    &tool_call.tool_call_id,
+                    &tool_call.tool_name,
+                )
+            });
+            let session = sessions.get(tool_call.session_id.as_str());
+            let conversation = conversations.get(tool_call.session_id.as_str());
+            let behavior_id = first_nonempty([
+                request.and_then(|request| request.behavior_id.as_deref()),
+                conversation.and_then(|conversation| conversation.behavior_id.as_deref()),
+                session.and_then(|session| session.behavior_id.as_deref()),
+            ]);
+            let behavior = behavior_id.and_then(|behavior_id| behaviors.get(behavior_id));
+            let metadata = request.and_then(parse_request_metadata);
+            let run_id = args
+                .run_id
+                .clone()
+                .or_else(|| metadata_string(metadata.as_ref(), "run_id"))
+                .or_else(|| metadata_string(metadata.as_ref(), "runId"));
+            let case_id = args
+                .case_id
+                .clone()
+                .or_else(|| metadata_string(metadata.as_ref(), "case_id"))
+                .or_else(|| metadata_string(metadata.as_ref(), "caseId"));
+            let backend_id = first_nonempty([
+                request.and_then(|request| request.backend_id.as_deref()),
+                behavior.and_then(|behavior| behavior.backend_id.as_deref()),
+            ]);
+            let agent_did = first_nonempty([
+                request.and_then(|request| request.agent_did.as_deref()),
+                conversation.and_then(|conversation| conversation.agent_did.as_deref()),
+                behavior.and_then(|behavior| behavior.agent_did.as_deref()),
+            ]);
+
+            AmyToolCallTraceRecord {
+                run_id,
+                case_id,
+                prompt: request.and_then(|request| request.content.clone()),
+                agent_did: agent_did.map(ToOwned::to_owned),
+                behavior_id: behavior_id.map(ToOwned::to_owned),
+                session_id: tool_call.session_id.clone(),
+                request_id: request.map(|request| request.request_id.clone()),
+                request_status: request.and_then(|request| request.status.clone()),
+                request_lifecycle_state: request
+                    .and_then(|request| request.lifecycle_state.clone()),
+                request_failure_reason: request.and_then(|request| request.failure_reason.clone()),
+                response_status: response.and_then(|response| response.status.clone()),
+                response_error_message: response
+                    .and_then(|response| response.error_message.clone()),
+                request_failure_class,
+                backend_id: backend_id.map(ToOwned::to_owned),
+                model_name: behavior.and_then(|behavior| behavior.model_name.clone()),
+                inference_profile_id: behavior
+                    .and_then(|behavior| behavior.inference_profile_id.clone()),
+                raw_assistant_message,
+                raw_tool_call_json,
+                tool_call_id: tool_call.tool_call_id.clone(),
+                native_or_meta_tool: tool_call.tool_name.clone(),
+                selected_service_id: analysis.selected_service_id,
+                selected_tool_name: analysis.selected_tool_name,
+                raw_arguments: tool_call.args.clone(),
+                argument_parse_result: analysis.argument_parse_result,
+                schema_validation_result: analysis.schema_validation_result,
+                validation_errors: analysis.validation_errors,
+                repair_attempt: None,
+                final_arguments_sent: analysis.final_arguments_sent,
+                tool_result: tool_call.result.clone(),
+                tool_result_ok: analysis.tool_result_ok,
+                tool_call_completed: tool_call.status.eq_ignore_ascii_case("completed"),
+                tool_status: tool_call.status.clone(),
+                task_outcome: None,
+                tool_failure_class: analysis.tool_failure_class,
+                tool_error: analysis.tool_error,
+                failure_class: analysis.tool_failure_class,
+                started_at: tool_call.started_at.clone(),
+                completed_at: tool_call.completed_at.clone(),
+                latency_ms: latency_ms(
+                    tool_call.started_at.as_deref(),
+                    tool_call.completed_at.as_deref(),
+                ),
+                retry_count: request.and_then(|request| request.retry_count),
+            }
+        })
+        .collect()
+}
+
+async fn load_tool_calls(
+    access: &ConfigAccess,
+    limit: usize,
+    session_id: Option<&str>,
+) -> Result<Vec<ToolCallRow>> {
+    let filter = session_id
+        .map(|session_id| {
+            format!(
+                r#"filter: {{ session_id: {{ _eq: "{}" }} }}, "#,
+                escape_graphql_string(session_id)
+            )
+        })
+        .unwrap_or_default();
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                {filter}
+                order: {{ started_at: DESC }},
+                limit: {limit}
+            ) {{
+                session_id
+                message_sequence
+                tool_name
+                tool_call_id
+                args
+                result
+                status
+                started_at
+                completed_at
+            }}
+        }}"#
+    );
+    load_rows(access, "AgentToolCall", &query).await
+}
+
+async fn load_request_by_id(access: &ConfigAccess, request_id: &str) -> Result<RequestRow> {
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{}" }} }},
+                order: {{ created_at: DESC }},
+                limit: 1
+            ) {{
+                request_id
+                agent_did
+                behavior_id
+                session_id
+                content
+                metadata
+                status
+                lifecycle_state
+                backend_id
+                failure_reason
+                created_at
+                retry_count
+            }}
+        }}"#,
+        escape_graphql_string(request_id)
+    );
+    load_rows::<RequestRow>(access, "AgentRequest", &query)
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("request {request_id} not found"))
+}
+
+async fn load_requests_for_sessions(
+    access: &ConfigAccess,
+    session_ids: &[String],
+) -> Result<Vec<RequestRow>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ session_id: {{ _in: {} }} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                request_id
+                agent_did
+                behavior_id
+                session_id
+                content
+                metadata
+                status
+                lifecycle_state
+                backend_id
+                failure_reason
+                created_at
+                retry_count
+            }}
+        }}"#,
+        graphql_string_list_literal(session_ids)
+    );
+    load_rows(access, "AgentRequest", &query).await
+}
+
+async fn load_responses_for_sessions(
+    access: &ConfigAccess,
+    session_ids: &[String],
+) -> Result<Vec<ResponseRow>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{ session_id: {{ _in: {} }} }},
+                order: {{ created_at: ASC }}
+            ) {{
+                request_id
+                session_id
+                status
+                error_message
+                materialized_message_sequence
+            }}
+        }}"#,
+        graphql_string_list_literal(session_ids)
+    );
+    load_rows(access, "AgentResponse", &query).await
+}
+
+async fn load_sessions(
+    access: &ConfigAccess,
+    session_ids: &[String],
+) -> Result<HashMap<String, SessionRow>> {
+    if session_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let query = format!(
+        r#"{{
+            AgentSession(
+                filter: {{ session_id: {{ _in: {} }} }}
+            ) {{
+                session_id
+                behavior_id
+            }}
+        }}"#,
+        graphql_string_list_literal(session_ids)
+    );
+    Ok(load_rows::<SessionRow>(access, "AgentSession", &query)
+        .await?
+        .into_iter()
+        .map(|row| (row.session_id.clone(), row))
+        .collect())
+}
+
+async fn load_conversations(
+    access: &ConfigAccess,
+    session_ids: &[String],
+) -> Result<HashMap<String, ConversationRow>> {
+    if session_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let query = format!(
+        r#"{{
+            AgentConversation(
+                filter: {{ session_id: {{ _in: {} }} }}
+            ) {{
+                session_id
+                agent_did
+                behavior_id
+            }}
+        }}"#,
+        graphql_string_list_literal(session_ids)
+    );
+    Ok(
+        load_rows::<ConversationRow>(access, "AgentConversation", &query)
+            .await?
+            .into_iter()
+            .map(|row| (row.session_id.clone(), row))
+            .collect(),
+    )
+}
+
+async fn load_messages_for_tool_calls(
+    access: &ConfigAccess,
+    tool_calls: &[ToolCallRow],
+) -> Result<HashMap<(String, i64), MessageRow>> {
+    let mut sequences_by_session: BTreeMap<String, BTreeSet<i64>> = BTreeMap::new();
+    for tool_call in tool_calls {
+        if let Some(sequence) = tool_call.message_sequence {
+            sequences_by_session
+                .entry(tool_call.session_id.clone())
+                .or_default()
+                .insert(sequence);
+        }
+    }
+
+    let mut out = HashMap::new();
+    for (session_id, sequences) in sequences_by_session {
+        let sequence_values = sequences.into_iter().collect::<Vec<_>>();
+        let query = format!(
+            r#"{{
+                AgentMessage(
+                    filter: {{
+                        _and: [
+                            {{ session_id: {{ _eq: "{}" }} }},
+                            {{ sequence: {{ _in: {} }} }}
+                        ]
+                    }}
+                ) {{
+                    session_id
+                    sequence
+                    role
+                    content
+                }}
+            }}"#,
+            escape_graphql_string(&session_id),
+            graphql_int_list_literal(&sequence_values)
+        );
+        for row in load_rows::<MessageRow>(access, "AgentMessage", &query).await? {
+            out.insert((row.session_id.clone(), row.sequence), row);
+        }
+    }
+    Ok(out)
+}
+
+async fn load_behaviors(
+    access: &ConfigAccess,
+    requests: &[RequestRow],
+    sessions: &HashMap<String, SessionRow>,
+    conversations: &HashMap<String, ConversationRow>,
+) -> Result<HashMap<String, BehaviorRow>> {
+    let mut behavior_ids = BTreeSet::new();
+    for request in requests {
+        if let Some(behavior_id) = request
+            .behavior_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            behavior_ids.insert(behavior_id.to_string());
+        }
+    }
+    for session in sessions.values() {
+        if let Some(behavior_id) = session
+            .behavior_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            behavior_ids.insert(behavior_id.to_string());
+        }
+    }
+    for conversation in conversations.values() {
+        if let Some(behavior_id) = conversation
+            .behavior_id
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        {
+            behavior_ids.insert(behavior_id.to_string());
+        }
+    }
+    if behavior_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let behavior_ids = behavior_ids.into_iter().collect::<Vec<_>>();
+    let query = format!(
+        r#"{{
+            AgentBehavior(
+                filter: {{ behavior_id: {{ _in: {} }} }}
+            ) {{
+                behavior_id
+                agent_did
+                backend_id
+                model_name
+                inference_profile_id
+            }}
+        }}"#,
+        graphql_string_list_literal(&behavior_ids)
+    );
+    Ok(load_rows::<BehaviorRow>(access, "AgentBehavior", &query)
+        .await?
+        .into_iter()
+        .map(|row| (row.behavior_id.clone(), row))
+        .collect())
+}
+
+async fn load_rows<T>(access: &ConfigAccess, collection: &str, query: &str) -> Result<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    graphql_rows_or_empty_if_collection_missing(access, collection, query)
+        .await?
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("decoding {collection} rows"))
+}
+
+fn infer_request_for_tool_call<'a>(
+    tool_call: &ToolCallRow,
+    requests: &[&'a RequestRow],
+    responses: &[&ResponseRow],
+) -> Option<&'a RequestRow> {
+    if let Some(sequence) = tool_call.message_sequence {
+        if let Some(response) = responses
+            .iter()
+            .filter_map(|response| {
+                let materialized = response.materialized_message_sequence?;
+                (materialized >= sequence).then_some((*response, materialized))
+            })
+            .min_by_key(|(_, materialized)| *materialized)
+            .map(|(response, _)| response)
+        {
+            if let Some(request) = requests
+                .iter()
+                .copied()
+                .find(|request| request.request_id == response.request_id)
+            {
+                return Some(request);
+            }
+        }
+    }
+
+    if let Some(started_at) = tool_call
+        .started_at
+        .as_deref()
+        .and_then(parse_rfc3339_millis)
+    {
+        if let Some(request) = requests
+            .iter()
+            .copied()
+            .filter_map(|request| {
+                let created_at = request
+                    .created_at
+                    .as_deref()
+                    .and_then(parse_rfc3339_millis)?;
+                (created_at <= started_at).then_some((request, created_at))
+            })
+            .max_by_key(|(_, created_at)| *created_at)
+            .map(|(request, _)| request)
+        {
+            return Some(request);
+        }
+    }
+
+    if requests.len() == 1 {
+        return requests.first().copied();
+    }
+
+    None
+}
+
+fn rows_by_session<T: HasSessionId>(rows: &[T]) -> HashMap<&str, Vec<&T>> {
+    let mut out: HashMap<&str, Vec<&T>> = HashMap::new();
+    for row in rows {
+        if let Some(session_id) = row.session_id() {
+            out.entry(session_id).or_default().push(row);
+        }
+    }
+    out
+}
+
+fn combined_request_failure_text(
+    request: Option<&RequestRow>,
+    response: Option<&ResponseRow>,
+) -> Option<String> {
+    let mut parts = Vec::new();
+    if let Some(request) = request {
+        push_nonempty(&mut parts, request.status.as_deref());
+        push_nonempty(&mut parts, request.lifecycle_state.as_deref());
+        push_nonempty(&mut parts, request.failure_reason.as_deref());
+    }
+    if let Some(response) = response {
+        push_nonempty(&mut parts, response.status.as_deref());
+        push_nonempty(&mut parts, response.error_message.as_deref());
+    }
+
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+fn parse_request_metadata(request: &RequestRow) -> Option<Value> {
+    let metadata = request.metadata.as_deref()?.trim();
+    if metadata.is_empty() {
+        return None;
+    }
+    serde_json::from_str(metadata).ok()
+}
+
+fn metadata_string(metadata: Option<&Value>, key: &str) -> Option<String> {
+    metadata?
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn first_nonempty<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> Option<&'a str> {
+    values
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+}
+
+fn push_nonempty(parts: &mut Vec<String>, value: Option<&str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        parts.push(value.to_string());
+    }
+}
+
+fn parse_rfc3339_millis(value: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+fn unique_tool_call_session_ids(tool_calls: &[ToolCallRow]) -> Vec<String> {
+    tool_calls
+        .iter()
+        .filter_map(|row| {
+            let session_id = row.session_id.trim();
+            (!session_id.is_empty()).then_some(session_id.to_string())
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn graphql_int_list_literal(values: &[i64]) -> String {
+    format!(
+        "[{}]",
+        values
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
+fn write_jsonl(path: Option<&std::path::Path>, records: &[AmyToolCallTraceRecord]) -> Result<()> {
+    let mut output = String::new();
+    for record in records {
+        output.push_str(&serde_json::to_string(record)?);
+        output.push('\n');
+    }
+
+    if let Some(path) = path {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("creating output directory {}", parent.display()))?;
+        }
+        fs::write(path, output).with_context(|| format!("writing JSONL {}", path.display()))?;
+    } else {
+        print!("{output}");
+    }
+    Ok(())
+}
+
+trait HasSessionId {
+    fn session_id(&self) -> Option<&str>;
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ToolCallRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    message_sequence: Option<i64>,
+    #[serde(default)]
+    tool_name: String,
+    #[serde(default)]
+    tool_call_id: String,
+    #[serde(default)]
+    args: String,
+    #[serde(default)]
+    result: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    content: Option<String>,
+    #[serde(default)]
+    metadata: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    backend_id: Option<String>,
+    #[serde(default)]
+    failure_reason: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    retry_count: Option<i64>,
+}
+
+impl HasSessionId for RequestRow {
+    fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ResponseRow {
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    error_message: Option<String>,
+    #[serde(default)]
+    materialized_message_sequence: Option<i64>,
+}
+
+impl HasSessionId for ResponseRow {
+    fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MessageRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    sequence: i64,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    content: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SessionRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    behavior_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ConversationRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BehaviorRow {
+    #[serde(default)]
+    behavior_id: String,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    backend_id: Option<String>,
+    #[serde(default)]
+    model_name: Option<String>,
+    #[serde(default)]
+    inference_profile_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_metadata_hydrates_run_and_case_ids() {
+        let request = RequestRow {
+            request_id: "req-1".to_string(),
+            metadata: Some(r#"{"run_id":"run-1","case_id":"case-1"}"#.to_string()),
+            ..empty_request()
+        };
+        let metadata = parse_request_metadata(&request);
+
+        assert_eq!(
+            metadata_string(metadata.as_ref(), "run_id").as_deref(),
+            Some("run-1")
+        );
+        assert_eq!(
+            metadata_string(metadata.as_ref(), "case_id").as_deref(),
+            Some("case-1")
+        );
+    }
+
+    #[test]
+    fn infers_request_by_materialized_message_sequence() {
+        let requests = vec![
+            RequestRow {
+                request_id: "req-1".to_string(),
+                session_id: Some("session-1".to_string()),
+                ..empty_request()
+            },
+            RequestRow {
+                request_id: "req-2".to_string(),
+                session_id: Some("session-1".to_string()),
+                ..empty_request()
+            },
+        ];
+        let request_refs = requests.iter().collect::<Vec<_>>();
+        let responses = [
+            ResponseRow {
+                request_id: "req-1".to_string(),
+                session_id: Some("session-1".to_string()),
+                materialized_message_sequence: Some(4),
+                ..empty_response()
+            },
+            ResponseRow {
+                request_id: "req-2".to_string(),
+                session_id: Some("session-1".to_string()),
+                materialized_message_sequence: Some(8),
+                ..empty_response()
+            },
+        ];
+        let response_refs = responses.iter().collect::<Vec<_>>();
+        let tool_call = ToolCallRow {
+            session_id: "session-1".to_string(),
+            message_sequence: Some(3),
+            ..empty_tool_call()
+        };
+
+        let request = infer_request_for_tool_call(&tool_call, &request_refs, &response_refs)
+            .expect("request");
+
+        assert_eq!(request.request_id, "req-1");
+    }
+
+    fn empty_tool_call() -> ToolCallRow {
+        ToolCallRow {
+            session_id: String::new(),
+            message_sequence: None,
+            tool_name: String::new(),
+            tool_call_id: String::new(),
+            args: String::new(),
+            result: String::new(),
+            status: String::new(),
+            started_at: None,
+            completed_at: None,
+        }
+    }
+
+    fn empty_request() -> RequestRow {
+        RequestRow {
+            request_id: String::new(),
+            agent_did: None,
+            behavior_id: None,
+            session_id: None,
+            content: None,
+            metadata: None,
+            status: None,
+            lifecycle_state: None,
+            backend_id: None,
+            failure_reason: None,
+            created_at: None,
+            retry_count: None,
+        }
+    }
+
+    fn empty_response() -> ResponseRow {
+        ResponseRow {
+            request_id: String::new(),
+            session_id: None,
+            status: None,
+            error_message: None,
+            materialized_message_sequence: None,
+        }
+    }
+}

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -156,6 +156,16 @@ Examples:
   defra-agent show runtime
   defra-agent show request REQUEST_ID
   defra-agent show response REQUEST_ID";
+const TRACE_AFTER_HELP: &str = "\
+Exports one JSON object per persisted AgentToolCall row. The command reads
+AgentSession, AgentRequest, AgentResponse, AgentMessage, AgentBehavior, and
+AgentToolCall rows, then infers Amy baseline fields without mutating runtime
+state.
+
+Examples:
+  defra-agent trace export --home /path/to/home
+  defra-agent trace export --graphql http://127.0.0.1:9191/api/v0/graphql
+  defra-agent trace export --graphql http://100.69.4.79:9191/api/v0/graphql --run-id amy-readonly-001 --limit 200 > amy-tool-calls.jsonl";
 const CONFIG_AFTER_HELP: &str = "\
 Examples:
   defra-agent config validate --root infra/agents/default
@@ -273,6 +283,7 @@ async fn main() -> Result<()> {
         Command::Chat(args) => commands::chat::chat(args).await,
         Command::P2p { command } => commands::p2p::dispatch(command).await,
         Command::Show { command } => commands::show::dispatch(command).await,
+        Command::Trace { command } => commands::trace::dispatch(command).await,
         Command::Status(args) => commands::status::status(args).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Config { command } => commands::config::dispatch(command).await,

--- a/crates/defra-agent-cli/tests/cli_trace_export.rs
+++ b/crates/defra-agent-cli/tests/cli_trace_export.rs
@@ -1,0 +1,497 @@
+mod support;
+use support::*;
+
+use anyhow::{Context, Result};
+use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+use defra_agent::ensure_runtime_schemas;
+use rig::completion::message::{AssistantContent, Message, ToolCall, ToolFunction};
+use rig::one_or_many::OneOrMany;
+use serde_json::{json, Value};
+
+#[tokio::test]
+async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+        seed_trace_export_rows(&node).await?;
+    }
+
+    let output = run_cli_text(
+        tempdir.path(),
+        &[
+            "trace",
+            "export",
+            "--home",
+            agent_home.to_str().context("agent home utf8")?,
+            "--run-id",
+            "run-cli",
+            "--case-id",
+            "case-cli",
+            "--limit",
+            "10",
+        ],
+    )?;
+    let mut records = output
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).context("parsing JSONL record"))
+        .collect::<Result<Vec<_>>>()?;
+    records.sort_by_key(|record| {
+        record
+            .get("tool_call_id")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string()
+    });
+
+    assert_eq!(records.len(), 3, "export output:\n{output}");
+    let find_record = |tool_call_id: &str| {
+        records
+            .iter()
+            .find(|record| record.get("tool_call_id").and_then(Value::as_str) == Some(tool_call_id))
+            .unwrap_or_else(|| panic!("missing record {tool_call_id}; output:\n{output}"))
+    };
+    let deadline = find_record("call-deadline");
+    let failed = find_record("call-fail");
+    let succeeded = find_record("call-success");
+
+    assert_eq!(
+        failed.get("tool_call_id").and_then(Value::as_str),
+        Some("call-fail")
+    );
+    assert_eq!(
+        failed.get("tool_status").and_then(Value::as_str),
+        Some("completed")
+    );
+    assert_eq!(
+        failed.get("tool_result_ok").and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        failed.get("tool_failure_class").and_then(Value::as_str),
+        Some("nonzero_command_exit")
+    );
+    assert_eq!(
+        failed
+            .get("tool_error")
+            .and_then(|value| value.get("retryable"))
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        failed.get("failure_class").and_then(Value::as_str),
+        Some("nonzero_command_exit")
+    );
+    assert!(failed
+        .get("request_failure_class")
+        .is_some_and(Value::is_null));
+    assert_eq!(
+        failed.get("request_id").and_then(Value::as_str),
+        Some("req-1")
+    );
+    assert_eq!(
+        failed.get("backend_id").and_then(Value::as_str),
+        Some("studios-cluster")
+    );
+    assert_eq!(
+        failed.get("model_name").and_then(Value::as_str),
+        Some("baa-ai/GLM-5.1-RAM-420GB-MLX")
+    );
+    assert_eq!(
+        failed.get("inference_profile_id").and_then(Value::as_str),
+        Some("amy")
+    );
+    assert_eq!(
+        failed
+            .get("raw_tool_call_json")
+            .and_then(|value| value.get("function"))
+            .and_then(|function| function.get("name"))
+            .and_then(Value::as_str),
+        Some("bash")
+    );
+    assert_eq!(failed.get("latency_ms").and_then(Value::as_i64), Some(1500));
+
+    assert_eq!(
+        succeeded.get("tool_call_id").and_then(Value::as_str),
+        Some("call-success")
+    );
+    assert_eq!(
+        succeeded.get("tool_status").and_then(Value::as_str),
+        Some("completed")
+    );
+    assert_eq!(
+        succeeded.get("tool_result_ok").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(succeeded
+        .get("tool_failure_class")
+        .is_some_and(Value::is_null));
+    assert!(succeeded.get("failure_class").is_some_and(Value::is_null));
+    assert_eq!(
+        succeeded.get("run_id").and_then(Value::as_str),
+        Some("run-cli")
+    );
+    assert_eq!(
+        succeeded.get("case_id").and_then(Value::as_str),
+        Some("case-cli")
+    );
+    assert_eq!(
+        succeeded.get("prompt").and_then(Value::as_str),
+        Some("Inspect the repo and show README.md")
+    );
+
+    assert_eq!(
+        deadline.get("tool_call_id").and_then(Value::as_str),
+        Some("call-deadline")
+    );
+    assert_eq!(
+        deadline.get("tool_result_ok").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(deadline
+        .get("tool_failure_class")
+        .is_some_and(Value::is_null));
+    assert_eq!(
+        deadline
+            .get("request_failure_class")
+            .and_then(Value::as_str),
+        Some("deadline_or_inference_failure")
+    );
+    assert_eq!(
+        deadline.get("request_status").and_then(Value::as_str),
+        Some("error")
+    );
+    assert_eq!(
+        deadline
+            .get("request_lifecycle_state")
+            .and_then(Value::as_str),
+        Some("failed")
+    );
+    assert_eq!(
+        deadline.get("response_status").and_then(Value::as_str),
+        Some("error")
+    );
+
+    Ok(())
+}
+
+async fn seed_trace_export_rows(node: &EmbeddedNode) -> Result<()> {
+    exec(
+        node,
+        r#"mutation {
+            create_AgentBehavior(input: {
+                behavior_id: "amy",
+                agent_did: "did:defra-agent:amy",
+                display_name: "Amy",
+                system_prompt: "baseline",
+                backend_id: "studios-cluster",
+                model_name: "baa-ai/GLM-5.1-RAM-420GB-MLX",
+                tool_selection_id: "default-tools",
+                inference_profile_id: "amy",
+                enabled: true,
+                created_at: "2026-05-04T12:00:00Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentSession(input: {
+                session_id: "session-1",
+                agent_name: "Amy",
+                behavior_id: "amy",
+                started: "2026-05-04T12:00:00Z",
+                status: "active"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentConversation(input: {
+                session_id: "session-1",
+                agent_name: "Amy",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                title: "Trace export test",
+                title_source: "test",
+                preview_text: "Inspect the repo",
+                status: "active",
+                created_at: "2026-05-04T12:00:00Z",
+                updated_at: "2026-05-04T12:00:05Z",
+                latest_request_id: "req-1"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentRequest(input: {
+                request_id: "req-1",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                session_id: "session-1",
+                content: "Inspect the repo and show README.md",
+                metadata: "{\"run_id\":\"run-metadata\",\"case_id\":\"case-metadata\"}",
+                status: "completed",
+                lifecycle_state: "complete",
+                backend_id: "studios-cluster",
+                failure_reason: "",
+                created_at: "2026-05-04T12:00:01Z",
+                retry_count: 0
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentResponse(input: {
+                response_key: "req-1",
+                request_id: "req-1",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                session_id: "session-1",
+                content: "done",
+                reasoning: "",
+                status: "completed",
+                error_message: "",
+                token_count: 12,
+                progress_seq: 3,
+                materialized_message_sequence: 4,
+                materialized_at: "2026-05-04T12:00:06Z",
+                created_at: "2026-05-04T12:00:01Z",
+                completed_at: "2026-05-04T12:00:06Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+
+    let success_message =
+        assistant_tool_message("call-success", "read", json!({"path":"README.md"}))?;
+    let failed_message = assistant_tool_message(
+        "call-fail",
+        "bash",
+        json!({"command":"grep","args":["-P","amy","README.md"]}),
+    )?;
+    exec(
+        node,
+        &format!(
+            r#"mutation {{
+                create_AgentMessage(input: {{
+                    message_key: "session-1:2",
+                    session_id: "session-1",
+                    sequence: 2,
+                    role: "assistant",
+                    content: "{}",
+                    timestamp: "2026-05-04T12:00:02Z"
+                }}) {{ _docID }}
+            }}"#,
+            escape_graphql_string(&success_message)
+        ),
+    )
+    .await?;
+    exec(
+        node,
+        &format!(
+            r#"mutation {{
+                create_AgentMessage(input: {{
+                    message_key: "session-1:3",
+                    session_id: "session-1",
+                    sequence: 3,
+                    role: "assistant",
+                    content: "{}",
+                    timestamp: "2026-05-04T12:00:03Z"
+                }}) {{ _docID }}
+            }}"#,
+            escape_graphql_string(&failed_message)
+        ),
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentToolCall(input: {
+                tool_call_key: "session-1:call-success",
+                session_id: "session-1",
+                message_sequence: 2,
+                tool_name: "read",
+                tool_call_id: "call-success",
+                args: "{\"path\":\"README.md\"}",
+                result: "README contents",
+                status: "completed",
+                started_at: "2026-05-04T12:00:02Z",
+                completed_at: "2026-05-04T12:00:03Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentToolCall(input: {
+                tool_call_key: "session-1:call-fail",
+                session_id: "session-1",
+                message_sequence: 3,
+                tool_name: "bash",
+                tool_call_id: "call-fail",
+                args: "{\"command\":\"grep\",\"args\":[\"-P\",\"amy\",\"README.md\"]}",
+                result: "cwd: /repo\ncommand: grep -P amy README.md\nexit_code: 2\nstdout:\n(empty)\nstderr:\ngrep: invalid option -- P",
+                status: "completed",
+                started_at: "2026-05-04T12:00:03Z",
+                completed_at: "2026-05-04T12:00:04.500Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+
+    exec(
+        node,
+        r#"mutation {
+            create_AgentSession(input: {
+                session_id: "session-2",
+                agent_name: "Amy",
+                behavior_id: "amy",
+                started: "2026-05-04T13:00:00Z",
+                status: "active"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentConversation(input: {
+                session_id: "session-2",
+                agent_name: "Amy",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                title: "Trace export deadline test",
+                title_source: "test",
+                preview_text: "Read a file then deadline",
+                status: "active",
+                created_at: "2026-05-04T13:00:00Z",
+                updated_at: "2026-05-04T13:00:10Z",
+                latest_request_id: "req-deadline"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentRequest(input: {
+                request_id: "req-deadline",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                session_id: "session-2",
+                content: "Read README.md but the request later times out",
+                metadata: "",
+                status: "error",
+                lifecycle_state: "failed",
+                backend_id: "studios-cluster",
+                failure_reason: "request deadline exceeded while waiting for inference stream item",
+                created_at: "2026-05-04T13:00:01Z",
+                retry_count: 0
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentResponse(input: {
+                response_key: "req-deadline",
+                request_id: "req-deadline",
+                agent_did: "did:defra-agent:amy",
+                behavior_id: "amy",
+                session_id: "session-2",
+                content: "",
+                reasoning: "",
+                status: "error",
+                error_message: "request deadline exceeded while waiting for inference stream item",
+                token_count: 0,
+                progress_seq: 3,
+                materialized_message_sequence: 4,
+                materialized_at: "2026-05-04T13:00:10Z",
+                created_at: "2026-05-04T13:00:01Z",
+                completed_at: "2026-05-04T13:00:10Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    let deadline_message =
+        assistant_tool_message("call-deadline", "read", json!({"path":"README.md"}))?;
+    exec(
+        node,
+        &format!(
+            r#"mutation {{
+                create_AgentMessage(input: {{
+                    message_key: "session-2:2",
+                    session_id: "session-2",
+                    sequence: 2,
+                    role: "assistant",
+                    content: "{}",
+                    timestamp: "2026-05-04T13:00:02Z"
+                }}) {{ _docID }}
+            }}"#,
+            escape_graphql_string(&deadline_message)
+        ),
+    )
+    .await?;
+    exec(
+        node,
+        r#"mutation {
+            create_AgentToolCall(input: {
+                tool_call_key: "session-2:call-deadline",
+                session_id: "session-2",
+                message_sequence: 2,
+                tool_name: "read",
+                tool_call_id: "call-deadline",
+                args: "{\"path\":\"README.md\"}",
+                result: "README contents",
+                status: "completed",
+                started_at: "2026-05-04T13:00:02Z",
+                completed_at: "2026-05-04T13:00:03Z"
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+    Ok(())
+}
+
+fn assistant_tool_message(call_id: &str, name: &str, arguments: Value) -> Result<String> {
+    serde_json::to_string(&Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+            id: call_id.to_string(),
+            call_id: Some(call_id.to_string()),
+            function: ToolFunction {
+                name: name.to_string(),
+                arguments,
+            },
+            signature: None,
+            additional_params: None,
+        })),
+    })
+    .context("serializing assistant tool message")
+}
+
+async fn exec(node: &EmbeddedNode, query: &str) -> Result<()> {
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!("GraphQL mutation failed: {:?}", response.errors);
+    }
+    Ok(())
+}

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -35,6 +35,7 @@ pub mod streaming;
 pub mod template;
 pub mod tool_surface;
 pub mod toolset;
+pub mod trace_export;
 pub(crate) mod trigger_engine;
 pub mod truncation;
 pub mod watcher;

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -1,0 +1,754 @@
+use chrono::{DateTime, Utc};
+use rig::completion::message::{AssistantContent, Message};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolFailureClass {
+    ServiceUnavailable,
+    ToolNotFound,
+    ResourceNotFound,
+    ServiceSchemaDrift,
+    InvalidJsonArguments,
+    ArgumentsNotObject,
+    ToolRuntimeError,
+    ToolTimeout,
+    NonzeroCommandExit,
+    DeadlineOrInferenceFailure,
+    Unclassified,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArgumentParseResult {
+    ValidObject,
+    InvalidJson,
+    ArgumentsNotObject,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchemaValidationResult {
+    NotEvaluated,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceValidationError {
+    pub code: String,
+    pub path: String,
+    pub message: String,
+    pub retryable: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ToolCallTraceAnalysis {
+    pub selected_service_id: Option<String>,
+    pub selected_tool_name: Option<String>,
+    pub argument_parse_result: ArgumentParseResult,
+    pub schema_validation_result: SchemaValidationResult,
+    pub validation_errors: Vec<TraceValidationError>,
+    pub final_arguments_sent: Option<Value>,
+    pub tool_result_ok: bool,
+    pub tool_failure_class: Option<ToolFailureClass>,
+    pub tool_error: Option<TraceToolError>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TraceToolError {
+    pub failure_class: ToolFailureClass,
+    pub retryable: Option<bool>,
+    pub raw_error_text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AmyToolCallTraceRecord {
+    pub run_id: Option<String>,
+    pub case_id: Option<String>,
+    pub prompt: Option<String>,
+    pub agent_did: Option<String>,
+    pub behavior_id: Option<String>,
+    pub session_id: String,
+    pub request_id: Option<String>,
+    pub request_status: Option<String>,
+    pub request_lifecycle_state: Option<String>,
+    pub request_failure_reason: Option<String>,
+    pub response_status: Option<String>,
+    pub response_error_message: Option<String>,
+    pub request_failure_class: Option<ToolFailureClass>,
+    pub backend_id: Option<String>,
+    pub model_name: Option<String>,
+    pub inference_profile_id: Option<String>,
+    pub raw_assistant_message: Option<Value>,
+    pub raw_tool_call_json: Option<Value>,
+    pub tool_call_id: String,
+    pub native_or_meta_tool: String,
+    pub selected_service_id: Option<String>,
+    pub selected_tool_name: Option<String>,
+    pub raw_arguments: String,
+    pub argument_parse_result: ArgumentParseResult,
+    pub schema_validation_result: SchemaValidationResult,
+    pub validation_errors: Vec<TraceValidationError>,
+    pub repair_attempt: Option<Value>,
+    pub final_arguments_sent: Option<Value>,
+    pub tool_result: String,
+    pub tool_result_ok: bool,
+    pub tool_call_completed: bool,
+    pub tool_status: String,
+    pub task_outcome: Option<String>,
+    pub tool_failure_class: Option<ToolFailureClass>,
+    pub tool_error: Option<TraceToolError>,
+    /// Deprecated compatibility alias for tool_failure_class.
+    pub failure_class: Option<ToolFailureClass>,
+    pub started_at: Option<String>,
+    pub completed_at: Option<String>,
+    pub latency_ms: Option<i64>,
+    pub retry_count: Option<i64>,
+}
+
+pub fn analyze_tool_call(
+    tool_name: &str,
+    raw_args: &str,
+    result: &str,
+    status: &str,
+) -> ToolCallTraceAnalysis {
+    let mut analysis = analyze_arguments(tool_name, raw_args);
+    if analysis.tool_failure_class.is_none() {
+        analysis.tool_failure_class = classify_result_text(result);
+    }
+
+    let completed = status.trim().eq_ignore_ascii_case("completed");
+    if analysis.tool_failure_class.is_none() && !completed {
+        analysis.tool_failure_class = Some(ToolFailureClass::Unclassified);
+    }
+
+    analysis.tool_result_ok = completed && analysis.tool_failure_class.is_none();
+    analysis.tool_error = analysis
+        .tool_failure_class
+        .map(|failure_class| TraceToolError {
+            failure_class,
+            retryable: retryable_for_failure_class(failure_class),
+            raw_error_text: raw_tool_error_text(result, &analysis),
+        });
+    analysis
+}
+
+pub fn analyze_request_failure(text: Option<&str>) -> Option<ToolFailureClass> {
+    classify_request_failure_text(text)
+}
+
+pub fn latency_ms(started_at: Option<&str>, completed_at: Option<&str>) -> Option<i64> {
+    let started = parse_rfc3339(started_at?)?;
+    let completed = parse_rfc3339(completed_at?)?;
+    Some(completed.signed_duration_since(started).num_milliseconds())
+}
+
+pub fn raw_message_json(content: &str) -> Value {
+    serde_json::from_str(content).unwrap_or_else(|_| Value::String(content.to_string()))
+}
+
+pub fn extract_raw_tool_call_json(
+    role: &str,
+    content: &str,
+    persisted_tool_call_id: &str,
+    persisted_tool_name: &str,
+) -> Option<Value> {
+    let message = defra_agent_protocol::transcript::decode_persisted_message(role, content);
+    let Message::Assistant { content, .. } = message else {
+        return None;
+    };
+
+    let mut first_name_match = None;
+    for item in content.iter() {
+        let AssistantContent::ToolCall(tool_call) = item else {
+            continue;
+        };
+
+        if tool_call.id == persisted_tool_call_id
+            || tool_call.call_id.as_deref() == Some(persisted_tool_call_id)
+        {
+            return serde_json::to_value(tool_call).ok();
+        }
+
+        if first_name_match.is_none() && tool_call.function.name == persisted_tool_name {
+            first_name_match = serde_json::to_value(tool_call).ok();
+        }
+    }
+
+    first_name_match
+}
+
+fn analyze_arguments(tool_name: &str, raw_args: &str) -> ToolCallTraceAnalysis {
+    let mut analysis = ToolCallTraceAnalysis {
+        selected_service_id: None,
+        selected_tool_name: None,
+        argument_parse_result: ArgumentParseResult::ValidObject,
+        schema_validation_result: SchemaValidationResult::NotEvaluated,
+        validation_errors: Vec::new(),
+        final_arguments_sent: None,
+        tool_result_ok: false,
+        tool_failure_class: None,
+        tool_error: None,
+    };
+
+    let parsed = match serde_json::from_str::<Value>(raw_args) {
+        Ok(value) => value,
+        Err(error) => {
+            analysis.argument_parse_result = ArgumentParseResult::InvalidJson;
+            analysis.tool_failure_class = Some(ToolFailureClass::InvalidJsonArguments);
+            analysis.validation_errors.push(TraceValidationError {
+                code: "invalid_json_arguments".to_string(),
+                path: "/".to_string(),
+                message: error.to_string(),
+                retryable: true,
+            });
+            return analysis;
+        }
+    };
+
+    let Some(object) = parsed.as_object() else {
+        analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+        analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
+        analysis.validation_errors.push(TraceValidationError {
+            code: "arguments_not_object".to_string(),
+            path: "/".to_string(),
+            message: "tool arguments must be a JSON object".to_string(),
+            retryable: true,
+        });
+        analysis.final_arguments_sent = Some(parsed);
+        return analysis;
+    };
+
+    analysis.final_arguments_sent = Some(parsed.clone());
+    if matches!(tool_name, "call_tool" | "describe_tool") {
+        analysis.selected_service_id = object
+            .get("service_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+        analysis.selected_tool_name = object
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+    }
+
+    if tool_name == "call_tool" {
+        apply_call_tool_argument_analysis(&mut analysis, object.get("arguments"));
+    }
+
+    analysis
+}
+
+fn apply_call_tool_argument_analysis(
+    analysis: &mut ToolCallTraceAnalysis,
+    arguments: Option<&Value>,
+) {
+    let Some(arguments) = arguments else {
+        analysis.final_arguments_sent = None;
+        return;
+    };
+
+    match arguments {
+        Value::Object(_) => {
+            analysis.final_arguments_sent = Some(arguments.clone());
+        }
+        Value::String(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(parsed) if parsed.is_object() => {
+                analysis.final_arguments_sent = Some(parsed);
+            }
+            Ok(parsed) => {
+                analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+                analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
+                analysis.final_arguments_sent = Some(json!({ "input": parsed }));
+                analysis.validation_errors.push(TraceValidationError {
+                    code: "arguments_not_object".to_string(),
+                    path: "/arguments".to_string(),
+                    message: "call_tool.arguments must decode to a JSON object".to_string(),
+                    retryable: true,
+                });
+            }
+            Err(error) => {
+                analysis.argument_parse_result = ArgumentParseResult::InvalidJson;
+                analysis.tool_failure_class = Some(ToolFailureClass::InvalidJsonArguments);
+                analysis.final_arguments_sent = Some(json!({ "input": raw }));
+                analysis.validation_errors.push(TraceValidationError {
+                    code: "invalid_json_arguments".to_string(),
+                    path: "/arguments".to_string(),
+                    message: error.to_string(),
+                    retryable: true,
+                });
+            }
+        },
+        Value::Null => {
+            analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+            analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
+            analysis.final_arguments_sent = None;
+            analysis.validation_errors.push(TraceValidationError {
+                code: "arguments_not_object".to_string(),
+                path: "/arguments".to_string(),
+                message: "call_tool.arguments must be a JSON object".to_string(),
+                retryable: true,
+            });
+        }
+        other => {
+            analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+            analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
+            analysis.final_arguments_sent = Some(json!({ "input": other }));
+            analysis.validation_errors.push(TraceValidationError {
+                code: "arguments_not_object".to_string(),
+                path: "/arguments".to_string(),
+                message: "call_tool.arguments must be a JSON object".to_string(),
+                retryable: true,
+            });
+        }
+    }
+}
+
+fn classify_result_text(result: &str) -> Option<ToolFailureClass> {
+    let trimmed = result.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if has_nonzero_exit_code(trimmed) {
+        return Some(ToolFailureClass::NonzeroCommandExit);
+    }
+    if looks_like_service_unavailable(&lower) {
+        return Some(ToolFailureClass::ServiceUnavailable);
+    }
+    if looks_like_service_schema_drift(&lower) {
+        return Some(ToolFailureClass::ServiceSchemaDrift);
+    }
+    if looks_like_resource_not_found(&lower) {
+        return Some(ToolFailureClass::ResourceNotFound);
+    }
+    if looks_like_tool_not_found(&lower) {
+        return Some(ToolFailureClass::ToolNotFound);
+    }
+    if looks_like_deadline_or_inference_failure(&lower) {
+        return Some(ToolFailureClass::DeadlineOrInferenceFailure);
+    }
+    if looks_like_tool_timeout(&lower) {
+        return Some(ToolFailureClass::ToolTimeout);
+    }
+    if looks_like_opaque_tool_error(&lower) {
+        return Some(ToolFailureClass::Unclassified);
+    }
+    if looks_like_tool_runtime_error(&lower) {
+        return Some(ToolFailureClass::ToolRuntimeError);
+    }
+
+    None
+}
+
+fn classify_request_failure_text(text: Option<&str>) -> Option<ToolFailureClass> {
+    let lower = text?.trim().to_ascii_lowercase();
+    if lower.is_empty() {
+        return None;
+    }
+    if looks_like_deadline_or_inference_failure(&lower) {
+        return Some(ToolFailureClass::DeadlineOrInferenceFailure);
+    }
+    None
+}
+
+fn has_nonzero_exit_code(result: &str) -> bool {
+    for line in result.lines() {
+        let trimmed = line.trim();
+        if let Some(raw_code) = trimmed.strip_prefix("exit_code:") {
+            return raw_code.trim().parse::<i64>().is_ok_and(|code| code != 0);
+        }
+    }
+
+    let lower = result.to_ascii_lowercase();
+    lower.contains("exit status: 1")
+        || lower.contains("exit status: 2")
+        || lower.contains("exit code 1")
+        || lower.contains("exit code 2")
+}
+
+fn looks_like_tool_not_found(lower: &str) -> bool {
+    (lower.contains("tool '") && lower.contains("' not found"))
+        || lower.contains("tool not found")
+        || lower.contains("unknown tool")
+}
+
+fn looks_like_resource_not_found(lower: &str) -> bool {
+    lower.contains("session not found")
+        || lower.contains("resource not found")
+        || lower.contains("document not found")
+        || lower.contains("record not found")
+        || lower.contains("entity not found")
+}
+
+fn looks_like_service_schema_drift(lower: &str) -> bool {
+    (lower.contains("parse error") && lower.contains("cannot query field"))
+        || lower.contains("cannot query field")
+        || lower.contains("unknown field")
+        || lower.contains("unknown argument")
+        || lower.contains("field is not defined")
+}
+
+fn looks_like_service_unavailable(lower: &str) -> bool {
+    lower.contains("currently unreachable")
+        || lower.contains("probe timed out")
+        || lower.contains("not found or offline")
+        || lower.contains("mcp handshake failed")
+        || lower.contains("connection refused")
+        || lower.contains("failed to connect")
+        || lower.contains("connection error")
+        || lower.contains("service unavailable")
+}
+
+fn looks_like_deadline_or_inference_failure(lower: &str) -> bool {
+    lower.contains("request deadline exceeded")
+        || lower.contains("deadline exceeded")
+        || lower.contains("inference timed out")
+        || lower.contains("stream liveness timeout")
+        || lower.contains("completion failed")
+        || lower.contains("model unreachable")
+}
+
+fn looks_like_tool_timeout(lower: &str) -> bool {
+    lower.contains("timed out after")
+        || lower.contains("timed out waiting")
+        || lower.contains("tool timeout")
+}
+
+fn looks_like_opaque_tool_error(lower: &str) -> bool {
+    lower.trim_end().ends_with("mcp call_tool")
+}
+
+fn looks_like_tool_runtime_error(lower: &str) -> bool {
+    lower.contains("returned an error")
+        || lower.contains("tool call failed")
+        || lower.contains("permission denied")
+        || lower.contains("no such file or directory")
+}
+
+fn retryable_for_failure_class(failure_class: ToolFailureClass) -> Option<bool> {
+    match failure_class {
+        ToolFailureClass::ServiceUnavailable
+        | ToolFailureClass::ToolTimeout
+        | ToolFailureClass::DeadlineOrInferenceFailure => Some(true),
+        ToolFailureClass::InvalidJsonArguments
+        | ToolFailureClass::ArgumentsNotObject
+        | ToolFailureClass::ToolNotFound => Some(true),
+        ToolFailureClass::ResourceNotFound
+        | ToolFailureClass::ServiceSchemaDrift
+        | ToolFailureClass::NonzeroCommandExit => Some(false),
+        ToolFailureClass::ToolRuntimeError | ToolFailureClass::Unclassified => None,
+    }
+}
+
+fn raw_tool_error_text(result: &str, analysis: &ToolCallTraceAnalysis) -> String {
+    let trimmed = result.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+    analysis
+        .validation_errors
+        .first()
+        .map(|error| error.message.clone())
+        .unwrap_or_default()
+}
+
+fn parse_rfc3339(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::completion::message::{Text, ToolCall, ToolFunction};
+    use rig::one_or_many::OneOrMany;
+
+    #[test]
+    fn successful_completed_result_has_no_failure_class() {
+        let analysis =
+            analyze_tool_call("read", r#"{"path":"README.md"}"#, "contents", "completed");
+
+        assert!(analysis.tool_result_ok);
+        assert_eq!(analysis.tool_failure_class, None);
+        assert_eq!(
+            analysis.argument_parse_result,
+            ArgumentParseResult::ValidObject
+        );
+    }
+
+    #[test]
+    fn completed_nonzero_command_exit_is_not_a_successful_outcome() {
+        let result = "cwd: /tmp\ncommand: grep -P foo README.md\nexit_code: 2\nstdout:\n(empty)\nstderr:\ngrep: invalid option -- P";
+        let analysis = analyze_tool_call("bash", r#"{"command":"grep"}"#, result, "completed");
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::NonzeroCommandExit)
+        );
+        assert_eq!(
+            analysis
+                .tool_error
+                .as_ref()
+                .and_then(|error| error.retryable),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn classifies_service_unavailable_from_tool_result_text() {
+        let result = "call_tool: service 'coding-session-store' is currently unreachable (last error: probe timed out)";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"coding-session-store","tool_name":"search","arguments":{}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ServiceUnavailable)
+        );
+        assert_eq!(
+            analysis.selected_service_id.as_deref(),
+            Some("coding-session-store")
+        );
+        assert_eq!(analysis.selected_tool_name.as_deref(), Some("search"));
+    }
+
+    #[test]
+    fn classifies_missing_mcp_tool() {
+        let result = "tool 'missing' not found on service 'x-data'. Available tools: search_posts";
+        let analysis = analyze_tool_call(
+            "describe_tool",
+            r#"{"service_id":"x-data","tool_name":"missing"}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ToolNotFound)
+        );
+    }
+
+    #[test]
+    fn classifies_missing_resource_separately_from_missing_tool() {
+        let result = "tool 'get_coding_session' on service 'coding-session-store' returned an error: session not found: stale-session";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"coding-session-store","tool_name":"get_coding_session","arguments":{"session_id":"stale-session"}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ResourceNotFound)
+        );
+        assert_eq!(
+            analysis
+                .tool_error
+                .as_ref()
+                .and_then(|error| error.retryable),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn classifies_service_schema_drift() {
+        let result = "tool 'deploy_history' on service 'observability-mcp' returned an error: deploy log query failed: parse error: Cannot query field \"DeployEvent\" on type \"Query\".";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"observability-mcp","tool_name":"deploy_history","arguments":{}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ServiceSchemaDrift)
+        );
+    }
+
+    #[test]
+    fn preserves_opaque_mcp_errors_as_unclassified_tool_errors() {
+        let result = "Toolset error: ToolCallError: ToolCallError: MCP call_tool";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"coding-session-store","tool_name":"search_coding_notes","arguments":{"topic":"amy"}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::Unclassified)
+        );
+        let error = analysis.tool_error.as_ref().expect("tool error");
+        assert_eq!(error.failure_class, ToolFailureClass::Unclassified);
+        assert_eq!(error.retryable, None);
+        assert_eq!(error.raw_error_text, result);
+    }
+
+    #[test]
+    fn request_deadline_is_classified_separately() {
+        let analysis = analyze_tool_call(
+            "read",
+            r#"{"path":"README.md"}"#,
+            "README contents",
+            "completed",
+        );
+
+        assert!(analysis.tool_result_ok);
+        assert_eq!(analysis.tool_failure_class, None);
+        assert_eq!(
+            analyze_request_failure(Some("request deadline exceeded while awaiting inference")),
+            Some(ToolFailureClass::DeadlineOrInferenceFailure)
+        );
+    }
+
+    #[test]
+    fn classifies_invalid_top_level_json_arguments() {
+        let analysis = analyze_tool_call("read", r#"{"path":"README.md""#, "", "called");
+
+        assert_eq!(
+            analysis.argument_parse_result,
+            ArgumentParseResult::InvalidJson
+        );
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::InvalidJsonArguments)
+        );
+        assert_eq!(analysis.validation_errors[0].code, "invalid_json_arguments");
+    }
+
+    #[test]
+    fn classifies_non_object_top_level_arguments() {
+        let analysis = analyze_tool_call("read", r#""README.md""#, "", "called");
+
+        assert_eq!(
+            analysis.argument_parse_result,
+            ArgumentParseResult::ArgumentsNotObject
+        );
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ArgumentsNotObject)
+        );
+    }
+
+    #[test]
+    fn classifies_stringified_call_tool_arguments_that_are_not_json() {
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"x-data","tool_name":"search","arguments":"query=defra"}"#,
+            "",
+            "called",
+        );
+
+        assert_eq!(
+            analysis.argument_parse_result,
+            ArgumentParseResult::InvalidJson
+        );
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::InvalidJsonArguments)
+        );
+        assert_eq!(analysis.validation_errors[0].path, "/arguments");
+        assert_eq!(
+            analysis.final_arguments_sent,
+            Some(json!({ "input": "query=defra" }))
+        );
+    }
+
+    #[test]
+    fn normalizes_stringified_call_tool_object_arguments() {
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"x-data","tool_name":"search","arguments":"{\"query\":\"defra\"}"}"#,
+            "ok",
+            "completed",
+        );
+
+        assert!(analysis.tool_result_ok);
+        assert_eq!(analysis.tool_failure_class, None);
+        assert_eq!(
+            analysis.final_arguments_sent,
+            Some(json!({ "query": "defra" }))
+        );
+    }
+
+    #[test]
+    fn classifies_tool_timeout() {
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"hf-data","tool_name":"search","arguments":{}}"#,
+            "service 'hf-data' timed out after 300s",
+            "completed",
+        );
+
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ToolTimeout)
+        );
+    }
+
+    #[test]
+    fn classifies_uncompleted_tool_call_without_tool_error_as_unclassified() {
+        let analysis = analyze_tool_call("read", r#"{"path":"README.md"}"#, "", "called");
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::Unclassified)
+        );
+    }
+
+    #[test]
+    fn extracts_raw_tool_call_json_from_persisted_assistant_message() {
+        let message = Message::Assistant {
+            id: None,
+            content: OneOrMany::many(vec![
+                AssistantContent::Text(Text {
+                    text: "Checking.".to_string(),
+                }),
+                AssistantContent::ToolCall(ToolCall {
+                    id: "internal-1".to_string(),
+                    call_id: Some("call-1".to_string()),
+                    function: ToolFunction {
+                        name: "read".to_string(),
+                        arguments: json!({ "path": "README.md" }),
+                    },
+                    signature: None,
+                    additional_params: None,
+                }),
+            ])
+            .unwrap(),
+        };
+        let raw = serde_json::to_string(&message).unwrap();
+
+        let tool_call = extract_raw_tool_call_json("assistant", &raw, "internal-1", "read")
+            .expect("tool call json");
+
+        assert_eq!(tool_call["id"], "internal-1");
+        assert_eq!(tool_call["function"]["name"], "read");
+    }
+
+    #[test]
+    fn computes_latency_from_rfc3339_timestamps() {
+        assert_eq!(
+            latency_ms(
+                Some("2026-05-04T12:00:00Z"),
+                Some("2026-05-04T12:00:01.250Z")
+            ),
+            Some(1250)
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add Amy-style tool-call JSONL trace records and failure classification for persisted defra-agent data
- add `defra-agent trace export` for local homes or GraphQL endpoints
- add classifier and CLI export-shape tests, including completed tool calls with failed outcomes

## Tests
- `cargo test -p defra-agent --lib`
- `cargo test -p defra-agent-cli`

## Notes
- Read-only export path; does not change tool execution behavior.
- No automatic argument repair added.
- No Amy manifests changed.