### PR TITLE
Add MCP tool argument error envelopes

### DIFF
--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
 
 use crate::health_checker::HealthStatus;
 
@@ -16,6 +17,19 @@ pub struct CallToolArgs {
     service_id: String,
     tool_name: String,
     arguments: serde_json::Value,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct StructuredToolError {
+    ok: bool,
+    failure_class: &'static str,
+    path: String,
+    message: String,
+    retryable: bool,
+    service_id: String,
+    tool_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    available_tools: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -65,11 +79,14 @@ impl Tool for CallToolTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let arguments = match &args.arguments {
-            serde_json::Value::String(s) => {
-                serde_json::from_str(s).unwrap_or(args.arguments.clone())
-            }
-            other => other.clone(),
+        let arguments =
+            match normalize_arguments(&args.service_id, &args.tool_name, &args.arguments) {
+                Ok(arguments) => arguments,
+                Err(error) => return Ok(error.to_result_text()),
+            };
+
+        let Value::Object(argument_object) = &arguments else {
+            unreachable!("normalize_arguments only returns object arguments")
         };
 
         let health = enforce_health_gate(&self.ctx.health, &args.service_id)
@@ -86,6 +103,18 @@ impl Tool for CallToolTool {
         } else {
             300
         };
+
+        if let Some(error) = self
+            .preflight_arguments(
+                &args.service_id,
+                &endpoint,
+                &args.tool_name,
+                argument_object,
+            )
+            .await
+        {
+            return Ok(error.to_result_text());
+        }
 
         let result = tokio::time::timeout(
             Duration::from_secs(timeout_secs),
@@ -124,5 +153,332 @@ impl Tool for CallToolTool {
         } else {
             text
         })
+    }
+}
+
+impl CallToolTool {
+    async fn preflight_arguments(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        tool_name: &str,
+        arguments: &Map<String, Value>,
+    ) -> Option<StructuredToolError> {
+        let list_result = match tokio::time::timeout(
+            Duration::from_secs(30),
+            self.ctx.mcp_pool.list_tools(service_id, endpoint),
+        )
+        .await
+        {
+            Ok(Ok(result)) => result,
+            Ok(Err(error)) => {
+                tracing::warn!(
+                    service_id,
+                    tool_name,
+                    error = %error,
+                    "skipping MCP argument preflight after list_tools failure"
+                );
+                return None;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    service_id,
+                    tool_name,
+                    "skipping MCP argument preflight after list_tools timeout"
+                );
+                return None;
+            }
+        };
+
+        let available_tools = list_result
+            .tools
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<Vec<_>>();
+        let Some(tool) = list_result.tools.iter().find(|tool| tool.name == tool_name) else {
+            return Some(StructuredToolError::tool_not_found(
+                service_id,
+                tool_name,
+                available_tools,
+            ));
+        };
+
+        validate_arguments_against_schema(
+            service_id,
+            tool_name,
+            arguments,
+            tool.input_schema.as_ref(),
+        )
+        .err()
+    }
+}
+
+impl StructuredToolError {
+    fn invalid_tool_arguments(
+        service_id: &str,
+        tool_name: &str,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            ok: false,
+            failure_class: "invalid_tool_arguments",
+            path: path.into(),
+            message: message.into(),
+            retryable: true,
+            service_id: service_id.to_string(),
+            tool_name: tool_name.to_string(),
+            available_tools: None,
+        }
+    }
+
+    fn tool_not_found(service_id: &str, tool_name: &str, available_tools: Vec<String>) -> Self {
+        Self {
+            ok: false,
+            failure_class: "tool_not_found",
+            path: "/tool_name".to_string(),
+            message: format!("tool '{tool_name}' was not found on service '{service_id}'"),
+            retryable: true,
+            service_id: service_id.to_string(),
+            tool_name: tool_name.to_string(),
+            available_tools: Some(available_tools),
+        }
+    }
+
+    fn to_result_text(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| {
+            format!(
+                r#"{{"ok":false,"failure_class":"{}","path":"{}","message":"{}","retryable":true,"service_id":"{}","tool_name":"{}"}}"#,
+                self.failure_class, self.path, self.message, self.service_id, self.tool_name
+            )
+        })
+    }
+}
+
+fn normalize_arguments(
+    service_id: &str,
+    tool_name: &str,
+    arguments: &Value,
+) -> Result<Value, StructuredToolError> {
+    match arguments {
+        Value::Object(_) => Ok(arguments.clone()),
+        Value::String(raw) => match serde_json::from_str::<Value>(raw) {
+            Ok(Value::Object(map)) => Ok(Value::Object(map)),
+            Ok(other) => Err(StructuredToolError::invalid_tool_arguments(
+                service_id,
+                tool_name,
+                "/arguments",
+                format!(
+                    "call_tool.arguments must decode to a JSON object, got {}",
+                    json_type_name(&other)
+                ),
+            )),
+            Err(error) => Err(StructuredToolError::invalid_tool_arguments(
+                service_id,
+                tool_name,
+                "/arguments",
+                format!(
+                    "call_tool.arguments must be a JSON object or stringified JSON object: {error}"
+                ),
+            )),
+        },
+        other => Err(StructuredToolError::invalid_tool_arguments(
+            service_id,
+            tool_name,
+            "/arguments",
+            format!(
+                "call_tool.arguments must be a JSON object, got {}",
+                json_type_name(other)
+            ),
+        )),
+    }
+}
+
+fn validate_arguments_against_schema(
+    service_id: &str,
+    tool_name: &str,
+    arguments: &Map<String, Value>,
+    schema: &Map<String, Value>,
+) -> Result<(), StructuredToolError> {
+    if let Some(required) = schema.get("required").and_then(Value::as_array) {
+        for raw_field in required {
+            let Some(field) = raw_field.as_str() else {
+                continue;
+            };
+            if !arguments.contains_key(field) {
+                return Err(StructuredToolError::invalid_tool_arguments(
+                    service_id,
+                    tool_name,
+                    format!("/arguments/{field}"),
+                    format!("missing required argument '{field}'"),
+                ));
+            }
+        }
+    }
+
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return Ok(());
+    };
+
+    for (field, field_schema) in properties {
+        let Some(value) = arguments.get(field) else {
+            continue;
+        };
+        let Some(expected_types) = schema_types(field_schema) else {
+            continue;
+        };
+        if expected_types
+            .iter()
+            .any(|expected| value_matches_schema_type(value, expected))
+        {
+            continue;
+        }
+
+        return Err(StructuredToolError::invalid_tool_arguments(
+            service_id,
+            tool_name,
+            format!("/arguments/{field}"),
+            format!(
+                "argument '{field}' must be {}, got {}",
+                expected_types.join(" or "),
+                json_type_name(value)
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+fn schema_types(schema: &Value) -> Option<Vec<String>> {
+    match schema.get("type") {
+        Some(Value::String(value)) => Some(vec![value.to_string()]),
+        Some(Value::Array(values)) => {
+            let types = values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>();
+            (!types.is_empty()).then_some(types)
+        }
+        _ => None,
+    }
+}
+
+fn value_matches_schema_type(value: &Value, expected: &str) -> bool {
+    match expected {
+        "array" => value.is_array(),
+        "boolean" => value.is_boolean(),
+        "integer" => value.as_i64().is_some() || value.as_u64().is_some(),
+        "null" => value.is_null(),
+        "number" => value.is_number(),
+        "object" => value.is_object(),
+        "string" => value.is_string(),
+        _ => true,
+    }
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Array(_) => "array",
+        Value::Bool(_) => "boolean",
+        Value::Null => "null",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "number",
+        Value::Object(_) => "object",
+        Value::String(_) => "string",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn search_schema() -> Map<String, Value> {
+        json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["query"]
+        })
+        .as_object()
+        .expect("object schema")
+        .clone()
+    }
+
+    #[test]
+    fn rejects_missing_required_field_from_mcp_schema() {
+        let arguments = json!({}).as_object().expect("arguments").clone();
+        let error = validate_arguments_against_schema(
+            "x-data",
+            "search_bookmarks",
+            &arguments,
+            &search_schema(),
+        )
+        .expect_err("missing query should fail");
+
+        assert_eq!(error.failure_class, "invalid_tool_arguments");
+        assert_eq!(error.path, "/arguments/query");
+        assert!(error.retryable);
+        assert_eq!(error.service_id, "x-data");
+        assert_eq!(error.tool_name, "search_bookmarks");
+    }
+
+    #[test]
+    fn rejects_non_object_arguments_before_mcp_call() {
+        let error = normalize_arguments("x-data", "search_bookmarks", &json!("query=amy"))
+            .expect_err("plain string arguments should fail");
+
+        assert_eq!(error.failure_class, "invalid_tool_arguments");
+        assert_eq!(error.path, "/arguments");
+        assert!(error.message.contains("stringified JSON object"));
+    }
+
+    #[test]
+    fn accepts_stringified_json_object_for_compatibility() {
+        let arguments =
+            normalize_arguments("x-data", "search_bookmarks", &json!("{\"query\":\"amy\"}"))
+                .expect("stringified object should normalize");
+
+        assert_eq!(arguments, json!({ "query": "amy" }));
+    }
+
+    #[test]
+    fn rejects_obvious_schema_type_mismatch() {
+        let arguments = json!({ "query": "amy", "limit": "5" })
+            .as_object()
+            .expect("arguments")
+            .clone();
+        let error = validate_arguments_against_schema(
+            "x-data",
+            "search_bookmarks",
+            &arguments,
+            &search_schema(),
+        )
+        .expect_err("string limit should fail");
+
+        assert_eq!(error.failure_class, "invalid_tool_arguments");
+        assert_eq!(error.path, "/arguments/limit");
+        assert!(error.message.contains("integer"));
+    }
+
+    #[test]
+    fn missing_tool_envelope_stays_tool_not_found() {
+        let error = StructuredToolError::tool_not_found(
+            "x-data",
+            "missing_search",
+            vec!["search_bookmarks".to_string()],
+        );
+
+        assert_eq!(error.failure_class, "tool_not_found");
+        assert_eq!(error.path, "/tool_name");
+        assert_eq!(error.service_id, "x-data");
+        assert_eq!(error.tool_name, "missing_search");
+        assert_eq!(
+            error.available_tools,
+            Some(vec!["search_bookmarks".to_string()])
+        );
     }
 }

--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -320,6 +320,19 @@ fn validate_arguments_against_schema(
         return Ok(());
     };
 
+    if schema.get("additionalProperties").and_then(Value::as_bool) == Some(false) {
+        for field in arguments.keys() {
+            if !properties.contains_key(field) {
+                return Err(StructuredToolError::invalid_tool_arguments(
+                    service_id,
+                    tool_name,
+                    format!("/arguments/{field}"),
+                    format!("unknown argument '{field}'"),
+                ));
+            }
+        }
+    }
+
     for (field, field_schema) in properties {
         let Some(value) = arguments.get(field) else {
             continue;
@@ -462,6 +475,36 @@ mod tests {
         assert_eq!(error.failure_class, "invalid_tool_arguments");
         assert_eq!(error.path, "/arguments/limit");
         assert!(error.message.contains("integer"));
+    }
+
+    #[test]
+    fn rejects_unknown_arguments_when_schema_disallows_additional_properties() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "repo_name": { "type": "string" },
+                "top_n": { "type": "integer" }
+            },
+            "additionalProperties": false
+        })
+        .as_object()
+        .expect("object schema")
+        .clone();
+        let arguments = json!({ "limit": 2 })
+            .as_object()
+            .expect("arguments")
+            .clone();
+        let error = validate_arguments_against_schema(
+            "coding-session-store",
+            "coding_overview",
+            &arguments,
+            &schema,
+        )
+        .expect_err("unknown field should fail");
+
+        assert_eq!(error.failure_class, "invalid_tool_arguments");
+        assert_eq!(error.path, "/arguments/limit");
+        assert!(error.message.contains("unknown argument"));
     }
 
     #[test]

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -10,6 +10,7 @@ pub enum ToolFailureClass {
     ToolNotFound,
     ResourceNotFound,
     ServiceSchemaDrift,
+    InvalidToolArguments,
     InvalidJsonArguments,
     ArgumentsNotObject,
     ToolRuntimeError,
@@ -31,6 +32,7 @@ pub enum ArgumentParseResult {
 #[serde(rename_all = "snake_case")]
 pub enum SchemaValidationResult {
     NotEvaluated,
+    Failed,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +59,14 @@ pub struct ToolCallTraceAnalysis {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceToolError {
     pub failure_class: ToolFailureClass,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
     pub retryable: Option<bool>,
     pub raw_error_text: String,
 }
@@ -113,7 +123,21 @@ pub fn analyze_tool_call(
     status: &str,
 ) -> ToolCallTraceAnalysis {
     let mut analysis = analyze_arguments(tool_name, raw_args);
-    if analysis.tool_failure_class.is_none() {
+    let structured_tool_error = structured_tool_error_from_result(result);
+    if let Some(error) = &structured_tool_error {
+        analysis.tool_failure_class = Some(error.failure_class);
+        if error.failure_class == ToolFailureClass::InvalidToolArguments {
+            analysis.schema_validation_result = SchemaValidationResult::Failed;
+        }
+        if let (Some(path), Some(message)) = (&error.path, &error.message) {
+            analysis.validation_errors.push(TraceValidationError {
+                code: failure_class_code(error.failure_class).to_string(),
+                path: path.clone(),
+                message: message.clone(),
+                retryable: error.retryable.unwrap_or(false),
+            });
+        }
+    } else if analysis.tool_failure_class.is_none() {
         analysis.tool_failure_class = classify_result_text(result);
     }
 
@@ -123,13 +147,25 @@ pub fn analyze_tool_call(
     }
 
     analysis.tool_result_ok = completed && analysis.tool_failure_class.is_none();
-    analysis.tool_error = analysis
-        .tool_failure_class
-        .map(|failure_class| TraceToolError {
-            failure_class,
-            retryable: retryable_for_failure_class(failure_class),
-            raw_error_text: raw_tool_error_text(result, &analysis),
-        });
+    analysis.tool_error = structured_tool_error.or_else(|| {
+        analysis
+            .tool_failure_class
+            .map(|failure_class| TraceToolError {
+                failure_class,
+                service_id: analysis.selected_service_id.clone(),
+                tool_name: analysis.selected_tool_name.clone(),
+                path: analysis
+                    .validation_errors
+                    .first()
+                    .map(|error| error.path.clone()),
+                message: analysis
+                    .validation_errors
+                    .first()
+                    .map(|error| error.message.clone()),
+                retryable: retryable_for_failure_class(failure_class),
+                raw_error_text: raw_tool_error_text(result, &analysis),
+            })
+    });
     analysis
 }
 
@@ -195,6 +231,7 @@ fn analyze_arguments(tool_name: &str, raw_args: &str) -> ToolCallTraceAnalysis {
         Ok(value) => value,
         Err(error) => {
             analysis.argument_parse_result = ArgumentParseResult::InvalidJson;
+            analysis.schema_validation_result = SchemaValidationResult::Failed;
             analysis.tool_failure_class = Some(ToolFailureClass::InvalidJsonArguments);
             analysis.validation_errors.push(TraceValidationError {
                 code: "invalid_json_arguments".to_string(),
@@ -208,6 +245,7 @@ fn analyze_arguments(tool_name: &str, raw_args: &str) -> ToolCallTraceAnalysis {
 
     let Some(object) = parsed.as_object() else {
         analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+        analysis.schema_validation_result = SchemaValidationResult::Failed;
         analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
         analysis.validation_errors.push(TraceValidationError {
             code: "arguments_not_object".to_string(),
@@ -257,6 +295,7 @@ fn apply_call_tool_argument_analysis(
             }
             Ok(parsed) => {
                 analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+                analysis.schema_validation_result = SchemaValidationResult::Failed;
                 analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
                 analysis.final_arguments_sent = Some(json!({ "input": parsed }));
                 analysis.validation_errors.push(TraceValidationError {
@@ -268,6 +307,7 @@ fn apply_call_tool_argument_analysis(
             }
             Err(error) => {
                 analysis.argument_parse_result = ArgumentParseResult::InvalidJson;
+                analysis.schema_validation_result = SchemaValidationResult::Failed;
                 analysis.tool_failure_class = Some(ToolFailureClass::InvalidJsonArguments);
                 analysis.final_arguments_sent = Some(json!({ "input": raw }));
                 analysis.validation_errors.push(TraceValidationError {
@@ -280,6 +320,7 @@ fn apply_call_tool_argument_analysis(
         },
         Value::Null => {
             analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+            analysis.schema_validation_result = SchemaValidationResult::Failed;
             analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
             analysis.final_arguments_sent = None;
             analysis.validation_errors.push(TraceValidationError {
@@ -291,6 +332,7 @@ fn apply_call_tool_argument_analysis(
         }
         other => {
             analysis.argument_parse_result = ArgumentParseResult::ArgumentsNotObject;
+            analysis.schema_validation_result = SchemaValidationResult::Failed;
             analysis.tool_failure_class = Some(ToolFailureClass::ArgumentsNotObject);
             analysis.final_arguments_sent = Some(json!({ "input": other }));
             analysis.validation_errors.push(TraceValidationError {
@@ -300,6 +342,68 @@ fn apply_call_tool_argument_analysis(
                 retryable: true,
             });
         }
+    }
+}
+
+fn structured_tool_error_from_result(result: &str) -> Option<TraceToolError> {
+    let trimmed = result.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let value = serde_json::from_str::<Value>(trimmed).ok()?;
+    let object = value.as_object()?;
+    if object.get("ok").and_then(Value::as_bool) != Some(false) {
+        return None;
+    }
+
+    let failure_class = object
+        .get("failure_class")
+        .and_then(Value::as_str)
+        .and_then(failure_class_from_str)?;
+    let retryable = object.get("retryable").and_then(Value::as_bool);
+
+    Some(TraceToolError {
+        failure_class,
+        service_id: object
+            .get("service_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        tool_name: object
+            .get("tool_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        path: object
+            .get("path")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        message: object
+            .get("message")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        retryable,
+        raw_error_text: trimmed.to_string(),
+    })
+}
+
+fn failure_class_from_str(raw: &str) -> Option<ToolFailureClass> {
+    serde_json::from_value(Value::String(raw.to_string())).ok()
+}
+
+fn failure_class_code(failure_class: ToolFailureClass) -> &'static str {
+    match failure_class {
+        ToolFailureClass::ServiceUnavailable => "service_unavailable",
+        ToolFailureClass::ToolNotFound => "tool_not_found",
+        ToolFailureClass::ResourceNotFound => "resource_not_found",
+        ToolFailureClass::ServiceSchemaDrift => "service_schema_drift",
+        ToolFailureClass::InvalidToolArguments => "invalid_tool_arguments",
+        ToolFailureClass::InvalidJsonArguments => "invalid_json_arguments",
+        ToolFailureClass::ArgumentsNotObject => "arguments_not_object",
+        ToolFailureClass::ToolRuntimeError => "tool_runtime_error",
+        ToolFailureClass::ToolTimeout => "tool_timeout",
+        ToolFailureClass::NonzeroCommandExit => "nonzero_command_exit",
+        ToolFailureClass::DeadlineOrInferenceFailure => "deadline_or_inference_failure",
+        ToolFailureClass::Unclassified => "unclassified",
     }
 }
 
@@ -318,6 +422,9 @@ fn classify_result_text(result: &str) -> Option<ToolFailureClass> {
     }
     if looks_like_service_schema_drift(&lower) {
         return Some(ToolFailureClass::ServiceSchemaDrift);
+    }
+    if looks_like_invalid_tool_arguments(&lower) {
+        return Some(ToolFailureClass::InvalidToolArguments);
     }
     if looks_like_resource_not_found(&lower) {
         return Some(ToolFailureClass::ResourceNotFound);
@@ -389,6 +496,16 @@ fn looks_like_service_schema_drift(lower: &str) -> bool {
         || lower.contains("field is not defined")
 }
 
+fn looks_like_invalid_tool_arguments(lower: &str) -> bool {
+    lower.contains("invalid_tool_arguments")
+        || lower.contains("invalid tool arguments")
+        || lower.contains("invalid arguments")
+        || lower.contains("invalid params")
+        || lower.contains("missing field")
+        || lower.contains("arguments must")
+        || (lower.contains("failed to deserialize") && lower.contains("parameter"))
+}
+
 fn looks_like_service_unavailable(lower: &str) -> bool {
     lower.contains("currently unreachable")
         || lower.contains("probe timed out")
@@ -431,7 +548,8 @@ fn retryable_for_failure_class(failure_class: ToolFailureClass) -> Option<bool> 
         ToolFailureClass::ServiceUnavailable
         | ToolFailureClass::ToolTimeout
         | ToolFailureClass::DeadlineOrInferenceFailure => Some(true),
-        ToolFailureClass::InvalidJsonArguments
+        ToolFailureClass::InvalidToolArguments
+        | ToolFailureClass::InvalidJsonArguments
         | ToolFailureClass::ArgumentsNotObject
         | ToolFailureClass::ToolNotFound => Some(true),
         ToolFailureClass::ResourceNotFound
@@ -533,6 +651,67 @@ mod tests {
         assert_eq!(
             analysis.tool_failure_class,
             Some(ToolFailureClass::ToolNotFound)
+        );
+    }
+
+    #[test]
+    fn structured_invalid_argument_envelope_marks_completed_tool_call_failed() {
+        let result = json!({
+            "ok": false,
+            "failure_class": "invalid_tool_arguments",
+            "path": "/arguments/query",
+            "message": "missing required argument 'query'",
+            "retryable": true,
+            "service_id": "x-data",
+            "tool_name": "search_bookmarks"
+        })
+        .to_string();
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"x-data","tool_name":"search_bookmarks","arguments":{}}"#,
+            &result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::InvalidToolArguments)
+        );
+        assert_eq!(
+            analysis.schema_validation_result,
+            SchemaValidationResult::Failed
+        );
+        assert_eq!(analysis.validation_errors[0].path, "/arguments/query");
+        let error = analysis.tool_error.as_ref().expect("tool error");
+        assert_eq!(error.failure_class, ToolFailureClass::InvalidToolArguments);
+        assert_eq!(error.service_id.as_deref(), Some("x-data"));
+        assert_eq!(error.tool_name.as_deref(), Some("search_bookmarks"));
+        assert_eq!(error.path.as_deref(), Some("/arguments/query"));
+        assert_eq!(error.retryable, Some(true));
+    }
+
+    #[test]
+    fn classifies_legacy_mcp_missing_field_text_as_invalid_arguments() {
+        let result = "Toolset error: ToolCallError: ToolCallError: MCP call_tool: JsonRpcError { code: -32602, message: \"missing field `query`\" }";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"x-data","tool_name":"search_bookmarks","arguments":{}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::InvalidToolArguments)
+        );
+        assert_eq!(
+            analysis
+                .tool_error
+                .as_ref()
+                .and_then(|error| error.retryable),
+            Some(true)
         );
     }
 

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -420,11 +420,11 @@ fn classify_result_text(result: &str) -> Option<ToolFailureClass> {
     if looks_like_service_unavailable(&lower) {
         return Some(ToolFailureClass::ServiceUnavailable);
     }
-    if looks_like_service_schema_drift(&lower) {
-        return Some(ToolFailureClass::ServiceSchemaDrift);
-    }
     if looks_like_invalid_tool_arguments(&lower) {
         return Some(ToolFailureClass::InvalidToolArguments);
+    }
+    if looks_like_service_schema_drift(&lower) {
+        return Some(ToolFailureClass::ServiceSchemaDrift);
     }
     if looks_like_resource_not_found(&lower) {
         return Some(ToolFailureClass::ResourceNotFound);
@@ -697,6 +697,30 @@ mod tests {
         let analysis = analyze_tool_call(
             "call_tool",
             r#"{"service_id":"x-data","tool_name":"search_bookmarks","arguments":{}}"#,
+            result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::InvalidToolArguments)
+        );
+        assert_eq!(
+            analysis
+                .tool_error
+                .as_ref()
+                .and_then(|error| error.retryable),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn classifies_mcp_unknown_field_deserialize_error_as_invalid_arguments() {
+        let result = "Toolset error: ToolCallError: ToolCallError: MCP call_tool: call_tool: Mcp error: -32602: failed to deserialize parameters: unknown field `limit`, expected one of `repo_name`, `path_contains`, `top_n`";
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"coding-session-store","tool_name":"coding_overview","arguments":{"limit":2}}"#,
             result,
             "completed",
         );


### PR DESCRIPTION

## Summary
- add structured MCP argument/schema error envelopes at the call_tool boundary
- classify missing required MCP arguments as invalid_tool_arguments with path, retryability, service_id, and tool_name
- classify MCP schema/deserialization errors during trace export so tool_result_ok reflects argument failures instead of successful prose text

## Evidence
Validated against live Amy after deploying this branch:
- 70/70 read-only stress-soak requests completed
- 184 tool-call rows exported
- 10/10 sparse argument cases exported as invalid_tool_arguments
- 10/10 sparse argument cases recovered after the structured error
- 0 request failures
- 0 write-safety violations

## Tests
- cargo test -p defra-agent --lib
