### PR TITLE
Add structured describe_tool missing-tool errors

### DIFF
--- a/crates/defra-agent-cli/tests/cli_trace_export.rs
+++ b/crates/defra-agent-cli/tests/cli_trace_export.rs
@@ -52,7 +52,7 @@ async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() 
             .to_string()
     });
 
-    assert_eq!(records.len(), 3, "export output:\n{output}");
+    assert_eq!(records.len(), 4, "export output:\n{output}");
     let find_record = |tool_call_id: &str| {
         records
             .iter()
@@ -61,6 +61,7 @@ async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() 
     };
     let deadline = find_record("call-deadline");
     let failed = find_record("call-fail");
+    let missing_tool = find_record("call-missing-tool");
     let succeeded = find_record("call-success");
 
     assert_eq!(
@@ -118,6 +119,30 @@ async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() 
         Some("bash")
     );
     assert_eq!(failed.get("latency_ms").and_then(Value::as_i64), Some(1500));
+
+    assert_eq!(
+        missing_tool.get("tool_result_ok").and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        missing_tool
+            .get("tool_failure_class")
+            .and_then(Value::as_str),
+        Some("tool_not_found")
+    );
+    assert_eq!(
+        missing_tool
+            .get("tool_error")
+            .and_then(|value| value.get("available_tools")),
+        Some(&json!(["search_posts"]))
+    );
+    assert_eq!(
+        missing_tool
+            .get("tool_error")
+            .and_then(|value| value.get("requested_tool_name"))
+            .and_then(Value::as_str),
+        Some("search_post")
+    );
 
     assert_eq!(
         succeeded.get("tool_call_id").and_then(Value::as_str),
@@ -285,6 +310,11 @@ async fn seed_trace_export_rows(node: &EmbeddedNode) -> Result<()> {
         "bash",
         json!({"command":"grep","args":["-P","amy","README.md"]}),
     )?;
+    let missing_tool_message = assistant_tool_message(
+        "call-missing-tool",
+        "describe_tool",
+        json!({"service_id":"x-data","tool_name":"search_post"}),
+    )?;
     exec(
         node,
         &format!(
@@ -316,6 +346,23 @@ async fn seed_trace_export_rows(node: &EmbeddedNode) -> Result<()> {
                 }}) {{ _docID }}
             }}"#,
             escape_graphql_string(&failed_message)
+        ),
+    )
+    .await?;
+    exec(
+        node,
+        &format!(
+            r#"mutation {{
+                create_AgentMessage(input: {{
+                    message_key: "session-1:4",
+                    session_id: "session-1",
+                    sequence: 4,
+                    role: "assistant",
+                    content: "{}",
+                    timestamp: "2026-05-04T12:00:04Z"
+                }}) {{ _docID }}
+            }}"#,
+            escape_graphql_string(&missing_tool_message)
         ),
     )
     .await?;
@@ -353,6 +400,40 @@ async fn seed_trace_export_rows(node: &EmbeddedNode) -> Result<()> {
                 completed_at: "2026-05-04T12:00:04.500Z"
             }) { _docID }
         }"#,
+    )
+    .await?;
+
+    let missing_tool_result = json!({
+        "ok": false,
+        "failure_class": "tool_not_found",
+        "path": "/tool_name",
+        "message": "tool 'search_post' was not found on service 'x-data'; available tools: search_posts",
+        "retryable": true,
+        "service_id": "x-data",
+        "tool_name": "search_post",
+        "requested_tool_name": "search_post",
+        "available_tools": ["search_posts"]
+    })
+    .to_string();
+    exec(
+        node,
+        &format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "session-1:call-missing-tool",
+                    session_id: "session-1",
+                    message_sequence: 4,
+                    tool_name: "describe_tool",
+                    tool_call_id: "call-missing-tool",
+                    args: "{{\"service_id\":\"x-data\",\"tool_name\":\"search_post\"}}",
+                    result: "{}",
+                    status: "completed",
+                    started_at: "2026-05-04T12:00:04Z",
+                    completed_at: "2026-05-04T12:00:04.250Z"
+                }}) {{ _docID }}
+            }}"#,
+            escape_graphql_string(&missing_tool_result)
+        ),
     )
     .await?;
 

--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -3,13 +3,14 @@ use std::time::Duration;
 use anyhow::{anyhow, Context as _};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use serde_json::{Map, Value};
 
 use crate::health_checker::HealthStatus;
 
 use super::shared::{
     enforce_health_gate, extract_text, lookup_service, MetaToolContext, MetaToolError,
+    StructuredToolError,
 };
 
 #[derive(Debug, Deserialize)]
@@ -17,19 +18,6 @@ pub struct CallToolArgs {
     service_id: String,
     tool_name: String,
     arguments: serde_json::Value,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-struct StructuredToolError {
-    ok: bool,
-    failure_class: &'static str,
-    path: String,
-    message: String,
-    retryable: bool,
-    service_id: String,
-    tool_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    available_tools: Option<Vec<String>>,
 }
 
 #[derive(Clone)]
@@ -210,48 +198,6 @@ impl CallToolTool {
             tool.input_schema.as_ref(),
         )
         .err()
-    }
-}
-
-impl StructuredToolError {
-    fn invalid_tool_arguments(
-        service_id: &str,
-        tool_name: &str,
-        path: impl Into<String>,
-        message: impl Into<String>,
-    ) -> Self {
-        Self {
-            ok: false,
-            failure_class: "invalid_tool_arguments",
-            path: path.into(),
-            message: message.into(),
-            retryable: true,
-            service_id: service_id.to_string(),
-            tool_name: tool_name.to_string(),
-            available_tools: None,
-        }
-    }
-
-    fn tool_not_found(service_id: &str, tool_name: &str, available_tools: Vec<String>) -> Self {
-        Self {
-            ok: false,
-            failure_class: "tool_not_found",
-            path: "/tool_name".to_string(),
-            message: format!("tool '{tool_name}' was not found on service '{service_id}'"),
-            retryable: true,
-            service_id: service_id.to_string(),
-            tool_name: tool_name.to_string(),
-            available_tools: Some(available_tools),
-        }
-    }
-
-    fn to_result_text(&self) -> String {
-        serde_json::to_string_pretty(self).unwrap_or_else(|_| {
-            format!(
-                r#"{{"ok":false,"failure_class":"{}","path":"{}","message":"{}","retryable":true,"service_id":"{}","tool_name":"{}"}}"#,
-                self.failure_class, self.path, self.message, self.service_id, self.tool_name
-            )
-        })
     }
 }
 

--- a/crates/defra-agent/src/meta_tools/describe.rs
+++ b/crates/defra-agent/src/meta_tools/describe.rs
@@ -1,9 +1,11 @@
-use anyhow::{anyhow, Context as _};
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
+use rmcp::model::{ListToolsResult, Tool as McpTool};
 use serde::Deserialize;
 
-use super::shared::{enforce_health_gate, lookup_service, MetaToolContext, MetaToolError};
+use super::shared::{
+    enforce_health_gate, lookup_service, MetaToolContext, MetaToolError, StructuredToolError,
+};
 
 #[derive(Debug, Deserialize)]
 pub struct DescribeToolArgs {
@@ -53,44 +55,208 @@ impl Tool for DescribeToolTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        enforce_health_gate(&self.ctx.health, &args.service_id)
-            .await
-            .context("describe_tool")?;
+        if let Err(error) = enforce_health_gate(&self.ctx.health, &args.service_id).await {
+            return Ok(StructuredToolError::service_unavailable(
+                &args.service_id,
+                &args.tool_name,
+                format!(
+                    "service '{}' is currently unavailable: {error:#}",
+                    args.service_id
+                ),
+                true,
+            )
+            .to_result_text());
+        }
 
-        let endpoint = lookup_service(&self.ctx, &args.service_id)
-            .await
-            .context("describe_tool")?;
+        let endpoint = match lookup_service(&self.ctx, &args.service_id).await {
+            Ok(endpoint) => endpoint,
+            Err(error) => {
+                return Ok(StructuredToolError::service_unavailable(
+                    &args.service_id,
+                    &args.tool_name,
+                    format!(
+                        "service '{}' is not available for describe_tool: {error:#}",
+                        args.service_id
+                    ),
+                    false,
+                )
+                .to_result_text());
+            }
+        };
 
-        let list_result = self
+        let list_result = match self
             .ctx
             .mcp_pool
             .list_tools(&args.service_id, &endpoint)
             .await
-            .context("listing tools from MCP server")?;
-
-        let tool = list_result.tools.iter().find(|t| t.name == args.tool_name);
-
-        match tool {
-            Some(t) => {
-                let desc = t.description.as_deref().unwrap_or("(no description)");
-                let schema_json = serde_json::to_string_pretty(&t.input_schema).unwrap_or_default();
-
-                Ok(format!(
-                    "## {name}\n{desc}\n\nInput schema:\n```json\n{schema_json}\n```",
-                    name = t.name,
-                ))
-            }
-            None => {
-                let available: Vec<&str> =
-                    list_result.tools.iter().map(|t| t.name.as_ref()).collect();
-                Err(anyhow!(
-                    "tool '{}' not found on service '{}'. Available tools: {}",
-                    args.tool_name,
-                    args.service_id,
-                    available.join(", ")
+        {
+            Ok(result) => result,
+            Err(error) => {
+                return Ok(StructuredToolError::service_unavailable(
+                    &args.service_id,
+                    &args.tool_name,
+                    format!(
+                        "service '{}' could not list tools for describe_tool: {error:#}",
+                        args.service_id
+                    ),
+                    true,
                 )
-                .into())
+                .to_result_text());
             }
+        };
+
+        match describe_tool_result(&args.service_id, &args.tool_name, &list_result) {
+            Ok(result) => Ok(result),
+            Err(error) => Ok(error.to_result_text()),
         }
+    }
+}
+
+fn describe_tool_result(
+    service_id: &str,
+    requested_tool_name: &str,
+    list_result: &ListToolsResult,
+) -> Result<String, StructuredToolError> {
+    let tool = list_result
+        .tools
+        .iter()
+        .find(|tool| tool.name == requested_tool_name);
+
+    match tool {
+        Some(tool) => Ok(format_tool_description(tool)),
+        None => {
+            let available_tools = list_result
+                .tools
+                .iter()
+                .map(|tool| tool.name.to_string())
+                .collect::<Vec<_>>();
+            Err(StructuredToolError::describe_tool_not_found(
+                service_id,
+                requested_tool_name,
+                available_tools,
+            ))
+        }
+    }
+}
+
+fn format_tool_description(tool: &McpTool) -> String {
+    let desc = tool.description.as_deref().unwrap_or("(no description)");
+    let schema_json = serde_json::to_string_pretty(&tool.input_schema).unwrap_or_default();
+
+    format!(
+        "## {name}\n{desc}\n\nInput schema:\n```json\n{schema_json}\n```",
+        name = tool.name,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rmcp::model::{ListToolsResult, Tool as McpTool};
+    use serde_json::{json, Value};
+
+    use super::*;
+    use crate::health_checker::ServiceHealthMap;
+    use crate::mcp_pool::McpPool;
+
+    fn x_data_search_tool() -> McpTool {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["query"]
+        })
+        .as_object()
+        .expect("schema object")
+        .clone();
+
+        McpTool::new("search_posts", "Search x-data posts.", Arc::new(schema))
+    }
+
+    #[test]
+    fn missing_x_data_tool_returns_structured_envelope_with_available_tools() {
+        let list_result = ListToolsResult::with_all_items(vec![x_data_search_tool()]);
+        let error = describe_tool_result("x-data", "search_post", &list_result)
+            .expect_err("missing tool should return envelope");
+
+        assert_eq!(error.failure_class, "tool_not_found");
+        assert_eq!(error.path, "/tool_name");
+        assert!(error.retryable);
+        assert_eq!(error.service_id, "x-data");
+        assert_eq!(error.tool_name, "search_post");
+        assert_eq!(error.requested_tool_name.as_deref(), Some("search_post"));
+        assert_eq!(
+            error.available_tools,
+            Some(vec!["search_posts".to_string()])
+        );
+
+        let value: Value = serde_json::from_str(&error.to_result_text()).expect("structured json");
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["failure_class"], "tool_not_found");
+        assert_eq!(value["requested_tool_name"], "search_post");
+        assert_eq!(value["available_tools"], json!(["search_posts"]));
+        assert!(value["message"]
+            .as_str()
+            .expect("message")
+            .contains("available tools: search_posts"));
+    }
+
+    #[test]
+    fn successful_describe_tool_output_format_stays_unchanged() {
+        let expected_schema = json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["query"]
+        });
+        let list_result = ListToolsResult::with_all_items(vec![x_data_search_tool()]);
+        let output = describe_tool_result("x-data", "search_posts", &list_result)
+            .expect("known tool should describe");
+
+        assert!(
+            output.starts_with("## search_posts\nSearch x-data posts.\n\nInput schema:\n```json\n")
+        );
+        assert!(output.ends_with("\n```"));
+        let schema_text = output
+            .split("```json\n")
+            .nth(1)
+            .and_then(|text| text.strip_suffix("\n```"))
+            .expect("schema block");
+        let schema: Value = serde_json::from_str(schema_text).expect("schema json");
+        assert_eq!(schema, expected_schema);
+    }
+
+    #[tokio::test]
+    async fn missing_service_returns_structured_envelope() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        let tool = DescribeToolTool::new(MetaToolContext {
+            node,
+            mcp_pool: McpPool::new(),
+            health: ServiceHealthMap::new(),
+            local_hostname: "studio-1".to_string(),
+            local_subnet: None,
+        });
+
+        let output = tool
+            .call(DescribeToolArgs {
+                service_id: "missing-service".to_string(),
+                tool_name: "search_posts".to_string(),
+            })
+            .await
+            .expect("missing service should be model-readable");
+        let value: Value = serde_json::from_str(&output).expect("structured json");
+
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["failure_class"], "service_unavailable");
+        assert_eq!(value["retryable"], false);
+        assert_eq!(value["service_id"], "missing-service");
+        assert_eq!(value["requested_tool_name"], "search_posts");
+        assert_eq!(value["path"], "/service_id");
     }
 }

--- a/crates/defra-agent/src/meta_tools/shared.rs
+++ b/crates/defra-agent/src/meta_tools/shared.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context as _};
 use defra_node::EmbeddedNode;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::health_checker::{HealthStatus, ServiceHealth, ServiceHealthMap};
 use crate::mcp_pool::resolve_mcp_url;
@@ -35,6 +35,119 @@ impl std::error::Error for MetaToolError {
 impl From<anyhow::Error> for MetaToolError {
     fn from(error: anyhow::Error) -> Self {
         Self(error)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(super) struct StructuredToolError {
+    pub(super) ok: bool,
+    pub(super) failure_class: &'static str,
+    pub(super) path: String,
+    pub(super) message: String,
+    pub(super) retryable: bool,
+    pub(super) service_id: String,
+    pub(super) tool_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) requested_tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) available_tools: Option<Vec<String>>,
+}
+
+impl StructuredToolError {
+    pub(super) fn invalid_tool_arguments(
+        service_id: &str,
+        tool_name: &str,
+        path: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            ok: false,
+            failure_class: "invalid_tool_arguments",
+            path: path.into(),
+            message: message.into(),
+            retryable: true,
+            service_id: service_id.to_string(),
+            tool_name: tool_name.to_string(),
+            requested_tool_name: None,
+            available_tools: None,
+        }
+    }
+
+    pub(super) fn tool_not_found(
+        service_id: &str,
+        tool_name: &str,
+        available_tools: Vec<String>,
+    ) -> Self {
+        Self {
+            ok: false,
+            failure_class: "tool_not_found",
+            path: "/tool_name".to_string(),
+            message: format!("tool '{tool_name}' was not found on service '{service_id}'"),
+            retryable: true,
+            service_id: service_id.to_string(),
+            tool_name: tool_name.to_string(),
+            requested_tool_name: None,
+            available_tools: Some(available_tools),
+        }
+    }
+
+    pub(super) fn describe_tool_not_found(
+        service_id: &str,
+        requested_tool_name: &str,
+        available_tools: Vec<String>,
+    ) -> Self {
+        let alternatives = if available_tools.is_empty() {
+            "no tools are currently advertised".to_string()
+        } else {
+            format!("available tools: {}", available_tools.join(", "))
+        };
+
+        Self {
+            ok: false,
+            failure_class: "tool_not_found",
+            path: "/tool_name".to_string(),
+            message: format!(
+                "tool '{requested_tool_name}' was not found on service '{service_id}'; {alternatives}"
+            ),
+            retryable: true,
+            service_id: service_id.to_string(),
+            tool_name: requested_tool_name.to_string(),
+            requested_tool_name: Some(requested_tool_name.to_string()),
+            available_tools: Some(available_tools),
+        }
+    }
+
+    pub(super) fn service_unavailable(
+        service_id: &str,
+        requested_tool_name: &str,
+        message: impl Into<String>,
+        retryable: bool,
+    ) -> Self {
+        Self {
+            ok: false,
+            failure_class: "service_unavailable",
+            path: "/service_id".to_string(),
+            message: message.into(),
+            retryable,
+            service_id: service_id.to_string(),
+            tool_name: requested_tool_name.to_string(),
+            requested_tool_name: Some(requested_tool_name.to_string()),
+            available_tools: None,
+        }
+    }
+
+    pub(super) fn to_result_text(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_else(|_| {
+            format!(
+                r#"{{"ok":false,"failure_class":"{}","path":"{}","message":"{}","retryable":{},"service_id":"{}","tool_name":"{}"}}"#,
+                self.failure_class,
+                self.path,
+                self.message,
+                self.retryable,
+                self.service_id,
+                self.tool_name
+            )
+        })
     }
 }
 

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -64,10 +64,14 @@ pub struct TraceToolError {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_tool_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
     pub retryable: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_tools: Option<Vec<String>>,
     pub raw_error_text: String,
 }
 
@@ -154,6 +158,7 @@ pub fn analyze_tool_call(
                 failure_class,
                 service_id: analysis.selected_service_id.clone(),
                 tool_name: analysis.selected_tool_name.clone(),
+                requested_tool_name: None,
                 path: analysis
                     .validation_errors
                     .first()
@@ -163,6 +168,7 @@ pub fn analyze_tool_call(
                     .first()
                     .map(|error| error.message.clone()),
                 retryable: retryable_for_failure_class(failure_class),
+                available_tools: None,
                 raw_error_text: raw_tool_error_text(result, &analysis),
             })
     });
@@ -362,6 +368,15 @@ fn structured_tool_error_from_result(result: &str) -> Option<TraceToolError> {
         .and_then(Value::as_str)
         .and_then(failure_class_from_str)?;
     let retryable = object.get("retryable").and_then(Value::as_bool);
+    let requested_tool_name = object
+        .get("requested_tool_name")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned);
+    let tool_name = object
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| requested_tool_name.clone());
 
     Some(TraceToolError {
         failure_class,
@@ -369,10 +384,8 @@ fn structured_tool_error_from_result(result: &str) -> Option<TraceToolError> {
             .get("service_id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
-        tool_name: object
-            .get("tool_name")
-            .and_then(Value::as_str)
-            .map(ToOwned::to_owned),
+        tool_name,
+        requested_tool_name,
         path: object
             .get("path")
             .and_then(Value::as_str)
@@ -382,8 +395,20 @@ fn structured_tool_error_from_result(result: &str) -> Option<TraceToolError> {
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
         retryable,
+        available_tools: string_array_field(object, "available_tools"),
         raw_error_text: trimmed.to_string(),
     })
+}
+
+fn string_array_field(object: &serde_json::Map<String, Value>, field: &str) -> Option<Vec<String>> {
+    let values = object.get(field)?.as_array()?;
+    Some(
+        values
+            .iter()
+            .filter_map(Value::as_str)
+            .map(ToOwned::to_owned)
+            .collect(),
+    )
 }
 
 fn failure_class_from_str(raw: &str) -> Option<ToolFailureClass> {
@@ -689,6 +714,46 @@ mod tests {
         assert_eq!(error.tool_name.as_deref(), Some("search_bookmarks"));
         assert_eq!(error.path.as_deref(), Some("/arguments/query"));
         assert_eq!(error.retryable, Some(true));
+    }
+
+    #[test]
+    fn structured_describe_tool_missing_tool_preserves_available_tools() {
+        let result = json!({
+            "ok": false,
+            "failure_class": "tool_not_found",
+            "path": "/tool_name",
+            "message": "tool 'search_post' was not found on service 'x-data'; available tools: search_posts",
+            "retryable": true,
+            "service_id": "x-data",
+            "tool_name": "search_post",
+            "requested_tool_name": "search_post",
+            "available_tools": ["search_posts"]
+        })
+        .to_string();
+        let analysis = analyze_tool_call(
+            "describe_tool",
+            r#"{"service_id":"x-data","tool_name":"search_post"}"#,
+            &result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ToolNotFound)
+        );
+        assert_eq!(analysis.validation_errors[0].code, "tool_not_found");
+        assert_eq!(analysis.validation_errors[0].path, "/tool_name");
+        let error = analysis.tool_error.as_ref().expect("tool error");
+        assert_eq!(error.failure_class, ToolFailureClass::ToolNotFound);
+        assert_eq!(error.service_id.as_deref(), Some("x-data"));
+        assert_eq!(error.tool_name.as_deref(), Some("search_post"));
+        assert_eq!(error.requested_tool_name.as_deref(), Some("search_post"));
+        assert_eq!(error.retryable, Some(true));
+        assert_eq!(
+            error.available_tools,
+            Some(vec!["search_posts".to_string()])
+        );
     }
 
     #[test]


### PR DESCRIPTION

## Summary
- adds shared structured tool error envelopes for meta-tool failures
- returns structured `tool_not_found` envelopes from `describe_tool`, including `requested_tool_name` and `available_tools`
- adds low-risk structured service failure envelopes for `describe_tool`
- extends trace export to preserve structured missing-tool details without prose parsing

## Evidence
Validated against live Amy with a read-only missing-tool smoke run after deploying the candidate binary:
- 2/2 requests completed
- 6 tool rows exported
- 2 structured `tool_not_found` rows
- 0 request failures
- 0 write-safety violations
- Amy recovered correctly in the wrong service/tool pair case and used available alternatives in the no-call missing-tool case

## Tests
- cargo test -p defra-agent meta_tools::describe
- cargo test -p defra-agent trace_export
- cargo test -p defra-agent meta_tools::call
- cargo test -p defra-agent-cli trace_export_emits_amy_style_jsonl_and_classifies_completed_failures
- git diff --check

## Stack
Stacked on #111 / `codex/tool-calling-optimizations`.
