### PR TITLE
Render compact describe_tool contracts

### DIFF
--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -41,16 +41,17 @@ impl Tool for CallToolTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Invoke a tool on a data service via MCP. Use discover_tools to \
-                find available services and tools, then describe_tool to get the input \
-                schema, then call_tool with the correct arguments."
+            description: "Invoke a tool on an MCP data service. Use discover_tools to \
+                find available services and tools, then describe_tool to get the compact \
+                input contract, then call_tool with the exact argument object. Native direct \
+                tools such as file or bash tools are called directly, not through call_tool."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "service_id": {
                         "type": "string",
-                        "description": "The service_id of the data service."
+                        "description": "The service_id of the MCP data service; not a native tool namespace."
                     },
                     "tool_name": {
                         "type": "string",
@@ -58,7 +59,7 @@ impl Tool for CallToolTool {
                     },
                     "arguments": {
                         "type": "object",
-                        "description": "The arguments to pass to the tool (see describe_tool for schema)."
+                        "description": "The exact tool arguments object from describe_tool's contract. Required fields appear as /arguments/<field> paths."
                     }
                 },
                 "required": ["service_id", "tool_name", "arguments"]

--- a/crates/defra-agent/src/meta_tools/describe.rs
+++ b/crates/defra-agent/src/meta_tools/describe.rs
@@ -2,6 +2,8 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 use rmcp::model::{ListToolsResult, Tool as McpTool};
 use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::collections::HashSet;
 
 use super::shared::{
     enforce_health_gate, lookup_service, MetaToolContext, MetaToolError, StructuredToolError,
@@ -11,6 +13,8 @@ use super::shared::{
 pub struct DescribeToolArgs {
     service_id: String,
     tool_name: String,
+    #[serde(default)]
+    raw_schema: bool,
 }
 
 #[derive(Clone)]
@@ -34,19 +38,27 @@ impl Tool for DescribeToolTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Get the full input schema for a specific tool on a data service. \
-                Use this before call_tool to understand the required arguments."
+            description: "Get a compact input contract for a specific MCP tool on a data service. \
+                Use this before call_tool to understand required arguments, optional arguments, \
+                defaults, constraints, examples, and unknown-field behavior. This does not \
+                describe native direct tools such as file or bash tools; use their direct tool \
+                definitions instead. Set raw_schema=true only when you need the exact JSON Schema."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
                     "service_id": {
                         "type": "string",
-                        "description": "The service_id of the data service."
+                        "description": "The service_id of the MCP data service; not a native tool namespace."
                     },
                     "tool_name": {
                         "type": "string",
                         "description": "The name of the tool to describe."
+                    },
+                    "raw_schema": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When true, return the exact raw JSON Schema instead of the compact contract."
                     }
                 },
                 "required": ["service_id", "tool_name"]
@@ -105,7 +117,12 @@ impl Tool for DescribeToolTool {
             }
         };
 
-        match describe_tool_result(&args.service_id, &args.tool_name, &list_result) {
+        match describe_tool_result(
+            &args.service_id,
+            &args.tool_name,
+            args.raw_schema,
+            &list_result,
+        ) {
             Ok(result) => Ok(result),
             Err(error) => Ok(error.to_result_text()),
         }
@@ -115,6 +132,7 @@ impl Tool for DescribeToolTool {
 fn describe_tool_result(
     service_id: &str,
     requested_tool_name: &str,
+    raw_schema: bool,
     list_result: &ListToolsResult,
 ) -> Result<String, StructuredToolError> {
     let tool = list_result
@@ -123,7 +141,7 @@ fn describe_tool_result(
         .find(|tool| tool.name == requested_tool_name);
 
     match tool {
-        Some(tool) => Ok(format_tool_description(tool)),
+        Some(tool) => Ok(format_tool_description(service_id, tool, raw_schema)),
         None => {
             let available_tools = list_result
                 .tools
@@ -139,14 +157,549 @@ fn describe_tool_result(
     }
 }
 
-fn format_tool_description(tool: &McpTool) -> String {
+fn format_tool_description(service_id: &str, tool: &McpTool, raw_schema: bool) -> String {
     let desc = tool.description.as_deref().unwrap_or("(no description)");
-    let schema_json = serde_json::to_string_pretty(&tool.input_schema).unwrap_or_default();
+    let schema_json = serde_json::to_string_pretty(tool.input_schema.as_ref()).unwrap_or_default();
 
-    format!(
-        "## {name}\n{desc}\n\nInput schema:\n```json\n{schema_json}\n```",
-        name = tool.name,
-    )
+    if raw_schema {
+        return format!(
+            "## {name}\n{desc}\n\nRaw input schema:\n```json\n{schema_json}\n```",
+            name = tool.name,
+        );
+    }
+
+    format_tool_contract(service_id, tool, desc, &schema_json)
+}
+
+fn format_tool_contract(service_id: &str, tool: &McpTool, desc: &str, schema_json: &str) -> String {
+    let schema = tool.input_schema.as_ref();
+    let fields = collect_argument_fields(schema);
+    let top_level_fields = fields
+        .iter()
+        .filter(|field| field.depth == 0)
+        .collect::<Vec<_>>();
+    let nested_fields = fields
+        .iter()
+        .filter(|field| field.depth > 0)
+        .collect::<Vec<_>>();
+    let required_fields = top_level_fields
+        .iter()
+        .filter(|field| field.required)
+        .copied()
+        .collect::<Vec<_>>();
+    let optional_fields = top_level_fields
+        .iter()
+        .filter(|field| !field.required)
+        .copied()
+        .collect::<Vec<_>>();
+
+    let mut out = String::new();
+    out.push_str(&format!("## {}\n", tool.name));
+    out.push_str(&format!("Purpose: {}\n\n", compact_text(desc, 360)));
+    out.push_str("Input contract:\n");
+    out.push_str("- Argument object: `/arguments`\n");
+    out.push_str(&format!(
+        "- Unknown top-level fields: {}\n",
+        additional_properties_behavior(schema)
+    ));
+    out.push_str("- Raw schema: call `describe_tool` with `raw_schema: true`.\n\n");
+
+    if top_level_fields.is_empty() {
+        out.push_str("Arguments: no named object fields are advertised by this schema.\n\n");
+    } else {
+        push_field_section(&mut out, "Required arguments", &required_fields, false);
+        push_field_section(&mut out, "Optional arguments", &optional_fields, false);
+    }
+
+    if !nested_fields.is_empty() {
+        push_field_section(&mut out, "Nested fields", &nested_fields, true);
+    }
+
+    if let Some(example) = example_arguments(schema) {
+        out.push_str("Example `call_tool.arguments`:\n```json\n");
+        out.push_str(&example);
+        out.push_str("\n```\n\n");
+    }
+
+    let mistakes = common_mistakes(service_id, tool, schema, &fields);
+    if !mistakes.is_empty() {
+        out.push_str("Common mistakes:\n");
+        for mistake in mistakes {
+            out.push_str(&format!("- {mistake}\n"));
+        }
+        out.push('\n');
+    }
+
+    let safety_notes = safety_notes(tool);
+    if !safety_notes.is_empty() {
+        out.push_str("Safety notes:\n");
+        for note in safety_notes {
+            out.push_str(&format!("- {note}\n"));
+        }
+        out.push('\n');
+    }
+
+    let compact_len = out.len();
+    out.push_str(&format!(
+        "Size: compact contract is {} chars; raw schema is {} chars.\n",
+        compact_len,
+        schema_json.len()
+    ));
+
+    out
+}
+
+#[derive(Debug, Clone)]
+struct ArgumentField {
+    path: String,
+    depth: usize,
+    required: bool,
+    type_summary: String,
+    details: Vec<String>,
+    description: Option<String>,
+}
+
+fn collect_argument_fields(schema: &Map<String, Value>) -> Vec<ArgumentField> {
+    let mut fields = Vec::new();
+    collect_object_fields(schema, "/arguments", 0, &mut fields);
+    fields
+}
+
+fn collect_object_fields(
+    schema: &Map<String, Value>,
+    base_path: &str,
+    depth: usize,
+    fields: &mut Vec<ArgumentField>,
+) {
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return;
+    };
+    let required_names = required_names(schema);
+
+    for (name, field_schema) in properties {
+        let path = format!("{base_path}/{}", json_pointer_segment(name));
+        let required = required_names.contains(name.as_str());
+        fields.push(argument_field(&path, depth, required, field_schema));
+        collect_nested_fields(field_schema, &path, depth + 1, fields);
+    }
+}
+
+fn collect_nested_fields(
+    schema: &Value,
+    path: &str,
+    depth: usize,
+    fields: &mut Vec<ArgumentField>,
+) {
+    if let Some(object_schema) = schema.as_object() {
+        collect_object_fields(object_schema, path, depth, fields);
+        if let Some(items) = object_schema.get("items") {
+            collect_array_item_fields(items, path, depth, fields);
+        }
+    }
+}
+
+fn collect_array_item_fields(
+    items: &Value,
+    path: &str,
+    depth: usize,
+    fields: &mut Vec<ArgumentField>,
+) {
+    let item_path = format!("{path}[]");
+    if let Some(item_schema) = items.as_object() {
+        if item_schema.get("properties").is_some() {
+            collect_object_fields(item_schema, &item_path, depth, fields);
+        } else if let Some(nested_items) = item_schema.get("items") {
+            collect_array_item_fields(nested_items, &item_path, depth, fields);
+        }
+    }
+}
+
+fn argument_field(path: &str, depth: usize, required: bool, schema: &Value) -> ArgumentField {
+    let schema_object = schema.as_object();
+    let mut details = Vec::new();
+
+    if let Some(object) = schema_object {
+        push_known_constraint(&mut details, object, "default");
+        push_known_constraint(&mut details, object, "const");
+        push_enum_constraint(&mut details, object);
+        push_known_constraint(&mut details, object, "format");
+        push_known_constraint(&mut details, object, "pattern");
+        push_known_constraint(&mut details, object, "minimum");
+        push_known_constraint(&mut details, object, "maximum");
+        push_known_constraint(&mut details, object, "exclusiveMinimum");
+        push_known_constraint(&mut details, object, "exclusiveMaximum");
+        push_known_constraint(&mut details, object, "minLength");
+        push_known_constraint(&mut details, object, "maxLength");
+        push_known_constraint(&mut details, object, "minItems");
+        push_known_constraint(&mut details, object, "maxItems");
+        push_known_constraint(&mut details, object, "uniqueItems");
+        push_examples(&mut details, object);
+        if is_object_like(object) {
+            details.push(format!(
+                "unknown nested fields: {}",
+                additional_properties_behavior(object)
+            ));
+        }
+    }
+
+    ArgumentField {
+        path: path.to_string(),
+        depth,
+        required,
+        type_summary: type_summary(schema),
+        details,
+        description: schema_description(schema),
+    }
+}
+
+fn push_field_section(out: &mut String, heading: &str, fields: &[&ArgumentField], nested: bool) {
+    out.push_str(&format!("{heading}:\n"));
+    if fields.is_empty() {
+        out.push_str("- none\n\n");
+        return;
+    }
+
+    for field in fields {
+        let mut annotations = vec![field.type_summary.clone()];
+        if nested {
+            annotations.push(if field.required {
+                "required".to_string()
+            } else {
+                "optional".to_string()
+            });
+        }
+        annotations.extend(field.details.iter().cloned());
+        let suffix = field
+            .description
+            .as_deref()
+            .map(|description| format!(" - {}", compact_text(description, 180)))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "- `{}` ({}){}\n",
+            field.path,
+            annotations.join("; "),
+            suffix
+        ));
+    }
+    out.push('\n');
+}
+
+fn required_names(schema: &Map<String, Value>) -> HashSet<&str> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| values.iter().filter_map(Value::as_str).collect())
+        .unwrap_or_default()
+}
+
+fn type_summary(schema: &Value) -> String {
+    let Some(object) = schema.as_object() else {
+        return "any".to_string();
+    };
+
+    if let Some(reference) = object.get("$ref").and_then(Value::as_str) {
+        return format!("ref {reference}");
+    }
+
+    if let Some(types) = object.get("type") {
+        match types {
+            Value::String(kind) => return type_summary_for_kind(kind, object),
+            Value::Array(kinds) => {
+                let rendered = kinds
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(|kind| type_summary_for_kind(kind, object))
+                    .collect::<Vec<_>>();
+                if !rendered.is_empty() {
+                    return rendered.join(" or ");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if object.get("properties").is_some() {
+        return "object".to_string();
+    }
+    if object.get("items").is_some() {
+        return type_summary_for_kind("array", object);
+    }
+    if let Some(options) = object.get("oneOf").and_then(Value::as_array) {
+        return options_summary("one of", options);
+    }
+    if let Some(options) = object.get("anyOf").and_then(Value::as_array) {
+        return options_summary("any of", options);
+    }
+    if object.get("enum").is_some() {
+        return "enum".to_string();
+    }
+
+    "any".to_string()
+}
+
+fn type_summary_for_kind(kind: &str, schema: &Map<String, Value>) -> String {
+    if kind == "array" {
+        let item_type = schema
+            .get("items")
+            .map(type_summary)
+            .unwrap_or_else(|| "any".to_string());
+        return format!("array<{item_type}>");
+    }
+    kind.to_string()
+}
+
+fn options_summary(label: &str, options: &[Value]) -> String {
+    let rendered = options.iter().map(type_summary).collect::<Vec<_>>();
+    if rendered.is_empty() {
+        label.to_string()
+    } else {
+        format!("{label}: {}", rendered.join(" | "))
+    }
+}
+
+fn schema_description(schema: &Value) -> Option<String> {
+    schema
+        .as_object()
+        .and_then(|object| object.get("description"))
+        .and_then(Value::as_str)
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn additional_properties_behavior(schema: &Map<String, Value>) -> String {
+    match schema.get("additionalProperties") {
+        Some(Value::Bool(false)) => "rejected (`additionalProperties: false`)".to_string(),
+        Some(Value::Bool(true)) => "allowed (`additionalProperties: true`)".to_string(),
+        Some(Value::Object(_)) => "allowed if they match the nested schema".to_string(),
+        Some(_) => "specified by schema but not a simple boolean".to_string(),
+        None => "not specified by schema".to_string(),
+    }
+}
+
+fn is_object_like(schema: &Map<String, Value>) -> bool {
+    schema
+        .get("type")
+        .and_then(Value::as_str)
+        .map(|kind| kind == "object")
+        .unwrap_or_else(|| schema.get("properties").is_some())
+}
+
+fn push_known_constraint(details: &mut Vec<String>, schema: &Map<String, Value>, key: &str) {
+    if let Some(value) = schema.get(key) {
+        details.push(format!("{key}: {}", compact_json(value)));
+    }
+}
+
+fn push_enum_constraint(details: &mut Vec<String>, schema: &Map<String, Value>) {
+    let Some(values) = schema.get("enum").and_then(Value::as_array) else {
+        return;
+    };
+    let mut rendered = values.iter().take(6).map(compact_json).collect::<Vec<_>>();
+    if values.len() > rendered.len() {
+        rendered.push(format!("... {} more", values.len() - rendered.len()));
+    }
+    details.push(format!("enum: {}", rendered.join(", ")));
+}
+
+fn push_examples(details: &mut Vec<String>, schema: &Map<String, Value>) {
+    if let Some(example) = schema.get("example") {
+        details.push(format!("example: {}", compact_json(example)));
+        return;
+    }
+    let Some(examples) = schema.get("examples").and_then(Value::as_array) else {
+        return;
+    };
+    let rendered = examples
+        .iter()
+        .take(2)
+        .map(compact_json)
+        .collect::<Vec<_>>();
+    if !rendered.is_empty() {
+        details.push(format!("examples: {}", rendered.join(", ")));
+    }
+}
+
+fn example_arguments(schema: &Map<String, Value>) -> Option<String> {
+    let value = example_for_object(schema, true);
+    serde_json::to_string_pretty(&value).ok()
+}
+
+fn example_for_object(schema: &Map<String, Value>, required_only: bool) -> Value {
+    let mut object = Map::new();
+    let required = required_names(schema);
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return Value::Object(object);
+    };
+
+    for (name, field_schema) in properties {
+        let field_is_required = required.contains(name.as_str());
+        let include = field_is_required
+            || (!required_only
+                && field_schema
+                    .as_object()
+                    .and_then(|field| field.get("default"))
+                    .is_some());
+        if include {
+            object.insert(name.clone(), example_for_schema(field_schema));
+        }
+    }
+
+    Value::Object(object)
+}
+
+fn example_for_schema(schema: &Value) -> Value {
+    let Some(object) = schema.as_object() else {
+        return Value::Null;
+    };
+    if let Some(value) = object.get("default") {
+        return value.clone();
+    }
+    if let Some(value) = object.get("const") {
+        return value.clone();
+    }
+    if let Some(value) = object
+        .get("examples")
+        .and_then(Value::as_array)
+        .and_then(|values| values.first())
+    {
+        return value.clone();
+    }
+    if let Some(value) = object.get("example") {
+        return value.clone();
+    }
+    if let Some(value) = object
+        .get("enum")
+        .and_then(Value::as_array)
+        .and_then(|values| values.first())
+    {
+        return value.clone();
+    }
+
+    match type_summary(schema).as_str() {
+        "boolean" => Value::Bool(true),
+        "integer" => Value::from(1),
+        "number" => Value::from(1.0),
+        "object" => example_for_object(object, true),
+        kind if kind.starts_with("array<") => {
+            let min_items = object.get("minItems").and_then(Value::as_u64).unwrap_or(0);
+            if min_items == 0 {
+                Value::Array(Vec::new())
+            } else {
+                Value::Array(vec![object
+                    .get("items")
+                    .map(example_for_schema)
+                    .unwrap_or(Value::Null)])
+            }
+        }
+        _ => Value::String("string".to_string()),
+    }
+}
+
+fn common_mistakes(
+    service_id: &str,
+    tool: &McpTool,
+    schema: &Map<String, Value>,
+    fields: &[ArgumentField],
+) -> Vec<String> {
+    let mut mistakes = vec![
+        "Put these fields inside `call_tool.arguments`; do not pass them beside `service_id` or `tool_name`.".to_string(),
+        "Use the exact field names and JSON types shown above.".to_string(),
+    ];
+
+    if schema.get("additionalProperties").and_then(Value::as_bool) == Some(false) {
+        mistakes.push(
+            "Do not add unlisted top-level fields; this schema rejects unknown arguments."
+                .to_string(),
+        );
+    }
+    if fields
+        .iter()
+        .any(|field| field.type_summary.starts_with("array<"))
+    {
+        mistakes.push(
+            "Use JSON arrays for array fields; do not pass comma-separated strings.".to_string(),
+        );
+    }
+    if service_id.contains("coding-session-store")
+        || tool.name.as_ref().contains("coding_")
+        || tool.name.as_ref().contains("coding")
+    {
+        mistakes.push(
+            "For coding-session-store tools, do not invent generic fields like `limit`; use `top_n`, `repo_name`, or `path_contains` only when listed."
+                .to_string(),
+        );
+    }
+    if service_id.contains("x-data")
+        || tool.name.as_ref().contains("search")
+        || tool.name.as_ref().contains("x_")
+    {
+        mistakes.push(
+            "For search tools, put the search text in `query` only when that field is listed; keep result limits within the documented constraints."
+                .to_string(),
+        );
+    }
+
+    mistakes
+}
+
+fn safety_notes(tool: &McpTool) -> Vec<String> {
+    let name = tool.name.as_ref().to_lowercase();
+    let description = tool.description.as_deref().unwrap_or("").to_lowercase();
+    let combined = format!("{name} {description}");
+
+    if combined.contains("service_status") || combined.contains("status") {
+        return vec![
+            "Observability/status-style tool; use it to check availability before depending on a service."
+                .to_string(),
+        ];
+    }
+
+    if [
+        "write", "delete", "remove", "update", "create", "insert", "patch", "save", "upload",
+        "execute", "run",
+    ]
+    .iter()
+    .any(|needle| combined.contains(needle))
+    {
+        return vec![
+            "This appears write-capable or execution-capable; verify target identifiers and payloads before calling."
+                .to_string(),
+        ];
+    }
+
+    if ["search", "list", "read", "overview", "lookup", "get"]
+        .iter()
+        .any(|needle| combined.contains(needle))
+    {
+        return vec![
+            "This appears read-only/lookup-style; inspect returned data before using it for follow-up writes."
+                .to_string(),
+        ];
+    }
+
+    Vec::new()
+}
+
+fn json_pointer_segment(value: &str) -> String {
+    value.replace('~', "~0").replace('/', "~1")
+}
+
+fn compact_json(value: &Value) -> String {
+    let rendered = serde_json::to_string(value).unwrap_or_else(|_| "<unrenderable>".to_string());
+    compact_text(&rendered, 120)
+}
+
+fn compact_text(value: &str, max_chars: usize) -> String {
+    let compact = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    if compact.chars().count() <= max_chars {
+        return compact;
+    }
+    let mut truncated = compact
+        .chars()
+        .take(max_chars.saturating_sub(3))
+        .collect::<String>();
+    truncated.push_str("...");
+    truncated
 }
 
 #[cfg(test)]
@@ -163,9 +716,20 @@ mod tests {
     fn x_data_search_tool() -> McpTool {
         let schema = json!({
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "query": { "type": "string" },
-                "limit": { "type": "integer" }
+                "query": {
+                    "type": "string",
+                    "description": "Search text.",
+                    "examples": ["defra"]
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum results to return.",
+                    "default": 10,
+                    "minimum": 1,
+                    "maximum": 100
+                }
             },
             "required": ["query"]
         })
@@ -179,7 +743,7 @@ mod tests {
     #[test]
     fn missing_x_data_tool_returns_structured_envelope_with_available_tools() {
         let list_result = ListToolsResult::with_all_items(vec![x_data_search_tool()]);
-        let error = describe_tool_result("x-data", "search_post", &list_result)
+        let error = describe_tool_result("x-data", "search_post", false, &list_result)
             .expect_err("missing tool should return envelope");
 
         assert_eq!(error.failure_class, "tool_not_found");
@@ -205,22 +769,51 @@ mod tests {
     }
 
     #[test]
-    fn successful_describe_tool_output_format_stays_unchanged() {
+    fn default_describe_tool_output_is_compact_contract() {
+        let list_result = ListToolsResult::with_all_items(vec![x_data_search_tool()]);
+        let output = describe_tool_result("x-data", "search_posts", false, &list_result)
+            .expect("known tool should describe");
+
+        assert!(output.starts_with("## search_posts\nPurpose: Search x-data posts."));
+        assert!(output.contains("Input contract:"));
+        assert!(output.contains("Required arguments:\n- `/arguments/query` (string; examples: \"defra\") - Search text."));
+        assert!(output.contains("Optional arguments:\n- `/arguments/limit` (integer; default: 10; minimum: 1; maximum: 100) - Maximum results to return."));
+        assert!(
+            output.contains("Unknown top-level fields: rejected (`additionalProperties: false`)")
+        );
+        assert!(output.contains("Raw schema: call `describe_tool` with `raw_schema: true`."));
+        assert!(output.contains("Example `call_tool.arguments`:"));
+        assert!(output.contains("\"query\": \"defra\""));
+        assert!(!output.contains("Input schema:\n```json"));
+    }
+
+    #[test]
+    fn raw_schema_can_still_be_requested() {
         let expected_schema = json!({
             "type": "object",
+            "additionalProperties": false,
             "properties": {
-                "query": { "type": "string" },
-                "limit": { "type": "integer" }
+                "query": {
+                    "type": "string",
+                    "description": "Search text.",
+                    "examples": ["defra"]
+                },
+                "limit": {
+                    "type": "integer",
+                    "description": "Maximum results to return.",
+                    "default": 10,
+                    "minimum": 1,
+                    "maximum": 100
+                }
             },
             "required": ["query"]
         });
         let list_result = ListToolsResult::with_all_items(vec![x_data_search_tool()]);
-        let output = describe_tool_result("x-data", "search_posts", &list_result)
-            .expect("known tool should describe");
+        let output = describe_tool_result("x-data", "search_posts", true, &list_result)
+            .expect("known tool should describe raw schema");
 
-        assert!(
-            output.starts_with("## search_posts\nSearch x-data posts.\n\nInput schema:\n```json\n")
-        );
+        assert!(output
+            .starts_with("## search_posts\nSearch x-data posts.\n\nRaw input schema:\n```json\n"));
         assert!(output.ends_with("\n```"));
         let schema_text = output
             .split("```json\n")
@@ -229,6 +822,112 @@ mod tests {
             .expect("schema block");
         let schema: Value = serde_json::from_str(schema_text).expect("schema json");
         assert_eq!(schema, expected_schema);
+    }
+
+    #[test]
+    fn nested_object_and_array_fields_render_compact_paths() {
+        let schema = json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" },
+                "filter": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "repo_name": { "type": "string" },
+                        "states": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["open", "closed"]
+                            }
+                        }
+                    },
+                    "required": ["repo_name"]
+                },
+                "sort": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "field": { "type": "string" },
+                            "direction": {
+                                "type": "string",
+                                "enum": ["asc", "desc"]
+                            }
+                        },
+                        "required": ["field"]
+                    }
+                }
+            },
+            "required": ["query", "filter"]
+        })
+        .as_object()
+        .expect("schema object")
+        .clone();
+        let tool = McpTool::new(
+            "search_coding_notes",
+            "Search coding notes.",
+            Arc::new(schema),
+        );
+        let list_result = ListToolsResult::with_all_items(vec![tool]);
+
+        let output = describe_tool_result(
+            "coding-session-store",
+            "search_coding_notes",
+            false,
+            &list_result,
+        )
+        .expect("known tool should describe");
+
+        assert!(output.contains("- `/arguments/query` (string)"));
+        assert!(output.contains("- `/arguments/filter` (object; unknown nested fields: rejected (`additionalProperties: false`))"));
+        assert!(output.contains("- `/arguments/filter/repo_name` (string; required)"));
+        assert!(output.contains("- `/arguments/filter/states` (array<string>; optional)"));
+        assert!(output.contains("- `/arguments/sort[]/field` (string; required)"));
+        assert!(output.contains(
+            "- `/arguments/sort[]/direction` (string; optional; enum: \"asc\", \"desc\")"
+        ));
+        assert!(output.contains("do not invent generic fields like `limit`"));
+    }
+
+    #[test]
+    fn compact_contract_is_smaller_than_representative_raw_schema() {
+        let properties = (0..40)
+            .map(|i| {
+                (
+                    format!("optional_field_{i}"),
+                    json!({
+                        "type": "string",
+                        "description": format!("Optional tuning field {i} with a deliberately verbose description that would be expensive in raw JSON Schema."),
+                        "default": format!("value-{i}")
+                    }),
+                )
+            })
+            .chain(std::iter::once((
+                "query".to_string(),
+                json!({
+                    "type": "string",
+                    "description": "Search text.",
+                    "examples": ["defra agent schema navigation"]
+                }),
+            )))
+            .collect::<Map<String, Value>>();
+        let mut schema = Map::new();
+        schema.insert("type".to_string(), json!("object"));
+        schema.insert("additionalProperties".to_string(), json!(false));
+        schema.insert("properties".to_string(), Value::Object(properties));
+        schema.insert("required".to_string(), json!(["query"]));
+        let raw_schema = serde_json::to_string_pretty(&schema).expect("raw schema");
+        let tool = McpTool::new("search_posts", "Search x-data posts.", Arc::new(schema));
+        let contract = format_tool_description("x-data", &tool, false);
+
+        assert!(
+            contract.len() < raw_schema.len(),
+            "compact contract should be smaller than raw schema: contract={}, raw={}",
+            contract.len(),
+            raw_schema.len()
+        );
     }
 
     #[tokio::test]
@@ -247,6 +946,7 @@ mod tests {
             .call(DescribeToolArgs {
                 service_id: "missing-service".to_string(),
                 tool_name: "search_posts".to_string(),
+                raw_schema: false,
             })
             .await
             .expect("missing service should be model-readable");

--- a/crates/defra-agent/src/meta_tools/discover.rs
+++ b/crates/defra-agent/src/meta_tools/discover.rs
@@ -34,10 +34,13 @@ impl Tool for DiscoverToolsTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Browse or search available data service tools. Returns a compact \
+            description: "Browse or search available MCP data service tools. Returns a compact \
                 index of services and their tools (name + one-line description). Call with \
                 no query to list all services, or provide a search query to filter. Use \
-                describe_tool to get full input schema before calling a tool."
+                describe_tool to get the compact required/optional argument contract before \
+                calling a tool; request raw_schema only when exact JSON Schema is needed. \
+                Native direct tools such as file or bash tools are not data services and are \
+                described by their own tool definitions."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -198,6 +201,9 @@ impl Tool for DiscoverToolsTool {
             for (tn, td) in &tool_names {
                 out.push_str(&format!("  - {tn}: {td}\n"));
             }
+            out.push_str(
+                "Next: call describe_tool with this service_id and a tool_name before call_tool.\n",
+            );
             out.push('\n');
         }
 

--- a/crates/defra-agent/src/prompt.rs
+++ b/crates/defra-agent/src/prompt.rs
@@ -36,16 +36,21 @@ const TITLE_GENERATION_SUFFIX: &str =
 const TOOL_DISCOVERY_GUIDANCE: &str = "\
 ## Tool Discovery
 
-You have access to data service tools via three meta-tools:
+You have access to MCP data service tools via three meta-tools. These meta-tools \
+are only for MCP data services; native direct tools such as file and bash tools \
+are already present in your direct tool list and should not be described or \
+called through a synthetic `native` service.
 
 1. **discover_tools** — Browse or search available data services. Call with no \
 arguments to see all services, or provide a query to filter. Returns service \
 names, descriptions, and tool listings.
 
-2. **describe_tool** — Get the full input schema for a specific tool. Call this \
-before using call_tool so you know the required arguments.
+2. **describe_tool** — Get a compact contract for a specific MCP data-service tool. Call this \
+before using call_tool so you know required arguments, optional arguments, \
+defaults, constraints, examples, and unknown-field behavior. Set raw_schema=true \
+only when you need the exact JSON Schema.
 
-3. **call_tool** — Invoke a tool on a data service. Pass the service_id, \
+3. **call_tool** — Invoke a tool on an MCP data service. Pass the service_id, \
 tool_name, and arguments object.
 
 Workflow: discover_tools -> describe_tool -> call_tool

--- a/crates/defra-agent/src/prompt/tests.rs
+++ b/crates/defra-agent/src/prompt/tests.rs
@@ -43,6 +43,8 @@ fn preamble_combines_prompt_and_behavior_name() {
     assert!(preamble.contains("discover_tools"));
     assert!(preamble.contains("describe_tool"));
     assert!(preamble.contains("call_tool"));
+    assert!(preamble.contains("native direct tools"));
+    assert!(preamble.contains("synthetic `native` service"));
     assert!(preamble.contains("list_files"));
 }
 

--- a/crates/defra-agent/src/toolset/bash_tools.rs
+++ b/crates/defra-agent/src/toolset/bash_tools.rs
@@ -57,10 +57,28 @@ impl Tool for ReadOnlyBashTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "command": { "type": "string" },
-                    "args": { "type": "array", "items": { "type": "string" } },
-                    "cwd": { "type": "string" },
-                    "timeout_secs": { "type": "integer" }
+                    "command": {
+                        "type": "string",
+                        "description": "Executable name or path from the read-only command allowlist."
+                    },
+                    "args": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "default": [],
+                        "description": "Exec-style arguments. Do not include the executable name here."
+                    },
+                    "cwd": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Working directory under the allowed root. Omit for the root."
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "default": self.default_timeout.as_secs(),
+                        "minimum": 1,
+                        "maximum": self.default_timeout.as_secs(),
+                        "description": "Timeout in seconds; higher values are capped by the tool."
+                    }
                 },
                 "required": ["command"]
             }),
@@ -103,10 +121,21 @@ impl Tool for UnrestrictedBashTool {
                     "args": {
                         "type": "array",
                         "items": { "type": "string" },
+                        "default": [],
                         "description": "Arguments for exec-style invocation. Leave empty to run command through /bin/sh -lc."
                     },
-                    "cwd": { "type": "string" },
-                    "timeout_secs": { "type": "integer" }
+                    "cwd": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Working directory under the configured writable root. Omit for the root."
+                    },
+                    "timeout_secs": {
+                        "type": "integer",
+                        "default": self.default_timeout.as_secs(),
+                        "minimum": 1,
+                        "maximum": self.default_timeout.as_secs(),
+                        "description": "Timeout in seconds; higher values are capped by the tool."
+                    }
                 },
                 "required": ["command"]
             }),

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -117,9 +117,23 @@ impl Tool for ListFilesTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string" },
-                    "recursive": { "type": "boolean" },
-                    "max_entries": { "type": "integer" }
+                    "path": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Directory to list, relative to the allowed root. Omit or pass an empty string for the root."
+                    },
+                    "recursive": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When true, walk subdirectories while still skipping common generated directories."
+                    },
+                    "max_entries": {
+                        "type": "integer",
+                        "default": self.default_max_entries,
+                        "minimum": 1,
+                        "maximum": self.default_max_entries,
+                        "description": "Maximum entries to return; higher values are capped by the tool."
+                    }
                 }
             }),
         }
@@ -163,10 +177,28 @@ impl Tool for ReadFileTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string" },
-                    "start_line": { "type": "integer" },
-                    "end_line": { "type": "integer" },
-                    "max_chars": { "type": "integer" }
+                    "path": {
+                        "type": "string",
+                        "description": "File to read, relative to the allowed root unless an allowed absolute path is provided."
+                    },
+                    "start_line": {
+                        "type": "integer",
+                        "default": 1,
+                        "minimum": 1,
+                        "description": "First 1-based line to return."
+                    },
+                    "end_line": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "description": "Last 1-based line to return. Omit to read through the file end."
+                    },
+                    "max_chars": {
+                        "type": "integer",
+                        "default": self.default_max_chars,
+                        "minimum": 1,
+                        "maximum": self.default_max_chars,
+                        "description": "Maximum characters to return; higher values are capped by the tool."
+                    }
                 },
                 "required": ["path"]
             }),
@@ -206,9 +238,22 @@ impl Tool for GlobTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "pattern": { "type": "string" },
-                    "path": { "type": "string" },
-                    "max_matches": { "type": "integer" }
+                    "pattern": {
+                        "type": "string",
+                        "description": "Glob pattern matched against paths displayed relative to the allowed root."
+                    },
+                    "path": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Directory to search, relative to the allowed root. Omit or pass an empty string for the root."
+                    },
+                    "max_matches": {
+                        "type": "integer",
+                        "default": self.default_max_matches,
+                        "minimum": 1,
+                        "maximum": self.default_max_matches,
+                        "description": "Maximum matching paths to return; higher values are capped by the tool."
+                    }
                 },
                 "required": ["pattern"]
             }),
@@ -251,10 +296,27 @@ impl Tool for GrepTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "pattern": { "type": "string" },
-                    "path": { "type": "string" },
-                    "case_sensitive": { "type": "boolean" },
-                    "max_matches": { "type": "integer" }
+                    "pattern": {
+                        "type": "string",
+                        "description": "Literal substring to search for in UTF-8 text files."
+                    },
+                    "path": {
+                        "type": "string",
+                        "default": ".",
+                        "description": "Directory to search, relative to the allowed root. Omit or pass an empty string for the root."
+                    },
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When false, match case-insensitively."
+                    },
+                    "max_matches": {
+                        "type": "integer",
+                        "default": self.default_max_matches,
+                        "minimum": 1,
+                        "maximum": self.default_max_matches,
+                        "description": "Maximum matching lines to return; higher values are capped by the tool."
+                    }
                 },
                 "required": ["pattern"]
             }),
@@ -313,8 +375,14 @@ impl Tool for WriteFileTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string" },
-                    "content": { "type": "string" }
+                    "path": {
+                        "type": "string",
+                        "description": "File to create or overwrite, relative to the configured writable root unless an allowed absolute path is provided."
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Complete file contents to write. Existing file contents are replaced."
+                    }
                 },
                 "required": ["path", "content"]
             }),
@@ -430,10 +498,23 @@ impl Tool for EditFileTool {
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "path": { "type": "string" },
-                    "old_text": { "type": "string" },
-                    "new_text": { "type": "string" },
-                    "replace_all": { "type": "boolean" }
+                    "path": {
+                        "type": "string",
+                        "description": "Existing file to edit, relative to the configured writable root unless an allowed absolute path is provided."
+                    },
+                    "old_text": {
+                        "type": "string",
+                        "description": "Exact text to replace. The call fails if this text is not found."
+                    },
+                    "new_text": {
+                        "type": "string",
+                        "description": "Replacement text."
+                    },
+                    "replace_all": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When false, replace only the first occurrence. When true, replace every occurrence."
+                    }
                 },
                 "required": ["path", "old_text", "new_text"]
             }),

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -29,6 +29,72 @@ fn toolset_presets_have_expected_counts() {
     assert_eq!(ToolSet::meta_only().native_tools().len(), 0);
 }
 
+#[tokio::test]
+async fn native_tool_definitions_include_model_facing_defaults_and_constraints() {
+    let root = temp_root("defra-agent-tool-definitions");
+    let context = ToolContext::new(root.clone(), false).unwrap();
+
+    let list_tool = ListFilesTool::new(context.clone(), DEFAULT_MAX_LIST_ENTRIES);
+    let list_def = rig::tool::Tool::definition(&list_tool, String::new()).await;
+    assert!(list_def.parameters.get("required").is_none());
+    assert_eq!(list_def.parameters["properties"]["path"]["default"], ".");
+    assert_eq!(
+        list_def.parameters["properties"]["recursive"]["default"],
+        false
+    );
+    assert_eq!(
+        list_def.parameters["properties"]["max_entries"]["maximum"],
+        DEFAULT_MAX_LIST_ENTRIES
+    );
+    assert!(
+        list_def.parameters["properties"]["max_entries"]["description"]
+            .as_str()
+            .unwrap()
+            .contains("capped by the tool")
+    );
+
+    let read_tool = ReadFileTool::new(context.clone(), DEFAULT_MAX_FILE_CHARS);
+    let read_def = rig::tool::Tool::definition(&read_tool, String::new()).await;
+    assert_eq!(read_def.parameters["required"], serde_json::json!(["path"]));
+    assert_eq!(
+        read_def.parameters["properties"]["start_line"]["default"],
+        1
+    );
+    assert_eq!(
+        read_def.parameters["properties"]["max_chars"]["maximum"],
+        DEFAULT_MAX_FILE_CHARS
+    );
+
+    let write_tool = WriteFileTool::new(context.clone());
+    let write_def = rig::tool::Tool::definition(&write_tool, String::new()).await;
+    assert_eq!(
+        write_def.parameters["required"],
+        serde_json::json!(["path", "content"])
+    );
+    assert!(write_def.parameters["properties"]["content"]["description"]
+        .as_str()
+        .unwrap()
+        .contains("Existing file contents are replaced"));
+
+    let bash_tool = UnrestrictedBashTool::new(
+        ToolContext::new(root, false).unwrap(),
+        Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+    );
+    let bash_def = rig::tool::Tool::definition(&bash_tool, String::new()).await;
+    assert_eq!(
+        bash_def.parameters["required"],
+        serde_json::json!(["command"])
+    );
+    assert_eq!(
+        bash_def.parameters["properties"]["args"]["default"],
+        serde_json::json!([])
+    );
+    assert_eq!(
+        bash_def.parameters["properties"]["timeout_secs"]["maximum"],
+        DEFAULT_COMMAND_TIMEOUT_SECS
+    );
+}
+
 fn temp_root(name: &str) -> PathBuf {
     let path = std::env::temp_dir().join(format!("{name}-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&path).unwrap();

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -516,9 +516,12 @@ fn looks_like_resource_not_found(lower: &str) -> bool {
 fn looks_like_service_schema_drift(lower: &str) -> bool {
     (lower.contains("parse error") && lower.contains("cannot query field"))
         || lower.contains("cannot query field")
-        || lower.contains("unknown field")
-        || lower.contains("unknown argument")
         || lower.contains("field is not defined")
+        || ((lower.contains("unknown field") || lower.contains("unknown argument"))
+            && (lower.contains("graphql")
+                || lower.contains("query failed")
+                || lower.contains(" on type ")
+                || lower.contains("validation error")))
 }
 
 fn looks_like_invalid_tool_arguments(lower: &str) -> bool {
@@ -619,6 +622,21 @@ mod tests {
             analysis.argument_parse_result,
             ArgumentParseResult::ValidObject
         );
+    }
+
+    #[test]
+    fn compact_contract_text_that_mentions_unknown_fields_is_successful() {
+        let result = "## coding_overview\n\nInput contract:\n- Unknown top-level fields: rejected (`additionalProperties: false`)\n\nCommon mistakes:\n- Do not add unlisted top-level fields; this schema rejects unknown arguments.";
+        let result = format!("{result}\n- Use the exact field names and JSON types shown above.");
+        let analysis = analyze_tool_call(
+            "describe_tool",
+            r#"{"service_id":"coding-session-store","tool_name":"coding_overview"}"#,
+            &result,
+            "completed",
+        );
+
+        assert!(analysis.tool_result_ok);
+        assert_eq!(analysis.tool_failure_class, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make `describe_tool` return compact model-readable contracts by default
- keep raw JSON Schema accessible with `raw_schema: true`
- add argument paths, required/optional sections, defaults, constraints, examples, unknown-field behavior, common mistakes, and safety notes
- enrich native file/bash tool schemas with descriptions/defaults/caps
- clarify that `discover_tools`/`describe_tool`/`call_tool` are MCP data-service meta-tools, not native direct-tool descriptors
- fix trace export so compact contract prose mentioning unknown-field behavior is not misclassified as schema drift

Stacked on #112 while #111/#112 remain open.

## Tests
- `cargo test -p defra-agent`
- `cargo test -p defra-agent meta_tools`
- `cargo test -p defra-agent prompt::tests`
- `cargo test -p defra-agent toolset::tests::native_tool_definitions_include_model_facing_defaults_and_constraints`
- `cargo test -p defra-agent trace_export::tests`
- `cargo test -p defra-agent-cli --test cli_trace_export`
- `cargo test -p defra-agent-cli --test cli_chat`
- `git diff --check`

## Amy validation
Deployed candidate to Amy on `studio-1:9191`.

- Final deployed commit: `cd122ac6b6e01bb6e8d177d9d0158e7464d087ea`
- `/version`: `git_dirty:false`, ref `codex/compact-describe-tool-contracts`
- `/healthz`: ok, runtime ready
- launchd: `system/com.amygdala.defra-agent.amy` running
- trace/report artifacts: `target/compact-contract-review/compact-contracts-20260505T145823Z/`

Schema-navigation suite:
- `x-data/search_bookmarks`: compact describe, then first `call_tool` succeeded with `{"query":"defra","limit":1}`.
- `coding-session-store/coding_overview`: compact describe, then first `call_tool` succeeded with `{}`; no unsupported `limit`.
- `observability-mcp/service_status`: compact describe, then first `call_tool` succeeded with `{}`.
- `raw_schema:true`: returned raw JSON Schema escape hatch and Amy identified required `query`.
- `bash_unrestricted`: initial run exposed a `service_id:"native"` detour; after the MCP/native wording patch, the retest made zero tool calls and correctly described shell-string mode from the native direct schema.

No production writes were requested or performed through data-service tools.
