### PR TITLE
Prove apply prefix safety and retry convergence

### DIFF
--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -21,6 +21,12 @@ use crate::{
 
 const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 
+// Topological desired-state write order. Every prefix is safe to observe: a
+// written document may only reference documents in earlier apply ranks, and a
+// retry recomputes diff against the partial state before continuing. Production
+// realizes the Lean retry model by rebuilding the live diff at the start of
+// each `config apply` attempt, then applying selected documents with
+// unique-field upserts or equivalent override writers.
 const CONFIG_APPLY_ORDER: [Collection; 9] = [
     Collection::InferenceBackend,
     Collection::InferenceProfile,
@@ -32,6 +38,9 @@ const CONFIG_APPLY_ORDER: [Collection; 9] = [
     Collection::EventTrigger,
     Collection::AgentPrincipal,
 ];
+
+#[cfg(test)]
+pub(crate) const CONFIG_APPLY_ORDER_FOR_TESTS: &[Collection] = &CONFIG_APPLY_ORDER;
 
 #[derive(Debug, Clone)]
 struct PreparedImportDocument {
@@ -217,6 +226,10 @@ fn generic_import_mutation_field(
     let alias = format!("doc_{index}");
     let add_literal = graphql_input_literal(&doc.add_doc)?;
     let field = if override_existing {
+        // This is the generic production bridge for apply retry convergence:
+        // after a partial prefix, rerunning `config apply` recomputes live diff
+        // and uses unique-field upsert so already-written rows are updated with
+        // the same desired payload while missing rows are created.
         let update_literal =
             graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
                 anyhow::anyhow!("missing update document for {collection_name}")
@@ -244,6 +257,9 @@ async fn apply_generic_import_document(
 ) -> Result<()> {
     let add_literal = graphql_input_literal(&doc.add_doc)?;
     let mutation = if override_existing {
+        // Per-document fallback preserves the same retry property as the batch
+        // path: the unique-field filter makes repeated successful writes land
+        // on the same logical document.
         let update_literal =
             graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
                 anyhow::anyhow!("missing update document for {collection_name}")
@@ -621,6 +637,37 @@ fn select_apply_docs_for_collection(
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn config_apply_order_contains_each_collection_once() {
+        let actual = CONFIG_APPLY_ORDER_FOR_TESTS
+            .iter()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let expected = Collection::ALL.into_iter().collect::<BTreeSet<_>>();
+
+        assert_eq!(actual, expected);
+        assert_eq!(CONFIG_APPLY_ORDER_FOR_TESTS.len(), Collection::ALL.len());
+    }
+
+    #[test]
+    fn config_apply_order_has_retry_safe_prefixes() {
+        for prefix_len in 0..=CONFIG_APPLY_ORDER_FOR_TESTS.len() {
+            let prefix = &CONFIG_APPLY_ORDER_FOR_TESTS[..prefix_len];
+            let suffix = &CONFIG_APPLY_ORDER_FOR_TESTS[prefix_len..];
+            for written in prefix {
+                for pending in suffix {
+                    assert!(
+                        written.apply_order() <= pending.apply_order(),
+                        "prefix {prefix_len} writes {:?} before lower-rank {:?}",
+                        written,
+                        pending,
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn build_aliased_mutation_wraps_all_fields() {

--- a/crates/defra-agent-cli/tests/cli_config_apply_order.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_order.rs
@@ -1,40 +1,58 @@
-/// Anchors the desired-state write order to the topological rank declared by
-/// `Collection::apply_order`.
-///
-/// This is a source-grep test: it reads the source of `config_import.rs` at
-/// compile time and asserts that the centralized `CONFIG_APPLY_ORDER` table
-/// appears in the expected order. No live DefraDB node is required.
-#[test]
-fn apply_desired_state_changes_order_matches_collection_apply_order() {
+use defra_agent::Collection;
+use std::collections::BTreeSet;
+
+fn config_apply_order_from_source() -> Vec<Collection> {
     let src = include_str!("../src/config_import.rs");
     let body_start = src.find("const CONFIG_APPLY_ORDER").unwrap();
     let body_end = src[body_start..].find("];").unwrap() + body_start;
     let body = &src[body_start..body_end];
 
     let re = regex::Regex::new(r"Collection::([A-Za-z]+)").unwrap();
-    let found: Vec<&str> = re
-        .captures_iter(body)
-        .map(|c| c.get(1).unwrap().as_str())
-        .collect();
+    re.captures_iter(body)
+        .map(|capture| {
+            let variant_name = capture.get(1).unwrap().as_str();
+            Collection::ALL
+                .into_iter()
+                .find(|collection| collection.graphql_type() == variant_name)
+                .unwrap_or_else(|| {
+                    panic!("unknown Collection variant in CONFIG_APPLY_ORDER: {variant_name}")
+                })
+        })
+        .collect()
+}
 
-    // Expected order preserves the existing manual order within each apply rank:
-    //   rank 0: InferenceBackend, InferenceProfile, ToolServiceRegistry, ToolSelection
-    //   rank 1: AgentBehavior
-    //   rank 2: Task, Schedule
-    //   rank 3: EventTrigger, AgentPrincipal
-    let expected = vec![
-        "InferenceBackend",
-        "InferenceProfile",
-        "ToolServiceRegistry",
-        "ToolSelection",
-        "AgentBehavior",
-        "Task",
-        "Schedule",
-        "EventTrigger",
-        "AgentPrincipal",
-    ];
-    assert_eq!(
-        found, expected,
-        "CONFIG_APPLY_ORDER does not match Collection::apply_order ranks"
-    );
+/// Anchors the centralized `CONFIG_APPLY_ORDER` table to the closed collection
+/// set without carrying a second hardcoded ordered array in this test.
+#[test]
+fn apply_desired_state_changes_order_contains_each_collection_once() {
+    let found = config_apply_order_from_source();
+    let actual = found.iter().copied().collect::<BTreeSet<_>>();
+    let expected = Collection::ALL.into_iter().collect::<BTreeSet<_>>();
+
+    assert_eq!(actual, expected);
+    assert_eq!(found.len(), Collection::ALL.len());
+}
+
+/// Guards the retry-safety comment on `CONFIG_APPLY_ORDER`: every split point is
+/// a durable prefix whose already-written referrers are at ranks no greater
+/// than any later dependency-writing rank. This directly invokes
+/// `Collection::apply_order()`, so rank drift in the Rust enum surfaces here.
+#[test]
+fn apply_desired_state_changes_order_has_retry_safe_prefixes() {
+    let order = config_apply_order_from_source();
+
+    for prefix_len in 0..=order.len() {
+        let prefix = &order[..prefix_len];
+        let suffix = &order[prefix_len..];
+        for written in prefix {
+            for pending in suffix {
+                assert!(
+                    written.apply_order() <= pending.apply_order(),
+                    "prefix {prefix_len} writes {:?} before lower-rank {:?}",
+                    written,
+                    pending,
+                );
+            }
+        }
+    }
 }

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile.lean
@@ -3,6 +3,7 @@ import Proofs.ApplyReconcile.Manifest
 import Proofs.ApplyReconcile.Diff
 import Proofs.ApplyReconcile.Apply
 import Proofs.ApplyReconcile.ApplyProperties
+import Proofs.ApplyReconcile.Prefix
 import Proofs.ApplyReconcile.RuntimeBridge
 import Proofs.ApplyReconcile.Convergence
 

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/Prefix.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/Prefix.lean
@@ -1,0 +1,139 @@
+import Proofs.ApplyReconcile.ApplyProperties
+
+/-!
+# Apply/Reconcile Prefix Semantics
+
+Partial apply semantics for crash/retry reasoning. A partial apply is any
+prefix of the sorted `diff M L`; retrying starts from the state produced by
+that prefix and recomputes `diff`.
+-/
+
+namespace ApplyReconcile
+
+/-- A concrete partial apply: some prefix of the full diff. -/
+structure ApplyPrefix (M : Manifest) (L : LiveState) where
+  steps    : List ApplyStep
+  isPrefix : List.IsPrefix steps (diff M L)
+
+namespace ApplyPrefix
+
+/-- State reached after applying this prefix. -/
+def state {M : Manifest} {L : LiveState} (p : ApplyPrefix M L) : LiveState :=
+  applyAll L p.steps
+
+@[simp]
+lemma state_live {M : Manifest} {L : LiveState} (p : ApplyPrefix M L) :
+    p.state.live = L.live :=
+  apply_preserves_live L p.steps
+
+end ApplyPrefix
+
+/-- The desired projection agrees with the manifest wherever the manifest
+    declares a document. Live-only documents outside the manifest are not
+    deleted by apply and are intentionally outside this predicate. -/
+def ManifestRealized (M : Manifest) (L : LiveState) : Prop :=
+  ∀ d : DocRef, ∀ f, M.docs d = some f → L.desired d = some f
+
+/-- Product-facing corollary scoped to documents that have already been written
+    by the current prefix. The stronger invariant is `applyPrefix_wellFormed`,
+    whose first conjunct covers every document in the prefix state. -/
+def PrefixReferrersClosed (pref : List ApplyStep) (L : LiveState) : Prop :=
+  ∀ s : ApplyStep, s ∈ pref → ∀ f, L.desired s.target = some f →
+    ∀ r ∈ referencesOf f, L.contains r = true
+
+/-- Every applied prefix preserves runtime-owned/live fields. -/
+theorem applyPrefix_preserves_live
+    {M : Manifest} {L : LiveState} (p : ApplyPrefix M L) :
+    p.state.live = L.live :=
+  p.state_live
+
+/-- Every applied prefix of a well-formed apply remains well-formed. -/
+theorem applyPrefix_wellFormed
+    {M : Manifest} {L : LiveState}
+    (hM : M.WellFormed) (hL : L.WellFormed)
+    (p : ApplyPrefix M L) :
+    p.state.WellFormed :=
+  apply_preserves_wellFormed hM hL p.steps p.isPrefix
+
+/-- Every already-written referrer in an applied prefix has all of its
+    references present in the prefix state. -/
+theorem applyPrefix_referrersClosed
+    {M : Manifest} {L : LiveState}
+    (hM : M.WellFormed) (hL : L.WellFormed)
+    (p : ApplyPrefix M L) :
+    PrefixReferrersClosed p.steps p.state := by
+  intro s _hs f hf r hr
+  exact (applyPrefix_wellFormed hM hL p).1 s.target f hf r hr
+
+/-- Complete apply realizes the manifest's desired projection. -/
+theorem apply_realizes_manifest_desired
+    {M : Manifest} {L : LiveState}
+    (hM : M.WellFormed) (hL : L.WellFormed) :
+    ManifestRealized M (applyAll L (diff M L)) :=
+  apply_realizes_manifest hM hL
+
+/-- Retrying from any applied prefix converges back to the manifest's desired
+    projection after recomputing `diff` from the prefix state. -/
+theorem retry_after_prefix_realizes_manifest
+    {M : Manifest} {L : LiveState}
+    (hM : M.WellFormed) (hL : L.WellFormed)
+    (p : ApplyPrefix M L) :
+    ManifestRealized M (applyAll p.state (diff M p.state)) :=
+  apply_realizes_manifest hM (applyPrefix_wellFormed hM hL p)
+
+/-- Retry convergence also preserves the runtime/live projection from the
+    original state across both the failed prefix and the retry pass. -/
+theorem retry_after_prefix_preserves_live
+    {M : Manifest} {L : LiveState} (p : ApplyPrefix M L) :
+    (applyAll p.state (diff M p.state)).live = L.live := by
+  rw [apply_preserves_live p.state (diff M p.state)]
+  exact p.state_live
+
+/-- If the live state's desired projection already realizes the manifest,
+    the recomputed diff is empty. -/
+theorem diff_eq_nil_of_manifestRealized
+    {M : Manifest} {L : LiveState}
+    (hrealized : ManifestRealized M L) :
+    diff M L = [] := by
+  unfold diff
+  let step? : DocRef → Option ApplyStep := fun d =>
+    match M.docs d, L.desired d with
+    | some f, none     => some (ApplyStep.create d f)
+    | some f, some g   => if f = g then none else some (ApplyStep.update d f)
+    | none,   _        => none
+  have hfilter : M.support.toList.filterMap step? = [] := by
+    apply List.eq_nil_iff_forall_not_mem.mpr
+    intro s hs
+    rw [List.mem_filterMap] at hs
+    obtain ⟨d, hd_mem, hd_step⟩ := hs
+    have hd_support : d ∈ M.support := (Finset.mem_toList).mp hd_mem
+    have hd_some : (M.docs d).isSome = true := (M.support_iff d).mp hd_support
+    obtain ⟨f, hf⟩ := Option.isSome_iff_exists.mp hd_some
+    have hdesired : L.desired d = some f := hrealized d f hf
+    have hstep_none : step? d = none := by
+      simp [step?, hf, hdesired]
+    rw [hstep_none] at hd_step
+    simp at hd_step
+  change (M.support.toList.filterMap step?).mergeSort ApplyStep.le = []
+  rw [hfilter]
+  exact List.mergeSort_nil
+
+/-- A converged state is an apply fixed point: rerunning diff/apply is a
+    no-op. -/
+theorem apply_idempotent_of_manifestRealized
+    {M : Manifest} {L : LiveState}
+    (hrealized : ManifestRealized M L) :
+    applyAll L (diff M L) = L := by
+  rw [diff_eq_nil_of_manifestRealized hrealized]
+  rfl
+
+/-- After a complete well-formed apply, rerunning diff/apply is idempotent. -/
+theorem apply_idempotent_after_convergence
+    {M : Manifest} {L : LiveState}
+    (hM : M.WellFormed) (hL : L.WellFormed) :
+    let L' := applyAll L (diff M L)
+    applyAll L' (diff M L') = L' := by
+  intro L'
+  exact apply_idempotent_of_manifestRealized (apply_realizes_manifest_desired hM hL)
+
+end ApplyReconcile

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -98,7 +98,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Fleet.lean` | Fleet-level scheduling and slot accounting |
 | `Proofs/SessionRecovery.lean` | Retry/reissue model for session-linked requests |
 | `Proofs/RuntimeReconcile.lean` | Barrel for runtime reconcile state, relational transitions, and executable semantics |
-| `Proofs/ApplyReconcile.lean` | Barrel for desired-state apply, runtime bridge, and convergence |
+| `Proofs/ApplyReconcile.lean` | Barrel for desired-state apply, prefix safety, runtime bridge, and convergence |
 | `Proofs/Triggers.lean` | Barrel for trigger types, dispatch, reachability, serial, latest-only, and lineage proofs |
 | `Proofs/Client.lean` | Barrel for client turn-state derivation and client theorems |
 | `Proofs/ClientShell.lean` | Barrel for multi-session shell workflow modules |
@@ -122,7 +122,7 @@ Semantic submodules:
 | `Proofs.Request` | `State`, `Transition`, `Executable`, `Properties` |
 | `Proofs.InferenceCall` | `State`, `Transition`, `Executable`, `Properties`, `SlotAccounting` |
 | `Proofs.RuntimeReconcile` | `State`, `Transition`, `Executable` |
-| `Proofs.ApplyReconcile` | `Collections`, `Manifest`, `Diff`, `Apply`, `ApplyProperties`, `RuntimeBridge`, `Convergence` |
+| `Proofs.ApplyReconcile` | `Collections`, `Manifest`, `Diff`, `Apply`, `ApplyProperties`, `Prefix`, `RuntimeBridge`, `Convergence` |
 | `Proofs.Triggers` | `Types`, `Dispatch`, `Reachability`, `SerialSupport`, `Serial`, `LatestOnly`, `Lineage` |
 | `Proofs.Triggers.SerialSupport` | `Counting`, `Preservation` |
 | `Proofs.Client` | `Types`, `Lifecycle`, `Terminal`, `Replacement` |
@@ -362,6 +362,13 @@ snapshots.
 - desired-state references must be closed and point to earlier apply ranks
 - apply steps write only `DesiredFields`
 - runtime-owned `LiveFields` are structurally untouched by apply
+- partial apply is modeled as any prefix of the sorted diff
+- every well-formed prefix preserves live-owned fields and keeps the full
+  desired projection reference-closed; an explicit corollary scopes that to
+  already-written referrers
+- retrying from any prefix by recomputing diff converges to the same manifest
+  desired projection
+- after convergence, another diff/apply pass is idempotent
 - `t_conv_runnable` is the apply-sensitive result: after a well-formed apply,
   every manifest behavior id is runnable
 - `t_conv` and `t_conv_published` are coverage corollaries over the resolved and
@@ -498,16 +505,18 @@ Rust/spec mismatches. There are currently no known active spec deviations.
 
 ## Known Limitations
 
-### Apply Atomicity
+### Apply Storage Atomicity
 
 `defra-agent-cli config apply` today is best-effort: if a write fails partway
-through the ordered apply sequence, the database is left in a partially updated
-state and there is no rollback. The `T-Conv` theorem in
-`Proofs/ApplyReconcile.lean` assumes apply runs to completion. It does not cover
-crash-mid-apply.
-
-Operators must retry `apply` after a failure and should treat a partial-apply
-state as manually inconsistent until resolved.
+through the ordered apply sequence, the database is left in a durable prefix and
+there is no rollback. `Proofs/ApplyReconcile/Prefix.lean` covers this non-atomic
+case: every prefix preserves runtime/live-owned fields, already-written
+referrers remain reference-closed, and rerunning `apply` from the prefix
+converges to the same manifest desired projection. Production realizes the
+model's "recompute diff after a prefix" retry step by rebuilding the live diff
+at the start of each `config apply` attempt and applying selected documents via
+unique-field upserts or equivalent override writers. The storage assumption is
+only that a reported successful mutation is durable before the next retry.
 
 ### Interrupted Inference Calls
 

--- a/crates/defra-agent/src/apply_model.rs
+++ b/crates/defra-agent/src/apply_model.rs
@@ -5,7 +5,8 @@
 //! exercise it, but production apply lives in `defra-agent-cli`.
 //! Conformance cases (`tests/apply_conformance.rs`) anchor the production
 //! code to the semantics pinned here; property tests (`tests/apply_property.rs`)
-//! exercise `diff`, `apply_one`, `apply_all` at generator scale.
+//! exercise `diff`, `apply_one`, `apply_prefix`, `retry_after_prefix`, and
+//! `apply_all` at generator scale.
 //!
 //! Variants, apply-order ranks, and `diff` ordering MUST agree with
 //! both the Lean `ApplyReconcile` module and the Rust
@@ -155,6 +156,53 @@ pub fn apply_all(l: &LiveState, steps: &[ApplyStep]) -> LiveState {
     steps.iter().fold(l.clone(), |acc, s| apply_one(&acc, s))
 }
 
+/// Apply the first `prefix_len` steps from a previously computed diff.
+/// This is the Rust analog of Lean `ApplyPrefix.state`: it models a crash or
+/// interruption after a durable prefix of the ordered write sequence.
+pub fn apply_prefix(l: &LiveState, steps: &[ApplyStep], prefix_len: usize) -> LiveState {
+    debug_assert!(
+        prefix_len <= steps.len(),
+        "apply prefix length must not exceed the diff length",
+    );
+    let len = prefix_len.min(steps.len());
+    apply_all(l, &steps[..len])
+}
+
+/// Recompute diff after an applied prefix and run the retry pass to completion.
+pub fn retry_after_prefix(m: &Manifest, l: &LiveState, prefix_len: usize) -> LiveState {
+    let initial_steps = diff(m, l).into_steps();
+    let prefix_state = apply_prefix(l, &initial_steps, prefix_len);
+    let retry_steps = diff(m, &prefix_state).into_steps();
+    apply_all(&prefix_state, &retry_steps)
+}
+
+/// Manifest-realized predicate mirrored from Lean:
+/// every manifest document is present with the requested desired payload.
+pub fn manifest_realized(m: &Manifest, l: &LiveState) -> bool {
+    m.docs
+        .iter()
+        .all(|(doc, desired)| l.desired.get(doc) == Some(desired))
+}
+
+/// Full desired-projection reference closure.
+pub fn desired_references_closed(l: &LiveState) -> bool {
+    l.desired
+        .values()
+        .flat_map(references_of)
+        .all(|r| l.desired.contains_key(&r))
+}
+
+/// Product-facing corollary scoped to documents already written by a prefix.
+pub fn prefix_referrers_closed(prefix: &[ApplyStep], l: &LiveState) -> bool {
+    prefix.iter().all(|step| {
+        l.desired
+            .get(step.target())
+            .into_iter()
+            .flat_map(references_of)
+            .all(|r| l.desired.contains_key(&r))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -178,5 +226,44 @@ mod tests {
             out.desired.get(&d).map(|f| f.content.as_str()),
             Some("desired-payload"),
         );
+    }
+
+    #[test]
+    fn retry_after_prefix_converges_and_is_idempotent() {
+        let backend = DocRef {
+            collection: Collection::InferenceBackend,
+            id: "b1".into(),
+        };
+        let behavior = DocRef {
+            collection: Collection::AgentBehavior,
+            id: "a1".into(),
+        };
+        let mut docs = BTreeMap::new();
+        docs.insert(backend.clone(), DesiredFields::opaque("backend"));
+        docs.insert(
+            behavior.clone(),
+            DesiredFields::with_refs("behavior", vec![backend.clone()]),
+        );
+        let m = Manifest { docs };
+        let mut live = BTreeMap::new();
+        live.insert(behavior.clone(), "runtime-live".to_string());
+        let l = LiveState {
+            desired: BTreeMap::new(),
+            live,
+        };
+
+        let steps = diff(&m, &l).into_steps();
+        let prefix = apply_prefix(&l, &steps, 1);
+        assert_eq!(prefix.live, l.live);
+        assert!(desired_references_closed(&prefix));
+        assert!(prefix_referrers_closed(&steps[..1], &prefix));
+
+        let retried = retry_after_prefix(&m, &l, 1);
+        let full = apply_all(&l, &steps);
+        assert_eq!(retried, full);
+        assert!(manifest_realized(&m, &retried));
+
+        let rediff = diff(&m, &retried).into_steps();
+        assert_eq!(apply_all(&retried, &rediff), retried);
     }
 }

--- a/crates/defra-agent/tests/apply_conformance.rs
+++ b/crates/defra-agent/tests/apply_conformance.rs
@@ -7,8 +7,9 @@
 //! reason about without running proptest.
 
 use defra_agent::apply_model::{
-    apply_all, diff, references_of, ApplyStep, Collection, DesiredFields, DocRef, LiveState,
-    Manifest,
+    apply_all, apply_prefix, desired_references_closed, diff, manifest_realized,
+    prefix_referrers_closed, references_of, retry_after_prefix, ApplyStep, Collection,
+    DesiredFields, DocRef, LiveState, Manifest,
 };
 use std::collections::BTreeMap;
 
@@ -229,4 +230,67 @@ fn manifest_with_principal_referencing_behavior_orders_behavior_first() {
             r,
         );
     }
+}
+
+#[test]
+fn retry_from_every_prefix_converges_to_complete_apply() {
+    let backend = r(Collection::InferenceBackend, "b1");
+    let behavior = r(Collection::AgentBehavior, "a1");
+    let task = r(Collection::Task, "t1");
+    let m = Manifest {
+        docs: {
+            let mut docs = BTreeMap::new();
+            docs.insert(backend.clone(), DesiredFields::opaque("b1-desired"));
+            docs.insert(
+                behavior.clone(),
+                DesiredFields::with_refs("a1-desired", vec![backend.clone()]),
+            );
+            docs.insert(
+                task.clone(),
+                DesiredFields::with_refs("t1-desired", vec![behavior.clone()]),
+            );
+            docs
+        },
+    };
+    let l = live(&[], &[(behavior.clone(), "runtime-owned")]);
+
+    let steps = diff(&m, &l).into_steps();
+    let complete = apply_all(&l, &steps);
+    assert!(manifest_realized(&m, &complete));
+    for prefix_len in 0..=steps.len() {
+        let prefix = apply_prefix(&l, &steps, prefix_len);
+        assert_eq!(
+            prefix.live, l.live,
+            "prefix {prefix_len} must preserve runtime/live fields",
+        );
+        assert!(
+            desired_references_closed(&prefix),
+            "prefix {prefix_len} should keep the full desired projection reference-closed",
+        );
+        assert!(
+            prefix_referrers_closed(&steps[..prefix_len], &prefix),
+            "prefix {prefix_len} should not leave already-written referrers dangling",
+        );
+        assert_eq!(
+            retry_after_prefix(&m, &l, prefix_len),
+            complete,
+            "retry after prefix {prefix_len} must converge to complete apply",
+        );
+    }
+}
+
+#[test]
+fn complete_apply_is_idempotent_after_convergence() {
+    let backend = r(Collection::InferenceBackend, "b1");
+    let m = manifest(&[(backend.clone(), "b1-new")]);
+    let l = live(
+        &[(backend.clone(), "b1-old")],
+        &[(backend.clone(), "runtime")],
+    );
+
+    let converged = apply_all(&l, &diff(&m, &l).into_steps());
+    assert!(manifest_realized(&m, &converged));
+    let reapplied = apply_all(&converged, &diff(&m, &converged).into_steps());
+
+    assert_eq!(reapplied, converged);
 }

--- a/crates/defra-agent/tests/apply_property.rs
+++ b/crates/defra-agent/tests/apply_property.rs
@@ -1,5 +1,7 @@
 use defra_agent::apply_model::{
-    apply_all, diff, references_of, Collection, DesiredFields, DocRef, LiveState, Manifest,
+    apply_all, apply_prefix, desired_references_closed, diff, manifest_realized,
+    prefix_referrers_closed, references_of, retry_after_prefix, Collection, DesiredFields, DocRef,
+    LiveState, Manifest,
 };
 use proptest::prelude::*;
 use std::collections::BTreeMap;
@@ -16,6 +18,7 @@ fn collection_strategy() -> impl Strategy<Value = Collection> {
         Just(Collection::ToolServiceRegistry),
         Just(Collection::Task),
         Just(Collection::Schedule),
+        Just(Collection::EventTrigger),
     ]
 }
 
@@ -228,7 +231,21 @@ proptest! {
     ) {
         let steps = diff(&m, &l).into_steps();
         let after = apply_all(&l, &steps);
-        prop_assert_eq!(after.live, l.live);
+        prop_assert_eq!(&after.live, &l.live);
+    }
+
+    /// P4b (prefix apply preserves live): every durable prefix of an apply pass
+    /// preserves runtime/live-owned fields.
+    #[test]
+    fn every_apply_prefix_preserves_live(
+        m in manifest_strategy(),
+        l in live_state_strategy(),
+    ) {
+        let steps = diff(&m, &l).into_steps();
+        for prefix_len in 0..=steps.len() {
+            let after_prefix = apply_prefix(&l, &steps, prefix_len);
+            prop_assert_eq!(&after_prefix.live, &l.live);
+        }
     }
 
     /// P2b (referential version of apply-ordering-preserves-references):
@@ -289,6 +306,61 @@ proptest! {
                 }
             }
         }
+    }
+
+    /// P6 (prefix reference closure): for manifests carrying real references,
+    /// every prefix keeps the full desired projection reference-closed. The
+    /// scoped already-written-referrer predicate is asserted as the
+    /// product-facing corollary.
+    #[test]
+    fn every_apply_prefix_closes_written_referrers(
+        m in referential_manifest_strategy_with_principal(),
+    ) {
+        let l = LiveState {
+            desired: BTreeMap::new(),
+            live: BTreeMap::new(),
+        };
+        let steps = diff(&m, &l).into_steps();
+        for prefix_len in 0..=steps.len() {
+            let after_prefix = apply_prefix(&l, &steps, prefix_len);
+            prop_assert!(
+                desired_references_closed(&after_prefix),
+                "prefix {prefix_len} left a dangling reference in the desired projection",
+            );
+            prop_assert!(
+                prefix_referrers_closed(&steps[..prefix_len], &after_prefix),
+                "prefix {prefix_len} left an already-written referrer dangling",
+            );
+        }
+    }
+
+    /// P7 (retry convergence): recomputing diff after any prefix and applying
+    /// to completion reaches exactly the same model state as a complete first
+    /// pass.
+    #[test]
+    fn retry_after_any_prefix_matches_complete_apply(
+        m in manifest_strategy(),
+        l in live_state_strategy(),
+    ) {
+        let steps = diff(&m, &l).into_steps();
+        let complete = apply_all(&l, &steps);
+        for prefix_len in 0..=steps.len() {
+            let retried = retry_after_prefix(&m, &l, prefix_len);
+            prop_assert_eq!(&retried, &complete);
+        }
+    }
+
+    /// P8 (idempotence): once apply has converged, a second diff/apply pass is
+    /// a no-op.
+    #[test]
+    fn apply_is_idempotent_after_convergence(
+        m in manifest_strategy(),
+        l in live_state_strategy(),
+    ) {
+        let converged = apply_all(&l, &diff(&m, &l).into_steps());
+        prop_assert!(manifest_realized(&m, &converged));
+        let reapplied = apply_all(&converged, &diff(&m, &converged).into_steps());
+        prop_assert_eq!(reapplied, converged);
     }
 }
 


### PR DESCRIPTION
## Summary
- add Lean ApplyReconcile prefix semantics and proofs for live-field preservation, written-referrer closure, retry convergence, and idempotence after convergence
- mirror prefix/retry/idempotence behavior in the Rust apply model with conformance and property coverage
- update CLI apply-order guard and proof README to describe prefix safety for non-atomic apply

## Verification
- lake build
- cargo test -p defra-agent --lib apply_model::tests
- cargo test -p defra-agent --test apply_conformance
- cargo test -p defra-agent --test apply_property
- cargo test -p defra-agent-cli --test cli_config_apply_order --test cli_config_apply_local --test cli_config_apply_graphql --test cli_config_apply_running --test cli_config_apply_e2e --test cli_config_export_import
- cargo fmt --all -- --check
- git diff --check
- rg -n "\bsorry\b|\badmit\b|\baxiom\b|unsafe" crates/defra-agent/proofs --glob '*.lean'
- find crates/defra-agent/proofs -path '*/.lake/*' -prune -o -name '*.lean' -print0 | xargs -0 wc -l | awk ' != "total" &&  > 500 {print}'