### PR TITLE
Add Lean command execution policy proofs

### DIFF
--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -569,6 +569,9 @@ fn validate_argv_prefixes(
             continue;
         }
 
+        // Bare prefixes are split with `split_ascii_whitespace` at runtime;
+        // after the non-empty trim check above, that cannot create empty
+        // tokens. JSON prefixes can contain empty strings, so validate them.
         if trimmed.starts_with('[') {
             match serde_json::from_str::<Vec<String>>(trimmed) {
                 Ok(tokens)

--- a/crates/defra-agent-cli/tests/cli_config_validate.rs
+++ b/crates/defra-agent-cli/tests/cli_config_validate.rs
@@ -65,6 +65,10 @@ async fn config_validate_accepts_normalized_manifest_root() -> Result<()> {
                 "file_tools_mode": "ReadOnly",
                 "enable_bash": true,
                 "bash_mode": "ReadOnly",
+                "command_execution_policy": "read_only",
+                "command_network_mode": "disabled",
+                "command_allowed_argv_prefixes": ["[\"git\",\"status\"]"],
+                "command_forbidden_argv_prefixes": ["git commit"],
                 "cli_tool_names": [],
                 "enable_meta_tools": true,
                 "delegate_to": []

--- a/crates/defra-agent-cli/tests/cli_config_validate.rs
+++ b/crates/defra-agent-cli/tests/cli_config_validate.rs
@@ -232,6 +232,92 @@ async fn config_validate_reports_reference_errors_and_fails_nonzero() -> Result<
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_validate_reports_command_policy_errors() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir
+        .path()
+        .join("infra")
+        .join("agents")
+        .join("policy-errors");
+    fs::create_dir_all(&home_dir)?;
+    fs::create_dir_all(&root)?;
+
+    let agent_did = format!("did:key:z{}", Uuid::new_v4().simple());
+    write_json_file(
+        &root.join("agent-principal.json"),
+        &serde_json::json!({
+            "agent_did": agent_did.clone(),
+            "display_name": "Policy Agent",
+            "default_behavior_id": "missing-behavior",
+            "enabled": true
+        }),
+    )?;
+
+    let dir = root.join("tool-selections").join("policy-tools");
+    fs::create_dir_all(&dir)?;
+    write_json_file(
+        &dir.join("object.json"),
+        &serde_json::json!({
+            "selection_id": "policy-tools",
+            "agent_did": agent_did,
+            "display_name": "Policy Tools",
+            "enable_file_tools": true,
+            "file_tools_mode": "ReadOnly",
+            "enable_bash": true,
+            "bash_mode": "ReadOnly",
+            "command_execution_policy": "side_effects",
+            "command_network_mode": "maybe",
+            "command_allowed_argv_prefixes": ["[\"git\", \"\"]"],
+            "command_forbidden_argv_prefixes": ["["],
+            "cli_tool_names": [],
+            "enable_meta_tools": true,
+            "delegate_to": []
+        }),
+    )?;
+
+    let output = run_cli_failure_stdout_json(
+        &home_dir,
+        &[
+            "config",
+            "validate",
+            "--root",
+            root.to_str().expect("utf-8 manifest root"),
+        ],
+    )?;
+
+    let errors = output
+        .get("errors")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("validate output missing errors array: {output}"))?;
+    let messages = errors
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        messages.contains("invalid command_execution_policy"),
+        "expected invalid command_execution_policy rejection, got:\n{messages}"
+    );
+    assert!(
+        messages.contains("invalid command_network_mode"),
+        "expected invalid command_network_mode rejection, got:\n{messages}"
+    );
+    assert!(
+        messages.contains(
+            "command_allowed_argv_prefixes JSON entry must contain non-empty argv tokens"
+        ),
+        "expected invalid allowed-prefix JSON rejection, got:\n{messages}"
+    );
+    assert!(
+        messages.contains("command_forbidden_argv_prefixes JSON entry is invalid"),
+        "expected invalid forbidden-prefix JSON rejection, got:\n{messages}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn config_validate_accepts_tool_services_dir_and_tasks_dir() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");

--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -11,6 +11,7 @@ import Proofs.RuntimeReconcile
 import Proofs.Triggers
 import Proofs.Client
 import Proofs.ClientShell
+import Proofs.CommandPolicy
 import Proofs.Properties.Safety
 import Proofs.Properties.Decidable
 import Proofs.Properties.Liveness

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy.lean
@@ -1,0 +1,11 @@
+import Proofs.CommandPolicy.Types
+import Proofs.CommandPolicy.Validation
+import Proofs.CommandPolicy.Sandbox
+import Proofs.CommandPolicy.Env
+import Proofs.CommandPolicy.Theorems
+
+/-!
+# Command Policy
+
+Barrel for command/tool execution policy models and safety proofs.
+-/

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
@@ -32,7 +32,8 @@ inductive EnvKey where
   | other
   deriving DecidableEq, Repr
 
-/-- Values preserved or forced by the filtered shell environment. -/
+/-- Symbolic values preserved or forced by the filtered shell environment.
+    The forced tags correspond to Rust constants: `cat`, `1`, `0`, and `dumb`. -/
 inductive EnvValue where
   | inherited
   | fallbackPath

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
@@ -1,0 +1,93 @@
+import Proofs.Basic
+
+/-!
+# Command Policy Environment Filtering
+
+Symbolic model of `build_shell_env_from_vars`.
+-/
+
+namespace CommandPolicy
+
+/-- Environment-name classes relevant to the shell filter. -/
+inductive EnvKey where
+  | path
+  | shell
+  | tmpdir
+  | temp
+  | tmp
+  | home
+  | lang
+  | lcAll
+  | lcCtype
+  | logname
+  | user
+  | pager
+  | gitPager
+  | noColor
+  | cliColor
+  | term
+  | key
+  | secret
+  | token
+  | other
+  deriving DecidableEq, Repr
+
+/-- Values preserved or forced by the filtered shell environment. -/
+inductive EnvValue where
+  | inherited
+  | fallbackPath
+  | forcedCat
+  | forcedNoColor
+  | forcedCliColorOff
+  | forcedDumb
+  deriving DecidableEq, Repr
+
+/-- Rust rejects names containing KEY, SECRET, or TOKEN. -/
+def containsSecretMarker : EnvKey → Bool
+  | .key => true
+  | .secret => true
+  | .token => true
+  | _ => false
+
+/-- Core environment names that may be inherited from the parent process. -/
+def coreEnvKey : EnvKey → Bool
+  | .path => true
+  | .shell => true
+  | .tmpdir => true
+  | .temp => true
+  | .tmp => true
+  | .home => true
+  | .lang => true
+  | .lcAll => true
+  | .lcCtype => true
+  | .logname => true
+  | .user => true
+  | _ => false
+
+/-- Noninteractive values forced after inheritance and secret filtering. -/
+def forcedEnvValue : EnvKey → Option EnvValue
+  | .pager => some .forcedCat
+  | .gitPager => some .forcedCat
+  | .noColor => some .forcedNoColor
+  | .cliColor => some .forcedCliColorOff
+  | .term => some .forcedDumb
+  | _ => none
+
+/-- Filtered environment lookup. `inputHas` abstracts whether a non-secret
+    parent variable exists. -/
+def filteredEnv
+    (inputHas : EnvKey → Bool)
+    (envKey : EnvKey) : Option EnvValue :=
+  if containsSecretMarker envKey then
+    none
+  else
+    match forcedEnvValue envKey with
+    | some value => some value
+    | none =>
+        match envKey with
+        | .path =>
+            if inputHas .path then some .inherited else some .fallbackPath
+        | _ =>
+            if coreEnvKey envKey && inputHas envKey then some .inherited else none
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Sandbox.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Sandbox.lean
@@ -1,0 +1,24 @@
+import Proofs.CommandPolicy.Types
+
+/-!
+# Command Policy Sandbox Selection
+
+Model of the sandbox label selected before command execution.
+-/
+
+namespace CommandPolicy
+
+/-- Select the sandbox envelope required by the execution mode. -/
+def selectSandbox
+    (support : RuntimeSupport)
+    (mode : ExecutionMode) : SandboxDecision :=
+  match mode with
+  | .readOnly => .selected .policyReadOnly
+  | .unrestricted => .selected .unsandboxedUnrestricted
+  | .workspaceWrite =>
+      if support.workspaceWriteSandboxEnforced then
+        .selected .macosSeatbelt
+      else
+        .denied .workspaceWriteSandboxUnavailable
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
@@ -39,17 +39,17 @@ theorem readOnly_validator_rejects_unallowlisted
     (allowlist : List String)
     (request : CommandRequest)
     (hunallowlisted :
-      commandAllowlisted request.command allowlist = false) :
+      commandAllowlisted request.lookupCommand allowlist = false) :
     validateReadOnlyCommand allowlist request =
-      .deny (.readOnlyCommandNotAllowlisted request.command) := by
+      .deny (.readOnlyCommandNotAllowlisted request.lookupCommand) := by
   simp [validateReadOnlyCommand, hunallowlisted]
 
 theorem readOnly_validator_allows_only_allowlisted
     (allowlist : List String)
     (request : CommandRequest)
     (hallow : validateReadOnlyCommand allowlist request = .allow) :
-    commandAllowlisted request.command allowlist = true := by
-  cases hlisted : commandAllowlisted request.command allowlist with
+    commandAllowlisted request.lookupCommand allowlist = true := by
+  cases hlisted : commandAllowlisted request.lookupCommand allowlist with
   | false =>
       simp [validateReadOnlyCommand, hlisted] at hallow
   | true =>
@@ -64,8 +64,30 @@ theorem disabled_network_unrestricted_fails_closed
 theorem disabled_network_readOnly_curl_denies
     (args : List String) :
     validateNetworkMode .readOnly .disabled
-        { command := "curl", args := args } =
+        { command := "curl", lookupCommand := "curl", args := args } =
       .deny (.disabledNetworkCommand "curl") := by
+  rfl
+
+theorem disabled_network_readOnly_lookup_curl_denies
+    (command : String)
+    (args : List String) :
+    validateNetworkMode .readOnly .disabled
+        { command := command, lookupCommand := "curl", args := args } =
+      .deny (.disabledNetworkCommand "curl") := by
+  rfl
+
+theorem disabled_network_readOnly_tailscale_ping_denies
+    (rest : List String) :
+    validateNetworkMode .readOnly .disabled
+        { command := "tailscale", lookupCommand := "tailscale", args := "ping" :: rest } =
+      .deny (.disabledNetworkCommand "tailscale") := by
+  rfl
+
+theorem disabled_network_readOnly_tailscale_netcheck_denies
+    (rest : List String) :
+    validateNetworkMode .readOnly .disabled
+        { command := "tailscale", lookupCommand := "tailscale", args := "netcheck" :: rest } =
+      .deny (.disabledNetworkCommand "tailscale") := by
   rfl
 
 theorem workspaceWrite_requires_enforced_sandbox

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
@@ -1,0 +1,136 @@
+import Proofs.CommandPolicy.Validation
+import Proofs.CommandPolicy.Sandbox
+import Proofs.CommandPolicy.Env
+
+/-!
+# Command Policy Theorems
+
+Safety properties for command/tool execution policy.
+-/
+
+namespace CommandPolicy
+
+theorem forbidden_prefixes_deny
+    (policy : Policy)
+    (request : CommandRequest)
+    (matched : List String)
+    (hmatch :
+      firstMatchingPrefix request.argv policy.forbiddenArgvPrefixes = some matched) :
+    validatePolicy policy request = .deny (.forbiddenPrefix matched) := by
+  simp [validatePolicy, hmatch]
+
+theorem allowed_prefixes_deny_unmatched
+    (policy : Policy)
+    (request : CommandRequest)
+    (first : List String)
+    (rest : List (List String))
+    (hconfigured : policy.allowedArgvPrefixes = first :: rest)
+    (hforbidden :
+      firstMatchingPrefix request.argv policy.forbiddenArgvPrefixes = none)
+    (hunmatched :
+      firstMatchingPrefix request.argv policy.allowedArgvPrefixes = none) :
+    validatePolicy policy request = .deny (.allowedPrefixRequired request.argv) := by
+  have hunmatched' :
+      firstMatchingPrefix request.argv (first :: rest) = none := by
+    simpa [hconfigured] using hunmatched
+  simp [validatePolicy, hforbidden, hconfigured, hunmatched']
+
+theorem readOnly_validator_rejects_unallowlisted
+    (allowlist : List String)
+    (request : CommandRequest)
+    (hunallowlisted :
+      commandAllowlisted request.command allowlist = false) :
+    validateReadOnlyCommand allowlist request =
+      .deny (.readOnlyCommandNotAllowlisted request.command) := by
+  simp [validateReadOnlyCommand, hunallowlisted]
+
+theorem readOnly_validator_allows_only_allowlisted
+    (allowlist : List String)
+    (request : CommandRequest)
+    (hallow : validateReadOnlyCommand allowlist request = .allow) :
+    commandAllowlisted request.command allowlist = true := by
+  cases hlisted : commandAllowlisted request.command allowlist with
+  | false =>
+      simp [validateReadOnlyCommand, hlisted] at hallow
+  | true =>
+      rfl
+
+theorem disabled_network_unrestricted_fails_closed
+    (request : CommandRequest) :
+    validateNetworkMode .unrestricted .disabled request =
+      .deny .disabledNetworkUnenforceable := by
+  rfl
+
+theorem disabled_network_readOnly_curl_denies
+    (args : List String) :
+    validateNetworkMode .readOnly .disabled
+        { command := "curl", args := args } =
+      .deny (.disabledNetworkCommand "curl") := by
+  rfl
+
+theorem workspaceWrite_requires_enforced_sandbox
+    (support : RuntimeSupport)
+    (sandbox : SandboxKind)
+    (hselected :
+      selectSandbox support .workspaceWrite = .selected sandbox) :
+    support.workspaceWriteSandboxEnforced = true ∧
+      sandbox = .macosSeatbelt := by
+  cases support with
+  | mk enforced =>
+      cases enforced
+      · simp [selectSandbox] at hselected
+      · simp [selectSandbox] at hselected ⊢
+        exact hselected.symm
+
+theorem workspaceWrite_without_enforced_sandbox_denies :
+    selectSandbox { workspaceWriteSandboxEnforced := false } .workspaceWrite =
+      .denied .workspaceWriteSandboxUnavailable := by
+  rfl
+
+theorem unrestricted_is_explicitly_unsandboxed
+    (support : RuntimeSupport) :
+    selectSandbox support .unrestricted =
+      .selected .unsandboxedUnrestricted := by
+  rfl
+
+theorem filtered_env_excludes_KEY
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .key = none := by
+  rfl
+
+theorem filtered_env_excludes_SECRET
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .secret = none := by
+  rfl
+
+theorem filtered_env_excludes_TOKEN
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .token = none := by
+  rfl
+
+theorem filtered_env_forces_PAGER
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .pager = some .forcedCat := by
+  rfl
+
+theorem filtered_env_forces_GIT_PAGER
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .gitPager = some .forcedCat := by
+  rfl
+
+theorem filtered_env_forces_NO_COLOR
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .noColor = some .forcedNoColor := by
+  rfl
+
+theorem filtered_env_forces_CLICOLOR
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .cliColor = some .forcedCliColorOff := by
+  rfl
+
+theorem filtered_env_forces_TERM
+    (inputHas : EnvKey → Bool) :
+    filteredEnv inputHas .term = some .forcedDumb := by
+  rfl
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
@@ -23,9 +23,15 @@ inductive NetworkMode where
   | enabled
   deriving DecidableEq, Repr
 
-/-- A command request after bash tool argument normalization. -/
+/-- A command request after bash tool argument normalization.
+
+`command` is the raw argv[0] used by allowed/forbidden argv-prefix checks.
+`lookupCommand` is the Rust `executable_name_lookup_key` result used by
+read-only command and network gates: the executable basename when available,
+otherwise the raw command string. -/
 structure CommandRequest where
   command : String
+  lookupCommand : String
   args : List String
   deriving DecidableEq, Repr
 

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
@@ -1,0 +1,83 @@
+import Proofs.Basic
+
+/-!
+# Command Policy Types
+
+Pure Lean vocabulary for the command/tool execution policy enforced by
+`toolset/shared/command.rs` and surfaced through desired-state tool selections.
+-/
+
+namespace CommandPolicy
+
+/-- Mirrors `CommandExecutionMode`. -/
+inductive ExecutionMode where
+  | readOnly
+  | workspaceWrite
+  | unrestricted
+  deriving DecidableEq, Repr
+
+/-- Mirrors `CommandNetworkMode`. -/
+inductive NetworkMode where
+  | inherit
+  | disabled
+  | enabled
+  deriving DecidableEq, Repr
+
+/-- A command request after bash tool argument normalization. -/
+structure CommandRequest where
+  command : String
+  args : List String
+  deriving DecidableEq, Repr
+
+namespace CommandRequest
+
+/-- The argv vector checked against allowed/forbidden prefixes. -/
+def argv (request : CommandRequest) : List String :=
+  request.command :: request.args
+
+end CommandRequest
+
+/-- Reasons the policy validator can deny a command. -/
+inductive DenialReason where
+  | forbiddenPrefix (matched : List String)
+  | allowedPrefixRequired (argv : List String)
+  | readOnlyCommandNotAllowlisted (command : String)
+  | disabledNetworkUnenforceable
+  | disabledNetworkCommand (command : String)
+  | workspaceWriteSandboxUnavailable
+  deriving DecidableEq, Repr
+
+/-- Executable validator result. -/
+inductive Decision where
+  | allow
+  | deny (reason : DenialReason)
+  deriving DecidableEq, Repr
+
+/-- Command execution policy as configured from a tool selection. -/
+structure Policy where
+  mode : ExecutionMode
+  allowedArgvPrefixes : List (List String)
+  forbiddenArgvPrefixes : List (List String)
+  networkMode : NetworkMode
+  readOnlyAllowlist : List String
+  deriving DecidableEq, Repr
+
+/-- Runtime sandbox labels emitted in command metadata. -/
+inductive SandboxKind where
+  | policyReadOnly
+  | macosSeatbelt
+  | unsandboxedUnrestricted
+  deriving DecidableEq, Repr
+
+/-- Sandbox selection may fail before spawning the process. -/
+inductive SandboxDecision where
+  | selected (sandbox : SandboxKind)
+  | denied (reason : DenialReason)
+  deriving DecidableEq, Repr
+
+/-- Host capabilities relevant to workspace-write sandbox enforcement. -/
+structure RuntimeSupport where
+  workspaceWriteSandboxEnforced : Bool
+  deriving DecidableEq, Repr
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
@@ -4,12 +4,17 @@ import Proofs.CommandPolicy.Types
 # Command Policy Validation
 
 Executable validation model for argv prefix filters, read-only command
-allowlisting, and disabled-network behavior.
+allowlisting, and disabled-network behavior. The raw `command` remains argv[0]
+for prefix checks; read-only and network command-name gates use
+`CommandRequest.lookupCommand`, matching Rust's `Path::file_name`
+normalization in `executable_name_lookup_key`.
 -/
 
 namespace CommandPolicy
 
-/-- Whether `candidate` matches the beginning of `argv`. -/
+/-- Candidate prefix → argv → whether the candidate matches the beginning of
+    argv. The empty candidate case is mathematically true but unreachable for
+    configured Rust prefixes because `parse_argv_prefix` rejects empties. -/
 def matchesPrefix : List String → List String → Bool
   | [], _ => true
   | _ :: _, [] => false
@@ -25,8 +30,8 @@ def firstMatchingPrefix (argv : List String) : List (List String) → Option (Li
       else
         firstMatchingPrefix argv rest
 
-/-- Read-only command allowlist check. The Rust implementation also normalizes
-    executable paths to file names; this model captures the allowlist gate. -/
+/-- Read-only command allowlist check over the basename-normalized lookup
+    command. -/
 def commandAllowlisted (command : String) (allowlist : List String) : Bool :=
   allowlist.any (fun allowed => decide (allowed = command))
 
@@ -34,17 +39,17 @@ def commandAllowlisted (command : String) (allowlist : List String) : Bool :=
 def validateReadOnlyCommand
     (allowlist : List String)
     (request : CommandRequest) : Decision :=
-  if commandAllowlisted request.command allowlist then
+  if commandAllowlisted request.lookupCommand allowlist then
     .allow
   else
-    .deny (.readOnlyCommandNotAllowlisted request.command)
+    .deny (.readOnlyCommandNotAllowlisted request.lookupCommand)
 
 /-- Read-only commands that cannot be allowed when network is disabled without
     a sandbox-level network denial. -/
 def readOnlyNetworkDenied (request : CommandRequest) : Bool :=
-  if request.command = "curl" then
+  if request.lookupCommand = "curl" then
     true
-  else if request.command = "tailscale" then
+  else if request.lookupCommand = "tailscale" then
     match request.args with
     | "ping" :: _ => true
     | "netcheck" :: _ => true
@@ -67,7 +72,7 @@ def validateNetworkMode
       | .unrestricted => .deny .disabledNetworkUnenforceable
       | .readOnly =>
           if readOnlyNetworkDenied request then
-            .deny (.disabledNetworkCommand request.command)
+            .deny (.disabledNetworkCommand request.lookupCommand)
           else
             .allow
 

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
@@ -1,0 +1,97 @@
+import Proofs.CommandPolicy.Types
+
+/-!
+# Command Policy Validation
+
+Executable validation model for argv prefix filters, read-only command
+allowlisting, and disabled-network behavior.
+-/
+
+namespace CommandPolicy
+
+/-- Whether `candidate` matches the beginning of `argv`. -/
+def matchesPrefix : List String → List String → Bool
+  | [], _ => true
+  | _ :: _, [] => false
+  | p :: ps, a :: rest =>
+      if p = a then matchesPrefix ps rest else false
+
+/-- First configured argv prefix that matches `argv`, preserving Rust's list order. -/
+def firstMatchingPrefix (argv : List String) : List (List String) → Option (List String)
+  | [] => none
+  | candidate :: rest =>
+      if matchesPrefix candidate argv then
+        some candidate
+      else
+        firstMatchingPrefix argv rest
+
+/-- Read-only command allowlist check. The Rust implementation also normalizes
+    executable paths to file names; this model captures the allowlist gate. -/
+def commandAllowlisted (command : String) (allowlist : List String) : Bool :=
+  allowlist.any (fun allowed => decide (allowed = command))
+
+/-- Validator used when the effective mode is `read_only`. -/
+def validateReadOnlyCommand
+    (allowlist : List String)
+    (request : CommandRequest) : Decision :=
+  if commandAllowlisted request.command allowlist then
+    .allow
+  else
+    .deny (.readOnlyCommandNotAllowlisted request.command)
+
+/-- Read-only commands that cannot be allowed when network is disabled without
+    a sandbox-level network denial. -/
+def readOnlyNetworkDenied (request : CommandRequest) : Bool :=
+  if request.command = "curl" then
+    true
+  else if request.command = "tailscale" then
+    match request.args with
+    | "ping" :: _ => true
+    | "netcheck" :: _ => true
+    | _ => false
+  else
+    false
+
+/-- Network-mode gate. `workspace_write` can enforce disabled networking through
+    its sandbox; `unrestricted` cannot, so it fails closed. -/
+def validateNetworkMode
+    (mode : ExecutionMode)
+    (networkMode : NetworkMode)
+    (request : CommandRequest) : Decision :=
+  match networkMode with
+  | .inherit => .allow
+  | .enabled => .allow
+  | .disabled =>
+      match mode with
+      | .workspaceWrite => .allow
+      | .unrestricted => .deny .disabledNetworkUnenforceable
+      | .readOnly =>
+          if readOnlyNetworkDenied request then
+            .deny (.disabledNetworkCommand request.command)
+          else
+            .allow
+
+/-- Validation once argv prefix checks have passed. -/
+def validateAfterPrefixes (policy : Policy) (request : CommandRequest) : Decision :=
+  match validateNetworkMode policy.mode policy.networkMode request with
+  | .deny reason => .deny reason
+  | .allow =>
+      match policy.mode with
+      | .readOnly => validateReadOnlyCommand policy.readOnlyAllowlist request
+      | .workspaceWrite => .allow
+      | .unrestricted => .allow
+
+/-- Policy validation order: forbidden prefixes, allowed-prefix list, network
+    gate, and finally the read-only allowlist. -/
+def validatePolicy (policy : Policy) (request : CommandRequest) : Decision :=
+  match firstMatchingPrefix request.argv policy.forbiddenArgvPrefixes with
+  | some matched => .deny (.forbiddenPrefix matched)
+  | none =>
+      match policy.allowedArgvPrefixes with
+      | [] => validateAfterPrefixes policy request
+      | _ :: _ =>
+          match firstMatchingPrefix request.argv policy.allowedArgvPrefixes with
+          | none => .deny (.allowedPrefixRequired request.argv)
+          | some _ => validateAfterPrefixes policy request
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -48,6 +48,15 @@ and terminal rows (`cancelled`, `completed`, `failed`) have released any permit.
 There is intentionally no denormalized persisted `FleetState` document that
 must carry the aggregate invariant.
 
+The command-policy model covers local validation and selection logic for
+`CommandExecutionMode`, `CommandNetworkMode`, argv allowed/forbidden prefixes,
+read-only command allowlisting, sandbox labels, and filtered shell environment
+keys. It does not prove that an invoked external binary is semantically
+read-only, nor does it prove the host kernel's sandbox implementation. Rust
+tests cover the parser/validator boundary and command metadata emitted by
+`toolset/shared/command.rs`; the Lean model covers the fail-closed policy
+ordering and sandbox/env invariants that those tests exercise.
+
 ## External Assumptions
 
 The `PersistenceState` model abstracts the storage commit boundary. Rust uses

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -20,9 +20,11 @@ The proofs are strongest where the runtime is a state machine:
 - desired-state apply ordering and field ownership
 - task, schedule, and event-trigger dispatch
 - client turn projection and desktop shell workflow state
+- command/tool execution policy for bash argv, network, sandbox, and shell env
 
 They do not prove storage guarantees, network delivery, provider behavior, UI
-rendering, or external tool behavior. Those are explicit model boundaries.
+rendering, external tool behavior, or host sandbox implementation details. Those
+are explicit model boundaries.
 
 ## Quick Start
 
@@ -37,7 +39,7 @@ lake build
 
 ## What Is Proven
 
-The current proof suite covers nine practical areas:
+The current proof suite covers ten practical areas:
 
 1. Request/process/persistence state transitions
 2. Inference-call lifecycle, request linkage, and cancellation terminality
@@ -48,6 +50,8 @@ The current proof suite covers nine practical areas:
 7. Trigger dispatch for manual, schedule, and event-driven tasks
 8. Client turn-state derivation from replicated request/response documents
 9. Client-shell workflow rules for selection, submission, and transport decoupling
+10. Command/tool execution policy: argv prefixes, read-only allowlists,
+    disabled-network fail-closed behavior, sandbox selection, and filtered env
 
 The proof boundary matters:
 
@@ -94,6 +98,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Triggers.lean` | Barrel for trigger types, dispatch, reachability, serial, latest-only, and lineage proofs |
 | `Proofs/Client.lean` | Barrel for client turn-state derivation and client theorems |
 | `Proofs/ClientShell.lean` | Barrel for multi-session shell workflow modules |
+| `Proofs/CommandPolicy.lean` | Barrel for command/tool execution policy validation, sandbox, env, and safety proofs |
 | `Proofs/Properties/Safety.lean` | Request/process/persistence safety properties S1-S6 |
 | `Proofs/Properties/Liveness.lean` | Request/process liveness properties L1-L3 |
 | `Proofs/Properties/SchedulingSafety.lean` | Scheduler/fleet safety properties S7-S9 |
@@ -117,6 +122,7 @@ Semantic submodules:
 | `Proofs.Triggers.SerialSupport` | `Counting`, `Preservation` |
 | `Proofs.Client` | `Types`, `Lifecycle`, `Terminal`, `Replacement` |
 | `Proofs.ClientShell` | `Types`, `Submission`, `Transition`, `Projection`, `Theorems` |
+| `Proofs.CommandPolicy` | `Types`, `Validation`, `Sandbox`, `Env`, `Theorems` |
 | `Proofs.Conformance.Triggers` | `Lifecycle`, `Materialization`, `Trace` |
 
 The top-level barrel imports remain the stable entry points for downstream code.

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -617,6 +617,37 @@ async fn unrestricted_bash_runs_shell_command_strings() {
 }
 
 #[tokio::test]
+async fn command_policy_explicit_unrestricted_reports_unsandboxed_metadata() {
+    let root = temp_root("defra-agent-unrestricted-policy");
+    let policy =
+        CommandExecutionPolicy::write_capable().with_mode(CommandExecutionMode::Unrestricted);
+    let tool = UnrestrictedBashTool::with_policy(
+        ToolContext::new(root, false).unwrap(),
+        Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+        policy,
+    );
+
+    let output = rig::tool::Tool::call(
+        &tool,
+        BashArgs {
+            command: "printf".to_string(),
+            args: vec!["ok".to_string()],
+            cwd: None,
+            timeout_secs: DEFAULT_COMMAND_TIMEOUT_SECS,
+            raw_json: false,
+        },
+    )
+    .await
+    .unwrap();
+
+    let meta = compact_exec_meta(&output);
+    assert_eq!(meta["ok"], true);
+    assert_eq!(meta["execution_mode"], "unrestricted");
+    assert_eq!(meta["sandbox"], "unsandboxed_unrestricted");
+    assert_eq!(meta["stdout_truncation"]["total_chars"], 2);
+}
+
+#[tokio::test]
 async fn bash_output_supports_raw_json_escape_hatch() {
     let root = temp_root("defra-agent-bash-raw-json");
     let tool = ReadOnlyBashTool::new(


### PR DESCRIPTION
Summary:
- Add Proofs.CommandPolicy with Lean models for command execution modes, network modes, argv prefix validation, read-only allowlisting, sandbox selection, and filtered shell env.
- Prove forbidden prefixes deny, unmatched allowed-prefix lists deny, read-only validation only allows allowlisted commands, disabled network fails closed for unrestricted commands, workspace_write requires an enforced sandbox, unrestricted is explicitly unsandboxed, and filtered env excludes KEY/SECRET/TOKEN while forcing pager/color vars.
- Add focused Rust coverage for explicit unrestricted sandbox metadata and CLI desired-state command-policy validation.
- Update proof docs and conformance boundaries.

Verification:
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent command_policy -- --nocapture
- cargo test -p defra-agent read_only_bash -- --nocapture
- cargo test -p defra-agent shell_environment_filters_secrets_and_forces_noninteractive_values -- --nocapture
- cargo test -p defra-agent workspace_write -- --nocapture
- cargo test -p defra-agent-cli config_validate_reports_command_policy_errors -- --nocapture
- cargo fmt --check
- git diff --check
- rg -n "\b(sorry|admit|axiom)\b|PLACEHOLDER|todo!\(\)" crates apps docs scripts --glob '!target/**' --glob '!**/.lake/**'
- find crates/defra-agent/proofs/Proofs -name '*.lean' -print0 | xargs -0 wc -l | sort -nr | head -5