### PR TITLE
Derive Rust conformance from Lean contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           components: rustfmt
 
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" --version
+
       - name: Install protobuf compiler
         run: |
           set -euo pipefail

--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -20,4 +20,5 @@ import Proofs.Conformance.DefraAgent
 import Proofs.Conformance.Boundaries
 import Proofs.Conformance.Deviations
 import Proofs.Conformance.SchedulerConformance
+import Proofs.Conformance.Contracts
 import Proofs.ApplyReconcile

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -64,6 +64,13 @@ The service-local proof and tests cover the consequence of an observed backend
 configuration: reconstructed running call rows do not exceed that backend's
 `max_concurrent`.
 
+The generated `SessionRecovery` conformance contract currently covers the
+finite failed-latest-request reissue witness (`failed -> pending`) instead of
+the full request lifecycle vocabulary. It is a smoke contract for the executable
+session boundary, not a complete request-state coverage claim. Future
+session-recovery executable witnesses should widen that contract before Rust
+depends on broader transition coverage from it.
+
 ## Closed Historical Items
 
 These were previous conformance gaps and are now closed product/spec behavior:

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -1,0 +1,388 @@
+import Proofs.Request
+import Proofs.Process
+import Proofs.Persistence
+import Proofs.SessionRecovery
+import Proofs.InferenceCall
+
+/-!
+# Rust Conformance Contracts
+
+This module is the Lean-owned extraction surface for Rust conformance tests.
+Rust runs this file with `lake env lean --run` and consumes the JSON emitted by
+`main`. State vocabularies and transition tables are evaluated from the Lean
+constructors, `toDefraDB` functions, executable `step?` functions, and finite
+witness contexts below.
+
+`RuntimeReconcile` is intentionally not included yet: its executable conformance
+contract should be added here after the executable runtime-reconcile PR lands.
+-/
+
+namespace Conformance.Contracts
+
+structure TransitionPair where
+  source : String
+  target : String
+  deriving DecidableEq, Repr
+
+structure VocabularyContract where
+  domain : String
+  values : List String
+  deriving Repr
+
+structure StateMachineContract where
+  domain : String
+  states : List String
+  stateCount : Nat
+  terminalStates : List String
+  nonterminalStates : List String
+  actions : List String
+  legalTransitions : List TransitionPair
+  illegalTransitions : List TransitionPair
+  deriving Repr
+
+def jsonString (s : String) : String :=
+  "\"" ++ s ++ "\""
+
+def jsonArray (values : List String) : String :=
+  "[" ++ String.intercalate "," values ++ "]"
+
+def jsonStringArray (values : List String) : String :=
+  jsonArray (values.map jsonString)
+
+def dedup {α : Type} [DecidableEq α] : List α → List α
+  | [] => []
+  | x :: xs =>
+      if x ∈ xs then
+        dedup xs
+      else
+        x :: dedup xs
+
+def without {α : Type} [DecidableEq α] (values excluded : List α) : List α :=
+  values.filter fun value => if value ∈ excluded then false else true
+
+def allPairs (states : List String) : List TransitionPair :=
+  states.flatMap fun source =>
+    states.map fun target => { source := source, target := target }
+
+def illegalPairs (states : List String) (legal : List TransitionPair) : List TransitionPair :=
+  without (allPairs states) legal
+
+def terminalNames {α : Type} [HasTerminal α]
+    (states : List α)
+    (name : α → String) : List String :=
+  states.filterMap fun state =>
+    if isTerminal state then some (name state) else none
+
+def actionNames {α : Type} (actions : List (String × α)) : List String :=
+  actions.map Prod.fst
+
+def transitionPairsFromSamples {σ α : Type}
+    (samples : List σ)
+    (actions : List (String × α))
+    (step : σ → α → Option σ)
+    (stateName : σ → String) : List TransitionPair :=
+  dedup <|
+    samples.flatMap fun pre =>
+      actions.filterMap fun action =>
+        match step pre action.snd with
+        | some post => some { source := stateName pre, target := stateName post }
+        | none => none
+
+def machineContract
+    (domain : String)
+    (states terminalStates actions : List String)
+    (legalTransitions : List TransitionPair) : StateMachineContract :=
+  let legalTransitions := dedup legalTransitions
+  { domain := domain
+  , states := states
+  , stateCount := states.length
+  , terminalStates := terminalStates
+  , nonterminalStates := without states terminalStates
+  , actions := actions
+  , legalTransitions := legalTransitions
+  , illegalTransitions := illegalPairs states legalTransitions
+  }
+
+def requestStates : List RequestState :=
+  [ .pending
+  , .claimed
+  , .processing
+  , .inputRequired
+  , .completed
+  , .failed
+  , .superseded
+  , .dead
+  , .interrupted
+  ]
+
+def requestStateNames : List String :=
+  requestStates.map RequestState.toDefraDB
+
+def requestActions : List (String × RequestContext.Action) :=
+  [ ("claim", .claim)
+  , ("dedupLose", .dedupLose)
+  , ("beginInference", .beginInference)
+  , ("advance", .advance)
+  , ("finish", .finish)
+  , ("fail", .fail)
+  , ("failBeforeStream", .failBeforeStream)
+  , ("expire", .expire)
+  , ("interruptBeforeClaim", .interruptBeforeClaim)
+  , ("interruptClaimed", .interruptClaimed)
+  , ("interruptProcessing", .interruptProcessing)
+  ]
+
+def contractBackend : BackendId :=
+  { val := "contract-backend" }
+
+def requestContext
+    (state : RequestState)
+    (admission : AdmissionState)
+    (hasInterrupt : Bool := false)
+    (validUntil : Option Time := none)
+    (currentTime : Time := 0) : RequestContext :=
+  { state := state
+  , origin := .interactive
+  , backend := contractBackend
+  , admission := admission
+  , deadline := 10
+  , claimTime := 0
+  , currentTime := currentTime
+  , retryCount := 0
+  , maxRetries := 3
+  , progressSeq := 0
+  , messageSeq := 0
+  , isLatest := true
+  , persistence := .uncommitted
+  , interruptRequestedAt := if hasInterrupt then some currentTime else none
+  , validUntil := validUntil
+  }
+
+def requestSamples : List RequestContext :=
+  [ requestContext .pending .released
+  , requestContext .pending .released true
+  , requestContext .pending .released false (some 0) 1
+  , requestContext .claimed .waiting
+  , requestContext .claimed .acquired
+  , requestContext .claimed .waiting true
+  , requestContext .claimed .acquired true
+  , requestContext .processing .executing
+  , requestContext .processing .executing true
+  , requestContext .inputRequired .executing
+  , requestContext .completed .released
+  , requestContext .failed .released
+  , requestContext .superseded .released
+  , requestContext .dead .released
+  , requestContext .interrupted .released
+  ]
+
+def requestMachine : StateMachineContract :=
+  machineContract
+    "Request"
+    requestStateNames
+    (terminalNames requestStates RequestState.toDefraDB)
+    (actionNames requestActions)
+    (transitionPairsFromSamples
+      requestSamples
+      requestActions
+      RequestContext.step?
+      (fun ctx => ctx.state.toDefraDB))
+
+def processStates : List ProcessState :=
+  [ .uninitialized, .recovering, .ready, .shuttingDown, .shutdown ]
+
+def processStateNames : List String :=
+  processStates.map ProcessState.toDefraDB
+
+def processActions : List (String × ProcessState.Action) :=
+  [ ("startupRecover", .startupRecover { hasStuckRequests := true, activeRequestCount := 1 })
+  , ("startupClean", .startupClean { hasStuckRequests := false, activeRequestCount := 0 })
+  , ("recoveryComplete", .recoveryComplete)
+  , ("beginShutdown", .beginShutdown)
+  , ("finishShutdown", .finishShutdown 0)
+  ]
+
+def processMachine : StateMachineContract :=
+  machineContract
+    "Process"
+    processStateNames
+    (terminalNames processStates ProcessState.toDefraDB)
+    (actionNames processActions)
+    (transitionPairsFromSamples
+      processStates
+      processActions
+      ProcessState.step?
+      ProcessState.toDefraDB)
+
+def persistenceStates : List PersistenceState :=
+  [ .uncommitted, .committing, .committed, .lost ]
+
+def persistenceStateNames : List String :=
+  persistenceStates.map PersistenceState.toDefraDB
+
+def persistenceActions : List (String × PersistenceState.Action) :=
+  [ ("flush", .flush)
+  , ("writeSuccess", .writeSuccess)
+  , ("writeFail", .writeFail)
+  , ("accumulate", .accumulate)
+  ]
+
+def persistenceMachine
+    (domain : String)
+    (policy : PersistenceState.FailurePolicy) : StateMachineContract :=
+  machineContract
+    domain
+    persistenceStateNames
+    (terminalNames persistenceStates PersistenceState.toDefraDB)
+    (actionNames persistenceActions)
+    (transitionPairsFromSamples
+      persistenceStates
+      persistenceActions
+      (fun state action => PersistenceState.step? policy state action)
+      PersistenceState.toDefraDB)
+
+def sessionRecoveryFailedId : RequestId := 1
+
+def sessionRecoveryNewId : RequestId := 2
+
+def sessionRecoveryFailedContext : RequestContext :=
+  requestContext .failed .released
+
+def sessionRecoveryPre : SessionState :=
+  { sessionId := 1
+  , behaviorId := 1
+  , requestIds := {sessionRecoveryFailedId}
+  , ctx := fun rid =>
+      if rid = sessionRecoveryFailedId then
+        sessionRecoveryFailedContext
+      else
+        requestContext .pending .released
+  , latest := sessionRecoveryFailedId
+  }
+
+def sessionRecoveryLegalTransitions : List TransitionPair :=
+  match SessionState.step?
+      sessionRecoveryPre
+      (.reissueFailed sessionRecoveryFailedId sessionRecoveryNewId) with
+  | some post =>
+      [ { source := (sessionRecoveryPre.ctx sessionRecoveryPre.latest).state.toDefraDB
+        , target := (post.ctx post.latest).state.toDefraDB
+        }
+      ]
+  | none => []
+
+def sessionRecoveryMachine : StateMachineContract :=
+  machineContract
+    "SessionRecovery"
+    [RequestState.failed.toDefraDB, RequestState.pending.toDefraDB]
+    []
+    ["reissueFailed"]
+    sessionRecoveryLegalTransitions
+
+def inferenceCallStates : List InferenceCallState :=
+  [ .queued, .running, .cancelled, .completed, .failed ]
+
+def inferenceCallStateNames : List String :=
+  inferenceCallStates.map InferenceCallState.toDefraDB
+
+def inferenceCallActions : List (String × InferenceCall.Action) :=
+  [ ("start", .start)
+  , ("complete", .complete)
+  , ("fail", .fail)
+  , ("cancel", .cancel)
+  ]
+
+def inferenceCallWithState (state : InferenceCallState) : InferenceCall :=
+  { callId := 1
+  , requestId := 1
+  , backend := contractBackend
+  , state := state
+  }
+
+def inferenceCallMachine : StateMachineContract :=
+  machineContract
+    "InferenceCall"
+    inferenceCallStateNames
+    (terminalNames inferenceCallStates InferenceCallState.toDefraDB)
+    (actionNames inferenceCallActions)
+    (transitionPairsFromSamples
+      (inferenceCallStates.map inferenceCallWithState)
+      inferenceCallActions
+      InferenceCall.step?
+      (fun call => call.state.toDefraDB))
+
+def vocabularies : List VocabularyContract :=
+  [ { domain := "RequestState", values := requestStateNames }
+  , { domain := "ExecutionOrigin", values :=
+        [.interactive, .scheduled].map ExecutionOrigin.toDefraDB }
+  , { domain := "ProcessState", values := processStateNames }
+  , { domain := "PersistenceState", values := persistenceStateNames }
+  , { domain := "PersistenceFailurePolicy", values :=
+        [.failOpen, .failClosed].map PersistenceState.FailurePolicy.toDefraDB }
+  , { domain := "SessionRecoveryLatestRequestState"
+    , values := [RequestState.failed.toDefraDB, RequestState.pending.toDefraDB]
+    }
+  , { domain := "InferenceCallState", values := inferenceCallStateNames }
+  , { domain := "InferenceCallTerminalReason", values :=
+        [ .cancelled
+        , .backendGone
+        , .queueFull
+        , .streamDroppedBeforeTerminalResponse
+        ].map InferenceCallTerminalReason.toDefraDB
+    }
+  ]
+
+def stateMachines : List StateMachineContract :=
+  [ requestMachine
+  , processMachine
+  , persistenceMachine "Persistence.failClosed" .failClosed
+  , persistenceMachine "Persistence.failOpen" .failOpen
+  , sessionRecoveryMachine
+  , inferenceCallMachine
+  ]
+
+def TransitionPair.toJson (pair : TransitionPair) : String :=
+  "{"
+    ++ "\"from\":" ++ jsonString pair.source ++ ","
+    ++ "\"to\":" ++ jsonString pair.target
+    ++ "}"
+
+def VocabularyContract.toJson (contract : VocabularyContract) : String :=
+  "{"
+    ++ "\"domain\":" ++ jsonString contract.domain ++ ","
+    ++ "\"values\":" ++ jsonStringArray contract.values
+    ++ "}"
+
+def StateMachineContract.toJson (contract : StateMachineContract) : String :=
+  "{"
+    ++ "\"domain\":" ++ jsonString contract.domain ++ ","
+    ++ "\"states\":" ++ jsonStringArray contract.states ++ ","
+    ++ "\"state_count\":" ++ toString contract.stateCount ++ ","
+    ++ "\"terminal_states\":" ++ jsonStringArray contract.terminalStates ++ ","
+    ++ "\"nonterminal_states\":" ++ jsonStringArray contract.nonterminalStates ++ ","
+    ++ "\"actions\":" ++ jsonStringArray contract.actions ++ ","
+    ++ "\"legal_transitions\":"
+      ++ jsonArray (contract.legalTransitions.map TransitionPair.toJson) ++ ","
+    ++ "\"illegal_transitions\":"
+      ++ jsonArray (contract.illegalTransitions.map TransitionPair.toJson)
+    ++ "}"
+
+def snapshotJson : String :=
+  "{"
+    ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
+    ++ "\"vocabularies\":"
+      ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
+    ++ "\"state_machines\":"
+      ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
+    ++ "\"follow_up_hooks\":["
+      ++ jsonString "RuntimeReconcile executable state machine contract"
+      ++ "]"
+    ++ "}"
+
+def main : IO Unit :=
+  IO.println snapshotJson
+
+end Conformance.Contracts
+
+def main : IO Unit :=
+  Conformance.Contracts.main

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -49,13 +49,10 @@ def jsonArray (values : List String) : String :=
 def jsonStringArray (values : List String) : String :=
   jsonArray (values.map jsonString)
 
-def dedup {α : Type} [DecidableEq α] : List α → List α
-  | [] => []
-  | x :: xs =>
-      if x ∈ xs then
-        dedup xs
-      else
-        x :: dedup xs
+def dedup {α : Type} [DecidableEq α] (values : List α) : List α :=
+  values.foldl
+    (fun seen value => if value ∈ seen then seen else seen ++ [value])
+    []
 
 def without {α : Type} [DecidableEq α] (values excluded : List α) : List α :=
   values.filter fun value => if value ∈ excluded then false else true
@@ -379,8 +376,16 @@ def snapshotJson : String :=
       ++ "]"
     ++ "}"
 
-def main : IO Unit :=
+def contractJsonBegin : String :=
+  "---BEGIN DEFRA LEAN CONTRACT JSON---"
+
+def contractJsonEnd : String :=
+  "---END DEFRA LEAN CONTRACT JSON---"
+
+def main : IO Unit := do
+  IO.println contractJsonBegin
   IO.println snapshotJson
+  IO.println contractJsonEnd
 
 end Conformance.Contracts
 

--- a/crates/defra-agent/proofs/Proofs/InferenceCall.lean
+++ b/crates/defra-agent/proofs/Proofs/InferenceCall.lean
@@ -1,11 +1,12 @@
 import Proofs.InferenceCall.State
 import Proofs.InferenceCall.Transition
+import Proofs.InferenceCall.Executable
 import Proofs.InferenceCall.Properties
 import Proofs.InferenceCall.SlotAccounting
 
 /-!
 # Inference Call Lifecycle
 
-Barrel import for persisted `InferenceCall` state, transitions, slot accounting,
-and cancellation properties.
+Barrel import for persisted `InferenceCall` state, transitions, executable
+semantics, slot accounting, and cancellation properties.
 -/

--- a/crates/defra-agent/proofs/Proofs/InferenceCall/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/InferenceCall/Executable.lean
@@ -1,0 +1,129 @@
+import Proofs.InferenceCall.Transition
+
+/-!
+# Executable Inference Call Semantics
+
+Executable actions, step function, replay, and equivalence with the relational
+transition model for a single persisted `InferenceCall` row.
+-/
+
+namespace InferenceCall
+
+/-- Executable inference-call actions mirroring `Transition`. -/
+inductive Action where
+  | start
+  | complete
+  | fail
+  | cancel
+  deriving DecidableEq, Repr
+
+/-- Executable transition function for the inference-call layer. -/
+def step? (pre : InferenceCall) : Action → Option InferenceCall
+  | .start =>
+      if pre.state = .queued then
+        some { pre with state := .running }
+      else
+        none
+  | .complete =>
+      if pre.state = .running then
+        some { pre with state := .completed }
+      else
+        none
+  | .fail =>
+      if pre.state = .running then
+        some { pre with state := .failed }
+      else
+        none
+  | .cancel =>
+      if pre.state = .queued ∨ pre.state = .running then
+        some pre.cancel
+      else
+        none
+
+/-- Replay a finite action list through the executable call semantics. -/
+def replay? : InferenceCall → List Action → Option InferenceCall
+  | s, [] => some s
+  | s, action :: rest =>
+      match step? s action with
+      | some s' => replay? s' rest
+      | none => none
+
+theorem step_sound
+    {pre post : InferenceCall}
+    {action : Action}
+    (h_step : step? pre action = some post) :
+    Transition pre post := by
+  cases action with
+  | start =>
+      simp [step?] at h_step
+      rcases h_step with ⟨h_state, h_post⟩
+      exact Transition.start h_state h_post.symm
+  | complete =>
+      simp [step?] at h_step
+      rcases h_step with ⟨h_state, h_post⟩
+      exact Transition.complete h_state h_post.symm
+  | fail =>
+      simp [step?] at h_step
+      rcases h_step with ⟨h_state, h_post⟩
+      exact Transition.fail h_state h_post.symm
+  | cancel =>
+      simp [step?] at h_step
+      rcases h_step with ⟨h_live, h_post⟩
+      cases h_live with
+      | inl h_queued =>
+          exact Transition.cancel
+            (CancellationTransition.cancel_before_stream h_queued h_post.symm)
+      | inr h_running =>
+          exact Transition.cancel
+            (CancellationTransition.cancel_during_stream h_running h_post.symm)
+
+theorem transition_complete
+    {pre post : InferenceCall}
+    (h_trans : Transition pre post) :
+    ∃ action : Action, step? pre action = some post := by
+  cases h_trans with
+  | start h_state h_post =>
+      exact ⟨.start, by simp [step?, h_state, h_post]⟩
+  | complete h_state h_post =>
+      exact ⟨.complete, by simp [step?, h_state, h_post]⟩
+  | fail h_state h_post =>
+      exact ⟨.fail, by simp [step?, h_state, h_post]⟩
+  | cancel h_cancel =>
+      cases h_cancel with
+      | cancel_before_stream h_state h_post =>
+          exact ⟨.cancel, by simp [step?, h_state, h_post]⟩
+      | cancel_during_stream h_state h_post =>
+          exact ⟨.cancel, by simp [step?, h_state, h_post]⟩
+
+theorem replay_sound
+    {pre post : InferenceCall}
+    {actions : List Action}
+    (h_replay : replay? pre actions = some post) :
+    Trace pre post := by
+  induction actions generalizing pre with
+  | nil =>
+      simp [replay?] at h_replay
+      subst h_replay
+      exact Trace.refl
+  | cons action rest ih =>
+      simp [replay?] at h_replay
+      rcases h_step : step? pre action with (_ | next)
+      · simp [h_step] at h_replay
+      · simp [h_step] at h_replay
+        have h_trans : Transition pre next := step_sound h_step
+        exact Trace.step h_trans (ih h_replay)
+
+theorem trace_complete
+    {pre post : InferenceCall}
+    (h_trace : Trace pre post) :
+    ∃ actions : List Action, replay? pre actions = some post := by
+  induction h_trace with
+  | refl =>
+      exact ⟨[], rfl⟩
+  | step h_trans h_trace ih =>
+      rcases transition_complete h_trans with ⟨action, h_action⟩
+      rcases ih with ⟨actions, h_actions⟩
+      refine ⟨action :: actions, ?_⟩
+      simp [replay?, h_action, h_actions]
+
+end InferenceCall

--- a/crates/defra-agent/proofs/Proofs/Persistence.lean
+++ b/crates/defra-agent/proofs/Proofs/Persistence.lean
@@ -18,6 +18,25 @@ inductive PersistenceState where
 
 namespace PersistenceState
 
+/-- String vocabulary for the persistence lifecycle contract. -/
+def toDefraDB : PersistenceState → String
+  | .uncommitted => "uncommitted"
+  | .committing => "committing"
+  | .committed => "committed"
+  | .lost => "lost"
+
+/-- Parse the persistence lifecycle contract vocabulary. -/
+def fromDefraDB? : String → Option PersistenceState
+  | "uncommitted" => some .uncommitted
+  | "committing" => some .committing
+  | "committed" => some .committed
+  | "lost" => some .lost
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (s : PersistenceState) :
+    fromDefraDB? s.toDefraDB = some s := by
+  cases s <;> rfl
+
 instance : HasTerminal PersistenceState where
   isTerminal s := s = .committed ∨ s = .lost
   isTerminal_dec s :=
@@ -32,6 +51,25 @@ inductive FailurePolicy where
   | failOpen
   | failClosed
   deriving DecidableEq, Repr
+
+namespace FailurePolicy
+
+/-- String vocabulary for persistence failure-policy contracts. -/
+def toDefraDB : FailurePolicy → String
+  | .failOpen => "failOpen"
+  | .failClosed => "failClosed"
+
+/-- Parse the persistence failure-policy contract vocabulary. -/
+def fromDefraDB? : String → Option FailurePolicy
+  | "failOpen" => some .failOpen
+  | "failClosed" => some .failClosed
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (policy : FailurePolicy) :
+    fromDefraDB? policy.toDefraDB = some policy := by
+  cases policy <;> rfl
+
+end FailurePolicy
 
 /-- Persistence transitions parameterized by failure policy. -/
 inductive Transition (policy : FailurePolicy) :

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -33,6 +33,10 @@ curl https://elan.lean-lang.org/elan-init.sh -sSf | sh -s -- -y
 # Build all proofs.
 cd crates/defra-agent/proofs
 lake build
+
+# Print the Rust conformance contract JSON used by Rust tests.
+lake build Proofs.Conformance.Contracts
+lake env lean --run Proofs/Conformance/Contracts.lean
 ```
 
 ## What Is Proven
@@ -103,6 +107,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Conformance/Boundaries.lean` | Intentional product policies and external assumptions at the Rust/Lean boundary |
 | `Proofs/Conformance/Deviations.lean` | Active unresolved Rust/spec mismatches; currently empty |
 | `Proofs/Conformance/SchedulerConformance.lean` | Scheduler-specific conformance notes |
+| `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, and legal/illegal transition pairs |
 | `Proofs/Conformance/Triggers.lean` | Barrel for trigger lifecycle/materialization conformance |
 
 Semantic submodules:
@@ -110,7 +115,7 @@ Semantic submodules:
 | Barrel | Submodules |
 |--------|------------|
 | `Proofs.Request` | `State`, `Transition`, `Executable`, `Properties` |
-| `Proofs.InferenceCall` | `State`, `Transition`, `Properties`, `SlotAccounting` |
+| `Proofs.InferenceCall` | `State`, `Transition`, `Executable`, `Properties`, `SlotAccounting` |
 | `Proofs.RuntimeReconcile` | `State`, `Transition` |
 | `Proofs.ApplyReconcile` | `Collections`, `Manifest`, `Diff`, `Apply`, `ApplyProperties`, `RuntimeBridge`, `Convergence` |
 | `Proofs.Triggers` | `Types`, `Dispatch`, `Reachability`, `SerialSupport`, `Serial`, `LatestOnly`, `Lineage` |
@@ -124,6 +129,38 @@ The top-level barrel imports remain the stable entry points for downstream code.
 Related implementation-facing doc:
 
 - `client-state-machine.md`: client turn observation protocol for app implementers
+
+## Rust Conformance Extraction
+
+Rust conformance tests do not hand-maintain separate Lean parity tables for the
+core executable machines. The test helper in `src/lean_vocab_test.rs` runs:
+
+```bash
+cd crates/defra-agent/proofs
+lake build Proofs.Conformance.Contracts
+lake env lean --run Proofs/Conformance/Contracts.lean
+```
+
+The emitted JSON is generated from Lean constructors, `toDefraDB` functions,
+terminal predicates, executable `step?` functions, and finite witness contexts.
+It currently covers:
+
+- `Request`
+- `Process`
+- `Persistence.failClosed`
+- `Persistence.failOpen`
+- `SessionRecovery`
+- `InferenceCall`
+
+When a Lean vocabulary, terminal partition, action, or legal transition changes,
+the generated JSON changes on the next Rust test run. The Rust tests then fail
+unless the runtime behavior or the documented product-boundary assertions are
+updated to match.
+
+`RuntimeReconcile` is intentionally exposed only as a follow-up hook in the JSON
+until its executable state-machine contract lands. Add it to
+`Proofs/Conformance/Contracts.lean` as another `StateMachineContract` once that
+PR is merged.
 
 ## Core Model
 

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -141,9 +141,11 @@ lake build Proofs.Conformance.Contracts
 lake env lean --run Proofs/Conformance/Contracts.lean
 ```
 
-The emitted JSON is generated from Lean constructors, `toDefraDB` functions,
-terminal predicates, executable `step?` functions, and finite witness contexts.
-It currently covers:
+The emitted JSON is printed between `---BEGIN DEFRA LEAN CONTRACT JSON---` and
+`---END DEFRA LEAN CONTRACT JSON---` sentinel lines so Rust can reject unrelated
+stdout. It is generated from Lean constructors, `toDefraDB` functions, terminal
+predicates, executable `step?` functions, and finite witness contexts. It
+currently covers:
 
 - `Request`
 - `Process`
@@ -151,6 +153,12 @@ It currently covers:
 - `Persistence.failOpen`
 - `SessionRecovery`
 - `InferenceCall`
+
+The current `SessionRecovery` contract is intentionally narrow: it covers the
+executable failed-latest-request reissue witness (`failed -> pending`) rather
+than the whole request lifecycle vocabulary. Widen this contract when the
+session-recovery executable model grows enough finite witnesses to represent the
+larger space directly.
 
 When a Lean vocabulary, terminal partition, action, or legal transition changes,
 the generated JSON changes on the next Rust test run. The Rust tests then fail

--- a/crates/defra-agent/src/admission/tests.rs
+++ b/crates/defra-agent/src/admission/tests.rs
@@ -12,7 +12,9 @@ use super::{
     BackendAdmissionConfig, CallKind,
 };
 use crate::lean_vocab_test::{
-    assert_lean_to_defradb_vocabulary_matches, lean_to_defradb_values, LeanVocabulary,
+    assert_lean_contract_vocabulary_set_matches, assert_lean_transition_is_illegal,
+    assert_lean_transition_is_legal, assert_state_machine_contract_is_complete,
+    lean_vocabulary_values, LeanContractVocabulary,
 };
 use crate::schema::ensure_schemas;
 use crate::watcher::AgentRequest;
@@ -56,41 +58,29 @@ fn request(request_id: &str) -> AgentRequest {
     }
 }
 
-const RUST_INFERENCE_CALL_STATES: &[&str] =
-    &["queued", "running", "cancelled", "completed", "failed"];
-const RUST_INFERENCE_CALL_TERMINAL_REASONS: &[&str] = &[
-    "Cancelled",
-    "BackendGone",
-    "QueueFull",
-    "StreamDroppedBeforeTerminalResponse",
-];
-const LEAN_INFERENCE_CALL_STATE_FILE: &str =
-    "crates/defra-agent/proofs/Proofs/InferenceCall/State.lean";
-const LEAN_INFERENCE_CALL_STATE_MODEL: &str =
-    include_str!("../../proofs/Proofs/InferenceCall/State.lean");
 const ADMISSION_TERMINAL_REASON_SOURCES: &[&str] = &[
     include_str!("controller.rs"),
     include_str!("permit.rs"),
     include_str!("registry.rs"),
 ];
+const ADMISSION_CALL_STATE_SOURCES: &[&str] = &[
+    include_str!("controller.rs"),
+    include_str!("permit.rs"),
+    include_str!("persistence.rs"),
+    include_str!("registry.rs"),
+];
 
 fn lean_inference_call_states() -> Vec<&'static str> {
-    lean_to_defradb_values(
-        LEAN_INFERENCE_CALL_STATE_FILE,
-        LEAN_INFERENCE_CALL_STATE_MODEL,
-        "InferenceCallState",
-    )
+    lean_vocabulary_values("InferenceCallState")
 }
 
-fn some_string_literals(source: &'static str) -> Vec<&'static str> {
+fn string_literals_after(source: &'static str, needle: &str) -> Vec<&'static str> {
     let mut rest = source;
     let mut values = Vec::new();
-    while let Some(start) = rest.find("Some(\"") {
-        let value_start = start + "Some(\"".len();
+    while let Some(start) = rest.find(needle) {
+        let value_start = start + needle.len();
         let after_start = &rest[value_start..];
-        let value_end = after_start
-            .find('"')
-            .expect("Some string literal must close");
+        let value_end = after_start.find('"').expect("string literal must close");
         values.push(&after_start[..value_end]);
         rest = &after_start[value_end + 1..];
     }
@@ -100,7 +90,29 @@ fn some_string_literals(source: &'static str) -> Vec<&'static str> {
 fn rust_literal_terminal_reasons_from_admission_sources() -> Vec<&'static str> {
     let mut values = ADMISSION_TERMINAL_REASON_SOURCES
         .iter()
-        .flat_map(|source| some_string_literals(source))
+        .flat_map(|source| string_literals_after(source, "Some(\""))
+        .filter(|value| !value.is_empty())
+        .collect::<Vec<_>>();
+    values.sort_unstable();
+    values.dedup();
+    values
+}
+
+fn rust_literal_call_states_from_admission_sources() -> Vec<&'static str> {
+    let patterns = [
+        "call_state: \"",
+        "add_call_mutation(call, \"",
+        "persist_terminal_call(node, call, \"",
+        "persist_existing_call_terminal(node, &call, \"",
+    ];
+    let mut values = ADMISSION_CALL_STATE_SOURCES
+        .iter()
+        .flat_map(|source| {
+            patterns
+                .iter()
+                .flat_map(|pattern| string_literals_after(source, pattern))
+        })
+        .filter(|value| !value.contains('{'))
         .collect::<Vec<_>>();
     values.sort_unstable();
     values.dedup();
@@ -225,32 +237,34 @@ async fn wait_for_request_call_state(
 
 #[test]
 fn rust_inference_call_state_vocabulary_matches_lean_model() {
-    assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-        lean_file: LEAN_INFERENCE_CALL_STATE_FILE,
-        model: LEAN_INFERENCE_CALL_STATE_MODEL,
-        namespace: "InferenceCallState",
-        rust_source: "RUST_INFERENCE_CALL_STATES",
-        rust_values: RUST_INFERENCE_CALL_STATES,
+    let rust_states = rust_literal_call_states_from_admission_sources();
+    assert_lean_contract_vocabulary_set_matches(LeanContractVocabulary {
+        domain: "InferenceCallState",
+        rust_source: "admission source call_state literals",
+        rust_values: &rust_states,
     });
 }
 
 #[test]
 fn rust_inference_call_terminal_reason_vocabulary_matches_lean_model() {
-    assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-        lean_file: LEAN_INFERENCE_CALL_STATE_FILE,
-        model: LEAN_INFERENCE_CALL_STATE_MODEL,
-        namespace: "InferenceCallTerminalReason",
-        rust_source: "RUST_INFERENCE_CALL_TERMINAL_REASONS",
-        rust_values: RUST_INFERENCE_CALL_TERMINAL_REASONS,
+    let rust_reasons = rust_literal_terminal_reasons_from_admission_sources();
+    assert_lean_contract_vocabulary_set_matches(LeanContractVocabulary {
+        domain: "InferenceCallTerminalReason",
+        rust_source: "admission system terminal reason literals",
+        rust_values: &rust_reasons,
     });
+}
 
-    let mut expected = RUST_INFERENCE_CALL_TERMINAL_REASONS.to_vec();
-    expected.sort_unstable();
-    assert_eq!(
-        rust_literal_terminal_reasons_from_admission_sources(),
-        expected,
-        "admission source literals for system terminal reasons must stay in the Lean parity contract"
-    );
+#[test]
+fn rust_inference_call_transition_table_matches_lean_contract() {
+    assert_state_machine_contract_is_complete("InferenceCall");
+    assert_lean_transition_is_legal("InferenceCall", "queued", "running");
+    assert_lean_transition_is_legal("InferenceCall", "queued", "cancelled");
+    assert_lean_transition_is_legal("InferenceCall", "running", "completed");
+    assert_lean_transition_is_legal("InferenceCall", "running", "failed");
+    assert_lean_transition_is_legal("InferenceCall", "running", "cancelled");
+    assert_lean_transition_is_illegal("InferenceCall", "queued", "completed");
+    assert_lean_transition_is_illegal("InferenceCall", "completed", "running");
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -67,6 +67,8 @@ enum LeanVocabularyParseError<'a> {
 }
 
 static LEAN_CONTRACT_SNAPSHOT: OnceLock<LeanContractSnapshot> = OnceLock::new();
+const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
+const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
 
 pub(crate) fn lean_contract_snapshot() -> &'static LeanContractSnapshot {
     LEAN_CONTRACT_SNAPSHOT.get_or_init(load_lean_contract_snapshot)
@@ -277,7 +279,7 @@ fn load_lean_contract_snapshot() -> LeanContractSnapshot {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let json = extract_json_object(&stdout);
+    let json = extract_contract_json(&stdout);
     serde_json::from_str(json).unwrap_or_else(|error| {
         panic!(
             "failed to parse Lean conformance contract JSON: {error}\n  stdout:\n{}",
@@ -313,14 +315,36 @@ fn proofs_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("proofs")
 }
 
-fn extract_json_object(stdout: &str) -> &str {
-    let start = stdout
-        .find('{')
-        .unwrap_or_else(|| panic!("Lean contract generator stdout did not contain JSON: {stdout}"));
-    let end = stdout
-        .rfind('}')
-        .unwrap_or_else(|| panic!("Lean contract generator stdout did not contain JSON: {stdout}"));
-    &stdout[start..=end]
+fn extract_contract_json(stdout: &str) -> &str {
+    let begin = unique_marker_position(stdout, CONTRACT_JSON_BEGIN);
+    let end = unique_marker_position(stdout, CONTRACT_JSON_END);
+    assert!(
+        begin < end,
+        "Lean contract JSON sentinel order is invalid\n  stdout:\n{}",
+        stdout
+    );
+
+    let json = stdout[begin + CONTRACT_JSON_BEGIN.len()..end].trim();
+    assert!(
+        !json.is_empty(),
+        "Lean contract JSON sentinel block was empty\n  stdout:\n{}",
+        stdout
+    );
+    json
+}
+
+fn unique_marker_position(stdout: &str, marker: &str) -> usize {
+    let positions = stdout
+        .match_indices(marker)
+        .map(|(position, _)| position)
+        .collect::<Vec<_>>();
+    match positions.as_slice() {
+        [position] => *position,
+        [] => panic!("Lean contract generator stdout did not contain {marker:?}: {stdout}"),
+        _ => panic!(
+            "Lean contract generator stdout contained duplicate {marker:?} sentinels: {stdout}"
+        ),
+    }
 }
 
 pub(crate) fn lean_to_defradb_values<'a>(
@@ -618,6 +642,15 @@ end Sample
             parse_lean_to_defradb_values(lean, "Sample").unwrap(),
             vec!["sample"]
         );
+    }
+
+    #[test]
+    fn extracts_contract_json_between_sentinels() {
+        let stdout = format!(
+            "debug {{noise}}\n{CONTRACT_JSON_BEGIN}\n{{\"ok\":true}}\n{CONTRACT_JSON_END}\nmore {{noise}}\n"
+        );
+
+        assert_eq!(extract_contract_json(&stdout), "{\"ok\":true}");
     }
 
     #[test]

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -1,3 +1,11 @@
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LeanVocabulary<'a> {
     pub(crate) lean_file: &'a str,
@@ -5,6 +13,45 @@ pub(crate) struct LeanVocabulary<'a> {
     pub(crate) namespace: &'a str,
     pub(crate) rust_source: &'a str,
     pub(crate) rust_values: &'a [&'a str],
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LeanContractVocabulary<'a> {
+    pub(crate) domain: &'a str,
+    pub(crate) rust_source: &'a str,
+    pub(crate) rust_values: &'a [&'a str],
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanContractSnapshot {
+    pub(crate) generated_by: String,
+    pub(crate) vocabularies: Vec<LeanVocabularyContract>,
+    pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    pub(crate) follow_up_hooks: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanVocabularyContract {
+    pub(crate) domain: String,
+    pub(crate) values: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanStateMachineContract {
+    pub(crate) domain: String,
+    pub(crate) states: Vec<String>,
+    pub(crate) state_count: usize,
+    pub(crate) terminal_states: Vec<String>,
+    pub(crate) nonterminal_states: Vec<String>,
+    pub(crate) actions: Vec<String>,
+    pub(crate) legal_transitions: Vec<LeanTransitionPair>,
+    pub(crate) illegal_transitions: Vec<LeanTransitionPair>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanTransitionPair {
+    pub(crate) from: String,
+    pub(crate) to: String,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -17,6 +64,166 @@ enum LeanVocabularyParseError<'a> {
         line: &'a str,
         reason: &'static str,
     },
+}
+
+static LEAN_CONTRACT_SNAPSHOT: OnceLock<LeanContractSnapshot> = OnceLock::new();
+
+pub(crate) fn lean_contract_snapshot() -> &'static LeanContractSnapshot {
+    LEAN_CONTRACT_SNAPSHOT.get_or_init(load_lean_contract_snapshot)
+}
+
+pub(crate) fn lean_vocabulary_contract(domain: &str) -> &'static LeanVocabularyContract {
+    lean_contract_snapshot()
+        .vocabularies
+        .iter()
+        .find(|contract| contract.domain == domain)
+        .unwrap_or_else(|| panic!("Lean vocabulary contract {domain:?} was not emitted"))
+}
+
+pub(crate) fn lean_state_machine_contract(domain: &str) -> &'static LeanStateMachineContract {
+    lean_contract_snapshot()
+        .state_machines
+        .iter()
+        .find(|contract| contract.domain == domain)
+        .unwrap_or_else(|| panic!("Lean state-machine contract {domain:?} was not emitted"))
+}
+
+pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {
+    lean_vocabulary_contract(domain)
+        .values
+        .iter()
+        .map(String::as_str)
+        .collect()
+}
+
+pub(crate) fn assert_lean_contract_vocabulary_matches(spec: LeanContractVocabulary<'_>) {
+    let lean_values = lean_vocabulary_values(spec.domain);
+    let missing_from_lean = values_missing_from(spec.rust_values, &lean_values);
+    let extra_in_lean = values_missing_from(&lean_values, spec.rust_values);
+    let duplicate_rust_values = duplicate_values(spec.rust_values);
+    let duplicate_lean_values = duplicate_values(&lean_values);
+
+    assert!(
+        spec.rust_values == lean_values.as_slice()
+            && missing_from_lean.is_empty()
+            && extra_in_lean.is_empty()
+            && duplicate_rust_values.is_empty()
+            && duplicate_lean_values.is_empty(),
+        "Rust/Lean vocabulary contract mismatch\n  Lean contract domain: {}\n  Rust vocabulary source: {}\n  missing Lean values (present in Rust): {:?}\n  extra Lean values (absent from Rust): {:?}\n  duplicate Rust values: {:?}\n  duplicate Lean values: {:?}\n  Rust values: {:?}\n  Lean values: {:?}",
+        spec.domain,
+        spec.rust_source,
+        missing_from_lean,
+        extra_in_lean,
+        duplicate_rust_values,
+        duplicate_lean_values,
+        spec.rust_values,
+        lean_values
+    );
+}
+
+pub(crate) fn assert_lean_contract_vocabulary_set_matches(spec: LeanContractVocabulary<'_>) {
+    let lean_values = lean_vocabulary_values(spec.domain);
+    let missing_from_lean = values_missing_from(spec.rust_values, &lean_values);
+    let extra_in_lean = values_missing_from(&lean_values, spec.rust_values);
+    let duplicate_rust_values = duplicate_values(spec.rust_values);
+    let duplicate_lean_values = duplicate_values(&lean_values);
+
+    assert!(
+        missing_from_lean.is_empty()
+            && extra_in_lean.is_empty()
+            && duplicate_rust_values.is_empty()
+            && duplicate_lean_values.is_empty(),
+        "Rust/Lean vocabulary contract set mismatch\n  Lean contract domain: {}\n  Rust vocabulary source: {}\n  missing Lean values (present in Rust): {:?}\n  extra Lean values (absent from Rust): {:?}\n  duplicate Rust values: {:?}\n  duplicate Lean values: {:?}\n  Rust values: {:?}\n  Lean values: {:?}",
+        spec.domain,
+        spec.rust_source,
+        missing_from_lean,
+        extra_in_lean,
+        duplicate_rust_values,
+        duplicate_lean_values,
+        spec.rust_values,
+        lean_values
+    );
+}
+
+pub(crate) fn assert_lean_transition_is_legal(domain: &str, from: &str, to: &str) {
+    let machine = lean_state_machine_contract(domain);
+    assert!(
+        machine
+            .legal_transitions
+            .iter()
+            .any(|pair| pair.from == from && pair.to == to),
+        "Lean state-machine contract {domain:?} does not allow transition {from:?} -> {to:?}\n  legal transitions: {:?}",
+        machine.legal_transitions
+    );
+    assert!(
+        !machine
+            .illegal_transitions
+            .iter()
+            .any(|pair| pair.from == from && pair.to == to),
+        "Lean state-machine contract {domain:?} marks transition {from:?} -> {to:?} as both legal and illegal"
+    );
+}
+
+pub(crate) fn assert_lean_transition_is_illegal(domain: &str, from: &str, to: &str) {
+    let machine = lean_state_machine_contract(domain);
+    assert!(
+        machine
+            .illegal_transitions
+            .iter()
+            .any(|pair| pair.from == from && pair.to == to),
+        "Lean state-machine contract {domain:?} does not mark transition {from:?} -> {to:?} illegal\n  illegal transitions: {:?}",
+        machine.illegal_transitions
+    );
+    assert!(
+        !machine
+            .legal_transitions
+            .iter()
+            .any(|pair| pair.from == from && pair.to == to),
+        "Lean state-machine contract {domain:?} marks transition {from:?} -> {to:?} as both legal and illegal"
+    );
+}
+
+pub(crate) fn assert_state_machine_contract_is_complete(domain: &str) {
+    let machine = lean_state_machine_contract(domain);
+    let duplicate_states = duplicate_string_values(&machine.states);
+    let duplicate_actions = duplicate_string_values(&machine.actions);
+    let duplicate_legal_pairs = duplicate_transition_pairs(&machine.legal_transitions);
+    let duplicate_illegal_pairs = duplicate_transition_pairs(&machine.illegal_transitions);
+    let expected_pairs = machine.state_count * machine.state_count;
+    let actual_pairs = machine.legal_transitions.len() + machine.illegal_transitions.len();
+
+    assert!(
+        machine.state_count == machine.states.len()
+            && duplicate_states.is_empty()
+            && duplicate_actions.is_empty()
+            && duplicate_legal_pairs.is_empty()
+            && duplicate_illegal_pairs.is_empty()
+            && actual_pairs == expected_pairs
+            && machine
+                .legal_transitions
+                .iter()
+                .all(|pair| !machine.illegal_transitions.contains(pair))
+            && machine
+                .legal_transitions
+                .iter()
+                .all(|pair| machine.states.contains(&pair.from) && machine.states.contains(&pair.to))
+            && machine
+                .illegal_transitions
+                .iter()
+                .all(|pair| machine.states.contains(&pair.from) && machine.states.contains(&pair.to)),
+        "Lean state-machine contract {domain:?} is incomplete or malformed\n  state_count: {}\n  states: {:?}\n  actions: {:?}\n  legal transitions: {:?}\n  illegal transitions: {:?}\n  duplicate states: {:?}\n  duplicate actions: {:?}\n  duplicate legal pairs: {:?}\n  duplicate illegal pairs: {:?}\n  expected pair partition size: {}\n  actual pair partition size: {}",
+        machine.state_count,
+        machine.states,
+        machine.actions,
+        machine.legal_transitions,
+        machine.illegal_transitions,
+        duplicate_states,
+        duplicate_actions,
+        duplicate_legal_pairs,
+        duplicate_illegal_pairs,
+        expected_pairs,
+        actual_pairs
+    );
 }
 
 pub(crate) fn assert_lean_to_defradb_vocabulary_matches(spec: LeanVocabulary<'_>) {
@@ -43,6 +250,77 @@ pub(crate) fn assert_lean_to_defradb_vocabulary_matches(spec: LeanVocabulary<'_>
         spec.rust_values,
         lean_values
     );
+}
+
+fn load_lean_contract_snapshot() -> LeanContractSnapshot {
+    let proofs_dir = proofs_dir();
+    run_lake_build(&proofs_dir);
+    let output = Command::new("lake")
+        .args(["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"])
+        .current_dir(&proofs_dir)
+        .output()
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to run Lean conformance contract generator in {}: {error}",
+                proofs_dir.display()
+            )
+        });
+
+    if !output.status.success() {
+        panic!(
+            "Lean conformance contract generator failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
+            proofs_dir.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json = extract_json_object(&stdout);
+    serde_json::from_str(json).unwrap_or_else(|error| {
+        panic!(
+            "failed to parse Lean conformance contract JSON: {error}\n  stdout:\n{}",
+            stdout
+        )
+    })
+}
+
+fn run_lake_build(proofs_dir: &Path) {
+    let output = Command::new("lake")
+        .args(["build", "Proofs.Conformance.Contracts"])
+        .current_dir(proofs_dir)
+        .output()
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to build Lean conformance contract target in {}: {error}",
+                proofs_dir.display()
+            )
+        });
+
+    if !output.status.success() {
+        panic!(
+            "Lean conformance contract build failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
+            proofs_dir.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn proofs_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("proofs")
+}
+
+fn extract_json_object(stdout: &str) -> &str {
+    let start = stdout
+        .find('{')
+        .unwrap_or_else(|| panic!("Lean contract generator stdout did not contain JSON: {stdout}"));
+    let end = stdout
+        .rfind('}')
+        .unwrap_or_else(|| panic!("Lean contract generator stdout did not contain JSON: {stdout}"));
+    &stdout[start..=end]
 }
 
 pub(crate) fn lean_to_defradb_values<'a>(
@@ -200,6 +478,29 @@ fn duplicate_values<'a>(values: &[&'a str]) -> Vec<&'a str> {
     duplicates
 }
 
+fn duplicate_string_values(values: &[String]) -> Vec<String> {
+    let refs = values.iter().map(String::as_str).collect::<Vec<_>>();
+    duplicate_values(&refs)
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+}
+
+fn duplicate_transition_pairs(values: &[LeanTransitionPair]) -> Vec<LeanTransitionPair> {
+    let mut seen = Vec::new();
+    let mut duplicates = Vec::new();
+    for value in values {
+        if seen.contains(value) {
+            if !duplicates.contains(value) {
+                duplicates.push(value.clone());
+            }
+        } else {
+            seen.push(value.clone());
+        }
+    }
+    duplicates
+}
+
 impl LeanVocabularyParseError<'_> {
     fn message(&self, lean_file: &str, namespace: &str) -> String {
         match self {
@@ -321,6 +622,8 @@ end Sample
 
     #[test]
     fn assertion_message_identifies_sources_and_differences() {
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
         let result = std::panic::catch_unwind(|| {
             assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
                 lean_file: "sample.lean",
@@ -330,6 +633,7 @@ end Sample
                 rust_values: &["one", "three"],
             });
         });
+        std::panic::set_hook(previous_hook);
 
         let panic = result.expect_err("assertion should fail");
         let message = panic_message(panic.as_ref());

--- a/crates/defra-agent/src/lifecycle.rs
+++ b/crates/defra-agent/src/lifecycle.rs
@@ -189,12 +189,10 @@ fn resolve_behavior_id(default_behavior_id: &str, requested_behavior_id: Option<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::lean_vocab_test::{assert_lean_to_defradb_vocabulary_matches, LeanVocabulary};
-
-    const LEAN_REQUEST_STATE_FILE: &str = "crates/defra-agent/proofs/Proofs/Request/State.lean";
-    const LEAN_REQUEST_STATE_MODEL: &str = include_str!("../proofs/Proofs/Request/State.lean");
-    const LEAN_SCHEDULING_FILE: &str = "crates/defra-agent/proofs/Proofs/Scheduling.lean";
-    const LEAN_SCHEDULING_MODEL: &str = include_str!("../proofs/Proofs/Scheduling.lean");
+    use crate::lean_vocab_test::{
+        assert_lean_contract_vocabulary_matches, assert_state_machine_contract_is_complete,
+        lean_state_machine_contract, LeanContractVocabulary,
+    };
 
     #[test]
     fn rust_request_lifecycle_state_vocabulary_matches_lean_model() {
@@ -203,10 +201,8 @@ mod tests {
             .copied()
             .map(PersistedLifecycleState::as_str)
             .collect::<Vec<_>>();
-        assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-            lean_file: LEAN_REQUEST_STATE_FILE,
-            model: LEAN_REQUEST_STATE_MODEL,
-            namespace: "RequestState",
+        assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+            domain: "RequestState",
             rust_source: "PersistedLifecycleState::ALL",
             rust_values: &rust_states,
         });
@@ -218,17 +214,21 @@ mod tests {
             ExecutionOrigin::Interactive.as_str(),
             ExecutionOrigin::Scheduled.as_str(),
         ];
-        assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-            lean_file: LEAN_SCHEDULING_FILE,
-            model: LEAN_SCHEDULING_MODEL,
-            namespace: "ExecutionOrigin",
+        assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+            domain: "ExecutionOrigin",
             rust_source: "ExecutionOrigin::{Interactive, Scheduled}",
             rust_values: &rust_origins,
         });
     }
 
     #[test]
-    fn persisted_lifecycle_terminal_partition_matches_trigger_bridge() {
+    fn request_state_machine_contract_is_complete() {
+        assert_state_machine_contract_is_complete("Request");
+    }
+
+    #[test]
+    fn persisted_lifecycle_terminal_partition_matches_lean_contract() {
+        let request_machine = lean_state_machine_contract("Request");
         let nonterminal = PersistedLifecycleState::ALL
             .iter()
             .copied()
@@ -244,17 +244,34 @@ mod tests {
 
         assert_eq!(
             nonterminal,
-            vec!["pending", "claimed", "processing", "inputRequired"]
+            request_machine
+                .nonterminal_states
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
         );
         assert_eq!(
             terminal,
-            vec!["completed", "failed", "superseded", "dead", "interrupted"]
+            request_machine
+                .terminal_states
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
         );
         assert!(PersistedLifecycleState::InputRequired.is_nonterminal());
         assert!(PersistedLifecycleState::Interrupted.is_terminal());
+        let expected_nonterminal_graphql_list = format!(
+            "[{}]",
+            request_machine
+                .nonterminal_states
+                .iter()
+                .map(|state| format!(r#""{state}""#))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
         assert_eq!(
             nonterminal_lifecycle_state_graphql_list(),
-            r#"["pending", "claimed", "processing", "inputRequired"]"#
+            expected_nonterminal_graphql_list
         );
         assert_eq!(
             ExecutionOrigin::from_persisted(Some("scheduled")),

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -5,7 +5,11 @@ use serde::Deserialize;
 
 use super::*;
 use crate::ensure_runtime_schemas;
-use crate::lean_vocab_test::{assert_lean_to_defradb_vocabulary_matches, LeanVocabulary};
+use crate::lean_vocab_test::{
+    assert_lean_contract_vocabulary_matches, assert_lean_to_defradb_vocabulary_matches,
+    assert_lean_transition_is_legal, assert_state_machine_contract_is_complete,
+    LeanContractVocabulary, LeanVocabulary,
+};
 
 #[derive(Debug, Deserialize)]
 struct AgentRuntimeRow {
@@ -60,8 +64,6 @@ async fn fetch_runtime_row(node: &defra_node::EmbeddedNode, agent_did: &str) -> 
 
 #[test]
 fn rust_process_state_vocabulary_matches_lean_model() {
-    const LEAN_PROCESS_FILE: &str = "crates/defra-agent/proofs/Proofs/Process.lean";
-    const LEAN_PROCESS_MODEL: &str = include_str!("../../proofs/Proofs/Process.lean");
     let rust_states = vec![
         ProcessLifecycleState::Uninitialized.as_str(),
         ProcessLifecycleState::Recovering.as_str(),
@@ -70,14 +72,22 @@ fn rust_process_state_vocabulary_matches_lean_model() {
         ProcessLifecycleState::Shutdown.as_str(),
     ];
 
-    assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-        lean_file: LEAN_PROCESS_FILE,
-        model: LEAN_PROCESS_MODEL,
-        namespace: "ProcessState",
+    assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+        domain: "ProcessState",
         rust_source:
             "ProcessLifecycleState::{Uninitialized, Recovering, Ready, ShuttingDown, Shutdown}",
         rust_values: &rust_states,
     });
+}
+
+#[test]
+fn rust_process_state_transitions_match_lean_contract() {
+    assert_state_machine_contract_is_complete("Process");
+    assert_lean_transition_is_legal("Process", "uninitialized", "recovering");
+    assert_lean_transition_is_legal("Process", "uninitialized", "ready");
+    assert_lean_transition_is_legal("Process", "recovering", "ready");
+    assert_lean_transition_is_legal("Process", "ready", "shuttingDown");
+    assert_lean_transition_is_legal("Process", "shuttingDown", "shutdown");
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -4,8 +4,14 @@ use defra_agent::graphql::escape_graphql_string;
 use defra_agent::lifecycle::{ClaimOutcome, ExecutionOrigin, TriggerLineage};
 use defra_agent::{write_manual_agent_request, DefraStreamWriter, RequestLifecycle};
 
+#[path = "../src/lean_vocab_test.rs"]
+mod lean_vocab_test;
 mod support;
 
+use lean_vocab_test::{
+    assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
+    assert_state_machine_contract_is_complete, lean_contract_snapshot, lean_vocabulary_values,
+};
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
     fetch_request_lineage_snapshot_by_tuple, fetch_request_snapshot, fetch_request_snapshot_raw,
@@ -18,6 +24,34 @@ use support::{
     create_response_with_status, set_interrupt_requested_at, set_request_lifecycle_state,
     set_valid_until, test_db, AGENT_DID, AGENT_NAME, BACKEND_ID, DEADLINE_SECS,
 };
+
+#[test]
+fn lean_executable_contracts_cover_initial_domains() {
+    for domain in [
+        "Request",
+        "Process",
+        "Persistence.failClosed",
+        "Persistence.failOpen",
+        "SessionRecovery",
+        "InferenceCall",
+    ] {
+        assert_state_machine_contract_is_complete(domain);
+    }
+
+    assert_lean_transition_is_legal("Persistence.failClosed", "committing", "uncommitted");
+    assert_lean_transition_is_legal("Persistence.failOpen", "committing", "lost");
+    assert_lean_transition_is_legal("SessionRecovery", "failed", "pending");
+    assert_lean_transition_is_legal("InferenceCall", "queued", "running");
+    assert_lean_transition_is_legal("InferenceCall", "running", "completed");
+    assert_lean_transition_is_legal("InferenceCall", "running", "failed");
+    assert!(
+        lean_contract_snapshot()
+            .follow_up_hooks
+            .iter()
+            .any(|hook| hook.contains("RuntimeReconcile")),
+        "RuntimeReconcile executable follow-up hook should remain visible"
+    );
+}
 
 #[tokio::test]
 async fn interactive_claim_snapshot_matches_claimed_waiting() {
@@ -44,6 +78,7 @@ async fn interactive_claim_snapshot_matches_claimed_waiting() {
     );
 
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+    assert_lean_transition_is_legal("Request", "pending", "claimed");
 
     assert_eq!(
         fetch_request_snapshot(&db.node, &doc_id).await,
@@ -145,6 +180,7 @@ async fn interactive_admission_and_progress_snapshots_match_execution_flow() {
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
     lifecycle.prepare_session_with_identity().await.unwrap();
     lifecycle.begin_execution().await.unwrap();
+    assert_lean_transition_is_legal("Request", "claimed", "processing");
     let response_doc_id = create_response_with_status(
         &db.node,
         &format!("resp-{request_id}"),
@@ -155,6 +191,7 @@ async fn interactive_admission_and_progress_snapshots_match_execution_flow() {
     .await;
     lifecycle.set_response_doc_id(&response_doc_id);
     lifecycle.advance().await.unwrap();
+    assert_lean_transition_is_legal("Request", "processing", "processing");
 
     assert_eq!(
         fetch_request_snapshot(&db.node, &doc_id).await,
@@ -231,6 +268,7 @@ async fn interactive_fail_before_stream_snapshot_matches_failed_released() {
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
     lifecycle.prepare_session_with_identity().await.unwrap();
     lifecycle.fail().await.unwrap();
+    assert_lean_transition_is_legal("Request", "claimed", "failed");
 
     assert_eq!(
         fetch_request_snapshot(&db.node, &doc_id).await,
@@ -1158,6 +1196,7 @@ async fn pending_interrupted_via_interrupt_before_claim() {
     );
 
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Interrupted);
+    assert_lean_transition_is_legal("Request", "pending", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.lifecycle_state, "interrupted");
@@ -1192,6 +1231,7 @@ async fn pending_dead_stale_via_expire() {
     );
 
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Expired);
+    assert_lean_transition_is_legal("Request", "pending", "dead");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.lifecycle_state, "dead");
@@ -1231,6 +1271,7 @@ async fn transition_to_interrupted_from_claimed() {
     let interrupt_at = chrono::Utc::now().to_rfc3339();
     set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
     lifecycle.transition_to_interrupted().await.unwrap();
+    assert_lean_transition_is_legal("Request", "claimed", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.status, "interrupted");
@@ -1291,6 +1332,7 @@ async fn processing_interrupted_preserves_partial_response() {
     assert!(stamped, "expected interrupted_at to be stamped");
 
     lifecycle.transition_to_interrupted().await.unwrap();
+    assert_lean_transition_is_legal("Request", "processing", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.status, "interrupted");
@@ -1342,6 +1384,10 @@ async fn input_required_interrupted() {
     let interrupt_at = chrono::Utc::now().to_rfc3339();
     set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
     lifecycle.transition_to_interrupted().await.unwrap();
+    // Core Lean Request semantics reserve inputRequired and have no active
+    // transition out of it; Rust keeps this repair path as a product boundary
+    // for replicated rows that already contain the reserved state.
+    assert_lean_transition_is_illegal("Request", "inputRequired", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.status, "interrupted");
@@ -1378,6 +1424,7 @@ async fn pending_tie_break_prefers_interrupt_over_expire() {
     );
 
     assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Interrupted);
+    assert_lean_transition_is_legal("Request", "pending", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.lifecycle_state, "interrupted");
@@ -1423,6 +1470,7 @@ async fn transition_to_interrupted_from_processing() {
 
     // Interrupt arm wins: transition_to_interrupted succeeds from processing.
     lifecycle.transition_to_interrupted().await.unwrap();
+    assert_lean_transition_is_legal("Request", "processing", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap.status, "interrupted");
@@ -1785,6 +1833,9 @@ async fn s1_interrupted_is_terminal_subsequent_transitions_are_no_ops() {
     let snap0 = fetch_request_snapshot(&db.node, &doc_id).await;
     assert_eq!(snap0.lifecycle_state, "interrupted");
     assert_eq!(snap0.status, "interrupted");
+    assert_lean_transition_is_illegal("Request", "interrupted", "completed");
+    assert_lean_transition_is_illegal("Request", "interrupted", "failed");
+    assert_lean_transition_is_illegal("Request", "interrupted", "processing");
 
     // Idempotent: calling transition_to_interrupted again is a no-op because
     // the `status._nin` filter excludes terminal rows.
@@ -1900,29 +1951,22 @@ fn conformance_mapping_all_9_lifecycle_states_round_trip() {
     // Per `Proofs/Conformance/DefraAgent.lean::toIdeal`, every
     // `DefraLifecycleState` maps to a specific `RequestState`. The Rust
     // `RequestLifecycleState` enum in `defra-agent-protocol::client_protocol`
-    // mirrors this. Assert all 9 string forms parse to the expected enum
-    // variant, that `as_str` round-trips, and that unknown strings reject.
+    // mirrors the Lean-generated RequestState vocabulary. Assert every Lean
+    // string form parses and round-trips, and that unknown strings reject.
     use defra_agent_protocol::client_protocol::RequestLifecycleState;
 
-    let cases = &[
-        ("pending", RequestLifecycleState::Pending),
-        ("claimed", RequestLifecycleState::Claimed),
-        ("processing", RequestLifecycleState::Processing),
-        ("inputRequired", RequestLifecycleState::InputRequired),
-        ("completed", RequestLifecycleState::Completed),
-        ("failed", RequestLifecycleState::Failed),
-        ("superseded", RequestLifecycleState::Superseded),
-        ("dead", RequestLifecycleState::Dead),
-        ("interrupted", RequestLifecycleState::Interrupted),
-    ];
-
-    for (s, expected) in cases {
-        let parsed = RequestLifecycleState::try_from(*s)
+    let lean_states = lean_vocabulary_values("RequestState");
+    assert_eq!(
+        lean_states.len(),
+        9,
+        "RequestState contract should be finite"
+    );
+    for s in lean_states {
+        let parsed = RequestLifecycleState::try_from(s)
             .unwrap_or_else(|e| panic!("failed to parse '{}': {:?}", s, e));
-        assert_eq!(parsed, *expected, "round-trip mismatch for '{}'", s);
         assert_eq!(
             parsed.as_str(),
-            *s,
+            s,
             "as_str must round-trip to the source string"
         );
     }
@@ -2145,6 +2189,7 @@ async fn manual_run_preserves_lineage_through_claim_transition() {
         ClaimOutcome::Claimed,
         "manual pending row must be claimable exactly once"
     );
+    assert_lean_transition_is_legal("Request", "pending", "claimed");
 
     // Post-claim: lifecycle_state flips to claimed; claimed_at / deadline
     // are stamped; lineage and execution origin are UNCHANGED.


### PR DESCRIPTION
## Summary
- add a Lean-owned JSON contract generator for Request, Process, Persistence, SessionRecovery, and InferenceCall executable state machines
- add executable InferenceCall semantics and persistence vocabularies used by the contract generator
- update Rust vocabulary and conformance tests to consume generated Lean contracts, including legal/illegal transition checks and a RuntimeReconcile follow-up hook

## Verification
- lake build
- cargo test -p defra-agent --lib vocabulary_matches_lean_model -- --nocapture
- cargo test -p defra-agent --lib contract -- --nocapture
- cargo test -p defra-agent --test state_machine_conformance -- --nocapture
- rg -n "sorry|admit|axiom" crates/defra-agent/proofs/Proofs crates/defra-agent/proofs/README.md
- find crates/defra-agent/proofs/Proofs -name "*.lean" -print0 | xargs -0 wc -l | sort -nr | head -20
- git diff --check