### PR TITLE
Model daemon storage observations

### DIFF
--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -1,6 +1,7 @@
 import Proofs.Basic
 import Proofs.Process
 import Proofs.Persistence
+import Proofs.StorageObservation
 import Proofs.Scheduling
 import Proofs.Request
 import Proofs.InferenceCall

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -57,14 +57,29 @@ tests cover the parser/validator boundary and command metadata emitted by
 `toolset/shared/command.rs`; the Lean model covers the fail-closed policy
 ordering and sandbox/env invariants that those tests exercise.
 
-## External Assumptions
+## Modeled Storage Observation Boundary
 
-The `PersistenceState` model abstracts the storage commit boundary. Rust uses
+`PersistenceState` remains the abstract committed/uncommitted lifecycle. The
+separate `StorageObservation` model records the daemon-visible storage facts
+that justify moving through that lifecycle:
+
+* an awaited mutation that returns success is treated as a committed write;
+* a mutation error is not treated as committed;
+* fail-closed storage errors return to retryable uncommitted state;
+* fail-open storage errors acknowledge the output as lost;
+* stale reads or missing/stale events may occur after a success ack, but they do
+  not invalidate the commit assumption; and
+* the daemon assumes a minimum visibility path: read-your-writes for local
+  confirmation paths, or eventual observation after a stale read/event.
+
+These are daemon storage assumptions, not proofs of DefraDB internals. Rust uses
 `StreamBuffer`, `DefraSessionHook`, and hook failure policy around DefraDB
-mutations; it does not persist a per-token `PersistenceState` document. The
-assumption is: DefraDB mutations that return success are durable for the modeled
-stream/session writes. Storage-engine crash windows, transport delivery, and
-CRDT/event-delivery guarantees are outside the core request proof.
+mutations; it does not persist a per-token `PersistenceState` or
+`StorageObservation` document. Storage-engine crash windows, transport delivery,
+global CRDT convergence, and event-bus delivery correctness remain external
+DefraDB/environment assumptions.
+
+## External Assumptions
 
 Backend health and availability observations are only as fresh as the backend
 documents visible at admission time. Endpoint freshness and network/provider

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -79,6 +79,10 @@ mutations; it does not persist a per-token `PersistenceState` or
 global CRDT convergence, and event-bus delivery correctness remain external
 DefraDB/environment assumptions.
 
+This section is the modeled part of the former broad storage assumption; the
+following section keeps the still-external DefraDB/environment assumptions
+separate.
+
 ## External Assumptions
 
 Backend health and availability observations are only as fresh as the backend

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -1,6 +1,7 @@
 import Proofs.Request
 import Proofs.Process
 import Proofs.Persistence
+import Proofs.StorageObservation
 import Proofs.SessionRecovery
 import Proofs.InferenceCall
 
@@ -240,6 +241,45 @@ def persistenceMachine
       (fun state action => PersistenceState.step? policy state action)
       PersistenceState.toDefraDB)
 
+def storageObservationStates : List StorageObservation :=
+  [ .noMutation
+  , .inFlight
+  , .successAcknowledged
+  , .mutationFailed
+  , .staleObserved
+  , .readVisible
+  , .lostAcknowledged
+  ]
+
+def storageObservationStateNames : List String :=
+  storageObservationStates.map StorageObservation.toContract
+
+def storageObservationActions : List (String × StorageObservation.Action) :=
+  [ ("beginMutation", .beginMutation)
+  , ("mutationSuccess", .mutationSuccess)
+  , ("mutationFailure", .mutationFailure)
+  , ("staleRead", .staleRead)
+  , ("staleEvent", .staleEvent)
+  , ("readYourWrites", .readYourWrites)
+  , ("eventArrives", .eventArrives)
+  , ("retryFailClosed", .retryFailClosed)
+  , ("acknowledgeLost", .acknowledgeLost)
+  ]
+
+def storageObservationMachine
+    (domain : String)
+    (policy : PersistenceState.FailurePolicy) : StateMachineContract :=
+  machineContract
+    domain
+    storageObservationStateNames
+    (terminalNames storageObservationStates StorageObservation.toContract)
+    (actionNames storageObservationActions)
+    (transitionPairsFromSamples
+      storageObservationStates
+      storageObservationActions
+      (fun state action => StorageObservation.step? policy state action)
+      StorageObservation.toContract)
+
 def sessionRecoveryFailedId : RequestId := 1
 
 def sessionRecoveryNewId : RequestId := 2
@@ -318,6 +358,7 @@ def vocabularies : List VocabularyContract :=
   , { domain := "PersistenceState", values := persistenceStateNames }
   , { domain := "PersistenceFailurePolicy", values :=
         [.failOpen, .failClosed].map PersistenceState.FailurePolicy.toDefraDB }
+  , { domain := "StorageObservation", values := storageObservationStateNames }
   , { domain := "SessionRecoveryLatestRequestState"
     , values := [RequestState.failed.toDefraDB, RequestState.pending.toDefraDB]
     }
@@ -336,6 +377,8 @@ def stateMachines : List StateMachineContract :=
   , processMachine
   , persistenceMachine "Persistence.failClosed" .failClosed
   , persistenceMachine "Persistence.failOpen" .failOpen
+  , storageObservationMachine "StorageObservation.failClosed" .failClosed
+  , storageObservationMachine "StorageObservation.failOpen" .failOpen
   , sessionRecoveryMachine
   , inferenceCallMachine
   ]

--- a/crates/defra-agent/proofs/Proofs/Properties/Decidable.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Decidable.lean
@@ -1,6 +1,7 @@
 import Proofs.Request
 import Proofs.Process
 import Proofs.Persistence
+import Proofs.StorageObservation
 import Proofs.InferenceCall
 import Proofs.Scheduling
 import Mathlib.Data.Fintype.Card
@@ -11,7 +12,7 @@ import Mathlib.Data.Fintype.Card
 Finite enumeration and simple coherence checks over the ideal state space.
 -/
 
-open RequestState ProcessState PersistenceState InferenceCallState ExecutionOrigin AdmissionState
+open RequestState ProcessState PersistenceState StorageObservation InferenceCallState ExecutionOrigin AdmissionState
 
 instance : Fintype RequestState :=
   Fintype.ofList
@@ -27,6 +28,12 @@ instance : Fintype ProcessState :=
 instance : Fintype PersistenceState :=
   Fintype.ofList
     [.uncommitted, .committing, .committed, .lost]
+    (fun s => by cases s <;> simp)
+
+instance : Fintype StorageObservation :=
+  Fintype.ofList
+    [.noMutation, .inFlight, .successAcknowledged, .mutationFailed,
+     .staleObserved, .readVisible, .lostAcknowledged]
     (fun s => by cases s <;> simp)
 
 instance : Fintype InferenceCallState :=
@@ -83,6 +90,19 @@ theorem persistence_no_deadlocks (s : PersistenceState) (h : ¬isTerminal s) :
   | committed => exact absurd (Or.inl rfl) h
   | lost => exact absurd (Or.inr rfl) h
 
+theorem storage_observation_no_deadlocks
+    (s : StorageObservation)
+    (h : ¬isTerminal s) :
+    ∃ s' : StorageObservation, s ≠ s' := by
+  cases s with
+  | noMutation => exact ⟨.inFlight, by decide⟩
+  | inFlight => exact ⟨.successAcknowledged, by decide⟩
+  | successAcknowledged => exact ⟨.readVisible, by decide⟩
+  | mutationFailed => exact ⟨.noMutation, by decide⟩
+  | staleObserved => exact ⟨.readVisible, by decide⟩
+  | readVisible => exact absurd (Or.inl rfl) h
+  | lostAcknowledged => exact absurd (Or.inr rfl) h
+
 theorem inference_call_no_deadlocks (s : InferenceCallState) (h : ¬isTerminal s) :
     ∃ s' : InferenceCallState, s ≠ s' := by
   cases s with
@@ -133,6 +153,7 @@ theorem terminal_requires_released (s : RequestState) (a : AdmissionState)
 #eval Fintype.card RequestState
 #eval Fintype.card ProcessState
 #eval Fintype.card PersistenceState
+#eval Fintype.card StorageObservation
 #eval Fintype.card InferenceCallState
 #eval Fintype.card RequestState * Fintype.card ProcessState * Fintype.card PersistenceState
 #eval Fintype.card ExecutionOrigin

--- a/crates/defra-agent/proofs/Proofs/StorageObservation.lean
+++ b/crates/defra-agent/proofs/Proofs/StorageObservation.lean
@@ -80,6 +80,9 @@ def toPersistence : StorageObservation -> PersistenceState
   | .inFlight => .committing
   | .successAcknowledged => .committed
   | .mutationFailed => .uncommitted
+  -- Stale observations only occur after a success ack in this model, so they
+  -- preserve the daemon's committed observation instead of proving storage
+  -- engine visibility.
   | .staleObserved => .committed
   | .readVisible => .committed
   | .lostAcknowledged => .lost
@@ -175,13 +178,18 @@ theorem failure_failOpen_refines_persistence :
 theorem success_acknowledged_committed :
     toPersistence .successAcknowledged = .committed := rfl
 
-theorem mutation_failed_not_committed :
+theorem mutation_failed_uncommitted :
     toPersistence .mutationFailed = .uncommitted := rfl
+
+theorem mutation_failed_ne_committed :
+    toPersistence .mutationFailed ≠ .committed := by
+  decide
 
 theorem stale_observation_preserves_success_commit :
     toPersistence .staleObserved = toPersistence .successAcknowledged := rfl
 
-/-- A terminal response write may rely on the success ack or a visible read. -/
+/-- Downstream bridge predicate: a terminal response write may rely on either
+    the local success ack or a later visible read observation. -/
 def terminalWriteObserved (obs : StorageObservation) : Prop :=
   obs = .successAcknowledged ∨ obs = .readVisible
 
@@ -204,6 +212,46 @@ theorem readYourWrites_visibility_path
   exact
     ⟨ .readVisible
     , Trace.step (Transition.read_your_writes (policy := policy)) Trace.refl
+    , rfl
+    ⟩
+
+theorem successful_mutation_eventual_visibility_path
+    {policy : PersistenceState.FailurePolicy} :
+    ∃ post : StorageObservation,
+      Trace policy .noMutation post ∧ post = .readVisible := by
+  exact
+    ⟨ .readVisible
+    , Trace.step
+        (Transition.begin_mutation (policy := policy))
+        (Trace.step
+          (Transition.mutation_success (policy := policy))
+          (Trace.step (Transition.read_your_writes (policy := policy)) Trace.refl))
+    , rfl
+    ⟩
+
+theorem failClosed_failed_mutation_retry_path :
+    ∃ post : StorageObservation,
+      Trace .failClosed .noMutation post ∧ post = .noMutation := by
+  exact
+    ⟨ .noMutation
+    , Trace.step
+        (Transition.begin_mutation (policy := .failClosed))
+        (Trace.step
+          (Transition.mutation_failure (policy := .failClosed))
+          (Trace.step (Transition.retry_fail_closed rfl) Trace.refl))
+    , rfl
+    ⟩
+
+theorem failOpen_failed_mutation_lost_path :
+    ∃ post : StorageObservation,
+      Trace .failOpen .noMutation post ∧ post = .lostAcknowledged := by
+  exact
+    ⟨ .lostAcknowledged
+    , Trace.step
+        (Transition.begin_mutation (policy := .failOpen))
+        (Trace.step
+          (Transition.mutation_failure (policy := .failOpen))
+          (Trace.step (Transition.acknowledge_lost rfl) Trace.refl))
     , rfl
     ⟩
 

--- a/crates/defra-agent/proofs/Proofs/StorageObservation.lean
+++ b/crates/defra-agent/proofs/Proofs/StorageObservation.lean
@@ -1,0 +1,234 @@
+import Proofs.Persistence
+
+/-!
+# Storage Observation Boundary
+
+This module models the daemon-visible storage facts used by persistence and
+session code. It deliberately does not model DefraDB internals. Instead, it
+records the minimum observations the daemon is allowed to rely on:
+
+* an awaited successful mutation is treated as a committed write,
+* a failed mutation is not treated as committed,
+* stale reads or missing events do not regress a successful mutation ack, and
+* a successful ack has read-your-writes and eventual-observation paths.
+-/
+
+/-- Daemon-local observations at the storage boundary. These are contract names,
+not persisted DefraDB values. -/
+inductive StorageObservation where
+  | noMutation
+  | inFlight
+  | successAcknowledged
+  | mutationFailed
+  | staleObserved
+  | readVisible
+  | lostAcknowledged
+  deriving DecidableEq, Repr
+
+namespace StorageObservation
+
+/-- Stable contract vocabulary for Rust tests. -/
+def toContract : StorageObservation -> String
+  | .noMutation => "noMutation"
+  | .inFlight => "inFlight"
+  | .successAcknowledged => "successAcknowledged"
+  | .mutationFailed => "mutationFailed"
+  | .staleObserved => "staleObserved"
+  | .readVisible => "readVisible"
+  | .lostAcknowledged => "lostAcknowledged"
+
+/-- Parse storage-observation contract vocabulary. -/
+def fromContract? : String -> Option StorageObservation
+  | "noMutation" => some .noMutation
+  | "inFlight" => some .inFlight
+  | "successAcknowledged" => some .successAcknowledged
+  | "mutationFailed" => some .mutationFailed
+  | "staleObserved" => some .staleObserved
+  | "readVisible" => some .readVisible
+  | "lostAcknowledged" => some .lostAcknowledged
+  | _ => none
+
+theorem fromContract_toContract (obs : StorageObservation) :
+    fromContract? obs.toContract = some obs := by
+  cases obs <;> rfl
+
+instance : HasTerminal StorageObservation where
+  isTerminal obs := obs = .readVisible ∨ obs = .lostAcknowledged
+  isTerminal_dec obs :=
+    match obs with
+    | .readVisible => isTrue (Or.inl rfl)
+    | .lostAcknowledged => isTrue (Or.inr rfl)
+    | .noMutation => isFalse (by intro h; cases h with
+        | inl h => exact absurd h (by decide)
+        | inr h => exact absurd h (by decide))
+    | .inFlight => isFalse (by intro h; cases h with
+        | inl h => exact absurd h (by decide)
+        | inr h => exact absurd h (by decide))
+    | .successAcknowledged => isFalse (by intro h; cases h with
+        | inl h => exact absurd h (by decide)
+        | inr h => exact absurd h (by decide))
+    | .mutationFailed => isFalse (by intro h; cases h with
+        | inl h => exact absurd h (by decide)
+        | inr h => exact absurd h (by decide))
+    | .staleObserved => isFalse (by intro h; cases h with
+        | inl h => exact absurd h (by decide)
+        | inr h => exact absurd h (by decide))
+
+/-- Projection from daemon observations into the existing persistence model. -/
+def toPersistence : StorageObservation -> PersistenceState
+  | .noMutation => .uncommitted
+  | .inFlight => .committing
+  | .successAcknowledged => .committed
+  | .mutationFailed => .uncommitted
+  | .staleObserved => .committed
+  | .readVisible => .committed
+  | .lostAcknowledged => .lost
+
+/-- Storage-observation actions. -/
+inductive Action where
+  | beginMutation
+  | mutationSuccess
+  | mutationFailure
+  | staleRead
+  | staleEvent
+  | readYourWrites
+  | eventArrives
+  | retryFailClosed
+  | acknowledgeLost
+  deriving DecidableEq, Repr
+
+/-- Relational storage-observation transitions parameterized by failure policy. -/
+inductive Transition (policy : PersistenceState.FailurePolicy) :
+    StorageObservation -> StorageObservation -> Prop where
+  | begin_mutation :
+      Transition policy .noMutation .inFlight
+  | mutation_success :
+      Transition policy .inFlight .successAcknowledged
+  | mutation_failure :
+      Transition policy .inFlight .mutationFailed
+  | stale_read :
+      Transition policy .successAcknowledged .staleObserved
+  | stale_event :
+      Transition policy .successAcknowledged .staleObserved
+  | read_your_writes :
+      Transition policy .successAcknowledged .readVisible
+  | event_arrives_after_success :
+      Transition policy .successAcknowledged .readVisible
+  | event_arrives_after_stale :
+      Transition policy .staleObserved .readVisible
+  | retry_fail_closed :
+      policy = .failClosed ->
+      Transition policy .mutationFailed .noMutation
+  | acknowledge_lost :
+      policy = .failOpen ->
+      Transition policy .mutationFailed .lostAcknowledged
+
+/-- Executable storage-observation transition function. -/
+def step? (policy : PersistenceState.FailurePolicy)
+    (pre : StorageObservation) : Action -> Option StorageObservation
+  | .beginMutation =>
+      if pre = .noMutation then some .inFlight else none
+  | .mutationSuccess =>
+      if pre = .inFlight then some .successAcknowledged else none
+  | .mutationFailure =>
+      if pre = .inFlight then some .mutationFailed else none
+  | .staleRead =>
+      if pre = .successAcknowledged then some .staleObserved else none
+  | .staleEvent =>
+      if pre = .successAcknowledged then some .staleObserved else none
+  | .readYourWrites =>
+      if pre = .successAcknowledged then some .readVisible else none
+  | .eventArrives =>
+      if pre = .successAcknowledged ∨ pre = .staleObserved then some .readVisible else none
+  | .retryFailClosed =>
+      if policy = .failClosed /\ pre = .mutationFailed then some .noMutation else none
+  | .acknowledgeLost =>
+      if policy = .failOpen /\ pre = .mutationFailed then some .lostAcknowledged else none
+
+/-- A trace is a sequence of valid storage observations. -/
+inductive Trace (policy : PersistenceState.FailurePolicy) :
+    StorageObservation -> StorageObservation -> Prop where
+  | refl {s : StorageObservation} : Trace policy s s
+  | step {s1 s2 s3 : StorageObservation} :
+      Transition policy s1 s2 -> Trace policy s2 s3 -> Trace policy s1 s3
+
+theorem begin_refines_persistence (policy : PersistenceState.FailurePolicy) :
+    PersistenceState.Transition policy
+      (toPersistence .noMutation) (toPersistence .inFlight) := by
+  exact PersistenceState.Transition.flush
+
+theorem success_refines_persistence (policy : PersistenceState.FailurePolicy) :
+    PersistenceState.Transition policy
+      (toPersistence .inFlight) (toPersistence .successAcknowledged) := by
+  exact PersistenceState.Transition.write_success
+
+theorem failure_failClosed_refines_persistence :
+    PersistenceState.Transition .failClosed
+      (toPersistence .inFlight) (toPersistence .mutationFailed) := by
+  exact PersistenceState.Transition.write_fail_closed rfl
+
+theorem failure_failOpen_refines_persistence :
+    PersistenceState.Transition .failOpen
+      (toPersistence .inFlight) (toPersistence .lostAcknowledged) := by
+  exact PersistenceState.Transition.write_fail_open rfl
+
+theorem success_acknowledged_committed :
+    toPersistence .successAcknowledged = .committed := rfl
+
+theorem mutation_failed_not_committed :
+    toPersistence .mutationFailed = .uncommitted := rfl
+
+theorem stale_observation_preserves_success_commit :
+    toPersistence .staleObserved = toPersistence .successAcknowledged := rfl
+
+/-- A terminal response write may rely on the success ack or a visible read. -/
+def terminalWriteObserved (obs : StorageObservation) : Prop :=
+  obs = .successAcknowledged ∨ obs = .readVisible
+
+theorem terminal_write_observed_committed
+    {obs : StorageObservation}
+    (h_obs : terminalWriteObserved obs) :
+    toPersistence obs = .committed := by
+  cases h_obs with
+  | inl h =>
+      rw [h]
+      rfl
+  | inr h =>
+      rw [h]
+      rfl
+
+theorem readYourWrites_visibility_path
+    {policy : PersistenceState.FailurePolicy} :
+    ∃ post : StorageObservation,
+      Trace policy .successAcknowledged post ∧ post = .readVisible := by
+  exact
+    ⟨ .readVisible
+    , Trace.step (Transition.read_your_writes (policy := policy)) Trace.refl
+    , rfl
+    ⟩
+
+theorem staleRead_eventual_visibility_path
+    {policy : PersistenceState.FailurePolicy} :
+    ∃ post : StorageObservation,
+      Trace policy .successAcknowledged post ∧ post = .readVisible := by
+  exact
+    ⟨ .readVisible
+    , Trace.step
+        (Transition.stale_read (policy := policy))
+        (Trace.step (Transition.event_arrives_after_stale (policy := policy)) Trace.refl)
+    , rfl
+    ⟩
+
+theorem staleEvent_eventual_visibility_path
+    {policy : PersistenceState.FailurePolicy} :
+    ∃ post : StorageObservation,
+      Trace policy .successAcknowledged post ∧ post = .readVisible := by
+  exact
+    ⟨ .readVisible
+    , Trace.step
+        (Transition.stale_event (policy := policy))
+        (Trace.step (Transition.event_arrives_after_stale (policy := policy)) Trace.refl)
+    , rfl
+    ⟩
+
+end StorageObservation

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -330,11 +330,13 @@ failure refine the existing `PersistenceState` transitions
 `failure_failOpen_refines_persistence`).
 
 Local observation theorems also record the daemon assumptions Rust relies on:
-`success_acknowledged_committed`, `mutation_failed_not_committed`,
+`success_acknowledged_committed`, `mutation_failed_uncommitted`,
+`mutation_failed_ne_committed`,
 `stale_observation_preserves_success_commit`,
 `terminal_write_observed_committed`,
-`readYourWrites_visibility_path`, `staleRead_eventual_visibility_path`, and
-`staleEvent_eventual_visibility_path`.
+`readYourWrites_visibility_path`, `successful_mutation_eventual_visibility_path`,
+`failClosed_failed_mutation_retry_path`, `failOpen_failed_mutation_lost_path`,
+`staleRead_eventual_visibility_path`, and `staleEvent_eventual_visibility_path`.
 
 ### Request/Process Liveness
 

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -13,6 +13,7 @@ state machines explicit enough that:
 The proofs are strongest where the runtime is a state machine:
 
 - request, process, and persistence lifecycle transitions
+- daemon-visible storage observation assumptions at the persistence boundary
 - inference-call lifecycle, cancellation transitions, and slot reconstruction
 - scheduler and fleet slot accounting from persisted call rows
 - session retry/reissue
@@ -22,9 +23,10 @@ The proofs are strongest where the runtime is a state machine:
 - client turn projection and desktop shell workflow state
 - command/tool execution policy for bash argv, network, sandbox, and shell env
 
-They do not prove storage guarantees, network delivery, provider behavior, UI
-rendering, external tool behavior, or host sandbox implementation details. Those
-are explicit model boundaries.
+They model daemon storage observations, but do not prove DefraDB storage-engine
+correctness, network delivery, provider behavior, UI rendering, external tool
+behavior, or host sandbox implementation details. Those are explicit model
+boundaries.
 
 ## Quick Start
 
@@ -43,18 +45,19 @@ lake env lean --run Proofs/Conformance/Contracts.lean
 
 ## What Is Proven
 
-The current proof suite covers ten practical areas:
+The current proof suite covers eleven practical areas:
 
 1. Request/process/persistence state transitions
-2. Inference-call lifecycle, request linkage, and cancellation terminality
-3. Scheduler slot accounting and admission/release
-4. Session recovery and retry/reissue semantics
-5. Runtime reconcile generation publication and visibility
-6. Desired-state apply ordering, reference closure, and apply/runtime field separation
-7. Trigger dispatch for manual, schedule, and event-driven tasks
-8. Client turn-state derivation from replicated request/response documents
-9. Client-shell workflow rules for selection, submission, and transport decoupling
-10. Command/tool execution policy: argv prefixes, read-only allowlists,
+2. Daemon storage-observation assumptions that refine persistence
+3. Inference-call lifecycle, request linkage, and cancellation terminality
+4. Scheduler slot accounting and admission/release
+5. Session recovery and retry/reissue semantics
+6. Runtime reconcile generation publication and visibility
+7. Desired-state apply ordering, reference closure, and apply/runtime field separation
+8. Trigger dispatch for manual, schedule, and event-driven tasks
+9. Client turn-state derivation from replicated request/response documents
+10. Client-shell workflow rules for selection, submission, and transport decoupling
+11. Command/tool execution policy: argv prefixes, read-only allowlists,
     disabled-network fail-closed behavior, sandbox selection, and filtered env
 
 The proof boundary matters:
@@ -63,8 +66,8 @@ The proof boundary matters:
   model.
 - Rust conformance tests check that persisted DefraDB-visible states refine
   that model.
-- External assumptions such as "DefraDB event arrived" or "provider streamed
-  bytes" are not proven here.
+- External assumptions such as "DefraDB eventually makes an acked mutation
+  visible" or "provider streamed bytes" are not proven here.
 
 ## Why This Matters
 
@@ -93,6 +96,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Request.lean` | Barrel for request state, transitions, executable semantics, and local properties |
 | `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, and cancellation properties |
 | `Proofs/Persistence.lean` | Persistence lifecycle model plus executable `Action`, `step?`, and `replay?` |
+| `Proofs/StorageObservation.lean` | Daemon-visible storage observation model and persistence bridge |
 | `Proofs/Composed.lean` | Cross-layer composition and guards |
 | `Proofs/Scheduling.lean` | Scheduler/backend slot state |
 | `Proofs/Fleet.lean` | Fleet-level scheduling and slot accounting |
@@ -157,6 +161,8 @@ currently covers:
 - `Process`
 - `Persistence.failClosed`
 - `Persistence.failOpen`
+- `StorageObservation.failClosed`
+- `StorageObservation.failOpen`
 - `SessionRecovery`
 - `InferenceCall`
 
@@ -236,6 +242,28 @@ Operational meaning:
   outcomes are considered valid; Rust currently treats this as an operational
   storage boundary rather than a persisted per-token state document
 
+### Layer 3b: Storage Observation Boundary
+
+States:
+
+- `noMutation`
+- `inFlight`
+- `successAcknowledged`
+- `mutationFailed`
+- `staleObserved`
+- `readVisible`
+- `lostAcknowledged`
+
+Operational meaning:
+
+- this layer models only what the daemon observed around storage writes and
+  follow-up reads/events
+- a successful mutation ack refines to `PersistenceState.committed`
+- a failed mutation does not refine to committed; fail-closed retries from
+  uncommitted, while fail-open acknowledges lost output
+- stale reads or stale/missing events can happen after a success ack, but the
+  model keeps that separate from DefraDB's internal correctness
+
 ### Layer 4: Inference Call Lifecycle
 
 States:
@@ -290,6 +318,23 @@ pre-claim requests to `dead/Stale` and by bounding inference retry sleeps and
 stream waits by the claimed deadline. Once work is claimed, retry exhaustion
 and deadline expiry remain ordinary terminal `failed` outcomes rather than
 being reclassified as `dead`.
+
+### Storage Observation Safety
+
+`Proofs/StorageObservation.lean` separates daemon-observed storage facts from
+DefraDB correctness. The bridge theorems state that starting a mutation,
+observing mutation success, and observing fail-open/fail-closed mutation
+failure refine the existing `PersistenceState` transitions
+(`begin_refines_persistence`, `success_refines_persistence`,
+`failure_failClosed_refines_persistence`, and
+`failure_failOpen_refines_persistence`).
+
+Local observation theorems also record the daemon assumptions Rust relies on:
+`success_acknowledged_committed`, `mutation_failed_not_committed`,
+`stale_observation_preserves_success_commit`,
+`terminal_write_observed_committed`,
+`readYourWrites_visibility_path`, `staleRead_eventual_visibility_path`, and
+`staleEvent_eventual_visibility_path`.
 
 ### Request/Process Liveness
 
@@ -421,7 +466,8 @@ state.
 ## Executable Model
 
 The core Lean layers are executable, not just relational. This includes
-request, process, persistence, session recovery, fleet, and runtime reconcile:
+request, process, persistence, storage observation, session recovery, fleet,
+and runtime reconcile:
 
 - `Action`: legal transition vocabulary
 - `step?`: executable one-step transition
@@ -471,10 +517,11 @@ The finite-state checks currently establish:
   successor; reserved `inputRequired` remains vocabulary-only
 - every non-terminal process state has at least one successor
 - every non-terminal persistence state has at least one successor
+- every non-terminal storage-observation state has at least one successor
 - every non-terminal inference-call state has at least one successor
 - admission-state invariants line up with request state
-- state counts stay as expected: 9 request, 5 process, 4 persistence, 5 call,
-  180 core composed
+- state counts stay as expected: 9 request, 5 process, 4 persistence,
+  7 storage-observation, 5 call, 180 core composed
 
 These checks are useful because they catch structural model regressions quickly,
 even before theorem-level reasoning matters.
@@ -497,8 +544,9 @@ Current boundaries:
 - Fleet aggregate slot state is reconstructed from `InferenceCall` rows rather
   than persisted as a single `FleetState` document. Only rows with
   `call_state = "running"` hold slots; queued and terminal rows do not.
-- `PersistenceState` is a proof abstraction over durable writes; DefraDB
-  successful-mutation durability is an external storage assumption.
+- `StorageObservation` records daemon-level storage assumptions: success acks,
+  failed mutations, stale reads/events, and minimum visibility paths. DefraDB
+  storage-engine correctness remains external.
 
 `Proofs/Conformance/Deviations.lean` is now reserved only for real unresolved
 Rust/spec mismatches. There are currently no known active spec deviations.
@@ -543,8 +591,8 @@ error strings remain open and are not treated as a closed Lean vocabulary.
 
 These proofs do not establish:
 
-- DefraDB read-your-writes semantics
-- DefraDB CRDT merge or event-delivery guarantees
+- DefraDB read-your-writes semantics beyond the modeled daemon assumption
+- DefraDB CRDT merge or event-delivery correctness
 - network reliability
 - provider/model correctness
 - MCP or external tool availability

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -190,17 +190,7 @@ impl DefraSessionHook {
     }
 
     fn decide_persistence_outcome(&self, context: &str, error: &anyhow::Error) -> PolicyDecision {
-        self.counters.failures.fetch_add(1, Ordering::Relaxed);
-        match self.failure_policy {
-            FailurePolicy::FailOpen => {
-                tracing::warn!(error = %error, context = %context, "persistence failed (fail-open)");
-                PolicyDecision::Continue
-            }
-            FailurePolicy::FailClosed => {
-                tracing::error!(error = %error, context = %context, "persistence failed (fail-closed) — terminating");
-                PolicyDecision::Terminate(format!("persistence failed: {error}"))
-            }
-        }
+        decide_persistence_outcome(self.failure_policy, &self.counters, context, error)
     }
 
     fn on_persistence_error(&self, context: &str, error: &anyhow::Error) -> HookAction {
@@ -270,6 +260,25 @@ impl DefraSessionHook {
                 PolicyDecision::Continue => Ok(()),
                 PolicyDecision::Terminate(_) => Err(e),
             },
+        }
+    }
+}
+
+fn decide_persistence_outcome(
+    failure_policy: FailurePolicy,
+    counters: &HookCounters,
+    context: &str,
+    error: &anyhow::Error,
+) -> PolicyDecision {
+    counters.failures.fetch_add(1, Ordering::Relaxed);
+    match failure_policy {
+        FailurePolicy::FailOpen => {
+            tracing::warn!(error = %error, context = %context, "persistence failed (fail-open)");
+            PolicyDecision::Continue
+        }
+        FailurePolicy::FailClosed => {
+            tracing::error!(error = %error, context = %context, "persistence failed (fail-closed) — terminating");
+            PolicyDecision::Terminate(format!("persistence failed: {error}"))
         }
     }
 }

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
@@ -67,6 +68,13 @@ fn session_state_for_test() -> SessionState {
     }
 }
 
+fn hook_counters_for_test() -> HookCounters {
+    HookCounters {
+        failures: AtomicU64::new(0),
+        successes: AtomicU64::new(0),
+    }
+}
+
 #[test]
 fn transcript_turn_state_allocates_new_assistant_after_saved_turn() {
     let mut state = session_state_for_test();
@@ -93,77 +101,45 @@ fn transcript_turn_state_rejects_stream_result_before_assistant_is_saved() {
     assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
 }
 
-#[tokio::test]
-async fn fail_closed_persistence_policy_returns_error_and_records_failure() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-hook-fail-closed-{}", uuid::Uuid::new_v4()));
-    let node = Arc::new(
-        defra_node::EmbeddedNode::builder()
-            .data_path(&data_path)
-            .build()
-            .await
-            .unwrap(),
-    );
-    let hook = DefraSessionHook::with_identity(
-        node,
-        "general",
-        "did:defra-agent:general",
+#[test]
+fn fail_closed_persistence_policy_terminates_and_records_failure() {
+    let counters = hook_counters_for_test();
+    let error = anyhow::anyhow!("synthetic persistence failure");
+
+    let decision = decide_persistence_outcome(
         FailurePolicy::FailClosed,
+        &counters,
+        "unit-test failure",
+        &error,
     );
 
-    let error = hook
-        .apply_persistence_policy(
-            Err(anyhow::anyhow!("synthetic persistence failure")),
-            "unit-test failure",
-        )
-        .unwrap_err();
-
-    assert!(error.to_string().contains("synthetic persistence failure"));
-    let stats = hook.stats();
-    assert_eq!(stats.persistence_failures, 1);
-    assert_eq!(stats.persistence_successes, 0);
-
-    let _ = std::fs::remove_dir_all(&data_path);
+    assert!(matches!(
+        decision,
+        PolicyDecision::Terminate(reason) if reason.contains("synthetic persistence failure")
+    ));
+    assert_eq!(counters.failures.load(Ordering::Relaxed), 1);
+    assert_eq!(counters.successes.load(Ordering::Relaxed), 0);
 }
 
-#[tokio::test]
-async fn fail_open_persistence_policy_continues_without_success_ack() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-hook-fail-open-{}", uuid::Uuid::new_v4()));
-    let node = Arc::new(
-        defra_node::EmbeddedNode::builder()
-            .data_path(&data_path)
-            .build()
-            .await
-            .unwrap(),
-    );
-    let hook = DefraSessionHook::with_identity(
-        node,
-        "general",
-        "did:defra-agent:general",
+#[test]
+fn fail_open_persistence_policy_continues_without_success_ack() {
+    let counters = hook_counters_for_test();
+    let error = anyhow::anyhow!("synthetic persistence failure");
+
+    let decision = decide_persistence_outcome(
         FailurePolicy::FailOpen,
+        &counters,
+        "unit-test failure",
+        &error,
     );
 
-    hook.apply_persistence_policy(
-        Err(anyhow::anyhow!("synthetic persistence failure")),
-        "unit-test failure",
-    )
-    .unwrap();
-
-    let stats = hook.stats();
-    assert_eq!(stats.persistence_failures, 1);
+    assert!(matches!(decision, PolicyDecision::Continue));
+    assert_eq!(counters.failures.load(Ordering::Relaxed), 1);
     assert_eq!(
-        stats.persistence_successes, 0,
+        counters.successes.load(Ordering::Relaxed),
+        0,
         "fail-open continuation must not count as a successful storage ack"
     );
-
-    hook.apply_persistence_policy(Ok(()), "unit-test success")
-        .unwrap();
-    let stats = hook.stats();
-    assert_eq!(stats.persistence_failures, 1);
-    assert_eq!(stats.persistence_successes, 1);
-
-    let _ = std::fs::remove_dir_all(&data_path);
 }
 
 async fn create_streaming_response(

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -93,6 +93,79 @@ fn transcript_turn_state_rejects_stream_result_before_assistant_is_saved() {
     assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
 }
 
+#[tokio::test]
+async fn fail_closed_persistence_policy_returns_error_and_records_failure() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-fail-closed-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    let hook = DefraSessionHook::with_identity(
+        node,
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::FailClosed,
+    );
+
+    let error = hook
+        .apply_persistence_policy(
+            Err(anyhow::anyhow!("synthetic persistence failure")),
+            "unit-test failure",
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("synthetic persistence failure"));
+    let stats = hook.stats();
+    assert_eq!(stats.persistence_failures, 1);
+    assert_eq!(stats.persistence_successes, 0);
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn fail_open_persistence_policy_continues_without_success_ack() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-fail-open-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    let hook = DefraSessionHook::with_identity(
+        node,
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::FailOpen,
+    );
+
+    hook.apply_persistence_policy(
+        Err(anyhow::anyhow!("synthetic persistence failure")),
+        "unit-test failure",
+    )
+    .unwrap();
+
+    let stats = hook.stats();
+    assert_eq!(stats.persistence_failures, 1);
+    assert_eq!(
+        stats.persistence_successes, 0,
+        "fail-open continuation must not count as a successful storage ack"
+    );
+
+    hook.apply_persistence_policy(Ok(()), "unit-test success")
+        .unwrap();
+    let stats = hook.stats();
+    assert_eq!(stats.persistence_failures, 1);
+    assert_eq!(stats.persistence_successes, 1);
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
 async fn create_streaming_response(
     node: &defra_node::EmbeddedNode,
     request_id: &str,

--- a/crates/defra-agent/src/streaming/tests.rs
+++ b/crates/defra-agent/src/streaming/tests.rs
@@ -268,6 +268,64 @@ async fn finalize_removes_buffer_after_successful_mutation() {
 }
 
 #[tokio::test]
+async fn finalize_treats_matching_terminal_observation_as_idempotent() {
+    let (node, data_path) = build_test_node("finalize-idempotent-terminal").await;
+    let writer = DefraStreamWriter::new(
+        node.clone(),
+        "did:defra-agent:test",
+        Duration::from_secs(60),
+    );
+    let request_id = uuid::Uuid::new_v4().to_string();
+    create_processing_request(&node, &request_id, "session-1").await;
+    let doc_id = writer
+        .begin("session-1", &request_id, "general")
+        .await
+        .unwrap();
+
+    writer.write_tokens(&doc_id, "final answer").await.unwrap();
+    let first = writer
+        .finalize(&doc_id, StreamStatus::Complete)
+        .await
+        .unwrap();
+    assert_eq!(first.content, "final answer");
+    assert!(!writer.buffers.lock().await.contains_key(&doc_id));
+
+    let second = writer
+        .finalize(&doc_id, StreamStatus::Complete)
+        .await
+        .unwrap();
+
+    assert_eq!(second.status, StreamStatus::Complete);
+    assert_eq!(second.content, "final answer");
+    assert_eq!(second.token_count, 2);
+    assert!(!writer.buffers.lock().await.contains_key(&doc_id));
+
+    let row = load_response(&node, &doc_id).await;
+    assert_eq!(
+        row.get("content").and_then(|value| value.as_str()),
+        Some("final answer")
+    );
+    assert_eq!(
+        row.get("status").and_then(|value| value.as_str()),
+        Some("complete")
+    );
+
+    let request_row = load_request(&node, &request_id).await;
+    assert_eq!(
+        request_row.get("status").and_then(|value| value.as_str()),
+        Some("completed")
+    );
+    assert_eq!(
+        request_row
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("completed")
+    );
+
+    let _ = fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
 async fn finalize_keeps_buffer_when_mutation_fails() {
     let (node, data_path) = build_test_node("finalize-failure").await;
     let writer = DefraStreamWriter::new(

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -32,6 +32,8 @@ fn lean_executable_contracts_cover_initial_domains() {
         "Process",
         "Persistence.failClosed",
         "Persistence.failOpen",
+        "StorageObservation.failClosed",
+        "StorageObservation.failOpen",
         "SessionRecovery",
         "InferenceCall",
     ] {
@@ -40,6 +42,31 @@ fn lean_executable_contracts_cover_initial_domains() {
 
     assert_lean_transition_is_legal("Persistence.failClosed", "committing", "uncommitted");
     assert_lean_transition_is_legal("Persistence.failOpen", "committing", "lost");
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
+        "inFlight",
+        "successAcknowledged",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
+        "mutationFailed",
+        "noMutation",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failOpen",
+        "mutationFailed",
+        "lostAcknowledged",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
+        "successAcknowledged",
+        "staleObserved",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
+        "staleObserved",
+        "readVisible",
+    );
     assert_lean_transition_is_legal("SessionRecovery", "failed", "pending");
     assert_lean_transition_is_legal("InferenceCall", "queued", "running");
     assert_lean_transition_is_legal("InferenceCall", "running", "completed");

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -42,10 +42,16 @@ fn lean_executable_contracts_cover_initial_domains() {
 
     assert_lean_transition_is_legal("Persistence.failClosed", "committing", "uncommitted");
     assert_lean_transition_is_legal("Persistence.failOpen", "committing", "lost");
+    assert_lean_transition_is_legal("StorageObservation.failClosed", "noMutation", "inFlight");
     assert_lean_transition_is_legal(
         "StorageObservation.failClosed",
         "inFlight",
         "successAcknowledged",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
+        "inFlight",
+        "mutationFailed",
     );
     assert_lean_transition_is_legal(
         "StorageObservation.failClosed",
@@ -64,8 +70,23 @@ fn lean_executable_contracts_cover_initial_domains() {
     );
     assert_lean_transition_is_legal(
         "StorageObservation.failClosed",
+        "successAcknowledged",
+        "readVisible",
+    );
+    assert_lean_transition_is_legal(
+        "StorageObservation.failClosed",
         "staleObserved",
         "readVisible",
+    );
+    assert_lean_transition_is_illegal(
+        "StorageObservation.failClosed",
+        "mutationFailed",
+        "lostAcknowledged",
+    );
+    assert_lean_transition_is_illegal(
+        "StorageObservation.failOpen",
+        "mutationFailed",
+        "noMutation",
     );
     assert_lean_transition_is_legal("SessionRecovery", "failed", "pending");
     assert_lean_transition_is_legal("InferenceCall", "queued", "running");


### PR DESCRIPTION
## Summary
- add a Lean StorageObservation model for daemon-visible mutation success, mutation failure, stale read/event observations, and visibility paths
- bridge storage observations back to the existing PersistenceState model and expose fail-open/fail-closed observation machines in the Lean contract JSON
- add Rust tests for hook failure policy and idempotent terminal stream finalization, and extend state-machine conformance coverage
- update proof docs and boundary notes to keep DefraDB correctness external

## Verification
- lake build
- cargo test -p defra-agent --lib hook::tests
- cargo test -p defra-agent --lib streaming::tests
- cargo test -p defra-agent --lib session::tests
- cargo test -p defra-agent --test interruption_integration
- cargo test -p defra-agent --test state_machine_conformance
- cargo fmt --check
- git diff --check
- rg -n 'sorry|admit|axiom|PLACEHOLDER|todo!\(\)' touched areas