### PR TITLE
Tighten client shell and tool execution proofs

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -183,6 +183,69 @@ fn session_snapshot_prefers_tracked_request_over_stale_conversation_latest_reque
 }
 
 #[test]
+fn session_snapshot_does_not_report_unobserved_preferred_request() {
+    let store = ClientStore::from_rows(ClientStoreRows {
+        conversations: vec![AgentConversationRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Amy".to_string()),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            title: Some("conversation".to_string()),
+            title_source: Some("generated".to_string()),
+            preview_text: Some("turn one".to_string()),
+            status: Some("active".to_string()),
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            updated_at: Some("2026-04-21T12:00:01Z".to_string()),
+            latest_request_id: Some("req-old".to_string()),
+        }],
+        requests: vec![AgentRequestRow {
+            request_id: "req-old".to_string(),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            session_id: Some("session-1".to_string()),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("turn one".to_string()),
+            status: Some("completed".to_string()),
+            lifecycle_state: Some("completed".to_string()),
+            backend_id: None,
+            execution_origin: Some("interactive".to_string()),
+            failure_reason: None,
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            claimed_at: None,
+            deadline: None,
+            retry_count: Some(0),
+            max_retries: Some(3),
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        }],
+        messages: vec![AgentMessageRow {
+            message_key: "msg-1".to_string(),
+            session_id: Some("session-1".to_string()),
+            sequence: Some(1),
+            role: Some("user".to_string()),
+            content: Some(user_message_json("turn one")),
+            timestamp: Some("2026-04-21T12:00:00Z".to_string()),
+        }],
+        ..ClientStoreRows::default()
+    });
+
+    let snapshot = build_session_snapshot_from_store(&store, "session-1", Some("req-new"))
+        .expect("session snapshot");
+
+    assert_eq!(
+        snapshot.latest_request_id.as_deref(),
+        Some("req-old"),
+        "Proofs.ClientShell.C9: an awaiting request retires only after the matching request is observed"
+    );
+    assert_eq!(snapshot.turn_state.as_deref(), Some("completed"));
+    assert!(snapshot.pending_turn.is_none());
+}
+
+#[test]
 fn session_snapshot_stays_renderable_across_single_turn_observation_updates() {
     let submitted = ClientStore::from_rows(ClientStoreRows {
         conversations: vec![AgentConversationRow {

--- a/apps/desktop-tauri/src/lib/chat-shell.test.ts
+++ b/apps/desktop-tauri/src/lib/chat-shell.test.ts
@@ -91,6 +91,64 @@ describe("projectChatShell", () => {
     expect(projection.sendStatus.kind).toBe("disabled");
   });
 
+  test("keeps awaiting observation until the matching request is observed", () => {
+    const projection = projectChatShell({
+      clientAvailable: true,
+      selectedAgentDid: "did:defra:amy",
+      selectedSessionId: "session-1",
+      draft: "follow up",
+      sending: false,
+      selectedConversation: conversation({ latestRequestId: "req-old", turnState: "completed" }),
+      session: session({ latestRequestId: "req-old", turnState: "completed" }),
+      localWorkflow: {
+        kind: "awaitingObservation",
+        sessionId: "session-1",
+        requestId: "req-new",
+      },
+    });
+
+    expect(projection.workflow).toEqual({
+      kind: "awaitingObservation",
+      sessionId: "session-1",
+      requestId: "req-new",
+    });
+    expect(projection.sendStatus).toEqual({
+      kind: "disabled",
+      reason: "waitingForRequestObservation",
+      hint: "Waiting for request observation",
+    });
+  });
+
+  test("ignores stale tracked workflow after user switches sessions", () => {
+    const projection = projectChatShell({
+      clientAvailable: true,
+      selectedAgentDid: "did:defra:amy",
+      selectedSessionId: "session-2",
+      draft: "new session follow up",
+      sending: false,
+      selectedConversation: conversation({
+        sessionId: "session-2",
+        latestRequestId: "req-2",
+        turnState: "completed",
+      }),
+      session: session({
+        sessionId: "session-2",
+        latestRequestId: "req-2",
+        turnState: "completed",
+      }),
+      localWorkflow: {
+        kind: "turnInProgress",
+        sessionId: "session-1",
+        requestId: "req-1",
+        turnState: "streaming",
+      },
+    });
+
+    expect(projection.workflow).toEqual({ kind: "ready" });
+    expect(projection.activeRequestId).toBe("req-2");
+    expect(projection.sendStatus).toEqual({ kind: "ready" });
+  });
+
   test("blocks inconsistent observation when latest request is missing", () => {
     const projection = projectChatShell({
       clientAvailable: true,

--- a/apps/desktop-tauri/src/lib/chat-shell.ts
+++ b/apps/desktop-tauri/src/lib/chat-shell.ts
@@ -115,8 +115,10 @@ export function projectChatShell(input: ProjectionInput): ChatShellProjection {
     : null;
 
   const trackedRequestId =
-    input.localWorkflow.kind === "awaitingObservation" ||
-    input.localWorkflow.kind === "turnInProgress"
+    (input.localWorkflow.kind === "awaitingObservation" ||
+      input.localWorkflow.kind === "turnInProgress") &&
+    (input.selectedSessionId === input.localWorkflow.sessionId ||
+      input.session?.sessionId === input.localWorkflow.sessionId)
       ? input.localWorkflow.requestId ?? null
       : null;
 
@@ -154,7 +156,13 @@ export function projectChatShell(input: ProjectionInput): ChatShellProjection {
       workflow = { kind: "ready" };
     }
   } else if (input.localWorkflow.kind === "turnInProgress") {
-    if (
+    const selectedMatches =
+      input.selectedSessionId === input.localWorkflow.sessionId ||
+      input.session?.sessionId === input.localWorkflow.sessionId;
+
+    if (!selectedMatches) {
+      workflow = { kind: "ready" };
+    } else if (
       observedTurnState &&
       activeRequestId === (input.localWorkflow.requestId ?? activeRequestId)
     ) {

--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -12,6 +12,7 @@ import Proofs.Triggers
 import Proofs.Client
 import Proofs.ClientShell
 import Proofs.CommandPolicy
+import Proofs.ToolExecution
 import Proofs.Properties.Safety
 import Proofs.Properties.Decidable
 import Proofs.Properties.Liveness

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -37,9 +37,19 @@ deadline expiry remain terminal `failed`.
 
 Tool-call failures are classified as permanent until tool metadata can prove
 retry safety. Retrying tool calls without health, idempotency, and side-effect
-metadata can repeat side effects, so the model leaves tool retry eligibility out
-of the request transition system and Rust treats `StreamingError::Tool(_)` as a
-permanent failure.
+metadata can repeat side effects, so the request transition system does not
+model tool retries and Rust treats `StreamingError::Tool(_)` as a permanent
+failure.
+
+`Proofs.ToolExecution` is the initial local model for future MCP/tool execution
+semantics. It currently proves only the service-local boundary Rust enforces:
+unreachable services and invalid preflight schemas block dispatch, `list_tools`
+transport retries are safe-read retries, and `call_tool` transport retries
+require explicit idempotency evidence. Rust does not currently persist or
+consume idempotency metadata for MCP tools, so `McpPool::call_tool` must not
+implicitly retry after dispatch failure. Future tool retries should first extend
+`ToolExecution.IdempotencyEvidence`, add a Rust contract for the advertised
+metadata, and only then widen `McpPool::call_tool` retry behavior.
 
 The scheduler's aggregate fleet slot state is reconstructed from
 `InferenceCall` rows. A backend's held slot count is the derived count of rows

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -312,7 +312,7 @@ def inferenceCallMachine : StateMachineContract :=
       (fun call => call.state.toDefraDB))
 
 def toolRetryDispositions : List ToolExecution.RetryDisposition :=
-  [ .doNotRetry, .retrySafeRead, .retryIdempotentToolCall ]
+  ToolExecution.RetryDisposition.all
 
 def toolRetryDispositionNames : List String :=
   toolRetryDispositions.map ToolExecution.RetryDisposition.toDefraDB

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -3,6 +3,7 @@ import Proofs.Process
 import Proofs.Persistence
 import Proofs.SessionRecovery
 import Proofs.InferenceCall
+import Proofs.ToolExecution
 
 /-!
 # Rust Conformance Contracts
@@ -310,6 +311,12 @@ def inferenceCallMachine : StateMachineContract :=
       InferenceCall.step?
       (fun call => call.state.toDefraDB))
 
+def toolRetryDispositions : List ToolExecution.RetryDisposition :=
+  [ .doNotRetry, .retrySafeRead, .retryIdempotentToolCall ]
+
+def toolRetryDispositionNames : List String :=
+  toolRetryDispositions.map ToolExecution.RetryDisposition.toDefraDB
+
 def vocabularies : List VocabularyContract :=
   [ { domain := "RequestState", values := requestStateNames }
   , { domain := "ExecutionOrigin", values :=
@@ -329,6 +336,7 @@ def vocabularies : List VocabularyContract :=
         , .streamDroppedBeforeTerminalResponse
         ].map InferenceCallTerminalReason.toDefraDB
     }
+  , { domain := "ToolRetryDisposition", values := toolRetryDispositionNames }
   ]
 
 def stateMachines : List StateMachineContract :=
@@ -375,6 +383,8 @@ def snapshotJson : String :=
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
     ++ "\"follow_up_hooks\":["
       ++ jsonString "RuntimeReconcile executable state machine contract"
+      ++ ","
+      ++ jsonString "ToolExecution idempotent MCP call retry contract"
       ++ "]"
     ++ "}"
 

--- a/crates/defra-agent/proofs/Proofs/ToolExecution.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution.lean
@@ -68,6 +68,16 @@ def toDefraDB : RetryDisposition → String
   | .retrySafeRead => "retrySafeRead"
   | .retryIdempotentToolCall => "retryIdempotentToolCall"
 
+/-- Exhaustive constructor list used by the Rust conformance vocabulary. -/
+def all : List RetryDisposition :=
+  [ .doNotRetry, .retrySafeRead, .retryIdempotentToolCall ]
+
+/-- Adding a retry disposition constructor must update `all`. -/
+theorem all_complete
+    (disposition : RetryDisposition) :
+    disposition ∈ all := by
+  cases disposition <;> simp [all]
+
 end RetryDisposition
 
 /-- Health/schema preflight. Stale services are allowed through with a longer

--- a/crates/defra-agent/proofs/Proofs/ToolExecution.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution.lean
@@ -1,0 +1,132 @@
+import Proofs.Basic
+
+/-!
+# Tool Execution Policy
+
+Initial model for MCP/native tool dispatch boundaries. It deliberately models
+only the service-local facts Rust can enforce today: health/schema preflight
+and retry eligibility. Tool side effects, remote service behavior, and schema
+soundness beyond the checked subset remain external assumptions.
+-/
+
+namespace ToolExecution
+
+/-- Coarse service health visible before dispatch. -/
+inductive Health where
+  | healthy
+  | stale
+  | unreachable
+  deriving DecidableEq, Repr
+
+/-- Result of argument/schema checks available before dispatch. -/
+inductive SchemaStatus where
+  | unchecked
+  | valid
+  | invalid
+  deriving DecidableEq, Repr
+
+/-- Evidence needed before a tool call can be retried after dispatch. -/
+inductive IdempotencyEvidence where
+  | unknown
+  | idempotent
+  | nonIdempotent
+  deriving DecidableEq, Repr
+
+/-- Tool operations that have different retry semantics. -/
+inductive ToolOperation where
+  | mcpListTools
+  | mcpCall
+  | nativeCommand
+  deriving DecidableEq, Repr
+
+/-- Failure classes at the tool boundary. -/
+inductive FailureClass where
+  | argumentInvalid
+  | serviceUnavailable
+  | transport
+  | toolReturnedError
+  | external
+  deriving DecidableEq, Repr
+
+/-- Pre-dispatch decision. -/
+inductive PreflightDecision where
+  | dispatch
+  | block (failure : FailureClass)
+  deriving DecidableEq, Repr
+
+/-- Retry class emitted by the model for Rust conformance docs/tests. -/
+inductive RetryDisposition where
+  | doNotRetry
+  | retrySafeRead
+  | retryIdempotentToolCall
+  deriving DecidableEq, Repr
+
+namespace RetryDisposition
+
+def toDefraDB : RetryDisposition → String
+  | .doNotRetry => "doNotRetry"
+  | .retrySafeRead => "retrySafeRead"
+  | .retryIdempotentToolCall => "retryIdempotentToolCall"
+
+end RetryDisposition
+
+/-- Health/schema preflight. Stale services are allowed through with a longer
+timeout; unreachable services and invalid arguments are blocked locally. -/
+def preflight
+    (health : Health)
+    (schema : SchemaStatus) : PreflightDecision :=
+  match health with
+  | .unreachable => .block .serviceUnavailable
+  | .healthy | .stale =>
+      match schema with
+      | .invalid => .block .argumentInvalid
+      | .unchecked | .valid => .dispatch
+
+/-- Retry eligibility after a failed operation. Listing tools is a safe read.
+Calling tools requires explicit idempotency evidence before a transport retry.
+Native command retries are outside this model. -/
+def retryDisposition
+    (operation : ToolOperation)
+    (idempotency : IdempotencyEvidence)
+    (failure : FailureClass) : RetryDisposition :=
+  match operation, idempotency, failure with
+  | .mcpListTools, _, .transport => .retrySafeRead
+  | .mcpCall, .idempotent, .transport => .retryIdempotentToolCall
+  | _, _, _ => .doNotRetry
+
+theorem unreachable_blocks_dispatch
+    (schema : SchemaStatus) :
+    preflight .unreachable schema = .block .serviceUnavailable := by
+  cases schema <;> rfl
+
+theorem invalid_schema_blocks_healthy_dispatch :
+    preflight .healthy .invalid = .block .argumentInvalid := rfl
+
+theorem invalid_schema_blocks_stale_dispatch :
+    preflight .stale .invalid = .block .argumentInvalid := rfl
+
+theorem mcp_call_without_idempotency_metadata_does_not_retry
+    (failure : FailureClass) :
+    retryDisposition .mcpCall .unknown failure = .doNotRetry := by
+  cases failure <;> rfl
+
+theorem mcp_call_transport_retry_requires_idempotency
+    (idempotency : IdempotencyEvidence)
+    (h_retry :
+      retryDisposition .mcpCall idempotency .transport =
+        .retryIdempotentToolCall) :
+    idempotency = .idempotent := by
+  cases idempotency <;> simp [retryDisposition] at h_retry ⊢
+
+theorem native_command_not_retried_by_tool_model
+    (idempotency : IdempotencyEvidence)
+    (failure : FailureClass) :
+    retryDisposition .nativeCommand idempotency failure = .doNotRetry := by
+  cases idempotency <;> cases failure <;> rfl
+
+theorem list_tools_transport_retry_is_safe_read
+    (idempotency : IdempotencyEvidence) :
+    retryDisposition .mcpListTools idempotency .transport = .retrySafeRead := by
+  cases idempotency <;> rfl
+
+end ToolExecution

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -21,6 +21,7 @@ The proofs are strongest where the runtime is a state machine:
 - task, schedule, and event-trigger dispatch
 - client turn projection and desktop shell workflow state
 - command/tool execution policy for bash argv, network, sandbox, and shell env
+- MCP/tool execution preflight and retry eligibility boundaries
 
 They do not prove storage guarantees, network delivery, provider behavior, UI
 rendering, external tool behavior, or host sandbox implementation details. Those
@@ -43,7 +44,7 @@ lake env lean --run Proofs/Conformance/Contracts.lean
 
 ## What Is Proven
 
-The current proof suite covers ten practical areas:
+The current proof suite covers eleven practical areas:
 
 1. Request/process/persistence state transitions
 2. Inference-call lifecycle, request linkage, and cancellation terminality
@@ -56,6 +57,8 @@ The current proof suite covers ten practical areas:
 9. Client-shell workflow rules for selection, submission, and transport decoupling
 10. Command/tool execution policy: argv prefixes, read-only allowlists,
     disabled-network fail-closed behavior, sandbox selection, and filtered env
+11. Tool execution boundary rules: schema/health preflight and MCP retry
+    eligibility before future idempotent tool retries are enabled
 
 The proof boundary matters:
 
@@ -103,6 +106,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Client.lean` | Barrel for client turn-state derivation and client theorems |
 | `Proofs/ClientShell.lean` | Barrel for multi-session shell workflow modules |
 | `Proofs/CommandPolicy.lean` | Barrel for command/tool execution policy validation, sandbox, env, and safety proofs |
+| `Proofs/ToolExecution.lean` | MCP/tool preflight and retry eligibility boundary model |
 | `Proofs/Properties/Safety.lean` | Request/process/persistence safety properties S1-S6 |
 | `Proofs/Properties/Liveness.lean` | Request/process liveness properties L1-L3 |
 | `Proofs/Properties/SchedulingSafety.lean` | Scheduler/fleet safety properties S7-S9 |
@@ -128,6 +132,7 @@ Semantic submodules:
 | `Proofs.Client` | `Types`, `Lifecycle`, `Terminal`, `Replacement` |
 | `Proofs.ClientShell` | `Types`, `Submission`, `Transition`, `Projection`, `Theorems` |
 | `Proofs.CommandPolicy` | `Types`, `Validation`, `Sandbox`, `Env`, `Theorems` |
+| `Proofs.ToolExecution` | standalone health/schema preflight and retry eligibility model |
 | `Proofs.Conformance.Triggers` | `Lifecycle`, `Materialization`, `Trace` |
 
 The top-level barrel imports remain the stable entry points for downstream code.
@@ -160,6 +165,10 @@ currently covers:
 - `SessionRecovery`
 - `InferenceCall`
 
+It also emits the `ToolRetryDisposition` vocabulary from
+`Proofs.ToolExecution` so Rust tests can reject accidental MCP `call_tool`
+retry drift before idempotency metadata exists.
+
 The current `SessionRecovery` contract is intentionally narrow: it covers the
 executable failed-latest-request reissue witness (`failed -> pending`) rather
 than the whole request lifecycle vocabulary. Widen this contract when the
@@ -175,6 +184,11 @@ updated to match.
 so this extraction stays scoped to the initial executable domains above. Add it
 to `Proofs/Conformance/Contracts.lean` as another `StateMachineContract` when
 the runtime-reconcile contract is ready to join the Rust conformance gate.
+
+`ToolExecution` currently exports only retry disposition vocabulary and theorems.
+Before adding idempotent MCP retries, extend that Lean model first with the
+metadata source, retry budget, and replay/idempotency assumptions, then add a
+Rust contract that ties advertised MCP metadata to the widened retry rule.
 
 ## Core Model
 

--- a/crates/defra-agent/proofs/client-state-machine.md
+++ b/crates/defra-agent/proofs/client-state-machine.md
@@ -214,6 +214,27 @@ projection. It proves that selection changes are local and transport-independent
 that transport input does not mutate shell state, and that awaiting submission
 state retires only after observing the matching request tip.
 
+## Desktop Shell Conformance Map
+
+The desktop shell is split across Rust snapshot construction and TypeScript
+local UI state. Lean models the intended shell machine; the current runtime
+enforces these parts:
+
+| Lean property | Runtime enforcement today | Coverage |
+|---|---|---|
+| C2 snapshot preserves selection | React selection state is separate from snapshot refresh. `projectChatShell` is pure and receives selection as input rather than writing it. | TypeScript projection tests cover stale tracked workflow after user session switch. |
+| C3 transport input is non-mutating | P2P health lives in `DesktopRuntimeSnapshot.p2pHealth`; it is projected separately from selected session/chat state. Auto-restart refreshes the selected session by id instead of rewriting selection from transport health. | Desktop shell effects rely on refs for selected session during restart. |
+| C4/C4' session selection is local | `onSelectSession` latches the clicked session and clears the loaded session snapshot if it belongs to another session. Store presence affects projection only. | TypeScript projection tests cover switching away from stale in-flight workflow. |
+| C6 start-submit is gated | `onSendMessage` checks `shellProjection.sendStatus === ready` before calling `sendChatMessage`; Rust submission APIs still validate required agent/session fields. | Existing chat-shell tests cover empty/missing/in-flight terminality gates. |
+| C9 awaiting retires only on matching request | Rust `build_session_snapshot_from_store(..., preferred_request_id)` reports a preferred request only if that request is actually in the observed store; TypeScript keeps `awaitingObservation` while latest/pending request ids do not match. | Rust snapshot test and TypeScript projection test cover missing/stale observed request ids. |
+
+The remaining Lean-only surface is a generated executable ClientShell contract:
+there is no Rust or TypeScript consumer of `step` yet. Future shell changes that
+add workflow states, blocker reasons, behavior-mismatch handling, or transport
+coupling should extend `Proofs/ClientShell` first, then either emit a
+`Proofs.Conformance.Contracts` vocabulary/state-machine contract or add a
+proof-linked runtime test that names the theorem it protects.
+
 ## Reference Pseudocode
 
 ### Swift

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -107,7 +107,10 @@ impl McpPool {
 
     /// Call a tool on the MCP server at `endpoint`.
     ///
-    /// Connects lazily, same as [`list_tools`](Self::list_tools).
+    /// Connects lazily, same as [`list_tools`](Self::list_tools). Unlike
+    /// `list_tools`, this does not retry after a dispatch failure: repeating an
+    /// MCP tool call can repeat side effects until services advertise
+    /// idempotency metadata that `Proofs.ToolExecution` can model.
     pub async fn call_tool(
         &self,
         service_id: &str,
@@ -116,29 +119,8 @@ impl McpPool {
         arguments: serde_json::Value,
     ) -> Result<CallToolResult> {
         self.get_or_connect(service_id, endpoint).await?;
-        let retry_arguments = arguments.clone();
-
-        match self
-            .call_tool_once(service_id, build_call_tool_params(tool_name, arguments))
+        self.call_tool_once(service_id, build_call_tool_params(tool_name, arguments))
             .await
-        {
-            Ok(result) => Ok(result),
-            Err(error) => {
-                tracing::warn!(
-                    service_id = %service_id,
-                    tool_name = %tool_name,
-                    error = %error,
-                    "MCP call_tool failed, evicting connection and retrying"
-                );
-                self.remove(service_id).await;
-                self.get_or_connect(service_id, endpoint).await?;
-                self.call_tool_once(
-                    service_id,
-                    build_call_tool_params(tool_name, retry_arguments),
-                )
-                .await
-            }
-        }
     }
 
     pub async fn remove(&self, service_id: &str) {

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -111,6 +111,9 @@ impl McpPool {
     /// `list_tools`, this does not retry after a dispatch failure: repeating an
     /// MCP tool call can repeat side effects until services advertise
     /// idempotency metadata that `Proofs.ToolExecution` can model.
+    /// A dead cached connection can therefore keep failing `call_tool` until
+    /// `list_tools` or explicit removal evicts it; this keeps recovery from
+    /// retransmitting a possibly mutating call.
     pub async fn call_tool(
         &self,
         service_id: &str,

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -6,6 +6,8 @@ use crate::lean_vocab_test::{assert_lean_contract_vocabulary_matches, LeanContra
 
 #[test]
 fn tool_retry_disposition_contract_matches_mcp_pool_policy() {
+    // TODO(idempotency): replace this shape pin with a Rust producer contract
+    // once MCP services advertise retry dispositions/idempotency metadata.
     assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
         domain: "ToolRetryDisposition",
         rust_source: "Proofs.ToolExecution retryDisposition / mcp_pool::call_tool",

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -1,4 +1,17 @@
 use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use crate::lean_vocab_test::{assert_lean_contract_vocabulary_matches, LeanContractVocabulary};
+
+#[test]
+fn tool_retry_disposition_contract_matches_mcp_pool_policy() {
+    assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+        domain: "ToolRetryDisposition",
+        rust_source: "Proofs.ToolExecution retryDisposition / mcp_pool::call_tool",
+        rust_values: &["doNotRetry", "retrySafeRead", "retryIdempotentToolCall"],
+    });
+}
 
 #[test]
 fn resolve_mcp_url_same_host_uses_localhost() {
@@ -68,4 +81,51 @@ fn resolve_mcp_url_no_subnet_uses_tailscale() {
         None,
     );
     assert_eq!(url, "http://100.76.203.120:9200/mcp");
+}
+
+#[tokio::test]
+async fn call_tool_does_not_retry_cached_dispatch_failure_without_idempotency_metadata() {
+    let pool = McpPool::new();
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_fn = Arc::clone(&calls);
+    let endpoint = "http://mcp.test/mcp";
+
+    {
+        let mut guard = pool.inner.write().await;
+        guard.insert(
+            "mutating-service".to_string(),
+            McpConnection {
+                endpoint: endpoint.to_string(),
+                list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
+                call_tool_fn: Box::new(move |_params| {
+                    let calls = Arc::clone(&calls_for_fn);
+                    Box::pin(async move {
+                        calls.fetch_add(1, Ordering::SeqCst);
+                        anyhow::bail!("transport dropped after dispatch")
+                    })
+                }),
+            },
+        );
+    }
+
+    let error = pool
+        .call_tool(
+            "mutating-service",
+            endpoint,
+            "write_record",
+            serde_json::json!({ "id": 1 }),
+        )
+        .await
+        .expect_err("dispatch failure should propagate");
+
+    assert!(error.to_string().contains("transport dropped"));
+    assert_eq!(
+        calls.load(Ordering::SeqCst),
+        1,
+        "Proofs.ToolExecution.mcp_call_without_idempotency_metadata_does_not_retry"
+    );
+    assert!(
+        pool.inner.read().await.contains_key("mutating-service"),
+        "a failed call_tool must not evict and reconnect without idempotency evidence"
+    );
 }


### PR DESCRIPTION
## Summary
- add `Proofs.ToolExecution` with a first retry/idempotency model for MCP tool calls and safe read retries
- emit a Lean-backed `ToolRetryDisposition` contract and align `McpPool::call_tool` so tool calls are not retried after dispatch without idempotency metadata
- add proof-linked desktop shell/snapshot tests for preferred request observation and stale workflow state after session switches
- document the ClientShell enforcement map and the future proof boundary for tool/MCP execution semantics

## Verification
- `lake build` from `crates/defra-agent/proofs`
- `lake env lean --run Proofs/Conformance/Contracts.lean`
- `bun test src/lib/chat-shell.test.ts` from `apps/desktop-tauri`
- `cargo fmt --all -- --check`
- `cargo test -p defra-agent mcp_pool --lib`
- `cargo test -p defra-agent meta_tools --lib`
- `cargo test -p defra-agent toolset::tests --lib`
- `cargo test -p defra-agent-desktop-tauri snapshot::tests::session_state --lib`
- `cargo test -p defra-agent-desktop-core --tests`
- `cargo test -p defra-agent --test state_machine_conformance lean_executable_contracts_cover_initial_domains`
- `git diff --check`
- Lean file size and forbidden placeholder scans for touched areas
