### PR TITLE
Strengthen trigger conformance contracts

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -57,6 +57,16 @@ tests cover the parser/validator boundary and command metadata emitted by
 `toolset/shared/command.rs`; the Lean model covers the fail-closed policy
 ordering and sandbox/env invariants that those tests exercise.
 
+The trigger-engine contract now has two layers. Lean emits finite executable
+dispatch cases from `Proofs.Conformance.Triggers.Contracts`; Rust consumes them
+in `trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases`.
+That generated contract covers manual fires with null trigger ids, schedule and
+event enabled-gate reachability, tuple-sensitive serial gating, latest-only
+supersession, manual latest-only without a trigger key, materialized lineage,
+and the interactive/scheduled execution-origin projection. A separate
+deterministic Rust lock test covers the latest-only critical section without
+using elapsed time as the only oracle.
+
 ## External Assumptions
 
 The `PersistenceState` model abstracts the storage commit boundary. Rust uses
@@ -72,6 +82,14 @@ behavior are environmental assumptions, not service-local state-machine facts.
 The service-local proof and tests cover the consequence of an observed backend
 configuration: reconstructed running call rows do not exceed that backend's
 `max_concurrent`.
+
+Trigger source delivery remains operational. Lean does not model the DefraDB
+event bus, control-watcher debounce, schedule tick cadence, subscription
+reconciliation timing, template-language parser behavior, or storage-engine
+delivery guarantees. Rust conformance tests cover those surfaces with bounded
+waits and persistence-shape assertions; the Lean-generated trigger contract
+covers the pure dispatch/reachability/concurrency semantics once a source has
+produced a `FireIntent`.
 
 The generated `SessionRecovery` conformance contract currently covers the
 finite failed-latest-request reissue witness (`failed -> pending`) instead of

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -62,8 +62,9 @@ dispatch cases from `Proofs.Conformance.Triggers.Contracts`; Rust consumes them
 in `trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases`.
 That generated contract covers manual fires with null trigger ids, schedule and
 event enabled-gate reachability, tuple-sensitive serial gating, latest-only
-supersession, manual latest-only without a trigger key, materialized lineage,
-and the interactive/scheduled execution-origin projection. A separate
+supersession, parallel bypass of in-flight gates, manual latest-only without a
+trigger key, materialized lineage, and the interactive/scheduled
+execution-origin projection. A separate
 deterministic Rust lock test covers the latest-only critical section without
 using elapsed time as the only oracle.
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -3,6 +3,7 @@ import Proofs.Process
 import Proofs.Persistence
 import Proofs.SessionRecovery
 import Proofs.InferenceCall
+import Proofs.Conformance.Triggers.Contracts
 
 /-!
 # Rust Conformance Contracts
@@ -373,6 +374,8 @@ def snapshotJson : String :=
       ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
     ++ "\"state_machines\":"
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
+    ++ "\"trigger_dispatch_cases\":"
+      ++ Conformance.TriggerContracts.triggerDispatchCasesJson ++ ","
     ++ "\"follow_up_hooks\":["
       ++ jsonString "RuntimeReconcile executable state machine contract"
       ++ "]"

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -374,6 +374,8 @@ def snapshotJson : String :=
       ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
     ++ "\"state_machines\":"
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
+    ++ "\"trigger_dispatch_case_count\":"
+      ++ toString Conformance.TriggerContracts.triggerDispatchCaseCount ++ ","
     ++ "\"trigger_dispatch_cases\":"
       ++ Conformance.TriggerContracts.triggerDispatchCasesJson ++ ","
     ++ "\"follow_up_hooks\":["

--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers.lean
@@ -1,6 +1,7 @@
 import Proofs.Conformance.Triggers.Lifecycle
 import Proofs.Conformance.Triggers.Materialization
 import Proofs.Conformance.Triggers.Trace
+import Proofs.Conformance.Triggers.Contracts
 
 /-!
 # Conformance Mapping: Trigger Layer -> Request Lifecycle

--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
@@ -118,6 +118,8 @@ def expectedSkipReason (scenario : TriggerScenario) : Option String :=
     | some _ =>
       match scenario.intent.concurrency with
       | .serial => some "serial: prior fire still in-flight"
+      -- Defensive for future skipped cases; current executable skips are
+      -- disabled triggers or serial gates.
       | .parallel | .latestOnly => none
 
 def expectedSupersedeCallKeys (scenario : TriggerScenario) : List TriggerKey :=
@@ -176,9 +178,9 @@ def contractJson (scenario : TriggerScenario) : String :=
           else
             "null") ++ ","
     ++ "\"expected_request_caused_by_id\":"
-      ++ (materialized.map causedById? |>.join |> jsonOptionString) ++ ","
+      ++ (materialized.bind causedById? |> jsonOptionString) ++ ","
     ++ "\"expected_request_caused_by_kind\":"
-      ++ (materialized.map causedByKind? |>.join |> jsonOptionString) ++ ","
+      ++ (materialized.bind causedByKind? |> jsonOptionString) ++ ","
     ++ "\"expected_execution_origin\":"
       ++ (materialized.map (fun request => request.executionOrigin.toDefraDB)
           |> jsonOptionString) ++ ","
@@ -233,6 +235,11 @@ def triggerDispatchScenarios : List TriggerScenario :=
     , before := { requests := [request "prior-event" "event-a" .event .serial false] }
     , intent := intent (some "event-a") .event .serial
     }
+  , { name := "schedule_parallel_ignores_prior_inflight"
+    , snap := snapshot ["sched-a"] []
+    , before := { requests := [request "prior-schedule" "sched-a" .schedule .serial false] }
+    , intent := intent (some "sched-a") .schedule .parallel
+    }
   , { name := "schedule_latest_only_clear_fires_with_supersede_call"
     , snap := snapshot ["sched-a"] []
     , before := SystemState.empty
@@ -243,12 +250,20 @@ def triggerDispatchScenarios : List TriggerScenario :=
     , before := { requests := [request "prior-schedule" "sched-a" .schedule .latestOnly false] }
     , intent := intent (some "sched-a") .schedule .latestOnly
     }
+  , { name := "event_latest_only_supersedes_prior"
+    , snap := snapshot [] ["event-a"]
+    , before := { requests := [request "prior-event" "event-a" .event .latestOnly false] }
+    , intent := intent (some "event-a") .event .latestOnly
+    }
   , { name := "manual_latest_only_without_key_fires_without_supersede"
     , snap := snapshot [] []
     , before := { requests := [request "prior-schedule" "sched-a" .schedule .latestOnly false] }
     , intent := intent none .manual .latestOnly
     }
   ]
+
+def triggerDispatchCaseCount : Nat :=
+  triggerDispatchScenarios.length
 
 def triggerDispatchCasesJson : String :=
   jsonArray (triggerDispatchScenarios.map contractJson)

--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
@@ -1,0 +1,251 @@
+import Proofs.Conformance.Triggers.Trace
+
+/-!
+# Trigger Dispatch Conformance Contracts
+
+Finite executable trigger scenarios emitted for Rust conformance tests.
+The cases are computed from `dispatch` and `dispatchStep`, so Rust can
+exercise the same branch matrix without hand-maintaining expected outcomes.
+-/
+
+namespace Conformance.TriggerContracts
+
+structure TriggerScenario where
+  name : String
+  snap : TriggerSnapshot
+  before : SystemState
+  intent : FireIntent
+
+def concurrencyName : ConcurrencyMode → String
+  | .parallel => "parallel"
+  | .serial => "serial"
+  | .latestOnly => "latest_only"
+
+def jsonString (s : String) : String :=
+  "\"" ++ s ++ "\""
+
+def jsonArray (values : List String) : String :=
+  "[" ++ String.intercalate "," values ++ "]"
+
+def jsonStringArray (values : List String) : String :=
+  jsonArray (values.map jsonString)
+
+def jsonOptionString : Option String → String
+  | none => "null"
+  | some value => jsonString value
+
+def jsonOptionNat : Option Nat → String
+  | none => "null"
+  | some value => toString value
+
+def keyJson (key : TriggerKey) : String :=
+  "{"
+    ++ "\"trigger_id\":" ++ jsonString key.1 ++ ","
+    ++ "\"trigger_kind\":" ++ jsonString key.2.toDefraDB
+    ++ "}"
+
+def schedule (triggerId : String) : ActiveSchedule :=
+  { triggerId := triggerId, enabled := true }
+
+def eventTrigger (triggerId : String) : ActiveEventTrigger :=
+  { triggerId := triggerId
+  , taskId := "task"
+  , sourceCollection := "WebhookEvent"
+  , eventKind := "created"
+  , enabled := true
+  , concurrency := .serial
+  }
+
+def snapshot (scheduleIds eventIds : List String) : TriggerSnapshot :=
+  { generation := 1
+  , activeSchedules := scheduleIds.map schedule
+  , activeEventTriggers := eventIds.map eventTrigger
+  }
+
+def intent
+    (triggerId : Option String)
+    (triggerKind : TriggerKind)
+    (concurrency : ConcurrencyMode) : FireIntent :=
+  { triggerId := triggerId
+  , triggerKind := triggerKind
+  , taskId := "task"
+  , concurrency := concurrency
+  }
+
+def request
+    (id triggerId : String)
+    (triggerKind : TriggerKind)
+    (concurrency : ConcurrencyMode)
+    (isTerminal : Bool) : AgentRequest :=
+  { id := id
+  , causedBy := some (triggerId, triggerKind)
+  , concurrency := concurrency
+  , isTerminal := isTerminal
+  , executionOrigin :=
+      match triggerKind with
+      | .manual => .interactive
+      | .schedule | .event => .scheduled
+  }
+
+def after (scenario : TriggerScenario) : SystemState :=
+  dispatchStep scenario.before scenario.snap scenario.intent
+
+def targetKey? (scenario : TriggerScenario) : Option TriggerKey :=
+  scenario.intent.triggerId.map fun triggerId =>
+    (triggerId, scenario.intent.triggerKind)
+
+def newRequest? (scenario : TriggerScenario) : Option AgentRequest :=
+  (after scenario).requests[scenario.before.requests.length]?
+
+def causedById? (request : AgentRequest) : Option String :=
+  request.causedBy.map Prod.fst
+
+def causedByKind? (request : AgentRequest) : Option String :=
+  request.causedBy.map fun key => key.2.toDefraDB
+
+def expectedResult (scenario : TriggerScenario) : String :=
+  if scenario.before.requests.length < (after scenario).requests.length then
+    "fired"
+  else
+    "skipped"
+
+def expectedSkipReason (scenario : TriggerScenario) : Option String :=
+  if expectedResult scenario = "fired" then
+    none
+  else
+    match dispatch scenario.snap scenario.intent with
+    | none => some "trigger disabled"
+    | some _ =>
+      match scenario.intent.concurrency with
+      | .serial => some "serial: prior fire still in-flight"
+      | .parallel | .latestOnly => none
+
+def expectedSupersedeCallKeys (scenario : TriggerScenario) : List TriggerKey :=
+  match dispatch scenario.snap scenario.intent, scenario.intent.concurrency, scenario.intent.triggerId with
+  | some _, .latestOnly, some triggerId => [(triggerId, scenario.intent.triggerKind)]
+  | _, _, _ => []
+
+def priorNonterminalKeys (scenario : TriggerScenario) : List TriggerKey :=
+  scenario.before.requests.filterMap fun request =>
+    if request.isTerminal then
+      none
+    else
+      request.causedBy
+
+def supersededPriorIds (scenario : TriggerScenario) : List String :=
+  match targetKey? scenario with
+  | none => []
+  | some key =>
+    scenario.before.requests.filterMap fun request =>
+      if (request.causedBy == some key) && !request.isTerminal then
+        if (after scenario).requests.any
+            (fun post => (post.id == request.id) && post.isTerminal) then
+          some request.id
+        else
+          none
+      else
+        none
+
+def targetNonterminalCountAfter? (scenario : TriggerScenario) : Option Nat :=
+  targetKey? scenario |>.map fun key =>
+    (after scenario).nonTerminalCountFor key
+
+def contractJson (scenario : TriggerScenario) : String :=
+  let materialized := newRequest? scenario
+  "{"
+    ++ "\"name\":" ++ jsonString scenario.name ++ ","
+    ++ "\"trigger_id\":" ++ jsonOptionString scenario.intent.triggerId ++ ","
+    ++ "\"trigger_kind\":" ++ jsonString scenario.intent.triggerKind.toDefraDB ++ ","
+    ++ "\"concurrency\":" ++ jsonString (concurrencyName scenario.intent.concurrency) ++ ","
+    ++ "\"active_schedule_ids\":"
+      ++ jsonStringArray (scenario.snap.activeSchedules.map ActiveSchedule.triggerId) ++ ","
+    ++ "\"active_event_trigger_ids\":"
+      ++ jsonStringArray (scenario.snap.activeEventTriggers.map ActiveEventTrigger.triggerId) ++ ","
+    ++ "\"prior_nonterminal_keys\":"
+      ++ jsonArray (priorNonterminalKeys scenario |>.map keyJson) ++ ","
+    ++ "\"expected_result\":" ++ jsonString (expectedResult scenario) ++ ","
+    ++ "\"expected_skip_reason\":" ++ jsonOptionString (expectedSkipReason scenario) ++ ","
+    ++ "\"expected_materialize_trigger_id\":"
+      ++ (if expectedResult scenario = "fired" then
+            jsonOptionString scenario.intent.triggerId
+          else
+            "null") ++ ","
+    ++ "\"expected_materialize_trigger_kind\":"
+      ++ (if expectedResult scenario = "fired" then
+            jsonOptionString (some scenario.intent.triggerKind.toDefraDB)
+          else
+            "null") ++ ","
+    ++ "\"expected_request_caused_by_id\":"
+      ++ (materialized.map causedById? |>.join |> jsonOptionString) ++ ","
+    ++ "\"expected_request_caused_by_kind\":"
+      ++ (materialized.map causedByKind? |>.join |> jsonOptionString) ++ ","
+    ++ "\"expected_execution_origin\":"
+      ++ (materialized.map (fun request => request.executionOrigin.toDefraDB)
+          |> jsonOptionString) ++ ","
+    ++ "\"expected_supersede_call_keys\":"
+      ++ jsonArray (expectedSupersedeCallKeys scenario |>.map keyJson) ++ ","
+    ++ "\"superseded_prior_ids\":"
+      ++ jsonStringArray (supersededPriorIds scenario) ++ ","
+    ++ "\"target_nonterminal_count_after\":"
+      ++ jsonOptionNat (targetNonterminalCountAfter? scenario) ++ ","
+    ++ "\"request_count_before\":" ++ toString scenario.before.requests.length ++ ","
+    ++ "\"request_count_after\":" ++ toString (after scenario).requests.length
+    ++ "}"
+
+def triggerDispatchScenarios : List TriggerScenario :=
+  [ { name := "manual_unconditional"
+    , snap := snapshot [] []
+    , before := SystemState.empty
+    , intent := intent none .manual .parallel
+    }
+  , { name := "schedule_disabled_is_unreachable"
+    , snap := snapshot [] []
+    , before := SystemState.empty
+    , intent := intent (some "sched-a") .schedule .serial
+    }
+  , { name := "event_disabled_is_unreachable"
+    , snap := snapshot [] []
+    , before := SystemState.empty
+    , intent := intent (some "event-a") .event .serial
+    }
+  , { name := "schedule_serial_clear_fires"
+    , snap := snapshot ["sched-a"] []
+    , before := SystemState.empty
+    , intent := intent (some "sched-a") .schedule .serial
+    }
+  , { name := "event_serial_clear_fires"
+    , snap := snapshot [] ["event-a"]
+    , before := SystemState.empty
+    , intent := intent (some "event-a") .event .serial
+    }
+  , { name := "schedule_serial_same_tuple_skips"
+    , snap := snapshot ["sched-a"] []
+    , before := { requests := [request "prior-schedule" "sched-a" .schedule .serial false] }
+    , intent := intent (some "sched-a") .schedule .serial
+    }
+  , { name := "schedule_serial_same_id_other_kind_fires"
+    , snap := snapshot ["shared"] []
+    , before := { requests := [request "prior-event" "shared" .event .serial false] }
+    , intent := intent (some "shared") .schedule .serial
+    }
+  , { name := "event_serial_same_tuple_skips"
+    , snap := snapshot [] ["event-a"]
+    , before := { requests := [request "prior-event" "event-a" .event .serial false] }
+    , intent := intent (some "event-a") .event .serial
+    }
+  , { name := "schedule_latest_only_supersedes_prior"
+    , snap := snapshot ["sched-a"] []
+    , before := { requests := [request "prior-schedule" "sched-a" .schedule .latestOnly false] }
+    , intent := intent (some "sched-a") .schedule .latestOnly
+    }
+  , { name := "manual_latest_only_without_key_fires_without_supersede"
+    , snap := snapshot [] []
+    , before := { requests := [request "prior-schedule" "sched-a" .schedule .latestOnly false] }
+    , intent := intent none .manual .latestOnly
+    }
+  ]
+
+def triggerDispatchCasesJson : String :=
+  jsonArray (triggerDispatchScenarios.map contractJson)
+
+end Conformance.TriggerContracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
@@ -233,6 +233,11 @@ def triggerDispatchScenarios : List TriggerScenario :=
     , before := { requests := [request "prior-event" "event-a" .event .serial false] }
     , intent := intent (some "event-a") .event .serial
     }
+  , { name := "schedule_latest_only_clear_fires_with_supersede_call"
+    , snap := snapshot ["sched-a"] []
+    , before := SystemState.empty
+    , intent := intent (some "sched-a") .schedule .latestOnly
+    }
   , { name := "schedule_latest_only_supersedes_prior"
     , snap := snapshot ["sched-a"] []
     , before := { requests := [request "prior-schedule" "sched-a" .schedule .latestOnly false] }

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -389,7 +389,17 @@ roots.
 - materialized requests carry complete trigger lineage
 
 `Proofs/Conformance/Triggers.lean` records the Rust/DefraDB shape used by the
-runtime trigger implementation.
+runtime trigger implementation. `Proofs/Conformance/Triggers/Contracts.lean`
+also emits finite trigger dispatch cases into the Rust conformance JSON. The
+in-crate Rust trigger-engine test consumes those generated cases and checks
+manual dispatch, schedule/event reachability, tuple-sensitive serial behavior,
+latest-only supersession, lineage, and execution-origin projection against the
+real `TriggerEngine::dispatch` path.
+
+Operational trigger-source behavior remains covered in Rust: DefraDB event
+delivery, control-watcher debounce, schedule tick cadence, subscription
+reconciliation timing, template parser failures, and persistence writeback
+shapes are integration/persistence concerns rather than Lean dispatch facts.
 
 ### Client Turn Projection
 
@@ -456,6 +466,12 @@ The Rust/Lean vocabulary checks compare Rust-visible strings against Lean
 process lifecycle states, runtime reconcile phases, trigger kinds,
 inference-call states, and the closed set of system-generated inference-call
 terminal reasons.
+
+Trigger conformance additionally consumes generated Lean dispatch cases. These
+cases are not a second hand-written table: Lean computes the pre/post request
+counts, expected materialization, supersede calls, lineage, and target
+non-terminal counts from `dispatch`/`dispatchStep`, and Rust checks the live
+engine against those values.
 
 Admission tests also reconstruct held backend slots from persisted
 `InferenceCall` rows during contention, queueing, completion, failure,

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -393,8 +393,8 @@ runtime trigger implementation. `Proofs/Conformance/Triggers/Contracts.lean`
 also emits finite trigger dispatch cases into the Rust conformance JSON. The
 in-crate Rust trigger-engine test consumes those generated cases and checks
 manual dispatch, schedule/event reachability, tuple-sensitive serial behavior,
-latest-only supersession, lineage, and execution-origin projection against the
-real `TriggerEngine::dispatch` path.
+latest-only supersession, parallel bypass of in-flight gates, lineage, and
+execution-origin projection against the real `TriggerEngine::dispatch` path.
 
 Operational trigger-source behavior remains covered in Rust: DefraDB event
 delivery, control-watcher debounce, schedule tick cadence, subscription

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -27,6 +27,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) generated_by: String,
     pub(crate) vocabularies: Vec<LeanVocabularyContract>,
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    pub(crate) trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
     pub(crate) follow_up_hooks: Vec<String>,
 }
 
@@ -52,6 +53,35 @@ pub(crate) struct LeanStateMachineContract {
 pub(crate) struct LeanTransitionPair {
     pub(crate) from: String,
     pub(crate) to: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanTriggerKeyContract {
+    pub(crate) trigger_id: String,
+    pub(crate) trigger_kind: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanTriggerDispatchCase {
+    pub(crate) name: String,
+    pub(crate) trigger_id: Option<String>,
+    pub(crate) trigger_kind: String,
+    pub(crate) concurrency: String,
+    pub(crate) active_schedule_ids: Vec<String>,
+    pub(crate) active_event_trigger_ids: Vec<String>,
+    pub(crate) prior_nonterminal_keys: Vec<LeanTriggerKeyContract>,
+    pub(crate) expected_result: String,
+    pub(crate) expected_skip_reason: Option<String>,
+    pub(crate) expected_materialize_trigger_id: Option<String>,
+    pub(crate) expected_materialize_trigger_kind: Option<String>,
+    pub(crate) expected_request_caused_by_id: Option<String>,
+    pub(crate) expected_request_caused_by_kind: Option<String>,
+    pub(crate) expected_execution_origin: Option<String>,
+    pub(crate) expected_supersede_call_keys: Vec<LeanTriggerKeyContract>,
+    pub(crate) superseded_prior_ids: Vec<String>,
+    pub(crate) target_nonterminal_count_after: Option<usize>,
+    pub(crate) request_count_before: usize,
+    pub(crate) request_count_after: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -96,6 +126,10 @@ pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {
         .iter()
         .map(String::as_str)
         .collect()
+}
+
+pub(crate) fn lean_trigger_dispatch_cases() -> &'static [LeanTriggerDispatchCase] {
+    &lean_contract_snapshot().trigger_dispatch_cases
 }
 
 pub(crate) fn assert_lean_contract_vocabulary_matches(spec: LeanContractVocabulary<'_>) {

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -27,6 +27,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) generated_by: String,
     pub(crate) vocabularies: Vec<LeanVocabularyContract>,
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    pub(crate) trigger_dispatch_case_count: usize,
     pub(crate) trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
     pub(crate) follow_up_hooks: Vec<String>,
 }
@@ -130,6 +131,10 @@ pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {
 
 pub(crate) fn lean_trigger_dispatch_cases() -> &'static [LeanTriggerDispatchCase] {
     &lean_contract_snapshot().trigger_dispatch_cases
+}
+
+pub(crate) fn lean_trigger_dispatch_case_count() -> usize {
+    lean_contract_snapshot().trigger_dispatch_case_count
 }
 
 pub(crate) fn assert_lean_contract_vocabulary_matches(spec: LeanContractVocabulary<'_>) {

--- a/crates/defra-agent/src/trigger_engine/production_materializer.rs
+++ b/crates/defra-agent/src/trigger_engine/production_materializer.rs
@@ -83,6 +83,13 @@ impl ProductionMaterializer {
     }
 }
 
+pub(crate) fn execution_origin_for_trigger_kind(trigger_kind: TriggerKind) -> ExecutionOrigin {
+    match trigger_kind {
+        TriggerKind::Manual => ExecutionOrigin::Interactive,
+        TriggerKind::Schedule | TriggerKind::Event => ExecutionOrigin::Scheduled,
+    }
+}
+
 impl MaterializerHandle for ProductionMaterializer {
     fn materialize(
         &self,
@@ -116,10 +123,7 @@ impl MaterializerHandle for ProductionMaterializer {
         // fires keep `Scheduled`. Keep the mapping local to the trait impl so
         // callers (who already decided the `TriggerKind`) don't need to know
         // the lifecycle-layer vocabulary.
-        let execution_origin = match trigger_kind {
-            TriggerKind::Manual => ExecutionOrigin::Interactive,
-            TriggerKind::Schedule | TriggerKind::Event => ExecutionOrigin::Scheduled,
-        };
+        let execution_origin = execution_origin_for_trigger_kind(trigger_kind);
 
         Box::pin(async move {
             let (behavior_name, behavior_did, _deadline_secs, _backend_id) = resolved?;

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 use std::time::{Duration, Instant};
@@ -20,8 +20,8 @@ use crate::ensure_runtime_schemas;
 use crate::graphql::escape_graphql_string;
 use crate::identity::KeyIdentity;
 use crate::lean_vocab_test::{
-    assert_lean_to_defradb_vocabulary_matches, lean_trigger_dispatch_cases,
-    LeanTriggerDispatchCase, LeanTriggerKeyContract, LeanVocabulary,
+    assert_lean_to_defradb_vocabulary_matches, lean_trigger_dispatch_case_count,
+    lean_trigger_dispatch_cases, LeanTriggerDispatchCase, LeanTriggerKeyContract, LeanVocabulary,
 };
 use crate::runtime_snapshot::{
     ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedEventTrigger, ResolvedRuntimeSnapshot,
@@ -30,7 +30,9 @@ use crate::runtime_snapshot::{
 use crate::tool_surface::BehaviorToolConfig;
 use crate::trigger_engine::event_source::EventSource;
 use crate::trigger_engine::manual_source::ManualSource;
-use crate::trigger_engine::production_materializer::ProductionMaterializer;
+use crate::trigger_engine::production_materializer::{
+    execution_origin_for_trigger_kind, ProductionMaterializer,
+};
 use crate::trigger_engine::schedule_source::ScheduleSource;
 use crate::BackendProviderKind;
 
@@ -70,12 +72,12 @@ struct MaterializeGate {
 /// so assertions can check both the call count and the rendered prompt that
 /// reached the materializer.
 ///
-/// `nonterminal_for` tracks `(trigger_id, trigger_kind)` tuples that
-/// `has_nonterminal_request_for_trigger` should report as having an in-flight
-/// request. Tests can pre-populate it to simulate prior fires; successful
-/// materializations with a trigger id also insert their tuple so sequential
-/// dispatches observe the same non-terminal state the production materializer
-/// persists.
+/// `nonterminal_for` counts `(trigger_id, trigger_kind)` tuples that
+/// `has_nonterminal_request_for_trigger` should report as having in-flight
+/// requests. Tests can pre-populate it to simulate prior fires. Lean contract
+/// tests can opt into counting successful materializations as new
+/// non-terminal requests, which mirrors production persistence without
+/// changing the default spy behavior expected by local unit tests.
 ///
 /// `materialize_delay` optionally pauses inside `materialize` before recording
 /// the call. Used by the `LatestOnly` serialization tests to widen the window
@@ -84,10 +86,11 @@ struct MaterializeGate {
 struct SpyMaterializer {
     materialize_calls: Arc<Mutex<Vec<MaterializeCall>>>,
     next_request_id: AtomicUsize,
-    nonterminal_for: Arc<Mutex<HashSet<(String, TriggerKind)>>>,
+    nonterminal_for: Arc<Mutex<HashMap<(String, TriggerKind), usize>>>,
     supersede_calls: Arc<Mutex<Vec<SupersedeCall>>>,
     materialize_delay: Mutex<Option<Duration>>,
     materialize_gate: Mutex<Option<MaterializeGate>>,
+    track_materialized_nonterminal: AtomicBool,
 }
 
 impl SpyMaterializer {
@@ -95,10 +98,11 @@ impl SpyMaterializer {
         Arc::new(Self {
             materialize_calls: Arc::new(Mutex::new(Vec::new())),
             next_request_id: AtomicUsize::new(0),
-            nonterminal_for: Arc::new(Mutex::new(HashSet::new())),
+            nonterminal_for: Arc::new(Mutex::new(HashMap::new())),
             supersede_calls: Arc::new(Mutex::new(Vec::new())),
             materialize_delay: Mutex::new(None),
             materialize_gate: Mutex::new(None),
+            track_materialized_nonterminal: AtomicBool::new(false),
         })
     }
 
@@ -114,21 +118,32 @@ impl SpyMaterializer {
         self.nonterminal_for
             .lock()
             .unwrap()
-            .iter()
-            .filter(|(id, kind)| id == trigger_id && *kind == trigger_kind)
-            .count()
+            .get(&(trigger_id.to_owned(), trigger_kind))
+            .copied()
+            .unwrap_or(0)
     }
 
     /// Pre-populate the in-flight set with `(trigger_id, trigger_kind)` so the
     /// next `has_nonterminal_request_for_trigger` call returns `true` for the
     /// matching tuple. Also makes `supersede_nonterminal_requests_for_trigger`
-    /// report `1` for that tuple (and clears it, mirroring a real terminal
-    /// transition) so LatestOnly tests can assert the count plumbed through.
+    /// report the tuple count (and clears it, mirroring real terminal
+    /// transitions) so LatestOnly tests can assert the count plumbed through.
     fn mark_nonterminal(&self, trigger_id: &str, trigger_kind: TriggerKind) {
         self.nonterminal_for
             .lock()
             .unwrap()
-            .insert((trigger_id.to_owned(), trigger_kind));
+            .entry((trigger_id.to_owned(), trigger_kind))
+            .and_modify(|count| *count += 1)
+            .or_insert(1);
+    }
+
+    /// Make successful materializations increment the in-flight tuple count.
+    /// The Lean-generated conformance cases use this to compare post-dispatch
+    /// non-terminal counts; ordinary unit tests keep the older explicit
+    /// `mark_nonterminal` behavior.
+    fn track_materialized_nonterminal(&self) {
+        self.track_materialized_nonterminal
+            .store(true, Ordering::SeqCst);
     }
 
     /// Install a delay that `materialize` will sleep for before recording its
@@ -164,6 +179,8 @@ impl MaterializerHandle for SpyMaterializer {
         let calls = self.materialize_calls.clone();
         let nonterminal_for = self.nonterminal_for.clone();
         let nonterminal_key = trigger_id.map(|id| (id.to_owned(), trigger_kind));
+        let track_materialized_nonterminal =
+            self.track_materialized_nonterminal.load(Ordering::SeqCst);
         let id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
         let delay = *self.materialize_delay.lock().unwrap();
         let gate = self.materialize_gate.lock().unwrap().clone();
@@ -176,8 +193,13 @@ impl MaterializerHandle for SpyMaterializer {
                 tokio::time::sleep(d).await;
             }
             calls.lock().unwrap().push(entry);
-            if let Some(key) = nonterminal_key {
-                nonterminal_for.lock().unwrap().insert(key);
+            if let (true, Some(key)) = (track_materialized_nonterminal, nonterminal_key) {
+                nonterminal_for
+                    .lock()
+                    .unwrap()
+                    .entry(key)
+                    .and_modify(|count| *count += 1)
+                    .or_insert(1);
             }
             Ok(format!("req-{id}"))
         })
@@ -190,7 +212,7 @@ impl MaterializerHandle for SpyMaterializer {
     ) -> Pin<Box<dyn Future<Output = anyhow::Result<bool>> + Send + '_>> {
         let set = self.nonterminal_for.clone();
         let key = (trigger_id.to_owned(), trigger_kind);
-        Box::pin(async move { Ok(set.lock().unwrap().contains(&key)) })
+        Box::pin(async move { Ok(set.lock().unwrap().get(&key).copied().unwrap_or(0) > 0) })
     }
 
     fn supersede_nonterminal_requests_for_trigger(
@@ -205,8 +227,7 @@ impl MaterializerHandle for SpyMaterializer {
             supersede_calls.lock().unwrap().push(key.clone());
             // Mirror a real terminal transition: the tuple is no longer
             // in-flight after supersede.
-            let removed = nonterm.lock().unwrap().remove(&key);
-            Ok(if removed { 1 } else { 0 })
+            Ok(nonterm.lock().unwrap().remove(&key).unwrap_or(0))
         })
     }
 }
@@ -343,8 +364,13 @@ fn snapshot_from_trigger_contract(
 async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
     let cases = lean_trigger_dispatch_cases();
     assert!(
-        cases.len() >= 11,
-        "Lean trigger dispatch contract should cover the branch matrix; got {cases:?}"
+        !cases.is_empty(),
+        "Lean trigger dispatch contract should emit at least one case"
+    );
+    assert_eq!(
+        cases.len(),
+        lean_trigger_dispatch_case_count(),
+        "Lean trigger dispatch case-count sentinel drifted"
     );
 
     for case in cases {
@@ -354,6 +380,7 @@ async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
         let snapshot = snapshot_from_trigger_contract(case, &task, concurrency);
         let (_tx, rx) = watch::channel(snapshot);
         let materializer = SpyMaterializer::new();
+        materializer.track_materialized_nonterminal();
         for key in &case.prior_nonterminal_keys {
             let (trigger_id, trigger_kind) = trigger_key_from_lean(key);
             materializer.mark_nonterminal(&trigger_id, trigger_kind);
@@ -418,14 +445,10 @@ async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
                 "Lean case {} rendered prompt drifted",
                 case.name
             );
-            let expected_origin = match kind {
-                TriggerKind::Manual => "interactive",
-                TriggerKind::Schedule | TriggerKind::Event => "scheduled",
-            };
             assert_eq!(
                 case.expected_execution_origin.as_deref(),
-                Some(expected_origin),
-                "Lean case {} execution-origin contract no longer matches runtime kind mapping",
+                Some(execution_origin_for_trigger_kind(*kind).as_str()),
+                "Lean case {} execution-origin contract no longer matches production materializer mapping",
                 case.name
             );
             let expected_request_kind = if trigger_id.is_some() {
@@ -466,6 +489,10 @@ async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
             "Lean case {} supersede calls drifted",
             case.name
         );
+        // The spy tracks tuple-level supersede calls and counts, not concrete
+        // request ids. Lean still emits `superseded_prior_ids` to document the
+        // exact model transition; this assertion keeps the Rust observable at
+        // the same abstraction boundary as `MaterializerHandle`.
         assert!(
             case.superseded_prior_ids.is_empty() || !supersede_calls.is_empty(),
             "Lean case {} cannot supersede prior ids without a Rust supersede call",

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -3,10 +3,11 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::task::Poll;
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Duration as ChronoDuration, SecondsFormat, Utc};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch, Notify};
 use tokio_util::sync::CancellationToken;
 
 use super::*;
@@ -18,7 +19,10 @@ use crate::document_config::{
 use crate::ensure_runtime_schemas;
 use crate::graphql::escape_graphql_string;
 use crate::identity::KeyIdentity;
-use crate::lean_vocab_test::{assert_lean_to_defradb_vocabulary_matches, LeanVocabulary};
+use crate::lean_vocab_test::{
+    assert_lean_to_defradb_vocabulary_matches, lean_trigger_dispatch_cases,
+    LeanTriggerDispatchCase, LeanTriggerKeyContract, LeanVocabulary,
+};
 use crate::runtime_snapshot::{
     ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedEventTrigger, ResolvedRuntimeSnapshot,
     ResolvedSchedule, ResolvedTask,
@@ -55,15 +59,23 @@ fn rust_trigger_kind_vocabulary_matches_lean_model() {
     });
 }
 
+#[derive(Clone)]
+struct MaterializeGate {
+    entered_tx: mpsc::UnboundedSender<()>,
+    release: Arc<Notify>,
+}
+
 /// Spy `MaterializerHandle` used by the engine tests. Records every
 /// `materialize` call it sees and hands back sequentially-numbered request ids
 /// so assertions can check both the call count and the rendered prompt that
 /// reached the materializer.
 ///
-/// `nonterminal_for` pre-populates the set of `(trigger_id, trigger_kind)`
-/// tuples that `has_nonterminal_request_for_trigger` should report as having
-/// an in-flight request. The concurrency gate tests insert tuples here to
-/// simulate a prior fire that has not yet reached a terminal state.
+/// `nonterminal_for` tracks `(trigger_id, trigger_kind)` tuples that
+/// `has_nonterminal_request_for_trigger` should report as having an in-flight
+/// request. Tests can pre-populate it to simulate prior fires; successful
+/// materializations with a trigger id also insert their tuple so sequential
+/// dispatches observe the same non-terminal state the production materializer
+/// persists.
 ///
 /// `materialize_delay` optionally pauses inside `materialize` before recording
 /// the call. Used by the `LatestOnly` serialization tests to widen the window
@@ -75,6 +87,7 @@ struct SpyMaterializer {
     nonterminal_for: Arc<Mutex<HashSet<(String, TriggerKind)>>>,
     supersede_calls: Arc<Mutex<Vec<SupersedeCall>>>,
     materialize_delay: Mutex<Option<Duration>>,
+    materialize_gate: Mutex<Option<MaterializeGate>>,
 }
 
 impl SpyMaterializer {
@@ -85,6 +98,7 @@ impl SpyMaterializer {
             nonterminal_for: Arc::new(Mutex::new(HashSet::new())),
             supersede_calls: Arc::new(Mutex::new(Vec::new())),
             materialize_delay: Mutex::new(None),
+            materialize_gate: Mutex::new(None),
         })
     }
 
@@ -94,6 +108,15 @@ impl SpyMaterializer {
 
     fn supersede_calls(&self) -> Vec<SupersedeCall> {
         self.supersede_calls.lock().unwrap().clone()
+    }
+
+    fn nonterminal_count_for(&self, trigger_id: &str, trigger_kind: TriggerKind) -> usize {
+        self.nonterminal_for
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(id, kind)| id == trigger_id && *kind == trigger_kind)
+            .count()
     }
 
     /// Pre-populate the in-flight set with `(trigger_id, trigger_kind)` so the
@@ -114,6 +137,15 @@ impl SpyMaterializer {
     fn set_materialize_delay(&self, delay: Duration) {
         *self.materialize_delay.lock().unwrap() = Some(delay);
     }
+
+    /// Block materialization until `release` is notified, sending one message
+    /// on `entered_tx` each time a materialize call reaches the gate.
+    fn set_materialize_gate(&self, entered_tx: mpsc::UnboundedSender<()>, release: Arc<Notify>) {
+        *self.materialize_gate.lock().unwrap() = Some(MaterializeGate {
+            entered_tx,
+            release,
+        });
+    }
 }
 
 impl MaterializerHandle for SpyMaterializer {
@@ -130,13 +162,23 @@ impl MaterializerHandle for SpyMaterializer {
             rendered_prompt.to_owned(),
         );
         let calls = self.materialize_calls.clone();
+        let nonterminal_for = self.nonterminal_for.clone();
+        let nonterminal_key = trigger_id.map(|id| (id.to_owned(), trigger_kind));
         let id = self.next_request_id.fetch_add(1, Ordering::SeqCst);
         let delay = *self.materialize_delay.lock().unwrap();
+        let gate = self.materialize_gate.lock().unwrap().clone();
         Box::pin(async move {
+            if let Some(gate) = gate {
+                let _ = gate.entered_tx.send(());
+                gate.release.notified().await;
+            }
             if let Some(d) = delay {
                 tokio::time::sleep(d).await;
             }
             calls.lock().unwrap().push(entry);
+            if let Some(key) = nonterminal_key {
+                nonterminal_for.lock().unwrap().insert(key);
+            }
             Ok(format!("req-{id}"))
         })
     }
@@ -204,6 +246,241 @@ fn resolved_schedule(schedule_id: &str, task: ResolvedTask) -> ResolvedSchedule 
         interval_secs: 60,
         enabled: true,
         concurrency: ConcurrencyMode::Serial,
+    }
+}
+
+fn resolved_schedule_with_concurrency(
+    schedule_id: &str,
+    task: ResolvedTask,
+    concurrency: ConcurrencyMode,
+) -> ResolvedSchedule {
+    ResolvedSchedule {
+        schedule_id: schedule_id.to_string(),
+        task_id: task.task_id.clone(),
+        task,
+        interval_secs: 60,
+        enabled: true,
+        concurrency,
+    }
+}
+
+fn resolved_event_trigger_with_concurrency(
+    trigger_id: &str,
+    task: ResolvedTask,
+    concurrency: ConcurrencyMode,
+) -> ResolvedEventTrigger {
+    ResolvedEventTrigger {
+        trigger_id: trigger_id.to_string(),
+        task_id: task.task_id.clone(),
+        task,
+        source_collection: "WebhookEvent".to_string(),
+        event_kind: "created".to_string(),
+        filter: None,
+        enabled: true,
+        concurrency,
+    }
+}
+
+fn trigger_kind_from_lean(value: &str) -> TriggerKind {
+    match value {
+        "schedule" => TriggerKind::Schedule,
+        "event" => TriggerKind::Event,
+        "manual" => TriggerKind::Manual,
+        other => panic!("unknown Lean trigger kind {other:?}"),
+    }
+}
+
+fn concurrency_from_lean(value: &str) -> ConcurrencyMode {
+    ConcurrencyMode::parse(value)
+        .unwrap_or_else(|| panic!("unknown Lean concurrency mode {value:?}"))
+}
+
+fn trigger_key_from_lean(key: &LeanTriggerKeyContract) -> (String, TriggerKind) {
+    (
+        key.trigger_id.clone(),
+        trigger_kind_from_lean(&key.trigger_kind),
+    )
+}
+
+fn snapshot_from_trigger_contract(
+    case: &LeanTriggerDispatchCase,
+    task: &ResolvedTask,
+    concurrency: ConcurrencyMode,
+) -> Arc<ActiveRuntimeSnapshot> {
+    let active_schedules = case
+        .active_schedule_ids
+        .iter()
+        .map(|id| {
+            (
+                id.clone(),
+                resolved_schedule_with_concurrency(id, task.clone(), concurrency),
+            )
+        })
+        .collect();
+    let active_event_triggers = case
+        .active_event_trigger_ids
+        .iter()
+        .map(|id| {
+            (
+                id.clone(),
+                resolved_event_trigger_with_concurrency(id, task.clone(), concurrency),
+            )
+        })
+        .collect();
+    let resolved = ResolvedRuntimeSnapshot::from_parts_with_admission_configs(
+        "general".to_string(),
+        Vec::new(),
+        HashMap::new(),
+        HashMap::new(),
+        HashMap::new(),
+    )
+    .with_schedules(active_schedules, HashSet::new())
+    .with_event_triggers(active_event_triggers, HashSet::new());
+    Arc::new(resolved.activate(1, HashMap::new()))
+}
+
+#[tokio::test]
+async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
+    let cases = lean_trigger_dispatch_cases();
+    assert!(
+        cases.len() >= 10,
+        "Lean trigger dispatch contract should cover the branch matrix; got {cases:?}"
+    );
+
+    for case in cases {
+        let trigger_kind = trigger_kind_from_lean(&case.trigger_kind);
+        let concurrency = concurrency_from_lean(&case.concurrency);
+        let task = resolved_task(&format!("lean case {}", case.name));
+        let snapshot = snapshot_from_trigger_contract(case, &task, concurrency);
+        let (_tx, rx) = watch::channel(snapshot);
+        let materializer = SpyMaterializer::new();
+        for key in &case.prior_nonterminal_keys {
+            let (trigger_id, trigger_kind) = trigger_key_from_lean(key);
+            materializer.mark_nonterminal(&trigger_id, trigger_kind);
+        }
+        let engine = TriggerEngine::new(rx, materializer.clone());
+
+        let intent = FireIntent {
+            trigger_id: case.trigger_id.clone(),
+            trigger_kind,
+            task,
+            concurrency,
+            event_vars: serde_json::json!({}),
+            doc_vars: None,
+            args_vars: None,
+            on_result: Box::new(|_| {}),
+        };
+
+        let result = engine.dispatch(intent).await;
+        let expected_delta = case
+            .request_count_after
+            .checked_sub(case.request_count_before)
+            .unwrap_or_else(|| panic!("Lean case {} shrank request count", case.name));
+
+        match (case.expected_result.as_str(), result) {
+            ("fired", FireResult::Fired { .. }) => {}
+            ("skipped", FireResult::Skipped { reason }) => assert_eq!(
+                Some(reason.as_str()),
+                case.expected_skip_reason.as_deref(),
+                "Lean case {} skip reason drifted",
+                case.name
+            ),
+            (expected, other) => panic!(
+                "Lean case {} expected {expected}, but TriggerEngine returned {other:?}",
+                case.name
+            ),
+        }
+
+        let calls = materializer.calls();
+        assert_eq!(
+            calls.len(),
+            expected_delta,
+            "Lean case {} materialize delta drifted",
+            case.name
+        );
+        if expected_delta == 1 {
+            let (trigger_id, kind, rendered) = &calls[0];
+            assert_eq!(
+                trigger_id.as_deref(),
+                case.expected_materialize_trigger_id.as_deref(),
+                "Lean case {} materialize trigger_id drifted",
+                case.name
+            );
+            assert_eq!(
+                kind.as_str(),
+                case.expected_materialize_trigger_kind.as_deref().unwrap(),
+                "Lean case {} materialize trigger_kind drifted",
+                case.name
+            );
+            assert_eq!(
+                rendered,
+                &format!("lean case {}", case.name),
+                "Lean case {} rendered prompt drifted",
+                case.name
+            );
+            let expected_origin = match kind {
+                TriggerKind::Manual => "interactive",
+                TriggerKind::Schedule | TriggerKind::Event => "scheduled",
+            };
+            assert_eq!(
+                case.expected_execution_origin.as_deref(),
+                Some(expected_origin),
+                "Lean case {} execution-origin contract no longer matches runtime kind mapping",
+                case.name
+            );
+            let expected_request_kind = if trigger_id.is_some() {
+                Some(kind.as_str())
+            } else {
+                None
+            };
+            assert_eq!(
+                case.expected_request_caused_by_id.as_deref(),
+                trigger_id.as_deref(),
+                "Lean case {} request caused_by id drifted",
+                case.name
+            );
+            assert_eq!(
+                case.expected_request_caused_by_kind.as_deref(),
+                expected_request_kind,
+                "Lean case {} request caused_by kind drifted",
+                case.name
+            );
+        } else {
+            assert!(
+                case.expected_materialize_trigger_id.is_none()
+                    && case.expected_materialize_trigger_kind.is_none()
+                    && case.expected_execution_origin.is_none(),
+                "Lean case {} should not carry materialization fields when skipped",
+                case.name
+            );
+        }
+
+        let supersede_calls = materializer.supersede_calls();
+        let expected_supersede_calls = case
+            .expected_supersede_call_keys
+            .iter()
+            .map(trigger_key_from_lean)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            supersede_calls, expected_supersede_calls,
+            "Lean case {} supersede calls drifted",
+            case.name
+        );
+        assert_eq!(
+            case.superseded_prior_ids.is_empty(),
+            expected_supersede_calls.is_empty(),
+            "Lean case {} should only supersede prior ids when Rust calls supersede",
+            case.name
+        );
+
+        if let Some(trigger_id) = case.trigger_id.as_deref() {
+            assert_eq!(
+                materializer.nonterminal_count_for(trigger_id, trigger_kind),
+                case.target_nonterminal_count_after.unwrap_or(0),
+                "Lean case {} target non-terminal count drifted",
+                case.name
+            );
+        }
     }
 }
 
@@ -475,6 +752,100 @@ async fn dispatch_latest_only_supersedes_prior_and_fires_new() {
     let (trigger_id, kind, _rendered) = &calls[0];
     assert_eq!(trigger_id.as_deref(), Some("sched-1"));
     assert_eq!(*kind, TriggerKind::Schedule);
+}
+
+#[tokio::test]
+async fn dispatch_latest_only_lock_blocks_second_supersede_until_first_materialize_finishes() {
+    let task = resolved_task("tick");
+    let schedule = resolved_schedule("sched-1", task.clone());
+    let snapshot = snapshot_with_schedules(HashMap::from([("sched-1".to_string(), schedule)]));
+    let (_tx, rx) = watch::channel(snapshot);
+    let materializer = SpyMaterializer::new();
+    let (entered_tx, mut entered_rx) = mpsc::unbounded_channel();
+    let release = Arc::new(Notify::new());
+    materializer.set_materialize_gate(entered_tx, release.clone());
+    let engine = Arc::new(TriggerEngine::new(rx, materializer.clone()));
+
+    let make_intent = || FireIntent {
+        trigger_id: Some("sched-1".to_string()),
+        trigger_kind: TriggerKind::Schedule,
+        task: task.clone(),
+        concurrency: ConcurrencyMode::LatestOnly,
+        event_vars: serde_json::json!({}),
+        doc_vars: None,
+        args_vars: None,
+        on_result: Box::new(|_| {}),
+    };
+
+    let engine1 = engine.clone();
+    let first_intent = make_intent();
+    let first = tokio::spawn(async move { engine1.dispatch(first_intent).await });
+    entered_rx
+        .recv()
+        .await
+        .expect("first LatestOnly dispatch should enter materialize gate");
+    assert_eq!(
+        materializer.supersede_calls(),
+        vec![("sched-1".to_string(), TriggerKind::Schedule)],
+        "first LatestOnly dispatch should supersede before materializing"
+    );
+
+    let second = engine.dispatch(make_intent());
+    tokio::pin!(second);
+    std::future::poll_fn(|cx| match second.as_mut().poll(cx) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(result) => panic!(
+            "second LatestOnly dispatch completed while the first held the per-trigger lock: {result:?}"
+        ),
+    })
+    .await;
+
+    assert_eq!(
+        materializer.supersede_calls().len(),
+        1,
+        "second LatestOnly dispatch must block on the per-trigger lock before superseding"
+    );
+    assert!(
+        entered_rx.try_recv().is_err(),
+        "second LatestOnly dispatch must not enter materialize while first is gated"
+    );
+
+    release.notify_waiters();
+    let first_result = first.await.unwrap();
+    assert!(
+        matches!(first_result, FireResult::Fired { .. }),
+        "first LatestOnly dispatch should finish after release, got {first_result:?}"
+    );
+
+    std::future::poll_fn(|cx| match second.as_mut().poll(cx) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(result) => panic!(
+            "second LatestOnly dispatch completed before its materialize gate was released: {result:?}"
+        ),
+    })
+    .await;
+    entered_rx
+        .try_recv()
+        .expect("second dispatch should enter materialize after the first releases the lock");
+    release.notify_waiters();
+    let second_result = second.await;
+    assert!(
+        matches!(second_result, FireResult::Fired { .. }),
+        "second LatestOnly dispatch should fire after the first releases, got {second_result:?}"
+    );
+    assert_eq!(
+        materializer.supersede_calls(),
+        vec![
+            ("sched-1".to_string(), TriggerKind::Schedule),
+            ("sched-1".to_string(), TriggerKind::Schedule),
+        ],
+        "the second supersede must occur only after the first materialize completes"
+    );
+    assert_eq!(
+        materializer.calls().len(),
+        2,
+        "both LatestOnly dispatches should materialize after serialized critical sections"
+    );
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -343,7 +343,7 @@ fn snapshot_from_trigger_contract(
 async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
     let cases = lean_trigger_dispatch_cases();
     assert!(
-        cases.len() >= 10,
+        cases.len() >= 11,
         "Lean trigger dispatch contract should cover the branch matrix; got {cases:?}"
     );
 
@@ -466,10 +466,9 @@ async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
             "Lean case {} supersede calls drifted",
             case.name
         );
-        assert_eq!(
-            case.superseded_prior_ids.is_empty(),
-            expected_supersede_calls.is_empty(),
-            "Lean case {} should only supersede prior ids when Rust calls supersede",
+        assert!(
+            case.superseded_prior_ids.is_empty() || !supersede_calls.is_empty(),
+            "Lean case {} cannot supersede prior ids without a Rust supersede call",
             case.name
         );
 

--- a/crates/defra-agent/tests/schedule_conformance.rs
+++ b/crates/defra-agent/tests/schedule_conformance.rs
@@ -40,17 +40,21 @@
 //!   toggling `enabled = false` after that drives another bump, matching the
 //!   behavior the engine relies on to stop firing disabled schedules.
 //!
-//! # Why not boot `DefraAgent::run`?
+//! # Engine semantics vs. operational timing
 //!
-//! The full bootstrap works for `schedule_insert_bumps_active_generation`
-//! (which just asserts the gen bump), but driving the engine to materialize
-//! an `AgentRequest` through the full startup → reconcile → engine tick loop
-//! is timing-sensitive: the control watcher has a 5s debounce, the schedule
-//! source ticks at 1s, and the backend health check must succeed before the
-//! behavior is admitted. The dedicated in-crate test already covers this end
-//! to end; duplicating it through a slower, more flaky integration surface
-//! adds no signal. These tests instead pin the persistence-layer contract
-//! the engine delegates to.
+//! The trigger-engine branch semantics are now pinned in-crate by
+//! `trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases`,
+//! which consumes finite cases emitted by
+//! `Proofs/Conformance/Triggers/Contracts.lean`. That generated contract
+//! covers schedule reachability, serial gating, latest-only supersession, and
+//! tuple-sensitive lineage without relying on the control watcher's debounce
+//! or the schedule source tick as the only correctness oracle.
+//!
+//! This file still boots `DefraAgent::run` only where the observable under
+//! test is operational reconfiguration (`active_generation` bumps). The other
+//! cases pin the persistence-layer contract the engine delegates to: DefraDB
+//! materialization lineage, non-terminal gating queries, supersede mutations,
+//! and source writeback shape.
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/defra-agent/tests/schedule_conformance.rs
+++ b/crates/defra-agent/tests/schedule_conformance.rs
@@ -47,8 +47,8 @@
 //! which consumes finite cases emitted by
 //! `Proofs/Conformance/Triggers/Contracts.lean`. That generated contract
 //! covers schedule reachability, serial gating, latest-only supersession, and
-//! tuple-sensitive lineage without relying on the control watcher's debounce
-//! or the schedule source tick as the only correctness oracle.
+//! parallel bypass of in-flight gates without relying on the control watcher's
+//! debounce or the schedule source tick as the only correctness oracle.
 //!
 //! This file still boots `DefraAgent::run` only where the observable under
 //! test is operational reconfiguration (`active_generation` bumps). The other

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -34,15 +34,22 @@
 //!   — two triggers on the same `source_collection` apply their own filters
 //!   independently; only the trigger whose filter matches fires.
 //!
-//! # Pragmatic split: fully engine-driven vs. persistence-contract
+//! # Pragmatic split: engine semantics vs. persistence/operational surfaces
 //!
-//! Cases 6, 7, 8 are asserted at the persistence-layer contract (seed an
-//! in-flight `AgentRequest` with the right lineage tuple + simulate the exact
-//! mutation / writeback the engine produces), mirroring PR 1's
-//! `schedule_conformance.rs::latest_only_supersedes_prior_fire` pattern. This
-//! is the same contract the engine wraps at runtime but sidesteps the control
-//! watcher's 5s debounce and the engine tick scheduling. Full-pipeline
-//! coverage for these transitions lives in `event_trigger_e2e.rs`.
+//! The pure trigger-engine branch matrix is pinned in-crate by
+//! `trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases`,
+//! which consumes finite cases emitted by
+//! `Proofs/Conformance/Triggers/Contracts.lean`. That Lean-generated contract
+//! covers manual dispatch, schedule/event reachability, tuple-sensitive serial
+//! gating, latest-only supersession, and lineage shape without depending on
+//! wall-clock debounce.
+//!
+//! Cases 6, 7, 8 remain asserted here at the persistence-layer contract (seed
+//! an in-flight `AgentRequest` with the right lineage tuple + simulate the
+//! exact mutation / writeback the production materializer/source produces).
+//! They are still valuable because they pin the DefraDB query/mutation shape
+//! the engine delegates to at runtime, but they are no longer the only
+//! correctness oracle for serial/latest-only trigger behavior.
 //!
 //! Cases 1, 2, 3, 4, 5, 9 boot a real `DefraAgent` so the EventSource loop
 //! actually observes DefraDB events; these are the tests where the

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -41,8 +41,8 @@
 //! which consumes finite cases emitted by
 //! `Proofs/Conformance/Triggers/Contracts.lean`. That Lean-generated contract
 //! covers manual dispatch, schedule/event reachability, tuple-sensitive serial
-//! gating, latest-only supersession, and lineage shape without depending on
-//! wall-clock debounce.
+//! gating, latest-only supersession, parallel bypass of in-flight gates, and
+//! lineage shape without depending on wall-clock debounce.
 //!
 //! Cases 6, 7, 8 remain asserted here at the persistence-layer contract (seed
 //! an in-flight `AgentRequest` with the right lineage tuple + simulate the


### PR DESCRIPTION
## Summary
- add Lean-generated trigger dispatch contract cases for manual, schedule/event reachability, serial, parallel, latest-only, lineage, and target non-terminal counts
- consume those generated cases in TriggerEngine dispatch tests against the live Rust engine and production materializer origin mapping
- add a deterministic latest-only per-trigger lock test and document the trigger proof/operational boundary

## Review follow-up
- added Parallel-with-prior and Event+LatestOnly generated cases
- replaced the magic Rust case-count sentinel with a Lean-emitted count
- made the spy opt into persistence-like non-terminal counting only for the generated contract harness
- documented the tuple-level supersede abstraction in the Rust test

## Verification
- lake build
- cargo test -p defra-agent trigger_engine::tests::
- cargo test -p defra-agent --test schedule_conformance
- cargo test -p defra-agent --test trigger_conformance
- cargo fmt --all -- --check
- git diff --check
- forbidden-token scan over touched files
- Lean touched-file line counts under 500