### PR TITLE
Enforce Lean runtime and session contracts from Rust

### DIFF
--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
@@ -222,6 +222,10 @@ pub async fn retry_request(
         .max_retries
         .unwrap_or(i64::from(DEFAULT_REQUEST_MAX_RETRIES));
     ensure_retry_parent_eligible(parent, retry_count - 1, max_retries)?;
+    // Lean checks `isLatest` inside one session-state transition. The desktop
+    // GraphQL API does not expose a transactional conditional create+update
+    // primitive here, so Rust enforces the same predicate as a database-backed
+    // preflight immediately before the coalesced write.
     ensure_latest_retry_parent(node, parent_session_id, parent_request_id).await?;
     let request_id = Uuid::new_v4().to_string();
     let session_id = parent_session_id.to_string();
@@ -279,6 +283,10 @@ fn ensure_retry_parent_eligible(
     parent_retry_count: i64,
     max_retries: i64,
 ) -> Result<()> {
+    // The Lean `.released` admission predicate is not persisted on
+    // `AgentRequestRow`; on this desktop surface it is represented by requiring
+    // the parent to be terminal failed/error. Non-terminal rows, including rows
+    // still waiting on admission, fail this lifecycle/status gate.
     let lifecycle_state = normalize_required(
         "lifecycle_state",
         parent
@@ -347,8 +355,14 @@ async fn ensure_latest_retry_parent(
         .and_then(|rows| rows.as_array())
         .and_then(|rows| rows.first())
         .and_then(|row| row.get("latest_request_id"))
-        .and_then(|value| value.as_str())
-        .unwrap_or_default();
+        .and_then(|value| value.as_str());
+
+    let Some(latest_request_id) = latest_request_id else {
+        bail!("retry parent conversation not found for session {session_id}");
+    };
+    let Some(latest_request_id) = normalize_optional_string(Some(latest_request_id)) else {
+        bail!("retry parent conversation for session {session_id} has no latest_request_id");
+    };
 
     if latest_request_id != parent_request_id {
         bail!(

--- a/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/chat/request.rs
@@ -221,8 +221,10 @@ pub async fn retry_request(
     let max_retries = parent
         .max_retries
         .unwrap_or(i64::from(DEFAULT_REQUEST_MAX_RETRIES));
+    ensure_retry_parent_eligible(parent, retry_count - 1, max_retries)?;
+    ensure_latest_retry_parent(node, parent_session_id, parent_request_id).await?;
     let request_id = Uuid::new_v4().to_string();
-    let session_id = Uuid::new_v4().to_string();
+    let session_id = parent_session_id.to_string();
     let created_at = Utc::now().to_rfc3339();
     let binding = resolve_agent_binding(store, agent_did, behavior_id, Some(parent_session_id))?;
 
@@ -270,6 +272,91 @@ pub async fn retry_request(
         agent_did: agent_did.to_string(),
         behavior_id: binding.behavior_id,
     })
+}
+
+fn ensure_retry_parent_eligible(
+    parent: &AgentRequestRow,
+    parent_retry_count: i64,
+    max_retries: i64,
+) -> Result<()> {
+    let lifecycle_state = normalize_required(
+        "lifecycle_state",
+        parent
+            .lifecycle_state
+            .as_deref()
+            .context("retry parent request must have a lifecycle_state")?,
+    )?;
+    let status = normalize_required(
+        "status",
+        parent
+            .status
+            .as_deref()
+            .context("retry parent request must have a status")?,
+    )?;
+
+    if lifecycle_state != "failed" || status != "error" {
+        bail!(
+            "retry parent request must be failed/error, got lifecycle_state={lifecycle_state} status={status}"
+        );
+    }
+    if parent_retry_count >= max_retries {
+        bail!(
+            "retry parent request exhausted retry budget: retry_count={parent_retry_count} max_retries={max_retries}"
+        );
+    }
+    if let Some(deadline) = normalize_optional_string(parent.deadline.as_deref()) {
+        let deadline = DateTime::parse_from_rfc3339(deadline)
+            .with_context(|| format!("retry parent request has invalid deadline {deadline:?}"))?
+            .with_timezone(&Utc);
+        if Utc::now() > deadline {
+            bail!(
+                "retry parent request deadline is closed: deadline={}",
+                deadline.to_rfc3339()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+async fn ensure_latest_retry_parent(
+    node: &EmbeddedNode,
+    session_id: &str,
+    parent_request_id: &str,
+) -> Result<()> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentConversation(
+                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
+                limit: 1
+            ) {{ latest_request_id }}
+        }}"#
+    );
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        bail!(
+            "querying retry parent conversation failed: {:?}",
+            resp.errors
+        );
+    }
+    let latest_request_id = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentConversation"))
+        .and_then(|rows| rows.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("latest_request_id"))
+        .and_then(|value| value.as_str())
+        .unwrap_or_default();
+
+    if latest_request_id != parent_request_id {
+        bail!(
+            "retry parent request must be latest for session {session_id}, got latest_request_id={latest_request_id}"
+        );
+    }
+
+    Ok(())
 }
 
 fn submit_request_extra_fields(options: &SubmitRequestOptions) -> String {

--- a/crates/defra-agent-desktop-core/tests/submission_api.rs
+++ b/crates/defra-agent-desktop-core/tests/submission_api.rs
@@ -331,11 +331,15 @@ async fn retry_request_rejects_generated_illegal_session_recovery_cases() -> Res
     let budget_exhausted = lean_session_recovery_case("illegal_retry_budget_exhausted");
     let deadline_closed = lean_session_recovery_case("illegal_deadline_closed");
     let non_latest = lean_session_recovery_case("illegal_non_latest_failed_request");
+    let duplicate_new_id = lean_session_recovery_case("illegal_new_request_id_already_exists");
+    let source_not_released = lean_session_recovery_case("illegal_source_not_released");
     for case in [
         source_not_failed,
         budget_exhausted,
         deadline_closed,
         non_latest,
+        duplicate_new_id,
+        source_not_released,
     ] {
         assert!(!case.legal, "{} should be illegal", case.name.as_str());
     }
@@ -366,6 +370,14 @@ async fn retry_request_rejects_generated_illegal_session_recovery_cases() -> Res
     assert!(
         err.contains("failed/error"),
         "source-not-failed guard should reject pending parent: {err}"
+    );
+
+    parent.status = Some("processing".to_string());
+    parent.lifecycle_state = Some(source_not_released.pre_latest_state.clone());
+    let err = core.retry_request(&parent).await.unwrap_err().to_string();
+    assert!(
+        err.contains("failed/error"),
+        "source-not-released guard should reject non-terminal parent status: {err}"
     );
 
     let past_deadline = chrono::Utc::now() - chrono::Duration::seconds(1);
@@ -613,16 +625,18 @@ async fn force_retry_parent_state(
     max_retries: i64,
     deadline: &str,
 ) -> Result<()> {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let escaped_deadline = escape_graphql_string(deadline);
     let mutation = format!(
         r#"mutation {{
             update_AgentRequest(
-                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
                 input: {{
                     status: "error",
                     lifecycle_state: "failed",
                     retry_count: {retry_count},
                     max_retries: {max_retries},
-                    deadline: "{deadline}"
+                    deadline: "{escaped_deadline}"
                 }}
             ) {{ _docID }}
         }}"#
@@ -640,6 +654,15 @@ async fn force_retry_parent_state(
         );
     }
     Ok(())
+}
+
+fn escape_graphql_string(value: &str) -> String {
+    value
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+        .replace('\t', "\\t")
 }
 
 async fn wait_for_connectable_iroh_addr(core: &ClientCore) -> Result<String> {

--- a/crates/defra-agent-desktop-core/tests/submission_api.rs
+++ b/crates/defra-agent-desktop-core/tests/submission_api.rs
@@ -7,6 +7,11 @@ use defra_agent_desktop_core::client::{
 use serde::Deserialize;
 use tokio::time::{sleep, Instant};
 
+#[path = "../../defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
+use lean_vocab_test::{assert_lean_transition_is_legal, lean_session_recovery_case};
+
 #[derive(Debug, Deserialize)]
 struct SessionRow {
     session_id: String,
@@ -202,6 +207,15 @@ async fn submit_request_writes_request_and_updates_conversation_summary() -> Res
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> Result<()> {
+    let legal_case = lean_session_recovery_case("legal_open_budget_latest");
+    assert!(legal_case.legal);
+    assert_eq!(legal_case.action.as_str(), "reissueFailed");
+    assert_lean_transition_is_legal(
+        "SessionRecovery",
+        &legal_case.pre_latest_state,
+        &legal_case.post_latest_state,
+    );
+
     let tempdir = tempfile::tempdir()?;
     let core = ClientCore::start_with_paths_and_options(
         DesktopPaths::from_root(tempdir.path()),
@@ -223,6 +237,21 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
         .find(|row| row.request_id == original.request_id)
         .cloned()
         .context("expected submitted parent request in desktop store")?;
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    force_retry_parent_state(
+        core.node(),
+        &original.request_id,
+        legal_case.pre_retry_count as i64,
+        legal_case.max_retries as i64,
+        &deadline.to_rfc3339(),
+    )
+    .await?;
+    let mut parent = parent;
+    parent.status = Some("error".to_string());
+    parent.lifecycle_state = Some(legal_case.pre_latest_state.clone());
+    parent.deadline = Some(deadline.to_rfc3339());
+    parent.retry_count = Some(legal_case.pre_retry_count as i64);
+    parent.max_retries = Some(legal_case.max_retries as i64);
 
     let retried = core.retry_request(&parent).await?;
 
@@ -254,15 +283,18 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
     assert_eq!(request.agent_did, "did:defra:amy");
     assert_eq!(request.behavior_id, "amy-code");
     assert_eq!(request.session_id, retried.session_id);
-    assert_ne!(request.session_id, created.session_id);
+    assert_eq!(request.session_id, created.session_id);
     assert_eq!(request.content, "first attempt");
     assert_eq!(request.status, "pending");
-    assert_eq!(request.lifecycle_state, "pending");
+    assert_eq!(
+        request.lifecycle_state,
+        legal_case.post_latest_state.as_str()
+    );
     assert_eq!(request.execution_origin, "interactive");
     assert_eq!(request.retry_parent_request, original.request_id);
     assert_eq!(request.retry_root_request, original.request_id);
-    assert_eq!(request.retry_count, 1);
-    assert_eq!(request.max_retries, 3);
+    assert_eq!(request.retry_count, legal_case.post_retry_count as i64);
+    assert_eq!(request.max_retries, legal_case.max_retries as i64);
 
     let original_conversation: ConversationRow = query_single(
         core.node(),
@@ -286,33 +318,113 @@ async fn retry_request_writes_retry_chain_and_updates_conversation_summary() -> 
     .await?;
     assert_eq!(original_conversation.preview_text, "first attempt");
     assert_eq!(original_conversation.status, "active");
-    assert_eq!(original_conversation.latest_request_id, original.request_id);
+    assert_eq!(original_conversation.latest_request_id, retried.request_id);
+    assert_eq!(core.store().focused_request_id(), Some(retried.request_id));
 
-    let retry_conversation: ConversationRow = query_single(
-        core.node(),
-        &format!(
-            r#"{{
-                AgentConversation(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
-                    session_id
-                    agent_name
-                    agent_did
-                    behavior_id
-                    title
-                    preview_text
-                    status
-                    latest_request_id
-                }}
-            }}"#,
-            retried.session_id
-        ),
-        "AgentConversation",
+    core.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn retry_request_rejects_generated_illegal_session_recovery_cases() -> Result<()> {
+    let source_not_failed = lean_session_recovery_case("illegal_source_not_failed");
+    let budget_exhausted = lean_session_recovery_case("illegal_retry_budget_exhausted");
+    let deadline_closed = lean_session_recovery_case("illegal_deadline_closed");
+    let non_latest = lean_session_recovery_case("illegal_non_latest_failed_request");
+    for case in [
+        source_not_failed,
+        budget_exhausted,
+        deadline_closed,
+        non_latest,
+    ] {
+        assert!(!case.legal, "{} should be illegal", case.name.as_str());
+    }
+
+    let tempdir = tempfile::tempdir()?;
+    let core = ClientCore::start_with_paths_and_options(
+        DesktopPaths::from_root(tempdir.path()),
+        ClientCoreOptions::local_only(),
     )
     .await?;
-    assert_eq!(retry_conversation.session_id, retried.session_id);
-    assert_eq!(retry_conversation.preview_text, "first attempt");
-    assert_eq!(retry_conversation.status, "active");
-    assert_eq!(retry_conversation.latest_request_id, retried.request_id);
-    assert_eq!(core.store().focused_request_id(), Some(retried.request_id));
+
+    let created = core
+        .create_conversation("did:defra:amy", Some("amy-code"))
+        .await?;
+    let original = core
+        .submit_request(&created.session_id, "did:defra:amy", "first attempt", None)
+        .await?;
+    let mut parent = core
+        .store()
+        .snapshot()
+        .requests
+        .iter()
+        .find(|row| row.request_id == original.request_id)
+        .cloned()
+        .context("expected submitted parent request in desktop store")?;
+
+    let err = core.retry_request(&parent).await.unwrap_err().to_string();
+    assert!(
+        err.contains("failed/error"),
+        "source-not-failed guard should reject pending parent: {err}"
+    );
+
+    let past_deadline = chrono::Utc::now() - chrono::Duration::seconds(1);
+    force_retry_parent_state(
+        core.node(),
+        &original.request_id,
+        deadline_closed.pre_retry_count as i64,
+        deadline_closed.max_retries as i64,
+        &past_deadline.to_rfc3339(),
+    )
+    .await?;
+    parent.status = Some("error".to_string());
+    parent.lifecycle_state = Some(deadline_closed.pre_latest_state.clone());
+    parent.deadline = Some(past_deadline.to_rfc3339());
+    parent.retry_count = Some(deadline_closed.pre_retry_count as i64);
+    parent.max_retries = Some(deadline_closed.max_retries as i64);
+    let err = core.retry_request(&parent).await.unwrap_err().to_string();
+    assert!(
+        err.contains("deadline is closed"),
+        "deadline-closed guard should reject expired parent: {err}"
+    );
+
+    let future_deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    force_retry_parent_state(
+        core.node(),
+        &original.request_id,
+        budget_exhausted.pre_retry_count as i64,
+        budget_exhausted.max_retries as i64,
+        &future_deadline.to_rfc3339(),
+    )
+    .await?;
+    parent.deadline = Some(future_deadline.to_rfc3339());
+    parent.retry_count = Some(budget_exhausted.pre_retry_count as i64);
+    parent.max_retries = Some(budget_exhausted.max_retries as i64);
+    let err = core.retry_request(&parent).await.unwrap_err().to_string();
+    assert!(
+        err.contains("exhausted retry budget"),
+        "retry-budget guard should reject exhausted parent: {err}"
+    );
+
+    force_retry_parent_state(
+        core.node(),
+        &original.request_id,
+        non_latest.pre_retry_count as i64,
+        non_latest.max_retries as i64,
+        &future_deadline.to_rfc3339(),
+    )
+    .await?;
+    parent.retry_count = Some(non_latest.pre_retry_count as i64);
+    parent.max_retries = Some(non_latest.max_retries as i64);
+    let newer = core
+        .submit_request(&created.session_id, "did:defra:amy", "newer attempt", None)
+        .await?;
+    let err = core.retry_request(&parent).await.unwrap_err().to_string();
+    assert!(
+        err.contains("must be latest"),
+        "non-latest guard should reject stale parent after {} became latest: {err}",
+        newer.request_id
+    );
 
     core.shutdown().await?;
     Ok(())
@@ -492,6 +604,42 @@ where
         .cloned()
         .with_context(|| format!("missing row for {root}"))?;
     Ok(serde_json::from_value(row)?)
+}
+
+async fn force_retry_parent_state(
+    node: &defra_node::EmbeddedNode,
+    request_id: &str,
+    retry_count: i64,
+    max_retries: i64,
+    deadline: &str,
+) -> Result<()> {
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                input: {{
+                    status: "error",
+                    lifecycle_state: "failed",
+                    retry_count: {retry_count},
+                    max_retries: {max_retries},
+                    deadline: "{deadline}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        bail!(
+            "force retry parent state failed: {}",
+            response
+                .errors
+                .iter()
+                .map(|error| error.message.as_str())
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+    }
+    Ok(())
 }
 
 async fn wait_for_connectable_iroh_addr(core: &ClientCore) -> Result<String> {

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
@@ -1,0 +1,352 @@
+import Proofs.RuntimeReconcile
+import Proofs.SessionRecovery
+
+/-!
+# Finite Conformance Witness Cases
+
+Representative executable witnesses emitted by `Proofs.Conformance.Contracts`.
+The cases stay finite and deterministic so Rust can consume them as a contract
+without re-implementing Lean evaluation.
+-/
+
+namespace Conformance.ContractCases
+
+structure RuntimeReconcileCase where
+  name : String
+  action : String
+  legal : Bool
+  prePhase : String
+  postPhase : String
+  preActiveGeneration : Nat
+  postActiveGeneration : Nat
+  preRouterGeneration : Nat
+  postRouterGeneration : Nat
+  preReadyGenerationCount : Nat
+  postReadyGenerationCount : Nat
+  preLiveGenerationCount : Nat
+  postLiveGenerationCount : Nat
+  preInFlightCount : Nat
+  postInFlightCount : Nat
+  trackedRequestId : RequestId
+  trackedSessionId : SessionId
+  trackedRequestGeneration : Generation
+  trackedRequestSession : SessionId
+  trackedRequestBehavior : BehaviorId
+  trackedSessionBehavior : BehaviorId
+  deriving Repr
+
+structure SessionRecoveryCase where
+  name : String
+  action : String
+  legal : Bool
+  preLatestState : String
+  postLatestState : String
+  failedId : RequestId
+  newId : RequestId
+  preLatestId : RequestId
+  postLatestId : RequestId
+  preSessionId : SessionId
+  postSessionId : SessionId
+  preBehaviorId : BehaviorId
+  postBehaviorId : BehaviorId
+  preRequestCount : Nat
+  postRequestCount : Nat
+  preRetryCount : Nat
+  postRetryCount : Nat
+  maxRetries : Nat
+  preDeadlineExceeded : Bool
+  postDeadlineExceeded : Bool
+  preFailedIsLatest : Bool
+  postFailedIsLatest : Bool
+  postNewIsLatest : Bool
+  oldRequestRetained : Bool
+  newRequestInserted : Bool
+  originPreserved : Bool
+  backendPreserved : Bool
+  deriving Repr
+
+def boolString (value : Bool) : String :=
+  if value then "true" else "false"
+
+def runtimeResolvedA : ResolvedSnapshot :=
+  { defaultBehavior := 10, runnable := {10}, unavailable := ∅ }
+
+def runtimeResolvedB : ResolvedSnapshot :=
+  { defaultBehavior := 20, runnable := {20}, unavailable := {10} }
+
+def runtimeBoot : RuntimeState :=
+  RuntimeState.bootState runtimeResolvedA
+
+def runtimeApplyingChanged : RuntimeState :=
+  { runtimeBoot with phase := .applying, pendingResolved := some runtimeResolvedB }
+
+def runtimePublishedBeforeRouter : RuntimeState :=
+  { runtimeBoot with
+    lastResolved := runtimeResolvedB
+  , active := runtimeResolvedB.activate 2
+  , routerObservedGeneration := 1
+  , readyGenerations := {1, 2}
+  , liveGenerations := {1, 2}
+  }
+
+def runtimeRouterObserved : RuntimeState :=
+  { runtimePublishedBeforeRouter with routerObservedGeneration := 2 }
+
+def runtimeWithInFlight : RuntimeState :=
+  { runtimeRouterObserved with
+    inFlight := {500}
+  , requestGeneration := Function.update runtimeRouterObserved.requestGeneration 500 2
+  , requestSession := Function.update runtimeRouterObserved.requestSession 500 100
+  , requestBehavior := Function.update runtimeRouterObserved.requestBehavior 500 20
+  , sessionBehavior := Function.update runtimeRouterObserved.sessionBehavior 100 (some 20)
+  }
+
+def runtimeCaseFromStep
+    (name actionName : String)
+    (pre : RuntimeState)
+    (action : RuntimeState.Action)
+    (trackedRequestId : RequestId := 0)
+    (trackedSessionId : SessionId := 0) : RuntimeReconcileCase :=
+  match RuntimeState.step? pre action with
+  | some post =>
+      { name := name
+      , action := actionName
+      , legal := true
+      , prePhase := pre.phase.toDefraDB
+      , postPhase := post.phase.toDefraDB
+      , preActiveGeneration := pre.active.generation
+      , postActiveGeneration := post.active.generation
+      , preRouterGeneration := pre.routerObservedGeneration
+      , postRouterGeneration := post.routerObservedGeneration
+      , preReadyGenerationCount := pre.readyGenerations.card
+      , postReadyGenerationCount := post.readyGenerations.card
+      , preLiveGenerationCount := pre.liveGenerations.card
+      , postLiveGenerationCount := post.liveGenerations.card
+      , preInFlightCount := pre.inFlight.card
+      , postInFlightCount := post.inFlight.card
+      , trackedRequestId := trackedRequestId
+      , trackedSessionId := trackedSessionId
+      , trackedRequestGeneration := post.requestGeneration trackedRequestId
+      , trackedRequestSession := post.requestSession trackedRequestId
+      , trackedRequestBehavior := post.requestBehavior trackedRequestId
+      , trackedSessionBehavior :=
+          match post.sessionBehavior trackedSessionId with
+          | some behaviorId => behaviorId
+          | none => 0
+      }
+  | none =>
+      { name := name
+      , action := actionName
+      , legal := false
+      , prePhase := pre.phase.toDefraDB
+      , postPhase := ""
+      , preActiveGeneration := pre.active.generation
+      , postActiveGeneration := 0
+      , preRouterGeneration := pre.routerObservedGeneration
+      , postRouterGeneration := 0
+      , preReadyGenerationCount := pre.readyGenerations.card
+      , postReadyGenerationCount := 0
+      , preLiveGenerationCount := pre.liveGenerations.card
+      , postLiveGenerationCount := 0
+      , preInFlightCount := pre.inFlight.card
+      , postInFlightCount := 0
+      , trackedRequestId := trackedRequestId
+      , trackedSessionId := trackedSessionId
+      , trackedRequestGeneration := 0
+      , trackedRequestSession := 0
+      , trackedRequestBehavior := 0
+      , trackedSessionBehavior := 0
+      }
+
+def runtimeReconcileCases : List RuntimeReconcileCase :=
+  [ runtimeCaseFromStep
+      "publish_changed_snapshot"
+      "publish"
+      runtimeApplyingChanged
+      (.publish runtimeResolvedB)
+  , runtimeCaseFromStep
+      "router_observe_published_generation"
+      "routerObserve"
+      runtimePublishedBeforeRouter
+      .routerObserve
+  , runtimeCaseFromStep
+      "accept_request_after_router_observe"
+      "acceptRequest"
+      runtimeRouterObserved
+      (.acceptRequest 100 500)
+      500
+      100
+  , runtimeCaseFromStep
+      "finish_request_releases_generation"
+      "finishRequest"
+      runtimeWithInFlight
+      (.finishRequest 500)
+      500
+      100
+  , runtimeCaseFromStep
+      "retire_unobserved_generation"
+      "retireGeneration"
+      runtimeRouterObserved
+      (.retireGeneration 1)
+  , runtimeCaseFromStep
+      "apply_failed_clears_pending"
+      "applyFailed"
+      runtimeApplyingChanged
+      .applyFailed
+  ]
+
+def contractBackend : BackendId :=
+  { val := "contract-backend" }
+
+def recoveryContext
+    (state : RequestState)
+    (admission : AdmissionState)
+    (retryCount maxRetries deadline currentTime : Nat)
+    (isLatest : Bool) : RequestContext :=
+  { state := state
+  , origin := .interactive
+  , backend := contractBackend
+  , admission := admission
+  , deadline := deadline
+  , claimTime := currentTime
+  , currentTime := currentTime
+  , retryCount := retryCount
+  , maxRetries := maxRetries
+  , progressSeq := 3
+  , messageSeq := 7
+  , isLatest := isLatest
+  , persistence := .committed
+  }
+
+def recoveryPre
+    (failedCtx latestCtx : RequestContext)
+    (latestId : RequestId := 1) : SessionState :=
+  { sessionId := 10
+  , behaviorId := 20
+  , requestIds := {1, 3}
+  , ctx := fun rid =>
+      if rid = 1 then failedCtx
+      else if rid = 3 then latestCtx
+      else recoveryContext .pending .released 0 3 10 0 false
+  , latest := latestId
+  }
+
+def recoveryCaseFromStep
+    (name : String)
+    (pre : SessionState)
+    (failedId newId : RequestId) : SessionRecoveryCase :=
+  let failedPre := pre.ctx failedId
+  match SessionState.step? pre (.reissueFailed failedId newId) with
+  | some post =>
+      let failedPost := post.ctx failedId
+      let newPost := post.ctx newId
+      { name := name
+      , action := "reissueFailed"
+      , legal := true
+      , preLatestState := (pre.ctx pre.latest).state.toDefraDB
+      , postLatestState := (post.ctx post.latest).state.toDefraDB
+      , failedId := failedId
+      , newId := newId
+      , preLatestId := pre.latest
+      , postLatestId := post.latest
+      , preSessionId := pre.sessionId
+      , postSessionId := post.sessionId
+      , preBehaviorId := pre.behaviorId
+      , postBehaviorId := post.behaviorId
+      , preRequestCount := pre.requestIds.card
+      , postRequestCount := post.requestIds.card
+      , preRetryCount := failedPre.retryCount
+      , postRetryCount := newPost.retryCount
+      , maxRetries := failedPre.maxRetries
+      , preDeadlineExceeded := decide failedPre.deadlineExceeded
+      , postDeadlineExceeded := decide newPost.deadlineExceeded
+      , preFailedIsLatest := failedPre.isLatest
+      , postFailedIsLatest := failedPost.isLatest
+      , postNewIsLatest := newPost.isLatest
+      , oldRequestRetained := decide (failedId ∈ post.requestIds)
+      , newRequestInserted := decide (newId ∈ post.requestIds)
+      , originPreserved := decide (newPost.origin = failedPre.origin)
+      , backendPreserved := decide (newPost.backend = failedPre.backend)
+      }
+  | none =>
+      { name := name
+      , action := "reissueFailed"
+      , legal := false
+      , preLatestState := (pre.ctx pre.latest).state.toDefraDB
+      , postLatestState := ""
+      , failedId := failedId
+      , newId := newId
+      , preLatestId := pre.latest
+      , postLatestId := 0
+      , preSessionId := pre.sessionId
+      , postSessionId := 0
+      , preBehaviorId := pre.behaviorId
+      , postBehaviorId := 0
+      , preRequestCount := pre.requestIds.card
+      , postRequestCount := 0
+      , preRetryCount := failedPre.retryCount
+      , postRetryCount := 0
+      , maxRetries := failedPre.maxRetries
+      , preDeadlineExceeded := decide failedPre.deadlineExceeded
+      , postDeadlineExceeded := false
+      , preFailedIsLatest := failedPre.isLatest
+      , postFailedIsLatest := false
+      , postNewIsLatest := false
+      , oldRequestRetained := false
+      , newRequestInserted := false
+      , originPreserved := false
+      , backendPreserved := false
+      }
+
+def sessionRecoveryCases : List SessionRecoveryCase :=
+  let openFailed := recoveryContext .failed .released 1 3 10 5 true
+  let lastBudgetFailed := recoveryContext .failed .released 2 3 10 5 true
+  let exhaustedFailed := recoveryContext .failed .released 3 3 10 5 true
+  let deadlineClosedFailed := recoveryContext .failed .released 1 3 10 11 true
+  let nonLatestFailed := recoveryContext .failed .released 1 3 10 5 false
+  let latestFailed := recoveryContext .failed .released 0 3 10 5 true
+  let pendingLatest := recoveryContext .pending .released 1 3 10 5 true
+  let claimedLatest := recoveryContext .failed .waiting 1 3 10 5 true
+  [ recoveryCaseFromStep
+      "legal_open_budget_latest"
+      (recoveryPre openFailed openFailed 1)
+      1
+      2
+  , recoveryCaseFromStep
+      "legal_last_retry_slot"
+      (recoveryPre lastBudgetFailed lastBudgetFailed 1)
+      1
+      2
+  , recoveryCaseFromStep
+      "illegal_retry_budget_exhausted"
+      (recoveryPre exhaustedFailed exhaustedFailed 1)
+      1
+      2
+  , recoveryCaseFromStep
+      "illegal_deadline_closed"
+      (recoveryPre deadlineClosedFailed deadlineClosedFailed 1)
+      1
+      2
+  , recoveryCaseFromStep
+      "illegal_non_latest_failed_request"
+      (recoveryPre nonLatestFailed latestFailed 3)
+      1
+      2
+  , recoveryCaseFromStep
+      "illegal_new_request_id_already_exists"
+      (recoveryPre openFailed openFailed 1)
+      1
+      3
+  , recoveryCaseFromStep
+      "illegal_source_not_failed"
+      (recoveryPre pendingLatest pendingLatest 1)
+      1
+      2
+  , recoveryCaseFromStep
+      "illegal_source_not_released"
+      (recoveryPre claimedLatest claimedLatest 1)
+      1
+      2
+  ]
+
+end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -3,23 +3,22 @@ import Proofs.Process
 import Proofs.Persistence
 import Proofs.SessionRecovery
 import Proofs.InferenceCall
+import Proofs.RuntimeReconcile
+import Proofs.Conformance.ContractCases
 
 /-!
 # Rust Conformance Contracts
 
 This module is the Lean-owned extraction surface for Rust conformance tests.
 Rust runs this file with `lake env lean --run` and consumes the JSON emitted by
-`main`. State vocabularies and transition tables are evaluated from the Lean
-constructors, `toDefraDB` functions, executable `step?` functions, and finite
-witness contexts below.
-
-`RuntimeReconcile` is intentionally exposed only as a follow-up hook here so
-this extraction stays scoped to the initial executable domains below. Add it as
-another `StateMachineContract` when the runtime-reconcile contract is ready to
-join the Rust conformance gate.
+`main`. State vocabularies, transition tables, and finite witness rows are
+evaluated from the Lean constructors, `toDefraDB` functions, and executable
+`step?` functions below.
 -/
 
 namespace Conformance.Contracts
+
+open Conformance.ContractCases
 
 structure TransitionPair where
   source : String
@@ -103,16 +102,8 @@ def machineContract
   }
 
 def requestStates : List RequestState :=
-  [ .pending
-  , .claimed
-  , .processing
-  , .inputRequired
-  , .completed
-  , .failed
-  , .superseded
-  , .dead
-  , .interrupted
-  ]
+  [ .pending, .claimed, .processing, .inputRequired, .completed
+  , .failed, .superseded, .dead, .interrupted ]
 
 def requestStateNames : List String :=
   requestStates.map RequestState.toDefraDB
@@ -240,35 +231,83 @@ def persistenceMachine
       (fun state action => PersistenceState.step? policy state action)
       PersistenceState.toDefraDB)
 
-def sessionRecoveryFailedId : RequestId := 1
+def runtimeReconcileStates : List ReconcilePhase :=
+  [ .idle, .debouncing, .resolving, .diffing, .applying ]
 
-def sessionRecoveryNewId : RequestId := 2
+def runtimeReconcileStateNames : List String :=
+  runtimeReconcileStates.map ReconcilePhase.toDefraDB
 
-def sessionRecoveryFailedContext : RequestContext :=
-  requestContext .failed .released
+def runtimeAckedChanged : RuntimeState :=
+  { runtimeBoot with ackedResolved := some runtimeResolvedB }
 
-def sessionRecoveryPre : SessionState :=
-  { sessionId := 1
-  , behaviorId := 1
-  , requestIds := {sessionRecoveryFailedId}
-  , ctx := fun rid =>
-      if rid = sessionRecoveryFailedId then
-        sessionRecoveryFailedContext
-      else
-        requestContext .pending .released
-  , latest := sessionRecoveryFailedId
+def runtimeDebouncingChanged : RuntimeState :=
+  { runtimeAckedChanged with
+    phase := .debouncing
+  , observedResolved := some runtimeResolvedB
   }
 
+def runtimeResolvingChanged : RuntimeState :=
+  { runtimeDebouncingChanged with phase := .resolving }
+
+def runtimeDiffingNoop : RuntimeState :=
+  { runtimeBoot with
+    phase := .diffing
+  , observedResolved := some runtimeResolvedA
+  , pendingResolved := some runtimeResolvedA
+  }
+
+def runtimeDiffingChanged : RuntimeState :=
+  { runtimeResolvingChanged with
+    phase := .diffing
+  , pendingResolved := some runtimeResolvedB
+  }
+
+def runtimeReconcileSamples : List RuntimeState :=
+  [ runtimeBoot
+  , runtimeAckedChanged
+  , runtimeDebouncingChanged
+  , runtimeResolvingChanged
+  , runtimeDiffingNoop
+  , runtimeDiffingChanged
+  , runtimeApplyingChanged
+  , runtimePublishedBeforeRouter
+  , runtimeRouterObserved
+  , runtimeWithInFlight
+  ]
+
+def runtimeReconcileActions : List (String × RuntimeState.Action) :=
+  [ ("ackWrite", .ackWrite runtimeResolvedB)
+  , ("observeDoc", .observeDoc runtimeResolvedB)
+  , ("startResolve", .startResolve)
+  , ("resolveVisible", .resolveVisible runtimeResolvedB)
+  , ("diffNoop", .diffNoop runtimeResolvedA)
+  , ("beginApply", .beginApply runtimeResolvedB)
+  , ("publish", .publish runtimeResolvedB)
+  , ("applyFailed", .applyFailed)
+  , ("routerObserve", .routerObserve)
+  , ("acceptRequest", .acceptRequest 100 500)
+  , ("finishRequest", .finishRequest 500)
+  , ("retireGeneration", .retireGeneration 1)
+  ]
+
+def runtimeReconcileMachine : StateMachineContract :=
+  machineContract
+    "RuntimeReconcile"
+    runtimeReconcileStateNames
+    []
+    (actionNames runtimeReconcileActions)
+    (transitionPairsFromSamples
+      runtimeReconcileSamples
+      runtimeReconcileActions
+      RuntimeState.step?
+      (fun state => state.phase.toDefraDB))
+
 def sessionRecoveryLegalTransitions : List TransitionPair :=
-  match SessionState.step?
-      sessionRecoveryPre
-      (.reissueFailed sessionRecoveryFailedId sessionRecoveryNewId) with
-  | some post =>
-      [ { source := (sessionRecoveryPre.ctx sessionRecoveryPre.latest).state.toDefraDB
-        , target := (post.ctx post.latest).state.toDefraDB
-        }
-      ]
-  | none => []
+  sessionRecoveryCases.filterMap fun witness =>
+    if witness.legal then
+      some { source := witness.preLatestState, target := witness.postLatestState }
+    else
+      none
 
 def sessionRecoveryMachine : StateMachineContract :=
   machineContract
@@ -318,6 +357,7 @@ def vocabularies : List VocabularyContract :=
   , { domain := "PersistenceState", values := persistenceStateNames }
   , { domain := "PersistenceFailurePolicy", values :=
         [.failOpen, .failClosed].map PersistenceState.FailurePolicy.toDefraDB }
+  , { domain := "ReconcilePhase", values := runtimeReconcileStateNames }
   , { domain := "SessionRecoveryLatestRequestState"
     , values := [RequestState.failed.toDefraDB, RequestState.pending.toDefraDB]
     }
@@ -336,6 +376,7 @@ def stateMachines : List StateMachineContract :=
   , processMachine
   , persistenceMachine "Persistence.failClosed" .failClosed
   , persistenceMachine "Persistence.failOpen" .failOpen
+  , runtimeReconcileMachine
   , sessionRecoveryMachine
   , inferenceCallMachine
   ]
@@ -366,6 +407,62 @@ def StateMachineContract.toJson (contract : StateMachineContract) : String :=
       ++ jsonArray (contract.illegalTransitions.map TransitionPair.toJson)
     ++ "}"
 
+def runtimeReconcileCaseJson (witness : RuntimeReconcileCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"legal\":" ++ boolString witness.legal ++ ","
+    ++ "\"pre_phase\":" ++ jsonString witness.prePhase ++ ","
+    ++ "\"post_phase\":" ++ jsonString witness.postPhase ++ ","
+    ++ "\"pre_active_generation\":" ++ toString witness.preActiveGeneration ++ ","
+    ++ "\"post_active_generation\":" ++ toString witness.postActiveGeneration ++ ","
+    ++ "\"pre_router_generation\":" ++ toString witness.preRouterGeneration ++ ","
+    ++ "\"post_router_generation\":" ++ toString witness.postRouterGeneration ++ ","
+    ++ "\"pre_ready_generation_count\":" ++ toString witness.preReadyGenerationCount ++ ","
+    ++ "\"post_ready_generation_count\":" ++ toString witness.postReadyGenerationCount ++ ","
+    ++ "\"pre_live_generation_count\":" ++ toString witness.preLiveGenerationCount ++ ","
+    ++ "\"post_live_generation_count\":" ++ toString witness.postLiveGenerationCount ++ ","
+    ++ "\"pre_in_flight_count\":" ++ toString witness.preInFlightCount ++ ","
+    ++ "\"post_in_flight_count\":" ++ toString witness.postInFlightCount ++ ","
+    ++ "\"tracked_request_id\":" ++ toString witness.trackedRequestId ++ ","
+    ++ "\"tracked_session_id\":" ++ toString witness.trackedSessionId ++ ","
+    ++ "\"tracked_request_generation\":" ++ toString witness.trackedRequestGeneration ++ ","
+    ++ "\"tracked_request_session\":" ++ toString witness.trackedRequestSession ++ ","
+    ++ "\"tracked_request_behavior\":" ++ toString witness.trackedRequestBehavior ++ ","
+    ++ "\"tracked_session_behavior\":" ++ toString witness.trackedSessionBehavior
+    ++ "}"
+
+def sessionRecoveryCaseJson (witness : SessionRecoveryCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"legal\":" ++ boolString witness.legal ++ ","
+    ++ "\"pre_latest_state\":" ++ jsonString witness.preLatestState ++ ","
+    ++ "\"post_latest_state\":" ++ jsonString witness.postLatestState ++ ","
+    ++ "\"failed_id\":" ++ toString witness.failedId ++ ","
+    ++ "\"new_id\":" ++ toString witness.newId ++ ","
+    ++ "\"pre_latest_id\":" ++ toString witness.preLatestId ++ ","
+    ++ "\"post_latest_id\":" ++ toString witness.postLatestId ++ ","
+    ++ "\"pre_session_id\":" ++ toString witness.preSessionId ++ ","
+    ++ "\"post_session_id\":" ++ toString witness.postSessionId ++ ","
+    ++ "\"pre_behavior_id\":" ++ toString witness.preBehaviorId ++ ","
+    ++ "\"post_behavior_id\":" ++ toString witness.postBehaviorId ++ ","
+    ++ "\"pre_request_count\":" ++ toString witness.preRequestCount ++ ","
+    ++ "\"post_request_count\":" ++ toString witness.postRequestCount ++ ","
+    ++ "\"pre_retry_count\":" ++ toString witness.preRetryCount ++ ","
+    ++ "\"post_retry_count\":" ++ toString witness.postRetryCount ++ ","
+    ++ "\"max_retries\":" ++ toString witness.maxRetries ++ ","
+    ++ "\"pre_deadline_exceeded\":" ++ boolString witness.preDeadlineExceeded ++ ","
+    ++ "\"post_deadline_exceeded\":" ++ boolString witness.postDeadlineExceeded ++ ","
+    ++ "\"pre_failed_is_latest\":" ++ boolString witness.preFailedIsLatest ++ ","
+    ++ "\"post_failed_is_latest\":" ++ boolString witness.postFailedIsLatest ++ ","
+    ++ "\"post_new_is_latest\":" ++ boolString witness.postNewIsLatest ++ ","
+    ++ "\"old_request_retained\":" ++ boolString witness.oldRequestRetained ++ ","
+    ++ "\"new_request_inserted\":" ++ boolString witness.newRequestInserted ++ ","
+    ++ "\"origin_preserved\":" ++ boolString witness.originPreserved ++ ","
+    ++ "\"backend_preserved\":" ++ boolString witness.backendPreserved
+    ++ "}"
+
 def snapshotJson : String :=
   "{"
     ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
@@ -373,9 +470,11 @@ def snapshotJson : String :=
       ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
     ++ "\"state_machines\":"
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
-    ++ "\"follow_up_hooks\":["
-      ++ jsonString "RuntimeReconcile executable state machine contract"
-      ++ "]"
+    ++ "\"runtime_reconcile_cases\":"
+      ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
+    ++ "\"session_recovery_cases\":"
+      ++ jsonArray (sessionRecoveryCases.map sessionRecoveryCaseJson) ++ ","
+    ++ "\"follow_up_hooks\":[]"
     ++ "}"
 
 def contractJsonBegin : String :=

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -157,24 +157,19 @@ currently covers:
 - `Process`
 - `Persistence.failClosed`
 - `Persistence.failOpen`
+- `RuntimeReconcile`
 - `SessionRecovery`
 - `InferenceCall`
 
-The current `SessionRecovery` contract is intentionally narrow: it covers the
-executable failed-latest-request reissue witness (`failed -> pending`) rather
-than the whole request lifecycle vocabulary. Widen this contract when the
-session-recovery executable model grows enough finite witnesses to represent the
-larger space directly.
+`RuntimeReconcile` and `SessionRecovery` also emit deterministic witness rows.
+Those rows keep the JSON small while pinning generation publication/router
+observation/request admission, and session retry guards for deadline closure,
+retry budget, latest-request status, and identity preservation.
 
 When a Lean vocabulary, terminal partition, action, or legal transition changes,
 the generated JSON changes on the next Rust test run. The Rust tests then fail
 unless the runtime behavior or the documented product-boundary assertions are
 updated to match.
-
-`RuntimeReconcile` is intentionally exposed only as a follow-up hook in the JSON
-so this extraction stays scoped to the initial executable domains above. Add it
-to `Proofs/Conformance/Contracts.lean` as another `StateMachineContract` when
-the runtime-reconcile contract is ready to join the Rust conformance gate.
 
 ## Core Model
 

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -11,6 +11,7 @@ use crate::config::BehaviorConfig;
 use crate::ensure_runtime_schemas;
 use crate::graphql::escape_graphql_string;
 use crate::identity::KeyIdentity;
+use crate::lean_vocab_test::lean_runtime_reconcile_case;
 use crate::runtime_status::RuntimeStatusHandle;
 use crate::tool_surface::{
     BehaviorToolConfig, FileToolMode, ToolCeiling, ToolSelection, ToolSurface,
@@ -86,6 +87,9 @@ async fn fetch_runtime_status(
 
 #[tokio::test]
 async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
+    let publish = lean_runtime_reconcile_case("publish_changed_snapshot");
+    assert!(publish.legal);
+
     let node = test_node().await;
     ensure_runtime_schemas(node.as_ref()).await.unwrap();
     let agent_did = "did:defra-agent:reconcile-test";
@@ -149,6 +153,10 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
     )
     .unwrap();
     let active_snapshot = supervisor.current_snapshot();
+    assert_eq!(
+        active_snapshot.generation,
+        publish.pre_active_generation as u64
+    );
     assert!(active_snapshot.dispatchers.contains_key("general"));
     let (active_tx, mut active_rx) = watch::channel(active_snapshot);
     let (proposal_tx, proposal_rx) = mpsc::channel(4);
@@ -161,7 +169,10 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
         .expect("generation update should publish")
         .unwrap();
     let updated_active = active_rx.borrow().clone();
-    assert_eq!(updated_active.generation, 2);
+    assert_eq!(
+        updated_active.generation,
+        publish.post_active_generation as u64
+    );
     assert_eq!(
         updated_active
             .behaviors
@@ -171,8 +182,11 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
         "updated prompt"
     );
     let status = fetch_runtime_status(node.as_ref(), agent_did).await;
-    assert_eq!(status.reconcile_phase, "idle");
-    assert_eq!(status.active_generation, 2);
+    assert_eq!(status.reconcile_phase, publish.post_phase.as_str());
+    assert_eq!(
+        status.active_generation,
+        publish.post_active_generation as i64
+    );
     assert_eq!(status.last_reconcile_result, "applied");
     assert!(status.last_reconcile_error.is_empty());
 
@@ -204,6 +218,9 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
 
 #[tokio::test]
 async fn generation_supervisor_keeps_previous_generation_after_failed_apply() {
+    let apply_failed = lean_runtime_reconcile_case("apply_failed_clears_pending");
+    assert!(apply_failed.legal);
+
     let node = test_node().await;
     ensure_runtime_schemas(node.as_ref()).await.unwrap();
     let agent_did = "did:defra-agent:reconcile-failure-test";
@@ -268,9 +285,15 @@ async fn generation_supervisor_keeps_previous_generation_after_failed_apply() {
     proposal_tx.send(invalid_snapshot).await.unwrap();
     tokio::time::sleep(Duration::from_millis(50)).await;
     assert!(!active_rx.has_changed().unwrap());
-    assert_eq!(active_rx.borrow().generation, 1);
+    assert_eq!(
+        active_rx.borrow().generation,
+        apply_failed.post_active_generation as u64
+    );
     let failed_status = fetch_runtime_status(node.as_ref(), agent_did).await;
-    assert_eq!(failed_status.reconcile_phase, "idle");
+    assert_eq!(
+        failed_status.reconcile_phase,
+        apply_failed.post_phase.as_str()
+    );
     assert_eq!(failed_status.active_generation, 0);
     assert_eq!(failed_status.last_reconcile_result, "error");
     assert!(!failed_status.last_reconcile_error.is_empty());

--- a/crates/defra-agent/src/agent/runtime/tests/router.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/router.rs
@@ -1,8 +1,12 @@
 use super::support::*;
 use super::*;
+use crate::lean_vocab_test::lean_runtime_reconcile_case;
 
 #[tokio::test]
 async fn router_dispatches_first_request_after_snapshot_change_to_latest_generation() {
+    let accept = lean_runtime_reconcile_case("accept_request_after_router_observe");
+    assert!(accept.legal);
+
     let agent_did = "did:defra-agent:router-latest-snapshot";
     let initial_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 1,
@@ -69,12 +73,18 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
     .expect("request should be returned");
 
     assert_eq!(request.request_id, "req-router");
-    assert_eq!(active_snapshot.generation, 2);
+    assert_eq!(
+        active_snapshot.generation,
+        accept.post_router_generation as u64
+    );
     assert_eq!(active_snapshot.default_behavior_id, "code");
 }
 
 #[tokio::test(start_paused = true)]
 async fn router_publishes_observed_generation_without_waiting_for_request() {
+    let router = lean_runtime_reconcile_case("router_observe_published_generation");
+    assert!(router.legal);
+
     let node = test_node().await;
     ensure_runtime_schemas(node.as_ref()).await.unwrap();
     let agent_did = "did:defra-agent:router-observed-generation";
@@ -124,7 +134,7 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
     tokio::task::yield_now().await;
 
     let row = fetch_runtime_status(node.as_ref(), agent_did).await;
-    assert_eq!(row.active_generation, 1);
+    assert_eq!(row.active_generation, router.pre_router_generation as i64);
     assert_eq!(row.last_reconcile_result, "startup");
 
     let query = format!(
@@ -152,12 +162,13 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
             .and_then(|row| row.get("router_generation"))
             .and_then(Value::as_i64)
             .unwrap_or_default();
-        if router_generation == 2 {
+        if router_generation == router.post_router_generation as i64 {
             break;
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "router generation did not advance to 2; last value={router_generation}"
+            "router generation did not advance to {}; last value={router_generation}",
+            router.post_router_generation
         );
         tokio::task::yield_now().await;
         tokio::time::advance(Duration::from_millis(10)).await;

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -27,6 +27,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) generated_by: String,
     pub(crate) vocabularies: Vec<LeanVocabularyContract>,
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
+    pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) follow_up_hooks: Vec<String>,
 }
 
@@ -52,6 +54,62 @@ pub(crate) struct LeanStateMachineContract {
 pub(crate) struct LeanTransitionPair {
     pub(crate) from: String,
     pub(crate) to: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanRuntimeReconcileCase {
+    pub(crate) name: String,
+    pub(crate) action: String,
+    pub(crate) legal: bool,
+    pub(crate) pre_phase: String,
+    pub(crate) post_phase: String,
+    pub(crate) pre_active_generation: usize,
+    pub(crate) post_active_generation: usize,
+    pub(crate) pre_router_generation: usize,
+    pub(crate) post_router_generation: usize,
+    pub(crate) pre_ready_generation_count: usize,
+    pub(crate) post_ready_generation_count: usize,
+    pub(crate) pre_live_generation_count: usize,
+    pub(crate) post_live_generation_count: usize,
+    pub(crate) pre_in_flight_count: usize,
+    pub(crate) post_in_flight_count: usize,
+    pub(crate) tracked_request_id: usize,
+    pub(crate) tracked_session_id: usize,
+    pub(crate) tracked_request_generation: usize,
+    pub(crate) tracked_request_session: usize,
+    pub(crate) tracked_request_behavior: usize,
+    pub(crate) tracked_session_behavior: usize,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanSessionRecoveryCase {
+    pub(crate) name: String,
+    pub(crate) action: String,
+    pub(crate) legal: bool,
+    pub(crate) pre_latest_state: String,
+    pub(crate) post_latest_state: String,
+    pub(crate) failed_id: usize,
+    pub(crate) new_id: usize,
+    pub(crate) pre_latest_id: usize,
+    pub(crate) post_latest_id: usize,
+    pub(crate) pre_session_id: usize,
+    pub(crate) post_session_id: usize,
+    pub(crate) pre_behavior_id: usize,
+    pub(crate) post_behavior_id: usize,
+    pub(crate) pre_request_count: usize,
+    pub(crate) post_request_count: usize,
+    pub(crate) pre_retry_count: usize,
+    pub(crate) post_retry_count: usize,
+    pub(crate) max_retries: usize,
+    pub(crate) pre_deadline_exceeded: bool,
+    pub(crate) post_deadline_exceeded: bool,
+    pub(crate) pre_failed_is_latest: bool,
+    pub(crate) post_failed_is_latest: bool,
+    pub(crate) post_new_is_latest: bool,
+    pub(crate) old_request_retained: bool,
+    pub(crate) new_request_inserted: bool,
+    pub(crate) origin_preserved: bool,
+    pub(crate) backend_preserved: bool,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -88,6 +146,22 @@ pub(crate) fn lean_state_machine_contract(domain: &str) -> &'static LeanStateMac
         .iter()
         .find(|contract| contract.domain == domain)
         .unwrap_or_else(|| panic!("Lean state-machine contract {domain:?} was not emitted"))
+}
+
+pub(crate) fn lean_runtime_reconcile_case(name: &str) -> &'static LeanRuntimeReconcileCase {
+    lean_contract_snapshot()
+        .runtime_reconcile_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean runtime-reconcile case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_session_recovery_case(name: &str) -> &'static LeanSessionRecoveryCase {
+    lean_contract_snapshot()
+        .session_recovery_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean session-recovery case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {
@@ -312,7 +386,16 @@ fn run_lake_build(proofs_dir: &Path) {
 }
 
 fn proofs_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("proofs")
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let direct = manifest_dir.join("proofs");
+    if direct.exists() {
+        return direct;
+    }
+    manifest_dir
+        .parent()
+        .map(|parent| parent.join("defra-agent/proofs"))
+        .filter(|candidate| candidate.exists())
+        .unwrap_or(direct)
 }
 
 fn extract_contract_json(stdout: &str) -> &str {

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -6,9 +6,8 @@ use serde::Deserialize;
 use super::*;
 use crate::ensure_runtime_schemas;
 use crate::lean_vocab_test::{
-    assert_lean_contract_vocabulary_matches, assert_lean_to_defradb_vocabulary_matches,
-    assert_lean_transition_is_legal, assert_state_machine_contract_is_complete,
-    LeanContractVocabulary, LeanVocabulary,
+    assert_lean_contract_vocabulary_matches, assert_lean_transition_is_legal,
+    assert_state_machine_contract_is_complete, lean_runtime_reconcile_case, LeanContractVocabulary,
 };
 
 #[derive(Debug, Deserialize)]
@@ -92,10 +91,6 @@ fn rust_process_state_transitions_match_lean_contract() {
 
 #[test]
 fn rust_reconcile_phase_vocabulary_matches_lean_model() {
-    const LEAN_RUNTIME_RECONCILE_FILE: &str =
-        "crates/defra-agent/proofs/Proofs/RuntimeReconcile/State.lean";
-    const LEAN_RUNTIME_RECONCILE_MODEL: &str =
-        include_str!("../../proofs/Proofs/RuntimeReconcile/State.lean");
     let rust_phases = vec![
         ReconcilePhase::Idle.as_str(),
         ReconcilePhase::Debouncing.as_str(),
@@ -104,13 +99,13 @@ fn rust_reconcile_phase_vocabulary_matches_lean_model() {
         ReconcilePhase::Applying.as_str(),
     ];
 
-    assert_lean_to_defradb_vocabulary_matches(LeanVocabulary {
-        lean_file: LEAN_RUNTIME_RECONCILE_FILE,
-        model: LEAN_RUNTIME_RECONCILE_MODEL,
-        namespace: "ReconcilePhase",
+    assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+        domain: "ReconcilePhase",
         rust_source: "ReconcilePhase::{Idle, Debouncing, Resolving, Diffing, Applying}",
         rust_values: &rust_phases,
     });
+    assert_state_machine_contract_is_complete("RuntimeReconcile");
+    assert_lean_transition_is_legal("RuntimeReconcile", "applying", "idle");
 }
 
 #[tokio::test]
@@ -208,4 +203,62 @@ async fn runtime_status_serializes_persisted_generation_updates() {
     assert_eq!(row.active_generation, 2);
     assert_eq!(row.router_generation, 2);
     assert_eq!(row.last_reconcile_result, "applied");
+}
+
+#[tokio::test]
+async fn runtime_status_generation_updates_match_lean_runtime_reconcile_cases() {
+    let publish = lean_runtime_reconcile_case("publish_changed_snapshot");
+    let router = lean_runtime_reconcile_case("router_observe_published_generation");
+    assert!(publish.legal);
+    assert!(router.legal);
+
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let status = RuntimeStatusHandle::new(node.clone(), "did:defra-agent:runtime-contract");
+    let startup = ActiveRuntimeSnapshot {
+        generation: publish.pre_active_generation as u64,
+        default_behavior_id: "general".to_string(),
+        behaviors: HashMap::new(),
+        tool_surfaces: HashMap::new(),
+        backend_admission_configs: HashMap::new(),
+        unavailable_behaviors: HashMap::new(),
+        active_schedules: HashMap::new(),
+        unavailable_schedules: HashSet::new(),
+        active_event_triggers: HashMap::new(),
+        unavailable_event_triggers: HashSet::new(),
+        active_tasks: HashMap::new(),
+        dispatchers: HashMap::new(),
+    };
+    let applied = ActiveRuntimeSnapshot {
+        generation: publish.post_active_generation as u64,
+        default_behavior_id: "general".to_string(),
+        behaviors: HashMap::new(),
+        tool_surfaces: HashMap::new(),
+        backend_admission_configs: HashMap::new(),
+        unavailable_behaviors: HashMap::new(),
+        active_schedules: HashMap::new(),
+        unavailable_schedules: HashSet::new(),
+        active_event_triggers: HashMap::new(),
+        unavailable_event_triggers: HashSet::new(),
+        active_tasks: HashMap::new(),
+        dispatchers: HashMap::new(),
+    };
+
+    status.publish_startup_snapshot(&startup).await;
+    status.set_reconcile_phase(ReconcilePhase::Applying).await;
+    status.publish_applied(&applied).await;
+    let row = fetch_runtime_row(node.as_ref(), "did:defra-agent:runtime-contract").await;
+    assert_eq!(row.reconcile_phase, publish.post_phase.as_str());
+    assert_eq!(row.active_generation, publish.post_active_generation as i64);
+    assert_eq!(row.router_generation, publish.post_router_generation as i64);
+    assert_eq!(row.last_reconcile_result, "applied");
+
+    status
+        .publish_router_generation(router.post_router_generation as u64)
+        .await;
+    let row = fetch_runtime_row(node.as_ref(), "did:defra-agent:runtime-contract").await;
+    assert_eq!(row.reconcile_phase, router.post_phase.as_str());
+    assert_eq!(row.active_generation, router.post_active_generation as i64);
+    assert_eq!(row.router_generation, router.post_router_generation as i64);
 }

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -10,7 +10,8 @@ mod support;
 
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
-    assert_state_machine_contract_is_complete, lean_contract_snapshot, lean_vocabulary_values,
+    assert_state_machine_contract_is_complete, lean_contract_snapshot, lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -32,12 +33,15 @@ fn lean_executable_contracts_cover_initial_domains() {
         "Process",
         "Persistence.failClosed",
         "Persistence.failOpen",
+        "RuntimeReconcile",
         "SessionRecovery",
         "InferenceCall",
     ] {
         assert_state_machine_contract_is_complete(domain);
     }
 
+    assert_lean_transition_is_legal("RuntimeReconcile", "applying", "idle");
+    assert_lean_transition_is_legal("RuntimeReconcile", "idle", "debouncing");
     assert_lean_transition_is_legal("Persistence.failClosed", "committing", "uncommitted");
     assert_lean_transition_is_legal("Persistence.failOpen", "committing", "lost");
     assert_lean_transition_is_legal("SessionRecovery", "failed", "pending");
@@ -45,12 +49,110 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_lean_transition_is_legal("InferenceCall", "running", "completed");
     assert_lean_transition_is_legal("InferenceCall", "running", "failed");
     assert!(
-        lean_contract_snapshot()
-            .follow_up_hooks
-            .iter()
-            .any(|hook| hook.contains("RuntimeReconcile")),
-        "RuntimeReconcile executable follow-up hook should remain visible"
+        lean_contract_snapshot().follow_up_hooks.is_empty(),
+        "RuntimeReconcile should be emitted as generated contract output, not a follow-up hook"
     );
+    assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
+    assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 8);
+}
+
+#[test]
+fn generated_runtime_reconcile_cases_pin_generation_and_admission_contract() {
+    let publish = lean_runtime_reconcile_case("publish_changed_snapshot");
+    assert!(publish.legal);
+    assert_eq!(publish.action.as_str(), "publish");
+    assert_eq!(publish.pre_phase.as_str(), "applying");
+    assert_eq!(publish.post_phase.as_str(), "idle");
+    assert_eq!(
+        publish.pre_active_generation + 1,
+        publish.post_active_generation
+    );
+    assert_eq!(
+        publish.pre_router_generation,
+        publish.post_router_generation
+    );
+    assert_eq!(
+        publish.pre_ready_generation_count + 1,
+        publish.post_ready_generation_count
+    );
+    assert_eq!(
+        publish.pre_live_generation_count + 1,
+        publish.post_live_generation_count
+    );
+
+    let router = lean_runtime_reconcile_case("router_observe_published_generation");
+    assert!(router.legal);
+    assert_eq!(router.pre_phase.as_str(), "idle");
+    assert_eq!(router.post_phase.as_str(), "idle");
+    assert_eq!(router.pre_active_generation, router.post_active_generation);
+    assert_eq!(router.post_router_generation, router.post_active_generation);
+
+    let accept = lean_runtime_reconcile_case("accept_request_after_router_observe");
+    assert!(accept.legal);
+    assert_eq!(accept.pre_phase.as_str(), "idle");
+    assert_eq!(accept.post_phase.as_str(), "idle");
+    assert_eq!(accept.pre_in_flight_count + 1, accept.post_in_flight_count);
+    assert_eq!(accept.tracked_request_id, 500);
+    assert_eq!(accept.tracked_session_id, 100);
+    assert_eq!(
+        accept.tracked_request_generation,
+        accept.post_router_generation
+    );
+    assert_eq!(accept.tracked_request_session, accept.tracked_session_id);
+    assert_eq!(
+        accept.tracked_request_behavior,
+        accept.tracked_session_behavior
+    );
+
+    let retire = lean_runtime_reconcile_case("retire_unobserved_generation");
+    assert!(retire.legal);
+    assert_eq!(
+        retire.pre_live_generation_count - 1,
+        retire.post_live_generation_count
+    );
+    assert_eq!(
+        retire.pre_ready_generation_count - 1,
+        retire.post_ready_generation_count
+    );
+}
+
+#[test]
+fn generated_session_recovery_cases_cover_retry_guards_and_preservation() {
+    let legal = lean_session_recovery_case("legal_open_budget_latest");
+    assert!(legal.legal);
+    assert_eq!(legal.action.as_str(), "reissueFailed");
+    assert_eq!(legal.pre_latest_state.as_str(), "failed");
+    assert_eq!(legal.post_latest_state.as_str(), "pending");
+    assert_eq!(legal.pre_retry_count + 1, legal.post_retry_count);
+    assert!(legal.post_retry_count <= legal.max_retries);
+    assert_eq!(legal.pre_session_id, legal.post_session_id);
+    assert_eq!(legal.pre_behavior_id, legal.post_behavior_id);
+    assert_eq!(legal.pre_request_count + 1, legal.post_request_count);
+    assert_eq!(legal.post_latest_id, legal.new_id);
+    assert!(legal.pre_failed_is_latest);
+    assert!(!legal.post_failed_is_latest);
+    assert!(legal.post_new_is_latest);
+    assert!(legal.old_request_retained);
+    assert!(legal.new_request_inserted);
+    assert!(legal.origin_preserved);
+    assert!(legal.backend_preserved);
+
+    let last_slot = lean_session_recovery_case("legal_last_retry_slot");
+    assert!(last_slot.legal);
+    assert_eq!(last_slot.post_retry_count, last_slot.max_retries);
+
+    for name in [
+        "illegal_retry_budget_exhausted",
+        "illegal_deadline_closed",
+        "illegal_non_latest_failed_request",
+        "illegal_new_request_id_already_exists",
+        "illegal_source_not_failed",
+        "illegal_source_not_released",
+    ] {
+        let case = lean_session_recovery_case(name);
+        assert!(!case.legal, "{name} must be rejected by Lean");
+        assert!(case.post_latest_state.is_empty());
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- emit RuntimeReconcile as generated Lean contract output with deterministic witness rows
- expand SessionRecovery generated cases for retry budget, deadline closure, latest-request, identity preservation, and legal/illegal retry transitions
- wire Rust conformance, runtime reconcile/router/status, and desktop retry tests to consume the generated Lean contracts

## Verification
- `lake build` in `crates/defra-agent/proofs`
- `cargo test -p defra-agent --test state_machine_conformance -- --nocapture`
- `cargo test -p defra-agent runtime_status -- --nocapture`
- `cargo test -p defra-agent generation_supervisor -- --nocapture`
- `cargo test -p defra-agent router_ -- --nocapture`
- `cargo test -p defra-agent-desktop-core --test submission_api retry_request_ -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- no touched Lean file over 500 lines
- no `sorry`/`admit`/`axiom`/`PLACEHOLDER`/`todo!()` in touched proof/Rust areas