### PR TITLE
Add conformance contract coverage ledger

### DIFF
--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -23,5 +23,6 @@ import Proofs.Conformance.DefraAgent
 import Proofs.Conformance.Boundaries
 import Proofs.Conformance.Deviations
 import Proofs.Conformance.SchedulerConformance
+import Proofs.Conformance.CoverageLedger
 import Proofs.Conformance.Contracts
 import Proofs.ApplyReconcile

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -128,6 +128,21 @@ session boundary, not a complete request-state coverage claim. Future
 session-recovery executable witnesses should widen that contract before Rust
 depends on broader transition coverage from it.
 
+## Coverage Ledger Policy
+
+`Proofs.Conformance.CoverageLedger` is the checked index for the
+`Proofs.Conformance.Contracts` JSON. Rust asserts that every emitted vocabulary,
+state machine, trigger-case group, runtime witness group, session-recovery
+witness group, and follow-up hook appears in that ledger exactly once.
+
+A ledger entry is acceptable only when it names a Rust/TypeScript consumer, an
+intentional product boundary recorded in this file, or an accepted follow-up.
+Future executable `ClientShell` or `ToolExecution` contracts should therefore
+add both the emitted contract domain and its runtime consumer in the same
+change. If the runtime consumer is deliberately deferred, the ledger entry must
+point here to describe the boundary or carry a follow-up hook; otherwise Rust
+will reject the generated contract as advisory-only.
+
 ## Closed Historical Items
 
 These were previous conformance gaps and are now closed product/spec behavior:

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -9,6 +9,7 @@ import Proofs.Conformance.Triggers.Contracts
 import Proofs.RuntimeReconcile
 import Proofs.Conformance.ContractCases
 import Proofs.ToolExecution
+import Proofs.Conformance.CoverageLedger
 
 /-!
 # Rust Conformance Contracts
@@ -426,7 +427,9 @@ def snapshotJson : String :=
       ++ jsonArray (sessionRecoveryCases.map sessionRecoveryCaseJson) ++ ","
     ++ "\"follow_up_hooks\":["
       ++ jsonString "ToolExecution idempotent MCP call retry contract"
-      ++ "]"
+      ++ "],"
+    ++ "\"coverage_ledger\":"
+      ++ coverageLedgerJson
     ++ "}"
 
 def contractJsonBegin : String :=

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -1,0 +1,177 @@
+import Proofs.Conformance.ContractTypes
+
+/-!
+# Conformance Coverage Ledger
+
+Every domain emitted by `Proofs.Conformance.Contracts` must have a Rust
+consumer or an explicitly accepted boundary/follow-up. Rust checks this ledger
+against the generated JSON so new Lean contracts cannot remain advisory-only.
+-/
+
+namespace Conformance.Contracts
+
+structure CoverageEntry where
+  category : String
+  domain : String
+  consumer : String
+  acceptedBoundary : String
+  acceptedFollowUp : String
+  deriving Repr
+
+def consumerCoverage
+    (category domain consumer : String)
+    (acceptedBoundary : String := "") : CoverageEntry :=
+  { category := category
+  , domain := domain
+  , consumer := consumer
+  , acceptedBoundary := acceptedBoundary
+  , acceptedFollowUp := ""
+  }
+
+def boundaryCoverage
+    (category domain acceptedBoundary : String)
+    (consumer : String := "") : CoverageEntry :=
+  { category := category
+  , domain := domain
+  , consumer := consumer
+  , acceptedBoundary := acceptedBoundary
+  , acceptedFollowUp := ""
+  }
+
+def followUpCoverage
+    (category domain acceptedFollowUp : String) : CoverageEntry :=
+  { category := category
+  , domain := domain
+  , consumer := ""
+  , acceptedBoundary := ""
+  , acceptedFollowUp := acceptedFollowUp
+  }
+
+def vocabularyCoverage : List CoverageEntry :=
+  [ consumerCoverage
+      "vocabulary"
+      "RequestState"
+      "lifecycle::tests::rust_request_lifecycle_state_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "vocabulary"
+      "ExecutionOrigin"
+      "lifecycle::tests::rust_execution_origin_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "vocabulary"
+      "ProcessState"
+      "runtime_status::tests::rust_process_state_vocabulary_matches_lean_model"
+  , boundaryCoverage
+      "vocabulary"
+      "PersistenceState"
+      "Proofs.Conformance.Boundaries: abstract persistence lifecycle, no per-token Rust document"
+  , boundaryCoverage
+      "vocabulary"
+      "PersistenceFailurePolicy"
+      "Proofs.Conformance.Boundaries: hook/storage failure-policy boundary"
+  , consumerCoverage
+      "vocabulary"
+      "ReconcilePhase"
+      "runtime_status::tests::rust_reconcile_phase_vocabulary_matches_lean_model"
+  , boundaryCoverage
+      "vocabulary"
+      "StorageObservation"
+      "Proofs.Conformance.Boundaries: daemon-visible storage observation boundary"
+  , consumerCoverage
+      "vocabulary"
+      "SessionRecoveryLatestRequestState"
+      "state_machine_conformance::generated_session_recovery_cases_cover_retry_guards_and_preservation"
+  , consumerCoverage
+      "vocabulary"
+      "InferenceCallState"
+      "admission::tests::rust_inference_call_state_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "vocabulary"
+      "InferenceCallTerminalReason"
+      "admission::tests::rust_inference_call_terminal_reason_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "vocabulary"
+      "ToolRetryDisposition"
+      "mcp_pool::tests::tool_retry_disposition_contract_matches_mcp_pool_policy"
+  ]
+
+def stateMachineCoverage : List CoverageEntry :=
+  [ consumerCoverage
+      "state_machine"
+      "Request"
+      "lifecycle::tests::request_state_machine_contract_is_complete"
+  , consumerCoverage
+      "state_machine"
+      "Process"
+      "runtime_status::tests::rust_process_state_transitions_match_lean_contract"
+  , boundaryCoverage
+      "state_machine"
+      "Persistence.failClosed"
+      "Proofs.Conformance.Boundaries: storage write failures are observed through Rust hooks"
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
+  , boundaryCoverage
+      "state_machine"
+      "Persistence.failOpen"
+      "Proofs.Conformance.Boundaries: fail-open acknowledges lost output at the hook boundary"
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
+  , boundaryCoverage
+      "state_machine"
+      "StorageObservation.failClosed"
+      "Proofs.Conformance.Boundaries: daemon observation model, not DefraDB internals"
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
+  , boundaryCoverage
+      "state_machine"
+      "StorageObservation.failOpen"
+      "Proofs.Conformance.Boundaries: daemon observation model, not DefraDB internals"
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
+  , consumerCoverage
+      "state_machine"
+      "RuntimeReconcile"
+      "runtime_status::tests::rust_reconcile_phase_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "state_machine"
+      "SessionRecovery"
+      "state_machine_conformance::generated_session_recovery_cases_cover_retry_guards_and_preservation"
+  , consumerCoverage
+      "state_machine"
+      "InferenceCall"
+      "admission::tests::rust_inference_call_transition_table_matches_lean_contract"
+  ]
+
+def caseCoverage : List CoverageEntry :=
+  [ consumerCoverage
+      "trigger_cases"
+      "TriggerDispatch"
+      "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases"
+  , consumerCoverage
+      "runtime_cases"
+      "RuntimeReconcileCases"
+      "runtime_status::tests::runtime_status_generation_updates_match_lean_runtime_reconcile_cases"
+  , consumerCoverage
+      "session_recovery_cases"
+      "SessionRecoveryCases"
+      "state_machine_conformance::generated_session_recovery_cases_cover_retry_guards_and_preservation"
+  ]
+
+def followUpHookCoverage : List CoverageEntry :=
+  [ followUpCoverage
+      "follow_up_hook"
+      "ToolExecution idempotent MCP call retry contract"
+      "Proofs.Conformance.Boundaries: add MCP idempotency metadata before widening retries"
+  ]
+
+def coverageLedger : List CoverageEntry :=
+  vocabularyCoverage ++ stateMachineCoverage ++ caseCoverage ++ followUpHookCoverage
+
+def CoverageEntry.toJson (entry : CoverageEntry) : String :=
+  "{"
+    ++ "\"category\":" ++ jsonString entry.category ++ ","
+    ++ "\"domain\":" ++ jsonString entry.domain ++ ","
+    ++ "\"consumer\":" ++ jsonString entry.consumer ++ ","
+    ++ "\"accepted_boundary\":" ++ jsonString entry.acceptedBoundary ++ ","
+    ++ "\"accepted_follow_up\":" ++ jsonString entry.acceptedFollowUp
+    ++ "}"
+
+def coverageLedgerJson : String :=
+  jsonArray (coverageLedger.map CoverageEntry.toJson)
+
+end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -18,13 +18,14 @@ structure CoverageEntry where
   acceptedFollowUp : String
   deriving Repr
 
+-- Consumer strings are documentation pointers; Rust checks domain coverage,
+-- not that these names resolve to test symbols.
 def consumerCoverage
-    (category domain consumer : String)
-    (acceptedBoundary : String := "") : CoverageEntry :=
+    (category domain consumer : String) : CoverageEntry :=
   { category := category
   , domain := domain
   , consumer := consumer
-  , acceptedBoundary := acceptedBoundary
+  , acceptedBoundary := ""
   , acceptedFollowUp := ""
   }
 

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -120,7 +120,8 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Conformance/Boundaries.lean` | Intentional product policies and external assumptions at the Rust/Lean boundary |
 | `Proofs/Conformance/Deviations.lean` | Active unresolved Rust/spec mismatches; currently empty |
 | `Proofs/Conformance/SchedulerConformance.lean` | Scheduler-specific conformance notes |
-| `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, and legal/illegal transition pairs |
+| `Proofs/Conformance/CoverageLedger.lean` | Checked ledger mapping every emitted conformance domain to a Rust consumer, accepted boundary, or accepted follow-up |
+| `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, legal/illegal transition pairs, witness rows, and the coverage ledger |
 | `Proofs/Conformance/Triggers.lean` | Barrel for trigger lifecycle/materialization conformance |
 
 Semantic submodules:
@@ -181,6 +182,15 @@ It also emits the `ToolRetryDisposition` vocabulary from
 `Proofs.ToolExecution` so Rust tests can reject accidental MCP `call_tool`
 retry drift before idempotency metadata exists.
 
+The same JSON includes `coverage_ledger`, maintained in
+`Proofs/Conformance/CoverageLedger.lean`. The Rust test
+`lean_contract_coverage_ledger_accounts_for_every_emitted_domain` compares that
+ledger against every emitted vocabulary domain, state-machine domain,
+trigger-case group, runtime witness group, session-recovery witness group, and
+follow-up hook. Each entry must name a Rust consumer or an accepted
+product-boundary/follow-up, so adding a Lean contract also requires making its
+runtime coverage explicit.
+
 When a Lean vocabulary, terminal partition, action, or legal transition changes,
 the generated JSON changes on the next Rust test run. The Rust tests then fail
 unless the runtime behavior or the documented product-boundary assertions are
@@ -189,7 +199,15 @@ updated to match.
 `ToolExecution` currently exports only retry disposition vocabulary and theorems.
 Before adding idempotent MCP retries, extend that Lean model first with the
 metadata source, retry budget, and replay/idempotency assumptions, then add a
-Rust contract that ties advertised MCP metadata to the widened retry rule.
+Rust contract that ties advertised MCP metadata to the widened retry rule and
+replace the `follow_up_hook` ledger entry with the executable contract domain.
+
+Future executable `ClientShell` or `ToolExecution` contracts should extend
+`Proofs.Conformance.Contracts` and add matching coverage-ledger entries in the
+same PR. If the runtime side is intentionally not executable yet, the entry must
+point to `Proofs.Conformance.Boundaries` or to an accepted follow-up rather than
+leaving the Lean contract advisory-only.
+
 ## Core Model
 
 ### Layer 1: Process Lifecycle
@@ -513,6 +531,7 @@ The main conformance files are:
 - `crates/defra-agent-cli/src/desired_state/tests.rs`
 - `Proofs/Conformance/DefraAgent.lean`
 - `Proofs/Conformance/Boundaries.lean`
+- `Proofs/Conformance/CoverageLedger.lean`
 - `Proofs/Conformance/SchedulerConformance.lean`
 - `Proofs/Conformance/Triggers.lean`
 - `Proofs/Conformance/Deviations.lean`

--- a/crates/defra-agent/proofs/client-state-machine.md
+++ b/crates/defra-agent/proofs/client-state-machine.md
@@ -233,7 +233,9 @@ there is no Rust or TypeScript consumer of `step` yet. Future shell changes that
 add workflow states, blocker reasons, behavior-mismatch handling, or transport
 coupling should extend `Proofs/ClientShell` first, then either emit a
 `Proofs.Conformance.Contracts` vocabulary/state-machine contract or add a
-proof-linked runtime test that names the theorem it protects.
+proof-linked runtime test that names the theorem it protects. Any emitted
+ClientShell contract must also add a `Proofs.Conformance.CoverageLedger` entry
+that names the Rust/TypeScript consumer or records the accepted boundary.
 
 ## Reference Pseudocode
 

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -32,6 +32,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) follow_up_hooks: Vec<String>,
+    pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -50,6 +51,15 @@ pub(crate) struct LeanStateMachineContract {
     pub(crate) actions: Vec<String>,
     pub(crate) legal_transitions: Vec<LeanTransitionPair>,
     pub(crate) illegal_transitions: Vec<LeanTransitionPair>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanCoverageEntry {
+    pub(crate) category: String,
+    pub(crate) domain: String,
+    pub(crate) consumer: String,
+    pub(crate) accepted_boundary: String,
+    pub(crate) accepted_follow_up: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use defra_agent::graphql::escape_graphql_string;
@@ -111,6 +112,94 @@ fn lean_executable_contracts_cover_initial_domains() {
     );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 8);
+}
+
+#[test]
+fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
+    let snapshot = lean_contract_snapshot();
+    let mut emitted = BTreeSet::new();
+
+    for vocabulary in &snapshot.vocabularies {
+        emitted.insert(("vocabulary".to_string(), vocabulary.domain.clone()));
+    }
+    for machine in &snapshot.state_machines {
+        emitted.insert(("state_machine".to_string(), machine.domain.clone()));
+    }
+    if snapshot.trigger_dispatch_case_count > 0 || !snapshot.trigger_dispatch_cases.is_empty() {
+        emitted.insert(("trigger_cases".to_string(), "TriggerDispatch".to_string()));
+    }
+    if !snapshot.runtime_reconcile_cases.is_empty() {
+        emitted.insert((
+            "runtime_cases".to_string(),
+            "RuntimeReconcileCases".to_string(),
+        ));
+    }
+    if !snapshot.session_recovery_cases.is_empty() {
+        emitted.insert((
+            "session_recovery_cases".to_string(),
+            "SessionRecoveryCases".to_string(),
+        ));
+    }
+    for hook in &snapshot.follow_up_hooks {
+        emitted.insert(("follow_up_hook".to_string(), hook.clone()));
+    }
+
+    let valid_categories = [
+        "vocabulary",
+        "state_machine",
+        "trigger_cases",
+        "runtime_cases",
+        "session_recovery_cases",
+        "follow_up_hook",
+    ];
+    let mut ledger = BTreeSet::new();
+
+    for entry in &snapshot.coverage_ledger {
+        assert!(
+            valid_categories.contains(&entry.category.as_str()),
+            "coverage ledger entry has unknown category: {:?}",
+            entry
+        );
+        assert!(
+            !entry.domain.trim().is_empty(),
+            "coverage ledger entry has an empty domain: {:?}",
+            entry
+        );
+
+        let has_consumer = !entry.consumer.trim().is_empty();
+        let has_boundary = !entry.accepted_boundary.trim().is_empty();
+        let has_follow_up = !entry.accepted_follow_up.trim().is_empty();
+        assert!(
+            has_consumer || has_boundary || has_follow_up,
+            "coverage ledger entry must name a consumer, boundary, or follow-up: {:?}",
+            entry
+        );
+        if entry.category == "follow_up_hook" {
+            assert!(
+                has_follow_up,
+                "follow-up hook ledger entries must carry accepted_follow_up text: {:?}",
+                entry
+            );
+        }
+
+        assert!(
+            ledger.insert((entry.category.clone(), entry.domain.clone())),
+            "duplicate coverage ledger entry for {:?} / {:?}",
+            entry.category,
+            entry.domain
+        );
+    }
+
+    let missing = emitted.difference(&ledger).cloned().collect::<Vec<_>>();
+    let extra = ledger.difference(&emitted).cloned().collect::<Vec<_>>();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "coverage ledger must exactly match emitted Lean contract domains\n  missing ledger entries: {:?}\n  extra ledger entries: {:?}\n  emitted: {:?}\n  ledger: {:?}",
+        missing,
+        extra,
+        emitted,
+        ledger
+    );
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -125,7 +125,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     for machine in &snapshot.state_machines {
         emitted.insert(("state_machine".to_string(), machine.domain.clone()));
     }
-    if snapshot.trigger_dispatch_case_count > 0 || !snapshot.trigger_dispatch_cases.is_empty() {
+    assert_eq!(
+        snapshot.trigger_dispatch_case_count,
+        snapshot.trigger_dispatch_cases.len(),
+        "Lean trigger dispatch case count drifted from emitted cases"
+    );
+    if !snapshot.trigger_dispatch_cases.is_empty() {
         emitted.insert(("trigger_cases".to_string(), "TriggerDispatch".to_string()));
     }
     if !snapshot.runtime_reconcile_cases.is_empty() {
@@ -144,6 +149,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
 
+    // Keep this mirrored with the category strings in CoverageLedger.lean.
     let valid_categories = [
         "vocabulary",
         "state_machine",


### PR DESCRIPTION
## Summary
- add a Lean coverage ledger for emitted conformance vocabularies, state machines, witness groups, trigger cases, and follow-up hooks
- emit the ledger in the Lean contract JSON and make Rust assert exact coverage for every emitted domain
- document the ledger policy and future ClientShell/ToolExecution extension path

## Verification
- lake build
- cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain -- --nocapture
- git diff --check
- cargo fmt --all --check
- project Lean file line-count check under crates/defra-agent/proofs/Proofs
- no forbidden placeholder additions in staged diff