### PR TITLE
Add generated ClientShell contract cases

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -619,7 +619,8 @@ fn request_state_for_turn(turn_state: Option<&str>) -> (&'static str, &'static s
         Some("failed") => ("failed", "failed"),
         Some("superseded") => ("superseded", "superseded"),
         Some("interrupted") => ("interrupted", "interrupted"),
-        _ => ("pending", "pending"),
+        Some(other) => panic!("unsupported Lean ClientShell turn state {other:?}"),
+        None => ("pending", "pending"),
     }
 }
 
@@ -628,6 +629,7 @@ fn response_status_for_turn(turn_state: Option<&str>) -> Option<&'static str> {
         Some("streaming") => Some("streaming"),
         Some("completed") => Some("complete"),
         Some("failed") => Some("error"),
-        _ => None,
+        Some("waitingForClaim") | Some("superseded") | Some("interrupted") | None => None,
+        Some(other) => panic!("unsupported Lean ClientShell turn state {other:?}"),
     }
 }

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+#[path = "../../../../../../../crates/defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
+use lean_vocab_test::{lean_client_shell_case, LeanClientShellCase};
+
 #[test]
 fn session_snapshot_can_be_built_without_conversation_row_when_session_is_observed() {
     let store = ClientStore::from_rows(ClientStoreRows {
@@ -246,6 +251,50 @@ fn session_snapshot_does_not_report_unobserved_preferred_request() {
 }
 
 #[test]
+fn session_snapshot_projection_consumes_generated_client_shell_contract_cases() {
+    for name in [
+        "awaiting_stale_request_observation",
+        "awaiting_matching_request_observation",
+        "terminal_follow_up_session_snapshot_without_summary",
+    ] {
+        let case = lean_client_shell_case(name);
+        let store = client_shell_contract_store(case);
+        let selected_session_id = contract_session_id(
+            case.desktop_selected_session_id
+                .expect("contract case should select a session"),
+        );
+        let preferred_request_id = case.desktop_preferred_request_id.map(contract_request_id);
+
+        let snapshot = build_session_snapshot_from_store(
+            &store,
+            &selected_session_id,
+            preferred_request_id.as_deref(),
+        )
+        .expect("session snapshot from generated ClientShell contract case");
+
+        assert_eq!(
+            snapshot.latest_request_id.as_deref(),
+            case.desktop_expected_latest_request_id
+                .map(contract_request_id)
+                .as_deref(),
+            "case {name} should project the Lean-observed latest request"
+        );
+        assert_eq!(
+            snapshot.turn_state.as_deref(),
+            case.desktop_expected_turn_state.as_deref(),
+            "case {name} should project the Lean-derived turn state"
+        );
+        if let Some(expect_pending) = case.desktop_expect_pending_turn {
+            assert_eq!(
+                snapshot.pending_turn.is_some(),
+                expect_pending,
+                "case {name} pending-turn projection drifted from Lean"
+            );
+        }
+    }
+}
+
+#[test]
 fn session_snapshot_stays_renderable_across_single_turn_observation_updates() {
     let submitted = ClientStore::from_rows(ClientStoreRows {
         conversations: vec![AgentConversationRow {
@@ -461,4 +510,124 @@ fn session_snapshot_stays_renderable_across_single_turn_observation_updates() {
     assert_eq!(completed_snapshot.turn_state.as_deref(), Some("completed"));
     assert!(completed_snapshot.active_response_overlay.is_none());
     assert!(completed_snapshot.pending_turn.is_none());
+}
+
+fn contract_session_id(id: usize) -> String {
+    format!("session-{id}")
+}
+
+fn contract_request_id(id: usize) -> String {
+    format!("req-{id}")
+}
+
+fn client_shell_contract_store(case: &LeanClientShellCase) -> ClientStore {
+    let session_id = contract_session_id(
+        case.desktop_selected_session_id
+            .expect("ClientShell desktop case should select a session"),
+    );
+    let observed_request_id = case.desktop_observed_request_id.map(contract_request_id);
+    let turn_state = case.desktop_observed_turn_state.as_deref();
+    let (request_status, lifecycle_state) = request_state_for_turn(turn_state);
+
+    let mut rows = ClientStoreRows {
+        sessions: vec![AgentSessionRow {
+            session_id: session_id.clone(),
+            agent_name: Some("Contract Agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            started: Some("2026-04-21T12:00:00Z".to_string()),
+            ended: None,
+            status: Some("active".to_string()),
+        }],
+        conversations: Vec::new(),
+        requests: Vec::new(),
+        responses: Vec::new(),
+        ..ClientStoreRows::default()
+    };
+
+    if case.frontend_conversation_present {
+        rows.conversations.push(AgentConversationRow {
+            session_id: session_id.clone(),
+            agent_name: Some("Contract Agent".to_string()),
+            agent_did: Some("did:defra:contract-agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            title: Some("contract conversation".to_string()),
+            title_source: Some("generated".to_string()),
+            preview_text: Some("contract prompt".to_string()),
+            status: Some("active".to_string()),
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            updated_at: Some("2026-04-21T12:01:00Z".to_string()),
+            latest_request_id: observed_request_id.clone(),
+        });
+    }
+
+    if let Some(request_id) = observed_request_id {
+        rows.requests.push(AgentRequestRow {
+            request_id: request_id.clone(),
+            agent_did: Some("did:defra:contract-agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            session_id: Some(session_id),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("contract prompt".to_string()),
+            status: Some(request_status.to_string()),
+            lifecycle_state: Some(lifecycle_state.to_string()),
+            backend_id: None,
+            execution_origin: Some("interactive".to_string()),
+            failure_reason: None,
+            created_at: Some("2026-04-21T12:01:00Z".to_string()),
+            claimed_at: None,
+            deadline: None,
+            retry_count: Some(0),
+            max_retries: Some(3),
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        });
+
+        if let Some(response_status) = response_status_for_turn(turn_state) {
+            rows.responses.push(AgentResponseRow {
+                response_key: format!("resp-{request_id}"),
+                request_id: Some(request_id),
+                agent_did: Some("did:defra:contract-agent".to_string()),
+                behavior_id: Some("contract-behavior".to_string()),
+                session_id: rows.requests.last().and_then(|row| row.session_id.clone()),
+                content: Some("contract response".to_string()),
+                reasoning: None,
+                status: Some(response_status.to_string()),
+                error_message: None,
+                token_count: Some(12),
+                progress_seq: Some(1),
+                materialized_message_sequence: None,
+                materialized_at: None,
+                created_at: Some("2026-04-21T12:01:01Z".to_string()),
+                completed_at: None,
+                interrupted_at: None,
+            });
+        }
+    }
+
+    ClientStore::from_rows(rows)
+}
+
+fn request_state_for_turn(turn_state: Option<&str>) -> (&'static str, &'static str) {
+    match turn_state {
+        Some("waitingForClaim") => ("pending", "pending"),
+        Some("streaming") => ("processing", "processing"),
+        Some("completed") => ("completed", "completed"),
+        Some("failed") => ("failed", "failed"),
+        Some("superseded") => ("superseded", "superseded"),
+        Some("interrupted") => ("interrupted", "interrupted"),
+        _ => ("pending", "pending"),
+    }
+}
+
+fn response_status_for_turn(turn_state: Option<&str>) -> Option<&'static str> {
+    match turn_state {
+        Some("streaming") => Some("streaming"),
+        Some("completed") => Some("complete"),
+        Some("failed") => Some("error"),
+        _ => None,
+    }
 }

--- a/apps/desktop-tauri/src/lib/chat-shell.test.ts
+++ b/apps/desktop-tauri/src/lib/chat-shell.test.ts
@@ -1,7 +1,56 @@
 import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join, parse } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { ConversationSummary, DesktopSessionSnapshot } from "./types";
-import { projectChatShell } from "./chat-shell";
+import {
+  projectChatShell,
+  type ChatBlockedReason,
+  type ChatWorkflowState,
+  type TurnState,
+} from "./chat-shell";
+
+const CONTRACT_JSON_BEGIN = "---BEGIN DEFRA LEAN CONTRACT JSON---";
+const CONTRACT_JSON_END = "---END DEFRA LEAN CONTRACT JSON---";
+
+type LeanClientShellCase = {
+  name: string;
+  frontend_client_available: boolean;
+  frontend_selected_agent_did: number | null;
+  frontend_selected_session_id: number | null;
+  frontend_composer_non_empty: boolean;
+  frontend_sending: boolean;
+  frontend_session_present: boolean;
+  frontend_session_id: number | null;
+  frontend_session_latest_request_id: number | null;
+  frontend_session_turn_state: TurnState | null;
+  frontend_session_pending_request_id: number | null;
+  frontend_conversation_present: boolean;
+  frontend_conversation_session_id: number | null;
+  frontend_conversation_latest_request_id: number | null;
+  frontend_conversation_turn_state: TurnState | null;
+  frontend_local_workflow_kind: string;
+  frontend_local_workflow_session: number | null;
+  frontend_local_workflow_request: number | null;
+  frontend_local_workflow_turn_state: TurnState | null;
+  frontend_expected_workflow_kind: string;
+  frontend_expected_workflow_session: number | null;
+  frontend_expected_workflow_request: number | null;
+  frontend_expected_workflow_turn_state: TurnState | null;
+  frontend_expected_workflow_reason: ChatBlockedReason | null;
+  frontend_expected_send_status: "ready" | "disabled";
+  frontend_expected_send_blocked_reason: ChatBlockedReason | null;
+  frontend_expected_active_request_id: number | null;
+  frontend_expected_turn_state: TurnState | null;
+};
+
+type LeanContractSnapshot = {
+  client_shell_cases: LeanClientShellCase[];
+};
+
+let leanContractSnapshot: LeanContractSnapshot | null = null;
 
 function conversation(overrides: Partial<ConversationSummary> = {}): ConversationSummary {
   return {
@@ -40,7 +89,204 @@ function session(overrides: Partial<DesktopSessionSnapshot> = {}): DesktopSessio
   };
 }
 
+function loadLeanClientShellCases() {
+  if (!leanContractSnapshot) {
+    const proofsDir = join(repoRoot(), "crates/defra-agent/proofs");
+    const command = "lake env lean --run Proofs/Conformance/Contracts.lean";
+    const result = spawnSync(
+      "lake",
+      ["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"],
+      {
+        cwd: proofsDir,
+        encoding: "utf8",
+      },
+    );
+
+    if (result.error) {
+      throw new Error(`failed to run ${command} in ${proofsDir}: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        `${command} failed in ${proofsDir}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+      );
+    }
+
+    const stdout = result.stdout.toString();
+    const begin = stdout.indexOf(CONTRACT_JSON_BEGIN);
+    const end = stdout.indexOf(CONTRACT_JSON_END);
+    if (begin < 0 || end < 0 || begin >= end) {
+      throw new Error(`${command} did not emit a valid ClientShell contract JSON sentinel block`);
+    }
+    leanContractSnapshot = JSON.parse(
+      stdout.slice(begin + CONTRACT_JSON_BEGIN.length, end).trim(),
+    ) as LeanContractSnapshot;
+  }
+
+  return leanContractSnapshot.client_shell_cases;
+}
+
+function repoRoot() {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  const root = parse(dir).root;
+  while (dir !== root) {
+    if (existsSync(join(dir, "crates/defra-agent/proofs/lakefile.lean"))) {
+      return dir;
+    }
+    dir = dirname(dir);
+  }
+  throw new Error("could not find repository root from chat-shell.test.ts");
+}
+
+function agentDid(id: number | null) {
+  return id === null ? null : `did:defra:agent-${id}`;
+}
+
+function sessionId(id: number | null) {
+  return id === null ? null : `session-${id}`;
+}
+
+function requestId(id: number | null) {
+  return id === null ? null : `req-${id}`;
+}
+
+function sessionFromContract(contractCase: LeanClientShellCase) {
+  if (!contractCase.frontend_session_present) {
+    return null;
+  }
+  return session({
+    sessionId: sessionId(contractCase.frontend_session_id) ?? "session-missing",
+    agentDid: agentDid(contractCase.frontend_selected_agent_did),
+    latestRequestId: requestId(contractCase.frontend_session_latest_request_id),
+    turnState: contractCase.frontend_session_turn_state,
+    pendingTurn: contractCase.frontend_session_pending_request_id
+      ? {
+          requestId: requestId(contractCase.frontend_session_pending_request_id)!,
+          content: "contract prompt",
+          lifecycleState: "processing",
+          createdAt: "2026-04-21T12:01:00Z",
+        }
+      : null,
+  });
+}
+
+function conversationFromContract(contractCase: LeanClientShellCase) {
+  if (!contractCase.frontend_conversation_present) {
+    return null;
+  }
+  return conversation({
+    sessionId: sessionId(contractCase.frontend_conversation_session_id) ?? "session-missing",
+    latestRequestId: requestId(contractCase.frontend_conversation_latest_request_id),
+    turnState: contractCase.frontend_conversation_turn_state,
+  });
+}
+
+function localWorkflowFromContract(contractCase: LeanClientShellCase): ChatWorkflowState {
+  switch (contractCase.frontend_local_workflow_kind) {
+    case "ready":
+      return { kind: "ready" };
+    case "submittingRequest":
+      return {
+        kind: "submittingRequest",
+        agentDid: agentDid(contractCase.frontend_selected_agent_did) ?? "did:defra:agent-missing",
+        sessionId: sessionId(contractCase.frontend_local_workflow_session),
+      };
+    case "awaitingObservation":
+      return {
+        kind: "awaitingObservation",
+        sessionId: sessionId(contractCase.frontend_local_workflow_session) ?? "session-missing",
+        requestId: requestId(contractCase.frontend_local_workflow_request) ?? "req-missing",
+      };
+    case "blocked":
+      return {
+        kind: "blocked",
+        reason: contractCase.frontend_expected_workflow_reason ?? "clientOffline",
+      };
+    default:
+      throw new Error(
+        `unsupported Lean frontend workflow ${contractCase.frontend_local_workflow_kind}`,
+      );
+  }
+}
+
+function expectedWorkflowFromContract(contractCase: LeanClientShellCase) {
+  switch (contractCase.frontend_expected_workflow_kind) {
+    case "ready":
+      return { kind: "ready" };
+    case "submittingRequest":
+      return {
+        kind: "submittingRequest",
+        sessionId: sessionId(contractCase.frontend_expected_workflow_session),
+      };
+    case "awaitingObservation":
+      return {
+        kind: "awaitingObservation",
+        sessionId: sessionId(contractCase.frontend_expected_workflow_session),
+        requestId: requestId(contractCase.frontend_expected_workflow_request),
+      };
+    case "turnInProgress":
+      return {
+        kind: "turnInProgress",
+        sessionId: sessionId(contractCase.frontend_expected_workflow_session),
+        requestId: requestId(contractCase.frontend_expected_workflow_request),
+        turnState: contractCase.frontend_expected_workflow_turn_state,
+      };
+    case "blocked":
+      return {
+        kind: "blocked",
+        reason: contractCase.frontend_expected_workflow_reason,
+      };
+    default:
+      throw new Error(
+        `unsupported Lean expected workflow ${contractCase.frontend_expected_workflow_kind}`,
+      );
+  }
+}
+
+function compactWorkflow(workflow: ChatWorkflowState) {
+  return Object.fromEntries(
+    Object.entries(workflow).filter(
+      ([key, value]) => key !== "agentDid" && value !== undefined && value !== null,
+    ),
+  );
+}
+
 describe("projectChatShell", () => {
+  test("matches generated Lean ClientShell projection contracts", () => {
+    for (const contractCase of loadLeanClientShellCases()) {
+      const projection = projectChatShell({
+        clientAvailable: contractCase.frontend_client_available,
+        selectedAgentDid: agentDid(contractCase.frontend_selected_agent_did),
+        selectedSessionId: sessionId(contractCase.frontend_selected_session_id),
+        draft: contractCase.frontend_composer_non_empty ? "follow up" : "",
+        sending: contractCase.frontend_sending,
+        selectedConversation: conversationFromContract(contractCase),
+        session: sessionFromContract(contractCase),
+        localWorkflow: localWorkflowFromContract(contractCase),
+      });
+
+      expect(compactWorkflow(projection.workflow)).toEqual(
+        expectedWorkflowFromContract(contractCase),
+      );
+      expect(projection.activeRequestId).toBe(
+        requestId(contractCase.frontend_expected_active_request_id),
+      );
+      expect(projection.turnState).toBe(
+        contractCase.frontend_expected_turn_state,
+      );
+
+      if (contractCase.frontend_expected_send_status === "ready") {
+        expect(projection.sendStatus).toEqual({ kind: "ready" });
+      } else {
+        expect(projection.sendStatus.kind).toBe("disabled");
+        if (projection.sendStatus.kind === "disabled") {
+          expect(projection.sendStatus.reason).toBe(
+            contractCase.frontend_expected_send_blocked_reason,
+          );
+        }
+      }
+    }
+  });
+
   test("blocks follow up while turn is streaming", () => {
     const projection = projectChatShell({
       clientAvailable: true,

--- a/apps/desktop-tauri/src/lib/chat-shell.test.ts
+++ b/apps/desktop-tauri/src/lib/chat-shell.test.ts
@@ -92,30 +92,17 @@ function session(overrides: Partial<DesktopSessionSnapshot> = {}): DesktopSessio
 function loadLeanClientShellCases() {
   if (!leanContractSnapshot) {
     const proofsDir = join(repoRoot(), "crates/defra-agent/proofs");
-    const command = "lake env lean --run Proofs/Conformance/Contracts.lean";
-    const result = spawnSync(
-      "lake",
-      ["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"],
-      {
-        cwd: proofsDir,
-        encoding: "utf8",
-      },
-    );
-
-    if (result.error) {
-      throw new Error(`failed to run ${command} in ${proofsDir}: ${result.error.message}`);
-    }
-    if (result.status !== 0) {
-      throw new Error(
-        `${command} failed in ${proofsDir}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
-      );
-    }
-
-    const stdout = result.stdout.toString();
-    const begin = stdout.indexOf(CONTRACT_JSON_BEGIN);
-    const end = stdout.indexOf(CONTRACT_JSON_END);
+    runLeanCommand(proofsDir, ["build", "Proofs.Conformance.Contracts"]);
+    const stdout = runLeanCommand(proofsDir, [
+      "env",
+      "lean",
+      "--run",
+      "Proofs/Conformance/Contracts.lean",
+    ]);
+    const begin = uniqueMarkerPosition(stdout, CONTRACT_JSON_BEGIN);
+    const end = uniqueMarkerPosition(stdout, CONTRACT_JSON_END);
     if (begin < 0 || end < 0 || begin >= end) {
-      throw new Error(`${command} did not emit a valid ClientShell contract JSON sentinel block`);
+      throw new Error("Lean ClientShell contract JSON sentinel order is invalid");
     }
     leanContractSnapshot = JSON.parse(
       stdout.slice(begin + CONTRACT_JSON_BEGIN.length, end).trim(),
@@ -123,6 +110,37 @@ function loadLeanClientShellCases() {
   }
 
   return leanContractSnapshot.client_shell_cases;
+}
+
+function runLeanCommand(proofsDir: string, args: string[]) {
+  const command = `lake ${args.join(" ")}`;
+  const result = spawnSync("lake", args, {
+    cwd: proofsDir,
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    throw new Error(`failed to run ${command} in ${proofsDir}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `${command} failed in ${proofsDir}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+
+  return result.stdout.toString();
+}
+
+function uniqueMarkerPosition(stdout: string, marker: string) {
+  const first = stdout.indexOf(marker);
+  const last = stdout.lastIndexOf(marker);
+  if (first < 0) {
+    throw new Error(`Lean contract generator stdout did not contain ${marker}`);
+  }
+  if (first !== last) {
+    throw new Error(`Lean contract generator stdout contained duplicate ${marker} sentinels`);
+  }
+  return first;
 }
 
 function repoRoot() {
@@ -243,6 +261,8 @@ function expectedWorkflowFromContract(contractCase: LeanClientShellCase) {
 }
 
 function compactWorkflow(workflow: ChatWorkflowState) {
+  // The Lean frontend contract models rendered workflow fields; TypeScript keeps
+  // agentDid on submittingRequest for the API callback path.
   return Object.fromEntries(
     Object.entries(workflow).filter(
       ([key, value]) => key !== "agentDid" && value !== undefined && value !== null,

--- a/crates/defra-agent/proofs/Proofs/ClientShell/Theorems.lean
+++ b/crates/defra-agent/proofs/Proofs/ClientShell/Theorems.lean
@@ -204,3 +204,12 @@ theorem select_session_clears_stale_awaiting
     (h_ne : oldSid ≠ newSid) :
     (step s (.user (.selectSession newSid)) store h ctx).workflow = .idle := by
   simp [step, workflowAfterSelectSession, h_wf, h_ne]
+
+/-- Re-selecting the same session preserves its awaiting workflow. The
+    stale-workflow cleanup only applies when the selected session changes. -/
+theorem select_session_preserves_same_session_awaiting
+    (s : ShellState) (store : LocalStore) (ctx : SubmitContext)
+    (sid : SessionId) (req : RequestId) (h : TransportHealth)
+    (h_wf : s.workflow = .awaiting sid req) :
+    (step s (.user (.selectSession sid)) store h ctx).workflow = .awaiting sid req := by
+  simp [step, workflowAfterSelectSession, h_wf]

--- a/crates/defra-agent/proofs/Proofs/ClientShell/Theorems.lean
+++ b/crates/defra-agent/proofs/Proofs/ClientShell/Theorems.lean
@@ -192,7 +192,15 @@ theorem select_session_clears_blocker
     (sid : SessionId) (r : BlockedReason) (h : TransportHealth)
     (h_wf : s.workflow = .blocked r) :
     (step s (.user (.selectSession sid)) store h ctx).workflow = .idle := by
-  show
-    (match s.workflow with | .blocked _ => (.idle : SubmissionWorkflow) | w => w)
-      = .idle
-  rw [h_wf]
+  simp [step, workflowAfterSelectSession, h_wf]
+
+/-- Selecting a different session clears an awaiting workflow tied to
+    the previous session. This is the Lean-side contract for the
+    frontend projection's stale-workflow-after-switch behavior. -/
+theorem select_session_clears_stale_awaiting
+    (s : ShellState) (store : LocalStore) (ctx : SubmitContext)
+    (oldSid newSid : SessionId) (req : RequestId) (h : TransportHealth)
+    (h_wf : s.workflow = .awaiting oldSid req)
+    (h_ne : oldSid ≠ newSid) :
+    (step s (.user (.selectSession newSid)) store h ctx).workflow = .idle := by
+  simp [step, workflowAfterSelectSession, h_wf, h_ne]

--- a/crates/defra-agent/proofs/Proofs/ClientShell/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/ClientShell/Transition.lean
@@ -8,6 +8,17 @@ One-step shell state transitions and snapshot workflow advancement.
 
 /-! ## Transition function -/
 
+/-- Session selection clears blockers and stale awaiting workflows. An
+    awaiting workflow for the same session remains meaningful; an
+    awaiting workflow for a different session belongs to the previous
+    view and must not gate the newly selected conversation. -/
+def workflowAfterSelectSession
+    (sid : SessionId) : SubmissionWorkflow → SubmissionWorkflow
+  | .blocked _        => .idle
+  | .awaiting sid' req =>
+      if sid' = sid then .awaiting sid' req else .idle
+  | w                 => w
+
 /-- The only way a snapshot may advance the workflow: an `awaiting sid
     req` retires to `.idle` when the store carries an observation for
     `sid` whose tip request is `req`. All other workflow states are
@@ -42,11 +53,9 @@ def step
           workflow  := .idle }
   | .user (.selectSession sid) =>
       -- latch unconditionally; any blocked state clears so the user
-      -- can navigate away from it
-      let cleared : SubmissionWorkflow :=
-        match s.workflow with
-        | .blocked _ => .idle
-        | w          => w
+      -- can navigate away from it; stale awaiting workflows from the
+      -- previous session also clear so they cannot gate the new view
+      let cleared := workflowAfterSelectSession sid s.workflow
       { s with
           selection := { s.selection with session := some sid },
           workflow  := cleared }

--- a/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts.lean
@@ -1,0 +1,667 @@
+import Proofs.ClientShell
+import Proofs.Conformance.ContractTypes
+
+/-!
+# ClientShell Executable Contract Cases
+
+Finite desktop/frontend witness rows generated from the Lean ClientShell
+`step`, `canSubmit`, and `projectChat` functions. The JSON fields are deliberately
+flat so Rust and TypeScript tests can consume them without re-implementing Lean.
+-/
+
+namespace Conformance.ClientShellContracts
+
+open Conformance.Contracts
+
+structure FrontendWorkflowContract where
+  kind      : String
+  sessionId : Option SessionId
+  requestId : Option RequestId
+  turnState : Option String
+  reason    : Option String
+  deriving Repr
+
+structure ClientShellContractCase where
+  name : String
+  property : String
+  input : String
+  preSelectionAgent : Option AgentDid
+  preSelectionSession : Option SessionId
+  postSelectionAgent : Option AgentDid
+  postSelectionSession : Option SessionId
+  preWorkflowKind : String
+  preWorkflowSession : Option SessionId
+  preWorkflowRequest : Option RequestId
+  postWorkflowKind : String
+  postWorkflowSession : Option SessionId
+  postWorkflowRequest : Option RequestId
+  selectionPreserved : Bool
+  workflowAdvanced : Bool
+  transportNoop : Bool
+  canSubmitBefore : Bool
+  canSubmitAfter : Bool
+  selectionHealth : String
+  projectionTurnState : Option String
+  projectionWorkflowKind : String
+  projectionWorkflowSession : Option SessionId
+  projectionWorkflowRequest : Option RequestId
+  sendDecision : String
+  sendBlockedReason : Option String
+  frontendClientAvailable : Bool
+  frontendSelectedAgentDid : Option AgentDid
+  frontendSelectedSessionId : Option SessionId
+  frontendComposerNonEmpty : Bool
+  frontendSending : Bool
+  frontendSessionPresent : Bool
+  frontendSessionId : Option SessionId
+  frontendSessionLatestRequestId : Option RequestId
+  frontendSessionTurnState : Option String
+  frontendSessionPendingRequestId : Option RequestId
+  frontendConversationPresent : Bool
+  frontendConversationSessionId : Option SessionId
+  frontendConversationLatestRequestId : Option RequestId
+  frontendConversationTurnState : Option String
+  frontendLocalWorkflowKind : String
+  frontendLocalWorkflowSession : Option SessionId
+  frontendLocalWorkflowRequest : Option RequestId
+  frontendLocalWorkflowTurnState : Option String
+  frontendExpectedWorkflowKind : String
+  frontendExpectedWorkflowSession : Option SessionId
+  frontendExpectedWorkflowRequest : Option RequestId
+  frontendExpectedWorkflowTurnState : Option String
+  frontendExpectedWorkflowReason : Option String
+  frontendExpectedSendStatus : String
+  frontendExpectedSendBlockedReason : Option String
+  frontendExpectedActiveRequestId : Option RequestId
+  frontendExpectedTurnState : Option String
+  desktopSelectedSessionId : Option SessionId
+  desktopPreferredRequestId : Option RequestId
+  desktopObservedRequestId : Option RequestId
+  desktopObservedTurnState : Option String
+  desktopExpectedLatestRequestId : Option RequestId
+  desktopExpectedTurnState : Option String
+  desktopExpectPendingTurn : Option Bool
+  deriving Repr
+
+def boolJson (value : Bool) : String :=
+  if value then "true" else "false"
+
+def jsonNatOption : Option Nat → String
+  | some value => toString value
+  | none       => "null"
+
+def jsonStringOption : Option String → String
+  | some value => jsonString value
+  | none       => "null"
+
+def jsonBoolOption : Option Bool → String
+  | some value => boolJson value
+  | none       => "null"
+
+def clientTurnStateName : ClientTurnState → String
+  | .waitingForClaim => "waitingForClaim"
+  | .streaming       => "streaming"
+  | .completed       => "completed"
+  | .failed          => "failed"
+  | .superseded      => "superseded"
+  | .interrupted     => "interrupted"
+
+def selectionHealthName : SelectionHealth → String
+  | .noSelection        => "noSelection"
+  | .resolved           => "resolved"
+  | .pendingObservation => "pendingObservation"
+  | .absent             => "absent"
+
+def workflowKind : SubmissionWorkflow → String
+  | .idle           => "idle"
+  | .creating _     => "creating"
+  | .submitting _ _ => "submitting"
+  | .awaiting _ _   => "awaiting"
+  | .blocked _      => "blocked"
+
+def workflowSession : SubmissionWorkflow → Option SessionId
+  | .submitting _ sid => sid
+  | .awaiting sid _   => some sid
+  | _                 => none
+
+def workflowRequest : SubmissionWorkflow → Option RequestId
+  | .awaiting _ req => some req
+  | _               => none
+
+def blockedReasonName : BlockedReason → String
+  | .clientOffline       => "clientOffline"
+  | .behaviorMismatch _ _ => "sessionBehaviorMismatch"
+  | .mutationRejected    => "mutationRejected"
+
+def sendBlockedReasonName : SendBlockedReason → String
+  | .clientOffline              => "clientOffline"
+  | .agentNotSelected           => "agentNotSelected"
+  | .composerEmpty              => "composerEmpty"
+  | .mutationInFlight           => "mutationInFlight"
+  | .awaitingObservation        => "awaitingObservation"
+  | .awaitingTurnTerminality _  => "awaitingTurnTerminality"
+  | .sessionBehaviorMismatch    => "sessionBehaviorMismatch"
+  | .sessionAbsent              => "sessionAbsent"
+  | .inconsistentObservation    => "inconsistentObservation"
+  | .workflowBlocked            => "workflowBlocked"
+
+def frontendBlockedReasonName : SendBlockedReason → String
+  | .clientOffline              => "clientOffline"
+  | .agentNotSelected           => "agentNotSelected"
+  | .composerEmpty              => "composerEmpty"
+  | .mutationInFlight           => "submittingRequest"
+  | .awaitingObservation        => "waitingForRequestObservation"
+  | .awaitingTurnTerminality _  => "awaitingTurnTerminality"
+  | .sessionBehaviorMismatch    => "sessionBehaviorMismatch"
+  | .sessionAbsent              => "conversationMissingFromSnapshot"
+  | .inconsistentObservation    => "inconsistentTurnObservation"
+  | .workflowBlocked            => "workflowBlocked"
+
+def sendDecisionKind : SendDecision → String
+  | .ready     => "ready"
+  | .blocked _ => "blocked"
+
+def sendDecisionReason : SendDecision → Option String
+  | .ready     => none
+  | .blocked r => some (sendBlockedReasonName r)
+
+def frontendSendStatus : SendDecision → String
+  | .ready     => "ready"
+  | .blocked _ => "disabled"
+
+def frontendSendReason : SendDecision → Option String
+  | .ready     => none
+  | .blocked r => some (frontendBlockedReasonName r)
+
+def inputName : ShellInput → String
+  | .user (.selectDeployment _ _)     => "selectDeployment"
+  | .user (.selectSession _)          => "selectSession"
+  | .user .requestNewConversation     => "requestNewConversation"
+  | .user .startSubmit                => "startSubmit"
+  | .user .acknowledgeBlocker         => "acknowledgeBlocker"
+  | .snapshot _                       => "snapshot"
+  | .mutation (.created _)            => "mutation.created"
+  | .mutation (.submitted _ _)        => "mutation.submitted"
+  | .mutation (.failed _)             => "mutation.failed"
+  | .transport .healthy               => "transport.healthy"
+  | .transport .degraded              => "transport.degraded"
+  | .transport .wedged                => "transport.wedged"
+
+def contractPeer : PeerId := 40
+def contractAgent : AgentDid := 20
+def alternateAgent : AgentDid := 21
+def contractBehavior : BehaviorId := 30
+def alternateBehavior : BehaviorId := 31
+def sid1 : SessionId := 1
+def sid2 : SessionId := 2
+def reqOld : RequestId := 100
+def reqNew : RequestId := 101
+def reqOther : RequestId := 202
+
+def turnWaiting : ClientTurnState :=
+  deriveAttempt
+    { request := { lifecycleState := .pending, isSuperseded := false }
+    , response := none
+    }
+
+def turnStreaming : ClientTurnState :=
+  deriveAttempt
+    { request := { lifecycleState := .processing, isSuperseded := false }
+    , response := some { status := .streaming }
+    }
+
+def turnCompleted : ClientTurnState :=
+  deriveAttempt
+    { request := { lifecycleState := .completed, isSuperseded := false }
+    , response := none
+    }
+
+def sessionObs
+    (sid : SessionId)
+    (req : Option RequestId)
+    (turn : Option ClientTurnState)
+    (agent : AgentDid := contractAgent)
+    (behavior : Option BehaviorId := some contractBehavior)
+    : SessionObservation :=
+  { sessionId := sid
+  , agentDid := agent
+  , behaviorId := behavior
+  , latestObservedRequest := req
+  , latestTurn := turn
+  }
+
+def storeWith (sessions : List SessionObservation) : LocalStore :=
+  { deployments := [(contractPeer, contractAgent), (contractPeer + 1, alternateAgent)]
+  , sessions := sessions
+  }
+
+def emptyStore : LocalStore :=
+  storeWith []
+
+def storeOldCompleted : LocalStore :=
+  storeWith [sessionObs sid1 (some reqOld) (some turnCompleted)]
+
+def storeNewCompleted : LocalStore :=
+  storeWith [sessionObs sid1 (some reqNew) (some turnCompleted)]
+
+def storeNewStreaming : LocalStore :=
+  storeWith [sessionObs sid1 (some reqNew) (some turnStreaming)]
+
+def storeSid2Completed : LocalStore :=
+  storeWith [sessionObs sid2 (some reqOther) (some turnCompleted) alternateAgent]
+
+def selectedShell
+    (session : Option SessionId)
+    (workflow : SubmissionWorkflow := .idle)
+    (agent : Option AgentDid := some contractAgent)
+    : ShellState :=
+  { selection := { peer := some contractPeer, agent := agent, session := session }
+  , workflow := workflow
+  }
+
+def ctxReady : SubmitContext :=
+  { clientAvailable := true
+  , composerNonEmpty := true
+  , requestedBehavior := some contractBehavior
+  }
+
+def ctxOffline : SubmitContext :=
+  { ctxReady with clientAvailable := false }
+
+def ctxEmptyComposer : SubmitContext :=
+  { ctxReady with composerNonEmpty := false }
+
+def optionOr {α : Type} (first second : Option α) : Option α :=
+  match first with
+  | some value => some value
+  | none       => second
+
+def selectedObservation (s : ShellState) (store : LocalStore) : Option SessionObservation :=
+  match s.selection.session with
+  | some sid => store.find sid
+  | none     => none
+
+def turnStateOptionName : Option ClientTurnState → Option String
+  | some turn => some (clientTurnStateName turn)
+  | none      => none
+
+def pendingRequestForFrontend (obs : Option SessionObservation) : Option RequestId :=
+  match obs with
+  | some observation =>
+      match observation.latestObservedRequest, observation.latestTurn with
+      | some req, some turn =>
+          if turn.isTerminal then none else some req
+      | _, _ => none
+  | none => none
+
+def trackedRequestForFrontend
+    (selection : Selection)
+    (obs : Option SessionObservation)
+    (workflow : SubmissionWorkflow) : Option RequestId :=
+  match workflow with
+  | .awaiting sid req =>
+      let selectedMatches := decide (selection.session = some sid)
+      let sessionMatches :=
+        match obs with
+        | some observation => decide (observation.sessionId = sid)
+        | none             => false
+      if selectedMatches || sessionMatches then some req else none
+  | _ => none
+
+def activeRequestForFrontend
+    (selection : Selection)
+    (obs : Option SessionObservation)
+    (workflow : SubmissionWorkflow) : Option RequestId :=
+  let tracked := trackedRequestForFrontend selection obs workflow
+  let pending := pendingRequestForFrontend obs
+  let observed := obs.bind (·.latestObservedRequest)
+  optionOr tracked (optionOr pending observed)
+
+def frontendWorkflowFromProjection
+    (state : ShellState)
+    (store : LocalStore)
+    (ctx : SubmitContext)
+    (activeRequest : Option RequestId) : FrontendWorkflowContract :=
+  let chat := projectChat state store ctx
+  match state.workflow with
+  | .creating _ =>
+      { kind := "submittingRequest"
+      , sessionId := none
+      , requestId := none
+      , turnState := none
+      , reason := none
+      }
+  | .submitting _ sid =>
+      { kind := "submittingRequest"
+      , sessionId := sid
+      , requestId := none
+      , turnState := none
+      , reason := none
+      }
+  | .awaiting sid req =>
+      { kind := "awaitingObservation"
+      , sessionId := some sid
+      , requestId := some req
+      , turnState := none
+      , reason := none
+      }
+  | .blocked reason =>
+      { kind := "blocked"
+      , sessionId := none
+      , requestId := none
+      , turnState := none
+      , reason := some (blockedReasonName reason)
+      }
+  | .idle =>
+      match chat.sendDecision with
+      | .ready =>
+          { kind := "ready"
+          , sessionId := none
+          , requestId := none
+          , turnState := none
+          , reason := none
+          }
+      | .blocked (.awaitingTurnTerminality turn) =>
+          { kind := "turnInProgress"
+          , sessionId := state.selection.session
+          , requestId := activeRequest
+          , turnState := some (clientTurnStateName turn)
+          , reason := none
+          }
+      | .blocked .composerEmpty =>
+          { kind := "ready"
+          , sessionId := none
+          , requestId := none
+          , turnState := none
+          , reason := none
+          }
+      | .blocked reason =>
+          { kind := "blocked"
+          , sessionId := none
+          , requestId := none
+          , turnState := none
+          , reason := some (frontendBlockedReasonName reason)
+          }
+
+def workflowTurnStateForFrontend
+    (store : LocalStore)
+    (workflow : SubmissionWorkflow) : Option String :=
+  match workflow with
+  | .awaiting sid _ => turnStateOptionName ((store.find sid).bind (·.latestTurn))
+  | _               => none
+
+def desktopPendingExpectation (obs : Option SessionObservation) : Option Bool :=
+  match obs with
+  | some observation =>
+      match observation.latestTurn with
+      | some turn => if turn.isTerminal then none else some true
+      | none      => none
+  | none => none
+
+def clientShellCaseFromStep
+    (name property : String)
+    (pre : ShellState)
+    (input : ShellInput)
+    (store : LocalStore)
+    (transport : TransportHealth)
+    (ctx : SubmitContext)
+    (frontendLocal frontendExpected : ShellState)
+    (frontendStore : LocalStore)
+    (conversationPresent : Bool := true) : ClientShellContractCase :=
+  let post := step pre input store transport ctx
+  let chat := projectChat frontendExpected frontendStore ctx
+  let obs := selectedObservation frontendLocal frontendStore
+  let activeRequest := activeRequestForFrontend frontendLocal.selection obs frontendLocal.workflow
+  let expectedWorkflow :=
+    frontendWorkflowFromProjection frontendExpected frontendStore ctx activeRequest
+  let selectedObs := selectedObservation frontendExpected frontendStore
+  let desktopPreferred :=
+    trackedRequestForFrontend frontendLocal.selection obs frontendLocal.workflow
+  { name := name
+  , property := property
+  , input := inputName input
+  , preSelectionAgent := pre.selection.agent
+  , preSelectionSession := pre.selection.session
+  , postSelectionAgent := post.selection.agent
+  , postSelectionSession := post.selection.session
+  , preWorkflowKind := workflowKind pre.workflow
+  , preWorkflowSession := workflowSession pre.workflow
+  , preWorkflowRequest := workflowRequest pre.workflow
+  , postWorkflowKind := workflowKind post.workflow
+  , postWorkflowSession := workflowSession post.workflow
+  , postWorkflowRequest := workflowRequest post.workflow
+  , selectionPreserved := decide (post.selection = pre.selection)
+  , workflowAdvanced := decide (post.workflow ≠ pre.workflow)
+  , transportNoop :=
+      match input with
+      | .transport _ => decide (post = pre)
+      | _            => false
+  , canSubmitBefore := canSubmit pre store ctx
+  , canSubmitAfter := canSubmit post frontendStore ctx
+  , selectionHealth := selectionHealthName chat.selectionHealth
+  , projectionTurnState := turnStateOptionName chat.turnState
+  , projectionWorkflowKind := workflowKind chat.workflow
+  , projectionWorkflowSession := workflowSession chat.workflow
+  , projectionWorkflowRequest := workflowRequest chat.workflow
+  , sendDecision := sendDecisionKind chat.sendDecision
+  , sendBlockedReason := sendDecisionReason chat.sendDecision
+  , frontendClientAvailable := ctx.clientAvailable
+  , frontendSelectedAgentDid := frontendLocal.selection.agent
+  , frontendSelectedSessionId := frontendLocal.selection.session
+  , frontendComposerNonEmpty := ctx.composerNonEmpty
+  , frontendSending :=
+      match frontendLocal.workflow with
+      | .submitting _ _ => true
+      | .creating _     => true
+      | _               => false
+  , frontendSessionPresent := obs.isSome
+  , frontendSessionId := obs.map (·.sessionId)
+  , frontendSessionLatestRequestId := obs.bind (·.latestObservedRequest)
+  , frontendSessionTurnState := turnStateOptionName (obs.bind (·.latestTurn))
+  , frontendSessionPendingRequestId := pendingRequestForFrontend obs
+  , frontendConversationPresent := conversationPresent && obs.isSome
+  , frontendConversationSessionId :=
+      if conversationPresent then obs.map (·.sessionId) else none
+  , frontendConversationLatestRequestId :=
+      if conversationPresent then obs.bind (·.latestObservedRequest) else none
+  , frontendConversationTurnState :=
+      if conversationPresent then turnStateOptionName (obs.bind (·.latestTurn)) else none
+  , frontendLocalWorkflowKind :=
+      match frontendLocal.workflow with
+      | .idle           => "ready"
+      | .creating _     => "submittingRequest"
+      | .submitting _ _ => "submittingRequest"
+      | .awaiting _ _   => "awaitingObservation"
+      | .blocked _      => "blocked"
+  , frontendLocalWorkflowSession := workflowSession frontendLocal.workflow
+  , frontendLocalWorkflowRequest := workflowRequest frontendLocal.workflow
+  , frontendLocalWorkflowTurnState :=
+      workflowTurnStateForFrontend frontendStore frontendLocal.workflow
+  , frontendExpectedWorkflowKind := expectedWorkflow.kind
+  , frontendExpectedWorkflowSession := expectedWorkflow.sessionId
+  , frontendExpectedWorkflowRequest := expectedWorkflow.requestId
+  , frontendExpectedWorkflowTurnState := expectedWorkflow.turnState
+  , frontendExpectedWorkflowReason := expectedWorkflow.reason
+  , frontendExpectedSendStatus := frontendSendStatus chat.sendDecision
+  , frontendExpectedSendBlockedReason := frontendSendReason chat.sendDecision
+  , frontendExpectedActiveRequestId := activeRequest
+  , frontendExpectedTurnState := turnStateOptionName (obs.bind (·.latestTurn))
+  , desktopSelectedSessionId := frontendLocal.selection.session
+  , desktopPreferredRequestId := desktopPreferred
+  , desktopObservedRequestId := selectedObs.bind (·.latestObservedRequest)
+  , desktopObservedTurnState := turnStateOptionName (selectedObs.bind (·.latestTurn))
+  , desktopExpectedLatestRequestId := selectedObs.bind (·.latestObservedRequest)
+  , desktopExpectedTurnState := turnStateOptionName (selectedObs.bind (·.latestTurn))
+  , desktopExpectPendingTurn := desktopPendingExpectation selectedObs
+  }
+
+def clientShellCases : List ClientShellContractCase :=
+  let awaitingNew := selectedShell (some sid1) (.awaiting sid1 reqNew)
+  let noAgent := selectedShell none .idle none
+  let staleBeforeSwitch :=
+    { selectedShell (some sid1) (.awaiting sid1 reqOld) with
+      selection := { peer := some contractPeer, agent := some alternateAgent, session := some sid1 }
+    }
+  let switchedStaleLocal :=
+    { staleBeforeSwitch with selection := { staleBeforeSwitch.selection with session := some sid2 } }
+  [ let input := ShellInput.snapshot storeNewCompleted
+    let post := step awaitingNew input emptyStore .healthy ctxReady
+    clientShellCaseFromStep
+      "snapshot_preserves_selection"
+      "selection_preservation"
+      awaitingNew input emptyStore .healthy ctxReady awaitingNew post storeNewCompleted
+  , let input := ShellInput.snapshot storeNewCompleted
+    let post := step awaitingNew input emptyStore .healthy ctxReady
+    clientShellCaseFromStep
+      "snapshot_workflow_advances_on_matching_request"
+      "snapshot_workflow_advance"
+      awaitingNew input emptyStore .healthy ctxReady awaitingNew post storeNewCompleted
+  , let input := ShellInput.snapshot storeOldCompleted
+    let post := step awaitingNew input emptyStore .healthy ctxReady
+    clientShellCaseFromStep
+      "awaiting_stale_request_observation"
+      "awaiting_matching_request_observation"
+      awaitingNew input emptyStore .healthy ctxReady awaitingNew post storeOldCompleted
+  , let input := ShellInput.snapshot storeNewStreaming
+    let post := step awaitingNew input emptyStore .healthy ctxReady
+    clientShellCaseFromStep
+      "awaiting_matching_request_observation"
+      "awaiting_matching_request_observation"
+      awaitingNew input emptyStore .healthy ctxReady awaitingNew post storeNewStreaming
+  , let input := ShellInput.user (.selectSession sid2)
+    let post := step staleBeforeSwitch input storeSid2Completed .wedged ctxReady
+    clientShellCaseFromStep
+      "stale_workflow_after_session_switch"
+      "stale_workflow_after_session_switch"
+      staleBeforeSwitch input storeSid2Completed .wedged ctxReady switchedStaleLocal post storeSid2Completed
+  , let pre := selectedShell (some sid1)
+    let input := ShellInput.transport .wedged
+    let post := step pre input storeNewCompleted .healthy ctxReady
+    clientShellCaseFromStep
+      "transport_noop"
+      "transport_noop"
+      pre input storeNewCompleted .healthy ctxReady pre post storeNewCompleted
+  , let pre := selectedShell none
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_client_offline"
+      "blocked_submit_gates"
+      pre input emptyStore .healthy ctxOffline pre pre emptyStore
+  , let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_agent_not_selected"
+      "blocked_submit_gates"
+      noAgent input emptyStore .healthy ctxReady noAgent noAgent emptyStore
+  , let pre := selectedShell none
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_composer_empty"
+      "blocked_submit_gates"
+      pre input emptyStore .healthy ctxEmptyComposer pre pre emptyStore
+  , let pre := selectedShell (some sid1) (.submitting contractAgent (some sid1))
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_mutation_in_flight"
+      "blocked_submit_gates"
+      pre input storeNewCompleted .healthy ctxReady pre pre storeNewCompleted
+  , let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_awaiting_observation"
+      "blocked_submit_gates"
+      awaitingNew input storeOldCompleted .healthy ctxReady awaitingNew awaitingNew storeOldCompleted
+  , let pre := selectedShell (some sid1)
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_session_absent"
+      "blocked_submit_gates"
+      pre input emptyStore .healthy ctxReady pre pre emptyStore
+  , let pre := selectedShell (some sid1)
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "blocked_submit_nonterminal_turn"
+      "blocked_submit_gates"
+      pre input storeNewStreaming .healthy ctxReady pre pre storeNewStreaming
+  , let pre := selectedShell (some sid1)
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "terminal_follow_up_allowed"
+      "terminal_follow_up_allowance"
+      pre input storeNewCompleted .healthy ctxReady pre pre storeNewCompleted
+  , let pre := selectedShell (some sid1)
+    let input := ShellInput.user .startSubmit
+    clientShellCaseFromStep
+      "terminal_follow_up_session_snapshot_without_summary"
+      "terminal_follow_up_allowance"
+      pre input storeNewCompleted .healthy ctxReady pre pre storeNewCompleted false
+  ]
+
+def ClientShellContractCase.toJson (witness : ClientShellContractCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"property\":" ++ jsonString witness.property ++ ","
+    ++ "\"input\":" ++ jsonString witness.input ++ ","
+    ++ "\"pre_selection_agent\":" ++ jsonNatOption witness.preSelectionAgent ++ ","
+    ++ "\"pre_selection_session\":" ++ jsonNatOption witness.preSelectionSession ++ ","
+    ++ "\"post_selection_agent\":" ++ jsonNatOption witness.postSelectionAgent ++ ","
+    ++ "\"post_selection_session\":" ++ jsonNatOption witness.postSelectionSession ++ ","
+    ++ "\"pre_workflow_kind\":" ++ jsonString witness.preWorkflowKind ++ ","
+    ++ "\"pre_workflow_session\":" ++ jsonNatOption witness.preWorkflowSession ++ ","
+    ++ "\"pre_workflow_request\":" ++ jsonNatOption witness.preWorkflowRequest ++ ","
+    ++ "\"post_workflow_kind\":" ++ jsonString witness.postWorkflowKind ++ ","
+    ++ "\"post_workflow_session\":" ++ jsonNatOption witness.postWorkflowSession ++ ","
+    ++ "\"post_workflow_request\":" ++ jsonNatOption witness.postWorkflowRequest ++ ","
+    ++ "\"selection_preserved\":" ++ boolJson witness.selectionPreserved ++ ","
+    ++ "\"workflow_advanced\":" ++ boolJson witness.workflowAdvanced ++ ","
+    ++ "\"transport_noop\":" ++ boolJson witness.transportNoop ++ ","
+    ++ "\"can_submit_before\":" ++ boolJson witness.canSubmitBefore ++ ","
+    ++ "\"can_submit_after\":" ++ boolJson witness.canSubmitAfter ++ ","
+    ++ "\"selection_health\":" ++ jsonString witness.selectionHealth ++ ","
+    ++ "\"projection_turn_state\":" ++ jsonStringOption witness.projectionTurnState ++ ","
+    ++ "\"projection_workflow_kind\":" ++ jsonString witness.projectionWorkflowKind ++ ","
+    ++ "\"projection_workflow_session\":" ++ jsonNatOption witness.projectionWorkflowSession ++ ","
+    ++ "\"projection_workflow_request\":" ++ jsonNatOption witness.projectionWorkflowRequest ++ ","
+    ++ "\"send_decision\":" ++ jsonString witness.sendDecision ++ ","
+    ++ "\"send_blocked_reason\":" ++ jsonStringOption witness.sendBlockedReason ++ ","
+    ++ "\"frontend_client_available\":" ++ boolJson witness.frontendClientAvailable ++ ","
+    ++ "\"frontend_selected_agent_did\":" ++ jsonNatOption witness.frontendSelectedAgentDid ++ ","
+    ++ "\"frontend_selected_session_id\":" ++ jsonNatOption witness.frontendSelectedSessionId ++ ","
+    ++ "\"frontend_composer_non_empty\":" ++ boolJson witness.frontendComposerNonEmpty ++ ","
+    ++ "\"frontend_sending\":" ++ boolJson witness.frontendSending ++ ","
+    ++ "\"frontend_session_present\":" ++ boolJson witness.frontendSessionPresent ++ ","
+    ++ "\"frontend_session_id\":" ++ jsonNatOption witness.frontendSessionId ++ ","
+    ++ "\"frontend_session_latest_request_id\":" ++ jsonNatOption witness.frontendSessionLatestRequestId ++ ","
+    ++ "\"frontend_session_turn_state\":" ++ jsonStringOption witness.frontendSessionTurnState ++ ","
+    ++ "\"frontend_session_pending_request_id\":" ++ jsonNatOption witness.frontendSessionPendingRequestId ++ ","
+    ++ "\"frontend_conversation_present\":" ++ boolJson witness.frontendConversationPresent ++ ","
+    ++ "\"frontend_conversation_session_id\":" ++ jsonNatOption witness.frontendConversationSessionId ++ ","
+    ++ "\"frontend_conversation_latest_request_id\":" ++ jsonNatOption witness.frontendConversationLatestRequestId ++ ","
+    ++ "\"frontend_conversation_turn_state\":" ++ jsonStringOption witness.frontendConversationTurnState ++ ","
+    ++ "\"frontend_local_workflow_kind\":" ++ jsonString witness.frontendLocalWorkflowKind ++ ","
+    ++ "\"frontend_local_workflow_session\":" ++ jsonNatOption witness.frontendLocalWorkflowSession ++ ","
+    ++ "\"frontend_local_workflow_request\":" ++ jsonNatOption witness.frontendLocalWorkflowRequest ++ ","
+    ++ "\"frontend_local_workflow_turn_state\":" ++ jsonStringOption witness.frontendLocalWorkflowTurnState ++ ","
+    ++ "\"frontend_expected_workflow_kind\":" ++ jsonString witness.frontendExpectedWorkflowKind ++ ","
+    ++ "\"frontend_expected_workflow_session\":" ++ jsonNatOption witness.frontendExpectedWorkflowSession ++ ","
+    ++ "\"frontend_expected_workflow_request\":" ++ jsonNatOption witness.frontendExpectedWorkflowRequest ++ ","
+    ++ "\"frontend_expected_workflow_turn_state\":" ++ jsonStringOption witness.frontendExpectedWorkflowTurnState ++ ","
+    ++ "\"frontend_expected_workflow_reason\":" ++ jsonStringOption witness.frontendExpectedWorkflowReason ++ ","
+    ++ "\"frontend_expected_send_status\":" ++ jsonString witness.frontendExpectedSendStatus ++ ","
+    ++ "\"frontend_expected_send_blocked_reason\":" ++ jsonStringOption witness.frontendExpectedSendBlockedReason ++ ","
+    ++ "\"frontend_expected_active_request_id\":" ++ jsonNatOption witness.frontendExpectedActiveRequestId ++ ","
+    ++ "\"frontend_expected_turn_state\":" ++ jsonStringOption witness.frontendExpectedTurnState ++ ","
+    ++ "\"desktop_selected_session_id\":" ++ jsonNatOption witness.desktopSelectedSessionId ++ ","
+    ++ "\"desktop_preferred_request_id\":" ++ jsonNatOption witness.desktopPreferredRequestId ++ ","
+    ++ "\"desktop_observed_request_id\":" ++ jsonNatOption witness.desktopObservedRequestId ++ ","
+    ++ "\"desktop_observed_turn_state\":" ++ jsonStringOption witness.desktopObservedTurnState ++ ","
+    ++ "\"desktop_expected_latest_request_id\":" ++ jsonNatOption witness.desktopExpectedLatestRequestId ++ ","
+    ++ "\"desktop_expected_turn_state\":" ++ jsonStringOption witness.desktopExpectedTurnState ++ ","
+    ++ "\"desktop_expect_pending_turn\":" ++ jsonBoolOption witness.desktopExpectPendingTurn
+    ++ "}"
+
+def clientShellCasesJson : String :=
+  jsonArray (clientShellCases.map ClientShellContractCase.toJson)
+
+def clientShellCaseCount : Nat :=
+  clientShellCases.length
+
+end Conformance.ClientShellContracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts.lean
@@ -145,6 +145,9 @@ def sendBlockedReasonName : SendBlockedReason → String
   | .inconsistentObservation    => "inconsistentObservation"
   | .workflowBlocked            => "workflowBlocked"
 
+/-- Frontend-facing names for the same `SendBlockedReason` constructors above.
+    This intentionally differs where the TypeScript shell exposes existing UI
+    vocabulary (`submittingRequest`, `waitingForRequestObservation`, etc.). -/
 def frontendBlockedReasonName : SendBlockedReason → String
   | .clientOffline              => "clientOffline"
   | .agentNotSelected           => "agentNotSelected"
@@ -504,6 +507,8 @@ def clientShellCases : List ClientShellContractCase :=
     }
   let switchedStaleLocal :=
     { staleBeforeSwitch with selection := { staleBeforeSwitch.selection with session := some sid2 } }
+  -- Case groups: snapshot selection/workflow, request observation, session
+  -- switching, transport no-op, submit gates, and terminal follow-up allowance.
   [ let input := ShellInput.snapshot storeNewCompleted
     let post := step awaitingNew input emptyStore .healthy ctxReady
     clientShellCaseFromStep

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -6,6 +6,7 @@ import Proofs.SessionRecovery
 import Proofs.InferenceCall
 import Proofs.Conformance.ContractTypes
 import Proofs.Conformance.Triggers.Contracts
+import Proofs.Conformance.ClientShell.Contracts
 import Proofs.RuntimeReconcile
 import Proofs.Conformance.ContractCases
 import Proofs.ToolExecution
@@ -427,6 +428,10 @@ def snapshotJson : String :=
       ++ toString Conformance.TriggerContracts.triggerDispatchCaseCount ++ ","
     ++ "\"trigger_dispatch_cases\":"
       ++ Conformance.TriggerContracts.triggerDispatchCasesJson ++ ","
+    ++ "\"client_shell_case_count\":"
+      ++ toString Conformance.ClientShellContracts.clientShellCaseCount ++ ","
+    ++ "\"client_shell_cases\":"
+      ++ Conformance.ClientShellContracts.clientShellCasesJson ++ ","
     ++ "\"runtime_reconcile_cases\":"
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
     ++ "\"session_recovery_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -151,6 +151,10 @@ def caseCoverage : List CoverageEntry :=
       "session_recovery_cases"
       "SessionRecoveryCases"
       "state_machine_conformance::generated_session_recovery_cases_cover_retry_guards_and_preservation"
+  , consumerCoverage
+      "client_shell_cases"
+      "ClientShellCases"
+      "state_machine_conformance::generated_client_shell_cases_cover_shell_projection_contracts"
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -121,7 +121,8 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Conformance/Deviations.lean` | Active unresolved Rust/spec mismatches; currently empty |
 | `Proofs/Conformance/SchedulerConformance.lean` | Scheduler-specific conformance notes |
 | `Proofs/Conformance/CoverageLedger.lean` | Checked ledger mapping every emitted conformance domain to a Rust consumer, accepted boundary, or accepted follow-up |
-| `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, legal/illegal transition pairs, witness rows, and the coverage ledger |
+| `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, legal/illegal transition pairs, witness rows, ClientShell cases, and the coverage ledger |
+| `Proofs/Conformance/ClientShell/Contracts.lean` | Generated finite ClientShell step/projection cases for frontend and desktop shell tests |
 | `Proofs/Conformance/Triggers.lean` | Barrel for trigger lifecycle/materialization conformance |
 
 Semantic submodules:
@@ -173,11 +174,13 @@ currently covers:
 - `SessionRecovery`
 - `InferenceCall`
 
-`RuntimeReconcile` and `SessionRecovery` also emit deterministic witness rows.
-Those rows keep the JSON small while pinning generation publication/router
-observation/request admission, and session retry guards for deadline closure,
-retry budget, latest-request status, duplicate new request ids, and identity
-preservation.
+`RuntimeReconcile`, `SessionRecovery`, and `ClientShell` also emit deterministic
+witness rows. Those rows keep the JSON small while pinning generation
+publication/router observation/request admission, session retry guards for
+deadline closure, retry budget, latest-request status, duplicate new request
+ids, and identity preservation, and shell projection behavior for selection
+preservation, matching request observation, stale workflow cleanup, transport
+no-op, submit gates, and terminal follow-up allowance.
 
 It also emits the `ToolRetryDisposition` vocabulary from
 `Proofs.ToolExecution` so Rust tests can reject accidental MCP `call_tool`
@@ -203,7 +206,7 @@ metadata source, retry budget, and replay/idempotency assumptions, then add a
 Rust contract that ties advertised MCP metadata to the widened retry rule and
 replace the `follow_up_hook` ledger entry with the executable contract domain.
 
-Future executable `ClientShell` or `ToolExecution` contracts should extend
+Future executable `ToolExecution` or other contracts should extend
 `Proofs.Conformance.Contracts` and add matching coverage-ledger entries in the
 same PR. If the runtime side is intentionally not executable yet, the entry must
 point to `Proofs.Conformance.Boundaries` or to an accepted follow-up rather than
@@ -513,8 +516,12 @@ desktop-style multi-session shell:
 - follow-up submission safety is independent from transport health
 - an awaiting submission only retires after the matching tip is observed
 
-This is the formal guard against render-time "repair" logic corrupting local UI
-state.
+`Proofs/Conformance/ClientShell/Contracts.lean` turns those properties into
+finite executable cases emitted through `Proofs.Conformance.Contracts`. The
+frontend `projectChatShell` test consumes the generated projection fields, and
+desktop Rust snapshot tests consume the generated observed/preferred request
+fields. This is the formal guard against render-time "repair" logic corrupting
+local UI state.
 
 ## Executable Model
 

--- a/crates/defra-agent/proofs/client-state-machine.md
+++ b/crates/defra-agent/proofs/client-state-machine.md
@@ -222,20 +222,22 @@ enforces these parts:
 
 | Lean property | Runtime enforcement today | Coverage |
 |---|---|---|
-| C2 snapshot preserves selection | React selection state is separate from snapshot refresh. `projectChatShell` is pure and receives selection as input rather than writing it. | TypeScript projection tests cover stale tracked workflow after user session switch. |
-| C3 transport input is non-mutating | P2P health lives in `DesktopRuntimeSnapshot.p2pHealth`; it is projected separately from selected session/chat state. Auto-restart refreshes the selected session by id instead of rewriting selection from transport health. | Desktop shell effects rely on refs for selected session during restart. |
-| C4/C4' session selection is local | `onSelectSession` latches the clicked session and clears the loaded session snapshot if it belongs to another session. Store presence affects projection only. | TypeScript projection tests cover switching away from stale in-flight workflow. |
-| C6 start-submit is gated | `onSendMessage` checks `shellProjection.sendStatus === ready` before calling `sendChatMessage`; Rust submission APIs still validate required agent/session fields. | Existing chat-shell tests cover empty/missing/in-flight terminality gates. |
-| C9 awaiting retires only on matching request | Rust `build_session_snapshot_from_store(..., preferred_request_id)` reports a preferred request only if that request is actually in the observed store; TypeScript keeps `awaitingObservation` while latest/pending request ids do not match. | Rust snapshot test and TypeScript projection test cover missing/stale observed request ids. |
+| C2 snapshot preserves selection | React selection state is separate from snapshot refresh. `projectChatShell` is pure and receives selection as input rather than writing it. | `Proofs.Conformance.ClientShell.Contracts` emits `snapshot_preserves_selection`; Rust conformance checks the generated pre/post selection fields. |
+| C3 transport input is non-mutating | P2P health lives in `DesktopRuntimeSnapshot.p2pHealth`; it is projected separately from selected session/chat state. Auto-restart refreshes the selected session by id instead of rewriting selection from transport health. | Generated `transport_noop` case checks that `step` returns the same shell state. |
+| C4/C4' session selection is local | `onSelectSession` latches the clicked session and clears the loaded session snapshot if it belongs to another session. Store presence affects projection only. | Generated `stale_workflow_after_session_switch` is consumed by TypeScript projection tests and Rust conformance. |
+| C6 start-submit is gated | `onSendMessage` checks `shellProjection.sendStatus === ready` before calling `sendChatMessage`; Rust submission APIs still validate required agent/session fields. | Generated `blocked_submit_*` cases cover offline client, missing agent, empty composer, mutation in flight, awaiting observation, missing session, and non-terminal turn gates. |
+| C9 awaiting retires only on matching request | Rust `build_session_snapshot_from_store(..., preferred_request_id)` reports a preferred request only if that request is actually in the observed store; TypeScript keeps `awaitingObservation` while latest/pending request ids do not match. | Generated stale/matching observation cases are consumed by both `projectChatShell` and desktop session snapshot tests. |
+| Terminal follow-up allowance | A terminal turn is trustworthy for a follow-up even when the conversation summary is missing but the session snapshot is present. | Generated terminal cases cover both summary-present and session-snapshot-only frontend paths. |
 
-The remaining Lean-only surface is a generated executable ClientShell contract:
-there is no Rust or TypeScript consumer of `step` yet. Future shell changes that
-add workflow states, blocker reasons, behavior-mismatch handling, or transport
-coupling should extend `Proofs/ClientShell` first, then either emit a
-`Proofs.Conformance.Contracts` vocabulary/state-machine contract or add a
-proof-linked runtime test that names the theorem it protects. Any emitted
-ClientShell contract must also add a `Proofs.Conformance.CoverageLedger` entry
-that names the Rust/TypeScript consumer or records the accepted boundary.
+`Proofs.Conformance.Contracts` now includes `client_shell_case_count` and
+`client_shell_cases`. Those cases are evaluated from `step`, `canSubmit`,
+`projectChat`, and the Lean turn derivation helpers, then consumed by
+frontend and desktop Rust tests. Future shell changes that add workflow states,
+blocker reasons, behavior-mismatch handling, or transport coupling should
+extend `Proofs.ClientShell` first and update this generated contract surface in
+the same change. The emitted ClientShell domain is also listed in
+`Proofs.Conformance.CoverageLedger`, so future contract additions must name a
+runtime consumer or an accepted boundary.
 
 ## Reference Pseudocode
 

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -29,6 +29,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
     pub(crate) trigger_dispatch_case_count: usize,
     pub(crate) trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
+    pub(crate) client_shell_case_count: usize,
+    pub(crate) client_shell_cases: Vec<LeanClientShellCase>,
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) follow_up_hooks: Vec<String>,
@@ -123,6 +125,38 @@ pub(crate) struct LeanRuntimeReconcileCase {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct LeanClientShellCase {
+    pub(crate) name: String,
+    pub(crate) property: String,
+    pub(crate) input: String,
+    pub(crate) pre_selection_session: Option<usize>,
+    pub(crate) post_selection_session: Option<usize>,
+    pub(crate) pre_workflow_kind: String,
+    pub(crate) pre_workflow_request: Option<usize>,
+    pub(crate) post_workflow_kind: String,
+    pub(crate) post_workflow_request: Option<usize>,
+    pub(crate) selection_preserved: bool,
+    pub(crate) workflow_advanced: bool,
+    pub(crate) transport_noop: bool,
+    pub(crate) can_submit_before: bool,
+    pub(crate) can_submit_after: bool,
+    pub(crate) send_decision: String,
+    pub(crate) send_blocked_reason: Option<String>,
+    pub(crate) frontend_expected_workflow_kind: String,
+    pub(crate) frontend_expected_send_status: String,
+    pub(crate) frontend_expected_send_blocked_reason: Option<String>,
+    pub(crate) frontend_expected_active_request_id: Option<usize>,
+    pub(crate) frontend_conversation_present: bool,
+    pub(crate) desktop_selected_session_id: Option<usize>,
+    pub(crate) desktop_preferred_request_id: Option<usize>,
+    pub(crate) desktop_observed_request_id: Option<usize>,
+    pub(crate) desktop_observed_turn_state: Option<String>,
+    pub(crate) desktop_expected_latest_request_id: Option<usize>,
+    pub(crate) desktop_expected_turn_state: Option<String>,
+    pub(crate) desktop_expect_pending_turn: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct LeanSessionRecoveryCase {
     pub(crate) name: String,
     pub(crate) action: String,
@@ -209,6 +243,14 @@ pub(crate) fn lean_session_recovery_case(name: &str) -> &'static LeanSessionReco
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean session-recovery case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_client_shell_case(name: &str) -> &'static LeanClientShellCase {
+    lean_contract_snapshot()
+        .client_shell_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean ClientShell case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {
@@ -445,6 +487,12 @@ fn proofs_dir() -> PathBuf {
     let direct = manifest_dir.join("proofs");
     if direct.exists() {
         return direct;
+    }
+    for ancestor in manifest_dir.ancestors() {
+        let candidate = ancestor.join("crates/defra-agent/proofs");
+        if candidate.exists() {
+            return candidate;
+        }
     }
     manifest_dir
         .parent()

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -11,8 +11,8 @@ mod support;
 
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
-    assert_state_machine_contract_is_complete, lean_contract_snapshot, lean_runtime_reconcile_case,
-    lean_session_recovery_case, lean_vocabulary_values,
+    assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -112,6 +112,11 @@ fn lean_executable_contracts_cover_initial_domains() {
     );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 10);
+    assert_eq!(
+        lean_contract_snapshot().client_shell_case_count,
+        lean_contract_snapshot().client_shell_cases.len()
+    );
+    assert_eq!(lean_contract_snapshot().client_shell_cases.len(), 15);
 }
 
 #[test]
@@ -145,6 +150,14 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "SessionRecoveryCases".to_string(),
         ));
     }
+    assert_eq!(
+        snapshot.client_shell_case_count,
+        snapshot.client_shell_cases.len(),
+        "Lean ClientShell case count drifted from emitted cases"
+    );
+    if !snapshot.client_shell_cases.is_empty() {
+        emitted.insert(("client_shell_cases".to_string(), "ClientShellCases".to_string()));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -156,6 +169,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "trigger_cases",
         "runtime_cases",
         "session_recovery_cases",
+        "client_shell_cases",
         "follow_up_hook",
     ];
     let mut ledger = BTreeSet::new();
@@ -206,6 +220,80 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         emitted,
         ledger
     );
+}
+
+#[test]
+fn generated_client_shell_cases_cover_shell_projection_contracts() {
+    let snapshot = lean_client_shell_case("snapshot_preserves_selection");
+    assert_eq!(snapshot.input.as_str(), "snapshot");
+    assert!(snapshot.selection_preserved);
+    assert_eq!(
+        snapshot.pre_selection_session,
+        snapshot.post_selection_session
+    );
+
+    let advanced = lean_client_shell_case("snapshot_workflow_advances_on_matching_request");
+    assert!(advanced.workflow_advanced);
+    assert_eq!(advanced.pre_workflow_kind.as_str(), "awaiting");
+    assert_eq!(advanced.post_workflow_kind.as_str(), "idle");
+    assert_eq!(advanced.pre_workflow_request, Some(101));
+    assert_eq!(advanced.post_workflow_request, None);
+
+    let stale = lean_client_shell_case("awaiting_stale_request_observation");
+    assert!(!stale.workflow_advanced);
+    assert_eq!(stale.post_workflow_kind.as_str(), "awaiting");
+    assert_eq!(
+        stale.frontend_expected_send_blocked_reason.as_deref(),
+        Some("waitingForRequestObservation")
+    );
+
+    let matching = lean_client_shell_case("awaiting_matching_request_observation");
+    assert_eq!(
+        matching.frontend_expected_workflow_kind.as_str(),
+        "turnInProgress"
+    );
+    assert_eq!(
+        matching.frontend_expected_send_blocked_reason.as_deref(),
+        Some("awaitingTurnTerminality")
+    );
+
+    let switched = lean_client_shell_case("stale_workflow_after_session_switch");
+    assert!(switched.workflow_advanced);
+    assert_eq!(switched.pre_selection_session, Some(1));
+    assert_eq!(switched.post_selection_session, Some(2));
+    assert_eq!(switched.post_workflow_kind.as_str(), "idle");
+    assert_eq!(switched.frontend_expected_send_status.as_str(), "ready");
+
+    let transport = lean_client_shell_case("transport_noop");
+    assert!(transport.transport_noop);
+    assert!(transport.selection_preserved);
+    assert!(!transport.workflow_advanced);
+
+    for (name, reason) in [
+        ("blocked_submit_client_offline", "clientOffline"),
+        ("blocked_submit_agent_not_selected", "agentNotSelected"),
+        ("blocked_submit_composer_empty", "composerEmpty"),
+        ("blocked_submit_mutation_in_flight", "mutationInFlight"),
+        ("blocked_submit_awaiting_observation", "awaitingObservation"),
+        ("blocked_submit_session_absent", "sessionAbsent"),
+        ("blocked_submit_nonterminal_turn", "awaitingTurnTerminality"),
+    ] {
+        let case = lean_client_shell_case(name);
+        assert!(!case.can_submit_before, "{name} should gate submit");
+        assert_eq!(case.send_decision.as_str(), "blocked");
+        assert_eq!(case.send_blocked_reason.as_deref(), Some(reason));
+        assert_eq!(case.frontend_expected_send_status.as_str(), "disabled");
+    }
+
+    let terminal = lean_client_shell_case("terminal_follow_up_allowed");
+    assert!(terminal.can_submit_before);
+    assert_eq!(terminal.send_decision.as_str(), "ready");
+    assert_eq!(terminal.frontend_expected_send_status.as_str(), "ready");
+
+    let no_summary = lean_client_shell_case("terminal_follow_up_session_snapshot_without_summary");
+    assert!(no_summary.can_submit_before);
+    assert_eq!(no_summary.frontend_expected_send_status.as_str(), "ready");
+    assert_eq!(no_summary.frontend_expected_active_request_id, Some(101));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add Lean-generated ClientShell contract cases for selection preservation, snapshot advance, matching/stale observations, stale session switch cleanup, transport no-op, submit gates, and terminal follow-up
- emit the cases through Proofs.Conformance.Contracts and deserialize them in Rust test helpers
- consume generated cases from TS projectChatShell tests and desktop Rust session snapshot tests

## Verification
- lake build
- bun test src/lib/chat-shell.test.ts
- cargo test -p defra-agent --test state_machine_conformance generated_client_shell_cases_cover_shell_projection_contracts
- cargo test -p defra-agent --test state_machine_conformance lean_executable_contracts_cover_initial_domains
- cargo test -p defra-agent-desktop-tauri session_snapshot_projection_consumes_generated_client_shell_contract_cases