### PR TITLE
Add ToolExecution conformance cases

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
@@ -39,6 +39,10 @@ def jsonArray (values : List String) : String :=
 def jsonStringArray (values : List String) : String :=
   jsonArray (values.map jsonString)
 
+def jsonOptionalString : Option String → String
+  | none => "null"
+  | some value => jsonString value
+
 def dedup {α : Type} [DecidableEq α] (values : List α) : List α :=
   values.foldl
     (fun seen value => if value ∈ seen then seen else seen ++ [value])

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -417,6 +417,25 @@ def sessionRecoveryCaseJson (witness : SessionRecoveryCase) : String :=
     ++ "\"backend_preserved\":" ++ boolString witness.backendPreserved
     ++ "}"
 
+def toolPreflightCaseJson (witness : ToolExecution.PreflightCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"health\":" ++ jsonString witness.health.toDefraDB ++ ","
+    ++ "\"schema_status\":" ++ jsonString witness.schema.toDefraDB ++ ","
+    ++ "\"decision\":" ++ jsonString witness.decision.toContract ++ ","
+    ++ "\"failure_class\":"
+      ++ jsonOptionalString ((witness.decision.failureClass).map ToolExecution.FailureClass.toDefraDB)
+    ++ "}"
+
+def toolRetryCaseJson (witness : ToolExecution.RetryCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"operation\":" ++ jsonString witness.operation.toDefraDB ++ ","
+    ++ "\"idempotency\":" ++ jsonString witness.idempotency.toDefraDB ++ ","
+    ++ "\"failure_class\":" ++ jsonString witness.failure.toDefraDB ++ ","
+    ++ "\"disposition\":" ++ jsonString witness.disposition.toDefraDB
+    ++ "}"
+
 def snapshotJson : String :=
   "{"
     ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
@@ -436,9 +455,11 @@ def snapshotJson : String :=
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
     ++ "\"session_recovery_cases\":"
       ++ jsonArray (sessionRecoveryCases.map sessionRecoveryCaseJson) ++ ","
-    ++ "\"follow_up_hooks\":["
-      ++ jsonString "ToolExecution idempotent MCP call retry contract"
-      ++ "],"
+    ++ "\"tool_preflight_cases\":"
+      ++ jsonArray (ToolExecution.preflightCases.map toolPreflightCaseJson) ++ ","
+    ++ "\"tool_retry_cases\":"
+      ++ jsonArray (ToolExecution.retryCases.map toolRetryCaseJson) ++ ","
+    ++ "\"follow_up_hooks\":[],"
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson
     ++ "}"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -92,7 +92,7 @@ def vocabularyCoverage : List CoverageEntry :=
   , consumerCoverage
       "vocabulary"
       "ToolRetryDisposition"
-      "mcp_pool::tests::tool_retry_disposition_contract_matches_mcp_pool_policy"
+      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy"
   ]
 
 def stateMachineCoverage : List CoverageEntry :=
@@ -155,14 +155,18 @@ def caseCoverage : List CoverageEntry :=
       "client_shell_cases"
       "ClientShellCases"
       "state_machine_conformance::generated_client_shell_cases_cover_shell_projection_contracts"
+  , consumerCoverage
+      "tool_cases"
+      "ToolExecutionPreflight"
+      "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts"
+  , consumerCoverage
+      "tool_cases"
+      "ToolExecutionRetry"
+      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy"
   ]
 
 def followUpHookCoverage : List CoverageEntry :=
-  [ followUpCoverage
-      "follow_up_hook"
-      "ToolExecution idempotent MCP call retry contract"
-      "Proofs.Conformance.Boundaries: add MCP idempotency metadata before widening retries"
-  ]
+  []
 
 def coverageLedger : List CoverageEntry :=
   vocabularyCoverage ++ stateMachineCoverage ++ caseCoverage ++ followUpHookCoverage

--- a/crates/defra-agent/proofs/Proofs/ToolExecution.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution.lean
@@ -18,12 +18,36 @@ inductive Health where
   | unreachable
   deriving DecidableEq, Repr
 
+namespace Health
+
+def toDefraDB : Health → String
+  | .healthy => "healthy"
+  | .stale => "stale"
+  | .unreachable => "unreachable"
+
+def all : List Health :=
+  [ .healthy, .stale, .unreachable ]
+
+end Health
+
 /-- Result of argument/schema checks available before dispatch. -/
 inductive SchemaStatus where
   | unchecked
   | valid
   | invalid
   deriving DecidableEq, Repr
+
+namespace SchemaStatus
+
+def toDefraDB : SchemaStatus → String
+  | .unchecked => "unchecked"
+  | .valid => "valid"
+  | .invalid => "invalid"
+
+def all : List SchemaStatus :=
+  [ .unchecked, .valid, .invalid ]
+
+end SchemaStatus
 
 /-- Evidence needed before a tool call can be retried after dispatch. -/
 inductive IdempotencyEvidence where
@@ -32,12 +56,36 @@ inductive IdempotencyEvidence where
   | nonIdempotent
   deriving DecidableEq, Repr
 
+namespace IdempotencyEvidence
+
+def toDefraDB : IdempotencyEvidence → String
+  | .unknown => "unknown"
+  | .idempotent => "idempotent"
+  | .nonIdempotent => "nonIdempotent"
+
+def all : List IdempotencyEvidence :=
+  [ .unknown, .idempotent, .nonIdempotent ]
+
+end IdempotencyEvidence
+
 /-- Tool operations that have different retry semantics. -/
 inductive ToolOperation where
   | mcpListTools
   | mcpCall
   | nativeCommand
   deriving DecidableEq, Repr
+
+namespace ToolOperation
+
+def toDefraDB : ToolOperation → String
+  | .mcpListTools => "mcpListTools"
+  | .mcpCall => "mcpCall"
+  | .nativeCommand => "nativeCommand"
+
+def all : List ToolOperation :=
+  [ .mcpListTools, .mcpCall, .nativeCommand ]
+
+end ToolOperation
 
 /-- Failure classes at the tool boundary. -/
 inductive FailureClass where
@@ -48,11 +96,42 @@ inductive FailureClass where
   | external
   deriving DecidableEq, Repr
 
+namespace FailureClass
+
+def toDefraDB : FailureClass → String
+  | .argumentInvalid => "argumentInvalid"
+  | .serviceUnavailable => "serviceUnavailable"
+  | .transport => "transport"
+  | .toolReturnedError => "toolReturnedError"
+  | .external => "external"
+
+def all : List FailureClass :=
+  [ .argumentInvalid
+  , .serviceUnavailable
+  , .transport
+  , .toolReturnedError
+  , .external
+  ]
+
+end FailureClass
+
 /-- Pre-dispatch decision. -/
 inductive PreflightDecision where
   | dispatch
   | block (failure : FailureClass)
   deriving DecidableEq, Repr
+
+namespace PreflightDecision
+
+def toContract : PreflightDecision → String
+  | .dispatch => "dispatch"
+  | .block _ => "block"
+
+def failureClass : PreflightDecision → Option FailureClass
+  | .dispatch => none
+  | .block failure => some failure
+
+end PreflightDecision
 
 /-- Retry class emitted by the model for Rust conformance docs/tests. -/
 inductive RetryDisposition where
@@ -92,6 +171,23 @@ def preflight
       | .invalid => .block .argumentInvalid
       | .unchecked | .valid => .dispatch
 
+/-- Generated witness row for Rust health/schema preflight conformance. -/
+structure PreflightCase where
+  name : String
+  health : Health
+  schema : SchemaStatus
+  decision : PreflightDecision
+  deriving Repr
+
+/-- Generated witness row for Rust retry-disposition conformance. -/
+structure RetryCase where
+  name : String
+  operation : ToolOperation
+  idempotency : IdempotencyEvidence
+  failure : FailureClass
+  disposition : RetryDisposition
+  deriving Repr
+
 /-- Retry eligibility after a failed operation. Listing tools is a safe read.
 Calling tools requires explicit idempotency evidence before a transport retry.
 Native command retries are outside this model. -/
@@ -103,6 +199,51 @@ def retryDisposition
   | .mcpListTools, _, .transport => .retrySafeRead
   | .mcpCall, .idempotent, .transport => .retryIdempotentToolCall
   | _, _, _ => .doNotRetry
+
+def preflightCaseName
+    (health : Health)
+    (schema : SchemaStatus)
+    (decision : PreflightDecision) : String :=
+  let suffix :=
+    match decision with
+    | .dispatch => "dispatch"
+    | .block failure => "blocks_" ++ failure.toDefraDB
+  "preflight_" ++ health.toDefraDB ++ "_" ++ schema.toDefraDB ++ "_" ++ suffix
+
+def retryCaseName
+    (operation : ToolOperation)
+    (idempotency : IdempotencyEvidence)
+    (failure : FailureClass)
+    (disposition : RetryDisposition) : String :=
+  "retry_"
+    ++ operation.toDefraDB ++ "_"
+    ++ idempotency.toDefraDB ++ "_"
+    ++ failure.toDefraDB ++ "_"
+    ++ disposition.toDefraDB
+
+/-- Exhaustive health/schema matrix evaluated from `preflight`. -/
+def preflightCases : List PreflightCase :=
+  Health.all.flatMap fun health =>
+    SchemaStatus.all.map fun schema =>
+      let decision := preflight health schema
+      { name := preflightCaseName health schema decision
+      , health := health
+      , schema := schema
+      , decision := decision
+      }
+
+/-- Exhaustive retry-disposition matrix evaluated from `retryDisposition`. -/
+def retryCases : List RetryCase :=
+  ToolOperation.all.flatMap fun operation =>
+    IdempotencyEvidence.all.flatMap fun idempotency =>
+      FailureClass.all.map fun failure =>
+        let disposition := retryDisposition operation idempotency failure
+        { name := retryCaseName operation idempotency failure disposition
+        , operation := operation
+        , idempotency := idempotency
+        , failure := failure
+        , disposition := disposition
+        }
 
 theorem unreachable_blocks_dispatch
     (schema : SchemaStatus) :

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -182,16 +182,17 @@ ids, and identity preservation, and shell projection behavior for selection
 preservation, matching request observation, stale workflow cleanup, transport
 no-op, submit gates, and terminal follow-up allowance.
 
-It also emits the `ToolRetryDisposition` vocabulary from
-`Proofs.ToolExecution` so Rust tests can reject accidental MCP `call_tool`
-retry drift before idempotency metadata exists.
+It also emits `ToolExecution` preflight and retry witness rows, plus the
+`ToolRetryDisposition` vocabulary, so Rust tests can reject accidental MCP
+preflight or `call_tool` retry drift before idempotency metadata changes.
 
 The same JSON includes `coverage_ledger`, maintained in
 `Proofs/Conformance/CoverageLedger.lean`. The Rust test
 `lean_contract_coverage_ledger_accounts_for_every_emitted_domain` compares that
 ledger against every emitted vocabulary domain, state-machine domain,
-trigger-case group, runtime witness group, session-recovery witness group, and
-follow-up hook. Each entry must name a Rust consumer or an accepted
+trigger-case group, runtime witness group, session-recovery witness group,
+ClientShell case group, ToolExecution case group, and follow-up hook. Each entry
+must name a Rust consumer or an accepted
 product-boundary/follow-up, so adding a Lean contract also requires making its
 runtime coverage explicit.
 
@@ -200,11 +201,10 @@ the generated JSON changes on the next Rust test run. The Rust tests then fail
 unless the runtime behavior or the documented product-boundary assertions are
 updated to match.
 
-`ToolExecution` currently exports only retry disposition vocabulary and theorems.
-Before adding idempotent MCP retries, extend that Lean model first with the
-metadata source, retry budget, and replay/idempotency assumptions, then add a
-Rust contract that ties advertised MCP metadata to the widened retry rule and
-replace the `follow_up_hook` ledger entry with the executable contract domain.
+`ToolExecution` exports executable preflight/retry contract cases. Before adding
+idempotent MCP retries, extend that Lean model first with the metadata source,
+retry budget, and replay/idempotency assumptions, then update the Rust contract
+that ties advertised MCP metadata to the widened retry rule.
 
 Future executable `ToolExecution` or other contracts should extend
 `Proofs.Conformance.Contracts` and add matching coverage-ledger entries in the

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -72,6 +72,11 @@ impl ServiceHealthMap {
         self.inner.write().await.insert(service_id, health);
     }
 
+    #[cfg(test)]
+    pub(crate) async fn set_for_test(&self, service_id: impl Into<String>, health: ServiceHealth) {
+        self.set(service_id.into(), health).await;
+    }
+
     async fn retain_services(&self, service_ids: &HashSet<String>) {
         self.inner
             .write()

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -33,6 +33,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) client_shell_cases: Vec<LeanClientShellCase>,
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
+    pub(crate) tool_preflight_cases: Vec<LeanToolPreflightCase>,
+    pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
@@ -193,6 +195,24 @@ pub(crate) struct LeanSessionRecoveryCase {
     pub(crate) backend_preserved: bool,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanToolPreflightCase {
+    pub(crate) name: String,
+    pub(crate) health: String,
+    pub(crate) schema_status: String,
+    pub(crate) decision: String,
+    pub(crate) failure_class: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanToolRetryCase {
+    pub(crate) name: String,
+    pub(crate) operation: String,
+    pub(crate) idempotency: String,
+    pub(crate) failure_class: String,
+    pub(crate) disposition: String,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -251,6 +271,30 @@ pub(crate) fn lean_client_shell_case(name: &str) -> &'static LeanClientShellCase
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean ClientShell case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_tool_preflight_cases() -> &'static [LeanToolPreflightCase] {
+    &lean_contract_snapshot().tool_preflight_cases
+}
+
+pub(crate) fn lean_tool_preflight_case(name: &str) -> &'static LeanToolPreflightCase {
+    lean_contract_snapshot()
+        .tool_preflight_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean tool preflight case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_tool_retry_cases() -> &'static [LeanToolRetryCase] {
+    &lean_contract_snapshot().tool_retry_cases
+}
+
+pub(crate) fn lean_tool_retry_case(name: &str) -> &'static LeanToolRetryCase {
+    lean_contract_snapshot()
+        .tool_retry_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean tool retry case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -127,6 +127,10 @@ impl ToolRetryDisposition {
     }
 }
 
+/// Test-only mirror of `Proofs.ToolExecution.retryDisposition`.
+///
+/// Production retry behavior is still encoded by the `list_tools` safe-read
+/// retry path and the absence of a `call_tool` retry loop.
 #[cfg(test)]
 pub(crate) fn tool_retry_disposition(
     operation: ToolExecutionOperation,

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -22,8 +22,10 @@ use tokio::sync::RwLock;
 /// generic parameter (which includes rmcp's internal reqwest 0.13 Client).
 type ListToolsFuture = Pin<Box<dyn Future<Output = Result<ListToolsResult>> + Send + 'static>>;
 type CallToolFuture = Pin<Box<dyn Future<Output = Result<CallToolResult>> + Send + 'static>>;
+type ConnectFuture = Pin<Box<dyn Future<Output = Result<McpConnection>> + Send + 'static>>;
 type ListToolsFn = dyn Fn() -> ListToolsFuture + Send + Sync;
 type CallToolFn = dyn Fn(CallToolRequestParams) -> CallToolFuture + Send + Sync;
+type ConnectFn = dyn Fn(String, String) -> ConnectFuture + Send + Sync;
 
 struct McpConnection {
     endpoint: String,
@@ -65,6 +67,85 @@ where
     }
 }
 
+async fn connect_mcp_service(service_id: &str, endpoint: &str) -> Result<McpConnection> {
+    let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(endpoint);
+    let client = ()
+        .serve(transport)
+        .await
+        .map_err(|e| anyhow::anyhow!("MCP handshake failed for {service_id} ({endpoint}): {e}"))?;
+    Ok(wrap_connection(endpoint.to_string(), client))
+}
+
+fn default_connect_fn() -> Arc<ConnectFn> {
+    Arc::new(|service_id: String, endpoint: String| {
+        Box::pin(async move { connect_mcp_service(&service_id, &endpoint).await })
+    })
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolExecutionOperation {
+    McpListTools,
+    McpCall,
+    NativeCommand,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolIdempotencyEvidence {
+    Unknown,
+    Idempotent,
+    NonIdempotent,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolFailureClass {
+    ArgumentInvalid,
+    ServiceUnavailable,
+    Transport,
+    ToolReturnedError,
+    External,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ToolRetryDisposition {
+    DoNotRetry,
+    RetrySafeRead,
+    RetryIdempotentToolCall,
+}
+
+#[cfg(test)]
+impl ToolRetryDisposition {
+    pub(crate) fn as_contract(self) -> &'static str {
+        match self {
+            Self::DoNotRetry => "doNotRetry",
+            Self::RetrySafeRead => "retrySafeRead",
+            Self::RetryIdempotentToolCall => "retryIdempotentToolCall",
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn tool_retry_disposition(
+    operation: ToolExecutionOperation,
+    idempotency: ToolIdempotencyEvidence,
+    failure: ToolFailureClass,
+) -> ToolRetryDisposition {
+    match (operation, idempotency, failure) {
+        (ToolExecutionOperation::McpListTools, _, ToolFailureClass::Transport) => {
+            ToolRetryDisposition::RetrySafeRead
+        }
+        (
+            ToolExecutionOperation::McpCall,
+            ToolIdempotencyEvidence::Idempotent,
+            ToolFailureClass::Transport,
+        ) => ToolRetryDisposition::RetryIdempotentToolCall,
+        _ => ToolRetryDisposition::DoNotRetry,
+    }
+}
+
 /// Connection pool for MCP data-service clients.
 ///
 /// Connections are created lazily on the first `list_tools` or `call_tool`
@@ -74,12 +155,28 @@ where
 #[derive(Clone)]
 pub struct McpPool {
     inner: Arc<RwLock<HashMap<String, McpConnection>>>,
+    connect_fn: Arc<ConnectFn>,
 }
 
 impl McpPool {
     pub fn new() -> Self {
         Self {
             inner: Arc::new(RwLock::new(HashMap::new())),
+            connect_fn: default_connect_fn(),
+        }
+    }
+
+    #[cfg(test)]
+    fn new_with_connector<F, Fut>(connector: F) -> Self
+    where
+        F: Fn(String, String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<McpConnection>> + Send + 'static,
+    {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            connect_fn: Arc::new(move |service_id, endpoint| {
+                Box::pin(connector(service_id, endpoint))
+            }),
         }
     }
 
@@ -186,15 +283,8 @@ impl McpPool {
         }
 
         tracing::info!(service_id, endpoint, "connecting MCP client");
-        let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(endpoint);
-        let client = ().serve(transport).await.map_err(|e| {
-            anyhow::anyhow!("MCP handshake failed for {service_id} ({endpoint}): {e}")
-        })?;
-
-        guard.insert(
-            service_id.to_string(),
-            wrap_connection(endpoint.to_string(), client),
-        );
+        let connection = (self.connect_fn)(service_id.to_string(), endpoint.to_string()).await?;
+        guard.insert(service_id.to_string(), connection);
         Ok(())
     }
 }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -2,17 +2,74 @@ use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
-use crate::lean_vocab_test::{assert_lean_contract_vocabulary_matches, LeanContractVocabulary};
+use crate::lean_vocab_test::{
+    assert_lean_contract_vocabulary_matches, lean_tool_retry_case, lean_tool_retry_cases,
+    LeanContractVocabulary, LeanToolRetryCase,
+};
 
 #[test]
-fn tool_retry_disposition_contract_matches_mcp_pool_policy() {
-    // TODO(idempotency): replace this shape pin with a Rust producer contract
-    // once MCP services advertise retry dispositions/idempotency metadata.
+fn tool_retry_disposition_contract_cases_match_mcp_pool_policy() {
     assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
         domain: "ToolRetryDisposition",
         rust_source: "Proofs.ToolExecution retryDisposition / mcp_pool::call_tool",
         rust_values: &["doNotRetry", "retrySafeRead", "retryIdempotentToolCall"],
     });
+
+    for case in lean_tool_retry_cases() {
+        let rust_disposition = tool_retry_disposition(
+            rust_operation(&case.operation),
+            rust_idempotency(&case.idempotency),
+            rust_failure_class(&case.failure_class),
+        );
+        assert_eq!(
+            rust_disposition.as_contract(),
+            case.disposition,
+            "Lean ToolExecution retry case {} must match mcp_pool policy",
+            case.name
+        );
+    }
+
+    assert_eq!(
+        lean_tool_retry_case("retry_mcpCall_idempotent_transport_retryIdempotentToolCall")
+            .disposition,
+        "retryIdempotentToolCall"
+    );
+    assert!(
+        lean_tool_retry_cases()
+            .iter()
+            .filter(|case| case.operation == "nativeCommand")
+            .all(|case| case.disposition == "doNotRetry"),
+        "Proofs.ToolExecution.native_command_not_retried_by_tool_model"
+    );
+}
+
+fn rust_operation(value: &str) -> ToolExecutionOperation {
+    match value {
+        "mcpListTools" => ToolExecutionOperation::McpListTools,
+        "mcpCall" => ToolExecutionOperation::McpCall,
+        "nativeCommand" => ToolExecutionOperation::NativeCommand,
+        other => panic!("unknown Lean tool operation {other:?}"),
+    }
+}
+
+fn rust_idempotency(value: &str) -> ToolIdempotencyEvidence {
+    match value {
+        "unknown" => ToolIdempotencyEvidence::Unknown,
+        "idempotent" => ToolIdempotencyEvidence::Idempotent,
+        "nonIdempotent" => ToolIdempotencyEvidence::NonIdempotent,
+        other => panic!("unknown Lean idempotency evidence {other:?}"),
+    }
+}
+
+fn rust_failure_class(value: &str) -> ToolFailureClass {
+    match value {
+        "argumentInvalid" => ToolFailureClass::ArgumentInvalid,
+        "serviceUnavailable" => ToolFailureClass::ServiceUnavailable,
+        "transport" => ToolFailureClass::Transport,
+        "toolReturnedError" => ToolFailureClass::ToolReturnedError,
+        "external" => ToolFailureClass::External,
+        other => panic!("unknown Lean tool failure class {other:?}"),
+    }
 }
 
 #[test]
@@ -86,7 +143,64 @@ fn resolve_mcp_url_no_subnet_uses_tailscale() {
 }
 
 #[tokio::test]
-async fn call_tool_does_not_retry_cached_dispatch_failure_without_idempotency_metadata() {
+async fn list_tools_transport_failure_retries_generated_safe_read_case() {
+    let case = lean_tool_retry_case("retry_mcpListTools_unknown_transport_retrySafeRead");
+    assert_eq!(case.operation, "mcpListTools");
+    assert_eq!(case.failure_class, "transport");
+    assert_eq!(case.disposition, "retrySafeRead");
+
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let list_calls = Arc::new(AtomicUsize::new(0));
+    let connect_attempts_for_fn = Arc::clone(&connect_attempts);
+    let list_calls_for_fn = Arc::clone(&list_calls);
+
+    let pool = McpPool::new_with_connector(move |_service_id, endpoint| {
+        let connect_attempts = Arc::clone(&connect_attempts_for_fn);
+        let list_calls = Arc::clone(&list_calls_for_fn);
+        async move {
+            let attempt = connect_attempts.fetch_add(1, Ordering::SeqCst) + 1;
+            Ok(McpConnection {
+                endpoint,
+                list_tools_fn: Box::new(move || {
+                    let list_calls = Arc::clone(&list_calls);
+                    Box::pin(async move {
+                        list_calls.fetch_add(1, Ordering::SeqCst);
+                        if attempt == 1 {
+                            anyhow::bail!("transport dropped while listing tools")
+                        }
+                        Ok(ListToolsResult::default())
+                    })
+                }),
+                call_tool_fn: Box::new(|_params| {
+                    Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                }),
+            })
+        }
+    });
+
+    pool.list_tools("read-service", "http://mcp.test/mcp")
+        .await
+        .expect("Lean safe-read case should retry list_tools transport failure");
+
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 2, "{:?}", case);
+    assert_eq!(list_calls.load(Ordering::SeqCst), 2, "{:?}", case);
+}
+
+#[tokio::test]
+async fn call_tool_transport_failure_obeys_generated_no_retry_cases_without_idempotency_metadata() {
+    for case in [
+        lean_tool_retry_case("retry_mcpCall_unknown_transport_doNotRetry"),
+        lean_tool_retry_case("retry_mcpCall_nonIdempotent_transport_doNotRetry"),
+    ] {
+        assert_call_tool_transport_no_retry(case).await;
+    }
+}
+
+async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
+    assert_eq!(case.operation, "mcpCall");
+    assert_eq!(case.failure_class, "transport");
+    assert_eq!(case.disposition, "doNotRetry");
+
     let pool = McpPool::new();
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_for_fn = Arc::clone(&calls);
@@ -95,7 +209,7 @@ async fn call_tool_does_not_retry_cached_dispatch_failure_without_idempotency_me
     {
         let mut guard = pool.inner.write().await;
         guard.insert(
-            "mutating-service".to_string(),
+            format!("mutating-service-{}", case.idempotency),
             McpConnection {
                 endpoint: endpoint.to_string(),
                 list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
@@ -112,7 +226,7 @@ async fn call_tool_does_not_retry_cached_dispatch_failure_without_idempotency_me
 
     let error = pool
         .call_tool(
-            "mutating-service",
+            &format!("mutating-service-{}", case.idempotency),
             endpoint,
             "write_record",
             serde_json::json!({ "id": 1 }),
@@ -124,10 +238,14 @@ async fn call_tool_does_not_retry_cached_dispatch_failure_without_idempotency_me
     assert_eq!(
         calls.load(Ordering::SeqCst),
         1,
-        "Proofs.ToolExecution.mcp_call_without_idempotency_metadata_does_not_retry"
+        "generated ToolExecution case {} must not retry call_tool",
+        case.name
     );
     assert!(
-        pool.inner.read().await.contains_key("mutating-service"),
+        pool.inner
+            .read()
+            .await
+            .contains_key(&format!("mutating-service-{}", case.idempotency)),
         "a failed call_tool must not evict and reconnect without idempotency evidence"
     );
 }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -205,11 +205,12 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
     let calls = Arc::new(AtomicUsize::new(0));
     let calls_for_fn = Arc::clone(&calls);
     let endpoint = "http://mcp.test/mcp";
+    let service_id = format!("mutating-service-{}", case.idempotency);
 
     {
         let mut guard = pool.inner.write().await;
         guard.insert(
-            format!("mutating-service-{}", case.idempotency),
+            service_id.clone(),
             McpConnection {
                 endpoint: endpoint.to_string(),
                 list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
@@ -226,7 +227,7 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
 
     let error = pool
         .call_tool(
-            &format!("mutating-service-{}", case.idempotency),
+            &service_id,
             endpoint,
             "write_record",
             serde_json::json!({ "id": 1 }),
@@ -242,10 +243,7 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
         case.name
     );
     assert!(
-        pool.inner
-            .read()
-            .await
-            .contains_key(&format!("mutating-service-{}", case.idempotency)),
+        pool.inner.read().await.contains_key(&service_id),
         "a failed call_tool must not evict and reconnect without idempotency evidence"
     );
 }

--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -352,7 +352,11 @@ fn json_type_name(value: &Value) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use serde_json::json;
+
+    use crate::health_checker::{HealthStatus, ServiceHealth, ServiceHealthMap};
+    use crate::lean_vocab_test::{lean_tool_preflight_cases, LeanToolPreflightCase};
 
     fn search_schema() -> Map<String, Value> {
         json!({
@@ -366,6 +370,89 @@ mod tests {
         .as_object()
         .expect("object schema")
         .clone()
+    }
+
+    #[tokio::test]
+    async fn generated_tool_preflight_cases_match_health_and_schema_gates() {
+        for case in lean_tool_preflight_cases() {
+            let actual = actual_preflight_contract(case).await;
+            assert_eq!(
+                actual.0, case.decision,
+                "Lean ToolExecution preflight case {} must match Rust dispatch decision",
+                case.name
+            );
+            assert_eq!(
+                actual.1, case.failure_class,
+                "Lean ToolExecution preflight case {} must match Rust failure class",
+                case.name
+            );
+        }
+    }
+
+    async fn actual_preflight_contract(case: &LeanToolPreflightCase) -> (String, Option<String>) {
+        let health_map = ServiceHealthMap::new();
+        health_map
+            .set_for_test(
+                "x-data",
+                ServiceHealth {
+                    status: rust_health_status(&case.health),
+                    last_seen: Utc::now(),
+                    last_error: (case.health == "unreachable")
+                        .then(|| "probe timed out".to_string()),
+                },
+            )
+            .await;
+
+        if enforce_health_gate(&health_map, "x-data").await.is_err() {
+            return ("block".to_string(), Some("serviceUnavailable".to_string()));
+        }
+
+        match case.schema_status.as_str() {
+            "unchecked" => ("dispatch".to_string(), None),
+            "valid" => {
+                let arguments = json!({ "query": "amy", "limit": 5 })
+                    .as_object()
+                    .expect("arguments")
+                    .clone();
+                let result = validate_arguments_against_schema(
+                    "x-data",
+                    "search_bookmarks",
+                    &arguments,
+                    &search_schema(),
+                );
+                assert!(
+                    result.is_ok(),
+                    "{} should pass schema validation",
+                    case.name
+                );
+                ("dispatch".to_string(), None)
+            }
+            "invalid" => {
+                let arguments = json!({ "limit": 5 })
+                    .as_object()
+                    .expect("arguments")
+                    .clone();
+                let error = validate_arguments_against_schema(
+                    "x-data",
+                    "search_bookmarks",
+                    &arguments,
+                    &search_schema(),
+                )
+                .expect_err("generated invalid-schema case should fail validation");
+                assert_eq!(error.failure_class, "invalid_tool_arguments");
+                ("block".to_string(), Some("argumentInvalid".to_string()))
+            }
+            other => panic!("unknown Lean schema status {other:?}"),
+        }
+    }
+
+    fn rust_health_status(value: &str) -> HealthStatus {
+        match value {
+            "healthy" => HealthStatus::Healthy,
+            "stale" => HealthStatus::Stale,
+            "unreachable" => HealthStatus::Unreachable,
+            other => panic!("unknown Lean health status {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -12,7 +12,9 @@ mod support;
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
     assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
-    lean_runtime_reconcile_case, lean_session_recovery_case, lean_vocabulary_values,
+    lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_tool_preflight_case, lean_tool_retry_case,
+    lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -105,10 +107,10 @@ fn lean_executable_contracts_cover_initial_domains() {
         "RuntimeReconcile should be emitted as generated contract output, not a follow-up hook"
     );
     assert!(
-        follow_up_hooks
+        !follow_up_hooks
             .iter()
             .any(|hook| hook.contains("ToolExecution")),
-        "ToolExecution remains a follow-up until idempotency metadata is modeled"
+        "ToolExecution should be emitted as generated contract output, not a follow-up hook"
     );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 10);
@@ -117,6 +119,8 @@ fn lean_executable_contracts_cover_initial_domains() {
         lean_contract_snapshot().client_shell_cases.len()
     );
     assert_eq!(lean_contract_snapshot().client_shell_cases.len(), 15);
+    assert_eq!(lean_contract_snapshot().tool_preflight_cases.len(), 9);
+    assert_eq!(lean_contract_snapshot().tool_retry_cases.len(), 45);
 }
 
 #[test]
@@ -158,6 +162,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     if !snapshot.client_shell_cases.is_empty() {
         emitted.insert(("client_shell_cases".to_string(), "ClientShellCases".to_string()));
     }
+    if !snapshot.tool_preflight_cases.is_empty() {
+        emitted.insert(("tool_cases".to_string(), "ToolExecutionPreflight".to_string()));
+    }
+    if !snapshot.tool_retry_cases.is_empty() {
+        emitted.insert(("tool_cases".to_string(), "ToolExecutionRetry".to_string()));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -170,6 +180,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "runtime_cases",
         "session_recovery_cases",
         "client_shell_cases",
+        "tool_cases",
         "follow_up_hook",
     ];
     let mut ledger = BTreeSet::new();
@@ -424,6 +435,46 @@ fn generated_session_recovery_cases_cover_retry_guards_and_preservation() {
         let case = lean_session_recovery_case(name);
         assert!(!case.legal, "{name} must be rejected by Lean");
         assert!(case.post_latest_state.is_empty());
+    }
+}
+
+#[test]
+fn generated_tool_execution_cases_cover_preflight_and_retry_contracts() {
+    let unreachable =
+        lean_tool_preflight_case("preflight_unreachable_valid_blocks_serviceUnavailable");
+    assert_eq!(unreachable.decision, "block");
+    assert_eq!(
+        unreachable.failure_class.as_deref(),
+        Some("serviceUnavailable")
+    );
+
+    let invalid = lean_tool_preflight_case("preflight_healthy_invalid_blocks_argumentInvalid");
+    assert_eq!(invalid.decision, "block");
+    assert_eq!(invalid.failure_class.as_deref(), Some("argumentInvalid"));
+
+    for name in [
+        "preflight_healthy_valid_dispatch",
+        "preflight_stale_valid_dispatch",
+    ] {
+        let case = lean_tool_preflight_case(name);
+        assert_eq!(case.decision, "dispatch", "{name}");
+        assert_eq!(case.failure_class, None, "{name}");
+    }
+
+    let safe_read = lean_tool_retry_case("retry_mcpListTools_unknown_transport_retrySafeRead");
+    assert_eq!(safe_read.disposition, "retrySafeRead");
+
+    let idempotent =
+        lean_tool_retry_case("retry_mcpCall_idempotent_transport_retryIdempotentToolCall");
+    assert_eq!(idempotent.disposition, "retryIdempotentToolCall");
+
+    for name in [
+        "retry_mcpCall_unknown_transport_doNotRetry",
+        "retry_mcpCall_nonIdempotent_transport_doNotRetry",
+        "retry_nativeCommand_idempotent_transport_doNotRetry",
+    ] {
+        let case = lean_tool_retry_case(name);
+        assert_eq!(case.disposition, "doNotRetry", "{name}");
     }
 }
 


### PR DESCRIPTION
## Summary
- emit executable ToolExecution preflight and retry-disposition cases from Lean conformance JSON
- load generated ToolExecution cases in Rust conformance helpers
- exercise generated MCP/tool execution cases for safe-read list_tools retry, no call_tool retry without idempotency metadata, health/schema preflight, and coverage pins

## Verification
- lake build
- cargo test -p defra-agent mcp_pool
- cargo test -p defra-agent generated_tool_preflight_cases_match_health_and_schema_gates
- cargo test -p defra-agent generated_tool_execution_cases_cover_preflight_and_retry_contracts
- cargo test -p defra-agent lean_executable_contracts_cover_initial_domains
- git diff --check
- no added sorry/admit/axiom/PLACEHOLDER/todo!() markers