### PR TITLE
Clarify trigger lineage proof docs

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Materialization.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Materialization.lean
@@ -45,10 +45,12 @@ theorem materializedTriggerRequest_origin
 
 /--
 If `dispatch` materializes `seed`, the origin assigned to the corresponding
-trigger request is lineage-consistent in the sense of `T4`.
+trigger request is lineage-consistent.
 
-The manual case depends on `dispatch`'s normalization theorem that forces
-manual lineage ids to `none`.
+This is the load-bearing lineage theorem for materialization: unlike
+`T4_lineage_completeness`, which only unfolds the `consistentLineage`
+predicate, this theorem connects actual `dispatch` output, manual lineage-id
+normalization, and the execution origin written into the materialized request.
 -/
 theorem dispatch_materializedTriggerRequest_consistentLineage
     (state : SystemState)

--- a/crates/defra-agent/proofs/Proofs/Properties/Decidable.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Decidable.lean
@@ -150,6 +150,13 @@ theorem terminal_requires_released (s : RequestState) (a : AdmissionState)
           subst h
           cases a <;> simp [RequestContext.coherentStateAdmission]
 
+/-!
+The following `#eval`s print finite-state cardinalities as build-time sanity
+output. They help reviewers notice accidental vocabulary/product-size drift,
+but the proof obligations in this module are the theorems above, not these
+diagnostic counts themselves.
+-/
+
 #eval Fintype.card RequestState
 #eval Fintype.card ProcessState
 #eval Fintype.card PersistenceState

--- a/crates/defra-agent/proofs/Proofs/Triggers/Lineage.lean
+++ b/crates/defra-agent/proofs/Proofs/Triggers/Lineage.lean
@@ -24,15 +24,18 @@ def consistentLineage (seed : RequestSeed) (origin : ExecutionOrigin) : Prop :=
   (seed.causedByTriggerKind = .schedule ∧ origin = .scheduled) ∨
   (seed.causedByTriggerKind = .event ∧ origin = .scheduled)
 
-/-- **Theorem T4 (lineage completeness).**
+/-- **Theorem T4 (lineage shape characterization).**
 
 The `consistentLineage` predicate fully characterizes admissible
-`(seed, origin)` pairs: every branch of the disjunction is exactly the
-set of lineage tuples `dispatch` may produce.
+`(seed, origin)` pairs at the predicate layer.
 
-Stated as an `iff` so it doubles as a definitional characterization,
-which makes it easy for downstream proofs (and conformance tests in
-Rust) to pattern-match on the three admissible shapes. -/
+This theorem is intentionally definitional: it states the three accepted
+lineage shapes as an `iff`, so downstream proofs can pattern-match on the
+manual, schedule, and event cases without reopening `consistentLineage`.
+The dispatch-specific substance lives one layer up in
+`dispatch_materializedTriggerRequest_consistentLineage`, which proves that
+actual `dispatch` output and the materialized request origin satisfy this
+predicate. -/
 theorem T4_lineage_completeness
     (seed : RequestSeed) (origin : ExecutionOrigin) :
     consistentLineage seed origin ↔

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -46,7 +46,7 @@ lake env lean --run Proofs/Conformance/Contracts.lean
 
 ## What Is Proven
 
-The current proof suite covers eleven practical areas:
+The current proof suite covers twelve practical areas:
 
 1. Request/process/persistence state transitions
 2. Daemon storage-observation assumptions that refine persistence
@@ -60,7 +60,7 @@ The current proof suite covers eleven practical areas:
 10. Client-shell workflow rules for selection, submission, and transport decoupling
 11. Command/tool execution policy: argv prefixes, read-only allowlists,
     disabled-network fail-closed behavior, sandbox selection, and filtered env
-11. Tool execution boundary rules: schema/health preflight and MCP retry
+12. Tool execution boundary rules: schema/health preflight and MCP retry
     eligibility before future idempotent tool retries are enabled
 
 The proof boundary matters:
@@ -475,7 +475,11 @@ roots.
 - `T3_latest_only_convergence` proves latest-only supersession directly from
   `dispatchStep`; `latestOnlyFireTransition_convergence` is only the abstract
   relation unwrapping lemma
-- materialized requests carry complete trigger lineage
+- `T4_lineage_completeness` is the definitional lineage shape theorem for
+  `consistentLineage`; the materialization substance is
+  `dispatch_materializedTriggerRequest_consistentLineage`, which connects
+  actual `dispatch` output, manual lineage-id normalization, and the execution
+  origin assigned to the materialized request
 
 `Proofs/Conformance/Triggers.lean` records the Rust/DefraDB shape used by the
 runtime trigger implementation. `Proofs/Conformance/Triggers/Contracts.lean`
@@ -587,11 +591,15 @@ The finite-state checks currently establish:
 - every non-terminal storage-observation state has at least one successor
 - every non-terminal inference-call state has at least one successor
 - admission-state invariants line up with request state
-- state counts stay as expected: 9 request, 5 process, 4 persistence,
-  7 storage-observation, 5 call, 180 core composed
+- the trailing `#eval` cardinalities print sanity counts for reviewers: 9
+  request, 5 process, 4 persistence, 7 storage-observation, 5 call, and 180
+  core composed states
 
 These checks are useful because they catch structural model regressions quickly,
-even before theorem-level reasoning matters.
+even before theorem-level reasoning matters. The `Fintype` instances
+structurally pin the finite vocabularies; the cardinality output is diagnostic
+and is not itself a separate proof obligation beyond those instances and the
+theorems established in `Proofs/Properties/Decidable.lean`.
 
 ## Boundaries And Deviations
 

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -12,9 +12,8 @@ mod support;
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
     assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
-    lean_runtime_reconcile_case,
-    lean_session_recovery_case, lean_tool_preflight_case, lean_tool_retry_case,
-    lean_vocabulary_values,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -160,10 +159,16 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "Lean ClientShell case count drifted from emitted cases"
     );
     if !snapshot.client_shell_cases.is_empty() {
-        emitted.insert(("client_shell_cases".to_string(), "ClientShellCases".to_string()));
+        emitted.insert((
+            "client_shell_cases".to_string(),
+            "ClientShellCases".to_string(),
+        ));
     }
     if !snapshot.tool_preflight_cases.is_empty() {
-        emitted.insert(("tool_cases".to_string(), "ToolExecutionPreflight".to_string()));
+        emitted.insert((
+            "tool_cases".to_string(),
+            "ToolExecutionPreflight".to_string(),
+        ));
     }
     if !snapshot.tool_retry_cases.is_empty() {
         emitted.insert(("tool_cases".to_string(), "ToolExecutionRetry".to_string()));


### PR DESCRIPTION
## Summary
- document T4 as a definitional lineage shape theorem and name dispatch_materializedTriggerRequest_consistentLineage as the load-bearing materialization theorem
- fix README proof-list numbering
- clarify that Decidable #eval cardinalities are diagnostic sanity output, not proof obligations
- apply the rustfmt-only conformance test formatting required by CI's Rust 1.95 toolchain

## Verification
- lake build
- cargo fmt --all --check