### PR TITLE
Emit typed conformance boundary metadata

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -1,3 +1,5 @@
+import Proofs.Conformance.ContractTypes
+
 /-!
 # Conformance Boundaries and Product Policies
 
@@ -134,6 +136,9 @@ depends on broader transition coverage from it.
 `Proofs.Conformance.Contracts` JSON. Rust asserts that every emitted vocabulary,
 state machine, trigger-case group, runtime witness group, session-recovery
 witness group, and follow-up hook appears in that ledger exactly once.
+Boundary and deviation metadata is emitted as structured review metadata and is
+shape-checked separately; ledger `accepted_boundary` fields reference the stable
+boundary ids emitted by this file.
 
 A ledger entry is acceptable only when it names a Rust/TypeScript consumer, an
 intentional product boundary recorded in this file, or an accepted follow-up.
@@ -155,3 +160,175 @@ These were previous conformance gaps and are now closed product/spec behavior:
 * Interrupting a request has an end-to-end path to cancelling queued/running
   linked `InferenceCall` rows.
 -/
+
+namespace Conformance.Contracts
+
+-- Rust pins the complete id set in
+-- state_machine_conformance::lean_boundary_metadata_is_typed_and_reviewable.
+-- That duplicated list is the deliberate review gate for boundary drift.
+structure Boundary where
+  id : String
+  domain : String
+  subject : String
+  statement : String
+  acceptedFailureMode : Option String := none
+  acceptedFollowUp : Option String := none
+  deriving Repr
+
+def boundaryRequestInputRequiredReservedId : String :=
+  "boundary.request.input-required-reserved"
+
+def boundaryRequestDeadPreclaimOnlyId : String :=
+  "boundary.request.dead-preclaim-only"
+
+def boundaryToolCallPermanentWithoutRetryEvidenceId : String :=
+  "boundary.tool-call.permanent-without-retry-evidence"
+
+def boundaryMcpCallToolDispatchRetryEvidenceId : String :=
+  "boundary.mcp.call-tool-dispatch-retry-evidence"
+
+def boundaryInferenceSlotsRunningRowDerivedId : String :=
+  "boundary.inference-slots.running-row-derived"
+
+def boundaryCommandPolicyHostExecutionAssumptionsId : String :=
+  "boundary.command-policy.host-execution-assumptions"
+
+def boundaryTriggerDispatchSourceDeliveryId : String :=
+  "boundary.trigger.dispatch-source-delivery"
+
+def boundaryPersistenceAbstractLifecycleId : String :=
+  "boundary.persistence.abstract-lifecycle"
+
+def boundaryStorageHookFailurePolicyId : String :=
+  "boundary.storage.hook-failure-policy"
+
+def boundaryStorageObservationDaemonVisibleId : String :=
+  "boundary.storage.observation-daemon-visible"
+
+def boundaryStorageMinimumVisibilityPathId : String :=
+  "boundary.storage.minimum-visibility-path"
+
+def boundaryBackendHealthAdmissionFreshnessId : String :=
+  "boundary.backend-health.admission-freshness"
+
+def boundarySessionRecoveryFailedLatestSmokeId : String :=
+  "boundary.session-recovery.failed-latest-smoke"
+
+def boundaryCoverageLedgerReviewDisciplineId : String :=
+  "boundary.coverage-ledger.review-discipline"
+
+def boundaries : List Boundary :=
+  [ { id := boundaryRequestInputRequiredReservedId
+    , domain := "RequestLifecycle"
+    , subject := "inputRequired vocabulary"
+    , statement :=
+        "inputRequired is reserved persisted and client protocol vocabulary; Rust does not emit it until a first-class approval or human-input loop exists."
+    , acceptedFollowUp :=
+        some "Future approval work should extend the core transition relation and Rust writer tests."
+    }
+  , { id := boundaryRequestDeadPreclaimOnlyId
+    , domain := "RequestLifecycle"
+    , subject := "dead terminal state"
+    , statement :=
+        "dead is terminal only for stale pre-claim work; post-claim provider, retry, tool, and deadline failures remain failed."
+    }
+  , { id := boundaryToolCallPermanentWithoutRetryEvidenceId
+    , domain := "ToolExecution"
+    , subject := "tool-call failure retry policy"
+    , statement :=
+        "Tool-call failures are permanent unless metadata proves retry safety; the request machine does not model tool retries."
+    , acceptedFollowUp :=
+        some "Future retries need health, idempotency, and side-effect metadata before widening Rust behavior."
+    }
+  , { id := boundaryMcpCallToolDispatchRetryEvidenceId
+    , domain := "ToolExecution"
+    , subject := "McpPool call_tool retry boundary"
+    , statement :=
+        "Rust does not persist MCP idempotency metadata, so McpPool::call_tool must not implicitly retry after dispatch failure."
+    , acceptedFollowUp :=
+        some "Extend ToolExecution.IdempotencyEvidence and add a Rust metadata contract before adding call_tool transport retries."
+    }
+  , { id := boundaryInferenceSlotsRunningRowDerivedId
+    , domain := "InferenceCall"
+    , subject := "fleet slot accounting"
+    , statement :=
+        "Backend held slots are derived from InferenceCall rows with call_state running; no denormalized FleetState document carries the aggregate invariant."
+    }
+  , { id := boundaryCommandPolicyHostExecutionAssumptionsId
+    , domain := "CommandPolicy"
+    , subject := "host command semantics"
+    , statement :=
+        "The command-policy model proves fail-closed policy ordering and sandbox/environment invariants, not external binary read-only semantics or host kernel sandbox correctness."
+    }
+  , { id := boundaryTriggerDispatchSourceDeliveryId
+    , domain := "TriggerDispatch"
+    , subject := "trigger source delivery"
+    , statement :=
+        "Lean covers pure dispatch and concurrency semantics once a FireIntent exists; DefraDB event delivery, schedule ticks, debounce, and template parsing remain operational assumptions."
+    }
+  , { id := boundaryPersistenceAbstractLifecycleId
+    , domain := "Persistence"
+    , subject := "abstract persistence lifecycle"
+    , statement :=
+        "PersistenceState is an abstract committed/uncommitted lifecycle; Rust does not persist a per-token PersistenceState document."
+    }
+  , { id := boundaryStorageHookFailurePolicyId
+    , domain := "Persistence"
+    , subject := "hook storage failure policy"
+    , statement :=
+        "Rust hook policy observes storage failure as fail-closed retry or fail-open lost output instead of exposing per-token persistence documents."
+    , acceptedFailureMode :=
+        some "Fail-open acknowledges lost output by policy."
+    }
+  , { id := boundaryStorageObservationDaemonVisibleId
+    , domain := "StorageObservation"
+    , subject := "daemon-visible storage facts"
+    , statement :=
+        "StorageObservation records daemon-visible mutation and read facts that justify lifecycle movement; it is not a proof of DefraDB internals."
+    }
+  , { id := boundaryStorageMinimumVisibilityPathId
+    , domain := "StorageObservation"
+    , subject := "minimum visibility path"
+    , statement :=
+        "After a successful mutation ack, stale reads or events may occur, but the daemon assumes read-your-writes for local confirmation or eventual later observation."
+    , acceptedFailureMode :=
+        some "Stale reads or missing events after success acknowledgement do not invalidate the commit assumption."
+    }
+  , { id := boundaryBackendHealthAdmissionFreshnessId
+    , domain := "Admission"
+    , subject := "backend health freshness"
+    , statement :=
+        "Backend health and availability observations are only as fresh as backend documents visible at admission time; provider and network behavior are environmental."
+    }
+  , { id := boundarySessionRecoveryFailedLatestSmokeId
+    , domain := "SessionRecovery"
+    , subject := "finite failed-latest witness"
+    , statement :=
+        "The generated SessionRecovery contract covers failed -> pending reissue as an executable smoke boundary, not full request-state transition coverage."
+    , acceptedFollowUp :=
+        some "Future executable witnesses should widen the contract before Rust depends on broader transition coverage."
+    }
+  , { id := boundaryCoverageLedgerReviewDisciplineId
+    , domain := "CoverageLedger"
+    , subject := "advisory contract guard"
+    , statement :=
+        "CoverageLedger is a checked index requiring every emitted domain to name a Rust or TypeScript consumer, accepted boundary, or follow-up; this boundary documents the ledger discipline as a whole."
+    }
+  ]
+
+def Boundary.toJson (boundary : Boundary) : String :=
+  "{"
+    ++ "\"id\":" ++ jsonString boundary.id ++ ","
+    ++ "\"domain\":" ++ jsonString boundary.domain ++ ","
+    ++ "\"subject\":" ++ jsonString boundary.subject ++ ","
+    ++ "\"statement\":" ++ jsonString boundary.statement ++ ","
+    ++ "\"accepted_failure_mode\":"
+      ++ jsonOptionalString boundary.acceptedFailureMode ++ ","
+    ++ "\"accepted_follow_up\":"
+      ++ jsonOptionalString boundary.acceptedFollowUp
+    ++ "}"
+
+def boundariesJson : String :=
+  jsonArray (boundaries.map Boundary.toJson)
+
+end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
@@ -30,8 +30,19 @@ structure StateMachineContract where
   illegalTransitions : List TransitionPair
   deriving Repr
 
+def jsonEscapeChar : Char → String
+  | '"' => "\\\""
+  | '\\' => "\\\\"
+  | '\n' => "\\n"
+  | '\r' => "\\r"
+  | '\t' => "\\t"
+  | c => String.mk [c]
+
+def jsonEscape (s : String) : String :=
+  String.intercalate "" ((String.toList s).map jsonEscapeChar)
+
 def jsonString (s : String) : String :=
-  "\"" ++ s ++ "\""
+  "\"" ++ jsonEscape s ++ "\""
 
 def jsonArray (values : List String) : String :=
   "[" ++ String.intercalate "," values ++ "]"

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -10,6 +10,7 @@ import Proofs.Conformance.ClientShell.Contracts
 import Proofs.RuntimeReconcile
 import Proofs.Conformance.ContractCases
 import Proofs.ToolExecution
+import Proofs.Conformance.Deviations
 import Proofs.Conformance.CoverageLedger
 
 /-!
@@ -459,6 +460,10 @@ def snapshotJson : String :=
       ++ jsonArray (ToolExecution.preflightCases.map toolPreflightCaseJson) ++ ","
     ++ "\"tool_retry_cases\":"
       ++ jsonArray (ToolExecution.retryCases.map toolRetryCaseJson) ++ ","
+    ++ "\"boundaries\":"
+      ++ boundariesJson ++ ","
+    ++ "\"deviations\":"
+      ++ deviationsJson ++ ","
     ++ "\"follow_up_hooks\":[],"
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -1,4 +1,5 @@
 import Proofs.Conformance.ContractTypes
+import Proofs.Conformance.Boundaries
 
 /-!
 # Conformance Coverage Ledger
@@ -64,11 +65,11 @@ def vocabularyCoverage : List CoverageEntry :=
   , boundaryCoverage
       "vocabulary"
       "PersistenceState"
-      "Proofs.Conformance.Boundaries: abstract persistence lifecycle, no per-token Rust document"
+      boundaryPersistenceAbstractLifecycleId
   , boundaryCoverage
       "vocabulary"
       "PersistenceFailurePolicy"
-      "Proofs.Conformance.Boundaries: hook/storage failure-policy boundary"
+      boundaryStorageHookFailurePolicyId
   , consumerCoverage
       "vocabulary"
       "ReconcilePhase"
@@ -76,7 +77,7 @@ def vocabularyCoverage : List CoverageEntry :=
   , boundaryCoverage
       "vocabulary"
       "StorageObservation"
-      "Proofs.Conformance.Boundaries: daemon-visible storage observation boundary"
+      boundaryStorageObservationDaemonVisibleId
   , consumerCoverage
       "vocabulary"
       "SessionRecoveryLatestRequestState"
@@ -107,22 +108,22 @@ def stateMachineCoverage : List CoverageEntry :=
   , boundaryCoverage
       "state_machine"
       "Persistence.failClosed"
-      "Proofs.Conformance.Boundaries: storage write failures are observed through Rust hooks"
+      boundaryStorageHookFailurePolicyId
       "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
   , boundaryCoverage
       "state_machine"
       "Persistence.failOpen"
-      "Proofs.Conformance.Boundaries: fail-open acknowledges lost output at the hook boundary"
+      boundaryStorageHookFailurePolicyId
       "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
   , boundaryCoverage
       "state_machine"
       "StorageObservation.failClosed"
-      "Proofs.Conformance.Boundaries: daemon observation model, not DefraDB internals"
+      boundaryStorageObservationDaemonVisibleId
       "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
   , boundaryCoverage
       "state_machine"
       "StorageObservation.failOpen"
-      "Proofs.Conformance.Boundaries: daemon observation model, not DefraDB internals"
+      boundaryStorageObservationDaemonVisibleId
       "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
   , consumerCoverage
       "state_machine"

--- a/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
@@ -12,3 +12,34 @@ Closed historical issues, intentional product policies, reserved vocabulary,
 and external storage/operational assumptions are documented in
 `Proofs.Conformance.Boundaries` instead of being listed as deviations.
 -/
+
+namespace Conformance.Contracts
+
+structure Deviation where
+  id : String
+  domain : String
+  subject : String
+  statement : String
+  acceptedFailureMode : Option String := none
+  acceptedFollowUp : Option String := none
+  deriving Repr
+
+def deviations : List Deviation :=
+  []
+
+def Deviation.toJson (deviation : Deviation) : String :=
+  "{"
+    ++ "\"id\":" ++ jsonString deviation.id ++ ","
+    ++ "\"domain\":" ++ jsonString deviation.domain ++ ","
+    ++ "\"subject\":" ++ jsonString deviation.subject ++ ","
+    ++ "\"statement\":" ++ jsonString deviation.statement ++ ","
+    ++ "\"accepted_failure_mode\":"
+      ++ jsonOptionalString deviation.acceptedFailureMode ++ ","
+    ++ "\"accepted_follow_up\":"
+      ++ jsonOptionalString deviation.acceptedFollowUp
+    ++ "}"
+
+def deviationsJson : String :=
+  jsonArray (deviations.map Deviation.toJson)
+
+end Conformance.Contracts

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -35,6 +35,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) tool_preflight_cases: Vec<LeanToolPreflightCase>,
     pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
+    pub(crate) boundaries: Vec<LeanBoundary>,
+    pub(crate) deviations: Vec<LeanDeviation>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
@@ -64,6 +66,26 @@ pub(crate) struct LeanCoverageEntry {
     pub(crate) consumer: String,
     pub(crate) accepted_boundary: String,
     pub(crate) accepted_follow_up: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanBoundary {
+    pub(crate) id: String,
+    pub(crate) domain: String,
+    pub(crate) subject: String,
+    pub(crate) statement: String,
+    pub(crate) accepted_failure_mode: Option<String>,
+    pub(crate) accepted_follow_up: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanDeviation {
+    pub(crate) id: String,
+    pub(crate) domain: String,
+    pub(crate) subject: String,
+    pub(crate) statement: String,
+    pub(crate) accepted_failure_mode: Option<String>,
+    pub(crate) accepted_follow_up: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -12,9 +12,8 @@ mod support;
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
     assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
-    lean_runtime_reconcile_case,
-    lean_session_recovery_case, lean_tool_preflight_case, lean_tool_retry_case,
-    lean_vocabulary_values,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -124,9 +123,148 @@ fn lean_executable_contracts_cover_initial_domains() {
 }
 
 #[test]
+fn lean_boundary_metadata_is_typed_and_reviewable() {
+    let snapshot = lean_contract_snapshot();
+    let expected_boundary_ids = [
+        "boundary.request.input-required-reserved",
+        "boundary.request.dead-preclaim-only",
+        "boundary.tool-call.permanent-without-retry-evidence",
+        "boundary.mcp.call-tool-dispatch-retry-evidence",
+        "boundary.inference-slots.running-row-derived",
+        "boundary.command-policy.host-execution-assumptions",
+        "boundary.trigger.dispatch-source-delivery",
+        "boundary.persistence.abstract-lifecycle",
+        "boundary.storage.hook-failure-policy",
+        "boundary.storage.observation-daemon-visible",
+        "boundary.storage.minimum-visibility-path",
+        "boundary.backend-health.admission-freshness",
+        "boundary.session-recovery.failed-latest-smoke",
+        "boundary.coverage-ledger.review-discipline",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect::<BTreeSet<_>>();
+
+    let mut actual_boundary_ids = BTreeSet::new();
+    let mut boundary_subjects = BTreeSet::new();
+    for boundary in &snapshot.boundaries {
+        assert!(
+            !boundary.id.trim().is_empty(),
+            "boundary id must be non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            !boundary.domain.trim().is_empty(),
+            "boundary domain must be non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            !boundary.subject.trim().is_empty(),
+            "boundary subject must be non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            !boundary.statement.trim().is_empty(),
+            "boundary statement must be non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            boundary
+                .accepted_failure_mode
+                .as_deref()
+                .map_or(true, |text| !text.trim().is_empty()),
+            "boundary accepted_failure_mode must be omitted or non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            boundary
+                .accepted_follow_up
+                .as_deref()
+                .map_or(true, |text| !text.trim().is_empty()),
+            "boundary accepted_follow_up must be omitted or non-empty: {:?}",
+            boundary
+        );
+        assert!(
+            actual_boundary_ids.insert(boundary.id.clone()),
+            "duplicate boundary id: {:?}",
+            boundary
+        );
+        assert!(
+            boundary_subjects.insert((boundary.domain.clone(), boundary.subject.clone())),
+            "duplicate boundary subject in domain {:?}: {:?}",
+            boundary.domain,
+            boundary
+        );
+    }
+
+    assert_eq!(
+        actual_boundary_ids, expected_boundary_ids,
+        "Lean boundary metadata ids changed; update this review-discipline list with the boundary data"
+    );
+}
+
+#[test]
+fn lean_deviation_metadata_is_empty_or_explicitly_classified() {
+    let snapshot = lean_contract_snapshot();
+    let mut deviation_ids = BTreeSet::new();
+    let mut deviation_subjects = BTreeSet::new();
+
+    for deviation in &snapshot.deviations {
+        assert!(
+            !deviation.id.trim().is_empty(),
+            "deviation id must be non-empty: {:?}",
+            deviation
+        );
+        assert!(
+            !deviation.domain.trim().is_empty(),
+            "deviation domain must be non-empty: {:?}",
+            deviation
+        );
+        assert!(
+            !deviation.subject.trim().is_empty(),
+            "deviation subject must be non-empty: {:?}",
+            deviation
+        );
+        assert!(
+            !deviation.statement.trim().is_empty(),
+            "deviation statement must be non-empty: {:?}",
+            deviation
+        );
+        assert!(
+            deviation
+                .accepted_failure_mode
+                .as_deref()
+                .is_some_and(|text| !text.trim().is_empty())
+                || deviation
+                    .accepted_follow_up
+                    .as_deref()
+                    .is_some_and(|text| !text.trim().is_empty()),
+            "active deviations must carry accepted_failure_mode or accepted_follow_up text: {:?}",
+            deviation
+        );
+        assert!(
+            deviation_ids.insert(deviation.id.clone()),
+            "duplicate deviation id: {:?}",
+            deviation
+        );
+        assert!(
+            deviation_subjects.insert((deviation.domain.clone(), deviation.subject.clone())),
+            "duplicate deviation subject in domain {:?}: {:?}",
+            deviation.domain,
+            deviation
+        );
+    }
+}
+
+#[test]
 fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     let snapshot = lean_contract_snapshot();
     let mut emitted = BTreeSet::new();
+    let boundary_ids = snapshot
+        .boundaries
+        .iter()
+        .map(|boundary| boundary.id.clone())
+        .collect::<BTreeSet<_>>();
 
     for vocabulary in &snapshot.vocabularies {
         emitted.insert(("vocabulary".to_string(), vocabulary.domain.clone()));
@@ -160,10 +298,16 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "Lean ClientShell case count drifted from emitted cases"
     );
     if !snapshot.client_shell_cases.is_empty() {
-        emitted.insert(("client_shell_cases".to_string(), "ClientShellCases".to_string()));
+        emitted.insert((
+            "client_shell_cases".to_string(),
+            "ClientShellCases".to_string(),
+        ));
     }
     if !snapshot.tool_preflight_cases.is_empty() {
-        emitted.insert(("tool_cases".to_string(), "ToolExecutionPreflight".to_string()));
+        emitted.insert((
+            "tool_cases".to_string(),
+            "ToolExecutionPreflight".to_string(),
+        ));
     }
     if !snapshot.tool_retry_cases.is_empty() {
         emitted.insert(("tool_cases".to_string(), "ToolExecutionRetry".to_string()));
@@ -209,6 +353,13 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             assert!(
                 has_follow_up,
                 "follow-up hook ledger entries must carry accepted_follow_up text: {:?}",
+                entry
+            );
+        }
+        if has_boundary {
+            assert!(
+                boundary_ids.contains(&entry.accepted_boundary),
+                "coverage ledger accepted_boundary must reference an emitted boundary id: {:?}",
                 entry
             );
         }


### PR DESCRIPTION
## Summary
- add typed Lean Boundary and Deviation metadata while preserving existing prose audit docs
- emit boundaries and deviations arrays in the Lean conformance JSON
- parse the new metadata in Rust conformance tests and validate ids, uniqueness, deviation classification, and coverage-ledger boundary links

## Verification
- lake build
- cargo test -p defra-agent --test state_machine_conformance