### PR TITLE
Add CommandPolicy generated conformance cases

### DIFF
--- a/crates/defra-agent/proofs/Proofs/CommandPolicy.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy.lean
@@ -3,6 +3,7 @@ import Proofs.CommandPolicy.Validation
 import Proofs.CommandPolicy.Sandbox
 import Proofs.CommandPolicy.Env
 import Proofs.CommandPolicy.Theorems
+import Proofs.CommandPolicy.Cases
 
 /-!
 # Command Policy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
@@ -1,0 +1,198 @@
+import Proofs.CommandPolicy.Validation
+import Proofs.CommandPolicy.Sandbox
+import Proofs.CommandPolicy.Env
+
+/-!
+# Command Policy Generated Cases
+
+Finite executable witnesses for the Rust command-policy conformance tests.
+These cases intentionally cover only local policy ordering, sandbox selection
+labels, and shell-environment filtering. External binary read-only behavior and
+host kernel sandbox correctness remain conformance boundaries.
+-/
+
+namespace CommandPolicy
+
+structure CommandPolicyCase where
+  name : String
+  category : String
+  policy : Policy
+  request : CommandRequest
+  decision : Decision
+  deriving Repr
+
+structure CommandSandboxCase where
+  name : String
+  category : String
+  mode : ExecutionMode
+  workspaceWriteSandboxEnforced : Bool
+  decision : SandboxDecision
+  deriving Repr
+
+structure CommandEnvCase where
+  name : String
+  envKey : EnvKey
+  inputPresent : Bool
+  inputName : String
+  inputValue : String
+  outputName : String
+  expected : Option EnvValue
+  deriving Repr
+
+def commandPolicy
+    (mode : ExecutionMode)
+    (allowed forbidden : List (List String))
+    (network : NetworkMode)
+    (allowlist : List String) : Policy :=
+  { mode := mode
+  , allowedArgvPrefixes := allowed
+  , forbiddenArgvPrefixes := forbidden
+  , networkMode := network
+  , readOnlyAllowlist := allowlist
+  }
+
+def commandRequest
+    (command lookupCommand : String)
+    (args : List String) : CommandRequest :=
+  { command := command, lookupCommand := lookupCommand, args := args }
+
+def validationCase
+    (name category : String)
+    (policy : Policy)
+    (request : CommandRequest) : CommandPolicyCase :=
+  { name := name
+  , category := category
+  , policy := policy
+  , request := request
+  , decision := validatePolicy policy request
+  }
+
+def sandboxCase
+    (name category : String)
+    (mode : ExecutionMode)
+    (workspaceWriteSandboxEnforced : Bool) : CommandSandboxCase :=
+  let support := { workspaceWriteSandboxEnforced := workspaceWriteSandboxEnforced }
+  { name := name
+  , category := category
+  , mode := mode
+  , workspaceWriteSandboxEnforced := workspaceWriteSandboxEnforced
+  , decision := selectSandbox support mode
+  }
+
+def envInput
+    (target : EnvKey)
+    (present : Bool) : EnvKey → Bool :=
+  fun candidate => if candidate = target then present else false
+
+def envCase
+    (name : String)
+    (envKey : EnvKey)
+    (inputPresent : Bool)
+    (inputValue : String := "input-value") : CommandEnvCase :=
+  { name := name
+  , envKey := envKey
+  , inputPresent := inputPresent
+  , inputName := envKey.sampleName
+  , inputValue := inputValue
+  , outputName := envKey.sampleName
+  , expected := filteredEnv (envInput envKey inputPresent) envKey
+  }
+
+def commandPolicyCases : List CommandPolicyCase :=
+  [ validationCase
+      "forbidden_prefix_wins_over_allowed_prefix_order"
+      "forbidden_prefix"
+      (commandPolicy
+        .readOnly
+        [["git", "status"]]
+        [["git"], ["git", "status", "--short"]]
+        .inherit
+        ["git"])
+      (commandRequest "git" "git" ["status", "--short"])
+  , validationCase
+      "allowed_prefix_required_precedes_network_and_allowlist"
+      "allowed_prefix_required"
+      (commandPolicy
+        .readOnly
+        [["git", "status"]]
+        []
+        .disabled
+        [])
+      (commandRequest "curl" "curl" ["https://example.com"])
+  , validationCase
+      "read_only_allowlisted_lookup_basename_allows"
+      "read_only_allowlist"
+      (commandPolicy .readOnly [] [] .inherit ["cat"])
+      (commandRequest "/bin/cat" "cat" ["README.md"])
+  , validationCase
+      "read_only_unallowlisted_denies"
+      "read_only_allowlist"
+      (commandPolicy .readOnly [] [] .inherit ["git"])
+      (commandRequest "cat" "cat" ["README.md"])
+  , validationCase
+      "disabled_network_unrestricted_fails_closed"
+      "disabled_network_failure"
+      (commandPolicy .unrestricted [] [] .disabled [])
+      (commandRequest "printf" "printf" ["ok"])
+  , validationCase
+      "disabled_network_read_only_curl_denies_before_allowlist"
+      "disabled_network_failure"
+      (commandPolicy .readOnly [] [] .disabled [])
+      (commandRequest "/usr/bin/curl" "curl" ["https://example.com"])
+  , validationCase
+      "disabled_network_read_only_tailscale_ping_denies"
+      "disabled_network_failure"
+      (commandPolicy .readOnly [] [] .disabled ["tailscale"])
+      (commandRequest "tailscale" "tailscale" ["ping", "100.64.0.1"])
+  , validationCase
+      "disabled_network_read_only_tailscale_netcheck_denies"
+      "disabled_network_failure"
+      (commandPolicy .readOnly [] [] .disabled ["tailscale"])
+      (commandRequest "tailscale" "tailscale" ["netcheck"])
+  , validationCase
+      "disabled_network_workspace_write_validates_for_sandbox_enforcement"
+      "disabled_network_failure"
+      (commandPolicy .workspaceWrite [] [] .disabled [])
+      (commandRequest "printf" "printf" ["ok"])
+  ]
+
+def commandSandboxCases : List CommandSandboxCase :=
+  [ sandboxCase
+      "read_only_selects_policy_read_only"
+      "read_only_sandbox_selection"
+      .readOnly
+      false
+  , sandboxCase
+      "workspace_write_enforced_selects_macos_seatbelt"
+      "workspace_write_sandbox_selection"
+      .workspaceWrite
+      true
+  , sandboxCase
+      "workspace_write_unenforced_denies"
+      "workspace_write_sandbox_selection"
+      .workspaceWrite
+      false
+  , sandboxCase
+      "unrestricted_selects_unsandboxed_unrestricted"
+      "unrestricted_unsandboxed_labeling"
+      .unrestricted
+      false
+  ]
+
+def commandEnvCases : List CommandEnvCase :=
+  [ envCase "env_path_inherited" .path true "/custom/bin"
+  , envCase "env_path_fallback_when_absent" .path false
+  , envCase "env_home_inherited" .home true "/tmp/home"
+  , envCase "env_home_absent_dropped" .home false
+  , envCase "env_key_marker_dropped" .key true "secret"
+  , envCase "env_secret_marker_dropped" .secret true "secret"
+  , envCase "env_token_marker_dropped" .token true "secret"
+  , envCase "env_other_key_dropped" .other true "drop"
+  , envCase "env_pager_forced_cat" .pager true "less"
+  , envCase "env_git_pager_forced_cat" .gitPager true "less"
+  , envCase "env_no_color_forced_on" .noColor false
+  , envCase "env_clicolor_forced_off" .cliColor false
+  , envCase "env_term_forced_dumb" .term true "xterm-256color"
+  ]
+
+end CommandPolicy

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
@@ -110,6 +110,16 @@ def commandPolicyCases : List CommandPolicyCase :=
         ["git"])
       (commandRequest "git" "git" ["status", "--short"])
   , validationCase
+      "forbidden_prefix_second_configured_match"
+      "forbidden_prefix"
+      (commandPolicy
+        .readOnly
+        []
+        [["git", "status", "--short"], ["git", "diff"]]
+        .inherit
+        ["git"])
+      (commandRequest "git" "git" ["diff", "--stat"])
+  , validationCase
       "allowed_prefix_required_precedes_network_and_allowlist"
       "allowed_prefix_required"
       (commandPolicy
@@ -189,6 +199,7 @@ def commandEnvCases : List CommandEnvCase :=
   , envCase "env_token_marker_dropped" .token true "secret"
   , envCase "env_other_key_dropped" .other true "drop"
   , envCase "env_pager_forced_cat" .pager true "less"
+  , envCase "env_pager_absent_still_forced_cat" .pager false
   , envCase "env_git_pager_forced_cat" .gitPager true "less"
   , envCase "env_no_color_forced_on" .noColor false
   , envCase "env_clicolor_forced_off" .cliColor false

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Env.lean
@@ -8,6 +8,9 @@ Symbolic model of `build_shell_env_from_vars`.
 
 namespace CommandPolicy
 
+def fallbackPath : String :=
+  "/usr/bin:/bin:/usr/sbin:/sbin"
+
 /-- Environment-name classes relevant to the shell filter. -/
 inductive EnvKey where
   | path
@@ -32,6 +35,54 @@ inductive EnvKey where
   | other
   deriving DecidableEq, Repr
 
+namespace EnvKey
+
+def toContract : EnvKey → String
+  | .path => "path"
+  | .shell => "shell"
+  | .tmpdir => "tmpdir"
+  | .temp => "temp"
+  | .tmp => "tmp"
+  | .home => "home"
+  | .lang => "lang"
+  | .lcAll => "lcAll"
+  | .lcCtype => "lcCtype"
+  | .logname => "logname"
+  | .user => "user"
+  | .pager => "pager"
+  | .gitPager => "gitPager"
+  | .noColor => "noColor"
+  | .cliColor => "cliColor"
+  | .term => "term"
+  | .key => "key"
+  | .secret => "secret"
+  | .token => "token"
+  | .other => "other"
+
+def sampleName : EnvKey → String
+  | .path => "PATH"
+  | .shell => "SHELL"
+  | .tmpdir => "TMPDIR"
+  | .temp => "TEMP"
+  | .tmp => "TMP"
+  | .home => "HOME"
+  | .lang => "LANG"
+  | .lcAll => "LC_ALL"
+  | .lcCtype => "LC_CTYPE"
+  | .logname => "LOGNAME"
+  | .user => "USER"
+  | .pager => "PAGER"
+  | .gitPager => "GIT_PAGER"
+  | .noColor => "NO_COLOR"
+  | .cliColor => "CLICOLOR"
+  | .term => "TERM"
+  | .key => "OPENAI_API_KEY"
+  | .secret => "DATABASE_SECRET"
+  | .token => "SESSION_TOKEN"
+  | .other => "UNRELATED"
+
+end EnvKey
+
 /-- Symbolic values preserved or forced by the filtered shell environment.
     The forced tags correspond to Rust constants: `cat`, `1`, `0`, and `dumb`. -/
 inductive EnvValue where
@@ -42,6 +93,26 @@ inductive EnvValue where
   | forcedCliColorOff
   | forcedDumb
   deriving DecidableEq, Repr
+
+namespace EnvValue
+
+def toContract : EnvValue → String
+  | .inherited => "inherited"
+  | .fallbackPath => "fallbackPath"
+  | .forcedCat => "forcedCat"
+  | .forcedNoColor => "forcedNoColor"
+  | .forcedCliColorOff => "forcedCliColorOff"
+  | .forcedDumb => "forcedDumb"
+
+def toRustValue (inputValue : String) : EnvValue → String
+  | .inherited => inputValue
+  | .fallbackPath => CommandPolicy.fallbackPath
+  | .forcedCat => "cat"
+  | .forcedNoColor => "1"
+  | .forcedCliColorOff => "0"
+  | .forcedDumb => "dumb"
+
+end EnvValue
 
 /-- Rust rejects names containing KEY, SECRET, or TOKEN. -/
 def containsSecretMarker : EnvKey → Bool

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
@@ -16,12 +16,30 @@ inductive ExecutionMode where
   | unrestricted
   deriving DecidableEq, Repr
 
+namespace ExecutionMode
+
+def toDefraDB : ExecutionMode → String
+  | .readOnly => "read_only"
+  | .workspaceWrite => "workspace_write"
+  | .unrestricted => "unrestricted"
+
+end ExecutionMode
+
 /-- Mirrors `CommandNetworkMode`. -/
 inductive NetworkMode where
   | inherit
   | disabled
   | enabled
   deriving DecidableEq, Repr
+
+namespace NetworkMode
+
+def toDefraDB : NetworkMode → String
+  | .inherit => "inherit"
+  | .disabled => "disabled"
+  | .enabled => "enabled"
+
+end NetworkMode
 
 /-- A command request after bash tool argument normalization.
 
@@ -53,11 +71,48 @@ inductive DenialReason where
   | workspaceWriteSandboxUnavailable
   deriving DecidableEq, Repr
 
+namespace DenialReason
+
+def toContract : DenialReason → String
+  | .forbiddenPrefix _ => "forbiddenPrefix"
+  | .allowedPrefixRequired _ => "allowedPrefixRequired"
+  | .readOnlyCommandNotAllowlisted _ => "readOnlyCommandNotAllowlisted"
+  | .disabledNetworkUnenforceable => "disabledNetworkUnenforceable"
+  | .disabledNetworkCommand _ => "disabledNetworkCommand"
+  | .workspaceWriteSandboxUnavailable => "workspaceWriteSandboxUnavailable"
+
+def matchedPrefix? : DenialReason → Option (List String)
+  | .forbiddenPrefix matched => some matched
+  | _ => none
+
+def argv? : DenialReason → Option (List String)
+  | .allowedPrefixRequired argv => some argv
+  | _ => none
+
+def command? : DenialReason → Option String
+  | .readOnlyCommandNotAllowlisted command => some command
+  | .disabledNetworkCommand command => some command
+  | _ => none
+
+end DenialReason
+
 /-- Executable validator result. -/
 inductive Decision where
   | allow
   | deny (reason : DenialReason)
   deriving DecidableEq, Repr
+
+namespace Decision
+
+def toContract : Decision → String
+  | .allow => "allow"
+  | .deny _ => "deny"
+
+def denialReason? : Decision → Option DenialReason
+  | .allow => none
+  | .deny reason => some reason
+
+end Decision
 
 /-- Command execution policy as configured from a tool selection. -/
 structure Policy where
@@ -75,11 +130,36 @@ inductive SandboxKind where
   | unsandboxedUnrestricted
   deriving DecidableEq, Repr
 
+namespace SandboxKind
+
+def toContract : SandboxKind → String
+  | .policyReadOnly => "policy_read_only"
+  | .macosSeatbelt => "macos_seatbelt"
+  | .unsandboxedUnrestricted => "unsandboxed_unrestricted"
+
+end SandboxKind
+
 /-- Sandbox selection may fail before spawning the process. -/
 inductive SandboxDecision where
   | selected (sandbox : SandboxKind)
   | denied (reason : DenialReason)
   deriving DecidableEq, Repr
+
+namespace SandboxDecision
+
+def toContract : SandboxDecision → String
+  | .selected _ => "selected"
+  | .denied _ => "denied"
+
+def sandbox? : SandboxDecision → Option SandboxKind
+  | .selected sandbox => some sandbox
+  | .denied _ => none
+
+def denialReason? : SandboxDecision → Option DenialReason
+  | .selected _ => none
+  | .denied reason => some reason
+
+end SandboxDecision
 
 /-- Host capabilities relevant to workspace-write sandbox enforcement. -/
 structure RuntimeSupport where

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -137,18 +137,19 @@ depends on broader transition coverage from it.
 `Proofs.Conformance.CoverageLedger` is the checked index for the
 `Proofs.Conformance.Contracts` JSON. Rust asserts that every emitted vocabulary,
 state machine, trigger-case group, runtime witness group, session-recovery
-witness group, and follow-up hook appears in that ledger exactly once.
+witness group, command-policy witness group, and follow-up hook appears in that
+ledger exactly once.
 Boundary and deviation metadata is emitted as structured review metadata and is
 shape-checked separately; ledger `accepted_boundary` fields reference the stable
 boundary ids emitted by this file.
 
 A ledger entry is acceptable only when it names a Rust/TypeScript consumer, an
 intentional product boundary recorded in this file, or an accepted follow-up.
-Future executable `ClientShell` or `ToolExecution` contracts should therefore
-add both the emitted contract domain and its runtime consumer in the same
-change. If the runtime consumer is deliberately deferred, the ledger entry must
-point here to describe the boundary or carry a follow-up hook; otherwise Rust
-will reject the generated contract as advisory-only.
+Future executable `ClientShell`, `ToolExecution`, or `CommandPolicy` contracts
+should therefore add both the emitted contract domain and its runtime consumer
+in the same change. If the runtime consumer is deliberately deferred, the
+ledger entry must point here to describe the boundary or carry a follow-up
+hook; otherwise Rust will reject the generated contract as advisory-only.
 
 ## Closed Historical Items
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -11,6 +11,7 @@ import Proofs.RuntimeReconcile
 import Proofs.Conformance.ContractCases
 import Proofs.ToolExecution
 import Proofs.Conformance.Deviations
+import Proofs.CommandPolicy.Cases
 import Proofs.Conformance.CoverageLedger
 
 /-!
@@ -479,6 +480,69 @@ def toolRetryCaseJson (witness : ToolExecution.RetryCase) : String :=
     ++ "\"disposition\":" ++ jsonString witness.disposition.toDefraDB
     ++ "}"
 
+def jsonStringMatrix (values : List (List String)) : String :=
+  jsonArray (values.map jsonStringArray)
+
+def jsonOptionalStringArray : Option (List String) → String
+  | none => "null"
+  | some values => jsonStringArray values
+
+def commandPolicyCaseJson (witness : CommandPolicy.CommandPolicyCase) : String :=
+  let reason := witness.decision.denialReason?
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"category\":" ++ jsonString witness.category ++ ","
+    ++ "\"mode\":" ++ jsonString witness.policy.mode.toDefraDB ++ ","
+    ++ "\"allowed_argv_prefixes\":"
+      ++ jsonStringMatrix witness.policy.allowedArgvPrefixes ++ ","
+    ++ "\"forbidden_argv_prefixes\":"
+      ++ jsonStringMatrix witness.policy.forbiddenArgvPrefixes ++ ","
+    ++ "\"network_mode\":" ++ jsonString witness.policy.networkMode.toDefraDB ++ ","
+    ++ "\"read_only_allowlist\":"
+      ++ jsonStringArray witness.policy.readOnlyAllowlist ++ ","
+    ++ "\"command\":" ++ jsonString witness.request.command ++ ","
+    ++ "\"lookup_command\":" ++ jsonString witness.request.lookupCommand ++ ","
+    ++ "\"args\":" ++ jsonStringArray witness.request.args ++ ","
+    ++ "\"decision\":" ++ jsonString witness.decision.toContract ++ ","
+    ++ "\"denial_reason\":"
+      ++ jsonOptionalString (reason.map CommandPolicy.DenialReason.toContract) ++ ","
+    ++ "\"matched_prefix\":"
+      ++ jsonOptionalStringArray (reason.bind CommandPolicy.DenialReason.matchedPrefix?) ++ ","
+    ++ "\"denied_argv\":"
+      ++ jsonOptionalStringArray (reason.bind CommandPolicy.DenialReason.argv?) ++ ","
+    ++ "\"denied_command\":"
+      ++ jsonOptionalString (reason.bind CommandPolicy.DenialReason.command?)
+    ++ "}"
+
+def commandSandboxCaseJson (witness : CommandPolicy.CommandSandboxCase) : String :=
+  let reason := witness.decision.denialReason?
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"category\":" ++ jsonString witness.category ++ ","
+    ++ "\"mode\":" ++ jsonString witness.mode.toDefraDB ++ ","
+    ++ "\"workspace_write_sandbox_enforced\":"
+      ++ boolString witness.workspaceWriteSandboxEnforced ++ ","
+    ++ "\"decision\":" ++ jsonString witness.decision.toContract ++ ","
+    ++ "\"sandbox\":"
+      ++ jsonOptionalString ((witness.decision.sandbox?).map CommandPolicy.SandboxKind.toContract) ++ ","
+    ++ "\"denial_reason\":"
+      ++ jsonOptionalString (reason.map CommandPolicy.DenialReason.toContract)
+    ++ "}"
+
+def commandEnvCaseJson (witness : CommandPolicy.CommandEnvCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"env_key\":" ++ jsonString witness.envKey.toContract ++ ","
+    ++ "\"input_present\":" ++ boolString witness.inputPresent ++ ","
+    ++ "\"input_name\":" ++ jsonString witness.inputName ++ ","
+    ++ "\"input_value\":" ++ jsonString witness.inputValue ++ ","
+    ++ "\"output_name\":" ++ jsonString witness.outputName ++ ","
+    ++ "\"expected_value_kind\":"
+      ++ jsonOptionalString (witness.expected.map CommandPolicy.EnvValue.toContract) ++ ","
+    ++ "\"expected_output_value\":"
+      ++ jsonOptionalString (witness.expected.map (fun value => value.toRustValue witness.inputValue))
+    ++ "}"
+
 def snapshotJson : String :=
   "{"
     ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
@@ -510,6 +574,12 @@ def snapshotJson : String :=
       ++ boundariesJson ++ ","
     ++ "\"deviations\":"
       ++ deviationsJson ++ ","
+    ++ "\"command_policy_cases\":"
+      ++ jsonArray (CommandPolicy.commandPolicyCases.map commandPolicyCaseJson) ++ ","
+    ++ "\"command_sandbox_cases\":"
+      ++ jsonArray (CommandPolicy.commandSandboxCases.map commandSandboxCaseJson) ++ ","
+    ++ "\"command_env_cases\":"
+      ++ jsonArray (CommandPolicy.commandEnvCases.map commandEnvCaseJson) ++ ","
     ++ "\"follow_up_hooks\":[],"
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -172,6 +172,18 @@ def caseCoverage : List CoverageEntry :=
       "tool_cases"
       "ToolExecutionRetry"
       "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy"
+  , consumerCoverage
+      "command_policy_cases"
+      "CommandPolicyValidation"
+      "toolset::tests::generated_command_policy_cases_match_rust_validation"
+  , consumerCoverage
+      "command_policy_cases"
+      "CommandPolicySandbox"
+      "toolset::tests::generated_command_sandbox_cases_match_rust_selection"
+  , consumerCoverage
+      "command_policy_cases"
+      "CommandPolicyEnv"
+      "toolset::tests::generated_command_env_cases_match_rust_filtering"
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -39,6 +39,9 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
     pub(crate) boundaries: Vec<LeanBoundary>,
     pub(crate) deviations: Vec<LeanDeviation>,
+    pub(crate) command_policy_cases: Vec<LeanCommandPolicyCase>,
+    pub(crate) command_sandbox_cases: Vec<LeanCommandSandboxCase>,
+    pub(crate) command_env_cases: Vec<LeanCommandEnvCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
@@ -274,6 +277,48 @@ pub(crate) struct LeanToolRetryCase {
     pub(crate) disposition: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanCommandPolicyCase {
+    pub(crate) name: String,
+    pub(crate) category: String,
+    pub(crate) mode: String,
+    pub(crate) allowed_argv_prefixes: Vec<Vec<String>>,
+    pub(crate) forbidden_argv_prefixes: Vec<Vec<String>>,
+    pub(crate) network_mode: String,
+    pub(crate) read_only_allowlist: Vec<String>,
+    pub(crate) command: String,
+    pub(crate) lookup_command: String,
+    pub(crate) args: Vec<String>,
+    pub(crate) decision: String,
+    pub(crate) denial_reason: Option<String>,
+    pub(crate) matched_prefix: Option<Vec<String>>,
+    pub(crate) denied_argv: Option<Vec<String>>,
+    pub(crate) denied_command: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanCommandSandboxCase {
+    pub(crate) name: String,
+    pub(crate) category: String,
+    pub(crate) mode: String,
+    pub(crate) workspace_write_sandbox_enforced: bool,
+    pub(crate) decision: String,
+    pub(crate) sandbox: Option<String>,
+    pub(crate) denial_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanCommandEnvCase {
+    pub(crate) name: String,
+    pub(crate) env_key: String,
+    pub(crate) input_present: bool,
+    pub(crate) input_name: String,
+    pub(crate) input_value: String,
+    pub(crate) output_name: String,
+    pub(crate) expected_value_kind: Option<String>,
+    pub(crate) expected_output_value: Option<String>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -378,6 +423,42 @@ pub(crate) fn lean_tool_retry_case(name: &str) -> &'static LeanToolRetryCase {
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean tool retry case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_command_policy_cases() -> &'static [LeanCommandPolicyCase] {
+    &lean_contract_snapshot().command_policy_cases
+}
+
+pub(crate) fn lean_command_policy_case(name: &str) -> &'static LeanCommandPolicyCase {
+    lean_contract_snapshot()
+        .command_policy_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean command policy case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_command_sandbox_cases() -> &'static [LeanCommandSandboxCase] {
+    &lean_contract_snapshot().command_sandbox_cases
+}
+
+pub(crate) fn lean_command_sandbox_case(name: &str) -> &'static LeanCommandSandboxCase {
+    lean_contract_snapshot()
+        .command_sandbox_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean command sandbox case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_command_env_cases() -> &'static [LeanCommandEnvCase] {
+    &lean_contract_snapshot().command_env_cases
+}
+
+pub(crate) fn lean_command_env_case(name: &str) -> &'static LeanCommandEnvCase {
+    lean_contract_snapshot()
+        .command_env_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean command env case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_vocabulary_values(domain: &str) -> Vec<&'static str> {

--- a/crates/defra-agent/src/toolset/shared.rs
+++ b/crates/defra-agent/src/toolset/shared.rs
@@ -4,7 +4,9 @@ mod filesystem;
 
 pub(crate) use command::parse_argv_prefixes;
 #[cfg(test)]
-pub(super) use command::{build_shell_env_from_vars, validate_read_only_command};
+pub(super) use command::{
+    build_shell_env_from_vars, select_sandbox_for_policy, validate_read_only_command,
+};
 pub(super) use command::{run_command, validate_command_policy};
 pub use command::{CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode};
 pub(super) use context::{ToolContext, ToolError};

--- a/crates/defra-agent/src/toolset/shared/command.rs
+++ b/crates/defra-agent/src/toolset/shared/command.rs
@@ -449,9 +449,13 @@ fn sandboxed_command_for_policy(
         CommandExecutionMode::Unrestricted => {
             Ok((command_name.to_string(), args.to_vec(), sandbox))
         }
-        CommandExecutionMode::WorkspaceWrite => {
-            sandboxed_workspace_write_command(root, command_name, args, policy.network_mode)
-        }
+        CommandExecutionMode::WorkspaceWrite => sandboxed_workspace_write_command(
+            root,
+            command_name,
+            args,
+            policy.network_mode,
+            sandbox,
+        ),
     }
 }
 
@@ -461,11 +465,8 @@ fn sandboxed_workspace_write_command(
     command_name: &str,
     args: &[String],
     network_mode: CommandNetworkMode,
+    sandbox: &'static str,
 ) -> Result<(String, Vec<String>, &'static str)> {
-    if !Path::new(SANDBOX_EXEC).exists() {
-        bail!("macOS sandbox-exec is required for workspace_write bash but was not found");
-    }
-
     let policy = macos_workspace_write_policy(network_mode);
     let mut sandbox_args = vec![
         "-p".to_string(),
@@ -475,7 +476,7 @@ fn sandboxed_workspace_write_command(
         command_name.to_string(),
     ];
     sandbox_args.extend(args.iter().cloned());
-    Ok((SANDBOX_EXEC.to_string(), sandbox_args, "macos_seatbelt"))
+    Ok((SANDBOX_EXEC.to_string(), sandbox_args, sandbox))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -484,6 +485,7 @@ fn sandboxed_workspace_write_command(
     _command_name: &str,
     _args: &[String],
     _network_mode: CommandNetworkMode,
+    _sandbox: &'static str,
 ) -> Result<(String, Vec<String>, &'static str)> {
     bail!("workspace_write bash requires macOS seatbelt sandbox enforcement on this build")
 }

--- a/crates/defra-agent/src/toolset/shared/command.rs
+++ b/crates/defra-agent/src/toolset/shared/command.rs
@@ -11,6 +11,8 @@ use super::context::ToolContext;
 
 const OUTPUT_META_PREFIX: &str = "defra_exec: ";
 const FALLBACK_PATH: &str = "/usr/bin:/bin:/usr/sbin:/sbin";
+#[cfg(target_os = "macos")]
+const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
 const CORE_ENV_VARS: &[&str] = &[
     "PATH", "SHELL", "TMPDIR", "TEMP", "TMP", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "LOGNAME",
     "USER",
@@ -405,21 +407,48 @@ fn validate_read_only_network_disabled(command: &str, args: &[String]) -> Result
     }
 }
 
+pub(in crate::toolset) fn select_sandbox_for_policy(
+    mode: CommandExecutionMode,
+    workspace_write_sandbox_enforced: bool,
+) -> Result<&'static str> {
+    match mode {
+        CommandExecutionMode::ReadOnly => Ok("policy_read_only"),
+        CommandExecutionMode::Unrestricted => Ok("unsandboxed_unrestricted"),
+        CommandExecutionMode::WorkspaceWrite if workspace_write_sandbox_enforced => {
+            Ok("macos_seatbelt")
+        }
+        CommandExecutionMode::WorkspaceWrite => {
+            if cfg!(target_os = "macos") {
+                bail!("macOS sandbox-exec is required for workspace_write bash but was not found")
+            } else {
+                bail!("workspace_write bash requires macOS seatbelt sandbox enforcement on this build")
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn workspace_write_sandbox_enforced() -> bool {
+    Path::new(SANDBOX_EXEC).exists()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn workspace_write_sandbox_enforced() -> bool {
+    false
+}
+
 fn sandboxed_command_for_policy(
     root: &Path,
     command_name: &str,
     args: &[String],
     policy: &CommandExecutionPolicy,
 ) -> Result<(String, Vec<String>, &'static str)> {
+    let sandbox = select_sandbox_for_policy(policy.mode, workspace_write_sandbox_enforced())?;
     match policy.mode {
-        CommandExecutionMode::ReadOnly => {
-            Ok((command_name.to_string(), args.to_vec(), "policy_read_only"))
+        CommandExecutionMode::ReadOnly => Ok((command_name.to_string(), args.to_vec(), sandbox)),
+        CommandExecutionMode::Unrestricted => {
+            Ok((command_name.to_string(), args.to_vec(), sandbox))
         }
-        CommandExecutionMode::Unrestricted => Ok((
-            command_name.to_string(),
-            args.to_vec(),
-            "unsandboxed_unrestricted",
-        )),
         CommandExecutionMode::WorkspaceWrite => {
             sandboxed_workspace_write_command(root, command_name, args, policy.network_mode)
         }
@@ -433,7 +462,6 @@ fn sandboxed_workspace_write_command(
     args: &[String],
     network_mode: CommandNetworkMode,
 ) -> Result<(String, Vec<String>, &'static str)> {
-    const SANDBOX_EXEC: &str = "/usr/bin/sandbox-exec";
     if !Path::new(SANDBOX_EXEC).exists() {
         bail!("macOS sandbox-exec is required for workspace_write bash but was not found");
     }

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -13,11 +13,16 @@ use super::file_tools::{
     EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, WriteFileTool,
 };
 use super::shared::{
-    build_shell_env_from_vars, validate_command_policy, validate_read_only_command,
-    CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode, ToolContext,
+    build_shell_env_from_vars, select_sandbox_for_policy, validate_command_policy,
+    validate_read_only_command, CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode,
+    ToolContext,
 };
 use super::*;
 use crate::ensure_schemas;
+use crate::lean_vocab_test::{
+    lean_command_env_cases, lean_command_policy_cases, lean_command_sandbox_cases,
+    LeanCommandPolicyCase,
+};
 use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
 
 #[test]
@@ -558,6 +563,180 @@ fn command_policy_applies_forbidden_and_allowed_prefixes() {
         &policy
     )
     .is_err());
+}
+
+#[test]
+fn generated_command_policy_cases_match_rust_validation() {
+    for case in lean_command_policy_cases() {
+        let mode = rust_command_execution_mode(&case.mode);
+        let network_mode = rust_command_network_mode(&case.network_mode);
+        let lookup_command = std::path::Path::new(&case.command)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(&case.command);
+        assert_eq!(
+            lookup_command, case.lookup_command,
+            "Lean command policy case {} must use Rust basename lookup",
+            case.name
+        );
+
+        let policy = CommandExecutionPolicy::read_only(case.read_only_allowlist.clone())
+            .with_mode(mode)
+            .with_allowed_argv_prefixes(case.allowed_argv_prefixes.clone())
+            .with_forbidden_argv_prefixes(case.forbidden_argv_prefixes.clone())
+            .with_network_mode(network_mode);
+        let result = validate_command_policy(&case.command, &case.args, &policy);
+
+        match case.decision.as_str() {
+            "allow" => assert!(
+                result.is_ok(),
+                "Lean CommandPolicy case {} should allow but Rust denied: {:?}",
+                case.name,
+                result.err()
+            ),
+            "deny" => {
+                let error = result.unwrap_err().to_string();
+                assert_command_denial_matches(case, &error);
+            }
+            other => panic!(
+                "Lean CommandPolicy case {} emitted unknown decision {other:?}",
+                case.name
+            ),
+        }
+    }
+}
+
+#[test]
+fn generated_command_sandbox_cases_match_rust_selection() {
+    for case in lean_command_sandbox_cases() {
+        let mode = rust_command_execution_mode(&case.mode);
+        let result = select_sandbox_for_policy(mode, case.workspace_write_sandbox_enforced);
+
+        match case.decision.as_str() {
+            "selected" => assert_eq!(
+                result.unwrap(),
+                case.sandbox.as_deref().unwrap(),
+                "Lean CommandPolicy sandbox case {} must match Rust sandbox label",
+                case.name
+            ),
+            "denied" => {
+                let error = result.unwrap_err().to_string();
+                assert_eq!(
+                    case.denial_reason.as_deref(),
+                    Some("workspaceWriteSandboxUnavailable"),
+                    "Lean CommandPolicy sandbox case {} denied for unexpected reason",
+                    case.name
+                );
+                assert!(
+                    error.contains("workspace_write") || error.contains("sandbox-exec"),
+                    "Lean CommandPolicy sandbox case {} expected workspace_write denial, got: {error}",
+                    case.name
+                );
+            }
+            other => panic!(
+                "Lean CommandPolicy sandbox case {} emitted unknown decision {other:?}",
+                case.name
+            ),
+        }
+    }
+}
+
+#[test]
+fn generated_command_env_cases_match_rust_filtering() {
+    for case in lean_command_env_cases() {
+        let vars = if case.input_present {
+            vec![(case.input_name.clone(), case.input_value.clone())]
+        } else {
+            Vec::new()
+        };
+        let env = build_shell_env_from_vars(vars);
+        let actual = env.get(&case.output_name).map(String::as_str);
+
+        assert_eq!(
+            actual,
+            case.expected_output_value.as_deref(),
+            "Lean CommandPolicy env case {} ({}) must match Rust shell env filtering; expected kind {:?}",
+            case.name,
+            case.env_key,
+            case.expected_value_kind
+        );
+    }
+}
+
+fn rust_command_execution_mode(value: &str) -> CommandExecutionMode {
+    CommandExecutionMode::parse(value)
+        .unwrap_or_else(|error| panic!("unknown Lean command execution mode {value:?}: {error}"))
+}
+
+fn rust_command_network_mode(value: &str) -> CommandNetworkMode {
+    CommandNetworkMode::parse(value)
+        .unwrap_or_else(|error| panic!("unknown Lean command network mode {value:?}: {error}"))
+}
+
+fn assert_command_denial_matches(case: &LeanCommandPolicyCase, error: &str) {
+    match case.denial_reason.as_deref() {
+        Some("forbiddenPrefix") => {
+            let matched = case
+                .matched_prefix
+                .as_ref()
+                .unwrap_or_else(|| panic!("Lean case {} missing matched_prefix", case.name));
+            assert!(
+                error.ends_with(&format!("prefix: {}", matched.join(" "))),
+                "Lean CommandPolicy case {} expected forbidden prefix {:?}, got Rust error: {error}",
+                case.name,
+                matched
+            );
+        }
+        Some("allowedPrefixRequired") => {
+            let argv = case
+                .denied_argv
+                .as_ref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_argv", case.name));
+            assert!(
+                error.ends_with(&format!("prefixes: {}", argv.join(" "))),
+                "Lean CommandPolicy case {} expected allowed-prefix denial for {:?}, got Rust error: {error}",
+                case.name,
+                argv
+            );
+        }
+        Some("readOnlyCommandNotAllowlisted") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            assert!(
+                error.contains("not allowed by the read-only bash tool") && error.contains(command),
+                "Lean CommandPolicy case {} expected read-only allowlist denial for {command:?}, got Rust error: {error}",
+                case.name
+            );
+        }
+        Some("disabledNetworkUnenforceable") => {
+            assert!(
+                error.contains("command_network_mode=disabled cannot be enforced"),
+                "Lean CommandPolicy case {} expected disabled-network unenforceable denial, got Rust error: {error}",
+                case.name
+            );
+        }
+        Some("disabledNetworkCommand") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            assert!(
+                error.contains(command) && error.contains("command_network_mode=disabled"),
+                "Lean CommandPolicy case {} expected disabled-network command denial for {command:?}, got Rust error: {error}",
+                case.name
+            );
+        }
+        Some(other) => panic!(
+            "Lean CommandPolicy case {} emitted unsupported denial reason {other:?}",
+            case.name
+        ),
+        None => panic!(
+            "Lean CommandPolicy case {} denied without a denial reason; Rust error: {error}",
+            case.name
+        ),
+    }
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -11,7 +11,8 @@ mod support;
 
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
-    assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
+    assert_state_machine_contract_is_complete, lean_client_shell_case, lean_command_env_case,
+    lean_command_policy_case, lean_command_sandbox_case, lean_contract_snapshot,
     lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case,
     lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
     lean_tool_retry_case, lean_vocabulary_values,
@@ -112,6 +113,12 @@ fn lean_executable_contracts_cover_initial_domains() {
             .any(|hook| hook.contains("ToolExecution")),
         "ToolExecution should be emitted as generated contract output, not a follow-up hook"
     );
+    assert!(
+        !follow_up_hooks
+            .iter()
+            .any(|hook| hook.contains("CommandPolicy")),
+        "CommandPolicy should be emitted as generated contract output, not a follow-up hook"
+    );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 10);
     assert_eq!(
@@ -131,6 +138,9 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().client_shell_cases.len(), 15);
     assert_eq!(lean_contract_snapshot().tool_preflight_cases.len(), 9);
     assert_eq!(lean_contract_snapshot().tool_retry_cases.len(), 45);
+    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 9);
+    assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
+    assert_eq!(lean_contract_snapshot().command_env_cases.len(), 13);
 }
 
 #[test]
@@ -332,6 +342,24 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     if !snapshot.tool_retry_cases.is_empty() {
         emitted.insert(("tool_cases".to_string(), "ToolExecutionRetry".to_string()));
     }
+    if !snapshot.command_policy_cases.is_empty() {
+        emitted.insert((
+            "command_policy_cases".to_string(),
+            "CommandPolicyValidation".to_string(),
+        ));
+    }
+    if !snapshot.command_sandbox_cases.is_empty() {
+        emitted.insert((
+            "command_policy_cases".to_string(),
+            "CommandPolicySandbox".to_string(),
+        ));
+    }
+    if !snapshot.command_env_cases.is_empty() {
+        emitted.insert((
+            "command_policy_cases".to_string(),
+            "CommandPolicyEnv".to_string(),
+        ));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -347,6 +375,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "fleet_cases",
         "client_shell_cases",
         "tool_cases",
+        "command_policy_cases",
         "follow_up_hook",
     ];
     let mut ledger = BTreeSet::new();
@@ -766,6 +795,54 @@ fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts() {
     assert_eq!(fleet_bound.slot_count, 2);
     assert_eq!(fleet_bound.max_concurrent, 2);
     assert!(fleet_bound.bounded_by_max_concurrent);
+}
+
+#[test]
+fn generated_command_policy_cases_cover_policy_sandbox_and_env_contracts() {
+    let forbidden = lean_command_policy_case("forbidden_prefix_wins_over_allowed_prefix_order");
+    assert_eq!(forbidden.category, "forbidden_prefix");
+    assert_eq!(forbidden.decision, "deny");
+    assert_eq!(forbidden.denial_reason.as_deref(), Some("forbiddenPrefix"));
+    assert_eq!(
+        forbidden.matched_prefix.as_ref(),
+        Some(&vec!["git".to_string()])
+    );
+
+    let allowed =
+        lean_command_policy_case("allowed_prefix_required_precedes_network_and_allowlist");
+    assert_eq!(allowed.decision, "deny");
+    assert_eq!(
+        allowed.denial_reason.as_deref(),
+        Some("allowedPrefixRequired")
+    );
+    assert_eq!(
+        allowed.denied_argv.as_ref(),
+        Some(&vec!["curl".to_string(), "https://example.com".to_string()])
+    );
+
+    let curl = lean_command_policy_case("disabled_network_read_only_curl_denies_before_allowlist");
+    assert_eq!(
+        curl.denial_reason.as_deref(),
+        Some("disabledNetworkCommand")
+    );
+    assert_eq!(curl.denied_command.as_deref(), Some("curl"));
+
+    let workspace = lean_command_sandbox_case("workspace_write_enforced_selects_macos_seatbelt");
+    assert_eq!(workspace.decision, "selected");
+    assert_eq!(workspace.sandbox.as_deref(), Some("macos_seatbelt"));
+
+    let unrestricted = lean_command_sandbox_case("unrestricted_selects_unsandboxed_unrestricted");
+    assert_eq!(
+        unrestricted.sandbox.as_deref(),
+        Some("unsandboxed_unrestricted")
+    );
+
+    let key = lean_command_env_case("env_key_marker_dropped");
+    assert_eq!(key.input_name, "OPENAI_API_KEY");
+    assert_eq!(key.expected_output_value, None);
+
+    let pager = lean_command_env_case("env_pager_forced_cat");
+    assert_eq!(pager.expected_output_value.as_deref(), Some("cat"));
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -138,9 +138,9 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().client_shell_cases.len(), 15);
     assert_eq!(lean_contract_snapshot().tool_preflight_cases.len(), 9);
     assert_eq!(lean_contract_snapshot().tool_retry_cases.len(), 45);
-    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 9);
+    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 10);
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
-    assert_eq!(lean_contract_snapshot().command_env_cases.len(), 13);
+    assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
 }
 
 #[test]
@@ -807,6 +807,11 @@ fn generated_command_policy_cases_cover_policy_sandbox_and_env_contracts() {
         forbidden.matched_prefix.as_ref(),
         Some(&vec!["git".to_string()])
     );
+    let second_forbidden = lean_command_policy_case("forbidden_prefix_second_configured_match");
+    assert_eq!(
+        second_forbidden.matched_prefix.as_ref(),
+        Some(&vec!["git".to_string(), "diff".to_string()])
+    );
 
     let allowed =
         lean_command_policy_case("allowed_prefix_required_precedes_network_and_allowlist");
@@ -843,6 +848,8 @@ fn generated_command_policy_cases_cover_policy_sandbox_and_env_contracts() {
 
     let pager = lean_command_env_case("env_pager_forced_cat");
     assert_eq!(pager.expected_output_value.as_deref(), Some("cat"));
+    let pager_absent = lean_command_env_case("env_pager_absent_still_forced_cat");
+    assert_eq!(pager_absent.expected_output_value.as_deref(), Some("cat"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add finite Lean CommandPolicy validation, sandbox, and env generated cases
- emit CommandPolicy case groups through the Lean conformance JSON and coverage ledger
- add Rust deserialization helpers plus generated-case tests against command policy, sandbox selection, and env filtering

## Verification
- lake build
- cargo test -p defra-agent --lib command -- --nocapture
- cargo test -p defra-agent --test state_machine_conformance