### PR TITLE
Align inputRequired runtime lifecycle policy

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -25,9 +25,11 @@ The current core request transition machine uses these current-product paths:
 
 `inputRequired` is reserved persisted/client protocol vocabulary. Rust does not
 currently emit it because there is no first-class approval or human-input loop;
-autonomous tool calls run inline. Future approval work should add an explicit
-extension module or widen the core transition relation together with Rust writer
-tests.
+autonomous tool calls run inline. Rust active runtime lifecycle filters are
+limited to `pending`, `claimed`, and `processing`, so reserved `inputRequired`
+rows are not interrupted or superseded by autonomous lifecycle code. Future
+approval work should add an explicit extension module or widen the core
+transition relation together with Rust writer tests.
 
 `dead` is a real terminal persisted state only for stale pre-claim work. Once a
 request is claimed, provider failures, retry exhaustion, tool failures, and

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -250,7 +250,8 @@ Operational meaning:
 - `claimed` owns admission but has not started inference
 - `processing` is actively executing
 - `inputRequired` is reserved for a blocked external-input cycle; current Rust
-  runtime code does not emit it because autonomous tool calls run inline
+  runtime code does not emit it because autonomous tool calls run inline, and
+  active runtime filters exclude it until that loop is modeled
 - `dead` is persisted only for stale pre-claim TTL expiry; post-claim provider
   failure, retry exhaustion, tool failure, and deadline expiry are terminal
   `failed`
@@ -601,8 +602,10 @@ are not deviations.
 
 Current boundaries:
 
-- `inputRequired` is reserved persisted/client vocabulary. Rust parses it and
-  treats it as non-terminal if observed, but the runtime does not emit it today.
+- `inputRequired` is reserved persisted/client vocabulary. Rust parses it as
+  non-terminal client vocabulary if observed, but active runtime lifecycle
+  filters use only `pending`, `claimed`, and `processing` until external input
+  is modeled.
 - `dead` is current product behavior only for stale pre-claim TTL expiry.
   Post-claim provider failure, retry exhaustion, tool failure, and deadline
   expiry remain terminal `failed`.

--- a/crates/defra-agent/src/lifecycle.rs
+++ b/crates/defra-agent/src/lifecycle.rs
@@ -120,12 +120,26 @@ impl PersistedLifecycleState {
         }
     }
 
-    #[cfg(test)]
     const fn is_terminal(self) -> bool {
         matches!(
             self,
             Self::Completed | Self::Failed | Self::Superseded | Self::Dead | Self::Interrupted
         )
+    }
+
+    fn from_persisted(value: &str) -> Option<Self> {
+        match value {
+            "pending" => Some(Self::Pending),
+            "claimed" => Some(Self::Claimed),
+            "processing" => Some(Self::Processing),
+            "inputRequired" => Some(Self::InputRequired),
+            "completed" => Some(Self::Completed),
+            "failed" => Some(Self::Failed),
+            "superseded" => Some(Self::Superseded),
+            "dead" => Some(Self::Dead),
+            "interrupted" => Some(Self::Interrupted),
+            _ => None,
+        }
     }
 
     #[cfg(test)]

--- a/crates/defra-agent/src/lifecycle.rs
+++ b/crates/defra-agent/src/lifecycle.rs
@@ -120,6 +120,7 @@ impl PersistedLifecycleState {
         }
     }
 
+    #[cfg(test)]
     const fn is_terminal(self) -> bool {
         matches!(
             self,
@@ -127,20 +128,48 @@ impl PersistedLifecycleState {
         )
     }
 
+    #[cfg(test)]
     const fn is_nonterminal(self) -> bool {
         !self.is_terminal()
     }
+
+    const fn is_active_runtime(self) -> bool {
+        matches!(self, Self::Pending | Self::Claimed | Self::Processing)
+    }
 }
 
-pub(crate) fn nonterminal_lifecycle_state_graphql_list() -> String {
-    let states = PersistedLifecycleState::ALL
-        .iter()
-        .copied()
-        .filter(|state| state.is_nonterminal())
+fn lifecycle_state_graphql_list(
+    states: impl IntoIterator<Item = PersistedLifecycleState>,
+) -> String {
+    let states = states
+        .into_iter()
         .map(|state| format!(r#""{}""#, state.as_str()))
         .collect::<Vec<_>>()
         .join(", ");
     format!("[{states}]")
+}
+
+#[cfg(test)]
+pub(crate) fn nonterminal_lifecycle_state_graphql_list() -> String {
+    lifecycle_state_graphql_list(
+        PersistedLifecycleState::ALL
+            .iter()
+            .copied()
+            .filter(|state| state.is_nonterminal()),
+    )
+}
+
+pub(crate) fn active_runtime_lifecycle_state_graphql_list() -> String {
+    lifecycle_state_graphql_list(
+        PersistedLifecycleState::ALL
+            .iter()
+            .copied()
+            .filter(|state| state.is_active_runtime()),
+    )
+}
+
+fn lifecycle_state_graphql_list_for(states: &[PersistedLifecycleState]) -> String {
+    lifecycle_state_graphql_list(states.iter().copied())
 }
 
 pub struct RequestLifecycle {
@@ -259,6 +288,7 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         assert!(PersistedLifecycleState::InputRequired.is_nonterminal());
+        assert!(!PersistedLifecycleState::InputRequired.is_active_runtime());
         assert!(PersistedLifecycleState::Interrupted.is_terminal());
         let expected_nonterminal_graphql_list = format!(
             "[{}]",
@@ -272,6 +302,10 @@ mod tests {
         assert_eq!(
             nonterminal_lifecycle_state_graphql_list(),
             expected_nonterminal_graphql_list
+        );
+        assert_eq!(
+            active_runtime_lifecycle_state_graphql_list(),
+            r#"["pending", "claimed", "processing"]"#
         );
         assert_eq!(
             ExecutionOrigin::from_persisted(Some("scheduled")),

--- a/crates/defra-agent/src/lifecycle/claim.rs
+++ b/crates/defra-agent/src/lifecycle/claim.rs
@@ -76,7 +76,11 @@ impl RequestLifecycle {
         let mutation = format!(
             r#"mutation {{
                 update_AgentRequest(
-                    filter: {{ _docID: {{ _eq: "{doc_id}" }}, status: {{ _eq: "pending" }} }},
+                    filter: {{
+                        _docID: {{ _eq: "{doc_id}" }},
+                        status: {{ _eq: "pending" }},
+                        lifecycle_state: {{ _eq: "pending" }}
+                    }},
                     input: {{
                         status: "interrupted",
                         lifecycle_state: "interrupted"
@@ -84,8 +88,34 @@ impl RequestLifecycle {
                 ) {{ _docID }}
             }}"#
         );
-        session::execute_mutation_with_retry(&self.node, &mutation, "interrupt_before_claim")
-            .await?;
+        let resp =
+            session::execute_mutation_with_retry(&self.node, &mutation, "interrupt_before_claim")
+                .await?;
+        if !resp
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentRequest"))
+            .is_some_and(response_has_documents)
+        {
+            let request_view = self.request_view().await?;
+            if request_view.as_ref().is_some_and(|row| {
+                row.status == "interrupted" && row.lifecycle_state.as_deref() == Some("interrupted")
+            }) {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "request {} could not transition pending -> interrupted; current status={} lifecycle_state={}",
+                self.request.request_id,
+                request_view
+                    .as_ref()
+                    .map(|row| row.status.as_str())
+                    .unwrap_or("missing"),
+                request_view
+                    .as_ref()
+                    .and_then(|row| row.lifecycle_state.as_deref())
+                    .unwrap_or("missing")
+            );
+        }
         Ok(())
     }
 
@@ -94,7 +124,11 @@ impl RequestLifecycle {
         let mutation = format!(
             r#"mutation {{
                 update_AgentRequest(
-                    filter: {{ _docID: {{ _eq: "{doc_id}" }}, status: {{ _eq: "pending" }} }},
+                    filter: {{
+                        _docID: {{ _eq: "{doc_id}" }},
+                        status: {{ _eq: "pending" }},
+                        lifecycle_state: {{ _eq: "pending" }}
+                    }},
                     input: {{
                         status: "dead",
                         lifecycle_state: "dead",
@@ -103,7 +137,33 @@ impl RequestLifecycle {
                 ) {{ _docID }}
             }}"#
         );
-        session::execute_mutation_with_retry(&self.node, &mutation, "expire_stale").await?;
+        let resp =
+            session::execute_mutation_with_retry(&self.node, &mutation, "expire_stale").await?;
+        if !resp
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentRequest"))
+            .is_some_and(response_has_documents)
+        {
+            let request_view = self.request_view().await?;
+            if request_view.as_ref().is_some_and(|row| {
+                row.status == "dead" && row.lifecycle_state.as_deref() == Some("dead")
+            }) {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "request {} could not transition pending -> dead; current status={} lifecycle_state={}",
+                self.request.request_id,
+                request_view
+                    .as_ref()
+                    .map(|row| row.status.as_str())
+                    .unwrap_or("missing"),
+                request_view
+                    .as_ref()
+                    .and_then(|row| row.lifecycle_state.as_deref())
+                    .unwrap_or("missing")
+            );
+        }
         self.failure_reason = Some("Stale".to_string());
         Ok(())
     }
@@ -165,7 +225,8 @@ impl RequestLifecycle {
                 update_AgentRequest(
                     filter: {{
                         _docID: {{ _eq: "{doc_id}" }},
-                        status: {{ _eq: "pending" }}
+                        status: {{ _eq: "pending" }},
+                        lifecycle_state: {{ _eq: "pending" }}
                     }},
                     input: {{
                         status: "processing",

--- a/crates/defra-agent/src/lifecycle/query.rs
+++ b/crates/defra-agent/src/lifecycle/query.rs
@@ -53,7 +53,7 @@ impl RequestLifecycle {
                 request_id = %self.request.request_id,
                 session_id = %self.request.session_id,
                 is_earliest,
-                non_terminal_count = rows.len(),
+                active_runtime_count = rows.len(),
                 duplicate_pending_count = duplicates_to_suppress.len(),
                 "deduplication check found multiple active runtime requests"
             );

--- a/crates/defra-agent/src/lifecycle/query.rs
+++ b/crates/defra-agent/src/lifecycle/query.rs
@@ -5,12 +5,14 @@ use super::*;
 impl RequestLifecycle {
     pub(super) async fn check_deduplication(&self) -> Result<DedupPlan> {
         let escaped_session_id = escape_graphql_string(&self.request.session_id);
+        let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
         let query = format!(
             r#"{{
                 AgentRequest(
                     filter: {{
                         session_id: {{ _eq: "{escaped_session_id}" }},
-                        status: {{ _in: ["pending", "processing"] }}
+                        status: {{ _in: ["pending", "processing"] }},
+                        lifecycle_state: {{ _in: {active_runtime_states} }}
                     }},
                     order: {{ created_at: ASC }}
                 ) {{
@@ -53,7 +55,7 @@ impl RequestLifecycle {
                 is_earliest,
                 non_terminal_count = rows.len(),
                 duplicate_pending_count = duplicates_to_suppress.len(),
-                "deduplication check found multiple non-terminal requests"
+                "deduplication check found multiple active runtime requests"
             );
         }
 

--- a/crates/defra-agent/src/lifecycle/rows.rs
+++ b/crates/defra-agent/src/lifecycle/rows.rs
@@ -11,7 +11,7 @@ pub(super) struct DedupPlan {
 pub(super) enum RequestStatusTransition {
     Updated,
     AlreadyTarget,
-    ConflictingTerminal(String),
+    ConflictingTerminal(RequestViewRow),
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -29,7 +29,7 @@ pub(super) struct StatusRow {
     pub(super) status: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(super) struct RequestViewRow {
     pub(super) status: String,
     pub(super) lifecycle_state: Option<String>,

--- a/crates/defra-agent/src/lifecycle/transition.rs
+++ b/crates/defra-agent/src/lifecycle/transition.rs
@@ -8,14 +8,19 @@ use anyhow::Context;
 use super::rows::{DedupRow, RequestStatusTransition, RequestViewRow};
 use super::*;
 
-fn request_view_is_terminal(view: &RequestViewRow) -> bool {
+fn request_status_is_terminal(status: &str) -> bool {
     matches!(
-        view.lifecycle_state.as_deref(),
-        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
-    ) || matches!(
-        view.status.as_str(),
+        status,
         "completed" | "error" | "superseded" | "dead" | "interrupted"
     )
+}
+
+fn request_view_is_terminal(view: &RequestViewRow) -> bool {
+    view.lifecycle_state
+        .as_deref()
+        .and_then(PersistedLifecycleState::from_persisted)
+        .is_some_and(PersistedLifecycleState::is_terminal)
+        || request_status_is_terminal(&view.status)
 }
 
 impl RequestLifecycle {
@@ -165,7 +170,8 @@ impl RequestLifecycle {
             RequestStatusTransition::ConflictingTerminal(current) => {
                 tracing::info!(
                     request_id = %self.request.request_id,
-                    current_status = %current,
+                    current_status = %current.status,
+                    current_lifecycle_state = %current.lifecycle_state.as_deref().unwrap_or("missing"),
                     "skipping completion because request is already terminal"
                 );
             }
@@ -189,6 +195,8 @@ impl RequestLifecycle {
     pub async fn transition_to_interrupted(&mut self) -> Result<()> {
         let doc_id = &self.request.doc_id;
         let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
+        // Keep the status guard as a defensive check for replicated rows whose
+        // status/lifecycle_state fields are temporarily divergent.
         let mutation = format!(
             r#"mutation {{
                 update_AgentRequest(
@@ -312,7 +320,8 @@ impl RequestLifecycle {
             RequestStatusTransition::ConflictingTerminal(current) => {
                 tracing::info!(
                     request_id = %self.request.request_id,
-                    current_status = %current,
+                    current_status = %current.status,
+                    current_lifecycle_state = %current.lifecycle_state.as_deref().unwrap_or("missing"),
                     "skipping failure because request is already terminal"
                 );
             }
@@ -327,6 +336,10 @@ impl RequestLifecycle {
         Ok(())
     }
 
+    /// Transition a request status/lifecycle pair through a modeled terminal
+    /// edge. `from_lifecycle_states` is part of the transition precondition:
+    /// callers must pass only Lean-modeled source states for the requested
+    /// transition, not the broader persisted nonterminal vocabulary.
     pub(super) async fn transition_request_status(
         &self,
         from_status: &str,
@@ -387,22 +400,24 @@ impl RequestLifecycle {
             return Ok(RequestStatusTransition::Updated);
         }
 
-        match self.request_status().await? {
-            Some(current) if current == target_status => Ok(RequestStatusTransition::AlreadyTarget),
+        match self.request_view().await? {
             Some(current)
-                if matches!(
-                    current.as_str(),
-                    "completed" | "error" | "superseded" | "dead" | "interrupted"
-                ) =>
+                if current.status == target_status
+                    && current.lifecycle_state.as_deref()
+                        == Some(target_lifecycle_state.as_str()) =>
             {
+                Ok(RequestStatusTransition::AlreadyTarget)
+            }
+            Some(current) if request_view_is_terminal(&current) => {
                 Ok(RequestStatusTransition::ConflictingTerminal(current))
             }
             Some(current) => anyhow::bail!(
-                "request {} could not transition {} -> {}; current status={}",
+                "request {} could not transition {} -> {}; current status={} lifecycle_state={}",
                 self.request.request_id,
                 from_status,
                 target_status,
-                current
+                current.status,
+                current.lifecycle_state.as_deref().unwrap_or("missing")
             ),
             None => anyhow::bail!(
                 "request {} disappeared while transitioning {} -> {}",

--- a/crates/defra-agent/src/lifecycle/transition.rs
+++ b/crates/defra-agent/src/lifecycle/transition.rs
@@ -5,8 +5,18 @@
 // submodules with no readability gain.
 use anyhow::Context;
 
-use super::rows::{DedupRow, RequestStatusTransition};
+use super::rows::{DedupRow, RequestStatusTransition, RequestViewRow};
 use super::*;
+
+fn request_view_is_terminal(view: &RequestViewRow) -> bool {
+    matches!(
+        view.lifecycle_state.as_deref(),
+        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
+    ) || matches!(
+        view.status.as_str(),
+        "completed" | "error" | "superseded" | "dead" | "interrupted"
+    )
+}
 
 impl RequestLifecycle {
     pub async fn record_failure_reason(&mut self, reason: &str) -> Result<()> {
@@ -114,6 +124,10 @@ impl RequestLifecycle {
         match self
             .transition_request_status(
                 "processing",
+                &[
+                    PersistedLifecycleState::Claimed,
+                    PersistedLifecycleState::Processing,
+                ],
                 "completed",
                 PersistedLifecycleState::Completed,
             )
@@ -166,20 +180,21 @@ impl RequestLifecycle {
         Ok(())
     }
 
-    /// Mark a non-terminal request as interrupted. This includes reserved
-    /// `inputRequired` rows if one already exists, but the runtime does not
-    /// currently emit `inputRequired` itself.
+    /// Mark a modeled active runtime request as interrupted.
     /// Writes `lifecycle_state="interrupted"` and `status="interrupted"` and
-    /// sets the in-memory state. Idempotent via the `_nin` filter on terminal
-    /// statuses: if the row is already terminal (completed/interrupted/dead/
-    /// superseded/error), the mutation is a no-op.
+    /// sets the in-memory state only when the persisted row is updated or was
+    /// already interrupted. Reserved `inputRequired` rows are parseable
+    /// persisted vocabulary, but they are not modeled interruptible runtime
+    /// states.
     pub async fn transition_to_interrupted(&mut self) -> Result<()> {
         let doc_id = &self.request.doc_id;
+        let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
         let mutation = format!(
             r#"mutation {{
                 update_AgentRequest(
                     filter: {{
                         _docID: {{ _eq: "{doc_id}" }},
+                        lifecycle_state: {{ _in: {active_runtime_states} }},
                         status: {{ _nin: ["completed", "interrupted", "dead", "superseded", "error"] }}
                     }},
                     input: {{
@@ -189,10 +204,45 @@ impl RequestLifecycle {
                 ) {{ _docID }}
             }}"#
         );
-        session::execute_mutation_with_retry(&self.node, &mutation, "transition_interrupted")
-            .await?;
-        self.state = LocalLifecycleState::Interrupted;
-        Ok(())
+        let resp =
+            session::execute_mutation_with_retry(&self.node, &mutation, "transition_interrupted")
+                .await?;
+        if resp
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentRequest"))
+            .is_some_and(response_has_documents)
+        {
+            self.state = LocalLifecycleState::Interrupted;
+            return Ok(());
+        }
+
+        match self.request_view().await? {
+            Some(current)
+                if current.status == "interrupted"
+                    && current.lifecycle_state.as_deref() == Some("interrupted") =>
+            {
+                self.state = LocalLifecycleState::Interrupted;
+                Ok(())
+            }
+            Some(current) if request_view_is_terminal(&current) => Ok(()),
+            Some(current) if current.lifecycle_state.as_deref() == Some("inputRequired") => {
+                anyhow::bail!(
+                    "cannot interrupt request_id={} from reserved lifecycle_state=inputRequired",
+                    self.request.request_id
+                )
+            }
+            Some(current) => anyhow::bail!(
+                "request {} could not transition to interrupted; current status={} lifecycle_state={}",
+                self.request.request_id,
+                current.status,
+                current.lifecycle_state.as_deref().unwrap_or("missing")
+            ),
+            None => anyhow::bail!(
+                "request {} disappeared while transitioning to interrupted",
+                self.request.request_id
+            ),
+        }
     }
 
     pub async fn fail(&mut self) -> Result<()> {
@@ -219,7 +269,15 @@ impl RequestLifecycle {
         )?;
 
         match self
-            .transition_request_status("processing", "error", PersistedLifecycleState::Failed)
+            .transition_request_status(
+                "processing",
+                &[
+                    PersistedLifecycleState::Claimed,
+                    PersistedLifecycleState::Processing,
+                ],
+                "error",
+                PersistedLifecycleState::Failed,
+            )
             .await?
         {
             RequestStatusTransition::Updated | RequestStatusTransition::AlreadyTarget => {
@@ -272,16 +330,19 @@ impl RequestLifecycle {
     pub(super) async fn transition_request_status(
         &self,
         from_status: &str,
+        from_lifecycle_states: &[PersistedLifecycleState],
         target_status: &str,
         target_lifecycle_state: PersistedLifecycleState,
     ) -> Result<RequestStatusTransition> {
         let doc_id = &self.request.doc_id;
+        let from_lifecycle_states = lifecycle_state_graphql_list_for(from_lifecycle_states);
         let mutation = format!(
             r#"mutation {{
                 update_AgentRequest(
                     filter: {{
                         _docID: {{ _eq: "{doc_id}" }},
-                        status: {{ _eq: "{from_status}" }}
+                        status: {{ _eq: "{from_status}" }},
+                        lifecycle_state: {{ _in: {from_lifecycle_states} }}
                     }},
                     input: {{
                         status: "{target_status}",
@@ -328,7 +389,12 @@ impl RequestLifecycle {
 
         match self.request_status().await? {
             Some(current) if current == target_status => Ok(RequestStatusTransition::AlreadyTarget),
-            Some(current) if matches!(current.as_str(), "completed" | "error" | "superseded") => {
+            Some(current)
+                if matches!(
+                    current.as_str(),
+                    "completed" | "error" | "superseded" | "dead" | "interrupted"
+                ) =>
+            {
                 Ok(RequestStatusTransition::ConflictingTerminal(current))
             }
             Some(current) => anyhow::bail!(
@@ -459,7 +525,8 @@ impl RequestLifecycle {
                     update_AgentRequest(
                         filter: {{
                             _docID: {{ _eq: "{doc_id}" }},
-                            status: {{ _eq: "pending" }}
+                            status: {{ _eq: "pending" }},
+                            lifecycle_state: {{ _eq: "pending" }}
                         }},
                         input: {{
                             status: "superseded",
@@ -517,7 +584,8 @@ impl RequestLifecycle {
                 update_AgentRequest(
                     filter: {{
                         _docID: {{ _eq: "{doc_id}" }},
-                        status: {{ _eq: "pending" }}
+                        status: {{ _eq: "pending" }},
+                        lifecycle_state: {{ _eq: "pending" }}
                     }},
                     input: {{
                         status: "superseded",
@@ -543,6 +611,32 @@ impl RequestLifecycle {
                 "failed to mark duplicate request_id={} superseded: {:?}",
                 self.request.request_id,
                 resp.errors
+            );
+        }
+
+        if !resp
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentRequest"))
+            .is_some_and(response_has_documents)
+        {
+            let request_view = self.request_view().await?;
+            if request_view.as_ref().is_some_and(|row| {
+                row.status == "superseded" && row.lifecycle_state.as_deref() == Some("superseded")
+            }) {
+                return Ok(());
+            }
+            anyhow::bail!(
+                "request {} could not transition pending -> superseded; current status={} lifecycle_state={}",
+                self.request.request_id,
+                request_view
+                    .as_ref()
+                    .map(|row| row.status.as_str())
+                    .unwrap_or("missing"),
+                request_view
+                    .as_ref()
+                    .and_then(|row| row.lifecycle_state.as_deref())
+                    .unwrap_or("missing")
             );
         }
 

--- a/crates/defra-agent/src/session/fork.rs
+++ b/crates/defra-agent/src/session/fork.rs
@@ -4,6 +4,7 @@ use defra_node::EmbeddedNode;
 use super::query::load_conversation_document;
 use super::retry::{execute_batch_mutation_with_retry, execute_mutation_with_retry};
 use crate::graphql::escape_graphql_string;
+use crate::lifecycle::active_runtime_lifecycle_state_graphql_list;
 
 #[derive(Debug, Clone)]
 pub struct ForkParams<'a> {
@@ -28,7 +29,7 @@ pub enum ForkError {
     ForkSourceNotFound(String),
     #[error("fork source's agent_did does not match caller")]
     ForkNotSameAgent,
-    #[error("fork source has a non-terminal AgentRequest and is busy")]
+    #[error("fork source has an active runtime AgentRequest and is busy")]
     ForkSourceBusy,
     #[error("fork_at_user_turn={0} is out of range (parent has only {1} user messages)")]
     ForkAtUserTurnOutOfRange(u32, u32),
@@ -42,12 +43,13 @@ pub enum ForkError {
 
 async fn verify_source_idle(node: &EmbeddedNode, source_session_id: &str) -> Result<bool> {
     let escaped = escape_graphql_string(source_session_id);
+    let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
     let query = format!(
         r#"{{
             AgentRequest(
                 filter: {{
                     session_id: {{ _eq: "{escaped}" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
+                    lifecycle_state: {{ _in: {active_runtime_states} }}
                 }},
                 limit: 1
             ) {{ request_id }}

--- a/crates/defra-agent/src/trigger_engine/mod.rs
+++ b/crates/defra-agent/src/trigger_engine/mod.rs
@@ -131,19 +131,19 @@ pub(crate) trait MaterializerHandle: Send + Sync {
         rendered_prompt: &str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<String>> + Send + '_>>;
 
-    /// Check whether any non-terminal `AgentRequest` is currently bound to
+    /// Check whether any active runtime `AgentRequest` is currently bound to
     /// this trigger. Used by the concurrency gate to decide whether a new
     /// fire should skip or supersede.
-    fn has_nonterminal_request_for_trigger(
+    fn has_active_runtime_request_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<bool>> + Send + '_>>;
 
-    /// Supersede any non-terminal requests bound to this trigger. Returns the
-    /// number of requests transitioned. Invoked by `LatestOnly` concurrency
-    /// before materializing the new fire.
-    fn supersede_nonterminal_requests_for_trigger(
+    /// Supersede any active runtime requests bound to this trigger. Returns
+    /// the number of requests transitioned. Invoked by `LatestOnly`
+    /// concurrency before materializing the new fire.
+    fn supersede_active_runtime_requests_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,
@@ -226,10 +226,10 @@ impl TriggerEngine {
     /// Current scope (Tasks 30-33): enabled gate against the active snapshot,
     /// then render the task's prompt template (render failures return
     /// `Errored` without materializing), then apply the intent's concurrency
-    /// mode (`Parallel` fires unconditionally; `Serial` skips when a
-    /// non-terminal request already exists for this trigger tuple;
-    /// `LatestOnly` supersedes any prior non-terminal request under a
-    /// per-trigger lock), then hand the rendered prompt to the materializer.
+    /// mode (`Parallel` fires unconditionally; `Serial` skips when an active
+    /// runtime request already exists for this trigger tuple; `LatestOnly`
+    /// supersedes any prior active runtime request under a per-trigger lock),
+    /// then hand the rendered prompt to the materializer.
     #[allow(dead_code)]
     async fn dispatch(&self, intent: FireIntent) -> FireResult {
         if let Some(error) = intent.well_formed_error() {
@@ -306,10 +306,9 @@ impl TriggerEngine {
         };
 
         // 3. Concurrency gate. `Parallel` skips the check entirely. `Serial`
-        // queries the materializer for a non-terminal request bound to the
-        // same `(trigger_id, trigger_kind)` tuple — matching on the tuple is
+        // queries the materializer for an active runtime request bound to the
+        // same `(trigger_id, trigger_kind)` tuple; matching on the tuple is
         // load-bearing because trigger_id alone is not unique across kinds.
-        // `LatestOnly` lands in Task 32.
         use crate::runtime_snapshot::ConcurrencyMode;
         match intent.concurrency {
             ConcurrencyMode::Parallel => {
@@ -322,7 +321,7 @@ impl TriggerEngine {
                 if let Some(trigger_id) = intent.trigger_id.as_deref() {
                     match self
                         .materializer
-                        .has_nonterminal_request_for_trigger(trigger_id, intent.trigger_kind)
+                        .has_active_runtime_request_for_trigger(trigger_id, intent.trigger_kind)
                         .await
                     {
                         Ok(true) => {
@@ -365,7 +364,10 @@ impl TriggerEngine {
                     let _guard = lock.lock().await;
                     match self
                         .materializer
-                        .supersede_nonterminal_requests_for_trigger(trigger_id, intent.trigger_kind)
+                        .supersede_active_runtime_requests_for_trigger(
+                            trigger_id,
+                            intent.trigger_kind,
+                        )
                         .await
                     {
                         Ok(_count) => { /* proceed to materialize under lock */ }

--- a/crates/defra-agent/src/trigger_engine/production_materializer.rs
+++ b/crates/defra-agent/src/trigger_engine/production_materializer.rs
@@ -7,12 +7,11 @@
 //!   `TriggerLineage` so the normal watcher/router/daemon path claims and
 //!   executes it while preserving `caused_by_trigger_id` /
 //!   `caused_by_trigger_kind`.
-//! * `has_nonterminal_request_for_trigger` performs a GraphQL query against
+//! * `has_active_runtime_request_for_trigger` performs a GraphQL query against
 //!   `AgentRequest`, filtering on the `(trigger_id, trigger_kind)` tuple and
-//!   the non-terminal lifecycle states (`pending`, `claimed`, `processing`,
-//!   `inputRequired`).
-//! * `supersede_nonterminal_requests_for_trigger` transitions every matching
-//!   non-terminal request to `lifecycle_state = superseded` /
+//!   the active runtime lifecycle states (`pending`, `claimed`, `processing`).
+//! * `supersede_active_runtime_requests_for_trigger` transitions every matching
+//!   active runtime request to `lifecycle_state = superseded` /
 //!   `status = superseded`.
 //!
 //! Behavior lookup happens against a `watch::Receiver<Arc<ActiveRuntimeSnapshot>>`
@@ -28,7 +27,7 @@ use tokio::sync::watch;
 
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::{
-    nonterminal_lifecycle_state_graphql_list, task_run_conversation_title,
+    active_runtime_lifecycle_state_graphql_list, task_run_conversation_title,
     write_pending_agent_request_with_lineage_and_conversation_title, ExecutionOrigin,
     TriggerLineage,
 };
@@ -154,7 +153,7 @@ impl MaterializerHandle for ProductionMaterializer {
         })
     }
 
-    fn has_nonterminal_request_for_trigger(
+    fn has_active_runtime_request_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,
@@ -162,18 +161,18 @@ impl MaterializerHandle for ProductionMaterializer {
         let node = self.node.clone();
         let escaped_trigger_id = escape_graphql_string(trigger_id);
         let trigger_kind_str = trigger_kind.as_str();
-        let nonterminal_states = nonterminal_lifecycle_state_graphql_list();
+        let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
         Box::pin(async move {
             // Strict tuple match on `(caused_by_trigger_id, caused_by_trigger_kind)`
-            // + non-terminal `lifecycle_state`. Limit 1 is sufficient: we only
-            // need a boolean signal for the concurrency gate.
+            // + active runtime `lifecycle_state`. Limit 1 is sufficient: we
+            // only need a boolean signal for the concurrency gate.
             let query = format!(
                 r#"query {{
                     AgentRequest(
                         filter: {{
                             caused_by_trigger_id: {{ _eq: "{trigger_id}" }},
                             caused_by_trigger_kind: {{ _eq: "{trigger_kind}" }},
-                            lifecycle_state: {{ _in: {nonterminal_states} }}
+                            lifecycle_state: {{ _in: {active_runtime_states} }}
                         }},
                         limit: 1
                     ) {{ _docID }}
@@ -184,7 +183,7 @@ impl MaterializerHandle for ProductionMaterializer {
             let resp = node.execute(&query).await;
             if resp.has_errors() {
                 anyhow::bail!(
-                    "query for nonterminal AgentRequest by trigger failed: {:?}",
+                    "query for active runtime AgentRequest by trigger failed: {:?}",
                     resp.errors
                 );
             }
@@ -199,7 +198,7 @@ impl MaterializerHandle for ProductionMaterializer {
         })
     }
 
-    fn supersede_nonterminal_requests_for_trigger(
+    fn supersede_active_runtime_requests_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,
@@ -207,21 +206,21 @@ impl MaterializerHandle for ProductionMaterializer {
         let node = self.node.clone();
         let escaped_trigger_id = escape_graphql_string(trigger_id);
         let trigger_kind_str = trigger_kind.as_str();
-        let nonterminal_states = nonterminal_lifecycle_state_graphql_list();
+        let active_runtime_states = active_runtime_lifecycle_state_graphql_list();
         Box::pin(async move {
-            // Single bulk update against the non-terminal tuple match. DefraDB
-            // returns the list of updated documents in the mutation response
-            // so we can count how many requests were transitioned — the
-            // engine's `LatestOnly` path treats this count as observational
-            // (logged, not gated on). Failure reason left blank; the engine
-            // layer does not have a structured reason to attach.
+            // Single bulk update against the active runtime tuple match.
+            // DefraDB returns the list of updated documents in the mutation
+            // response so we can count how many requests were transitioned;
+            // the engine's `LatestOnly` path treats this count as
+            // observational (logged, not gated on). Failure reason left blank;
+            // the engine layer does not have a structured reason to attach.
             let mutation = format!(
                 r#"mutation {{
                     update_AgentRequest(
                         filter: {{
                             caused_by_trigger_id: {{ _eq: "{trigger_id}" }},
                             caused_by_trigger_kind: {{ _eq: "{trigger_kind}" }},
-                            lifecycle_state: {{ _in: {nonterminal_states} }}
+                            lifecycle_state: {{ _in: {active_runtime_states} }}
                         }},
                         input: {{
                             status: "superseded",
@@ -235,7 +234,7 @@ impl MaterializerHandle for ProductionMaterializer {
             let resp = node.execute(&mutation).await;
             if resp.has_errors() {
                 anyhow::bail!(
-                    "supersede nonterminal AgentRequests by trigger failed: {:?}",
+                    "supersede active runtime AgentRequests by trigger failed: {:?}",
                     resp.errors
                 );
             }
@@ -251,7 +250,7 @@ impl MaterializerHandle for ProductionMaterializer {
                     trigger_id = %escaped_trigger_id,
                     trigger_kind = %trigger_kind_str,
                     count,
-                    "superseded non-terminal AgentRequests for trigger"
+                    "superseded active runtime AgentRequests for trigger"
                 );
             }
             Ok(count)

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -73,7 +73,7 @@ struct MaterializeGate {
 /// reached the materializer.
 ///
 /// `nonterminal_for` stores the concrete request ids for `(trigger_id,
-/// trigger_kind)` tuples that `has_nonterminal_request_for_trigger` should
+/// trigger_kind)` tuples that `has_active_runtime_request_for_trigger` should
 /// report as in-flight. Tests can pre-populate it to simulate prior fires.
 /// Lean contract tests can opt into adding successful materializations as new
 /// non-terminal requests, which mirrors production persistence without
@@ -130,8 +130,8 @@ impl SpyMaterializer {
     }
 
     /// Pre-populate the in-flight set with `(trigger_id, trigger_kind)` so the
-    /// next `has_nonterminal_request_for_trigger` call returns `true` for the
-    /// matching tuple. Also makes `supersede_nonterminal_requests_for_trigger`
+    /// next `has_active_runtime_request_for_trigger` call returns `true` for the
+    /// matching tuple. Also makes `supersede_active_runtime_requests_for_trigger`
     /// report the tuple count (and clears it, mirroring real terminal
     /// transitions) so LatestOnly tests can assert the count plumbed through.
     fn mark_nonterminal(&self, trigger_id: &str, trigger_kind: TriggerKind) {
@@ -223,7 +223,7 @@ impl MaterializerHandle for SpyMaterializer {
         })
     }
 
-    fn has_nonterminal_request_for_trigger(
+    fn has_active_runtime_request_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,
@@ -240,7 +240,7 @@ impl MaterializerHandle for SpyMaterializer {
         })
     }
 
-    fn supersede_nonterminal_requests_for_trigger(
+    fn supersede_active_runtime_requests_for_trigger(
         &self,
         trigger_id: &str,
         trigger_kind: TriggerKind,

--- a/crates/defra-agent/tests/schedule_conformance.rs
+++ b/crates/defra-agent/tests/schedule_conformance.rs
@@ -25,15 +25,15 @@
 //!   writeback path (`update_Schedule` with `last_status = "error"`) mirrors
 //!   what `ScheduleSource::on_result` writes on a render failure.
 //! * `serial_skips_when_prior_non_terminal` — the engine's
-//!   `has_nonterminal_request_for_trigger` query returns `true` exactly when a
-//!   request carrying the `(trigger_id, trigger_kind)` tuple is in a
-//!   non-terminal lifecycle state.
+//!   `has_active_runtime_request_for_trigger` query returns `true` exactly when a
+//!   request carrying the `(trigger_id, trigger_kind)` tuple is in an active
+//!   runtime lifecycle state.
 //! * `serial_advances_next_run_at_on_skip` — the Schedule writeback path
 //!   advances `next_run_at` by `interval_secs` on skip while leaving
 //!   apply-owned fields untouched.
 //! * `latest_only_supersedes_prior_fire` — the supersede mutation (same shape
-//!   as `supersede_nonterminal_requests_for_trigger` uses) transitions every
-//!   non-terminal request for a trigger tuple to `lifecycle_state = superseded`
+//!   as `supersede_active_runtime_requests_for_trigger` uses) transitions every
+//!   active runtime request for a trigger tuple to `lifecycle_state = superseded`
 //!   / `status = superseded`.
 //! * `generation_bump_reconfigures_active_schedules` — inserting a Schedule
 //!   post-startup drives a snapshot reload and bumps `active_generation`;
@@ -53,7 +53,7 @@
 //! This file still boots `DefraAgent::run` only where the observable under
 //! test is operational reconfiguration (`active_generation` bumps). The other
 //! cases pin the persistence-layer contract the engine delegates to: DefraDB
-//! materialization lineage, non-terminal gating queries, supersede mutations,
+//! materialization lineage, active runtime gating queries, supersede mutations,
 //! and source writeback shape.
 
 use std::sync::Arc;
@@ -351,10 +351,10 @@ async fn fetch_schedule_row(
     })
 }
 
-/// Query the same shape `ProductionMaterializer::has_nonterminal_request_for_trigger`
+/// Query the same shape `ProductionMaterializer::has_active_runtime_request_for_trigger`
 /// uses — filters by `(caused_by_trigger_id, caused_by_trigger_kind)` and the
-/// non-terminal lifecycle state set — and returns whether any row matches.
-async fn has_nonterminal_request_for_trigger(
+/// active runtime lifecycle state set — and returns whether any row matches.
+async fn has_active_runtime_request_for_trigger(
     node: &defra_agent::defra_node::EmbeddedNode,
     trigger_id: &str,
     trigger_kind: &str,
@@ -367,7 +367,7 @@ async fn has_nonterminal_request_for_trigger(
                 filter: {{
                     caused_by_trigger_id: {{ _eq: "{escaped_trigger_id}" }},
                     caused_by_trigger_kind: {{ _eq: "{escaped_trigger_kind}" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
+                    lifecycle_state: {{ _in: ["pending", "claimed", "processing"] }}
                 }},
                 limit: 1
             ) {{ _docID }}
@@ -376,7 +376,7 @@ async fn has_nonterminal_request_for_trigger(
     let resp = node.execute(&query).await;
     assert!(
         !resp.has_errors(),
-        "has_nonterminal_request_for_trigger query failed: {:?}",
+        "has_active_runtime_request_for_trigger query failed: {:?}",
         resp.errors
     );
     resp.data
@@ -387,11 +387,11 @@ async fn has_nonterminal_request_for_trigger(
         .unwrap_or(false)
 }
 
-/// Mirrors `ProductionMaterializer::supersede_nonterminal_requests_for_trigger`:
-/// transitions every non-terminal request bound to `(trigger_id, trigger_kind)`
+/// Mirrors `ProductionMaterializer::supersede_active_runtime_requests_for_trigger`:
+/// transitions every active runtime request bound to `(trigger_id, trigger_kind)`
 /// to `lifecycle_state = superseded` / `status = superseded`. Returns the
 /// number of documents updated.
-async fn supersede_nonterminal_requests_for_trigger(
+async fn supersede_active_runtime_requests_for_trigger(
     node: &defra_agent::defra_node::EmbeddedNode,
     trigger_id: &str,
     trigger_kind: &str,
@@ -404,7 +404,7 @@ async fn supersede_nonterminal_requests_for_trigger(
                 filter: {{
                     caused_by_trigger_id: {{ _eq: "{escaped_trigger_id}" }},
                     caused_by_trigger_kind: {{ _eq: "{escaped_trigger_kind}" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
+                    lifecycle_state: {{ _in: ["pending", "claimed", "processing"] }}
                 }},
                 input: {{
                     status: "superseded",
@@ -416,7 +416,7 @@ async fn supersede_nonterminal_requests_for_trigger(
     let resp = node.execute(&mutation).await;
     assert!(
         !resp.has_errors(),
-        "supersede_nonterminal_requests_for_trigger failed: {:?}",
+        "supersede_active_runtime_requests_for_trigger failed: {:?}",
         resp.errors
     );
     resp.data
@@ -848,9 +848,9 @@ async fn template_render_failure_records_error_status() {
     );
 }
 
-/// Serial concurrency must gate: when a non-terminal `AgentRequest` already
+/// Serial concurrency must gate: when an active runtime `AgentRequest` already
 /// exists for the `(trigger_id, trigger_kind)` tuple, the engine's
-/// concurrency-gate query (`has_nonterminal_request_for_trigger`) must return
+/// concurrency-gate query (`has_active_runtime_request_for_trigger`) must return
 /// `true`, and a new fire must not materialize a second `AgentRequest` for the
 /// same trigger. We pin this by:
 /// 1. Seeding an in-flight request via the lifecycle entry point the engine
@@ -886,7 +886,7 @@ async fn serial_skips_when_prior_non_terminal() {
     );
     // The engine's gating query must see it.
     assert!(
-        has_nonterminal_request_for_trigger(db.node.as_ref(), "sched-serial-skip", "schedule")
+        has_active_runtime_request_for_trigger(db.node.as_ref(), "sched-serial-skip", "schedule")
             .await,
         "gating query must see the in-flight request"
     );
@@ -1025,7 +1025,7 @@ async fn latest_only_supersedes_prior_fire() {
     let prior_request_id = prior.request().request_id.clone();
 
     // Step 1: supersede (what the LatestOnly path does before materializing).
-    let superseded_count = supersede_nonterminal_requests_for_trigger(
+    let superseded_count = supersede_active_runtime_requests_for_trigger(
         db.node.as_ref(),
         "sched-latest-only",
         "schedule",
@@ -1076,7 +1076,7 @@ async fn latest_only_supersedes_prior_fire() {
     // The gating query must NOT see the superseded prior (it's terminal);
     // it DOES see the newly claimed fire.
     assert!(
-        has_nonterminal_request_for_trigger(db.node.as_ref(), "sched-latest-only", "schedule")
+        has_active_runtime_request_for_trigger(db.node.as_ref(), "sched-latest-only", "schedule")
             .await,
         "after materialize, the new claimed request must be visible to the gating query"
     );

--- a/crates/defra-agent/tests/schedule_conformance.rs
+++ b/crates/defra-agent/tests/schedule_conformance.rs
@@ -24,7 +24,7 @@
 //! * `template_render_failure_records_error_status` — the `Schedule` runtime
 //!   writeback path (`update_Schedule` with `last_status = "error"`) mirrors
 //!   what `ScheduleSource::on_result` writes on a render failure.
-//! * `serial_skips_when_prior_non_terminal` — the engine's
+//! * `serial_skips_when_prior_active_runtime` — the engine's
 //!   `has_active_runtime_request_for_trigger` query returns `true` exactly when a
 //!   request carrying the `(trigger_id, trigger_kind)` tuple is in an active
 //!   runtime lifecycle state.
@@ -859,7 +859,7 @@ async fn template_render_failure_records_error_status() {
 /// 3. Asserting `true`; then simulating the Skipped writeback and asserting
 ///    no second AgentRequest is created.
 #[tokio::test]
-async fn serial_skips_when_prior_non_terminal() {
+async fn serial_skips_when_prior_active_runtime() {
     let db = test_db("schedule-conformance-serial-skip").await;
 
     let lineage = TriggerLineage {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -12,9 +12,8 @@ mod support;
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
     assert_state_machine_contract_is_complete, lean_client_shell_case, lean_contract_snapshot,
-    lean_runtime_reconcile_case,
-    lean_session_recovery_case, lean_tool_preflight_case, lean_tool_retry_case,
-    lean_vocabulary_values,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_vocabulary_values,
 };
 use support::snapshots::{
     fetch_conversation_snapshot, fetch_request_lineage_snapshot,
@@ -160,10 +159,16 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "Lean ClientShell case count drifted from emitted cases"
     );
     if !snapshot.client_shell_cases.is_empty() {
-        emitted.insert(("client_shell_cases".to_string(), "ClientShellCases".to_string()));
+        emitted.insert((
+            "client_shell_cases".to_string(),
+            "ClientShellCases".to_string(),
+        ));
     }
     if !snapshot.tool_preflight_cases.is_empty() {
-        emitted.insert(("tool_cases".to_string(), "ToolExecutionPreflight".to_string()));
+        emitted.insert((
+            "tool_cases".to_string(),
+            "ToolExecutionPreflight".to_string(),
+        ));
     }
     if !snapshot.tool_retry_cases.is_empty() {
         emitted.insert(("tool_cases".to_string(), "ToolExecutionRetry".to_string()));
@@ -838,9 +843,9 @@ async fn scheduled_materialization_persists_trigger_lineage() {
 // `ProductionMaterializer` issues, and assert the resulting on-disk snapshot.
 // -----------------------------------------------------------------------------
 
-/// Serial concurrency: when a non-terminal request already exists for the
+/// Serial concurrency: when an active runtime request already exists for the
 /// `(trigger_id, trigger_kind)` tuple, the materializer's
-/// `has_nonterminal_request_for_trigger` query must observe it (the engine
+/// `has_active_runtime_request_for_trigger` query must observe it (the engine
 /// turns this into `FireResult::Skipped`). The state-machine conformance
 /// assertion: no second `AgentRequest` is created for the tuple — the count
 /// observed before and after the skip decision is the same.
@@ -867,13 +872,13 @@ async fn serial_skip_does_not_create_request() {
     .unwrap();
 
     // Run the exact query `ProductionMaterializer` uses to gate the fire.
-    // Expect `true` — a non-terminal request for this tuple exists.
+    // Expect `true` — an active runtime request for this tuple exists.
     let gating_query = r#"query {
             AgentRequest(
                 filter: {
                     caused_by_trigger_id: { _eq: "sched-serial" },
                     caused_by_trigger_kind: { _eq: "schedule" },
-                    lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                    lifecycle_state: { _in: ["pending", "claimed", "processing"] }
                 },
                 limit: 1
             ) { _docID }
@@ -937,7 +942,7 @@ async fn serial_skip_does_not_create_request() {
         "serial skip must not create a new AgentRequest"
     );
 
-    // Sanity: the seeded request is still in its non-terminal state
+    // Sanity: the seeded request is still in its active runtime state
     // (the skip decision neither advances nor terminates it).
     let still_claimed = fetch_request_snapshot(&db.node, &seeded.request().doc_id).await;
     assert_eq!(still_claimed.lifecycle_state, "claimed");
@@ -946,7 +951,7 @@ async fn serial_skip_does_not_create_request() {
 
 /// LatestOnly concurrency: when a new fire arrives for a trigger tuple with an
 /// in-flight request, the engine supersedes the prior via the same mutation
-/// shape `ProductionMaterializer::supersede_nonterminal_requests_for_trigger`
+/// shape `ProductionMaterializer::supersede_active_runtime_requests_for_trigger`
 /// uses. The seeded request must transition
 /// `(processing / claimed) -> (superseded / superseded)` exactly.
 #[tokio::test]
@@ -976,13 +981,13 @@ async fn latest_only_transition_to_superseded() {
     assert_eq!(before.status, "processing");
 
     // Run the engine's supersede mutation verbatim (the shape in
-    // `production_materializer::supersede_nonterminal_requests_for_trigger`).
+    // `production_materializer::supersede_active_runtime_requests_for_trigger`).
     let supersede = r#"mutation {
             update_AgentRequest(
                 filter: {
                     caused_by_trigger_id: { _eq: "sched-latest" },
                     caused_by_trigger_kind: { _eq: "schedule" },
-                    lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                    lifecycle_state: { _in: ["pending", "claimed", "processing"] }
                 },
                 input: {
                     status: "superseded",
@@ -1030,6 +1035,93 @@ async fn latest_only_transition_to_superseded() {
             failure_reason: "".into(),
         }
     );
+}
+
+#[tokio::test]
+async fn active_runtime_trigger_filters_ignore_input_required() {
+    let db = test_db("transition-input-required-active-filter").await;
+
+    let lineage = TriggerLineage {
+        trigger_id: Some("sched-input-required".into()),
+        trigger_kind: Some("schedule".into()),
+    };
+    let seeded = RequestLifecycle::materialize_claimed_with_execution_binding(
+        db.node.clone(),
+        AGENT_NAME,
+        AGENT_DID,
+        "reserved inputRequired seed",
+        DEADLINE_SECS,
+        ExecutionOrigin::Scheduled,
+        BACKEND_ID,
+        lineage,
+    )
+    .await
+    .unwrap();
+    set_request_lifecycle_state(&db.node, &seeded.request().doc_id, "inputRequired").await;
+
+    let gating_query = r#"query {
+        AgentRequest(
+            filter: {
+                caused_by_trigger_id: { _eq: "sched-input-required" },
+                caused_by_trigger_kind: { _eq: "schedule" },
+                lifecycle_state: { _in: ["pending", "claimed", "processing"] }
+            },
+            limit: 1
+        ) { _docID }
+    }"#;
+    let gate = db.node.execute(gating_query).await;
+    assert!(
+        !gate.has_errors(),
+        "gating query errored: {:?}",
+        gate.errors
+    );
+    let gate_rows = gate
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        gate_rows.is_empty(),
+        "active runtime gate must not observe reserved inputRequired rows"
+    );
+
+    let supersede = r#"mutation {
+        update_AgentRequest(
+            filter: {
+                caused_by_trigger_id: { _eq: "sched-input-required" },
+                caused_by_trigger_kind: { _eq: "schedule" },
+                lifecycle_state: { _in: ["pending", "claimed", "processing"] }
+            },
+            input: {
+                status: "superseded",
+                lifecycle_state: "superseded"
+            }
+        ) { _docID }
+    }"#;
+    let resp = db.node.execute(supersede).await;
+    assert!(
+        !resp.has_errors(),
+        "supersede mutation errored: {:?}",
+        resp.errors
+    );
+    let updated_rows = resp
+        .data
+        .as_ref()
+        .and_then(|d| d.get("update_AgentRequest"))
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        updated_rows.is_empty(),
+        "active runtime supersede must not transition reserved inputRequired rows"
+    );
+    assert_lean_transition_is_illegal("Request", "inputRequired", "superseded");
+
+    let snap = fetch_request_snapshot(&db.node, &seeded.request().doc_id).await;
+    assert_eq!(snap.status, "processing");
+    assert_eq!(snap.lifecycle_state, "inputRequired");
 }
 
 /// Template render failure (`FireResult::Errored`): the engine must NOT
@@ -1163,7 +1255,7 @@ async fn fire_errored_does_not_create_request() {
 // need their own independent assertions.
 // -----------------------------------------------------------------------------
 
-/// Serial concurrency (event kind): when a non-terminal request with
+/// Serial concurrency (event kind): when an active runtime request with
 /// `caused_by_trigger_kind = "event"` already exists for the tuple, the
 /// materializer's gating query observes it and the engine skips. The
 /// state-machine conformance assertion: no second `AgentRequest` is created
@@ -1191,13 +1283,13 @@ async fn serial_skip_event_does_not_create_request() {
     .unwrap();
 
     // Run the exact query `ProductionMaterializer` uses to gate the fire.
-    // Expect `true` — a non-terminal request for this tuple exists.
+    // Expect `true` — an active runtime request for this tuple exists.
     let gating_query = r#"query {
         AgentRequest(
             filter: {
                 caused_by_trigger_id: { _eq: "trigger-event-serial" },
                 caused_by_trigger_kind: { _eq: "event" },
-                lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                lifecycle_state: { _in: ["pending", "claimed", "processing"] }
             },
             limit: 1
         ) { _docID }
@@ -1260,7 +1352,7 @@ async fn serial_skip_event_does_not_create_request() {
         "serial skip on event-kind trigger must not create a new AgentRequest"
     );
 
-    // Sanity: the seeded request is still in its non-terminal state.
+    // Sanity: the seeded request is still in its active runtime state.
     let still_claimed = fetch_request_snapshot(&db.node, &seeded.request().doc_id).await;
     assert_eq!(still_claimed.lifecycle_state, "claimed");
     assert_eq!(still_claimed.status, "processing");
@@ -1299,13 +1391,13 @@ async fn latest_only_event_transition_to_superseded() {
 
     // Run the engine's supersede mutation verbatim, filtered on the event
     // kind's lineage tuple (the shape in
-    // `production_materializer::supersede_nonterminal_requests_for_trigger`).
+    // `production_materializer::supersede_active_runtime_requests_for_trigger`).
     let supersede = r#"mutation {
         update_AgentRequest(
             filter: {
                 caused_by_trigger_id: { _eq: "trigger-event-latest" },
                 caused_by_trigger_kind: { _eq: "event" },
-                lifecycle_state: { _in: ["pending", "claimed", "processing", "inputRequired"] }
+                lifecycle_state: { _in: ["pending", "claimed", "processing"] }
             },
             input: {
                 status: "superseded",
@@ -1514,7 +1606,7 @@ async fn fork_does_not_transition_parent_lifecycle_state() {
     create_agent_behavior(&db.node, AGENT_NAME, AGENT_DID).await;
 
     // Parent has a completed AgentRequest + AgentResponse so the parent is idle
-    // (no non-terminal lifecycle_state) and fork is allowed.
+    // (no active runtime lifecycle_state) and fork is allowed.
     let request_id = uuid::Uuid::new_v4().to_string();
     let request_doc_id = create_request(
         &db.node,
@@ -1774,11 +1866,10 @@ async fn processing_interrupted_preserves_partial_response() {
 }
 
 #[tokio::test]
-async fn input_required_interrupted() {
-    // Simulates an interrupt arriving for a reserved `inputRequired` row. The
-    // current product preserves this vocabulary for protocol parity but does
-    // not emit it, so this test sets the DB lifecycle_state directly and relies
-    // on the _nin filter in `transition_to_interrupted` to allow the move.
+async fn input_required_interrupt_is_rejected_without_transition() {
+    // `inputRequired` is reserved persisted/client vocabulary. Rust may parse
+    // and display it, but the core lifecycle cannot interrupt it until Lean
+    // models an external-input loop.
     let db = test_db("input-required-interrupted").await;
     let request_id = uuid::Uuid::new_v4().to_string();
     let session_id = uuid::Uuid::new_v4().to_string();
@@ -1808,15 +1899,43 @@ async fn input_required_interrupted() {
 
     let interrupt_at = chrono::Utc::now().to_rfc3339();
     set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
-    lifecycle.transition_to_interrupted().await.unwrap();
-    // Core Lean Request semantics reserve inputRequired and have no active
-    // transition out of it; Rust keeps this repair path as a product boundary
-    // for replicated rows that already contain the reserved state.
+    let err = lifecycle
+        .transition_to_interrupted()
+        .await
+        .expect_err("inputRequired is not an interruptible runtime state");
+    assert!(
+        err.to_string().contains("inputRequired"),
+        "error should name the reserved state: {err:?}"
+    );
     assert_lean_transition_is_illegal("Request", "inputRequired", "interrupted");
 
     let snap = fetch_request_snapshot(&db.node, &doc_id).await;
-    assert_eq!(snap.status, "interrupted");
-    assert_eq!(snap.lifecycle_state, "interrupted");
+    assert_eq!(snap.status, "processing");
+    assert_eq!(snap.lifecycle_state, "inputRequired");
+
+    let complete_err = lifecycle
+        .complete()
+        .await
+        .expect_err("inputRequired must not complete through a status-only transition");
+    assert!(
+        complete_err.to_string().contains("processing"),
+        "complete error should describe the persisted status: {complete_err:?}"
+    );
+    assert_lean_transition_is_illegal("Request", "inputRequired", "completed");
+
+    let fail_err = lifecycle
+        .fail()
+        .await
+        .expect_err("inputRequired must not fail through a status-only transition");
+    assert!(
+        fail_err.to_string().contains("processing"),
+        "fail error should describe the persisted status: {fail_err:?}"
+    );
+    assert_lean_transition_is_illegal("Request", "inputRequired", "failed");
+
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(snap.status, "processing");
+    assert_eq!(snap.lifecycle_state, "inputRequired");
 }
 
 #[tokio::test]
@@ -2395,6 +2514,12 @@ fn conformance_mapping_all_9_lifecycle_states_round_trip() {
             "as_str must round-trip to the source string"
         );
     }
+    assert_eq!(
+        RequestLifecycleState::try_from("inputRequired")
+            .expect("reserved vocabulary should parse")
+            .as_str(),
+        "inputRequired"
+    );
 
     // Unknown strings must reject.
     assert!(RequestLifecycleState::try_from("bogus").is_err());

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -1918,8 +1918,8 @@ async fn input_required_interrupt_is_rejected_without_transition() {
         .await
         .expect_err("inputRequired must not complete through a status-only transition");
     assert!(
-        complete_err.to_string().contains("processing"),
-        "complete error should describe the persisted status: {complete_err:?}"
+        complete_err.to_string().contains("inputRequired"),
+        "complete error should describe the persisted lifecycle_state: {complete_err:?}"
     );
     assert_lean_transition_is_illegal("Request", "inputRequired", "completed");
 
@@ -1928,8 +1928,8 @@ async fn input_required_interrupt_is_rejected_without_transition() {
         .await
         .expect_err("inputRequired must not fail through a status-only transition");
     assert!(
-        fail_err.to_string().contains("processing"),
-        "fail error should describe the persisted status: {fail_err:?}"
+        fail_err.to_string().contains("inputRequired"),
+        "fail error should describe the persisted lifecycle_state: {fail_err:?}"
     );
     assert_lean_transition_is_illegal("Request", "inputRequired", "failed");
 

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -22,8 +22,8 @@
 //! * `subscription_reconciles_on_generation_bump` — re-pointing a trigger from
 //!   collection A to collection B bumps `active_generation` and only B-side
 //!   writes fire afterwards.
-//! * `serial_skips_when_prior_non_terminal` — the engine's gating query sees a
-//!   non-terminal `(trigger_id, "event")` tuple and the serial trigger skips.
+//! * `serial_skips_when_prior_non_terminal` — the engine's gating query sees an
+//!   active runtime `(trigger_id, "event")` tuple and the serial trigger skips.
 //! * `latest_only_supersedes_prior_fire` — the supersede mutation the engine
 //!   would run transitions the in-flight event-kind request to
 //!   `superseded`, and a new materialize lands with the same lineage.
@@ -394,8 +394,8 @@ async fn fetch_event_trigger_row(node: &EmbeddedNode, trigger_id: &str) -> Optio
     })
 }
 
-/// Mirrors `ProductionMaterializer::has_nonterminal_request_for_trigger`.
-async fn has_nonterminal_request_for_trigger(
+/// Mirrors `ProductionMaterializer::has_active_runtime_request_for_trigger`.
+async fn has_active_runtime_request_for_trigger(
     node: &EmbeddedNode,
     trigger_id: &str,
     trigger_kind: &str,
@@ -408,7 +408,7 @@ async fn has_nonterminal_request_for_trigger(
                 filter: {{
                     caused_by_trigger_id: {{ _eq: "{escaped_trigger_id}" }},
                     caused_by_trigger_kind: {{ _eq: "{escaped_trigger_kind}" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
+                    lifecycle_state: {{ _in: ["pending", "claimed", "processing"] }}
                 }},
                 limit: 1
             ) {{ _docID }}
@@ -417,7 +417,7 @@ async fn has_nonterminal_request_for_trigger(
     let resp = node.execute(&query).await;
     assert!(
         !resp.has_errors(),
-        "has_nonterminal_request_for_trigger failed: {:?}",
+        "has_active_runtime_request_for_trigger failed: {:?}",
         resp.errors
     );
     resp.data
@@ -428,8 +428,8 @@ async fn has_nonterminal_request_for_trigger(
         .unwrap_or(false)
 }
 
-/// Mirrors `ProductionMaterializer::supersede_nonterminal_requests_for_trigger`.
-async fn supersede_nonterminal_requests_for_trigger(
+/// Mirrors `ProductionMaterializer::supersede_active_runtime_requests_for_trigger`.
+async fn supersede_active_runtime_requests_for_trigger(
     node: &EmbeddedNode,
     trigger_id: &str,
     trigger_kind: &str,
@@ -442,7 +442,7 @@ async fn supersede_nonterminal_requests_for_trigger(
                 filter: {{
                     caused_by_trigger_id: {{ _eq: "{escaped_trigger_id}" }},
                     caused_by_trigger_kind: {{ _eq: "{escaped_trigger_kind}" }},
-                    lifecycle_state: {{ _in: ["pending", "claimed", "processing", "inputRequired"] }}
+                    lifecycle_state: {{ _in: ["pending", "claimed", "processing"] }}
                 }},
                 input: {{
                     status: "superseded",
@@ -454,7 +454,7 @@ async fn supersede_nonterminal_requests_for_trigger(
     let resp = node.execute(&mutation).await;
     assert!(
         !resp.has_errors(),
-        "supersede_nonterminal_requests_for_trigger failed: {:?}",
+        "supersede_active_runtime_requests_for_trigger failed: {:?}",
         resp.errors
     );
     resp.data
@@ -1027,7 +1027,7 @@ async fn subscription_reconciles_on_generation_bump() {
     agent.shutdown().await;
 }
 
-/// Serial concurrency: when a non-terminal request already exists for the
+/// Serial concurrency: when an active runtime request already exists for the
 /// event-kind lineage tuple, the engine's gating query sees it → `FireResult::Skipped`.
 /// No second `AgentRequest` materializes for the same tuple. Asserted at the
 /// persistence-layer contract (PR 1 pattern).
@@ -1053,7 +1053,7 @@ async fn serial_skips_when_prior_non_terminal() {
     .unwrap();
 
     assert!(
-        has_nonterminal_request_for_trigger(db.node.as_ref(), "trigger-event-serial", "event",)
+        has_active_runtime_request_for_trigger(db.node.as_ref(), "trigger-event-serial", "event",)
             .await,
         "gating query must see the in-flight event-kind request"
     );
@@ -1098,7 +1098,7 @@ async fn latest_only_supersedes_prior_fire() {
     .unwrap();
     let prior_request_id = prior.request().request_id.clone();
 
-    let superseded = supersede_nonterminal_requests_for_trigger(
+    let superseded = supersede_active_runtime_requests_for_trigger(
         db.node.as_ref(),
         "trigger-event-latest",
         "event",
@@ -1144,7 +1144,7 @@ async fn latest_only_supersedes_prior_fire() {
         2
     );
     assert!(
-        has_nonterminal_request_for_trigger(db.node.as_ref(), "trigger-event-latest", "event",)
+        has_active_runtime_request_for_trigger(db.node.as_ref(), "trigger-event-latest", "event",)
             .await,
         "after materialize, the new claimed request must be visible to the gating query"
     );

--- a/crates/defra-agent/tests/trigger_conformance.rs
+++ b/crates/defra-agent/tests/trigger_conformance.rs
@@ -22,7 +22,7 @@
 //! * `subscription_reconciles_on_generation_bump` — re-pointing a trigger from
 //!   collection A to collection B bumps `active_generation` and only B-side
 //!   writes fire afterwards.
-//! * `serial_skips_when_prior_non_terminal` — the engine's gating query sees an
+//! * `serial_skips_when_prior_active_runtime` — the engine's gating query sees an
 //!   active runtime `(trigger_id, "event")` tuple and the serial trigger skips.
 //! * `latest_only_supersedes_prior_fire` — the supersede mutation the engine
 //!   would run transitions the in-flight event-kind request to
@@ -1032,7 +1032,7 @@ async fn subscription_reconciles_on_generation_bump() {
 /// No second `AgentRequest` materializes for the same tuple. Asserted at the
 /// persistence-layer contract (PR 1 pattern).
 #[tokio::test]
-async fn serial_skips_when_prior_non_terminal() {
+async fn serial_skips_when_prior_active_runtime() {
     let db = test_db("trigger-conformance-event-serial-skip").await;
 
     let lineage = TriggerLineage {


### PR DESCRIPTION
## Summary
- keep inputRequired as persisted/client vocabulary while splitting active runtime lifecycle states to pending/claimed/processing
- prevent core lifecycle mutations from transitioning reserved inputRequired rows to interrupted, superseded, completed, failed, claimed, or dead via status-only filters
- rename trigger materializer active-runtime filter methods and add conformance coverage for inputRequired exclusion
- document the boundary in Lean Boundaries and proofs README

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent lifecycle::tests
- cargo test -p defra-agent --test state_machine_conformance input_required
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent --test trigger_conformance
- cargo test -p defra-agent --test schedule_conformance
- cargo fmt -p defra-agent -- --check
- git diff --check
- rg -n "sorry|admit|axiom|PLACEHOLDER|todo!\(|#\[ignore\]|ignore =" over touched files