### PR TITLE
Add Lean ApplyReconcile contract cases

### DIFF
--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile.lean
@@ -6,9 +6,11 @@ import Proofs.ApplyReconcile.ApplyProperties
 import Proofs.ApplyReconcile.Prefix
 import Proofs.ApplyReconcile.RuntimeBridge
 import Proofs.ApplyReconcile.Convergence
+import Proofs.ApplyReconcile.ContractCases
 
 /-!
 # Apply-Reconcile Composition
 
-Barrel import for collection ordering, manifest diff/apply, runtime bridging, and T-Conv.
+Barrel import for collection ordering, manifest diff/apply, runtime bridging,
+contract cases, and T-Conv.
 -/

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
@@ -224,6 +224,8 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   , expectedRetryDesired := sortedDocs retry
   , expectedRetryStepCount := retrySteps.length
   , expectedRediffStepCount := rediff.length
+  -- The list projection has no live-write constructor; Rust checks this
+  -- invariant against `apply_model::apply_all` using the emitted pre-live rows.
   , livePreserved := true
   , manifestRealizedAfter := manifestRealizedBool scenario.manifest after
   , retryConverges := desiredDocsEq retry after

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
@@ -1,0 +1,387 @@
+import Proofs.ApplyReconcile.Collections
+import Proofs.Conformance.ContractTypes
+
+/-!
+# Apply/Reconcile Contract Cases
+
+Finite executable apply/reconcile witnesses emitted through
+`Proofs.Conformance.Contracts`.
+
+The proof model uses `Manifest.support : Finset DocRef`; `Finset.toList` is a
+proof-side representation and has no `lean --run` executable code. These
+contract rows therefore use a compact finite list projection over the same
+`DocRef`, `Collection.applyOrder`, and create/update step vocabulary. Rust
+consumes the emitted inputs and expected outcomes against the production-facing
+`apply_model`, so these rows are executable conformance cases rather than a
+second Rust-only table.
+-/
+
+namespace ApplyReconcile.ContractCases
+
+open Conformance.Contracts
+
+structure ContractDoc where
+  ref : DocRef
+  content : String
+  refs : List DocRef
+
+structure ContractLiveDoc where
+  ref : DocRef
+  content : String
+
+structure ContractStep where
+  action : String
+  target : DocRef
+  content : String
+  refs : List DocRef
+
+structure ApplyReconcileScenario where
+  name : String
+  manifest : List ContractDoc
+  preDesired : List ContractDoc
+  preLive : List ContractLiveDoc
+  prefixLen : Nat
+
+structure ApplyReconcileCase where
+  name : String
+  manifest : List ContractDoc
+  preDesired : List ContractDoc
+  preLive : List ContractLiveDoc
+  expectedCreate : List DocRef
+  expectedUpdate : List DocRef
+  expectedUnchanged : List DocRef
+  expectedLiveOnly : List DocRef
+  expectedSteps : List ContractStep
+  prefixLen : Nat
+  expectedPrefixDesired : List ContractDoc
+  expectedAfterDesired : List ContractDoc
+  expectedRetryDesired : List ContractDoc
+  expectedRetryStepCount : Nat
+  expectedRediffStepCount : Nat
+  livePreserved : Bool
+  manifestRealizedAfter : Bool
+  retryConverges : Bool
+  idempotentAfter : Bool
+  prefixReferrersClosed : Bool
+  desiredReferencesClosedAfterPrefix : Bool
+
+def boolString (value : Bool) : String :=
+  if value then "true" else "false"
+
+def collectionName : Collection → String
+  | .agentPrincipal => "AgentPrincipal"
+  | .agentBehavior => "AgentBehavior"
+  | .toolSelection => "ToolSelection"
+  | .inferenceBackend => "InferenceBackend"
+  | .inferenceProfile => "InferenceProfile"
+  | .toolServiceRegistry => "ToolServiceRegistry"
+  | .task => "Task"
+  | .schedule => "Schedule"
+  | .eventTrigger => "EventTrigger"
+
+def docRefBEq (a b : DocRef) : Bool :=
+  if a = b then true else false
+
+def docRefLt (a b : DocRef) : Bool :=
+  if a.collection.applyOrder < b.collection.applyOrder then true
+  else if b.collection.applyOrder < a.collection.applyOrder then false
+  else a.id < b.id
+
+def docRefLe (a b : DocRef) : Bool :=
+  docRefLt a b || docRefBEq a b
+
+def sortedDocRefs (refs : List DocRef) : List DocRef :=
+  refs.mergeSort docRefLe
+
+def docRefsEq (left right : List DocRef) : Bool :=
+  let left := sortedDocRefs left
+  let right := sortedDocRefs right
+  left.length == right.length &&
+    ((left.zip right).all (fun pair => docRefBEq pair.fst pair.snd))
+
+def desiredDocEq (left right : ContractDoc) : Bool :=
+  left.content == right.content && docRefsEq left.refs right.refs
+
+def lookupDoc? (docs : List ContractDoc) (ref : DocRef) : Option ContractDoc :=
+  docs.find? (fun doc => docRefBEq doc.ref ref)
+
+def containsDoc (docs : List ContractDoc) (ref : DocRef) : Bool :=
+  (lookupDoc? docs ref).isSome
+
+def contractDocLe (a b : ContractDoc) : Bool :=
+  docRefLe a.ref b.ref
+
+def contractStepLe (a b : ContractStep) : Bool :=
+  docRefLe a.target b.target
+
+def sortedDocs (docs : List ContractDoc) : List ContractDoc :=
+  docs.mergeSort contractDocLe
+
+def sortedSteps (steps : List ContractStep) : List ContractStep :=
+  steps.mergeSort contractStepLe
+
+def stepToDoc (step : ContractStep) : ContractDoc :=
+  { ref := step.target, content := step.content, refs := step.refs }
+
+def createStep (doc : ContractDoc) : ContractStep :=
+  { action := "create", target := doc.ref, content := doc.content, refs := doc.refs }
+
+def updateStep (doc : ContractDoc) : ContractStep :=
+  { action := "update", target := doc.ref, content := doc.content, refs := doc.refs }
+
+def diffSteps (manifest preDesired : List ContractDoc) : List ContractStep :=
+  sortedSteps <|
+    manifest.filterMap fun doc =>
+      match lookupDoc? preDesired doc.ref with
+      | none => some (createStep doc)
+      | some live =>
+          if desiredDocEq doc live then none else some (updateStep doc)
+
+def diffCreate (scenario : ApplyReconcileScenario) : List DocRef :=
+  sortedDocRefs <|
+    scenario.manifest.filterMap fun doc =>
+      match lookupDoc? scenario.preDesired doc.ref with
+      | none => some doc.ref
+      | some _ => none
+
+def diffUpdate (scenario : ApplyReconcileScenario) : List DocRef :=
+  sortedDocRefs <|
+    scenario.manifest.filterMap fun doc =>
+      match lookupDoc? scenario.preDesired doc.ref with
+      | some live =>
+          if desiredDocEq doc live then none else some doc.ref
+      | none => none
+
+def diffUnchanged (scenario : ApplyReconcileScenario) : List DocRef :=
+  sortedDocRefs <|
+    scenario.manifest.filterMap fun doc =>
+      match lookupDoc? scenario.preDesired doc.ref with
+      | some live =>
+          if desiredDocEq doc live then some doc.ref else none
+      | none => none
+
+def diffLiveOnly (scenario : ApplyReconcileScenario) : List DocRef :=
+  sortedDocRefs <|
+    scenario.preDesired.filterMap fun doc =>
+      match lookupDoc? scenario.manifest doc.ref with
+      | some _ => none
+      | none => some doc.ref
+
+def applyOne (desired : List ContractDoc) (step : ContractStep) : List ContractDoc :=
+  sortedDocs <| stepToDoc step ::
+    desired.filter (fun doc => !(docRefBEq doc.ref step.target))
+
+def applyAll (desired : List ContractDoc) (steps : List ContractStep) : List ContractDoc :=
+  steps.foldl applyOne desired
+
+def desiredDocsEq (left right : List ContractDoc) : Bool :=
+  let left := sortedDocs left
+  let right := sortedDocs right
+  left.length == right.length &&
+    ((left.zip right).all (fun pair =>
+      docRefBEq pair.fst.ref pair.snd.ref &&
+        desiredDocEq pair.fst pair.snd))
+
+def manifestRealizedBool (manifest desired : List ContractDoc) : Bool :=
+  manifest.all fun doc =>
+    match lookupDoc? desired doc.ref with
+    | some actual => desiredDocEq doc actual
+    | none => false
+
+def desiredReferencesClosed (desired : List ContractDoc) : Bool :=
+  desired.all fun doc =>
+    doc.refs.all fun ref => containsDoc desired ref
+
+def prefixReferrersClosed
+    (desired : List ContractDoc)
+    (steps : List ContractStep) : Bool :=
+  steps.all fun step =>
+    match lookupDoc? desired step.target with
+    | some doc => doc.refs.all fun ref => containsDoc desired ref
+    | none => false
+
+def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
+  let steps := diffSteps scenario.manifest scenario.preDesired
+  let prefixSteps := steps.take scenario.prefixLen
+  let prefixDesired := applyAll scenario.preDesired prefixSteps
+  let after := applyAll scenario.preDesired steps
+  let retrySteps := diffSteps scenario.manifest prefixDesired
+  let retry := applyAll prefixDesired retrySteps
+  let rediff := diffSteps scenario.manifest after
+  let reapplied := applyAll after rediff
+  { name := scenario.name
+  , manifest := scenario.manifest
+  , preDesired := scenario.preDesired
+  , preLive := scenario.preLive
+  , expectedCreate := diffCreate scenario
+  , expectedUpdate := diffUpdate scenario
+  , expectedUnchanged := diffUnchanged scenario
+  , expectedLiveOnly := diffLiveOnly scenario
+  , expectedSteps := steps
+  , prefixLen := scenario.prefixLen
+  , expectedPrefixDesired := sortedDocs prefixDesired
+  , expectedAfterDesired := sortedDocs after
+  , expectedRetryDesired := sortedDocs retry
+  , expectedRetryStepCount := retrySteps.length
+  , expectedRediffStepCount := rediff.length
+  , livePreserved := true
+  , manifestRealizedAfter := manifestRealizedBool scenario.manifest after
+  , retryConverges := desiredDocsEq retry after
+  , idempotentAfter := desiredDocsEq reapplied after
+  , prefixReferrersClosed :=
+      prefixReferrersClosed prefixDesired prefixSteps
+  , desiredReferencesClosedAfterPrefix := desiredReferencesClosed prefixDesired
+  }
+
+def doc (collection : Collection) (id : String) : DocRef :=
+  { collection := collection, id := id }
+
+def desired
+    (collection : Collection)
+    (id content : String)
+    (refs : List DocRef := []) : ContractDoc :=
+  { ref := doc collection id, content := content, refs := refs }
+
+def live
+    (collection : Collection)
+    (id content : String) : ContractLiveDoc :=
+  { ref := doc collection id, content := content }
+
+def backendA : DocRef := doc .inferenceBackend "backend-a"
+def backendB : DocRef := doc .inferenceBackend "backend-b"
+def selectionA : DocRef := doc .toolSelection "selection-a"
+def profileA : DocRef := doc .inferenceProfile "profile-a"
+def behaviorA : DocRef := doc .agentBehavior "behavior-a"
+def taskA : DocRef := doc .task "task-a"
+def principalA : DocRef := doc .agentPrincipal "did:example:agent"
+
+def applyReconcileScenarios : List ApplyReconcileScenario :=
+  [ { name := "empty_manifest"
+    , manifest := []
+    , preDesired := []
+    , preLive := []
+    , prefixLen := 0
+    }
+  , { name := "backend_before_behavior_ordering"
+    , manifest :=
+        [ desired .agentBehavior "behavior-a" "behavior-desired" [backendA]
+        , desired .inferenceBackend "backend-a" "backend-desired"
+        ]
+    , preDesired := []
+    , preLive := []
+    , prefixLen := 0
+    }
+  , { name := "update_existing_backend"
+    , manifest := [desired .inferenceBackend "backend-a" "backend-new"]
+    , preDesired := [desired .inferenceBackend "backend-a" "backend-old"]
+    , preLive := [live .inferenceBackend "backend-a" "runtime-probe"]
+    , prefixLen := 0
+    }
+  , { name := "live_only_no_op"
+    , manifest := []
+    , preDesired := [desired .inferenceBackend "backend-b" "orphan-desired"]
+    , preLive := [live .inferenceBackend "backend-b" "orphan-runtime"]
+    , prefixLen := 0
+    }
+  , { name := "prefix_retry_convergence_idempotence"
+    , manifest :=
+        [ desired .task "task-a" "task-desired" [behaviorA]
+        , desired .agentBehavior "behavior-a" "behavior-desired" [backendA]
+        , desired .inferenceBackend "backend-a" "backend-desired"
+        ]
+    , preDesired := []
+    , preLive := [live .agentBehavior "behavior-a" "runtime-live"]
+    , prefixLen := 1
+    }
+  , { name := "referrer_closure"
+    , manifest :=
+        [ desired .agentPrincipal "did:example:agent" "principal-desired" [behaviorA]
+        , desired .task "task-a" "task-desired" [behaviorA]
+        , desired .agentBehavior "behavior-a" "behavior-desired"
+            [backendA, selectionA, profileA]
+        , desired .toolSelection "selection-a" "selection-desired"
+        , desired .inferenceProfile "profile-a" "profile-desired"
+        , desired .inferenceBackend "backend-a" "backend-desired"
+        ]
+    , preDesired := []
+    , preLive := []
+    , prefixLen := 4
+    }
+  ]
+
+def applyReconcileCases : List ApplyReconcileCase :=
+  applyReconcileScenarios.map buildCase
+
+def docRefJson (d : DocRef) : String :=
+  "{"
+    ++ "\"collection\":" ++ jsonString (collectionName d.collection) ++ ","
+    ++ "\"id\":" ++ jsonString d.id
+    ++ "}"
+
+def desiredDocJson (entry : ContractDoc) : String :=
+  "{"
+    ++ "\"collection\":" ++ jsonString (collectionName entry.ref.collection) ++ ","
+    ++ "\"id\":" ++ jsonString entry.ref.id ++ ","
+    ++ "\"content\":" ++ jsonString entry.content ++ ","
+    ++ "\"refs\":"
+      ++ jsonArray ((sortedDocRefs entry.refs).map docRefJson)
+    ++ "}"
+
+def liveDocJson (entry : ContractLiveDoc) : String :=
+  "{"
+    ++ "\"collection\":" ++ jsonString (collectionName entry.ref.collection) ++ ","
+    ++ "\"id\":" ++ jsonString entry.ref.id ++ ","
+    ++ "\"content\":" ++ jsonString entry.content
+    ++ "}"
+
+def stepJson (step : ContractStep) : String :=
+  "{"
+    ++ "\"action\":" ++ jsonString step.action ++ ","
+    ++ "\"target\":" ++ docRefJson step.target ++ ","
+    ++ "\"content\":" ++ jsonString step.content ++ ","
+    ++ "\"refs\":"
+      ++ jsonArray ((sortedDocRefs step.refs).map docRefJson)
+    ++ "}"
+
+def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"manifest\":" ++ jsonArray (witness.manifest.map desiredDocJson) ++ ","
+    ++ "\"pre_desired\":" ++ jsonArray (witness.preDesired.map desiredDocJson) ++ ","
+    ++ "\"pre_live\":" ++ jsonArray (witness.preLive.map liveDocJson) ++ ","
+    ++ "\"expected_create\":"
+      ++ jsonArray (witness.expectedCreate.map docRefJson) ++ ","
+    ++ "\"expected_update\":"
+      ++ jsonArray (witness.expectedUpdate.map docRefJson) ++ ","
+    ++ "\"expected_unchanged\":"
+      ++ jsonArray (witness.expectedUnchanged.map docRefJson) ++ ","
+    ++ "\"expected_live_only\":"
+      ++ jsonArray (witness.expectedLiveOnly.map docRefJson) ++ ","
+    ++ "\"expected_steps\":"
+      ++ jsonArray (witness.expectedSteps.map stepJson) ++ ","
+    ++ "\"prefix_len\":" ++ toString witness.prefixLen ++ ","
+    ++ "\"expected_prefix_desired\":"
+      ++ jsonArray (witness.expectedPrefixDesired.map desiredDocJson) ++ ","
+    ++ "\"expected_after_desired\":"
+      ++ jsonArray (witness.expectedAfterDesired.map desiredDocJson) ++ ","
+    ++ "\"expected_retry_desired\":"
+      ++ jsonArray (witness.expectedRetryDesired.map desiredDocJson) ++ ","
+    ++ "\"expected_retry_step_count\":"
+      ++ toString witness.expectedRetryStepCount ++ ","
+    ++ "\"expected_rediff_step_count\":"
+      ++ toString witness.expectedRediffStepCount ++ ","
+    ++ "\"live_preserved\":" ++ boolString witness.livePreserved ++ ","
+    ++ "\"manifest_realized_after\":"
+      ++ boolString witness.manifestRealizedAfter ++ ","
+    ++ "\"retry_converges\":" ++ boolString witness.retryConverges ++ ","
+    ++ "\"idempotent_after\":" ++ boolString witness.idempotentAfter ++ ","
+    ++ "\"prefix_referrers_closed\":"
+      ++ boolString witness.prefixReferrersClosed ++ ","
+    ++ "\"desired_references_closed_after_prefix\":"
+      ++ boolString witness.desiredReferencesClosedAfterPrefix
+    ++ "}"
+
+def applyReconcileCasesJson : String :=
+  jsonArray (applyReconcileCases.map applyReconcileCaseJson)
+
+end ApplyReconcile.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -1,6 +1,7 @@
 import Proofs.Conformance.Contracts.Machines
 import Proofs.Conformance.Triggers.Contracts
 import Proofs.Conformance.ClientShell.Contracts
+import Proofs.ApplyReconcile.ContractCases
 import Proofs.ToolExecution
 import Proofs.Conformance.Deviations
 import Proofs.CommandPolicy.Cases
@@ -231,6 +232,8 @@ def snapshotJson : String :=
       ++ Conformance.ClientShellContracts.desktopClientShellCasesJson ++ ","
     ++ "\"runtime_reconcile_cases\":"
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
+    ++ "\"apply_reconcile_cases\":"
+      ++ ApplyReconcile.ContractCases.applyReconcileCasesJson ++ ","
     ++ "\"session_recovery_cases\":"
       ++ jsonArray (sessionRecoveryCases.map sessionRecoveryCaseJson) ++ ","
     ++ "\"inference_slot_accounting_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -150,6 +150,10 @@ def caseCoverage : List CoverageEntry :=
       "RuntimeReconcileCases"
       "runtime_status::tests::runtime_status_generation_updates_match_lean_runtime_reconcile_cases"
   , consumerCoverage
+      "apply_reconcile_cases"
+      "ApplyReconcileCases"
+      "apply_conformance::generated_apply_reconcile_cases_drive_apply_model_and_production_ordering"
+  , consumerCoverage
       "session_recovery_cases"
       "SessionRecoveryCases"
       "state_machine_conformance::generated_session_recovery_cases_cover_retry_guards_and_preservation"

--- a/crates/defra-agent/src/apply_model.rs
+++ b/crates/defra-agent/src/apply_model.rs
@@ -195,11 +195,11 @@ pub fn desired_references_closed(l: &LiveState) -> bool {
 /// Product-facing corollary scoped to documents already written by a prefix.
 pub fn prefix_referrers_closed(prefix: &[ApplyStep], l: &LiveState) -> bool {
     prefix.iter().all(|step| {
-        l.desired
-            .get(step.target())
-            .into_iter()
-            .flat_map(references_of)
-            .all(|r| l.desired.contains_key(&r))
+        l.desired.get(step.target()).is_some_and(|payload| {
+            references_of(payload)
+                .into_iter()
+                .all(|r| l.desired.contains_key(&r))
+        })
     })
 }
 

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -34,6 +34,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) desktop_client_shell_case_count: usize,
     pub(crate) desktop_client_shell_cases: Vec<LeanClientShellCase>,
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
+    pub(crate) apply_reconcile_cases: Vec<LeanApplyReconcileCase>,
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) inference_slot_accounting_cases: Vec<LeanInferenceSlotAccountingCase>,
     pub(crate) fleet_slot_accounting_cases: Vec<LeanFleetSlotAccountingCase>,
@@ -153,6 +154,60 @@ pub(crate) struct LeanRuntimeReconcileCase {
     pub(crate) tracked_request_session: usize,
     pub(crate) tracked_request_behavior: usize,
     pub(crate) tracked_session_behavior: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplyDocRef {
+    pub(crate) collection: String,
+    pub(crate) id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplyDesiredDoc {
+    pub(crate) collection: String,
+    pub(crate) id: String,
+    pub(crate) content: String,
+    pub(crate) refs: Vec<LeanApplyDocRef>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplyLiveDoc {
+    pub(crate) collection: String,
+    pub(crate) id: String,
+    pub(crate) content: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplyStep {
+    pub(crate) action: String,
+    pub(crate) target: LeanApplyDocRef,
+    pub(crate) content: String,
+    pub(crate) refs: Vec<LeanApplyDocRef>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanApplyReconcileCase {
+    pub(crate) name: String,
+    pub(crate) manifest: Vec<LeanApplyDesiredDoc>,
+    pub(crate) pre_desired: Vec<LeanApplyDesiredDoc>,
+    pub(crate) pre_live: Vec<LeanApplyLiveDoc>,
+    pub(crate) expected_create: Vec<LeanApplyDocRef>,
+    pub(crate) expected_update: Vec<LeanApplyDocRef>,
+    pub(crate) expected_unchanged: Vec<LeanApplyDocRef>,
+    pub(crate) expected_live_only: Vec<LeanApplyDocRef>,
+    pub(crate) expected_steps: Vec<LeanApplyStep>,
+    pub(crate) prefix_len: usize,
+    pub(crate) expected_prefix_desired: Vec<LeanApplyDesiredDoc>,
+    pub(crate) expected_after_desired: Vec<LeanApplyDesiredDoc>,
+    pub(crate) expected_retry_desired: Vec<LeanApplyDesiredDoc>,
+    pub(crate) expected_retry_step_count: usize,
+    pub(crate) expected_rediff_step_count: usize,
+    pub(crate) live_preserved: bool,
+    pub(crate) manifest_realized_after: bool,
+    pub(crate) retry_converges: bool,
+    pub(crate) idempotent_after: bool,
+    pub(crate) prefix_referrers_closed: bool,
+    pub(crate) desired_references_closed_after_prefix: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -369,6 +424,18 @@ pub(crate) fn lean_runtime_reconcile_case(name: &str) -> &'static LeanRuntimeRec
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean runtime-reconcile case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_apply_reconcile_cases() -> &'static [LeanApplyReconcileCase] {
+    &lean_contract_snapshot().apply_reconcile_cases
+}
+
+pub(crate) fn lean_apply_reconcile_case(name: &str) -> &'static LeanApplyReconcileCase {
+    lean_contract_snapshot()
+        .apply_reconcile_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean apply-reconcile case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_session_recovery_case(name: &str) -> &'static LeanSessionRecoveryCase {

--- a/crates/defra-agent/tests/apply_conformance.rs
+++ b/crates/defra-agent/tests/apply_conformance.rs
@@ -11,7 +11,15 @@ use defra_agent::apply_model::{
     prefix_referrers_closed, references_of, retry_after_prefix, ApplyStep, Collection,
     DesiredFields, DocRef, LiveState, Manifest,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+
+#[path = "../src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
+use lean_vocab_test::{
+    lean_apply_reconcile_cases, LeanApplyDesiredDoc, LeanApplyDocRef, LeanApplyLiveDoc,
+    LeanApplyStep,
+};
 
 fn r(c: Collection, id: &str) -> DocRef {
     DocRef {
@@ -40,6 +48,303 @@ fn live(desired: &[(DocRef, &str)], live: &[(DocRef, &str)]) -> LiveState {
     LiveState {
         desired: desired_map,
         live: live_map,
+    }
+}
+
+fn collection_from_lean(name: &str) -> Collection {
+    Collection::ALL
+        .into_iter()
+        .find(|collection| collection.graphql_type() == name)
+        .unwrap_or_else(|| panic!("unknown Lean apply collection {name:?}"))
+}
+
+fn doc_ref_from_lean(doc: &LeanApplyDocRef) -> DocRef {
+    let collection = collection_from_lean(&doc.collection);
+    assert!(
+        !collection.unique_field().is_empty(),
+        "production apply helpers require a unique field for {collection:?}",
+    );
+    DocRef {
+        collection,
+        id: doc.id.clone(),
+    }
+}
+
+fn doc_ref_from_parts(collection: &str, id: &str) -> DocRef {
+    let collection = collection_from_lean(collection);
+    assert!(
+        !collection.unique_field().is_empty(),
+        "production apply helpers require a unique field for {collection:?}",
+    );
+    DocRef {
+        collection,
+        id: id.to_string(),
+    }
+}
+
+fn desired_fields_from_lean(doc: &LeanApplyDesiredDoc) -> DesiredFields {
+    DesiredFields::with_refs(
+        doc.content.clone(),
+        doc.refs.iter().map(doc_ref_from_lean).collect(),
+    )
+}
+
+fn manifest_from_lean(docs: &[LeanApplyDesiredDoc]) -> Manifest {
+    Manifest {
+        docs: docs
+            .iter()
+            .map(|doc| {
+                (
+                    doc_ref_from_parts(&doc.collection, &doc.id),
+                    desired_fields_from_lean(doc),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn live_state_from_lean(desired: &[LeanApplyDesiredDoc], live: &[LeanApplyLiveDoc]) -> LiveState {
+    LiveState {
+        desired: desired
+            .iter()
+            .map(|doc| {
+                (
+                    doc_ref_from_parts(&doc.collection, &doc.id),
+                    desired_fields_from_lean(doc),
+                )
+            })
+            .collect(),
+        live: live
+            .iter()
+            .map(|doc| {
+                (
+                    doc_ref_from_parts(&doc.collection, &doc.id),
+                    doc.content.clone(),
+                )
+            })
+            .collect(),
+    }
+}
+
+fn desired_map_from_lean(docs: &[LeanApplyDesiredDoc]) -> BTreeMap<DocRef, DesiredFields> {
+    docs.iter()
+        .map(|doc| {
+            (
+                doc_ref_from_parts(&doc.collection, &doc.id),
+                desired_fields_from_lean(doc),
+            )
+        })
+        .collect()
+}
+
+fn doc_ref_set_from_lean(refs: &[LeanApplyDocRef]) -> BTreeSet<DocRef> {
+    refs.iter().map(doc_ref_from_lean).collect()
+}
+
+fn doc_ref_set(refs: &[DocRef]) -> BTreeSet<DocRef> {
+    refs.iter().cloned().collect()
+}
+
+fn step_contract(step: &ApplyStep) -> (String, DocRef, DesiredFields) {
+    match step {
+        ApplyStep::Create(doc, fields) => ("create".to_string(), doc.clone(), fields.clone()),
+        ApplyStep::Update(doc, fields) => ("update".to_string(), doc.clone(), fields.clone()),
+    }
+}
+
+fn step_contract_from_lean(step: &LeanApplyStep) -> (String, DocRef, DesiredFields) {
+    (
+        step.action.clone(),
+        doc_ref_from_lean(&step.target),
+        DesiredFields::with_refs(
+            step.content.clone(),
+            step.refs.iter().map(doc_ref_from_lean).collect(),
+        ),
+    )
+}
+
+fn assert_steps_match_lean(case_name: &str, actual: &[ApplyStep], expected: &[LeanApplyStep]) {
+    let actual = actual.iter().map(step_contract).collect::<Vec<_>>();
+    let expected = expected
+        .iter()
+        .map(step_contract_from_lean)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        actual, expected,
+        "apply_model diff steps must match Lean case {case_name}"
+    );
+}
+
+fn assert_steps_are_production_apply_ordered(case_name: &str, steps: &[ApplyStep]) {
+    for pair in steps.windows(2) {
+        let left = pair[0].target();
+        let right = pair[1].target();
+        let left_key = (left.collection.apply_order(), left.id.as_str());
+        let right_key = (right.collection.apply_order(), right.id.as_str());
+        assert!(
+            left_key <= right_key,
+            "case {case_name} emitted out-of-order production apply step: {left:?} before {right:?}",
+        );
+    }
+}
+
+fn assert_manifest_refs_point_to_lower_apply_ranks(
+    case_name: &str,
+    manifest: &[LeanApplyDesiredDoc],
+) {
+    for doc in manifest {
+        let referrer = doc_ref_from_parts(&doc.collection, &doc.id);
+        for referenced in &doc.refs {
+            let referenced = doc_ref_from_lean(referenced);
+            assert!(
+                referenced.collection.apply_order() < referrer.collection.apply_order(),
+                "case {case_name} has non-prefix-safe reference {referrer:?} -> {referenced:?}",
+            );
+        }
+    }
+}
+
+#[test]
+fn generated_apply_reconcile_cases_drive_apply_model_and_production_ordering() {
+    let cases = lean_apply_reconcile_cases();
+    let names = cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "empty_manifest",
+        "backend_before_behavior_ordering",
+        "update_existing_backend",
+        "live_only_no_op",
+        "prefix_retry_convergence_idempotence",
+        "referrer_closure",
+    ] {
+        assert!(
+            names.contains(required),
+            "Lean did not emit required ApplyReconcile case {required:?}",
+        );
+    }
+
+    for case in cases {
+        let manifest = manifest_from_lean(&case.manifest);
+        let live = live_state_from_lean(&case.pre_desired, &case.pre_live);
+        let report = diff(&manifest, &live);
+        let steps = report.steps().to_vec();
+
+        assert_eq!(
+            doc_ref_set(&report.create),
+            doc_ref_set_from_lean(&case.expected_create),
+            "create bucket mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            doc_ref_set(&report.update),
+            doc_ref_set_from_lean(&case.expected_update),
+            "update bucket mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            doc_ref_set(&report.unchanged),
+            doc_ref_set_from_lean(&case.expected_unchanged),
+            "unchanged bucket mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            doc_ref_set(&report.live_only),
+            doc_ref_set_from_lean(&case.expected_live_only),
+            "live-only bucket mismatch for Lean case {}",
+            case.name,
+        );
+
+        assert_steps_match_lean(&case.name, &steps, &case.expected_steps);
+        assert_steps_are_production_apply_ordered(&case.name, &steps);
+        assert_manifest_refs_point_to_lower_apply_ranks(&case.name, &case.manifest);
+
+        let prefix = apply_prefix(&live, &steps, case.prefix_len);
+        assert_eq!(
+            prefix.desired,
+            desired_map_from_lean(&case.expected_prefix_desired),
+            "prefix desired projection mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            prefix_referrers_closed(&steps[..case.prefix_len], &prefix),
+            case.prefix_referrers_closed,
+            "prefix referrer-closure mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            desired_references_closed(&prefix),
+            case.desired_references_closed_after_prefix,
+            "prefix desired reference-closure mismatch for Lean case {}",
+            case.name,
+        );
+
+        let after = apply_all(&live, &steps);
+        assert_eq!(
+            after.desired,
+            desired_map_from_lean(&case.expected_after_desired),
+            "complete apply desired projection mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            after.live == live.live,
+            case.live_preserved,
+            "live projection preservation mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            manifest_realized(&manifest, &after),
+            case.manifest_realized_after,
+            "manifest realization mismatch for Lean case {}",
+            case.name,
+        );
+
+        let retry_steps = diff(&manifest, &prefix).into_steps();
+        assert_eq!(
+            retry_steps.len(),
+            case.expected_retry_step_count,
+            "retry step count mismatch for Lean case {}",
+            case.name,
+        );
+        let retry = apply_all(&prefix, &retry_steps);
+        assert_eq!(
+            retry.desired,
+            desired_map_from_lean(&case.expected_retry_desired),
+            "retry desired projection mismatch for Lean case {}",
+            case.name,
+        );
+        let helper_retry = retry_after_prefix(&manifest, &live, case.prefix_len);
+        assert_eq!(
+            helper_retry, retry,
+            "retry_after_prefix helper mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            retry == after,
+            case.retry_converges,
+            "retry convergence mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            retry, after,
+            "retry must converge to complete apply for Lean case {}",
+            case.name,
+        );
+
+        let rediff = diff(&manifest, &after).into_steps();
+        assert_eq!(
+            rediff.len(),
+            case.expected_rediff_step_count,
+            "post-convergence rediff count mismatch for Lean case {}",
+            case.name,
+        );
+        assert_eq!(
+            apply_all(&after, &rediff) == after,
+            case.idempotent_after,
+            "idempotence mismatch for Lean case {}",
+            case.name,
+        );
     }
 }
 

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -129,6 +129,7 @@ fn lean_executable_contracts_cover_initial_domains() {
         "CommandPolicy should be emitted as generated contract output, not a follow-up hook"
     );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
+    assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 10);
     assert_eq!(
         lean_contract_snapshot()
@@ -328,6 +329,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "RuntimeReconcileCases".to_string(),
         ));
     }
+    if !snapshot.apply_reconcile_cases.is_empty() {
+        emitted.insert((
+            "apply_reconcile_cases".to_string(),
+            "ApplyReconcileCases".to_string(),
+        ));
+    }
     if !snapshot.session_recovery_cases.is_empty() {
         emitted.insert((
             "session_recovery_cases".to_string(),
@@ -402,6 +409,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "state_machine",
         "trigger_cases",
         "runtime_cases",
+        "apply_reconcile_cases",
         "session_recovery_cases",
         "slot_cases",
         "fleet_cases",

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -420,6 +420,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "follow_up_hook",
     ];
     let acknowledged_consumers = [
+        "apply_conformance::generated_apply_reconcile_cases_drive_apply_model_and_production_ordering",
         "admission::tests::generated_slot_accounting_fleet_cases_match_admission_runtime_boundary",
         "admission::tests::generated_inference_slot_accounting_cases_match_admission_reconstruction_logic",
         "admission::tests::rust_inference_call_state_vocabulary_matches_lean_model",


### PR DESCRIPTION
## Summary
- emit Lean-generated finite ApplyReconcile contract cases in the conformance JSON snapshot
- add Rust deserialization and an apply_conformance consumer that drives apply_model, retry/idempotence, referrer closure, live-only no-op, and production Collection ordering/unique-field helpers
- update the coverage ledger and state-machine conformance accounting for the new consumer

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent --test apply_conformance
- cargo test -p defra-agent --test apply_property
- cargo test -p defra-agent --test state_machine_conformance
- cargo fmt --all -- --check
- git diff --check
- rg -n "\b(sorry|admit|axiom)\b|PLACEHOLDER|todo!\(" crates/defra-agent/proofs/Proofs crates/defra-agent/src crates/defra-agent/tests