### PR TITLE
Extend CommandPolicy read-only safety contracts

### DIFF
--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
@@ -98,7 +98,46 @@ def envCase
   , expected := filteredEnv (envInput envKey inputPresent) envKey
   }
 
-def commandPolicyCases : List CommandPolicyCase :=
+def defaultReadOnlyAllowlist : List String :=
+  [ "pwd"
+  , "ls"
+  , "find"
+  , "cat"
+  , "head"
+  , "tail"
+  , "sed"
+  , "grep"
+  , "rg"
+  , "wc"
+  , "stat"
+  , "file"
+  , "git"
+  , "date"
+  , "hostname"
+  , "uptime"
+  , "df"
+  , "vm_stat"
+  , "ps"
+  , "lsof"
+  , "curl"
+  , "launchctl"
+  , "tailscale"
+  , "sudo"
+  ]
+
+def readOnlySafetyPolicy : Policy :=
+  commandPolicy .readOnly [] [] .inherit defaultReadOnlyAllowlist
+
+def readOnlySafetyCase
+    (name command lookupCommand : String)
+    (args : List String) : CommandPolicyCase :=
+  validationCase
+    name
+    "read_only_argv_safety"
+    readOnlySafetyPolicy
+    (commandRequest command lookupCommand args)
+
+def commandPolicyOrderingCases : List CommandPolicyCase :=
   [ validationCase
       "forbidden_prefix_wins_over_allowed_prefix_order"
       "forbidden_prefix"
@@ -165,6 +204,187 @@ def commandPolicyCases : List CommandPolicyCase :=
       (commandPolicy .workspaceWrite [] [] .disabled [])
       (commandRequest "printf" "printf" ["ok"])
   ]
+
+def readOnlySafetyCases : List CommandPolicyCase :=
+  [ readOnlySafetyCase
+      "read_only_git_status_allows"
+      "git"
+      "git"
+      ["status", "--short"]
+  , readOnlySafetyCase
+      "read_only_git_branch_list_allows"
+      "git"
+      "git"
+      ["branch", "--list", "--format=%(refname:short)"]
+  , readOnlySafetyCase
+      "read_only_sed_print_allows"
+      "sed"
+      "sed"
+      ["-n", "1,10p", "README.md"]
+  , readOnlySafetyCase
+      "read_only_find_type_file_allows"
+      "find"
+      "find"
+      [".", "-maxdepth", "2", "-type", "f"]
+  , readOnlySafetyCase
+      "read_only_rg_search_allows"
+      "rg"
+      "rg"
+      ["-n", "needle", "."]
+  , readOnlySafetyCase
+      "read_only_curl_http_get_allows"
+      "curl"
+      "curl"
+      ["-fsS", "https://example.com/metrics"]
+  , readOnlySafetyCase
+      "read_only_launchctl_print_allows"
+      "launchctl"
+      "launchctl"
+      ["print", "system/com.example.agent"]
+  , readOnlySafetyCase
+      "read_only_tailscale_status_allows"
+      "tailscale"
+      "tailscale"
+      ["status"]
+  , readOnlySafetyCase
+      "read_only_tailscale_netcheck_allows"
+      "tailscale"
+      "tailscale"
+      ["netcheck"]
+  , readOnlySafetyCase
+      "read_only_sudo_launchctl_print_allows"
+      "sudo"
+      "sudo"
+      ["/bin/launchctl", "print", "system/com.example.agent"]
+  , readOnlySafetyCase
+      "read_only_git_global_config_denies"
+      "git"
+      "git"
+      ["-c", "core.pager=cat", "status"]
+  , readOnlySafetyCase
+      "read_only_git_config_env_denies"
+      "git"
+      "git"
+      ["--config-env=GIT_CONFIG_GLOBAL=ENV_FILE", "status"]
+  , readOnlySafetyCase
+      "read_only_git_output_flag_denies"
+      "git"
+      "git"
+      ["diff", "--output=/tmp/defra-agent-diff.txt"]
+  , readOnlySafetyCase
+      "read_only_git_exec_flag_denies"
+      "git"
+      "git"
+      ["log", "--exec=touch /tmp/defra-agent-nope"]
+  , readOnlySafetyCase
+      "read_only_git_commit_subcommand_denies"
+      "git"
+      "git"
+      ["commit", "-m", "nope"]
+  , readOnlySafetyCase
+      "read_only_git_branch_delete_denies"
+      "git"
+      "git"
+      ["branch", "-D", "main"]
+  , readOnlySafetyCase
+      "read_only_sed_in_place_short_denies"
+      "sed"
+      "sed"
+      ["-i", "s/a/b/g", "README.md"]
+  , readOnlySafetyCase
+      "read_only_sed_in_place_long_denies"
+      "sed"
+      "sed"
+      ["--in-place", "s/a/b/g", "README.md"]
+  , readOnlySafetyCase
+      "read_only_find_delete_denies"
+      "find"
+      "find"
+      [".", "-delete"]
+  , readOnlySafetyCase
+      "read_only_find_exec_denies"
+      "find"
+      "find"
+      [".", "-exec", "rm", "{}", ";"]
+  , readOnlySafetyCase
+      "read_only_find_fprint_denies"
+      "find"
+      "find"
+      [".", "-fprint0", "out"]
+  , readOnlySafetyCase
+      "read_only_rg_pre_denies"
+      "rg"
+      "rg"
+      ["--pre", "touch /tmp/defra-agent-nope", "needle"]
+  , readOnlySafetyCase
+      "read_only_rg_search_zip_denies"
+      "rg"
+      "rg"
+      ["--search-zip", "needle"]
+  , readOnlySafetyCase
+      "read_only_curl_post_denies"
+      "curl"
+      "curl"
+      ["-X", "POST", "https://example.com/graphql"]
+  , readOnlySafetyCase
+      "read_only_curl_data_denies"
+      "curl"
+      "curl"
+      ["--data={}", "https://example.com/graphql"]
+  , readOnlySafetyCase
+      "read_only_curl_output_denies"
+      "curl"
+      "curl"
+      ["-o", "/tmp/defra-agent-out", "https://example.com/metrics"]
+  , readOnlySafetyCase
+      "read_only_curl_upload_denies"
+      "curl"
+      "curl"
+      ["-T", "payload.json", "https://example.com/upload"]
+  , readOnlySafetyCase
+      "read_only_curl_config_denies"
+      "curl"
+      "curl"
+      ["-K", "curlrc", "https://example.com/metrics"]
+  , readOnlySafetyCase
+      "read_only_curl_missing_http_url_denies"
+      "curl"
+      "curl"
+      ["-fsS", "example.com/metrics"]
+  , readOnlySafetyCase
+      "read_only_launchctl_bootout_denies"
+      "launchctl"
+      "launchctl"
+      ["bootout", "system/com.example.agent"]
+  , readOnlySafetyCase
+      "read_only_launchctl_missing_subcommand_denies"
+      "launchctl"
+      "launchctl"
+      []
+  , readOnlySafetyCase
+      "read_only_tailscale_up_denies"
+      "tailscale"
+      "tailscale"
+      ["up"]
+  , readOnlySafetyCase
+      "read_only_sudo_launchctl_wrong_path_denies"
+      "sudo"
+      "sudo"
+      ["/usr/bin/launchctl", "print", "system/com.example.agent"]
+  , readOnlySafetyCase
+      "read_only_sudo_rm_denies"
+      "sudo"
+      "sudo"
+      ["rm", "-rf", "/tmp/defra-agent-nope"]
+  , readOnlySafetyCase
+      "read_only_sudo_missing_command_denies"
+      "sudo"
+      "sudo"
+      []
+  ]
+
+def commandPolicyCases : List CommandPolicyCase :=
+  commandPolicyOrderingCases ++ readOnlySafetyCases
 
 def commandSandboxCases : List CommandSandboxCase :=
   [ sandboxCase

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Types.lean
@@ -66,6 +66,10 @@ inductive DenialReason where
   | forbiddenPrefix (matched : List String)
   | allowedPrefixRequired (argv : List String)
   | readOnlyCommandNotAllowlisted (command : String)
+  | readOnlyArgumentNotAllowed (command : String) (argument : String)
+  | readOnlySubcommandRequired (command : String)
+  | readOnlySubcommandNotAllowlisted (command : String) (subcommand : String)
+  | readOnlyUrlRequired (command : String)
   | disabledNetworkUnenforceable
   | disabledNetworkCommand (command : String)
   | workspaceWriteSandboxUnavailable
@@ -77,6 +81,10 @@ def toContract : DenialReason → String
   | .forbiddenPrefix _ => "forbiddenPrefix"
   | .allowedPrefixRequired _ => "allowedPrefixRequired"
   | .readOnlyCommandNotAllowlisted _ => "readOnlyCommandNotAllowlisted"
+  | .readOnlyArgumentNotAllowed _ _ => "readOnlyArgumentNotAllowed"
+  | .readOnlySubcommandRequired _ => "readOnlySubcommandRequired"
+  | .readOnlySubcommandNotAllowlisted _ _ => "readOnlySubcommandNotAllowlisted"
+  | .readOnlyUrlRequired _ => "readOnlyUrlRequired"
   | .disabledNetworkUnenforceable => "disabledNetworkUnenforceable"
   | .disabledNetworkCommand _ => "disabledNetworkCommand"
   | .workspaceWriteSandboxUnavailable => "workspaceWriteSandboxUnavailable"
@@ -91,7 +99,19 @@ def argv? : DenialReason → Option (List String)
 
 def command? : DenialReason → Option String
   | .readOnlyCommandNotAllowlisted command => some command
+  | .readOnlyArgumentNotAllowed command _ => some command
+  | .readOnlySubcommandRequired command => some command
+  | .readOnlySubcommandNotAllowlisted command _ => some command
+  | .readOnlyUrlRequired command => some command
   | .disabledNetworkCommand command => some command
+  | _ => none
+
+def argument? : DenialReason → Option String
+  | .readOnlyArgumentNotAllowed _ argument => some argument
+  | _ => none
+
+def subcommand? : DenialReason → Option String
+  | .readOnlySubcommandNotAllowlisted _ subcommand => some subcommand
   | _ => none
 
 end DenialReason

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
@@ -4,10 +4,13 @@ import Proofs.CommandPolicy.Types
 # Command Policy Validation
 
 Executable validation model for argv prefix filters, read-only command
-allowlisting, and disabled-network behavior. The raw `command` remains argv[0]
-for prefix checks; read-only and network command-name gates use
-`CommandRequest.lookupCommand`, matching Rust's `Path::file_name`
-normalization in `executable_name_lookup_key`.
+allowlisting, read-only command-family argv filters, and disabled-network
+behavior. The raw `command` remains argv[0] for prefix checks; read-only and
+network command-name gates use `CommandRequest.lookupCommand`, matching Rust's
+`Path::file_name` normalization in `executable_name_lookup_key`.
+
+The command-family filters prove only local argv policy. They do not claim
+external binary read-only semantics or host/kernel sandbox enforcement.
 -/
 
 namespace CommandPolicy
@@ -35,12 +38,266 @@ def firstMatchingPrefix (argv : List String) : List (List String) → Option (Li
 def commandAllowlisted (command : String) (allowlist : List String) : Bool :=
   allowlist.any (fun allowed => decide (allowed = command))
 
+def stringMatches (value expected : String) : Bool :=
+  decide (value = expected)
+
+def stringIn (value : String) (values : List String) : Bool :=
+  values.any (fun candidate => stringMatches value candidate)
+
+def firstArgWhere (p : String → Bool) : List String → Option String
+  | [] => none
+  | arg :: rest =>
+      if p arg then
+        some arg
+      else
+        firstArgWhere p rest
+
+def anyArgWhere (p : String → Bool) (args : List String) : Bool :=
+  (firstArgWhere p args).isSome
+
+def argStartsWith (arg candidatePrefix : String) : Bool :=
+  arg.startsWith candidatePrefix
+
+def sedArgumentDenied (arg : String) : Bool :=
+  stringMatches arg "-i"
+    || stringMatches arg "--in-place"
+    || argStartsWith arg "-i"
+
+def validateSedArgs (args : List String) : Decision :=
+  match firstArgWhere sedArgumentDenied args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "sed" arg)
+  | none => .allow
+
+def findArgumentDenied (arg : String) : Bool :=
+  stringIn arg
+    [ "-delete"
+    , "-exec"
+    , "-execdir"
+    , "-ok"
+    , "-okdir"
+    , "-fprint"
+    , "-fprint0"
+    , "-fprintf"
+    , "-fls"
+    ]
+
+def validateFindArgs (args : List String) : Decision :=
+  match firstArgWhere findArgumentDenied args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "find" arg)
+  | none => .allow
+
+def ripgrepArgumentDenied (arg : String) : Bool :=
+  stringIn arg ["--search-zip", "-z"]
+    || stringMatches arg "--pre"
+    || argStartsWith arg "--pre="
+    || stringMatches arg "--hostname-bin"
+    || argStartsWith arg "--hostname-bin="
+
+def validateRipgrepArgs (args : List String) : Decision :=
+  match firstArgWhere ripgrepArgumentDenied args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "rg" arg)
+  | none => .allow
+
+def launchctlSubcommandAllowed (subcommand : String) : Bool :=
+  stringIn subcommand ["list", "print", "print-disabled", "blame"]
+
+def validateLaunchctlArgs (args : List String) : Decision :=
+  match args with
+  | [] => .deny (.readOnlySubcommandRequired "launchctl")
+  | subcommand :: _ =>
+      if launchctlSubcommandAllowed subcommand then
+        .allow
+      else
+        .deny (.readOnlySubcommandNotAllowlisted "launchctl" subcommand)
+
+def tailscaleSubcommandAllowed (subcommand : String) : Bool :=
+  stringIn subcommand ["status", "ip", "netcheck", "version", "ping"]
+
+def validateTailscaleArgs (args : List String) : Decision :=
+  match args with
+  | [] => .deny (.readOnlySubcommandRequired "tailscale")
+  | subcommand :: _ =>
+      if tailscaleSubcommandAllowed subcommand then
+        .allow
+      else
+        .deny (.readOnlySubcommandNotAllowlisted "tailscale" subcommand)
+
+def curlArgumentDenied (arg : String) : Bool :=
+  stringIn arg
+      [ "-d"
+      , "--data"
+      , "--data-raw"
+      , "--data-binary"
+      , "--data-urlencode"
+      , "-F"
+      , "--form"
+      , "-T"
+      , "--upload-file"
+      , "-X"
+      , "--request"
+      , "-o"
+      , "--output"
+      , "-O"
+      , "--remote-name"
+      , "--remote-header-name"
+      , "-K"
+      , "--config"
+      , "--next"
+      ]
+    || argStartsWith arg "-d"
+    || argStartsWith arg "--data="
+    || argStartsWith arg "-F"
+    || argStartsWith arg "--form="
+    || argStartsWith arg "-T"
+    || argStartsWith arg "--upload-file="
+    || argStartsWith arg "-X"
+    || argStartsWith arg "--request="
+    || argStartsWith arg "-o"
+    || argStartsWith arg "--output="
+    || argStartsWith arg "-O"
+    || argStartsWith arg "-K"
+    || argStartsWith arg "--config="
+
+def curlHasHttpUrl (arg : String) : Bool :=
+  argStartsWith arg "http://" || argStartsWith arg "https://"
+
+def validateCurlArgs (args : List String) : Decision :=
+  match firstArgWhere curlArgumentDenied args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "curl" arg)
+  | none =>
+      if anyArgWhere curlHasHttpUrl args then
+        .allow
+      else
+        .deny (.readOnlyUrlRequired "curl")
+
+def gitGlobalOptionDenied (arg : String) : Bool :=
+  stringIn arg
+      [ "-C"
+      , "-c"
+      , "--config-env"
+      , "--exec-path"
+      , "--git-dir"
+      , "--namespace"
+      , "--super-prefix"
+      , "--work-tree"
+      ]
+    || argStartsWith arg "-C"
+    || argStartsWith arg "-c"
+    || argStartsWith arg "--config-env="
+    || argStartsWith arg "--exec-path="
+    || argStartsWith arg "--git-dir="
+    || argStartsWith arg "--namespace="
+    || argStartsWith arg "--super-prefix="
+    || argStartsWith arg "--work-tree="
+
+def gitOptionConsumesNext (arg : String) : Bool :=
+  stringIn arg
+    [ "-C"
+    , "-c"
+    , "--config-env"
+    , "--exec-path"
+    , "--git-dir"
+    , "--namespace"
+    , "--super-prefix"
+    , "--work-tree"
+    ]
+
+def findGitSubcommand : List String → Option (String × List String)
+  | [] => none
+  | arg :: rest =>
+      if gitOptionConsumesNext arg then
+        match rest with
+        | [] => none
+        | _ :: remaining => findGitSubcommand remaining
+      else if stringMatches arg "--" || argStartsWith arg "-" then
+        findGitSubcommand rest
+      else
+        some (arg, rest)
+
+def gitReadOnlyFlagDenied (arg : String) : Bool :=
+  stringIn arg ["--output", "--ext-diff", "--textconv", "--exec", "--paginate"]
+    || argStartsWith arg "--output="
+    || argStartsWith arg "--exec="
+
+def gitBranchArgAllowed (arg : String) : Bool :=
+  stringIn arg
+    [ "--list"
+    , "-l"
+    , "--show-current"
+    , "-a"
+    , "--all"
+    , "-r"
+    , "--remotes"
+    , "-v"
+    , "-vv"
+    , "--verbose"
+    ]
+    || argStartsWith arg "--format="
+
+def validateGitBranchArgs (args : List String) : Decision :=
+  match firstArgWhere (fun arg => if gitBranchArgAllowed arg then false else true) args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "git" arg)
+  | none => .allow
+
+def gitReadOnlySubcommandAllowed (subcommand : String) : Bool :=
+  stringIn subcommand ["status", "diff", "show", "log", "ls-files", "grep", "rev-parse"]
+
+def validateGitArgs (args : List String) : Decision :=
+  match firstArgWhere gitGlobalOptionDenied args with
+  | some arg => .deny (.readOnlyArgumentNotAllowed "git" arg)
+  | none =>
+      match findGitSubcommand args with
+      | none => .deny (.readOnlySubcommandRequired "git")
+      | some (subcommand, subcommandArgs) =>
+          match firstArgWhere gitReadOnlyFlagDenied subcommandArgs with
+          | some arg => .deny (.readOnlyArgumentNotAllowed "git" arg)
+          | none =>
+              if gitReadOnlySubcommandAllowed subcommand then
+                .allow
+              else if stringMatches subcommand "branch" then
+                validateGitBranchArgs subcommandArgs
+              else
+                .deny (.readOnlySubcommandNotAllowlisted "git" subcommand)
+
+def sudoCommandName (command : String) : String :=
+  if stringMatches command "/bin/launchctl"
+      || stringMatches command "/usr/bin/launchctl"
+      || stringMatches command "/sbin/launchctl" then
+    "launchctl"
+  else
+    command
+
+def validateSudoArgs (args : List String) : Decision :=
+  match args with
+  | [] => .deny (.readOnlySubcommandRequired "sudo")
+  | command :: rest =>
+      let commandName := sudoCommandName command
+      if stringMatches commandName "launchctl" then
+        if stringMatches command "/bin/launchctl" then
+          validateLaunchctlArgs rest
+        else
+          .deny (.readOnlyArgumentNotAllowed "sudo" command)
+      else
+        .deny (.readOnlySubcommandNotAllowlisted "sudo" commandName)
+
+def validateReadOnlyArgs (request : CommandRequest) : Decision :=
+  match request.lookupCommand with
+  | "sed" => validateSedArgs request.args
+  | "find" => validateFindArgs request.args
+  | "git" => validateGitArgs request.args
+  | "rg" => validateRipgrepArgs request.args
+  | "launchctl" => validateLaunchctlArgs request.args
+  | "tailscale" => validateTailscaleArgs request.args
+  | "curl" => validateCurlArgs request.args
+  | "sudo" => validateSudoArgs request.args
+  | _ => .allow
+
 /-- Validator used when the effective mode is `read_only`. -/
 def validateReadOnlyCommand
     (allowlist : List String)
     (request : CommandRequest) : Decision :=
   if commandAllowlisted request.lookupCommand allowlist then
-    .allow
+    validateReadOnlyArgs request
   else
     .deny (.readOnlyCommandNotAllowlisted request.lookupCommand)
 

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
@@ -59,8 +59,7 @@ def argStartsWith (arg candidatePrefix : String) : Bool :=
   arg.startsWith candidatePrefix
 
 def sedArgumentDenied (arg : String) : Bool :=
-  stringMatches arg "-i"
-    || stringMatches arg "--in-place"
+  stringMatches arg "--in-place"
     || argStartsWith arg "-i"
 
 def validateSedArgs (args : List String) : Decision :=
@@ -170,6 +169,9 @@ def validateCurlArgs (args : List String) : Decision :=
       else
         .deny (.readOnlyUrlRequired "curl")
 
+/-- Matches Rust decisions for exact and attached git global-option forms.
+    The `startsWith` branches also cover bare `-C`/`-c`, which are already
+    denied by the exact list above. -/
 def gitGlobalOptionDenied (arg : String) : Bool :=
   stringIn arg
       [ "-C"
@@ -235,7 +237,7 @@ def gitBranchArgAllowed (arg : String) : Bool :=
     || argStartsWith arg "--format="
 
 def validateGitBranchArgs (args : List String) : Decision :=
-  match firstArgWhere (fun arg => if gitBranchArgAllowed arg then false else true) args with
+  match firstArgWhere (fun arg => !gitBranchArgAllowed arg) args with
   | some arg => .deny (.readOnlyArgumentNotAllowed "git" arg)
   | none => .allow
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -170,7 +170,11 @@ def commandPolicyCaseJson (witness : CommandPolicy.CommandPolicyCase) : String :
     ++ "\"denied_argv\":"
       ++ jsonOptionalStringArray (reason.bind CommandPolicy.DenialReason.argv?) ++ ","
     ++ "\"denied_command\":"
-      ++ jsonOptionalString (reason.bind CommandPolicy.DenialReason.command?)
+      ++ jsonOptionalString (reason.bind CommandPolicy.DenialReason.command?) ++ ","
+    ++ "\"denied_argument\":"
+      ++ jsonOptionalString (reason.bind CommandPolicy.DenialReason.argument?) ++ ","
+    ++ "\"denied_subcommand\":"
+      ++ jsonOptionalString (reason.bind CommandPolicy.DenialReason.subcommand?)
     ++ "}"
 
 def commandSandboxCaseJson (witness : CommandPolicy.CommandSandboxCase) : String :=

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -294,6 +294,8 @@ pub(crate) struct LeanCommandPolicyCase {
     pub(crate) matched_prefix: Option<Vec<String>>,
     pub(crate) denied_argv: Option<Vec<String>>,
     pub(crate) denied_command: Option<String>,
+    pub(crate) denied_argument: Option<String>,
+    pub(crate) denied_subcommand: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -21,8 +21,8 @@ use super::shared::{
 use super::*;
 use crate::ensure_schemas;
 use crate::lean_vocab_test::{
-    lean_command_env_cases, lean_command_policy_cases, lean_command_sandbox_cases,
-    LeanCommandPolicyCase,
+    lean_command_env_cases, lean_command_policy_case, lean_command_policy_cases,
+    lean_command_sandbox_cases, LeanCommandPolicyCase,
 };
 use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
 
@@ -657,6 +657,99 @@ fn generated_command_policy_cases_cover_read_only_safety_matrix() {
             "Lean CommandPolicy contract must emit read-only safety case {name}"
         );
     }
+
+    for name in [
+        "read_only_git_status_allows",
+        "read_only_git_branch_list_allows",
+        "read_only_sed_print_allows",
+        "read_only_find_type_file_allows",
+        "read_only_rg_search_allows",
+        "read_only_curl_http_get_allows",
+        "read_only_launchctl_print_allows",
+        "read_only_tailscale_status_allows",
+        "read_only_tailscale_netcheck_allows",
+        "read_only_sudo_launchctl_print_allows",
+    ] {
+        let case = lean_command_policy_case(name);
+        assert_eq!(case.decision, "allow");
+        assert_eq!(case.denial_reason, None);
+    }
+
+    for (name, argument) in [
+        ("read_only_git_global_config_denies", "-c"),
+        (
+            "read_only_git_config_env_denies",
+            "--config-env=GIT_CONFIG_GLOBAL=ENV_FILE",
+        ),
+        (
+            "read_only_git_output_flag_denies",
+            "--output=/tmp/defra-agent-diff.txt",
+        ),
+        (
+            "read_only_git_exec_flag_denies",
+            "--exec=touch /tmp/defra-agent-nope",
+        ),
+        ("read_only_git_branch_delete_denies", "-D"),
+        ("read_only_sed_in_place_short_denies", "-i"),
+        ("read_only_sed_in_place_long_denies", "--in-place"),
+        ("read_only_find_delete_denies", "-delete"),
+        ("read_only_find_exec_denies", "-exec"),
+        ("read_only_find_fprint_denies", "-fprint0"),
+        ("read_only_rg_pre_denies", "--pre"),
+        ("read_only_rg_search_zip_denies", "--search-zip"),
+        ("read_only_curl_post_denies", "-X"),
+        ("read_only_curl_data_denies", "--data={}"),
+        ("read_only_curl_output_denies", "-o"),
+        ("read_only_curl_upload_denies", "-T"),
+        ("read_only_curl_config_denies", "-K"),
+        (
+            "read_only_sudo_launchctl_wrong_path_denies",
+            "/usr/bin/launchctl",
+        ),
+    ] {
+        let case = lean_command_policy_case(name);
+        assert_eq!(case.decision, "deny");
+        assert_eq!(
+            case.denial_reason.as_deref(),
+            Some("readOnlyArgumentNotAllowed")
+        );
+        assert_eq!(case.denied_argument.as_deref(), Some(argument));
+    }
+
+    for (name, subcommand) in [
+        ("read_only_git_commit_subcommand_denies", "commit"),
+        ("read_only_launchctl_bootout_denies", "bootout"),
+        ("read_only_tailscale_up_denies", "up"),
+        ("read_only_sudo_rm_denies", "rm"),
+    ] {
+        let case = lean_command_policy_case(name);
+        assert_eq!(case.decision, "deny");
+        assert_eq!(
+            case.denial_reason.as_deref(),
+            Some("readOnlySubcommandNotAllowlisted")
+        );
+        assert_eq!(case.denied_subcommand.as_deref(), Some(subcommand));
+    }
+
+    for name in [
+        "read_only_launchctl_missing_subcommand_denies",
+        "read_only_sudo_missing_command_denies",
+    ] {
+        let case = lean_command_policy_case(name);
+        assert_eq!(case.decision, "deny");
+        assert_eq!(
+            case.denial_reason.as_deref(),
+            Some("readOnlySubcommandRequired")
+        );
+    }
+
+    let missing_url = lean_command_policy_case("read_only_curl_missing_http_url_denies");
+    assert_eq!(missing_url.decision, "deny");
+    assert_eq!(
+        missing_url.denial_reason.as_deref(),
+        Some("readOnlyUrlRequired")
+    );
+    assert_eq!(missing_url.denied_command.as_deref(), Some("curl"));
 }
 
 #[test]

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
@@ -607,6 +608,58 @@ fn generated_command_policy_cases_match_rust_validation() {
 }
 
 #[test]
+fn generated_command_policy_cases_cover_read_only_safety_matrix() {
+    let emitted = lean_command_policy_cases()
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let expected = [
+        "read_only_git_status_allows",
+        "read_only_git_branch_list_allows",
+        "read_only_git_global_config_denies",
+        "read_only_git_config_env_denies",
+        "read_only_git_output_flag_denies",
+        "read_only_git_exec_flag_denies",
+        "read_only_git_commit_subcommand_denies",
+        "read_only_git_branch_delete_denies",
+        "read_only_sed_print_allows",
+        "read_only_sed_in_place_short_denies",
+        "read_only_sed_in_place_long_denies",
+        "read_only_find_type_file_allows",
+        "read_only_find_delete_denies",
+        "read_only_find_exec_denies",
+        "read_only_find_fprint_denies",
+        "read_only_rg_search_allows",
+        "read_only_rg_pre_denies",
+        "read_only_rg_search_zip_denies",
+        "read_only_curl_http_get_allows",
+        "read_only_curl_post_denies",
+        "read_only_curl_data_denies",
+        "read_only_curl_output_denies",
+        "read_only_curl_upload_denies",
+        "read_only_curl_config_denies",
+        "read_only_curl_missing_http_url_denies",
+        "read_only_launchctl_print_allows",
+        "read_only_launchctl_bootout_denies",
+        "read_only_launchctl_missing_subcommand_denies",
+        "read_only_tailscale_status_allows",
+        "read_only_tailscale_netcheck_allows",
+        "read_only_tailscale_up_denies",
+        "read_only_sudo_launchctl_print_allows",
+        "read_only_sudo_launchctl_wrong_path_denies",
+        "read_only_sudo_rm_denies",
+        "read_only_sudo_missing_command_denies",
+    ];
+
+    for name in expected {
+        assert!(
+            emitted.contains(name),
+            "Lean CommandPolicy contract must emit read-only safety case {name}"
+        );
+    }
+}
+
+#[test]
 fn generated_command_sandbox_cases_match_rust_selection() {
     for case in lean_command_sandbox_cases() {
         let mode = rust_command_execution_mode(&case.mode);
@@ -710,6 +763,54 @@ fn assert_command_denial_matches(case: &LeanCommandPolicyCase, error: &str) {
                 case.name
             );
         }
+        Some("readOnlyArgumentNotAllowed") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            let argument = case
+                .denied_argument
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_argument", case.name));
+            assert_read_only_argument_denial_matches(&case.name, command, argument, error);
+        }
+        Some("readOnlySubcommandRequired") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            assert!(
+                error.contains(command) && (error.contains("requires") || error.contains("approved")),
+                "Lean CommandPolicy case {} expected required-subcommand denial for {command:?}, got Rust error: {error}",
+                case.name
+            );
+        }
+        Some("readOnlySubcommandNotAllowlisted") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            let subcommand = case
+                .denied_subcommand
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_subcommand", case.name));
+            assert!(
+                error.contains(command) && error.contains(subcommand) && error.contains("not allowed"),
+                "Lean CommandPolicy case {} expected read-only subcommand denial for {command:?} {subcommand:?}, got Rust error: {error}",
+                case.name
+            );
+        }
+        Some("readOnlyUrlRequired") => {
+            let command = case
+                .denied_command
+                .as_deref()
+                .unwrap_or_else(|| panic!("Lean case {} missing denied_command", case.name));
+            assert!(
+                error.contains(command) && error.contains("requires an http:// or https:// URL"),
+                "Lean CommandPolicy case {} expected read-only URL requirement denial for {command:?}, got Rust error: {error}",
+                case.name
+            );
+        }
         Some("disabledNetworkUnenforceable") => {
             assert!(
                 error.contains("command_network_mode=disabled cannot be enforced"),
@@ -735,6 +836,50 @@ fn assert_command_denial_matches(case: &LeanCommandPolicyCase, error: &str) {
         None => panic!(
             "Lean CommandPolicy case {} denied without a denial reason; Rust error: {error}",
             case.name
+        ),
+    }
+}
+
+fn assert_read_only_argument_denial_matches(
+    case_name: &str,
+    command: &str,
+    argument: &str,
+    error: &str,
+) {
+    match command {
+        "sed" => assert!(
+            error.contains("sed in-place edits are not allowed"),
+            "Lean CommandPolicy case {case_name} expected sed in-place denial for {argument:?}, got Rust error: {error}"
+        ),
+        "find" => assert!(
+            error.contains("find arguments that can write or execute are not allowed"),
+            "Lean CommandPolicy case {case_name} expected find write/exec denial for {argument:?}, got Rust error: {error}"
+        ),
+        "sudo" if argument.ends_with("launchctl") => assert!(
+            error.contains("sudo launchctl must use the absolute /bin/launchctl path"),
+            "Lean CommandPolicy case {case_name} expected sudo launchctl path denial for {argument:?}, got Rust error: {error}"
+        ),
+        "git" if argument == "-c" || argument == "-C" || argument.starts_with("--config-env") => {
+            assert!(
+                error.contains("git global options")
+                    && error.contains("not allowed")
+                    && error.contains("config"),
+                "Lean CommandPolicy case {case_name} expected git config/global-option denial for {argument:?}, got Rust error: {error}"
+            );
+        }
+        "git" => assert!(
+            error.contains("git")
+                && error.contains(argument)
+                && (error.contains("not allowed") || error.contains("not read-only")),
+            "Lean CommandPolicy case {case_name} expected git argument denial for {argument:?}, got Rust error: {error}"
+        ),
+        "rg" | "curl" => assert!(
+            error.contains(command) && error.contains(argument) && error.contains("not allowed"),
+            "Lean CommandPolicy case {case_name} expected {command} argument denial for {argument:?}, got Rust error: {error}"
+        ),
+        other => assert!(
+            error.contains(other) && error.contains("not allowed"),
+            "Lean CommandPolicy case {case_name} expected read-only argument denial for {other:?} {argument:?}, got Rust error: {error}"
         ),
     }
 }

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -142,7 +142,7 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().client_shell_cases.len(), 15);
     assert_eq!(lean_contract_snapshot().tool_preflight_cases.len(), 9);
     assert_eq!(lean_contract_snapshot().tool_retry_cases.len(), 45);
-    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 10);
+    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 45);
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
 }


### PR DESCRIPTION
## Summary
- model command-family read-only argv safety checks in Lean for git, sed, find, rg, curl, launchctl, tailscale, and sudo
- emit 35 additional Lean-generated CommandPolicy cases covering safe and unsafe read-only shapes
- extend Rust conformance tests to consume new denial details and assert the generated safety matrix drives validate_command_policy

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent generated_command -- --nocapture
- cargo test -p defra-agent toolset::tests::read_only_bash
- cargo test -p defra-agent --test state_machine_conformance
- cargo fmt --all -- --check
- git diff --check
- rg hygiene scan for sorry/admit/axiom/PLACEHOLDER/todo!(; only pre-existing CLAUDE.md prose mention of zero sorrys)