### PR TITLE
Persist AgentToolCall trace enrichment

### DIFF
--- a/crates/defra-agent-protocol/schemas/README.md
+++ b/crates/defra-agent-protocol/schemas/README.md
@@ -76,7 +76,7 @@ These documents record user requests, assistant output, and conversation history
 | `AgentSession` | `session_id`, `behavior_id`, `status`, `started`, `ended` | ties a sequence of requests to one behavior | session manager | `chat`, inspection, recovery |
 | `AgentConversation` | `session_id`, `agent_did`, `behavior_id`, `title`, `preview_text`, `status`, `latest_request_id` | high-level conversation summary per session | session/conversation layer | UI and inspection |
 | `AgentMessage` | `message_key`, `session_id`, `sequence`, `role`, `content`, `timestamp` | ordered transcript entries | session/history layer | chat history, TUI, debugging |
-| `AgentToolCall` | `tool_call_key`, `session_id`, `tool_name`, `tool_call_id`, `args`, `result`, `status` | concrete tool invocation records within a session | runtime/tool persistence | chat progress, TUI, diagnostics |
+| `AgentToolCall` | `tool_call_key`, `session_id`, `tool_name`, `tool_call_id`, `args`, `result`, `status`, trace enrichment fields | concrete tool invocation records within a session | runtime/tool persistence | chat progress, TUI, diagnostics |
 | `AgentToolResult` | `agent_did`, `session_id`, `tool_name`, `tool_input`, `output_text`, `truncated`, `discarded_because_interrupted` | normalized tool result persistence | tool persistence hook | compaction and later inspection |
 | `CompactionEntry` | `compaction_key`, `session_id`, `summary`, `messages_compacted`, token counts | persisted compaction summaries | compaction layer | session reconstruction and debugging |
 

--- a/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
@@ -9,4 +9,8 @@ type AgentToolCall @branchable {
     status: String
     started_at: DateTime
     completed_at: DateTime
+    selected_service_id: String
+    selected_tool_name: String
+    tool_failure_class: String
+    latency_ms: Int
 }

--- a/crates/defra-agent-protocol/src/graphql.rs
+++ b/crates/defra-agent-protocol/src/graphql.rs
@@ -597,6 +597,10 @@ pub fn session_shape_query(session_id: &str) -> String {
                 status
                 args
                 result
+                selected_service_id
+                selected_tool_name
+                tool_failure_class
+                latency_ms
             }}
             AgentToolResult(filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }}, order: {{ created_at: ASC }}) {{
                 agent_did

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -307,6 +307,14 @@ pub struct AgentToolCallRow {
     pub started_at: Option<String>,
     #[serde(default)]
     pub completed_at: Option<String>,
+    #[serde(default)]
+    pub selected_service_id: Option<String>,
+    #[serde(default)]
+    pub selected_tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_failure_class: Option<String>,
+    #[serde(default)]
+    pub latency_ms: Option<i64>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/defra-agent/src/session/fork.rs
+++ b/crates/defra-agent/src/session/fork.rs
@@ -336,6 +336,7 @@ async fn copy_tool_calls(
                 order: {{ message_sequence: ASC }}
             ) {{
                 message_sequence tool_name tool_call_id args result status started_at completed_at
+                selected_service_id selected_tool_name tool_failure_class latency_ms
             }}
         }}"#
     );
@@ -370,6 +371,10 @@ async fn copy_tool_calls(
             .get("completed_at")
             .and_then(|v| v.as_str())
             .unwrap_or("");
+        let selected_service_id = row.get("selected_service_id").and_then(|v| v.as_str());
+        let selected_tool_name = row.get("selected_tool_name").and_then(|v| v.as_str());
+        let tool_failure_class = row.get("tool_failure_class").and_then(|v| v.as_str());
+        let latency_ms = row.get("latency_ms").and_then(json_i64);
         let tool_call_id_escaped = escape_graphql_string(tool_call_id);
         let tool_call_key = format!("{child_session_escaped}:{tool_call_id_escaped}");
         mutation_fields.push(format!(
@@ -383,7 +388,11 @@ async fn copy_tool_calls(
                     result: "{result_escaped}",
                     status: "{status_escaped}",
                     started_at: "{started_at_escaped}",
-                    completed_at: "{completed_at_escaped}"
+                    completed_at: "{completed_at_escaped}",
+                    selected_service_id: {selected_service_id},
+                    selected_tool_name: {selected_tool_name},
+                    tool_failure_class: {tool_failure_class},
+                    latency_ms: {latency_ms}
                 }}) {{ _docID }}
             "#,
             tool_name_escaped = escape_graphql_string(tool_name),
@@ -392,6 +401,10 @@ async fn copy_tool_calls(
             status_escaped = escape_graphql_string(status),
             started_at_escaped = escape_graphql_string(started_at),
             completed_at_escaped = escape_graphql_string(completed_at),
+            selected_service_id = nullable_string_literal(selected_service_id),
+            selected_tool_name = nullable_string_literal(selected_tool_name),
+            tool_failure_class = nullable_string_literal(tool_failure_class),
+            latency_ms = nullable_i64_literal(latency_ms),
         ));
     }
     execute_batch_mutation_with_retry(node, &mutation_fields, "fork::copy_tool_calls").await?;
@@ -619,4 +632,22 @@ async fn create_child_session_and_conversation(
     );
     execute_mutation_with_retry(node, &conv_mutation, "fork::create_conversation").await?;
     Ok(())
+}
+
+fn nullable_string_literal(value: Option<&str>) -> String {
+    value
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn nullable_i64_literal(value: Option<i64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn json_i64(value: &serde_json::Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
 }

--- a/crates/defra-agent/src/session/rows.rs
+++ b/crates/defra-agent/src/session/rows.rs
@@ -23,7 +23,11 @@ pub(super) struct CompactionEntryRow {
 pub(super) struct ToolCallDocument {
     #[serde(rename = "_docID")]
     pub(super) doc_id: String,
+    pub(super) tool_name: String,
+    pub(super) args: String,
     pub(super) started_at: String,
+    #[serde(default)]
+    pub(super) completed_at: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/defra-agent/src/session/tests.rs
+++ b/crates/defra-agent/src/session/tests.rs
@@ -165,6 +165,284 @@ async fn complete_tool_call_preserves_started_at_datetime() {
 }
 
 #[tokio::test]
+async fn complete_tool_call_persists_trace_enrichment_for_successful_meta_call() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-daemon-tool-call-{}", uuid::Uuid::new_v4()));
+    let node = defra_node::EmbeddedNode::builder()
+        .data_path(&data_path)
+        .build()
+        .await
+        .unwrap();
+    ensure_schemas(&node).await.unwrap();
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "call_tool",
+        "call-meta-123",
+        r#"{"service_id":"x-data","tool_name":"search_posts","arguments":{"query":"amy"}}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    complete_tool_call(
+        &node,
+        "session-1",
+        "call-meta-123",
+        "search results",
+        "completed",
+    )
+    .await
+    .unwrap();
+
+    let row = load_tool_call_trace_row(&node, "call-meta-123").await;
+    assert_eq!(
+        row.get("selected_service_id")
+            .and_then(|value| value.as_str()),
+        Some("x-data")
+    );
+    assert_eq!(
+        row.get("selected_tool_name")
+            .and_then(|value| value.as_str()),
+        Some("search_posts")
+    );
+    assert!(row
+        .get("tool_failure_class")
+        .is_some_and(|value| value.is_null()));
+    assert!(row
+        .get("latency_ms")
+        .and_then(|value| value.as_i64())
+        .is_some_and(|value| value >= 0));
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn complete_tool_call_persists_known_failure_class() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-daemon-tool-call-{}", uuid::Uuid::new_v4()));
+    let node = defra_node::EmbeddedNode::builder()
+        .data_path(&data_path)
+        .build()
+        .await
+        .unwrap();
+    ensure_schemas(&node).await.unwrap();
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "describe_tool",
+        "call-missing-tool",
+        r#"{"service_id":"x-data","tool_name":"missing"}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    complete_tool_call(
+        &node,
+        "session-1",
+        "call-missing-tool",
+        "tool 'missing' not found on service 'x-data'. Available tools: search_posts",
+        "completed",
+    )
+    .await
+    .unwrap();
+
+    let row = load_tool_call_trace_row(&node, "call-missing-tool").await;
+    assert_eq!(
+        row.get("tool_failure_class")
+            .and_then(|value| value.as_str()),
+        Some("tool_not_found")
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn save_tool_call_update_preserves_existing_trace_enrichment() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-daemon-tool-call-{}", uuid::Uuid::new_v4()));
+    let node = defra_node::EmbeddedNode::builder()
+        .data_path(&data_path)
+        .build()
+        .await
+        .unwrap();
+    ensure_schemas(&node).await.unwrap();
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "call_tool",
+        "call-resaved-tool",
+        r#"{"service_id":"x-data","tool_name":"search_posts","arguments":{"query":"amy"}}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "call_tool",
+        "call-resaved-tool",
+        r#"{"service_id":"other-service","tool_name":"other_tool","arguments":{}}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    let row = load_tool_call_trace_row(&node, "call-resaved-tool").await;
+    assert_eq!(
+        row.get("selected_service_id")
+            .and_then(|value| value.as_str()),
+        Some("x-data")
+    );
+    assert_eq!(
+        row.get("selected_tool_name")
+            .and_then(|value| value.as_str()),
+        Some("search_posts")
+    );
+    assert!(row
+        .get("tool_failure_class")
+        .is_some_and(|value| value.is_null()));
+    assert!(row.get("latency_ms").is_some_and(|value| value.is_null()));
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn save_tool_call_does_not_clobber_completed_trace_enrichment() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-daemon-tool-call-{}", uuid::Uuid::new_v4()));
+    let node = defra_node::EmbeddedNode::builder()
+        .data_path(&data_path)
+        .build()
+        .await
+        .unwrap();
+    ensure_schemas(&node).await.unwrap();
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "describe_tool",
+        "call-resaved-complete",
+        r#"{"service_id":"x-data","tool_name":"missing"}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    complete_tool_call(
+        &node,
+        "session-1",
+        "call-resaved-complete",
+        "tool 'missing' not found on service 'x-data'. Available tools: search_posts",
+        "completed",
+    )
+    .await
+    .unwrap();
+    let completed_row = load_tool_call_trace_row(&node, "call-resaved-complete").await;
+    let completed_latency = completed_row
+        .get("latency_ms")
+        .and_then(|value| value.as_i64())
+        .expect("completed latency");
+
+    save_tool_call(
+        &node,
+        "session-1",
+        1,
+        "describe_tool",
+        "call-resaved-complete",
+        r#"{"service_id":"other-service","tool_name":"other_tool"}"#,
+        "called",
+    )
+    .await
+    .unwrap();
+
+    let row = load_tool_call_trace_row(&node, "call-resaved-complete").await;
+    assert_eq!(
+        row.get("selected_service_id")
+            .and_then(|value| value.as_str()),
+        Some("x-data")
+    );
+    assert_eq!(
+        row.get("selected_tool_name")
+            .and_then(|value| value.as_str()),
+        Some("missing")
+    );
+    assert_eq!(
+        row.get("tool_failure_class")
+            .and_then(|value| value.as_str()),
+        Some("tool_not_found")
+    );
+    assert_eq!(
+        row.get("latency_ms").and_then(|value| value.as_i64()),
+        Some(completed_latency)
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn agent_tool_call_trace_enrichment_fields_are_nullable_for_old_rows() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-daemon-tool-call-{}", uuid::Uuid::new_v4()));
+    let node = defra_node::EmbeddedNode::builder()
+        .data_path(&data_path)
+        .build()
+        .await
+        .unwrap();
+    ensure_schemas(&node).await.unwrap();
+
+    let resp = node
+        .execute(
+            r#"mutation {
+                create_AgentToolCall(input: {
+                    tool_call_key: "session-1:old-call",
+                    session_id: "session-1",
+                    message_sequence: 1,
+                    tool_name: "read_file",
+                    tool_call_id: "old-call",
+                    args: "{\"path\":\"src/lib.rs\"}",
+                    result: "file contents",
+                    status: "completed",
+                    started_at: "2026-05-07T12:00:00Z",
+                    completed_at: "2026-05-07T12:00:01Z"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "create legacy tool call failed: {:?}",
+        resp.errors
+    );
+
+    let row = load_tool_call_trace_row(&node, "old-call").await;
+    for field in [
+        "selected_service_id",
+        "selected_tool_name",
+        "tool_failure_class",
+        "latency_ms",
+    ] {
+        assert!(
+            row.get(field).is_some_and(|value| value.is_null()),
+            "expected {field} to be null, got {:?}",
+            row.get(field)
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
 async fn close_session_preserves_started_datetime() {
     let data_path =
         std::env::temp_dir().join(format!("agent-daemon-session-{}", uuid::Uuid::new_v4()));
@@ -228,6 +506,41 @@ async fn close_session_preserves_started_datetime() {
         .is_some_and(|value| !value.is_empty()));
 
     let _ = std::fs::remove_dir_all(&data_path);
+}
+
+async fn load_tool_call_trace_row(
+    node: &defra_node::EmbeddedNode,
+    tool_call_id: &str,
+) -> serde_json::Value {
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let resp = node
+        .execute(&format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{ tool_call_id: {{ _eq: "{tool_call_id}" }} }},
+                    limit: 1
+                ) {{
+                    selected_service_id
+                    selected_tool_name
+                    tool_failure_class
+                    latency_ms
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "query tool call trace fields failed: {:?}",
+        resp.errors
+    );
+
+    resp.data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| value.as_array())
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("tool call trace row")
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/session/tool_calls.rs
+++ b/crates/defra-agent/src/session/tool_calls.rs
@@ -1,8 +1,7 @@
-use super::retry::{
-    execute_mutation_with_retry, execute_query_timed, log_mutation_timing, retry_operation,
-};
+use super::retry::{execute_query_timed, log_mutation_timing, retry_operation};
 use super::rows::{ToolCallDocument, ToolCallResultRow};
 use super::*;
+use crate::trace_export::{analyze_tool_call, latency_ms, ToolCallTraceAnalysis, ToolFailureClass};
 
 pub(crate) async fn save_tool_call(
     node: &EmbeddedNode,
@@ -13,38 +12,99 @@ pub(crate) async fn save_tool_call(
     args: &str,
     status: &str,
 ) -> Result<()> {
+    retry_operation("save_tool_call", || async {
+        if let Some(tool_call) =
+            load_optional_tool_call_document(node, session_id, tool_call_id).await?
+        {
+            if tool_call_is_completed(&tool_call) {
+                return Ok(());
+            }
+
+            return update_started_tool_call(node, &tool_call, status).await;
+        }
+
+        create_tool_call(
+            node,
+            session_id,
+            message_sequence,
+            tool_name,
+            tool_call_id,
+            args,
+            status,
+        )
+        .await
+    })
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_tool_call(
+    node: &EmbeddedNode,
+    session_id: &str,
+    message_sequence: u32,
+    tool_name: &str,
+    tool_call_id: &str,
+    args: &str,
+    status: &str,
+) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
+    let trace_fields = trace_fields_for_started_call(tool_name, args);
     let escaped_args = escape_graphql_string(args);
     let escaped_session_id = escape_graphql_string(session_id);
     let escaped_tool_call_id = escape_graphql_string(tool_call_id);
     let escaped_tool_name = escape_graphql_string(tool_name);
     let escaped_status = escape_graphql_string(status);
     let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
+    let selected_service_id = nullable_string_literal(trace_fields.selected_service_id.as_deref());
+    let selected_tool_name = nullable_string_literal(trace_fields.selected_tool_name.as_deref());
+    let tool_failure_class = nullable_string_literal(trace_fields.tool_failure_class.as_deref());
 
     let mutation = format!(
         r#"mutation {{
-            upsert_AgentToolCall(
-                filter: {{ tool_call_key: {{ _eq: "{tool_call_key}" }} }},
-                add: {{
-                    tool_call_key: "{tool_call_key}",
-                    session_id: "{escaped_session_id}",
-                    message_sequence: {message_sequence},
-                    tool_name: "{escaped_tool_name}",
-                    tool_call_id: "{escaped_tool_call_id}",
-                    args: "{escaped_args}",
-                    result: "",
-                    status: "{escaped_status}",
-                    started_at: "{now}"
-                }},
-                update: {{
-                    status: "{escaped_status}"
-                }}
-            ) {{ _docID }}
+            create_AgentToolCall(input: {{
+                tool_call_key: "{tool_call_key}",
+                session_id: "{escaped_session_id}",
+                message_sequence: {message_sequence},
+                tool_name: "{escaped_tool_name}",
+                tool_call_id: "{escaped_tool_call_id}",
+                args: "{escaped_args}",
+                result: "",
+                status: "{escaped_status}",
+                started_at: "{now}",
+                selected_service_id: {selected_service_id},
+                selected_tool_name: {selected_tool_name},
+                tool_failure_class: {tool_failure_class},
+                latency_ms: null
+            }}) {{ _docID }}
         }}"#
     );
 
-    execute_mutation_with_retry(node, &mutation, "save_tool_call").await?;
-    Ok(())
+    execute_tool_call_mutation_once(node, &mutation, "save_tool_call").await
+}
+
+async fn update_started_tool_call(
+    node: &EmbeddedNode,
+    tool_call: &ToolCallDocument,
+    status: &str,
+) -> Result<()> {
+    let escaped_started_at = escape_graphql_string(&tool_call.started_at);
+    let escaped_status = escape_graphql_string(status);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{
+                    _docID: {{ _eq: "{doc_id}" }}
+                }},
+                input: {{
+                    started_at: "{escaped_started_at}",
+                    status: "{escaped_status}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+        doc_id = tool_call.doc_id,
+    );
+
+    execute_tool_call_mutation_once(node, &mutation, "save_tool_call").await
 }
 
 pub(crate) async fn complete_tool_call(
@@ -61,7 +121,15 @@ pub(crate) async fn complete_tool_call(
         let tool_call = load_tool_call_document(node, session_id, tool_call_id).await?;
 
         let now = chrono::Utc::now().to_rfc3339();
+        let trace_fields = trace_fields_for_completed_call(&tool_call, result, status, &now);
         let escaped_started_at = escape_graphql_string(&tool_call.started_at);
+        let selected_service_id =
+            nullable_string_literal(trace_fields.selected_service_id.as_deref());
+        let selected_tool_name =
+            nullable_string_literal(trace_fields.selected_tool_name.as_deref());
+        let tool_failure_class =
+            nullable_string_literal(trace_fields.tool_failure_class.as_deref());
+        let latency_ms = nullable_i64_literal(trace_fields.latency_ms);
         let mutation = format!(
             r#"mutation {{
                 update_AgentToolCall(
@@ -72,7 +140,11 @@ pub(crate) async fn complete_tool_call(
                         started_at: "{escaped_started_at}",
                         result: "{escaped_result}",
                         status: "{escaped_status}",
-                        completed_at: "{now}"
+                        completed_at: "{now}",
+                        selected_service_id: {selected_service_id},
+                        selected_tool_name: {selected_tool_name},
+                        tool_failure_class: {tool_failure_class},
+                        latency_ms: {latency_ms}
                     }}
                 ) {{ _docID }}
             }}"#,
@@ -156,7 +228,10 @@ async fn load_tool_call_document(
                 limit: 1
             ) {{
                 _docID
+                tool_name
+                args
                 started_at
+                completed_at
             }}
         }}"#
     );
@@ -185,4 +260,133 @@ async fn load_tool_call_document(
             "loading tool call for completion: no AgentToolCall for session_id={session_id} tool_call_id={tool_call_id}"
         )
     })
+}
+
+async fn load_optional_tool_call_document(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> Result<Option<ToolCallDocument>> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_tool_call_id = escape_graphql_string(tool_call_id);
+    let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    tool_call_key: {{ _eq: "{tool_call_key}" }}
+                }},
+                limit: 1
+            ) {{
+                _docID
+                tool_name
+                args
+                started_at
+                completed_at
+            }}
+        }}"#
+    );
+
+    let resp = execute_query_timed(node, &query, "load_tool_call_document").await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "loading tool call session_id={} tool_call_id={}: {:?}",
+            session_id,
+            tool_call_id,
+            resp.errors
+        );
+    }
+
+    let mut rows: Vec<ToolCallDocument> = match resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+    {
+        Some(value) => serde_json::from_value(value.clone())?,
+        None => Vec::new(),
+    };
+
+    Ok(rows.pop())
+}
+
+fn tool_call_is_completed(tool_call: &ToolCallDocument) -> bool {
+    tool_call
+        .completed_at
+        .as_deref()
+        .is_some_and(|value| !value.is_empty())
+}
+
+async fn execute_tool_call_mutation_once(
+    node: &EmbeddedNode,
+    mutation: &str,
+    operation: &str,
+) -> Result<()> {
+    let started_at = std::time::Instant::now();
+    let resp = node.execute(mutation).await;
+    log_mutation_timing(operation, started_at.elapsed());
+
+    if !resp.has_errors() {
+        return Ok(());
+    }
+
+    anyhow::bail!("{operation} mutation failed: {:?}", resp.errors)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ToolCallTraceFields {
+    selected_service_id: Option<String>,
+    selected_tool_name: Option<String>,
+    tool_failure_class: Option<String>,
+    latency_ms: Option<i64>,
+}
+
+fn trace_fields_for_started_call(tool_name: &str, args: &str) -> ToolCallTraceFields {
+    // At call start only arguments are known; completion recomputes with the real result/status.
+    let analysis = analyze_tool_call(tool_name, args, "", "completed");
+    ToolCallTraceFields::from_analysis(analysis, None)
+}
+
+fn trace_fields_for_completed_call(
+    tool_call: &ToolCallDocument,
+    result: &str,
+    status: &str,
+    completed_at: &str,
+) -> ToolCallTraceFields {
+    let analysis = analyze_tool_call(&tool_call.tool_name, &tool_call.args, result, status);
+    ToolCallTraceFields::from_analysis(
+        analysis,
+        latency_ms(Some(&tool_call.started_at), Some(completed_at)),
+    )
+}
+
+impl ToolCallTraceFields {
+    fn from_analysis(analysis: ToolCallTraceAnalysis, latency_ms: Option<i64>) -> Self {
+        Self {
+            selected_service_id: analysis.selected_service_id,
+            selected_tool_name: analysis.selected_tool_name,
+            tool_failure_class: analysis
+                .tool_failure_class
+                .and_then(tool_failure_class_string),
+            latency_ms,
+        }
+    }
+}
+
+fn tool_failure_class_string(failure_class: ToolFailureClass) -> Option<String> {
+    match serde_json::to_value(failure_class).ok()? {
+        serde_json::Value::String(value) => Some(value),
+        _ => None,
+    }
+}
+
+fn nullable_string_literal(value: Option<&str>) -> String {
+    value
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .unwrap_or_else(|| "null".to_string())
+}
+
+fn nullable_i64_literal(value: Option<i64>) -> String {
+    value
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string())
 }

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -217,7 +217,8 @@ pub fn analyze_request_failure(text: Option<&str>) -> Option<ToolFailureClass> {
 pub fn latency_ms(started_at: Option<&str>, completed_at: Option<&str>) -> Option<i64> {
     let started = parse_rfc3339(started_at?)?;
     let completed = parse_rfc3339(completed_at?)?;
-    Some(completed.signed_duration_since(started).num_milliseconds())
+    let latency = completed.signed_duration_since(started).num_milliseconds();
+    (latency >= 0).then_some(latency)
 }
 
 pub fn raw_message_json(content: &str) -> Value {
@@ -1342,6 +1343,14 @@ mod tests {
                 Some("2026-05-04T12:00:01.250Z")
             ),
             Some(1250)
+        );
+    }
+
+    #[test]
+    fn ignores_negative_latency_from_rfc3339_timestamps() {
+        assert_eq!(
+            latency_ms(Some("2026-05-04T12:00:01Z"), Some("2026-05-04T12:00:00Z")),
+            None
         );
     }
 }

--- a/crates/defra-agent/tests/fork_invariants.rs
+++ b/crates/defra-agent/tests/fork_invariants.rs
@@ -1,3 +1,4 @@
+use defra_agent::graphql::escape_graphql_string;
 use defra_agent::session::{fork, ForkError, ForkParams};
 
 mod support;
@@ -11,6 +12,48 @@ use support::{
     create_agent_tool_call, create_agent_tool_result, create_compaction_entry, create_request,
     test_db, AGENT_DID, AGENT_NAME,
 };
+
+async fn set_tool_call_trace_fields(
+    node: &defra_node::EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+    selected_service_id: &str,
+    selected_tool_name: &str,
+    tool_failure_class: &str,
+    latency_ms: i64,
+    started_at: &str,
+    completed_at: &str,
+) {
+    let session_id = escape_graphql_string(session_id);
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let tool_call_key = format!("{session_id}:{tool_call_id}");
+    let selected_service_id = escape_graphql_string(selected_service_id);
+    let selected_tool_name = escape_graphql_string(selected_tool_name);
+    let tool_failure_class = escape_graphql_string(tool_failure_class);
+    let started_at = escape_graphql_string(started_at);
+    let completed_at = escape_graphql_string(completed_at);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ tool_call_key: {{ _eq: "{tool_call_key}" }} }},
+                input: {{
+                    started_at: "{started_at}",
+                    completed_at: "{completed_at}",
+                    selected_service_id: "{selected_service_id}",
+                    selected_tool_name: "{selected_tool_name}",
+                    tool_failure_class: "{tool_failure_class}",
+                    latency_ms: {latency_ms}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "set tool call trace fields failed: {:?}",
+        resp.errors
+    );
+}
 
 #[tokio::test]
 async fn fork_copies_message_prefix_up_to_user_turn_boundary() {
@@ -152,12 +195,24 @@ async fn fork_copies_tool_calls_up_to_user_turn_boundary() {
         parent_session,
         2,
         "tc-1",
-        "read_file",
-        r#"{"path":"foo"}"#,
-        "file contents",
+        "describe_tool",
+        r#"{"service_id":"x-data","tool_name":"missing"}"#,
+        "tool 'missing' not found on service 'x-data'. Available tools: search_posts",
         "completed",
         "2026-04-21T10:00:02Z",
+        "2026-04-21T10:00:02.025Z",
+    )
+    .await;
+    set_tool_call_trace_fields(
+        &db.node,
+        parent_session,
+        "tc-1",
+        "x-data",
+        "missing",
+        "tool_not_found",
+        25,
         "2026-04-21T10:00:02Z",
+        "2026-04-21T10:00:02.025Z",
     )
     .await;
     create_agent_message(
@@ -227,6 +282,19 @@ async fn fork_copies_tool_calls_up_to_user_turn_boundary() {
         child_tool_calls[0].tool_call_key,
         format!("{}:tc-1", outcome.session_id)
     );
+    assert_eq!(
+        child_tool_calls[0].selected_service_id.as_deref(),
+        Some("x-data")
+    );
+    assert_eq!(
+        child_tool_calls[0].selected_tool_name.as_deref(),
+        Some("missing")
+    );
+    assert_eq!(
+        child_tool_calls[0].tool_failure_class.as_deref(),
+        Some("tool_not_found")
+    );
+    assert_eq!(child_tool_calls[0].latency_ms, Some(25));
 
     assert_eq!(outcome.copied_tool_calls, 1);
 }

--- a/crates/defra-agent/tests/support/snapshots.rs
+++ b/crates/defra-agent/tests/support/snapshots.rs
@@ -508,6 +508,14 @@ pub struct ToolCallSnapshot {
     pub status: String,
     pub started_at: String,
     pub completed_at: String,
+    #[serde(default)]
+    pub selected_service_id: Option<String>,
+    #[serde(default)]
+    pub selected_tool_name: Option<String>,
+    #[serde(default)]
+    pub tool_failure_class: Option<String>,
+    #[serde(default)]
+    pub latency_ms: Option<i64>,
 }
 
 pub async fn fetch_tool_call_snapshots_for_session(
@@ -523,6 +531,7 @@ pub async fn fetch_tool_call_snapshots_for_session(
             ) {{
                 tool_call_key session_id message_sequence tool_name tool_call_id
                 args result status started_at completed_at
+                selected_service_id selected_tool_name tool_failure_class latency_ms
             }}
         }}"#
     );


### PR DESCRIPTION
# Persist AgentToolCall trace enrichment

Add four nullable fields to `AgentToolCall` rows so they carry enough trace data to drive structured stress and judge scoring without parsing semi-structured tool result text:

- `selected_service_id` - MCP service routed to (differs from `tool_name` for meta-tools like `call_tool` / `describe_tool`)
- `selected_tool_name` - inner tool name when a meta-tool dispatched
- `tool_failure_class` - structured failure classifier already used by `trace_export`
- `latency_ms` - completion duration in milliseconds, populated only when both timestamps exist and the duration is non-negative

## Scope

- Schema: `agent_tool_call.graphql` adds four nullable fields.
- Protocol row + GraphQL session-shape query carry the new fields end-to-end.
- `session::tool_calls::save_tool_call` and `complete_tool_call` populate the new fields by calling `trace_export::analyze_tool_call` at the persistence boundary. The same `analyze_tool_call` and `latency_ms` helpers used by the trace-export path now run at the time of write, so persisted rows match what `trace_export` would produce.
- `save_tool_call` can only derive argument-based fields at call start. It invokes analysis with placeholder result/status to reuse the same helper when creating a new row. Duplicate saves preserve the existing row's `started_at` and enrichment fields; rows that have already completed are treated as materialized and are not clobbered by a late/redundant save.
- `session::fork::copy_tool_calls` is updated to preserve the new fields when a session forks. Without this, forked AgentToolCall rows would silently drop enrichment data.
- `trace_export::latency_ms` now clamps negative durations to `None` instead of returning a negative value. New unit test covers this.

## Compatibility

- All four fields are nullable. Old rows continue to deserialize. No backfill is required; only forward-going rows need enrichment.
- The amygdala-side schema extension and reader in `amygdala-schemas` / `amygdala-evals` already landed, with `Option<...>` reads that work against current and enriched defra-agent builds.

## Why not extend `AmyToolCallTraceRecord` instead?

`AmyToolCallTraceRecord` is built by the trace-export CLI after rows are loaded; it is not in scope at the runtime hook/session persistence boundary. Computing the same analysis from `tool_name`, `args`, `result`, `status`, and timestamps using the existing `trace_export` helpers keeps the change localized and avoids coupling runtime persistence to the export-only record shape.

## Reference

- Spec: `amygdala/docs/superpowers/specs/2026-05-07-agent-tool-call-trace-enrichment.md`
- Consumer: `amygdala/crates/amygdala-evals/src/defra/hydrate.rs`

## Tests

`CARGO_INCREMENTAL=0 cargo test -p defra-agent` passes.

New tests cover:

- Successful MCP meta-tool enrichment populates service/tool fields and latency, with no failure class.
- Known failing calls persist the expected snake_case `tool_failure_class`.
- Duplicate saves do not overwrite existing start-time enrichment.
- Late duplicate saves after completion do not clobber completion-time enrichment.
- Old rows with no enrichment fields remain queryable with null values.
- Forked sessions preserve non-null enrichment fields.
- Negative latency timestamps return `None`.
