### PR TITLE
Add boundary runtime coverage cases

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -107,9 +107,11 @@ mutations; it does not persist a per-token `PersistenceState` or
 local hook classification: successful mutation results count as local success
 acks, fail-closed mutation failures propagate an error and remain uncommitted,
 and fail-open mutation failures continue as acknowledged lost output without a
-success ack. Storage-engine crash windows, transport delivery, global CRDT
-convergence, stale-read recovery, and event-bus delivery correctness remain
-external DefraDB/environment assumptions.
+success ack. They also cover local classification of direct read-your-writes,
+stale read/event, and later visible-read observations. Storage-engine crash
+windows, transport delivery, global CRDT convergence, the arrival of later
+visibility observations, and event-bus delivery correctness remain external
+DefraDB/environment assumptions.
 
 This section is the modeled part of the former broad storage assumption; the
 following section keeps the still-external DefraDB/environment assumptions
@@ -315,7 +317,7 @@ def boundaries : List Boundary :=
     , domain := "StorageObservation"
     , subject := "daemon-visible storage facts"
     , statement :=
-        "Lean-generated cases and Rust hook tests cover local success/failure observation classification; daemon-visible storage facts remain observations, not proofs of DefraDB internals."
+        "Lean-generated cases and Rust hook tests cover local success/failure and stale/read-visible observation classification; daemon-visible storage facts remain observations, not proofs of DefraDB internals."
     }
   , { id := boundaryStorageMinimumVisibilityPathId
     , domain := "StorageObservation"

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -103,9 +103,13 @@ that justify moving through that lifecycle:
 These are daemon storage assumptions, not proofs of DefraDB internals. Rust uses
 `StreamBuffer`, `DefraSessionHook`, and hook failure policy around DefraDB
 mutations; it does not persist a per-token `PersistenceState` or
-`StorageObservation` document. Storage-engine crash windows, transport delivery,
-global CRDT convergence, and event-bus delivery correctness remain external
-DefraDB/environment assumptions.
+`StorageObservation` document. Lean-generated runtime cases cover only the
+local hook classification: successful mutation results count as local success
+acks, fail-closed mutation failures propagate an error and remain uncommitted,
+and fail-open mutation failures continue as acknowledged lost output without a
+success ack. Storage-engine crash windows, transport delivery, global CRDT
+convergence, stale-read recovery, and event-bus delivery correctness remain
+external DefraDB/environment assumptions.
 
 This section is the modeled part of the former broad storage assumption; the
 following section keeps the still-external DefraDB/environment assumptions
@@ -116,9 +120,13 @@ separate.
 Backend health and availability observations are only as fresh as the backend
 documents visible at admission time. Endpoint freshness and network/provider
 behavior are environmental assumptions, not service-local state-machine facts.
-The service-local proof and tests cover the consequence of an observed backend
-configuration: reconstructed running call rows do not exceed that backend's
-`max_concurrent`.
+Lean-generated runtime cases and Rust tests cover the service-local admission
+classification for an observed backend document: a backend is available only
+when `enabled = true` and `probe_status = "healthy"`. They also cover the
+consequence of an observed backend configuration: reconstructed running call
+rows do not exceed that backend's `max_concurrent`. They do not prove that the
+backend document is fresh, that a probe result reflects current endpoint
+availability, or that provider/network calls will succeed.
 
 Trigger source delivery remains operational. Lean does not model the DefraDB
 event bus, control-watcher debounce, schedule tick cadence, subscription
@@ -142,9 +150,10 @@ depends on broader transition coverage from it.
 account for every emitted vocabulary, state machine, trigger dispatch case
 group, runtime-reconcile witness group, session-recovery witness group,
 inference-slot witness group, fleet-slot witness group, frontend/desktop
-ClientShell witness group, tool-execution witness group, command-policy
-validation/sandbox/env witness group, and follow-up hook; Rust checks that each
-appears in that ledger exactly once.
+ClientShell witness group, boundary-runtime policy witness group,
+tool-execution witness group, command-policy validation/sandbox/env witness
+group, and follow-up hook; Rust checks that each appears in that ledger exactly
+once.
 Boundary and deviation metadata is emitted as structured review metadata and is
 shape-checked separately; ledger `accepted_boundary` fields reference the stable
 boundary ids emitted by this file.
@@ -152,13 +161,14 @@ boundary ids emitted by this file.
 A ledger entry is acceptable only when it names a Rust/TypeScript consumer, an
 intentional product boundary recorded in this file, or an accepted follow-up.
 Future executable trigger, runtime, session-recovery, slot/fleet,
-`ClientShell`, `ToolExecution`, or `CommandPolicy` contracts should therefore
-add both the emitted contract domain and its runtime consumer in the same
-change. ClientShell rows should be assigned to the frontend list when they only
-exercise React shell state and to the desktop list when they exercise the Rust
-session-snapshot bridge. If the runtime consumer is deliberately deferred, the
-ledger entry must point here to describe the boundary or carry a follow-up hook;
-otherwise Rust will reject the generated contract as advisory-only.
+boundary-runtime, `ClientShell`, `ToolExecution`, or `CommandPolicy` contracts
+should therefore add both the emitted contract domain and its runtime consumer
+in the same change. ClientShell rows should be assigned to the frontend list
+when they only exercise React shell state and to the desktop list when they
+exercise the Rust session-snapshot bridge. If the runtime consumer is
+deliberately deferred, the ledger entry must point here to describe the
+boundary or carry a follow-up hook; otherwise Rust will reject the generated
+contract as advisory-only.
 
 ## Closed Historical Items
 
@@ -297,7 +307,7 @@ def boundaries : List Boundary :=
     , domain := "Persistence"
     , subject := "hook storage failure policy"
     , statement :=
-        "Rust hook policy observes storage failure as fail-closed retry or fail-open lost output instead of exposing per-token persistence documents."
+        "Lean-generated cases and Rust hook tests cover local fail-closed termination versus fail-open lost-output continuation; Rust still does not expose per-token persistence documents."
     , acceptedFailureMode :=
         some "Fail-open acknowledges lost output by policy."
     }
@@ -305,7 +315,7 @@ def boundaries : List Boundary :=
     , domain := "StorageObservation"
     , subject := "daemon-visible storage facts"
     , statement :=
-        "StorageObservation records daemon-visible mutation and read facts that justify lifecycle movement; it is not a proof of DefraDB internals."
+        "Lean-generated cases and Rust hook tests cover local success/failure observation classification; daemon-visible storage facts remain observations, not proofs of DefraDB internals."
     }
   , { id := boundaryStorageMinimumVisibilityPathId
     , domain := "StorageObservation"
@@ -319,7 +329,7 @@ def boundaries : List Boundary :=
     , domain := "Admission"
     , subject := "backend health freshness"
     , statement :=
-        "Backend health and availability observations are only as fresh as backend documents visible at admission time; provider and network behavior are environmental."
+        "Lean-generated cases and Rust tests cover observed-document admission availability; backend document freshness, probes, provider behavior, and network behavior remain environmental."
     }
   , { id := boundarySessionRecoveryFailedLatestSmokeId
     , domain := "SessionRecovery"

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
@@ -1,6 +1,7 @@
 import Proofs.Conformance.ContractCases.Runtime
 import Proofs.Conformance.ContractCases.SlotAccounting
 import Proofs.Conformance.ContractCases.SessionRecovery
+import Proofs.Conformance.ContractCases.BoundaryRuntime
 
 /-!
 # Finite Conformance Witness Cases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
@@ -58,6 +58,10 @@ def hookResultForMutation
       | .failOpen => "ok"
       | .failClosed => "err"
 
+def actionNameForMutationResult : MutationResult -> String
+  | .success => "mutationSuccess"
+  | .failure => "mutationFailure"
+
 def storageObservationForMutation
     (policy : PersistenceState.FailurePolicy)
     (result : MutationResult) : StorageObservation :=
@@ -111,12 +115,38 @@ def storageObservationRuntimeCase
   let postObservation := storageObservationForMutation policy result
   { name := name
   , policy := policy.toDefraDB
+  , action := actionNameForMutationResult result
+  , preObservation := StorageObservation.toContract .inFlight
   , mutationResult := result.toContract
   , postObservation := postObservation.toContract
   , postPersistence := (StorageObservation.toPersistence postObservation).toDefraDB
   , hookResult := hookResultForMutation policy result
-  , recordsFailure := if result = .failure then true else false
-  , recordsSuccess := if result = .success then true else false
+  , recordsFailure := decide (result = .failure)
+  , recordsSuccess := decide (result = .success)
+  , terminalWriteObserved := terminalWriteObservedBool postObservation
+  , externalVisibilityClaimed := false
+  }
+
+def storageVisibilityRuntimeCase
+    (name : String)
+    (policy : PersistenceState.FailurePolicy)
+    (preObservation : StorageObservation)
+    (actionName : String)
+    (action : StorageObservation.Action) : StorageObservationRuntimeCase :=
+  let postObservation :=
+    match StorageObservation.step? policy preObservation action with
+    | some obs => obs
+    | none => preObservation
+  { name := name
+  , policy := policy.toDefraDB
+  , action := actionName
+  , preObservation := preObservation.toContract
+  , mutationResult := "notApplicable"
+  , postObservation := postObservation.toContract
+  , postPersistence := (StorageObservation.toPersistence postObservation).toDefraDB
+  , hookResult := "notApplicable"
+  , recordsFailure := false
+  , recordsSuccess := false
   , terminalWriteObserved := terminalWriteObservedBool postObservation
   , externalVisibilityClaimed := false
   }
@@ -138,10 +168,34 @@ def storageObservationRuntimeCases : List StorageObservationRuntimeCase :=
       "fail_open_failure_acknowledges_lost_output"
       .failOpen
       .failure
+  , storageVisibilityRuntimeCase
+      "read_your_writes_success_ack_is_visible"
+      .failClosed
+      .successAcknowledged
+      "readYourWrites"
+      .readYourWrites
+  , storageVisibilityRuntimeCase
+      "stale_read_preserves_committed_observation"
+      .failClosed
+      .successAcknowledged
+      "staleRead"
+      .staleRead
+  , storageVisibilityRuntimeCase
+      "stale_event_preserves_committed_observation"
+      .failClosed
+      .successAcknowledged
+      "staleEvent"
+      .staleEvent
+  , storageVisibilityRuntimeCase
+      "event_after_stale_observation_is_visible"
+      .failClosed
+      .staleObserved
+      "eventArrives"
+      .eventArrives
   ]
 
 def backendAvailable (enabled : Bool) (probeStatus : BackendProbeStatus) : Bool :=
-  enabled && (if probeStatus = .healthy then true else false)
+  enabled && decide (probeStatus = .healthy)
 
 def backendHealthAdmissionCase
     (name : String)

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
@@ -1,0 +1,183 @@
+import Proofs.Persistence
+import Proofs.StorageObservation
+import Proofs.Conformance.ContractCases.Types
+
+/-!
+# Boundary Runtime Witness Cases
+
+Finite executable cases for service-local decisions that sit next to external
+boundaries. These rows deliberately classify only Rust-owned policy outcomes;
+they do not claim DefraDB durability, event delivery, endpoint freshness, or
+provider/network behavior.
+-/
+
+namespace Conformance.ContractCases
+
+inductive MutationResult where
+  | success
+  | failure
+  deriving DecidableEq, Repr
+
+namespace MutationResult
+
+def toContract : MutationResult -> String
+  | .success => "success"
+  | .failure => "failure"
+
+end MutationResult
+
+inductive BackendProbeStatus where
+  | healthy
+  | unhealthy
+  | unknown
+  | stale
+  deriving DecidableEq, Repr
+
+namespace BackendProbeStatus
+
+def toDefraDB : BackendProbeStatus -> String
+  | .healthy => "healthy"
+  | .unhealthy => "unhealthy"
+  | .unknown => "unknown"
+  | .stale => "stale"
+
+end BackendProbeStatus
+
+def hookDecisionForFailure (policy : PersistenceState.FailurePolicy) : String :=
+  match policy with
+  | .failOpen => "continue"
+  | .failClosed => "terminate"
+
+def hookResultForMutation
+    (policy : PersistenceState.FailurePolicy)
+    (result : MutationResult) : String :=
+  match result with
+  | .success => "ok"
+  | .failure =>
+      match policy with
+      | .failOpen => "ok"
+      | .failClosed => "err"
+
+def storageObservationForMutation
+    (policy : PersistenceState.FailurePolicy)
+    (result : MutationResult) : StorageObservation :=
+  match result with
+  | .success => .successAcknowledged
+  | .failure =>
+      match policy with
+      | .failOpen => .lostAcknowledged
+      | .failClosed => .mutationFailed
+
+def terminalWriteObservedBool (obs : StorageObservation) : Bool :=
+  match obs with
+  | .successAcknowledged => true
+  | .readVisible => true
+  | _ => false
+
+def persistenceFailurePolicyCase
+    (name : String)
+    (policy : PersistenceState.FailurePolicy) :
+    PersistenceFailurePolicyCase :=
+  let postPersistence :=
+    match PersistenceState.step? policy .committing .writeFail with
+    | some state => state
+    | none => .uncommitted
+  let postObservation := storageObservationForMutation policy .failure
+  { name := name
+  , policy := policy.toDefraDB
+  , action := "writeFail"
+  , prePersistence := PersistenceState.toDefraDB .committing
+  , postPersistence := postPersistence.toDefraDB
+  , postStorageObservation := postObservation.toContract
+  , hookDecision := hookDecisionForFailure policy
+  , recordsFailure := true
+  , recordsSuccess := false
+  , externalDurabilityClaimed := false
+  }
+
+def persistenceFailurePolicyCases : List PersistenceFailurePolicyCase :=
+  [ persistenceFailurePolicyCase
+      "fail_closed_write_failure_terminates_without_success_ack"
+      .failClosed
+  , persistenceFailurePolicyCase
+      "fail_open_write_failure_continues_as_lost_without_success_ack"
+      .failOpen
+  ]
+
+def storageObservationRuntimeCase
+    (name : String)
+    (policy : PersistenceState.FailurePolicy)
+    (result : MutationResult) : StorageObservationRuntimeCase :=
+  let postObservation := storageObservationForMutation policy result
+  { name := name
+  , policy := policy.toDefraDB
+  , mutationResult := result.toContract
+  , postObservation := postObservation.toContract
+  , postPersistence := (StorageObservation.toPersistence postObservation).toDefraDB
+  , hookResult := hookResultForMutation policy result
+  , recordsFailure := if result = .failure then true else false
+  , recordsSuccess := if result = .success then true else false
+  , terminalWriteObserved := terminalWriteObservedBool postObservation
+  , externalVisibilityClaimed := false
+  }
+
+def storageObservationRuntimeCases : List StorageObservationRuntimeCase :=
+  [ storageObservationRuntimeCase
+      "fail_closed_success_ack_counts_local_commit"
+      .failClosed
+      .success
+  , storageObservationRuntimeCase
+      "fail_open_success_ack_counts_local_commit"
+      .failOpen
+      .success
+  , storageObservationRuntimeCase
+      "fail_closed_failure_reports_mutation_failed"
+      .failClosed
+      .failure
+  , storageObservationRuntimeCase
+      "fail_open_failure_acknowledges_lost_output"
+      .failOpen
+      .failure
+  ]
+
+def backendAvailable (enabled : Bool) (probeStatus : BackendProbeStatus) : Bool :=
+  enabled && (if probeStatus = .healthy then true else false)
+
+def backendHealthAdmissionCase
+    (name : String)
+    (enabled : Bool)
+    (probeStatus : BackendProbeStatus) : BackendHealthAdmissionCase :=
+  let expectedAvailable := backendAvailable enabled probeStatus
+  { name := name
+  , enabled := enabled
+  , probeStatus := probeStatus.toDefraDB
+  , expectedAvailable := expectedAvailable
+  , admissionDecision := if expectedAvailable then "available" else "unavailable"
+  , observedDocumentOnly := true
+  , externalEndpointFreshnessClaimed := false
+  }
+
+def backendHealthAdmissionCases : List BackendHealthAdmissionCase :=
+  [ backendHealthAdmissionCase
+      "enabled_healthy_backend_is_available_from_observed_document"
+      true
+      .healthy
+  , backendHealthAdmissionCase
+      "disabled_healthy_backend_is_unavailable_from_observed_document"
+      false
+      .healthy
+  , backendHealthAdmissionCase
+      "enabled_unhealthy_backend_is_unavailable_from_observed_document"
+      true
+      .unhealthy
+  , backendHealthAdmissionCase
+      "enabled_unknown_backend_is_unavailable_from_observed_document"
+      true
+      .unknown
+  , backendHealthAdmissionCase
+      "enabled_stale_backend_is_unavailable_from_observed_document"
+      true
+      .stale
+  ]
+
+end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -122,6 +122,8 @@ structure PersistenceFailurePolicyCase where
 structure StorageObservationRuntimeCase where
   name : String
   policy : String
+  action : String
+  preObservation : String
   mutationResult : String
   postObservation : String
   postPersistence : String

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -106,6 +106,42 @@ structure FleetSlotAccountingCase where
   aggregateReconstructedNotPersisted : Bool
   deriving Repr
 
+structure PersistenceFailurePolicyCase where
+  name : String
+  policy : String
+  action : String
+  prePersistence : String
+  postPersistence : String
+  postStorageObservation : String
+  hookDecision : String
+  recordsFailure : Bool
+  recordsSuccess : Bool
+  externalDurabilityClaimed : Bool
+  deriving Repr
+
+structure StorageObservationRuntimeCase where
+  name : String
+  policy : String
+  mutationResult : String
+  postObservation : String
+  postPersistence : String
+  hookResult : String
+  recordsFailure : Bool
+  recordsSuccess : Bool
+  terminalWriteObserved : Bool
+  externalVisibilityClaimed : Bool
+  deriving Repr
+
+structure BackendHealthAdmissionCase where
+  name : String
+  enabled : Bool
+  probeStatus : String
+  expectedAvailable : Bool
+  admissionDecision : String
+  observedDocumentOnly : Bool
+  externalEndpointFreshnessClaimed : Bool
+  deriving Repr
+
 def boolString (value : Bool) : String :=
   if value then "true" else "false"
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -147,6 +147,8 @@ def storageObservationRuntimeCaseJson
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
     ++ "\"policy\":" ++ jsonString witness.policy ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"pre_observation\":" ++ jsonString witness.preObservation ++ ","
     ++ "\"mutation_result\":" ++ jsonString witness.mutationResult ++ ","
     ++ "\"post_observation\":" ++ jsonString witness.postObservation ++ ","
     ++ "\"post_persistence\":" ++ jsonString witness.postPersistence ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -125,6 +125,56 @@ def fleetSlotAccountingCaseJson (witness : FleetSlotAccountingCase) : String :=
       ++ boolString witness.aggregateReconstructedNotPersisted
     ++ "}"
 
+def persistenceFailurePolicyCaseJson
+    (witness : PersistenceFailurePolicyCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"policy\":" ++ jsonString witness.policy ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"pre_persistence\":" ++ jsonString witness.prePersistence ++ ","
+    ++ "\"post_persistence\":" ++ jsonString witness.postPersistence ++ ","
+    ++ "\"post_storage_observation\":"
+      ++ jsonString witness.postStorageObservation ++ ","
+    ++ "\"hook_decision\":" ++ jsonString witness.hookDecision ++ ","
+    ++ "\"records_failure\":" ++ boolString witness.recordsFailure ++ ","
+    ++ "\"records_success\":" ++ boolString witness.recordsSuccess ++ ","
+    ++ "\"external_durability_claimed\":"
+      ++ boolString witness.externalDurabilityClaimed
+    ++ "}"
+
+def storageObservationRuntimeCaseJson
+    (witness : StorageObservationRuntimeCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"policy\":" ++ jsonString witness.policy ++ ","
+    ++ "\"mutation_result\":" ++ jsonString witness.mutationResult ++ ","
+    ++ "\"post_observation\":" ++ jsonString witness.postObservation ++ ","
+    ++ "\"post_persistence\":" ++ jsonString witness.postPersistence ++ ","
+    ++ "\"hook_result\":" ++ jsonString witness.hookResult ++ ","
+    ++ "\"records_failure\":" ++ boolString witness.recordsFailure ++ ","
+    ++ "\"records_success\":" ++ boolString witness.recordsSuccess ++ ","
+    ++ "\"terminal_write_observed\":"
+      ++ boolString witness.terminalWriteObserved ++ ","
+    ++ "\"external_visibility_claimed\":"
+      ++ boolString witness.externalVisibilityClaimed
+    ++ "}"
+
+def backendHealthAdmissionCaseJson
+    (witness : BackendHealthAdmissionCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"enabled\":" ++ boolString witness.enabled ++ ","
+    ++ "\"probe_status\":" ++ jsonString witness.probeStatus ++ ","
+    ++ "\"expected_available\":"
+      ++ boolString witness.expectedAvailable ++ ","
+    ++ "\"admission_decision\":"
+      ++ jsonString witness.admissionDecision ++ ","
+    ++ "\"observed_document_only\":"
+      ++ boolString witness.observedDocumentOnly ++ ","
+    ++ "\"external_endpoint_freshness_claimed\":"
+      ++ boolString witness.externalEndpointFreshnessClaimed
+    ++ "}"
+
 def toolPreflightCaseJson (witness : ToolExecution.PreflightCase) : String :=
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
@@ -240,6 +290,15 @@ def snapshotJson : String :=
       ++ jsonArray (inferenceSlotAccountingCases.map inferenceSlotAccountingCaseJson) ++ ","
     ++ "\"fleet_slot_accounting_cases\":"
       ++ jsonArray (fleetSlotAccountingCases.map fleetSlotAccountingCaseJson) ++ ","
+    ++ "\"persistence_failure_policy_cases\":"
+      ++ jsonArray
+        (persistenceFailurePolicyCases.map persistenceFailurePolicyCaseJson) ++ ","
+    ++ "\"storage_observation_runtime_cases\":"
+      ++ jsonArray
+        (storageObservationRuntimeCases.map storageObservationRuntimeCaseJson) ++ ","
+    ++ "\"backend_health_admission_cases\":"
+      ++ jsonArray
+        (backendHealthAdmissionCases.map backendHealthAdmissionCaseJson) ++ ","
     ++ "\"tool_preflight_cases\":"
       ++ jsonArray (ToolExecution.preflightCases.map toolPreflightCaseJson) ++ ","
     ++ "\"tool_retry_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -166,6 +166,21 @@ def caseCoverage : List CoverageEntry :=
       "FleetSlotAccounting"
       boundaryFleetSlotAccountingDerivedViewId
       "admission::tests::generated_slot_accounting_fleet_cases_match_admission_runtime_boundary"
+  , boundaryCoverage
+      "persistence_policy_cases"
+      "PersistenceFailurePolicyCases"
+      boundaryStorageHookFailurePolicyId
+      "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions"
+  , boundaryCoverage
+      "storage_observation_cases"
+      "StorageObservationRuntimeCases"
+      boundaryStorageObservationDaemonVisibleId
+      "hook::tests::generated_storage_observation_cases_match_hook_runtime_classification"
+  , boundaryCoverage
+      "backend_health_cases"
+      "BackendHealthAdmissionCases"
+      boundaryBackendHealthAdmissionFreshnessId
+      "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy"
   , consumerCoverage
       "frontend_client_shell_cases"
       "FrontendClientShellCases"

--- a/crates/defra-agent/src/backend_registry/tests.rs
+++ b/crates/defra-agent/src/backend_registry/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
+use crate::admission::BackendAdmissionConfig;
 use crate::backend_provider::BackendProviderKind;
+use crate::lean_vocab_test::lean_backend_health_admission_cases;
 
 #[test]
 fn inference_backend_from_value_parses() {
@@ -83,4 +85,61 @@ fn is_available_requires_enabled_and_healthy() {
         ..healthy.clone()
     };
     assert!(!unhealthy.is_available());
+}
+
+#[test]
+fn generated_backend_health_admission_cases_match_registry_and_admission_policy() {
+    let cases = lean_backend_health_admission_cases();
+    assert_eq!(cases.len(), 5);
+
+    for case in cases {
+        let backend = InferenceBackend {
+            backend_id: case.name.clone(),
+            name: case.name.clone(),
+            provider_kind: BackendProviderKind::OpenAiCompatible,
+            endpoint: "http://localhost:8000/v1".into(),
+            api_key: None,
+            api_key_env_var: None,
+            max_concurrent: 1,
+            max_queue_depth: DEFAULT_MAX_QUEUE_DEPTH,
+            enabled: case.enabled,
+            models: Vec::new(),
+            probe_status: case.probe_status.clone(),
+        };
+        let admission_config =
+            BackendAdmissionConfig::from_backend(&backend).expect("valid backend config");
+
+        assert_eq!(
+            backend.is_available(),
+            case.expected_available,
+            "{} registry availability drifted from Lean case",
+            case.name
+        );
+        assert_eq!(
+            admission_config.is_available(),
+            case.expected_available,
+            "{} admission availability drifted from Lean case",
+            case.name
+        );
+        assert_eq!(
+            case.admission_decision.as_str(),
+            if case.expected_available {
+                "available"
+            } else {
+                "unavailable"
+            },
+            "{}",
+            case.name
+        );
+        assert!(
+            case.observed_document_only,
+            "{} must stay scoped to the observed backend document",
+            case.name
+        );
+        assert!(
+            !case.external_endpoint_freshness_claimed,
+            "{} must not claim endpoint/provider freshness",
+            case.name
+        );
+    }
 }

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -210,45 +210,51 @@ fn generated_persistence_failure_policy_cases_match_hook_decisions() {
 #[tokio::test]
 async fn generated_storage_observation_cases_match_hook_runtime_classification() {
     let cases = lean_storage_observation_runtime_cases();
-    assert_eq!(cases.len(), 4);
+    assert_eq!(cases.len(), 8);
     let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
 
     for case in cases {
-        let hook = DefraSessionHook::with_identity(
-            node.clone(),
-            "agent",
-            "did:defra-agent:test",
-            failure_policy_from_contract(&case.policy),
-        );
-        let result = match case.mutation_result.as_str() {
-            "success" => Ok(()),
-            "failure" => Err(anyhow::anyhow!(
-                "generated storage-observation failure for {}",
-                case.name
-            )),
-            other => panic!("unknown Lean mutation result {other:?}"),
-        };
-        let actual_result = hook.apply_persistence_policy(result, &case.name);
-        let stats = hook.stats();
+        if case.mutation_result == "notApplicable" {
+            assert_eq!(case.hook_result, "notApplicable", "{}", case.name);
+            assert!(!case.records_failure, "{}", case.name);
+            assert!(!case.records_success, "{}", case.name);
+        } else {
+            let hook = DefraSessionHook::with_identity(
+                node.clone(),
+                "agent",
+                "did:defra-agent:test",
+                failure_policy_from_contract(&case.policy),
+            );
+            let result = match case.mutation_result.as_str() {
+                "success" => Ok(()),
+                "failure" => Err(anyhow::anyhow!(
+                    "generated storage-observation failure for {}",
+                    case.name
+                )),
+                other => panic!("unknown Lean mutation result {other:?}"),
+            };
+            let actual_result = hook.apply_persistence_policy(result, &case.name);
+            let stats = hook.stats();
 
-        assert_eq!(
-            actual_result.is_ok(),
-            case.hook_result == "ok",
-            "{}",
-            case.name
-        );
-        assert_eq!(
-            stats.persistence_failures,
-            u64::from(case.records_failure),
-            "{}",
-            case.name
-        );
-        assert_eq!(
-            stats.persistence_successes,
-            u64::from(case.records_success),
-            "{}",
-            case.name
-        );
+            assert_eq!(
+                actual_result.is_ok(),
+                case.hook_result == "ok",
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                stats.persistence_failures,
+                u64::from(case.records_failure),
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                stats.persistence_successes,
+                u64::from(case.records_success),
+                "{}",
+                case.name
+            );
+        }
         assert!(
             !case.external_visibility_claimed,
             "{} must not claim storage-engine visibility",
@@ -257,16 +263,49 @@ async fn generated_storage_observation_cases_match_hook_runtime_classification()
 
         match case.post_observation.as_str() {
             "successAcknowledged" => {
+                assert_eq!(case.action, "mutationSuccess");
+                assert_eq!(case.pre_observation, "inFlight");
                 assert_eq!(case.post_persistence, "committed");
                 assert!(case.terminal_write_observed, "{}", case.name);
             }
             "mutationFailed" => {
+                assert_eq!(case.action, "mutationFailure");
+                assert_eq!(case.pre_observation, "inFlight");
                 assert_eq!(case.post_persistence, "uncommitted");
                 assert!(!case.terminal_write_observed, "{}", case.name);
             }
             "lostAcknowledged" => {
+                assert_eq!(case.action, "mutationFailure");
+                assert_eq!(case.pre_observation, "inFlight");
                 assert_eq!(case.post_persistence, "lost");
                 assert!(!case.terminal_write_observed, "{}", case.name);
+            }
+            "staleObserved" => {
+                assert!(
+                    matches!(case.action.as_str(), "staleRead" | "staleEvent"),
+                    "{}",
+                    case.name
+                );
+                assert_eq!(case.pre_observation, "successAcknowledged");
+                assert_eq!(case.post_persistence, "committed");
+                assert!(!case.terminal_write_observed, "{}", case.name);
+            }
+            "readVisible" => {
+                assert!(
+                    matches!(case.action.as_str(), "readYourWrites" | "eventArrives"),
+                    "{}",
+                    case.name
+                );
+                assert!(
+                    matches!(
+                        case.pre_observation.as_str(),
+                        "successAcknowledged" | "staleObserved"
+                    ),
+                    "{}",
+                    case.name
+                );
+                assert_eq!(case.post_persistence, "committed");
+                assert!(case.terminal_write_observed, "{}", case.name);
             }
             other => panic!("unexpected Lean storage observation {other:?}"),
         }

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -15,6 +15,9 @@ use serde_json::json;
 
 use super::*;
 use crate::ensure_schemas;
+use crate::lean_vocab_test::{
+    lean_persistence_failure_policy_cases, lean_storage_observation_runtime_cases,
+};
 
 #[derive(Clone, Default)]
 struct TestModel;
@@ -72,6 +75,14 @@ fn hook_counters_for_test() -> HookCounters {
     HookCounters {
         failures: AtomicU64::new(0),
         successes: AtomicU64::new(0),
+    }
+}
+
+fn failure_policy_from_contract(policy: &str) -> FailurePolicy {
+    match policy {
+        "failOpen" => FailurePolicy::FailOpen,
+        "failClosed" => FailurePolicy::FailClosed,
+        other => panic!("unknown Lean persistence failure policy {other:?}"),
     }
 }
 
@@ -140,6 +151,126 @@ fn fail_open_persistence_policy_continues_without_success_ack() {
         0,
         "fail-open continuation must not count as a successful storage ack"
     );
+}
+
+#[test]
+fn generated_persistence_failure_policy_cases_match_hook_decisions() {
+    let cases = lean_persistence_failure_policy_cases();
+    assert_eq!(cases.len(), 2);
+
+    for case in cases {
+        let counters = hook_counters_for_test();
+        let error = anyhow::anyhow!("generated persistence failure for {}", case.name);
+        let decision = decide_persistence_outcome(
+            failure_policy_from_contract(&case.policy),
+            &counters,
+            &case.name,
+            &error,
+        );
+        let actual_decision = match decision {
+            PolicyDecision::Continue => "continue",
+            PolicyDecision::Terminate(_) => "terminate",
+        };
+
+        assert_eq!(case.action, "writeFail", "{}", case.name);
+        assert_eq!(case.pre_persistence, "committing", "{}", case.name);
+        assert_eq!(actual_decision, case.hook_decision, "{}", case.name);
+        assert_eq!(
+            counters.failures.load(Ordering::Relaxed),
+            u64::from(case.records_failure),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            counters.successes.load(Ordering::Relaxed),
+            u64::from(case.records_success),
+            "{}",
+            case.name
+        );
+        assert!(
+            !case.external_durability_claimed,
+            "{} must not claim DefraDB durability",
+            case.name
+        );
+
+        match case.policy.as_str() {
+            "failClosed" => {
+                assert_eq!(case.post_persistence, "uncommitted");
+                assert_eq!(case.post_storage_observation, "mutationFailed");
+            }
+            "failOpen" => {
+                assert_eq!(case.post_persistence, "lost");
+                assert_eq!(case.post_storage_observation, "lostAcknowledged");
+            }
+            other => panic!("unknown Lean persistence failure policy {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn generated_storage_observation_cases_match_hook_runtime_classification() {
+    let cases = lean_storage_observation_runtime_cases();
+    assert_eq!(cases.len(), 4);
+    let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+
+    for case in cases {
+        let hook = DefraSessionHook::with_identity(
+            node.clone(),
+            "agent",
+            "did:defra-agent:test",
+            failure_policy_from_contract(&case.policy),
+        );
+        let result = match case.mutation_result.as_str() {
+            "success" => Ok(()),
+            "failure" => Err(anyhow::anyhow!(
+                "generated storage-observation failure for {}",
+                case.name
+            )),
+            other => panic!("unknown Lean mutation result {other:?}"),
+        };
+        let actual_result = hook.apply_persistence_policy(result, &case.name);
+        let stats = hook.stats();
+
+        assert_eq!(
+            actual_result.is_ok(),
+            case.hook_result == "ok",
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            stats.persistence_failures,
+            u64::from(case.records_failure),
+            "{}",
+            case.name
+        );
+        assert_eq!(
+            stats.persistence_successes,
+            u64::from(case.records_success),
+            "{}",
+            case.name
+        );
+        assert!(
+            !case.external_visibility_claimed,
+            "{} must not claim storage-engine visibility",
+            case.name
+        );
+
+        match case.post_observation.as_str() {
+            "successAcknowledged" => {
+                assert_eq!(case.post_persistence, "committed");
+                assert!(case.terminal_write_observed, "{}", case.name);
+            }
+            "mutationFailed" => {
+                assert_eq!(case.post_persistence, "uncommitted");
+                assert!(!case.terminal_write_observed, "{}", case.name);
+            }
+            "lostAcknowledged" => {
+                assert_eq!(case.post_persistence, "lost");
+                assert!(!case.terminal_write_observed, "{}", case.name);
+            }
+            other => panic!("unexpected Lean storage observation {other:?}"),
+        }
+    }
 }
 
 async fn create_streaming_response(

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -341,6 +341,8 @@ pub(crate) struct LeanPersistenceFailurePolicyCase {
 pub(crate) struct LeanStorageObservationRuntimeCase {
     pub(crate) name: String,
     pub(crate) policy: String,
+    pub(crate) action: String,
+    pub(crate) pre_observation: String,
     pub(crate) mutation_result: String,
     pub(crate) post_observation: String,
     pub(crate) post_persistence: String,

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -38,6 +38,9 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
     pub(crate) inference_slot_accounting_cases: Vec<LeanInferenceSlotAccountingCase>,
     pub(crate) fleet_slot_accounting_cases: Vec<LeanFleetSlotAccountingCase>,
+    pub(crate) persistence_failure_policy_cases: Vec<LeanPersistenceFailurePolicyCase>,
+    pub(crate) storage_observation_runtime_cases: Vec<LeanStorageObservationRuntimeCase>,
+    pub(crate) backend_health_admission_cases: Vec<LeanBackendHealthAdmissionCase>,
     pub(crate) tool_preflight_cases: Vec<LeanToolPreflightCase>,
     pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
     pub(crate) boundaries: Vec<LeanBoundary>,
@@ -321,6 +324,45 @@ pub(crate) struct LeanFleetSlotAccountingCase {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct LeanPersistenceFailurePolicyCase {
+    pub(crate) name: String,
+    pub(crate) policy: String,
+    pub(crate) action: String,
+    pub(crate) pre_persistence: String,
+    pub(crate) post_persistence: String,
+    pub(crate) post_storage_observation: String,
+    pub(crate) hook_decision: String,
+    pub(crate) records_failure: bool,
+    pub(crate) records_success: bool,
+    pub(crate) external_durability_claimed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanStorageObservationRuntimeCase {
+    pub(crate) name: String,
+    pub(crate) policy: String,
+    pub(crate) mutation_result: String,
+    pub(crate) post_observation: String,
+    pub(crate) post_persistence: String,
+    pub(crate) hook_result: String,
+    pub(crate) records_failure: bool,
+    pub(crate) records_success: bool,
+    pub(crate) terminal_write_observed: bool,
+    pub(crate) external_visibility_claimed: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanBackendHealthAdmissionCase {
+    pub(crate) name: String,
+    pub(crate) enabled: bool,
+    pub(crate) probe_status: String,
+    pub(crate) expected_available: bool,
+    pub(crate) admission_decision: String,
+    pub(crate) observed_document_only: bool,
+    pub(crate) external_endpoint_freshness_claimed: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct LeanToolPreflightCase {
     pub(crate) name: String,
     pub(crate) health: String,
@@ -478,6 +520,20 @@ pub(crate) fn lean_fleet_slot_accounting_case(name: &str) -> &'static LeanFleetS
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean fleet slot-accounting case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_persistence_failure_policy_cases() -> &'static [LeanPersistenceFailurePolicyCase]
+{
+    &lean_contract_snapshot().persistence_failure_policy_cases
+}
+
+pub(crate) fn lean_storage_observation_runtime_cases(
+) -> &'static [LeanStorageObservationRuntimeCase] {
+    &lean_contract_snapshot().storage_observation_runtime_cases
+}
+
+pub(crate) fn lean_backend_health_admission_cases() -> &'static [LeanBackendHealthAdmissionCase] {
+    &lean_contract_snapshot().backend_health_admission_cases
 }
 
 pub(crate) fn lean_tool_preflight_cases() -> &'static [LeanToolPreflightCase] {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -151,7 +151,7 @@ fn lean_executable_contracts_cover_initial_domains() {
         lean_contract_snapshot()
             .storage_observation_runtime_cases
             .len(),
-        4
+        8
     );
     assert_eq!(
         lean_contract_snapshot()

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -142,6 +142,24 @@ fn lean_executable_contracts_cover_initial_domains() {
         5
     );
     assert_eq!(
+        lean_contract_snapshot()
+            .persistence_failure_policy_cases
+            .len(),
+        2
+    );
+    assert_eq!(
+        lean_contract_snapshot()
+            .storage_observation_runtime_cases
+            .len(),
+        4
+    );
+    assert_eq!(
+        lean_contract_snapshot()
+            .backend_health_admission_cases
+            .len(),
+        5
+    );
+    assert_eq!(
         lean_contract_snapshot().frontend_client_shell_case_count,
         lean_contract_snapshot().frontend_client_shell_cases.len()
     );
@@ -350,6 +368,24 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     if !snapshot.fleet_slot_accounting_cases.is_empty() {
         emitted.insert(("fleet_cases".to_string(), "FleetSlotAccounting".to_string()));
     }
+    if !snapshot.persistence_failure_policy_cases.is_empty() {
+        emitted.insert((
+            "persistence_policy_cases".to_string(),
+            "PersistenceFailurePolicyCases".to_string(),
+        ));
+    }
+    if !snapshot.storage_observation_runtime_cases.is_empty() {
+        emitted.insert((
+            "storage_observation_cases".to_string(),
+            "StorageObservationRuntimeCases".to_string(),
+        ));
+    }
+    if !snapshot.backend_health_admission_cases.is_empty() {
+        emitted.insert((
+            "backend_health_cases".to_string(),
+            "BackendHealthAdmissionCases".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.frontend_client_shell_case_count,
         snapshot.frontend_client_shell_cases.len(),
@@ -413,6 +449,9 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "session_recovery_cases",
         "slot_cases",
         "fleet_cases",
+        "persistence_policy_cases",
+        "storage_observation_cases",
+        "backend_health_cases",
         "frontend_client_shell_cases",
         "desktop_client_shell_cases",
         "tool_cases",
@@ -426,6 +465,9 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "admission::tests::rust_inference_call_state_vocabulary_matches_lean_model",
         "admission::tests::rust_inference_call_terminal_reason_vocabulary_matches_lean_model",
         "admission::tests::rust_inference_call_transition_table_matches_lean_contract",
+        "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy",
+        "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions",
+        "hook::tests::generated_storage_observation_cases_match_hook_runtime_classification",
         "lifecycle::tests::request_state_machine_contract_is_complete",
         "lifecycle::tests::rust_execution_origin_vocabulary_matches_lean_model",
         "lifecycle::tests::rust_request_lifecycle_state_vocabulary_matches_lean_model",


### PR DESCRIPTION
## Summary
- add Lean-generated boundary runtime cases for persistence failure policy, storage observation classification, and backend health admission availability
- add Rust consumers that assert local hook/admission decisions only, without claiming DefraDB durability, event delivery, endpoint freshness, or provider/network behavior
- update boundary wording and CoverageLedger to distinguish covered local policy from remaining external assumptions

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent --test runtime_observability
- cargo test -p defra-agent generated_
- cargo fmt --all -- --check
- git diff --check
- rg hygiene scan for sorry/admit/axiom/unsafe/native_decide/PLACEHOLDER/TODO/FIXME in touched proof/Rust files