### PR TITLE
Add generated lifecycle transition conformance cases

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
@@ -2,11 +2,14 @@ import Proofs.Conformance.ContractCases.Runtime
 import Proofs.Conformance.ContractCases.SlotAccounting
 import Proofs.Conformance.ContractCases.SessionRecovery
 import Proofs.Conformance.ContractCases.BoundaryRuntime
+import Proofs.Conformance.ContractCases.LifecycleTransitions
 
 /-!
 # Finite Conformance Witness Cases
 
 Representative executable witnesses emitted by `Proofs.Conformance.Contracts`.
 The cases stay finite and deterministic so Rust can consume them as a contract
-without re-implementing Lean evaluation.
+without re-implementing Lean evaluation. Request and Process transition cases
+cover every source/target pair and classify reserved product vocabulary
+separately from ordinary denied transitions.
 -/

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
@@ -32,6 +32,10 @@ end LifecycleTransitionClassification
 def lifecycleTransitionCaseName (domain source target : String) : String :=
   domain ++ ":" ++ source ++ "->" ++ target
 
+/-- Return the action that witnesses a source/target pair in the supplied finite
+    samples. Current Request and Process lifecycle contracts intentionally keep
+    a one-action-per-pair surface; if a future model adds aliases for the same
+    pair, update the emitted case shape instead of relying on list order. -/
 def actionForPairFromSamples {σ α : Type}
     (samples : List σ)
     (actions : List (String × α))
@@ -91,6 +95,9 @@ def requestTransitionContext
   , validUntil := validUntil
   }
 
+/-- Finite witnesses for action preconditions. Every legal Request action must
+    have at least one sample satisfying its guards here, otherwise its pair is
+    classified as denied and the Rust generated-case harness will report drift. -/
 def requestTransitionSamples : List RequestContext :=
   [ requestTransitionContext .pending .released
   , requestTransitionContext .pending .released true
@@ -124,6 +131,9 @@ def requestTransitionClassification
   match action with
   | some _ => .legal
   | none =>
+      -- Current product policy has exactly one reserved request state. Adding
+      -- another reserved persisted state must update this classifier and the
+      -- Rust reserved-state assertion together.
       if source = .inputRequired ∨ target = .inputRequired then
         .productUnreachable
       else

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/LifecycleTransitions.lean
@@ -1,0 +1,200 @@
+import Proofs.Request
+import Proofs.Process
+import Proofs.Conformance.Boundaries
+import Proofs.Conformance.ContractCases.Types
+
+/-!
+# Lifecycle Transition Case Partitions
+
+Generated Request and Process source/target pairs for Rust conformance tests.
+Each finite state square is classified as legal, ordinary illegal, or
+product-unreachable. The current product-unreachable Request pairs are exactly
+the reserved `inputRequired` vocabulary surface.
+-/
+
+namespace Conformance.ContractCases
+
+inductive LifecycleTransitionClassification where
+  | legal
+  | illegal
+  | productUnreachable
+  deriving DecidableEq, Repr
+
+namespace LifecycleTransitionClassification
+
+def toContract : LifecycleTransitionClassification → String
+  | .legal => "legal"
+  | .illegal => "illegal"
+  | .productUnreachable => "productUnreachable"
+
+end LifecycleTransitionClassification
+
+def lifecycleTransitionCaseName (domain source target : String) : String :=
+  domain ++ ":" ++ source ++ "->" ++ target
+
+def actionForPairFromSamples {σ α : Type}
+    (samples : List σ)
+    (actions : List (String × α))
+    (step : σ → α → Option σ)
+    (stateName : σ → String)
+    (source target : String) : Option String :=
+  let candidates :=
+    samples.flatMap fun pre =>
+      actions.filterMap fun action =>
+        match step pre action.snd with
+        | some post =>
+            if stateName pre = source ∧ stateName post = target then
+              some action.fst
+            else
+              none
+        | none => none
+  candidates.head?
+
+def requestTransitionStates : List RequestState :=
+  [ .pending, .claimed, .processing, .inputRequired, .completed
+  , .failed, .superseded, .dead, .interrupted ]
+
+def requestTransitionActions : List (String × RequestContext.Action) :=
+  [ ("claim", .claim)
+  , ("dedupLose", .dedupLose)
+  , ("beginInference", .beginInference)
+  , ("advance", .advance)
+  , ("finish", .finish)
+  , ("fail", .fail)
+  , ("failBeforeStream", .failBeforeStream)
+  , ("expire", .expire)
+  , ("interruptBeforeClaim", .interruptBeforeClaim)
+  , ("interruptClaimed", .interruptClaimed)
+  , ("interruptProcessing", .interruptProcessing)
+  ]
+
+def requestTransitionContext
+    (state : RequestState)
+    (admission : AdmissionState)
+    (hasInterrupt : Bool := false)
+    (validUntil : Option Time := none)
+    (currentTime : Time := 0) : RequestContext :=
+  { state := state
+  , origin := .interactive
+  , backend := contractBackend
+  , admission := admission
+  , deadline := 10
+  , claimTime := 0
+  , currentTime := currentTime
+  , retryCount := 0
+  , maxRetries := 3
+  , progressSeq := 0
+  , messageSeq := 0
+  , isLatest := true
+  , persistence := .uncommitted
+  , interruptRequestedAt := if hasInterrupt then some currentTime else none
+  , validUntil := validUntil
+  }
+
+def requestTransitionSamples : List RequestContext :=
+  [ requestTransitionContext .pending .released
+  , requestTransitionContext .pending .released true
+  , requestTransitionContext .pending .released false (some 0) 1
+  , requestTransitionContext .claimed .waiting
+  , requestTransitionContext .claimed .acquired
+  , requestTransitionContext .claimed .waiting true
+  , requestTransitionContext .claimed .acquired true
+  , requestTransitionContext .processing .executing
+  , requestTransitionContext .processing .executing true
+  , requestTransitionContext .inputRequired .executing
+  , requestTransitionContext .completed .released
+  , requestTransitionContext .failed .released
+  , requestTransitionContext .superseded .released
+  , requestTransitionContext .dead .released
+  , requestTransitionContext .interrupted .released
+  ]
+
+def requestTransitionAction? (source target : String) : Option String :=
+  actionForPairFromSamples
+    requestTransitionSamples
+    requestTransitionActions
+    RequestContext.step?
+    (fun ctx => ctx.state.toDefraDB)
+    source
+    target
+
+def requestTransitionClassification
+    (source target : RequestState)
+    (action : Option String) : LifecycleTransitionClassification :=
+  match action with
+  | some _ => .legal
+  | none =>
+      if source = .inputRequired ∨ target = .inputRequired then
+        .productUnreachable
+      else
+        .illegal
+
+def requestTransitionCase (source target : RequestState) : LifecycleTransitionCase :=
+  let sourceName := source.toDefraDB
+  let targetName := target.toDefraDB
+  let action := requestTransitionAction? sourceName targetName
+  let classification := requestTransitionClassification source target action
+  { name := lifecycleTransitionCaseName "Request" sourceName targetName
+  , domain := "Request"
+  , fromState := sourceName
+  , toState := targetName
+  , classification := classification.toContract
+  , action := action
+  , boundary :=
+      match classification with
+      | .productUnreachable =>
+          some Conformance.Contracts.boundaryRequestInputRequiredReservedId
+      | _ => none
+  }
+
+def requestTransitionCases : List LifecycleTransitionCase :=
+  requestTransitionStates.flatMap fun source =>
+    requestTransitionStates.map fun target =>
+      requestTransitionCase source target
+
+def processTransitionStates : List ProcessState :=
+  [ .uninitialized, .recovering, .ready, .shuttingDown, .shutdown ]
+
+def processTransitionActions : List (String × ProcessState.Action) :=
+  [ ("startupRecover", .startupRecover { hasStuckRequests := true, activeRequestCount := 1 })
+  , ("startupClean", .startupClean { hasStuckRequests := false, activeRequestCount := 0 })
+  , ("recoveryComplete", .recoveryComplete)
+  , ("beginShutdown", .beginShutdown)
+  , ("finishShutdown", .finishShutdown 0)
+  ]
+
+def processTransitionAction? (source target : String) : Option String :=
+  actionForPairFromSamples
+    processTransitionStates
+    processTransitionActions
+    ProcessState.step?
+    ProcessState.toDefraDB
+    source
+    target
+
+def processTransitionClassification
+    (action : Option String) : LifecycleTransitionClassification :=
+  match action with
+  | some _ => .legal
+  | none => .illegal
+
+def processTransitionCase (source target : ProcessState) : LifecycleTransitionCase :=
+  let sourceName := source.toDefraDB
+  let targetName := target.toDefraDB
+  let action := processTransitionAction? sourceName targetName
+  let classification := processTransitionClassification action
+  { name := lifecycleTransitionCaseName "Process" sourceName targetName
+  , domain := "Process"
+  , fromState := sourceName
+  , toState := targetName
+  , classification := classification.toContract
+  , action := action
+  , boundary := none
+  }
+
+def processTransitionCases : List LifecycleTransitionCase :=
+  processTransitionStates.flatMap fun source =>
+    processTransitionStates.map fun target =>
+      processTransitionCase source target
+
+end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -154,6 +154,16 @@ structure BackendHealthAdmissionCase where
   externalEndpointFreshnessClaimed : Bool
   deriving Repr
 
+structure LifecycleTransitionCase where
+  name : String
+  domain : String
+  fromState : String
+  toState : String
+  classification : String
+  action : Option String
+  boundary : Option String
+  deriving Repr
+
 def boolString (value : Bool) : String :=
   if value then "true" else "false"
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean
@@ -5,9 +5,10 @@ import Proofs.Conformance.Contracts.Json
 
 This module is the Lean-owned extraction surface for Rust conformance tests.
 Rust runs this file with `lake env lean --run` and consumes the JSON emitted by
-`main`. State vocabularies, transition tables, and finite witness rows are
-evaluated from the Lean constructors, `toDefraDB` functions, and executable
-`step?` functions in the imported submodules.
+`main`. State vocabularies, transition tables, classified Request/Process
+transition cases, and finite witness rows are evaluated from the Lean
+constructors, `toDefraDB` functions, and executable `step?` functions in the
+imported submodules.
 -/
 
 namespace Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -17,6 +17,17 @@ namespace Conformance.Contracts
 
 open Conformance.ContractCases
 
+def lifecycleTransitionCaseJson (witness : LifecycleTransitionCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"domain\":" ++ jsonString witness.domain ++ ","
+    ++ "\"from\":" ++ jsonString witness.fromState ++ ","
+    ++ "\"to\":" ++ jsonString witness.toState ++ ","
+    ++ "\"classification\":" ++ jsonString witness.classification ++ ","
+    ++ "\"action\":" ++ jsonOptionalString witness.action ++ ","
+    ++ "\"boundary\":" ++ jsonOptionalString witness.boundary
+    ++ "}"
+
 def runtimeReconcileCaseJson (witness : RuntimeReconcileCase) : String :=
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
@@ -280,6 +291,10 @@ def snapshotJson : String :=
       ++ jsonArray (vocabularies.map VocabularyContract.toJson) ++ ","
     ++ "\"state_machines\":"
       ++ jsonArray (stateMachines.map StateMachineContract.toJson) ++ ","
+    ++ "\"request_transition_cases\":"
+      ++ jsonArray (requestTransitionCases.map lifecycleTransitionCaseJson) ++ ","
+    ++ "\"process_transition_cases\":"
+      ++ jsonArray (processTransitionCases.map lifecycleTransitionCaseJson) ++ ","
     ++ "\"trigger_dispatch_case_count\":"
       ++ toString Conformance.TriggerContracts.triggerDispatchCaseCount ++ ","
     ++ "\"trigger_dispatch_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -142,6 +142,14 @@ def stateMachineCoverage : List CoverageEntry :=
 
 def caseCoverage : List CoverageEntry :=
   [ consumerCoverage
+      "lifecycle_transition_cases"
+      "RequestTransitions"
+      "state_machine_conformance::generated_request_transition_cases_cover_lifecycle_policy"
+  , consumerCoverage
+      "lifecycle_transition_cases"
+      "ProcessTransitions"
+      "runtime_status::tests::generated_process_transition_cases_match_runtime_status_policy"
+  , consumerCoverage
       "trigger_cases"
       "TriggerDispatch"
       "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases"

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -598,6 +598,11 @@ reconstructed count never exceeds backend `max_concurrent`.
 
 The finite-state checks currently establish:
 
+- generated Request transition cases enumerate the full 9x9 state square as
+  legal, illegal, or product-unreachable, with `inputRequired` pairs classified
+  as reserved current-product vocabulary
+- generated Process transition cases enumerate the full 5x5 state square as
+  legal or illegal
 - every active current-product non-terminal request state has at least one
   successor; reserved `inputRequired` remains vocabulary-only
 - every non-terminal process state has at least one successor
@@ -610,7 +615,10 @@ The finite-state checks currently establish:
   core composed states
 
 These checks are useful because they catch structural model regressions quickly,
-even before theorem-level reasoning matters. The `Fintype` instances
+even before theorem-level reasoning matters. Rust consumes the generated
+Request and Process transition cases directly: legal cases are driven through
+deterministic lifecycle/status paths, ordinary illegal cases must have no Rust
+writer path, and reserved cases must cite their boundary. The `Fintype` instances
 structurally pin the finite vocabularies; the cardinality output is diagnostic
 and is not itself a separate proof obligation beyond those instances and the
 theorems established in `Proofs/Properties/Decidable.lean`.

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -27,6 +28,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) generated_by: String,
     pub(crate) vocabularies: Vec<LeanVocabularyContract>,
     pub(crate) state_machines: Vec<LeanStateMachineContract>,
+    pub(crate) request_transition_cases: Vec<LeanLifecycleTransitionCase>,
+    pub(crate) process_transition_cases: Vec<LeanLifecycleTransitionCase>,
     pub(crate) trigger_dispatch_case_count: usize,
     pub(crate) trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
     pub(crate) frontend_client_shell_case_count: usize,
@@ -103,6 +106,17 @@ pub(crate) struct LeanDeviation {
 pub(crate) struct LeanTransitionPair {
     pub(crate) from: String,
     pub(crate) to: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanLifecycleTransitionCase {
+    pub(crate) name: String,
+    pub(crate) domain: String,
+    pub(crate) from: String,
+    pub(crate) to: String,
+    pub(crate) classification: String,
+    pub(crate) action: Option<String>,
+    pub(crate) boundary: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -472,6 +486,14 @@ pub(crate) fn lean_state_machine_contract(domain: &str) -> &'static LeanStateMac
         .unwrap_or_else(|| panic!("Lean state-machine contract {domain:?} was not emitted"))
 }
 
+pub(crate) fn lean_request_transition_cases() -> &'static [LeanLifecycleTransitionCase] {
+    &lean_contract_snapshot().request_transition_cases
+}
+
+pub(crate) fn lean_process_transition_cases() -> &'static [LeanLifecycleTransitionCase] {
+    &lean_contract_snapshot().process_transition_cases
+}
+
 pub(crate) fn lean_runtime_reconcile_case(name: &str) -> &'static LeanRuntimeReconcileCase {
     lean_contract_snapshot()
         .runtime_reconcile_cases
@@ -751,6 +773,83 @@ pub(crate) fn assert_state_machine_contract_is_complete(domain: &str) {
         duplicate_illegal_pairs,
         expected_pairs,
         actual_pairs
+    );
+}
+
+pub(crate) fn assert_lifecycle_transition_cases_partition(
+    domain: &str,
+    states: &[&str],
+    cases: &[LeanLifecycleTransitionCase],
+) {
+    let expected_pairs = states
+        .iter()
+        .flat_map(|from| {
+            states
+                .iter()
+                .map(move |to| ((*from).to_string(), (*to).to_string()))
+        })
+        .collect::<BTreeSet<_>>();
+    let mut actual_pairs = BTreeSet::new();
+    let mut invalid_cases = Vec::new();
+
+    for case in cases {
+        if case.domain != domain {
+            invalid_cases.push(format!("{} has wrong domain {:?}", case.name, case.domain));
+        }
+        if !matches!(
+            case.classification.as_str(),
+            "legal" | "illegal" | "productUnreachable"
+        ) {
+            invalid_cases.push(format!(
+                "{} has invalid classification {:?}",
+                case.name, case.classification
+            ));
+        }
+        if case.classification == "legal" && case.action.is_none() {
+            invalid_cases.push(format!("{} legal case missing action", case.name));
+        }
+        if case.classification != "legal" && case.action.is_some() {
+            invalid_cases.push(format!("{} non-legal case has action", case.name));
+        }
+        if case.classification == "productUnreachable" && case.boundary.is_none() {
+            invalid_cases.push(format!(
+                "{} product-unreachable case missing boundary",
+                case.name
+            ));
+        }
+        if case.classification != "productUnreachable" && case.boundary.is_some() {
+            invalid_cases.push(format!("{} reachable case has boundary", case.name));
+        }
+        if !expected_pairs.contains(&(case.from.clone(), case.to.clone())) {
+            invalid_cases.push(format!(
+                "{} has pair outside {domain} vocabulary: {:?} -> {:?}",
+                case.name, case.from, case.to
+            ));
+        }
+        if !actual_pairs.insert((case.from.clone(), case.to.clone())) {
+            invalid_cases.push(format!(
+                "{} duplicates pair {:?} -> {:?}",
+                case.name, case.from, case.to
+            ));
+        }
+    }
+
+    let missing = expected_pairs
+        .difference(&actual_pairs)
+        .cloned()
+        .collect::<Vec<_>>();
+    let extra = actual_pairs
+        .difference(&expected_pairs)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    assert!(
+        invalid_cases.is_empty() && missing.is_empty() && extra.is_empty(),
+        "Lean lifecycle transition cases for {domain:?} do not form a state^2 partition\n  invalid cases: {:?}\n  missing pairs: {:?}\n  extra pairs: {:?}\n  cases: {:?}",
+        invalid_cases,
+        missing,
+        extra,
+        cases
     );
 }
 

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -7,7 +7,9 @@ use super::*;
 use crate::ensure_runtime_schemas;
 use crate::lean_vocab_test::{
     assert_lean_contract_vocabulary_matches, assert_lean_transition_is_legal,
-    assert_state_machine_contract_is_complete, lean_runtime_reconcile_case, LeanContractVocabulary,
+    assert_lifecycle_transition_cases_partition, assert_state_machine_contract_is_complete,
+    lean_process_transition_cases, lean_runtime_reconcile_case, lean_vocabulary_values,
+    LeanContractVocabulary, LeanLifecycleTransitionCase,
 };
 
 #[derive(Debug, Deserialize)]
@@ -87,6 +89,144 @@ fn rust_process_state_transitions_match_lean_contract() {
     assert_lean_transition_is_legal("Process", "recovering", "ready");
     assert_lean_transition_is_legal("Process", "ready", "shuttingDown");
     assert_lean_transition_is_legal("Process", "shuttingDown", "shutdown");
+    assert_lifecycle_transition_cases_partition(
+        "Process",
+        &lean_vocabulary_values("ProcessState"),
+        lean_process_transition_cases(),
+    );
+}
+
+fn rust_process_transition_action(from: &str, to: &str) -> Option<&'static str> {
+    match (from, to) {
+        ("uninitialized", "recovering") => Some("startupRecover"),
+        ("uninitialized", "ready") => Some("startupClean"),
+        ("recovering", "ready") => Some("recoveryComplete"),
+        ("ready", "shuttingDown") => Some("beginShutdown"),
+        ("shuttingDown", "shutdown") => Some("finishShutdown"),
+        _ => None,
+    }
+}
+
+fn rust_process_transition_classification(from: &str, to: &str) -> &'static str {
+    if rust_process_transition_action(from, to).is_some() {
+        "legal"
+    } else {
+        "illegal"
+    }
+}
+
+fn process_state_from_contract(state: &str) -> ProcessLifecycleState {
+    match state {
+        "uninitialized" => ProcessLifecycleState::Uninitialized,
+        "recovering" => ProcessLifecycleState::Recovering,
+        "ready" => ProcessLifecycleState::Ready,
+        "shuttingDown" => ProcessLifecycleState::ShuttingDown,
+        "shutdown" => ProcessLifecycleState::Shutdown,
+        other => panic!("unknown generated Process state {other:?}"),
+    }
+}
+
+async fn drive_generated_process_legal_case(case: &LeanLifecycleTransitionCase) {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let agent_did = format!("did:defra-agent:process-contract:{}", case.name);
+    let status = RuntimeStatusHandle::new(node.clone(), agent_did.clone());
+    let action = case
+        .action
+        .as_deref()
+        .expect("legal Process transition case must carry an action");
+
+    match action {
+        "startupRecover" | "startupClean" => {
+            status
+                .set_process_state(process_state_from_contract(&case.to))
+                .await;
+        }
+        "recoveryComplete" => {
+            status
+                .set_process_state(ProcessLifecycleState::Recovering)
+                .await;
+            status.set_process_state(ProcessLifecycleState::Ready).await;
+        }
+        "beginShutdown" => {
+            status.set_process_state(ProcessLifecycleState::Ready).await;
+            status
+                .set_process_state(ProcessLifecycleState::ShuttingDown)
+                .await;
+        }
+        "finishShutdown" => {
+            status
+                .set_process_state(ProcessLifecycleState::ShuttingDown)
+                .await;
+            status
+                .set_process_state(ProcessLifecycleState::Shutdown)
+                .await;
+        }
+        other => panic!(
+            "generated Process transition {} has unsupported action {other:?}",
+            case.name
+        ),
+    }
+
+    let row = fetch_runtime_row(node.as_ref(), &agent_did).await;
+    assert_eq!(
+        row.process_state, case.to,
+        "generated Process transition {} expected {} -> {} classified as {} via {:?}, got persisted process_state={}",
+        case.name, case.from, case.to, case.classification, case.action, row.process_state
+    );
+}
+
+#[tokio::test]
+async fn generated_process_transition_cases_match_runtime_status_policy() {
+    let mut legal_count = 0;
+    let mut illegal_count = 0;
+
+    for case in lean_process_transition_cases() {
+        let rust_classification = rust_process_transition_classification(&case.from, &case.to);
+        assert_eq!(
+            case.classification, rust_classification,
+            "Process transition {} expected classification drift for {} -> {}; Lean action={:?} boundary={:?}",
+            case.name, case.from, case.to, case.action, case.boundary
+        );
+
+        match case.classification.as_str() {
+            "legal" => {
+                legal_count += 1;
+                assert_eq!(
+                    case.action.as_deref(),
+                    rust_process_transition_action(&case.from, &case.to),
+                    "Process transition {} legal writer action drifted for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+                drive_generated_process_legal_case(case).await;
+            }
+            "illegal" => {
+                illegal_count += 1;
+                assert!(
+                    rust_process_transition_action(&case.from, &case.to).is_none(),
+                    "Process transition {} is ordinary illegal but Rust has a writer path for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+            }
+            "productUnreachable" => {
+                panic!(
+                    "Process transition {} unexpectedly emitted product-unreachable classification",
+                    case.name
+                );
+            }
+            other => panic!(
+                "generated Process transition {} has unknown classification {other:?}",
+                case.name
+            ),
+        }
+    }
+
+    assert_eq!(legal_count, 5);
+    assert_eq!(illegal_count, 20);
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -18,11 +18,12 @@ use admission_slot_accounting::{
 };
 use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
-    assert_state_machine_contract_is_complete, lean_client_shell_case, lean_command_env_case,
-    lean_command_policy_case, lean_command_sandbox_case, lean_contract_snapshot,
-    lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case,
+    assert_lifecycle_transition_cases_partition, assert_state_machine_contract_is_complete,
+    lean_client_shell_case, lean_command_env_case, lean_command_policy_case,
+    lean_command_sandbox_case, lean_contract_snapshot, lean_fleet_slot_accounting_case,
+    lean_inference_slot_accounting_case, lean_request_transition_cases,
     lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
-    lean_tool_retry_case, lean_vocabulary_values,
+    lean_tool_retry_case, lean_vocabulary_values, LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -119,6 +120,11 @@ fn lean_executable_contracts_cover_initial_domains() {
             "interrupted"
         ]
     );
+    assert_lifecycle_transition_cases_partition(
+        "Request",
+        &lean_vocabulary_values("RequestState"),
+        lean_request_transition_cases(),
+    );
     assert_lean_transition_is_legal("SessionRecovery", "failed", "pending");
     assert_lean_transition_is_illegal("SessionRecovery", "dead", "pending");
     assert_lean_transition_is_illegal("SessionRecovery", "superseded", "pending");
@@ -147,6 +153,8 @@ fn lean_executable_contracts_cover_initial_domains() {
         "CommandPolicy should be emitted as generated contract output, not a follow-up hook"
     );
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
+    assert_eq!(lean_contract_snapshot().request_transition_cases.len(), 81);
+    assert_eq!(lean_contract_snapshot().process_transition_cases.len(), 25);
     assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 18);
     assert_eq!(
@@ -351,6 +359,18 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     for machine in &snapshot.state_machines {
         emitted.insert(("state_machine".to_string(), machine.domain.clone()));
     }
+    if !snapshot.request_transition_cases.is_empty() {
+        emitted.insert((
+            "lifecycle_transition_cases".to_string(),
+            "RequestTransitions".to_string(),
+        ));
+    }
+    if !snapshot.process_transition_cases.is_empty() {
+        emitted.insert((
+            "lifecycle_transition_cases".to_string(),
+            "ProcessTransitions".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.trigger_dispatch_case_count,
         snapshot.trigger_dispatch_cases.len(),
@@ -461,6 +481,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     let valid_categories = [
         "vocabulary",
         "state_machine",
+        "lifecycle_transition_cases",
         "trigger_cases",
         "runtime_cases",
         "apply_reconcile_cases",
@@ -1660,6 +1681,233 @@ fn generated_command_policy_cases_cover_policy_sandbox_and_env_contracts() {
     assert_eq!(pager.expected_output_value.as_deref(), Some("cat"));
     let pager_absent = lean_command_env_case("env_pager_absent_still_forced_cat");
     assert_eq!(pager_absent.expected_output_value.as_deref(), Some("cat"));
+}
+
+fn rust_request_transition_action(from: &str, to: &str) -> Option<&'static str> {
+    match (from, to) {
+        ("pending", "claimed") => Some("claim"),
+        ("pending", "superseded") => Some("dedupLose"),
+        ("claimed", "processing") => Some("beginInference"),
+        ("processing", "processing") => Some("advance"),
+        ("processing", "completed") => Some("finish"),
+        ("processing", "failed") => Some("fail"),
+        ("claimed", "failed") => Some("failBeforeStream"),
+        ("pending", "dead") => Some("expire"),
+        ("pending", "interrupted") => Some("interruptBeforeClaim"),
+        ("claimed", "interrupted") => Some("interruptClaimed"),
+        ("processing", "interrupted") => Some("interruptProcessing"),
+        _ => None,
+    }
+}
+
+fn rust_request_transition_classification(from: &str, to: &str) -> &'static str {
+    if rust_request_transition_action(from, to).is_some() {
+        "legal"
+    } else if from == "inputRequired" || to == "inputRequired" {
+        "productUnreachable"
+    } else {
+        "illegal"
+    }
+}
+
+fn request_lifecycle_for_case(
+    db: &support::TestDb,
+    doc_id: String,
+    request_id: String,
+    session_id: String,
+    created_at: String,
+) -> RequestLifecycle {
+    let request = build_request(doc_id, request_id, session_id, created_at);
+    RequestLifecycle::new_with_execution_binding(
+        db.node.clone(),
+        AGENT_NAME,
+        AGENT_DID,
+        request,
+        DEADLINE_SECS,
+        ExecutionOrigin::Interactive,
+        BACKEND_ID,
+    )
+}
+
+async fn drive_generated_request_legal_case(case: &LeanLifecycleTransitionCase) {
+    let db = test_db("generated-request-transition").await;
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let doc_id = create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+    let action = case
+        .action
+        .as_deref()
+        .expect("legal Request transition case must carry an action");
+    let mut lifecycle = request_lifecycle_for_case(
+        &db,
+        doc_id.clone(),
+        request_id.clone(),
+        session_id.clone(),
+        created_at.clone(),
+    );
+
+    match action {
+        "claim" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+        }
+        "dedupLose" => {
+            let earlier = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+            create_request(
+                &db.node,
+                &format!("earlier-{request_id}"),
+                &session_id,
+                "processing",
+                &earlier,
+            )
+            .await;
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Superseded);
+        }
+        "beginInference" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.begin_execution().await.unwrap();
+        }
+        "advance" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.begin_execution().await.unwrap();
+            let response_doc_id = create_response_with_status(
+                &db.node,
+                &format!("resp-{request_id}"),
+                &request_id,
+                &session_id,
+                "streaming",
+            )
+            .await;
+            lifecycle.set_response_doc_id(&response_doc_id);
+            lifecycle.advance().await.unwrap();
+        }
+        "finish" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.begin_execution().await.unwrap();
+            lifecycle.complete().await.unwrap();
+        }
+        "fail" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.begin_execution().await.unwrap();
+            lifecycle.fail().await.unwrap();
+        }
+        "failBeforeStream" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.fail().await.unwrap();
+        }
+        "expire" => {
+            let past = (chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339();
+            set_valid_until(&db.node, &doc_id, &past).await;
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Expired);
+        }
+        "interruptBeforeClaim" => {
+            let interrupt_at = chrono::Utc::now().to_rfc3339();
+            set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Interrupted);
+        }
+        "interruptClaimed" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            let interrupt_at = chrono::Utc::now().to_rfc3339();
+            set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
+            lifecycle.transition_to_interrupted().await.unwrap();
+        }
+        "interruptProcessing" => {
+            assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+            lifecycle.prepare_session_with_identity().await.unwrap();
+            lifecycle.begin_execution().await.unwrap();
+            let interrupt_at = chrono::Utc::now().to_rfc3339();
+            set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
+            lifecycle.transition_to_interrupted().await.unwrap();
+        }
+        other => panic!(
+            "generated Request transition {} has unsupported action {other:?}",
+            case.name
+        ),
+    }
+
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(
+        snap.lifecycle_state, case.to,
+        "generated Request transition {} expected {} -> {} classified as {} via {:?}, got persisted lifecycle_state={}",
+        case.name, case.from, case.to, case.classification, case.action, snap.lifecycle_state
+    );
+}
+
+#[tokio::test]
+async fn generated_request_transition_cases_cover_lifecycle_policy() {
+    let mut legal_count = 0;
+    let mut illegal_count = 0;
+    let mut product_unreachable_count = 0;
+
+    for case in lean_request_transition_cases() {
+        let rust_classification = rust_request_transition_classification(&case.from, &case.to);
+        assert_eq!(
+            case.classification, rust_classification,
+            "Request transition {} expected classification drift for {} -> {}; Lean action={:?} boundary={:?}",
+            case.name, case.from, case.to, case.action, case.boundary
+        );
+
+        match case.classification.as_str() {
+            "legal" => {
+                legal_count += 1;
+                assert_eq!(
+                    case.action.as_deref(),
+                    rust_request_transition_action(&case.from, &case.to),
+                    "Request transition {} legal writer action drifted for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+                drive_generated_request_legal_case(case).await;
+            }
+            "illegal" => {
+                illegal_count += 1;
+                assert!(
+                    rust_request_transition_action(&case.from, &case.to).is_none(),
+                    "Request transition {} is ordinary illegal but Rust has a writer path for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+            }
+            "productUnreachable" => {
+                product_unreachable_count += 1;
+                assert!(
+                    case.from == "inputRequired" || case.to == "inputRequired",
+                    "Request transition {} product-unreachable classification must be scoped to reserved inputRequired, got {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+                assert_eq!(
+                    case.boundary.as_deref(),
+                    Some("boundary.request.input-required-reserved"),
+                    "Request transition {} must cite the reserved inputRequired boundary",
+                    case.name
+                );
+                assert!(
+                    rust_request_transition_action(&case.from, &case.to).is_none(),
+                    "Request transition {} is reserved but Rust has a writer path for {} -> {}",
+                    case.name,
+                    case.from,
+                    case.to
+                );
+            }
+            other => panic!(
+                "generated Request transition {} has unknown classification {other:?}",
+                case.name
+            ),
+        }
+    }
+
+    assert_eq!(legal_count, 11);
+    assert_eq!(illegal_count, 53);
+    assert_eq!(product_unreachable_count, 17);
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -175,6 +175,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "runtime_status_generation_updates_match_lean_runtime_reconcile_cases",
         },
         ConformanceConsumer::RustTest {
+            id: "runtime_status::tests::generated_process_transition_cases_match_runtime_status_policy",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/runtime_status/tests.rs",
+            module_path: "runtime_status::tests",
+            function: "generated_process_transition_cases_match_runtime_status_policy",
+        },
+        ConformanceConsumer::RustTest {
             id: "runtime_status::tests::rust_process_state_transitions_match_lean_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/runtime_status/tests.rs",
@@ -201,6 +208,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
             module_path: "state_machine_conformance",
             function: "generated_session_recovery_cases_drive_db_backed_reissue_contract",
+        },
+        ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_request_transition_cases_cover_lifecycle_policy",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_request_transition_cases_cover_lifecycle_policy",
         },
         ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts",


### PR DESCRIPTION
## Summary
- emit generated Request and Process lifecycle transition case arrays from Lean with legal/illegal/product-unreachable classifications
- add Rust conformance harnesses that iterate the generated cases and drive every legal Request/Process transition through deterministic product paths
- update coverage ledger and proof docs for the new transition-case domains

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent --test lifecycle_claim --test lifecycle_terminal --test lifecycle_recovery
- cargo test -p defra-agent lifecycle::tests
- cargo test -p defra-agent runtime_status::tests
- cargo fmt --all -- --check
- git diff --check
- hygiene scan for sorry/admit/axiom/unsafe/native_decide/PLACEHOLDER/TODO/FIXME in touched proof/Rust areas