### PR TITLE
Add MCP service allowlists to ToolSelection

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/config.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/config.rs
@@ -226,6 +226,7 @@ pub(crate) async fn save_tool_selection_config(
             command_network_mode: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: Some(false),
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         });
     row.agent_did = Some(agent_did);
@@ -256,6 +257,12 @@ pub(crate) async fn save_tool_selection_config(
         .filter(|value| !value.is_empty())
         .collect();
     row.enable_meta_tools = request.enable_meta_tools.or(row.enable_meta_tools);
+    row.allowed_mcp_service_ids = request
+        .allowed_mcp_service_ids
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect();
     row.delegate_to = request
         .delegate_to
         .into_iter()

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime.rs
@@ -167,6 +167,7 @@ pub(crate) async fn build_runtime_snapshot(core: &ClientCore) -> DesktopRuntimeS
                     command_network_mode: normalize_optional(row.command_network_mode.as_deref()),
                     cli_tool_names: row.cli_tool_names.clone(),
                     enable_meta_tools: row.enable_meta_tools,
+                    allowed_mcp_service_ids: row.allowed_mcp_service_ids.clone(),
                     delegate_to: row.delegate_to.clone(),
                 })
                 .collect::<Vec<_>>();

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/requests.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/requests.rs
@@ -118,6 +118,8 @@ pub(crate) struct ToolSelectionSaveRequest {
     pub command_network_mode: Option<String>,
     pub cli_tool_names: Vec<String>,
     pub enable_meta_tools: Option<bool>,
+    #[serde(default)]
+    pub allowed_mcp_service_ids: Vec<String>,
     pub delegate_to: Vec<String>,
 }
 

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/deployment.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/deployment.rs
@@ -97,6 +97,7 @@ pub(crate) struct ToolSelectionView {
     pub command_network_mode: Option<String>,
     pub cli_tool_names: Vec<String>,
     pub enable_meta_tools: Option<bool>,
+    pub allowed_mcp_service_ids: Vec<String>,
     pub delegate_to: Vec<String>,
 }
 

--- a/apps/desktop-tauri/src-tauri/src/runner/live_fixture/agent.rs
+++ b/apps/desktop-tauri/src-tauri/src/runner/live_fixture/agent.rs
@@ -121,6 +121,7 @@ async fn seed_live_behavior_documents(
         command_network_mode: None,
         cli_tool_names: vec!["rg".to_string()],
         enable_meta_tools: Some(false),
+        allowed_mcp_service_ids: Vec::new(),
         delegate_to: vec![],
     })
     .await?;

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -120,10 +120,19 @@ export function ToolSelectionConfigEditor({
   const [bashMode, setBashMode] = useState("ReadOnly");
   const [cliToolNames, setCliToolNames] = useState("");
   const [enableMetaTools, setEnableMetaTools] = useState(false);
+  const [allowedMcpServiceIds, setAllowedMcpServiceIds] = useState("");
   const [delegateTo, setDelegateTo] = useState("");
   const ceiling = normalizeToolCeiling(toolCeiling);
   const fileToolsDisabledByCeiling = ceiling === "MetaOnly";
   const writeToolsDisabledByCeiling = ceiling !== "Readwrite";
+  const toolServiceIdKey = useMemo(
+    () =>
+      toolServiceRegistries
+        .map((service) => service.serviceId)
+        .sort()
+        .join("\n"),
+    [toolServiceRegistries],
+  );
 
   useEffect(() => {
     setSelectionId(toolSelection?.selectionId ?? "");
@@ -139,17 +148,36 @@ export function ToolSelectionConfigEditor({
     );
     setCliToolNames((toolSelection?.cliToolNames ?? []).join("\n"));
     setEnableMetaTools(toolSelection?.enableMetaTools ?? false);
-    setDelegateTo((toolSelection?.delegateTo ?? []).join("\n"));
-  }, [toolSelection]);
+    const knownServiceIds = new Set(
+      toolServiceIdKey.split("\n").filter(Boolean),
+    );
+    const existingAllowedServiceIds = toolSelection?.allowedMcpServiceIds ?? [];
+    const existingDelegateTo = toolSelection?.delegateTo ?? [];
+    const legacyServiceDelegates =
+      existingAllowedServiceIds.length === 0
+        ? existingDelegateTo.filter((value) => knownServiceIds.has(value))
+        : [];
+    setAllowedMcpServiceIds(
+      (existingAllowedServiceIds.length > 0
+        ? existingAllowedServiceIds
+        : legacyServiceDelegates
+      ).join("\n"),
+    );
+    setDelegateTo(
+      existingDelegateTo
+        .filter((value) => !knownServiceIds.has(value))
+        .join("\n"),
+    );
+  }, [toolSelection, toolServiceIdKey]);
 
-  function toggleDelegateTo(serviceId: string, checked: boolean) {
-    const values = new Set(linesToArray(delegateTo));
+  function toggleAllowedMcpService(serviceId: string, checked: boolean) {
+    const values = new Set(linesToArray(allowedMcpServiceIds));
     if (checked) {
       values.add(serviceId);
     } else {
       values.delete(serviceId);
     }
-    setDelegateTo(Array.from(values).sort().join("\n"));
+    setAllowedMcpServiceIds(Array.from(values).sort().join("\n"));
   }
 
   async function submitToolSelection(event: FormEvent) {
@@ -177,6 +205,7 @@ export function ToolSelectionConfigEditor({
       bashMode: effectiveBashMode,
       cliToolNames: linesToArray(cliToolNames),
       enableMetaTools,
+      allowedMcpServiceIds: linesToArray(allowedMcpServiceIds),
       delegateTo: linesToArray(delegateTo),
     });
     onSaved(nextId);
@@ -312,19 +341,22 @@ export function ToolSelectionConfigEditor({
           <span>Meta tools</span>
         </label>
         <div className="field">
-          <span>Linked HTTP MCP services</span>
-          <div className="linked-doc-list" data-testid="tool-delegate-to">
+          <span>MCP service allowlist</span>
+          <div className="linked-doc-list" data-testid="tool-allowed-mcp-services">
             {toolServiceRegistries.map((service) => {
               const serviceId = service.serviceId;
-              const checked = linesToArray(delegateTo).includes(serviceId);
+              const checked = linesToArray(allowedMcpServiceIds).includes(serviceId);
               return (
                 <label className="checkbox" key={serviceId}>
                   <input
                     checked={checked}
-                    data-testid={`tool-delegate-${serviceId}`}
+                    data-testid={`tool-allowed-mcp-service-${serviceId}`}
                     disabled={!enableMetaTools}
                     onChange={(event) =>
-                      toggleDelegateTo(serviceId, event.currentTarget.checked)
+                      toggleAllowedMcpService(
+                        serviceId,
+                        event.currentTarget.checked,
+                      )
                     }
                     type="checkbox"
                   />
@@ -338,6 +370,15 @@ export function ToolSelectionConfigEditor({
           </div>
         </div>
       </div>
+      <label className="field">
+        <span>Delegate agent DIDs</span>
+        <textarea
+          className="config-small-textarea"
+          data-testid="tool-delegate-to"
+          onChange={(event) => setDelegateTo(event.currentTarget.value)}
+          value={delegateTo}
+        />
+      </label>
       <div className="config-actions">
         <button
           className="primary-button"

--- a/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
+++ b/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
@@ -72,10 +72,15 @@ export function toolCeilingIcons(
       .filter((selection) => selection.enableBash)
       .map((selection) => selection.bashMode),
   );
-  const metaDelegates = uniqueValues(
+  const allowedMetaServices = uniqueValues(
     source
       .filter((selection) => selection.enableMetaTools)
-      .flatMap((selection) => selection.delegateTo),
+      .flatMap((selection) => selection.allowedMcpServiceIds ?? []),
+  );
+  const unrestrictedMetaServices = source.some(
+    (selection) =>
+      selection.enableMetaTools &&
+      (selection.allowedMcpServiceIds ?? []).length === 0,
   );
   const cliTools = uniqueValues(
     source.flatMap((selection) => selection.cliToolNames),
@@ -99,11 +104,13 @@ export function toolCeilingIcons(
       }. Server ceiling: ${ceilingLabel}.`,
     });
   }
-  if (metaDelegates.length) {
+  if (allowedMetaServices.length || unrestrictedMetaServices) {
     icons.push({
       kind: "meta",
       tone: "meta",
-      title: `Delegation: call configured MCP delegates (${metaDelegates.join(", ")}).`,
+      title: unrestrictedMetaServices
+        ? "MCP services: discover and call all online MCP services."
+        : `MCP services: discover and call ${allowedMetaServices.join(", ")}.`,
     });
   }
   if (cliTools.length) {

--- a/apps/desktop-tauri/src/lib/types/deployment.ts
+++ b/apps/desktop-tauri/src/lib/types/deployment.ts
@@ -67,6 +67,7 @@ export type ToolSelectionView = {
   bashMode?: string | null;
   cliToolNames: string[];
   enableMetaTools?: boolean | null;
+  allowedMcpServiceIds: string[];
   delegateTo: string[];
 };
 

--- a/apps/desktop-tauri/src/lib/types/requests.ts
+++ b/apps/desktop-tauri/src/lib/types/requests.ts
@@ -54,6 +54,7 @@ export type ToolSelectionSaveRequest = {
   bashMode?: string | null;
   cliToolNames: string[];
   enableMetaTools?: boolean | null;
+  allowedMcpServiceIds: string[];
   delegateTo: string[];
 };
 

--- a/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
+++ b/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
@@ -50,6 +50,9 @@ const toolSelections: ToolSelectionView[] = [
   {
     selectionId: "default-tools",
     displayName: "Default Tools",
+    cliToolNames: [],
+    allowedMcpServiceIds: [],
+    delegateTo: [],
   },
 ];
 

--- a/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
@@ -370,7 +370,7 @@ describe("config panel action buttons", () => {
     );
   });
 
-  it("makes tool service delegates explicit in tool selections", async () => {
+  it("makes MCP service allowlists explicit in tool selections", async () => {
     const onSaveToolSelectionConfig = vi.fn<
       [(request: ToolSelectionSaveRequest) => Promise<unknown>]
     >(() => Promise.resolve());
@@ -385,6 +385,7 @@ describe("config panel action buttons", () => {
         toolSelection={{
           ...toolSelection,
           enableMetaTools: false,
+          allowedMcpServiceIds: [],
           delegateTo: [],
         }}
         toolServiceRegistries={[toolService]}
@@ -393,17 +394,53 @@ describe("config panel action buttons", () => {
       />,
     );
 
-    expect(screen.getByTestId("tool-delegate-mcp-local")).toBeDisabled();
+    expect(screen.getByTestId("tool-allowed-mcp-service-mcp-local")).toBeDisabled();
     fireEvent.click(screen.getByTestId("tool-enable-meta-tools"));
-    expect(screen.getByTestId("tool-delegate-mcp-local")).not.toBeDisabled();
-    fireEvent.click(screen.getByTestId("tool-delegate-mcp-local"));
+    expect(screen.getByTestId("tool-allowed-mcp-service-mcp-local")).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId("tool-allowed-mcp-service-mcp-local"));
     fireEvent.click(screen.getByTestId("tool-selection-save"));
 
     await waitFor(() =>
       expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           enableMetaTools: true,
-          delegateTo: ["mcp-local"],
+          allowedMcpServiceIds: ["mcp-local"],
+        }),
+      ),
+    );
+  });
+
+  it("migrates legacy service delegates into the MCP allowlist on save", async () => {
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={{
+          ...toolSelection,
+          allowedMcpServiceIds: [],
+          delegateTo: ["mcp-local", "did:key:zDelegate"],
+        }}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-allowed-mcp-service-mcp-local")).toBeChecked();
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowedMcpServiceIds: ["mcp-local"],
+          delegateTo: ["did:key:zDelegate"],
         }),
       ),
     );

--- a/apps/desktop-tauri/tests/config-panel-buttons/fixtures.ts
+++ b/apps/desktop-tauri/tests/config-panel-buttons/fixtures.ts
@@ -39,7 +39,8 @@ export const toolSelection: ToolSelectionView = {
   bashMode: "ReadOnly",
   cliToolNames: ["grep"],
   enableMetaTools: true,
-  delegateTo: ["mcp-local"],
+  allowedMcpServiceIds: ["mcp-local"],
+  delegateTo: [],
 };
 
 export const toolService: ToolServiceRegistryView = {

--- a/apps/desktop-tauri/tests/config-panel-wiring/fixtures.tsx
+++ b/apps/desktop-tauri/tests/config-panel-wiring/fixtures.tsx
@@ -108,7 +108,8 @@ export const deployment: DeploymentView = {
       bashMode: "ReadOnly",
       cliToolNames: ["grep"],
       enableMetaTools: true,
-      delegateTo: ["service-a"],
+      allowedMcpServiceIds: ["service-a"],
+      delegateTo: [],
     },
     {
       selectionId: "tools-b",
@@ -120,6 +121,7 @@ export const deployment: DeploymentView = {
       bashMode: "ReadOnly",
       cliToolNames: [],
       enableMetaTools: false,
+      allowedMcpServiceIds: [],
       delegateTo: [],
     },
   ],

--- a/apps/desktop-tauri/tests/tauri-driver.live.config.test.tsx
+++ b/apps/desktop-tauri/tests/tauri-driver.live.config.test.tsx
@@ -106,7 +106,7 @@ describeLive("Tauri app live bridge runner config flow", () => {
         await driver.setChecked("tool-enable-file-tools", true);
         await driver.setChecked("tool-enable-bash", true);
         await driver.setChecked("tool-enable-meta-tools", true);
-        await driver.setChecked(`tool-delegate-${toolServiceId}`, true);
+        await driver.setChecked(`tool-allowed-mcp-service-${toolServiceId}`, true);
         await driver.replaceInput(
           "tool-file-tool-root",
           fileToolRoot,
@@ -117,7 +117,7 @@ describeLive("Tauri app live bridge runner config flow", () => {
           const selection = current.toolSelections.find(
             (selection) => selection.selectionId === toolSelectionId,
           );
-          expect(selection?.delegateTo).toContain(toolServiceId);
+          expect(selection?.allowedMcpServiceIds).toContain(toolServiceId);
           expect(selection?.fileToolRoot).toBe(fileToolRoot);
         });
 

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -622,6 +622,8 @@ pub(crate) struct ToolSelectionUpsertArgs {
     pub(crate) cli_tool_names: Vec<String>,
     #[arg(long, default_value_t = true)]
     pub(crate) enable_meta_tools: bool,
+    #[arg(long = "allowed-mcp-service-id")]
+    pub(crate) allowed_mcp_service_ids: Vec<String>,
     #[arg(long = "delegate-to")]
     pub(crate) delegate_to: Vec<String>,
 }

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -31,6 +31,7 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         command_network_mode: None,
         cli_tool_names: Some(args.cli_tool_names.clone()),
         enable_meta_tools: Some(args.enable_meta_tools),
+        allowed_mcp_service_ids: Some(args.allowed_mcp_service_ids.clone()),
         delegate_to: Some(args.delegate_to.clone()),
     };
     let doc_id = write_tool_selection_document(&access, &selection).await?;
@@ -45,6 +46,7 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         "bash_mode": bash_mode,
         "cli_tool_names": args.cli_tool_names,
         "enable_meta_tools": args.enable_meta_tools,
+        "allowed_mcp_service_ids": args.allowed_mcp_service_ids,
         "delegate_to": args.delegate_to,
     });
     print_json(&output)?;

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -540,6 +540,7 @@ fn standard_tool_selection(
         command_network_mode: None,
         cli_tool_names: Some(Vec::new()),
         enable_meta_tools: Some(true),
+        allowed_mcp_service_ids: Some(Vec::new()),
         delegate_to: Some(Vec::new()),
     }
 }

--- a/crates/defra-agent-cli/src/config_writes/tool_selection.rs
+++ b/crates/defra-agent-cli/src/config_writes/tool_selection.rs
@@ -76,6 +76,10 @@ fn tool_selection_fields(selection: &ToolSelectionDocument, include_id: bool) ->
                 .and_then(|values| string_list_field("cli_tool_names", values)),
             optional_bool_field("enable_meta_tools", selection.enable_meta_tools),
             selection
+                .allowed_mcp_service_ids
+                .as_ref()
+                .and_then(|values| string_list_field("allowed_mcp_service_ids", values)),
+            selection
                 .delegate_to
                 .as_ref()
                 .and_then(|values| string_list_field("delegate_to", values)),

--- a/crates/defra-agent-cli/src/desired_state/convert.rs
+++ b/crates/defra-agent-cli/src/desired_state/convert.rs
@@ -112,6 +112,7 @@ pub(crate) fn manifest_from_export_bundle(
                         "command_network_mode",
                         "cli_tool_names",
                         "enable_meta_tools",
+                        "allowed_mcp_service_ids",
                         "delegate_to",
                     ],
                 )

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -114,6 +114,8 @@ pub(crate) struct DesiredToolSelection {
     pub(crate) cli_tool_names: Vec<String>,
     pub(crate) enable_meta_tools: bool,
     #[serde(default)]
+    pub(crate) allowed_mcp_service_ids: Vec<String>,
+    #[serde(default)]
     pub(crate) delegate_to: Vec<String>,
 }
 

--- a/crates/defra-agent-cli/src/desired_state/normalize.rs
+++ b/crates/defra-agent-cli/src/desired_state/normalize.rs
@@ -51,6 +51,8 @@ pub(crate) fn normalize_manifest(manifest: &mut DesiredStateManifest) {
         selection.command_forbidden_argv_prefixes.dedup();
         selection.cli_tool_names.sort();
         selection.cli_tool_names.dedup();
+        selection.allowed_mcp_service_ids.sort();
+        selection.allowed_mcp_service_ids.dedup();
         selection.delegate_to.sort();
         selection.delegate_to.dedup();
     }

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -60,6 +60,27 @@ fn sample_task(task_id: &str) -> DesiredTask {
     }
 }
 
+fn sample_tool_selection(selection_id: &str) -> DesiredToolSelection {
+    DesiredToolSelection {
+        selection_id: selection_id.to_string(),
+        agent_did: "did:defra-agent:test".to_string(),
+        display_name: None,
+        enable_file_tools: false,
+        file_tools_mode: "ReadOnly".to_string(),
+        file_tool_root: None,
+        enable_bash: false,
+        bash_mode: "ReadOnly".to_string(),
+        command_execution_policy: None,
+        command_allowed_argv_prefixes: Vec::new(),
+        command_forbidden_argv_prefixes: Vec::new(),
+        command_network_mode: None,
+        cli_tool_names: Vec::new(),
+        enable_meta_tools: true,
+        allowed_mcp_service_ids: Vec::new(),
+        delegate_to: Vec::new(),
+    }
+}
+
 fn sample_schedule(schedule_id: &str, task_id: &str) -> DesiredSchedule {
     DesiredSchedule {
         schedule_id: schedule_id.to_string(),
@@ -516,6 +537,34 @@ fn diff_manifests_marks_task_update_when_prompt_changes() {
     assert!(report.collections.tasks.create.is_empty());
     assert!(report.collections.tasks.unchanged.is_empty());
     assert_eq!(report.counts.tasks.update, 1);
+}
+
+#[test]
+fn diff_manifests_marks_tool_selection_update_when_mcp_allowlist_changes() {
+    let mut desired = empty_manifest("did:defra-agent:test");
+    let mut desired_selection = sample_tool_selection("service-tools");
+    desired_selection.allowed_mcp_service_ids = vec!["x-data".to_string()];
+    desired.tool_selections.push(desired_selection);
+
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.tool_selections
+        .push(sample_tool_selection("service-tools"));
+
+    let report = diff_manifests(
+        &PathBuf::from("/tmp/fake-root"),
+        "local",
+        &desired,
+        Some(&live.agent_principal),
+        &live,
+    );
+
+    assert_eq!(
+        report.collections.tool_selections.update,
+        vec!["service-tools"]
+    );
+    assert!(report.collections.tool_selections.create.is_empty());
+    assert!(report.collections.tool_selections.unchanged.is_empty());
+    assert_eq!(report.counts.tool_selections.update, 1);
 }
 
 #[test]

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -120,6 +120,12 @@ pub(crate) fn validate_manifest(manifest: &DesiredStateManifest, errors: &mut Ve
             &selection.command_forbidden_argv_prefixes,
             errors,
         );
+        validate_non_empty_values(
+            &selection.selection_id,
+            "allowed_mcp_service_ids",
+            &selection.allowed_mcp_service_ids,
+            errors,
+        );
     }
 
     for profile in &manifest.inference_profiles {
@@ -583,6 +589,21 @@ fn validate_argv_prefixes(
                     "tool selection {selection_id} {field} JSON entry is invalid: {error}"
                 )),
             }
+        }
+    }
+}
+
+fn validate_non_empty_values(
+    selection_id: &str,
+    field: &str,
+    values: &[String],
+    errors: &mut Vec<String>,
+) {
+    for value in values {
+        if value.trim().is_empty() {
+            errors.push(format!(
+                "tool selection {selection_id} has an empty {field} entry"
+            ));
         }
     }
 }

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -253,7 +253,7 @@ const CONFIG_SCHEMA_COLLECTIONS: &[&str] = &[
 pub(crate) const EXPORT_AGENT_PRINCIPAL_FIELDS: &str =
     "agent_did display_name default_behavior_id enabled created_at created_by";
 pub(crate) const EXPORT_AGENT_BEHAVIOR_FIELDS: &str = "behavior_id agent_did display_name system_prompt backend_id model_name tool_selection_id inference_profile_id compaction_strategy compaction_threshold enabled created_at";
-pub(crate) const EXPORT_TOOL_SELECTION_FIELDS: &str = "selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools delegate_to";
+pub(crate) const EXPORT_TOOL_SELECTION_FIELDS: &str = "selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools allowed_mcp_service_ids delegate_to";
 pub(crate) const EXPORT_INFERENCE_BACKEND_FIELDS: &str =
     "backend_id name provider_kind endpoint api_key api_key_env_var max_concurrent max_queue_depth enabled models last_probe probe_status";
 pub(crate) const EXPORT_INFERENCE_PROFILE_FIELDS: &str =

--- a/crates/defra-agent-cli/tests/cli_config_tools.rs
+++ b/crates/defra-agent-cli/tests/cli_config_tools.rs
@@ -50,6 +50,8 @@ async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()
             &selection_id,
             "--enable-file-tools",
             "--enable-bash",
+            "--allowed-mcp-service-id",
+            "x-data",
         ],
     )?;
     let doc_id = output
@@ -64,6 +66,12 @@ async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()
         output.get("bash_mode").and_then(Value::as_str),
         Some("ReadOnly")
     );
+    assert_eq!(
+        output
+            .pointer("/allowed_mcp_service_ids/0")
+            .and_then(Value::as_str),
+        Some("x-data")
+    );
 
     let query = format!(
         r#"{{
@@ -74,6 +82,7 @@ async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()
                 file_tool_root
                 enable_bash
                 bash_mode
+                allowed_mcp_service_ids
             }}
         }}"#,
         escape_graphql_string(doc_id),
@@ -97,6 +106,11 @@ async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()
     assert_eq!(
         row.get("bash_mode").and_then(Value::as_str),
         Some("ReadOnly")
+    );
+    assert_eq!(
+        row.pointer("/allowed_mcp_service_ids/0")
+            .and_then(Value::as_str),
+        Some("x-data")
     );
 
     Ok(())

--- a/crates/defra-agent-cli/tests/cli_config_validate.rs
+++ b/crates/defra-agent-cli/tests/cli_config_validate.rs
@@ -71,6 +71,7 @@ async fn config_validate_accepts_normalized_manifest_root() -> Result<()> {
                 "command_forbidden_argv_prefixes": ["git commit"],
                 "cli_tool_names": [],
                 "enable_meta_tools": true,
+                "allowed_mcp_service_ids": ["x-data"],
                 "delegate_to": []
             }),
         )?;

--- a/crates/defra-agent-cli/tests/support/fs.rs
+++ b/crates/defra-agent-cli/tests/support/fs.rs
@@ -174,6 +174,7 @@ pub fn write_manifest_root_from_export(root: &Path, exported: &Value) -> Result<
             "command_network_mode",
             "cli_tool_names",
             "enable_meta_tools",
+            "allowed_mcp_service_ids",
             "delegate_to",
         ],
     )?;
@@ -375,6 +376,7 @@ pub async fn assert_runtime_init_state(
                 enable_bash
                 bash_mode
                 enable_meta_tools
+                allowed_mcp_service_ids
             }}
         }}"#,
         escape_graphql_string(agent_did),
@@ -507,6 +509,13 @@ pub async fn assert_runtime_init_state(
             .get("enable_meta_tools")
             .and_then(Value::as_bool),
         Some(true)
+    );
+    assert!(
+        tool_selection
+            .get("allowed_mcp_service_ids")
+            .and_then(Value::as_array)
+            .is_some_and(Vec::is_empty),
+        "expected default tool selection MCP allowlist to be empty: {tool_selection}"
     );
 
     Ok(())

--- a/crates/defra-agent-desktop-core/src/client/mutations/manage/tools.rs
+++ b/crates/defra-agent-desktop-core/src/client/mutations/manage/tools.rs
@@ -79,6 +79,10 @@ fn build_upsert_tool_selection_mutation(row: &ToolSelectionRow) -> Result<String
             "enable_meta_tools",
             row.enable_meta_tools,
         )),
+        Some(graphql_string_list_field(
+            "allowed_mcp_service_ids",
+            &row.allowed_mcp_service_ids,
+        )),
         Some(graphql_string_list_field("delegate_to", &row.delegate_to)),
     ];
     let update_fields = [
@@ -127,6 +131,10 @@ fn build_upsert_tool_selection_mutation(row: &ToolSelectionRow) -> Result<String
         Some(graphql_optional_bool_field(
             "enable_meta_tools",
             row.enable_meta_tools,
+        )),
+        Some(graphql_string_list_field(
+            "allowed_mcp_service_ids",
+            &row.allowed_mcp_service_ids,
         )),
         Some(graphql_string_list_field("delegate_to", &row.delegate_to)),
     ];

--- a/crates/defra-agent-desktop-core/src/client/query.rs
+++ b/crates/defra-agent-desktop-core/src/client/query.rs
@@ -40,7 +40,7 @@ const COMPACTION_ENTRY_FIELDS: &str = "compaction_key session_id sequence summar
 const TASK_FIELDS: &str = "task_id name description behavior_id prompt_template enabled output_schema_ref created_at updated_at";
 const SCHEDULE_FIELDS: &str = "schedule_id task_id interval_secs enabled concurrency next_run_at last_attempt_at last_status last_error fire_count created_at updated_at";
 const EVENT_TRIGGER_FIELDS: &str = "trigger_id task_id source_collection event_kind filter enabled concurrency created_at updated_at last_attempt_at last_fired_source_doc_id last_status last_error fire_count";
-const TOOL_SELECTION_FIELDS: &str = "selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools delegate_to";
+const TOOL_SELECTION_FIELDS: &str = "selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools allowed_mcp_service_ids delegate_to";
 const INFERENCE_BACKEND_FIELDS: &str = "backend_id name provider_kind endpoint api_key api_key_env_var max_concurrent max_queue_depth enabled models last_probe probe_status";
 const INFERENCE_PROFILE_FIELDS: &str = "profile_id display_name context_window max_output_tokens max_turns temperature stream_batch_ms deadline_duration_secs";
 const TOOL_SERVICE_REGISTRY_FIELDS: &str = "service_id display_name description hostname tailscale_ip lan_ip mcp_port mcp_path status version updated_at";
@@ -262,7 +262,7 @@ pub async fn load_tool_selections(node: &EmbeddedNode) -> Result<Vec<ToolSelecti
     load_rows(
         node,
         "ToolSelection",
-        "query { ToolSelection { selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools delegate_to } }",
+        "query { ToolSelection { selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools allowed_mcp_service_ids delegate_to } }",
     )
     .await
 }
@@ -629,7 +629,7 @@ query DesktopRemoteSnapshot {
   Task { task_id name description behavior_id prompt_template enabled output_schema_ref created_at updated_at }
   Schedule { schedule_id task_id interval_secs enabled concurrency next_run_at last_attempt_at last_status last_error fire_count created_at updated_at }
   EventTrigger { trigger_id task_id source_collection event_kind filter enabled concurrency created_at updated_at last_attempt_at last_fired_source_doc_id last_status last_error fire_count }
-  ToolSelection { selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools delegate_to }
+  ToolSelection { selection_id agent_did display_name enable_file_tools file_tools_mode file_tool_root enable_bash bash_mode command_execution_policy command_allowed_argv_prefixes command_forbidden_argv_prefixes command_network_mode cli_tool_names enable_meta_tools allowed_mcp_service_ids delegate_to }
   InferenceBackend { backend_id name provider_kind endpoint api_key api_key_env_var max_concurrent max_queue_depth enabled models last_probe probe_status }
   InferenceProfile { profile_id display_name context_window max_output_tokens max_turns temperature stream_batch_ms deadline_duration_secs }
   ToolServiceRegistry { service_id display_name description hostname tailscale_ip lan_ip mcp_port mcp_path status version updated_at }

--- a/crates/defra-agent-desktop-core/tests/manage_view.rs
+++ b/crates/defra-agent-desktop-core/tests/manage_view.rs
@@ -74,6 +74,7 @@ async fn manage_document_saves_refresh_store() -> Result<()> {
         command_network_mode: None,
         cli_tool_names: vec!["rg".to_string(), "cargo".to_string()],
         enable_meta_tools: Some(true),
+        allowed_mcp_service_ids: Vec::new(),
         delegate_to: vec!["planner".to_string()],
     })
     .await?;

--- a/crates/defra-agent-protocol/schemas/README.md
+++ b/crates/defra-agent-protocol/schemas/README.md
@@ -52,7 +52,7 @@ These documents describe what the agent is and how it should run.
 |------------|------------|------------|------------|---------|
 | `AgentPrincipal` | `agent_did`, `default_behavior_id`, `enabled` | `default_behavior_id -> AgentBehavior.behavior_id` | `init`, config/bootstrap code | document boot, reconcile, scheduler/task defaulting |
 | `AgentBehavior` | `behavior_id`, `agent_did`, `backend_id`, `model_name`, `tool_selection_id`, `inference_profile_id`, `enabled` | `backend_id -> InferenceBackend.backend_id`, `tool_selection_id -> ToolSelection.selection_id`, `inference_profile_id -> InferenceProfile.profile_id` | `init`, `config behavior set`, library builder/document bootstrap | runtime resolution, request routing, scheduler |
-| `ToolSelection` | `selection_id`, `agent_did`, file/bash/meta/delegate fields, command execution policy fields | selected by `AgentBehavior.tool_selection_id` | `init`, `config tools set` | tool-surface resolution |
+| `ToolSelection` | `selection_id`, `agent_did`, file/bash/meta/delegate fields, MCP service allowlist, command execution policy fields | selected by `AgentBehavior.tool_selection_id` | `init`, `config tools set` | tool-surface resolution |
 | `InferenceBackend` | `backend_id`, `provider_kind`, `endpoint`, `api_key`, `api_key_env_var`, `max_concurrent`, `max_queue_depth`, `enabled`, `models`, `probe_status` | selected by `AgentBehavior.backend_id` | `init`, `config backend set`, desired-state manifests, health/probe updates | startup readiness, runtime execution, scheduler execution |
 | `InferenceProfile` | `profile_id`, context/output/temperature/deadline fields | selected by `AgentBehavior.inference_profile_id` | `config profile set` | runtime resolution |
 
@@ -187,6 +187,9 @@ Those are treated as current desired state rather than append-only history.
 Some boundaries are deliberate:
 
 - `ToolSelection` is the behavior-selected tool surface.
+- `ToolSelection.allowed_mcp_service_ids` optionally narrows meta-tools to a
+  behavior-specific set of MCP service IDs. Missing or empty means all online
+  `ToolServiceRegistry` services remain visible for backward compatibility.
 - `ToolCeiling` is not stored here; it is an operator safety cap applied at
   runtime.
 - Command execution policy lives on `ToolSelection`: `command_execution_policy`

--- a/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
@@ -13,5 +13,6 @@ type ToolSelection {
     command_network_mode: String
     cli_tool_names: [String]
     enable_meta_tools: Boolean
+    allowed_mcp_service_ids: [String]
     delegate_to: [String]
 }

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -493,6 +493,8 @@ pub struct ToolSelectionRow {
     #[serde(default)]
     pub enable_meta_tools: Option<bool>,
     #[serde(default, deserialize_with = "deserialize_string_vec")]
+    pub allowed_mcp_service_ids: Vec<String>,
+    #[serde(default, deserialize_with = "deserialize_string_vec")]
     pub delegate_to: Vec<String>,
 }
 
@@ -623,6 +625,7 @@ mod tests {
         }"#;
         let row: ToolSelectionRow = serde_json::from_str(json).expect("parse");
         assert!(row.cli_tool_names.is_empty());
+        assert!(row.allowed_mcp_service_ids.is_empty());
         assert!(row.delegate_to.is_empty());
     }
 
@@ -632,10 +635,12 @@ mod tests {
             "selection_id": "sel-2",
             "agent_did": "did:defra:amy",
             "cli_tool_names": null,
+            "allowed_mcp_service_ids": null,
             "delegate_to": null
         }"#;
         let row: ToolSelectionRow = serde_json::from_str(json).expect("parse");
         assert!(row.cli_tool_names.is_empty());
+        assert!(row.allowed_mcp_service_ids.is_empty());
         assert!(row.delegate_to.is_empty());
     }
 
@@ -645,10 +650,12 @@ mod tests {
             "selection_id": "sel-3",
             "agent_did": "did:defra:amy",
             "cli_tool_names": "",
+            "allowed_mcp_service_ids": "",
             "delegate_to": ""
         }"#;
         let row: ToolSelectionRow = serde_json::from_str(json).expect("parse");
         assert!(row.cli_tool_names.is_empty());
+        assert!(row.allowed_mcp_service_ids.is_empty());
         assert!(row.delegate_to.is_empty());
     }
 }

--- a/crates/defra-agent/examples/serve_default_behavior.rs
+++ b/crates/defra-agent/examples/serve_default_behavior.rs
@@ -134,6 +134,7 @@ async fn seed_demo_documents(
             command_network_mode: None,
             cli_tool_names: Some(Vec::new()),
             enable_meta_tools: Some(true),
+            allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
         },
     )

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -299,6 +299,10 @@ pub(crate) fn tool_selection_from_document(
         command_policy: command_policy_from_document(selection, bash)?,
         cli_tool_names: selection.cli_tool_names.clone().unwrap_or_default(),
         enable_meta_tools: selection.enable_meta_tools.unwrap_or(true),
+        allowed_mcp_service_ids: selection
+            .allowed_mcp_service_ids
+            .clone()
+            .unwrap_or_default(),
         delegate_to: selection.delegate_to.clone().unwrap_or_default(),
     })
 }

--- a/crates/defra-agent/src/agent/builder.rs
+++ b/crates/defra-agent/src/agent/builder.rs
@@ -245,6 +245,16 @@ impl BehaviorBuilder {
         self
     }
 
+    pub fn allowed_mcp_service_ids<I, S>(mut self, service_ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.behavior.tool_selection.allowed_mcp_service_ids =
+            service_ids.into_iter().map(Into::into).collect();
+        self
+    }
+
     pub fn delegate_to<I, S>(mut self, delegate_to: I) -> Self
     where
         I: IntoIterator<Item = S>,

--- a/crates/defra-agent/src/agent/document_view/tests.rs
+++ b/crates/defra-agent/src/agent/document_view/tests.rs
@@ -101,6 +101,7 @@ async fn load_document_runtime_view_includes_referenced_documents() {
             command_network_mode: None,
             cli_tool_names: Some(Vec::new()),
             enable_meta_tools: Some(false),
+            allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
         },
     )
@@ -166,6 +167,7 @@ async fn apply_control_update_reconciles_tool_selection_via_doc_id() {
             command_network_mode: None,
             cli_tool_names: Some(Vec::new()),
             enable_meta_tools: Some(false),
+            allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
         },
     )

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -368,6 +368,7 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
                 command_policy: None,
                 cli_tool_names: Vec::new(),
                 enable_meta_tools: false,
+                allowed_mcp_service_ids: Vec::new(),
                 delegate_to: Vec::new(),
             },
             &ToolCeiling::readonly(),

--- a/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
@@ -222,6 +222,7 @@ async fn control_watcher_resolves_tool_selection_into_reconciled_tool_surface() 
             command_network_mode: None,
             cli_tool_names: Some(Vec::new()),
             enable_meta_tools: Some(false),
+            allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
         },
     )

--- a/crates/defra-agent/src/agent/tests/document_loading.rs
+++ b/crates/defra-agent/src/agent/tests/document_loading.rs
@@ -130,6 +130,7 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
             command_network_mode: None,
             cli_tool_names: Some(Vec::new()),
             enable_meta_tools: Some(false),
+            allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(vec!["did:defra-agent:amy-code".to_string()]),
         },
     )

--- a/crates/defra-agent/src/document_config/tests.rs
+++ b/crates/defra-agent/src/document_config/tests.rs
@@ -13,11 +13,13 @@ fn tool_selection_document_accepts_empty_string_arrays() {
         "bash_mode": "disabled",
         "cli_tool_names": "",
         "enable_meta_tools": false,
+        "allowed_mcp_service_ids": "",
         "delegate_to": ""
     }))
     .expect("empty string arrays should deserialize");
 
     assert_eq!(document.cli_tool_names, Some(Vec::new()));
+    assert_eq!(document.allowed_mcp_service_ids, Some(Vec::new()));
     assert_eq!(document.delegate_to, Some(Vec::new()));
 }
 
@@ -34,11 +36,16 @@ fn tool_selection_document_accepts_string_array_values() {
         "bash_mode": "disabled",
         "cli_tool_names": ["rg"],
         "enable_meta_tools": false,
+        "allowed_mcp_service_ids": ["x-data"],
         "delegate_to": ["did:defra-agent:other"]
     }))
     .expect("string arrays should deserialize");
 
     assert_eq!(document.cli_tool_names, Some(vec!["rg".to_string()]));
+    assert_eq!(
+        document.allowed_mcp_service_ids,
+        Some(vec!["x-data".to_string()])
+    );
     assert_eq!(
         document.delegate_to,
         Some(vec!["did:defra-agent:other".to_string()])

--- a/crates/defra-agent/src/document_config/tool_selection.rs
+++ b/crates/defra-agent/src/document_config/tool_selection.rs
@@ -38,6 +38,11 @@ pub struct ToolSelectionDocument {
         default,
         deserialize_with = "super::serde_helpers::deserialize_optional_string_vec"
     )]
+    pub allowed_mcp_service_ids: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "super::serde_helpers::deserialize_optional_string_vec"
+    )]
     pub delegate_to: Option<Vec<String>>,
 }
 
@@ -80,6 +85,7 @@ pub(crate) async fn load_tool_selection_record(
                 command_network_mode
                 cli_tool_names
                 enable_meta_tools
+                allowed_mcp_service_ids
                 delegate_to
             }}
         }}"#
@@ -122,6 +128,7 @@ pub(crate) async fn load_tool_selection_by_doc_id(
                 command_network_mode
                 cli_tool_names
                 enable_meta_tools
+                allowed_mcp_service_ids
                 delegate_to
             }}
         }}"#
@@ -164,6 +171,7 @@ pub(crate) async fn list_tool_selection_records(
                 command_network_mode
                 cli_tool_names
                 enable_meta_tools
+                allowed_mcp_service_ids
                 delegate_to
             }}
         }}"#
@@ -200,6 +208,7 @@ pub(crate) async fn list_all_tool_selection_records(
                 command_network_mode
                 cli_tool_names
                 enable_meta_tools
+                allowed_mcp_service_ids
                 delegate_to
             }
         }"#;
@@ -264,6 +273,10 @@ pub async fn upsert_tool_selection(
             "enable_meta_tools",
             selection.enable_meta_tools,
         ),
+        graphql_fields::graphql_string_list_field(
+            "allowed_mcp_service_ids",
+            selection.allowed_mcp_service_ids.as_deref(),
+        ),
         graphql_fields::graphql_string_list_field("delegate_to", selection.delegate_to.as_deref()),
     ]
     .into_iter()
@@ -311,6 +324,10 @@ pub async fn upsert_tool_selection(
         graphql_fields::graphql_optional_bool_field(
             "enable_meta_tools",
             selection.enable_meta_tools,
+        ),
+        graphql_fields::graphql_string_list_field(
+            "allowed_mcp_service_ids",
+            selection.allowed_mcp_service_ids.as_deref(),
         ),
         graphql_fields::graphql_string_list_field("delegate_to", selection.delegate_to.as_deref()),
     ]

--- a/crates/defra-agent/src/meta_tools.rs
+++ b/crates/defra-agent/src/meta_tools.rs
@@ -25,6 +25,7 @@ pub fn build_meta_tools(
     health: ServiceHealthMap,
     local_hostname: String,
     local_subnet: Option<String>,
+    allowed_mcp_service_ids: Vec<String>,
 ) -> Vec<Box<dyn rig::tool::ToolDyn>> {
     let ctx = MetaToolContext {
         node,
@@ -32,6 +33,7 @@ pub fn build_meta_tools(
         health,
         local_hostname,
         local_subnet,
+        allowed_mcp_service_ids,
     };
     vec![
         Box::new(DiscoverToolsTool::new(ctx.clone())),

--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -68,6 +68,13 @@ impl Tool for CallToolTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        if let Some(error) = self
+            .ctx
+            .blocked_service_error(&args.service_id, &args.tool_name)
+        {
+            return Ok(error.to_result_text());
+        }
+
         let arguments =
             match normalize_arguments(&args.service_id, &args.tool_name, &args.arguments) {
                 Ok(arguments) => arguments,
@@ -354,9 +361,11 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use serde_json::json;
+    use std::sync::Arc;
 
     use crate::health_checker::{HealthStatus, ServiceHealth, ServiceHealthMap};
     use crate::lean_vocab_test::{lean_tool_preflight_cases, LeanToolPreflightCase};
+    use crate::mcp_pool::McpPool;
 
     fn search_schema() -> Map<String, Value> {
         json!({
@@ -453,6 +462,37 @@ mod tests {
             "unreachable" => HealthStatus::Unreachable,
             other => panic!("unknown Lean health status {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn disallowed_service_returns_before_argument_validation() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        let tool = CallToolTool::new(MetaToolContext {
+            node,
+            mcp_pool: McpPool::new(),
+            health: ServiceHealthMap::new(),
+            local_hostname: "studio-1".to_string(),
+            local_subnet: None,
+            allowed_mcp_service_ids: vec!["x-data".to_string()],
+        });
+
+        let output = tool
+            .call(CallToolArgs {
+                service_id: "observability-mcp".to_string(),
+                tool_name: "query_metrics".to_string(),
+                arguments: json!("not an object"),
+            })
+            .await
+            .expect("disallowed service should return structured text");
+        let value: Value = serde_json::from_str(&output).expect("structured json");
+
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["failure_class"], "tool_not_allowed");
+        assert_eq!(value["path"], "/service_id");
+        assert_eq!(value["retryable"], false);
+        assert_eq!(value["service_id"], "observability-mcp");
+        assert_eq!(value["tool_name"], "query_metrics");
+        assert_eq!(value["allowed_mcp_service_ids"], json!(["x-data"]));
     }
 
     #[test]

--- a/crates/defra-agent/src/meta_tools/describe.rs
+++ b/crates/defra-agent/src/meta_tools/describe.rs
@@ -67,6 +67,13 @@ impl Tool for DescribeToolTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        if let Some(error) = self
+            .ctx
+            .blocked_service_error(&args.service_id, &args.tool_name)
+        {
+            return Ok(error.to_result_text());
+        }
+
         if let Err(error) = enforce_health_gate(&self.ctx.health, &args.service_id).await {
             return Ok(StructuredToolError::service_unavailable(
                 &args.service_id,
@@ -931,6 +938,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn disallowed_service_returns_before_registry_lookup() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        let tool = DescribeToolTool::new(MetaToolContext {
+            node,
+            mcp_pool: McpPool::new(),
+            health: ServiceHealthMap::new(),
+            local_hostname: "studio-1".to_string(),
+            local_subnet: None,
+            allowed_mcp_service_ids: vec!["x-data".to_string()],
+        });
+
+        let output = tool
+            .call(DescribeToolArgs {
+                service_id: "observability-mcp".to_string(),
+                tool_name: "query_metrics".to_string(),
+                raw_schema: false,
+            })
+            .await
+            .expect("disallowed service should be model-readable");
+        let value: Value = serde_json::from_str(&output).expect("structured json");
+
+        assert_eq!(value["ok"], false);
+        assert_eq!(value["failure_class"], "tool_not_allowed");
+        assert_eq!(value["path"], "/service_id");
+        assert_eq!(value["retryable"], false);
+        assert_eq!(value["service_id"], "observability-mcp");
+        assert_eq!(value["requested_tool_name"], "query_metrics");
+        assert_eq!(value["allowed_mcp_service_ids"], json!(["x-data"]));
+    }
+
+    #[tokio::test]
     async fn missing_service_returns_structured_envelope() {
         let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
         crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
@@ -940,6 +978,7 @@ mod tests {
             health: ServiceHealthMap::new(),
             local_hostname: "studio-1".to_string(),
             local_subnet: None,
+            allowed_mcp_service_ids: Vec::new(),
         });
 
         let output = tool

--- a/crates/defra-agent/src/meta_tools/discover.rs
+++ b/crates/defra-agent/src/meta_tools/discover.rs
@@ -93,8 +93,23 @@ impl Tool for DiscoverToolsTool {
             }
         };
 
+        let services = services
+            .into_iter()
+            .filter(|svc| {
+                svc.get("service_id")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|service_id| self.ctx.is_mcp_service_allowed(service_id))
+            })
+            .collect::<Vec<_>>();
+
         if services.is_empty() {
-            return Ok("No data services are currently online.".to_string());
+            if self.ctx.allowed_mcp_service_ids.is_empty() {
+                return Ok("No data services are currently online.".to_string());
+            }
+            return Ok(format!(
+                "No allowed data services are currently online. Allowed services: {}.",
+                self.ctx.allowed_mcp_service_ids.join(", ")
+            ));
         }
 
         let query_lower = args.query.as_deref().map(|q| q.to_lowercase());
@@ -216,5 +231,63 @@ impl Tool for DiscoverToolsTool {
         } else {
             Ok(out)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::health_checker::ServiceHealthMap;
+    use crate::mcp_pool::McpPool;
+
+    #[tokio::test]
+    async fn discover_filters_out_disallowed_registry_services() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        let mutation = r#"mutation {
+            upsert_ToolServiceRegistry(
+                filter: { service_id: { _eq: "observability-mcp" } },
+                add: {
+                    service_id: "observability-mcp",
+                    display_name: "Observability",
+                    description: "Metrics and logs",
+                    hostname: "localhost",
+                    tailscale_ip: "",
+                    lan_ip: "",
+                    mcp_port: 1,
+                    mcp_path: "/mcp",
+                    status: "online"
+                },
+                update: { status: "online" }
+            ) { _docID }
+        }"#;
+        let response = node.execute(mutation).await;
+        assert!(
+            !response.has_errors(),
+            "registry insert failed: {:?}",
+            response.errors
+        );
+
+        let tool = DiscoverToolsTool::new(MetaToolContext {
+            node,
+            mcp_pool: McpPool::new(),
+            health: ServiceHealthMap::new(),
+            local_hostname: "studio-1".to_string(),
+            local_subnet: None,
+            allowed_mcp_service_ids: vec!["x-data".to_string()],
+        });
+
+        let output = tool
+            .call(DiscoverToolsArgs { query: None })
+            .await
+            .expect("discover should return model-readable text");
+
+        assert_eq!(
+            output,
+            "No allowed data services are currently online. Allowed services: x-data."
+        );
+        assert!(!output.contains("observability-mcp"));
     }
 }

--- a/crates/defra-agent/src/meta_tools/shared.rs
+++ b/crates/defra-agent/src/meta_tools/shared.rs
@@ -15,6 +15,34 @@ pub struct MetaToolContext {
     pub health: ServiceHealthMap,
     pub local_hostname: String,
     pub local_subnet: Option<String>,
+    pub allowed_mcp_service_ids: Vec<String>,
+}
+
+impl MetaToolContext {
+    pub(super) fn is_mcp_service_allowed(&self, service_id: &str) -> bool {
+        mcp_service_allowed(&self.allowed_mcp_service_ids, service_id)
+    }
+
+    pub(super) fn blocked_service_error(
+        &self,
+        service_id: &str,
+        tool_name: &str,
+    ) -> Option<StructuredToolError> {
+        (!self.is_mcp_service_allowed(service_id)).then(|| {
+            StructuredToolError::tool_not_allowed(
+                service_id,
+                tool_name,
+                self.allowed_mcp_service_ids.clone(),
+            )
+        })
+    }
+}
+
+pub(super) fn mcp_service_allowed(allowed_mcp_service_ids: &[String], service_id: &str) -> bool {
+    allowed_mcp_service_ids.is_empty()
+        || allowed_mcp_service_ids
+            .iter()
+            .any(|allowed| allowed == service_id)
 }
 
 #[derive(Debug)]
@@ -51,6 +79,8 @@ pub(super) struct StructuredToolError {
     pub(super) requested_tool_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) available_tools: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) allowed_mcp_service_ids: Option<Vec<String>>,
 }
 
 impl StructuredToolError {
@@ -70,6 +100,7 @@ impl StructuredToolError {
             tool_name: tool_name.to_string(),
             requested_tool_name: None,
             available_tools: None,
+            allowed_mcp_service_ids: None,
         }
     }
 
@@ -88,6 +119,7 @@ impl StructuredToolError {
             tool_name: tool_name.to_string(),
             requested_tool_name: None,
             available_tools: Some(available_tools),
+            allowed_mcp_service_ids: None,
         }
     }
 
@@ -114,6 +146,7 @@ impl StructuredToolError {
             tool_name: requested_tool_name.to_string(),
             requested_tool_name: Some(requested_tool_name.to_string()),
             available_tools: Some(available_tools),
+            allowed_mcp_service_ids: None,
         }
     }
 
@@ -133,6 +166,29 @@ impl StructuredToolError {
             tool_name: requested_tool_name.to_string(),
             requested_tool_name: Some(requested_tool_name.to_string()),
             available_tools: None,
+            allowed_mcp_service_ids: None,
+        }
+    }
+
+    pub(super) fn tool_not_allowed(
+        service_id: &str,
+        requested_tool_name: &str,
+        allowed_mcp_service_ids: Vec<String>,
+    ) -> Self {
+        Self {
+            ok: false,
+            failure_class: "tool_not_allowed",
+            path: "/service_id".to_string(),
+            message: format!(
+                "service '{service_id}' is not allowed for this behavior; allowed services: {}",
+                allowed_mcp_service_ids.join(", ")
+            ),
+            retryable: false,
+            service_id: service_id.to_string(),
+            tool_name: requested_tool_name.to_string(),
+            requested_tool_name: Some(requested_tool_name.to_string()),
+            available_tools: None,
+            allowed_mcp_service_ids: Some(allowed_mcp_service_ids),
         }
     }
 

--- a/crates/defra-agent/src/meta_tools/tests.rs
+++ b/crates/defra-agent/src/meta_tools/tests.rs
@@ -1,4 +1,7 @@
-use super::shared::{escape_graphql, extract_text, lookup_service_query, MetaToolError};
+use super::shared::{
+    escape_graphql, extract_text, lookup_service_query, mcp_service_allowed, MetaToolError,
+    StructuredToolError,
+};
 
 fn make_call_result(texts: &[&str]) -> rmcp::model::CallToolResult {
     use rmcp::model::CallToolResult;
@@ -49,6 +52,38 @@ fn lookup_service_query_prefers_latest_online_row() {
 fn lookup_service_query_escapes_service_id() {
     let query = lookup_service_query("x\"data");
     assert!(query.contains(r#"service_id: { _eq: "x\"data" }"#));
+}
+
+#[test]
+fn empty_mcp_allowlist_allows_any_service() {
+    assert!(mcp_service_allowed(&[], "x-data"));
+    assert!(mcp_service_allowed(&[], "observability-mcp"));
+}
+
+#[test]
+fn mcp_allowlist_matches_service_id_exactly() {
+    let allowlist = vec!["x-data".to_string(), "hf-data".to_string()];
+
+    assert!(mcp_service_allowed(&allowlist, "x-data"));
+    assert!(!mcp_service_allowed(&allowlist, "observability-mcp"));
+}
+
+#[test]
+fn blocked_mcp_service_returns_tool_not_allowed_error() {
+    let error = StructuredToolError::tool_not_allowed(
+        "observability-mcp",
+        "query_metrics",
+        vec!["x-data".to_string()],
+    );
+
+    assert_eq!(error.failure_class, "tool_not_allowed");
+    assert_eq!(error.path, "/service_id");
+    assert!(!error.retryable);
+    assert_eq!(error.service_id, "observability-mcp");
+    assert_eq!(
+        error.allowed_mcp_service_ids,
+        Some(vec!["x-data".to_string()])
+    );
 }
 
 #[test]

--- a/crates/defra-agent/src/tool_surface/behavior_config.rs
+++ b/crates/defra-agent/src/tool_surface/behavior_config.rs
@@ -15,6 +15,7 @@ use super::ToolSurface;
 pub struct BehaviorToolConfig {
     host_tools: ToolSet,
     enable_meta_tools: bool,
+    allowed_mcp_service_ids: Vec<String>,
     delegate_to: Vec<String>,
     custom_tools: Vec<CustomToolFactory>,
 }
@@ -24,6 +25,7 @@ impl BehaviorToolConfig {
         Self {
             host_tools: ToolSet::meta_only(),
             enable_meta_tools: true,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
             custom_tools: Vec::new(),
         }
@@ -42,6 +44,7 @@ impl BehaviorToolConfig {
             command_policy,
             cli_tool_names,
             enable_meta_tools,
+            allowed_mcp_service_ids,
             delegate_to,
         } = selection;
         let file_tools =
@@ -60,6 +63,7 @@ impl BehaviorToolConfig {
         Ok(Self {
             host_tools,
             enable_meta_tools,
+            allowed_mcp_service_ids: dedupe_strings(allowed_mcp_service_ids),
             delegate_to: dedupe_strings(delegate_to),
             custom_tools,
         })
@@ -71,6 +75,10 @@ impl BehaviorToolConfig {
 
     pub fn meta_tools_requested(&self) -> bool {
         self.enable_meta_tools
+    }
+
+    pub fn allowed_mcp_service_ids(&self) -> &[String] {
+        &self.allowed_mcp_service_ids
     }
 
     pub fn delegate_to(&self) -> &[String] {
@@ -94,6 +102,7 @@ impl BehaviorToolConfig {
         Ok(ToolSurface {
             host_tools: self.host_tools.clone(),
             include_meta_tools,
+            allowed_mcp_service_ids: self.allowed_mcp_service_ids.clone(),
             delegate_to: self.delegate_to.clone(),
             custom_tools: self.custom_tools.clone(),
         })
@@ -111,6 +120,7 @@ impl std::fmt::Debug for BehaviorToolConfig {
         f.debug_struct("BehaviorToolConfig")
             .field("host_tools", &self.host_tools)
             .field("enable_meta_tools", &self.enable_meta_tools)
+            .field("allowed_mcp_service_ids", &self.allowed_mcp_service_ids)
             .field("delegate_to", &self.delegate_to)
             .field(
                 "custom_tools",

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -24,6 +24,7 @@ const DEFAULT_CLI_TIMEOUT_SECS: u64 = 10;
 pub struct ToolSurface {
     host_tools: ToolSet,
     include_meta_tools: bool,
+    allowed_mcp_service_ids: Vec<String>,
     delegate_to: Vec<String>,
     custom_tools: Vec<CustomToolFactory>,
 }
@@ -35,6 +36,10 @@ impl ToolSurface {
 
     pub fn includes_meta_tools(&self) -> bool {
         self.include_meta_tools
+    }
+
+    pub fn allowed_mcp_service_ids(&self) -> &[String] {
+        &self.allowed_mcp_service_ids
     }
 
     pub fn delegate_to(&self) -> &[String] {
@@ -68,6 +73,7 @@ impl ToolSurface {
                 runtime.health_map.clone(),
                 runtime.local_hostname.clone(),
                 runtime.local_subnet.clone(),
+                self.allowed_mcp_service_ids.clone(),
             ));
         }
         for tool in &self.custom_tools {
@@ -82,6 +88,7 @@ impl std::fmt::Debug for ToolSurface {
         f.debug_struct("ToolSurface")
             .field("host_tools", &self.host_tools)
             .field("include_meta_tools", &self.include_meta_tools)
+            .field("allowed_mcp_service_ids", &self.allowed_mcp_service_ids)
             .field("delegate_to", &self.delegate_to)
             .field(
                 "custom_tools",

--- a/crates/defra-agent/src/tool_surface/selection.rs
+++ b/crates/defra-agent/src/tool_surface/selection.rs
@@ -17,6 +17,7 @@ pub struct ToolSelection {
     pub command_policy: Option<CommandExecutionPolicy>,
     pub cli_tool_names: Vec<String>,
     pub enable_meta_tools: bool,
+    pub allowed_mcp_service_ids: Vec<String>,
     pub delegate_to: Vec<String>,
 }
 
@@ -29,6 +30,7 @@ impl Default for ToolSelection {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: true,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         }
     }

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -21,6 +21,7 @@ fn selection_file_tool_root_clamps_within_operator_root() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root.clone()),
@@ -74,6 +75,7 @@ fn selection_file_tool_root_rejects_escape_outside_operator_root() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),
@@ -101,6 +103,7 @@ fn readonly_selection_file_tool_root_rejects_escape_outside_operator_root() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readonly_at(operator_root),
@@ -128,6 +131,7 @@ fn downgraded_off_selection_ignores_stale_file_tool_root() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::meta_only(),
@@ -152,6 +156,7 @@ fn selection_without_root_inherits_operator_root() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root.clone()),
@@ -188,6 +193,7 @@ fn selection_cli_tools_require_ceiling_entries() {
             command_policy: None,
             cli_tool_names: vec!["rg".to_string()],
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),
@@ -221,6 +227,7 @@ fn selection_cli_tools_expose_only_ceiling_entries() {
             command_policy: None,
             cli_tool_names: vec!["rg".to_string(), "cargo".to_string()],
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ceiling,
@@ -242,6 +249,35 @@ fn selection_cli_tools_expose_only_ceiling_entries() {
     );
 }
 
+#[test]
+fn selection_mcp_service_allowlist_is_deduped() {
+    let config = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection {
+            file_tools: FileToolMode::Off,
+            file_tool_root: None,
+            bash: BashMode::Off,
+            command_policy: None,
+            cli_tool_names: Vec::new(),
+            enable_meta_tools: true,
+            allowed_mcp_service_ids: vec![
+                "x-data".to_string(),
+                "x-data".to_string(),
+                "observability-mcp".to_string(),
+            ],
+            delegate_to: Vec::new(),
+        },
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert_eq!(
+        config.allowed_mcp_service_ids(),
+        &["x-data".to_string(), "observability-mcp".to_string()]
+    );
+}
+
 #[cfg(unix)]
 #[test]
 fn selection_file_tool_root_rejects_symlink_escape_for_missing_child() {
@@ -259,6 +295,7 @@ fn selection_file_tool_root_rejects_symlink_escape_for_missing_child() {
             command_policy: None,
             cli_tool_names: Vec::new(),
             enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
             delegate_to: Vec::new(),
         },
         &ToolCeiling::readwrite(operator_root),

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -8,6 +8,7 @@ use serde_json::{json, Value};
 pub enum ToolFailureClass {
     ServiceUnavailable,
     ToolNotFound,
+    ToolNotAllowed,
     ResourceNotFound,
     ServiceSchemaDrift,
     InvalidToolArguments,
@@ -565,6 +566,7 @@ fn failure_class_code(failure_class: ToolFailureClass) -> &'static str {
     match failure_class {
         ToolFailureClass::ServiceUnavailable => "service_unavailable",
         ToolFailureClass::ToolNotFound => "tool_not_found",
+        ToolFailureClass::ToolNotAllowed => "tool_not_allowed",
         ToolFailureClass::ResourceNotFound => "resource_not_found",
         ToolFailureClass::ServiceSchemaDrift => "service_schema_drift",
         ToolFailureClass::InvalidToolArguments => "invalid_tool_arguments",
@@ -726,7 +728,8 @@ fn retryable_for_failure_class(failure_class: ToolFailureClass) -> Option<bool> 
         | ToolFailureClass::InvalidJsonArguments
         | ToolFailureClass::ArgumentsNotObject
         | ToolFailureClass::ToolNotFound => Some(true),
-        ToolFailureClass::ResourceNotFound
+        ToolFailureClass::ToolNotAllowed
+        | ToolFailureClass::ResourceNotFound
         | ToolFailureClass::ServiceSchemaDrift
         | ToolFailureClass::NonzeroCommandExit => Some(false),
         ToolFailureClass::ToolRuntimeError | ToolFailureClass::Unclassified => None,
@@ -1080,6 +1083,42 @@ mod tests {
             error.available_tools,
             Some(vec!["search_posts".to_string()])
         );
+    }
+
+    #[test]
+    fn structured_tool_not_allowed_is_non_retryable() {
+        let result = json!({
+            "ok": false,
+            "failure_class": "tool_not_allowed",
+            "path": "/service_id",
+            "message": "service 'observability-mcp' is not allowed for this behavior",
+            "retryable": false,
+            "service_id": "observability-mcp",
+            "tool_name": "query_metrics",
+            "requested_tool_name": "query_metrics",
+            "allowed_mcp_service_ids": ["x-data"]
+        })
+        .to_string();
+        let analysis = analyze_tool_call(
+            "call_tool",
+            r#"{"service_id":"observability-mcp","tool_name":"query_metrics","arguments":{}}"#,
+            &result,
+            "completed",
+        );
+
+        assert!(!analysis.tool_result_ok);
+        assert_eq!(
+            analysis.tool_failure_class,
+            Some(ToolFailureClass::ToolNotAllowed)
+        );
+        assert_eq!(analysis.validation_errors[0].code, "tool_not_allowed");
+        assert_eq!(analysis.validation_errors[0].path, "/service_id");
+        assert_eq!(analysis.validation_errors[0].retryable, false);
+        let error = analysis.tool_error.as_ref().expect("tool error");
+        assert_eq!(error.failure_class, ToolFailureClass::ToolNotAllowed);
+        assert_eq!(error.service_id.as_deref(), Some("observability-mcp"));
+        assert_eq!(error.tool_name.as_deref(), Some("query_metrics"));
+        assert_eq!(error.retryable, Some(false));
     }
 
     #[test]

--- a/demo/manifest/tool-selections.json
+++ b/demo/manifest/tool-selections.json
@@ -10,6 +10,7 @@
     "bash_mode": "Unrestricted",
     "cli_tool_names": [],
     "enable_meta_tools": true,
+    "allowed_mcp_service_ids": [],
     "delegate_to": []
   }
 ]


### PR DESCRIPTION
## Summary
- add `allowed_mcp_service_ids` to ToolSelection schema/config rows and runtime tool-surface resolution
- scope `discover_tools`, `describe_tool`, and `call_tool` to the per-behavior MCP service allowlist
- wire desired-state, CLI, desktop config/types, and tests for the new field

## Verification
- `cargo check --workspace --all-targets`
- `cargo test -p defra-agent meta_tools --lib`
- `cargo test -p defra-agent-cli desired_state`
- `cargo test -p defra-agent-cli --test cli_config_diff --test cli_config_apply_local`
- `npm --prefix apps/desktop-tauri test -- config-panel-buttons.test.tsx`
- `npm --prefix apps/desktop-tauri run build`
- `git diff --check`

Closes #150