### PR TITLE
Fix tool-result AgentMessage dedupe

### DIFF
--- a/crates/defra-agent/src/agent/stream_processor.rs
+++ b/crates/defra-agent/src/agent/stream_processor.rs
@@ -95,10 +95,17 @@ impl<'a> StreamProcessor<'a> {
             }
             Ok(MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
                 tool_call,
-                ..
+                internal_call_id,
             })) => {
                 let _ = self.stream_writer.flush_pending(self.doc_id).await?;
                 self.lifecycle.advance().await?;
+                self.persistence_hook
+                    .register_stream_tool_call_identity(
+                        &internal_call_id,
+                        &tool_call.id,
+                        tool_call.call_id.as_deref(),
+                    )
+                    .await;
                 self.assistant_turn.push_tool_call(tool_call);
                 Ok(StreamAction::Continue)
             }

--- a/crates/defra-agent/src/agent/stream_processor/tests.rs
+++ b/crates/defra-agent/src/agent/stream_processor/tests.rs
@@ -274,11 +274,21 @@ fn tool_call_item(
     args_json: &str,
     internal_id: &str,
 ) -> Result<MultiTurnStreamItem<()>, rig::agent::StreamingError> {
+    tool_call_item_with_ids(name, args_json, internal_id, internal_id, None)
+}
+
+fn tool_call_item_with_ids(
+    name: &str,
+    args_json: &str,
+    tool_id: &str,
+    internal_id: &str,
+    call_id: Option<&str>,
+) -> Result<MultiTurnStreamItem<()>, rig::agent::StreamingError> {
     Ok(MultiTurnStreamItem::StreamAssistantItem(
         StreamedAssistantContent::ToolCall {
             tool_call: ToolCall {
-                id: internal_id.to_string(),
-                call_id: None,
+                id: tool_id.to_string(),
+                call_id: call_id.map(ToOwned::to_owned),
                 function: ToolFunction {
                     name: name.to_string(),
                     arguments: serde_json::from_str(args_json).unwrap(),
@@ -296,11 +306,20 @@ fn tool_result_item(
     result_json: &str,
     internal_id: &str,
 ) -> Result<MultiTurnStreamItem<()>, rig::agent::StreamingError> {
+    tool_result_item_with_call_id(tool_id, None, result_json, internal_id)
+}
+
+fn tool_result_item_with_call_id(
+    tool_id: &str,
+    call_id: Option<&str>,
+    result_json: &str,
+    internal_id: &str,
+) -> Result<MultiTurnStreamItem<()>, rig::agent::StreamingError> {
     Ok(MultiTurnStreamItem::StreamUserItem(
         StreamedUserContent::ToolResult {
             tool_result: ToolResult {
                 id: tool_id.to_string(),
-                call_id: None,
+                call_id: call_id.map(ToOwned::to_owned),
                 content: OneOrMany::one(ToolResultContent::Text(Text {
                     text: result_json.to_string(),
                 })),
@@ -315,6 +334,169 @@ fn final_item(response_text: &str) -> Result<MultiTurnStreamItem<()>, rig::agent
         response_text,
         rig::completion::Usage::new(),
     ))
+}
+
+#[tokio::test]
+async fn hook_persisted_tool_result_dedupes_matching_stream_result() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-stream-processor-tool-dedupe-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = crate::hook::DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:test",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(
+            &hook,
+            &user_text_message("discover available tools"),
+            &[]
+        )
+        .await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let request_doc_id = create_pending_request(&node, &request_id, &session_id).await;
+    let request = AgentRequest {
+        doc_id: request_doc_id,
+        request_id: request_id.clone(),
+        agent_did: "did:defra-agent:test".to_string(),
+        behavior_id: Some("general".to_string()),
+        session_id: session_id.clone(),
+        content: "discover available tools".to_string(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
+        execution_origin: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+    };
+
+    let mut lifecycle = RequestLifecycle::new_with_execution_binding(
+        node.clone(),
+        "general",
+        "did:defra-agent:test",
+        request,
+        30,
+        ExecutionOrigin::Interactive,
+        "test-backend",
+    );
+    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+
+    let stream_writer = DefraStreamWriter::new(
+        node.clone(),
+        "did:defra-agent:test",
+        Duration::from_millis(0),
+    );
+    let response_doc_id = stream_writer
+        .begin(&session_id, &request_id, "general")
+        .await
+        .unwrap();
+    lifecycle.set_response_doc_id(&response_doc_id);
+
+    let mut processor =
+        StreamProcessor::new(&hook, &stream_writer, &mut lifecycle, &response_doc_id);
+
+    let stored_call_id = "OaoTQYzCdoptKiK_mdhBA";
+    let model_result_id = "c6b8bdeb-ab92-4481-b763-bdafbd463904";
+    let tool_args = r#"{"tool":"discover_tools"}"#;
+    let tool_result = r#"{"tools":["discover_tools","describe_tool"]}"#;
+
+    processor
+        .process_item(tool_call_item_with_ids(
+            "discover_tools",
+            tool_args,
+            model_result_id,
+            model_result_id,
+            Some(model_result_id),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(
+            &hook,
+            "discover_tools",
+            Some(model_result_id.to_string()),
+            stored_call_id,
+            tool_args,
+        )
+        .await,
+        rig::agent::ToolCallHookAction::Continue
+    ));
+    assert!(processor
+        .persist_partial_turn("persist streamed assistant tool call")
+        .await
+        .unwrap());
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_result(
+            &hook,
+            "discover_tools",
+            Some(model_result_id.to_string()),
+            stored_call_id,
+            tool_args,
+            tool_result,
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    processor
+        .process_item(tool_result_item_with_call_id(
+            model_result_id,
+            Some(model_result_id),
+            tool_result,
+            model_result_id,
+        ))
+        .await
+        .unwrap();
+
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    let tool_results = history
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => match content.first_ref() {
+                UserContent::ToolResult(tool_result) => Some(tool_result),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        tool_results.len(),
+        1,
+        "hook and stream paths must materialize one logical tool result"
+    );
+    assert_eq!(tool_results[0].id, model_result_id);
+    assert_eq!(tool_results[0].call_id.as_deref(), Some(model_result_id));
+    assert!(matches!(
+        tool_results[0].content.first_ref(),
+        ToolResultContent::Text(Text { text }) if text == tool_result
+    ));
+    assert_eq!(
+        crate::session::load_tool_call_result(&node, &session_id, stored_call_id)
+            .await
+            .unwrap(),
+        tool_result
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
@@ -38,13 +38,20 @@ enum TranscriptTurnState {
     AssistantPersisted { sequence: u32 },
 }
 
+#[derive(Debug, Clone, Default)]
+struct ToolResultIdentity {
+    result_id: Option<String>,
+    call_id: Option<String>,
+}
+
 struct SessionState {
     session_id: Option<String>,
     current_request_id: Option<String>,
     agent_name: String,
     sequence: u32,
     transcript_turn: TranscriptTurnState,
-    persisted_tool_result_ids: HashSet<String>,
+    persisted_tool_result_keys: HashSet<String>,
+    tool_result_identities: HashMap<String, ToolResultIdentity>,
     initialized: bool,
 }
 
@@ -80,28 +87,132 @@ impl SessionState {
         Ok(sequence)
     }
 
-    fn mark_tool_result_seen_for_persisted_turn(&mut self, internal_call_id: &str) -> bool {
-        matches!(
-            self.transcript_turn,
-            TranscriptTurnState::AssistantPersisted { .. }
-        ) && self
-            .persisted_tool_result_ids
-            .insert(internal_call_id.to_string())
+    fn register_tool_result_identity(
+        &mut self,
+        internal_call_id: &str,
+        result_id: Option<&str>,
+        call_id: Option<&str>,
+    ) {
+        let identity = self
+            .tool_result_identities
+            .entry(internal_call_id.to_string())
+            .or_default();
+        if let Some(result_id) = non_empty(result_id) {
+            identity.result_id = Some(result_id.to_string());
+        }
+        if let Some(call_id) = non_empty(call_id) {
+            identity.call_id = Some(call_id.to_string());
+        }
     }
 
-    fn mark_stream_tool_result_seen(&mut self, internal_call_id: &str) -> anyhow::Result<bool> {
+    fn tool_result_message_identity(
+        &self,
+        internal_call_id: &str,
+        call_id: Option<&str>,
+    ) -> (String, Option<String>) {
+        let registered = self.tool_result_identities.get(internal_call_id);
+        let result_id = registered
+            .and_then(|identity| identity.result_id.clone())
+            .or_else(|| non_empty(call_id).map(ToOwned::to_owned))
+            .unwrap_or_else(|| internal_call_id.to_string());
+        let call_id = registered
+            .and_then(|identity| identity.call_id.clone())
+            .or_else(|| non_empty(call_id).map(ToOwned::to_owned));
+
+        (result_id, call_id)
+    }
+
+    fn mark_tool_result_seen_for_persisted_turn(
+        &mut self,
+        internal_call_id: &str,
+        result_id: Option<&str>,
+        call_id: Option<&str>,
+    ) -> bool {
+        self.register_tool_result_identity(internal_call_id, result_id, call_id);
         if !matches!(
             self.transcript_turn,
             TranscriptTurnState::AssistantPersisted { .. }
         ) {
+            return false;
+        }
+
+        let keys = self.tool_result_dedupe_keys(internal_call_id, result_id, call_id);
+        self.mark_tool_result_keys_seen(keys)
+    }
+
+    fn mark_stream_tool_result_seen(
+        &mut self,
+        internal_call_id: &str,
+        result_id: &str,
+        call_id: Option<&str>,
+    ) -> anyhow::Result<bool> {
+        self.register_tool_result_identity(internal_call_id, Some(result_id), call_id);
+        let keys = self.tool_result_dedupe_keys(internal_call_id, Some(result_id), call_id);
+        if !matches!(
+            self.transcript_turn,
+            TranscriptTurnState::AssistantPersisted { .. }
+        ) {
+            if self.tool_result_keys_already_seen(&keys) {
+                self.persist_tool_result_keys(keys);
+                return Ok(false);
+            }
             anyhow::bail!(
                 "cannot persist streamed tool result before its assistant turn is persisted"
             );
         }
-        Ok(self
-            .persisted_tool_result_ids
-            .insert(internal_call_id.to_string()))
+        Ok(self.mark_tool_result_keys_seen(keys))
     }
+
+    fn tool_result_dedupe_keys(
+        &self,
+        internal_call_id: &str,
+        result_id: Option<&str>,
+        call_id: Option<&str>,
+    ) -> Vec<String> {
+        // The hook, stream item, and transcript can expose different IDs for
+        // the same tool result. Persist all known aliases and skip when any
+        // alias has already materialized the result message.
+        let mut keys = Vec::new();
+        push_tool_result_key(&mut keys, "internal", Some(internal_call_id));
+
+        if let Some(identity) = self.tool_result_identities.get(internal_call_id) {
+            push_tool_result_key(&mut keys, "result", identity.result_id.as_deref());
+            push_tool_result_key(&mut keys, "call", identity.call_id.as_deref());
+        }
+        push_tool_result_key(&mut keys, "result", result_id);
+        push_tool_result_key(&mut keys, "call", call_id);
+
+        keys
+    }
+
+    fn mark_tool_result_keys_seen(&mut self, keys: Vec<String>) -> bool {
+        let already_seen = self.tool_result_keys_already_seen(&keys);
+        self.persist_tool_result_keys(keys);
+        !already_seen
+    }
+
+    fn tool_result_keys_already_seen(&self, keys: &[String]) -> bool {
+        keys.iter()
+            .any(|key| self.persisted_tool_result_keys.contains(key))
+    }
+
+    fn persist_tool_result_keys(&mut self, keys: Vec<String>) {
+        self.persisted_tool_result_keys.extend(keys);
+    }
+}
+
+fn push_tool_result_key(keys: &mut Vec<String>, namespace: &str, value: Option<&str>) {
+    let Some(value) = non_empty(value) else {
+        return;
+    };
+    let key = format!("{namespace}:{value}");
+    if !keys.iter().any(|existing| existing == &key) {
+        keys.push(key);
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| (!value.is_empty()).then_some(value))
 }
 
 #[derive(Clone)]
@@ -141,7 +252,8 @@ impl DefraSessionHook {
                 agent_name: agent_name.to_string(),
                 sequence: 0,
                 transcript_turn: TranscriptTurnState::Idle,
-                persisted_tool_result_ids: HashSet::new(),
+                persisted_tool_result_keys: HashSet::new(),
+                tool_result_identities: HashMap::new(),
                 initialized: false,
             })),
         }
@@ -172,7 +284,8 @@ impl DefraSessionHook {
                 agent_name: agent_name.to_string(),
                 sequence: max_seq,
                 transcript_turn: TranscriptTurnState::Idle,
-                persisted_tool_result_ids: HashSet::new(),
+                persisted_tool_result_keys: HashSet::new(),
+                tool_result_identities: HashMap::new(),
                 initialized: true,
             })),
         })
@@ -228,6 +341,19 @@ impl DefraSessionHook {
 
     pub async fn set_active_request_id(&self, request_id: Option<String>) {
         self.state.lock().await.current_request_id = request_id;
+    }
+
+    pub(crate) async fn register_stream_tool_call_identity(
+        &self,
+        internal_call_id: &str,
+        result_id: &str,
+        call_id: Option<&str>,
+    ) {
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            Some(result_id),
+            call_id,
+        );
     }
 
     pub async fn mark_current_response_materialized(&self, sequence: u32) -> anyhow::Result<()> {

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -55,7 +55,11 @@ impl DefraSessionHook {
 
         let should_persist = {
             let mut state = self.state.lock().await;
-            state.mark_stream_tool_result_seen(internal_call_id)?
+            state.mark_stream_tool_result_seen(
+                internal_call_id,
+                &tool_result.id,
+                tool_result.call_id.as_deref(),
+            )?
         };
         if !should_persist {
             return Ok(());
@@ -160,13 +164,18 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
     async fn on_tool_call(
         &self,
         tool_name: &str,
-        _tool_call_id: Option<String>,
+        tool_call_id: Option<String>,
         internal_call_id: &str,
         args: &str,
     ) -> ToolCallHookAction {
         let result: anyhow::Result<()> = async {
             let (session_id, seq) = self.ensure_assistant_turn_sequence().await?;
             let storage_id = internal_call_id.to_string();
+            self.state.lock().await.register_tool_result_identity(
+                internal_call_id,
+                None,
+                tool_call_id.as_deref(),
+            );
             session::save_tool_call(
                 &self.node,
                 &session_id,
@@ -205,15 +214,25 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
         result: &str,
     ) -> HookAction {
         let persist_result: anyhow::Result<()> = async {
-            let (session_id, should_persist_message) = {
+            let (session_id, should_persist_message, persisted_result_id, persisted_call_id) = {
                 let mut state = self.state.lock().await;
                 let session_id = state
                     .session_id
                     .clone()
                     .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
-                let should_persist_message =
-                    state.mark_tool_result_seen_for_persisted_turn(internal_call_id);
-                (session_id, should_persist_message)
+                let should_persist_message = state.mark_tool_result_seen_for_persisted_turn(
+                    internal_call_id,
+                    None,
+                    tool_call_id.as_deref(),
+                );
+                let (persisted_result_id, persisted_call_id) =
+                    state.tool_result_message_identity(internal_call_id, tool_call_id.as_deref());
+                (
+                    session_id,
+                    should_persist_message,
+                    persisted_result_id,
+                    persisted_call_id,
+                )
             };
 
             let truncator =
@@ -242,8 +261,8 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
             if should_persist_message {
                 let tool_result_message = Message::User {
                     content: OneOrMany::one(UserContent::ToolResult(ToolResult {
-                        id: internal_call_id.to_string(),
-                        call_id: tool_call_id,
+                        id: persisted_result_id,
+                        call_id: persisted_call_id,
                         content: OneOrMany::one(ToolResultContent::Text(Text {
                             text: truncated.text.clone(),
                         })),

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -66,7 +66,8 @@ fn session_state_for_test() -> SessionState {
         agent_name: "agent".to_string(),
         sequence: 0,
         transcript_turn: TranscriptTurnState::Idle,
-        persisted_tool_result_ids: std::collections::HashSet::new(),
+        persisted_tool_result_keys: std::collections::HashSet::new(),
+        tool_result_identities: std::collections::HashMap::new(),
         initialized: true,
     }
 }
@@ -93,8 +94,12 @@ fn transcript_turn_state_allocates_new_assistant_after_saved_turn() {
     assert_eq!(state.begin_or_continue_assistant_turn(), 1);
     assert_eq!(state.begin_or_continue_assistant_turn(), 1);
     assert_eq!(state.persist_assistant_turn().unwrap(), 1);
-    assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
-    assert!(!state.mark_stream_tool_result_seen("call-1").unwrap());
+    assert!(state
+        .mark_stream_tool_result_seen("call-1", "call-1", None)
+        .unwrap());
+    assert!(!state
+        .mark_stream_tool_result_seen("call-1", "call-1", None)
+        .unwrap());
 
     state.reset_after_user_message();
     assert_eq!(state.begin_or_continue_assistant_turn(), 2);
@@ -105,11 +110,31 @@ fn transcript_turn_state_allocates_new_assistant_after_saved_turn() {
 fn transcript_turn_state_rejects_stream_result_before_assistant_is_saved() {
     let mut state = session_state_for_test();
 
-    assert!(state.mark_stream_tool_result_seen("call-1").is_err());
+    assert!(state
+        .mark_stream_tool_result_seen("call-1", "call-1", None)
+        .is_err());
     assert_eq!(state.begin_or_continue_assistant_turn(), 1);
-    assert!(state.mark_stream_tool_result_seen("call-1").is_err());
+    assert!(state
+        .mark_stream_tool_result_seen("call-1", "call-1", None)
+        .is_err());
     assert_eq!(state.persist_assistant_turn().unwrap(), 1);
-    assert!(state.mark_stream_tool_result_seen("call-1").unwrap());
+    assert!(state
+        .mark_stream_tool_result_seen("call-1", "call-1", None)
+        .unwrap());
+}
+
+#[test]
+fn transcript_turn_state_preserves_distinct_tool_results() {
+    let mut state = session_state_for_test();
+
+    assert_eq!(state.begin_or_continue_assistant_turn(), 1);
+    assert_eq!(state.persist_assistant_turn().unwrap(), 1);
+    assert!(state
+        .mark_stream_tool_result_seen("internal-1", "result-1", Some("call-1"))
+        .unwrap());
+    assert!(state
+        .mark_stream_tool_result_seen("internal-2", "result-2", Some("call-2"))
+        .unwrap());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #156.

## Summary
- track tool-result dedupe aliases across Rig internal IDs, streamed ToolResult IDs, and optional call IDs
- register streamed tool-call identities before result persistence so hook and stream paths agree on the logical result
- add a combined hook + StreamProcessor regression for mismatched storage/model IDs and a distinct-result guard

## Verification
- cargo test -p defra-agent hook_persisted_tool_result_dedupes_matching_stream_result -- --nocapture
- cargo test -p defra-agent agent::stream_processor::tests -- --nocapture
- cargo test -p defra-agent hook::tests -- --nocapture
- cargo test -p defra-agent transcript_turn_state_preserves_distinct_tool_results -- --nocapture
- cargo fmt --all -- --check
- git diff --check

Lean/client docs were not touched; lake build was not needed.