### PR TITLE
Deduplicate tool-result transcript messages

### DIFF
--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -54,6 +54,7 @@ struct SessionState {
     sequence: u32,
     transcript_turn: TranscriptTurnState,
     persisted_tool_result_keys: HashSet<String>,
+    persisted_tool_result_message_sequences: HashMap<String, u32>,
     tool_result_identities: HashMap<String, ToolResultIdentity>,
     initialized: bool,
 }
@@ -258,6 +259,7 @@ impl DefraSessionHook {
                 sequence: 0,
                 transcript_turn: TranscriptTurnState::Idle,
                 persisted_tool_result_keys: HashSet::new(),
+                persisted_tool_result_message_sequences: HashMap::new(),
                 tool_result_identities: HashMap::new(),
                 initialized: false,
             })),
@@ -292,6 +294,7 @@ impl DefraSessionHook {
                 sequence: max_seq,
                 transcript_turn: TranscriptTurnState::Idle,
                 persisted_tool_result_keys: HashSet::new(),
+                persisted_tool_result_message_sequences: HashMap::new(),
                 tool_result_identities: HashMap::new(),
                 initialized: true,
             })),

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -9,27 +9,40 @@ use crate::session;
 use crate::tool_call_lifecycle::runtime::{classify_managed_tool_result, ManagedToolTerminal};
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
-use super::DefraSessionHook;
+use super::{non_empty, DefraSessionHook};
 
 impl DefraSessionHook {
     pub async fn persist_message(&self, message: &Message) -> anyhow::Result<u32> {
-        let (session_id, sequence, role) = {
+        let content = serde_json::to_string(message)?;
+        let (session_id, sequence, role, message_key) = {
             let mut state = self.state.lock().await;
             let session_id = state
                 .session_id
                 .clone()
                 .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
+            let message_key = tool_result_message_key(&session_id, message)?;
+            if let Some(existing_sequence) = message_key
+                .as_ref()
+                .and_then(|key| state.persisted_tool_result_message_sequences.get(key))
+            {
+                return Ok(*existing_sequence);
+            }
 
             match message {
                 Message::User { .. } => {
                     state.sequence += 1;
                     let sequence = state.sequence;
                     state.reset_after_user_message();
-                    (session_id, sequence, "user")
+                    if let Some(key) = message_key.as_ref() {
+                        state
+                            .persisted_tool_result_message_sequences
+                            .insert(key.clone(), sequence);
+                    }
+                    (session_id, sequence, "user", message_key)
                 }
                 Message::Assistant { .. } => {
                     let sequence = state.persist_assistant_turn()?;
-                    (session_id, sequence, "assistant")
+                    (session_id, sequence, "assistant", None)
                 }
                 Message::System { .. } => {
                     anyhow::bail!("system messages are not persisted in session history");
@@ -37,8 +50,22 @@ impl DefraSessionHook {
             }
         };
 
-        let content = serde_json::to_string(message)?;
-        session::save_message(&self.node, &session_id, sequence, role, &content).await?;
+        match message_key {
+            Some(message_key) => {
+                session::save_message_with_key(
+                    &self.node,
+                    &session_id,
+                    sequence,
+                    role,
+                    &content,
+                    &message_key,
+                )
+                .await?;
+            }
+            None => {
+                session::save_message(&self.node, &session_id, sequence, role, &content).await?;
+            }
+        }
         Ok(sequence)
     }
 
@@ -366,6 +393,39 @@ fn render_tool_result_text(tool_result: &ToolResult) -> String {
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+fn tool_result_message_key(session_id: &str, message: &Message) -> anyhow::Result<Option<String>> {
+    let Message::User { content } = message else {
+        return Ok(None);
+    };
+    if content.len() != 1 {
+        return Ok(None);
+    }
+    let UserContent::ToolResult(tool_result) = content.first_ref() else {
+        return Ok(None);
+    };
+
+    let Some(logical_id) = non_empty(Some(tool_result.id.as_str()))
+        .or_else(|| non_empty(tool_result.call_id.as_deref()))
+    else {
+        return Ok(None);
+    };
+    let content_json = serde_json::to_string(&tool_result.content)?;
+    Ok(Some(format!(
+        "{session_id}:tool-result:{:016x}:{:016x}",
+        stable_hash(logical_id.as_bytes()),
+        stable_hash(content_json.as_bytes())
+    )))
+}
+
+fn stable_hash(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
 }
 
 /// Classify a runtime error string into a FailureClass. Defaults to

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -68,6 +68,7 @@ fn session_state_for_test() -> SessionState {
         sequence: 0,
         transcript_turn: TranscriptTurnState::Idle,
         persisted_tool_result_keys: std::collections::HashSet::new(),
+        persisted_tool_result_message_sequences: std::collections::HashMap::new(),
         tool_result_identities: std::collections::HashMap::new(),
         initialized: true,
     }
@@ -989,6 +990,236 @@ async fn streaming_turn_persists_full_assistant_history_in_sequence() {
         row.get("status").and_then(|value| value.as_str()),
         Some("completed")
     );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn duplicate_tool_result_message_observation_reuses_transcript_row() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-hook-tool-result-message-dedupe-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(
+            &hook,
+            &user_text_message("Inspect /tmp/main.rs"),
+            &[]
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    let stored_call_id = "OaoTQYzCdoptKiK_mdhBA";
+    let model_result_id = "c6b8bdeb-ab92-4481-b763-bdafbd463904";
+    let tool_args = r#"{"file_path":"/tmp/main.rs"}"#;
+    let tool_result_text = "fn main() {}\n";
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(
+            &hook,
+            "read",
+            Some(model_result_id.to_string()),
+            stored_call_id,
+            tool_args,
+        )
+        .await,
+        ToolCallHookAction::Continue
+    ));
+
+    hook.persist_message(&Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+            id: model_result_id.to_string(),
+            call_id: Some(model_result_id.to_string()),
+            function: ToolFunction {
+                name: "read".to_string(),
+                arguments: json!({ "file_path": "/tmp/main.rs" }),
+            },
+            signature: None,
+            additional_params: None,
+        })),
+    })
+    .await
+    .unwrap();
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_result(
+            &hook,
+            "read",
+            Some(model_result_id.to_string()),
+            stored_call_id,
+            tool_args,
+            tool_result_text,
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    let duplicate_tool_result_message = Message::User {
+        content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+            id: model_result_id.to_string(),
+            call_id: Some(model_result_id.to_string()),
+            content: OneOrMany::one(ToolResultContent::Text(Text {
+                text: tool_result_text.to_string(),
+            })),
+        })),
+    };
+    let reused_sequence = hook
+        .persist_message(&duplicate_tool_result_message)
+        .await
+        .unwrap();
+    assert_eq!(
+        reused_sequence, 3,
+        "a duplicate observation must reuse the first tool-result message sequence"
+    );
+
+    let session_id = hook.session_id().await.expect("session id");
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    assert_eq!(
+        history.len(),
+        3,
+        "transcript should contain user prompt, assistant tool call, and one tool result"
+    );
+
+    let tool_results = history
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => match content.first_ref() {
+                UserContent::ToolResult(tool_result) => Some(tool_result),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        tool_results.len(),
+        1,
+        "one logical tool result must materialize as one transcript message"
+    );
+    assert_eq!(tool_results[0].id, model_result_id);
+    assert_eq!(tool_results[0].call_id.as_deref(), Some(model_result_id));
+    assert!(matches!(
+        tool_results[0].content.first_ref(),
+        ToolResultContent::Text(Text { text }) if text == tool_result_text
+    ));
+
+    let resp = node
+        .execute(&format!(
+            r#"{{
+                AgentToolCall(filter: {{ session_id: {{ _eq: "{session_id}" }} }}) {{
+                    tool_call_key
+                    tool_call_id
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "query tool calls failed: {:?}",
+        resp.errors
+    );
+    let tool_call_rows = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| value.as_array())
+        .cloned()
+        .expect("tool call rows");
+    assert_eq!(tool_call_rows.len(), 1);
+    let tool_call_keys = tool_call_rows
+        .iter()
+        .filter_map(|row| row.get("tool_call_key").and_then(|value| value.as_str()))
+        .collect::<std::collections::HashSet<_>>();
+    let tool_call_ids = tool_call_rows
+        .iter()
+        .filter_map(|row| row.get("tool_call_id").and_then(|value| value.as_str()))
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(tool_call_keys.len(), 1);
+    assert_eq!(tool_call_ids.len(), 1);
+    assert_eq!(tool_call_ids.iter().next().copied(), Some(stored_call_id));
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn tool_result_message_dedupe_preserves_distinct_result_ids() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-hook-tool-result-distinct-message-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(
+            &hook,
+            &user_text_message("Run two tools"),
+            &[]
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    for result_id in ["result-1", "result-2"] {
+        hook.persist_message(&Message::User {
+            content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+                id: result_id.to_string(),
+                call_id: Some(result_id.to_string()),
+                content: OneOrMany::one(ToolResultContent::Text(Text {
+                    text: "same payload".to_string(),
+                })),
+            })),
+        })
+        .await
+        .unwrap();
+    }
+
+    let session_id = hook.session_id().await.expect("session id");
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    let tool_results = history
+        .iter()
+        .filter_map(|message| match message {
+            Message::User { content } => match content.first_ref() {
+                UserContent::ToolResult(tool_result) => Some(tool_result.id.as_str()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(tool_results, vec!["result-1", "result-2"]);
 
     let _ = std::fs::remove_dir_all(&data_path);
 }

--- a/crates/defra-agent/src/session.rs
+++ b/crates/defra-agent/src/session.rs
@@ -30,7 +30,7 @@ pub(crate) use conversation::{
 };
 pub use fork::{fork, ForkError, ForkOutcome, ForkParams};
 pub use history::load_history;
-pub(crate) use history::{mark_response_materialized, save_message};
+pub(crate) use history::{mark_response_materialized, save_message, save_message_with_key};
 pub(crate) use query::load_session_behavior_id;
 pub use retry::count_active_sessions;
 pub(crate) use retry::execute_mutation_with_retry;

--- a/crates/defra-agent/src/session/history.rs
+++ b/crates/defra-agent/src/session/history.rs
@@ -53,18 +53,50 @@ pub(crate) async fn save_message(
     role: &str,
     content: &str,
 ) -> Result<()> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let message_key = format!("{escaped_session_id}:{sequence}");
+    save_message_inner(node, session_id, sequence, role, content, &message_key).await
+}
+
+pub(crate) async fn save_message_with_key(
+    node: &EmbeddedNode,
+    session_id: &str,
+    sequence: u32,
+    role: &str,
+    content: &str,
+    message_key: &str,
+) -> Result<()> {
+    let escaped_message_key = escape_graphql_string(message_key);
+    save_message_inner(
+        node,
+        session_id,
+        sequence,
+        role,
+        content,
+        &escaped_message_key,
+    )
+    .await
+}
+
+async fn save_message_inner(
+    node: &EmbeddedNode,
+    session_id: &str,
+    sequence: u32,
+    role: &str,
+    content: &str,
+    escaped_message_key: &str,
+) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     let escaped = escape_graphql_string(content);
     let escaped_session_id = escape_graphql_string(session_id);
     let escaped_role = escape_graphql_string(role);
-    let message_key = format!("{escaped_session_id}:{sequence}");
 
     let mutation = format!(
         r#"mutation {{
             upsert_AgentMessage(
-                filter: {{ message_key: {{ _eq: "{message_key}" }} }},
+                filter: {{ message_key: {{ _eq: "{escaped_message_key}" }} }},
                 add: {{
-                    message_key: "{message_key}",
+                    message_key: "{escaped_message_key}",
                     session_id: "{escaped_session_id}",
                     sequence: {sequence},
                     role: "{escaped_role}",


### PR DESCRIPTION
Fixes #156.\n\n## Summary\n- add transcript-boundary idempotency for persisted tool-result user messages using a deterministic message key derived from session, logical result id, and tool-result payload\n- preserve the existing stream/hook alias dedupe while making duplicate AgentMessage writes collapse through AgentMessage.message_key upsert\n- add regression coverage for a duplicate post-PR-158 tool-result message observation and a guard that distinct result IDs with identical payloads remain distinct\n\n## Verification\n- cargo test -p defra-agent tool_result_message -- --nocapture\n- cargo test -p defra-agent duplicate_tool_result_message_observation_reuses_transcript_row -- --nocapture\n- cargo test -p defra-agent hook::tests::streaming_turn_persists_full_assistant_history_in_sequence -- --nocapture\n- cargo test -p defra-agent hook::tests::tool_call_after_saved_assistant_starts_new_turn_without_orphan_result -- --nocapture\n- cargo test -p defra-agent agent::stream_processor::tests -- --nocapture\n- cargo test -p defra-agent session::tests -- --nocapture\n- cargo test -p defra-agent --test tool_call_lifecycle_conformance -- --nocapture\n- cargo test -p defra-agent completion_response_marks_agent_response_as_materialized -- --nocapture\n- cargo test -p defra-agent --test fork_invariants -- --nocapture\n- cargo fmt --all -- --check\n- git diff --check\n\nNo production manifests were changed. No Lean/proof files were touched, so lake build was not required. A broad hook::tests run was intentionally stopped after it began building Lean contract tests unrelated to this Rust-only change.