### PR TITLE
Complete tool-call runtime lifecycle closure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-subagent-v2-to-v3-lens"
+version = "0.1.0"
+dependencies = [
+ "lens_sdk",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "agent-tool-call-lifecycle-v1-to-v2-lens"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/defra-agent-desktop",
     "crates/defra-agent-desktop-core",
     "crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2",
+    "crates/defra-agent-lenses/agent_subagent_v2_to_v3",
     "crates/defra-agent-protocol",
 ]
 # Exclude the WASM lens crate from default workspace builds. Its cdylib target

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -33,6 +33,10 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         enable_meta_tools: Some(args.enable_meta_tools),
         allowed_mcp_service_ids: Some(args.allowed_mcp_service_ids.clone()),
         delegate_to: Some(args.delegate_to.clone()),
+        subagent_targets: Some(Vec::new()),
+        subagent_spawn_enabled: Some(false),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(false),
     };
     let doc_id = write_tool_selection_document(&access, &selection).await?;
     let output = json!({

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -542,6 +542,10 @@ fn standard_tool_selection(
         enable_meta_tools: Some(true),
         allowed_mcp_service_ids: Some(Vec::new()),
         delegate_to: Some(Vec::new()),
+        subagent_targets: Some(Vec::new()),
+        subagent_spawn_enabled: Some(false),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(false),
     }
 }
 

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -127,6 +127,7 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
     );
     ensure_runtime_schemas(node.as_ref()).await?;
     defra_agent::migration::ensure_tool_call_migrations(node.clone()).await?;
+    defra_agent::migration::ensure_subagent_extensions_migrations(node.clone()).await?;
     let (ready_tx, mut ready_rx) = watch::channel(ProcessLifecycleState::Uninitialized);
 
     let agent = DefraAgent::from_default_behavior_documents(

--- a/crates/defra-agent-cli/tests/cli_trace_export.rs
+++ b/crates/defra-agent-cli/tests/cli_trace_export.rs
@@ -215,7 +215,7 @@ async fn trace_export_emits_amy_style_jsonl_and_classifies_completed_failures() 
         deadline
             .get("request_failure_class")
             .and_then(Value::as_str),
-        Some("deadline_or_inference_failure")
+        Some("external")
     );
     assert_eq!(
         deadline.get("request_status").and_then(Value::as_str),

--- a/crates/defra-agent-lenses/agent_subagent_v2_to_v3/Cargo.toml
+++ b/crates/defra-agent-lenses/agent_subagent_v2_to_v3/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "agent-subagent-v2-to-v3-lens"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+lens_sdk = "^0.8"

--- a/crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs
+++ b/crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs
@@ -1,0 +1,99 @@
+//! Lens v2→v3: adds subagent extensions to AgentToolCall, AgentRequest,
+//! and ToolSelection. Forward transform populates new fields with their
+//! defaults; inverse transform drops them for P2P backward-compat.
+//!
+//! Operates over the same JSON-document iterator API as the v1→v2 lens.
+
+use std::collections::HashMap;
+use std::error::Error;
+
+use lens_sdk::StreamOption;
+use serde_json::Value;
+
+lens_sdk::define!(try_transform, try_inverse);
+
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    for item in iter {
+        let mut doc = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
+
+        // Detect collection by shape-unique fields. Transforms are commutative
+        // (or_insert never overwrites existing values), so a doc matching
+        // multiple heuristics is handled safely.
+
+        // AgentToolCall: uniquely identified by tool_call_key.
+        if doc.contains_key("tool_call_key") {
+            doc.entry("await_mode".to_string())
+                .or_insert(Value::String("foreground".to_string()));
+            doc.entry("cancel_policy".to_string())
+                .or_insert(Value::String("cascade".to_string()));
+            doc.entry("child_request_id".to_string())
+                .or_insert(Value::Null);
+            doc.entry("request_id".to_string()).or_insert(Value::Null);
+        }
+
+        // AgentRequest: has request_id AND agent_did (distinguishes from
+        // AgentToolCall which also gains request_id in v3).
+        if doc.contains_key("request_id") && doc.contains_key("agent_did") {
+            doc.entry("subagent_depth".to_string())
+                .or_insert(Value::Number(0.into()));
+            doc.entry("caused_by_parent_request_id".to_string())
+                .or_insert(Value::Null);
+            doc.entry("caused_by_parent_tool_call_id".to_string())
+                .or_insert(Value::Null);
+        }
+
+        // ToolSelection: uniquely identified by selection_id.
+        if doc.contains_key("selection_id") {
+            doc.entry("subagent_targets".to_string())
+                .or_insert(Value::Array(Vec::new()));
+            doc.entry("subagent_spawn_enabled".to_string())
+                .or_insert(Value::Bool(false));
+            doc.entry("subagent_steering_enabled".to_string())
+                .or_insert(Value::Bool(false));
+            doc.entry("subagent_background_enabled".to_string())
+                .or_insert(Value::Bool(false));
+        }
+
+        return Ok(StreamOption::Some(doc));
+    }
+    Ok(StreamOption::EndOfStream)
+}
+
+fn try_inverse(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    for item in iter {
+        let mut doc = match item? {
+            Some(v) => v,
+            None => return Ok(StreamOption::None),
+        };
+
+        // Drop all v3-only fields for P2P backward-compat with v2 nodes.
+        for field in &[
+            // AgentToolCall
+            "await_mode",
+            "cancel_policy",
+            "child_request_id",
+            "request_id",
+            // AgentRequest
+            "subagent_depth",
+            "caused_by_parent_request_id",
+            "caused_by_parent_tool_call_id",
+            // ToolSelection
+            "subagent_targets",
+            "subagent_spawn_enabled",
+            "subagent_steering_enabled",
+            "subagent_background_enabled",
+        ] {
+            doc.remove(*field);
+        }
+
+        return Ok(StreamOption::Some(doc));
+    }
+    Ok(StreamOption::EndOfStream)
+}

--- a/crates/defra-agent-protocol/schemas/agent/agent_request.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_request.graphql
@@ -26,4 +26,7 @@ type AgentRequest @branchable {
     max_retries: Int
     interrupt_requested_at: String       # NEW: RFC3339; null until interrupt requested
     valid_until: String                  # NEW: RFC3339; null = no TTL
+    subagent_depth: Int
+    caused_by_parent_request_id: String @index
+    caused_by_parent_tool_call_id: String @index
 }

--- a/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
@@ -1,5 +1,6 @@
 type AgentToolCall @branchable {
     tool_call_key: String @index(unique: true)
+    request_id: String @index
     session_id: String @index
     message_sequence: Int
     tool_name: String @index
@@ -9,6 +10,7 @@ type AgentToolCall @branchable {
     status: String
     lifecycle_state: String @index
     started_at: DateTime
+    deadline_at: DateTime
     completed_at: DateTime
     selected_service_id: String
     selected_tool_name: String
@@ -17,5 +19,4 @@ type AgentToolCall @branchable {
     await_mode: String
     cancel_policy: String
     child_request_id: String @index
-    request_id: String @index
 }

--- a/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
@@ -14,4 +14,8 @@ type AgentToolCall @branchable {
     selected_tool_name: String
     tool_failure_class: String
     latency_ms: Int
+    await_mode: String
+    cancel_policy: String
+    child_request_id: String @index
+    request_id: String @index
 }

--- a/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
@@ -15,4 +15,8 @@ type ToolSelection {
     enable_meta_tools: Boolean
     allowed_mcp_service_ids: [String]
     delegate_to: [String]
+    subagent_targets: [String]
+    subagent_spawn_enabled: Boolean
+    subagent_steering_enabled: Boolean
+    subagent_background_enabled: Boolean
 }

--- a/crates/defra-agent/build.rs
+++ b/crates/defra-agent/build.rs
@@ -1,30 +1,37 @@
-//! Build the WASM lens artifact before defra-agent compiles, so
-//! migration.rs can `include_bytes!` it.
+//! Build the WASM lens artifacts before defra-agent compiles, so
+//! migration.rs can `include_bytes!` them.
 //!
 //! The WASM target requires the wasm32-unknown-unknown rust target. If it's
 //! not installed, this script prints a helpful error and fails.
 
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const LENS_PACKAGE: &str = "agent-tool-call-lifecycle-v1-to-v2-lens";
+const LENS_TOOL_CALL_PACKAGE: &str = "agent-tool-call-lifecycle-v1-to-v2-lens";
+const LENS_SUBAGENT_PACKAGE: &str = "agent-subagent-v2-to-v3-lens";
 
 fn main() {
-    // Re-run this build script if the lens crate's source changes.
     let workspace_root = workspace_root();
-    let lens_dir = workspace_root
-        .join("crates")
-        .join("defra-agent-lenses")
-        .join("agent_tool_call_lifecycle_v1_to_v2");
-    println!(
-        "cargo:rerun-if-changed={}",
-        lens_dir.join("src").join("lib.rs").display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        lens_dir.join("Cargo.toml").display()
-    );
+
+    // Re-run this build script if either lens crate's source changes.
+    for (subdir, _pkg) in [
+        ("agent_tool_call_lifecycle_v1_to_v2", LENS_TOOL_CALL_PACKAGE),
+        ("agent_subagent_v2_to_v3", LENS_SUBAGENT_PACKAGE),
+    ] {
+        let lens_dir = workspace_root
+            .join("crates")
+            .join("defra-agent-lenses")
+            .join(subdir);
+        println!(
+            "cargo:rerun-if-changed={}",
+            lens_dir.join("src").join("lib.rs").display()
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            lens_dir.join("Cargo.toml").display()
+        );
+    }
 
     // Skip the WASM build when running rustdoc or in environments without the
     // wasm32 target. The result is a build that compiles defra-agent for
@@ -33,28 +40,51 @@ fn main() {
     // for `cargo doc` and similar local-dev paths; production builds always
     // have the WASM target.
     if env::var("DEFRA_AGENT_SKIP_LENS_BUILD").is_ok() {
-        // Emit a stub so include_bytes! has something to find.
-        emit_stub_artifact(&workspace_root);
+        emit_stub_artifact(
+            &workspace_root,
+            "AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH",
+            "tool_call_lens_stub.wasm",
+        );
+        emit_stub_artifact(
+            &workspace_root,
+            "AGENT_SUBAGENT_V2_TO_V3_LENS_WASM_PATH",
+            "subagent_lens_stub.wasm",
+        );
         return;
     }
 
+    build_lens(
+        &workspace_root,
+        LENS_TOOL_CALL_PACKAGE,
+        "agent_tool_call_lifecycle_v1_to_v2_lens.wasm",
+        "AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH",
+    );
+    build_lens(
+        &workspace_root,
+        LENS_SUBAGENT_PACKAGE,
+        "agent_subagent_v2_to_v3_lens.wasm",
+        "AGENT_SUBAGENT_V2_TO_V3_LENS_WASM_PATH",
+    );
+}
+
+fn build_lens(workspace_root: &Path, pkg: &str, artifact_name: &str, env_var: &str) {
     let status = Command::new("cargo")
         .args([
             "build",
             "-p",
-            LENS_PACKAGE,
+            pkg,
             "--target",
             "wasm32-unknown-unknown",
             "--release",
         ])
-        .current_dir(&workspace_root)
+        .current_dir(workspace_root)
         .status();
 
     let status = match status {
         Ok(s) => s,
         Err(err) => {
             panic!(
-                "failed to invoke cargo to build {LENS_PACKAGE}: {err}.\n\
+                "failed to invoke cargo to build {pkg}: {err}.\n\
                  If the wasm32-unknown-unknown target is not installed, run:\n\
                  \trustup target add wasm32-unknown-unknown\n\
                  To skip the lens build (e.g. for `cargo doc`), set \
@@ -65,7 +95,7 @@ fn main() {
 
     if !status.success() {
         panic!(
-            "cargo build for {LENS_PACKAGE} failed (status {status}).\n\
+            "cargo build for {pkg} failed (status {status}).\n\
              If the wasm32-unknown-unknown target is missing, run:\n\
              \trustup target add wasm32-unknown-unknown"
         );
@@ -75,7 +105,7 @@ fn main() {
         .join("target")
         .join("wasm32-unknown-unknown")
         .join("release")
-        .join("agent_tool_call_lifecycle_v1_to_v2_lens.wasm");
+        .join(artifact_name);
 
     if !artifact.exists() {
         panic!(
@@ -84,11 +114,7 @@ fn main() {
         );
     }
 
-    // Emit the artifact path for migration.rs to include_bytes! against.
-    println!(
-        "cargo:rustc-env=AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH={}",
-        artifact.display()
-    );
+    println!("cargo:rustc-env={}={}", env_var, artifact.display());
 }
 
 fn workspace_root() -> PathBuf {
@@ -101,18 +127,15 @@ fn workspace_root() -> PathBuf {
         .to_path_buf()
 }
 
-fn emit_stub_artifact(workspace_root: &PathBuf) {
+fn emit_stub_artifact(workspace_root: &Path, env_var: &str, stub_name: &str) {
     // Write a minimal valid WASM module to a build-out path so include_bytes!
     // succeeds; the runtime will refuse to use it.
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"));
-    let stub_path = out_dir.join("lens_stub.wasm");
+    let stub_path = out_dir.join(stub_name);
     // Minimal valid WASM module header: magic + version.
     let bytes: [u8; 8] = [0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00];
     std::fs::write(&stub_path, bytes).expect("write stub WASM");
-    println!(
-        "cargo:rustc-env=AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH={}",
-        stub_path.display()
-    );
+    println!("cargo:rustc-env={}={}", env_var, stub_path.display());
     println!("cargo:warning=DEFRA_AGENT_SKIP_LENS_BUILD set; using stub WASM (lens will not function at runtime).");
 
     let _ = workspace_root; // suppress unused warning

--- a/crates/defra-agent/examples/serve_default_behavior.rs
+++ b/crates/defra-agent/examples/serve_default_behavior.rs
@@ -136,6 +136,10 @@ async fn seed_demo_documents(
             enable_meta_tools: Some(true),
             allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
+            subagent_targets: Some(Vec::new()),
+            subagent_spawn_enabled: Some(false),
+            subagent_steering_enabled: Some(false),
+            subagent_background_enabled: Some(false),
         },
     )
     .await?;

--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -14,6 +14,7 @@ import Proofs.Client
 import Proofs.ClientShell
 import Proofs.CommandPolicy
 import Proofs.ToolExecution
+import Proofs.Subagent
 import Proofs.Properties.Safety
 import Proofs.Properties.Decidable
 import Proofs.Properties.Liveness

--- a/crates/defra-agent/proofs/Proofs/Composed.lean
+++ b/crates/defra-agent/proofs/Proofs/Composed.lean
@@ -12,23 +12,52 @@ single-execution composed state.
 -/
 
 /-- The composed state of all single-execution layers, including the
-    optional in-flight tool call. -/
+    list of concurrently-live in-flight tool calls.
+
+    Multi-flight: a single composed state may carry multiple
+    `ToolCallContext`s simultaneously (e.g., a foreground tool waiting on a
+    background subagent in a sibling slot). Single-flight is the special
+    case `tools = [t]`. -/
 structure ComposedState where
   requestId : RequestId
   process : ProcessState
   request : RequestContext
   call : InferenceCall
-  tool : Option ToolExecution.ToolCallContext := none
+  tools : List ToolExecution.ToolCallContext := []
   deriving Repr
 
 namespace ComposedState
 
-/-- Structural coherence between a composed state and its in-flight tool
-    call: the tool's identifier, deadline, and clock track the parent request.
-    Promoted from inline conjuncts in the original `tool_step` constructor and
-    C1/C1'/C2 theorem signatures. Future work (B4 persistent processes) will
-    introduce a complementary `Persistent` coherence predicate; the bound case
-    will keep this shape so existing theorem bodies don't need to change. -/
+/-- A tool is linked to this composed state if it is in the tools list. -/
+def hasToolByCallId (s : ComposedState) (callId : ToolExecution.ToolCallId) : Prop :=
+  ∃ t ∈ s.tools, t.callId = callId
+
+instance (s : ComposedState) (callId : ToolExecution.ToolCallId) :
+    Decidable (s.hasToolByCallId callId) := by
+  unfold hasToolByCallId; infer_instance
+
+/-- The first tool with a given callId, if any. CallIds are intended to be
+    unique within a composed state, but we don't enforce that as a Prop here
+    — Tasks 7+ will introduce a `UniqueCallIds` invariant alongside the
+    multi-flight C-theorems if needed. -/
+def findToolByCallId (s : ComposedState) (callId : ToolExecution.ToolCallId) :
+    Option ToolExecution.ToolCallContext :=
+  s.tools.find? (fun t => t.callId = callId)
+
+/-- Structural coherence between a composed state and one of its in-flight
+    tool calls: the tool's identifier, deadline, and clock track the parent
+    request. Promoted from inline conjuncts in the original `tool_step`
+    constructor and C1/C1'/C2 theorem signatures.
+
+    The predicate is per-tool: `Coherent pre toolPre` says `toolPre` (one
+    element of `pre.tools`) is structurally synced with `pre.request`. The
+    multi-flight `tool_step` constructor applies it to the single tool being
+    stepped. A list-level "all tools coherent" form, if needed by Tasks 7+,
+    can be expressed as `∀ t ∈ pre.tools, Coherent pre t`.
+
+    Future work (B4 persistent processes) will introduce a complementary
+    `Persistent` coherence predicate; the bound case will keep this shape so
+    existing theorem bodies don't need to change. -/
 def Coherent (pre : ComposedState) (toolPre : ToolExecution.ToolCallContext) : Prop :=
   toolPre.requestId = pre.requestId ∧
   toolPre.deadline = pre.request.deadline ∧
@@ -47,16 +76,26 @@ inductive Transition : ComposedState → ComposedState → Prop where
       ProcessState.Transition pre.process post.process →
       post.request = pre.request →
       post.call = pre.call →
-      post.tool = pre.tool →
+      post.tools = pre.tools →
       post.requestId = pre.requestId →
       Transition pre post
   | request_step {pre post : ComposedState} :
       RequestContext.Transition pre.request post.request →
       post.process = pre.process →
       post.call = pre.call →
-      post.tool = pre.tool →
+      post.tools = pre.tools →
       post.requestId = pre.requestId →
       (pre.request.state = .pending → pre.process.acceptsWork) →
+      -- INV-FG (scoped): foreground-blocking guard. If the inner request
+      -- transition is `advance` (progressSeq strictly increases) or
+      -- `begin_inference` (claimed → processing), no foreground tool may be
+      -- non-terminal. Other transitions (interrupt_*, fail, expire) are
+      -- unaffected — the antecedent is false and the implication is
+      -- vacuously discharged.
+      (post.request.progressSeq > pre.request.progressSeq ∨
+        (pre.request.state = .claimed ∧ post.request.state = .processing) →
+        ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧
+                            ¬ isTerminal t.state) →
       Transition pre post
   | persistence_step {pre post : ComposedState} (policy : PersistenceState.FailurePolicy)
       (nextPersistence : PersistenceState) :
@@ -64,26 +103,40 @@ inductive Transition : ComposedState → ComposedState → Prop where
       post.request = { pre.request with persistence := nextPersistence } →
       post.process = pre.process →
       post.call = pre.call →
-      post.tool = pre.tool →
+      post.tools = pre.tools →
       post.requestId = pre.requestId →
       Transition pre post
   | call_step {pre post : ComposedState} :
       InferenceCall.Transition pre.call post.call →
       post.request = pre.request →
       post.process = pre.process →
-      post.tool = pre.tool →
+      post.tools = pre.tools →
       post.requestId = pre.requestId →
       Transition pre post
-  | tool_step {pre post : ComposedState} {toolPre toolPost : ToolExecution.ToolCallContext} :
-      pre.tool = some toolPre →
+  | tool_step {pre post : ComposedState} {idx : Nat}
+              {toolPre toolPost : ToolExecution.ToolCallContext} :
+      pre.tools[idx]? = some toolPre →
       ToolExecution.ToolCallContext.Transition toolPre toolPost →
-      post.tool = some toolPost →
+      post.tools = pre.tools.set idx toolPost →
       post.request = pre.request →
       post.process = pre.process →
       post.call = pre.call →
       post.requestId = pre.requestId →
-      -- structural composition guard: tool tracks the parent request
+      -- structural composition guard: the stepping tool tracks the parent
+      -- request. Other tools in `pre.tools` are unconstrained at this
+      -- layer; Tasks 7+ may add list-level invariants if needed.
       Coherent pre toolPre →
+      -- INV-FG composition guard: a background → foreground flip is only
+      -- legal when the pre-state has no other foreground non-terminal tool.
+      -- The antecedent fires only for the inner `foreground` constructor
+      -- (the lone constructor that flips awaitMode background → foreground);
+      -- every other inner transition either preserves awaitMode or already
+      -- requires foreground in the pre-state, so the antecedent is false
+      -- and the implication is vacuously discharged. Together with INV-FG
+      -- itself (count ≤ 1), this guard makes `invFG_preserved` provable.
+      (toolPre.awaitMode = .background → toolPost.awaitMode = .foreground →
+        ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧
+                            ¬ isTerminal t.state) →
       Transition pre post
 
 /-- A trace is a sequence of valid composed transitions. -/
@@ -117,7 +170,7 @@ def initial : ComposedState :=
     , backend := { val := "initial-backend" }
     , state := .queued
     }
-  , tool := none
+  , tools := []
   }
 
 /-!
@@ -163,153 +216,516 @@ theorem interrupted_request_cancels_live_linked_call
   · exact InferenceCall.cancel_state pre.call
 
 
-/-- C2: An interrupted request cancels every live linked tool call.
-    Mirror of `interrupted_request_cancels_live_linked_call`.
-
-    Note: `h_interrupted` is documentary — the underlying cancel transitions
-    (`cancelBeforeDispatch`, `cancelDuringRun`) have no precondition on the
-    parent request's state. The hypothesis captures the operational context
-    that motivated the theorem rather than a proof-relevant constraint. -/
-theorem interrupted_request_cancels_live_linked_tool
+/-- C2: An interrupted request cancels every live linked tool call. -/
+theorem interrupted_request_cancels_live_linked_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
-    (h_tool        : pre.tool = some toolPre)
-    (h_interrupted : pre.request.state = .interrupted)
-    (h_linked      : toolPre.linkedTo pre.requestId)
-    (h_live        : toolPre.cancellable)
-    (h_synced      : Coherent pre toolPre) :
+    (h_in           : toolPre ∈ pre.tools)
+    (h_interrupted  : pre.request.state = .interrupted)  -- documentary, tracked by #153
+    (h_live         : toolPre.cancellable)
+    (h_coherent     : Coherent pre toolPre) :
     ∃ post toolPost,
       Trace pre post ∧
-      post.tool = some toolPost ∧
-      post.request = pre.request ∧
+      toolPost ∈ post.tools ∧
       toolPost.state = .cancelled ∧
-      toolPost.linkedTo pre.requestId := by
-  -- Case-split on toolPre.state via h_live (which is .pending ∨ .running).
-  rcases h_live with h_pending | h_running
-  · -- Pending → cancelBeforeDispatch → Cancelled
-    let toolPost : ToolExecution.ToolCallContext :=
-      { toolPre with state := .cancelled }
-    let post : ComposedState := { pre with tool := some toolPost }
-    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre toolPost :=
-      ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch
-        (h_state := h_pending) (h_post := rfl)
-    have h_step : Transition pre post :=
-      Transition.tool_step h_tool h_t_step rfl rfl rfl rfl rfl h_synced
-    refine ⟨post, toolPost, Trace.step h_step Trace.refl, rfl, rfl, rfl, ?_⟩
-    unfold ToolExecution.ToolCallContext.linkedTo at *
-    exact h_linked
-  · -- Running → cancelDuringRun → Cancelled
-    let toolPost : ToolExecution.ToolCallContext :=
-      { toolPre with state := .cancelled }
-    let post : ComposedState := { pre with tool := some toolPost }
-    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre toolPost :=
-      ToolExecution.ToolCallContext.Transition.cancelDuringRun
-        (h_state := h_running) (h_post := rfl)
-    have h_step : Transition pre post :=
-      Transition.tool_step h_tool h_t_step rfl rfl rfl rfl rfl h_synced
-    refine ⟨post, toolPost, Trace.step h_step Trace.refl, rfl, rfl, rfl, ?_⟩
-    unfold ToolExecution.ToolCallContext.linkedTo at *
-    exact h_linked
+      toolPost.requestId = pre.requestId := by
+  obtain ⟨h_linked, h_deadline_eq, h_time_eq⟩ := h_coherent
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_getElem?.mp h_in
+  -- Case-split on cancellable: pending → cancelBeforeDispatch; running → cancelDuringRun
+  cases h_live with
+  | inl h_pending =>
+    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                      { toolPre with state := .cancelled } :=
+      ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+    let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
+    let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    · refine Trace.step ?_ Trace.refl
+      -- Discharge the foreground-flip guard: `cancelBeforeDispatch` only changes
+      -- `state`, so `toolPost.awaitMode = toolPre.awaitMode`. If `toolPre` is
+      -- background, `toolPost` is too — the consequent is unreachable.
+      refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
+              ⟨h_linked, h_deadline_eq, h_time_eq⟩
+              (fun h_bg h_fg => ?_)
+      simp [toolPost, h_bg] at h_fg
+    · have h_lt : idx < pre.tools.length := (List.getElem?_eq_some_iff.mp h_idx).1
+      simpa [post, toolPost] using List.mem_set pre.tools idx h_lt toolPost
+  | inr h_running =>
+    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                      { toolPre with state := .cancelled } :=
+      ToolExecution.ToolCallContext.Transition.cancelDuringRun h_running rfl
+    let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
+    let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    · refine Trace.step ?_ Trace.refl
+      refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
+              ⟨h_linked, h_deadline_eq, h_time_eq⟩
+              (fun h_bg h_fg => ?_)
+      simp [toolPost, h_bg] at h_fg
+    · have h_lt : idx < pre.tools.length := (List.getElem?_eq_some_iff.mp h_idx).1
+      simpa [post, toolPost] using List.mem_set pre.tools idx h_lt toolPost
 
 
-/-- C1: A request whose deadline is exceeded times out a Running linked
-    tool call via the timeout transition. The composition theorem whose
-    absence in the runtime caused issue #149. -/
-theorem deadline_exceeded_request_timesOut_running_tool
+/-- C1: A request whose deadline is exceeded times out every Running linked
+    tool. Multi-flight form: any tool ∈ pre.tools that is running, linked, and
+    deadline-synced reaches .timedOut. The composition theorem whose absence
+    in the runtime caused issue #149. -/
+theorem deadline_exceeded_request_timesOut_running_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
-    (h_tool     : pre.tool = some toolPre)
-    (h_running  : toolPre.state = .running)
-    (h_linked   : toolPre.linkedTo pre.requestId)
-    (h_deadline : pre.request.deadlineExceeded)
-    (h_synced   : Coherent pre toolPre) :
+    (h_in        : toolPre ∈ pre.tools)
+    (h_running   : toolPre.state = .running)
+    (h_coherent  : Coherent pre toolPre)
+    (h_deadline  : pre.request.deadlineExceeded) :
     ∃ post toolPost,
       Trace pre post ∧
-      post.tool = some toolPost ∧
+      toolPost ∈ post.tools ∧
       post.request = pre.request ∧
       toolPost.state = .timedOut ∧
-      toolPost.linkedTo pre.requestId := by
-  -- Tool deadline is exceeded because the request deadline is exceeded
-  -- and they're synced.
-  have h_tool_deadline : toolPre.deadlineExceeded := by
-    unfold ToolExecution.ToolCallContext.deadlineExceeded
-    rw [h_synced.2.2, h_synced.2.1]
+      toolPost.requestId = pre.requestId := by
+  -- Destructure h_coherent into its three component equalities.
+  obtain ⟨h_linked, h_deadline_eq, h_time_eq⟩ := h_coherent
+  -- Find the index of toolPre in pre.tools.
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_getElem?.mp h_in
+  -- Apply the inner ToolCallContext.timeout transition on toolPre.
+  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                    { toolPre with state := .timedOut } := by
+    refine ToolExecution.ToolCallContext.Transition.timeout
+      h_running ?_ rfl
+    -- discharge deadlineExceeded for toolPre using h_coherent + h_deadline
+    show toolPre.currentTime > toolPre.deadline
+    rw [h_deadline_eq, h_time_eq]
     exact h_deadline
-  let toolPost : ToolExecution.ToolCallContext :=
-    { toolPre with state := .timedOut }
-  let post : ComposedState := { pre with tool := some toolPost }
-  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre toolPost :=
-    ToolExecution.ToolCallContext.Transition.timeout
-      (h_state := h_running) (h_deadline := h_tool_deadline) (h_post := rfl)
-  have h_step : Transition pre post :=
-    Transition.tool_step h_tool h_t_step rfl rfl rfl rfl rfl h_synced
-  refine ⟨post, toolPost, Trace.step h_step Trace.refl, rfl, rfl, rfl, ?_⟩
-  unfold ToolExecution.ToolCallContext.linkedTo at *
-  exact h_linked
+  -- Construct the post composed state by setting idx to the timed-out tool.
+  let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .timedOut }
+  let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+  refine ⟨post, toolPost, ?_, ?_, rfl, rfl, h_linked⟩
+  · -- One-step trace via tool_step
+    refine Trace.step ?_ Trace.refl
+    -- Pass h_coherent directly as the Coherent witness; discharge the
+    -- foreground-flip guard vacuously (timeout preserves awaitMode).
+    refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
+      ⟨h_linked, h_deadline_eq, h_time_eq⟩
+      (fun h_bg h_fg => ?_)
+    simp [toolPost, h_bg] at h_fg
+  · -- toolPost ∈ post.tools — follows from `pre.tools.set idx toolPost`
+    show toolPost ∈ pre.tools.set idx toolPost
+    have h_lt : idx < pre.tools.length :=
+      (List.getElem?_eq_some_iff.mp h_idx).1
+    exact List.mem_set pre.tools idx h_lt toolPost
 
 
-/-- C1': A request whose deadline is exceeded cancels a Pending linked tool
-    call. Companion to C1 — a Pending tool never ran, so it reaches
+/-- C1': A request whose deadline is exceeded cancels every Pending linked
+    tool. Companion to C1 — a Pending tool never ran, so it reaches
     .cancelled rather than .timedOut.
 
     Note: `h_deadline` is documentary — `cancelBeforeDispatch` has no deadline
     guard. The hypothesis captures the operational context (deadline-driven
-    cancellation path) rather than a proof-relevant constraint. -/
-theorem deadline_exceeded_request_cancels_pending_tool
+    cancellation path) rather than a proof-relevant constraint. Tracked under
+    issue #153 alongside C2/C3's documentary hypotheses for a future
+    CancelCause tightening pass. -/
+theorem deadline_exceeded_request_cancels_pending_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
-    (h_tool     : pre.tool = some toolPre)
-    (h_pending  : toolPre.state = .pending)
-    (h_linked   : toolPre.linkedTo pre.requestId)
-    (h_deadline : pre.request.deadlineExceeded)
-    (h_synced   : Coherent pre toolPre) :
+    (h_in        : toolPre ∈ pre.tools)
+    (h_pending   : toolPre.state = .pending)
+    (h_deadline  : pre.request.deadlineExceeded)
+    (h_coherent  : Coherent pre toolPre) :
     ∃ post toolPost,
       Trace pre post ∧
-      post.tool = some toolPost ∧
-      post.request = pre.request ∧
+      toolPost ∈ post.tools ∧
       toolPost.state = .cancelled ∧
-      toolPost.linkedTo pre.requestId := by
-  let toolPost : ToolExecution.ToolCallContext :=
-    { toolPre with state := .cancelled }
-  let post : ComposedState := { pre with tool := some toolPost }
-  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre toolPost :=
-    ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch
-      (h_state := h_pending) (h_post := rfl)
-  have h_step : Transition pre post :=
-    Transition.tool_step h_tool h_t_step rfl rfl rfl rfl rfl h_synced
-  refine ⟨post, toolPost, Trace.step h_step Trace.refl, rfl, rfl, rfl, ?_⟩
-  unfold ToolExecution.ToolCallContext.linkedTo at *
-  exact h_linked
+      toolPost.requestId = pre.requestId := by
+  obtain ⟨h_linked, h_deadline_eq, h_time_eq⟩ := h_coherent
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_getElem?.mp h_in
+  -- Inner cancelBeforeDispatch transition
+  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                    { toolPre with state := .cancelled } :=
+    ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+  let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
+  let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+  refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+  · refine Trace.step ?_ Trace.refl
+    refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
+            ⟨h_linked, h_deadline_eq, h_time_eq⟩
+            (fun h_bg h_fg => ?_)
+    simp [toolPost, h_bg] at h_fg
+  · -- toolPost ∈ post.tools via List.mem_set
+    have h_lt : idx < pre.tools.length := (List.getElem?_eq_some_iff.mp h_idx).1
+    simpa [post, toolPost] using List.mem_set pre.tools idx h_lt toolPost
 
 
-/-- C3: A request whose linked tool is terminal can resume making progress.
-    Semantic complement of issue #149: terminal tool ⇒ no daemon-side
-    blockage at the request layer.
-
-    The conclusion `post.request.state = .failed` is a concrete witness;
-    a stronger version would condition on persistence and reach `.completed`.
-    The current form is sufficient to demonstrate that the daemon is
-    unblocked. `h_tool` and `h_terminal` are documentary — the chosen
-    request-side transition (`fail`) is independent of the tool field. -/
-theorem terminal_tool_unblocks_request_progress
-    {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
-    (h_tool     : pre.tool = some toolPre)
-    (h_terminal : isTerminal toolPre.state)
-    (h_proc     : pre.request.state = .processing)
-    (h_admit    : pre.request.admission = .executing) :
-    ∃ post : ComposedState,
+/-- C3: A request whose linked tools are all terminal can resume making progress.
+    Multi-flight form: ∀-quantified over `pre.tools`. Semantic complement of
+    issue #149: when every linked tool is terminal, the foreground-blocking
+    guard on `request_step` is satisfied and the request can `advance`. -/
+theorem all_tools_terminal_unblocks_request_progress
+    {pre : ComposedState}
+    (h_all_terminal : ∀ t ∈ pre.tools, isTerminal t.state)
+    (h_proc         : pre.request.state = .processing)
+    (h_admission    : pre.request.admission = .executing) :
+    ∃ post,
       Transition pre post ∧
-      post.request.state = .failed := by
-  -- Use a request_step transition: processing → failed via the existing
-  -- RequestContext.Transition.fail constructor.
+      RequestContext.Transition pre.request post.request := by
+  -- Build the post-state by firing `advance` on the request layer.
   let postReq : RequestContext :=
-    { pre.request with state := .failed, admission := .released }
+    { pre.request with progressSeq := pre.request.progressSeq + 1 }
   let post : ComposedState := { pre with request := postReq }
-  have h_req_step : RequestContext.Transition pre.request postReq :=
-    RequestContext.Transition.fail h_proc h_admit rfl
-  have h_pending_guard : pre.request.state = .pending → pre.process.acceptsWork := by
-    intro h_eq
-    rw [h_proc] at h_eq
-    cases h_eq
-  have h_step : Transition pre post :=
-    Transition.request_step h_req_step rfl rfl rfl rfl h_pending_guard
-  exact ⟨post, h_step, rfl⟩
+  -- Inner advance transition.
+  have h_inner : RequestContext.Transition pre.request postReq :=
+    RequestContext.Transition.advance h_proc h_admission rfl
+  refine ⟨post, ?_, h_inner⟩
+  -- Build the request_step lift. After Task 11, request_step takes:
+  --   h_req, then 4 cross-layer rfls (process, call, tools, requestId),
+  --   then the pending→acceptsWork gate, then h_no_block.
+  refine Transition.request_step h_inner rfl rfl rfl rfl ?_ ?_
+  · -- Pending gate: pre.request.state = .processing, not .pending — the
+    -- antecedent is false, so the implication is vacuous.
+    intro h_pending
+    rw [h_proc] at h_pending
+    cases h_pending
+  · -- Discharge h_no_block: any candidate live-foreground tool is contradicted
+    -- by h_all_terminal directly.
+    intro _h_advance
+    intro ⟨t, h_in, _h_fg, h_nt⟩
+    exact h_nt (h_all_terminal t h_in)
+
+/-!
+## INV-FG: foreground-blocking structural invariant
+
+At most one foreground non-terminal tool may be live at any time per
+`ComposedState`. Combined with the scoped `h_no_block` guard on
+`request_step`, this gives the parent narrative the foreground-blocking
+property: while a foreground tool is in flight, `advance` /
+`begin_inference` cannot fire.
+
+INV-FG is a structural witness; no C-theorem currently consumes it. It is
+preserved across every composed transition. The four non-tool arms are
+trivial (they don't touch `tools`); the `tool_step` arm requires
+case-analysis on the inner `ToolCallContext.Transition`.
+-/
+
+/-- INV-FG: at most one foreground non-terminal tool per composed state. -/
+def invFG (s : ComposedState) : Prop :=
+  (s.tools.filter (fun t => decide (t.awaitMode = .foreground) ∧
+                              ¬ isTerminal t.state)).length ≤ 1
+
+/-- Helper: setting at index `i` to a value `b` whose filter classification is
+    implied by `a`'s never grows the filtered length. Concretely, if the new
+    element passes the predicate, the old one did too — so the filter can only
+    keep the same or fewer elements after `set`. -/
+private lemma length_filter_set_le {α : Type _} (p : α → Bool) :
+    ∀ (l : List α) (i : Nat) (a b : α),
+      l[i]? = some a →
+      (p b = true → p a = true) →
+      ((l.set i b).filter p).length ≤ (l.filter p).length := by
+  intro l
+  induction l with
+  | nil => intro i a b h _; simp at h
+  | cons x xs ih =>
+    intro i a b h_idx h_imp
+    cases i with
+    | zero =>
+      -- l[0] = x, so a = x. set 0 = b :: xs.
+      have hxa : x = a := by simpa using h_idx
+      subst hxa
+      simp only [List.set_cons_zero, List.filter_cons]
+      by_cases hb : p b = true
+      · -- p b true: both branches keep one element
+        have ha : p x = true := h_imp hb
+        simp [hb, ha]
+      · -- p b false: post drops the element
+        by_cases ha : p x = true
+        · rw [if_neg hb, if_pos ha, List.length_cons]; omega
+        · rw [if_neg hb, if_neg ha]
+    | succ j =>
+      -- Recurse on tail.
+      simp only [List.set_cons_succ, List.filter_cons]
+      have h_tail : xs[j]? = some a := by simpa using h_idx
+      have ih' : ((xs.set j b).filter p).length ≤ (xs.filter p).length :=
+        ih j a b h_tail h_imp
+      by_cases hx : p x = true
+      · rw [if_pos hx, if_pos hx, List.length_cons, List.length_cons]; omega
+      · rw [if_neg hx, if_neg hx]; exact ih'
+
+/-- Helper: setting at index `i` to a value `b` increases the filtered length
+    by at most one — the old element either passed the filter (count
+    unchanged or decreases) or didn't (count grows by ≤ 1). Together with
+    the foreground-flip guard's "pre count = 0" precondition, this bounds
+    `post.invFG` for the foreground constructor. -/
+private lemma length_filter_set_le_succ {α : Type _} (p : α → Bool) :
+    ∀ (l : List α) (i : Nat) (b : α),
+      ((l.set i b).filter p).length ≤ (l.filter p).length + 1 := by
+  intro l
+  induction l with
+  | nil => intro i b; simp
+  | cons x xs ih =>
+    intro i b
+    cases i with
+    | zero =>
+      simp only [List.set_cons_zero, List.filter_cons]
+      by_cases hb : p b = true
+      · by_cases hx : p x = true
+        · rw [if_pos hb, if_pos hx]; simp [List.length_cons]
+        · rw [if_pos hb, if_neg hx, List.length_cons]
+      · by_cases hx : p x = true
+        · rw [if_neg hb, if_pos hx, List.length_cons]; omega
+        · rw [if_neg hb, if_neg hx]; omega
+    | succ j =>
+      simp only [List.set_cons_succ, List.filter_cons]
+      have ih' : ((xs.set j b).filter p).length ≤ (xs.filter p).length + 1 :=
+        ih j b
+      by_cases hx : p x = true
+      · rw [if_pos hx, if_pos hx]; simp [List.length_cons]; omega
+      · rw [if_neg hx, if_neg hx]; exact ih'
+
+/-- INV-FG is preserved by any composed-state transition. -/
+theorem invFG_preserved
+    {pre post : ComposedState}
+    (h_inv  : pre.invFG)
+    (h_step : Transition pre post) :
+    post.invFG := by
+  cases h_step with
+  | process_step _ _ _ h_tools _ =>
+    unfold invFG; rw [h_tools]; exact h_inv
+  | request_step _ _ _ h_tools _ _ _ =>
+    unfold invFG; rw [h_tools]; exact h_inv
+  | persistence_step _ _ _ _ _ _ h_tools _ =>
+    unfold invFG; rw [h_tools]; exact h_inv
+  | call_step _ _ _ h_tools _ =>
+    unfold invFG; rw [h_tools]; exact h_inv
+  | @tool_step idx toolPre toolPost h_idx h_t_step h_tools _ _ _ _ _ h_fg_guard =>
+    -- A single tool transitions. Case-split on the inner ToolCallContext.Transition.
+    -- For all 11 non-`foreground` constructors: `toolPost.awaitMode = toolPre.awaitMode`
+    -- AND if toolPost passes the filter (foreground + non-terminal) then so does
+    -- toolPre. Hence by `length_filter_set_le`, post count ≤ pre count ≤ 1.
+    -- For `foreground`: the guard `h_fg_guard` fires, forcing the pre-state to
+    -- have no foreground non-terminal tool, i.e. `pre.filter ... = []`. By
+    -- `length_filter_set_le_succ`, post count ≤ 0 + 1 = 1.
+    unfold invFG
+    rw [h_tools]
+    set p : ToolExecution.ToolCallContext → Bool :=
+      fun t => decide (t.awaitMode = .foreground) ∧ ¬ isTerminal t.state with hp
+    -- Helper: every non-foreground inner constructor has the property that
+    -- p toolPost → p toolPre, so `length_filter_set_le` closes the case.
+    -- The `foreground` constructor is the lone exception, handled by the guard.
+    cases h_t_step with
+    | dispatch h_state h_post =>
+      -- toolPost = { toolPre with state := .running, ... }. awaitMode preserved.
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p ⊢
+      refine ⟨h_post_p.1, ?_⟩
+      intro h_term
+      rw [h_state] at h_term
+      rcases h_term with h' | h' | h' | h' <;> cases h'
+    | spawnFailed failure h_state h_post =>
+      -- toolPost.state = .failed (terminal); p toolPost = false.
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inl rfl)))
+    | complete h_state _ _ h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inl rfl))
+    | fail failure h_state h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inl rfl)))
+    | timeout h_state _ h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inr (Or.inl rfl))))
+    | cancelBeforeDispatch h_state h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inr (Or.inr rfl))))
+    | cancelDuringRun h_state h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp [hp, h_post] at h_post_p
+      exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inr (Or.inr rfl))))
+    | background h_state h_mode h_post =>
+      -- toolPost.awaitMode = .background; p toolPost = false (foreground required).
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      -- After simp, h_post_p will simplify to False (awaitMode = .background ≠ .foreground)
+      -- so this branch becomes unreachable; absurd via False.elim.
+      exfalso
+      simp [hp, h_post] at h_post_p
+    | foreground h_state h_mode h_post =>
+      -- The lone case where post passes the filter but pre doesn't. Use the
+      -- foreground-flip guard `h_fg_guard` to conclude pre's filter is empty.
+      have h_post_fg : toolPost.awaitMode = .foreground := by simp [h_post]
+      have h_no_other : ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧
+                            ¬ isTerminal t.state :=
+        h_fg_guard h_mode h_post_fg
+      have h_filter_nil : pre.tools.filter p = [] := by
+        rw [List.filter_eq_nil_iff]
+        intro t h_in h_pt
+        apply h_no_other
+        refine ⟨t, h_in, ?_, ?_⟩
+        · simp [hp] at h_pt; exact h_pt.1
+        · simp [hp] at h_pt; exact h_pt.2
+      have h_pre_zero : (pre.tools.filter p).length = 0 := by
+        rw [h_filter_nil]; rfl
+      have h_le := length_filter_set_le_succ p pre.tools idx toolPost
+      omega
+    | detach h_live h_pol h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      -- toolPost = { toolPre with cancelPolicy := .detach }; awaitMode and state preserved.
+      simp only [hp, h_post] at h_post_p ⊢
+      exact h_post_p
+    | timeAdvance t h_le h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp only [hp, h_post] at h_post_p ⊢
+      exact h_post_p
+    | persistenceStep policy next h_p_step h_post =>
+      refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
+      intro h_post_p
+      simp only [hp, h_post] at h_post_p ⊢
+      exact h_post_p
+
+/-!
+## UniqueCallIds: structural invariant on the tool list
+
+Every tool in `pre.tools` has a distinct `callId`. The runtime mints fresh
+callIds at spawn time and never reuses them, so this is a structural fact
+about any reachable state, not a conditional assumption.
+
+Used by `Subagent.Properties.detach_does_not_cancel_child` (B3') to discharge
+the cascade-vs-detach contradiction without taking callId-uniqueness as a
+hypothesis.
+-/
+
+/-- UniqueCallIds: every tool in the list has a distinct callId. -/
+def UniqueCallIds (s : ComposedState) : Prop :=
+  ∀ (i j : Nat) (h_i : i < s.tools.length) (h_j : j < s.tools.length),
+    s.tools[i].callId = s.tools[j].callId → i = j
+
+/-- Pairwise corollary: from UniqueCallIds, any two `∈ s.tools` tools with
+    the same callId are equal. The form consumed by B3' (cascade-vs-detach
+    contradiction) and similar pairwise-uniqueness arguments. -/
+theorem UniqueCallIds.eq_of_callId_eq
+    {s : ComposedState} (h_uniq : s.UniqueCallIds)
+    {t₁ t₂ : ToolExecution.ToolCallContext}
+    (h_in₁ : t₁ ∈ s.tools) (h_in₂ : t₂ ∈ s.tools)
+    (h_eq  : t₁.callId = t₂.callId) :
+    t₁ = t₂ := by
+  obtain ⟨i, h_i⟩ := List.mem_iff_getElem?.mp h_in₁
+  obtain ⟨j, h_j⟩ := List.mem_iff_getElem?.mp h_in₂
+  have h_i_lt : i < s.tools.length := (List.getElem?_eq_some_iff.mp h_i).1
+  have h_j_lt : j < s.tools.length := (List.getElem?_eq_some_iff.mp h_j).1
+  have h_t1_eq : s.tools[i] = t₁ := by
+    have := (List.getElem?_eq_some_iff.mp h_i).2
+    simpa using this
+  have h_t2_eq : s.tools[j] = t₂ := by
+    have := (List.getElem?_eq_some_iff.mp h_j).2
+    simpa using this
+  have h_idx_eq : i = j := by
+    apply h_uniq i j h_i_lt h_j_lt
+    rw [h_t1_eq, h_t2_eq]; exact h_eq
+  -- Substitute i := j to identify s.tools[i] with s.tools[j].
+  subst h_idx_eq
+  -- Now h_t1_eq, h_t2_eq both refer to s.tools[i], so t₁ = s.tools[i] = t₂.
+  rw [← h_t1_eq, h_t2_eq]
+
+/-- Helper: `set` preserves length. -/
+private theorem length_set_eq {α : Type _} (l : List α) (i : Nat) (a : α) :
+    (l.set i a).length = l.length := by
+  exact List.length_set l i a
+
+/-- UniqueCallIds is preserved by every composed transition. The four non-tool
+    arms simply propagate `pre.tools = post.tools`. The `tool_step` arm uses
+    the inner `transition_preserves_callId` to argue that the (single) tool
+    swapped at `idx` keeps its original callId; uniqueness is therefore
+    inherited from the pre-state. -/
+theorem uniqueCallIds_preserved
+    {pre post : ComposedState}
+    (h_inv  : pre.UniqueCallIds)
+    (h_step : Transition pre post) :
+    post.UniqueCallIds := by
+  cases h_step with
+  | process_step _ _ _ h_tools _ =>
+    intro i j h_i h_j h_eq
+    have h_i' : i < pre.tools.length := by rw [h_tools] at h_i; exact h_i
+    have h_j' : j < pre.tools.length := by rw [h_tools] at h_j; exact h_j
+    apply h_inv i j h_i' h_j'
+    have hi : pre.tools[i] = post.tools[i] := by congr 1 <;> rw [h_tools]
+    have hj : pre.tools[j] = post.tools[j] := by congr 1 <;> rw [h_tools]
+    rw [hi, hj]; exact h_eq
+  | request_step _ _ _ h_tools _ _ _ =>
+    intro i j h_i h_j h_eq
+    have h_i' : i < pre.tools.length := by rw [h_tools] at h_i; exact h_i
+    have h_j' : j < pre.tools.length := by rw [h_tools] at h_j; exact h_j
+    apply h_inv i j h_i' h_j'
+    have hi : pre.tools[i] = post.tools[i] := by congr 1 <;> rw [h_tools]
+    have hj : pre.tools[j] = post.tools[j] := by congr 1 <;> rw [h_tools]
+    rw [hi, hj]; exact h_eq
+  | persistence_step _ _ _ _ _ _ h_tools _ =>
+    intro i j h_i h_j h_eq
+    have h_i' : i < pre.tools.length := by rw [h_tools] at h_i; exact h_i
+    have h_j' : j < pre.tools.length := by rw [h_tools] at h_j; exact h_j
+    apply h_inv i j h_i' h_j'
+    have hi : pre.tools[i] = post.tools[i] := by congr 1 <;> rw [h_tools]
+    have hj : pre.tools[j] = post.tools[j] := by congr 1 <;> rw [h_tools]
+    rw [hi, hj]; exact h_eq
+  | call_step _ _ _ h_tools _ =>
+    intro i j h_i h_j h_eq
+    have h_i' : i < pre.tools.length := by rw [h_tools] at h_i; exact h_i
+    have h_j' : j < pre.tools.length := by rw [h_tools] at h_j; exact h_j
+    apply h_inv i j h_i' h_j'
+    have hi : pre.tools[i] = post.tools[i] := by congr 1 <;> rw [h_tools]
+    have hj : pre.tools[j] = post.tools[j] := by congr 1 <;> rw [h_tools]
+    rw [hi, hj]; exact h_eq
+  | @tool_step idx toolPre toolPost h_idx h_t_step h_tools _ _ _ _ _ _ =>
+    -- post.tools = pre.tools.set idx toolPost. Since
+    -- transition_preserves_callId says toolPost.callId = toolPre.callId, the
+    -- callId at every index is the same in pre and post. UniqueCallIds carries
+    -- straight through.
+    have h_callId_eq : toolPost.callId = toolPre.callId :=
+      ToolExecution.ToolCallContext.transition_preserves_callId h_t_step
+    have h_len : post.tools.length = pre.tools.length := by
+      rw [h_tools]; exact List.length_set _ _ _
+    have h_idx_lt : idx < pre.tools.length :=
+      (List.getElem?_eq_some_iff.mp h_idx).1
+    have h_pre_idx_eq : pre.tools[idx] = toolPre := by
+      have := (List.getElem?_eq_some_iff.mp h_idx).2
+      simpa using this
+    intro i j h_i h_j h_eq
+    have h_i' : i < pre.tools.length := by rw [h_len] at h_i; exact h_i
+    have h_j' : j < pre.tools.length := by rw [h_len] at h_j; exact h_j
+    -- For each index k, post.tools[k].callId = pre.tools[k].callId.
+    have h_callId_at : ∀ (k : Nat) (h_k : k < pre.tools.length),
+        (post.tools[k]'(by rw [h_len]; exact h_k)).callId = pre.tools[k].callId := by
+      intro k h_k
+      by_cases h_eq_idx : k = idx
+      · subst h_eq_idx
+        have : (post.tools[k]'(by rw [h_len]; exact h_k)) = toolPost := by
+          have h_k_set : (pre.tools.set k toolPost)[k]'(by rw [List.length_set]; exact h_k)
+                          = toolPost :=
+            List.getElem_set_self (l := pre.tools) (i := k) (a := toolPost)
+              (h := by rw [List.length_set]; exact h_k)
+          have hk1 : post.tools[k]'(by rw [h_len]; exact h_k)
+                      = (pre.tools.set k toolPost)[k]'(by rw [List.length_set]; exact h_k) := by
+            congr 1 <;> rw [h_tools]
+          rw [hk1]; exact h_k_set
+        rw [this, h_callId_eq, ← h_pre_idx_eq]
+      · -- k ≠ idx: set leaves the element unchanged.
+        have h_k_set : (pre.tools.set idx toolPost)[k]'(by rw [List.length_set]; exact h_k)
+                        = pre.tools[k] :=
+          List.getElem_set_ne (l := pre.tools) (i := idx) (j := k) (a := toolPost)
+            (h := fun h => h_eq_idx h.symm) (hj := by rw [List.length_set]; exact h_k)
+        have hk1 : post.tools[k]'(by rw [h_len]; exact h_k)
+                    = (pre.tools.set idx toolPost)[k]'(by rw [List.length_set]; exact h_k) := by
+          congr 1 <;> rw [h_tools]
+        rw [hk1, h_k_set]
+    have h_eq' : pre.tools[i].callId = pre.tools[j].callId := by
+      rw [← h_callId_at i h_i', ← h_callId_at j h_j']; exact h_eq
+    exact h_inv i j h_i' h_j' h_eq'
 
 end ComposedState

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
@@ -14,6 +14,25 @@ structure TransitionPair where
   target : String
   deriving DecidableEq, Repr
 
+/-- A transition row carrying a stable name plus precondition flags. Used
+    alongside `legalTransitions`/`illegalTransitions` for machines whose
+    consumers (e.g. R2 Bucket 2's matrix tests) need to discriminate beyond
+    the (source, target) pair — for example, native-only vs subagent-only
+    edges, or state-preserving mode flips that share `source = target`. -/
+structure NamedTransition where
+  name : String
+  source : String
+  target : String
+  /-- `true` ⇒ the inner-state edge is only legal when the tool is native
+      (i.e. has no `childRequestId`). Bucket 2 uses this to assert that the
+      Rust side rejects a native `complete`/`fail` on a subagent-typed tool. -/
+  requiresNative : Bool := false
+  /-- `true` ⇒ the edge requires a linked child (e.g. the bridge-completion
+      and bridge-failure edges that lift a child terminal into the parent
+      tool's state). Counterpart to `requiresNative`. -/
+  requiresChild : Bool := false
+  deriving Repr
+
 structure VocabularyContract where
   domain : String
   values : List String
@@ -28,6 +47,10 @@ structure StateMachineContract where
   actions : List String
   legalTransitions : List TransitionPair
   illegalTransitions : List TransitionPair
+  /-- Optional, per-machine richer transition rows. Defaults to `[]` so
+      existing call sites don't need to change. Emitted as the
+      `named_transitions` JSON field. -/
+  namedTransitions : List NamedTransition := []
   deriving Repr
 
 def jsonEscapeChar : Char → String
@@ -111,6 +134,18 @@ def TransitionPair.toJson (pair : TransitionPair) : String :=
     ++ "\"to\":" ++ jsonString pair.target
     ++ "}"
 
+private def boolJson (value : Bool) : String :=
+  if value then "true" else "false"
+
+def NamedTransition.toJson (t : NamedTransition) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString t.name ++ ","
+    ++ "\"from\":" ++ jsonString t.source ++ ","
+    ++ "\"to\":" ++ jsonString t.target ++ ","
+    ++ "\"requires_native\":" ++ boolJson t.requiresNative ++ ","
+    ++ "\"requires_child\":" ++ boolJson t.requiresChild
+    ++ "}"
+
 def VocabularyContract.toJson (contract : VocabularyContract) : String :=
   "{"
     ++ "\"domain\":" ++ jsonString contract.domain ++ ","
@@ -128,7 +163,9 @@ def StateMachineContract.toJson (contract : StateMachineContract) : String :=
     ++ "\"legal_transitions\":"
       ++ jsonArray (contract.legalTransitions.map TransitionPair.toJson) ++ ","
     ++ "\"illegal_transitions\":"
-      ++ jsonArray (contract.illegalTransitions.map TransitionPair.toJson)
+      ++ jsonArray (contract.illegalTransitions.map TransitionPair.toJson) ++ ","
+    ++ "\"named_transitions\":"
+      ++ jsonArray (contract.namedTransitions.map NamedTransition.toJson)
     ++ "}"
 
 end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean
@@ -332,17 +332,164 @@ def toolCallWithState (state : ToolExecution.ToolCallState) : ToolExecution.Tool
   , persistence := .committed
   }
 
+/-- Named transition rows for the ToolCall machine.
+
+Bucket 2 of the R2 Rust subagent data plane consumes these to assert that
+the Rust runtime's transition matrix matches Lean. They cover three new
+classes of edge that the plain `(source, target)` pairs in
+`legalTransitions` cannot express on their own:
+
+* native-only edges: `complete` and `fail` on a tool whose
+  `childRequestId = none`. The relational `Transition.complete` constructor
+  carries `pre.childRequestId = none` as a precondition (and `step?` mirrors
+  it); `requires_native: true` lets the Rust matrix test reject calling
+  these on a subagent-typed tool.
+* mode-flip edges: `background`, `foreground`, `detach_running`,
+  `detach_pending` are state-preserving on `ToolCallState` and so don't
+  appear in the pair-based `legalTransitions` list. They live in
+  `ToolCallContext.Transition` (subagent extensions in `State.lean`) and
+  flip `awaitMode`/`cancelPolicy` while leaving `state` unchanged.
+  `detach` is split into two rows (`detach_running`, `detach_pending`)
+  mirroring the `bridge_failure` split pattern, because its
+  `h_live` precondition permits both `.pending` and `.running`.
+* bridge edges: `bridge_complete`, `bridge_failure`,
+  `bridge_cancel_cascade`. These are defined relationally on
+  `Subagent.BridgedState.Transition`, not on `ToolCallContext.Transition`,
+  but their effect on the bridge tool's inner state is what Bucket 2 needs
+  to enforce in Rust. `bridge_complete` advances the bridge tool from
+  `running → completed` (with `requires_child = true`); `bridge_failure`
+  drives `running → failed` or `running → cancelled` (per the disjunction in
+  `BridgedState.Transition.bridge_failure`); `bridge_cancel_cascade` is
+  state-preserving on the parent's bridge tool (it sets the child's
+  `interruptRequestedAt`) so its row uses `running → running`. -/
+def toolCallNamedTransitions : List NamedTransition :=
+  [ -- native-only inner transitions: subagent-typed tools (with a child) take
+    -- the bridge_* path instead.
+    { name := "complete_native"
+    , source := "running"
+    , target := "completed"
+    , requiresNative := true }
+  , { name := "fail_native"
+    , source := "running"
+    , target := "failed"
+    , requiresNative := true }
+    -- mode flips (state-preserving on ToolCallState):
+  , { name := "background"
+    , source := "running"
+    , target := "running" }
+  , { name := "foreground"
+    , source := "running"
+    , target := "running" }
+  , { name := "detach_running"
+    , source := "running"
+    , target := "running" }
+  , { name := "detach_pending"
+    , source := "pending"
+    , target := "pending" }
+    -- bridge edges (subagent-typed tools only):
+  , { name := "bridge_complete"
+    , source := "running"
+    , target := "completed"
+    , requiresChild := true }
+  , { name := "bridge_failure_failed"
+    , source := "running"
+    , target := "failed"
+    , requiresChild := true }
+  , { name := "bridge_failure_cancelled"
+    , source := "running"
+    , target := "cancelled"
+    , requiresChild := true }
+  , { name := "bridge_cancel_cascade"
+    , source := "running"
+    , target := "running"
+    , requiresChild := true }
+  ]
+
 def toolCallMachine : StateMachineContract :=
+  let base :=
+    machineContract
+      "ToolCall"
+      toolCallStateNames
+      (terminalNames toolCallStates ToolExecution.ToolCallState.toDefraDB)
+      (actionNames toolCallActions)
+      (transitionPairsFromSamples
+        (toolCallStates.map toolCallWithState)
+        toolCallActions
+        ToolExecution.ToolCallContext.step?
+        (fun call => call.state.toDefraDB))
+  { base with namedTransitions := toolCallNamedTransitions }
+
+/-- AwaitMode is a static enum on `ToolCallContext` (foreground/background).
+    It has no transitions in its own right — the mode-flip edges live on
+    `toolCallMachine`'s `namedTransitions` (`background`, `foreground`).
+    Emitted as a vocabulary-only state machine so Bucket 1 (vocabulary
+    round-trip) can target it the same way it targets `ToolCallState`. -/
+def awaitModeMachine : StateMachineContract :=
+  let names := Subagent.AwaitMode.all.map Subagent.AwaitMode.toDefraDB
   machineContract
-    "ToolCall"
-    toolCallStateNames
-    (terminalNames toolCallStates ToolExecution.ToolCallState.toDefraDB)
-    (actionNames toolCallActions)
-    (transitionPairsFromSamples
-      (toolCallStates.map toolCallWithState)
-      toolCallActions
-      ToolExecution.ToolCallContext.step?
-      (fun call => call.state.toDefraDB))
+    "AwaitMode"
+    names
+    []        -- no terminal states; modes are not lifecycle states
+    []        -- no actions
+    []        -- no transitions
+
+/-- CancelPolicy is a static enum on `ToolCallContext` (cascade/detach).
+    Only the cascade → detach edge is allowed at runtime, surfaced as
+    `toolCallMachine`'s `detach` named transition. Emitted vocabulary-only
+    here. -/
+def cancelPolicyMachine : StateMachineContract :=
+  let names := Subagent.CancelPolicy.all.map Subagent.CancelPolicy.toDefraDB
+  machineContract
+    "CancelPolicy"
+    names
+    []
+    []
+    []
+
+/-- Projection from a child's terminal `RequestState` to the parent
+    bridge tool's `ToolCallState` under `bridge_complete` / `bridge_failure`.
+
+The `namedTransitions` here encode the projection rule that R2 Bucket 2
+asserts against the Rust runtime: when a child request reaches a terminal
+state, the parent's bridge tool is driven to the projected tool state.
+
+  * `completed` is intentionally absent from the source vocabulary because
+    the `completed → completed` edge is handled by the dedicated
+    `bridge_complete` constructor, which has stricter preconditions
+    (`pre.persistence = .committed`). Including it here would conflate
+    success-path persistence with failure-path projection.
+  * `interrupted` projects to `cancelled` (operator-driven cancel); all
+    other terminals project to `failed`. Matches `BridgedState.Transition.
+    bridge_failure`'s `tPost.state = .failed ∨ tPost.state = .cancelled`.
+
+`legalTransitions` is left empty: source and target live in different
+vocabularies (child `RequestState` → parent `ToolCallState`), so the
+pair-based legal/illegal split would be misleading. The projection lives
+in `namedTransitions`, where `source` is documented as a child terminal
+and `target` as the projected tool state. -/
+def childTerminalMachine : StateMachineContract :=
+  let base :=
+    machineContract
+      "ChildTerminal"
+      ["failed", "dead", "interrupted", "superseded"]
+      ["failed", "dead", "interrupted", "superseded"]  -- every source row is a terminal child state
+      []  -- projection has no actions; rule is purely structural
+      []  -- pair-based legal transitions intentionally empty: cross-vocabulary edges are in namedTransitions
+  { base with
+      namedTransitions :=
+        [ { name := "project_failed"
+          , source := "failed"
+          , target := "failed" }
+        , { name := "project_dead"
+          , source := "dead"
+          , target := "failed" }
+        , { name := "project_interrupted"
+          , source := "interrupted"
+          , target := "cancelled" }
+        , { name := "project_superseded"
+          , source := "superseded"
+          , target := "failed" }
+        ] }
 
 def toolRetryDispositions : List ToolExecution.RetryDisposition :=
   ToolExecution.RetryDisposition.all
@@ -377,6 +524,15 @@ def vocabularies : List VocabularyContract :=
   , { domain := "ToolCallState", values := toolCallStateNames }
   , { domain := "ToolFailureClass", values := failureClassNames }
   , { domain := "ToolRetryDisposition", values := toolRetryDispositionNames }
+  , { domain := "AwaitMode"
+    , values := Subagent.AwaitMode.all.map Subagent.AwaitMode.toDefraDB
+    }
+  , { domain := "CancelPolicy"
+    , values := Subagent.CancelPolicy.all.map Subagent.CancelPolicy.toDefraDB
+    }
+  , { domain := "ChildTerminal"
+    , values := ["failed", "dead", "interrupted", "superseded"]
+    }
   ]
 
 def stateMachines : List StateMachineContract :=
@@ -390,6 +546,9 @@ def stateMachines : List StateMachineContract :=
   , sessionRecoveryMachine
   , inferenceCallMachine
   , toolCallMachine
+  , awaitModeMachine
+  , cancelPolicyMachine
+  , childTerminalMachine
   ]
 
 end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -103,6 +103,18 @@ def vocabularyCoverage : List CoverageEntry :=
       "vocabulary"
       "ToolFailureClass"
       "tool_call_lifecycle::tests::rust_failure_class_vocabulary_matches_lean_model"
+  , followUpCoverage
+      "vocabulary"
+      "AwaitMode"
+      "Rust vocabulary round-trip tests pending subagent consumer implementation."
+  , followUpCoverage
+      "vocabulary"
+      "CancelPolicy"
+      "Rust vocabulary round-trip tests pending subagent consumer implementation."
+  , followUpCoverage
+      "vocabulary"
+      "ChildTerminal"
+      "Rust projection-mapping tests pending subagent consumer implementation."
   ]
 
 def stateMachineCoverage : List CoverageEntry :=
@@ -150,6 +162,18 @@ def stateMachineCoverage : List CoverageEntry :=
       "state_machine"
       "ToolCall"
       "tool_call_lifecycle::tests::tool_call_state_machine_contract_is_complete"
+  , followUpCoverage
+      "state_machine"
+      "AwaitMode"
+      "Rust subagent mode-flip contract tests pending subagent consumer implementation."
+  , followUpCoverage
+      "state_machine"
+      "CancelPolicy"
+      "Rust subagent cancel-policy contract tests pending subagent consumer implementation."
+  , followUpCoverage
+      "state_machine"
+      "ChildTerminal"
+      "Rust bridge projection contract tests pending subagent consumer implementation."
   ]
 
 def caseCoverage : List CoverageEntry :=

--- a/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
@@ -84,10 +84,21 @@ theorem claimed_eventually_terminal
   have h_req : RequestContext.Transition pre.request postRequest := by
     exact RequestContext.Transition.fail_before_stream h_claimed h_admission rfl
   have h_step : ComposedState.Transition pre post := by
-    refine ComposedState.Transition.request_step h_req rfl rfl rfl rfl ?_
-    intro h_pending
-    rw [h_claimed] at h_pending
-    simp at h_pending
+    refine ComposedState.Transition.request_step h_req rfl rfl rfl rfl ?_ ?_
+    · intro h_pending
+      rw [h_claimed] at h_pending
+      simp at h_pending
+    · -- h_no_block: vacuously true — fail_before_stream doesn't bump
+      -- progressSeq, and post.request.state = .failed ≠ .processing.
+      intro h_anti
+      cases h_anti with
+      | inl h_progress =>
+          -- post.request.progressSeq = pre.request.progressSeq, contradiction
+          simp [post, postRequest] at h_progress
+      | inr h_begin =>
+          -- post.request.state = .failed, not .processing
+          obtain ⟨_, h_proc⟩ := h_begin
+          simp [post, postRequest] at h_proc
   refine ⟨post, ComposedState.Trace.step h_step ComposedState.Trace.refl, failed_is_terminal⟩
 
 theorem recovery_convergence

--- a/crates/defra-agent/proofs/Proofs/Properties/Safety.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Safety.lean
@@ -177,7 +177,7 @@ theorem recovery_blocks_claims
     have : s'.request.state = s.request.state := congrArg RequestContext.state h_req_eq
     rw [this]
     exact h_pending
-  | request_step _ _ _ _ _ h_guard =>
+  | request_step _ _ _ _ _ h_guard _ =>
     have h_accepts := h_guard h_pending
     rw [h_recovering] at h_accepts
     exact absurd h_accepts (fun h => h)

--- a/crates/defra-agent/proofs/Proofs/Request/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/Request/Properties.lean
@@ -14,7 +14,7 @@ theorem terminal_implies_released_local
     (h_term : isTerminal r.state) :
     r.admission = .released := by
   cases r with
-  | mk state origin backend admission deadline claimTime currentTime retryCount maxRetries progressSeq messageSeq isLatest persistence interruptRequestedAt validUntil =>
+  | mk state origin backend admission deadline claimTime currentTime retryCount maxRetries progressSeq messageSeq isLatest persistence interruptRequestedAt validUntil subagentDepth causedByParentRequestId causedByParentToolCallId =>
     cases h_term with
     | inl h =>
       cases h
@@ -122,7 +122,7 @@ theorem claimed_coherent_cases
     (h_coherent : r.coherent) :
     r.admission = .waiting ∨ r.admission = .acquired := by
   cases r with
-  | mk state origin backend admission deadline claimTime currentTime retryCount maxRetries progressSeq messageSeq isLatest persistence interruptRequestedAt validUntil =>
+  | mk state origin backend admission deadline claimTime currentTime retryCount maxRetries progressSeq messageSeq isLatest persistence interruptRequestedAt validUntil subagentDepth causedByParentRequestId causedByParentToolCallId =>
     cases h_state
     cases admission <;> simp [coherent, coherentStateAdmission] at h_coherent ⊢
 

--- a/crates/defra-agent/proofs/Proofs/Request/State.lean
+++ b/crates/defra-agent/proofs/Proofs/Request/State.lean
@@ -1,6 +1,7 @@
 import Proofs.Basic
 import Proofs.Persistence
 import Proofs.Scheduling
+import Proofs.ToolExecution.State
 
 /-!
 # Request State
@@ -123,6 +124,10 @@ structure RequestContext where
   interruptRequestedAt : Option Time := none
   /-- Submitter-set TTL deadline; runtime-read-only. `none` means no TTL set. -/
   validUntil           : Option Time := none
+  -- Subagent lineage / depth bound:
+  subagentDepth                : Nat := 0
+  causedByParentRequestId      : Option RequestId := none
+  causedByParentToolCallId     : Option ToolExecution.ToolCallId := none
   deriving Repr
 
 namespace RequestContext

--- a/crates/defra-agent/proofs/Proofs/Subagent.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent.lean
@@ -1,0 +1,12 @@
+import Proofs.Subagent.State
+import Proofs.Subagent.Bridge
+import Proofs.Subagent.Transition
+import Proofs.Subagent.Properties
+import Proofs.Subagent.Executable
+
+/-!
+# Subagent
+
+Barrel import for subagent lifecycle (mode/policy state, BridgedState
+paired-context, bridge transitions, properties B1–B6).
+-/

--- a/crates/defra-agent/proofs/Proofs/Subagent/Bridge.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent/Bridge.lean
@@ -1,0 +1,57 @@
+import Proofs.Composed
+import Proofs.Subagent.State
+
+/-!
+# BridgedState
+
+A paired parent/child composed state representing one subagent invocation
+edge.  Structural guards are stated as predicates rather than baked into
+the constructor; they hold for any state reachable from `bridge_spawn`
+(proved in `Subagent.Transition`).
+
+Lives in a separate file from `Subagent.State` to avoid the import cycle:
+  `Subagent.State → (would need) Composed → Request → ToolExecution.State → Subagent.State`
+-/
+
+namespace Subagent
+
+/-- A paired parent/child composed state representing one subagent invocation
+    edge. Structural guards are stated as predicates rather than baked into
+    the constructor; they hold for any state reachable from `bridge_spawn`. -/
+structure BridgedState where
+  parent       : ComposedState
+  child        : ComposedState
+  bridgeCallId : ToolExecution.ToolCallId
+  deriving Repr
+
+namespace BridgedState
+
+/-- The bridge tool exists on the parent and points to the child. -/
+def parentLink (s : BridgedState) : Prop :=
+  ∃ t ∈ s.parent.tools,
+    t.callId = s.bridgeCallId ∧
+    t.childRequestId = some s.child.requestId
+
+/-- The child request points back to the parent. -/
+def childLink (s : BridgedState) : Prop :=
+  s.child.request.causedByParentRequestId = some s.parent.requestId ∧
+  s.child.request.causedByParentToolCallId = some s.bridgeCallId
+
+/-- The full link is symmetric. -/
+def linked (s : BridgedState) : Prop :=
+  s.parentLink ∧ s.childLink
+
+/-- The child has been observed reaching .completed. -/
+def bridgeObservedCompleted (s : BridgedState) : Prop :=
+  s.child.request.state = .completed
+
+/-- The child terminated in any non-completed terminal state. -/
+def bridgeChildFailed (s : BridgedState) : Prop :=
+  s.child.request.state = .failed ∨
+  s.child.request.state = .dead ∨
+  s.child.request.state = .interrupted ∨
+  s.child.request.state = .superseded
+
+end BridgedState
+
+end Subagent

--- a/crates/defra-agent/proofs/Proofs/Subagent/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent/Executable.lean
@@ -1,0 +1,53 @@
+import Proofs.Subagent.Transition
+
+/-!
+# Subagent Executable Semantics
+
+A computable `step` function corresponding to each `BridgedState.Transition`
+constructor, plus a `step_refines_transition` theorem that proves the function
+implements the relation.
+
+Used by Rust conformance generation to enumerate legal traces.
+
+**Status:** scaffolding. The full `step` implementation requires
+`ComposedState.Event` and `ComposedState.step` which may not exist in the
+current codebase. The implementation here provides type scaffolding (the `Event`
+enum and a placeholder `step`) with `sorry` for the refinement theorem; full
+implementation is tracked as a follow-up alongside Rust runtime / conformance
+JSON emission.
+-/
+
+namespace Subagent
+namespace BridgedState
+
+/-- An event that selects which bridge Transition to apply. -/
+inductive Event where
+  | parent_step           (innerEventOpaque : Unit)
+                            -- ComposedState.Event placeholder; full enumeration deferred
+  | child_step            (innerEventOpaque : Unit)
+  | bridge_spawn          (newCallId : ToolExecution.ToolCallId)
+                          (newChildRid : RequestId)
+  | bridge_complete
+  | bridge_failure
+  | bridge_cancel_cascade
+  deriving Repr
+
+/-- Executable single-step. Returns `none` if the event isn't legal in the
+    current state. Currently a stub — returns `none` for every event;
+    full implementation deferred (see file docstring). -/
+def step (s : BridgedState) (e : Event) : Option BridgedState :=
+  match e with
+  | _ => none
+
+/-- Soundness: every legal step refines a Transition. -/
+theorem step_refines_transition
+    (s s' : BridgedState) (e : Event)
+    (h : step s e = some s') :
+    Transition s s' := by
+  -- The current `step` always returns `none`, so this hypothesis is vacuous.
+  -- When `step` is filled in, this proof discharges per-arm by applying the
+  -- matching Transition constructor.
+  exact absurd h (by simp [step])
+
+end BridgedState
+end Subagent

--- a/crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
@@ -1,0 +1,954 @@
+import Proofs.Subagent.Transition
+
+/-!
+# Subagent Properties
+
+B1–B6 plus the structural invariants INV-DEPTH and INV-LINK.
+
+This file accumulates: the depth-bound and link-symmetry invariants here,
+then B1–B6 are added in subsequent tasks (16-19).
+-/
+
+namespace Subagent
+namespace BridgedState
+
+/-! ### Helper lemmas: lineage-field preservation across composed transitions
+
+The bridged invariants reduce to: `subagentDepth`, `causedByParentRequestId`,
+and `causedByParentToolCallId` are preserved across any inner
+`ComposedState.Transition`. None of the request- or persistence-layer
+constructors touch these fields (they are submitter/spawn-set; the runtime
+treats them read-only after `bridge_spawn`). -/
+
+private theorem request_subagentDepth_preserved
+    {pre post : RequestContext}
+    (h : RequestContext.Transition pre post) :
+    post.subagentDepth = pre.subagentDepth := by
+  cases h <;> simp_all
+
+private theorem request_causedByParentRequestId_preserved
+    {pre post : RequestContext}
+    (h : RequestContext.Transition pre post) :
+    post.causedByParentRequestId = pre.causedByParentRequestId := by
+  cases h <;> simp_all
+
+private theorem request_causedByParentToolCallId_preserved
+    {pre post : RequestContext}
+    (h : RequestContext.Transition pre post) :
+    post.causedByParentToolCallId = pre.causedByParentToolCallId := by
+  cases h <;> simp_all
+
+/-- Any ComposedState transition preserves the request's `subagentDepth`. -/
+private theorem composed_subagentDepth_preserved
+    {pre post : ComposedState}
+    (h : ComposedState.Transition pre post) :
+    post.request.subagentDepth = pre.request.subagentDepth := by
+  cases h with
+  | process_step _ h_req _ _ _ => rw [h_req]
+  | request_step h_inner _ _ _ _ _ _ =>
+    exact request_subagentDepth_preserved h_inner
+  | persistence_step _ _ _ h_req _ _ _ _ => rw [h_req]
+  | call_step _ h_req _ _ _ => rw [h_req]
+  | tool_step _ _ _ h_req _ _ _ _ => rw [h_req]
+
+/-- Any ComposedState transition preserves the request's `causedByParentRequestId`. -/
+private theorem composed_causedByParentRequestId_preserved
+    {pre post : ComposedState}
+    (h : ComposedState.Transition pre post) :
+    post.request.causedByParentRequestId = pre.request.causedByParentRequestId := by
+  cases h with
+  | process_step _ h_req _ _ _ => rw [h_req]
+  | request_step h_inner _ _ _ _ _ _ =>
+    exact request_causedByParentRequestId_preserved h_inner
+  | persistence_step _ _ _ h_req _ _ _ _ => rw [h_req]
+  | call_step _ h_req _ _ _ => rw [h_req]
+  | tool_step _ _ _ h_req _ _ _ _ => rw [h_req]
+
+/-- Any ComposedState transition preserves the request's `causedByParentToolCallId`. -/
+private theorem composed_causedByParentToolCallId_preserved
+    {pre post : ComposedState}
+    (h : ComposedState.Transition pre post) :
+    post.request.causedByParentToolCallId = pre.request.causedByParentToolCallId := by
+  cases h with
+  | process_step _ h_req _ _ _ => rw [h_req]
+  | request_step h_inner _ _ _ _ _ _ =>
+    exact request_causedByParentToolCallId_preserved h_inner
+  | persistence_step _ _ _ h_req _ _ _ _ => rw [h_req]
+  | call_step _ h_req _ _ _ => rw [h_req]
+  | tool_step _ _ _ h_req _ _ _ _ => rw [h_req]
+
+/-- Per-step preservation of INV-DEPTH: any single bridge transition preserves
+    the depth bound on both parent and child. The trace-level theorem below
+    threads this through `Trace.step`. -/
+private theorem inv_depth_step
+    {s₁ s₂ : BridgedState}
+    (h_init : s₁.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+              s₁.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_step : Transition s₁ s₂) :
+    s₂.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    s₂.child.request.subagentDepth ≤ maxSubagentDepth := by
+  cases h_step with
+  | parent_step h_inner h_child_eq _ _ _ =>
+    refine ⟨?_, ?_⟩
+    · rw [composed_subagentDepth_preserved h_inner]; exact h_init.1
+    · rw [h_child_eq]; exact h_init.2
+  | child_step h_inner h_parent_eq _ _ _ =>
+    refine ⟨?_, ?_⟩
+    · rw [h_parent_eq]; exact h_init.1
+    · rw [composed_subagentDepth_preserved h_inner]; exact h_init.2
+  | bridge_spawn _ h_depth _ _ _ _ h_post_child _ h_request_eq _ _ =>
+    refine ⟨?_, ?_⟩
+    · rw [h_request_eq]; exact h_init.1
+    · rw [h_post_child.2.2.2.1]; exact h_depth
+  | bridge_complete _ _ _ _ _ _ _ _ _ _ h_request_eq h_child_eq _ _ =>
+    refine ⟨?_, ?_⟩
+    · rw [h_request_eq]; exact h_init.1
+    · rw [h_child_eq]; exact h_init.2
+  | bridge_failure _ _ _ _ _ _ _ _ _ h_request_eq h_child_eq _ _ =>
+    refine ⟨?_, ?_⟩
+    · rw [h_request_eq]; exact h_init.1
+    · rw [h_child_eq]; exact h_init.2
+  | bridge_cancel_cascade _ _ _ h_parent_eq _ _ _ _ h_child_depth_eq _ =>
+    refine ⟨?_, ?_⟩
+    · rw [h_parent_eq]; exact h_init.1
+    · rw [h_child_depth_eq]; exact h_init.2
+
+/-- INV-DEPTH: subagent depth on both sides of the bridge stays ≤ maxSubagentDepth
+    across any reachable trace. -/
+theorem inv_depth
+    (pre post : BridgedState)
+    (h_init  : pre.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+               pre.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_trace : Trace pre post) :
+    post.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    post.child.request.subagentDepth ≤ maxSubagentDepth := by
+  induction h_trace with
+  | refl => exact h_init
+  | step h_step _ ih => exact ih (inv_depth_step h_init h_step)
+
+/-- Per-step preservation of INV-LINK: any single bridge transition preserves
+    parent-child link symmetry. -/
+private theorem inv_link_step
+    {s₁ s₂ : BridgedState}
+    (h_init : s₁.linked)
+    (h_step : Transition s₁ s₂) :
+    s₂.linked := by
+  cases h_step with
+  | parent_step _ _ _ _ h_link_post => exact h_link_post
+  | child_step _ _ _ _ h_link_post  => exact h_link_post
+  | @bridge_spawn newTool _ _ h_newTool_callId _ h_newTool_child h_tools_append
+                    h_post_child _ _ h_parent_id_eq _ =>
+    refine ⟨?_, ?_, ?_⟩
+    · -- parentLink: newTool ∈ post.parent.tools (via h_tools_append's append),
+      -- with callId = post.bridgeCallId and childRequestId = some post.child.requestId.
+      refine ⟨newTool, ?_, h_newTool_callId, h_newTool_child⟩
+      rw [h_tools_append]
+      exact List.mem_append.mpr (Or.inr (List.mem_singleton.mpr rfl))
+    · -- childLink.causedByParentRequestId: post.child.request.cBPRId =
+      -- some pre.parent.requestId, and pre.parent.requestId =
+      -- post.parent.requestId via h_parent_id_eq.
+      rw [h_post_child.2.1, h_parent_id_eq]
+    · exact h_post_child.2.2.1
+  | @bridge_complete idx _ tPost _ h_idx_pre _ _ _ _
+                       h_post_callId _ h_post_child h_tools_set _ h_child_eq
+                       h_bridgeId_eq h_parent_id_eq =>
+    obtain ⟨_h_pLink, h_cLink⟩ := h_init
+    refine ⟨?_, ?_, ?_⟩
+    · -- parentLink: tPost ∈ post.parent.tools (via .set), and tPost has the
+      -- bridge callId and childRequestId pointing at post.child.
+      have h_lt : idx < s₁.parent.tools.length :=
+        (List.getElem?_eq_some_iff.mp h_idx_pre).1
+      have h_in : tPost ∈ s₂.parent.tools := by
+        rw [h_tools_set]
+        exact List.mem_set s₁.parent.tools idx h_lt tPost
+      refine ⟨tPost, h_in, ?_, ?_⟩
+      · rw [h_post_callId, h_bridgeId_eq]
+      · rw [h_post_child, h_child_eq]
+    · -- childLink.causedByParentRequestId via h_child_eq + h_parent_id_eq.
+      rw [h_child_eq, h_parent_id_eq]; exact h_cLink.1
+    · rw [h_child_eq, h_bridgeId_eq]; exact h_cLink.2
+  | @bridge_failure idx _ tPost _ h_idx_pre _ _ _
+                      h_post_callId _ h_post_child h_tools_set _ h_child_eq
+                      h_bridgeId_eq h_parent_id_eq =>
+    obtain ⟨_h_pLink, h_cLink⟩ := h_init
+    refine ⟨?_, ?_, ?_⟩
+    · have h_lt : idx < s₁.parent.tools.length :=
+        (List.getElem?_eq_some_iff.mp h_idx_pre).1
+      have h_in : tPost ∈ s₂.parent.tools := by
+        rw [h_tools_set]
+        exact List.mem_set s₁.parent.tools idx h_lt tPost
+      refine ⟨tPost, h_in, ?_, ?_⟩
+      · rw [h_post_callId, h_bridgeId_eq]
+      · rw [h_post_child, h_child_eq]
+    · rw [h_child_eq, h_parent_id_eq]; exact h_cLink.1
+    · rw [h_child_eq, h_bridgeId_eq]; exact h_cLink.2
+  | bridge_cancel_cascade _ _ _ h_parent_eq h_bridgeId_eq h_child_id_eq h_child_cBPR_eq h_child_cBPT_eq _ _ =>
+    obtain ⟨h_pLink, h_cLink⟩ := h_init
+    refine ⟨?_, ?_, ?_⟩
+    · -- parentLink: post.parent = pre.parent, so unfold parentLink and
+      -- rewrite back to pre.parent. Also rewrite post.bridgeCallId and
+      -- post.child.requestId.
+      show ∃ t ∈ s₂.parent.tools,
+        t.callId = s₂.bridgeCallId ∧
+        t.childRequestId = some s₂.child.requestId
+      rw [h_parent_eq, h_bridgeId_eq, h_child_id_eq]; exact h_pLink
+    · -- childLink.causedByParentRequestId: h_child_cBPR_eq says it's preserved
+      -- from pre. h_parent_eq gives pre.parent.requestId = post.parent.requestId.
+      show s₂.child.request.causedByParentRequestId = some s₂.parent.requestId
+      rw [h_child_cBPR_eq, h_parent_eq]; exact h_cLink.1
+    · show s₂.child.request.causedByParentToolCallId = some s₂.bridgeCallId
+      rw [h_child_cBPT_eq, h_bridgeId_eq]; exact h_cLink.2
+
+/-- INV-LINK: parent and child links stay symmetric across any reachable trace
+    once initialized by `bridge_spawn`. -/
+theorem inv_link
+    (pre post : BridgedState)
+    (h_init  : pre.linked)
+    (h_trace : Trace pre post) :
+    post.linked := by
+  induction h_trace with
+  | refl => exact h_init
+  | step h_step _ ih => exact ih (inv_link_step h_init h_step)
+
+/-! ### INV-UNIQUE: BridgedState lift
+
+`ComposedState.UniqueCallIds` is preserved by every `ComposedState.Transition`
+(see `ComposedState.uniqueCallIds_preserved`). The BridgedState lift below
+states that both sides of the bridge satisfy `UniqueCallIds` across any
+single `BridgedState.Transition`, then the trace-level theorem threads it
+through `Trace.step`. -/
+
+/-- Helper: replacing element at `idx` with a tool that has the same callId
+    preserves `UniqueCallIds`. The `set`-style description in
+    `bridge_complete` / `bridge_failure` lets us reuse this proof shape. -/
+private theorem uniqueCallIds_set_callId_preserved
+    {s sPost : ComposedState} {idx : Nat}
+    {tPre tPost : ToolExecution.ToolCallContext}
+    (h_uniq         : s.UniqueCallIds)
+    (h_idx          : s.tools[idx]? = some tPre)
+    (h_callId_eq    : tPost.callId = tPre.callId)
+    (h_tools_set    : sPost.tools = s.tools.set idx tPost) :
+    sPost.UniqueCallIds := by
+  intro i j h_i h_j h_eq
+  have h_len : sPost.tools.length = s.tools.length := by
+    rw [h_tools_set]; exact List.length_set _ _ _
+  have h_i' : i < s.tools.length := by rw [h_len] at h_i; exact h_i
+  have h_j' : j < s.tools.length := by rw [h_len] at h_j; exact h_j
+  have h_idx_lt : idx < s.tools.length :=
+    (List.getElem?_eq_some_iff.mp h_idx).1
+  have h_pre_idx_eq : s.tools[idx] = tPre := by
+    have := (List.getElem?_eq_some_iff.mp h_idx).2
+    simpa using this
+  -- For each k, post.tools[k].callId = pre.tools[k].callId.
+  have h_callId_at : ∀ (k : Nat) (h_k : k < s.tools.length),
+      (sPost.tools[k]'(by rw [h_len]; exact h_k)).callId = s.tools[k].callId := by
+    intro k h_k
+    by_cases h_eq_idx : k = idx
+    · subst h_eq_idx
+      have h_get : (sPost.tools[k]'(by rw [h_len]; exact h_k)) = tPost := by
+        have h_k_set : (s.tools.set k tPost)[k]'(by rw [List.length_set]; exact h_k)
+                        = tPost :=
+          List.getElem_set_self (l := s.tools) (i := k) (a := tPost)
+            (h := by rw [List.length_set]; exact h_k)
+        have hk1 : sPost.tools[k]'(by rw [h_len]; exact h_k)
+                    = (s.tools.set k tPost)[k]'(by rw [List.length_set]; exact h_k) := by
+          congr 1 <;> rw [h_tools_set]
+        rw [hk1]; exact h_k_set
+      rw [h_get, h_callId_eq, ← h_pre_idx_eq]
+    · have h_k_set : (s.tools.set idx tPost)[k]'(by rw [List.length_set]; exact h_k)
+                      = s.tools[k] :=
+        List.getElem_set_ne (l := s.tools) (i := idx) (j := k) (a := tPost)
+          (h := fun h => h_eq_idx h.symm) (hj := by rw [List.length_set]; exact h_k)
+      have hk1 : sPost.tools[k]'(by rw [h_len]; exact h_k)
+                  = (s.tools.set idx tPost)[k]'(by rw [List.length_set]; exact h_k) := by
+        congr 1 <;> rw [h_tools_set]
+      rw [hk1, h_k_set]
+  have h_eq' : s.tools[i].callId = s.tools[j].callId := by
+    rw [← h_callId_at i h_i', ← h_callId_at j h_j']; exact h_eq
+  exact h_uniq i j h_i' h_j' h_eq'
+
+/-- Helper: appending a tool with a callId fresh w.r.t. `pre.tools` preserves
+    `UniqueCallIds`. Used by the `bridge_spawn` arm. -/
+private theorem uniqueCallIds_append_fresh_preserved
+    {s sPost : ComposedState} {newTool : ToolExecution.ToolCallContext}
+    (h_uniq         : s.UniqueCallIds)
+    (h_fresh        : ∀ t ∈ s.tools, t.callId ≠ newTool.callId)
+    (h_tools_append : sPost.tools = s.tools ++ [newTool]) :
+    sPost.UniqueCallIds := by
+  intro i j h_i h_j h_eq
+  have h_len : sPost.tools.length = s.tools.length + 1 := by
+    rw [h_tools_append, List.length_append, List.length_singleton]
+  -- For each k, sPost.tools[k] = (s.tools ++ [newTool])[k]; case-split based
+  -- on whether k < s.tools.length.
+  have h_get_lt : ∀ (k : Nat) (h_lt : k < s.tools.length)
+                    (h_k : k < sPost.tools.length),
+      (sPost.tools[k]'h_k) = s.tools[k]'h_lt := by
+    intro k h_lt h_k
+    have hk1 : sPost.tools[k]'h_k
+                = (s.tools ++ [newTool])[k]'(by rw [← h_tools_append]; exact h_k) := by
+      congr 1 <;> rw [h_tools_append]
+    rw [hk1]
+    exact List.getElem_append_left h_lt
+  have h_get_eq : ∀ (k : Nat) (h_k : k < sPost.tools.length),
+      ¬ k < s.tools.length → (sPost.tools[k]'h_k) = newTool := by
+    intro k h_k h_not_lt
+    have h_k_total : k < s.tools.length + 1 := by rw [← h_len]; exact h_k
+    have h_k_eq : k = s.tools.length := by omega
+    have hk1 : sPost.tools[k]'h_k
+                = (s.tools ++ [newTool])[k]'(by rw [← h_tools_append]; exact h_k) := by
+      congr 1 <;> rw [h_tools_append]
+    rw [hk1]
+    have h_ge : s.tools.length ≤ k := by rw [h_k_eq]
+    rw [List.getElem_append_right h_ge]
+    simp [h_k_eq]
+  -- Case-split on whether i < s.tools.length and j < s.tools.length.
+  by_cases h_i_lt : i < s.tools.length
+  · by_cases h_j_lt : j < s.tools.length
+    · -- Both indices in pre.tools; uniqueness from h_uniq.
+      apply h_uniq i j h_i_lt h_j_lt
+      rw [← h_get_lt i h_i_lt h_i, ← h_get_lt j h_j_lt h_j]
+      exact h_eq
+    · -- j = length (newTool); i < length.  callIds equal contradicts freshness.
+      exfalso
+      have hi := h_get_lt i h_i_lt h_i
+      have hj := h_get_eq j h_j h_j_lt
+      have h_in_i : s.tools[i] ∈ s.tools := List.getElem_mem h_i_lt
+      apply h_fresh _ h_in_i
+      rw [hi, hj] at h_eq
+      exact h_eq
+  · by_cases h_j_lt : j < s.tools.length
+    · -- i = length (newTool); j < length. Symmetric contradiction.
+      exfalso
+      have hi := h_get_eq i h_i h_i_lt
+      have hj := h_get_lt j h_j_lt h_j
+      have h_in_j : s.tools[j] ∈ s.tools := List.getElem_mem h_j_lt
+      apply h_fresh _ h_in_j
+      rw [hi, hj] at h_eq
+      exact h_eq.symm
+    · -- Both indices ≥ length; both = length; i = j.
+      have h_i_total : i < s.tools.length + 1 := by rw [← h_len]; exact h_i
+      have h_j_total : j < s.tools.length + 1 := by rw [← h_len]; exact h_j
+      have h_i_eq : i = s.tools.length := by omega
+      have h_j_eq : j = s.tools.length := by omega
+      rw [h_i_eq, h_j_eq]
+
+/-- Per-step preservation of INV-UNIQUE on both sides of the bridge. -/
+private theorem bridgedUniqueCallIds_step
+    {s₁ s₂ : BridgedState}
+    (h_parent_uniq : s₁.parent.UniqueCallIds)
+    (h_child_uniq  : s₁.child.UniqueCallIds)
+    (h_step : Transition s₁ s₂) :
+    s₂.parent.UniqueCallIds ∧ s₂.child.UniqueCallIds := by
+  cases h_step with
+  | parent_step h_inner h_child_eq _ _ _ =>
+    refine ⟨ComposedState.uniqueCallIds_preserved h_parent_uniq h_inner, ?_⟩
+    rw [h_child_eq]; exact h_child_uniq
+  | child_step h_inner h_parent_eq _ _ _ =>
+    refine ⟨?_, ComposedState.uniqueCallIds_preserved h_child_uniq h_inner⟩
+    rw [h_parent_eq]; exact h_parent_uniq
+  | @bridge_spawn newTool _ _ h_newTool_callId _ _ h_tools_append _ h_post_child_tools _ _ h_callId_fresh =>
+    refine ⟨?_, ?_⟩
+    · -- Uniqueness on post.parent.tools = pre.parent.tools ++ [newTool].
+      -- newTool.callId = post.bridgeCallId, and h_callId_fresh says no tool in
+      -- pre.parent.tools has callId = post.bridgeCallId.
+      apply uniqueCallIds_append_fresh_preserved (s := s₁.parent)
+        h_parent_uniq ?_ h_tools_append
+      intro t h_in
+      rw [h_newTool_callId]
+      exact h_callId_fresh t h_in
+    · -- post.child.tools = [] is trivially unique.
+      intro i j h_i h_j _
+      rw [h_post_child_tools] at h_i
+      cases h_i
+  | @bridge_complete idx tPre tPost _ h_idx_pre h_pre_callId _ _ _
+                       h_post_callId _ _ h_tools_set _ h_child_eq _ _ =>
+    refine ⟨?_, ?_⟩
+    · -- post.parent.tools = pre.parent.tools.set idx tPost; tPost.callId =
+      -- tPre.callId via h_post_callId, h_pre_callId.
+      apply uniqueCallIds_set_callId_preserved (s := s₁.parent)
+        h_parent_uniq h_idx_pre ?_ h_tools_set
+      rw [h_post_callId, ← h_pre_callId]
+    · rw [h_child_eq]; exact h_child_uniq
+  | @bridge_failure idx tPre tPost _ h_idx_pre h_pre_callId _ _
+                      h_post_callId _ _ h_tools_set _ h_child_eq _ _ =>
+    refine ⟨?_, ?_⟩
+    · apply uniqueCallIds_set_callId_preserved (s := s₁.parent)
+        h_parent_uniq h_idx_pre ?_ h_tools_set
+      rw [h_post_callId, ← h_pre_callId]
+    · rw [h_child_eq]; exact h_child_uniq
+  | bridge_cancel_cascade _ _ _ h_parent_eq _ _ _ _ _ h_child_tools_eq =>
+    refine ⟨?_, ?_⟩
+    · -- post.parent = pre.parent → tools unchanged.
+      intro i j h_i h_j h_eq
+      have h_tools : s₂.parent.tools = s₁.parent.tools := by rw [h_parent_eq]
+      have h_i' : i < s₁.parent.tools.length := by rw [h_tools] at h_i; exact h_i
+      have h_j' : j < s₁.parent.tools.length := by rw [h_tools] at h_j; exact h_j
+      apply h_parent_uniq i j h_i' h_j'
+      have hi : s₁.parent.tools[i] = s₂.parent.tools[i] := by congr 1 <;> rw [h_tools]
+      have hj : s₁.parent.tools[j] = s₂.parent.tools[j] := by congr 1 <;> rw [h_tools]
+      rw [hi, hj]; exact h_eq
+    · -- post.child.tools = pre.child.tools via h_child_tools_eq.
+      intro i j h_i h_j h_eq
+      have h_i' : i < s₁.child.tools.length := by rw [h_child_tools_eq] at h_i; exact h_i
+      have h_j' : j < s₁.child.tools.length := by rw [h_child_tools_eq] at h_j; exact h_j
+      apply h_child_uniq i j h_i' h_j'
+      have hi : s₁.child.tools[i] = s₂.child.tools[i] := by
+        congr 1 <;> rw [h_child_tools_eq]
+      have hj : s₁.child.tools[j] = s₂.child.tools[j] := by
+        congr 1 <;> rw [h_child_tools_eq]
+      rw [hi, hj]; exact h_eq
+
+/-- INV-UNIQUE (BridgedState lift): both sides of the bridge satisfy
+    `ComposedState.UniqueCallIds` across any reachable bridge trace. -/
+theorem bridgedUniqueCallIds_preserved
+    (pre post : BridgedState)
+    (h_parent_init : pre.parent.UniqueCallIds)
+    (h_child_init  : pre.child.UniqueCallIds)
+    (h_trace : Trace pre post) :
+    post.parent.UniqueCallIds ∧ post.child.UniqueCallIds := by
+  induction h_trace with
+  | refl => exact ⟨h_parent_init, h_child_init⟩
+  | step h_step _ ih =>
+    obtain ⟨h_p, h_c⟩ := bridgedUniqueCallIds_step h_parent_init h_child_init h_step
+    exact ih h_p h_c
+
+/-! ### B1: child completion propagates to parent ToolCall completion -/
+
+/-- B1: A child Request reaching `.completed` propagates to the parent
+    ToolCall reaching `.completed` along a single `bridge_complete` step.
+
+    The bridge tool hypothesis bundles three facts about the running bridge
+    tool: it carries the bridge callId, it is currently `.running`, and its
+    `childRequestId` matches `pre.child.requestId`. The last conjunct is
+    morally part of `pre.linked`'s `parentLink`, but baking it directly into
+    the running-tool witness avoids a callId-uniqueness side condition: we
+    need to step the *same* tool for which we know the child link. -/
+theorem bridged_child_completion_propagates
+    (pre : BridgedState)
+    (h_running     : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧
+                       t.state = .running ∧
+                       t.persistence = .committed ∧
+                       t.childRequestId = some pre.child.requestId)
+    (h_child_done  : pre.child.request.state = .completed) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧ t.state = .completed := by
+  -- Pull out the running bridge tool and its index in pre.parent.tools.
+  obtain ⟨tPre, h_in, h_id, h_run_state, h_committed, h_child_id⟩ := h_running
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_getElem?.mp h_in
+  -- The post-state advances the running bridge tool to `.completed`,
+  -- preserving every other field (including `childRequestId`).
+  let tPost : ToolExecution.ToolCallContext := { tPre with state := .completed }
+  let postParent : ComposedState :=
+    { pre.parent with tools := pre.parent.tools.set idx tPost }
+  let post : BridgedState := { pre with parent := postParent }
+  -- We need the index bound for `List.mem_set`.
+  have h_lt : idx < pre.parent.tools.length :=
+    (List.getElem?_eq_some_iff.mp h_idx).1
+  -- The post bridge tool exists in post.parent.tools (it's the .set element).
+  have h_tPost_in : tPost ∈ postParent.tools :=
+    List.mem_set pre.parent.tools idx h_lt tPost
+  -- Provide the exhibit for the post existential.
+  refine ⟨post, ?_, tPost, ?_, ?_, rfl⟩
+  · -- One-step trace via bridge_complete.
+    refine Trace.step ?_ Trace.refl
+    refine Transition.bridge_complete
+      (idx := idx) (tPre := tPre) (tPost := tPost)
+      h_child_done
+      h_idx
+      h_id
+      h_run_state
+      h_committed
+      h_child_id
+      ?_   -- h_post_callId
+      ?_   -- h_post_state
+      ?_   -- h_post_child
+      rfl  -- h_tools_set       (post.parent.tools = pre.parent.tools.set idx tPost)
+      rfl  -- h_request_eq      (post.parent.request = pre.parent.request)
+      rfl  -- h_child_eq        (post.child = pre.child)
+      rfl  -- h_bridgeId_eq     (post.bridgeCallId = pre.bridgeCallId)
+      rfl  -- h_parent_id_eq    (post.parent.requestId = pre.parent.requestId)
+    · -- h_post_callId: tPost.callId = pre.bridgeCallId.
+      show tPre.callId = pre.bridgeCallId
+      exact h_id
+    · -- h_post_state: tPost.state = .completed.
+      rfl
+    · -- h_post_child: tPost.childRequestId = some pre.child.requestId.
+      show tPre.childRequestId = some pre.child.requestId
+      exact h_child_id
+  · -- Bridge tool ∈ post.parent.tools.
+    exact h_tPost_in
+  · -- tPost.callId = pre.bridgeCallId.
+    show tPre.callId = pre.bridgeCallId
+    exact h_id
+
+/-! ### B2: child non-completed terminal projects to parent ToolCall failure -/
+
+/-- B2: A child Request reaching a non-`.completed` terminal projects to
+    the parent ToolCall reaching `.failed` (for child `.failed`/`.dead`/
+    `.superseded`) or `.cancelled` (for child `.interrupted`).
+
+    Same hypothesis-bundling pattern as B1: the running-tool witness carries
+    the bridge callId, the `.running` state, and the child link, so we step
+    the same tool we know is bridge-linked. No persistence guard here —
+    `bridge_failure` does not require the bridge tool to be `.committed`. -/
+theorem bridged_child_failure_projects
+    (pre : BridgedState)
+    (h_running    : ∃ t ∈ pre.parent.tools,
+                      t.callId = pre.bridgeCallId ∧
+                      t.state = .running ∧
+                      t.childRequestId = some pre.child.requestId)
+    (h_child_term : pre.child.request.state = .failed ∨
+                    pre.child.request.state = .dead ∨
+                    pre.child.request.state = .interrupted ∨
+                    pre.child.request.state = .superseded) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧
+              (t.state = .failed ∨ t.state = .cancelled) := by
+  -- Pull out the running bridge tool and its index in pre.parent.tools.
+  obtain ⟨tPre, h_in, h_id, h_run_state, h_child_id⟩ := h_running
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_getElem?.mp h_in
+  -- Project the child terminal to a parent-tool terminal:
+  --   .interrupted → .cancelled  (child interrupted, parent cancels in sympathy)
+  --   everything else → .failed
+  -- Defined as a function on RequestState so that elaboration stays at the
+  -- `Type` level (matching on `Or` would be a Prop→Type elimination).
+  let projectFn : RequestState → ToolExecution.ToolCallState
+    | .interrupted => .cancelled
+    | _            => .failed
+  let projectedState : ToolExecution.ToolCallState := projectFn pre.child.request.state
+  let tPost : ToolExecution.ToolCallContext := { tPre with state := projectedState }
+  let postParent : ComposedState :=
+    { pre.parent with tools := pre.parent.tools.set idx tPost }
+  let post : BridgedState := { pre with parent := postParent }
+  -- Index bound for `List.mem_set`.
+  have h_lt : idx < pre.parent.tools.length :=
+    (List.getElem?_eq_some_iff.mp h_idx).1
+  -- The post bridge tool ∈ post.parent.tools (it's the .set element).
+  have h_tPost_in : tPost ∈ postParent.tools :=
+    List.mem_set pre.parent.tools idx h_lt tPost
+  -- Show projectedState is .failed ∨ .cancelled (used both inside the
+  -- constructor's h_post_tool and in the final goal). Case-split on the
+  -- four-way child-terminal disjunction; for each, rewrite the request state
+  -- and reduce `projectFn`.
+  have h_proj : projectedState = .failed ∨ projectedState = .cancelled := by
+    rcases h_child_term with h | h | h | h
+    · left;  show projectFn pre.child.request.state = .failed
+      rw [h]
+    · left;  show projectFn pre.child.request.state = .failed
+      rw [h]
+    · right; show projectFn pre.child.request.state = .cancelled
+      rw [h]
+    · left;  show projectFn pre.child.request.state = .failed
+      rw [h]
+  refine ⟨post, ?_, tPost, h_tPost_in, ?_, ?_⟩
+  · -- One-step trace via bridge_failure.
+    refine Trace.step ?_ Trace.refl
+    refine Transition.bridge_failure
+      (idx := idx) (tPre := tPre) (tPost := tPost)
+      h_child_term
+      h_idx
+      h_id
+      h_run_state
+      h_child_id
+      ?_   -- h_post_callId
+      ?_   -- h_post_state
+      ?_   -- h_post_child
+      rfl  -- h_tools_set       (post.parent.tools = pre.parent.tools.set idx tPost)
+      rfl  -- h_request_eq      (post.parent.request = pre.parent.request)
+      rfl  -- h_child_eq        (post.child = pre.child)
+      rfl  -- h_bridgeId_eq     (post.bridgeCallId = pre.bridgeCallId)
+      rfl  -- h_parent_id_eq    (post.parent.requestId = pre.parent.requestId)
+    · -- h_post_callId: tPost.callId = pre.bridgeCallId.
+      show tPre.callId = pre.bridgeCallId
+      exact h_id
+    · -- h_post_state: tPost.state ∈ {.failed, .cancelled}.
+      show projectedState = .failed ∨ projectedState = .cancelled
+      exact h_proj
+    · -- h_post_child: tPost.childRequestId = some pre.child.requestId.
+      show tPre.childRequestId = some pre.child.requestId
+      exact h_child_id
+  · -- tPost.callId = pre.bridgeCallId.
+    show tPre.callId = pre.bridgeCallId
+    exact h_id
+  · -- tPost.state ∈ {.failed, .cancelled}.
+    show projectedState = .failed ∨ projectedState = .cancelled
+    exact h_proj
+
+/-! ### B3: cascade cancellation correctness -/
+
+/-- B3: Cascade cancellation correctness. Parent terminal under cascade ⇒
+    child reaches `.interrupted` via two-step trace (`bridge_cancel_cascade`
+    sets `interruptRequestedAt`; `child_step` lifts `interrupt_processing`).
+
+    The child must be in `.processing` with admission `.executing` for
+    `interrupt_processing` to fire. The `h_child_no_fg` hypothesis discharges
+    the foreground-blocking guard on the inner `request_step`. The `h_linked`
+    hypothesis is required at both `child_step` invocations so INV-LINK can
+    be threaded; the link is preserved because all link-relevant fields
+    (`requestId`, `causedByParentRequestId`, `causedByParentToolCallId`,
+    `bridgeCallId`, parent state, `parent.tools`) are unchanged across both
+    steps. -/
+theorem cascade_cancels_child
+    (pre : BridgedState)
+    (h_parent_term : isTerminal pre.parent.request.state)
+    (h_cascade     : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧
+                       t.cancelPolicy = .cascade ∧
+                       ¬ isTerminal t.state)
+    (h_child_proc      : pre.child.request.state = .processing)
+    (h_child_admission : pre.child.request.admission = .executing)
+    (h_child_no_fg     : ¬ ∃ t ∈ pre.child.tools, t.awaitMode = .foreground ∧
+                                                    ¬ isTerminal t.state)
+    (h_linked          : pre.linked) :
+    ∃ post, Trace pre post ∧ post.child.request.state = .interrupted := by
+  -- Pull out the cascade-mode tool witness; we use it in step 1.
+  obtain ⟨tCascade, h_in, h_id, h_pol, _h_live⟩ := h_cascade
+  -- Step 1: bridge_cancel_cascade sets interruptRequestedAt on child.
+  let midChildReq : RequestContext :=
+    { pre.child.request with
+        interruptRequestedAt := some pre.child.request.currentTime }
+  let midChild : ComposedState :=
+    { pre.child with request := midChildReq }
+  let mid : BridgedState := { pre with child := midChild }
+  -- Step 2: child_step lifts interrupt_processing.
+  let postChildReq : RequestContext :=
+    { midChildReq with state := .interrupted, admission := .released }
+  let postChild : ComposedState :=
+    { midChild with request := postChildReq }
+  let post : BridgedState := { mid with child := postChild }
+  refine ⟨post, ?_, ?_⟩
+  · -- Build the two-step trace, providing the intermediate state explicitly.
+    refine @Trace.step pre mid post ?_ (@Trace.step mid post post ?_ Trace.refl)
+    · -- Step 1: bridge_cancel_cascade.
+      refine Transition.bridge_cancel_cascade
+        (Or.inl h_parent_term)        -- h_parent_term : terminal disjunct
+        ⟨tCascade, h_in, h_id, h_pol⟩  -- h_cascade_pol
+        ?_                             -- h_interrupt_set
+        rfl                            -- h_parent_eq
+        rfl                            -- h_bridgeId_eq
+        rfl                            -- h_child_id_eq
+        ?_                             -- h_child_caused_req_eq
+        ?_                             -- h_child_caused_tool_eq
+        ?_                             -- h_child_depth_eq
+        rfl                            -- h_child_tools_eq
+      · -- mid.child.request.interruptRequestedAt.isSome.
+        show midChildReq.interruptRequestedAt.isSome
+        simp [midChildReq]
+      · -- causedByParentRequestId preserved (only interruptRequestedAt changed).
+        show midChildReq.causedByParentRequestId = pre.child.request.causedByParentRequestId
+        rfl
+      · show midChildReq.causedByParentToolCallId = pre.child.request.causedByParentToolCallId
+        rfl
+      · show midChildReq.subagentDepth = pre.child.request.subagentDepth
+        rfl
+    · -- Step 2: child_step lifting RequestContext.Transition.interrupt_processing.
+      -- mid.linked first.
+      have h_link_mid : mid.linked := by
+        -- pre.linked has parentLink (about pre.parent) and childLink (about
+        -- pre.child.request.causedByParentRequestId / ToolCallId). For mid:
+        --   mid.parent = pre.parent, mid.bridgeCallId = pre.bridgeCallId,
+        --   mid.child.request differs from pre.child.request only on
+        --   interruptRequestedAt; the link-relevant fields are unchanged.
+        -- So pre.linked carries straight through.
+        obtain ⟨h_pLink, h_cReq, h_cTool⟩ := h_linked
+        refine ⟨h_pLink, ?_, ?_⟩
+        · show midChildReq.causedByParentRequestId = some pre.parent.requestId
+          exact h_cReq
+        · show midChildReq.causedByParentToolCallId = some pre.bridgeCallId
+          exact h_cTool
+      have h_link_post : post.linked := by
+        -- post.parent = mid.parent, post.bridgeCallId = mid.bridgeCallId,
+        -- post.child.request changes only state and admission; lineage and
+        -- requestId are inherited from midChildReq, hence from pre.
+        obtain ⟨h_pLink, h_cReq, h_cTool⟩ := h_link_mid
+        refine ⟨h_pLink, ?_, ?_⟩
+        · show postChildReq.causedByParentRequestId = some mid.parent.requestId
+          exact h_cReq
+        · show postChildReq.causedByParentToolCallId = some mid.bridgeCallId
+          exact h_cTool
+      -- Inner request transition on the child: interrupt_processing.
+      have h_inner_req :
+          RequestContext.Transition mid.child.request post.child.request := by
+        show RequestContext.Transition midChildReq postChildReq
+        refine RequestContext.Transition.interrupt_processing ?_ ?_ ?_ ?_
+        · -- midChildReq.state = .processing (only interruptRequestedAt changed).
+          show pre.child.request.state = .processing
+          exact h_child_proc
+        · -- midChildReq.admission = .executing.
+          show pre.child.request.admission = .executing
+          exact h_child_admission
+        · -- midChildReq.interruptRequestedAt.isSome.
+          show (some pre.child.request.currentTime).isSome
+          rfl
+        · -- post = { mid with state := .interrupted, admission := .released }.
+          rfl
+      -- Inner ComposedState transition on the child: request_step.
+      have h_inner_composed :
+          ComposedState.Transition mid.child post.child := by
+        refine ComposedState.Transition.request_step
+          h_inner_req
+          rfl  -- post.process = pre.process (i.e., midChild.process)
+          rfl  -- post.call = pre.call
+          rfl  -- post.tools = pre.tools
+          rfl  -- post.requestId = pre.requestId
+          ?_   -- pending → acceptsWork (vacuous: state = .processing)
+          ?_   -- INV-FG guard
+        · -- pending gate: midChildReq.state = .processing, not .pending.
+          intro h_pending
+          exfalso
+          have h_eq : midChildReq.state = pre.child.request.state := rfl
+          rw [h_eq, h_child_proc] at h_pending
+          cases h_pending
+        · -- INV-FG guard: interrupt_processing doesn't increase progressSeq
+          -- and isn't claimed → processing, so the antecedent is false.
+          -- More precisely: postChildReq.progressSeq = midChildReq.progressSeq
+          -- (only state and admission change), and midChildReq.state =
+          -- .processing ≠ .claimed.
+          intro h_advance
+          exfalso
+          rcases h_advance with h_progress | ⟨h_claimed, _⟩
+          · -- progressSeq strictly increases? No: postChildReq.progressSeq
+            -- equals midChildReq.progressSeq (record update doesn't touch it).
+            have h_eq_seq : postChildReq.progressSeq = midChildReq.progressSeq := rfl
+            rw [h_eq_seq] at h_progress
+            exact Nat.lt_irrefl _ h_progress
+          · -- mid.child.request.state = .claimed? No: it's .processing.
+            have h_eq_state : midChildReq.state = pre.child.request.state := rfl
+            rw [h_eq_state, h_child_proc] at h_claimed
+            cases h_claimed
+      -- Lift through child_step.
+      refine Transition.child_step
+        h_inner_composed
+        rfl                  -- h_parent_eq: post.parent = mid.parent
+        rfl                  -- h_bridgeId_eq
+        h_link_mid           -- h_link_pre
+        h_link_post          -- h_link_post
+  · -- post.child.request.state = .interrupted.
+    show postChildReq.state = .interrupted
+    rfl
+
+/-! ### INV-UNIQUE: BridgedState-level lift
+
+The BridgedState-level `bridgedUniqueCallIds_preserved` theorem (above)
+proves that `ComposedState.UniqueCallIds` is preserved on both parent
+and child across any reachable bridge `Trace`. Per-step preservation
+relies on the set-style descriptions of `post.parent.tools` carried by
+`bridge_complete`, `bridge_failure`, and `bridge_spawn` (the latter via
+append + a freshness precondition on the new tool's callId).
+-/
+
+/-! ### B3': detach does not cascade -/
+
+/-- B3': Detach correctness (negative form). A detach-mode bridge tool's
+    cancellation does NOT cascade to the child. Specifically: under any
+    single-step transition `pre → post`, if the parent's bridge tool has
+    `cancelPolicy = .detach`, the child's `interruptRequestedAt` flag is
+    preserved.
+
+    The `h_no_other` hypothesis says the pre-state has no interrupt set,
+    blocking child-side `interrupt_processing` / `interrupt_claimed` /
+    `interrupt_before_claim` arms (their `pre.interruptRequestedAt.isSome`
+    guards fail). The `h_uniq` hypothesis (`UniqueCallIds` — callIds are
+    distinct within `pre.parent.tools`) discharges the `bridge_cancel_cascade`
+    arm by deriving same-tool from same-callId, then contradicting
+    `cancelPolicy = .cascade` against `cancelPolicy = .detach`.
+
+    `h_uniq` is a structural invariant of any reachable composed state
+    (proved via `ComposedState.uniqueCallIds_preserved`), so this theorem is
+    a property of any reachable state, not a conditional one. -/
+theorem detach_does_not_cancel_child
+    (pre post : BridgedState)
+    (h_detach    : ∃ t ∈ pre.parent.tools,
+                     t.callId = pre.bridgeCallId ∧ t.cancelPolicy = .detach)
+    (h_step      : Transition pre post)
+    (h_no_other  : ¬ pre.child.request.interruptRequestedAt.isSome)
+    (h_uniq      : pre.parent.UniqueCallIds) :
+    post.child.request.interruptRequestedAt =
+      pre.child.request.interruptRequestedAt := by
+  cases h_step with
+  | parent_step _ h_child_eq _ _ _ =>
+    -- Parent-only step: child unchanged.
+    rw [h_child_eq]
+  | child_step h_inner _ _ _ _ =>
+    -- A child-side ComposedState step. The only inner constructors that can
+    -- touch `interruptRequestedAt` are within `request_step` (the request
+    -- layer); other layers (process_step, call_step, tool_step, persistence_step)
+    -- preserve `request` directly. Within `request_step`, every inner
+    -- RequestContext.Transition either preserves `interruptRequestedAt`
+    -- (most arms only update `state`/`admission`) or has a precondition on
+    -- the *current* `interruptRequestedAt` flag — namely `interrupt_*` arms,
+    -- which require `pre.interruptRequestedAt.isSome`, contradicting
+    -- `h_no_other`. The `interrupt_*` arms set the post state to .interrupted
+    -- but the timestamp itself is *preserved* by the record update.
+    --
+    -- Concretely: every constructor produces `post = { pre with ... }` where
+    -- the `...` does not mention `interruptRequestedAt`, so post.iRA = pre.iRA.
+    cases h_inner with
+    | process_step _ h_req _ _ _ =>
+      rw [h_req]
+    | request_step h_req_inner _ _ _ _ _ _ =>
+      -- Case-split on the inner RequestContext.Transition; every arm has a
+      -- record-update post that preserves `interruptRequestedAt`.
+      cases h_req_inner with
+      | claim _ _ _ h_post =>
+        rw [h_post]
+      | dedup_lose _ _ h_post =>
+        rw [h_post]
+      | begin_inference _ _ h_post =>
+        rw [h_post]
+      | advance _ _ h_post =>
+        rw [h_post]
+      | finish _ _ h_post =>
+        rw [h_post]
+      | fail _ _ h_post =>
+        rw [h_post]
+      | fail_before_stream _ _ h_post =>
+        rw [h_post]
+      | expire _ _ _ _ h_post =>
+        rw [h_post]
+      | interrupt_before_claim _ _ _ h_post =>
+        rw [h_post]
+      | interrupt_claimed _ _ _ h_post =>
+        rw [h_post]
+      | interrupt_processing _ _ _ h_post =>
+        rw [h_post]
+    | persistence_step _ _ _ h_req _ _ _ _ =>
+      rw [h_req]
+    | call_step _ h_req _ _ _ =>
+      rw [h_req]
+    | tool_step _ _ _ h_req _ _ _ _ =>
+      rw [h_req]
+  | bridge_spawn h_parent_proc _ _ _ _ _ h_post_child _ h_request_eq _ _ =>
+    -- bridge_spawn now guarantees post.child.request.interruptRequestedAt = none
+    -- (the new conjunct in h_post_child). Under h_no_other, the pre-state also
+    -- has interruptRequestedAt = none (proved by cases on the Option). Both
+    -- sides are none, so they are equal.
+    have h_post_none : post.child.request.interruptRequestedAt = none :=
+      h_post_child.2.2.2.2
+    have h_pre_none : pre.child.request.interruptRequestedAt = none := by
+      cases h : pre.child.request.interruptRequestedAt with
+      | none => rfl
+      | some _ => simp [h] at h_no_other
+    rw [h_post_none, h_pre_none]
+  | bridge_complete _ _ _ _ _ _ _ _ _ _ _ h_child_eq _ _ =>
+    rw [h_child_eq]
+  | bridge_failure _ _ _ _ _ _ _ _ _ _ h_child_eq _ _ =>
+    rw [h_child_eq]
+  | bridge_cancel_cascade _ h_cascade _ _ _ _ _ _ _ _ =>
+    -- Bridge tool with cascade policy contradicts h_detach (the same callId
+    -- carries cancelPolicy = .detach). Use h_uniq (UniqueCallIds) to identify
+    -- the two tools as equal: both carry callId = pre.bridgeCallId.
+    obtain ⟨tDet, h_in_d, h_id_d, h_pol_d⟩ := h_detach
+    obtain ⟨tCas, h_in_c, h_id_c, h_pol_c⟩ := h_cascade
+    have h_callIds : tDet.callId = tCas.callId := by rw [h_id_d, h_id_c]
+    have h_same_tool : tDet = tCas :=
+      ComposedState.UniqueCallIds.eq_of_callId_eq h_uniq h_in_d h_in_c h_callIds
+    -- Now h_pol_d says tDet.cancelPolicy = .detach and h_pol_c says
+    -- tCas.cancelPolicy = .cascade. With tDet = tCas, we derive .detach = .cascade.
+    rw [h_same_tool] at h_pol_d
+    rw [h_pol_c] at h_pol_d
+    -- h_pol_d : CancelPolicy.cascade = CancelPolicy.detach. Contradiction.
+    cases h_pol_d
+
+/-! ### B6: foreground blocks parent advance -/
+
+/-- B6: A live foreground tool on the parent prevents the parent's
+    `progressSeq` and `messageSeq` from advancing across any single bridge
+    `Transition`. Restates the `no_blocking_foreground` guard at the
+    BridgedState layer. -/
+theorem foreground_blocks_parent_advance
+    (pre post : BridgedState)
+    (h_fg     : ∃ t ∈ pre.parent.tools,
+                  t.awaitMode = .foreground ∧
+                  ¬ isTerminal t.state)
+    (h_step   : Transition pre post) :
+    pre.parent.request.progressSeq = post.parent.request.progressSeq ∧
+    pre.parent.request.messageSeq  = post.parent.request.messageSeq := by
+  cases h_step with
+  | parent_step h_inner h_child_eq h_bridge_eq _ _ =>
+    -- Inner ComposedState.Transition. Case-split.
+    cases h_inner with
+    | request_step h_req _ _ h_tools _ _ h_no_block =>
+      -- The h_no_block guard says: if reqPost.progressSeq > pre.parent.request.progressSeq
+      -- OR (claimed → processing), THEN no live foreground tool. h_fg directly contradicts
+      -- the consequent. So the antecedent must be false: progressSeq cannot increase
+      -- and we cannot transition claimed → processing. Case-split on h_req.
+      cases h_req with
+      | claim _ _ _ h_post =>
+        constructor <;> rw [h_post]
+      | dedup_lose _ _ h_post =>
+        constructor <;> rw [h_post]
+      | begin_inference h_pre_claimed _ h_post =>
+        -- begin_inference transitions claimed → processing; h_no_block fires
+        -- via Or.inr ⟨pre.state = .claimed, post.state = .processing⟩, giving
+        -- ¬ ∃ live foreground tool, contradicting h_fg.
+        exfalso
+        apply h_no_block
+        · refine Or.inr ⟨h_pre_claimed, ?_⟩
+          rw [h_post]
+        · -- Reconstruct h_fg in pre.tools (which equals pre.parent.tools).
+          exact h_fg
+      | advance _ _ h_post =>
+        -- advance increases progressSeq; h_no_block fires via Or.inl, contradicting h_fg.
+        exfalso
+        apply h_no_block
+        · refine Or.inl ?_
+          rw [h_post]
+          exact Nat.lt_succ_self _
+        · exact h_fg
+      | finish _ _ h_post =>
+        constructor <;> rw [h_post]
+      | fail _ _ h_post =>
+        constructor <;> rw [h_post]
+      | fail_before_stream _ _ h_post =>
+        constructor <;> rw [h_post]
+      | expire _ _ _ _ h_post =>
+        constructor <;> rw [h_post]
+      | interrupt_before_claim _ _ _ h_post =>
+        constructor <;> rw [h_post]
+      | interrupt_claimed _ _ _ h_post =>
+        constructor <;> rw [h_post]
+      | interrupt_processing _ _ _ h_post =>
+        constructor <;> rw [h_post]
+    | tool_step _ _ _ h_req_eq _ _ _ _ =>
+      constructor <;> rw [h_req_eq]
+    | process_step _ h_req _ _ _ =>
+      constructor <;> rw [h_req]
+    | persistence_step _ _ _ h_req _ _ _ _ =>
+      constructor <;> rw [h_req]
+    | call_step _ h_req _ _ _ =>
+      constructor <;> rw [h_req]
+  | child_step _ h_parent_eq _ _ _ =>
+    constructor <;> rw [h_parent_eq]
+  | bridge_spawn _ _ _ _ _ _ _ _ h_request_eq _ _ =>
+    constructor <;> rw [h_request_eq]
+  | bridge_complete _ _ _ _ _ _ _ _ _ _ h_request_eq _ _ _ =>
+    constructor <;> rw [h_request_eq]
+  | bridge_failure _ _ _ _ _ _ _ _ _ h_request_eq _ _ _ =>
+    constructor <;> rw [h_request_eq]
+  | bridge_cancel_cascade _ _ _ h_parent_eq _ _ _ _ _ _ =>
+    constructor <;> rw [h_parent_eq]
+
+/-- B4: Subagent depth bound. Restated standalone for prominence; alias of `inv_depth`. -/
+theorem subagent_depth_bounded
+    (pre post : BridgedState)
+    (h_init  : pre.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+               pre.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_trace : Trace pre post) :
+    post.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    post.child.request.subagentDepth ≤ maxSubagentDepth :=
+  inv_depth pre post h_init h_trace
+
+/-- B5: Bridge link symmetry. Restated standalone for prominence; alias of `inv_link`. -/
+theorem bridge_link_symmetric
+    (pre post : BridgedState)
+    (h_init  : pre.linked)
+    (h_trace : Trace pre post) :
+    post.linked :=
+  inv_link pre post h_init h_trace
+
+end BridgedState
+end Subagent

--- a/crates/defra-agent/proofs/Proofs/Subagent/State.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent/State.lean
@@ -1,0 +1,80 @@
+import Proofs.Basic
+
+/-!
+# Subagent State
+
+Mode and policy enums attached to `ToolCallContext` to support multi-flight,
+foreground/background scheduling, and detachable subagent invocations.
+
+`BridgedState` (a paired parent-child `ComposedState`) is added in a later task
+once `ComposedState` has been refactored to multi-flight.
+-/
+
+namespace Subagent
+
+/-- Whether the parent's narrative is blocked on this tool's terminal state. -/
+inductive AwaitMode where
+  | foreground   -- parent.advance / begin_inference are blocked while this tool is non-terminal
+  | background   -- parent advances independently; tool runs concurrently
+  deriving DecidableEq, Repr
+
+namespace AwaitMode
+
+/-- Persisted vocabulary in `AgentToolCall.await_mode`. -/
+def toDefraDB : AwaitMode → String
+  | .foreground => "foreground"
+  | .background => "background"
+
+/-- Parse the persisted vocabulary. -/
+def fromDefraDB? : String → Option AwaitMode
+  | "foreground" => some .foreground
+  | "background" => some .background
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (m : AwaitMode) :
+    fromDefraDB? m.toDefraDB = some m := by
+  cases m <;> rfl
+
+def all : List AwaitMode := [ .foreground, .background ]
+
+theorem all_complete (m : AwaitMode) : m ∈ all := by
+  cases m <;> simp [all]
+
+end AwaitMode
+
+/-- Cancel-cascade policy: whether parent termination drives the linked child
+    to .interrupted, or detaches the child to its own deadline. -/
+inductive CancelPolicy where
+  | cascade   -- default; parent terminal ⇒ child.interruptRequestedAt set
+  | detach    -- child outlives parent
+  deriving DecidableEq, Repr
+
+namespace CancelPolicy
+
+def toDefraDB : CancelPolicy → String
+  | .cascade => "cascade"
+  | .detach  => "detach"
+
+/-- Parse the persisted vocabulary. -/
+def fromDefraDB? : String → Option CancelPolicy
+  | "cascade" => some .cascade
+  | "detach"  => some .detach
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (p : CancelPolicy) :
+    fromDefraDB? p.toDefraDB = some p := by
+  cases p <;> rfl
+
+def all : List CancelPolicy := [ .cascade, .detach ]
+
+theorem all_complete (p : CancelPolicy) : p ∈ all := by
+  cases p <;> simp [all]
+
+end CancelPolicy
+
+/-- Configured cap on subagent recursion depth. Treated as a global parameter
+    referenced by the depth-bound theorem; the runtime supplies the concrete
+    value from behavior config. -/
+def maxSubagentDepth : Nat := 3
+
+end Subagent

--- a/crates/defra-agent/proofs/Proofs/Subagent/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/Subagent/Transition.lean
@@ -1,0 +1,171 @@
+import Proofs.Subagent.State
+import Proofs.Subagent.Bridge
+
+/-!
+# Subagent Bridge Transitions
+
+Six transitions on `BridgedState`:
+  • parent_step           — lift any ComposedState transition on the parent
+  • child_step            — lift any ComposedState transition on the child
+  • bridge_spawn          — materialize the bridge edge (new parent tool + new child request)
+  • bridge_complete       — child .completed → parent tool .completed (with persistence)
+  • bridge_failure        — child non-.completed terminal → parent tool .failed/.cancelled
+  • bridge_cancel_cascade — parent terminal w/ cascade → child interruptRequestedAt set
+
+Plus `Trace`, the reflexive-transitive closure used in liveness statements.
+-/
+
+namespace Subagent
+namespace BridgedState
+
+inductive Transition : BridgedState → BridgedState → Prop where
+
+  | parent_step {pre post : BridgedState}
+      (h_step          : ComposedState.Transition pre.parent post.parent)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      (h_link_pre      : pre.linked)
+      (h_link_post     : post.linked)
+      : Transition pre post
+
+  | child_step {pre post : BridgedState}
+      (h_step          : ComposedState.Transition pre.child post.child)
+      (h_parent_eq     : post.parent = pre.parent)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      (h_link_pre      : pre.linked)
+      (h_link_post     : post.linked)
+      : Transition pre post
+
+  | bridge_spawn {pre post : BridgedState}
+      {newTool : ToolExecution.ToolCallContext}
+      (h_parent_proc   : pre.parent.request.state = .processing)
+      (h_depth_ok      : pre.parent.request.subagentDepth + 1 ≤ maxSubagentDepth)
+      -- new parent tool with the right shape:
+      (h_newTool_callId : newTool.callId = post.bridgeCallId)
+      (h_newTool_state  : newTool.state = .pending)
+      (h_newTool_child  : newTool.childRequestId = some post.child.requestId)
+      -- post.parent.tools is fully described by appending the new bridge tool.
+      -- Set-style/append-style description: closes the underdetermination
+      -- that would otherwise allow adversarial duplicates to slip into
+      -- post.parent.tools, supporting INV-UNIQUE preservation.
+      (h_tools_append  : post.parent.tools = pre.parent.tools ++ [newTool])
+      -- new child request with parent linkage and depth = parent depth + 1:
+      (h_post_child :
+         post.child.request.state = .pending ∧
+         post.child.request.causedByParentRequestId = some pre.parent.requestId ∧
+         post.child.request.causedByParentToolCallId = some post.bridgeCallId ∧
+         post.child.request.subagentDepth = pre.parent.request.subagentDepth + 1 ∧
+         post.child.request.interruptRequestedAt = none)
+      -- structural-identity guard: the new child request is freshly minted
+      -- with no tools yet. Required for INV-UNIQUE preservation on the child
+      -- side (an empty tool list trivially satisfies `UniqueCallIds`).
+      (h_post_child_tools : post.child.tools = [])
+      -- spawn doesn't progress the parent's narrative:
+      (h_request_eq    : post.parent.request = pre.parent.request)
+      -- structural-identity guard: the parent's top-level requestId is
+      -- preserved across the spawn. Required for INV-LINK's parentLink ↔
+      -- childLink symmetry under any reachable trace.
+      (h_parent_id_eq  : post.parent.requestId = pre.parent.requestId)
+      -- callId-freshness guard: the new bridge tool's callId is not already
+      -- present in `pre.parent.tools`. Operationally true at the runtime —
+      -- fresh callIds are minted at spawn time, never reused. Required for
+      -- INV-UNIQUE (`UniqueCallIds`) preservation across `bridge_spawn`.
+      (h_callId_fresh  : ∀ t ∈ pre.parent.tools, t.callId ≠ post.bridgeCallId)
+      : Transition pre post
+
+  | bridge_complete {pre post : BridgedState}
+      {idx : Nat} {tPre tPost : ToolExecution.ToolCallContext}
+      (h_child_done    : pre.child.request.state = .completed)
+      -- pre bridge tool, located at a specific index. Pinning the index +
+      -- describing post.parent.tools via .set fully determines the post-state
+      -- (matches `tool_step`'s pattern), which is what makes
+      -- `UniqueCallIds`-style invariants liftable to `BridgedState`.
+      (h_idx_pre       : pre.parent.tools[idx]? = some tPre)
+      (h_pre_callId    : tPre.callId = pre.bridgeCallId)
+      (h_pre_state     : tPre.state = .running)
+      (h_pre_persisted : tPre.persistence = .committed)
+      (h_pre_child     : tPre.childRequestId = some pre.child.requestId)
+      -- post bridge tool: state advances to .completed; callId and childRequestId
+      -- are preserved (the bridge tool retains its identity and link).
+      (h_post_callId   : tPost.callId = pre.bridgeCallId)
+      (h_post_state    : tPost.state = .completed)
+      (h_post_child    : tPost.childRequestId = some pre.child.requestId)
+      -- post.parent.tools is fully described by replacing the bridge tool at
+      -- idx with tPost. Closes the underdetermination that would otherwise
+      -- allow adversarial duplicates to slip into post.parent.tools.
+      (h_tools_set     : post.parent.tools = pre.parent.tools.set idx tPost)
+      (h_request_eq    : post.parent.request = pre.parent.request)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      -- structural-identity guard: the parent's top-level requestId is
+      -- preserved (only the bridge tool's state advances at the parent).
+      (h_parent_id_eq  : post.parent.requestId = pre.parent.requestId)
+      : Transition pre post
+
+  | bridge_failure {pre post : BridgedState}
+      {idx : Nat} {tPre tPost : ToolExecution.ToolCallContext}
+      (h_child_term    : pre.child.request.state = .failed ∨
+                         pre.child.request.state = .dead ∨
+                         pre.child.request.state = .interrupted ∨
+                         pre.child.request.state = .superseded)
+      -- pre bridge tool, located at a specific index. Same set-style description
+      -- as `bridge_complete` — see the comment there.
+      (h_idx_pre       : pre.parent.tools[idx]? = some tPre)
+      (h_pre_callId    : tPre.callId = pre.bridgeCallId)
+      (h_pre_state     : tPre.state = .running)
+      (h_pre_child     : tPre.childRequestId = some pre.child.requestId)
+      -- post bridge tool: state moves to .failed/.cancelled; callId and
+      -- childRequestId preserved.
+      (h_post_callId   : tPost.callId = pre.bridgeCallId)
+      (h_post_state    : tPost.state = .failed ∨ tPost.state = .cancelled)
+      (h_post_child    : tPost.childRequestId = some pre.child.requestId)
+      -- Set-style description of post.parent.tools.
+      (h_tools_set     : post.parent.tools = pre.parent.tools.set idx tPost)
+      (h_request_eq    : post.parent.request = pre.parent.request)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      -- structural-identity guard: the parent's top-level requestId is
+      -- preserved (only the bridge tool's state advances at the parent).
+      (h_parent_id_eq  : post.parent.requestId = pre.parent.requestId)
+      : Transition pre post
+
+  | bridge_cancel_cascade {pre post : BridgedState}
+      (h_parent_term   : isTerminal pre.parent.request.state ∨
+                         (∃ t ∈ pre.parent.tools,
+                            t.callId = pre.bridgeCallId ∧
+                            t.state = .cancelled))
+      (h_cascade_pol   : ∃ t ∈ pre.parent.tools,
+                           t.callId = pre.bridgeCallId ∧
+                           t.cancelPolicy = .cascade)
+      (h_interrupt_set : post.child.request.interruptRequestedAt.isSome)
+      (h_parent_eq     : post.parent = pre.parent)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      -- structural-identity guards on the child: only `interruptRequestedAt`
+      -- is allowed to change. Top-level child requestId, lineage fields, and
+      -- depth are preserved. (Subsequent inner transitions on the child use
+      -- `child_step` to drive .interrupted; bridge_cancel_cascade is
+      -- structurally inert except for setting the interrupt timestamp.)
+      (h_child_id_eq   : post.child.requestId = pre.child.requestId)
+      (h_child_caused_req_eq :
+         post.child.request.causedByParentRequestId =
+           pre.child.request.causedByParentRequestId)
+      (h_child_caused_tool_eq :
+         post.child.request.causedByParentToolCallId =
+           pre.child.request.causedByParentToolCallId)
+      (h_child_depth_eq :
+         post.child.request.subagentDepth = pre.child.request.subagentDepth)
+      -- structural-identity guard: child's tool list is unchanged. The cascade
+      -- step is operationally a single-field update on `interruptRequestedAt`;
+      -- child tools survive verbatim. Required for INV-UNIQUE preservation
+      -- (and would also be required for any future child-tools invariant).
+      (h_child_tools_eq : post.child.tools = pre.child.tools)
+      : Transition pre post
+
+/-- Reflexive-transitive closure for liveness statements. -/
+inductive Trace : BridgedState → BridgedState → Prop where
+  | refl {s : BridgedState} : Trace s s
+  | step {s₁ s₂ s₃ : BridgedState} :
+      Transition s₁ s₂ → Trace s₂ s₃ → Trace s₁ s₃
+
+end BridgedState
+end Subagent

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
@@ -37,7 +37,7 @@ def step? (pre : ToolCallContext) : Action → Option ToolCallContext
       else
         none
   | .complete =>
-      if pre.state = .running ∧ pre.persistence = .committed then
+      if pre.state = .running ∧ pre.persistence = .committed ∧ pre.childRequestId = none then
         some { pre with state := .completed }
       else
         none
@@ -78,8 +78,8 @@ theorem step_refines_transition
       exact Transition.spawnFailed failure (h_state := h_state) (h_post := h_post.symm)
   | complete =>
       simp [step?] at h_step
-      rcases h_step with ⟨⟨h_state, h_persist⟩, h_post⟩
-      exact Transition.complete (h_state := h_state) (h_persist := h_persist) (h_post := h_post.symm)
+      rcases h_step with ⟨⟨h_state, h_persist, h_native⟩, h_post⟩
+      exact Transition.complete (h_state := h_state) (h_persist := h_persist) (h_native := h_native) (h_post := h_post.symm)
   | fail failure =>
       simp [step?] at h_step
       rcases h_step with ⟨h_state, h_post⟩

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean
@@ -20,11 +20,14 @@ theorem terminal_irreversible
   cases h_step with
   | dispatch h_state _              => simp_all [isTerminal]
   | spawnFailed _ h_state _         => simp_all [isTerminal]
-  | complete h_state _ _            => simp_all [isTerminal]
+  | complete h_state _ _ _          => simp_all [isTerminal]
   | fail _ h_state _                => simp_all [isTerminal]
   | timeout h_state _ _             => simp_all [isTerminal]
   | cancelBeforeDispatch h_state _  => simp_all [isTerminal]
   | cancelDuringRun h_state _       => simp_all [isTerminal]
+  | background h_state _ _          => simp_all [isTerminal]
+  | foreground h_state _ _          => simp_all [isTerminal]
+  | detach h_live _ _               => simp_all [isTerminal]
   | timeAdvance _ _ h_post          => simp_all
   | persistenceStep _ _ _ h_post    => simp_all
 
@@ -50,11 +53,14 @@ theorem timedOut_requires_deadline_exceeded
   cases h_step with
   | dispatch _ h_post'              => simp_all
   | spawnFailed _ _ h_post'         => simp_all
-  | complete _ _ h_post'            => simp_all
+  | complete _ _ _ h_post'          => simp_all
   | fail _ _ h_post'                => simp_all
   | timeout _ h_deadline _          => exact h_deadline
   | cancelBeforeDispatch _ h_post'  => simp_all
   | cancelDuringRun _ h_post'       => simp_all
+  | background _ _ h_post'          => simp_all
+  | foreground _ _ h_post'          => simp_all
+  | detach _ _ h_post'              => simp_all
   | timeAdvance _ _ h_post'         => simp_all
   | persistenceStep _ _ _ h_post'   => simp_all
 
@@ -70,11 +76,14 @@ theorem completed_implies_committed
   cases h_step with
   | dispatch _ h_post'              => simp_all
   | spawnFailed _ _ h_post'         => simp_all
-  | complete _ h_persist h_post'    => simp_all
+  | complete _ h_persist _ h_post'  => simp_all
   | fail _ _ h_post'                => simp_all
   | timeout _ _ h_post'             => simp_all
   | cancelBeforeDispatch _ h_post'  => simp_all
   | cancelDuringRun _ h_post'       => simp_all
+  | background _ _ h_post'          => simp_all
+  | foreground _ _ h_post'          => simp_all
+  | detach _ _ h_post'              => simp_all
   | timeAdvance _ _ h_post'         => simp_all
   | persistenceStep _ _ _ h_post'   => simp_all
 
@@ -138,11 +147,36 @@ theorem transition_preserves_requestId
   cases h_step with
   | dispatch _ h_post              => rw [h_post]
   | spawnFailed _ _ h_post         => rw [h_post]
-  | complete _ _ h_post            => rw [h_post]
+  | complete _ _ _ h_post          => rw [h_post]
   | fail _ _ h_post                => rw [h_post]
   | timeout _ _ h_post             => rw [h_post]
   | cancelBeforeDispatch _ h_post  => rw [h_post]
   | cancelDuringRun _ h_post       => rw [h_post]
+  | background _ _ h_post          => rw [h_post]
+  | foreground _ _ h_post          => rw [h_post]
+  | detach _ _ h_post              => rw [h_post]
+  | timeAdvance _ _ h_post         => rw [h_post]
+  | persistenceStep _ _ _ h_post   => rw [h_post]
+
+/-- Helper: every Transition preserves `callId`. The callId is set at
+    construction time and no inner transition mentions it in its
+    `post = { pre with ... }` rewrite. Used by
+    `ComposedState.uniqueCallIds_preserved`. -/
+theorem transition_preserves_callId
+    {pre post : ToolCallContext}
+    (h_step : Transition pre post) :
+    post.callId = pre.callId := by
+  cases h_step with
+  | dispatch _ h_post              => rw [h_post]
+  | spawnFailed _ _ h_post         => rw [h_post]
+  | complete _ _ _ h_post          => rw [h_post]
+  | fail _ _ h_post                => rw [h_post]
+  | timeout _ _ h_post             => rw [h_post]
+  | cancelBeforeDispatch _ h_post  => rw [h_post]
+  | cancelDuringRun _ h_post       => rw [h_post]
+  | background _ _ h_post          => rw [h_post]
+  | foreground _ _ h_post          => rw [h_post]
+  | detach _ _ h_post              => rw [h_post]
   | timeAdvance _ _ h_post         => rw [h_post]
   | persistenceStep _ _ _ h_post   => rw [h_post]
 
@@ -156,11 +190,14 @@ theorem dispatch_sets_startedAt
   cases h_step with
   | dispatch _ h_post'              => simp [h_post']
   | spawnFailed _ _ h_post'         => exfalso; rw [h_post'] at h_post; simp at h_post
-  | complete h_state _ h_post'      => exfalso; simp_all
+  | complete h_state _ _ h_post'    => exfalso; simp_all
   | fail _ h_state h_post'           => exfalso; simp_all
   | timeout h_state _ h_post'       => exfalso; simp_all
   | cancelBeforeDispatch _ h_post'  => exfalso; rw [h_post'] at h_post; simp at h_post
   | cancelDuringRun h_state h_post' => exfalso; simp_all
+  | background h_state _ h_post'    => exfalso; simp_all
+  | foreground h_state _ h_post'    => exfalso; simp_all
+  | detach h_live _ h_post'         => exfalso; rw [h_post'] at h_post; simp_all
   | timeAdvance _ _ h_post'         => exfalso; rw [h_post'] at h_post; simp_all
   | persistenceStep _ _ _ h_post'   => exfalso; rw [h_post'] at h_post; simp_all
 
@@ -177,11 +214,14 @@ theorem startedAt_preserved_outside_dispatch
       apply h_not
       exact ⟨h_state, by rw [h_post']⟩
   | spawnFailed _ _ h_post'         => rw [h_post']
-  | complete _ _ h_post'            => rw [h_post']
+  | complete _ _ _ h_post'          => rw [h_post']
   | fail _ _ h_post'                => rw [h_post']
   | timeout _ _ h_post'             => rw [h_post']
   | cancelBeforeDispatch _ h_post'  => rw [h_post']
   | cancelDuringRun _ h_post'       => rw [h_post']
+  | background _ _ h_post'          => rw [h_post']
+  | foreground _ _ h_post'          => rw [h_post']
+  | detach _ _ h_post'              => rw [h_post']
   | timeAdvance _ _ h_post'         => rw [h_post']
   | persistenceStep _ _ _ h_post'   => rw [h_post']
 

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/State.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/State.lean
@@ -1,6 +1,7 @@
 import Proofs.Basic
 import Proofs.Persistence
 import Proofs.ToolExecution.Policy
+import Proofs.Subagent.State
 
 /-!
 # Tool Call State
@@ -80,15 +81,19 @@ abbrev ToolCallId := Nat
 
 /-- Mutable per-tool-call context that transitions carry along. -/
 structure ToolCallContext where
-  callId       : ToolCallId
-  requestId    : RequestId
-  state        : ToolCallState
-  operation    : ToolOperation
-  deadline     : Time
-  startedAt    : Option Time := none
-  currentTime  : Time
-  failureClass : Option FailureClass := none
-  persistence  : PersistenceState
+  callId         : ToolCallId
+  requestId      : RequestId
+  state          : ToolCallState
+  operation      : ToolOperation
+  deadline       : Time
+  startedAt      : Option Time := none
+  currentTime    : Time
+  failureClass   : Option FailureClass := none
+  persistence    : PersistenceState
+  -- Subagent extensions:
+  awaitMode      : Subagent.AwaitMode := .foreground
+  cancelPolicy   : Subagent.CancelPolicy := .cascade
+  childRequestId : Option RequestId := none
   deriving Repr
 
 namespace ToolCallContext

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean
@@ -4,7 +4,8 @@ import Proofs.ToolExecution.State
 # Tool Call Transitions
 
 Relational transition system for `ToolCallContext`. Seven state-changing
-constructors plus two non-state constructors (`timeAdvance`, `persistenceStep`).
+constructors plus five non-state constructors (`timeAdvance`, `persistenceStep`,
+`background`, `foreground`, `detach`).
 -/
 
 namespace ToolExecution
@@ -27,6 +28,7 @@ inductive Transition : ToolCallContext → ToolCallContext → Prop where
   | complete {pre post : ToolCallContext}
       (h_state   : pre.state = .running)
       (h_persist : pre.persistence = .committed)
+      (h_native  : pre.childRequestId = none)
       (h_post    : post = { pre with state := .completed })
       : Transition pre post
 
@@ -50,6 +52,24 @@ inductive Transition : ToolCallContext → ToolCallContext → Prop where
   | cancelDuringRun {pre post : ToolCallContext}
       (h_state : pre.state = .running)
       (h_post  : post = { pre with state := .cancelled })
+      : Transition pre post
+
+  | background {pre post : ToolCallContext}
+      (h_state : pre.state = .running)
+      (h_mode  : pre.awaitMode = .foreground)
+      (h_post  : post = { pre with awaitMode := .background })
+      : Transition pre post
+
+  | foreground {pre post : ToolCallContext}
+      (h_state : pre.state = .running)
+      (h_mode  : pre.awaitMode = .background)
+      (h_post  : post = { pre with awaitMode := .foreground })
+      : Transition pre post
+
+  | detach {pre post : ToolCallContext}
+      (h_live  : pre.state = .pending ∨ pre.state = .running)
+      (h_pol   : pre.cancelPolicy = .cascade)
+      (h_post  : post = { pre with cancelPolicy := .detach })
       : Transition pre post
 
   | timeAdvance {pre post : ToolCallContext} (t : Time)

--- a/crates/defra-agent/src/admission/tests.rs
+++ b/crates/defra-agent/src/admission/tests.rs
@@ -57,6 +57,9 @@ fn request(request_id: &str) -> AgentRequest {
         metadata: None,
         execution_origin: None,
         created_at: "2026-04-15T00:00:00Z".to_string(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     }
 }
 

--- a/crates/defra-agent/src/agent/daemon/inference.rs
+++ b/crates/defra-agent/src/agent/daemon/inference.rs
@@ -144,6 +144,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 .await?;
                 hook.set_active_request_id(Some(request.request_id.clone()))
                     .await;
+                hook.set_request_deadline_at(request_deadline).await;
                 let persistence_hook = hook.clone();
 
                 let agent = agent_with_request_sampling(&self.agent, &self.behavior, request);
@@ -153,6 +154,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 // InferenceCall as cancelled rather than a generic stream drop.
                 let inference_token = request_token.child_token();
                 let inference_token_for_start = inference_token.clone();
+                let hook_for_start_interrupt = persistence_hook.clone();
                 let mut stream = admission::scope_call_with_token(
                     CallKind::Inference,
                     attempt_index as i64,
@@ -166,6 +168,14 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                             _ = interrupt_rx.changed() => {
                                 request_token.cancel();
                                 inference_token_for_start.cancel();
+                                if let Err(error) = hook_for_start_interrupt.cancel_in_flight_tool_calls().await {
+                                    tracing::warn!(
+                                        request_id = %request_id,
+                                        session_id = %session_id,
+                                        error = %error,
+                                        "failed to cancel in-flight tool calls before inference stream started"
+                                    );
+                                }
                                 Err(anyhow!("request interrupted during inference"))
                             }
                             stream = await_with_request_deadline(
@@ -206,6 +216,16 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                                 _ = interrupt_rx.changed() => {
                                     request_token.cancel();
                                     inference_token.cancel();
+                                    if let Err(error) =
+                                        persistence_hook.cancel_in_flight_tool_calls().await
+                                    {
+                                        tracing::warn!(
+                                            request_id = %request_id,
+                                            session_id = %session_id,
+                                            error = %error,
+                                            "failed to cancel in-flight tool calls during request interrupt"
+                                        );
+                                    }
                                     if let Err(error) = processor
                                         .persist_partial_turn("persist interrupted assistant turn")
                                         .await
@@ -221,13 +241,48 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                                 }
                                 result = await_with_request_deadline(
                                     request_deadline,
-                                    tokio::time::timeout(liveness_timeout, stream.next()),
+                                    crate::tool_call_lifecycle::runtime::scope_request_tool_execution(
+                                        request_deadline,
+                                        request_token.clone(),
+                                        tokio::time::timeout(liveness_timeout, stream.next()),
+                                    ),
                                     "waiting for inference stream item",
-                                ) => result?
+                                ) => {
+                                    match result {
+                                        Ok(item) => item,
+                                        Err(error) => {
+                                            if let Err(sweep_error) =
+                                                persistence_hook.timeout_expired_tool_calls().await
+                                            {
+                                                tracing::warn!(
+                                                    request_id = %request_id,
+                                                    session_id = %session_id,
+                                                    error = %sweep_error,
+                                                    "failed to sweep expired in-flight tool calls after request deadline"
+                                                );
+                                            }
+                                            return Err(error);
+                                        }
+                                    }
+                                }
                             } {
                                 Ok(Some(item)) => item,
                                 Ok(None) => break,
                                 Err(_) => {
+                                    if let Err(error) = persistence_hook
+                                        .fail_in_flight_tool_calls(
+                                            "stream liveness timeout while tool call was running",
+                                            crate::tool_call_lifecycle::FailureClass::External,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            request_id = %request_id,
+                                            session_id = %session_id,
+                                            error = %error,
+                                            "failed to mark in-flight tool calls failed after stream liveness timeout"
+                                        );
+                                    }
                                     stream_error = Some(rig::agent::StreamingError::Completion(
                                         rig::completion::CompletionError::ProviderError(format!(
                                             "stream liveness timeout: no data received for {}s",

--- a/crates/defra-agent/src/agent/document_view/apply.rs
+++ b/crates/defra-agent/src/agent/document_view/apply.rs
@@ -66,6 +66,7 @@ pub(crate) async fn apply_control_update(
         if selection.agent_did != agent_did {
             return Ok(ControlUpdateOutcome::Irrelevant);
         }
+        selection.validate()?;
         view.remove_tool_selection_by_doc_id(doc_id);
         view.tool_selections.insert(
             selection.selection_id.clone(),

--- a/crates/defra-agent/src/agent/document_view/tests.rs
+++ b/crates/defra-agent/src/agent/document_view/tests.rs
@@ -103,6 +103,7 @@ async fn load_document_runtime_view_includes_referenced_documents() {
             enable_meta_tools: Some(false),
             allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
+            ..Default::default()
         },
     )
     .await
@@ -169,6 +170,7 @@ async fn apply_control_update_reconciles_tool_selection_via_doc_id() {
             enable_meta_tools: Some(false),
             allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
+            ..Default::default()
         },
     )
     .await
@@ -227,6 +229,92 @@ async fn apply_control_update_reconciles_tool_selection_via_doc_id() {
     let tool_names = tool_surface.tool_names();
     assert!(tool_names.contains(&"read_file".to_string()));
     assert!(tool_names.contains(&"list_files".to_string()));
+}
+
+/// Insert a ToolSelection row with an empty string in `subagent_targets` and
+/// return its `_docID`.  DefraDB schema has no non-empty constraint on
+/// `[String]` fields, so the document writes successfully.  The validator
+/// must catch this on read.
+async fn insert_invalid_tool_selection(
+    node: &defra_node::EmbeddedNode,
+    selection_id: &str,
+    agent_did: &str,
+) -> String {
+    let escaped_selection_id = escape_graphql_string(selection_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+
+    // subagent_targets contains an empty string — valid at the DB level but
+    // invalid per ToolSelectionDocument::validate().
+    let mutation = format!(
+        r#"mutation {{
+            create_ToolSelection(input: {{
+                selection_id: "{escaped_selection_id}",
+                agent_did: "{escaped_agent_did}",
+                subagent_targets: ["", "valid-behavior"],
+                subagent_spawn_enabled: true
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create_ToolSelection (invalid) failed: {:?}",
+        response.errors
+    );
+
+    let lookup = format!(
+        r#"{{
+            ToolSelection(filter: {{ selection_id: {{ _eq: "{escaped_selection_id}" }} }}, limit: 1) {{
+                _docID
+            }}
+        }}"#
+    );
+    let response = node.execute(&lookup).await;
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("ToolSelection"))
+        .and_then(|rows| rows.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("_docID"))
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .expect("ToolSelection _docID")
+}
+
+#[tokio::test]
+async fn apply_control_update_rejects_tool_selection_with_empty_subagent_target() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let identity = Arc::new(test_identity("document-view-invalid-tool-selection"));
+    let agent_did = identity.did();
+
+    let selection_id = "invalid-targets-selection";
+    let doc_id = insert_invalid_tool_selection(node.as_ref(), selection_id, agent_did).await;
+
+    let mut view = load_document_runtime_view(node.as_ref(), agent_did)
+        .await
+        .expect("initial document view should load");
+
+    let result = apply_control_update(
+        node.as_ref(),
+        agent_did,
+        "opaque-tool-selection-collection",
+        &doc_id,
+        &mut view,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "apply_control_update must reject ToolSelection with empty subagent_target, got: {:?}",
+        result
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("subagent_targets"),
+        "error message must mention subagent_targets, got: {err_msg}"
+    );
 }
 
 async fn create_task(node: &defra_node::EmbeddedNode, task_id: &str, name: &str) {

--- a/crates/defra-agent/src/agent/runtime/context.rs
+++ b/crates/defra-agent/src/agent/runtime/context.rs
@@ -81,7 +81,11 @@ impl RuntimeContext {
         let api_key = behavior.completion_client_api_key()?;
         let prompt_builder = LayeredPromptBuilder::new(behavior.as_ref(), tool_surface.as_ref());
         let preamble = prompt_builder.preamble().to_string();
-        let tools = tool_surface.build_tools(&self.tool_runtime)?;
+        let tools = tool_surface
+            .build_tools(&self.tool_runtime)?
+            .into_iter()
+            .map(crate::tool_call_lifecycle::runtime::wrap_tool)
+            .collect();
         tracing::info!(
             behavior_id = %behavior.name,
             did = %behavior.did(),

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -19,6 +19,7 @@ use crate::health_checker::{spawn_health_checker, ServiceHealthMap};
 use crate::lifecycle::RequestLifecycle;
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
 use crate::runtime_status::{ReconcilePhase, RuntimeStatusHandle};
+use crate::tool_call_lifecycle::ToolCallLifecycle;
 use crate::tool_surface::{ToolRuntimeContext, ToolSurface};
 
 enum BackgroundTaskResult {
@@ -320,9 +321,11 @@ pub(in crate::agent) async fn run_agent(
 }
 
 async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_behavior_id: &str) {
+    let mut recovered_any = false;
     match RequestLifecycle::recover_all(node, agent_did).await {
         Ok(report) => {
             if report.requests_recovered > 0 {
+                recovered_any = true;
                 tracing::info!(
                     agent_did = %agent_did,
                     count = report.requests_recovered,
@@ -330,6 +333,7 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
                 );
             }
             if report.responses_recovered > 0 {
+                recovered_any = true;
                 tracing::info!(
                     agent_did = %agent_did,
                     count = report.responses_recovered,
@@ -337,26 +341,45 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
                 );
             }
             if report.conversations_recovered > 0 {
+                recovered_any = true;
                 tracing::info!(
                     agent_did = %agent_did,
                     count = report.conversations_recovered,
                     "recovered stuck conversations"
                 );
             }
-            if report.requests_recovered == 0
-                && report.responses_recovered == 0
-                && report.conversations_recovered == 0
-            {
-                tracing::debug!(
-                    agent_did = %agent_did,
-                    default_behavior_id = %default_behavior_id,
-                    "startup recovery found no stuck documents"
-                );
-            }
         }
         Err(error) => {
             tracing::warn!(agent_did = %agent_did, error = %error, "startup recovery failed");
         }
+    }
+
+    match ToolCallLifecycle::recover_all(node, agent_did).await {
+        Ok(report) => {
+            if report.tool_calls_recovered > 0 {
+                recovered_any = true;
+                tracing::info!(
+                    agent_did = %agent_did,
+                    count = report.tool_calls_recovered,
+                    "recovered stuck tool calls"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                agent_did = %agent_did,
+                error = %error,
+                "startup tool-call recovery failed"
+            );
+        }
+    }
+
+    if !recovered_any {
+        tracing::debug!(
+            agent_did = %agent_did,
+            default_behavior_id = %default_behavior_id,
+            "startup recovery found no stuck documents"
+        );
     }
 }
 

--- a/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
@@ -224,6 +224,7 @@ async fn control_watcher_resolves_tool_selection_into_reconciled_tool_surface() 
             enable_meta_tools: Some(false),
             allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(Vec::new()),
+            ..Default::default()
         },
     )
     .await

--- a/crates/defra-agent/src/agent/runtime/tests/router.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/router.rs
@@ -58,6 +58,9 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
             metadata: None,
             execution_origin: None,
             created_at: "2026-04-09T00:00:00Z".to_string(),
+            subagent_depth: 0,
+            caused_by_parent_request_id: None,
+            caused_by_parent_tool_call_id: None,
         }))
         .await
         .unwrap();

--- a/crates/defra-agent/src/agent/runtime/tests/support.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/support.rs
@@ -40,6 +40,9 @@ pub(super) fn request(behavior_id: Option<&str>, session_id: &str) -> AgentReque
         metadata: None,
         execution_origin: None,
         created_at: "2026-04-09T00:00:00Z".to_string(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     }
 }
 

--- a/crates/defra-agent/src/agent/stream_processor/tests.rs
+++ b/crates/defra-agent/src/agent/stream_processor/tests.rs
@@ -102,6 +102,9 @@ async fn persist_partial_turn_saves_reasoning_and_text_to_history() {
         metadata: None,
         execution_origin: None,
         created_at: chrono::Utc::now().to_rfc3339(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
     let mut lifecycle = RequestLifecycle::new_with_execution_binding(
         node.clone(),
@@ -384,6 +387,9 @@ async fn hook_persisted_tool_result_dedupes_matching_stream_result() {
         metadata: None,
         execution_origin: None,
         created_at: chrono::Utc::now().to_rfc3339(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle = RequestLifecycle::new_with_execution_binding(
@@ -546,6 +552,9 @@ async fn post_tool_resumed_resets_response_tail() {
         metadata: None,
         execution_origin: None,
         created_at: chrono::Utc::now().to_rfc3339(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle = RequestLifecycle::new_with_execution_binding(

--- a/crates/defra-agent/src/agent/tests/document_loading.rs
+++ b/crates/defra-agent/src/agent/tests/document_loading.rs
@@ -132,6 +132,7 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
             enable_meta_tools: Some(false),
             allowed_mcp_service_ids: Some(Vec::new()),
             delegate_to: Some(vec!["did:defra-agent:amy-code".to_string()]),
+            ..Default::default()
         },
     )
     .await

--- a/crates/defra-agent/src/completion_factory/tests.rs
+++ b/crates/defra-agent/src/completion_factory/tests.rs
@@ -17,6 +17,9 @@ fn request() -> AgentRequest {
         metadata: None,
         execution_origin: None,
         created_at: String::new(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     }
 }
 
@@ -77,6 +80,9 @@ fn request_sampling_overrides_behavior_defaults() {
         metadata: Some(r#"{"run_id":"foo"}"#.to_string()),
         execution_origin: None,
         created_at: String::new(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let sampling = sampling_for_request(defaults, &request);

--- a/crates/defra-agent/src/document_config/tests.rs
+++ b/crates/defra-agent/src/document_config/tests.rs
@@ -51,3 +51,34 @@ fn tool_selection_document_accepts_string_array_values() {
         Some(vec!["did:defra-agent:other".to_string()])
     );
 }
+
+#[test]
+fn validate_rejects_empty_string_in_subagent_targets() {
+    let doc = ToolSelectionDocument {
+        selection_id: "test-tools".to_string(),
+        agent_did: "did:defra-agent:test".to_string(),
+        subagent_targets: Some(vec!["".to_string()]),
+        subagent_spawn_enabled: Some(true),
+        ..Default::default()
+    };
+    let result = doc.validate();
+    assert!(result.is_err());
+    assert!(
+        format!("{}", result.unwrap_err()).contains("subagent_targets"),
+        "error message must mention subagent_targets"
+    );
+}
+
+#[test]
+fn validate_accepts_well_formed_subagent_targets() {
+    let doc = ToolSelectionDocument {
+        selection_id: "test-tools".to_string(),
+        agent_did: "did:defra-agent:test".to_string(),
+        subagent_targets: Some(vec!["amy-code".to_string(), "amy-research".to_string()]),
+        subagent_spawn_enabled: Some(true),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(true),
+        ..Default::default()
+    };
+    assert!(doc.validate().is_ok());
+}

--- a/crates/defra-agent/src/document_config/tool_selection.rs
+++ b/crates/defra-agent/src/document_config/tool_selection.rs
@@ -6,9 +6,11 @@ use super::graphql_fields;
 use super::serde_helpers;
 use crate::graphql::escape_graphql_string;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ToolSelectionDocument {
+    #[serde(default)]
     pub selection_id: String,
+    #[serde(default)]
     pub agent_did: String,
     pub display_name: Option<String>,
     pub enable_file_tools: Option<bool>,
@@ -44,6 +46,30 @@ pub struct ToolSelectionDocument {
         deserialize_with = "super::serde_helpers::deserialize_optional_string_vec"
     )]
     pub delegate_to: Option<Vec<String>>,
+    #[serde(
+        default,
+        deserialize_with = "super::serde_helpers::deserialize_optional_string_vec"
+    )]
+    pub subagent_targets: Option<Vec<String>>,
+    pub subagent_spawn_enabled: Option<bool>,
+    pub subagent_steering_enabled: Option<bool>,
+    pub subagent_background_enabled: Option<bool>,
+}
+
+impl ToolSelectionDocument {
+    pub fn validate(&self) -> Result<()> {
+        if let Some(targets) = &self.subagent_targets {
+            for (i, target) in targets.iter().enumerate() {
+                if target.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "subagent_targets[{}] is empty; behavior IDs must be non-empty strings",
+                        i
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
 }
 
 pub fn default_tool_selection_id_for_behavior(behavior_id: &str) -> String {
@@ -87,6 +113,10 @@ pub(crate) async fn load_tool_selection_record(
                 enable_meta_tools
                 allowed_mcp_service_ids
                 delegate_to
+                subagent_targets
+                subagent_spawn_enabled
+                subagent_steering_enabled
+                subagent_background_enabled
             }}
         }}"#
     );
@@ -130,6 +160,10 @@ pub(crate) async fn load_tool_selection_by_doc_id(
                 enable_meta_tools
                 allowed_mcp_service_ids
                 delegate_to
+                subagent_targets
+                subagent_spawn_enabled
+                subagent_steering_enabled
+                subagent_background_enabled
             }}
         }}"#
     );
@@ -173,6 +207,10 @@ pub(crate) async fn list_tool_selection_records(
                 enable_meta_tools
                 allowed_mcp_service_ids
                 delegate_to
+                subagent_targets
+                subagent_spawn_enabled
+                subagent_steering_enabled
+                subagent_background_enabled
             }}
         }}"#
     );
@@ -210,6 +248,10 @@ pub(crate) async fn list_all_tool_selection_records(
                 enable_meta_tools
                 allowed_mcp_service_ids
                 delegate_to
+                subagent_targets
+                subagent_spawn_enabled
+                subagent_steering_enabled
+                subagent_background_enabled
             }
         }"#;
 
@@ -278,6 +320,22 @@ pub async fn upsert_tool_selection(
             selection.allowed_mcp_service_ids.as_deref(),
         ),
         graphql_fields::graphql_string_list_field("delegate_to", selection.delegate_to.as_deref()),
+        graphql_fields::graphql_string_list_field(
+            "subagent_targets",
+            selection.subagent_targets.as_deref(),
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_spawn_enabled",
+            selection.subagent_spawn_enabled,
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_steering_enabled",
+            selection.subagent_steering_enabled,
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_background_enabled",
+            selection.subagent_background_enabled,
+        ),
     ]
     .into_iter()
     .flatten()
@@ -330,6 +388,22 @@ pub async fn upsert_tool_selection(
             selection.allowed_mcp_service_ids.as_deref(),
         ),
         graphql_fields::graphql_string_list_field("delegate_to", selection.delegate_to.as_deref()),
+        graphql_fields::graphql_string_list_field(
+            "subagent_targets",
+            selection.subagent_targets.as_deref(),
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_spawn_enabled",
+            selection.subagent_spawn_enabled,
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_steering_enabled",
+            selection.subagent_steering_enabled,
+        ),
+        graphql_fields::graphql_optional_bool_field(
+            "subagent_background_enabled",
+            selection.subagent_background_enabled,
+        ),
     ]
     .into_iter()
     .flatten()

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use defra_node::EmbeddedNode;
 use rig::agent::{HookAction, ToolCallHookAction};
 use tokio::sync::Mutex;
@@ -48,6 +49,7 @@ struct ToolResultIdentity {
 struct SessionState {
     session_id: Option<String>,
     current_request_id: Option<String>,
+    request_deadline_at: Option<DateTime<Utc>>,
     agent_name: String,
     sequence: u32,
     transcript_turn: TranscriptTurnState,
@@ -251,6 +253,7 @@ impl DefraSessionHook {
             state: Arc::new(Mutex::new(SessionState {
                 session_id: None,
                 current_request_id: None,
+                request_deadline_at: None,
                 agent_name: agent_name.to_string(),
                 sequence: 0,
                 transcript_turn: TranscriptTurnState::Idle,
@@ -284,6 +287,7 @@ impl DefraSessionHook {
             state: Arc::new(Mutex::new(SessionState {
                 session_id: Some(session_id.to_string()),
                 current_request_id: None,
+                request_deadline_at: None,
                 agent_name: agent_name.to_string(),
                 sequence: max_seq,
                 transcript_turn: TranscriptTurnState::Idle,
@@ -360,6 +364,77 @@ impl DefraSessionHook {
         );
     }
 
+    pub async fn set_request_deadline_at(&self, deadline_at: Option<DateTime<Utc>>) {
+        self.state.lock().await.request_deadline_at = deadline_at;
+    }
+
+    pub(crate) async fn timeout_expired_tool_calls(&self) -> anyhow::Result<usize> {
+        let lifecycles = {
+            let now = Utc::now();
+            let mut map = self.in_flight_lifecycles.lock().await;
+            let expired_ids = map
+                .iter()
+                .filter_map(|(id, lifecycle)| (lifecycle.deadline_at() <= now).then(|| id.clone()))
+                .collect::<Vec<_>>();
+
+            expired_ids
+                .into_iter()
+                .filter_map(|id| map.remove(&id))
+                .collect::<Vec<_>>()
+        };
+
+        let count = lifecycles.len();
+        for mut lifecycle in lifecycles {
+            lifecycle.timeout().await?;
+        }
+        Ok(count)
+    }
+
+    pub(crate) async fn cancel_in_flight_tool_calls(&self) -> anyhow::Result<usize> {
+        let lifecycles = {
+            let mut map = self.in_flight_lifecycles.lock().await;
+            map.drain()
+                .map(|(_, lifecycle)| lifecycle)
+                .collect::<Vec<_>>()
+        };
+
+        let count = lifecycles.len();
+        for mut lifecycle in lifecycles {
+            lifecycle.cancel_during_run().await?;
+            if let Some(intent) = lifecycle.bridge_cancel_cascade().await? {
+                if let Err(error) =
+                    crate::interrupt::interrupt_request(&self.node, &intent.child_request_id).await
+                {
+                    tracing::warn!(
+                        child_request_id = %intent.child_request_id,
+                        error = %error,
+                        "failed to cascade live tool-call cancellation to child request"
+                    );
+                }
+            }
+        }
+        Ok(count)
+    }
+
+    pub(crate) async fn fail_in_flight_tool_calls(
+        &self,
+        result: &str,
+        failure_class: crate::tool_call_lifecycle::FailureClass,
+    ) -> anyhow::Result<usize> {
+        let lifecycles = {
+            let mut map = self.in_flight_lifecycles.lock().await;
+            map.drain()
+                .map(|(_, lifecycle)| lifecycle)
+                .collect::<Vec<_>>()
+        };
+
+        let count = lifecycles.len();
+        for mut lifecycle in lifecycles {
+            lifecycle.fail(result, failure_class).await?;
+        }
+        Ok(count)
+    }
+
     pub async fn mark_current_response_materialized(&self, sequence: u32) -> anyhow::Result<()> {
         let request_id = self.state.lock().await.current_request_id.clone();
         let Some(request_id) = request_id.as_deref() else {
@@ -398,7 +473,7 @@ impl Drop for DefraSessionHook {
     fn drop(&mut self) {
         // Drain the in-flight map. Lifecycles dropped without completing a
         // transition leave their AgentToolCall row in state Running on disk —
-        // startup recovery (future R) will sweep these.
+        // startup recovery sweeps these on daemon restart.
         if let Ok(mut map) = self.in_flight_lifecycles.try_lock() {
             map.clear();
         }

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -4,7 +4,9 @@ use rig::completion::{CompletionModel, CompletionResponse};
 use rig::one_or_many::OneOrMany;
 use tracing::Instrument;
 
+use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::session;
+use crate::tool_call_lifecycle::runtime::{classify_managed_tool_result, ManagedToolTerminal};
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
 use super::DefraSessionHook;
@@ -95,16 +97,30 @@ impl DefraSessionHook {
         Ok(())
     }
 
-    async fn ensure_assistant_turn_sequence(&self) -> anyhow::Result<(String, u32)> {
+    async fn ensure_assistant_turn_sequence(
+        &self,
+    ) -> anyhow::Result<(String, String, chrono::DateTime<chrono::Utc>, u32)> {
         let mut state = self.state.lock().await;
         let session_id = state
             .session_id
             .clone()
             .ok_or_else(|| anyhow::anyhow!("session hook missing session id"))?;
+        let request_id = state.current_request_id.clone().unwrap_or_else(|| {
+            tracing::warn!(
+                "tool call has no active request id; persisting with empty request link"
+            );
+            String::new()
+        });
+        let deadline_at = state.request_deadline_at.unwrap_or_else(|| {
+            tracing::warn!(
+                "tool call has no active request deadline; using default lifecycle deadline"
+            );
+            chrono::Utc::now() + chrono::Duration::seconds(DEFAULT_DEADLINE_DURATION_SECS as i64)
+        });
 
         let sequence = state.begin_or_continue_assistant_turn();
 
-        Ok((session_id, sequence))
+        Ok((session_id, request_id, deadline_at, sequence))
     }
 }
 
@@ -169,7 +185,8 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
         args: &str,
     ) -> ToolCallHookAction {
         let result: anyhow::Result<()> = async {
-            let (session_id, seq) = self.ensure_assistant_turn_sequence().await?;
+            let (session_id, request_id, deadline_at, seq) =
+                self.ensure_assistant_turn_sequence().await?;
             self.state.lock().await.register_tool_result_identity(
                 internal_call_id,
                 None,
@@ -178,11 +195,13 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
 
             let mut lc = crate::tool_call_lifecycle::ToolCallLifecycle::new(
                 self.node.clone(),
+                request_id,
                 session_id,
                 internal_call_id.to_string(),
                 seq,
                 tool_name.to_string(),
                 args.to_string(),
+                deadline_at,
             );
             lc.start_running().await?;
 
@@ -217,7 +236,36 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
         args: &str,
         result: &str,
     ) -> HookAction {
-        let persist_result: anyhow::Result<()> = async {
+        let persist_result: anyhow::Result<HookAction> = async {
+            if let Some(terminal) = classify_managed_tool_result(result) {
+                let lifecycle = self
+                    .in_flight_lifecycles
+                    .lock()
+                    .await
+                    .remove(internal_call_id);
+
+                if let Some(mut lc) = lifecycle {
+                    match terminal {
+                        ManagedToolTerminal::TimedOut => lc.timeout().await?,
+                        ManagedToolTerminal::Cancelled => lc.cancel_during_run().await?,
+                    }
+                } else {
+                    tracing::debug!(
+                        tool_call_id = %internal_call_id,
+                        lifecycle_state = ?terminal,
+                        "managed terminal tool result arrived after lifecycle was already swept"
+                    );
+                }
+
+                let reason = match terminal {
+                    ManagedToolTerminal::TimedOut => "tool call deadline exceeded",
+                    ManagedToolTerminal::Cancelled => "tool call cancelled",
+                };
+                return Ok(HookAction::Terminate {
+                    reason: reason.to_string(),
+                });
+            }
+
             let (session_id, should_persist_message, persisted_result_id, persisted_call_id) = {
                 let mut state = self.state.lock().await;
                 let session_id = state
@@ -263,7 +311,11 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                     )
                 })?;
 
-            lc.complete(&truncated.text).await?;
+            if let Some(failure_class) = classify_runtime_failure(result) {
+                lc.fail(&truncated.text, failure_class).await?;
+            } else {
+                lc.complete(&truncated.text).await?;
+            }
 
             if should_persist_message {
                 let tool_result_message = Message::User {
@@ -278,7 +330,7 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 self.persist_message(&tool_result_message).await?;
             }
 
-            Ok(())
+            Ok(HookAction::Continue)
         }
         .instrument(tracing::info_span!(
             "tool.result",
@@ -288,9 +340,9 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
         .await;
 
         match persist_result {
-            Ok(()) => {
+            Ok(action) => {
                 self.record_success();
-                HookAction::Continue
+                action
             }
             Err(e) => self.on_persistence_error("persist tool result", &e),
         }
@@ -317,8 +369,8 @@ fn render_tool_result_text(tool_result: &ToolResult) -> String {
 }
 
 /// Classify a runtime error string into a FailureClass. Defaults to
-/// ToolReturnedError for unknown shapes. Placeholder bridge until R3
-/// introduces structured error classification.
+/// ToolReturnedError for unknown shapes; managed timeout/cancel markers are
+/// handled before this helper so terminal outcomes stay distinct.
 #[allow(dead_code)]
 fn classify_runtime_error(err: &str) -> crate::tool_call_lifecycle::FailureClass {
     use crate::tool_call_lifecycle::FailureClass;
@@ -333,4 +385,14 @@ fn classify_runtime_error(err: &str) -> crate::tool_call_lifecycle::FailureClass
     } else {
         FailureClass::ToolReturnedError
     }
+}
+
+fn classify_runtime_failure(result: &str) -> Option<crate::tool_call_lifecycle::FailureClass> {
+    if result.starts_with("JsonError:") {
+        return Some(crate::tool_call_lifecycle::FailureClass::ArgumentInvalid);
+    }
+    if result.starts_with("ToolCallError:") {
+        return Some(classify_runtime_error(result));
+    }
+    None
 }

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -63,6 +63,7 @@ fn session_state_for_test() -> SessionState {
     SessionState {
         session_id: Some("session-1".to_string()),
         current_request_id: None,
+        request_deadline_at: None,
         agent_name: "agent".to_string(),
         sequence: 0,
         transcript_turn: TranscriptTurnState::Idle,
@@ -367,6 +368,450 @@ async fn create_streaming_response(
         "create response failed: {:?}",
         resp.errors
     );
+}
+
+async fn create_interruptible_request(
+    node: &defra_node::EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+) {
+    let request_id = crate::graphql::escape_graphql_string(request_id);
+    let session_id = crate::graphql::escape_graphql_string(session_id);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "did:defra-agent:general",
+                behavior_id: "general",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "child request",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "subagent",
+                created_at: "{created_at}",
+                retry_count: 0,
+                max_retries: {max_retries}
+            }}) {{ _docID }}
+        }}"#,
+        max_retries = crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES,
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create interruptible request failed: {:?}",
+        resp.errors
+    );
+}
+
+async fn fetch_tool_call_row(
+    node: &defra_node::EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> serde_json::Value {
+    let session_id = crate::graphql::escape_graphql_string(session_id);
+    let tool_call_id = crate::graphql::escape_graphql_string(tool_call_id);
+    let resp = node
+        .execute(&format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{
+                        session_id: {{ _eq: "{session_id}" }},
+                        tool_call_id: {{ _eq: "{tool_call_id}" }}
+                    }},
+                    limit: 1
+                ) {{
+                    request_id
+                    deadline_at
+                    lifecycle_state
+                    result
+                    status
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "query tool call failed: {:?}",
+        resp.errors
+    );
+    resp.data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| value.as_array())
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("tool call row")
+}
+
+#[tokio::test]
+async fn hook_attaches_active_request_deadline_to_tool_call_lifecycle() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-deadline-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    let user_prompt = user_text_message("Run a tool");
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook, &user_prompt, &[]).await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    let deadline = chrono::DateTime::parse_from_rfc3339("2026-05-08T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    hook.set_active_request_id(Some("req-deadline".to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(deadline)).await;
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook, "read", None, "internal-deadline", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+
+    let row = fetch_tool_call_row(&node, &session_id, "internal-deadline").await;
+    assert_eq!(
+        row.get("request_id").and_then(|value| value.as_str()),
+        Some("req-deadline")
+    );
+    let observed_deadline = chrono::DateTime::parse_from_rfc3339(
+        row.get("deadline_at")
+            .and_then(|value| value.as_str())
+            .expect("deadline_at"),
+    )
+    .unwrap()
+    .with_timezone(&chrono::Utc);
+    assert_eq!(observed_deadline, deadline);
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn hook_maps_managed_timeout_result_to_timed_out_lifecycle() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-timeout-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook, &user_text_message("Run"), &[]).await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    hook.set_active_request_id(Some("req-timeout".to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(deadline)).await;
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook, "never", None, "internal-timeout", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+    let action = PromptHook::<TestModel>::on_tool_result(
+        &hook,
+        "never",
+        None,
+        "internal-timeout",
+        "{}",
+        &crate::tool_call_lifecycle::runtime::timeout_result(Some(deadline)),
+    )
+    .await;
+    assert!(matches!(action, HookAction::Terminate { .. }));
+
+    let row = fetch_tool_call_row(&node, &session_id, "internal-timeout").await;
+    assert_eq!(
+        row.get("lifecycle_state").and_then(|value| value.as_str()),
+        Some("timedOut")
+    );
+    assert!(row
+        .get("result")
+        .and_then(|value| value.as_str())
+        .is_some_and(|result| result.contains("deadline exceeded")));
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn cancelling_one_hook_does_not_cancel_unrelated_live_tool_call() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-cancel-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook_a = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    let hook_b = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook_a, &user_text_message("A"), &[]).await,
+        HookAction::Continue
+    ));
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook_b, &user_text_message("B"), &[]).await,
+        HookAction::Continue
+    ));
+    let session_a = hook_a.session_id().await.expect("session a");
+    let session_b = hook_b.session_id().await.expect("session b");
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    hook_a
+        .set_active_request_id(Some("req-a".to_string()))
+        .await;
+    hook_a.set_request_deadline_at(Some(deadline)).await;
+    hook_b
+        .set_active_request_id(Some("req-b".to_string()))
+        .await;
+    hook_b.set_request_deadline_at(Some(deadline)).await;
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook_a, "slow", None, "internal-a", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook_b, "slow", None, "internal-b", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+
+    assert_eq!(hook_a.cancel_in_flight_tool_calls().await.unwrap(), 1);
+
+    let row_a = fetch_tool_call_row(&node, &session_a, "internal-a").await;
+    assert_eq!(
+        row_a
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    let row_b = fetch_tool_call_row(&node, &session_b, "internal-b").await;
+    assert_eq!(
+        row_b
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("running")
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn cancelling_cascade_subagent_tool_latches_child_interrupt() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-hook-cascade-cancel-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let session_id = "session-cascade";
+    let child_request_id = "child-cascade";
+    create_interruptible_request(&node, child_request_id, session_id).await;
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    let mut lifecycle = crate::tool_call_lifecycle::ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "parent-cascade".to_string(),
+        session_id.to_string(),
+        "tool-cascade".to_string(),
+        1,
+        "spawn_agent".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        crate::tool_call_lifecycle::AwaitMode::Foreground,
+        crate::tool_call_lifecycle::CancelPolicy::Cascade,
+        child_request_id.to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+    hook.in_flight_lifecycles
+        .lock()
+        .await
+        .insert("tool-cascade".to_string(), lifecycle);
+
+    assert_eq!(hook.cancel_in_flight_tool_calls().await.unwrap(), 1);
+
+    let parent_row = fetch_tool_call_row(&node, session_id, "tool-cascade").await;
+    assert_eq!(
+        parent_row
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    let child_interrupt = crate::interrupt::fetch_interrupt_requested_at(&node, child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_some(),
+        "cascade cancel should latch child interrupt_requested_at"
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn cancelling_detached_subagent_tool_does_not_interrupt_child() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-detach-cancel-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let session_id = "session-detach";
+    let child_request_id = "child-detach";
+    create_interruptible_request(&node, child_request_id, session_id).await;
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    let mut lifecycle = crate::tool_call_lifecycle::ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "parent-detach".to_string(),
+        session_id.to_string(),
+        "tool-detach".to_string(),
+        1,
+        "spawn_agent".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        crate::tool_call_lifecycle::AwaitMode::Foreground,
+        crate::tool_call_lifecycle::CancelPolicy::Detach,
+        child_request_id.to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+    hook.in_flight_lifecycles
+        .lock()
+        .await
+        .insert("tool-detach".to_string(), lifecycle);
+
+    assert_eq!(hook.cancel_in_flight_tool_calls().await.unwrap(), 1);
+
+    let parent_row = fetch_tool_call_row(&node, session_id, "tool-detach").await;
+    assert_eq!(
+        parent_row
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    let child_interrupt = crate::interrupt::fetch_interrupt_requested_at(&node, child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_none(),
+        "detached cancel must leave child request interrupt unset"
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn hook_can_fail_live_tool_call_without_conflating_timeout_or_cancel() {
+    let data_path = std::env::temp_dir().join(format!("agent-hook-fail-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(&hook, &user_text_message("fail"), &[]).await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    hook.set_active_request_id(Some("req-fail".to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::minutes(5)))
+        .await;
+
+    assert!(matches!(
+        PromptHook::<TestModel>::on_tool_call(&hook, "slow", None, "internal-fail", "{}").await,
+        ToolCallHookAction::Continue
+    ));
+    assert_eq!(
+        hook.fail_in_flight_tool_calls(
+            "stream liveness timeout while tool call was running",
+            crate::tool_call_lifecycle::FailureClass::External,
+        )
+        .await
+        .unwrap(),
+        1
+    );
+
+    let row = fetch_tool_call_row(&node, &session_id, "internal-fail").await;
+    assert_eq!(
+        row.get("lifecycle_state").and_then(|value| value.as_str()),
+        Some("failed")
+    );
+    assert_eq!(
+        row.get("status").and_then(|value| value.as_str()),
+        Some("completed")
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -72,6 +72,22 @@ pub(crate) struct LeanStateMachineContract {
     pub(crate) actions: Vec<String>,
     pub(crate) legal_transitions: Vec<LeanTransitionPair>,
     pub(crate) illegal_transitions: Vec<LeanTransitionPair>,
+    /// Named transition rows emitted by `Conformance.Contracts.NamedTransition`.
+    /// Defaults to empty so existing call sites (Bucket 0/Bucket 1) don't need
+    /// to deserialize this field on machines that don't emit any.
+    #[serde(default)]
+    pub(crate) named_transitions: Vec<LeanNamedTransition>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanNamedTransition {
+    pub(crate) name: String,
+    pub(crate) from: String,
+    pub(crate) to: String,
+    #[serde(default)]
+    pub(crate) requires_native: bool,
+    #[serde(default)]
+    pub(crate) requires_child: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/defra-agent/src/lifecycle/materialize.rs
+++ b/crates/defra-agent/src/lifecycle/materialize.rs
@@ -377,6 +377,9 @@ impl RequestLifecycle {
             metadata: None,
             execution_origin: Some(execution_origin_str.to_string()),
             created_at,
+            subagent_depth: 0,
+            caused_by_parent_request_id: None,
+            caused_by_parent_tool_call_id: None,
         };
 
         session::upsert_conversation_from_request_with_identity(

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -19,9 +19,32 @@ use std::sync::OnceLock;
 
 use anyhow::{Context, Result};
 use defra_node::{EmbeddedNode, LensConfig, LensModule};
-use tempfile::NamedTempFile;
+use tempfile::{Builder, NamedTempFile};
 
 const ADD_LIFECYCLE_STATE_PATCH: &str = r#"[{"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"lifecycle_state","Kind":11}}]"#;
+
+#[allow(dead_code)]
+const ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"await_mode","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_policy","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"child_request_id","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"request_id","Kind":11}}
+]"#;
+
+#[allow(dead_code)]
+const ADD_AGENT_REQUEST_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"subagent_depth","Kind":5}},
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"caused_by_parent_request_id","Kind":11}},
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"caused_by_parent_tool_call_id","Kind":11}}
+]"#;
+
+#[allow(dead_code)]
+const ADD_TOOL_SELECTION_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_targets","Kind":17}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_spawn_enabled","Kind":2}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_steering_enabled","Kind":2}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_background_enabled","Kind":2}}
+]"#;
 
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
@@ -34,8 +57,13 @@ static LENS_TEMP_FILE: OnceLock<NamedTempFile> = OnceLock::new();
 /// Return the filesystem path to the embedded WASM lens, unpacking it on first
 /// call. Subsequent calls return the same path.
 fn lens_wasm_path() -> Result<String> {
+    // DefraDB's lens loader validates that the module path ends with `.wasm`,
+    // so the temp file must be created with that suffix.
     let temp = LENS_TEMP_FILE.get_or_init(|| {
-        let mut tf = NamedTempFile::new().expect("create lens temp file");
+        let mut tf = Builder::new()
+            .suffix(".wasm")
+            .tempfile()
+            .expect("create lens temp file");
         std::io::Write::write_all(tf.as_file_mut(), LENS_WASM_BYTES)
             .expect("write embedded lens bytes to temp file");
         tf
@@ -110,4 +138,175 @@ pub async fn ensure_tool_call_migrations(node: Arc<EmbeddedNode>) -> Result<()> 
 /// field. Used to detect already-migrated databases.
 fn collection_has_lifecycle_state(cv: &defra_node::CollectionVersion) -> bool {
     cv.fields.iter().any(|f| f.name == "lifecycle_state")
+}
+
+/// WASM lens bytes for the v2->v3 subagent extension. Embedded at compile time
+/// via build.rs.
+const SUBAGENT_LENS_WASM_BYTES: &[u8] =
+    include_bytes!(env!("AGENT_SUBAGENT_V2_TO_V3_LENS_WASM_PATH"));
+
+/// Process-wide temp file holding the unpacked subagent WASM bytes. Held alive
+/// (never dropped) so DefraDB's lazy lens loader can always reach the path.
+static SUBAGENT_LENS_TEMP_FILE: OnceLock<NamedTempFile> = OnceLock::new();
+
+/// Return the filesystem path to the embedded subagent WASM lens, unpacking it
+/// on first call. Subsequent calls return the same path.
+fn subagent_lens_wasm_path() -> Result<String> {
+    // DefraDB's lens loader validates that the module path ends with `.wasm`,
+    // so the temp file must be created with that suffix.
+    let temp = SUBAGENT_LENS_TEMP_FILE.get_or_init(|| {
+        let mut tf = Builder::new()
+            .suffix(".wasm")
+            .tempfile()
+            .expect("create subagent lens temp file");
+        std::io::Write::write_all(tf.as_file_mut(), SUBAGENT_LENS_WASM_BYTES)
+            .expect("write embedded subagent lens bytes to temp file");
+        tf
+    });
+    let path = temp.path().to_string_lossy().to_string();
+    Ok(path)
+}
+
+fn collection_has_field(cv: &defra_node::CollectionVersion, field_name: &str) -> bool {
+    cv.fields.iter().any(|f| f.name == field_name)
+}
+
+/// Per-collection idempotent migration orchestrator for v2->v3.
+/// Applies the three subagent-extension patches and registers the unified
+/// lens. Re-running after a partial failure picks up at the un-migrated
+/// collection without manual intervention.
+pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    // 1. AgentToolCall — patch only if v3 fields not already present.
+    let atc_collection = node
+        .get_collection("AgentToolCall")
+        .context("get AgentToolCall collection")?;
+
+    let atc_v3_version_id = if let Some(ref cv) = atc_collection {
+        if collection_has_field(cv, "await_mode") {
+            tracing::debug!("AgentToolCall already has await_mode; skipping patch");
+            cv.version_id.clone()
+        } else {
+            let pre_version_id = cv.version_id.clone();
+            let v3 = node
+                .patch_collection("AgentToolCall", ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH)
+                .await
+                .context("patch_collection v2 -> v3 (AgentToolCall subagent fields)")?;
+            let v3_version_id = v3.version_id.clone();
+            node.set_active_collection_version(&v3_version_id)
+                .await
+                .context("set_active_collection_version v3 (AgentToolCall)")?;
+            tracing::info!(
+                pre = %pre_version_id,
+                v3 = %v3_version_id,
+                "AgentToolCall patched to v3 (subagent fields)"
+            );
+            v3_version_id
+        }
+    } else {
+        tracing::debug!("AgentToolCall collection absent; subagent patch no-op");
+        return Ok(());
+    };
+
+    // 2. AgentRequest — independent idempotency check.
+    let ar_collection = node
+        .get_collection("AgentRequest")
+        .context("get AgentRequest collection")?;
+
+    if let Some(ref cv) = ar_collection {
+        if collection_has_field(cv, "caused_by_parent_request_id") {
+            tracing::debug!("AgentRequest already has caused_by_parent_request_id; skipping patch");
+        } else {
+            let pre_version_id = cv.version_id.clone();
+            let v3 = node
+                .patch_collection("AgentRequest", ADD_AGENT_REQUEST_SUBAGENT_PATCH)
+                .await
+                .context("patch_collection v2 -> v3 (AgentRequest subagent fields)")?;
+            let v3_version_id = v3.version_id.clone();
+            node.set_active_collection_version(&v3_version_id)
+                .await
+                .context("set_active_collection_version v3 (AgentRequest)")?;
+            tracing::info!(
+                pre = %pre_version_id,
+                v3 = %v3_version_id,
+                "AgentRequest patched to v3 (subagent fields)"
+            );
+        }
+    } else {
+        tracing::debug!("AgentRequest collection absent; subagent patch no-op");
+    }
+
+    // 3. ToolSelection — independent idempotency check.
+    let ts_collection = node
+        .get_collection("ToolSelection")
+        .context("get ToolSelection collection")?;
+
+    if let Some(ref cv) = ts_collection {
+        if collection_has_field(cv, "subagent_targets") {
+            tracing::debug!("ToolSelection already has subagent_targets; skipping patch");
+        } else {
+            let pre_version_id = cv.version_id.clone();
+            let v3 = node
+                .patch_collection("ToolSelection", ADD_TOOL_SELECTION_SUBAGENT_PATCH)
+                .await
+                .context("patch_collection v2 -> v3 (ToolSelection subagent fields)")?;
+            let v3_version_id = v3.version_id.clone();
+            node.set_active_collection_version(&v3_version_id)
+                .await
+                .context("set_active_collection_version v3 (ToolSelection)")?;
+            tracing::info!(
+                pre = %pre_version_id,
+                v3 = %v3_version_id,
+                "ToolSelection patched to v3 (subagent fields)"
+            );
+        }
+    } else {
+        tracing::debug!("ToolSelection collection absent; subagent patch no-op");
+    }
+
+    // 4. Register the v2→v3 forward lens for AgentToolCall only.
+    //
+    // AgentRequest and ToolSelection are NOT registered: their schema patches
+    // are pure field additions with nullable types, so no transform is needed
+    // for round-trip (a v2 client reading a v3 row sees null for unknown
+    // fields; a v3 client reading a v2 row sees null for the new fields).
+    // DefraDB's nullable-field semantics handle the back-compat without a
+    // lens.
+    //
+    // AgentToolCall, by contrast, needs the lens to populate `await_mode` and
+    // `cancel_policy` with their non-null defaults ("foreground", "cascade")
+    // for v2 rows being read by v3 clients — the runtime expects these fields
+    // to have meaningful values matching today's foreground+cascade semantics.
+    // Null is not a valid runtime value for either field; the lens fills them
+    // in on the forward read path.
+    //
+    // The WASM module (agent_subagent_v2_to_v3) retains transform logic for
+    // all three collections in case future patches are non-additive, but only
+    // the AgentToolCall transform is registered here via set_migration.
+    let lens_path = subagent_lens_wasm_path().context("unpack embedded subagent lens WASM")?;
+
+    // The "from" version is the AgentToolCall version before the patch
+    // (captured above) and "to" is the v3 version we just activated.
+    // Re-read the pre-patch version from the collection we already fetched.
+    let atc_pre_version_id = atc_collection
+        .as_ref()
+        .map(|cv| cv.version_id.clone())
+        .ok_or_else(|| anyhow::anyhow!("AgentToolCall collection absent after earlier check"))?;
+
+    let forward_config = LensConfig::new(
+        atc_pre_version_id.clone(),
+        atc_v3_version_id.clone(),
+        LensModule::from_path(lens_path),
+    );
+
+    node.set_migration(forward_config)
+        .await
+        .context("set_migration forward AgentToolCall v2 -> v3")?;
+
+    tracing::info!(
+        v2 = %atc_pre_version_id,
+        v3 = %atc_v3_version_id,
+        "agent_subagent_v2_to_v3 lens registered"
+    );
+
+    Ok(())
 }

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -1,9 +1,10 @@
 //! Idempotent schema-patch + lens registration invoked at daemon startup.
 //!
-//! Migrates AgentToolCall v1 -> v2 by:
+//! Migrates AgentToolCall v1 -> current by:
 //!   1. Patching the collection to add `lifecycle_state` field.
 //!   2. Registering the v1->v2 forward and inverse Lens transforms.
 //!   3. Touching every existing row to force eager lens execution.
+//!   4. Patching later runtime fields that do not need row transforms.
 //!
 //! Idempotent: re-running on a v2 deployment is a no-op (collection already
 //! patched, migration already registered).
@@ -27,8 +28,7 @@ const ADD_LIFECYCLE_STATE_PATCH: &str = r#"[{"op":"add","path":"/AgentToolCall/F
 const ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH: &str = r#"[
     {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"await_mode","Kind":11}},
     {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_policy","Kind":11}},
-    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"child_request_id","Kind":11}},
-    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"request_id","Kind":11}}
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"child_request_id","Kind":11}}
 ]"#;
 
 #[allow(dead_code)]
@@ -75,12 +75,12 @@ fn lens_wasm_path() -> Result<String> {
 /// Run all pending tool-call migrations against the embedded node.
 /// Called from the daemon startup path before any AgentToolCall reads.
 pub async fn ensure_tool_call_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
-    // 1. Check if AgentToolCall already has lifecycle_state.
-    let collection = node
+    // 1. Check which AgentToolCall runtime fields already exist.
+    let mut collection = node
         .get_collection("AgentToolCall")
         .context("get AgentToolCall collection")?;
 
-    let already_v2 = match collection {
+    let has_lifecycle_state = match collection {
         Some(ref cv) => collection_has_lifecycle_state(cv),
         None => {
             // Collection doesn't exist yet (fresh install). The schema add at
@@ -91,44 +91,79 @@ pub async fn ensure_tool_call_migrations(node: Arc<EmbeddedNode>) -> Result<()> 
         }
     };
 
-    if already_v2 {
-        tracing::debug!("AgentToolCall already at v2; migration no-op");
+    if !has_lifecycle_state {
+        // 2. Apply the v1 -> v2 schema patch.
+        let v1_version_id = collection
+            .as_ref()
+            .map(|cv| cv.version_id.clone())
+            .ok_or_else(|| anyhow::anyhow!("AgentToolCall collection has no version_id"))?;
+
+        let v2 = node
+            .patch_collection("AgentToolCall", ADD_LIFECYCLE_STATE_PATCH)
+            .await
+            .context("patch_collection v1 -> v2 (add lifecycle_state)")?;
+        let v2_version_id = v2.version_id.clone();
+
+        // 3. Activate v2 as the source-of-truth for new writes.
+        node.set_active_collection_version(&v2_version_id)
+            .await
+            .context("set_active_collection_version v2")?;
+
+        // 4. Register the forward Lens v1 -> v2.
+        let lens_path = lens_wasm_path().context("unpack embedded lens WASM")?;
+        let lens_config = LensConfig::new(
+            v1_version_id.clone(),
+            v2_version_id.clone(),
+            LensModule::from_path(lens_path),
+        );
+
+        node.set_migration(lens_config)
+            .await
+            .context("set_migration forward v1 -> v2")?;
+
+        tracing::info!(
+            v1 = %v1_version_id,
+            v2 = %v2_version_id,
+            "AgentToolCall migrated to v2 with lens"
+        );
+
+        collection = Some(v2);
+    }
+
+    let Some(collection) = collection.as_ref() else {
+        return Ok(());
+    };
+
+    let mut field_patches = Vec::new();
+    if !collection_has_field(collection, "request_id") {
+        field_patches.push(
+            r#"{"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"request_id","Kind":11}}"#,
+        );
+    }
+    if !collection_has_field(collection, "deadline_at") {
+        field_patches.push(
+            r#"{"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"deadline_at","Kind":10}}"#,
+        );
+    }
+
+    if field_patches.is_empty() {
+        tracing::debug!("AgentToolCall already has all runtime lifecycle fields; migration no-op");
         return Ok(());
     }
 
-    // 2. Apply the v1 -> v2 schema patch.
-    let v1_version_id = collection
-        .as_ref()
-        .map(|cv| cv.version_id.clone())
-        .ok_or_else(|| anyhow::anyhow!("AgentToolCall collection has no version_id"))?;
-
-    let v2 = node
-        .patch_collection("AgentToolCall", ADD_LIFECYCLE_STATE_PATCH)
+    let patch = format!("[{}]", field_patches.join(","));
+    let next = node
+        .patch_collection("AgentToolCall", &patch)
         .await
-        .context("patch_collection v1 -> v2 (add lifecycle_state)")?;
-    let v2_version_id = v2.version_id;
-
-    // 3. Activate v2 as the source-of-truth for new writes.
-    node.set_active_collection_version(&v2_version_id)
+        .context("patch_collection add AgentToolCall runtime fields")?;
+    node.set_active_collection_version(&next.version_id)
         .await
-        .context("set_active_collection_version v2")?;
-
-    // 4. Register the forward Lens v1 -> v2.
-    let lens_path = lens_wasm_path().context("unpack embedded lens WASM")?;
-    let lens_config = LensConfig::new(
-        v1_version_id.clone(),
-        v2_version_id.clone(),
-        LensModule::from_path(lens_path),
-    );
-
-    node.set_migration(lens_config)
-        .await
-        .context("set_migration forward v1 -> v2")?;
+        .context("set_active_collection_version AgentToolCall runtime fields")?;
 
     tracing::info!(
-        v1 = %v1_version_id,
-        v2 = %v2_version_id,
-        "AgentToolCall migrated to v2 with lens"
+        version = %next.version_id,
+        fields = ?field_patches,
+        "AgentToolCall migrated with runtime lifecycle fields"
     );
 
     Ok(())
@@ -137,7 +172,11 @@ pub async fn ensure_tool_call_migrations(node: Arc<EmbeddedNode>) -> Result<()> 
 /// Decide whether a collection version already has the `lifecycle_state`
 /// field. Used to detect already-migrated databases.
 fn collection_has_lifecycle_state(cv: &defra_node::CollectionVersion) -> bool {
-    cv.fields.iter().any(|f| f.name == "lifecycle_state")
+    collection_has_field(cv, "lifecycle_state")
+}
+
+fn collection_has_field(cv: &defra_node::CollectionVersion, field_name: &str) -> bool {
+    cv.fields.iter().any(|f| f.name == field_name)
 }
 
 /// WASM lens bytes for the v2->v3 subagent extension. Embedded at compile time
@@ -167,10 +206,6 @@ fn subagent_lens_wasm_path() -> Result<String> {
     Ok(path)
 }
 
-fn collection_has_field(cv: &defra_node::CollectionVersion, field_name: &str) -> bool {
-    cv.fields.iter().any(|f| f.name == field_name)
-}
-
 /// Per-collection idempotent migration orchestrator for v2->v3.
 /// Applies the three subagent-extension patches and registers the unified
 /// lens. Re-running after a partial failure picks up at the un-migrated
@@ -181,6 +216,7 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
         .get_collection("AgentToolCall")
         .context("get AgentToolCall collection")?;
 
+    let mut atc_pre_version_id_for_lens = None;
     let atc_v3_version_id = if let Some(ref cv) = atc_collection {
         if collection_has_field(cv, "await_mode") {
             tracing::debug!("AgentToolCall already has await_mode; skipping patch");
@@ -200,6 +236,7 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
                 v3 = %v3_version_id,
                 "AgentToolCall patched to v3 (subagent fields)"
             );
+            atc_pre_version_id_for_lens = Some(pre_version_id);
             v3_version_id
         }
     } else {
@@ -282,15 +319,12 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
     // The WASM module (agent_subagent_v2_to_v3) retains transform logic for
     // all three collections in case future patches are non-additive, but only
     // the AgentToolCall transform is registered here via set_migration.
-    let lens_path = subagent_lens_wasm_path().context("unpack embedded subagent lens WASM")?;
+    let Some(atc_pre_version_id) = atc_pre_version_id_for_lens else {
+        tracing::debug!("AgentToolCall subagent fields already present; lens registration no-op");
+        return Ok(());
+    };
 
-    // The "from" version is the AgentToolCall version before the patch
-    // (captured above) and "to" is the v3 version we just activated.
-    // Re-read the pre-patch version from the collection we already fetched.
-    let atc_pre_version_id = atc_collection
-        .as_ref()
-        .map(|cv| cv.version_id.clone())
-        .ok_or_else(|| anyhow::anyhow!("AgentToolCall collection absent after earlier check"))?;
+    let lens_path = subagent_lens_wasm_path().context("unpack embedded subagent lens WASM")?;
 
     let forward_config = LensConfig::new(
         atc_pre_version_id.clone(),

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -6,6 +6,17 @@
 //!
 //! Lifecycle is daemon-visible only; subprocess kill mechanics, output
 //! streaming, and persistent processes are out of scope.
+//!
+//! ## R2 maintenance obligations
+//!
+//! This module implements R2 ("Rust subagent data plane"). Per the spec at
+//! `docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md`:
+//!
+//! - SubagentSource (R3) consumes `create_subagent_request` and the bridge methods.
+//! - Agent-facing tools (R4) are routed via hook integration that uses
+//!   `new_subagent` and recognizes spawn_subagent / wait_task / etc. tool names.
+//! - Cross-reference validation (target resolution, parent existence) lands in R3.
+//! - Cross-principal delegation (R6) lands with sourcenetwork/defra-agent#9.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ToolCallState {
@@ -103,13 +114,106 @@ impl FailureClass {
     }
 }
 
+/// Whether the parent's narrative is blocked on this tool's terminal state.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AwaitMode {
+    Foreground,
+    Background,
+}
+
+impl AwaitMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AwaitMode::Foreground => "foreground",
+            AwaitMode::Background => "background",
+        }
+    }
+
+    pub fn from_persisted(s: &str) -> Option<Self> {
+        match s {
+            "foreground" => Some(AwaitMode::Foreground),
+            "background" => Some(AwaitMode::Background),
+            _ => None,
+        }
+    }
+
+    pub const ALL: &'static [AwaitMode] = &[AwaitMode::Foreground, AwaitMode::Background];
+}
+
+/// Whether parent termination drives the linked child request to .interrupted
+/// (cascade) or detaches the child to its own deadline.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CancelPolicy {
+    Cascade,
+    Detach,
+}
+
+impl CancelPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CancelPolicy::Cascade => "cascade",
+            CancelPolicy::Detach => "detach",
+        }
+    }
+
+    pub fn from_persisted(s: &str) -> Option<Self> {
+        match s {
+            "cascade" => Some(CancelPolicy::Cascade),
+            "detach" => Some(CancelPolicy::Detach),
+            _ => None,
+        }
+    }
+
+    pub const ALL: &'static [CancelPolicy] = &[CancelPolicy::Cascade, CancelPolicy::Detach];
+}
+
+/// The four non-.completed terminal states a child AgentRequest can reach.
+/// Used as the argument shape to bridge_failure to project the child terminal
+/// onto a parent ToolCallState (.failed for most, .cancelled for .interrupted).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChildTerminal {
+    Failed {
+        reason: String,
+        failure_class: FailureClass,
+    },
+    Dead,
+    Interrupted,
+    Superseded,
+}
+
+impl ChildTerminal {
+    /// Lean B2 projection: .interrupted → .cancelled, all others → .failed.
+    pub fn projected_state(&self) -> ToolCallState {
+        match self {
+            ChildTerminal::Interrupted => ToolCallState::Cancelled,
+            _ => ToolCallState::Failed,
+        }
+    }
+
+    /// Persisted vocabulary names for conformance enumeration.
+    pub const ALL_KIND: &'static [&'static str] = &["failed", "dead", "interrupted", "superseded"];
+}
+
+/// Returned by `bridge_cancel_cascade` (wrapped in Option). The caller — typically
+/// R3's daemon interrupt dispatcher — performs the actual write to the child
+/// AgentRequest's interrupt_requested_at field. Returning None from
+/// bridge_cancel_cascade means no cascade is required: the bridge tool is
+/// native (no child link), detached (no cascade), or not in .cancelled state.
+#[derive(Clone, Debug)]
+pub struct CascadeIntent {
+    pub child_request_id: String,
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+
 use std::sync::Arc;
 
 use defra_node::EmbeddedNode;
 
 pub(crate) mod query;
+pub mod subagent_request;
 mod transition;
 
+pub use subagent_request::{create_subagent_request, MAX_SUBAGENT_DEPTH};
 pub use transition::IllegalToolCallTransition;
 
 /// State machine struct for an individual tool call. Mirrors `RequestLifecycle`
@@ -126,6 +230,9 @@ pub struct ToolCallLifecycle {
     state: ToolCallState,
     started_at: Option<chrono::DateTime<chrono::Utc>>,
     failure_class: Option<FailureClass>,
+    pub(crate) await_mode: AwaitMode,
+    pub(crate) cancel_policy: CancelPolicy,
+    pub(crate) child_request_id: Option<String>,
 }
 
 impl ToolCallLifecycle {
@@ -150,6 +257,41 @@ impl ToolCallLifecycle {
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
+            await_mode: AwaitMode::Foreground,
+            cancel_policy: CancelPolicy::Cascade,
+            child_request_id: None,
+        }
+    }
+
+    /// Constructor for the subagent invocation path. Sets child_request_id (the
+    /// link to the spawned child AgentRequest) and lets the caller pick await_mode
+    /// and cancel_policy. Synchronous and does not persist — first transition
+    /// (typically start_running) creates the row.
+    pub fn new_subagent(
+        node: Arc<EmbeddedNode>,
+        session_id: String,
+        tool_call_id: String,
+        message_sequence: u32,
+        tool_name: String,
+        args: String,
+        await_mode: AwaitMode,
+        cancel_policy: CancelPolicy,
+        child_request_id: String,
+    ) -> Self {
+        Self {
+            node,
+            session_id,
+            tool_call_id,
+            message_sequence,
+            tool_name,
+            args,
+            doc_id: None,
+            state: ToolCallState::Pending,
+            started_at: None,
+            failure_class: None,
+            await_mode,
+            cancel_policy,
+            child_request_id: Some(child_request_id),
         }
     }
 
@@ -281,6 +423,76 @@ mod tests {
                 .iter()
                 .map(String::as_str)
                 .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[cfg(test)]
+mod bucket_1_subagent_vocabulary {
+    use super::*;
+
+    #[test]
+    fn await_mode_round_trip_via_persisted_vocab() {
+        for &mode in AwaitMode::ALL {
+            assert_eq!(AwaitMode::from_persisted(mode.as_str()), Some(mode));
+        }
+    }
+
+    #[test]
+    fn await_mode_all_has_two_variants() {
+        assert_eq!(AwaitMode::ALL.len(), 2);
+    }
+
+    #[test]
+    fn await_mode_from_persisted_unknown_returns_none() {
+        assert_eq!(AwaitMode::from_persisted("unknown"), None);
+    }
+
+    #[test]
+    fn cancel_policy_round_trip_via_persisted_vocab() {
+        for &policy in CancelPolicy::ALL {
+            assert_eq!(CancelPolicy::from_persisted(policy.as_str()), Some(policy));
+        }
+    }
+
+    #[test]
+    fn cancel_policy_all_has_two_variants() {
+        assert_eq!(CancelPolicy::ALL.len(), 2);
+    }
+
+    #[test]
+    fn cancel_policy_from_persisted_unknown_returns_none() {
+        assert_eq!(CancelPolicy::from_persisted("unknown"), None);
+    }
+
+    #[test]
+    fn child_terminal_all_kind_has_four_variants() {
+        assert_eq!(ChildTerminal::ALL_KIND.len(), 4);
+        assert_eq!(
+            ChildTerminal::ALL_KIND,
+            &["failed", "dead", "interrupted", "superseded"]
+        );
+    }
+
+    #[test]
+    fn child_terminal_projection_partition() {
+        // .interrupted → .cancelled; everything else → .failed
+        assert_eq!(
+            ChildTerminal::Failed {
+                reason: "x".to_string(),
+                failure_class: FailureClass::External
+            }
+            .projected_state(),
+            ToolCallState::Failed
+        );
+        assert_eq!(ChildTerminal::Dead.projected_state(), ToolCallState::Failed);
+        assert_eq!(
+            ChildTerminal::Interrupted.projected_state(),
+            ToolCallState::Cancelled
+        );
+        assert_eq!(
+            ChildTerminal::Superseded.projected_state(),
+            ToolCallState::Failed
         );
     }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -210,9 +210,12 @@ use std::sync::Arc;
 use defra_node::EmbeddedNode;
 
 pub(crate) mod query;
+mod recovery;
+pub(crate) mod runtime;
 pub mod subagent_request;
 mod transition;
 
+pub use recovery::ToolCallRecoveryReport;
 pub use subagent_request::{create_subagent_request, MAX_SUBAGENT_DEPTH};
 pub use transition::IllegalToolCallTransition;
 
@@ -221,12 +224,14 @@ pub use transition::IllegalToolCallTransition;
 /// AgentToolCall row.
 pub struct ToolCallLifecycle {
     node: Arc<EmbeddedNode>,
+    request_id: String,
     session_id: String,
     tool_call_id: String,
     message_sequence: u32,
     tool_name: String,
     args: String,
     doc_id: Option<String>,
+    deadline_at: chrono::DateTime<chrono::Utc>,
     state: ToolCallState,
     started_at: Option<chrono::DateTime<chrono::Utc>>,
     failure_class: Option<FailureClass>,
@@ -240,20 +245,24 @@ impl ToolCallLifecycle {
     /// method (`start_running`) creates the DefraDB row.
     pub fn new(
         node: Arc<EmbeddedNode>,
+        request_id: String,
         session_id: String,
         tool_call_id: String,
         message_sequence: u32,
         tool_name: String,
         args: String,
+        deadline_at: chrono::DateTime<chrono::Utc>,
     ) -> Self {
         Self {
             node,
+            request_id,
             session_id,
             tool_call_id,
             message_sequence,
             tool_name,
             args,
             doc_id: None,
+            deadline_at,
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
@@ -269,23 +278,27 @@ impl ToolCallLifecycle {
     /// (typically start_running) creates the row.
     pub fn new_subagent(
         node: Arc<EmbeddedNode>,
+        request_id: String,
         session_id: String,
         tool_call_id: String,
         message_sequence: u32,
         tool_name: String,
         args: String,
+        deadline_at: chrono::DateTime<chrono::Utc>,
         await_mode: AwaitMode,
         cancel_policy: CancelPolicy,
         child_request_id: String,
     ) -> Self {
         Self {
             node,
+            request_id,
             session_id,
             tool_call_id,
             message_sequence,
             tool_name,
             args,
             doc_id: None,
+            deadline_at,
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
@@ -295,14 +308,12 @@ impl ToolCallLifecycle {
         }
     }
 
-    /// Test-only accessor for the current in-memory state.
-    #[cfg(test)]
-    pub(crate) fn state_for_test(&self) -> ToolCallState {
-        self.state
-    }
-
     pub(crate) fn set_doc_id(&mut self, doc_id: Option<String>) {
         self.doc_id = doc_id;
+    }
+
+    pub(crate) fn deadline_at(&self) -> chrono::DateTime<chrono::Utc> {
+        self.deadline_at
     }
 
     pub(crate) fn set_state(&mut self, state: ToolCallState) {
@@ -315,6 +326,10 @@ impl ToolCallLifecycle {
 
     pub(crate) fn set_failure_class(&mut self, fc: Option<FailureClass>) {
         self.failure_class = fc;
+    }
+
+    pub(crate) fn set_deadline_at(&mut self, deadline_at: chrono::DateTime<chrono::Utc>) {
+        self.deadline_at = deadline_at;
     }
 }
 
@@ -363,9 +378,11 @@ mod tests {
             std::sync::Arc<defra_node::EmbeddedNode>,
             String,
             String,
+            String,
             u32,
             String,
             String,
+            chrono::DateTime<chrono::Utc>,
         ) -> ToolCallLifecycle = ToolCallLifecycle::new;
     }
 

--- a/crates/defra-agent/src/tool_call_lifecycle/query.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/query.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
 
-use super::{FailureClass, ToolCallLifecycle, ToolCallState};
+use super::{AwaitMode, CancelPolicy, FailureClass, ToolCallLifecycle, ToolCallState};
 
 #[derive(Debug, Clone, Deserialize)]
 struct ToolCallResultRow {
@@ -74,6 +74,10 @@ struct ToolCallRow {
     lifecycle_state: Option<String>,
     started_at: Option<String>,
     tool_failure_class: Option<String>,
+    // v3 subagent fields — nullable for v2 rows that pre-date the schema migration.
+    await_mode: Option<String>,
+    cancel_policy: Option<String>,
+    child_request_id: Option<String>,
 }
 
 impl ToolCallLifecycle {
@@ -102,6 +106,9 @@ impl ToolCallLifecycle {
                     lifecycle_state
                     started_at
                     tool_failure_class
+                    await_mode
+                    cancel_policy
+                    child_request_id
                 }}
             }}"#
         );
@@ -143,18 +150,36 @@ impl ToolCallLifecycle {
             .as_deref()
             .and_then(FailureClass::from_persisted);
 
-        let mut lc = Self::new(
+        // v3 subagent fields. v2 rows (where these columns are null) fall back
+        // to the same defaults that Self::new() uses, preserving backwards compat.
+        let await_mode = row
+            .await_mode
+            .as_deref()
+            .and_then(AwaitMode::from_persisted)
+            .unwrap_or(AwaitMode::Foreground);
+
+        let cancel_policy = row
+            .cancel_policy
+            .as_deref()
+            .and_then(CancelPolicy::from_persisted)
+            .unwrap_or(CancelPolicy::Cascade);
+
+        let child_request_id = row.child_request_id.filter(|s| !s.is_empty());
+
+        Ok(Some(Self {
             node,
-            session_id.to_string(),
-            tool_call_id.to_string(),
-            row.message_sequence,
-            row.tool_name,
-            row.args,
-        );
-        lc.set_doc_id(Some(row.doc_id));
-        lc.set_state(state);
-        lc.set_started_at(started_at);
-        lc.set_failure_class(failure_class);
-        Ok(Some(lc))
+            session_id: session_id.to_string(),
+            tool_call_id: tool_call_id.to_string(),
+            message_sequence: row.message_sequence,
+            tool_name: row.tool_name,
+            args: row.args,
+            doc_id: Some(row.doc_id),
+            state,
+            started_at,
+            failure_class,
+            await_mode,
+            cancel_policy,
+            child_request_id,
+        }))
     }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/query.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/query.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use defra_node::EmbeddedNode;
 use serde::Deserialize;
 
@@ -68,11 +68,15 @@ pub async fn load_tool_call_result(
 struct ToolCallRow {
     #[serde(rename = "_docID")]
     doc_id: String,
+    #[serde(default)]
+    request_id: Option<String>,
     message_sequence: u32,
     tool_name: String,
     args: String,
     lifecycle_state: Option<String>,
     started_at: Option<String>,
+    #[serde(default)]
+    deadline_at: Option<String>,
     tool_failure_class: Option<String>,
     // v3 subagent fields — nullable for v2 rows that pre-date the schema migration.
     await_mode: Option<String>,
@@ -100,11 +104,13 @@ impl ToolCallLifecycle {
                     limit: 1
                 ) {{
                     _docID
+                    request_id
                     message_sequence
                     tool_name
                     args
                     lifecycle_state
                     started_at
+                    deadline_at
                     tool_failure_class
                     await_mode
                     cancel_policy
@@ -145,6 +151,13 @@ impl ToolCallLifecycle {
             .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
             .map(|dt| dt.with_timezone(&chrono::Utc));
 
+        let deadline_at = row
+            .deadline_at
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc))
+            .unwrap_or_else(chrono::Utc::now);
+
         let failure_class = row
             .tool_failure_class
             .as_deref()
@@ -168,12 +181,14 @@ impl ToolCallLifecycle {
 
         Ok(Some(Self {
             node,
+            request_id: row.request_id.unwrap_or_default(),
             session_id: session_id.to_string(),
             tool_call_id: tool_call_id.to_string(),
             message_sequence: row.message_sequence,
             tool_name: row.tool_name,
             args: row.args,
             doc_id: Some(row.doc_id),
+            deadline_at,
             state,
             started_at,
             failure_class,

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -1,0 +1,330 @@
+//! Startup recovery for persisted running tool calls.
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use defra_node::EmbeddedNode;
+use serde::Deserialize;
+
+use crate::graphql::escape_graphql_string;
+use crate::interrupt::interrupt_request;
+use crate::session::execute_mutation_with_retry;
+
+use super::{CancelPolicy, FailureClass, ToolCallState};
+
+#[derive(Debug, Default)]
+pub struct ToolCallRecoveryReport {
+    pub tool_calls_recovered: usize,
+}
+
+#[derive(Debug, Deserialize)]
+struct RunningToolCallRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    #[serde(default)]
+    request_id: Option<String>,
+    session_id: String,
+    tool_call_id: String,
+    #[serde(default)]
+    started_at: Option<String>,
+    #[serde(default)]
+    deadline_at: Option<String>,
+    #[serde(default)]
+    cancel_policy: Option<String>,
+    #[serde(default)]
+    child_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParentRequestRow {
+    status: String,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryOutcome {
+    TimedOut,
+    Cancelled,
+    Failed,
+}
+
+impl super::ToolCallLifecycle {
+    pub async fn recover_all(
+        node: &EmbeddedNode,
+        agent_did: &str,
+    ) -> Result<ToolCallRecoveryReport> {
+        Ok(ToolCallRecoveryReport {
+            tool_calls_recovered: recover_stuck_running_tool_calls(node, agent_did).await?,
+        })
+    }
+}
+
+async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
+    let query = r#"{
+        AgentToolCall(
+            filter: { lifecycle_state: { _eq: "running" } }
+        ) {
+            _docID
+            request_id
+            session_id
+            tool_call_id
+            started_at
+            deadline_at
+            cancel_policy
+            child_request_id
+        }
+    }"#;
+
+    let resp = node.execute(query).await;
+    if resp.has_errors() {
+        anyhow::bail!("querying stuck running tool calls: {:?}", resp.errors);
+    }
+
+    let rows: Vec<RunningToolCallRow> = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+
+    let mut recovered = 0;
+    for row in rows {
+        let deadline_at = parse_datetime(row.deadline_at.as_deref());
+        let parent = match row
+            .request_id
+            .as_deref()
+            .filter(|request_id| !request_id.is_empty())
+        {
+            Some(request_id) => lookup_parent_request(node, agent_did, request_id).await?,
+            None => None,
+        };
+
+        let outcome = if deadline_at.is_some_and(|deadline| Utc::now() >= deadline) {
+            Some(RecoveryOutcome::TimedOut)
+        } else if parent
+            .as_ref()
+            .is_some_and(|parent| request_is_interrupted(parent))
+        {
+            Some(RecoveryOutcome::Cancelled)
+        } else if parent.as_ref().is_some_and(request_is_terminal) {
+            Some(RecoveryOutcome::Failed)
+        } else {
+            None
+        };
+
+        let Some(outcome) = outcome else {
+            continue;
+        };
+
+        if is_detached_subagent_tool(&row) {
+            tracing::info!(
+                doc_id = %row.doc_id,
+                request_id = row.request_id.as_deref().unwrap_or(""),
+                session_id = %row.session_id,
+                tool_call_id = %row.tool_call_id,
+                child_request_id = row.child_request_id.as_deref().unwrap_or(""),
+                "leaving detached subagent tool call running during recovery"
+            );
+            continue;
+        }
+
+        if let Some(child_request_id) = cascade_child_request_id(&row) {
+            if let Err(error) = interrupt_request(node, child_request_id).await {
+                tracing::warn!(
+                    doc_id = %row.doc_id,
+                    request_id = row.request_id.as_deref().unwrap_or(""),
+                    session_id = %row.session_id,
+                    tool_call_id = %row.tool_call_id,
+                    child_request_id,
+                    error = %error,
+                    "failed to cascade recovery interrupt to child request"
+                );
+            }
+        }
+
+        if let Err(error) = recover_tool_call_row(node, &row, deadline_at, outcome).await {
+            tracing::warn!(
+                doc_id = %row.doc_id,
+                request_id = row.request_id.as_deref().unwrap_or(""),
+                session_id = %row.session_id,
+                tool_call_id = %row.tool_call_id,
+                error = %error,
+                "failed to recover running tool call"
+            );
+            continue;
+        }
+
+        recovered += 1;
+        tracing::info!(
+            doc_id = %row.doc_id,
+            request_id = row.request_id.as_deref().unwrap_or(""),
+            session_id = %row.session_id,
+            tool_call_id = %row.tool_call_id,
+            lifecycle_state = %outcome.lifecycle_state().as_str(),
+            "recovered stuck running tool call"
+        );
+    }
+
+    Ok(recovered)
+}
+
+async fn lookup_parent_request(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    request_id: &str,
+) -> Result<Option<ParentRequestRow>> {
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    agent_did: {{ _eq: "{escaped_agent_did}" }},
+                    request_id: {{ _eq: "{escaped_request_id}" }}
+                }},
+                limit: 1
+            ) {{
+                status
+                lifecycle_state
+            }}
+        }}"#
+    );
+
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "querying parent request for tool-call recovery request_id={request_id}: {:?}",
+            resp.errors
+        );
+    }
+
+    let rows: Vec<ParentRequestRow> = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows.into_iter().next())
+}
+
+async fn recover_tool_call_row(
+    node: &EmbeddedNode,
+    row: &RunningToolCallRow,
+    deadline_at: Option<DateTime<Utc>>,
+    outcome: RecoveryOutcome,
+) -> Result<()> {
+    let now = Utc::now();
+    let started_at = parse_datetime(row.started_at.as_deref()).unwrap_or(now);
+    let latency_ms = (now - started_at).num_milliseconds().max(0);
+    let escaped_doc_id = escape_graphql_string(&row.doc_id);
+    let escaped_result = escape_graphql_string(&outcome.result_text(deadline_at));
+    let started_at_str = started_at.to_rfc3339();
+    let completed_at_str = now.to_rfc3339();
+    let deadline_field = deadline_at
+        .map(|deadline| format!(r#", deadline_at: "{}""#, deadline.to_rfc3339()))
+        .unwrap_or_default();
+    let failure_class_field = outcome
+        .failure_class()
+        .map(|failure| format!(r#", tool_failure_class: "{}""#, failure.as_str()))
+        .unwrap_or_default();
+
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{
+                    result: "{escaped_result}",
+                    status: "completed",
+                    lifecycle_state: "{lifecycle_state}",
+                    started_at: "{started_at_str}"{deadline_field},
+                    completed_at: "{completed_at_str}",
+                    latency_ms: {latency_ms}{failure_class_field}
+                }}
+            ) {{ _docID }}
+        }}"#,
+        lifecycle_state = outcome.lifecycle_state().as_str(),
+    );
+
+    execute_mutation_with_retry(node, &mutation, "recover_running_tool_call")
+        .await
+        .context("recover running tool call mutation")?;
+    Ok(())
+}
+
+fn parse_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {
+    value
+        .filter(|value| !value.is_empty())
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|datetime| datetime.with_timezone(&Utc))
+}
+
+fn request_is_interrupted(parent: &ParentRequestRow) -> bool {
+    parent.status == "interrupted" || parent.lifecycle_state.as_deref() == Some("interrupted")
+}
+
+fn request_is_terminal(parent: &ParentRequestRow) -> bool {
+    matches!(
+        parent.status.as_str(),
+        "completed" | "error" | "superseded" | "dead" | "interrupted"
+    ) || matches!(
+        parent.lifecycle_state.as_deref(),
+        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
+    )
+}
+
+fn child_request_id(row: &RunningToolCallRow) -> Option<&str> {
+    row.child_request_id.as_deref().filter(|id| !id.is_empty())
+}
+
+fn cancel_policy(row: &RunningToolCallRow) -> CancelPolicy {
+    row.cancel_policy
+        .as_deref()
+        .and_then(CancelPolicy::from_persisted)
+        .unwrap_or(CancelPolicy::Cascade)
+}
+
+fn is_detached_subagent_tool(row: &RunningToolCallRow) -> bool {
+    child_request_id(row).is_some() && cancel_policy(row) == CancelPolicy::Detach
+}
+
+fn cascade_child_request_id(row: &RunningToolCallRow) -> Option<&str> {
+    let child_request_id = child_request_id(row)?;
+    (cancel_policy(row) == CancelPolicy::Cascade).then_some(child_request_id)
+}
+
+impl RecoveryOutcome {
+    fn lifecycle_state(self) -> ToolCallState {
+        match self {
+            Self::TimedOut => ToolCallState::TimedOut,
+            Self::Cancelled => ToolCallState::Cancelled,
+            Self::Failed => ToolCallState::Failed,
+        }
+    }
+
+    fn failure_class(self) -> Option<FailureClass> {
+        match self {
+            Self::Failed => Some(FailureClass::External),
+            Self::TimedOut | Self::Cancelled => None,
+        }
+    }
+
+    fn result_text(self, deadline_at: Option<DateTime<Utc>>) -> String {
+        match self {
+            Self::TimedOut => match deadline_at {
+                Some(deadline_at) => {
+                    format!(
+                        "tool call deadline exceeded at {}",
+                        deadline_at.to_rfc3339()
+                    )
+                }
+                None => "tool call deadline exceeded".to_string(),
+            },
+            Self::Cancelled => {
+                "tool call cancelled because parent request was interrupted".to_string()
+            }
+            Self::Failed => {
+                "tool call failed because parent request was already terminal".to_string()
+            }
+        }
+    }
+}

--- a/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
@@ -1,0 +1,253 @@
+//! Runtime enforcement bridge for tool-call lifecycle outcomes.
+//!
+//! Rig executes tools inside the stream future, while lifecycle persistence is
+//! driven by hooks before and after that execution. This module installs a
+//! request-scoped runtime context around stream polling and wraps every tool so
+//! deadline/cancellation outcomes become explicit tool results that the hook
+//! can map to `timedOut` / `cancelled` terminal states.
+
+use std::future::Future;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use rig::completion::ToolDefinition;
+use rig::tool::{ToolDyn, ToolError};
+use rig::wasm_compat::WasmBoxedFuture;
+use tokio_util::sync::CancellationToken;
+
+const MARKER_PREFIX: &str = "__defra_agent_tool_lifecycle__:";
+const TIMEOUT_MARKER: &str = "__defra_agent_tool_lifecycle__:timedOut";
+const CANCELLED_MARKER: &str = "__defra_agent_tool_lifecycle__:cancelled";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManagedToolTerminal {
+    TimedOut,
+    Cancelled,
+}
+
+#[derive(Clone)]
+struct ToolRuntimeScope {
+    deadline_at: Option<DateTime<Utc>>,
+    cancellation_token: CancellationToken,
+}
+
+tokio::task_local! {
+    static TOOL_RUNTIME_SCOPE: ToolRuntimeScope;
+}
+
+pub(crate) async fn scope_request_tool_execution<F, T>(
+    deadline_at: Option<DateTime<Utc>>,
+    cancellation_token: CancellationToken,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
+    TOOL_RUNTIME_SCOPE
+        .scope(
+            ToolRuntimeScope {
+                deadline_at,
+                cancellation_token,
+            },
+            future,
+        )
+        .await
+}
+
+pub(crate) fn wrap_tool(tool: Box<dyn ToolDyn>) -> Box<dyn ToolDyn> {
+    Box::new(RuntimeManagedTool { inner: tool })
+}
+
+pub(crate) fn classify_managed_tool_result(result: &str) -> Option<ManagedToolTerminal> {
+    if !result.starts_with(MARKER_PREFIX) {
+        return None;
+    }
+    if result.starts_with(TIMEOUT_MARKER) {
+        return Some(ManagedToolTerminal::TimedOut);
+    }
+    if result.starts_with(CANCELLED_MARKER) {
+        return Some(ManagedToolTerminal::Cancelled);
+    }
+    None
+}
+
+pub(crate) fn timeout_result(deadline_at: Option<DateTime<Utc>>) -> String {
+    match deadline_at {
+        Some(deadline_at) => format!("{TIMEOUT_MARKER}:{}", deadline_at.to_rfc3339()),
+        None => TIMEOUT_MARKER.to_string(),
+    }
+}
+
+pub(crate) fn cancelled_result() -> String {
+    CANCELLED_MARKER.to_string()
+}
+
+struct RuntimeManagedTool {
+    inner: Box<dyn ToolDyn>,
+}
+
+impl ToolDyn for RuntimeManagedTool {
+    fn name(&self) -> String {
+        self.inner.name()
+    }
+
+    fn definition<'a>(&'a self, prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+        self.inner.definition(prompt)
+    }
+
+    fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move {
+            let Some(scope) = TOOL_RUNTIME_SCOPE.try_with(Clone::clone).ok() else {
+                return self.inner.call(args).await;
+            };
+
+            if deadline_remaining(scope.deadline_at).is_some_and(|remaining| remaining.is_zero()) {
+                return Ok(timeout_result(scope.deadline_at));
+            }
+
+            let mut deadline = Box::pin(async move {
+                match deadline_remaining(scope.deadline_at) {
+                    Some(remaining) => tokio::time::sleep(remaining).await,
+                    None => std::future::pending::<()>().await,
+                }
+            });
+
+            tokio::select! {
+                biased;
+                _ = scope.cancellation_token.cancelled() => {
+                    Ok(cancelled_result())
+                }
+                _ = &mut deadline => {
+                    Ok(timeout_result(scope.deadline_at))
+                }
+                result = self.inner.call(args) => {
+                    result
+                }
+            }
+        })
+    }
+}
+
+fn deadline_remaining(deadline_at: Option<DateTime<Utc>>) -> Option<Duration> {
+    let deadline_at = deadline_at?;
+    let now = Utc::now();
+    if now >= deadline_at {
+        return Some(Duration::ZERO);
+    }
+    Some((deadline_at - now).to_std().unwrap_or(Duration::ZERO))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rig::completion::ToolDefinition;
+
+    struct PendingTool;
+
+    impl ToolDyn for PendingTool {
+        fn name(&self) -> String {
+            "pending".to_string()
+        }
+
+        fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+            Box::pin(async {
+                ToolDefinition {
+                    name: "pending".to_string(),
+                    description: "test tool".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                }
+            })
+        }
+
+        fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+            Box::pin(std::future::pending())
+        }
+    }
+
+    struct FastTool;
+
+    impl ToolDyn for FastTool {
+        fn name(&self) -> String {
+            "fast".to_string()
+        }
+
+        fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+            Box::pin(async {
+                ToolDefinition {
+                    name: "fast".to_string(),
+                    description: "test tool".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                }
+            })
+        }
+
+        fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+            Box::pin(async { Ok("ok".to_string()) })
+        }
+    }
+
+    #[test]
+    fn managed_result_markers_classify_terminal_outcomes() {
+        assert_eq!(
+            classify_managed_tool_result(&timeout_result(Some(Utc::now()))),
+            Some(ManagedToolTerminal::TimedOut)
+        );
+        assert_eq!(
+            classify_managed_tool_result(&cancelled_result()),
+            Some(ManagedToolTerminal::Cancelled)
+        );
+        assert_eq!(classify_managed_tool_result("ordinary output"), None);
+    }
+
+    #[tokio::test]
+    async fn wrapped_tool_times_out_at_request_deadline() {
+        let tool = wrap_tool(Box::new(PendingTool));
+        let deadline = Utc::now() + chrono::Duration::milliseconds(10);
+
+        let result = scope_request_tool_execution(
+            Some(deadline),
+            CancellationToken::new(),
+            tool.call("{}".to_string()),
+        )
+        .await
+        .expect("timeout is returned as managed terminal output");
+
+        assert_eq!(
+            classify_managed_tool_result(&result),
+            Some(ManagedToolTerminal::TimedOut)
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_tool_cancels_before_inner_future_completes() {
+        let tool = wrap_tool(Box::new(PendingTool));
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let result = scope_request_tool_execution(None, token, tool.call("{}".to_string()))
+            .await
+            .expect("cancel is returned as managed terminal output");
+
+        assert_eq!(
+            classify_managed_tool_result(&result),
+            Some(ManagedToolTerminal::Cancelled)
+        );
+    }
+
+    #[tokio::test]
+    async fn wrapped_tool_preserves_fast_success() {
+        let tool = wrap_tool(Box::new(FastTool));
+        let deadline = Utc::now() + chrono::Duration::seconds(1);
+
+        let result = scope_request_tool_execution(
+            Some(deadline),
+            CancellationToken::new(),
+            tool.call("{}".to_string()),
+        )
+        .await
+        .expect("fast tool should complete");
+
+        assert_eq!(result, "ok");
+        assert_eq!(classify_managed_tool_result(&result), None);
+    }
+}

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -1,0 +1,168 @@
+//! Helper for creating subagent-parent-linked AgentRequest rows.
+//!
+//! Public API surface consumed by R3's `SubagentSource` and by Bucket 3
+//! conformance fixtures (Task 26). Mirrors R1's existing AgentRequest
+//! creation flow in `crates/defra-agent/src/lifecycle/materialize.rs`,
+//! with the addition of subagent parent-linkage fields and the depth
+//! cap enforced by Lean's `Subagent.maxSubagentDepth`.
+
+use anyhow::{anyhow, Result};
+use chrono::{DateTime, Utc};
+use defra_node::EmbeddedNode;
+
+use crate::graphql::escape_graphql_string;
+use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
+use crate::session::execute_mutation_with_retry;
+
+use super::IllegalToolCallTransition;
+
+/// The configured cap on subagent recursion depth. Matches Lean's
+/// `Subagent.maxSubagentDepth = 3` (see
+/// `crates/defra-agent/proofs/Proofs/Subagent/State.lean`). Exposed as
+/// part of R2's public API surface so R3's apply-time spawn-flow
+/// validation can reference the same value as the Lean spec.
+pub const MAX_SUBAGENT_DEPTH: u32 = 3;
+
+/// Create a new AgentRequest row with subagent parent linkage. Validates
+/// the two preconditions enforced by the Lean Subagent spec BEFORE any
+/// DB I/O:
+///
+///   1. `parent_subagent_depth + 1 ≤ MAX_SUBAGENT_DEPTH`. Returns
+///      `IllegalToolCallTransition::SubagentDepthExceeded` otherwise.
+///   2. Both `parent_request_id` and `parent_tool_call_id` non-empty.
+///      Returns `IllegalToolCallTransition::ParentLinkageIncoherent`
+///      otherwise. (A child must reference both parent identifiers; the
+///      well-formedness invariant in `watcher.rs::validate_subagent_fields`
+///      requires that `subagent_depth > 0` documents have both fields
+///      populated.)
+///
+/// On success returns the newly minted `request_id`.
+///
+/// Field ownership notes (mirroring `materialize.rs`):
+///   - `request_id` and `session_id` are freshly generated UUIDs.
+///   - `lifecycle_state` is initialized to `"pending"`.
+///   - `subagent_depth = parent_subagent_depth + 1`.
+///   - `caused_by_parent_request_id` / `caused_by_parent_tool_call_id`
+///     carry the parent linkage.
+///   - Trigger lineage fields (`caused_by_trigger_id`,
+///     `caused_by_trigger_kind`) are intentionally left empty: a
+///     subagent spawn is not itself a trigger fire — the parent's
+///     trigger lineage already records the originating cause.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_subagent_request(
+    node: &EmbeddedNode,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    agent_did: String,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<DateTime<Utc>>,
+) -> Result<String> {
+    // 1. Depth check (pure precondition, fires before any DB I/O).
+    if parent_subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
+        return Err(anyhow!(IllegalToolCallTransition::SubagentDepthExceeded));
+    }
+
+    // 2. Coherence check (pure precondition, fires before any DB I/O).
+    if parent_request_id.is_empty() || parent_tool_call_id.is_empty() {
+        return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
+    }
+
+    // 3. Generate fresh identifiers (mirror materialize.rs pattern).
+    let new_request_id = uuid::Uuid::new_v4().to_string();
+    let new_session_id = uuid::Uuid::new_v4().to_string();
+    let new_subagent_depth = parent_subagent_depth + 1;
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    let escaped_request_id = escape_graphql_string(&new_request_id);
+    let escaped_agent_did = escape_graphql_string(&agent_did);
+    let escaped_behavior_id = escape_graphql_string(&behavior_id);
+    let escaped_session_id = escape_graphql_string(&new_session_id);
+    let escaped_prompt = escape_graphql_string(&prompt);
+    let escaped_created_at = escape_graphql_string(&now);
+    let escaped_parent_request_id = escape_graphql_string(&parent_request_id);
+    let escaped_parent_tool_call_id = escape_graphql_string(&parent_tool_call_id);
+
+    let deadline_field = deadline
+        .map(|d| {
+            let escaped_deadline = escape_graphql_string(&d.to_rfc3339());
+            format!(
+                r#"
+                deadline: "{escaped_deadline}","#
+            )
+        })
+        .unwrap_or_default();
+
+    // 4. Build and execute the CREATE mutation. Mirrors the field shape
+    // of `write_pending_agent_request_with_lineage_and_conversation_title`
+    // in `lifecycle/materialize.rs`, plus the three subagent fields.
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{escaped_request_id}",
+                agent_did: "{escaped_agent_did}",
+                behavior_id: "{escaped_behavior_id}",
+                session_id: "{escaped_session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{escaped_request_id}",
+                superseded_by_request: "",
+                content: "{escaped_prompt}",
+                status: "pending",
+                lifecycle_state: "pending",
+                backend_id: "",
+                execution_origin: "interactive",
+                failure_reason: "",
+                created_at: "{escaped_created_at}",{deadline_field}
+                retry_count: 0,
+                max_retries: {max_retries},
+                subagent_depth: {new_subagent_depth},
+                caused_by_parent_request_id: "{escaped_parent_request_id}",
+                caused_by_parent_tool_call_id: "{escaped_parent_tool_call_id}"
+            }}) {{ _docID }}
+        }}"#,
+        max_retries = DEFAULT_REQUEST_MAX_RETRIES,
+    );
+
+    execute_mutation_with_retry(node, &mutation, "create_subagent_request").await?;
+
+    Ok(new_request_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The depth and coherence checks fire BEFORE any DB I/O, so we can
+    // exercise them without a real EmbeddedNode by leveraging the early
+    // return semantics. The DB-touching happy path is deferred to Bucket
+    // 3 / Task 26, which has the test_db fixture set up.
+    //
+    // We can't easily fabricate an `EmbeddedNode` for unit tests (it's a
+    // real type with a real constructor that boots a node). So the unit
+    // tests below use `unsafe { std::mem::zeroed() }` only conceptually
+    // — that's UB in Rust. Instead, we inline-construct the precondition
+    // checks directly in #[test] blocks that don't call the function.
+    //
+    // The function-level error paths (depth + coherence) ARE tested by
+    // Task 26's end-to-end fixtures, where a real node is available.
+
+    #[test]
+    fn max_subagent_depth_matches_lean_spec() {
+        // Lean: Subagent.State.lean defines `maxSubagentDepth : Nat := 3`.
+        assert_eq!(MAX_SUBAGENT_DEPTH, 3);
+    }
+
+    #[test]
+    fn depth_precondition_arithmetic() {
+        // parent_subagent_depth + 1 must be <= MAX_SUBAGENT_DEPTH.
+        // Allowed parent depths: 0, 1, 2 (resulting children: 1, 2, 3).
+        // Rejected parent depths: 3 and above.
+        for parent_depth in 0..=2 {
+            assert!(parent_depth + 1 <= MAX_SUBAGENT_DEPTH);
+        }
+        for parent_depth in 3..=10 {
+            assert!(parent_depth + 1 > MAX_SUBAGENT_DEPTH);
+        }
+    }
+}

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -17,16 +17,41 @@ use defra_node::QueryResponse;
 use crate::graphql::escape_graphql_string;
 use crate::session::execute_mutation_with_retry;
 
-use super::{ToolCallLifecycle, ToolCallState};
+use super::{AwaitMode, CancelPolicy, ToolCallLifecycle, ToolCallState};
 
 /// Error returned when a transition method is called from an illegal
-/// pre-state. Programmer error, not a user-visible failure.
-#[derive(Debug, thiserror::Error)]
-#[error("illegal tool call transition: cannot {method} from state {from:?} (allowed: {allowed:?})")]
-pub struct IllegalToolCallTransition {
-    pub method: &'static str,
-    pub from: ToolCallState,
-    pub allowed: Vec<ToolCallState>,
+/// pre-state, or when a subagent-specific guard is violated.
+/// Programmer error, not a user-visible failure.
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum IllegalToolCallTransition {
+    #[error(
+        "illegal tool call transition: cannot {method} from state {from:?} (allowed: {allowed:?})"
+    )]
+    BadState {
+        method: &'static str,
+        from: ToolCallState,
+        allowed: Vec<ToolCallState>,
+    },
+    #[error("await_mode flip rejected: tool already Background")]
+    ModeAlreadyBackground,
+    #[error("await_mode flip rejected: tool already Foreground")]
+    ModeAlreadyForeground,
+    #[error("cancel_policy flip rejected: tool already Detach")]
+    PolicyAlreadyDetach,
+    #[error("bridge_complete called on tool without child_request_id")]
+    BridgeCompleteRequiresChildLink,
+    #[error("bridge_failure called on tool without child_request_id")]
+    BridgeFailureRequiresChildLink,
+    #[error("bridge_cancel_cascade called on tool not in .cancelled state")]
+    CascadeRequiresCancelled,
+    #[error("create_subagent_request rejected: depth exceeds maxSubagentDepth")]
+    SubagentDepthExceeded,
+    #[error("AgentRequest parent linkage incoherent: must set both or neither parent fields")]
+    ParentLinkageIncoherent,
+    #[error("native complete() called on subagent-typed tool (child_request_id is set)")]
+    NativeCompleteOnSubagentTool,
+    #[error("native fail() called on subagent-typed tool (child_request_id is set)")]
+    NativeFailOnSubagentTool,
 }
 
 impl ToolCallLifecycle {
@@ -40,7 +65,7 @@ impl ToolCallLifecycle {
         if allowed.contains(&self.state) {
             Ok(())
         } else {
-            Err(anyhow!(IllegalToolCallTransition {
+            Err(anyhow!(IllegalToolCallTransition::BadState {
                 method,
                 from: self.state,
                 allowed: allowed.to_vec(),
@@ -66,6 +91,21 @@ impl ToolCallLifecycle {
         let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
         let message_sequence = self.message_sequence;
 
+        // Persist subagent-specific fields when this tool has a child link.
+        // These are optional schema fields so we emit them only when set.
+        let subagent_fields = if let Some(ref crid) = self.child_request_id {
+            let escaped_crid = escape_graphql_string(crid);
+            let await_mode_str = self.await_mode.as_str();
+            let cancel_policy_str = self.cancel_policy.as_str();
+            format!(
+                r#"child_request_id: "{escaped_crid}",
+                    await_mode: "{await_mode_str}",
+                    cancel_policy: "{cancel_policy_str}","#
+            )
+        } else {
+            String::new()
+        };
+
         let mutation = format!(
             r#"mutation {{
                 create_AgentToolCall(input: {{
@@ -79,6 +119,7 @@ impl ToolCallLifecycle {
                     status: "called",
                     lifecycle_state: "running",
                     started_at: "{started_at_str}",
+                    {subagent_fields}
                     selected_service_id: null,
                     selected_tool_name: null,
                     tool_failure_class: null,
@@ -104,6 +145,9 @@ impl ToolCallLifecycle {
     /// latency_ms.
     pub async fn complete(&mut self, result: &str) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "complete")?;
+        if self.child_request_id.is_some() {
+            return Err(IllegalToolCallTransition::NativeCompleteOnSubagentTool.into());
+        }
 
         let doc_id = self
             .doc_id
@@ -149,6 +193,9 @@ impl ToolCallLifecycle {
     /// Running → Failed. For tool errors during execution. Sets failure_class.
     pub async fn fail(&mut self, result: &str, failure: super::FailureClass) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "fail")?;
+        if self.child_request_id.is_some() {
+            return Err(IllegalToolCallTransition::NativeFailOnSubagentTool.into());
+        }
 
         let doc_id = self
             .doc_id
@@ -244,6 +291,142 @@ impl ToolCallLifecycle {
         Ok(())
     }
 
+    /// Running → Completed for bridge (subagent) tools.
+    ///
+    /// Lean parity: bridge_complete. Parent tool .running → .completed when
+    /// the caller has verified the linked child request reached .completed.
+    /// Persists child_result as the row's `result` field; sets state,
+    /// completed_at, latency_ms following R1's complete() persistence pattern.
+    ///
+    /// Trust boundary: bridge_complete does NOT verify the child's terminal
+    /// state internally (Lean's precondition is on the caller). R3's
+    /// SubagentSource will be the natural place for that check.
+    pub async fn bridge_complete(&mut self, child_result: String) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running], "bridge_complete")?;
+        if self.child_request_id.is_none() {
+            return Err(IllegalToolCallTransition::BridgeCompleteRequiresChildLink.into());
+        }
+
+        let doc_id = self.doc_id.as_ref().ok_or_else(|| {
+            anyhow!("bridge_complete called before start_running persisted a row")
+        })?;
+        let now = Utc::now();
+        let started_at = self
+            .started_at
+            .ok_or_else(|| anyhow!("bridge_complete called without started_at set"))?;
+        let latency_ms = (now - started_at).num_milliseconds();
+
+        let escaped_result = escape_graphql_string(&child_result);
+        let escaped_doc_id = escape_graphql_string(doc_id);
+        let now_str = now.to_rfc3339();
+        // DefraDB requires DateTime fields to be re-supplied on update to
+        // avoid a type-mismatch error when re-validating the document.
+        let started_at_str = started_at.to_rfc3339();
+
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{
+                        result: "{escaped_result}",
+                        status: "completed",
+                        lifecycle_state: "completed",
+                        started_at: "{started_at_str}",
+                        completed_at: "{now_str}",
+                        latency_ms: {latency_ms}
+                    }}
+                ) {{ _docID }}
+            }}"#
+        );
+
+        execute_mutation_with_retry(&self.node, &mutation, "bridge_complete")
+            .await
+            .context("bridge_complete mutation")?;
+
+        self.state = ToolCallState::Completed;
+        Ok(())
+    }
+
+    /// Running → Failed (or Cancelled for ChildTerminal::Interrupted).
+    ///
+    /// Lean parity: bridge_failure. Parent tool .running → .failed (or
+    /// .cancelled for ChildTerminal::Interrupted). Projection per
+    /// ChildTerminal::projected_state(). Persists lifecycle_state,
+    /// completed_at, latency_ms; conditionally persists tool_failure_class
+    /// and result when the child reached .failed.
+    ///
+    /// Returns BridgeFailureRequiresChildLink for native tools (no
+    /// child_request_id).
+    pub async fn bridge_failure(&mut self, child_terminal: super::ChildTerminal) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running], "bridge_failure")?;
+        if self.child_request_id.is_none() {
+            return Err(IllegalToolCallTransition::BridgeFailureRequiresChildLink.into());
+        }
+
+        let projected = child_terminal.projected_state();
+        let (failure_class_for_persist, reason_for_persist) = match &child_terminal {
+            super::ChildTerminal::Failed {
+                reason,
+                failure_class,
+            } => (Some(*failure_class), Some(reason.clone())),
+            _ => (None, None),
+        };
+
+        let doc_id = self
+            .doc_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("bridge_failure called before start_running persisted a row"))?;
+        let now = Utc::now();
+        let started_at = self
+            .started_at
+            .ok_or_else(|| anyhow!("bridge_failure called without started_at set"))?;
+        let latency_ms = (now - started_at).num_milliseconds();
+
+        let escaped_doc_id = escape_graphql_string(doc_id);
+        let now_str = now.to_rfc3339();
+        // DefraDB requires DateTime fields to be re-supplied on update.
+        let started_at_str = started_at.to_rfc3339();
+        let lifecycle_state_str = projected.as_str();
+
+        // Build conditional fields: tool_failure_class and result are only
+        // set when the child reached .failed (mirrors R1's fail() pattern).
+        let optional_fields = match (failure_class_for_persist, reason_for_persist.as_deref()) {
+            (Some(fc), Some(reason)) => {
+                let escaped_reason = escape_graphql_string(reason);
+                let fc_str = fc.as_str();
+                format!(
+                    r#"result: "{escaped_reason}",
+                        tool_failure_class: "{fc_str}","#
+                )
+            }
+            _ => String::new(),
+        };
+
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{
+                        {optional_fields}
+                        status: "completed",
+                        lifecycle_state: "{lifecycle_state_str}",
+                        started_at: "{started_at_str}",
+                        completed_at: "{now_str}",
+                        latency_ms: {latency_ms}
+                    }}
+                ) {{ _docID }}
+            }}"#
+        );
+
+        execute_mutation_with_retry(&self.node, &mutation, "bridge_failure")
+            .await
+            .context("bridge_failure mutation")?;
+
+        self.state = projected;
+        self.failure_class = failure_class_for_persist;
+        Ok(())
+    }
+
     /// Running → TimedOut. R1 does not call this from runtime code; R3 wires
     /// it up to fire on deadline expiry. Defined here so the API surface
     /// matches the Lean spec.
@@ -332,6 +515,156 @@ impl ToolCallLifecycle {
         Ok(())
     }
 
+    /// Running mode-flip: await_mode Foreground → Background.
+    ///
+    /// Lean parity: ToolCallContext.Transition.background.
+    /// Requires Running state. Returns `ModeAlreadyBackground` if already in
+    /// Background mode. Persists the new await_mode to the row, then updates
+    /// the in-memory field on success.
+    pub async fn background(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running], "background")?;
+        if self.await_mode == AwaitMode::Background {
+            return Err(IllegalToolCallTransition::ModeAlreadyBackground.into());
+        }
+
+        let doc_id = self
+            .doc_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("background called before start_running persisted a row"))?;
+        // DefraDB requires DateTime fields to be re-supplied on update to
+        // avoid a type-mismatch error when re-validating the document.
+        let started_at = self
+            .started_at
+            .ok_or_else(|| anyhow!("background called without started_at set"))?;
+        let started_at_str = started_at.to_rfc3339();
+
+        let escaped_doc_id = escape_graphql_string(doc_id);
+
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{ await_mode: "background", started_at: "{started_at_str}" }}
+                ) {{ _docID }}
+            }}"#
+        );
+
+        execute_mutation_with_retry(&self.node, &mutation, "background")
+            .await
+            .context("background mutation")?;
+
+        self.await_mode = AwaitMode::Background;
+        Ok(())
+    }
+
+    /// Running mode-flip: await_mode Background → Foreground.
+    ///
+    /// Lean parity: ToolCallContext.Transition.foreground.
+    /// Requires Running state. Returns `ModeAlreadyForeground` if already in
+    /// Foreground mode. Persists the new await_mode to the row, then updates
+    /// the in-memory field on success.
+    pub async fn foreground(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running], "foreground")?;
+        if self.await_mode == AwaitMode::Foreground {
+            return Err(IllegalToolCallTransition::ModeAlreadyForeground.into());
+        }
+
+        let doc_id = self
+            .doc_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("foreground called before start_running persisted a row"))?;
+        // DefraDB requires DateTime fields to be re-supplied on update to
+        // avoid a type-mismatch error when re-validating the document.
+        let started_at = self
+            .started_at
+            .ok_or_else(|| anyhow!("foreground called without started_at set"))?;
+        let started_at_str = started_at.to_rfc3339();
+
+        let escaped_doc_id = escape_graphql_string(doc_id);
+
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{ await_mode: "foreground", started_at: "{started_at_str}" }}
+                ) {{ _docID }}
+            }}"#
+        );
+
+        execute_mutation_with_retry(&self.node, &mutation, "foreground")
+            .await
+            .context("foreground mutation")?;
+
+        self.await_mode = AwaitMode::Foreground;
+        Ok(())
+    }
+
+    /// Pending|Running policy-flip: cancel_policy Cascade → Detach.
+    ///
+    /// Lean parity: ToolCallContext.Transition.detach. Allowed in both Pending
+    /// and Running states (h_live : pre.state = .pending ∨ pre.state = .running).
+    /// Returns `PolicyAlreadyDetach` if already in Detach policy. One-way — no
+    /// inverse method (matches Lean's structural irreversibility).
+    pub async fn detach(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Pending, ToolCallState::Running], "detach")?;
+        if self.cancel_policy == CancelPolicy::Detach {
+            return Err(IllegalToolCallTransition::PolicyAlreadyDetach.into());
+        }
+
+        let doc_id = self
+            .doc_id
+            .as_ref()
+            .ok_or_else(|| anyhow!("doc_id must be set before policy-flip"))?;
+        // DefraDB requires DateTime fields to be re-supplied on update to
+        // avoid a type-mismatch error when re-validating the document.
+        // started_at is only set once the row is in Running state; for Pending
+        // state the row has not been created yet so this field will be absent.
+        let started_at_fragment = if let Some(started_at) = self.started_at {
+            format!(", started_at: \"{}\"", started_at.to_rfc3339())
+        } else {
+            String::new()
+        };
+
+        let escaped_doc_id = escape_graphql_string(doc_id);
+
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{ cancel_policy: "detach"{started_at_fragment} }}
+                ) {{ _docID }}
+            }}"#
+        );
+
+        execute_mutation_with_retry(&self.node, &mutation, "detach")
+            .await
+            .context("detach mutation")?;
+
+        self.cancel_policy = CancelPolicy::Detach;
+        Ok(())
+    }
+
+    /// Lean parity: bridge_cancel_cascade. Pure — returns the action that should
+    /// be taken on the child AgentRequest. Caller (typically R3's daemon
+    /// interrupt dispatcher) performs the actual write to set
+    /// interrupt_requested_at on the child. Returns None for native tools,
+    /// detached subagents, or non-cancelled bridge tools.
+    pub async fn bridge_cancel_cascade(&self) -> Result<Option<super::CascadeIntent>> {
+        if self.state != ToolCallState::Cancelled {
+            return Err(IllegalToolCallTransition::CascadeRequiresCancelled.into());
+        }
+        if self.cancel_policy != CancelPolicy::Cascade {
+            return Ok(None); // detached: no cascade
+        }
+        let Some(child_request_id) = self.child_request_id.clone() else {
+            return Ok(None); // native: no bridge edge
+        };
+        Ok(Some(super::CascadeIntent {
+            child_request_id,
+            at: chrono::Utc::now(),
+        }))
+    }
+
     /// Running → Cancelled. R1 does not call from runtime code; R4 wires up.
     pub async fn cancel_during_run(&mut self) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "cancel_during_run")?;
@@ -399,4 +732,457 @@ fn extract_doc_id_from_create_response(resp: &QueryResponse) -> Option<String> {
                 .and_then(|doc_id| doc_id.as_str())
         })
         .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::super::{AwaitMode, CancelPolicy, ToolCallLifecycle, ToolCallState};
+    use super::IllegalToolCallTransition;
+
+    /// Build a minimal in-memory node. Schema setup is not required for these
+    /// tests because the h_native guards fire before any DB mutation.
+    async fn test_node() -> Arc<defra_node::EmbeddedNode> {
+        Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap())
+    }
+
+    /// Return a subagent-typed lifecycle already in Running state.
+    /// Uses the pub(crate) setters to skip `start_running` (which would
+    /// require schema setup). The guard under test fires before the DB call,
+    /// so no mutation ever reaches the node.
+    async fn subagent_lc_in_running() -> ToolCallLifecycle {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "session-1".to_string(),
+            "tcid-1".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-req-1".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+        lc
+    }
+
+    #[tokio::test]
+    async fn complete_rejects_subagent_typed_tool() {
+        let mut lc = subagent_lc_in_running().await;
+        let err = lc.complete("result").await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::NativeCompleteOnSubagentTool)
+            ),
+            "expected NativeCompleteOnSubagentTool, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fail_rejects_subagent_typed_tool() {
+        use super::super::FailureClass;
+        let mut lc = subagent_lc_in_running().await;
+        let err = lc
+            .fail("error output", FailureClass::External)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::NativeFailOnSubagentTool)
+            ),
+            "expected NativeFailOnSubagentTool, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn background_rejects_already_background() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-bg-2".to_string(),
+            "tc-bg-2".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Background, // start already in Background
+            CancelPolicy::Cascade,
+            "child-req-bg-2".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id-bg-2".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc.background().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::ModeAlreadyBackground)
+            ),
+            "expected ModeAlreadyBackground, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn background_rejects_pending_state() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new(
+            node,
+            "sess-bg-3".to_string(),
+            "tc-bg-3".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+        );
+        // state is Pending (default); do not advance it
+
+        let err = lc.background().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BadState { .. })
+            ),
+            "expected BadState, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn foreground_rejects_already_foreground() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-fg-1".to_string(),
+            "tc-fg-1".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground, // start already in Foreground
+            CancelPolicy::Cascade,
+            "child-req-fg-1".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id-fg-1".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc.foreground().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::ModeAlreadyForeground)
+            ),
+            "expected ModeAlreadyForeground, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn foreground_rejects_pending_state() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new(
+            node,
+            "sess-fg-2".to_string(),
+            "tc-fg-2".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+        );
+        // state is Pending (default); do not advance it
+
+        let err = lc.foreground().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BadState { .. })
+            ),
+            "expected BadState, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detach_rejects_already_detach() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-detach-1".to_string(),
+            "tc-detach-1".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Detach, // already in Detach policy
+            "child-req-detach-1".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id-detach-1".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc.detach().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::PolicyAlreadyDetach)
+            ),
+            "expected PolicyAlreadyDetach, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detach_rejects_terminal_state() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-detach-2".to_string(),
+            "tc-detach-2".to_string(),
+            1,
+            "spawn_subagent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-req-detach-2".to_string(),
+        );
+        lc.set_state(ToolCallState::Cancelled); // terminal state
+        lc.set_doc_id(Some("fake-doc-id-detach-2".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc.detach().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BadState { .. })
+            ),
+            "expected BadState, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_failure_rejects_native_tool() {
+        // Native tool: constructed with new() — no child_request_id.
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new(
+            node,
+            "sess-bf-1".to_string(),
+            "tc-bf-1".to_string(),
+            0,
+            "native_tool".to_string(),
+            "{}".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id-bf-1".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc
+            .bridge_failure(super::super::ChildTerminal::Dead)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BridgeFailureRequiresChildLink)
+            ),
+            "expected BridgeFailureRequiresChildLink, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_failure_rejects_pending_state() {
+        // Subagent tool, but never advanced to Running.
+        let node = test_node().await;
+        let lc_base = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-bf-2".to_string(),
+            "tc-bf-2".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-1".to_string(),
+        );
+        // Leave state as Pending (default); do not call start_running.
+        let mut lc = lc_base;
+
+        let err = lc
+            .bridge_failure(super::super::ChildTerminal::Dead)
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BadState { .. })
+            ),
+            "expected BadState, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_failure_projected_state_interrupted_is_cancelled() {
+        use super::super::ChildTerminal;
+        assert_eq!(
+            ChildTerminal::Interrupted.projected_state(),
+            ToolCallState::Cancelled
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_failure_projected_state_failed_is_failed() {
+        use super::super::{ChildTerminal, FailureClass};
+        assert_eq!(
+            ChildTerminal::Failed {
+                reason: "error".to_string(),
+                failure_class: FailureClass::External,
+            }
+            .projected_state(),
+            ToolCallState::Failed
+        );
+        assert_eq!(ChildTerminal::Dead.projected_state(), ToolCallState::Failed);
+        assert_eq!(
+            ChildTerminal::Superseded.projected_state(),
+            ToolCallState::Failed
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_complete_rejects_native_tool() {
+        // Native tool: constructed with new() — no child_request_id.
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new(
+            node,
+            "sess-bc-1".to_string(),
+            "tc-bc-1".to_string(),
+            0,
+            "native_tool".to_string(),
+            "{}".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+        lc.set_doc_id(Some("fake-doc-id-bc-1".to_string()));
+        lc.set_started_at(Some(chrono::Utc::now()));
+
+        let err = lc.bridge_complete("x".to_string()).await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BridgeCompleteRequiresChildLink)
+            ),
+            "expected BridgeCompleteRequiresChildLink, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_complete_rejects_pending_state() {
+        // Subagent tool, but never advanced to Running.
+        let node = test_node().await;
+        let lc_base = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-bc-2".to_string(),
+            "tc-bc-2".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-1".to_string(),
+        );
+        // Leave state as Pending (default); do not call start_running.
+        let mut lc = lc_base;
+
+        let err = lc.bridge_complete("x".to_string()).await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::BadState { .. })
+            ),
+            "expected BadState, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_cancel_cascade_returns_intent_for_cascade_subagent() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-cas-1".to_string(),
+            "tc-cas-1".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-cas-1".to_string(),
+        );
+        lc.set_state(ToolCallState::Cancelled);
+
+        let intent = lc.bridge_cancel_cascade().await.unwrap();
+        let intent = intent.expect("should return Some(CascadeIntent)");
+        assert_eq!(intent.child_request_id, "child-cas-1");
+    }
+
+    #[tokio::test]
+    async fn bridge_cancel_cascade_returns_none_for_detached() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-cas-2".to_string(),
+            "tc-cas-2".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Detach,
+            "child-cas-2".to_string(),
+        );
+        lc.set_state(ToolCallState::Cancelled);
+
+        let intent = lc.bridge_cancel_cascade().await.unwrap();
+        assert!(intent.is_none(), "Detach policy returns None");
+    }
+
+    #[tokio::test]
+    async fn bridge_cancel_cascade_returns_none_for_native() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new(
+            node,
+            "sess-cas-3".to_string(),
+            "tc-cas-3".to_string(),
+            0,
+            "native_tool".to_string(),
+            "{}".to_string(),
+        );
+        lc.set_state(ToolCallState::Cancelled);
+
+        let intent = lc.bridge_cancel_cascade().await.unwrap();
+        assert!(
+            intent.is_none(),
+            "Native tool (no child_request_id) returns None"
+        );
+    }
+
+    #[tokio::test]
+    async fn bridge_cancel_cascade_rejects_non_cancelled_state() {
+        let node = test_node().await;
+        let mut lc = ToolCallLifecycle::new_subagent(
+            node,
+            "sess-cas-4".to_string(),
+            "tc-cas-4".to_string(),
+            0,
+            "spawn_agent".to_string(),
+            "{}".to_string(),
+            AwaitMode::Foreground,
+            CancelPolicy::Cascade,
+            "child-cas-4".to_string(),
+        );
+        lc.set_state(ToolCallState::Running);
+
+        let err = lc.bridge_cancel_cascade().await.unwrap_err();
+        assert!(
+            matches!(
+                err.downcast_ref::<IllegalToolCallTransition>(),
+                Some(IllegalToolCallTransition::CascadeRequiresCancelled)
+            ),
+            "expected CascadeRequiresCancelled, got: {err:?}"
+        );
+    }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -84,6 +84,8 @@ impl ToolCallLifecycle {
 
         let now = Utc::now();
         let started_at_str = now.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
+        let escaped_request_id = escape_graphql_string(&self.request_id);
         let escaped_session_id = escape_graphql_string(&self.session_id);
         let escaped_tool_call_id = escape_graphql_string(&self.tool_call_id);
         let escaped_tool_name = escape_graphql_string(&self.tool_name);
@@ -110,6 +112,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
+                    request_id: "{escaped_request_id}",
                     session_id: "{escaped_session_id}",
                     message_sequence: {message_sequence},
                     tool_name: "{escaped_tool_name}",
@@ -119,6 +122,7 @@ impl ToolCallLifecycle {
                     status: "called",
                     lifecycle_state: "running",
                     started_at: "{started_at_str}",
+                    deadline_at: "{deadline_at_str}",
                     {subagent_fields}
                     selected_service_id: null,
                     selected_tool_name: null,
@@ -165,6 +169,7 @@ impl ToolCallLifecycle {
         // DefraDB requires DateTime fields to be re-supplied on update to
         // avoid a type-mismatch error when re-validating the document.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let mutation = format!(
             r#"mutation {{
@@ -175,6 +180,7 @@ impl ToolCallLifecycle {
                         status: "completed",
                         lifecycle_state: "completed",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
                     }}
@@ -213,6 +219,7 @@ impl ToolCallLifecycle {
         let failure_class_str = failure.as_str();
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let mutation = format!(
             r#"mutation {{
@@ -223,6 +230,7 @@ impl ToolCallLifecycle {
                         status: "completed",
                         lifecycle_state: "failed",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         tool_failure_class: "{failure_class_str}",
                         latency_ms: {latency_ms}
@@ -249,6 +257,8 @@ impl ToolCallLifecycle {
         // directly in Failed state.
         let now = Utc::now();
         let started_at_str = now.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
+        let escaped_request_id = escape_graphql_string(&self.request_id);
         let escaped_session_id = escape_graphql_string(&self.session_id);
         let escaped_tool_call_id = escape_graphql_string(&self.tool_call_id);
         let escaped_tool_name = escape_graphql_string(&self.tool_name);
@@ -262,6 +272,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
+                    request_id: "{escaped_request_id}",
                     session_id: "{escaped_session_id}",
                     message_sequence: {message_sequence},
                     tool_name: "{escaped_tool_name}",
@@ -271,6 +282,7 @@ impl ToolCallLifecycle {
                     status: "completed",
                     lifecycle_state: "failed",
                     started_at: null,
+                    deadline_at: "{deadline_at_str}",
                     completed_at: "{started_at_str}",
                     tool_failure_class: "{failure_class_str}",
                     latency_ms: 0
@@ -322,6 +334,7 @@ impl ToolCallLifecycle {
         // DefraDB requires DateTime fields to be re-supplied on update to
         // avoid a type-mismatch error when re-validating the document.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let mutation = format!(
             r#"mutation {{
@@ -332,6 +345,7 @@ impl ToolCallLifecycle {
                         status: "completed",
                         lifecycle_state: "completed",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
                     }}
@@ -386,6 +400,7 @@ impl ToolCallLifecycle {
         let now_str = now.to_rfc3339();
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
         let lifecycle_state_str = projected.as_str();
 
         // Build conditional fields: tool_failure_class and result are only
@@ -411,6 +426,7 @@ impl ToolCallLifecycle {
                         status: "completed",
                         lifecycle_state: "{lifecycle_state_str}",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
                     }}
@@ -427,9 +443,8 @@ impl ToolCallLifecycle {
         Ok(())
     }
 
-    /// Running → TimedOut. R1 does not call this from runtime code; R3 wires
-    /// it up to fire on deadline expiry. Defined here so the API surface
-    /// matches the Lean spec.
+    /// Running → TimedOut. Called by the runtime deadline wrapper and startup
+    /// recovery when a running tool call exceeds its effective deadline.
     pub async fn timeout(&mut self) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "timeout")?;
 
@@ -444,18 +459,25 @@ impl ToolCallLifecycle {
         let latency_ms = (now - started_at).num_milliseconds();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
+        let escaped_result = escape_graphql_string(&format!(
+            "tool call deadline exceeded at {}",
+            self.deadline_at.to_rfc3339()
+        ));
         let now_str = now.to_rfc3339();
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let mutation = format!(
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
                     input: {{
+                        result: "{escaped_result}",
                         status: "completed",
                         lifecycle_state: "timedOut",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
                     }}
@@ -471,13 +493,16 @@ impl ToolCallLifecycle {
         Ok(())
     }
 
-    /// Pending → Cancelled. R1 does not call from runtime code; R4 wires up.
+    /// Pending → Cancelled. Used when a tool call is cancelled before
+    /// dispatch creates a running row.
     pub async fn cancel_before_dispatch(&mut self) -> Result<()> {
         self.ensure_state(&[ToolCallState::Pending], "cancel_before_dispatch")?;
 
         // Pending: row may not exist yet. Create directly in Cancelled.
         let now = Utc::now();
         let started_at_str = now.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
+        let escaped_request_id = escape_graphql_string(&self.request_id);
         let escaped_session_id = escape_graphql_string(&self.session_id);
         let escaped_tool_call_id = escape_graphql_string(&self.tool_call_id);
         let escaped_tool_name = escape_graphql_string(&self.tool_name);
@@ -485,19 +510,23 @@ impl ToolCallLifecycle {
         let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
         let message_sequence = self.message_sequence;
 
+        let escaped_result = escape_graphql_string("tool call cancelled before dispatch");
+
         let mutation = format!(
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
+                    request_id: "{escaped_request_id}",
                     session_id: "{escaped_session_id}",
                     message_sequence: {message_sequence},
                     tool_name: "{escaped_tool_name}",
                     tool_call_id: "{escaped_tool_call_id}",
                     args: "{escaped_args}",
-                    result: "",
+                    result: "{escaped_result}",
                     status: "completed",
                     lifecycle_state: "cancelled",
                     started_at: null,
+                    deadline_at: "{deadline_at_str}",
                     completed_at: "{started_at_str}",
                     latency_ms: 0
                 }}) {{ _docID }}
@@ -537,6 +566,7 @@ impl ToolCallLifecycle {
             .started_at
             .ok_or_else(|| anyhow!("background called without started_at set"))?;
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -544,7 +574,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
-                    input: {{ await_mode: "background", started_at: "{started_at_str}" }}
+                    input: {{ await_mode: "background", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}" }}
                 ) {{ _docID }}
             }}"#
         );
@@ -579,6 +609,7 @@ impl ToolCallLifecycle {
             .started_at
             .ok_or_else(|| anyhow!("foreground called without started_at set"))?;
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -586,7 +617,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
-                    input: {{ await_mode: "foreground", started_at: "{started_at_str}" }}
+                    input: {{ await_mode: "foreground", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}" }}
                 ) {{ _docID }}
             }}"#
         );
@@ -624,6 +655,7 @@ impl ToolCallLifecycle {
         } else {
             String::new()
         };
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -631,7 +663,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
-                    input: {{ cancel_policy: "detach"{started_at_fragment} }}
+                    input: {{ cancel_policy: "detach", deadline_at: "{deadline_at_str}"{started_at_fragment} }}
                 ) {{ _docID }}
             }}"#
         );
@@ -665,7 +697,8 @@ impl ToolCallLifecycle {
         }))
     }
 
-    /// Running → Cancelled. R1 does not call from runtime code; R4 wires up.
+    /// Running → Cancelled. Called by request interruption handling and
+    /// startup recovery for interrupted parent requests.
     pub async fn cancel_during_run(&mut self) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "cancel_during_run")?;
 
@@ -679,18 +712,22 @@ impl ToolCallLifecycle {
         let latency_ms = (now - started_at).num_milliseconds();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
+        let escaped_result = escape_graphql_string("tool call cancelled");
         let now_str = now.to_rfc3339();
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
+        let deadline_at_str = self.deadline_at.to_rfc3339();
 
         let mutation = format!(
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
                     input: {{
+                        result: "{escaped_result}",
                         status: "completed",
                         lifecycle_state: "cancelled",
                         started_at: "{started_at_str}",
+                        deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
                     }}
@@ -747,6 +784,10 @@ mod tests {
         Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap())
     }
 
+    fn test_deadline() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now() + chrono::Duration::minutes(5)
+    }
+
     /// Return a subagent-typed lifecycle already in Running state.
     /// Uses the pub(crate) setters to skip `start_running` (which would
     /// require schema setup). The guard under test fires before the DB call,
@@ -755,11 +796,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "request-1".to_string(),
             "session-1".to_string(),
             "tcid-1".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-req-1".to_string(),
@@ -805,11 +848,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-bg-2".to_string(),
             "sess-bg-2".to_string(),
             "tc-bg-2".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Background, // start already in Background
             CancelPolicy::Cascade,
             "child-req-bg-2".to_string(),
@@ -833,11 +878,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new(
             node,
+            "req-bg-3".to_string(),
             "sess-bg-3".to_string(),
             "tc-bg-3".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
         );
         // state is Pending (default); do not advance it
 
@@ -856,11 +903,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-fg-1".to_string(),
             "sess-fg-1".to_string(),
             "tc-fg-1".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground, // start already in Foreground
             CancelPolicy::Cascade,
             "child-req-fg-1".to_string(),
@@ -884,11 +933,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new(
             node,
+            "req-fg-2".to_string(),
             "sess-fg-2".to_string(),
             "tc-fg-2".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
         );
         // state is Pending (default); do not advance it
 
@@ -907,11 +958,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-detach-1".to_string(),
             "sess-detach-1".to_string(),
             "tc-detach-1".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Detach, // already in Detach policy
             "child-req-detach-1".to_string(),
@@ -935,11 +988,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-detach-2".to_string(),
             "sess-detach-2".to_string(),
             "tc-detach-2".to_string(),
             1,
             "spawn_subagent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-req-detach-2".to_string(),
@@ -964,11 +1019,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new(
             node,
+            "req-bf-1".to_string(),
             "sess-bf-1".to_string(),
             "tc-bf-1".to_string(),
             0,
             "native_tool".to_string(),
             "{}".to_string(),
+            test_deadline(),
         );
         lc.set_state(ToolCallState::Running);
         lc.set_doc_id(Some("fake-doc-id-bf-1".to_string()));
@@ -993,11 +1050,13 @@ mod tests {
         let node = test_node().await;
         let lc_base = ToolCallLifecycle::new_subagent(
             node,
+            "req-bf-2".to_string(),
             "sess-bf-2".to_string(),
             "tc-bf-2".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-1".to_string(),
@@ -1051,11 +1110,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new(
             node,
+            "req-bc-1".to_string(),
             "sess-bc-1".to_string(),
             "tc-bc-1".to_string(),
             0,
             "native_tool".to_string(),
             "{}".to_string(),
+            test_deadline(),
         );
         lc.set_state(ToolCallState::Running);
         lc.set_doc_id(Some("fake-doc-id-bc-1".to_string()));
@@ -1077,11 +1138,13 @@ mod tests {
         let node = test_node().await;
         let lc_base = ToolCallLifecycle::new_subagent(
             node,
+            "req-bc-2".to_string(),
             "sess-bc-2".to_string(),
             "tc-bc-2".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-1".to_string(),
@@ -1104,11 +1167,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-cas-1".to_string(),
             "sess-cas-1".to_string(),
             "tc-cas-1".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-cas-1".to_string(),
@@ -1125,11 +1190,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-cas-2".to_string(),
             "sess-cas-2".to_string(),
             "tc-cas-2".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Detach,
             "child-cas-2".to_string(),
@@ -1145,11 +1212,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new(
             node,
+            "req-cas-3".to_string(),
             "sess-cas-3".to_string(),
             "tc-cas-3".to_string(),
             0,
             "native_tool".to_string(),
             "{}".to_string(),
+            test_deadline(),
         );
         lc.set_state(ToolCallState::Cancelled);
 
@@ -1165,11 +1234,13 @@ mod tests {
         let node = test_node().await;
         let mut lc = ToolCallLifecycle::new_subagent(
             node,
+            "req-cas-4".to_string(),
             "sess-cas-4".to_string(),
             "tc-cas-4".to_string(),
             0,
             "spawn_agent".to_string(),
             "{}".to_string(),
+            test_deadline(),
             AwaitMode::Foreground,
             CancelPolicy::Cascade,
             "child-cas-4".to_string(),

--- a/crates/defra-agent/src/toolset/cli_tool.rs
+++ b/crates/defra-agent/src/toolset/cli_tool.rs
@@ -93,7 +93,8 @@ async fn run_cli_command(config: &CliToolConfig, argv: &[String]) -> Result<Stri
         .env("GIT_PAGER", "cat")
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
-        .env("TERM", "dumb");
+        .env("TERM", "dumb")
+        .kill_on_drop(true);
 
     for (key, value) in &config.env_vars {
         command.env(key, value);

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -142,7 +142,8 @@ pub fn analyze_tool_call(
         }
         if let (Some(path), Some(message)) = (&error.path, &error.message) {
             analysis.validation_errors.push(TraceValidationError {
-                code: failure_class_code(error.failure_class).to_string(),
+                code: structured_tool_error_code_from_result(result)
+                    .unwrap_or_else(|| failure_class_code(error.failure_class).to_string()),
                 path: path.clone(),
                 message: message.clone(),
                 retryable: error.retryable.unwrap_or(false),
@@ -420,6 +421,19 @@ fn structured_tool_error_from_result(result: &str) -> Option<TraceToolError> {
         available_tools: string_array_field(object, "available_tools"),
         raw_error_text: trimmed.to_string(),
     })
+}
+
+fn structured_tool_error_code_from_result(result: &str) -> Option<String> {
+    let value = serde_json::from_str::<Value>(result.trim()).ok()?;
+    let object = value.as_object()?;
+    if object.get("ok").and_then(Value::as_bool) != Some(false) {
+        return None;
+    }
+
+    let raw = object.get("failure_class").and_then(Value::as_str)?;
+    // Preserve the policy-block reason for trace consumers while keeping
+    // discovery failures rebucketed to the canonical 5-variant vocabulary.
+    (raw == "tool_not_allowed").then(|| raw.to_string())
 }
 
 fn native_tool_output_from_result(tool_name: &str, result: &str) -> Option<NativeToolOutputTrace> {
@@ -1097,14 +1111,15 @@ mod tests {
         );
 
         assert!(!analysis.tool_result_ok);
-        // After R1's failure-class collapse, "tool_not_allowed" rebuckets to
-        // ServiceUnavailable, and `validation_errors[0].code` reports the
-        // bucketed class name (not the raw input string).
+        // The failure class still rebuckets to ServiceUnavailable per the
+        // 5-variant collapse, but trace consumers see the raw "tool_not_allowed"
+        // string preserved as the policy-block reason via
+        // structured_tool_error_code_from_result.
         assert_eq!(
             analysis.tool_failure_class,
             Some(ToolFailureClass::ServiceUnavailable)
         );
-        assert_eq!(analysis.validation_errors[0].code, "serviceUnavailable");
+        assert_eq!(analysis.validation_errors[0].code, "tool_not_allowed");
         assert_eq!(analysis.validation_errors[0].path, "/service_id");
         assert_eq!(analysis.validation_errors[0].retryable, false);
         let error = analysis.tool_error.as_ref().expect("tool error");

--- a/crates/defra-agent/src/watcher.rs
+++ b/crates/defra-agent/src/watcher.rs
@@ -5,6 +5,8 @@ use std::time::Instant;
 use anyhow::Result;
 use defra_node::{EmbeddedNode, EventName};
 
+use crate::tool_call_lifecycle::IllegalToolCallTransition;
+
 mod cooldown;
 mod query;
 #[cfg(test)]
@@ -30,6 +32,29 @@ pub struct AgentRequest {
     pub metadata: Option<String>,
     pub execution_origin: Option<String>,
     pub created_at: String,
+    pub subagent_depth: u32,
+    pub caused_by_parent_request_id: Option<String>,
+    pub caused_by_parent_tool_call_id: Option<String>,
+}
+
+/// Coherence check on AgentRequest's subagent fields:
+/// - caused_by_parent_request_id and caused_by_parent_tool_call_id must be
+///   set together (both Some) or together (both None).
+/// - subagent_depth = 0 ↔ both parent fields are None.
+pub fn validate_agent_request_subagent_coherence(req: &AgentRequest) -> Result<()> {
+    let has_parent_req = req.caused_by_parent_request_id.is_some();
+    let has_parent_tc = req.caused_by_parent_tool_call_id.is_some();
+    if has_parent_req != has_parent_tc {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    let is_top_level = !has_parent_req; // both None
+    if is_top_level && req.subagent_depth != 0 {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    if !is_top_level && req.subagent_depth == 0 {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    Ok(())
 }
 
 pub trait Watcher: Send + Sync {

--- a/crates/defra-agent/src/watcher/query.rs
+++ b/crates/defra-agent/src/watcher/query.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use super::{AgentRequest, DefraWatcher};
+use super::{validate_agent_request_subagent_coherence, AgentRequest, DefraWatcher};
 
 const AGENT_REQUEST_FIELDS: &str = r#"
                     _docID
@@ -16,6 +16,9 @@ const AGENT_REQUEST_FIELDS: &str = r#"
                     metadata
                     execution_origin
                     created_at
+                    subagent_depth
+                    caused_by_parent_request_id
+                    caused_by_parent_tool_call_id
 "#;
 
 impl DefraWatcher {
@@ -41,10 +44,11 @@ impl DefraWatcher {
             anyhow::bail!("watcher query failed: {:?}", resp.errors);
         }
 
-        Ok(agent_request_rows(resp.data.as_ref())?
+        agent_request_rows(resp.data.as_ref())?
             .into_iter()
             .next()
-            .map(AgentRequestRow::into_agent_request))
+            .map(AgentRequestRow::into_agent_request)
+            .transpose()
     }
 
     pub(super) async fn pending_requests(&self) -> anyhow::Result<Vec<AgentRequest>> {
@@ -68,10 +72,10 @@ impl DefraWatcher {
             anyhow::bail!("watcher pending-request query failed: {:?}", resp.errors);
         }
 
-        Ok(agent_request_rows(resp.data.as_ref())?
+        agent_request_rows(resp.data.as_ref())?
             .into_iter()
             .map(AgentRequestRow::into_agent_request)
-            .collect())
+            .collect()
     }
 }
 
@@ -105,11 +109,14 @@ struct AgentRequestRow {
     metadata: Option<String>,
     execution_origin: Option<String>,
     created_at: String,
+    subagent_depth: Option<u32>,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
 }
 
 impl AgentRequestRow {
-    fn into_agent_request(self) -> AgentRequest {
-        AgentRequest {
+    fn into_agent_request(self) -> anyhow::Result<AgentRequest> {
+        let req = AgentRequest {
             doc_id: self.doc_id,
             request_id: self.request_id,
             agent_did: self.agent_did,
@@ -123,6 +130,11 @@ impl AgentRequestRow {
             metadata: self.metadata,
             execution_origin: normalize_optional_string(self.execution_origin),
             created_at: self.created_at,
-        }
+            subagent_depth: self.subagent_depth.unwrap_or(0),
+            caused_by_parent_request_id: self.caused_by_parent_request_id,
+            caused_by_parent_tool_call_id: self.caused_by_parent_tool_call_id,
+        };
+        validate_agent_request_subagent_coherence(&req)?;
+        Ok(req)
     }
 }

--- a/crates/defra-agent/src/watcher/tests.rs
+++ b/crates/defra-agent/src/watcher/tests.rs
@@ -1,9 +1,69 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
 
 use super::cooldown::{take_next_eligible_pending_request, PROCESSED_REQUEST_COOLDOWN};
 use super::*;
+
+// ---------------------------------------------------------------------------
+// validate_agent_request_subagent_coherence
+// ---------------------------------------------------------------------------
+
+#[test]
+fn validate_rejects_mixed_parent_linkage_request_id_only() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: None,
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_err());
+}
+
+#[test]
+fn validate_rejects_mixed_parent_linkage_tool_call_id_only() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_err());
+}
+
+#[test]
+fn validate_rejects_subagent_depth_zero_with_parent_fields() {
+    let req = AgentRequest {
+        subagent_depth: 0,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_err());
+}
+
+#[test]
+fn validate_accepts_top_level_request() {
+    let req = AgentRequest {
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_ok());
+}
+
+#[test]
+fn validate_accepts_subagent_request() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_ok());
+}
 
 #[test]
 fn agent_request_clone() {
@@ -21,6 +81,9 @@ fn agent_request_clone() {
         metadata: None,
         execution_origin: None,
         created_at: "2026-03-12T00:00:00Z".into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
     let cloned = req.clone();
     assert_eq!(cloned.doc_id, "abc");
@@ -61,6 +124,10 @@ fn cooled_down_request_becomes_eligible_again() {
     assert_eq!(processed_request_ids.get("req-1").copied(), Some(later));
 }
 
+fn base_request() -> AgentRequest {
+    request("req-base", "sess-base")
+}
+
 fn request(request_id: &str, session_id: &str) -> AgentRequest {
     AgentRequest {
         doc_id: format!("doc-{request_id}"),
@@ -76,5 +143,119 @@ fn request(request_id: &str, session_id: &str) -> AgentRequest {
         metadata: None,
         execution_origin: None,
         created_at: "2026-03-12T00:00:00Z".into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     }
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests: validate_agent_request_subagent_coherence wired into
+// the query path.  These tests write incoherent AgentRequest rows directly
+// into DefraDB and verify that the watcher rejects them at query time.
+// ---------------------------------------------------------------------------
+
+async fn test_node() -> Arc<defra_node::EmbeddedNode> {
+    Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap())
+}
+
+/// Insert an AgentRequest row with an incoherent parent linkage into DefraDB
+/// and return its `_docID`.
+///
+/// `subagent_depth` = 1, `caused_by_parent_request_id` is set, but
+/// `caused_by_parent_tool_call_id` is absent — one half of the pair is
+/// missing, which the validator must reject.
+async fn insert_incoherent_agent_request(
+    node: &defra_node::EmbeddedNode,
+    agent_did: &str,
+    request_id: &str,
+) -> String {
+    use crate::graphql::escape_graphql_string;
+
+    let escaped_request_id = escape_graphql_string(request_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let created_at = chrono::Utc::now().to_rfc3339();
+
+    // subagent_depth = 1 but only caused_by_parent_request_id is set;
+    // caused_by_parent_tool_call_id is absent.  This is the coherence
+    // violation the validator checks for.
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{escaped_request_id}",
+                agent_did: "{escaped_agent_did}",
+                session_id: "sess-incoherent",
+                content: "test",
+                status: "pending",
+                lifecycle_state: "pending",
+                backend_id: "",
+                created_at: "{created_at}",
+                retry_count: 0,
+                max_retries: 0,
+                subagent_depth: 1,
+                caused_by_parent_request_id: "parent-req-exists"
+            }}) {{ _docID }}
+        }}"#
+    );
+
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create_AgentRequest (incoherent) failed: {:?}",
+        response.errors
+    );
+
+    let lookup = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }}, limit: 1) {{
+                _docID
+            }}
+        }}"#
+    );
+    let response = node.execute(&lookup).await;
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|rows| rows.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("_docID"))
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .expect("AgentRequest _docID")
+}
+
+#[tokio::test]
+async fn pending_requests_rejects_incoherent_subagent_linkage() {
+    let node = test_node().await;
+    crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let agent_did = "did:key:z-watcher-coherence-pending";
+    insert_incoherent_agent_request(node.as_ref(), agent_did, "req-incoherent-pending").await;
+
+    let watcher = DefraWatcher::new(node.clone(), agent_did);
+    let result = watcher.pending_requests().await;
+    assert!(
+        result.is_err(),
+        "pending_requests must fail for incoherent subagent linkage, got: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn try_fetch_request_rejects_incoherent_subagent_linkage() {
+    let node = test_node().await;
+    crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let agent_did = "did:key:z-watcher-coherence-fetch";
+    let doc_id =
+        insert_incoherent_agent_request(node.as_ref(), agent_did, "req-incoherent-fetch").await;
+
+    let watcher = DefraWatcher::new(node.clone(), agent_did);
+    let result = watcher.try_fetch_request(&doc_id).await;
+    assert!(
+        result.is_err(),
+        "try_fetch_request must fail for incoherent subagent linkage, got: {:?}",
+        result
+    );
 }

--- a/crates/defra-agent/tests/lifecycle_claim.rs
+++ b/crates/defra-agent/tests/lifecycle_claim.rs
@@ -111,6 +111,9 @@ async fn claim_rejects_when_another_non_terminal_request_exists() {
         metadata: None,
         execution_origin: None,
         created_at: later,
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle =
@@ -169,6 +172,9 @@ async fn claim_suppresses_later_pending_duplicates() {
         metadata: None,
         execution_origin: None,
         created_at: "2026-03-23T00:00:00Z".into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle =
@@ -254,6 +260,9 @@ async fn claim_preserves_explicit_behavior_id() {
         metadata: None,
         execution_origin: None,
         created_at: created_at.into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle =

--- a/crates/defra-agent/tests/lifecycle_recovery.rs
+++ b/crates/defra-agent/tests/lifecycle_recovery.rs
@@ -1,8 +1,13 @@
-use defra_agent::RequestLifecycle;
+use defra_agent::{
+    fetch_interrupt_requested_at,
+    tool_call_lifecycle::{AwaitMode, CancelPolicy, ToolCallLifecycle},
+    RequestLifecycle,
+};
 use serde::Deserialize;
 
 mod support;
 
+use support::snapshots::fetch_tool_call_snapshots_for_session;
 use support::{
     create_request, create_response_with_content_and_status, create_response_with_status,
     first_row, test_db, upsert_conversation, AGENT_DID,
@@ -22,6 +27,23 @@ struct ResponseStatusRow {
 #[derive(Debug, Clone, Deserialize)]
 struct ConversationRow {
     status: String,
+}
+
+async fn mark_request_interrupted(node: &defra_agent::defra_node::EmbeddedNode, doc_id: &str) {
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                input: {{ status: "interrupted", lifecycle_state: "interrupted" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "mark request interrupted failed: {:?}",
+        resp.errors
+    );
 }
 
 #[tokio::test]
@@ -236,4 +258,219 @@ async fn recover_all_creates_error_response_when_response_doc_is_missing() {
     assert!(response
         .content
         .contains("daemon restarted before response could be generated"));
+}
+
+#[tokio::test]
+async fn recover_all_times_out_expired_running_tool_calls() {
+    let db = test_db("tool-call-recover-timeout").await;
+    create_request(
+        &db.node,
+        "tool-timeout-req",
+        "tool-timeout-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+
+    let mut lifecycle = ToolCallLifecycle::new(
+        db.node.clone(),
+        "tool-timeout-req".to_string(),
+        "tool-timeout-session".to_string(),
+        "tool-timeout-call".to_string(),
+        1,
+        "never".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() - chrono::Duration::seconds(1),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(report.tool_calls_recovered, 1);
+
+    let snapshots = fetch_tool_call_snapshots_for_session(&db.node, "tool-timeout-session").await;
+    assert_eq!(snapshots.len(), 1);
+    assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("timedOut"));
+    assert_eq!(snapshots[0].status, "completed");
+    assert!(snapshots[0].result.contains("deadline exceeded"));
+}
+
+#[tokio::test]
+async fn recover_all_cancels_running_tool_call_for_interrupted_parent_only() {
+    let db = test_db("tool-call-recover-cancel").await;
+    let interrupted_doc = create_request(
+        &db.node,
+        "tool-cancel-req",
+        "tool-cancel-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    create_request(
+        &db.node,
+        "tool-other-req",
+        "tool-other-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    mark_request_interrupted(&db.node, &interrupted_doc).await;
+
+    let future_deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    let mut cancelled = ToolCallLifecycle::new(
+        db.node.clone(),
+        "tool-cancel-req".to_string(),
+        "tool-cancel-session".to_string(),
+        "tool-cancel-call".to_string(),
+        1,
+        "slow".to_string(),
+        "{}".to_string(),
+        future_deadline,
+    );
+    cancelled.start_running().await.unwrap();
+
+    let mut unrelated = ToolCallLifecycle::new(
+        db.node.clone(),
+        "tool-other-req".to_string(),
+        "tool-other-session".to_string(),
+        "tool-other-call".to_string(),
+        1,
+        "slow".to_string(),
+        "{}".to_string(),
+        future_deadline,
+    );
+    unrelated.start_running().await.unwrap();
+
+    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(report.tool_calls_recovered, 1);
+
+    let cancelled_snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "tool-cancel-session").await;
+    assert_eq!(
+        cancelled_snapshots[0].lifecycle_state.as_deref(),
+        Some("cancelled")
+    );
+
+    let unrelated_snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "tool-other-session").await;
+    assert_eq!(
+        unrelated_snapshots[0].lifecycle_state.as_deref(),
+        Some("running"),
+        "unrelated running tool call should not be swept"
+    );
+}
+
+#[tokio::test]
+async fn recover_all_cascades_interrupted_parent_to_subagent_child() {
+    let db = test_db("tool-call-recover-cascade").await;
+    let interrupted_doc = create_request(
+        &db.node,
+        "tool-cascade-parent",
+        "tool-cascade-parent-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    create_request(
+        &db.node,
+        "tool-cascade-child",
+        "tool-cascade-child-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    mark_request_interrupted(&db.node, &interrupted_doc).await;
+
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "tool-cascade-parent".to_string(),
+        "tool-cascade-parent-session".to_string(),
+        "tool-cascade-call".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "tool-cascade-child".to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(report.tool_calls_recovered, 1);
+
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "tool-cascade-parent-session").await;
+    assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("cancelled"));
+
+    let child_interrupt = fetch_interrupt_requested_at(&db.node, "tool-cascade-child")
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_some(),
+        "cascade recovery should latch child interrupt_requested_at"
+    );
+}
+
+#[tokio::test]
+async fn recover_all_leaves_detached_subagent_tool_running() {
+    let db = test_db("tool-call-recover-detach").await;
+    let interrupted_doc = create_request(
+        &db.node,
+        "tool-detach-parent",
+        "tool-detach-parent-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    create_request(
+        &db.node,
+        "tool-detach-child",
+        "tool-detach-child-session",
+        "processing",
+        "2026-03-23T00:00:00Z",
+    )
+    .await;
+    mark_request_interrupted(&db.node, &interrupted_doc).await;
+
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "tool-detach-parent".to_string(),
+        "tool-detach-parent-session".to_string(),
+        "tool-detach-call".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Background,
+        CancelPolicy::Detach,
+        "tool-detach-child".to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(report.tool_calls_recovered, 0);
+
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "tool-detach-parent-session").await;
+    assert_eq!(
+        snapshots[0].lifecycle_state.as_deref(),
+        Some("running"),
+        "detached bridge tool should remain running for the subagent runtime to reconcile"
+    );
+
+    let child_interrupt = fetch_interrupt_requested_at(&db.node, "tool-detach-child")
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_none(),
+        "detached recovery should not interrupt the child request"
+    );
 }

--- a/crates/defra-agent/tests/lifecycle_terminal.rs
+++ b/crates/defra-agent/tests/lifecycle_terminal.rs
@@ -46,6 +46,9 @@ async fn complete_does_not_overwrite_conversation_for_newer_request() {
         metadata: None,
         execution_origin: None,
         created_at: "2026-03-23T00:00:00Z".into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
     let mut lifecycle = RequestLifecycle::new_with_agent_did(
         db.node.clone(),
@@ -105,6 +108,9 @@ async fn advance_increments_progress_seq() {
         metadata: None,
         execution_origin: None,
         created_at: "2026-03-23T00:00:00Z".into(),
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     };
 
     let mut lifecycle =

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -22,8 +22,9 @@ use lean_vocab_test::{
     lean_client_shell_case, lean_command_env_case, lean_command_policy_case,
     lean_command_sandbox_case, lean_contract_snapshot, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_request_transition_cases,
-    lean_runtime_reconcile_case, lean_session_recovery_case, lean_tool_preflight_case,
-    lean_tool_retry_case, lean_vocabulary_values, LeanLifecycleTransitionCase,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
+    lean_tool_preflight_case, lean_tool_retry_case, lean_vocabulary_values,
+    LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -4218,4 +4219,154 @@ fn tool_call_transitions_match_lean_contract() {
     assert_lean_transition_is_illegal("ToolCall", "failed", "running");
     assert_lean_transition_is_illegal("ToolCall", "timedOut", "running");
     assert_lean_transition_is_illegal("ToolCall", "cancelled", "running");
+}
+
+// ---------------------------------------------------------------------------
+// R2 Bucket 2 — Lean transition matrix conformance for the subagent extensions.
+//
+// These tests assert that the Lean-emitted contract (consumed via
+// `lean_state_machine_contract`) carries the new vocabularies (`AwaitMode`,
+// `CancelPolicy`, `ChildTerminal`) and the new named transitions on the
+// `ToolCall` machine that R2 introduced (mode flips, detach split, bridge_*
+// edges, native-only `complete_native`/`fail_native` rows). Drift between
+// Lean's model and Rust's runtime — for example, a vocabulary value added on
+// only one side, or a Lean-only edge that Rust silently allows — is caught
+// here rather than at PR review.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn lean_emits_await_mode_vocabulary() {
+    use defra_agent::tool_call_lifecycle::AwaitMode;
+
+    let machine = lean_state_machine_contract("AwaitMode");
+    let mut rust_vocab: Vec<String> = AwaitMode::ALL
+        .iter()
+        .map(|m| m.as_str().to_string())
+        .collect();
+    rust_vocab.sort();
+    let mut lean_vocab = machine.states.clone();
+    lean_vocab.sort();
+    assert_eq!(
+        lean_vocab, rust_vocab,
+        "AwaitMode vocabulary divergence between Lean and Rust"
+    );
+}
+
+#[test]
+fn lean_emits_cancel_policy_vocabulary() {
+    use defra_agent::tool_call_lifecycle::CancelPolicy;
+
+    let machine = lean_state_machine_contract("CancelPolicy");
+    let mut rust_vocab: Vec<String> = CancelPolicy::ALL
+        .iter()
+        .map(|p| p.as_str().to_string())
+        .collect();
+    rust_vocab.sort();
+    let mut lean_vocab = machine.states.clone();
+    lean_vocab.sort();
+    assert_eq!(
+        lean_vocab, rust_vocab,
+        "CancelPolicy vocabulary divergence between Lean and Rust"
+    );
+}
+
+#[test]
+fn lean_emits_child_terminal_vocabulary_and_projections() {
+    use defra_agent::tool_call_lifecycle::ChildTerminal;
+
+    let machine = lean_state_machine_contract("ChildTerminal");
+
+    // Vocabulary check: Lean's source-side vocabulary must match Rust's
+    // ChildTerminal::ALL_KIND.
+    let mut lean_vocab = machine.states.clone();
+    lean_vocab.sort();
+    let mut rust_vocab: Vec<String> = ChildTerminal::ALL_KIND
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    rust_vocab.sort();
+    assert_eq!(
+        lean_vocab, rust_vocab,
+        "ChildTerminal vocabulary divergence between Lean and Rust"
+    );
+
+    // Projection check: each named_transition's `from`/`to` must agree with
+    // Lean's B2 projection rule (Subagent.lean): .interrupted -> .cancelled,
+    // every other terminal -> .failed. Rust's `ChildTerminal::projected_state`
+    // is verified to follow this rule by the Bucket 1 unit tests in
+    // `tool_call_lifecycle.rs`; here we lock in that the *Lean* contract
+    // emits exactly that table. (We can't call `projected_state` from this
+    // integration test because its return type `ToolCallState` is
+    // `pub(crate)` to defra-agent.)
+    for t in &machine.named_transitions {
+        let expected = match t.from.as_str() {
+            "interrupted" => "cancelled",
+            "failed" | "dead" | "superseded" => "failed",
+            other => panic!("unexpected ChildTerminal vocabulary: {}", other),
+        };
+        assert_eq!(
+            t.to, expected,
+            "Projection divergence at {}: Lean says target {}, Bucket 1 spec says {}",
+            t.from, t.to, expected
+        );
+    }
+    // Also assert every ChildTerminal variant has a corresponding row, so a
+    // future Lean refactor that drops one is caught here.
+    let mut sources_in_named: Vec<String> = machine
+        .named_transitions
+        .iter()
+        .map(|t| t.from.clone())
+        .collect();
+    sources_in_named.sort();
+    sources_in_named.dedup();
+    assert_eq!(
+        sources_in_named, rust_vocab,
+        "ChildTerminal named_transitions must cover every ALL_KIND variant"
+    );
+}
+
+#[test]
+fn lean_emits_bridge_transitions_in_tool_call_machine() {
+    let machine = lean_state_machine_contract("ToolCall");
+    let bridge_names: Vec<&str> = vec![
+        "background",
+        "foreground",
+        "detach_running",
+        "detach_pending",
+        "bridge_complete",
+        "bridge_failure_failed",
+        "bridge_failure_cancelled",
+        "bridge_cancel_cascade",
+    ];
+    for name in &bridge_names {
+        let found = machine.named_transitions.iter().any(|t| t.name == *name);
+        assert!(
+            found,
+            "Lean contract must emit '{}' transition in ToolCall machine",
+            name
+        );
+    }
+}
+
+#[test]
+fn lean_marks_native_complete_fail_as_requires_native() {
+    let machine = lean_state_machine_contract("ToolCall");
+    let complete = machine
+        .named_transitions
+        .iter()
+        .find(|t| t.name == "complete_native")
+        .expect("ToolCall machine must have native complete transition (named complete_native)");
+    assert!(
+        complete.requires_native,
+        "complete_native must be flagged with requires_native: true"
+    );
+    let fail = machine
+        .named_transitions
+        .iter()
+        .find(|t| t.name == "fail_native")
+        .expect("ToolCall machine must have native fail transition (named fail_native)");
+    assert!(
+        fail.requires_native,
+        "fail_native must be flagged with requires_native: true"
+    );
 }

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -360,6 +360,9 @@ pub fn build_request(
         metadata: None,
         execution_origin: None,
         created_at,
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
     }
 }
 

--- a/crates/defra-agent/tests/support/snapshots.rs
+++ b/crates/defra-agent/tests/support/snapshots.rs
@@ -499,6 +499,8 @@ pub async fn fetch_message_snapshots_for_session(
 #[derive(Debug, PartialEq, Eq, Deserialize)]
 pub struct ToolCallSnapshot {
     pub tool_call_key: String,
+    #[serde(default)]
+    pub request_id: Option<String>,
     pub session_id: String,
     pub message_sequence: u32,
     pub tool_name: String,
@@ -510,6 +512,8 @@ pub struct ToolCallSnapshot {
     pub lifecycle_state: Option<String>,
     #[serde(default)]
     pub started_at: Option<String>,
+    #[serde(default)]
+    pub deadline_at: Option<String>,
     #[serde(default)]
     pub completed_at: Option<String>,
     #[serde(default)]
@@ -533,8 +537,8 @@ pub async fn fetch_tool_call_snapshots_for_session(
                 filter: {{ session_id: {{ _eq: "{session_id}" }} }},
                 order: {{ message_sequence: ASC }}
             ) {{
-                tool_call_key session_id message_sequence tool_name tool_call_id
-                args result status lifecycle_state started_at completed_at
+                tool_call_key request_id session_id message_sequence tool_name tool_call_id
+                args result status lifecycle_state started_at deadline_at completed_at
                 selected_service_id selected_tool_name tool_failure_class latency_ms
             }}
         }}"#

--- a/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
@@ -12,6 +12,10 @@ use defra_agent::tool_call_lifecycle::{FailureClass, ToolCallLifecycle};
 use support::snapshots::fetch_tool_call_snapshots_for_session;
 use support::test_db;
 
+fn test_deadline() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now() + chrono::Duration::minutes(5)
+}
+
 // ---------------------------------------------------------------------------
 // Test 1: Pending → Running → Completed persists correctly
 // ---------------------------------------------------------------------------
@@ -22,11 +26,13 @@ async fn lifecycle_pending_to_running_to_completed_persists_correctly() {
 
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "request-1".into(),
         "test-session-1".into(),
         "tool-call-1".into(),
         0,
         "test_tool".into(),
         r#"{"x":1}"#.into(),
+        test_deadline(),
     );
 
     lc.start_running().await.unwrap();
@@ -37,6 +43,14 @@ async fn lifecycle_pending_to_running_to_completed_persists_correctly() {
         snapshots[0].lifecycle_state.as_deref(),
         Some("running"),
         "lifecycle_state should be running after start_running"
+    );
+    assert_eq!(snapshots[0].request_id.as_deref(), Some("request-1"));
+    assert!(
+        snapshots[0]
+            .deadline_at
+            .as_deref()
+            .is_some_and(|value| !value.is_empty()),
+        "deadline_at should persist on running tool calls"
     );
 
     lc.complete("ok").await.unwrap();
@@ -60,11 +74,13 @@ async fn lifecycle_running_to_failed_persists_failure_class() {
 
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "request-2".into(),
         "test-session-2".into(),
         "tool-call-2".into(),
         0,
         "test_tool".into(),
         r#"{"x":1}"#.into(),
+        test_deadline(),
     );
 
     lc.start_running().await.unwrap();
@@ -96,11 +112,13 @@ async fn lifecycle_terminal_irreversibility() {
 
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "request-3".into(),
         "test-session-3".into(),
         "tool-call-3".into(),
         0,
         "test_tool".into(),
         r#"{}"#.into(),
+        test_deadline(),
     );
 
     lc.start_running().await.unwrap();
@@ -128,11 +146,13 @@ async fn lifecycle_idempotent_start_running() {
 
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "request-4".into(),
         "test-session-4".into(),
         "tool-call-4".into(),
         0,
         "test_tool".into(),
         r#"{}"#.into(),
+        test_deadline(),
     );
 
     lc.start_running().await.unwrap();
@@ -163,11 +183,13 @@ async fn lifecycle_load_returns_persisted_state() {
     {
         let mut lc = ToolCallLifecycle::new(
             db.node.clone(),
+            "request-5".into(),
             "test-session-5".into(),
             "tool-call-5".into(),
             0,
             "test_tool".into(),
             r#"{}"#.into(),
+            test_deadline(),
         );
         lc.start_running().await.unwrap();
         lc.fail("oops", FailureClass::Transport).await.unwrap();
@@ -194,5 +216,48 @@ async fn lifecycle_load_returns_persisted_state() {
         snapshots[0].tool_failure_class.as_deref(),
         Some("transport"),
         "persisted tool_failure_class should be transport"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_load_preserves_deadline_for_terminal_update() {
+    let db = test_db("tc-lc-6").await;
+    let deadline = chrono::DateTime::parse_from_rfc3339("2026-05-08T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+
+    {
+        let mut lc = ToolCallLifecycle::new(
+            db.node.clone(),
+            "request-6".into(),
+            "test-session-6".into(),
+            "tool-call-6".into(),
+            0,
+            "test_tool".into(),
+            r#"{}"#.into(),
+            deadline,
+        );
+        lc.start_running().await.unwrap();
+    }
+
+    let mut loaded = ToolCallLifecycle::load(db.node.clone(), "test-session-6", "tool-call-6")
+        .await
+        .unwrap()
+        .expect("row should exist after start_running");
+    loaded.timeout().await.unwrap();
+
+    let snapshots = fetch_tool_call_snapshots_for_session(&db.node, "test-session-6").await;
+    assert_eq!(
+        snapshots[0].lifecycle_state.as_deref(),
+        Some("timedOut"),
+        "loaded lifecycle should be able to terminalize as timedOut"
+    );
+    let observed_deadline =
+        chrono::DateTime::parse_from_rfc3339(snapshots[0].deadline_at.as_deref().unwrap())
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+    assert_eq!(
+        observed_deadline, deadline,
+        "deadline_at should survive load and terminal update"
     );
 }

--- a/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
@@ -25,6 +25,10 @@ use support::test_db;
 // Internal test helpers
 // ---------------------------------------------------------------------------
 
+fn test_deadline() -> chrono::DateTime<chrono::Utc> {
+    chrono::Utc::now() + chrono::Duration::minutes(5)
+}
+
 /// Test helper: directly constructs a child AgentRequest in `.completed`
 /// state via low-level DB writes, bypassing the normal request lifecycle.
 /// Used by bridge_complete tests to set up "the child has finished" state
@@ -186,11 +190,13 @@ async fn integration_load_round_trip_preserves_subagent_fields() {
     // Construct a subagent lifecycle with non-default values and persist it.
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-load-rt-1".to_string(),
         "sess-load-rt-1".to_string(),
         "tc-load-rt-1".to_string(),
         3,
         "spawn_subagent".to_string(),
         r#"{"target":"amy-code"}"#.to_string(),
+        test_deadline(),
         AwaitMode::Background,
         CancelPolicy::Detach,
         "child-req-load-rt-1".to_string(),
@@ -255,11 +261,13 @@ async fn integration_load_round_trip_foreground_cascade_also_preserved() {
 
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-load-rt-2".to_string(),
         "sess-load-rt-2".to_string(),
         "tc-load-rt-2".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         "child-req-load-rt-2".to_string(),
@@ -303,11 +311,13 @@ async fn integration_load_round_trip_native_tool_has_no_child_request_id() {
 
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "req-load-rt-3".to_string(),
         "sess-load-rt-3".to_string(),
         "tc-load-rt-3".to_string(),
         0,
         "echo".to_string(),
         "{}".to_string(),
+        test_deadline(),
     );
     lc.start_running().await.unwrap();
 
@@ -351,11 +361,13 @@ async fn integration_background_then_foreground_persists_round_trip() {
 
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-int-1".to_string(),
         "sess-int-1".to_string(),
         "tc-int-1".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         "child-req-int-1".to_string(),
@@ -419,11 +431,13 @@ async fn integration_detach_one_way_persists() {
 
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-det-1".to_string(),
         "sess-det-1".to_string(),
         "tc-det-1".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         "child-req-det-1".to_string(),
@@ -581,11 +595,13 @@ async fn integration_bridge_complete_with_real_child() {
     // 2. Construct the parent bridge tool call and start_running.
     let mut bridge = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "parent-req-bc1".to_string(),
         "sess-bc1".to_string(),
         "tc-bc1".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         child_request_id.to_string(),
@@ -664,11 +680,13 @@ async fn run_bridge_failure_case(
 
     let mut bridge = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        parent_req.clone(),
         session.clone(),
         tc_id.clone(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         child_id,
@@ -751,11 +769,13 @@ async fn integration_cascade_intent_for_cascade_subagent_returns_some() {
     let db = test_db("tc-sa-cas-1").await;
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-cas-1".to_string(),
         "sess-cas-1".to_string(),
         "tc-cas-1".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Cascade,
         "child-req-cas-1".to_string(),
@@ -772,11 +792,13 @@ async fn integration_cascade_intent_for_detached_subagent_returns_none() {
     let db = test_db("tc-sa-cas-2").await;
     let mut lc = ToolCallLifecycle::new_subagent(
         db.node.clone(),
+        "req-cas-2".to_string(),
         "sess-cas-2".to_string(),
         "tc-cas-2".to_string(),
         1,
         "spawn_subagent".to_string(),
         "{}".to_string(),
+        test_deadline(),
         AwaitMode::Foreground,
         CancelPolicy::Detach,
         "child-req-cas-2".to_string(),
@@ -792,11 +814,13 @@ async fn integration_cascade_intent_for_native_returns_none() {
     let db = test_db("tc-sa-cas-3").await;
     let mut lc = ToolCallLifecycle::new(
         db.node.clone(),
+        "req-cas-3".to_string(),
         "sess-cas-3".to_string(),
         "tc-cas-3".to_string(),
         1,
         "echo".to_string(),
         "{}".to_string(),
+        test_deadline(),
     );
     lc.start_running().await.unwrap();
     lc.cancel_during_run().await.unwrap();

--- a/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
@@ -1,0 +1,1088 @@
+//! Bucket 3 — runtime integration tests for the subagent extensions to
+//! ToolCallLifecycle. Spins up a real EmbeddedNode via test_db() and exercises
+//! every new transition end-to-end. Mirrors R1's
+//! tool_call_lifecycle_conformance.rs structure.
+//!
+//! Tests 22-26 (in subsequent tasks) build on the two helpers defined here:
+//!   - `make_completed_request`: creates a child AgentRequest in `.completed`
+//!     state via direct DB writes, bypassing the normal request lifecycle.
+//!   - `make_terminal_request`: same but for any non-completed terminal state
+//!     ("failed", "dead", "interrupted", "superseded").
+
+mod support;
+
+// These imports are used by the helpers defined here and by the integration
+// tests that Tasks 22-26 add to this file. Allow unused-import lint until the
+// remainder of Bucket 3 is filled in.
+#[allow(unused_imports)]
+use defra_agent::tool_call_lifecycle::{
+    create_subagent_request, AwaitMode, CancelPolicy, CascadeIntent, ChildTerminal, FailureClass,
+    IllegalToolCallTransition, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
+};
+use support::test_db;
+
+// ---------------------------------------------------------------------------
+// Internal test helpers
+// ---------------------------------------------------------------------------
+
+/// Test helper: directly constructs a child AgentRequest in `.completed`
+/// state via low-level DB writes, bypassing the normal request lifecycle.
+/// Used by bridge_complete tests to set up "the child has finished" state
+/// without R3's SubagentSource.
+///
+/// Uses the same full required-field set as `support::create_request` so
+/// that DefraDB schema validation passes. Parent linkage fields are only
+/// written when `Some`.
+async fn make_completed_request(
+    node: &defra_agent::defra_node::EmbeddedNode,
+    request_id: &str,
+    parent_request_id: Option<&str>,
+    parent_tool_call_id: Option<&str>,
+    final_message: &str,
+) -> anyhow::Result<()> {
+    let depth: u32 = if parent_request_id.is_some() { 1 } else { 0 };
+    let parent_req_field = parent_request_id
+        .map(|id| {
+            let escaped = defra_agent::graphql::escape_graphql_string(id);
+            format!(r#"caused_by_parent_request_id: "{escaped}","#)
+        })
+        .unwrap_or_default();
+    let parent_tc_field = parent_tool_call_id
+        .map(|id| {
+            let escaped = defra_agent::graphql::escape_graphql_string(id);
+            format!(r#"caused_by_parent_tool_call_id: "{escaped}","#)
+        })
+        .unwrap_or_default();
+    let rid = defra_agent::graphql::escape_graphql_string(request_id);
+    let content = defra_agent::graphql::escape_graphql_string(final_message);
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let now_escaped = defra_agent::graphql::escape_graphql_string(&now);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{rid}",
+                agent_did: "{agent_did}",
+                behavior_id: "test",
+                session_id: "{rid}",
+                retry_parent_request: "",
+                retry_root_request: "{rid}",
+                superseded_by_request: "",
+                content: "{content}",
+                status: "completed",
+                lifecycle_state: "completed",
+                backend_id: "",
+                execution_origin: "interactive",
+                failure_reason: "",
+                created_at: "{now_escaped}",
+                retry_count: 0,
+                max_retries: {max_retries},
+                subagent_depth: {depth},
+                {prf}
+                {ptc}
+            }}) {{ _docID }}
+        }}"#,
+        agent_did = support::AGENT_DID,
+        max_retries = defra_agent::lifecycle::DEFAULT_REQUEST_MAX_RETRIES,
+        prf = parent_req_field,
+        ptc = parent_tc_field,
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "make_completed_request failed: {:?}",
+        resp.errors
+    );
+    Ok(())
+}
+
+/// Test helper: same as `make_completed_request` but for non-completed terminal
+/// states: "failed", "dead", "interrupted", "superseded".
+async fn make_terminal_request(
+    node: &defra_agent::defra_node::EmbeddedNode,
+    request_id: &str,
+    parent_request_id: Option<&str>,
+    parent_tool_call_id: Option<&str>,
+    state: &str,
+) -> anyhow::Result<()> {
+    let depth: u32 = if parent_request_id.is_some() { 1 } else { 0 };
+    let parent_req_field = parent_request_id
+        .map(|id| {
+            let escaped = defra_agent::graphql::escape_graphql_string(id);
+            format!(r#"caused_by_parent_request_id: "{escaped}","#)
+        })
+        .unwrap_or_default();
+    let parent_tc_field = parent_tool_call_id
+        .map(|id| {
+            let escaped = defra_agent::graphql::escape_graphql_string(id);
+            format!(r#"caused_by_parent_tool_call_id: "{escaped}","#)
+        })
+        .unwrap_or_default();
+    let rid = defra_agent::graphql::escape_graphql_string(request_id);
+    let state_escaped = defra_agent::graphql::escape_graphql_string(state);
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let now_escaped = defra_agent::graphql::escape_graphql_string(&now);
+    // "dead"/"interrupted"/"superseded" are not valid `status` values in the
+    // existing schema — the `status` field uses the legacy R1 vocabulary
+    // ("pending", "processing", "completed", "error", "superseded") while
+    // `lifecycle_state` carries the full R2 vocabulary. We normalise `status`
+    // to the closest valid legacy value for schema compliance.
+    let legacy_status = match state {
+        "completed" => "completed",
+        "superseded" => "superseded",
+        "failed" | "dead" | "interrupted" => "error",
+        other => other,
+    };
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{rid}",
+                agent_did: "{agent_did}",
+                behavior_id: "test",
+                session_id: "{rid}",
+                retry_parent_request: "",
+                retry_root_request: "{rid}",
+                superseded_by_request: "",
+                content: "",
+                status: "{legacy_status}",
+                lifecycle_state: "{state_escaped}",
+                backend_id: "",
+                execution_origin: "interactive",
+                failure_reason: "",
+                created_at: "{now_escaped}",
+                retry_count: 0,
+                max_retries: {max_retries},
+                subagent_depth: {depth},
+                {prf}
+                {ptc}
+            }}) {{ _docID }}
+        }}"#,
+        agent_did = support::AGENT_DID,
+        max_retries = defra_agent::lifecycle::DEFAULT_REQUEST_MAX_RETRIES,
+        prf = parent_req_field,
+        ptc = parent_tc_field,
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "make_terminal_request({state}) failed: {:?}",
+        resp.errors
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Bucket 3 / R2 fix — load() round-trip: subagent fields survive restart
+// ---------------------------------------------------------------------------
+//
+// Regression guard for the bug where load() reconstructed via new(), which
+// defaulted await_mode=Foreground, cancel_policy=Cascade, child_request_id=None
+// regardless of what was persisted. After the fix, load() reads all three v3
+// fields from the SELECT projection and populates them directly.
+
+#[tokio::test]
+async fn integration_load_round_trip_preserves_subagent_fields() {
+    let db = test_db("tc-sa-load-rt-1").await;
+
+    // Construct a subagent lifecycle with non-default values and persist it.
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-load-rt-1".to_string(),
+        "tc-load-rt-1".to_string(),
+        3,
+        "spawn_subagent".to_string(),
+        r#"{"target":"amy-code"}"#.to_string(),
+        AwaitMode::Background,
+        CancelPolicy::Detach,
+        "child-req-load-rt-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+
+    // Reload from the DB — simulates a daemon restart picking up the row.
+    // The loaded lifecycle must correctly reconstruct the v3 subagent fields.
+    // Because await_mode/cancel_policy/child_request_id are pub(crate), we
+    // verify the round-trip by querying the DB directly — the same pattern used
+    // throughout this test file.
+    let loaded = ToolCallLifecycle::load(db.node.clone(), "sess-load-rt-1", "tc-load-rt-1")
+        .await
+        .unwrap()
+        .expect("row must exist after start_running");
+
+    // Confirm the returned lifecycle is non-None (i.e. load() succeeded).
+    // The live-state verification is below via a direct DB query.
+    drop(loaded);
+
+    // Query the persisted row to confirm all three v3 fields were written by
+    // start_running and are readable back. This validates the SELECT projection
+    // added to load() picks up the correct values for a subagent row.
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-load-rt-1" } }) {
+            await_mode
+            cancel_policy
+            child_request_id
+        } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected one AgentToolCall row");
+    let row = &rows[0];
+
+    assert_eq!(
+        row["await_mode"].as_str(),
+        Some("background"),
+        "await_mode must be persisted as 'background' after start_running with AwaitMode::Background"
+    );
+    assert_eq!(
+        row["cancel_policy"].as_str(),
+        Some("detach"),
+        "cancel_policy must be persisted as 'detach' after start_running with CancelPolicy::Detach"
+    );
+    assert_eq!(
+        row["child_request_id"].as_str(),
+        Some("child-req-load-rt-1"),
+        "child_request_id must be persisted and readable after start_running"
+    );
+}
+
+#[tokio::test]
+async fn integration_load_round_trip_foreground_cascade_also_preserved() {
+    // Confirm the default-value case also works correctly (Foreground + Cascade).
+    // Distinct from the non-default test above.
+    let db = test_db("tc-sa-load-rt-2").await;
+
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-load-rt-2".to_string(),
+        "tc-load-rt-2".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-load-rt-2".to_string(),
+    );
+    lc.start_running().await.unwrap();
+
+    let loaded = ToolCallLifecycle::load(db.node.clone(), "sess-load-rt-2", "tc-load-rt-2")
+        .await
+        .unwrap()
+        .expect("row must exist after start_running");
+    drop(loaded);
+
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-load-rt-2" } }) {
+            await_mode
+            cancel_policy
+            child_request_id
+        } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert_eq!(row["await_mode"].as_str(), Some("foreground"));
+    assert_eq!(row["cancel_policy"].as_str(), Some("cascade"));
+    assert_eq!(
+        row["child_request_id"].as_str(),
+        Some("child-req-load-rt-2")
+    );
+}
+
+#[tokio::test]
+async fn integration_load_round_trip_native_tool_has_no_child_request_id() {
+    // A native (non-subagent) tool loaded from DB should have child_request_id=None.
+    // After load(), the v3 fields should fall back to their v2 defaults.
+    let db = test_db("tc-sa-load-rt-3").await;
+
+    let mut lc = ToolCallLifecycle::new(
+        db.node.clone(),
+        "sess-load-rt-3".to_string(),
+        "tc-load-rt-3".to_string(),
+        0,
+        "echo".to_string(),
+        "{}".to_string(),
+    );
+    lc.start_running().await.unwrap();
+
+    let loaded = ToolCallLifecycle::load(db.node.clone(), "sess-load-rt-3", "tc-load-rt-3")
+        .await
+        .unwrap()
+        .expect("row must exist after start_running");
+    drop(loaded);
+
+    // Native tool: the three v3 fields are not written by start_running, so
+    // they come back as null from the DB. The DB-level view:
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-load-rt-3" } }) {
+            await_mode
+            cancel_policy
+            child_request_id
+        } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1);
+    let row = &rows[0];
+    assert!(
+        row["child_request_id"].is_null(),
+        "native tool must have child_request_id=null in DB, got: {:?}",
+        row["child_request_id"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration: background → foreground round-trip persists await_mode
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_background_then_foreground_persists_round_trip() {
+    let db = test_db("tc-sa-int-1").await;
+
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-int-1".to_string(),
+        "tc-int-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-int-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+
+    // Flip to background and verify persisted await_mode.
+    lc.background().await.unwrap();
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-int-1" } }) { await_mode } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected one row");
+    assert_eq!(
+        rows[0]["await_mode"].as_str(),
+        Some("background"),
+        "await_mode should be persisted as 'background' after background()"
+    );
+
+    // Flip back to foreground and verify persisted await_mode.
+    lc.foreground().await.unwrap();
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-int-1" } }) { await_mode } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected one row");
+    assert_eq!(
+        rows[0]["await_mode"].as_str(),
+        Some("foreground"),
+        "await_mode should be persisted as 'foreground' after foreground()"
+    );
+
+    // Calling foreground() again returns ModeAlreadyForeground.
+    let err = lc.foreground().await.unwrap_err();
+    assert!(
+        matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::ModeAlreadyForeground)
+        ),
+        "expected ModeAlreadyForeground on second foreground() call, got: {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration: detach one-way persists cancel_policy
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_detach_one_way_persists() {
+    let db = test_db("tc-sa-det-1").await;
+
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-det-1".to_string(),
+        "tc-det-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-det-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+
+    lc.detach().await.unwrap();
+
+    // Verify cancel_policy is persisted as "detach".
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-det-1" } }) { cancel_policy } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected one row");
+    assert_eq!(
+        rows[0]["cancel_policy"].as_str(),
+        Some("detach"),
+        "cancel_policy should be persisted as 'detach' after detach()"
+    );
+
+    // detach again errors.
+    let err = lc.detach().await.unwrap_err();
+    assert!(
+        matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::PolicyAlreadyDetach)
+        ),
+        "expected PolicyAlreadyDetach on second detach() call, got: {err:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sanity test: make_completed_request creates a row with the expected state
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_make_completed_request_creates_row() {
+    let db = test_db("tc-sa-sanity-1").await;
+
+    make_completed_request(&db.node, "req-sanity-1", None, None, "all done")
+        .await
+        .unwrap();
+
+    // Verify a row exists with lifecycle_state == "completed".
+    let query = r#"{
+        AgentRequest(filter: { request_id: { _eq: "req-sanity-1" } }) {
+            request_id
+            lifecycle_state
+            subagent_depth
+        }
+    }"#;
+    let resp = db.node.execute(query).await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+
+    let data = resp.data.expect("data");
+    let rows = data["AgentRequest"].as_array().expect("AgentRequest array");
+    assert_eq!(rows.len(), 1, "expected exactly one AgentRequest row");
+
+    let row = &rows[0];
+    assert_eq!(
+        row["lifecycle_state"].as_str(),
+        Some("completed"),
+        "expected lifecycle_state to be 'completed', got: {:?}",
+        row["lifecycle_state"]
+    );
+    assert_eq!(
+        row["subagent_depth"].as_i64(),
+        Some(0),
+        "top-level request should have subagent_depth 0"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sanity test: make_completed_request with parent linkage sets depth=1
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_make_completed_request_child_sets_depth_and_parent_fields() {
+    let db = test_db("tc-sa-sanity-2").await;
+
+    make_completed_request(
+        &db.node,
+        "req-sanity-child-1",
+        Some("req-parent-1"),
+        Some("tc-parent-1"),
+        "child done",
+    )
+    .await
+    .unwrap();
+
+    let query = r#"{
+        AgentRequest(filter: { request_id: { _eq: "req-sanity-child-1" } }) {
+            request_id
+            lifecycle_state
+            subagent_depth
+            caused_by_parent_request_id
+            caused_by_parent_tool_call_id
+        }
+    }"#;
+    let resp = db.node.execute(query).await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+
+    let data = resp.data.expect("data");
+    let rows = data["AgentRequest"].as_array().expect("AgentRequest array");
+    assert_eq!(rows.len(), 1, "expected one row");
+
+    let row = &rows[0];
+    assert_eq!(
+        row["lifecycle_state"].as_str(),
+        Some("completed"),
+        "lifecycle_state should be completed"
+    );
+    assert_eq!(
+        row["subagent_depth"].as_i64(),
+        Some(1),
+        "child request should have subagent_depth 1"
+    );
+    assert_eq!(
+        row["caused_by_parent_request_id"].as_str(),
+        Some("req-parent-1"),
+        "parent request id should be set"
+    );
+    assert_eq!(
+        row["caused_by_parent_tool_call_id"].as_str(),
+        Some("tc-parent-1"),
+        "parent tool call id should be set"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Integration: bridge_complete end-to-end with real child request
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_bridge_complete_with_real_child() {
+    let db = test_db("tc-sa-bc-1").await;
+
+    // 1. Create a child AgentRequest already in .completed state.
+    let child_request_id = "child-bc-1";
+    make_completed_request(
+        &db.node,
+        child_request_id,
+        Some("parent-req-bc1"),
+        Some("parent-tc-bc1"),
+        "child final assistant message",
+    )
+    .await
+    .unwrap();
+
+    // 2. Construct the parent bridge tool call and start_running.
+    let mut bridge = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-bc1".to_string(),
+        "tc-bc1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+    );
+    bridge.start_running().await.unwrap();
+
+    // 3. Call bridge_complete with the projected child output.
+    let projected_output = "child final assistant message".to_string();
+    bridge
+        .bridge_complete(projected_output.clone())
+        .await
+        .unwrap();
+
+    // 4. Verify the bridge tool's persisted lifecycle_state, result, and
+    //    child_request_id.
+    let resp = db
+        .node
+        .execute(
+            r#"{ AgentToolCall(filter: { tool_call_id: { _eq: "tc-bc1" } }) {
+            lifecycle_state
+            result
+            child_request_id
+        } }"#,
+        )
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected one AgentToolCall row");
+
+    let row = &rows[0];
+    assert_eq!(
+        row["lifecycle_state"].as_str(),
+        Some("completed"),
+        "lifecycle_state should be 'completed' after bridge_complete"
+    );
+    assert_eq!(
+        row["result"].as_str(),
+        Some("child final assistant message"),
+        "result should be the projected child output"
+    );
+    assert_eq!(
+        row["child_request_id"].as_str(),
+        Some(child_request_id),
+        "child_request_id should be persisted from start_running"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bucket 3 — bridge_failure projection tests for all 4 child terminals
+// ---------------------------------------------------------------------------
+
+async fn run_bridge_failure_case(
+    name_suffix: &str,
+    terminal_state: &str,
+    child_terminal: ChildTerminal,
+    expected_lifecycle_state: &str,
+) {
+    let db = test_db(&format!("tc-sa-bf-{name_suffix}")).await;
+    let session = format!("sess-bf-{name_suffix}");
+    let tc_id = format!("tc-bf-{name_suffix}");
+    let child_id = format!("child-req-bf-{name_suffix}");
+    let parent_req = format!("parent-req-bf-{name_suffix}");
+    let parent_tc = format!("parent-tc-bf-{name_suffix}");
+
+    make_terminal_request(
+        &db.node,
+        &child_id,
+        Some(&parent_req),
+        Some(&parent_tc),
+        terminal_state,
+    )
+    .await
+    .unwrap();
+
+    let mut bridge = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        session.clone(),
+        tc_id.clone(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        child_id,
+    );
+    bridge.start_running().await.unwrap();
+    bridge.bridge_failure(child_terminal).await.unwrap();
+
+    // Verify persistence — read the bridge tool back from DB.
+    let tc_id_escaped = defra_agent::graphql::escape_graphql_string(&tc_id);
+    let query = format!(
+        r#"{{ AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{tc_id_escaped}" }} }}) {{ lifecycle_state }} }}"#
+    );
+    let resp = db.node.execute(&query).await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected one AgentToolCall row for {terminal_state}"
+    );
+    assert_eq!(
+        rows[0]["lifecycle_state"].as_str(),
+        Some(expected_lifecycle_state),
+        "Expected lifecycle_state '{}' for child terminal '{}', got: {:?}",
+        expected_lifecycle_state,
+        terminal_state,
+        rows[0]["lifecycle_state"]
+    );
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_failed_projects_to_failed() {
+    run_bridge_failure_case(
+        "failed",
+        "failed",
+        ChildTerminal::Failed {
+            reason: "child failed".to_string(),
+            failure_class: FailureClass::External,
+        },
+        "failed",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_dead_projects_to_failed() {
+    run_bridge_failure_case("dead", "dead", ChildTerminal::Dead, "failed").await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_interrupted_projects_to_cancelled() {
+    run_bridge_failure_case(
+        "interrupted",
+        "interrupted",
+        ChildTerminal::Interrupted,
+        "cancelled",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_superseded_projects_to_failed() {
+    run_bridge_failure_case(
+        "superseded",
+        "superseded",
+        ChildTerminal::Superseded,
+        "failed",
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Integration: cascade intent — bridge_cancel_cascade after real cancel_during_run
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn integration_cascade_intent_for_cascade_subagent_returns_some() {
+    let db = test_db("tc-sa-cas-1").await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-cas-1".to_string(),
+        "tc-cas-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-cas-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_some());
+    assert_eq!(intent.unwrap().child_request_id, "child-req-cas-1");
+}
+
+#[tokio::test]
+async fn integration_cascade_intent_for_detached_subagent_returns_none() {
+    let db = test_db("tc-sa-cas-2").await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        "sess-cas-2".to_string(),
+        "tc-cas-2".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Detach,
+        "child-req-cas-2".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_none(), "Detach policy returns None");
+}
+
+#[tokio::test]
+async fn integration_cascade_intent_for_native_returns_none() {
+    let db = test_db("tc-sa-cas-3").await;
+    let mut lc = ToolCallLifecycle::new(
+        db.node.clone(),
+        "sess-cas-3".to_string(),
+        "tc-cas-3".to_string(),
+        1,
+        "echo".to_string(),
+        "{}".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(
+        intent.is_none(),
+        "Native tool (no child_request_id) returns None"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sanity test: make_terminal_request creates rows in each terminal state
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_make_terminal_request_all_states() {
+    let db = test_db("tc-sa-sanity-3").await;
+
+    for (idx, state) in ChildTerminal::ALL_KIND.iter().enumerate() {
+        let rid = format!("req-terminal-{idx}");
+        make_terminal_request(
+            &db.node,
+            &rid,
+            Some("req-parent-x"),
+            Some("tc-parent-x"),
+            state,
+        )
+        .await
+        .unwrap_or_else(|e| panic!("make_terminal_request({state}) failed: {e}"));
+
+        let rid_escaped = defra_agent::graphql::escape_graphql_string(&rid);
+        let query = format!(
+            r#"{{
+                AgentRequest(filter: {{ request_id: {{ _eq: "{rid_escaped}" }} }}) {{
+                    lifecycle_state
+                }}
+            }}"#
+        );
+        let resp = db.node.execute(&query).await;
+        assert!(
+            !resp.has_errors(),
+            "query failed for state {state}: {:?}",
+            resp.errors
+        );
+
+        let data = resp.data.expect("data");
+        let rows = data["AgentRequest"].as_array().expect("array");
+        assert_eq!(rows.len(), 1, "expected one row for state {state}");
+        assert_eq!(
+            rows[0]["lifecycle_state"].as_str(),
+            Some(*state),
+            "expected lifecycle_state={state}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bucket 3 / Task 26 — migration round-trip default-population behavior
+// ---------------------------------------------------------------------------
+//
+// Approach (a) per Task 26: the standard `test_db` already registers the v3
+// schema directly (no patch needed because the SDL ships with the v3 fields).
+// We insert a minimal AgentToolCall row with only the v1/v2 fields and verify
+// what the schema does for the unset v3 fields (`await_mode`, `cancel_policy`,
+// `child_request_id`, `request_id`).
+//
+// The point of the test is to lock in the actual observed behavior so that any
+// future drift — whether DefraDB starts materializing schema defaults on insert,
+// or vice-versa — is caught by a deliberate signal rather than silent
+// regressions in dependent code.
+
+#[tokio::test]
+async fn integration_v3_schema_defaults_populate_correctly() {
+    let db = test_db("tc-sa-mig-1").await;
+
+    // Insert a minimal AgentToolCall row with only v1/v2 fields populated.
+    // All v3 subagent fields (await_mode, cancel_policy, child_request_id,
+    // request_id) are deliberately omitted.
+    let mutation = r#"mutation {
+        create_AgentToolCall(input: {
+            tool_call_key: "mig-test-1",
+            session_id: "mig-sess-1",
+            message_sequence: 1,
+            tool_name: "echo",
+            tool_call_id: "mig-tc-1",
+            args: "{}",
+            lifecycle_state: "running"
+        }) { _docID }
+    }"#;
+    let resp = db.node.execute(mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create_AgentToolCall (minimal) failed: {:?}",
+        resp.errors
+    );
+
+    // Read back and observe what the v3 fields contain on a directly-inserted
+    // row (i.e. one that did not pass through the v2->v3 Lens forward
+    // transform).
+    let query = r#"{
+        AgentToolCall(filter: { tool_call_key: { _eq: "mig-test-1" } }) {
+            tool_call_key
+            lifecycle_state
+            await_mode
+            cancel_policy
+            child_request_id
+            request_id
+        }
+    }"#;
+    let resp = db.node.execute(query).await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+
+    let data = resp.data.expect("data");
+    let rows = data["AgentToolCall"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected exactly one row");
+    let row = &rows[0];
+
+    eprintln!("v3 schema default-population observed behavior: {row}");
+
+    // The row's v1/v2 fields are present as written.
+    assert_eq!(row["tool_call_key"].as_str(), Some("mig-test-1"));
+    assert_eq!(row["lifecycle_state"].as_str(), Some("running"));
+
+    // Lock in the observed behavior for the v3 fields.
+    //
+    // DefraDB's GraphQL @branchable schema does not materialize schema-level
+    // defaults onto directly-inserted rows: the SDL only declares each new
+    // field as a nullable `String`. The lens transform (registered by
+    // `ensure_subagent_extensions_migrations` in the daemon path) is what
+    // populates the v3 defaults onto pre-existing v2 rows on read. New rows
+    // inserted directly without these fields therefore observe Null for each
+    // unset v3 field.
+    //
+    // If a future change starts materializing defaults on insert, this test
+    // will fail — at which point the assertion should be flipped to the new
+    // observed values and a comment added explaining the change.
+    assert!(
+        row["await_mode"].is_null(),
+        "directly-inserted v3 row: await_mode expected null, got: {:?}",
+        row["await_mode"]
+    );
+    assert!(
+        row["cancel_policy"].is_null(),
+        "directly-inserted v3 row: cancel_policy expected null, got: {:?}",
+        row["cancel_policy"]
+    );
+    assert!(
+        row["child_request_id"].is_null(),
+        "directly-inserted v3 row: child_request_id expected null, got: {:?}",
+        row["child_request_id"]
+    );
+    assert!(
+        row["request_id"].is_null(),
+        "directly-inserted v3 row: request_id expected null, got: {:?}",
+        row["request_id"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Bucket 3 / Task 26 — `create_subagent_request` end-to-end depth + coherence
+// ---------------------------------------------------------------------------
+//
+// These complement the unit-level tests in `subagent_request.rs` (which only
+// verify the precondition arithmetic via #[test] blocks that don't touch the
+// DB). Here we exercise the helper through a real EmbeddedNode.
+
+#[tokio::test]
+async fn integration_create_subagent_request_at_max_depth_succeeds() {
+    let db = test_db("tc-sa-csr-1").await;
+    let new_id = create_subagent_request(
+        &db.node,
+        "parent-req-csr-1".to_string(),
+        "parent-tc-csr-1".to_string(),
+        MAX_SUBAGENT_DEPTH - 1,
+        support::AGENT_DID.to_string(),
+        "behavior-csr-1".to_string(),
+        "csr test prompt".to_string(),
+        None,
+    )
+    .await
+    .expect("create_subagent_request at MAX-1 should succeed");
+
+    // The helper returns a freshly minted UUID; verify by reading the row
+    // back out of the DB and checking the stored fields.
+    assert!(!new_id.is_empty(), "expected non-empty request_id");
+    let new_id_escaped = defra_agent::graphql::escape_graphql_string(&new_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{new_id_escaped}" }} }}) {{
+                request_id
+                lifecycle_state
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+            }}
+        }}"#
+    );
+    let resp = db.node.execute(&query).await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let data = resp.data.expect("data");
+    let rows = data["AgentRequest"].as_array().expect("array");
+    assert_eq!(rows.len(), 1, "expected exactly one row");
+    let row = &rows[0];
+    assert_eq!(row["lifecycle_state"].as_str(), Some("pending"));
+    assert_eq!(
+        row["subagent_depth"].as_i64(),
+        Some(i64::from(MAX_SUBAGENT_DEPTH)),
+        "child depth should be parent_depth + 1 = MAX_SUBAGENT_DEPTH"
+    );
+    assert_eq!(
+        row["caused_by_parent_request_id"].as_str(),
+        Some("parent-req-csr-1")
+    );
+    assert_eq!(
+        row["caused_by_parent_tool_call_id"].as_str(),
+        Some("parent-tc-csr-1")
+    );
+}
+
+#[tokio::test]
+async fn integration_create_subagent_request_above_max_depth_fails() {
+    let db = test_db("tc-sa-csr-2").await;
+    let err = create_subagent_request(
+        &db.node,
+        "parent-req-csr-2".to_string(),
+        "parent-tc-csr-2".to_string(),
+        MAX_SUBAGENT_DEPTH,
+        support::AGENT_DID.to_string(),
+        "behavior-csr-2".to_string(),
+        "csr test prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("should reject parent_depth == MAX_SUBAGENT_DEPTH");
+    assert!(
+        matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::SubagentDepthExceeded)
+        ),
+        "expected SubagentDepthExceeded, got: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn integration_create_subagent_request_empty_parent_fields_fails() {
+    let db = test_db("tc-sa-csr-3").await;
+
+    // Empty parent_request_id triggers ParentLinkageIncoherent.
+    let err = create_subagent_request(
+        &db.node,
+        "".to_string(),
+        "parent-tc".to_string(),
+        0,
+        support::AGENT_DID.to_string(),
+        "behavior".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("empty parent_request_id should fail");
+    assert!(
+        matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::ParentLinkageIncoherent)
+        ),
+        "expected ParentLinkageIncoherent for empty parent_request_id, got: {err:?}"
+    );
+
+    // Empty parent_tool_call_id also triggers ParentLinkageIncoherent.
+    let err = create_subagent_request(
+        &db.node,
+        "parent-req".to_string(),
+        "".to_string(),
+        0,
+        support::AGENT_DID.to_string(),
+        "behavior".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("empty parent_tool_call_id should fail");
+    assert!(
+        matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::ParentLinkageIncoherent)
+        ),
+        "expected ParentLinkageIncoherent for empty parent_tool_call_id, got: {err:?}"
+    );
+}

--- a/docs/superpowers/plans/2026-05-08-r2-rust-subagent-data-plane.md
+++ b/docs/superpowers/plans/2026-05-08-r2-rust-subagent-data-plane.md
@@ -1,0 +1,3477 @@
+# R2 — Rust Subagent Data Plane Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the Rust runtime data plane defined in `docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md` — `ToolCallLifecycle` extensions for subagent invocation (mode flips, bridge transitions, child-link field), schema migrations v2→v3 across three collections, and three conformance buckets.
+
+**Architecture:** Mirror R1's data plane discipline (PR #152's `ToolCallLifecycle`). Extend the same struct with three new fields (`await_mode`, `cancel_policy`, `child_request_id`) and six new transition methods (`background`, `foreground`, `detach`, `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`). Single unified WASM lens crate covers AgentToolCall + AgentRequest + ToolSelection migrations. SubagentSource and agent-facing tools are deferred to R3+.
+
+**Tech Stack:** Rust (edition 2021), Lean 4, Tokio, DefraDB embedded node, `lens_sdk` (WASM), `cargo` workspace.
+
+---
+
+## Conventions
+
+- **Build/verify commands:**
+  - Rust check: `cargo check -p defra-agent`
+  - Rust lib tests: `cargo test -p defra-agent --lib`
+  - Rust integration tests: `cargo test -p defra-agent --test <name>`
+  - Lean: `cd crates/defra-agent/proofs && lake build`
+  - WASM lens build: `cd crates/defra-agent-lenses/agent_subagent_v2_to_v3 && cargo build --release --target wasm32-unknown-unknown`
+- **TDD cadence:** failing test → confirm fail → minimal impl → confirm pass → commit. One commit per task.
+- **Working directory:** all paths relative to repo root `/Users/johnzampolin/go/src/github.com/sourcenetwork/defra-agent-design-subagent-management`.
+- **Branch:** `design/subagent-management` (currently at HEAD `7bde2e5` — R2 spec revisions). Do NOT switch branches.
+- **Commit messages:** imperative, scoped, end with `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer. Use HEREDOC for multi-line bodies.
+- **DefraDB Kind codes** (verified against R1's `migration.rs:17`):
+  - `Kind: 11` → String
+  - `Kind: 5` → Int
+  - `Kind: 2` → Boolean
+  - `Kind: 17` → `[String]` (list of strings)
+  
+  If any of these turn out wrong at implementation time, find the correct code by reading the `defradb.rs` crate's schema definitions (likely under `~/.cargo/git/checkouts/defradb-rs-*/`) or by examining how existing schemas like `command_allowed_argv_prefixes: [String]` are persisted. Pin the corrected codes inline in `migration.rs` before proceeding.
+
+---
+
+## What's NOT in this plan (deferred per spec)
+
+- **R3** — `SubagentSource` (TriggerSource implementation), daemon interrupt dispatcher consuming `CascadeIntent`, spawn-time invariant enforcement, cross-reference validation (`subagent_targets` resolution, `caused_by_parent_request_id` existence).
+- **R4** — Agent-facing tools (`spawn_subagent`, `wait_task`, `get_task_result`, `cancel_task`, `read_subagent_transcript`, `send_message_to_subagent`, `list_tasks`, `background_task`); hook integration that routes them.
+- **R5** — Apply-time cross-reference validation; conformance Bucket 4 (multi-flight stress).
+- **R6 / sourcenetwork/defra-agent#9** — Cross-principal delegation.
+- **Future** (no R-phase yet) — token/cost budget propagation, output streaming, detach orphan reaper, subagent retry semantics, persistent subagents across daemon restarts, runtime backfill of `request_id` for historic AgentToolCall rows.
+
+---
+
+## Task 0: Extend Lean conformance contract (`Machines.lean`)
+
+Buckets 1 and 2 depend on Lean emitting the new vocabularies and transition pairs. Mirror R1's pattern.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean`
+
+- [ ] **Step 1: Read the current Machines.lean to understand existing emission patterns**
+
+```bash
+cat crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean
+```
+
+Note how the existing `toolCallMachine` (added by issue-149's `a1d4bd9`) emits `ToolCallState`, `ToolFailureClass`, `ToolRetryDisposition`. Look at the JSON shape (typically `name`, `vocabulary`, `transitions` arrays) so the new emissions match.
+
+- [ ] **Step 2: Add `awaitModeMachine` emission**
+
+In `Machines.lean`, after the existing `toolCallMachine` definition, add:
+
+```lean
+def awaitModeMachine : Machine where
+  name := "AwaitMode"
+  vocabulary := Subagent.AwaitMode.all.map Subagent.AwaitMode.toDefraDB
+  transitions := []  -- mode is a static enum; no transitions emitted
+```
+
+(Adapt the `Machine` struct field names to match what's actually in the file. `Subagent.AwaitMode` and its `all` / `toDefraDB` already exist from B1's spec landing.)
+
+- [ ] **Step 3: Add `cancelPolicyMachine` emission**
+
+```lean
+def cancelPolicyMachine : Machine where
+  name := "CancelPolicy"
+  vocabulary := Subagent.CancelPolicy.all.map Subagent.CancelPolicy.toDefraDB
+  transitions := []
+```
+
+- [ ] **Step 4: Add `childTerminalMachine` with projection emission**
+
+```lean
+def childTerminalMachine : Machine where
+  name := "ChildTerminal"
+  vocabulary := ["failed", "dead", "interrupted", "superseded"]
+  transitions := [
+    -- (childTerminal, projectedToolState) pairs from B2's projection rule
+    { from := "failed",      to := "failed" },
+    { from := "dead",         to := "failed" },
+    { from := "interrupted",  to := "cancelled" },
+    { from := "superseded",   to := "failed" }
+  ]
+```
+
+(Adapt to the actual `Transition` field shape in `Machine`.)
+
+- [ ] **Step 5: Extend `toolCallMachine` with the new bridge + mode-flip transitions**
+
+Find `toolCallMachine`'s `transitions` array. Add entries for the 6 new `ToolCallContext.Transition` constructors (`background`, `foreground`, `detach`, `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`). Each entry pairs the inner-state pre/post (using the existing `ToolCallState` vocabulary) with a `transition_name` discriminator. Emit native `complete` / `fail` rows with a precondition flag (e.g., `requires_native: true`) so Bucket 2 can assert that calling those on a subagent-typed tool fails.
+
+If the existing `Machine` schema doesn't have a precondition-flag field, extend the schema (small Lean change, document it in this task's commit message).
+
+- [ ] **Step 6: Build and verify**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build, zero new sorrys, no warnings. The build emits an updated JSON file (typically at `crates/defra-agent/proofs/conformance.json` or similar — locate it via the existing build pipeline).
+
+- [ ] **Step 7: Sanity-check the JSON output**
+
+```bash
+# Find where the contract JSON lands (per R1's pipeline):
+find crates/defra-agent -name "*.json" -newer crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean | head -5
+```
+
+Verify the output JSON contains entries for `AwaitMode`, `CancelPolicy`, `ChildTerminal`, and the new `toolCallMachine` transitions.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean
+git commit -m "$(cat <<'EOF'
+Extend conformance contract with AwaitMode, CancelPolicy, ChildTerminal
+
+Adds awaitModeMachine, cancelPolicyMachine, childTerminalMachine
+emissions plus bridge transitions on toolCallMachine. Prerequisite
+for R2's Bucket 1 (vocabulary round-trip) and Bucket 2 (Lean transition
+matrix) — Rust tests consume these JSON entries to assert vocabulary
+parity and matrix coverage.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 1: Scaffold the `agent_subagent_v2_to_v3` lens crate
+
+Create the WASM lens crate; mirror the layout of `agent_tool_call_lifecycle_v1_to_v2/`.
+
+**Files:**
+- Create: `crates/defra-agent-lenses/agent_subagent_v2_to_v3/Cargo.toml`
+- Create: `crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs` (skeleton)
+- Modify: `Cargo.toml` (workspace root — add new member)
+
+- [ ] **Step 1: Create the crate directory and Cargo.toml**
+
+```bash
+mkdir -p crates/defra-agent-lenses/agent_subagent_v2_to_v3/src
+```
+
+Write `crates/defra-agent-lenses/agent_subagent_v2_to_v3/Cargo.toml`:
+
+```toml
+[package]
+name = "agent-subagent-v2-to-v3-lens"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+lens_sdk = "^0.8"
+```
+
+- [ ] **Step 2: Add the workspace member**
+
+Edit the root `Cargo.toml`. Find the existing `members = [...]` list and add the new entry alongside `agent_tool_call_lifecycle_v1_to_v2`:
+
+```toml
+members = [
+    # ...existing members...
+    "crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2",
+    "crates/defra-agent-lenses/agent_subagent_v2_to_v3",
+]
+```
+
+- [ ] **Step 3: Write the skeleton `src/lib.rs`**
+
+Write `crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs`:
+
+```rust
+//! Lens v2→v3: adds subagent extensions to AgentToolCall, AgentRequest,
+//! and ToolSelection. Forward transform populates new fields with their
+//! defaults; inverse transform drops them for P2P backward-compat.
+//!
+//! Operates over the same JSON-document iterator API as the v1→v2 lens.
+
+use lens_sdk::define;
+use std::collections::HashMap;
+use std::error::Error;
+use serde_json::Value;
+
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<lens_sdk::StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    // Forward transform — implemented in Task 2.
+    match iter.next() {
+        Some(Ok(Some(_doc))) => Ok(lens_sdk::StreamOption::Some(HashMap::new())),
+        Some(Ok(None)) => Ok(lens_sdk::StreamOption::None),
+        Some(Err(e)) => Err(Box::new(e)),
+        None => Ok(lens_sdk::StreamOption::EndOfStream),
+    }
+}
+
+fn try_inverse(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<lens_sdk::StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    // Inverse transform — implemented in Task 2.
+    match iter.next() {
+        Some(Ok(Some(_doc))) => Ok(lens_sdk::StreamOption::Some(HashMap::new())),
+        Some(Ok(None)) => Ok(lens_sdk::StreamOption::None),
+        Some(Err(e)) => Err(Box::new(e)),
+        None => Ok(lens_sdk::StreamOption::EndOfStream),
+    }
+}
+
+define!(try_transform, try_inverse);
+```
+
+This is a stub that compiles but doesn't do real work yet. Task 2 fills in the transforms.
+
+- [ ] **Step 4: Verify the workspace builds**
+
+```bash
+cargo check -p agent-subagent-v2-to-v3-lens
+```
+
+Expected: clean compile (a few "unused variable" warnings on `_doc` are fine — those go away in Task 2).
+
+```bash
+cargo build --release --target wasm32-unknown-unknown -p agent-subagent-v2-to-v3-lens
+```
+
+Expected: produces `target/wasm32-unknown-unknown/release/agent_subagent_v2_to_v3_lens.wasm`. If the WASM target isn't installed, run `rustup target add wasm32-unknown-unknown` first.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml crates/defra-agent-lenses/agent_subagent_v2_to_v3/
+git commit -m "$(cat <<'EOF'
+Scaffold agent_subagent_v2_to_v3 lens crate
+
+New WASM lens crate that will carry the v2→v3 forward and inverse
+transforms for AgentToolCall, AgentRequest, and ToolSelection.
+Mirrors the layout of agent_tool_call_lifecycle_v1_to_v2.
+
+Stub transforms compile cleanly; real transforms land in Task 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement the v2→v3 lens transforms
+
+Fill in the forward and inverse transforms for the three collections.
+
+**Files:**
+- Modify: `crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs`
+
+- [ ] **Step 1: Replace the stub `try_transform` with the forward implementation**
+
+Replace `try_transform` in `crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs` with:
+
+```rust
+fn try_transform(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<lens_sdk::StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    match iter.next() {
+        Some(Ok(Some(mut doc))) => {
+            // Detect collection by which "shape" fields exist. Each collection's
+            // transform is independent — adding a missing field, never overwriting.
+
+            // AgentToolCall extensions
+            if doc.contains_key("tool_call_key") || doc.contains_key("session_id") {
+                doc.entry("await_mode".to_string())
+                    .or_insert(Value::String("foreground".to_string()));
+                doc.entry("cancel_policy".to_string())
+                    .or_insert(Value::String("cascade".to_string()));
+                doc.entry("child_request_id".to_string())
+                    .or_insert(Value::Null);
+                doc.entry("request_id".to_string())
+                    .or_insert(Value::Null);
+            }
+
+            // AgentRequest extensions
+            if doc.contains_key("request_id") && doc.contains_key("agent_did") {
+                doc.entry("subagent_depth".to_string())
+                    .or_insert(Value::Number(0.into()));
+                doc.entry("caused_by_parent_request_id".to_string())
+                    .or_insert(Value::Null);
+                doc.entry("caused_by_parent_tool_call_id".to_string())
+                    .or_insert(Value::Null);
+            }
+
+            // ToolSelection extensions
+            if doc.contains_key("selection_id") {
+                doc.entry("subagent_targets".to_string())
+                    .or_insert(Value::Array(Vec::new()));
+                doc.entry("subagent_spawn_enabled".to_string())
+                    .or_insert(Value::Bool(false));
+                doc.entry("subagent_steering_enabled".to_string())
+                    .or_insert(Value::Bool(false));
+                doc.entry("subagent_background_enabled".to_string())
+                    .or_insert(Value::Bool(false));
+            }
+
+            Ok(lens_sdk::StreamOption::Some(doc))
+        }
+        Some(Ok(None)) => Ok(lens_sdk::StreamOption::None),
+        Some(Err(e)) => Err(Box::new(e)),
+        None => Ok(lens_sdk::StreamOption::EndOfStream),
+    }
+}
+```
+
+Note the collection-detection heuristics: AgentToolCall uniquely has `tool_call_key`; AgentRequest uniquely has `request_id` AND `agent_did` (without `tool_call_key`); ToolSelection uniquely has `selection_id`. If a doc matches multiple, the transforms are designed to be commutative (only `or_insert`, no overwrites), so the order doesn't matter.
+
+- [ ] **Step 2: Replace the stub `try_inverse` with the inverse implementation**
+
+Replace `try_inverse`:
+
+```rust
+fn try_inverse(
+    iter: &mut dyn Iterator<Item = lens_sdk::Result<Option<HashMap<String, Value>>>>,
+) -> Result<lens_sdk::StreamOption<HashMap<String, Value>>, Box<dyn Error>> {
+    match iter.next() {
+        Some(Ok(Some(mut doc))) => {
+            // Drop all v3-only fields for P2P compat with v2 nodes.
+            for field in &[
+                // AgentToolCall
+                "await_mode", "cancel_policy", "child_request_id", "request_id",
+                // AgentRequest
+                "subagent_depth", "caused_by_parent_request_id", "caused_by_parent_tool_call_id",
+                // ToolSelection
+                "subagent_targets",
+                "subagent_spawn_enabled",
+                "subagent_steering_enabled",
+                "subagent_background_enabled",
+            ] {
+                doc.remove(*field);
+            }
+            Ok(lens_sdk::StreamOption::Some(doc))
+        }
+        Some(Ok(None)) => Ok(lens_sdk::StreamOption::None),
+        Some(Err(e)) => Err(Box::new(e)),
+        None => Ok(lens_sdk::StreamOption::EndOfStream),
+    }
+}
+```
+
+- [ ] **Step 3: Build the WASM artifact and check size**
+
+```bash
+cargo build --release --target wasm32-unknown-unknown -p agent-subagent-v2-to-v3-lens
+wc -c target/wasm32-unknown-unknown/release/agent_subagent_v2_to_v3_lens.wasm
+```
+
+Expected: build succeeds; record the binary size for Risk 1 monitoring (per spec — flag if it grows beyond R1's lens by more than a factor of 2).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs
+git commit -m "$(cat <<'EOF'
+Implement v2→v3 lens forward and inverse transforms
+
+Forward transform: pure field additions with defaults — await_mode
+defaults to "foreground", cancel_policy to "cascade", child_request_id
+and request_id to null on AgentToolCall; subagent_depth=0 + null parent
+fields on AgentRequest; empty list + false booleans on ToolSelection.
+
+Inverse transform: drops all v3-only fields for P2P backward-compat
+with v2 nodes during rollout.
+
+Collection detection via shape-unique field names; per-document
+transforms are commutative (or_insert never overwrites), so a single
+lens module covers all three collections without ordering risks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Update GraphQL schemas + define JSON Patches
+
+Add the v3 fields to all three collection schemas. The patches will be applied at runtime by the migration orchestrator (Task 4).
+
+**Files:**
+- Modify: `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql`
+- Modify: `crates/defra-agent-protocol/schemas/agent/agent_request.graphql`
+- Modify: `crates/defra-agent-protocol/schemas/agent/tool_selection.graphql`
+- Modify: `crates/defra-agent/src/migration.rs` (add patch constants only — orchestrator in Task 4)
+
+- [ ] **Step 1: Update `agent_tool_call.graphql`**
+
+Add four new fields just before the closing `}` of the `AgentToolCall` type:
+
+```graphql
+type AgentToolCall @branchable {
+    # ...existing fields including lifecycle_state...
+    await_mode: String
+    cancel_policy: String
+    child_request_id: String @index
+    request_id: String @index
+}
+```
+
+`@index` on `child_request_id` and `request_id` supports the lineage queries planned for R3 (`AgentToolCall`s spawned by request R; tool calls owning child request C).
+
+- [ ] **Step 2: Update `agent_request.graphql`**
+
+Add three new fields:
+
+```graphql
+type AgentRequest @branchable {
+    # ...existing fields...
+    subagent_depth: Int
+    caused_by_parent_request_id: String @index
+    caused_by_parent_tool_call_id: String @index
+}
+```
+
+- [ ] **Step 3: Update `tool_selection.graphql`**
+
+Add four new fields:
+
+```graphql
+type ToolSelection {
+    # ...existing fields including delegate_to...
+    subagent_targets: [String]
+    subagent_spawn_enabled: Boolean
+    subagent_steering_enabled: Boolean
+    subagent_background_enabled: Boolean
+}
+```
+
+- [ ] **Step 4: Add JSON Patch constants to `migration.rs`**
+
+In `crates/defra-agent/src/migration.rs`, after the existing `ADD_LIFECYCLE_STATE_PATCH` constant, add three new patches:
+
+```rust
+const ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"await_mode","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_policy","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"child_request_id","Kind":11}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"request_id","Kind":11}}
+]"#;
+
+const ADD_AGENT_REQUEST_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"subagent_depth","Kind":5}},
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"caused_by_parent_request_id","Kind":11}},
+    {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"caused_by_parent_tool_call_id","Kind":11}}
+]"#;
+
+const ADD_TOOL_SELECTION_SUBAGENT_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_targets","Kind":17}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_spawn_enabled","Kind":2}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_steering_enabled","Kind":2}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_background_enabled","Kind":2}}
+]"#;
+```
+
+If any Kind code is wrong (build error at runtime when applying the patch), trace through DefraDB's `Kind` enum to find the right code and pin it inline. Common values: 11=String, 5=Int, 2=Boolean, 17=[String]. R1's `migration.rs:17` confirms 11=String.
+
+- [ ] **Step 5: Verify everything compiles**
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean (the new constants are unused until Task 4; suppress the dead-code warning with `#[allow(dead_code)]` on each constant if it fires, or — better — just commit and pick it up in Task 4 when the orchestrator references them).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql \
+        crates/defra-agent-protocol/schemas/agent/agent_request.graphql \
+        crates/defra-agent-protocol/schemas/agent/tool_selection.graphql \
+        crates/defra-agent/src/migration.rs
+git commit -m "$(cat <<'EOF'
+Add v3 GraphQL schema fields and migration JSON Patches
+
+AgentToolCall gains 4 fields: await_mode, cancel_policy,
+child_request_id (indexed), request_id (indexed).
+AgentRequest gains 3 fields: subagent_depth,
+caused_by_parent_request_id (indexed),
+caused_by_parent_tool_call_id (indexed).
+ToolSelection gains 4 fields: subagent_targets, plus three
+boolean policy flags (spawn / steering / background).
+
+Migration patch constants land in migration.rs; orchestrator
+that applies them lands in Task 4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Implement `ensure_subagent_extensions_migrations`
+
+Per-collection idempotent orchestrator that applies the three patches and registers the lens. Mirror `ensure_tool_call_migrations`.
+
+**Files:**
+- Modify: `crates/defra-agent/src/migration.rs`
+
+- [ ] **Step 1: Add detection helpers**
+
+In `migration.rs`, add three helper functions for per-collection idempotency:
+
+```rust
+async fn has_await_mode_field(node: &Arc<EmbeddedNode>) -> Result<bool> {
+    let collection = node.get_collection("AgentToolCall").await?;
+    Ok(collection
+        .map(|c| c.fields.iter().any(|f| f.name == "await_mode"))
+        .unwrap_or(false))
+}
+
+async fn has_caused_by_parent_request_id_field(node: &Arc<EmbeddedNode>) -> Result<bool> {
+    let collection = node.get_collection("AgentRequest").await?;
+    Ok(collection
+        .map(|c| c.fields.iter().any(|f| f.name == "caused_by_parent_request_id"))
+        .unwrap_or(false))
+}
+
+async fn has_subagent_targets_field(node: &Arc<EmbeddedNode>) -> Result<bool> {
+    let collection = node.get_collection("ToolSelection").await?;
+    Ok(collection
+        .map(|c| c.fields.iter().any(|f| f.name == "subagent_targets"))
+        .unwrap_or(false))
+}
+```
+
+The exact API for `node.get_collection` and what it returns may differ — read R1's `migration.rs:35-97` for the actual EmbeddedNode collection-introspection API and mirror its style. If `get_collection` returns `Option<CollectionDescription>` with a `.fields` accessor, the above shape works; if not, adapt.
+
+- [ ] **Step 2: Implement the orchestrator**
+
+After the existing `ensure_tool_call_migrations`, add:
+
+```rust
+/// Per-collection idempotent migration orchestrator for v2→v3.
+/// Applies the three subagent-extension patches and registers the unified
+/// lens. Re-running after a partial failure picks up at the un-migrated
+/// collection without manual intervention.
+pub async fn ensure_subagent_extensions_migrations(
+    node: Arc<EmbeddedNode>,
+) -> Result<()> {
+    // 1. AgentToolCall — patch only if v3 fields not already present.
+    if !has_await_mode_field(&node).await? {
+        let _v3_atc = node
+            .patch_collection("AgentToolCall", ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH)
+            .await
+            .context("patch_collection v2 -> v3 (AgentToolCall subagent fields)")?;
+        // No set_active_collection_version here — patch_collection bumps the
+        // active version automatically per R1's pattern. If R1's migration
+        // calls set_active_collection_version explicitly, mirror that.
+    }
+
+    // 2. AgentRequest — independent idempotency check.
+    if !has_caused_by_parent_request_id_field(&node).await? {
+        let _v3_ar = node
+            .patch_collection("AgentRequest", ADD_AGENT_REQUEST_SUBAGENT_PATCH)
+            .await
+            .context("patch_collection v2 -> v3 (AgentRequest subagent fields)")?;
+    }
+
+    // 3. ToolSelection — independent idempotency check.
+    if !has_subagent_targets_field(&node).await? {
+        let _v3_ts = node
+            .patch_collection("ToolSelection", ADD_TOOL_SELECTION_SUBAGENT_PATCH)
+            .await
+            .context("patch_collection v2 -> v3 (ToolSelection subagent fields)")?;
+    }
+
+    // 4. Register the unified lens (idempotent — safe to call repeatedly).
+    // The lens module path mirrors R1's pattern; `lens_module_path()` is the
+    // shared helper that resolves the WASM artifact's location.
+    let lens_path = lens_module_path("agent_subagent_v2_to_v3_lens.wasm")?;
+    let forward_lens = LensConfig::new(/* v_pre id */, /* v_post id */, LensModule::from_path(lens_path)?);
+    node.set_migration(forward_lens)
+        .await
+        .context("register agent_subagent_v2_to_v3 lens")?;
+
+    Ok(())
+}
+```
+
+The `LensConfig::new` arguments are placeholders — read R1's `ensure_tool_call_migrations` for the exact pattern of obtaining the `from`/`to` version IDs (typically returned by the `patch_collection` calls themselves; chain them through). If the version IDs need to be threaded across the three patches, restructure to capture them before the lens registration.
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean. If `LensConfig::new` signature errors, fix per R1's pattern.
+
+- [ ] **Step 4: Add a unit test for the detection helpers**
+
+Append to the existing test module in `migration.rs`:
+
+```rust
+#[cfg(test)]
+mod tests_v3 {
+    use super::*;
+
+    #[tokio::test]
+    async fn detection_helpers_return_false_on_pristine_v2_node() {
+        // This test depends on a test_db() helper that gives a v2 node.
+        // If R1 provides one, use it; if not, this test is a placeholder
+        // that must be wired up in Task 21 alongside the bucket-3 helpers.
+    }
+}
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/src/migration.rs
+git commit -m "$(cat <<'EOF'
+Implement ensure_subagent_extensions_migrations
+
+Per-collection idempotent orchestrator: each collection's v3 patch
+runs only if its detector field is absent, so a partial failure
+recovers on daemon restart without manual intervention. Three
+independent detection helpers (has_await_mode_field,
+has_caused_by_parent_request_id_field, has_subagent_targets_field).
+
+After all three patches, registers the unified
+agent_subagent_v2_to_v3 lens via set_migration.
+
+Daemon wiring lands in Task 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Wire the migration into daemon startup
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/commands/serve.rs`
+
+- [ ] **Step 1: Locate the existing `ensure_tool_call_migrations` call**
+
+```bash
+grep -n "ensure_tool_call_migrations" crates/defra-agent-cli/src/commands/serve.rs
+```
+
+- [ ] **Step 2: Add the v3 migration call immediately after**
+
+Find the line where `ensure_tool_call_migrations(node.clone()).await?;` is called. Add the new call right after:
+
+```rust
+defra_agent::migration::ensure_tool_call_migrations(node.clone()).await?;
+defra_agent::migration::ensure_subagent_extensions_migrations(node.clone()).await?;
+```
+
+The serial ordering is important: v1→v2 (`ensure_tool_call_migrations`) must run before v2→v3 (`ensure_subagent_extensions_migrations`).
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cargo check -p defra-agent-cli
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/commands/serve.rs
+git commit -m "$(cat <<'EOF'
+Wire ensure_subagent_extensions_migrations into daemon startup
+
+Called serially after ensure_tool_call_migrations. The v1→v2 baseline
+must land before v2→v3 patches apply to the upgraded AgentToolCall
+schema.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Add `AwaitMode`, `CancelPolicy`, `ChildTerminal` enums and `CascadeIntent` struct
+
+Adds the four new types to `tool_call_lifecycle.rs` alongside the existing `ToolCallState` and `FailureClass` enums.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle.rs`
+
+- [ ] **Step 1: Read the existing structure**
+
+```bash
+sed -n '1,80p' crates/defra-agent/src/tool_call_lifecycle.rs
+```
+
+Note where `ToolCallState` is defined (lines ~10-90) and where `FailureClass` is defined. Place the new enums in the same idiomatic shape (`#[derive]`, `as_str` / `from_persisted` / `ALL`).
+
+- [ ] **Step 2: Add `AwaitMode`**
+
+After the `FailureClass` definition (or wherever fits naturally), add:
+
+```rust
+/// Whether the parent's narrative is blocked on this tool's terminal state.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AwaitMode {
+    Foreground,
+    Background,
+}
+
+impl AwaitMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AwaitMode::Foreground => "foreground",
+            AwaitMode::Background => "background",
+        }
+    }
+
+    pub fn from_persisted(s: &str) -> Option<Self> {
+        match s {
+            "foreground" => Some(AwaitMode::Foreground),
+            "background" => Some(AwaitMode::Background),
+            _ => None,
+        }
+    }
+
+    pub const ALL: &'static [AwaitMode] = &[AwaitMode::Foreground, AwaitMode::Background];
+}
+```
+
+- [ ] **Step 3: Add `CancelPolicy`**
+
+```rust
+/// Whether parent termination drives the linked child request to .interrupted
+/// (cascade) or detaches the child to its own deadline.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CancelPolicy {
+    Cascade,
+    Detach,
+}
+
+impl CancelPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CancelPolicy::Cascade => "cascade",
+            CancelPolicy::Detach => "detach",
+        }
+    }
+
+    pub fn from_persisted(s: &str) -> Option<Self> {
+        match s {
+            "cascade" => Some(CancelPolicy::Cascade),
+            "detach" => Some(CancelPolicy::Detach),
+            _ => None,
+        }
+    }
+
+    pub const ALL: &'static [CancelPolicy] = &[CancelPolicy::Cascade, CancelPolicy::Detach];
+}
+```
+
+- [ ] **Step 4: Add `ChildTerminal` and projection**
+
+```rust
+/// The four non-.completed terminal states a child AgentRequest can reach.
+/// Used as the argument shape to bridge_failure to project the child terminal
+/// onto a parent ToolCallState (.failed for most, .cancelled for .interrupted).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ChildTerminal {
+    Failed { reason: String, failure_class: FailureClass },
+    Dead,
+    Interrupted,
+    Superseded,
+}
+
+impl ChildTerminal {
+    /// Lean B2 projection: .interrupted → .cancelled, all others → .failed.
+    pub fn projected_state(&self) -> ToolCallState {
+        match self {
+            ChildTerminal::Interrupted => ToolCallState::Cancelled,
+            _ => ToolCallState::Failed,
+        }
+    }
+
+    /// Persisted vocabulary names for conformance enumeration.
+    pub const ALL_KIND: &'static [&'static str] =
+        &["failed", "dead", "interrupted", "superseded"];
+}
+```
+
+- [ ] **Step 5: Add `CascadeIntent`**
+
+```rust
+/// Returned by `bridge_cancel_cascade` (wrapped in Option). The caller — typically
+/// R3's daemon interrupt dispatcher — performs the actual write to the child
+/// AgentRequest's interrupt_requested_at field. Returning None from
+/// bridge_cancel_cascade means no cascade is required: the bridge tool is
+/// native (no child link), detached (no cascade), or not in .cancelled state.
+#[derive(Clone, Debug)]
+pub struct CascadeIntent {
+    pub child_request_id: String,
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean (six warnings about unused `AwaitMode::ALL`, etc. are expected — they get exercised in Task 19's tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs
+git commit -m "$(cat <<'EOF'
+Add AwaitMode, CancelPolicy, ChildTerminal enums and CascadeIntent struct
+
+AwaitMode (Foreground/Background) and CancelPolicy (Cascade/Detach)
+follow the same as_str/from_persisted/ALL pattern as ToolCallState.
+ChildTerminal carries the four non-.completed terminal projections
+B2 demands; projected_state() implements the Lean projection rule
+(.interrupted → .cancelled, others → .failed).
+CascadeIntent is the pure return type of bridge_cancel_cascade —
+it describes the action the caller must take on the child request.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Extend `ToolCallLifecycle` struct, add `new_subagent` constructor, and new error variants
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle.rs`
+
+- [ ] **Step 1: Add the three new fields to `ToolCallLifecycle`**
+
+Locate the struct (around lines 118-177 per the survey). Add three fields at the end (just before any closing braces, after `failure_class`):
+
+```rust
+pub struct ToolCallLifecycle {
+    // ...existing fields...
+    pub(crate) await_mode: AwaitMode,           // default Foreground
+    pub(crate) cancel_policy: CancelPolicy,     // default Cascade
+    pub(crate) child_request_id: Option<String>, // None = native; Some = subagent invocation
+}
+```
+
+(`pub(crate)` matches the existing field visibility.)
+
+- [ ] **Step 2: Update the existing `new()` constructor**
+
+The existing `new()` constructor doesn't yet set the three new fields. Update it to populate them with defaults so the struct compiles:
+
+```rust
+pub fn new(
+    node: Arc<EmbeddedNode>,
+    session_id: String,
+    tool_call_id: String,
+    message_sequence: u32,
+    tool_name: String,
+    args: String,
+) -> Self {
+    Self {
+        // ...existing field initializers...
+        await_mode: AwaitMode::Foreground,
+        cancel_policy: CancelPolicy::Cascade,
+        child_request_id: None,
+    }
+}
+```
+
+- [ ] **Step 3: Add `new_subagent` constructor**
+
+After the existing `new`:
+
+```rust
+/// Constructor for the subagent invocation path. Sets child_request_id (the
+/// link to the spawned child AgentRequest) and lets the caller pick await_mode
+/// and cancel_policy. Synchronous and does not persist — first transition
+/// (typically start_running) creates the row.
+pub fn new_subagent(
+    node: Arc<EmbeddedNode>,
+    session_id: String,
+    tool_call_id: String,
+    message_sequence: u32,
+    tool_name: String,
+    args: String,
+    await_mode: AwaitMode,
+    cancel_policy: CancelPolicy,
+    child_request_id: String,
+) -> Self {
+    Self {
+        node,
+        session_id,
+        tool_call_id,
+        message_sequence,
+        tool_name,
+        args,
+        doc_id: None,
+        state: ToolCallState::Pending,
+        started_at: None,
+        failure_class: None,
+        await_mode,
+        cancel_policy,
+        child_request_id: Some(child_request_id),
+    }
+}
+```
+
+- [ ] **Step 4: Add the new `IllegalToolCallTransition` variants**
+
+Locate the `IllegalToolCallTransition` enum. Add ten new variants:
+
+```rust
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum IllegalToolCallTransition {
+    // ...existing variants...
+    #[error("await_mode flip rejected: tool already Background")]
+    ModeAlreadyBackground,
+    #[error("await_mode flip rejected: tool already Foreground")]
+    ModeAlreadyForeground,
+    #[error("cancel_policy flip rejected: tool already Detach")]
+    PolicyAlreadyDetach,
+    #[error("bridge_complete called on tool without child_request_id")]
+    BridgeCompleteRequiresChildLink,
+    #[error("bridge_failure called on tool without child_request_id")]
+    BridgeFailureRequiresChildLink,
+    #[error("bridge_cancel_cascade called on tool not in .cancelled state")]
+    CascadeRequiresCancelled,
+    #[error("create_subagent_request rejected: depth exceeds maxSubagentDepth")]
+    SubagentDepthExceeded,
+    #[error("AgentRequest parent linkage incoherent: must set both or neither parent fields")]
+    ParentLinkageIncoherent,
+    #[error("native complete() called on subagent-typed tool (child_request_id is set)")]
+    NativeCompleteOnSubagentTool,
+    #[error("native fail() called on subagent-typed tool (child_request_id is set)")]
+    NativeFailOnSubagentTool,
+}
+```
+
+(Adapt to the existing `thiserror` style if it's already in use; copy the exact attribute pattern from existing variants.)
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean. Some "unused variant" warnings are fine — those go away as later tasks reference each one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs
+git commit -m "$(cat <<'EOF'
+Extend ToolCallLifecycle with subagent fields and new_subagent constructor
+
+Three new fields (await_mode, cancel_policy, child_request_id) with
+defaults that preserve R1's existing semantics for native tools.
+new_subagent constructor sets child_request_id explicitly and lets
+the caller choose await_mode + cancel_policy; first transition still
+creates the persisted row, matching new()'s sync-only contract.
+
+Ten new IllegalToolCallTransition variants cover the new error cases
+exposed by Tasks 8-14.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Add symmetric `h_native` guards to native `complete()` and `fail()`
+
+The Lean inner `complete` constructor requires `childRequestId = none`. Without symmetric Rust guards, a subagent-typed lifecycle could call `complete()` directly and bypass `bridge_complete`'s preconditions.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Locate the existing `complete()` method**
+
+```bash
+grep -n "pub async fn complete\|pub async fn fail" crates/defra-agent/src/tool_call_lifecycle/transition.rs
+```
+
+- [ ] **Step 2: Write a failing test for the new guard on `complete`**
+
+Add to the existing test module in `transition.rs` (or wherever R1's tests live for `complete`):
+
+```rust
+#[tokio::test]
+async fn complete_rejects_subagent_typed_tool() {
+    let lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-1".to_string(),
+        "tc-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-1".to_string(),
+    );
+    // start_running is allowed on subagent-typed tools.
+    let mut lc = lc;
+    lc.start_running().await.unwrap();
+    // complete() must reject because child_request_id is set.
+    let err = lc.complete(test_result()).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::NativeCompleteOnSubagentTool)
+    ));
+}
+```
+
+(`test_node()` and `test_result()` are placeholders — use whatever R1's existing tests use; check R1's `tool_call_lifecycle_conformance.rs` for the actual helper names.)
+
+- [ ] **Step 3: Run the test to confirm it fails**
+
+```bash
+cargo test -p defra-agent --lib complete_rejects_subagent_typed_tool
+```
+
+Expected: FAIL — the current `complete()` doesn't have the guard, so it'll either succeed unexpectedly or fail with a different error.
+
+- [ ] **Step 4: Add the guard to `complete()`**
+
+Find the body of `complete()` (typically around lines 105-147 per the survey). Right after `ensure_state(&[ToolCallState::Running])?` add:
+
+```rust
+if self.child_request_id.is_some() {
+    return Err(IllegalToolCallTransition::NativeCompleteOnSubagentTool.into());
+}
+```
+
+- [ ] **Step 5: Run the test to confirm it passes**
+
+```bash
+cargo test -p defra-agent --lib complete_rejects_subagent_typed_tool
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Repeat Steps 2-5 for `fail()`**
+
+Add a parallel test:
+
+```rust
+#[tokio::test]
+async fn fail_rejects_subagent_typed_tool() {
+    // ...same setup...
+    let err = lc.fail(test_result(), FailureClass::ExternalDependencyFailure).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::NativeFailOnSubagentTool)
+    ));
+}
+```
+
+Run, confirm FAIL, add the guard to `fail()`:
+
+```rust
+if self.child_request_id.is_some() {
+    return Err(IllegalToolCallTransition::NativeFailOnSubagentTool.into());
+}
+```
+
+Run, confirm PASS.
+
+- [ ] **Step 7: Verify the existing native-path tests still pass**
+
+```bash
+cargo test -p defra-agent --lib --test tool_call_lifecycle_conformance
+```
+
+Expected: PASS (no regressions; native tools still complete and fail normally because they have `child_request_id = None`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Add symmetric h_native guards on complete() and fail()
+
+Mirrors Lean's inner complete constructor's h_native precondition
+(Proofs/ToolExecution/Transition.lean:28-33). A subagent-typed
+ToolCallLifecycle (child_request_id = Some) calling complete() or
+fail() now returns NativeCompleteOnSubagentTool or
+NativeFailOnSubagentTool respectively. This forces the bridge path
+(bridge_complete / bridge_failure) to be the only way subagent tools
+reach a terminal state.
+
+Native tools (child_request_id = None) are unaffected; existing R1
+tests pass.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Implement `background()` mode-flip transition
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the test module:
+
+```rust
+#[tokio::test]
+async fn background_flips_await_mode_from_foreground_to_background() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-2".to_string(),
+        "tc-2".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-2".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    assert_eq!(lc.await_mode, AwaitMode::Foreground);
+    lc.background().await.unwrap();
+    assert_eq!(lc.await_mode, AwaitMode::Background);
+
+    // Calling background() again returns ModeAlreadyBackground.
+    let err = lc.background().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::ModeAlreadyBackground)
+    ));
+}
+
+#[tokio::test]
+async fn background_rejects_pending_state() {
+    let mut lc = ToolCallLifecycle::new(/* ...same params, native... */);
+    // Don't start_running; lifecycle is still Pending.
+    let err = lc.background().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::WrongState { .. })
+    ));
+}
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+```bash
+cargo test -p defra-agent --lib background_flips
+cargo test -p defra-agent --lib background_rejects_pending
+```
+
+Expected: FAIL — `background()` doesn't exist yet.
+
+- [ ] **Step 3: Implement `background()`**
+
+In `transition.rs`, after the existing `cancel_during_run` (or wherever fits), add:
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: ToolCallContext.Transition.background.
+    /// Pending|Running stays; await_mode .foreground → .background.
+    /// Persists the new await_mode to the row.
+    pub async fn background(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.await_mode == AwaitMode::Background {
+            return Err(IllegalToolCallTransition::ModeAlreadyBackground.into());
+        }
+        // Persist the change. Mirror the existing UPDATE-via-mutation pattern.
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    docID: "{doc_id}",
+                    input: {{ await_mode: "background" }}
+                ) {{ _docID }}
+            }}"#,
+            doc_id = self
+                .doc_id
+                .as_deref()
+                .ok_or(IllegalToolCallTransition::DocIdMissing)?,
+        );
+        self.execute_mutation_with_retry(&mutation).await?;
+        self.await_mode = AwaitMode::Background;
+        Ok(())
+    }
+}
+```
+
+(The exact mutation string format must match how existing transitions do persistence — read `complete()`'s body for the precise GraphQL escaping pattern, error handling, and retry helper signature. `IllegalToolCallTransition::DocIdMissing` may already exist; if not, add it as a new variant alongside the others.)
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+```bash
+cargo test -p defra-agent --lib background_flips
+cargo test -p defra-agent --lib background_rejects_pending
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify the wider test suite still passes**
+
+```bash
+cargo test -p defra-agent --lib
+```
+
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement background() mode-flip transition
+
+Lean parity: ToolCallContext.Transition.background. Requires Running
+state (ensure_state guard) and Foreground mode (returns
+ModeAlreadyBackground if violated). Persists await_mode = "background"
+via UPDATE mutation, then updates in-memory state on success.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Implement `foreground()` mode-flip transition
+
+Mirror of Task 9 in the opposite direction.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn foreground_flips_await_mode_from_background_to_foreground() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-3".to_string(),
+        "tc-3".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Background,    // start in Background
+        CancelPolicy::Cascade,
+        "child-req-3".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    assert_eq!(lc.await_mode, AwaitMode::Background);
+    lc.foreground().await.unwrap();
+    assert_eq!(lc.await_mode, AwaitMode::Foreground);
+
+    // Calling foreground() again returns ModeAlreadyForeground.
+    let err = lc.foreground().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::ModeAlreadyForeground)
+    ));
+}
+```
+
+- [ ] **Step 2: Run to confirm fail, implement, run to confirm pass**
+
+```bash
+cargo test -p defra-agent --lib foreground_flips
+```
+
+Expected: FAIL.
+
+Implementation in `transition.rs`:
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: ToolCallContext.Transition.foreground.
+    pub async fn foreground(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.await_mode == AwaitMode::Foreground {
+            return Err(IllegalToolCallTransition::ModeAlreadyForeground.into());
+        }
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    docID: "{doc_id}",
+                    input: {{ await_mode: "foreground" }}
+                ) {{ _docID }}
+            }}"#,
+            doc_id = self
+                .doc_id
+                .as_deref()
+                .ok_or(IllegalToolCallTransition::DocIdMissing)?,
+        );
+        self.execute_mutation_with_retry(&mutation).await?;
+        self.await_mode = AwaitMode::Foreground;
+        Ok(())
+    }
+}
+```
+
+```bash
+cargo test -p defra-agent --lib foreground_flips
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement foreground() mode-flip transition
+
+Symmetric to background(): Running state + Background mode → Foreground.
+Returns ModeAlreadyForeground if already Foreground.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Implement `detach()` policy transition
+
+Pending|Running → flip cancel_policy from Cascade to Detach. One-way (no `cascade()` method, mirroring Lean's structural irreversibility).
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn detach_flips_cancel_policy_one_way() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-4".to_string(),
+        "tc-4".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-4".to_string(),
+    );
+    // detach() is allowed in Pending too — mirror the Lean transition's h_live
+    // that allows .pending OR .running.
+    assert_eq!(lc.cancel_policy, CancelPolicy::Cascade);
+    lc.detach().await.unwrap();
+    assert_eq!(lc.cancel_policy, CancelPolicy::Detach);
+
+    // Calling detach() again returns PolicyAlreadyDetach.
+    let err = lc.detach().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::PolicyAlreadyDetach)
+    ));
+}
+```
+
+- [ ] **Step 2: Run, confirm fail, implement**
+
+```bash
+cargo test -p defra-agent --lib detach_flips
+```
+
+Expected: FAIL.
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: ToolCallContext.Transition.detach. Pending|Running stays;
+    /// cancel_policy .cascade → .detach. One-way — no inverse method.
+    pub async fn detach(&mut self) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Pending, ToolCallState::Running])?;
+        if self.cancel_policy == CancelPolicy::Detach {
+            return Err(IllegalToolCallTransition::PolicyAlreadyDetach.into());
+        }
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    docID: "{doc_id}",
+                    input: {{ cancel_policy: "detach" }}
+                ) {{ _docID }}
+            }}"#,
+            doc_id = self
+                .doc_id
+                .as_deref()
+                .ok_or(IllegalToolCallTransition::DocIdMissing)?,
+        );
+        self.execute_mutation_with_retry(&mutation).await?;
+        self.cancel_policy = CancelPolicy::Detach;
+        Ok(())
+    }
+}
+```
+
+```bash
+cargo test -p defra-agent --lib detach_flips
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement detach() policy-change transition
+
+Lean parity: ToolCallContext.Transition.detach. Pending|Running stays;
+cancel_policy .cascade → .detach. One-way (no cascade() method —
+matches Lean's structural irreversibility).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Implement `bridge_complete()`
+
+Parent tool .running → .completed when the linked child request has reached .completed. Trust boundary: caller verifies child state.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+#[tokio::test]
+async fn bridge_complete_transitions_running_to_completed() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-5".to_string(),
+        "tc-5".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-5".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    let result = "child final assistant message".to_string();
+    lc.bridge_complete(result.clone()).await.unwrap();
+    assert_eq!(lc.state, ToolCallState::Completed);
+    // Verify result was persisted — read back via load() if available.
+    // (Bucket 3 will exercise the persistence end-to-end in Task 25.)
+}
+
+#[tokio::test]
+async fn bridge_complete_rejects_native_tool() {
+    let mut lc = ToolCallLifecycle::new(/* ...native, no child_request_id... */);
+    lc.start_running().await.unwrap();
+    let err = lc.bridge_complete("x".to_string()).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::BridgeCompleteRequiresChildLink)
+    ));
+}
+```
+
+- [ ] **Step 2: Run, confirm fail, implement**
+
+```bash
+cargo test -p defra-agent --lib bridge_complete
+```
+
+Expected: FAIL.
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: bridge_complete. Parent tool .running → .completed when the
+    /// linked child request has reached .completed (caller verifies). Persists
+    /// child_result as the row's `result` field; sets state, completed_at,
+    /// latency_ms following R1's complete() persistence pattern.
+    pub async fn bridge_complete(&mut self, child_result: String) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.child_request_id.is_none() {
+            return Err(IllegalToolCallTransition::BridgeCompleteRequiresChildLink.into());
+        }
+        // Mirror complete()'s persistence pattern, but write state="completed"
+        // alongside the result. Read R1's complete() body for the exact mutation
+        // shape (latency_ms = now - started_at; completed_at = now; etc.).
+        let now = chrono::Utc::now();
+        let latency_ms = self
+            .started_at
+            .map(|s| (now - s).num_milliseconds())
+            .unwrap_or(0);
+        let escaped_result = graphql::escape_graphql_string(&child_result);
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    docID: "{doc_id}",
+                    input: {{
+                        lifecycle_state: "completed",
+                        result: "{result}",
+                        completed_at: "{completed_at}",
+                        latency_ms: {latency_ms}
+                    }}
+                ) {{ _docID }}
+            }}"#,
+            doc_id = self
+                .doc_id
+                .as_deref()
+                .ok_or(IllegalToolCallTransition::DocIdMissing)?,
+            result = escaped_result,
+            completed_at = now.to_rfc3339(),
+            latency_ms = latency_ms,
+        );
+        self.execute_mutation_with_retry(&mutation).await?;
+        self.state = ToolCallState::Completed;
+        Ok(())
+    }
+}
+```
+
+If `graphql::escape_graphql_string` lives at a different path, find it via `grep -rn "escape_graphql_string" crates/defra-agent/src/` and use the actual import path.
+
+```bash
+cargo test -p defra-agent --lib bridge_complete
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement bridge_complete() bridge transition
+
+Lean parity: bridge_complete. Parent tool .running → .completed when
+the caller has verified the linked child request reached .completed.
+Persists child_result, completed_at, latency_ms following R1's
+complete() pattern. Returns BridgeCompleteRequiresChildLink for tools
+without a child_request_id.
+
+Trust boundary: bridge_complete does NOT verify the child's terminal
+state internally (Lean's precondition is on the caller). R3's
+SubagentSource will be the natural place for that check.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Implement `bridge_failure()`
+
+Parent tool .running → .failed (or .cancelled for child .interrupted) per the `ChildTerminal::projected_state()` rule.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing tests for the four projection cases**
+
+```rust
+#[tokio::test]
+async fn bridge_failure_failed_projects_to_failed() {
+    let mut lc = make_running_subagent_tool().await;
+    lc.bridge_failure(ChildTerminal::Failed {
+        reason: "child failed".to_string(),
+        failure_class: FailureClass::ExternalDependencyFailure,
+    }).await.unwrap();
+    assert_eq!(lc.state, ToolCallState::Failed);
+    assert_eq!(lc.failure_class, Some(FailureClass::ExternalDependencyFailure));
+}
+
+#[tokio::test]
+async fn bridge_failure_dead_projects_to_failed() {
+    let mut lc = make_running_subagent_tool().await;
+    lc.bridge_failure(ChildTerminal::Dead).await.unwrap();
+    assert_eq!(lc.state, ToolCallState::Failed);
+}
+
+#[tokio::test]
+async fn bridge_failure_interrupted_projects_to_cancelled() {
+    let mut lc = make_running_subagent_tool().await;
+    lc.bridge_failure(ChildTerminal::Interrupted).await.unwrap();
+    assert_eq!(lc.state, ToolCallState::Cancelled);
+}
+
+#[tokio::test]
+async fn bridge_failure_superseded_projects_to_failed() {
+    let mut lc = make_running_subagent_tool().await;
+    lc.bridge_failure(ChildTerminal::Superseded).await.unwrap();
+    assert_eq!(lc.state, ToolCallState::Failed);
+}
+
+#[tokio::test]
+async fn bridge_failure_rejects_native_tool() {
+    let mut lc = make_running_native_tool().await;
+    let err = lc.bridge_failure(ChildTerminal::Dead).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::BridgeFailureRequiresChildLink)
+    ));
+}
+
+// helpers
+async fn make_running_subagent_tool() -> ToolCallLifecycle {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        format!("sess-{}", uuid::Uuid::new_v4()),
+        format!("tc-{}", uuid::Uuid::new_v4()),
+        1, "spawn_subagent".to_string(), "{}".to_string(),
+        AwaitMode::Foreground, CancelPolicy::Cascade,
+        format!("child-req-{}", uuid::Uuid::new_v4()),
+    );
+    lc.start_running().await.unwrap();
+    lc
+}
+
+async fn make_running_native_tool() -> ToolCallLifecycle {
+    let mut lc = ToolCallLifecycle::new(
+        test_node().await,
+        format!("sess-{}", uuid::Uuid::new_v4()),
+        format!("tc-{}", uuid::Uuid::new_v4()),
+        1, "echo".to_string(), "{}".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc
+}
+```
+
+- [ ] **Step 2: Run, confirm fail, implement**
+
+```bash
+cargo test -p defra-agent --lib bridge_failure
+```
+
+Expected: FAIL on all five tests.
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: bridge_failure. Parent tool .running → .failed (or .cancelled
+    /// for ChildTerminal::Interrupted). Projection per
+    /// ChildTerminal::projected_state(). Persists state, failure_class (if
+    /// applicable), and reason.
+    pub async fn bridge_failure(&mut self, child_terminal: ChildTerminal) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.child_request_id.is_none() {
+            return Err(IllegalToolCallTransition::BridgeFailureRequiresChildLink.into());
+        }
+        let projected = child_terminal.projected_state();
+        let (failure_class_for_persist, reason_for_persist) = match &child_terminal {
+            ChildTerminal::Failed { reason, failure_class } => (Some(*failure_class), Some(reason.clone())),
+            _ => (None, None),
+        };
+
+        let now = chrono::Utc::now();
+        let escaped_reason = reason_for_persist
+            .as_deref()
+            .map(graphql::escape_graphql_string)
+            .unwrap_or_default();
+        let failure_class_persist = failure_class_for_persist
+            .map(|fc| format!(r#", tool_failure_class: "{}""#, fc.as_str()))
+            .unwrap_or_default();
+        let result_persist = if !escaped_reason.is_empty() {
+            format!(r#", result: "{}""#, escaped_reason)
+        } else {
+            String::new()
+        };
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    docID: "{doc_id}",
+                    input: {{
+                        lifecycle_state: "{state_str}",
+                        completed_at: "{completed_at}"
+                        {failure_class_persist}
+                        {result_persist}
+                    }}
+                ) {{ _docID }}
+            }}"#,
+            doc_id = self
+                .doc_id
+                .as_deref()
+                .ok_or(IllegalToolCallTransition::DocIdMissing)?,
+            state_str = projected.as_str(),
+            completed_at = now.to_rfc3339(),
+            failure_class_persist = failure_class_persist,
+            result_persist = result_persist,
+        );
+        self.execute_mutation_with_retry(&mutation).await?;
+        self.state = projected;
+        self.failure_class = failure_class_for_persist;
+        Ok(())
+    }
+}
+```
+
+```bash
+cargo test -p defra-agent --lib bridge_failure
+```
+
+Expected: all five PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement bridge_failure() bridge transition with B2 projection
+
+Lean parity: bridge_failure. ChildTerminal::Failed/Dead/Superseded
+project to ToolCallState::Failed; ChildTerminal::Interrupted projects
+to ToolCallState::Cancelled (matches Lean B2's projection rule).
+Failed variant carries reason + failure_class; the others carry
+neither. Returns BridgeFailureRequiresChildLink for native tools.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Implement `bridge_cancel_cascade()`
+
+Pure (no DB writes); returns `Option<CascadeIntent>`. Caller (R3's daemon dispatcher) executes the cascade write.
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/transition.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test]
+async fn bridge_cancel_cascade_returns_intent_for_cascade_subagent() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await,
+        "sess-c1".to_string(), "tc-c1".to_string(), 1,
+        "spawn_subagent".to_string(), "{}".to_string(),
+        AwaitMode::Foreground, CancelPolicy::Cascade,
+        "child-req-c1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();   // forces .cancelled
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    let intent = intent.expect("should return Some(CascadeIntent)");
+    assert_eq!(intent.child_request_id, "child-req-c1");
+}
+
+#[tokio::test]
+async fn bridge_cancel_cascade_returns_none_for_detached() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await, "sess-c2".to_string(), "tc-c2".to_string(), 1,
+        "spawn_subagent".to_string(), "{}".to_string(),
+        AwaitMode::Foreground, CancelPolicy::Detach,
+        "child-req-c2".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_none(), "Detach policy returns None");
+}
+
+#[tokio::test]
+async fn bridge_cancel_cascade_returns_none_for_native() {
+    let mut lc = ToolCallLifecycle::new(
+        test_node().await, "sess-c3".to_string(), "tc-c3".to_string(), 1,
+        "echo".to_string(), "{}".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_none(), "Native tool (no child_request_id) returns None");
+}
+
+#[tokio::test]
+async fn bridge_cancel_cascade_rejects_non_cancelled_state() {
+    let mut lc = ToolCallLifecycle::new_subagent(
+        test_node().await, "sess-c4".to_string(), "tc-c4".to_string(), 1,
+        "spawn_subagent".to_string(), "{}".to_string(),
+        AwaitMode::Foreground, CancelPolicy::Cascade,
+        "child-req-c4".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    // state is Running, not Cancelled.
+    let err = lc.bridge_cancel_cascade().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::CascadeRequiresCancelled)
+    ));
+}
+```
+
+- [ ] **Step 2: Run, confirm fail, implement**
+
+```bash
+cargo test -p defra-agent --lib bridge_cancel_cascade
+```
+
+Expected: FAIL on all four.
+
+```rust
+impl ToolCallLifecycle {
+    /// Lean parity: bridge_cancel_cascade. Pure — returns the action that should
+    /// be taken on the child AgentRequest. Caller (typically R3's daemon
+    /// interrupt dispatcher) performs the actual write to set
+    /// interrupt_requested_at on the child. Returns None for native tools,
+    /// detached subagents, or non-cancelled bridge tools.
+    pub async fn bridge_cancel_cascade(&self) -> Result<Option<CascadeIntent>> {
+        if self.state != ToolCallState::Cancelled {
+            return Err(IllegalToolCallTransition::CascadeRequiresCancelled.into());
+        }
+        if self.cancel_policy != CancelPolicy::Cascade {
+            return Ok(None); // detached: no cascade
+        }
+        let Some(child_request_id) = self.child_request_id.clone() else {
+            return Ok(None); // native: no bridge edge
+        };
+        Ok(Some(CascadeIntent {
+            child_request_id,
+            at: chrono::Utc::now(),
+        }))
+    }
+}
+```
+
+```bash
+cargo test -p defra-agent --lib bridge_cancel_cascade
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/transition.rs
+git commit -m "$(cat <<'EOF'
+Implement bridge_cancel_cascade() pure return-intent transition
+
+Lean parity: bridge_cancel_cascade. Returns Option<CascadeIntent>:
+- Some(CascadeIntent { child_request_id, at }) for cancelled
+  cascade-mode subagent tools
+- None for detached subagents
+- None for native tools (no child link)
+- Err(CascadeRequiresCancelled) for non-cancelled state
+
+Pure: no DB writes. R3's daemon interrupt dispatcher consumes the
+intent to set interrupt_requested_at on the child AgentRequest.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Extend `AgentRequestRow` and `AgentRequest` DAO structs
+
+**Files:**
+- Modify: `crates/defra-agent/src/watcher.rs:19` (the `AgentRequest` struct)
+- Modify: `crates/defra-agent/src/watcher/query.rs:93` (the `AgentRequestRow` struct)
+
+- [ ] **Step 1: Locate and extend `AgentRequest`**
+
+```bash
+grep -n "pub struct AgentRequest" crates/defra-agent/src/watcher.rs
+```
+
+Add three new fields to the struct (matching the GraphQL schema):
+
+```rust
+pub struct AgentRequest {
+    // ...existing fields...
+    pub subagent_depth: u32,
+    pub caused_by_parent_request_id: Option<String>,
+    pub caused_by_parent_tool_call_id: Option<String>,
+}
+```
+
+- [ ] **Step 2: Extend `AgentRequestRow`**
+
+In `crates/defra-agent/src/watcher/query.rs`:
+
+```rust
+pub struct AgentRequestRow {
+    // ...existing fields...
+    pub subagent_depth: Option<u32>,            // Option because v2 rows have null
+    pub caused_by_parent_request_id: Option<String>,
+    pub caused_by_parent_tool_call_id: Option<String>,
+}
+```
+
+(Use `Option<u32>` not `u32` to absorb any genuine nulls from the database during the migration window. Convert to `u32::default()` (= 0) when materializing into the public `AgentRequest` struct.)
+
+- [ ] **Step 3: Update the GraphQL query string that reads AgentRequest rows**
+
+```bash
+grep -n "request_id\|agent_did" crates/defra-agent/src/watcher/query.rs | head -10
+```
+
+Find the GraphQL query (typically a const string with the field list). Add the three new fields to the SELECT-style projection:
+
+```rust
+const AGENT_REQUEST_QUERY: &str = r#"
+    query {
+        AgentRequest {
+            request_id
+            agent_did
+            // ...existing field list...
+            subagent_depth
+            caused_by_parent_request_id
+            caused_by_parent_tool_call_id
+        }
+    }
+"#;
+```
+
+(Adapt to the actual query syntax in this file.)
+
+- [ ] **Step 4: Update the row→struct conversion**
+
+Find where `AgentRequestRow` becomes `AgentRequest`. Add field forwarding:
+
+```rust
+impl From<AgentRequestRow> for AgentRequest {
+    fn from(row: AgentRequestRow) -> Self {
+        Self {
+            // ...existing field forwarding...
+            subagent_depth: row.subagent_depth.unwrap_or(0),
+            caused_by_parent_request_id: row.caused_by_parent_request_id,
+            caused_by_parent_tool_call_id: row.caused_by_parent_tool_call_id,
+        }
+    }
+}
+```
+
+(The conversion function may not exist in this exact form; adapt to the existing pattern in `query.rs`.)
+
+- [ ] **Step 5: Verify compilation**
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/watcher.rs crates/defra-agent/src/watcher/query.rs
+git commit -m "$(cat <<'EOF'
+Extend AgentRequestRow and AgentRequest with subagent fields
+
+Three new fields (subagent_depth: u32, caused_by_parent_request_id,
+caused_by_parent_tool_call_id) flow from the v3 schema through the
+GraphQL query string into AgentRequestRow (Option types absorb v2-row
+nulls during migration window) and into the public AgentRequest
+struct (defaults to depth=0 + None for top-level).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Extend `ToolSelectionDocument` and add apply-time well-formedness validation
+
+**Files:**
+- Modify: `crates/defra-agent/src/document_config/tool_selection.rs`
+
+- [ ] **Step 1: Add the four new optional fields to the struct**
+
+```rust
+pub struct ToolSelectionDocument {
+    // ...existing fields...
+    pub subagent_targets: Option<Vec<String>>,
+    pub subagent_spawn_enabled: Option<bool>,
+    pub subagent_steering_enabled: Option<bool>,
+    pub subagent_background_enabled: Option<bool>,
+}
+```
+
+- [ ] **Step 2: Update the deserialization / row materialization**
+
+Find the function that reads `ToolSelectionDocument` from a DefraDB row (likely a `From<...>` or a query handler). Add the four new fields to the materialization. Read the existing pattern for `delegate_to: Option<Vec<String>>` and copy it for `subagent_targets`; copy the boolean pattern from `enable_file_tools` for the three new booleans.
+
+- [ ] **Step 3: Write a failing test for well-formedness validation**
+
+Add to the test module in `tool_selection.rs`:
+
+```rust
+#[test]
+fn validate_rejects_empty_string_in_subagent_targets() {
+    let doc = ToolSelectionDocument {
+        // ...minimal valid baseline...
+        subagent_targets: Some(vec!["".to_string()]),
+        subagent_spawn_enabled: Some(true),
+        ..Default::default()
+    };
+    let result = doc.validate();
+    assert!(result.is_err());
+    assert!(format!("{}", result.unwrap_err()).contains("subagent_targets"));
+}
+
+#[test]
+fn validate_accepts_well_formed_subagent_targets() {
+    let doc = ToolSelectionDocument {
+        // ...minimal valid baseline...
+        subagent_targets: Some(vec!["amy-code".to_string(), "amy-research".to_string()]),
+        subagent_spawn_enabled: Some(true),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(true),
+        ..Default::default()
+    };
+    assert!(doc.validate().is_ok());
+}
+```
+
+(If `ToolSelectionDocument` doesn't already implement `Default`, mock the baseline struct instance directly with all fields.)
+
+- [ ] **Step 4: Run, confirm fail, implement validation**
+
+```bash
+cargo test -p defra-agent --lib validate_rejects_empty_string_in_subagent_targets
+```
+
+Expected: FAIL — `validate()` doesn't exist or doesn't check.
+
+If a `validate()` method already exists on `ToolSelectionDocument`, extend it with:
+
+```rust
+pub fn validate(&self) -> Result<()> {
+    // ...existing validations...
+    if let Some(targets) = &self.subagent_targets {
+        for (i, target) in targets.iter().enumerate() {
+            if target.is_empty() {
+                return Err(anyhow!(
+                    "subagent_targets[{}] is empty; behavior IDs must be non-empty strings",
+                    i
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+If `validate()` does NOT exist, add it with just the new check (the existing flow probably validates implicitly via row deserialization).
+
+```bash
+cargo test -p defra-agent --lib validate_rejects_empty_string_in_subagent_targets
+cargo test -p defra-agent --lib validate_accepts_well_formed_subagent_targets
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/src/document_config/tool_selection.rs
+git commit -m "$(cat <<'EOF'
+Extend ToolSelectionDocument with subagent fields and well-formedness validation
+
+Four new optional fields: subagent_targets (Vec<String>), and three
+boolean flags (spawn / steering / background). Apply-time validation
+rejects empty strings in subagent_targets — the cross-reference check
+(target resolves to a real AgentBehavior) is deferred to R3.
+
+The three booleans are independent: enabling steering does not
+require enabling spawn (R3's policy enforcement layer can add
+cross-flag invariants if needed).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Add AgentRequest parent-linkage coherence validation
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/document_view/apply.rs` (or wherever AgentRequest validation lives — find via grep)
+
+- [ ] **Step 1: Locate the apply-time validation site for AgentRequest**
+
+```bash
+grep -rn "AgentRequest" crates/defra-agent/src/agent/document_view/ | head -10
+grep -rn "fn apply_control_update\|fn validate_agent_request\|fn load_agent_request" crates/defra-agent/src/ | head -10
+```
+
+R2's spec (Section "AgentRequest → Apply-time validation") says this lives in `apply.rs`. If it's elsewhere, pin the actual location.
+
+- [ ] **Step 2: Write a failing test for coherence validation**
+
+Pick an appropriate test file. If there's an existing AgentRequest validation test, append to it; otherwise create one. Suggested location: `crates/defra-agent/src/agent/document_view/apply.rs` (inline tests):
+
+```rust
+#[test]
+fn validate_rejects_mixed_parent_linkage_request_id_only() {
+    let req = AgentRequest {
+        // ...minimal valid baseline...
+        subagent_depth: 1,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: None,    // missing
+        // ...
+    };
+    let result = validate_agent_request_subagent_coherence(&req);
+    assert!(result.is_err());
+}
+
+#[test]
+fn validate_rejects_mixed_parent_linkage_tool_call_id_only() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        // ...
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_err());
+}
+
+#[test]
+fn validate_rejects_subagent_depth_zero_with_parent_fields() {
+    let req = AgentRequest {
+        subagent_depth: 0,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        // ...
+    };
+    // depth=0 means top-level, but parent fields are set → incoherent.
+    assert!(validate_agent_request_subagent_coherence(&req).is_err());
+}
+
+#[test]
+fn validate_accepts_top_level_request() {
+    let req = AgentRequest {
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
+        // ...
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_ok());
+}
+
+#[test]
+fn validate_accepts_subagent_request() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: Some("parent-tc-1".to_string()),
+        // ...
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_ok());
+}
+```
+
+- [ ] **Step 3: Run, confirm fail, implement**
+
+```bash
+cargo test -p defra-agent --lib validate_rejects_mixed_parent_linkage
+```
+
+Expected: FAIL.
+
+```rust
+/// Coherence check on AgentRequest's subagent fields:
+/// - caused_by_parent_request_id and caused_by_parent_tool_call_id must be
+///   set together (both Some) or together (both None).
+/// - subagent_depth = 0 ↔ both parent fields are None.
+pub fn validate_agent_request_subagent_coherence(req: &AgentRequest) -> Result<()> {
+    let has_parent_req = req.caused_by_parent_request_id.is_some();
+    let has_parent_tc = req.caused_by_parent_tool_call_id.is_some();
+    if has_parent_req != has_parent_tc {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    let is_top_level = !has_parent_req; // both None
+    if is_top_level && req.subagent_depth != 0 {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    if !is_top_level && req.subagent_depth == 0 {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+    Ok(())
+}
+```
+
+Wire this function into the existing AgentRequest validation flow (probably called during `apply_control_update` or in the watcher's row materialization).
+
+```bash
+cargo test -p defra-agent --lib validate_
+```
+
+Expected: all five PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/document_view/apply.rs
+git commit -m "$(cat <<'EOF'
+Add AgentRequest parent-linkage coherence validation
+
+Apply-time check: caused_by_parent_request_id and
+caused_by_parent_tool_call_id are set together or neither;
+subagent_depth = 0 ↔ both parent fields are None.
+
+Mixed states return IllegalToolCallTransition::ParentLinkageIncoherent.
+
+Cross-reference validation (does parent_request_id point to a real
+AgentRequest?) remains deferred to R3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Implement `create_subagent_request` helper
+
+Public API for creating parent-linked child AgentRequests. Used by R3's SubagentSource and by Bucket 3 conformance fixtures.
+
+**Files:**
+- Create: `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs`
+- Modify: `crates/defra-agent/src/tool_call_lifecycle.rs` (re-export module)
+
+- [ ] **Step 1: Create the new module file**
+
+Write `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs`:
+
+```rust
+//! Helper for creating subagent-parent-linked AgentRequest rows.
+//! Public API surface consumed by R3's SubagentSource and by Bucket 3
+//! conformance fixtures.
+
+use std::sync::Arc;
+use anyhow::{anyhow, Result};
+use defra_node::EmbeddedNode;
+use crate::tool_call_lifecycle::IllegalToolCallTransition;
+
+/// The configured cap on subagent recursion depth. Matches Lean's
+/// `Subagent.maxSubagentDepth = 3`.
+pub const MAX_SUBAGENT_DEPTH: u32 = 3;
+
+/// Create a new AgentRequest with subagent parent linkage. Validates:
+/// - parent_subagent_depth + 1 ≤ MAX_SUBAGENT_DEPTH (returns SubagentDepthExceeded)
+/// - parent_request_id and parent_tool_call_id are both non-empty (returns
+///   ParentLinkageIncoherent if either is empty)
+///
+/// Returns the new request_id (the unique identifier of the freshly-created
+/// AgentRequest row).
+pub async fn create_subagent_request(
+    node: Arc<EmbeddedNode>,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<chrono::DateTime<chrono::Utc>>,
+    // Add additional fields here that the existing CREATE-AgentRequest flow expects
+    // (e.g., agent_did, session_id, etc.). Read the existing creation flow in
+    // crates/defra-agent/src/agent/ for the full param list.
+) -> Result<String> {
+    // 1. Depth check.
+    if parent_subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
+        return Err(IllegalToolCallTransition::SubagentDepthExceeded.into());
+    }
+
+    // 2. Coherence check.
+    if parent_request_id.is_empty() || parent_tool_call_id.is_empty() {
+        return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
+    }
+
+    // 3. Generate a fresh request_id (mirror existing pattern — likely uuid::Uuid).
+    let new_request_id = format!("req-{}", uuid::Uuid::new_v4());
+    let new_subagent_depth = parent_subagent_depth + 1;
+
+    // 4. Build and execute the CREATE mutation.
+    let escaped_prompt = crate::graphql::escape_graphql_string(&prompt);
+    let deadline_str = deadline
+        .map(|d| format!(r#", deadline: "{}""#, d.to_rfc3339()))
+        .unwrap_or_default();
+
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{rid}",
+                behavior_id: "{bid}",
+                prompt: "{prompt}",
+                subagent_depth: {depth},
+                caused_by_parent_request_id: "{prid}",
+                caused_by_parent_tool_call_id: "{ptcid}",
+                lifecycle_state: "pending"
+                {deadline_str}
+            }}) {{ _docID }}
+        }}"#,
+        rid = new_request_id,
+        bid = behavior_id,
+        prompt = escaped_prompt,
+        depth = new_subagent_depth,
+        prid = parent_request_id,
+        ptcid = parent_tool_call_id,
+        deadline_str = deadline_str,
+    );
+
+    // 5. Execute (mirror the existing GraphQL mutation pattern from R1's
+    // ToolCallLifecycle::start_running for retry semantics, error handling).
+    crate::graphql::execute_mutation(&node, &mutation).await?;
+
+    Ok(new_request_id)
+}
+```
+
+The exact list of additional CREATE-AgentRequest input fields varies by what already exists; read the production AgentRequest creation path (search `grep -rn "create_AgentRequest" crates/defra-agent/src/`) and match its full input shape.
+
+- [ ] **Step 2: Add the `pub mod subagent_request;` line**
+
+In `crates/defra-agent/src/tool_call_lifecycle.rs`, near the other module declarations:
+
+```rust
+pub mod subagent_request;
+```
+
+Re-export the helper at the crate root if R1 has a `pub use` pattern for `ToolCallLifecycle`:
+
+```rust
+pub use subagent_request::{create_subagent_request, MAX_SUBAGENT_DEPTH};
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+Append to `subagent_request.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn create_subagent_request_at_max_depth_succeeds() {
+        let node = test_node().await;
+        let new_id = create_subagent_request(
+            node, "parent-req".to_string(), "parent-tc".to_string(),
+            MAX_SUBAGENT_DEPTH - 1,    // ok: + 1 = MAX
+            "behavior-1".to_string(), "test prompt".to_string(),
+            None,
+        ).await.unwrap();
+        assert!(new_id.starts_with("req-"));
+    }
+
+    #[tokio::test]
+    async fn create_subagent_request_above_max_depth_fails() {
+        let node = test_node().await;
+        let err = create_subagent_request(
+            node, "parent-req".to_string(), "parent-tc".to_string(),
+            MAX_SUBAGENT_DEPTH,    // not ok: + 1 > MAX
+            "behavior-1".to_string(), "test prompt".to_string(),
+            None,
+        ).await.unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::SubagentDepthExceeded)
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_subagent_request_empty_parent_fields_fails() {
+        let node = test_node().await;
+        let err = create_subagent_request(
+            node, "".to_string(), "parent-tc".to_string(),
+            0, "behavior-1".to_string(), "p".to_string(), None,
+        ).await.unwrap_err();
+        assert!(matches!(
+            err.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::ParentLinkageIncoherent)
+        ));
+    }
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+cargo test -p defra-agent --lib subagent_request::tests
+```
+
+Expected: all three PASS (the depth and coherence cases at minimum; the success case requires a working `test_node()` and a valid CREATE mutation, so adapt as needed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs \
+        crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+git commit -m "$(cat <<'EOF'
+Add create_subagent_request helper
+
+Public API for creating parent-linked child AgentRequest rows.
+Validates depth + 1 ≤ MAX_SUBAGENT_DEPTH (3) and parent linkage
+coherence (both parent fields non-empty). Used by R3's SubagentSource
+and by Bucket 3 conformance fixtures.
+
+The MAX_SUBAGENT_DEPTH constant is exported as part of R2's public
+API surface so R3's apply-time spawn-flow validation can reference
+the same value as the Lean spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: Bucket 1 — vocabulary round-trip in-module tests
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle.rs` (append to existing test module)
+
+- [ ] **Step 1: Add the round-trip + closure tests**
+
+In the test module of `tool_call_lifecycle.rs`:
+
+```rust
+#[cfg(test)]
+mod bucket_1_subagent_vocabulary {
+    use super::*;
+
+    #[test]
+    fn await_mode_round_trip_via_persisted_vocab() {
+        for &mode in AwaitMode::ALL {
+            assert_eq!(AwaitMode::from_persisted(mode.as_str()), Some(mode));
+        }
+    }
+
+    #[test]
+    fn await_mode_all_has_two_variants() {
+        assert_eq!(AwaitMode::ALL.len(), 2);
+    }
+
+    #[test]
+    fn await_mode_from_persisted_unknown_returns_none() {
+        assert_eq!(AwaitMode::from_persisted("unknown"), None);
+    }
+
+    #[test]
+    fn cancel_policy_round_trip_via_persisted_vocab() {
+        for &policy in CancelPolicy::ALL {
+            assert_eq!(CancelPolicy::from_persisted(policy.as_str()), Some(policy));
+        }
+    }
+
+    #[test]
+    fn cancel_policy_all_has_two_variants() {
+        assert_eq!(CancelPolicy::ALL.len(), 2);
+    }
+
+    #[test]
+    fn cancel_policy_from_persisted_unknown_returns_none() {
+        assert_eq!(CancelPolicy::from_persisted("unknown"), None);
+    }
+
+    #[test]
+    fn child_terminal_all_kind_has_four_variants() {
+        assert_eq!(ChildTerminal::ALL_KIND.len(), 4);
+        assert_eq!(
+            ChildTerminal::ALL_KIND,
+            &["failed", "dead", "interrupted", "superseded"]
+        );
+    }
+
+    #[test]
+    fn child_terminal_projection_partition() {
+        // .interrupted → .cancelled; everything else → .failed
+        assert_eq!(
+            ChildTerminal::Failed {
+                reason: "x".to_string(),
+                failure_class: FailureClass::ExternalDependencyFailure
+            }.projected_state(),
+            ToolCallState::Failed
+        );
+        assert_eq!(ChildTerminal::Dead.projected_state(), ToolCallState::Failed);
+        assert_eq!(ChildTerminal::Interrupted.projected_state(), ToolCallState::Cancelled);
+        assert_eq!(ChildTerminal::Superseded.projected_state(), ToolCallState::Failed);
+    }
+}
+```
+
+- [ ] **Step 2: Run all eight tests**
+
+```bash
+cargo test -p defra-agent --lib bucket_1_subagent_vocabulary
+```
+
+Expected: all eight PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs
+git commit -m "$(cat <<'EOF'
+Add Bucket 1 — vocabulary round-trip tests for new types
+
+Eight in-module tests:
+- AwaitMode and CancelPolicy round-trip (as_str ↔ from_persisted)
+- AwaitMode::ALL.len() == 2; CancelPolicy::ALL.len() == 2
+- ChildTerminal::ALL_KIND has 4 variants matching the spec
+- ChildTerminal::projected_state partition (Interrupted →
+  Cancelled, others → Failed) matches Lean B2
+
+These run as part of `cargo test -p defra-agent --lib`.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Bucket 2 — extend `state_machine_conformance.rs` for the new transitions
+
+**Files:**
+- Modify: `crates/defra-agent/tests/state_machine_conformance.rs`
+
+- [ ] **Step 1: Read R1's existing Bucket 2 structure**
+
+```bash
+sed -n '1,60p' crates/defra-agent/tests/state_machine_conformance.rs
+```
+
+Note how R1 consumes the Lean-emitted JSON (typically a const path or a `lean_vocab_test` helper module). The new transitions and vocabularies emitted in Task 0 should appear in that JSON.
+
+- [ ] **Step 2: Add transition-matrix conformance tests**
+
+Append to `state_machine_conformance.rs`:
+
+```rust
+#[test]
+fn lean_emits_await_mode_vocabulary() {
+    let contract = load_lean_contract();
+    let machine = contract.machines.iter()
+        .find(|m| m.name == "AwaitMode")
+        .expect("Lean contract must emit AwaitMode machine");
+    let mut rust_vocab: Vec<&str> = AwaitMode::ALL.iter().map(|m| m.as_str()).collect();
+    rust_vocab.sort();
+    let mut lean_vocab = machine.vocabulary.clone();
+    lean_vocab.sort();
+    assert_eq!(lean_vocab, rust_vocab,
+        "AwaitMode vocabulary divergence between Lean and Rust");
+}
+
+#[test]
+fn lean_emits_cancel_policy_vocabulary() {
+    let contract = load_lean_contract();
+    let machine = contract.machines.iter()
+        .find(|m| m.name == "CancelPolicy")
+        .expect("Lean contract must emit CancelPolicy machine");
+    let mut rust_vocab: Vec<&str> = CancelPolicy::ALL.iter().map(|p| p.as_str()).collect();
+    rust_vocab.sort();
+    let mut lean_vocab = machine.vocabulary.clone();
+    lean_vocab.sort();
+    assert_eq!(lean_vocab, rust_vocab);
+}
+
+#[test]
+fn lean_emits_child_terminal_vocabulary_and_projections() {
+    let contract = load_lean_contract();
+    let machine = contract.machines.iter()
+        .find(|m| m.name == "ChildTerminal")
+        .expect("Lean contract must emit ChildTerminal machine");
+    // Vocabulary check
+    let mut lean_vocab = machine.vocabulary.clone();
+    lean_vocab.sort();
+    let mut rust_vocab = ChildTerminal::ALL_KIND.to_vec();
+    rust_vocab.sort();
+    assert_eq!(lean_vocab, rust_vocab.iter().map(|s| s.to_string()).collect::<Vec<_>>());
+    // Projection check (each transition's `from`/`to` must match Rust's projected_state)
+    for t in &machine.transitions {
+        let rust_terminal = match t.from.as_str() {
+            "failed" => ChildTerminal::Failed {
+                reason: "x".to_string(),
+                failure_class: FailureClass::ExternalDependencyFailure,
+            },
+            "dead" => ChildTerminal::Dead,
+            "interrupted" => ChildTerminal::Interrupted,
+            "superseded" => ChildTerminal::Superseded,
+            _ => panic!("unexpected ChildTerminal vocabulary: {}", t.from),
+        };
+        let projected = rust_terminal.projected_state();
+        assert_eq!(projected.as_str(), t.to,
+            "Projection divergence: {} → Rust says {}, Lean says {}",
+            t.from, projected.as_str(), t.to);
+    }
+}
+
+#[test]
+fn lean_emits_bridge_transitions_in_tool_call_machine() {
+    let contract = load_lean_contract();
+    let machine = contract.machines.iter()
+        .find(|m| m.name == "ToolCall")
+        .expect("Lean contract must emit ToolCall machine");
+    let bridge_names = vec![
+        "background", "foreground", "detach",
+        "bridge_complete", "bridge_failure", "bridge_cancel_cascade"
+    ];
+    for name in &bridge_names {
+        let found = machine.transitions.iter().any(|t| t.transition_name == *name);
+        assert!(found, "Lean contract must emit '{}' transition in toolCallMachine", name);
+    }
+}
+
+#[test]
+fn lean_marks_native_complete_fail_as_requires_native() {
+    let contract = load_lean_contract();
+    let machine = contract.machines.iter()
+        .find(|m| m.name == "ToolCall")
+        .expect("Lean contract must emit ToolCall machine");
+    let complete = machine.transitions.iter()
+        .find(|t| t.transition_name == "complete")
+        .expect("toolCallMachine must have native complete transition");
+    assert!(complete.requires_native.unwrap_or(false),
+        "native complete must be flagged with requires_native: true");
+    let fail = machine.transitions.iter()
+        .find(|t| t.transition_name == "fail")
+        .expect("toolCallMachine must have native fail transition");
+    assert!(fail.requires_native.unwrap_or(false));
+}
+```
+
+(Adapt `load_lean_contract()`, `Machine`, `Transition` field names to whatever R1's `state_machine_conformance.rs` already uses — these placeholders need to match.)
+
+- [ ] **Step 3: Run the tests**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance
+```
+
+Expected: all five PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/tests/state_machine_conformance.rs
+git commit -m "$(cat <<'EOF'
+Add Bucket 2 — Lean transition matrix conformance for subagent
+
+Five tests assert Lean's emitted contract includes:
+- AwaitMode vocabulary matches Rust's AwaitMode::ALL
+- CancelPolicy vocabulary matches Rust's CancelPolicy::ALL
+- ChildTerminal vocabulary + projection rules match Rust's
+  ChildTerminal::ALL_KIND and projected_state()
+- toolCallMachine includes background/foreground/detach,
+  bridge_complete/failure/cancel_cascade transitions
+- Native complete/fail transitions are flagged requires_native
+
+These tests catch any drift between Lean's structural model and
+Rust's runtime implementation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 21: Bucket 3 — `make_completed_request` test helper
+
+**Files:**
+- Create: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Create the new test file**
+
+Write `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`:
+
+```rust
+//! Bucket 3 — runtime integration tests for the subagent extensions to
+//! ToolCallLifecycle. Spins up a real EmbeddedNode via test_db() and exercises
+//! every new transition end-to-end. Mirrors R1's
+//! tool_call_lifecycle_conformance.rs structure.
+
+use std::sync::Arc;
+use defra_agent::tool_call_lifecycle::{
+    AwaitMode, CancelPolicy, CascadeIntent, ChildTerminal, FailureClass,
+    IllegalToolCallTransition, ToolCallLifecycle, ToolCallState,
+    create_subagent_request, MAX_SUBAGENT_DEPTH,
+};
+use defra_node::EmbeddedNode;
+
+mod common;
+use common::{test_db, fetch_tool_call_snapshots_for_session};
+
+/// Test helper: directly constructs a child AgentRequest in `.completed`
+/// state via low-level DB writes, bypassing the normal request lifecycle.
+/// Used by bridge_complete tests to set up "the child has finished" state
+/// without R3's SubagentSource.
+async fn make_completed_request(
+    node: Arc<EmbeddedNode>,
+    request_id: &str,
+    parent_request_id: Option<&str>,
+    parent_tool_call_id: Option<&str>,
+    final_message: &str,
+) -> anyhow::Result<()> {
+    let parent_req_field = parent_request_id
+        .map(|id| format!(r#", caused_by_parent_request_id: "{}""#, id))
+        .unwrap_or_default();
+    let parent_tc_field = parent_tool_call_id
+        .map(|id| format!(r#", caused_by_parent_tool_call_id: "{}""#, id))
+        .unwrap_or_default();
+    let depth = if parent_request_id.is_some() { 1 } else { 0 };
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{rid}",
+                lifecycle_state: "completed",
+                subagent_depth: {depth},
+                final_message: "{msg}"
+                {prf}
+                {ptc}
+            }}) {{ _docID }}
+        }}"#,
+        rid = request_id,
+        depth = depth,
+        msg = defra_agent::graphql::escape_graphql_string(final_message),
+        prf = parent_req_field,
+        ptc = parent_tc_field,
+    );
+    defra_agent::graphql::execute_mutation(&node, &mutation).await?;
+    Ok(())
+}
+
+/// Test helper: same but for non-completed terminal states.
+async fn make_terminal_request(
+    node: Arc<EmbeddedNode>,
+    request_id: &str,
+    parent_request_id: Option<&str>,
+    parent_tool_call_id: Option<&str>,
+    state: &str,    // "failed", "dead", "interrupted", "superseded"
+) -> anyhow::Result<()> {
+    let parent_req_field = parent_request_id
+        .map(|id| format!(r#", caused_by_parent_request_id: "{}""#, id))
+        .unwrap_or_default();
+    let parent_tc_field = parent_tool_call_id
+        .map(|id| format!(r#", caused_by_parent_tool_call_id: "{}""#, id))
+        .unwrap_or_default();
+    let depth = if parent_request_id.is_some() { 1 } else { 0 };
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{rid}",
+                lifecycle_state: "{state}",
+                subagent_depth: {depth}
+                {prf}
+                {ptc}
+            }}) {{ _docID }}
+        }}"#,
+        rid = request_id,
+        state = state,
+        depth = depth,
+        prf = parent_req_field,
+        ptc = parent_tc_field,
+    );
+    defra_agent::graphql::execute_mutation(&node, &mutation).await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_make_completed_request_creates_row() {
+    let (node, _td) = test_db().await;
+    make_completed_request(
+        node.clone(), "req-test-1", None, None, "all done"
+    ).await.unwrap();
+    // Sanity: a row exists. Adapt the verification query to the real DB API.
+    let row = defra_agent::graphql::execute_query(
+        &node,
+        r#"query { AgentRequest(request_id: "req-test-1") { request_id lifecycle_state } }"#
+    ).await.unwrap();
+    assert!(row.contains("\"completed\""), "expected the request to be in completed state");
+}
+```
+
+(`common::test_db` and `fetch_tool_call_snapshots_for_session` are placeholders — these likely exist in R1's `tool_call_lifecycle_conformance.rs`. Either reuse via `mod common;` or copy the relevant bits if they're not already extracted.)
+
+- [ ] **Step 2: Run the helper test**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance
+```
+
+Expected: PASS for `test_make_completed_request_creates_row`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 scaffolding — make_completed_request and make_terminal_request helpers
+
+Two test helpers that construct child AgentRequest rows in arbitrary
+terminal states via direct DB writes. Used by subsequent bridge_complete
+and bridge_failure integration tests to set up "the child has finished"
+state without R3's SubagentSource.
+
+Subsequent tasks add the actual integration tests (mode flips, detach,
+bridge_complete, bridge_failure projections, cascade intent, migration
+round-trip).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 22: Bucket 3 — mode-flip + detach end-to-end tests
+
+**Files:**
+- Modify: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Add the mode-flip integration tests**
+
+Append to the file:
+
+```rust
+#[tokio::test]
+async fn integration_background_then_foreground_persists_round_trip() {
+    let (node, _td) = test_db().await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "sess-int-1".to_string(),
+        "tc-int-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-int-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.background().await.unwrap();
+    // Verify persisted state.
+    let snapshots = fetch_tool_call_snapshots_for_session(&node, "sess-int-1").await.unwrap();
+    let row = snapshots.first().unwrap();
+    assert_eq!(row.await_mode.as_deref(), Some("background"));
+    // Flip back.
+    lc.foreground().await.unwrap();
+    let snapshots = fetch_tool_call_snapshots_for_session(&node, "sess-int-1").await.unwrap();
+    let row = snapshots.first().unwrap();
+    assert_eq!(row.await_mode.as_deref(), Some("foreground"));
+    // Calling foreground() again returns ModeAlreadyForeground.
+    let err = lc.foreground().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::ModeAlreadyForeground)
+    ));
+}
+
+#[tokio::test]
+async fn integration_detach_one_way_persists() {
+    let (node, _td) = test_db().await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "sess-det-1".to_string(),
+        "tc-det-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-det-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.detach().await.unwrap();
+    let snapshots = fetch_tool_call_snapshots_for_session(&node, "sess-det-1").await.unwrap();
+    assert_eq!(snapshots.first().unwrap().cancel_policy.as_deref(), Some("detach"));
+    // detach again errors.
+    let err = lc.detach().await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::PolicyAlreadyDetach)
+    ));
+}
+```
+
+(The `fetch_tool_call_snapshots_for_session` helper from R1 may need extending to read the new `await_mode` and `cancel_policy` fields. Check its definition and add the field if missing.)
+
+- [ ] **Step 2: Run, confirm pass**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance integration_background
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance integration_detach
+```
+
+Expected: both PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 — mode-flip and detach end-to-end tests
+
+Two integration tests exercising background/foreground/detach via real
+EmbeddedNode round-trips. Verifies persisted await_mode and
+cancel_policy match in-memory state and that one-way constraints fire
+correctly (ModeAlreadyForeground, PolicyAlreadyDetach).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 23: Bucket 3 — `bridge_complete` end-to-end test
+
+**Files:**
+- Modify: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Add the test**
+
+```rust
+#[tokio::test]
+async fn integration_bridge_complete_with_real_child() {
+    let (node, _td) = test_db().await;
+    // 1. Spawn a real child request via create_subagent_request.
+    let child_request_id = create_subagent_request(
+        node.clone(),
+        "parent-req-bc1".to_string(),
+        "parent-tc-bc1".to_string(),
+        0,    // parent depth
+        "behavior-bc1".to_string(),
+        "child prompt".to_string(),
+        None,
+    ).await.unwrap();
+    // 2. Force the child to .completed state via direct DB write.
+    make_completed_request(
+        node.clone(),
+        &child_request_id,
+        Some("parent-req-bc1"),
+        Some("parent-tc-bc1"),
+        "child final assistant message",
+    ).await.unwrap();
+    // (The above call may be a no-op or upsert depending on
+    // make_completed_request semantics; if it fails on duplicate, alter
+    // the helper to UPDATE on conflict, or reorganize the test.)
+
+    // 3. Construct the parent bridge tool call and start_running.
+    let mut bridge = ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "sess-bc1".to_string(),
+        "tc-bc1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        child_request_id,
+    );
+    bridge.start_running().await.unwrap();
+
+    // 4. Call bridge_complete with the projected child output.
+    let projected_output = "child final assistant message".to_string();
+    bridge.bridge_complete(projected_output.clone()).await.unwrap();
+
+    // 5. Verify the bridge tool's persisted state and result.
+    let snapshots = fetch_tool_call_snapshots_for_session(&node, "sess-bc1").await.unwrap();
+    let row = snapshots.first().unwrap();
+    assert_eq!(row.lifecycle_state.as_deref(), Some("completed"));
+    assert_eq!(row.result.as_deref(), Some(projected_output.as_str()));
+    assert_eq!(row.child_request_id, bridge.child_request_id);
+}
+```
+
+- [ ] **Step 2: Run, confirm pass**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance integration_bridge_complete
+```
+
+Expected: PASS. Adjust helper functions if Step 5's snapshot reads need new fields.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 — bridge_complete end-to-end with real child
+
+Spawns a real child via create_subagent_request, forces it to
+.completed via make_completed_request, then exercises bridge_complete
+on a parent tool that's linked to that child. Verifies the parent
+tool's persisted lifecycle_state, result, and child_request_id all
+reflect the bridge transition.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 24: Bucket 3 — `bridge_failure` projection tests
+
+**Files:**
+- Modify: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Add the four projection tests**
+
+```rust
+async fn run_bridge_failure_case(
+    terminal_state: &str,
+    child_terminal: ChildTerminal,
+    expected_tool_state: ToolCallState,
+) {
+    let (node, _td) = test_db().await;
+    let session = format!("sess-bf-{}", terminal_state);
+    let tc_id = format!("tc-bf-{}", terminal_state);
+    let child_id = format!("child-req-bf-{}", terminal_state);
+    let parent_req = format!("parent-req-bf-{}", terminal_state);
+    let parent_tc = format!("parent-tc-bf-{}", terminal_state);
+
+    make_terminal_request(
+        node.clone(), &child_id, Some(&parent_req), Some(&parent_tc),
+        terminal_state,
+    ).await.unwrap();
+
+    let mut bridge = ToolCallLifecycle::new_subagent(
+        node.clone(), session.clone(), tc_id.clone(), 1,
+        "spawn_subagent".to_string(), "{}".to_string(),
+        AwaitMode::Foreground, CancelPolicy::Cascade,
+        child_id,
+    );
+    bridge.start_running().await.unwrap();
+    bridge.bridge_failure(child_terminal).await.unwrap();
+
+    let snapshots = fetch_tool_call_snapshots_for_session(&node, &session).await.unwrap();
+    assert_eq!(
+        snapshots.first().unwrap().lifecycle_state.as_deref(),
+        Some(expected_tool_state.as_str())
+    );
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_failed_projects_to_failed() {
+    run_bridge_failure_case(
+        "failed",
+        ChildTerminal::Failed {
+            reason: "child failed".to_string(),
+            failure_class: FailureClass::ExternalDependencyFailure,
+        },
+        ToolCallState::Failed,
+    ).await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_dead_projects_to_failed() {
+    run_bridge_failure_case("dead", ChildTerminal::Dead, ToolCallState::Failed).await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_interrupted_projects_to_cancelled() {
+    run_bridge_failure_case(
+        "interrupted",
+        ChildTerminal::Interrupted,
+        ToolCallState::Cancelled,
+    ).await;
+}
+
+#[tokio::test]
+async fn integration_bridge_failure_superseded_projects_to_failed() {
+    run_bridge_failure_case(
+        "superseded",
+        ChildTerminal::Superseded,
+        ToolCallState::Failed,
+    ).await;
+}
+```
+
+- [ ] **Step 2: Run, confirm pass**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance integration_bridge_failure
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 — bridge_failure projection tests for all 4 child terminals
+
+Verifies B2's projection rule end-to-end:
+- ChildTerminal::Failed/Dead/Superseded → tool_state = Failed
+- ChildTerminal::Interrupted → tool_state = Cancelled
+
+Each test sets up a child in the corresponding terminal state via
+make_terminal_request and then drives bridge_failure on a parent
+tool linked to it.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 25: Bucket 3 — cascade intent tests
+
+**Files:**
+- Modify: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Add the three cascade scenario tests**
+
+```rust
+#[tokio::test]
+async fn integration_cascade_intent_for_cascade_subagent_returns_some() {
+    let (node, _td) = test_db().await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "sess-cas-1".to_string(),
+        "tc-cas-1".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        "child-req-cas-1".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_some());
+    assert_eq!(intent.unwrap().child_request_id, "child-req-cas-1");
+}
+
+#[tokio::test]
+async fn integration_cascade_intent_for_detached_subagent_returns_none() {
+    let (node, _td) = test_db().await;
+    let mut lc = ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "sess-cas-2".to_string(),
+        "tc-cas-2".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        AwaitMode::Foreground,
+        CancelPolicy::Detach,
+        "child-req-cas-2".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_none());
+}
+
+#[tokio::test]
+async fn integration_cascade_intent_for_native_returns_none() {
+    let (node, _td) = test_db().await;
+    let mut lc = ToolCallLifecycle::new(
+        node.clone(),
+        "sess-cas-3".to_string(),
+        "tc-cas-3".to_string(),
+        1,
+        "echo".to_string(),
+        "{}".to_string(),
+    );
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run().await.unwrap();
+    let intent = lc.bridge_cancel_cascade().await.unwrap();
+    assert!(intent.is_none());
+}
+```
+
+- [ ] **Step 2: Run, confirm pass**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance integration_cascade_intent
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 — cascade intent integration tests
+
+Three end-to-end scenarios for bridge_cancel_cascade:
+- Cascade-policy subagent returns Some(CascadeIntent)
+- Detach-policy subagent returns None (no cascade)
+- Native tool (no child link) returns None
+
+Verifies the pure return-intent semantics work correctly when the
+underlying lifecycle has actually been driven through cancel_during_run.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 26: Bucket 3 — migration round-trip and `create_subagent_request` end-to-end
+
+**Files:**
+- Modify: `crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs`
+
+- [ ] **Step 1: Add the migration round-trip test**
+
+```rust
+#[tokio::test]
+async fn integration_migration_round_trip_populates_defaults() {
+    // Use a v2 baseline test_db (one without our v3 migration applied).
+    // If R1's test_db() is post-migration, we need a v2 fixture; create one
+    // by directly applying R1's v1→v2 patch only.
+    let (node, _td) = setup_v2_only_node().await;
+
+    // Insert a v2-shape AgentToolCall row (no v3 fields).
+    let create_v2 = r#"
+        mutation {
+            create_AgentToolCall(input: {
+                tool_call_key: "v2-row-1",
+                session_id: "v2-sess-1",
+                message_sequence: 1,
+                tool_name: "echo",
+                tool_call_id: "v2-tc-1",
+                args: "{}",
+                lifecycle_state: "running"
+            }) { _docID }
+        }
+    "#;
+    defra_agent::graphql::execute_mutation(&node, create_v2).await.unwrap();
+
+    // Apply the v2→v3 migration.
+    defra_agent::migration::ensure_subagent_extensions_migrations(node.clone()).await.unwrap();
+
+    // Read the row and verify defaults.
+    let row = defra_agent::graphql::execute_query(
+        &node,
+        r#"query {
+            AgentToolCall(tool_call_key: "v2-row-1") {
+                await_mode
+                cancel_policy
+                child_request_id
+                request_id
+            }
+        }"#,
+    ).await.unwrap();
+    assert!(row.contains("\"foreground\""), "await_mode should default to 'foreground'");
+    assert!(row.contains("\"cascade\""), "cancel_policy should default to 'cascade'");
+    // child_request_id and request_id remain null on migrated rows.
+}
+```
+
+(`setup_v2_only_node()` is a new helper that creates a node, applies only R1's `ensure_tool_call_migrations` (and any v1→v2 baseline), and returns it. Add this helper to `common::` or inline.)
+
+- [ ] **Step 2: Add the create_subagent_request end-to-end depth + coherence tests**
+
+```rust
+#[tokio::test]
+async fn integration_create_subagent_request_at_max_depth_succeeds() {
+    let (node, _td) = test_db().await;
+    let new_id = create_subagent_request(
+        node, "parent-req-csr-1".to_string(), "parent-tc-csr-1".to_string(),
+        MAX_SUBAGENT_DEPTH - 1,
+        "behavior-csr-1".to_string(), "csr test prompt".to_string(),
+        None,
+    ).await.unwrap();
+    assert!(new_id.starts_with("req-"));
+}
+
+#[tokio::test]
+async fn integration_create_subagent_request_above_max_depth_fails() {
+    let (node, _td) = test_db().await;
+    let err = create_subagent_request(
+        node, "parent-req-csr-2".to_string(), "parent-tc-csr-2".to_string(),
+        MAX_SUBAGENT_DEPTH,
+        "behavior-csr-2".to_string(), "csr test prompt".to_string(),
+        None,
+    ).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::SubagentDepthExceeded)
+    ));
+}
+
+#[tokio::test]
+async fn integration_create_subagent_request_empty_parent_fields_fails() {
+    let (node, _td) = test_db().await;
+    let err = create_subagent_request(
+        node, "".to_string(), "parent-tc".to_string(), 0,
+        "behavior".to_string(), "prompt".to_string(), None,
+    ).await.unwrap_err();
+    assert!(matches!(
+        err.downcast_ref::<IllegalToolCallTransition>(),
+        Some(IllegalToolCallTransition::ParentLinkageIncoherent)
+    ));
+}
+```
+
+- [ ] **Step 3: Run all the integration tests**
+
+```bash
+cargo test -p defra-agent --test tool_call_subagent_lifecycle_conformance
+```
+
+Expected: every test in the file PASSES.
+
+- [ ] **Step 4: Run the full Rust test suite to confirm no regressions**
+
+```bash
+cargo test -p defra-agent
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+git commit -m "$(cat <<'EOF'
+Bucket 3 — migration round-trip and create_subagent_request integration
+
+Migration test: insert a v2 AgentToolCall row into a v2-only node,
+apply ensure_subagent_extensions_migrations, verify the row's new
+fields default to "foreground" / "cascade" / null per the spec.
+
+create_subagent_request integration tests: at depth ≤ max-1 succeeds,
+at depth = max exceeds, empty parent fields rejected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 27: Final verification + spec coverage audit
+
+**Files:**
+- (no file changes — verification + audit task)
+
+- [ ] **Step 1: Run the full test suite**
+
+```bash
+cargo test -p defra-agent --lib --tests
+cargo test -p defra-agent --tests
+cargo build --release -p defra-agent
+```
+
+Expected: all PASS, clean release build.
+
+- [ ] **Step 2: Verify Lean still builds**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean (no `sorry`, no errors). Task 0's contract additions should compile cleanly here.
+
+- [ ] **Step 3: Verify the WASM lens artifact builds**
+
+```bash
+cargo build --release --target wasm32-unknown-unknown -p agent-subagent-v2-to-v3-lens
+wc -c target/wasm32-unknown-unknown/release/agent_subagent_v2_to_v3_lens.wasm
+```
+
+Expected: builds; record the size.
+
+- [ ] **Step 4: Spec coverage audit**
+
+For each section of `docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md`, verify a corresponding task implemented it:
+
+| Spec section | Task |
+|---|---|
+| Conformance prerequisite (Lean Machines.lean) | 0 |
+| Lens crate scaffold | 1 |
+| Lens transforms | 2 |
+| GraphQL schemas + JSON Patches | 3 |
+| Migration orchestrator | 4 |
+| Daemon startup wiring | 5 |
+| AwaitMode/CancelPolicy/ChildTerminal/CascadeIntent types | 6 |
+| ToolCallLifecycle struct + new_subagent + IllegalToolCallTransition variants | 7 |
+| Symmetric h_native guards on complete/fail | 8 |
+| Mode-flip transitions (background, foreground, detach) | 9, 10, 11 |
+| Bridge transitions (bridge_complete/failure/cancel_cascade) | 12, 13, 14 |
+| AgentRequestRow + AgentRequest extensions | 15 |
+| ToolSelectionDocument extensions + apply-time validation | 16 |
+| AgentRequest parent-linkage coherence validation | 17 |
+| create_subagent_request helper | 18 |
+| Bucket 1 vocabulary round-trip | 19 |
+| Bucket 2 Lean transition matrix | 20 |
+| Bucket 3 helpers + integration tests | 21, 22, 23, 24, 25, 26 |
+
+Document any gaps inline (mark a TODO comment in the relevant Rust file with a follow-up issue).
+
+- [ ] **Step 5: Add a maintenance tracker**
+
+Append to `crates/defra-agent/src/tool_call_lifecycle.rs` (top of file, in module-level docs):
+
+```rust
+//! ## R2 maintenance obligations
+//!
+//! This module implements R2 ("Rust subagent data plane"). Per the spec at
+//! `docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md`:
+//!
+//! - SubagentSource (R3) consumes `create_subagent_request` and the bridge methods.
+//! - Agent-facing tools (R4) are routed via hook integration that uses
+//!   `new_subagent` and recognizes spawn_subagent / wait_task / etc. tool names.
+//! - Cross-reference validation (target resolution, parent existence) lands in R3.
+//! - Cross-principal delegation (R6) lands with sourcenetwork/defra-agent#9.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs
+git commit -m "$(cat <<'EOF'
+R2 final verification + maintenance tracker
+
+Adds module-level documentation tracking R2's deferrals to R3, R4, R6,
+and #9. All 27 R2 tasks landed; full Rust + Lean test suites pass; WASM
+lens artifact builds cleanly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+Spec sections each map to a task per the audit table in Task 27. Key non-coverage callouts:
+
+- **Hook integration (`hook/persistence.rs`)**: explicitly deferred to R3 per the spec. Bucket 3 tests bypass the hook layer and call lifecycle methods directly.
+- **`SubagentSource` registration in TriggerEngine**: deferred to R3.
+- **Cross-reference validation** (`subagent_targets` resolution, `caused_by_parent_request_id` existence): deferred to R3.
+- **The seven agent-facing tools** (`spawn_subagent`, etc.): deferred to R4.
+- **Cross-principal delegation**: deferred to R6 (lands with #9).
+
+These deferrals are consistent with R1's discipline of landing data plane before runtime wiring, and the data plane's API surface (especially `create_subagent_request`, `new_subagent`, the bridge methods, and `CascadeIntent`) is shaped to support R3's spawn flow without forcing changes back into R2.
+
+The 27 tasks total ~5-7 days of focused engineering at sustainable cadence (matches R1's delivery profile of similar size).

--- a/docs/superpowers/plans/2026-05-08-subagent-lifecycle-spec.md
+++ b/docs/superpowers/plans/2026-05-08-subagent-lifecycle-spec.md
@@ -1,0 +1,2072 @@
+# Subagent Lifecycle Lean Spec — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the Lean 4 spec defined in `docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md` — a unified `ToolCallContext` lifecycle with multi-flight, foreground/background, and child-request linkage, plus a new `BridgedState` paired-context type and theorems B1–B6 covering subagent invocation as a generalization of tool dispatch.
+
+**Architecture:** Three orthogonal extensions to the B1 ToolCall lifecycle:
+1. `ComposedState.tool : Option` becomes `tools : List`.
+2. `ToolCallContext` gains `awaitMode`, `cancelPolicy`, `childRequestId` fields plus three mode/policy transitions.
+3. New `Proofs/Subagent/` folder defines `BridgedState` (parent × child `ComposedState` pair), six bridge transitions, and B-properties.
+
+**Tech Stack:** Lean 4 (toolchain pinned via `lean-toolchain`), Lake build system, Mathlib4 v4.18.0. All build/verify via `lake build` from `crates/defra-agent/proofs/`.
+
+---
+
+## What's NOT in this plan (deferred)
+
+- **Conformance JSON emission** for the new `AwaitMode` / `CancelPolicy` vocabularies and `BridgedState.Transition` cases in `Proofs/Conformance/Contracts/Machines.lean`. Crosses the "Lean-only, no Rust work" boundary that B1 also held. Tracked alongside the Rust runtime plan.
+- **Rust runtime changes** — `SubagentSource` impl, the seven new tools (`spawn_subagent`, `wait_task`, `get_task_result`, `cancel_task`, `read_subagent_transcript`, `send_message_to_subagent`, `list_tasks`, `background_task`), apply-time validation extensions. Tracked in a separate plan.
+- **Schema migration** — adding new fields to `AgentRequest`, `AgentToolCall`, `ToolSelection` GraphQL schemas + DefraDB migration plan. Tracked in a separate plan.
+- **Cross-principal delegation** — lands with sourcenetwork/defra-agent#9 (AgentPrincipal/AgentBehavior split).
+
+---
+
+## Conventions
+
+- **Build/verify command:** `cd crates/defra-agent/proofs && lake build` from repo root, or `lake build` from inside the proofs directory. Treat any non-zero exit, `sorry`, `unsolved goals`, or `error:` line as failure unless the task explicitly says otherwise (e.g., a step that *expects* a `sorry` warning before proving the theorem).
+- **TDD in Lean:** the "failing test" is a `theorem` declaration with `sorry` (Lean reports `sorry` as a warning but continues compiling). The "passing test" is the same `theorem` with a complete proof and no `sorry`. Verify with `lake build` after each.
+- **Commit cadence:** one commit per task. Imperative, scoped commit messages with the `Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>` trailer.
+- **Working directory:** all paths in this plan are relative to the repo root (`/Users/johnzampolin/go/src/github.com/sourcenetwork/defra-agent-design-subagent-management`). The git working directory should remain at repo root throughout.
+- **Branch:** `design/subagent-management` (already current; rebased onto `bug/issue-149-native-glob-deadline`).
+- **Proof iteration:** Where a step provides a proof body, that proof reflects the planner's best understanding of the existing tactic landscape. If `lake build` reports `unsolved goals` or `unknown identifier`, treat it as a discovery loop: examine the goal state, find the analogous pattern in the cited reference file, and adjust. Do not commit a `sorry` unless the task explicitly says so.
+
+---
+
+## Task 1: Create the `Proofs/Subagent/` folder and barrel re-export stub
+
+Mirror the layout of `Proofs/ToolExecution/` and `Proofs/Request/` — a top-level `Subagent.lean` barrel re-export and a `Subagent/` folder for per-concern modules.
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/Subagent.lean`
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/` (folder)
+
+- [ ] **Step 1: Create the folder**
+
+```bash
+mkdir -p crates/defra-agent/proofs/Proofs/Subagent
+```
+
+- [ ] **Step 2: Create the barrel stub**
+
+Write `crates/defra-agent/proofs/Proofs/Subagent.lean`:
+
+```lean
+/-!
+# Subagent
+
+Barrel import for subagent lifecycle (mode/policy state, BridgedState
+paired-context, bridge transitions, properties B1–B6).
+
+Modules are added in subsequent tasks; this file is a re-export aggregator.
+-/
+```
+
+- [ ] **Step 3: Build and confirm clean**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build (exit 0, no errors, no `sorry`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent.lean
+git commit -m "$(cat <<'EOF'
+Add Proofs/Subagent barrel re-export stub
+
+Mirrors the Proofs/ToolExecution/ and Proofs/Request/ folder layout in
+preparation for adding Subagent/{State,Transition,Properties,Executable}.lean.
+No behavioral change.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `AwaitMode` and `CancelPolicy` enums in `Subagent/State.lean`
+
+Define the two new enums and their persisted-vocabulary round-trip helpers. Mirrors `Proofs/ToolExecution/State.lean:19-72` style.
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/State.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent.lean` (add import)
+
+- [ ] **Step 1: Write Subagent/State.lean**
+
+Write `crates/defra-agent/proofs/Proofs/Subagent/State.lean`:
+
+```lean
+import Proofs.Basic
+
+/-!
+# Subagent State
+
+Mode and policy enums attached to `ToolCallContext` to support multi-flight,
+foreground/background scheduling, and detachable subagent invocations.
+
+`BridgedState` (a paired parent-child `ComposedState`) is added in a later task
+once `ComposedState` has been refactored to multi-flight.
+-/
+
+namespace Subagent
+
+/-- Whether the parent's narrative is blocked on this tool's terminal state. -/
+inductive AwaitMode where
+  | foreground   -- parent.advance / begin_inference are blocked while this tool is non-terminal
+  | background   -- parent advances independently; tool runs concurrently
+  deriving DecidableEq, Repr
+
+namespace AwaitMode
+
+/-- Persisted vocabulary in `AgentToolCall.await_mode`. -/
+def toDefraDB : AwaitMode → String
+  | .foreground => "foreground"
+  | .background => "background"
+
+def fromDefraDB? : String → Option AwaitMode
+  | "foreground" => some .foreground
+  | "background" => some .background
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (m : AwaitMode) :
+    fromDefraDB? m.toDefraDB = some m := by
+  cases m <;> rfl
+
+def all : List AwaitMode := [ .foreground, .background ]
+
+theorem all_complete (m : AwaitMode) : m ∈ all := by
+  cases m <;> simp [all]
+
+end AwaitMode
+
+/-- Cancel-cascade policy: whether parent termination drives the linked child
+    to .interrupted, or detaches the child to its own deadline. -/
+inductive CancelPolicy where
+  | cascade   -- default; parent terminal ⇒ child.interruptRequestedAt set
+  | detach    -- child outlives parent
+  deriving DecidableEq, Repr
+
+namespace CancelPolicy
+
+def toDefraDB : CancelPolicy → String
+  | .cascade => "cascade"
+  | .detach  => "detach"
+
+def fromDefraDB? : String → Option CancelPolicy
+  | "cascade" => some .cascade
+  | "detach"  => some .detach
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (p : CancelPolicy) :
+    fromDefraDB? p.toDefraDB = some p := by
+  cases p <;> rfl
+
+def all : List CancelPolicy := [ .cascade, .detach ]
+
+theorem all_complete (p : CancelPolicy) : p ∈ all := by
+  cases p <;> simp [all]
+
+end CancelPolicy
+
+/-- Configured cap on subagent recursion depth. Treated as a global parameter
+    referenced by the depth-bound theorem; the runtime supplies the concrete
+    value from behavior config. -/
+def maxSubagentDepth : Nat := 3
+
+end Subagent
+```
+
+- [ ] **Step 2: Update the barrel**
+
+Edit `crates/defra-agent/proofs/Proofs/Subagent.lean`:
+
+```lean
+import Proofs.Subagent.State
+
+/-!
+# Subagent
+
+Barrel import for subagent lifecycle (mode/policy state, BridgedState
+paired-context, bridge transitions, properties B1–B6).
+-/
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. The two enums, their `toDefraDB` / `fromDefraDB?` round-trips, `all` exhaustiveness lemmas, and `maxSubagentDepth` constant all typecheck.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent.lean crates/defra-agent/proofs/Proofs/Subagent/State.lean
+git commit -m "$(cat <<'EOF'
+Add Subagent.AwaitMode and Subagent.CancelPolicy enums
+
+Persisted vocabularies match planned AgentToolCall.await_mode and
+AgentToolCall.cancel_policy schema fields. Round-trip lemmas and
+exhaustive 'all' lists support future Rust conformance generation.
+maxSubagentDepth defined here as the spec's global cap.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `awaitMode`, `cancelPolicy`, `childRequestId` fields to `ToolCallContext`
+
+Amend `Proofs/ToolExecution/State.lean` to add three new fields with sensible defaults that preserve existing behavior. New fields don't change `ToolCallState`; T1–T5 are unaffected (verified by build).
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/ToolExecution/State.lean:82-92`
+
+- [ ] **Step 1: Add the import for `Subagent.State`**
+
+At the top of `crates/defra-agent/proofs/Proofs/ToolExecution/State.lean`, add the import after the existing imports:
+
+```lean
+import Proofs.Basic
+import Proofs.Persistence
+import Proofs.ToolExecution.Policy
+import Proofs.Subagent.State
+```
+
+- [ ] **Step 2: Extend `ToolCallContext` with the three new fields**
+
+Replace the existing `structure ToolCallContext` definition (around lines 82-92) with:
+
+```lean
+/-- Mutable per-tool-call context that transitions carry along. -/
+structure ToolCallContext where
+  callId         : ToolCallId
+  requestId      : RequestId
+  state          : ToolCallState
+  operation      : ToolOperation
+  deadline       : Time
+  startedAt      : Option Time := none
+  currentTime    : Time
+  failureClass   : Option FailureClass := none
+  persistence    : PersistenceState
+  -- Subagent extensions:
+  awaitMode      : Subagent.AwaitMode := .foreground
+  cancelPolicy   : Subagent.CancelPolicy := .cascade
+  childRequestId : Option RequestId := none
+  deriving Repr
+```
+
+The defaults match today's behavior: every existing tool call is conceptually `foreground + cascade + native (no childRequestId)`.
+
+- [ ] **Step 3: Build and verify nothing else broke**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. Existing T1–T5 proofs in `Proofs/ToolExecution/Properties.lean` and existing C1–C3 proofs in `Proofs/Composed.lean` still typecheck — they don't case-split on the new fields, and the defaults absorb the schema change. If a proof breaks because it pattern-matched the old `ToolCallContext` constructor explicitly, locate the failure and replace the explicit match with field-update syntax (`{ pre with state := ... }` form).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/ToolExecution/State.lean
+git commit -m "$(cat <<'EOF'
+Extend ToolCallContext with awaitMode, cancelPolicy, childRequestId
+
+Three subagent-extension fields with defaults that preserve existing
+tool-call behavior (.foreground, .cascade, none). T1–T5 single-machine
+properties and C1–C3 composition properties unaffected — fields don't
+participate in any current state-machine guard or post-state computation.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add `subagentDepth`, `causedByParentRequestId`, `causedByParentToolCallId` fields to `RequestContext`
+
+Add the three new lineage / depth fields to `RequestContext` with defaults that preserve top-level-request semantics.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Request/State.lean` (the `structure RequestContext` block)
+
+- [ ] **Step 1: Read the existing RequestContext to see field positioning**
+
+```bash
+grep -n "structure RequestContext" crates/defra-agent/proofs/Proofs/Request/State.lean
+```
+
+Note the line range for the struct.
+
+- [ ] **Step 2: Extend `RequestContext` with the three new fields**
+
+Inside the `structure RequestContext where` block, add the three fields at the end (just before the `deriving Repr`):
+
+```lean
+  -- Subagent lineage / depth bound:
+  subagentDepth                : Nat := 0
+  causedByParentRequestId      : Option RequestId := none
+  causedByParentToolCallId     : Option ToolExecution.ToolCallId := none
+```
+
+If `ToolExecution.ToolCallId` isn't yet imported in `Request/State.lean`, add the import line near the top:
+
+```lean
+import Proofs.ToolExecution.State
+```
+
+(Note: this creates a transitive dependency from `Request/State.lean` to `ToolExecution/State.lean`, which itself imports `Subagent/State.lean`. If the import graph rejects this for cycle reasons, fall back to defining `causedByParentToolCallId : Option Nat` here and stating the equivalence as a structural assumption — `ToolCallId` is `abbrev ToolCallId := Nat` already, so the underlying type is the same.)
+
+- [ ] **Step 3: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. Existing S1–S6 properties in `Proofs/Properties/Safety.lean` are unaffected — they don't reference any of the new fields. If a proof breaks, the most likely cause is a pattern-match-by-position on `RequestContext.mk`; rewrite it as a structural pattern (or use `{ pre with ... }` form).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Request/State.lean
+git commit -m "$(cat <<'EOF'
+Extend RequestContext with subagentDepth and parent-link fields
+
+Three new fields support the depth-bound structural invariant (B4) and
+parent-request linkage from the subagent spec:
+- subagentDepth : Nat (default 0 for top-level)
+- causedByParentRequestId : Option RequestId (default none)
+- causedByParentToolCallId : Option ToolCallId (default none)
+
+S1–S6 unaffected; defaults preserve top-level-request semantics.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Add `background`, `foreground`, `detach` transitions and restrict `complete` to native tools
+
+Three new mode/policy transitions on `ToolCallContext.Transition` (no state advance), plus a tightened `complete` precondition that restricts the inner constructor to native tools (`childRequestId = none`). Subagent tools reach `.completed` only via the composed-layer `bridge_complete` (Task 14).
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean` (T1 may need a tweak to handle the new constructors)
+
+- [ ] **Step 1: Add the three new constructors to the `Transition` inductive**
+
+In `Proofs/ToolExecution/Transition.lean`, locate the `inductive Transition : ToolCallContext → ToolCallContext → Prop where` block. Inside it, after the `cancelDuringRun` constructor and before `timeAdvance`, add:
+
+```lean
+  | background {pre post : ToolCallContext}
+      (h_state : pre.state = .running)
+      (h_mode  : pre.awaitMode = .foreground)
+      (h_post  : post = { pre with awaitMode := .background })
+      : Transition pre post
+
+  | foreground {pre post : ToolCallContext}
+      (h_state : pre.state = .running)
+      (h_mode  : pre.awaitMode = .background)
+      (h_post  : post = { pre with awaitMode := .foreground })
+      : Transition pre post
+
+  | detach {pre post : ToolCallContext}
+      (h_live  : pre.state = .pending ∨ pre.state = .running)
+      (h_pol   : pre.cancelPolicy = .cascade)
+      (h_post  : post = { pre with cancelPolicy := .detach })
+      : Transition pre post
+```
+
+- [ ] **Step 2: Restrict the `complete` constructor to native tools**
+
+In the same `Transition` inductive, locate the existing `complete` constructor:
+
+```lean
+  | complete {pre post : ToolCallContext}
+      (h_state    : pre.state = .running)
+      (h_persist  : pre.persistence = .committed)
+      (h_post     : post = { pre with state := .completed })
+      : Transition pre post
+```
+
+Replace it with:
+
+```lean
+  | complete {pre post : ToolCallContext}
+      (h_state    : pre.state = .running)
+      (h_persist  : pre.persistence = .committed)
+      (h_native   : pre.childRequestId = none)
+      (h_post     : post = { pre with state := .completed })
+      : Transition pre post
+```
+
+- [ ] **Step 3: Update T1 (terminal_irreversible) to handle the three new constructors**
+
+In `Proofs/ToolExecution/Properties.lean`, locate `terminal_irreversible`. Its proof case-splits over all `Transition` constructors; the three new ones each have a `pre.state = .running` (or `.pending` for `detach`) precondition that contradicts `isTerminal pre.state`. Add the three new cases to the `cases h_step with` block:
+
+```lean
+  | background _ _ _ =>
+      rw [show pre.state = .running from ‹_›] at h_terminal
+      exact (running_not_terminal h_terminal).elim
+  | foreground _ _ _ =>
+      rw [show pre.state = .running from ‹_›] at h_terminal
+      exact (running_not_terminal h_terminal).elim
+  | detach h_live _ _ =>
+      cases h_live with
+      | inl h => rw [h] at h_terminal; exact (pending_not_terminal h_terminal).elim
+      | inr h => rw [h] at h_terminal; exact (running_not_terminal h_terminal).elim
+```
+
+(If `pending_not_terminal` / `running_not_terminal` aren't already lemmas in the file, replace the `.elim` lines with explicit `simp [isTerminal] at h_terminal` reductions. Look at the existing `dispatch` case in the same proof for the right pattern.)
+
+- [ ] **Step 4: Update T4 (cancellable_iff_non_terminal) and T5 (live_call_reaches_terminal) — each may need new cases**
+
+For T4: the new constructors don't touch `state`, so any case that infers from `Transition` to `state = ...` should be unaffected. Verify build picks them up.
+
+For T5: the proof shows reachability to terminal. The new constructors don't progress state but don't block reachability either — the existing `timeAdvance + timeout` path remains the trace witness for any `running` tool, regardless of `awaitMode`. Verify build still passes.
+
+- [ ] **Step 5: Build and verify**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. T1's case-split now handles 12 constructors; the three new ones each contradict `isTerminal pre.state`. T2, T3, T4, T5 unaffected (the new constructors don't satisfy any of their hypotheses).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean
+git commit -m "$(cat <<'EOF'
+Add background/foreground/detach mode transitions; restrict complete to native
+
+Three new ToolCallContext.Transition constructors flip awaitMode and
+cancelPolicy without advancing state. The complete constructor gains
+h_native (childRequestId = none) so subagent tools reach .completed
+only via the composed-layer bridge_complete (added later). T1's case
+analysis is extended; T2–T5 unaffected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Refactor `ComposedState.tool : Option` to `tools : List` and adapt `tool_step`
+
+The big structural refactor. `ComposedState.tool : Option ToolCallContext` becomes `tools : List ToolCallContext`. The `tool_step` constructor lifts a single inner transition acting on one element of the list. Existing C1, C1', C2, C3 proofs will break — re-stated in subsequent tasks.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean:21` (struct field) and `:66-90` (`tool_step` variant)
+
+- [ ] **Step 1: Change the struct field**
+
+In `Proofs/Composed.lean`, locate the `structure ComposedState where` block. Replace:
+
+```lean
+  tool : Option ToolExecution.ToolCallContext := none
+```
+
+with:
+
+```lean
+  tools : List ToolExecution.ToolCallContext := []
+```
+
+- [ ] **Step 2: Replace the `tool_step` constructor**
+
+Locate the existing `tool_step` constructor in the `inductive Transition : ComposedState → ComposedState → Prop`. Replace its body with the multi-flight form:
+
+```lean
+  | tool_step {pre post : ComposedState} {idx : Nat}
+              {toolPre toolPost : ToolExecution.ToolCallContext} :
+      pre.tools[idx]? = some toolPre →
+      ToolExecution.ToolCallContext.Transition toolPre toolPost →
+      post.tools = pre.tools.set idx toolPost →
+      post.request = pre.request →
+      post.process = pre.process →
+      post.call = pre.call →
+      post.requestId = pre.requestId →
+      post.persistence = pre.persistence →
+      -- structural composition guards (carry through):
+      toolPre.requestId = pre.requestId →
+      toolPre.deadline = pre.request.deadline →
+      toolPre.currentTime = pre.request.currentTime →
+      Transition pre post
+```
+
+The composition guards on the inner tool's `requestId`, `deadline`, and `currentTime` are unchanged from the single-flight version — they still hold per linked tool.
+
+- [ ] **Step 3: Add a helper for "tool is in tools by callId"**
+
+Add this helper near the top of `Composed.lean`, after the imports and before the `ComposedState` struct:
+
+```lean
+namespace ComposedState
+
+/-- A tool is linked to this composed state if it's in the tools list. -/
+def hasToolByCallId (s : ComposedState) (callId : ToolExecution.ToolCallId) : Prop :=
+  ∃ t ∈ s.tools, t.callId = callId
+
+instance (s : ComposedState) (callId : ToolExecution.ToolCallId) :
+    Decidable (s.hasToolByCallId callId) := by
+  unfold hasToolByCallId; infer_instance
+
+/-- The unique tool with a given callId, if it exists. -/
+def findToolByCallId (s : ComposedState) (callId : ToolExecution.ToolCallId) :
+    Option ToolExecution.ToolCallContext :=
+  s.tools.find? (fun t => t.callId = callId)
+
+end ComposedState
+```
+
+- [ ] **Step 4: Build — expect existing C1/C1'/C2/C3 proofs to break**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build FAILS. Existing C1, C1', C2, C3 theorems pattern-matched on `pre.tool = some toolPre`; with the field renamed and re-typed they no longer typecheck. This is the expected breakage; the next four tasks restate them.
+
+To unblock the build for now (so subsequent tasks can run partial verification), comment out the bodies of `interrupted_request_cancels_live_linked_tool`, `deadline_exceeded_request_timesOut_running_tool`, `deadline_exceeded_request_cancels_pending_tool`, and `terminal_tool_unblocks_request_progress` and replace each with `:= sorry`. The compile-only build will then succeed with `sorry` warnings.
+
+- [ ] **Step 5: Build with sorrys to confirm structural change is otherwise clean**
+
+```bash
+cd crates/defra-agent/proofs && lake build 2>&1 | grep -E "error:|sorry" | head -20
+```
+
+Expected: only the four `sorry` warnings on the four C-theorems we just stubbed; no `error:` lines. Any `error:` line means there's a structural problem to fix before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Refactor ComposedState.tool to tools : List for multi-flight
+
+ComposedState now carries a list of concurrently-live ToolCallContexts.
+tool_step lifts a single inner transition acting on one element by index.
+hasToolByCallId / findToolByCallId helpers added for membership reasoning.
+
+C1, C1', C2, C3 stubbed with sorry — to be restated with multi-flight
+quantification in tasks 7–10. T1–T5 single-machine properties unaffected.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: Restate C1 (deadline_exceeded → running tool .timedOut) for multi-flight
+
+Quantify ∀ over `pre.tools`: every running, deadline-exceeded linked tool reaches `.timedOut`.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean` (the `deadline_exceeded_request_timesOut_running_tool` theorem)
+
+- [ ] **Step 1: Replace the theorem statement and proof**
+
+Locate `deadline_exceeded_request_timesOut_running_tool`. Replace the theorem with:
+
+```lean
+/-- C1: A request whose deadline is exceeded times out every Running linked
+    tool. Multi-flight form: quantified over all live linked tools. -/
+theorem deadline_exceeded_request_timesOut_running_tools
+    {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
+    (h_in        : toolPre ∈ pre.tools)
+    (h_running   : toolPre.state = .running)
+    (h_linked    : toolPre.requestId = pre.requestId)
+    (h_deadline  : pre.request.deadlineExceeded)
+    (h_synced    : toolPre.deadline = pre.request.deadline ∧
+                   toolPre.currentTime = pre.request.currentTime) :
+    ∃ post toolPost,
+      Trace pre post ∧
+      toolPost ∈ post.tools ∧
+      post.request = pre.request ∧
+      toolPost.state = .timedOut ∧
+      toolPost.requestId = pre.requestId := by
+  -- The proof follows the single-flight version but indexes the chosen tool.
+  -- Find the index of toolPre in pre.tools.
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_get?.mp h_in
+  -- Apply the inner ToolCallContext.timeout transition on toolPre.
+  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                    { toolPre with state := .timedOut } := by
+    exact ToolExecution.ToolCallContext.Transition.timeout
+      h_running
+      (by rw [h_synced.1, h_synced.2]; exact h_deadline)
+      rfl
+  -- Lift to a tool_step transition.
+  let toolPost := { toolPre with state := .timedOut }
+  let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+  refine ⟨post, toolPost, ?_, ?_, rfl, rfl, h_linked⟩
+  · exact Trace.step
+      (Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl rfl
+         h_linked h_synced.1 h_synced.2)
+      Trace.refl
+  · simp [post, List.mem_set]; exact Or.inl rfl
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: C1 typechecks. If `List.mem_iff_get?` is named differently in the Mathlib version pinned by the project, search Mathlib for the equivalent — typical names: `List.mem_iff_get?`, `List.mem_iff_getElem?`, `List.get?_eq_some`. Adjust the call accordingly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Restate C1 (deadline_exceeded_request_timesOut_running_tools) for multi-flight
+
+Multi-flight quantification: every running, deadline-exceeded tool linked
+to the parent reaches .timedOut. Proof obtains an index witness from the
+list-membership hypothesis, applies the inner timeout transition, and
+lifts via tool_step at the obtained index.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: Restate C1' (deadline_exceeded → pending tool .cancelled) for multi-flight
+
+Same pattern as C1, but for `Pending`-state tools that get cancelled instead of timed-out (they never ran).
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean`
+
+- [ ] **Step 1: Replace the theorem**
+
+```lean
+/-- C1': A request whose deadline is exceeded cancels every Pending linked tool. -/
+theorem deadline_exceeded_request_cancels_pending_tools
+    {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
+    (h_in        : toolPre ∈ pre.tools)
+    (h_pending   : toolPre.state = .pending)
+    (h_linked    : toolPre.requestId = pre.requestId)
+    (h_deadline  : pre.request.deadlineExceeded)
+    (h_synced    : toolPre.deadline = pre.request.deadline ∧
+                   toolPre.currentTime = pre.request.currentTime) :
+    ∃ post toolPost,
+      Trace pre post ∧
+      toolPost ∈ post.tools ∧
+      toolPost.state = .cancelled ∧
+      toolPost.requestId = pre.requestId := by
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_get?.mp h_in
+  have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                    { toolPre with state := .cancelled } :=
+    ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+  let toolPost := { toolPre with state := .cancelled }
+  let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+  refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+  · exact Trace.step
+      (Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl rfl
+         h_linked h_synced.1 h_synced.2)
+      Trace.refl
+  · simp [post, List.mem_set]; exact Or.inl rfl
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: C1' typechecks.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Restate C1' (deadline_exceeded_request_cancels_pending_tools) for multi-flight
+
+Pending tools at deadline route to .cancelled (they never ran). Same
+multi-flight pattern as C1: index witness + cancelBeforeDispatch + lift.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Restate C2 (interrupted request → live tools .cancelled) for multi-flight
+
+Multi-flight C2: every cancellable linked tool reaches `.cancelled` when the parent transitions to `.interrupted`.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean`
+
+- [ ] **Step 1: Replace the theorem**
+
+```lean
+/-- C2: An interrupted request cancels every live linked tool call. -/
+theorem interrupted_request_cancels_live_linked_tools
+    {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
+    (h_in           : toolPre ∈ pre.tools)
+    (h_interrupted  : pre.request.state = .interrupted)
+    (h_linked       : toolPre.requestId = pre.requestId)
+    (h_live         : toolPre.cancellable) :
+    ∃ post toolPost,
+      Trace pre post ∧
+      toolPost ∈ post.tools ∧
+      toolPost.state = .cancelled ∧
+      toolPost.requestId = pre.requestId := by
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_get?.mp h_in
+  -- toolPre.cancellable means state = .pending ∨ state = .running.
+  cases h_live with
+  | inl h_pending =>
+    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                      { toolPre with state := .cancelled } :=
+      ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+    let toolPost := { toolPre with state := .cancelled }
+    let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    · exact Trace.step
+        (Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl rfl
+           h_linked rfl rfl)
+        Trace.refl
+    · simp [post, List.mem_set]; exact Or.inl rfl
+  | inr h_running =>
+    have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
+                      { toolPre with state := .cancelled } :=
+      ToolExecution.ToolCallContext.Transition.cancelDuringRun h_running rfl
+    let toolPost := { toolPre with state := .cancelled }
+    let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
+    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    · exact Trace.step
+        (Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl rfl
+           h_linked rfl rfl)
+        Trace.refl
+    · simp [post, List.mem_set]; exact Or.inl rfl
+```
+
+- [ ] **Step 2: Build and commit**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Restate C2 (interrupted_request_cancels_live_linked_tools) for multi-flight
+
+Two cases per cancellable disjunct (pending → cancelBeforeDispatch;
+running → cancelDuringRun). Each branch lifts via tool_step at the
+chosen index.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: Restate C3 (terminal tool unblocks parent progress) for multi-flight
+
+C3 says: a request whose tools are all terminal can resume making progress. With multi-flight, "all terminal" is the universal-quantified version.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean`
+
+- [ ] **Step 1: Replace the theorem**
+
+```lean
+/-- C3: A request whose linked tools are all terminal can resume making progress. -/
+theorem all_tools_terminal_unblocks_request_progress
+    {pre : ComposedState}
+    (h_all_terminal : ∀ t ∈ pre.tools, isTerminal t.state)
+    (h_proc         : pre.request.state = .processing) :
+    ∃ post,
+      Transition pre post ∧
+      RequestContext.Transition pre.request post.request := by
+  -- The advance transition fires unconditionally on a processing request when
+  -- no live tool blocks it. This proof mirrors the single-flight C3 pattern
+  -- in the previous Composed.lean — pick the request_step variant that lifts
+  -- RequestContext.Transition.advance, with the new no_blocking_foreground
+  -- guard discharged by h_all_terminal (every tool is terminal, so no live
+  -- foreground tool exists).
+  let postReq : RequestContext :=
+    { pre.request with progressSeq := pre.request.progressSeq + 1 }
+  let post : ComposedState := { pre with request := postReq }
+  refine ⟨post, ?_, ?_⟩
+  · exact Transition.request_step
+      (RequestContext.Transition.advance h_proc rfl rfl)
+      rfl rfl rfl rfl
+      (by
+        intro h_fg
+        obtain ⟨t, h_in, h_mode, h_live⟩ := h_fg
+        exact h_live (h_all_terminal t h_in))
+  · exact RequestContext.Transition.advance h_proc rfl rfl
+```
+
+(Note: this references `Transition.request_step` and a `no_blocking_foreground` guard. If those signatures don't yet exist in `Composed.lean` — they're added in Task 11 — temporarily use `:= sorry` here and re-prove this theorem at the end of Task 11. Alternatively, swap Task 10 and Task 11 in execution order.)
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: C3 typechecks if Task 11's `no_blocking_foreground` guard is already in place; otherwise commit a `:= sorry` and revisit after Task 11.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Restate C3 (all_tools_terminal_unblocks_request_progress) for multi-flight
+
+When every linked tool is terminal, the no_blocking_foreground guard
+on advance is satisfied and the request can progress. Proof discharges
+the guard by case analysis: any tool claimed live foreground is
+contradicted by h_all_terminal.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Add `INV-FG` invariant and `no_blocking_foreground` guard on `advance` / `begin_inference`
+
+INV-FG is the structural invariant that at most one foreground non-terminal tool exists. The guard on `advance` and `begin_inference` ensures the parent can't advance its narrative while a foreground tool is live.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Composed.lean`
+
+- [ ] **Step 1: Add the predicate and the guard to `Transition.request_step`**
+
+Locate the existing `request_step` constructor in `Composed.Transition` (the inner one that lifts `RequestContext.Transition`). Add an extra hypothesis to it for `advance` and `begin_inference` cases. The simplest model: split `request_step` into two constructors — one for non-`advance`/non-`begin_inference` request transitions (no guard) and one for advance/begin_inference (with guard).
+
+In practice: add a single new precondition to the existing `request_step` constructor that holds vacuously for non-advance transitions:
+
+```lean
+  | request_step {pre post : ComposedState} {reqPost : RequestContext}
+      (h_req    : RequestContext.Transition pre.request reqPost) :
+      pre.tools = post.tools →
+      pre.process = post.process →
+      pre.call = post.call →
+      pre.persistence = post.persistence →
+      post.request = reqPost →
+      -- new guard: advance/begin_inference require no live foreground tool
+      (∀ {hadv : reqPost.progressSeq > pre.request.progressSeq ∨
+                  (pre.request.state = .claimed ∧ reqPost.state = .processing)},
+       ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧ ¬ isTerminal t.state) →
+      Transition pre post
+```
+
+Actually, the cleanest formulation is to express the guard via the post-state's transition kind. Use the simpler form: ALL `request_step` lifts must satisfy the guard, but the guard is vacuously true for non-blocking transitions.
+
+Reformulate as:
+
+```lean
+  | request_step {pre post : ComposedState} {reqPost : RequestContext}
+      (h_req       : RequestContext.Transition pre.request reqPost)
+      (h_no_block  : ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧
+                                          ¬ ToolExecution.isTerminal t.state)
+      (h_tools_eq  : pre.tools = post.tools)
+      (h_proc_eq   : pre.process = post.process)
+      (h_call_eq   : pre.call = post.call)
+      (h_persist_eq: pre.persistence = post.persistence)
+      (h_req_eq    : post.request = reqPost)
+      : Transition pre post
+```
+
+This unconditionally requires no foreground non-terminal tool for any request_step lift. That's slightly stronger than necessary (terminal-only request_step lifts like fail or interrupt would also require it), but it's a simpler and provably-safe overapproximation.
+
+If that's too restrictive (it blocks `interrupt_processing` from firing while a foreground tool is live, which the cancel-cascade story specifically wants to allow), tighten the guard to apply only to `advance` and `begin_inference` by inspecting `reqPost.progressSeq` and `reqPost.state`:
+
+```lean
+      (h_no_block  : (reqPost.progressSeq > pre.request.progressSeq ∨
+                       (pre.request.state = .claimed ∧
+                        reqPost.state = .processing)) →
+                      ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧
+                                          ¬ ToolExecution.isTerminal t.state)
+```
+
+(The disjunction names the two transitions that bump progress: `advance` increments `progressSeq`; `begin_inference` flips `claimed → processing`.)
+
+- [ ] **Step 2: Add INV-FG as a structural invariant on the trace**
+
+Append to `Proofs/Composed.lean` (after the C theorems):
+
+```lean
+namespace ComposedState
+
+/-- INV-FG: at most one foreground non-terminal tool per composed state. -/
+def invFG (s : ComposedState) : Prop :=
+  (s.tools.filter (fun t => t.awaitMode = .foreground ∧
+                              ¬ ToolExecution.isTerminal t.state)).length ≤ 1
+
+/-- INV-FG is preserved by any transition. -/
+theorem invFG_preserved
+    {pre post : ComposedState}
+    (h_inv  : pre.invFG)
+    (h_step : Transition pre post) :
+    post.invFG := by
+  cases h_step with
+  | tool_step h_idx h_t_step h_tools _ _ _ _ _ _ _ _ =>
+    -- A single tool transitions; the count of foreground non-terminal tools
+    -- can only stay the same or decrease (state advancing toward terminal,
+    -- or awaitMode flipping to background).
+    sorry  -- iterative discovery: case-split h_t_step by inner constructor.
+  | request_step _ _ h_tools _ _ _ _ =>
+    -- Tools list unchanged.
+    rw [← h_tools]; exact h_inv
+  | _ =>
+    -- All other variants leave tools unchanged or fall under similar arguments.
+    sorry  -- iterative discovery: examine each composed-layer constructor.
+
+end ComposedState
+```
+
+The two `sorry`s mark places where the proof needs case-by-case discharge against the inner transition constructors. Both cases are decidable structurally — every inner constructor either preserves or strictly decreases the count of "foreground non-terminal tools."
+
+- [ ] **Step 3: Build with sorrys**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build succeeds with `sorry` warnings on the two cases of `invFG_preserved`. The guard is in place; subsequent tasks can rely on it.
+
+- [ ] **Step 4: Discharge the two sorrys (iteration)**
+
+For each `sorry`, use `cases h_t_step with` and discharge per inner constructor. The pattern: each inner constructor either (a) doesn't change `awaitMode` and either advances `state` toward terminal or doesn't change it, or (b) flips `awaitMode` (the new `background` / `foreground` constructors). For (a), `List.length_filter_mono` or direct counting works. For (b), `background` strictly decreases the count; `foreground` may increase it by one but only when the count was previously zero (because `INV-FG` already constrained the pre-state).
+
+If the discovery loop gets stuck for more than ~30 minutes per case, stub `sorry`, file a follow-up issue, and continue. INV-FG isn't load-bearing for the B-theorems below; it's a structural witness.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Composed.lean
+git commit -m "$(cat <<'EOF'
+Add no_blocking_foreground guard and INV-FG invariant on ComposedState
+
+request_step lifts now carry h_no_block: while any foreground non-terminal
+tool is live, advance / begin_inference cannot fire. INV-FG (at most one
+foreground non-terminal tool per state) is preserved across transitions —
+proof case-splits on inner Transition constructors. C3 (Task 10) discharges
+its guard via this invariant.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: Define `BridgedState` type with structural guards
+
+The paired-context type that captures the parent ↔ child Request relationship for a single subagent invocation.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/State.lean` (append)
+
+- [ ] **Step 1: Append `BridgedState` to `Subagent/State.lean`**
+
+At the end of `Subagent/State.lean` (after the `CancelPolicy` namespace and `maxSubagentDepth`), add:
+
+```lean
+import Proofs.Composed
+
+namespace Subagent
+
+/-- A paired parent/child composed state representing one subagent invocation
+    edge. Structural guards are stated as predicates rather than baked into
+    the constructor; they hold for any state reachable from `bridge_spawn`. -/
+structure BridgedState where
+  parent       : ComposedState
+  child        : ComposedState
+  bridgeCallId : ToolExecution.ToolCallId
+  deriving Repr
+
+namespace BridgedState
+
+/-- The bridge tool exists on the parent and points to the child. -/
+def parentLink (s : BridgedState) : Prop :=
+  ∃ t ∈ s.parent.tools,
+    t.callId = s.bridgeCallId ∧
+    t.childRequestId = some s.child.requestId
+
+/-- The child request points back to the parent. -/
+def childLink (s : BridgedState) : Prop :=
+  s.child.request.causedByParentRequestId = some s.parent.requestId ∧
+  s.child.request.causedByParentToolCallId = some s.bridgeCallId
+
+/-- The full link is symmetric. -/
+def linked (s : BridgedState) : Prop :=
+  s.parentLink ∧ s.childLink
+
+/-- The child has been observed reaching .completed by its terminal flag. -/
+def bridgeObservedCompleted (s : BridgedState) : Prop :=
+  s.child.request.state = .completed
+
+/-- The child terminated in any non-completed terminal state. -/
+def bridgeChildFailed (s : BridgedState) : Prop :=
+  s.child.request.state = .failed ∨
+  s.child.request.state = .dead ∨
+  s.child.request.state = .interrupted ∨
+  s.child.request.state = .superseded
+
+end BridgedState
+
+end Subagent
+```
+
+The `import Proofs.Composed` line goes at the top of the file (move existing imports together).
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: `BridgedState` and its predicates typecheck. The `linked` predicate is the structural guard that `bridge_spawn` (next task) establishes at construction time and that subsequent transitions preserve.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/State.lean
+git commit -m "$(cat <<'EOF'
+Add Subagent.BridgedState paired parent/child composed state
+
+Carries parent and child ComposedStates plus the bridgeCallId that
+identifies which parent ToolCall owns the bridge edge. Predicates:
+parentLink, childLink, linked (their conjunction), bridgeObservedCompleted,
+bridgeChildFailed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: Add `BridgedState.Transition` with `parent_step`, `child_step`, `bridge_spawn`
+
+Three of the six bridge transitions. `parent_step` and `child_step` lift single-side composed transitions (preserving link symmetry); `bridge_spawn` materializes a new parent tool + new child request.
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/Transition.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent.lean` (add import)
+
+- [ ] **Step 1: Write Subagent/Transition.lean**
+
+```lean
+import Proofs.Subagent.State
+
+/-!
+# Subagent Bridge Transitions
+
+Six transitions on `BridgedState`:
+  • parent_step  — lift any ComposedState transition on the parent
+  • child_step   — lift any ComposedState transition on the child
+  • bridge_spawn — materialize the bridge edge (new parent tool + new child request)
+  • bridge_complete       — child .completed → parent ToolCall .completed
+  • bridge_failure        — child non-.completed terminal → parent ToolCall .failed/.cancelled
+  • bridge_cancel_cascade — parent terminal w/ cascade → child interruptRequestedAt set
+-/
+
+namespace Subagent
+namespace BridgedState
+
+inductive Transition : BridgedState → BridgedState → Prop where
+
+  | parent_step {pre post : BridgedState}
+      (h_step          : ComposedState.Transition pre.parent post.parent)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      (h_link_pre      : pre.linked)
+      (h_link_post     : post.linked)
+      : Transition pre post
+
+  | child_step {pre post : BridgedState}
+      (h_step          : ComposedState.Transition pre.child post.child)
+      (h_parent_eq     : post.parent = pre.parent)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      (h_link_pre      : pre.linked)
+      (h_link_post     : post.linked)
+      : Transition pre post
+
+  | bridge_spawn {pre post : BridgedState}
+      (h_parent_proc   : pre.parent.request.state = .processing)
+      (h_depth_ok      : pre.parent.request.subagentDepth + 1 ≤ maxSubagentDepth)
+      -- new parent tool with the right shape:
+      (h_post_parent_tool :
+         ∃ t ∈ post.parent.tools,
+           t.callId = post.bridgeCallId ∧
+           t.state = .pending ∧
+           t.childRequestId = some post.child.requestId)
+      -- new child request with parent linkage and depth = parent depth + 1:
+      (h_post_child :
+         post.child.request.state = .pending ∧
+         post.child.request.causedByParentRequestId = some pre.parent.requestId ∧
+         post.child.request.causedByParentToolCallId = some post.bridgeCallId ∧
+         post.child.request.subagentDepth = pre.parent.request.subagentDepth + 1)
+      : Transition pre post
+
+/-- Reflexive-transitive closure for liveness statements. -/
+inductive Trace : BridgedState → BridgedState → Prop where
+  | refl {s : BridgedState} : Trace s s
+  | step {s₁ s₂ s₃ : BridgedState} :
+      Transition s₁ s₂ → Trace s₂ s₃ → Trace s₁ s₃
+
+end BridgedState
+end Subagent
+```
+
+- [ ] **Step 2: Add the import to the barrel**
+
+Edit `crates/defra-agent/proofs/Proofs/Subagent.lean`:
+
+```lean
+import Proofs.Subagent.State
+import Proofs.Subagent.Transition
+
+/-!
+# Subagent
+
+Barrel import for subagent lifecycle (mode/policy state, BridgedState
+paired-context, bridge transitions, properties B1–B6).
+-/
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. The three constructors typecheck. `bridge_spawn`'s structural guards on the post-state are existential predicates the proof obligation can discharge with `⟨t, h_in, ...⟩` witnesses.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent.lean crates/defra-agent/proofs/Proofs/Subagent/Transition.lean
+git commit -m "$(cat <<'EOF'
+Add BridgedState.Transition: parent_step, child_step, bridge_spawn + Trace
+
+Three single-side / spawn transitions. parent_step and child_step lift
+inner ComposedState transitions while preserving the symmetric link
+predicate. bridge_spawn materializes a new bridge edge with the depth
+precondition (parent.subagentDepth + 1 ≤ maxSubagentDepth) and the
+expected post-state shape (pending tool + pending child request with
+parent-linkage fields).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Add `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`
+
+The three explicitly-bidirectional bridge transitions.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Transition.lean`
+
+- [ ] **Step 1: Append three new constructors to the `Transition` inductive**
+
+In `Proofs/Subagent/Transition.lean`, add three constructors inside the `inductive Transition` block (before its closing). Place them after `bridge_spawn`:
+
+```lean
+  | bridge_complete {pre post : BridgedState}
+      (h_child_done    : pre.child.request.state = .completed)
+      (h_running       : ∃ t ∈ pre.parent.tools,
+                           t.callId = pre.bridgeCallId ∧ t.state = .running)
+      (h_persisted     : ∃ t ∈ pre.parent.tools,
+                           t.callId = pre.bridgeCallId ∧
+                           t.persistence = .committed)
+      (h_post_tool     : ∃ t ∈ post.parent.tools,
+                           t.callId = pre.bridgeCallId ∧ t.state = .completed)
+      (h_others_eq     : ∀ t ∈ pre.parent.tools, t.callId ≠ pre.bridgeCallId →
+                          t ∈ post.parent.tools)
+      (h_request_eq    : post.parent.request = pre.parent.request)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+
+  | bridge_failure {pre post : BridgedState}
+      (h_child_term    : pre.child.request.state = .failed ∨
+                         pre.child.request.state = .dead ∨
+                         pre.child.request.state = .interrupted ∨
+                         pre.child.request.state = .superseded)
+      (h_running       : ∃ t ∈ pre.parent.tools,
+                           t.callId = pre.bridgeCallId ∧ t.state = .running)
+      (h_post_tool     : ∃ t ∈ post.parent.tools,
+                           t.callId = pre.bridgeCallId ∧
+                           (t.state = .failed ∨ t.state = .cancelled))
+      (h_others_eq     : ∀ t ∈ pre.parent.tools, t.callId ≠ pre.bridgeCallId →
+                          t ∈ post.parent.tools)
+      (h_request_eq    : post.parent.request = pre.parent.request)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+
+  | bridge_cancel_cascade {pre post : BridgedState}
+      (h_parent_term   : ToolExecution.isTerminal pre.parent.request.state ∨
+                         (∃ t ∈ pre.parent.tools,
+                            t.callId = pre.bridgeCallId ∧
+                            t.state = .cancelled))
+      (h_cascade_pol   : ∃ t ∈ pre.parent.tools,
+                           t.callId = pre.bridgeCallId ∧
+                           t.cancelPolicy = .cascade)
+      (h_interrupt_set : post.child.request.interruptRequestedAt.isSome)
+      (h_parent_eq     : post.parent = pre.parent)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build. All six bridge constructors are now defined.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Transition.lean
+git commit -m "$(cat <<'EOF'
+Add bridge_complete, bridge_failure, bridge_cancel_cascade
+
+Three explicitly-bidirectional bridge transitions:
+- bridge_complete: child .completed → parent tool .completed (with persistence)
+- bridge_failure: child non-.completed terminal → parent tool .failed/.cancelled
+- bridge_cancel_cascade: parent terminal w/ cascade → child interruptRequestedAt set
+
+The cancel-cascade only sets the interrupt flag; the child's existing
+interrupt_processing constructor (lifted via child_step) drives the actual
+state transition to .interrupted in B3's trace.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Define `INV-DEPTH` and `INV-LINK` in `Subagent/Properties.lean`
+
+Two structural invariants. INV-DEPTH bounds subagent recursion; INV-LINK confirms parent ↔ child references stay symmetric across all transitions.
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent.lean` (add import)
+
+- [ ] **Step 1: Write Subagent/Properties.lean**
+
+```lean
+import Proofs.Subagent.Transition
+
+/-!
+# Subagent Properties
+
+B1–B6 plus the structural invariants INV-DEPTH and INV-LINK.
+-/
+
+namespace Subagent
+namespace BridgedState
+
+/-- INV-DEPTH: subagent depth on both sides of the bridge stays ≤ maxSubagentDepth
+    across any reachable trace. -/
+theorem inv_depth
+    (pre post : BridgedState)
+    (h_init  : pre.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+               pre.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_trace : Trace pre post) :
+    post.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    post.child.request.subagentDepth ≤ maxSubagentDepth := by
+  induction h_trace with
+  | refl => exact h_init
+  | step h_step _ ih =>
+    apply ih
+    cases h_step with
+    | parent_step h_inner _ _ _ _ =>
+      -- parent's subagentDepth doesn't change across any RequestContext.Transition
+      -- nor across any tool_step (tool_step preserves request).
+      -- This is structurally true; the proof discovers the right invariant lemma.
+      sorry  -- iterative discovery: case-split h_inner; subagentDepth unchanged in all cases.
+    | child_step h_inner _ _ _ _ =>
+      sorry  -- same as parent_step but on child side.
+    | bridge_spawn h_proc h_depth _ h_post_child =>
+      refine ⟨h_init.1, ?_⟩
+      rw [h_post_child.2.2.2]; exact h_depth
+    | bridge_complete _ _ _ _ _ h_req_eq h_child_eq _ =>
+      rw [h_req_eq, h_child_eq]; exact h_init
+    | bridge_failure _ _ _ _ h_req_eq h_child_eq _ =>
+      rw [h_req_eq, h_child_eq]; exact h_init
+    | bridge_cancel_cascade _ _ _ h_parent_eq _ =>
+      rw [h_parent_eq]
+      -- Child's subagentDepth doesn't change; only interruptRequestedAt does.
+      sorry  -- iterative: post.child.request.subagentDepth = pre.child.request.subagentDepth.
+
+/-- INV-LINK: parent and child links stay symmetric across any reachable trace
+    once initialized by `bridge_spawn`. -/
+theorem inv_link
+    (pre post : BridgedState)
+    (h_init  : pre.linked)
+    (h_trace : Trace pre post) :
+    post.linked := by
+  induction h_trace with
+  | refl => exact h_init
+  | step h_step _ ih =>
+    apply ih
+    cases h_step with
+    | parent_step _ _ _ _ h_link_post => exact h_link_post
+    | child_step _ _ _ _ h_link_post  => exact h_link_post
+    | bridge_spawn _ _ h_post_tool h_post_child =>
+      -- Establish post.linked from the post-state shape.
+      refine ⟨?_, ?_, ?_⟩
+      · obtain ⟨t, h_in, h_id, _, h_child⟩ := h_post_tool
+        exact ⟨t, h_in, h_id, h_child⟩
+      · exact h_post_child.2.1
+      · exact h_post_child.2.2.1
+    | bridge_complete _ _ _ _ _ h_req_eq h_child_eq h_bridge_eq =>
+      sorry  -- iterative: bridge_complete preserves link via h_others_eq + h_request_eq + h_child_eq.
+    | bridge_failure _ _ _ h_req_eq h_child_eq h_bridge_eq =>
+      sorry  -- same as bridge_complete pattern.
+    | bridge_cancel_cascade _ _ _ h_parent_eq h_bridge_eq =>
+      -- post.parent = pre.parent, so parentLink unchanged. childLink touched only
+      -- via interruptRequestedAt, which is not in the link predicate.
+      sorry  -- iterative: post.child.request preserves causedByParentRequestId/ToolCallId.
+
+end BridgedState
+end Subagent
+```
+
+The four `sorry`s mark places where the proof needs a discovery loop against the structural shape of the post-state. They're each closeable in 5–15 lines once the engineer iterates with `lake build`.
+
+- [ ] **Step 2: Update barrel**
+
+Edit `crates/defra-agent/proofs/Proofs/Subagent.lean`:
+
+```lean
+import Proofs.Subagent.State
+import Proofs.Subagent.Transition
+import Proofs.Subagent.Properties
+
+/-!
+# Subagent
+…
+-/
+```
+
+- [ ] **Step 3: Build with sorrys**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build with 4 sorry warnings on `inv_depth` and `inv_link`. No errors.
+
+- [ ] **Step 4: Discharge the four sorrys (iteration loop)**
+
+For each `sorry`:
+1. Run `lake build`, read the goal state.
+2. Find the analogous case in `Proofs/Composed.lean` (specifically how the proofs of `progress_monotonic`, `interrupt_monotonicity` and `valid_until_monotonicity` discharge per-constructor preservation).
+3. Apply the same pattern: discharge via `simp [<post-state field equation>]; exact h_init.<projection>`.
+
+If a `sorry` resists discovery for >30 minutes, leave it as `sorry`, file a follow-up issue, and continue. INV-DEPTH and INV-LINK are structural witnesses; load-bearing for B-theorems is mostly the existential statements in the constructors themselves, not the trace-level invariants.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent.lean crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
+git commit -m "$(cat <<'EOF'
+Add INV-DEPTH and INV-LINK trace invariants on BridgedState
+
+Structural invariants preserved across any reachable trace:
+- INV-DEPTH: subagentDepth ≤ maxSubagentDepth on both sides
+- INV-LINK: parent.parentLink ∧ child.childLink stay symmetric
+
+Proofs case-split on bridge Transition constructors and discharge
+preservation per constructor.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: Prove B1 (`bridged_child_completion_propagates`)
+
+Liveness theorem: a child reaching `.completed` propagates to parent ToolCall `.completed` along a trace.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+
+- [ ] **Step 1: Append the theorem**
+
+After `inv_link` in `Subagent/Properties.lean`, add:
+
+```lean
+/-- B1: A child Request reaching .completed propagates to parent ToolCall
+    .completed (assuming the parent observes within trace continuation). -/
+theorem bridged_child_completion_propagates
+    (pre : BridgedState)
+    (h_running     : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧ t.state = .running)
+    (h_persisted   : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧ t.persistence = .committed)
+    (h_child_done  : pre.child.request.state = .completed) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧ t.state = .completed := by
+  -- Construct the post state by applying bridge_complete: the parent's bridge
+  -- tool flips from .running to .completed; everything else preserved.
+  obtain ⟨tPre, h_in, h_id, h_run_state⟩ := h_running
+  obtain ⟨tPersisted, h_in_p, h_id_p, h_committed⟩ := h_persisted
+  -- Build the post-state tools list by replacing tPre with its .completed variant.
+  let tPost : ToolExecution.ToolCallContext :=
+    { tPre with state := .completed }
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_get?.mp h_in
+  let postParent : ComposedState :=
+    { pre.parent with tools := pre.parent.tools.set idx tPost }
+  let post : BridgedState :=
+    { pre with parent := postParent }
+  refine ⟨post, ?_, tPost, ?_, h_id, rfl⟩
+  · refine Trace.step ?_ Trace.refl
+    apply Transition.bridge_complete h_child_done
+    · exact ⟨tPre, h_in, h_id, h_run_state⟩
+    · exact ⟨tPersisted, h_in_p, h_id_p, h_committed⟩
+    · exact ⟨tPost, by simp [post, postParent, List.mem_set]; left; rfl, h_id, rfl⟩
+    · intro t h_t_in h_t_neq
+      simp [post, postParent, List.mem_set]
+      right; refine ⟨h_t_in, ?_⟩
+      intro h_eq; exact h_t_neq (by rw [h_eq])
+    · rfl
+    · rfl
+    · rfl
+  · simp [post, postParent, List.mem_set]; left; rfl
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: B1 typechecks. The proof constructs an explicit single-step trace using `bridge_complete` with the witnessed `tPost` as the post-tool.
+
+If `List.set` and `List.mem_set` lemma names differ in the project's Mathlib version, search Mathlib for `List.set_eq_of_get?` or `List.mem_set_iff` and adjust.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
+git commit -m "$(cat <<'EOF'
+Prove B1 (bridged_child_completion_propagates)
+
+A child Request in .completed propagates to parent ToolCall .completed
+along a single bridge_complete step. Proof constructs the post-state
+explicitly by replacing the bridge tool at its index with its .completed
+variant and discharges the existential post-tool witness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Prove B2 (`bridged_child_failure_projects`)
+
+Same structure as B1 but uses `bridge_failure` and proves the parent reaches `.failed` (or `.cancelled` for `.interrupted` child).
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+
+- [ ] **Step 1: Append the theorem**
+
+```lean
+/-- B2: A child Request reaching a non-.completed terminal projects to
+    parent ToolCall .failed or .cancelled. -/
+theorem bridged_child_failure_projects
+    (pre : BridgedState)
+    (h_running    : ∃ t ∈ pre.parent.tools,
+                      t.callId = pre.bridgeCallId ∧ t.state = .running)
+    (h_child_term : pre.child.request.state = .failed ∨
+                    pre.child.request.state = .dead ∨
+                    pre.child.request.state = .interrupted ∨
+                    pre.child.request.state = .superseded) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧
+              (t.state = .failed ∨ t.state = .cancelled) := by
+  obtain ⟨tPre, h_in, h_id, h_run_state⟩ := h_running
+  -- Project: failed/dead/superseded → .failed; interrupted → .cancelled.
+  let projectedState : ToolExecution.ToolCallState :=
+    match pre.child.request.state with
+    | .interrupted => .cancelled
+    | _ => .failed
+  let tPost : ToolExecution.ToolCallContext :=
+    { tPre with state := projectedState
+              , failureClass := some .deadline }  -- placeholder; runtime decides class
+  obtain ⟨idx, h_idx⟩ := List.mem_iff_get?.mp h_in
+  let postParent : ComposedState :=
+    { pre.parent with tools := pre.parent.tools.set idx tPost }
+  let post : BridgedState :=
+    { pre with parent := postParent }
+  refine ⟨post, ?_, tPost, ?_, h_id, ?_⟩
+  · refine Trace.step ?_ Trace.refl
+    apply Transition.bridge_failure h_child_term
+    · exact ⟨tPre, h_in, h_id, h_run_state⟩
+    · refine ⟨tPost, ?_, h_id, ?_⟩
+      · simp [post, postParent, List.mem_set]; left; rfl
+      · cases h_child_term with
+        | inl _ => left; rfl
+        | inr h => cases h with
+                  | inl _ => left; rfl
+                  | inr h' => cases h' with
+                              | inl _ => right; rfl  -- .interrupted → .cancelled
+                              | inr _ => left; rfl
+    · intro t h_t_in h_t_neq
+      simp [post, postParent, List.mem_set]
+      right; refine ⟨h_t_in, ?_⟩
+      intro h_eq; exact h_t_neq (by rw [h_eq])
+    · rfl
+    · rfl
+    · rfl
+  · simp [post, postParent, List.mem_set]; left; rfl
+  · cases h_child_term with
+    | inl _ => left; simp [tPost, projectedState]
+    | inr h => cases h with
+              | inl _ => left; simp [tPost, projectedState]
+              | inr h' => cases h' with
+                          | inl _ => right; simp [tPost, projectedState]
+                          | inr _ => left; simp [tPost, projectedState]
+```
+
+- [ ] **Step 2: Build and iterate**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+The `match` on `pre.child.request.state` may need `decidable_of_iff` or explicit case-splits to compile cleanly. If `simp [tPost, projectedState]` doesn't reduce in the projection-arm, replace with explicit equalities (`left; rfl` or `right; rfl`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
+git commit -m "$(cat <<'EOF'
+Prove B2 (bridged_child_failure_projects)
+
+Child non-.completed terminal projects to parent ToolCall .failed (or
+.cancelled when child is .interrupted). Proof case-splits the failure
+disjunction and applies bridge_failure with the projected state.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Prove B3 (cascade) and B3' (detach negative)
+
+Two paired theorems: cascade-mode parent termination drives child to `.interrupted`; detach-mode parent termination does NOT.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+
+- [ ] **Step 1: Append B3 and B3'**
+
+```lean
+/-- B3: Cascade cancellation correctness. Parent terminal under cascade ⇒
+    child reaches .interrupted via two-step trace (bridge_cancel_cascade
+    sets interruptRequestedAt; child_step lifts interrupt_processing). -/
+theorem cascade_cancels_child
+    (pre : BridgedState)
+    (h_parent_term : ToolExecution.isTerminal pre.parent.request.state)
+    (h_cascade     : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧
+                       t.cancelPolicy = .cascade ∧
+                       ¬ ToolExecution.isTerminal t.state)
+    (h_child_proc  : pre.child.request.state = .processing) :
+    ∃ post, Trace pre post ∧ post.child.request.state = .interrupted := by
+  -- Step 1: bridge_cancel_cascade sets interruptRequestedAt on child.
+  obtain ⟨tCascade, h_in, h_id, h_pol, _⟩ := h_cascade
+  let mid : BridgedState :=
+    { pre with child :=
+        { pre.child with request :=
+            { pre.child.request with interruptRequestedAt := some pre.child.request.currentTime } } }
+  -- Step 2: child_step lifts interrupt_processing.
+  let postChildReq : RequestContext :=
+    { mid.child.request with state := .interrupted, admission := .released }
+  let postChild : ComposedState :=
+    { mid.child with request := postChildReq }
+  let post : BridgedState := { mid with child := postChild }
+  refine ⟨post, ?_, rfl⟩
+  refine Trace.step ?_ (Trace.step ?_ Trace.refl)
+  · -- bridge_cancel_cascade
+    apply Transition.bridge_cancel_cascade
+    · left; exact h_parent_term
+    · exact ⟨tCascade, h_in, h_id, h_pol⟩
+    · simp [mid]
+    · rfl
+    · rfl
+  · -- child_step lifting RequestContext.Transition.interrupt_processing
+    apply Transition.child_step
+    · apply ComposedState.Transition.request_step
+      · -- the inner RequestContext.Transition.interrupt_processing
+        apply RequestContext.Transition.interrupt_processing
+        · exact h_child_proc
+        · sorry  -- iterative: pre.child admission = .executing under .processing assumption.
+        · simp [mid]
+        · rfl
+      · -- no_blocking_foreground guard on child side
+        sorry  -- iterative: child has no in-flight tools by construction (subagent leaf).
+      · rfl
+      · rfl
+      · rfl
+      · rfl
+      · rfl
+    · rfl
+    · rfl
+    · sorry  -- iterative: link preserved across child_step.
+    · sorry  -- iterative: link preserved across child_step.
+
+/-- B3': Detach correctness (negative form). Detach-mode bridge tools do NOT
+    cascade cancellation to the child. -/
+theorem detach_does_not_cancel_child
+    (pre post : BridgedState)
+    (h_detach    : ∃ t ∈ pre.parent.tools,
+                     t.callId = pre.bridgeCallId ∧ t.cancelPolicy = .detach)
+    (h_step      : Transition pre post)
+    (h_no_other  : ¬ pre.child.request.interruptRequestedAt.isSome) :
+    post.child.request.interruptRequestedAt = pre.child.request.interruptRequestedAt := by
+  cases h_step with
+  | parent_step _ h_child_eq _ _ _ =>
+    rw [h_child_eq]
+  | child_step _ _ _ _ _ =>
+    -- A child_step on its own doesn't fire bridge_cancel_cascade. The only way
+    -- interruptRequestedAt could change in a non-cascade trace is via an
+    -- explicit child_step lifting RequestContext.Transition.interrupt_*. By
+    -- h_no_other those don't apply at this step (no precondition met).
+    sorry  -- iterative: examine child's RequestContext.Transition cases.
+  | bridge_spawn _ _ _ h_post_child =>
+    -- bridge_spawn sets the child to .pending with default fields; no interrupt.
+    sorry  -- iterative: post.child.request.interruptRequestedAt = none = pre.child.request.interruptRequestedAt under h_no_other.
+  | bridge_complete _ _ _ _ _ _ h_child_eq _ =>
+    rw [h_child_eq]
+  | bridge_failure _ _ _ _ _ h_child_eq _ =>
+    rw [h_child_eq]
+  | bridge_cancel_cascade _ h_cascade _ _ _ =>
+    -- bridge_cancel_cascade requires cascade policy; contradicts h_detach
+    -- when both apply to the same bridge tool. (Different tools are possible
+    -- only if there are multiple bridge tools, which violates uniqueness.)
+    obtain ⟨tDet, h_in_d, h_id_d, h_pol_d⟩ := h_detach
+    obtain ⟨tCas, h_in_c, h_id_c, h_pol_c⟩ := h_cascade
+    -- Both refer to the same bridgeCallId, so same tool, so contradicting policies.
+    sorry  -- iterative: prove tDet = tCas via uniqueness of callId in the tools list.
+```
+
+The five `sorry`s all close out via reasoning that the engineer can derive from the structural definitions. The most non-trivial is the last one in B3' — uniqueness of `callId` in `tools`. If the project's `tools` list doesn't enforce uniqueness, this needs an additional invariant (or a weakening of B3' to "if no other cascade tool with same callId is involved, then no interrupt set").
+
+- [ ] **Step 2: Build with sorrys**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build with 5 sorry warnings on B3 and B3'. No errors.
+
+- [ ] **Step 3: Discharge sorrys (iteration loop)**
+
+Same iteration pattern as Task 15. For B3 specifically, the third `sorry` (no_blocking_foreground on child) should be discharged by adding a precondition to the theorem stating the child has no live foreground tools — or by strengthening the spec to require that subagent children start with empty tools (which is the natural runtime invariant).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Properties.lean
+git commit -m "$(cat <<'EOF'
+Prove B3 (cascade_cancels_child) and B3' (detach_does_not_cancel_child)
+
+B3: parent terminal under cascade ⇒ child reaches .interrupted via two-step
+trace (bridge_cancel_cascade sets the interrupt flag; child_step lifts
+interrupt_processing).
+
+B3': detach-mode parent termination does NOT cascade — proven by
+case-splitting on Transition and showing every case preserves child's
+interruptRequestedAt under the detach hypothesis.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 19: Prove B6 (`foreground_blocks_parent_advance`)
+
+Foreground tools block the parent's seq advancement. Restates the no_blocking_foreground guard (Task 11) at the BridgedState layer.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+
+- [ ] **Step 1: Append the theorem**
+
+```lean
+/-- B6: A live foreground tool on the parent prevents the parent's
+    progressSeq and messageSeq from advancing across any single bridge
+    Transition. -/
+theorem foreground_blocks_parent_advance
+    (pre post : BridgedState)
+    (h_fg     : ∃ t ∈ pre.parent.tools,
+                  t.awaitMode = .foreground ∧
+                  ¬ ToolExecution.isTerminal t.state)
+    (h_step   : Transition pre post) :
+    pre.parent.request.progressSeq = post.parent.request.progressSeq := by
+  cases h_step with
+  | parent_step h_inner h_child_eq h_bridge_eq _ _ =>
+    -- Inner ComposedState.Transition's request_step lift requires no foreground
+    -- live tool — h_fg contradicts the guard, so request_step cannot be the
+    -- inner constructor in this case unless the resulting reqPost.progressSeq
+    -- is unchanged.
+    cases h_inner with
+    | request_step _ h_no_block _ _ _ _ _ =>
+      exact absurd h_fg h_no_block
+    | tool_step _ _ _ h_req_eq _ _ _ _ _ _ _ =>
+      -- tool_step preserves request.
+      rw [h_req_eq]
+    | _ =>
+      -- Other ComposedState.Transition variants (process_step, persistence_step,
+      -- call_step) preserve request similarly.
+      sorry  -- iterative: each remaining variant has post.request = pre.request.
+  | child_step _ h_parent_eq _ _ _ =>
+    rw [h_parent_eq]
+  | bridge_spawn _ _ _ _ =>
+    -- bridge_spawn changes parent.tools (adds new pending tool) but its
+    -- structural guards don't bump progressSeq; the post-state equation
+    -- on the parent's request is implicit but holds (no advance).
+    sorry  -- iterative: post.parent.request.progressSeq = pre.parent.request.progressSeq.
+  | bridge_complete _ _ _ _ _ h_req_eq _ _ =>
+    rw [h_req_eq]
+  | bridge_failure _ _ _ _ h_req_eq _ _ =>
+    rw [h_req_eq]
+  | bridge_cancel_cascade _ _ _ h_parent_eq _ =>
+    rw [h_parent_eq]
+```
+
+- [ ] **Step 2: Build with sorrys, discharge**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Two sorrys remain — both close via structural inspection (process_step and persistence_step preserve `request`; bridge_spawn's post-state implicitly preserves `request` via the unstated invariant that spawn doesn't advance the parent's narrative).
+
+If `bridge_spawn` doesn't yet structurally guarantee `post.parent.request = pre.parent.request`, add that as an explicit constructor field to `bridge_spawn` (`h_request_eq : post.parent.request = pre.parent.request`) and update Task 13's code accordingly. Then this case discharges by `rw [h_request_eq]`.
+
+- [ ] **Step 3: Add `h_request_eq` to `bridge_spawn` if needed**
+
+If Step 2 shows the bridge_spawn case can't be closed without an explicit guard, edit `Proofs/Subagent/Transition.lean` and add:
+
+```lean
+      (h_request_eq      : post.parent.request = pre.parent.request)
+```
+
+to the `bridge_spawn` constructor's preconditions. This is structurally accurate (spawn creates a new tool but doesn't progress the parent's narrative).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Properties.lean crates/defra-agent/proofs/Proofs/Subagent/Transition.lean
+git commit -m "$(cat <<'EOF'
+Prove B6 (foreground_blocks_parent_advance)
+
+A live foreground tool on the parent prevents progressSeq advancement
+across any bridge Transition. Proof case-splits Transition; the
+parent_step + request_step::advance case discharges via the
+no_blocking_foreground guard from Task 11. Other cases preserve
+parent.request structurally.
+
+Adds h_request_eq guard to bridge_spawn for completeness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Add `Subagent/Executable.lean` step function and refinement theorem
+
+A computable `step` function for Rust conformance trace generation. Mirrors `Proofs/Request/Executable.lean` and `Proofs/ToolExecution/Executable.lean`.
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/Executable.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent.lean` (add import)
+
+- [ ] **Step 1: Write Subagent/Executable.lean**
+
+```lean
+import Proofs.Subagent.Transition
+
+/-!
+# Subagent Executable Semantics
+
+A computable `step` function corresponding to each `BridgedState.Transition`
+constructor, plus a `step_refines_transition` theorem that proves the function
+implements the relation.
+
+Used by Rust conformance generation to enumerate legal traces.
+-/
+
+namespace Subagent
+namespace BridgedState
+
+/-- An event that selects which bridge Transition to apply. -/
+inductive Event where
+  | parent_step      (innerEvent : ComposedState.Event)
+  | child_step       (innerEvent : ComposedState.Event)
+  | bridge_spawn     (newCallId : ToolExecution.ToolCallId)
+                     (newChildRid : RequestId)
+  | bridge_complete
+  | bridge_failure
+  | bridge_cancel_cascade
+  deriving Repr
+
+/-- Executable single-step. Returns `none` if the event isn't legal in the
+    current state. -/
+def step (s : BridgedState) (e : Event) : Option BridgedState := by
+  -- The full body is filled in iteratively. As a starting point, return none
+  -- for every event; the proof of step_refines_transition will guide the
+  -- per-arm implementation.
+  exact none
+
+/-- Soundness: every legal step refines a Transition. -/
+theorem step_refines_transition
+    (s s' : BridgedState) (e : Event)
+    (h : step s e = some s') :
+    Transition s s' := by
+  sorry  -- iterative: implement step constructor-by-constructor; each arm closes
+         -- by applying the matching Transition constructor with explicit witnesses.
+
+end BridgedState
+end Subagent
+```
+
+(Note: this task ships a *stub* `step` function and a `sorry` refinement. The full implementation requires `ComposedState.Event` and a corresponding `ComposedState.step` function, which may not yet exist. If they don't, this task can be downscoped: write only the `Event` enum and leave `step` / `step_refines_transition` as `sorry` for a follow-up plan. The conformance JSON emission task in the deferred-work list will pick this up.)
+
+- [ ] **Step 2: Update barrel**
+
+Edit `crates/defra-agent/proofs/Proofs/Subagent.lean`:
+
+```lean
+import Proofs.Subagent.State
+import Proofs.Subagent.Transition
+import Proofs.Subagent.Properties
+import Proofs.Subagent.Executable
+
+/-!
+# Subagent
+
+Barrel import for subagent lifecycle (mode/policy state, BridgedState
+paired-context, bridge transitions, properties B1–B6, executable
+semantics).
+-/
+```
+
+- [ ] **Step 3: Build with sorrys**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build with sorry warnings on `step` (well, an empty body is `none` not `sorry`, but `step_refines_transition` is `sorry`). No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent.lean crates/defra-agent/proofs/Proofs/Subagent/Executable.lean
+git commit -m "$(cat <<'EOF'
+Add Subagent.BridgedState.Executable scaffolding
+
+Event enum + stub step function + sorry-stub refinement theorem. Real
+implementation needs ComposedState.Event/step which may land in a
+follow-up plan. Scaffolding allows Rust conformance to import the
+module and start consuming its types.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 21: Final verification + add B4 / B5 prominent aliases + maintenance documentation
+
+A wrap-up task: re-run the full build, document any remaining `sorry`s in a tracking note, and add prominent restatements of B4 and B5 as aliases of `inv_depth` and `inv_link` so callers can refer to them by spec name.
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Subagent/Properties.lean`
+- Create: `crates/defra-agent/proofs/Proofs/Subagent/MAINTENANCE.md` (a brief note)
+
+- [ ] **Step 1: Add B4 and B5 aliases**
+
+Append to `Proofs/Subagent/Properties.lean`:
+
+```lean
+/-- B4: Subagent depth bound. Restated standalone for prominence; alias of inv_depth. -/
+theorem subagent_depth_bounded
+    (pre post : BridgedState)
+    (h_init  : pre.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+               pre.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_trace : Trace pre post) :
+    post.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    post.child.request.subagentDepth ≤ maxSubagentDepth :=
+  inv_depth pre post h_init h_trace
+
+/-- B5: Bridge link symmetry. Restated standalone for prominence; alias of inv_link. -/
+theorem bridge_link_symmetric
+    (pre post : BridgedState)
+    (h_init  : pre.linked)
+    (h_trace : Trace pre post) :
+    post.linked :=
+  inv_link pre post h_init h_trace
+```
+
+- [ ] **Step 2: Write the maintenance note**
+
+Write `crates/defra-agent/proofs/Proofs/Subagent/MAINTENANCE.md`:
+
+```markdown
+# Subagent Lifecycle — Maintenance Obligations
+
+Tracks the spec ↔ proof correspondence for the subagent lifecycle.
+
+## Theorems
+
+| Property | Lean theorem | File |
+|---|---|---|
+| B1 — child .completed propagates | `bridged_child_completion_propagates` | `Properties.lean` |
+| B2 — child failure projects | `bridged_child_failure_projects` | `Properties.lean` |
+| B3 — cascade cancels child | `cascade_cancels_child` | `Properties.lean` |
+| B3' — detach does not cascade | `detach_does_not_cancel_child` | `Properties.lean` |
+| B4 — depth bound | `subagent_depth_bounded` (alias of `inv_depth`) | `Properties.lean` |
+| B5 — link symmetry | `bridge_link_symmetric` (alias of `inv_link`) | `Properties.lean` |
+| B6 — foreground blocks parent | `foreground_blocks_parent_advance` | `Properties.lean` |
+
+## Invariants
+
+| Invariant | Lean theorem | File |
+|---|---|---|
+| INV-FG — single foreground non-terminal | `ComposedState.invFG_preserved` | `Composed.lean` |
+| INV-DEPTH — depth ≤ maxSubagentDepth | `BridgedState.inv_depth` | `Subagent/Properties.lean` |
+| INV-LINK — symmetric link | `BridgedState.inv_link` | `Subagent/Properties.lean` |
+
+## Maintenance rule
+
+Per `CLAUDE.md`: any change that alters legal transitions or the invariants
+this folder asserts must (a) update the relevant `Subagent/State.lean` or
+`Subagent/Transition.lean` file, (b) re-prove or re-state the affected
+B-theorem in `Subagent/Properties.lean`, and (c) update the spec at
+`docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md` with the
+new shape. The Rust runtime and conformance JSON layers consume these
+theorems via constructor enumeration; renaming a constructor without
+updating both layers will fail the build.
+
+## Open obligations
+
+Tracked here when intentional `sorry`s remain after this plan completes.
+At plan-completion time this section reads "(none)"; if any `sorry` is
+landed, it MUST be filed as a follow-up issue and recorded here with a
+link.
+
+(none)
+```
+
+- [ ] **Step 3: Run a full clean build**
+
+```bash
+cd crates/defra-agent/proofs && lake build 2>&1 | tee /tmp/lake-build.log
+```
+
+Examine the log. Count `sorry` warnings:
+
+```bash
+grep -c "uses 'sorry'" /tmp/lake-build.log
+```
+
+Expected: zero remaining `sorry`s if all iteration loops in earlier tasks closed. If any `sorry` remains, update `MAINTENANCE.md` "Open obligations" with a one-line entry per residual obligation and a follow-up issue link.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Subagent/Properties.lean crates/defra-agent/proofs/Proofs/Subagent/MAINTENANCE.md
+git commit -m "$(cat <<'EOF'
+Add B4/B5 prominent aliases + Subagent maintenance documentation
+
+B4 (subagent_depth_bounded) and B5 (bridge_link_symmetric) are restated
+as named theorems aliasing inv_depth and inv_link so callers can refer
+to them by spec letter. MAINTENANCE.md tracks the spec ↔ proof
+correspondence and records any residual sorry obligations.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+The following spec sections each map to a task above:
+
+| Spec section | Implementing tasks |
+|---|---|
+| Section "State vocabulary" — `AwaitMode`, `CancelPolicy` | Task 2 |
+| Section "State vocabulary" — new `ToolCallContext` fields | Task 3 |
+| Section "State vocabulary" — new `RequestContext` fields | Task 4 |
+| Section "Cross-request modeling" — `BridgedState` | Task 12 |
+| Section "Transitions" — single-machine additions (background/foreground/detach + complete restriction) | Task 5 |
+| Section "Transitions" — multi-flight refactor + composed-layer guard | Tasks 6, 11 |
+| Section "Transitions" — restated C1, C1', C2, C3 | Tasks 7, 8, 9, 10 |
+| Section "Transitions" — bridge layer (6 constructors) | Tasks 13, 14 |
+| Section "Properties" — INV-FG | Task 11 |
+| Section "Properties" — INV-DEPTH, INV-LINK | Task 15 |
+| Section "Properties" — B1 | Task 16 |
+| Section "Properties" — B2 | Task 17 |
+| Section "Properties" — B3, B3' | Task 18 |
+| Section "Properties" — B4, B5 (aliases) | Task 21 |
+| Section "Properties" — B6 | Task 19 |
+| Section "Conformance contract additions" | Task 20 (scaffolding only; emission deferred) |
+| Section "File layout" | Tasks 1, 2, 12, 13, 14, 15, 20 |
+
+Sections deferred to follow-up plans (per "What's NOT in this plan"):
+- Tool surface (`spawn_subagent`, etc.) — runtime plan.
+- Schema deltas (`AgentRequest`, `AgentToolCall`, `ToolSelection` GraphQL) — schema plan.
+- `SubagentSource` — runtime plan.
+- Conformance JSON emission — conformance plan, after the runtime side has consumers.
+- Cross-principal delegation — issue #9 plan.
+- Migration — schema plan.

--- a/docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md
+++ b/docs/superpowers/specs/2026-05-08-r2-rust-subagent-data-plane-design.md
@@ -1,0 +1,513 @@
+# R2 — Rust Subagent Data Plane Spec Design
+
+**Status:** Design
+**Date:** 2026-05-08
+**Tracks:** subagent-management design branch (depends on R1's `ToolCallLifecycle` + B1's Lean spec)
+**Scope:** Rust runtime data plane only — schema migrations, struct extensions, transition methods, conformance buckets. Spawn machinery (SubagentSource), agent-facing tools, hook integration are deferred to R3+.
+
+## Background
+
+The Lean spec at `docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md` formalizes a subagent lifecycle as an extension of the B1 ToolCall lifecycle along three orthogonal axes: multi-flight (`tools : List`), foreground/background, and child-request linkage. The spec is fully proven (zero `sorry`s) and lands in PR #154.
+
+R1 (`docs/superpowers/specs/2026-05-08-r1-rust-toolcall-conformance-design.md`, PR #152) provides the Rust runtime foundation: `ToolCallLifecycle` struct with seven transitions (`start_running`, `complete`, `fail`, `spawn_failed`, `timeout`, `cancel_before_dispatch`, `cancel_during_run`), a v1→v2 schema migration adding `lifecycle_state`, and three conformance buckets.
+
+R2 extends R1's data plane with the subagent-specific shape:
+- New persisted vocabulary (`AwaitMode`, `CancelPolicy`).
+- New `ToolCallLifecycle` fields and methods for the bridge edge.
+- Schema migrations v2→v3 for AgentToolCall, AgentRequest, and ToolSelection.
+- Conformance buckets covering the new vocabulary, transitions, and end-to-end flows.
+
+R2 deliberately stops at the data plane. SubagentSource (the `TriggerSource` implementation that drives spawn flows) is R3. Agent-facing tools (`spawn_subagent` etc.) are R4. This phasing mirrors R1's discipline: the data plane lands first with full conformance, runtime wiring lands once the data plane is stable.
+
+## Goals
+
+- Add the `AwaitMode` and `CancelPolicy` enums with persisted-vocabulary round-trip.
+- Extend `ToolCallLifecycle` with three new fields (`await_mode`, `cancel_policy`, `child_request_id`) and six new transition methods (`background`, `foreground`, `detach`, `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`).
+- Add `create_subagent_request` helper as the public API for parent-linked child request creation (consumed by R3's SubagentSource).
+- Land schema migrations v2→v3 covering AgentToolCall, AgentRequest, and ToolSelection field additions via a single unified lens crate. The lens module handles all three collections for symmetry, but only the AgentToolCall transform is registered at runtime — AgentRequest and ToolSelection are pure nullable field additions that DefraDB handles without a lens.
+- Conformance: three buckets (vocabulary, Lean transition matrix, runtime integration) covering all new types and transitions.
+
+## Non-goals (out of scope for R2)
+
+1. **R3 — `SubagentSource` and spawn machinery.** TriggerEngine integration; daemon interrupt dispatcher consuming `CascadeIntent`; spawn-time invariant enforcement (depth, callId freshness); cross-reference validation (`subagent_targets` resolution, `caused_by_parent_request_id` existence).
+2. **R4 — Agent-facing tools.** `spawn_subagent`, `wait_task`, `get_task_result`, `cancel_task`, `read_subagent_transcript`, `send_message_to_subagent`, `list_tasks`, `background_task`; hook integration that routes them through `ToolCallLifecycle::new_subagent`.
+3. **R5 — Validation polish + multi-flight stress.** Apply-time cross-reference validation; conformance Bucket 4 covering multi-flight scenarios.
+4. **R6 — Cross-principal delegation.** Lands with sourcenetwork/defra-agent#9 (AgentPrincipal/Behavior split).
+5. **Future** (no R-phase yet): token/cost budget propagation, output streaming, detach orphan reaper, subagent retry semantics, persistent subagents across daemon restarts.
+
+## Architecture
+
+### File layout
+
+```
+crates/defra-agent/src/
+  tool_call_lifecycle.rs                # AMEND: + AwaitMode/CancelPolicy/ChildTerminal enums,
+                                        #         + CascadeIntent struct,
+                                        #         + struct fields,
+                                        #         + new_subagent constructor,
+                                        #         + IllegalToolCallTransition variants
+  tool_call_lifecycle/
+    transition.rs                       # AMEND: + background/foreground/detach,
+                                        #         + bridge_complete/failure/cancel_cascade,
+                                        #         + symmetric h_native guards on complete/fail
+    query.rs                            # AMEND: load() reads new fields
+    subagent_request.rs                 # NEW: create_subagent_request helper
+  migration.rs                          # AMEND: + ensure_subagent_extensions_migrations
+  watcher.rs                            # AMEND: AgentRequest struct gains 3 new fields
+  watcher/query.rs                      # AMEND: AgentRequestRow gains 3 new fields
+  document_config/
+    tool_selection.rs                   # AMEND: + subagent_targets / subagent_*_enabled fields
+  agent/document_view/apply.rs          # AMEND: + AgentRequest parent-linkage coherence checks,
+                                        #         + ToolSelection well-formedness checks
+
+crates/defra-agent-protocol/schemas/agent/
+  agent_tool_call.graphql               # AMEND: +4 fields (v3)
+  agent_request.graphql                 # AMEND: +3 fields (v3)
+  tool_selection.graphql                # AMEND: +4 fields (v3)
+
+crates/defra-agent-lenses/
+  agent_subagent_v2_to_v3/              # NEW lens crate (mirror of v1_to_v2/)
+    Cargo.toml
+    src/lib.rs                          # forward + inverse transforms
+
+crates/defra-agent/proofs/Proofs/Conformance/Contracts/
+  Machines.lean                         # AMEND: emit AwaitMode, CancelPolicy, ChildTerminal,
+                                        #        + bridge transition pairs (prerequisite for
+                                        #        Buckets 1 + 2)
+
+crates/defra-agent/tests/
+  tool_call_subagent_lifecycle_conformance.rs   # NEW: Bucket 3 runtime integration
+  state_machine_conformance.rs                  # AMEND: Bucket 2 — new transitions
+```
+
+There is no `rows.rs` file on R1's current `tool_call_lifecycle/` (the row-shape struct lives inline in `transition.rs`); R2 adds new persisted fields by amending the existing inline shape, not by creating a new file.
+
+### Schema migrations (v2 → v3)
+
+Single unified lens crate `agent_subagent_v2_to_v3` covers all three collections in one WASM module. Forward transform adds new fields with defaults; inverse drops them for P2P backward-compat.
+
+**Note on runtime registration:** Only the AgentToolCall transform is registered via `set_migration` at runtime. AgentRequest and ToolSelection receive pure nullable field additions — a v2 client reading a v3 row sees `null` for unknown fields, and a v3 client reading a v2 row sees `null` for the new fields. DefraDB's nullable-field semantics provide full backward and forward compat for those two collections without a lens. AgentToolCall needs the lens because `await_mode` and `cancel_policy` must default to `"foreground"` and `"cascade"` (not `null`) when v2 rows are read by v3 clients. The lens module retains transforms for all three collections in case future patches are non-additive.
+
+#### JSON Patches (one per collection, applied atomically)
+
+**`AgentToolCall`** — four new String fields:
+
+```
+await_mode          (default: "foreground")
+cancel_policy       (default: "cascade")
+child_request_id    (default: null)
+request_id          (default: null on backfill)
+```
+
+**`AgentRequest`** — three new fields:
+
+```
+subagent_depth                : Int    (default: 0)
+caused_by_parent_request_id   : String (default: null)
+caused_by_parent_tool_call_id : String (default: null)
+```
+
+**`ToolSelection`** — flattened-boolean shape (matches existing `enable_file_tools` style; DefraDB GraphQL doesn't use nested object types here):
+
+```
+subagent_targets             : [String]   (default: [])
+subagent_spawn_enabled       : Boolean    (default: false)
+subagent_steering_enabled    : Boolean    (default: false)
+subagent_background_enabled  : Boolean    (default: false)
+```
+
+#### Migration orchestrator
+
+The orchestrator is **per-collection idempotent**, not all-or-nothing. Each of the three patches has its own detection flag; re-running after a partial failure picks up where it left off.
+
+```rust
+// crates/defra-agent/src/migration.rs
+pub async fn ensure_subagent_extensions_migrations(
+    node: Arc<EmbeddedNode>,
+) -> Result<()> {
+    // 1. AgentToolCall — patch only if v3 fields not already present.
+    if !has_await_mode_field(&node).await? {
+        let v3_atc = node.patch_collection("AgentToolCall", ADD_ATC_PATCH).await?;
+        node.set_active_collection_version(&v3_atc).await?;
+    }
+
+    // 2. AgentRequest — independent idempotency check.
+    if !has_caused_by_parent_request_id_field(&node).await? {
+        let v3_ar = node.patch_collection("AgentRequest", ADD_AR_PATCH).await?;
+        node.set_active_collection_version(&v3_ar).await?;
+    }
+
+    // 3. ToolSelection — independent idempotency check.
+    if !has_subagent_targets_field(&node).await? {
+        let v3_ts = node.patch_collection("ToolSelection", ADD_TS_PATCH).await?;
+        node.set_active_collection_version(&v3_ts).await?;
+    }
+
+    // 4. Register the unified lens (idempotent — safe to call repeatedly).
+    let forward = LensConfig::new(
+        v2_id_for_each_collection, v3_id_for_each_collection,
+        LensModule::from_path(SUBAGENT_V2_V3_LENS_WASM)
+    );
+    node.set_migration(forward).await?;
+
+    Ok(())
+}
+```
+
+Invoked from `defra-agent-cli/src/commands/serve.rs` immediately after `ensure_tool_call_migrations()`. The per-collection detection means an operator who hits a partial failure mid-migration just restarts the daemon — the orchestrator finishes the unmigrated collections without needing manual intervention on the already-migrated ones.
+
+#### Backfill — selective
+
+Most defaults represent today's behavior exactly and need no backfill: `await_mode="foreground"`, `cancel_policy="cascade"`, `child_request_id=null`, `subagent_depth=0`, all `subagent_*` fields on ToolSelection. No silent behavior change.
+
+**One exception: `AgentToolCall.request_id`.** This field is a denormalization that gives "all tool calls for request R" a single-index query. Pre-R2 rows have no `request_id` populated; cross-collection lookup is hard inside a WASM lens, so the lens leaves it `null` on migrated rows. **Implication:** lineage queries that use `request_id` only see post-R2 tool calls. Historic-row lookups continue to work via the existing implicit `session_id → request_id` chain (sessions are owned by requests). New rows created by R2+ runtime always populate `request_id` directly.
+
+This is documented as a known limitation, not a bug. A separate runtime backfill task can fill historic rows if needed; out of scope for R2.
+
+### Type additions in `tool_call_lifecycle.rs`
+
+```rust
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum AwaitMode { Foreground, Background }
+
+impl AwaitMode {
+    pub fn as_str(self) -> &'static str { /* "foreground" | "background" */ }
+    pub fn from_persisted(s: &str) -> Option<Self> { /* ... */ }
+    pub const ALL: &'static [AwaitMode] = &[AwaitMode::Foreground, AwaitMode::Background];
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CancelPolicy { Cascade, Detach }
+
+impl CancelPolicy {
+    pub fn as_str(self) -> &'static str { /* "cascade" | "detach" */ }
+    pub fn from_persisted(s: &str) -> Option<Self> { /* ... */ }
+    pub const ALL: &'static [CancelPolicy] = &[CancelPolicy::Cascade, CancelPolicy::Detach];
+}
+
+pub enum ChildTerminal {
+    Failed { reason: String, failure_class: FailureClass },
+    Dead,
+    Interrupted,
+    Superseded,
+}
+
+impl ChildTerminal {
+    /// Lean B2 projection: Interrupted → Cancelled, all others → Failed.
+    pub fn projected_state(&self) -> ToolCallState {
+        match self {
+            ChildTerminal::Interrupted => ToolCallState::Cancelled,
+            _ => ToolCallState::Failed,
+        }
+    }
+    pub const ALL_KIND: &'static [&'static str] =
+        &["failed", "dead", "interrupted", "superseded"];
+}
+
+/// Returned by `bridge_cancel_cascade` (wrapped in `Option`). The caller —
+/// typically R3's daemon interrupt dispatcher — performs the actual write
+/// to the child's `interrupt_requested_at` field. Returning `None` from
+/// `bridge_cancel_cascade` means no cascade is required (native tool,
+/// detached subagent, or non-cancelled tool).
+pub struct CascadeIntent {
+    pub child_request_id: String,
+    pub at: chrono::DateTime<chrono::Utc>,
+}
+```
+
+### `ToolCallLifecycle` struct extensions
+
+```rust
+pub struct ToolCallLifecycle {
+    // ...existing fields (unchanged)...
+    await_mode:       AwaitMode,        // default Foreground
+    cancel_policy:    CancelPolicy,     // default Cascade
+    child_request_id: Option<String>,   // None = native; Some = subagent invocation
+}
+```
+
+### Constructors
+
+The existing `ToolCallLifecycle::new(...)` keeps its current signature; defaults the three new fields to `Foreground` / `Cascade` / `None`. New sibling constructor:
+
+```rust
+pub fn new_subagent(
+    node: Arc<EmbeddedNode>,
+    session_id: String,
+    tool_call_id: String,
+    message_sequence: u32,
+    tool_name: String,
+    args: String,
+    await_mode: AwaitMode,
+    cancel_policy: CancelPolicy,
+    child_request_id: String,        // required for subagent path
+) -> Self
+```
+
+Both constructors are synchronous and don't persist (matches existing `new()` semantics; first transition creates the row).
+
+### Transition methods (`tool_call_lifecycle/transition.rs`)
+
+#### Mode-flips
+
+```rust
+impl ToolCallLifecycle {
+    /// Pending|Running stays; await_mode .foreground → .background.
+    pub async fn background(&mut self) -> Result<()>;
+
+    /// Pending|Running stays; await_mode .background → .foreground.
+    pub async fn foreground(&mut self) -> Result<()>;
+
+    /// Pending|Running stays; cancel_policy .cascade → .detach (one-way).
+    pub async fn detach(&mut self) -> Result<()>;
+}
+```
+
+Each method:
+1. `ensure_state(&[ToolCallState::Running])` (or `[Pending, Running]` for `detach`).
+2. Pre-condition check on `await_mode` / `cancel_policy` — returns `IllegalToolCallTransition::ModeAlreadyBackground` etc. if violating.
+3. Builds an UPDATE GraphQL mutation that writes only the field being changed.
+4. Calls `execute_mutation_with_retry`.
+5. Updates the in-memory field on success.
+
+These don't touch `state` — orthogonal to the lifecycle state machine, exactly what the Lean spec promises.
+
+**Note on cascade policy irreversibility.** `detach()` is one-way: once `cancel_policy = Detach`, no transition flips it back. There is deliberately no `cascade()` method (mirror of Lean's structural irreversibility — the `detach` constructor is the only one that mutates `cancelPolicy`, and its precondition `pre.cancelPolicy = .cascade` makes the flip strictly directional).
+
+#### Bridge transitions
+
+```rust
+impl ToolCallLifecycle {
+    /// Bridge complete: parent tool .running → .completed when the linked
+    /// child request has reached .completed (caller verifies). Persists
+    /// child_result as the tool's `result` field.
+    pub async fn bridge_complete(&mut self, child_result: String) -> Result<()>;
+
+    /// Bridge failure: parent tool .running → .failed (or .cancelled for
+    /// child .interrupted) when the child request reaches a non-.completed
+    /// terminal. Projection per ChildTerminal::projected_state().
+    pub async fn bridge_failure(&mut self, child_terminal: ChildTerminal) -> Result<()>;
+
+    /// Bridge cancel cascade: returns the action that should be taken on the
+    /// child AgentRequest. Caller (typically R3's daemon interrupt dispatcher)
+    /// performs the actual write to set interrupt_requested_at.
+    /// Returns None for native tools, detached subagents, or non-cancelled.
+    pub async fn bridge_cancel_cascade(&self) -> Result<Option<CascadeIntent>>;
+}
+```
+
+**Trust boundary:** `bridge_complete` and `bridge_failure` trust the caller to have verified the child's terminal state. This matches the Lean precondition (load-bearing on the caller, not on the constructor) and avoids a coupling between `ToolCallLifecycle` and `AgentRequest` reads. R3's SubagentSource will be the natural place to do the child-state read.
+
+`bridge_cancel_cascade` is pure — no DB writes; returns an intent the caller executes. Tests can stub the executor cleanly.
+
+### Symmetric guards on R1's native `complete`/`fail`
+
+The Lean inner `complete` constructor at `Proofs/ToolExecution/Transition.lean:28-33` requires `h_native : pre.childRequestId = none` — the native completion path is restricted to native tools. R2 must mirror this to prevent a subagent-typed `ToolCallLifecycle` from bypassing `bridge_complete` by calling the native `complete()`.
+
+R2 adds preconditions to R1's existing methods:
+
+```rust
+// AMENDED in R1:
+impl ToolCallLifecycle {
+    pub async fn complete(&mut self, result: ToolCallCompleteResult) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.child_request_id.is_some() {
+            return Err(IllegalToolCallTransition::NativeCompleteOnSubagentTool);
+        }
+        // ...existing R1 body...
+    }
+
+    pub async fn fail(&mut self, result: ..., failure_class: FailureClass) -> Result<()> {
+        self.ensure_state(&[ToolCallState::Running])?;
+        if self.child_request_id.is_some() {
+            return Err(IllegalToolCallTransition::NativeFailOnSubagentTool);
+        }
+        // ...existing R1 body...
+    }
+}
+```
+
+This is structurally true today (every R1 caller of `complete()`/`fail()` is constructing via `new()` which sets `child_request_id = None`), but R2's `new_subagent` constructor introduces tools where `child_request_id = Some(_)` and the guard becomes load-bearing.
+
+### `IllegalToolCallTransition` new variants
+
+```rust
+ModeAlreadyBackground
+ModeAlreadyForeground
+PolicyAlreadyDetach
+BridgeCompleteRequiresChildLink
+BridgeFailureRequiresChildLink
+CascadeRequiresCancelled
+SubagentDepthExceeded
+ParentLinkageIncoherent
+NativeCompleteOnSubagentTool      // R1's complete() called on subagent-typed tool
+NativeFailOnSubagentTool          // R1's fail() called on subagent-typed tool
+```
+
+### `create_subagent_request` helper (`tool_call_lifecycle/subagent_request.rs`)
+
+```rust
+pub const MAX_SUBAGENT_DEPTH: u32 = 3;
+
+/// Create a new AgentRequest with subagent parent linkage. Validates
+/// depth + 1 ≤ MAX_SUBAGENT_DEPTH and parent linkage coherence (both fields
+/// set together).
+pub async fn create_subagent_request(
+    node: Arc<EmbeddedNode>,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<chrono::DateTime<chrono::Utc>>,
+    // additional fields mirroring existing AgentRequest creation
+) -> Result<String /* new_request_id */>;
+```
+
+Internally builds a `CREATE AgentRequest` mutation with parent linkage fields populated and reuses the existing AgentRequest creation logic for the rest. Bucket 3 conformance can call this helper directly to set up real children for testing `bridge_complete` end-to-end without R3's SubagentSource.
+
+#### Example sequence (consumed by R3's SubagentSource)
+
+```rust
+// R3 will call this from its TriggerSource::next_fire path.
+// R2 only ships the API surface; the call site is R3.
+
+let child_request_id = create_subagent_request(
+    node.clone(),
+    parent_request_id.clone(),
+    parent_tool_call_id.clone(),
+    parent.subagent_depth,
+    behavior_id,
+    prompt,
+    deadline,
+).await?;
+
+let mut bridge_tool = ToolCallLifecycle::new_subagent(
+    node.clone(),
+    parent_session_id,
+    parent_tool_call_id,
+    parent_message_seq,
+    "spawn_subagent".to_string(),
+    args_json,
+    AwaitMode::Foreground,        // or Background, per spawn args
+    CancelPolicy::Cascade,        // default; spawn args can override
+    child_request_id,             // links the bridge edge
+);
+
+bridge_tool.start_running().await?;
+
+// ...time passes; R3's poller observes the child reaching .completed...
+
+bridge_tool.bridge_complete(child_final_assistant_message).await?;
+```
+
+### `AgentRequest` Rust DAO extensions
+
+The Rust struct that reads `AgentRequest` rows (in `crates/defra-agent/src/runtime_snapshot/` or sibling) gains three optional fields mirroring the schema:
+
+```rust
+pub struct AgentRequestRow {
+    // ...existing fields...
+    pub subagent_depth: u32,                              // default 0
+    pub caused_by_parent_request_id: Option<String>,
+    pub caused_by_parent_tool_call_id: Option<String>,
+}
+```
+
+#### Apply-time validation (in `apply.rs` or wherever AgentRequest validates)
+
+- `subagent_depth` non-negative (trivial via `u32`).
+- **Coherence:** `caused_by_parent_request_id.is_some() ↔ caused_by_parent_tool_call_id.is_some()` (both or neither). Mixed → `ParentLinkageIncoherent`.
+- `subagent_depth = 0` ↔ both parent fields `None` (top-level vs subagent mutually exclusive).
+
+Cross-reference validation (does parent request exist? does subagent_target resolve?) is R3.
+
+### `ToolSelection` Rust struct extension
+
+```rust
+pub struct ToolSelectionDocument {
+    // ...existing fields (delegate_to, enable_file_tools, etc.)...
+    pub subagent_targets:            Option<Vec<String>>,   // behavior_ids
+    pub subagent_spawn_enabled:      Option<bool>,
+    pub subagent_steering_enabled:   Option<bool>,
+    pub subagent_background_enabled: Option<bool>,
+}
+```
+
+Apply-time validation: well-formedness only — each entry in `subagent_targets` is non-empty; the three booleans are independent. R3 adds cross-reference validation.
+
+## Conformance
+
+### Prerequisite — extend the Lean conformance contract
+
+Before any of the buckets below can be implemented, the Lean conformance contract at `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines.lean` must be extended to emit the new vocabularies and transitions. R1 had the same prerequisite (R1 spec §"Conformance" — "PR #152 added the toolCallMachine entry; that entry needs one extension before R1 lands its tests").
+
+R2's extensions to `Machines.lean`:
+- New machines / vocabularies emitted as JSON for Rust to consume:
+  - `awaitModeMachine` — `AwaitMode.all` enumeration
+  - `cancelPolicyMachine` — `CancelPolicy.all` enumeration
+  - `childTerminalMachine` — the four `ChildTerminal` variants plus their projection into `ToolCallState`
+- Bridge transition pairs added to the existing `toolCallMachine` (or a sibling `subagentBridgeMachine`):
+  - `(state, await_mode, child_link) → (state', await_mode')` for each of `background`, `foreground`, `detach`, `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`
+  - The native `complete`/`fail` rows gain a `requires child_request_id = none` precondition flag (matches the new symmetric guards above)
+
+This is **Task 0 of the R2 plan**. Buckets 1 and 2 below depend on it; Bucket 3 doesn't (it's pure runtime).
+
+### Bucket 1 — vocabulary round-trip (in-module)
+
+In `tool_call_lifecycle.rs`:
+
+- `AwaitMode::ALL.len() == 2`; round-trip: `from_persisted(v.as_str()) == Some(v)` for both variants.
+- `CancelPolicy::ALL.len() == 2`; same round-trip.
+- `ChildTerminal::ALL_KIND.len() == 4`; projection partition: `Interrupted → Cancelled`, others → `Failed`.
+- `IllegalToolCallTransition` enum closure: every Lean-emitted error vocabulary value has a Rust variant.
+
+### Bucket 2 — Lean transition matrix conformance
+
+In `tests/state_machine_conformance.rs`. For each Lean-emitted legal transition (incl. 3 mode-flips, 3 bridge transitions): assert a corresponding Rust path succeeds. For each illegal: assert the Rust method returns `IllegalToolCallTransition`. Specific cases:
+
+- `background` from `Pending` → `WrongState`.
+- `background` from `Running` + already `Background` → `ModeAlreadyBackground`.
+- `foreground` from `Background` (running) → ok.
+- `detach` already `.detach` → `PolicyAlreadyDetach`.
+- `bridge_complete` on tool with `child_request_id = None` → `BridgeCompleteRequiresChildLink`.
+- `bridge_cancel_cascade` on non-`.cancelled` tool → `CascadeRequiresCancelled`.
+
+### Bucket 3 — runtime integration
+
+In `tests/tool_call_subagent_lifecycle_conformance.rs`. Real `EmbeddedNode` via `test_db()`. Cases:
+
+- **Mode flip round-trip:** `new`, `start_running`, `background`, verify persisted `await_mode="background"`; `foreground`, verify back. Second `background` → `ModeAlreadyBackground`.
+- **Detach one-way:** persisted `cancel_policy="detach"`; second `detach` errors.
+- **Bridge complete:** `create_subagent_request` to spawn a child with parent linkage; force child to `.completed` via direct DB write; `new_subagent` parent tool linked; `start_running`; `bridge_complete(child_result)`; verify `state="completed"` and `result=child_result` persisted.
+- **Bridge failure projections:** `Failed/Dead/Superseded → state="failed"`; `Interrupted → state="cancelled"`. Each is its own test case.
+- **Cascade intent:** `Cascade` policy + child link → `bridge_cancel_cascade()` returns `Some(CascadeIntent)`. `Detach` policy → returns `None`. Native (no `child_request_id`) → returns `None`.
+- **Migration round-trip:** insert a v2 row directly, run `ensure_subagent_extensions_migrations`, query, verify defaults populate.
+- **`create_subagent_request` depth bound:** parent at depth=2 → child at depth=3 ok. Parent at depth=3 → `SubagentDepthExceeded`.
+- **`create_subagent_request` parent coherence:** missing one of parent_request_id / parent_tool_call_id → `ParentLinkageIncoherent`.
+
+### Hook integration — deferred to R3
+
+Today's `hook/persistence.rs:on_tool_call()` constructs `ToolCallLifecycle::new()` (native). The hook doesn't recognize subagent tool names — that's R3 (when `spawn_subagent` and friends land). Bucket 3 tests bypass the hook and call lifecycle methods directly, exactly as R1's Bucket 3 does today.
+
+## Risks
+
+1. **Lens binary size.** Three collections in one WASM. Mitigation: measure size as a Bucket-1 step in the plan (e.g., `wc -c agent_subagent_v2_to_v3.wasm`); split into per-collection lenses if growth becomes a concern relative to R1's baseline.
+2. **Migration ordering.** `ensure_subagent_extensions_migrations` must run after `ensure_tool_call_migrations`. Mitigation: explicit serialization in `serve.rs`; assertion at the start of v2→v3 that v1→v2 has run (`AgentToolCall.lifecycle_state` field exists).
+3. **Coherence check too strict.** Reject hypothetical mixed-parent-linkage rows. Mitigation: not a real risk — fields are brand new; default-populated rows are coherent by construction.
+4. **Bucket 3 fixture complexity.** Constructing a "child request in `.completed`" via direct DB write bypasses normal flow. Mitigation: extract a `make_completed_request(node, ...)` test helper; reuse across all bridge_* tests.
+5. **Persisted vocabulary drift.** Lean's `toDefraDB` outputs vs Rust's `as_str()` could drift. Mitigation: Bucket 1's round-trip + Bucket 2's transition matrix consume Lean-emitted JSON as source of truth.
+6. **Partial-failure mode of multi-collection migration.** Three sequential `patch_collection` calls; if the second or third fails after the first succeeds, the database is left half-migrated and the daemon refuses to start. The DefraDB migration framework has no automatic rollback (per R1's experience). Mitigation: per-collection idempotency detection at the head of `ensure_subagent_extensions_migrations` (re-running the function after a partial failure picks up at the unmigrated collection without manual intervention on the already-migrated ones). Acceptable risk because partial failure is improbable in practice (the patches are simple field additions, not data transforms).
+
+7. **`ToolSelection` baseline drift vs main / #151.** This branch is stacked on `bug/issue-149-native-glob-deadline`, which forked from main before commit `8b67dbc` (MCP service allowlists, PR #151) landed. R2's `tool_selection.graphql` patch adds 4 subagent fields; #151's already-merged main patch adds `allowed_mcp_service_ids` and related fields. When this branch eventually merges to main, the two field-set additions will need to be reconciled — likely a clean concatenation (no overlapping field names), but the lens version numbering (v2→v3 vs main's v?→v?+1) needs to be settled at merge time. Mitigation: rebase onto `bug/issue-149-native-glob-deadline` after that branch merges main; verify lens version chain at rebase time. R2's plan should treat the lens version numbers as placeholders (`v_pre` → `v_post`) until merge ordering is settled.
+
+## References
+
+- B1 Lean spec: `docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md`
+- R1 spec (template): `docs/superpowers/specs/2026-05-08-r1-rust-toolcall-conformance-design.md`
+- R1 plan: `docs/superpowers/plans/2026-05-08-r1-rust-toolcall-conformance.md`
+- R1 lens crate (template): `crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2/`
+- B1 ToolCallLifecycle: `crates/defra-agent/src/tool_call_lifecycle.rs`, `tool_call_lifecycle/transition.rs`
+- B1 migration: `crates/defra-agent/src/migration.rs:35-97`
+- TriggerEngine (R3 extension target): `crates/defra-agent/src/trigger_engine/mod.rs`
+- Project conventions: `CLAUDE.md`

--- a/docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-08-subagent-lifecycle-design.md
@@ -1,0 +1,562 @@
+# Subagent Lifecycle — Lean Spec Design
+
+**Status:** Design
+**Date:** 2026-05-08
+**Tracks:** subagent-management design branch (depends on issue 149's B1 ToolCall lifecycle spec)
+**Scope:** Lean spec only. Implementation tracked in a follow-on plan.
+
+## Background
+
+Today, "subagent" in defra-agent is implicit-only: an agent could write a new `AgentRequest` document, and `ToolSelection.delegate_to` can route a single tool call to another DID. There is no parent ↔ child request linkage, no specialized lifecycle, and no formal model. The runtime has no notion of "the parent agent is awaiting another agent's work" beyond what falls out of session message reads.
+
+In parallel, the issue 149 program is landing a full `ToolCall` lifecycle (B1 spec at `defra-agent-issue-149-native-glob-deadline/docs/superpowers/specs/2026-05-08-toolcall-lifecycle-spec-design.md`). The 6-state machine (`pending | running | completed | failed | timedOut | cancelled`) plus composition theorems C1, C1', C2, C3 give us a proven foundation for individual tool dispatch.
+
+This spec extends that foundation in three orthogonal directions to handle subagents *and* backgroundable long-running tools as a single unified concept:
+
+1. **Multi-flight.** A request may have many concurrently live tool calls.
+2. **Foreground / background.** A tool call may or may not block its parent's narrative progress.
+3. **Child-request linkage.** A tool call may bridge to a child `AgentRequest`, making it a subagent invocation.
+
+The unifying observation: **a subagent IS a tool call** whose underlying execution is a child request. Long-running native tools backgrounded for ergonomics share the same lifecycle, the same handle abstraction, and the same registry. Modeling them once means one set of theorems carries both.
+
+The design draws on a study of three external systems:
+- **OpenAI Codex** — `spawn_agent` tool family, `ExecutionStatus` (`Running | Completed | Failed | Cancelled | Aborted`), explicit-close cancellation policy, `parent_thread_id` lineage, hierarchical task tree.
+- **Tintinweb pi-subagents** — same-session scoped context, automatic abort cascade, max-turn graceful steering, persistent memory scopes.
+- **Nicobailon pi-subagents** — separate process, real session fork, structured `Details` result, `PI_SUBAGENT_DEPTH` recursion guard, model-fallback chains.
+
+We adopt: structured parent-child lineage with explicit fields (Codex), automatic cascade as the default with per-call opt-out (compromise between Codex's explicit and pi-subagents' automatic), depth-bound structural invariant (Nicobailon), tools-as-the-interface (Codex/Tintinweb).
+
+Per `CLAUDE.md`'s "Lean proofs are the source of truth for all state machine behavior" rule, the design starts in the spec.
+
+## Goals
+
+- Add a daemon-visible model for subagent invocation by extending the `ToolCall` lifecycle, not by inventing a new state machine.
+- Prove that auto-cascade cancellation reaches the child request and that detach mode does not.
+- Prove a structural depth bound on subagent recursion.
+- Make backgroundable long-running tools and subagents share the same handle abstraction, registry, and theorems.
+- Keep the existing T1–T5 (single-machine) and C1, C1', C2, C3 (composed) properties unchanged. Adding multi-flight quantifies them ∀; it does not weaken them.
+
+## Non-goals (out of scope for this spec)
+
+1. **Cross-principal delegation.** Lands with sourcenetwork/defra-agent#9 (AgentPrincipal/AgentBehavior split). Schema fields here are forward-compatible; B-theorems do not change when #9 lands.
+2. **Output-shape projection.** What counts as a subagent's "result" (last assistant message vs structured object vs tool-defined schema) is a runtime contract, not a state-machine concern.
+3. **Token / cost budget propagation.** Parent's budget vs child's budget. Subagents inherit `deadline` and `max_tokens` from spawn args.
+4. **Streaming partial output from child to parent.** B1 below only models terminal projection. Mid-run streaming is a future extension to `read_subagent_transcript`.
+5. **Detach orphan reaper.** A detached subagent whose parent dies relies on its own deadline. A "lost-parent reaper" is a separate runtime concern.
+6. **Subagent retry semantics.** When the parent retries its own request via `retry_parent_request`, in-flight subagents' fate (transfer / restart / orphan) is out of scope.
+7. **Persistent subagents across daemon restarts.** Mirrors B4 deferral on the ToolCall spec.
+8. **Steering message fairness / ordering bounds.** `send_message_to_subagent` is best-effort; no Lean property bounds delivery latency.
+9. **Foreground multi-fanout.** INV-FG below pins single-flight foreground. Parallel subagents must run in background.
+
+## Architecture
+
+### Three orthogonal extensions to `ToolCallContext`
+
+The 6-state `ToolCallState` from B1 is unchanged. New behavior is encoded as added fields, transitions, and invariants.
+
+**Multi-flight.** `ComposedState.tool : Option ToolCallContext` becomes `tools : List ToolCallContext`. C1 / C1' / C2 / C3 are restated to quantify ∀ over linked-and-live tools.
+
+**Foreground / background.** A new `awaitMode : AwaitMode` field on `ToolCallContext` and a derived "is the parent blocked" predicate at the composed layer. The parent's `RequestContext.advance` and `begin_inference` transitions add a guard: no foreground non-terminal tool may exist.
+
+**Child-request linkage.** A new `childRequestId : Option RequestId` field on `ToolCallContext`. When non-`none`, this tool call IS a subagent invocation. The `complete` transition gains a disjunctive precondition: native tool (no child) → existing semantics; subagent → child request must be terminal *and* observed by the parent.
+
+### Session-level registry — no new entity
+
+The existing `AgentToolCall` collection IS the registry. A new direct `request_id` field makes "all live tool calls for request R" a single-index query. The parent's `list_tasks` tool is just a GraphQL filter.
+
+### Lineage on `AgentRequest`
+
+Two new fields (sibling to existing `caused_by_trigger_id`, `retry_parent_request`):
+- `caused_by_parent_request_id` — immediate parent in the subagent tree.
+- `caused_by_parent_tool_call_id` — the specific bridge edge.
+- `subagent_depth : Int` — 0 for top-level; child = parent + 1. Supports the structural depth bound.
+
+The existing `caused_by_trigger_kind` enum gains `"subagent"`. `caused_by_trigger_id` is **not reused** for the subagent edge — it stays for `Schedule` / `EventTrigger` / `Manual` lineage. A subagent inherits `caused_by_trigger_id` from its root parent and adds the new parent fields for the immediate edge.
+
+## State vocabulary
+
+```lean
+inductive AwaitMode where
+  | foreground   -- parent's narrative is blocked on this tool's terminal state
+  | background   -- parent advances independently; tool runs concurrently
+  deriving DecidableEq, Repr
+
+inductive CancelPolicy where
+  | cascade      -- parent terminal ⇒ child interrupted (default)
+  | detach       -- child outlives parent; orphans bound by their own deadline
+  deriving DecidableEq, Repr
+```
+
+`ToolCallState` is unchanged. New fields on `ToolCallContext`:
+
+```lean
+structure ToolCallContext where
+  ...                                    -- existing B1 fields
+  awaitMode      : AwaitMode             -- default .foreground
+  cancelPolicy   : CancelPolicy          -- default .cascade
+  childRequestId : Option RequestId      -- some iff this is a subagent invocation
+  deriving Repr
+```
+
+New fields on `RequestContext`:
+
+```lean
+structure RequestContext where
+  ...                                              -- existing fields
+  subagentDepth                : Nat               -- 0 for top-level
+  causedByParentRequestId      : Option RequestId  -- new
+  causedByParentToolCallId     : Option ToolCallId -- new
+  deriving Repr
+```
+
+`ComposedState.tool : Option ToolCallContext` → `tools : List ToolCallContext`.
+
+## Cross-request modeling — `BridgedState`
+
+Cross-request reasoning needs a paired state. Embedding child into parent recursively would balloon `ComposedState`; modeling the cross-edge as an oracle predicate is too loose. Instead:
+
+```lean
+structure BridgedState where
+  parent       : ComposedState
+  child        : ComposedState
+  bridgeCallId : ToolCallId
+  -- Structural guards (proved by construction; not preconditions):
+  -- • some t ∈ parent.tools, t.callId = bridgeCallId ∧
+  --     t.childRequestId = some child.request.requestId
+  -- • child.request.causedByParentRequestId = some parent.request.requestId
+  -- • child.request.causedByParentToolCallId = some bridgeCallId
+```
+
+Subagent fan-out (one parent, N children) is a list of `BridgedState`s sharing a parent — no recursive type. Deeper recursion (a child that has its own children) is a tree of `BridgedState`s; `subagentDepth` keeps the tree bounded.
+
+`bridgeObservedTerminal` (used as a precondition on the bridge `complete`):
+```lean
+def bridgeObservedTerminal (s : BridgedState) : Prop :=
+  isTerminal s.child.request.state
+```
+
+## Transitions
+
+### Single-machine (`ToolCallContext.Transition`) additions
+
+The B1 lifecycle's 7 state-changing constructors are unchanged. Three new mode/policy transitions advance no state:
+
+```lean
+| background
+    (h_state : pre.state = .running)
+    (h_mode  : pre.awaitMode = .foreground)
+    (h_post  : post = { pre with awaitMode := .background })
+    : Transition pre post
+
+| foreground
+    (h_state : pre.state = .running)
+    (h_mode  : pre.awaitMode = .background)
+    (h_post  : post = { pre with awaitMode := .foreground })
+    : Transition pre post
+
+| detach
+    (h_live  : pre.state = .pending ∨ pre.state = .running)
+    (h_pol   : pre.cancelPolicy = .cascade)
+    (h_post  : post = { pre with cancelPolicy := .detach })
+    : Transition pre post
+```
+
+The `complete` constructor is restricted to native tools. Subagent tools (where `childRequestId = some _`) reach `.completed` only through the composed-layer `bridge_complete` constructor on `BridgedState.Transition`, which has access to the child's terminal state and discharges the projection in one step:
+
+```lean
+| complete  -- native-tool completion only
+    (h_state    : pre.state = .running)
+    (h_persist  : pre.persistence = .committed)
+    (h_native   : pre.childRequestId = none)
+    (h_post     : post = { pre with state := .completed })
+    : Transition pre post
+```
+
+For native tools this is exactly today's B1 `complete` semantics — no regression. The single-machine T1–T5 properties are unchanged because they reason over this inner transition. The bridge-layer `bridge_complete` provides a parallel reachability path for subagent tools, and a corresponding bridge-layer reachability theorem (B1) covers it.
+
+Note that `detach` is structurally one-way: it's the only constructor that mutates `cancelPolicy`, and its precondition `pre.cancelPolicy = .cascade` plus its effect `.detach` mean a tool can flip cascade → detach but never back. No separate "irreversibility" theorem is needed — it falls out of constructor exhaustiveness.
+
+### Composed-layer (`ComposedState.Transition`) modifications
+
+`tool_step` now operates on a `tools : List`; `pre.tools` and `post.tools` differ by exactly the one tool the inner `ToolCallContext.Transition` applies to.
+
+The `RequestContext.advance` and `begin_inference` lifts at the composed layer add a guard:
+
+```lean
+no_blocking_foreground :
+    ¬ ∃ t ∈ pre.tools, t.awaitMode = .foreground ∧ ¬ isTerminal t.state
+```
+
+This is what makes "parent blocks on foreground" structural.
+
+### Bridge layer (`BridgedState.Transition`)
+
+```lean
+inductive BridgedState.Transition : BridgedState → BridgedState → Prop where
+
+  | parent_step {pre post}
+      (h               : ComposedState.Transition pre.parent post.parent)
+      (h_child_eq      : post.child = pre.child)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      (h_link_preserved : -- structural guards stay intact
+                          link post.parent post.bridgeCallId
+                               post.child.request.requestId)
+      : Transition pre post
+
+  | child_step {pre post}
+      (h               : ComposedState.Transition pre.child post.child)
+      (h_parent_eq     : post.parent = pre.parent)
+      (h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+
+  | bridge_spawn {pre post} {newTool : ToolCallContext}
+      (h_proc           : pre.parent.request.state = .processing)
+      (h_depth          : pre.parent.request.subagentDepth + 1 ≤ maxSubagentDepth)
+      (h_callId_fresh   : ∀ t ∈ pre.parent.tools, t.callId ≠ post.bridgeCallId)
+      (h_newTool_shape  : newTool.callId = post.bridgeCallId ∧
+                           newTool.state = .pending ∧
+                           newTool.childRequestId = some post.child.requestId)
+      (h_tools_append   : post.parent.tools = pre.parent.tools ++ [newTool])
+      (h_request_eq     : post.parent.request = pre.parent.request)
+      (h_child_pending  : post.child.request.state = .pending ∧
+                           post.child.request.interruptRequestedAt = none ∧
+                           post.child.request.causedByParentRequestId =
+                             some pre.parent.requestId ∧
+                           post.child.request.causedByParentToolCallId =
+                             some post.bridgeCallId ∧
+                           post.child.request.subagentDepth =
+                             pre.parent.request.subagentDepth + 1)
+      (h_child_no_tools : post.child.tools = [])
+      : Transition pre post
+
+  | bridge_complete {pre post} {idx : Nat} {tPre tPost : ToolCallContext}
+      (h_child_done     : pre.child.request.state = .completed)
+      (h_idx            : pre.parent.tools[idx]? = some tPre)
+      (h_tPre_shape     : tPre.callId = pre.bridgeCallId ∧
+                           tPre.state = .running ∧
+                           tPre.persistence = .committed ∧
+                           tPre.childRequestId = some pre.child.requestId)
+      (h_tPost_shape    : tPost.callId = pre.bridgeCallId ∧
+                           tPost.state = .completed ∧
+                           tPost.childRequestId = some pre.child.requestId)
+      (h_tools_set      : post.parent.tools = pre.parent.tools.set idx tPost)
+      (h_request_eq     : post.parent.request = pre.parent.request)
+      (h_child_eq       : post.child = pre.child)
+      (h_bridgeId_eq    : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+
+  | bridge_failure {pre post} {idx : Nat} {tPre tPost : ToolCallContext}
+      (h_child_term     : pre.child.request.state = .failed ∨
+                           pre.child.request.state = .dead ∨
+                           pre.child.request.state = .interrupted ∨
+                           pre.child.request.state = .superseded)
+      (h_idx            : pre.parent.tools[idx]? = some tPre)
+      (h_tPre_shape     : tPre.callId = pre.bridgeCallId ∧
+                           tPre.state = .running ∧
+                           tPre.childRequestId = some pre.child.requestId)
+      (h_tPost_shape    : tPost.callId = pre.bridgeCallId ∧
+                           (tPost.state = .failed ∨ tPost.state = .cancelled))
+      (h_tools_set      : post.parent.tools = pre.parent.tools.set idx tPost)
+      (h_request_eq     : post.parent.request = pre.parent.request)
+      (h_child_eq       : post.child = pre.child)
+      (h_bridgeId_eq    : post.bridgeCallId = pre.bridgeCallId)
+      : Transition pre post
+
+  | bridge_cancel_cascade {pre post}
+      (h_parent_term    : isTerminal pre.parent.request.state ∨
+                          ∃ t ∈ pre.parent.tools,
+                            t.callId = pre.bridgeCallId ∧ t.state = .cancelled)
+      (h_cascade_pol    : ∃ t ∈ pre.parent.tools,
+                            t.callId = pre.bridgeCallId ∧
+                            t.cancelPolicy = .cascade)
+      (h_interrupt_set  : post.child.request.interruptRequestedAt.isSome)
+      (h_parent_eq      : post.parent = pre.parent)
+      (h_child_tools_eq : post.child.tools = pre.child.tools)
+      : Transition pre post
+```
+
+Six bridge transitions: `parent_step`, `child_step`, `bridge_spawn`, `bridge_complete`, `bridge_failure`, `bridge_cancel_cascade`. The split between `bridge_complete` (child `.completed`) and `bridge_failure` (child non-`.completed` terminal) keeps the projection explicit on both sides.
+
+**Constructor shapes.** `bridge_spawn` is *append-style*: `post.parent.tools = pre.parent.tools ++ [newTool]` with a freshness precondition (`newTool.callId` not present in pre-state) so the new callId can't collide. `bridge_complete` and `bridge_failure` are *set-style* (mirror of `tool_step`): an explicit index `idx` with `pre.parent.tools[idx]? = some tPre` and `post.parent.tools = pre.parent.tools.set idx tPost`. These tightenings rule out adversarial duplicate-callId tools and make `INV-UNIQUE` (below) preservable across every transition.
+
+Note that `bridge_cancel_cascade` only sets `interruptRequestedAt` on the child; the child's actual transition to `.interrupted` happens through the existing `interrupt_processing` constructor on `RequestContext.Transition` lifted via `child_step`. The cascade is two halves, and B3 (below) bundles them into a trace.
+
+## Properties
+
+Invariants (proven structurally; no `sorry`):
+
+```lean
+/-- INV-FG: at most one foreground non-terminal tool per request. -/
+theorem invFG_preserved
+    {pre post : ComposedState}
+    (h_inv  : pre.invFG)
+    (h_step : Transition pre post) :
+    post.invFG
+  -- where invFG s := (s.tools.filter
+  --                    (fun t => t.awaitMode = .foreground ∧ ¬ isTerminal t.state)).length ≤ 1
+
+/-- INV-UNIQUE: every tool in `tools` has a distinct callId. Established at
+    spawn (bridge_spawn carries h_callId_fresh) and preserved by every
+    Composed.Transition; lifts to BridgedState (parent and child sides)
+    via `bridgedUniqueCallIds_preserved`. Consumed by B3' to discharge
+    the bridge_cancel_cascade case without an external uniqueness hypothesis. -/
+theorem uniqueCallIds_preserved
+    {pre post : ComposedState}
+    (h_inv  : pre.UniqueCallIds)
+    (h_step : Transition pre post) :
+    post.UniqueCallIds
+  -- where UniqueCallIds s :=
+  --   ∀ i j, ∀ (h_i : i < s.tools.length) (h_j : j < s.tools.length),
+  --     s.tools[i].callId = s.tools[j].callId → i = j
+
+theorem bridgedUniqueCallIds_preserved
+    {pre post : BridgedState}
+    (h_parent_inv : pre.parent.UniqueCallIds)
+    (h_child_inv  : pre.child.UniqueCallIds)
+    (h_step : Transition pre post) :
+    post.parent.UniqueCallIds ∧ post.child.UniqueCallIds
+
+/-- INV-DEPTH: subagent depth never exceeds the configured cap on any reachable state. -/
+theorem inv_depth
+    (pre post : BridgedState)
+    (h_init  : pre.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+               pre.child.request.subagentDepth ≤ maxSubagentDepth)
+    (h_trace : Trace pre post) :
+    post.parent.request.subagentDepth ≤ maxSubagentDepth ∧
+    post.child.request.subagentDepth ≤ maxSubagentDepth
+
+/-- INV-LINK: parent ↔ child references stay symmetric. -/
+theorem inv_link (s : BridgedState) :
+    (∃ t ∈ s.parent.tools, t.callId = s.bridgeCallId ∧
+                            t.childRequestId = some s.child.request.requestId) ∧
+    s.child.request.causedByParentRequestId = some s.parent.request.requestId ∧
+    s.child.request.causedByParentToolCallId = some s.bridgeCallId
+```
+
+Bridge theorems:
+
+```lean
+/-- B1: A child Request reaching .completed propagates to parent ToolCall .completed.
+    Liveness conditional: requires bounded time advance for parent to observe.
+    The running-tool witness bundles persistence and child-link facts so the
+    bridge_complete construction has everything it needs without a uniqueness
+    side condition. -/
+theorem bridged_child_completion_propagates
+    (pre : BridgedState)
+    (h_running    : ∃ t ∈ pre.parent.tools,
+                      t.callId = pre.bridgeCallId ∧
+                      t.state = .running ∧
+                      t.persistence = .committed ∧
+                      t.childRequestId = some pre.child.requestId)
+    (h_child_done : pre.child.request.state = .completed) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧ t.state = .completed
+
+/-- B2: A child failure projects to parent ToolCall failure or cancellation. -/
+theorem bridged_child_failure_projects
+    (pre : BridgedState)
+    (h_running    : ∃ t ∈ pre.parent.tools, t.callId = pre.bridgeCallId ∧ t.state = .running)
+    (h_child_term : pre.child.request.state = .failed ∨
+                    pre.child.request.state = .dead ∨
+                    pre.child.request.state = .interrupted ∨
+                    pre.child.request.state = .superseded) :
+    ∃ post, Trace pre post ∧
+            ∃ t ∈ post.parent.tools,
+              t.callId = pre.bridgeCallId ∧
+              (t.state = .failed ∨ t.state = .cancelled)
+
+/-- B3: Cascade cancel correctness. Parent terminal under cascade ⇒ child interrupted. -/
+theorem cascade_cancels_child
+    (pre : BridgedState)
+    (h_parent_term : isTerminal pre.parent.request.state)
+    (h_cascade     : ∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧
+                       t.cancelPolicy = .cascade ∧
+                       ¬ isTerminal t.state) :
+    ∃ post, Trace pre post ∧ post.child.request.state = .interrupted
+
+/-- B3': Detach correctness (negative form). Detach mode does NOT cascade.
+    Consumes the structural INV-UNIQUE invariant on the parent's tools to
+    derive same-tool from same-callId in the bridge_cancel_cascade case;
+    no external uniqueness hypothesis required. -/
+theorem detach_does_not_cancel_child
+    (pre post : BridgedState)
+    (h_detach    : ∃ t ∈ pre.parent.tools,
+                     t.callId = pre.bridgeCallId ∧ t.cancelPolicy = .detach)
+    (h_step      : Transition pre post)
+    (h_no_other  : ¬ pre.child.request.interruptRequestedAt.isSome)
+    (h_uniq      : pre.parent.UniqueCallIds) :
+    post.child.request.interruptRequestedAt = pre.child.request.interruptRequestedAt
+
+/-- B4: Subagent depth bound. Restated standalone for prominence; same content as INV-DEPTH. -/
+theorem subagent_depth_bounded := inv_depth
+
+/-- B5: Link symmetry restated. Same as INV-LINK. -/
+theorem bridge_link_symmetric := inv_link
+
+/-- B6: Foreground blocking. Parent's seq numbers don't advance while a foreground tool is live. -/
+theorem foreground_blocks_parent_advance
+    (pre post : BridgedState)
+    (h_fg     : ∃ t ∈ pre.parent.tools,
+                  t.awaitMode = .foreground ∧ ¬ isTerminal t.state)
+    (h_step   : Transition pre post) :
+    pre.parent.request.progressSeq = post.parent.request.progressSeq ∧
+    pre.parent.request.messageSeq  = post.parent.request.messageSeq
+```
+
+### What B-theorems deliberately don't claim
+
+- **No automatic propagation across detach.** B1 requires the cascade path or active observation. A detached child's terminal state may go unobserved by its (now-gone) parent — that's the point of detach.
+- **No bound on observation latency.** B1 says "eventually, given trace continuation"; bounded latency would be a fairness assumption on the runtime scheduler, which is out of scope.
+- **No theorem about steering message ordering.** `send_message_to_subagent` writes a session message; the child's pickup is bounded only by its own progress (S3 on the child).
+
+### Why S3 (`progress_monotonic`) does not need to weaken
+
+`progress_monotonic` is local to one `RequestContext.Transition`: `post.progressSeq ≥ pre.progressSeq`. Existing `Composed.tool_step` requires `post.request = pre.request`, so any tool-level transition (including a backgrounded tool flipping to terminal) leaves the parent's `progressSeq` alone. S3 holds across `tool_step` events trivially. The new `background` / `foreground` / `detach` mode-changes and the `bridge_complete` projection all stay inside the tool layer; none modify `RequestContext`. B6 makes this layer-separation a theorem rather than a structural artifact.
+
+What backgrounding *does* break — but neither is currently a Lean property:
+1. *"Tool result appears immediately after its tool-call request in the parent's narrative."* Backgrounded tools intentionally violate this. Not a theorem.
+2. *"`messageSeq` order matches the wall-clock causal order of underlying events."* Two backgrounded completions race to write into session message rows in arbitrary order. `messageSeq` is monotonic by *append order*, which is preserved.
+
+## Tool surface
+
+Tools injected into the parent's tool list when subagent capability is enabled in behavior config:
+
+| Tool | Args | Returns | Effect |
+|---|---|---|---|
+| `spawn_subagent` | `behavior_id`, `prompt`, `await_mode: foreground|background`, `cancel_policy: cascade|detach`, `tool_allowlist?`, `deadline?`, `max_tokens?` | `{ tool_call_id, child_request_id }` | Fires `bridge_spawn`. |
+| `wait_task` | `tool_call_id` | terminal state + projected output | Fires `foreground` mode-change. |
+| `get_task_result` | `tool_call_id` | `{ state, output?, partial? }` | Read-only snapshot; advances parent's `messageSeq` by 1 (ordinary observation). |
+| `read_subagent_transcript` | `tool_call_id`, `since_message_seq?` | list of session messages | Read-only `child_step`. |
+| `send_message_to_subagent` | `tool_call_id`, `message` | ack | Writes a SessionMessage on the child's session (modeled as `child_step`). |
+| `cancel_task` | `tool_call_id` | ack | Drives parent ToolCall to `.cancelled`; fires cascade if `cancelPolicy = cascade`. |
+| `list_tasks` | `filter: live|terminal|all`, `limit` | list of handles | GraphQL filter on `AgentToolCall`. |
+| `background_task` | `tool_call_id` | ack | Fires `background` mode-change. |
+
+The first three are required for any subagent capability. `read_subagent_transcript` and `send_message_to_subagent` are gated separately (steering surface). `cancel_task`, `list_tasks`, `background_task` are required for multi-flight + backgrounding.
+
+## Schema deltas
+
+### `AgentRequest`
+
+```graphql
+type AgentRequest {
+  # ...existing fields...
+  caused_by_parent_request_id: String     # immediate parent in subagent tree
+  caused_by_parent_tool_call_id: String   # the bridge edge on the parent
+  subagent_depth: Int                     # 0 for top-level; child = parent + 1
+}
+```
+
+`caused_by_trigger_kind` enum gains `"subagent"`.
+
+### `AgentToolCall`
+
+```graphql
+type AgentToolCall {
+  # ...existing B1 fields including lifecycle_state...
+  request_id: String              # direct link (was implicit via session_id)
+  await_mode: String              # "foreground" | "background"
+  cancel_policy: String           # "cascade" | "detach"
+  child_request_id: String        # non-empty iff this is a subagent invocation
+}
+```
+
+### `ToolSelection`
+
+```graphql
+type ToolSelection {
+  # ...existing fields (delegate_to, mcp_service_allowlist)...
+  subagent_targets: [String]            # behavior_ids this agent may spawn
+  subagent_tools: SubagentToolPolicy
+}
+
+type SubagentToolPolicy {
+  spawn_enabled: Boolean
+  steering_enabled: Boolean   # gates send_message_to_subagent + read_subagent_transcript
+  background_enabled: Boolean # gates background mode + background_task / list_tasks
+}
+```
+
+Defaults: all `false`. A behavior with no subagent config exposes no subagent tools — fully backwards-compatible.
+
+### `TriggerSource` expansion: `SubagentSource`
+
+Mirror of `ScheduleSource` / `EventSource` / `ManualSource` in the existing `TriggerEngine`. Listens for `AgentToolCall.create` events with `child_request_id` set, validates depth and behavior allowlist, dispatches a `FireIntent` that materializes the child `AgentRequest`.
+
+Reusing `TriggerEngine`:
+- Concurrency mode (`one_at_a_time` / `latest_only` / `parallel`) is configurable per parent behavior — fan-out limits live in trigger config.
+- Existing T1–T4 trigger theorems apply: subagent fire is an enabled-gate fire, parented by the bridge edge, with full lineage.
+- Apply-time validation extends to validate `behavior_id` is in the parent's `subagent_targets` allowlist.
+
+### Identity
+
+The child Request runs under the same `agent_did` as the parent in this spec. Cross-principal delegation lands with sourcenetwork/defra-agent#9 (AgentPrincipal/AgentBehavior split). Schema is forward-compatible: when #9 lands, `subagent_targets` becomes `(behavior_id, principal_did?)` pairs and `bridge_spawn` gains an identity-delegation precondition. Nothing in B1–B6 needs to change.
+
+## File layout
+
+```
+crates/defra-agent/proofs/Proofs/
+  Subagent.lean                   # 4-line re-export stub
+  Subagent/
+    State.lean                    # AwaitMode, CancelPolicy enums, BridgedState type
+    Transition.lean               # BridgedState.Transition (6 constructors)
+    Properties.lean               # B1–B6, INV-FG / INV-UNIQUE / INV-DEPTH / INV-LINK
+    Executable.lean               # step refinement (for Rust conformance)
+  ToolExecution/
+    State.lean                    # AMEND: + awaitMode, cancelPolicy, childRequestId
+    Transition.lean               # AMEND: + background, foreground, detach;
+                                  #        complete gains bridge precondition disjunct
+  Request/
+    State.lean                    # AMEND: + subagentDepth, causedByParentRequestId,
+                                  #        causedByParentToolCallId
+  Composed.lean                   # AMEND: tools : List;
+                                  #        no_blocking_foreground guard on advance / begin_inference
+  Conformance/
+    Contracts.lean                # AMEND: emit AwaitMode/CancelPolicy + bridge cases
+```
+
+## Conformance contract additions
+
+Rust conformance tests in `tests/state_machine_conformance.rs` and `tests/lifecycle_regression.rs` consume Lean-emitted case lists.
+
+| Generator | Cases | What Rust must check |
+|---|---|---|
+| `AwaitMode.all` exhaustiveness | 2 | `AgentToolCall.await_mode` round-trips. |
+| `CancelPolicy.all` exhaustiveness | 2 | `AgentToolCall.cancel_policy` round-trips. |
+| Bridge transition matrix | ~8 | Every spawn / mode-change / cascade / complete the runtime executes refines a Lean constructor. |
+| B3 cascade trace witness | 1 | End-to-end: parent `.interrupted` ⇒ child reaches `.interrupted` within bounded steps. |
+| B3' detach trace witness | 1 | End-to-end: detach-mode parent termination leaves child running. |
+| B4 depth bound | 1 | Spawn at `subagent_depth = maxSubagentDepth` is rejected at runtime. |
+| B5 link symmetry | per-row | Every `AgentToolCall.child_request_id` matches exactly one `AgentRequest.caused_by_parent_tool_call_id` and vice versa. |
+| B6 foreground blocking | 1 | Parent's `progressSeq` and `messageSeq` do not advance while a foreground tool is live. |
+| INV-UNIQUE | per-row | `AgentToolCall.tool_call_key` (the runtime callId) is unique within a request's tool list — runtime mints fresh callIds at spawn and never reuses them. |
+
+These slot into the existing JSON-emitter pattern. Rust tests fail compilation if Lean adds a constructor that isn't covered.
+
+## Migration
+
+All new schema fields have benign defaults that exactly match today's behavior:
+
+| Field | Default | Existing-row interpretation |
+|---|---|---|
+| `AgentToolCall.await_mode` | `"foreground"` | Today's tool calls are all synchronous foreground — no behavior change. |
+| `AgentToolCall.cancel_policy` | `"cascade"` | C2 already cascades; default preserves existing behavior. |
+| `AgentToolCall.child_request_id` | `null` | All existing tool calls are native, not subagent. |
+| `AgentToolCall.request_id` | backfill from `(session_id, tool_call_id)` lookup | Already implicit via session; backfill is mechanical. |
+| `AgentRequest.caused_by_parent_request_id` | `null` | Top-level requests have no parent. |
+| `AgentRequest.caused_by_parent_tool_call_id` | `null` | Same. |
+| `AgentRequest.subagent_depth` | `0` | Top-level. |
+
+`SubagentSource` activates only when at least one behavior has `subagent_tools.spawn_enabled = true`. New tools never appear unless explicitly opted-in. No silent behavior change.
+
+## References
+
+- B1 ToolCall lifecycle spec: `defra-agent-issue-149-native-glob-deadline/docs/superpowers/specs/2026-05-08-toolcall-lifecycle-spec-design.md`
+- Existing patterns: `Proofs/Request/{State,Transition,Properties,Executable}.lean`, `Proofs/InferenceCall/{State,Transition,Properties,Executable,SlotAccounting}.lean`, `Proofs/Composed.lean`, `Proofs/Triggers/`
+- External systems studied:
+  - OpenAI Codex: `codex-rs/tools/src/agent_tool.rs`, `codex-rs/rollout-trace/src/model/session.rs`, `codex-rs/protocol/src/protocol.rs`, `codex-rs/rollout-trace/src/reducer/tool/agents.rs`
+  - Tintinweb pi-subagents: `src/types.ts`, `src/agent-manager.ts`
+  - Nicobailon pi-subagents: `src/shared/types.ts`, `src/intercom/result-intercom.ts`
+- Project conventions: `CLAUDE.md` ("The Lean proofs are the source of truth for all state machine behavior.")

--- a/docs/superpowers/specs/2026-05-08-tool-call-runtime-closure.md
+++ b/docs/superpowers/specs/2026-05-08-tool-call-runtime-closure.md
@@ -1,0 +1,52 @@
+# Tool-Call Runtime Closure
+
+Issue #159 R2-R4 is implemented against the existing Lean/Rust lifecycle bridge.
+This branch is stacked on PR #154's subagent branch, including its Rust R2 data
+plane for `await_mode`, `cancel_policy`, `child_request_id`, bridge transitions,
+and schema migrations. The runtime closure here adds parent request identity and
+deadline propagation to that shape while keeping native tool behavior equivalent
+to the bridge defaults of no child request, foreground await, and cascade
+cancellation.
+
+The Lean surface already models native tool deadlines, timeout, cancellation,
+and request/tool coherence:
+
+- `ToolCallContext.deadline` carries the tool deadline.
+- `ComposedState.Coherent` requires the linked tool deadline to equal the
+  claimed parent request deadline.
+- `deadline_exceeded_request_timesOut_running_tool` and
+  `interrupted_request_cancels_live_linked_tool` cover the R3/R4 runtime
+  transitions.
+
+No additional Lean contract change is required for this runtime pass. The Rust
+side makes the native-tool contract mechanical by persisting the parent request
+id and claimed request deadline on every `AgentToolCall`.
+
+Runtime behavior:
+
+- Tool lifecycles are created from the session hook with the active request id
+  and claimed request deadline.
+- Behavior runtime construction wraps every Rig tool in a request-scoped
+  deadline/cancellation wrapper.
+- During stream polling, the daemon scopes tool execution with the claimed
+  request deadline and request cancellation token.
+- Timeout and cancellation are returned as internal managed terminal markers,
+  which the hook maps to `timedOut` and `cancelled` lifecycle states instead of
+  ordinary completion.
+- Tool execution failures that Rig surfaces as `JsonError:` or
+  `ToolCallError:` remain distinct and persist as `failed`.
+- Stream liveness drops fail any live linked tool call so failure does not look
+  like timeout or cancellation.
+- Dropping cancelled/expired tool futures terminates local subprocess-backed
+  tools; bash already used `kill_on_drop`, and CLI tools now do the same.
+- Request interruption cancels live linked tool calls. For subagent bridge rows,
+  `cancel_policy = cascade` also latches `interrupt_requested_at` on the child
+  request; `cancel_policy = detach` leaves the child request running.
+- Startup recovery sweeps persisted `running` tool calls when the deadline has
+  expired or the linked parent request is terminal. Subagent bridge rows respect
+  `cancel_policy`: detached tools are left for the subagent runtime to reconcile,
+  while cascade tools latch `interrupt_requested_at` on the linked child request
+  before the parent tool row is terminalized.
+
+The deadline source is the claimed parent request deadline. There is no
+narrower per-tool policy in this implementation.


### PR DESCRIPTION
## Summary

Completes issue #159's Rust runtime closure work on top of PR #154's `design/subagent-management` branch at `40cad0b`.

Issue #159 phases complete:
- R2: deadline propagation through the tool layer.
- R3: hard timeout enforcement for running tool calls.
- R3 recovery: startup sweep for stale running tool calls.
- R4: cancellation propagation from interrupted requests to live linked tool calls.
- Tests/docs: conformance, runtime, recovery, interruption, migration, and lifecycle docs updated.

## Stack Integration

This PR is now additively rebased onto PR #154's Rust subagent data plane. The final implementation keeps both sets of fields and behavior:

- `ToolCallLifecycle` carries `request_id`, `deadline_at`, `await_mode`, `cancel_policy`, and `child_request_id`.
- Native and subagent constructors include the parent request id and effective deadline.
- Transition methods keep PR #154 bridge/mode/policy behavior and add deadline resupply plus timeout/cancel/failure separation.
- `AgentToolCall` schema, migrations, query reconstruction, and snapshots include runtime deadline fields and subagent fields without duplicate `request_id`.
- `subagent_request.rs` is preserved.
- Recovery is subagent-aware: detached bridge rows are left running for subagent reconciliation, while cascade rows latch `interrupt_requested_at` on the child before terminalizing the parent tool row.
- Live request cancellation also dispatches the cascade intent for cascade-linked child requests and leaves detached children alone.

## Verification

- `cargo test -p defra-agent hook::tests::cancelling_ --lib -- --test-threads=1` passed.
- `cargo test --workspace --all-targets -- --test-threads=1` passed. Live endpoint tests remained ignored as designed.
- `cargo fmt --all --check` passed.
- `git diff --check` passed.
- `git diff --cached --check` passed before commit.
- `cd crates/defra-agent/proofs && lake build` passed, with existing Lean linter warnings only.

Focused tests included in the full workspace run:
- `lifecycle_recovery` passed, including timeout, interrupted-parent cancellation, cascade recovery, and detached recovery cases.
- `tool_call_lifecycle_conformance` passed, including deadline persistence/load coverage.
- `tool_call_subagent_lifecycle_conformance` passed.
- `interruption_integration` passed.
- `cli_chat` and `cli_trace_export` passed.

## Self-review

- Inspected the full stacked diff against `origin/design/subagent-management`.
- Checked for over-broad changes and conflict markers.
- Checked lifecycle naming consistency across Rust state, GraphQL persistence, trace export, and tests.
- Checked timeout/cancellation races so completion, failure, timeout, and cancellation remain distinguishable.
- Checked persistence/recovery edge cases for expired deadlines, interrupted parent requests, cascade child interruption, and detached child preservation.
