### PR TITLE
R3: add SubagentSource runtime dispatch

### DIFF
--- a/crates/defra-agent/src/agent/document_view/apply.rs
+++ b/crates/defra-agent/src/agent/document_view/apply.rs
@@ -67,6 +67,7 @@ pub(crate) async fn apply_control_update(
             return Ok(ControlUpdateOutcome::Irrelevant);
         }
         selection.validate()?;
+        validate_subagent_targets_resolve(&selection, view)?;
         view.remove_tool_selection_by_doc_id(doc_id);
         view.tool_selections.insert(
             selection.selection_id.clone(),
@@ -188,4 +189,19 @@ pub(crate) async fn apply_control_update(
     }
 
     Ok(ControlUpdateOutcome::Irrelevant)
+}
+
+fn validate_subagent_targets_resolve(
+    selection: &crate::document_config::ToolSelectionDocument,
+    view: &DocumentRuntimeView,
+) -> Result<()> {
+    for target in selection.subagent_targets.iter().flatten() {
+        if !view.behaviors.contains_key(target) {
+            anyhow::bail!(
+                "ToolSelection {} subagent_targets entry {target:?} does not resolve to an AgentBehavior",
+                selection.selection_id,
+            );
+        }
+    }
+    Ok(())
 }

--- a/crates/defra-agent/src/agent/document_view/tests.rs
+++ b/crates/defra-agent/src/agent/document_view/tests.rs
@@ -317,6 +317,60 @@ async fn apply_control_update_rejects_tool_selection_with_empty_subagent_target(
     );
 }
 
+#[tokio::test]
+async fn apply_control_update_rejects_tool_selection_with_missing_subagent_target() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let identity = Arc::new(test_identity("document-view-missing-subagent-target"));
+    let agent_did = identity.did();
+    let selection_id = "missing-targets-selection";
+    let escaped_selection_id = escape_graphql_string(selection_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let mutation = format!(
+        r#"mutation {{
+            create_ToolSelection(input: {{
+                selection_id: "{escaped_selection_id}",
+                agent_did: "{escaped_agent_did}",
+                subagent_targets: ["missing-behavior"],
+                subagent_spawn_enabled: true
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create_ToolSelection failed: {:?}",
+        response.errors
+    );
+    let record = crate::document_config::load_tool_selection_record(node.as_ref(), selection_id)
+        .await
+        .unwrap()
+        .expect("tool selection record");
+    let mut view = load_document_runtime_view(node.as_ref(), agent_did)
+        .await
+        .expect("initial document view should load");
+
+    let result = apply_control_update(
+        node.as_ref(),
+        agent_did,
+        "opaque-tool-selection-collection",
+        &record.0,
+        &mut view,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "apply_control_update must reject missing subagent target, got: {:?}",
+        result
+    );
+    let err_msg = format!("{}", result.unwrap_err());
+    assert!(
+        err_msg.contains("missing-behavior") && err_msg.contains("AgentBehavior"),
+        "error message must mention the missing target and AgentBehavior, got: {err_msg}"
+    );
+}
+
 async fn create_task(node: &defra_node::EmbeddedNode, task_id: &str, name: &str) {
     let escaped_task_id = escape_graphql_string(task_id);
     let escaped_name = escape_graphql_string(name);

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -131,6 +131,7 @@ pub(in crate::agent) async fn run_agent(
     let trigger_engine_node = agent.node.clone();
     let trigger_engine_schedule_snapshot_rx = active_snapshot_rx.clone();
     let trigger_engine_event_snapshot_rx = active_snapshot_rx.clone();
+    let trigger_engine_subagent_snapshot_rx = active_snapshot_rx.clone();
     let trigger_engine_engine_snapshot_rx = active_snapshot_rx.clone();
     let trigger_engine_materializer_snapshot_rx = active_snapshot_rx.clone();
     let trigger_engine_cancel = cancel.child_token();
@@ -167,13 +168,23 @@ pub(in crate::agent) async fn run_agent(
         let event_source: Box<dyn crate::trigger_engine::TriggerSource> =
             Box::new(crate::trigger_engine::event_source::EventSource::new(
                 trigger_engine_event_snapshot_rx,
+                trigger_engine_node.clone(),
+                trigger_engine_cancel.clone(),
+            ));
+        let subagent_source: Box<dyn crate::trigger_engine::TriggerSource> =
+            Box::new(crate::trigger_engine::subagent_source::SubagentSource::new(
+                trigger_engine_subagent_snapshot_rx,
                 trigger_engine_node,
                 trigger_engine_cancel.clone(),
             ));
         let manual_source_box: Box<dyn crate::trigger_engine::TriggerSource> =
             Box::new(manual_source);
-        let sources: Vec<Box<dyn crate::trigger_engine::TriggerSource>> =
-            vec![schedule_source, event_source, manual_source_box];
+        let sources: Vec<Box<dyn crate::trigger_engine::TriggerSource>> = vec![
+            schedule_source,
+            event_source,
+            subagent_source,
+            manual_source_box,
+        ];
         let engine = crate::trigger_engine::TriggerEngine::new(
             trigger_engine_engine_snapshot_rx,
             materializer,

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -15,7 +15,8 @@
 //! - SubagentSource (R3) consumes `create_subagent_request` and the bridge methods.
 //! - Agent-facing tools (R4) are routed via hook integration that uses
 //!   `new_subagent` and recognizes spawn_subagent / wait_task / etc. tool names.
-//! - Cross-reference validation (target resolution, parent existence) lands in R3.
+//! - Cross-reference validation (target resolution, parent existence) is wired
+//!   by R3's `SubagentSource` work.
 //! - Cross-principal delegation (R6) lands with sourcenetwork/defra-agent#9.
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -216,7 +217,9 @@ pub mod subagent_request;
 mod transition;
 
 pub use recovery::ToolCallRecoveryReport;
-pub use subagent_request::{create_subagent_request, MAX_SUBAGENT_DEPTH};
+pub use subagent_request::{
+    create_subagent_request, create_subagent_request_with_request_id, MAX_SUBAGENT_DEPTH,
+};
 pub use transition::IllegalToolCallTransition;
 
 /// State machine struct for an individual tool call. Mirrors `RequestLifecycle`

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -9,7 +9,10 @@ use crate::graphql::escape_graphql_string;
 use crate::interrupt::interrupt_request;
 use crate::session::execute_mutation_with_retry;
 
-use super::{CancelPolicy, FailureClass, ToolCallState};
+use super::{
+    subagent_request::create_subagent_request_with_request_id, CancelPolicy, FailureClass,
+    ToolCallState,
+};
 
 #[derive(Debug, Default)]
 pub struct ToolCallRecoveryReport {
@@ -25,6 +28,8 @@ struct RunningToolCallRow {
     session_id: String,
     tool_call_id: String,
     #[serde(default)]
+    args: String,
+    #[serde(default)]
     started_at: Option<String>,
     #[serde(default)]
     deadline_at: Option<String>,
@@ -36,9 +41,22 @@ struct RunningToolCallRow {
 
 #[derive(Debug, Deserialize)]
 struct ParentRequestRow {
+    agent_did: String,
     status: String,
     #[serde(default)]
     lifecycle_state: Option<String>,
+    #[serde(default)]
+    subagent_depth: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpawnArgs {
+    #[serde(alias = "target", alias = "target_behavior_id")]
+    behavior_id: String,
+    #[serde(alias = "message", alias = "content")]
+    prompt: String,
+    #[serde(default)]
+    deadline: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,39 +71,126 @@ impl super::ToolCallLifecycle {
         node: &EmbeddedNode,
         agent_did: &str,
     ) -> Result<ToolCallRecoveryReport> {
+        let materialized_children = recover_orphan_subagent_children(node, agent_did).await?;
+        if materialized_children > 0 {
+            tracing::info!(
+                materialized_children,
+                "materialized orphan subagent child requests during tool-call recovery"
+            );
+        }
+
         Ok(ToolCallRecoveryReport {
             tool_calls_recovered: recover_stuck_running_tool_calls(node, agent_did).await?,
         })
     }
 }
 
-async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
-    let query = r#"{
-        AgentToolCall(
-            filter: { lifecycle_state: { _eq: "running" } }
-        ) {
-            _docID
-            request_id
-            session_id
-            tool_call_id
-            started_at
-            deadline_at
-            cancel_policy
-            child_request_id
-        }
-    }"#;
+async fn recover_orphan_subagent_children(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
+    let rows = load_running_tool_call_rows(node).await?;
+    let mut materialized = 0;
 
-    let resp = node.execute(query).await;
-    if resp.has_errors() {
-        anyhow::bail!("querying stuck running tool calls: {:?}", resp.errors);
+    for row in rows {
+        let Some(child_request_id) = child_request_id(&row).map(str::to_string) else {
+            continue;
+        };
+        if child_request_exists(node, &child_request_id).await? {
+            continue;
+        }
+
+        let parent_request_id = match row
+            .request_id
+            .as_deref()
+            .filter(|request_id| !request_id.is_empty())
+        {
+            Some(request_id) => request_id.to_string(),
+            None => {
+                tracing::warn!(
+                    doc_id = %row.doc_id,
+                    session_id = %row.session_id,
+                    tool_call_id = %row.tool_call_id,
+                    child_request_id = %child_request_id,
+                    "cannot materialize orphan subagent child without parent request_id"
+                );
+                continue;
+            }
+        };
+
+        let Some(parent) = lookup_parent_request(node, agent_did, &parent_request_id).await? else {
+            tracing::warn!(
+                doc_id = %row.doc_id,
+                request_id = %parent_request_id,
+                session_id = %row.session_id,
+                tool_call_id = %row.tool_call_id,
+                child_request_id = %child_request_id,
+                "cannot materialize orphan subagent child because parent AgentRequest is missing"
+            );
+            continue;
+        };
+
+        let spawn_args = match serde_json::from_str::<SpawnArgs>(&row.args) {
+            Ok(spawn_args) => spawn_args,
+            Err(error) => {
+                tracing::warn!(
+                    doc_id = %row.doc_id,
+                    request_id = %parent_request_id,
+                    session_id = %row.session_id,
+                    tool_call_id = %row.tool_call_id,
+                    child_request_id = %child_request_id,
+                    error = %error,
+                    "cannot materialize orphan subagent child because tool args are invalid"
+                );
+                continue;
+            }
+        };
+
+        let parent_depth = parent
+            .subagent_depth
+            .and_then(|depth| u32::try_from(depth).ok())
+            .unwrap_or(0);
+        let deadline =
+            effective_deadline(row.deadline_at.as_deref(), spawn_args.deadline.as_deref());
+
+        if let Err(error) = create_subagent_request_with_request_id(
+            node,
+            child_request_id.clone(),
+            parent_request_id.clone(),
+            row.tool_call_id.clone(),
+            parent_depth,
+            parent.agent_did,
+            spawn_args.behavior_id,
+            spawn_args.prompt,
+            deadline,
+        )
+        .await
+        {
+            tracing::warn!(
+                doc_id = %row.doc_id,
+                request_id = %parent_request_id,
+                session_id = %row.session_id,
+                tool_call_id = %row.tool_call_id,
+                child_request_id = %child_request_id,
+                error = %error,
+                "failed to materialize orphan subagent child request during recovery"
+            );
+            continue;
+        }
+
+        materialized += 1;
+        tracing::info!(
+            doc_id = %row.doc_id,
+            request_id = %parent_request_id,
+            session_id = %row.session_id,
+            tool_call_id = %row.tool_call_id,
+            child_request_id = %child_request_id,
+            "materialized orphan subagent child request during recovery"
+        );
     }
 
-    let rows: Vec<RunningToolCallRow> = resp
-        .data
-        .as_ref()
-        .and_then(|data| data.get("AgentToolCall"))
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_default();
+    Ok(materialized)
+}
+
+async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
+    let rows = load_running_tool_call_rows(node).await?;
 
     let mut recovered = 0;
     for row in rows {
@@ -168,6 +273,37 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
     Ok(recovered)
 }
 
+async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningToolCallRow>> {
+    let query = r#"{
+        AgentToolCall(
+            filter: { lifecycle_state: { _eq: "running" } }
+        ) {
+            _docID
+            request_id
+            session_id
+            tool_call_id
+            args
+            started_at
+            deadline_at
+            cancel_policy
+            child_request_id
+        }
+    }"#;
+
+    let resp = node.execute(query).await;
+    if resp.has_errors() {
+        anyhow::bail!("querying stuck running tool calls: {:?}", resp.errors);
+    }
+
+    let rows: Vec<RunningToolCallRow> = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows)
+}
+
 async fn lookup_parent_request(
     node: &EmbeddedNode,
     agent_did: &str,
@@ -184,8 +320,10 @@ async fn lookup_parent_request(
                 }},
                 limit: 1
             ) {{
+                agent_did
                 status
                 lifecycle_state
+                subagent_depth
             }}
         }}"#
     );
@@ -205,6 +343,31 @@ async fn lookup_parent_request(
         .and_then(|value| serde_json::from_value(value.clone()).ok())
         .unwrap_or_default();
     Ok(rows.into_iter().next())
+}
+
+async fn child_request_exists(node: &EmbeddedNode, request_id: &str) -> Result<bool> {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                limit: 1
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "querying child request for tool-call recovery: {:?}",
+            resp.errors
+        );
+    }
+    Ok(resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(serde_json::Value::as_array)
+        .is_some_and(|rows| !rows.is_empty()))
 }
 
 async fn recover_tool_call_row(
@@ -256,6 +419,18 @@ fn parse_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {
         .filter(|value| !value.is_empty())
         .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
         .map(|datetime| datetime.with_timezone(&Utc))
+}
+
+fn effective_deadline(
+    tool_deadline: Option<&str>,
+    args_deadline: Option<&str>,
+) -> Option<DateTime<Utc>> {
+    match (parse_datetime(tool_deadline), parse_datetime(args_deadline)) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
 }
 
 fn request_is_interrupted(parent: &ParentRequestRow) -> bool {

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -9,6 +9,7 @@
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use defra_node::EmbeddedNode;
+use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
@@ -23,9 +24,42 @@ use super::IllegalToolCallTransition;
 /// validation can reference the same value as the Lean spec.
 pub const MAX_SUBAGENT_DEPTH: u32 = 3;
 
-/// Create a new AgentRequest row with subagent parent linkage. Validates
-/// the two preconditions enforced by the Lean Subagent spec BEFORE any
-/// DB I/O:
+/// Create a new AgentRequest row with subagent parent linkage. Allocates a
+/// fresh request id before delegating to the request-id-aware implementation
+/// used by R3's `SubagentSource`.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_subagent_request(
+    node: &EmbeddedNode,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    agent_did: String,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<DateTime<Utc>>,
+) -> Result<String> {
+    let new_request_id = uuid::Uuid::new_v4().to_string();
+    create_subagent_request_with_request_id(
+        node,
+        new_request_id,
+        parent_request_id,
+        parent_tool_call_id,
+        parent_subagent_depth,
+        agent_did,
+        behavior_id,
+        prompt,
+        deadline,
+    )
+    .await
+}
+
+/// Create a new AgentRequest row with subagent parent linkage and a caller-
+/// supplied request id. `SubagentSource` uses this path to preserve B5 link
+/// symmetry: the child `AgentRequest.request_id` must equal the parent
+/// `AgentToolCall.child_request_id` that caused the spawn.
+///
+/// Validates the preconditions enforced by the Lean Subagent spec before
+/// creation:
 ///
 ///   1. `parent_subagent_depth + 1 ≤ MAX_SUBAGENT_DEPTH`. Returns
 ///      `IllegalToolCallTransition::SubagentDepthExceeded` otherwise.
@@ -35,22 +69,25 @@ pub const MAX_SUBAGENT_DEPTH: u32 = 3;
 ///      well-formedness invariant in `watcher.rs::validate_subagent_fields`
 ///      requires that `subagent_depth > 0` documents have both fields
 ///      populated.)
+///   3. `parent_request_id` resolves to an existing `AgentRequest` owned by
+///      the same `agent_did` as the child request.
 ///
-/// On success returns the newly minted `request_id`.
+/// On success returns the child `request_id`.
 ///
 /// Field ownership notes (mirroring `materialize.rs`):
-///   - `request_id` and `session_id` are freshly generated UUIDs.
+///   - `request_id` is caller-supplied; `session_id` is a freshly generated
+///     UUID.
 ///   - `lifecycle_state` is initialized to `"pending"`.
 ///   - `subagent_depth = parent_subagent_depth + 1`.
 ///   - `caused_by_parent_request_id` / `caused_by_parent_tool_call_id`
 ///     carry the parent linkage.
-///   - Trigger lineage fields (`caused_by_trigger_id`,
-///     `caused_by_trigger_kind`) are intentionally left empty: a
-///     subagent spawn is not itself a trigger fire — the parent's
-///     trigger lineage already records the originating cause.
+///   - Trigger lineage fields identify the bridge edge:
+///     `caused_by_trigger_kind = "subagent"` and
+///     `caused_by_trigger_id = parent_tool_call_id`.
 #[allow(clippy::too_many_arguments)]
-pub async fn create_subagent_request(
+pub async fn create_subagent_request_with_request_id(
     node: &EmbeddedNode,
+    request_id: String,
     parent_request_id: String,
     parent_tool_call_id: String,
     parent_subagent_depth: u32,
@@ -65,17 +102,23 @@ pub async fn create_subagent_request(
     }
 
     // 2. Coherence check (pure precondition, fires before any DB I/O).
-    if parent_request_id.is_empty() || parent_tool_call_id.is_empty() {
+    if request_id.is_empty() || parent_request_id.is_empty() || parent_tool_call_id.is_empty() {
         return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
     }
 
-    // 3. Generate fresh identifiers (mirror materialize.rs pattern).
-    let new_request_id = uuid::Uuid::new_v4().to_string();
+    // 3. Cross-reference check (R3): the parent link must point at a real
+    // AgentRequest before the child can be materialized.
+    let parent_agent_did = parent_request_agent_did(node, &parent_request_id).await?;
+    if parent_agent_did.as_deref() != Some(agent_did.as_str()) {
+        return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
+    }
+
+    // 4. Generate fresh session identifier (mirror materialize.rs pattern).
     let new_session_id = uuid::Uuid::new_v4().to_string();
     let new_subagent_depth = parent_subagent_depth + 1;
     let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
 
-    let escaped_request_id = escape_graphql_string(&new_request_id);
+    let escaped_request_id = escape_graphql_string(&request_id);
     let escaped_agent_did = escape_graphql_string(&agent_did);
     let escaped_behavior_id = escape_graphql_string(&behavior_id);
     let escaped_session_id = escape_graphql_string(&new_session_id);
@@ -118,7 +161,9 @@ pub async fn create_subagent_request(
                 max_retries: {max_retries},
                 subagent_depth: {new_subagent_depth},
                 caused_by_parent_request_id: "{escaped_parent_request_id}",
-                caused_by_parent_tool_call_id: "{escaped_parent_tool_call_id}"
+                caused_by_parent_tool_call_id: "{escaped_parent_tool_call_id}",
+                caused_by_trigger_id: "{escaped_parent_tool_call_id}",
+                caused_by_trigger_kind: "subagent"
             }}) {{ _docID }}
         }}"#,
         max_retries = DEFAULT_REQUEST_MAX_RETRIES,
@@ -126,7 +171,41 @@ pub async fn create_subagent_request(
 
     execute_mutation_with_retry(node, &mutation, "create_subagent_request").await?;
 
-    Ok(new_request_id)
+    Ok(request_id)
+}
+
+#[derive(Debug, Deserialize)]
+struct ParentRequestLookupRow {
+    agent_did: String,
+}
+
+async fn parent_request_agent_did(
+    node: &EmbeddedNode,
+    parent_request_id: &str,
+) -> Result<Option<String>> {
+    let escaped_parent_request_id = escape_graphql_string(parent_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_parent_request_id}" }} }},
+                limit: 1
+            ) {{ agent_did }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query parent AgentRequest for create_subagent_request failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<ParentRequestLookupRow> = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows.into_iter().next().map(|row| row.agent_did))
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/trigger_engine/event_source.rs
+++ b/crates/defra-agent/src/trigger_engine/event_source.rs
@@ -735,6 +735,7 @@ impl EventSource {
                 event_vars,
                 doc_vars,
                 args_vars: None,
+                pre_materialized_request_id: None,
                 on_result: Box::new(move |result| {
                     EventSource::spawn_runtime_field_write(
                         node_for_callback,

--- a/crates/defra-agent/src/trigger_engine/manual_source.rs
+++ b/crates/defra-agent/src/trigger_engine/manual_source.rs
@@ -90,6 +90,7 @@ impl ManualTriggerHandle {
             }),
             doc_vars: None,
             args_vars: Some(args),
+            pre_materialized_request_id: None,
             on_result: Box::new(move |result| {
                 // Caller may have dropped the receiver — that's fine.
                 let _ = result_tx.send(result);

--- a/crates/defra-agent/src/trigger_engine/mod.rs
+++ b/crates/defra-agent/src/trigger_engine/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod event_source;
 pub(crate) mod manual_source;
 pub(crate) mod production_materializer;
 pub(crate) mod schedule_source;
+pub(crate) mod subagent_source;
 
 #[cfg(test)]
 mod tests;
@@ -65,6 +66,7 @@ pub(crate) struct FireIntent {
     pub(crate) event_vars: serde_json::Value,
     pub(crate) doc_vars: Option<serde_json::Value>,
     pub(crate) args_vars: Option<serde_json::Value>,
+    pub(crate) pre_materialized_request_id: Option<String>,
     pub(crate) on_result: Box<dyn FnOnce(FireResult) + Send>,
 }
 
@@ -236,6 +238,12 @@ impl TriggerEngine {
             let result = FireResult::Errored {
                 error: error.to_string(),
             };
+            (intent.on_result)(result.clone());
+            return result;
+        }
+
+        if let Some(request_id) = intent.pre_materialized_request_id.clone() {
+            let result = FireResult::Fired { request_id };
             (intent.on_result)(result.clone());
             return result;
         }

--- a/crates/defra-agent/src/trigger_engine/schedule_source.rs
+++ b/crates/defra-agent/src/trigger_engine/schedule_source.rs
@@ -193,6 +193,7 @@ impl TriggerSource for ScheduleSource {
                         event_vars,
                         doc_vars: None,
                         args_vars: None,
+                        pre_materialized_request_id: None,
                         on_result: Box::new(move |result| {
                             let updates = match &result {
                                 FireResult::Fired { request_id } => {

--- a/crates/defra-agent/src/trigger_engine/subagent_source.rs
+++ b/crates/defra-agent/src/trigger_engine/subagent_source.rs
@@ -1,0 +1,443 @@
+//! Subagent-backed `TriggerSource`.
+//!
+//! Observes `AgentToolCall` rows with a non-empty `child_request_id` and
+//! materializes the linked child `AgentRequest`. The child is created before
+//! the intent reaches `TriggerEngine`; the returned `FireIntent` carries the
+//! pre-materialized request id so dispatch records a `Fired` result without
+//! creating a second request.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use defra_node::{EmbeddedNode, EventName};
+use serde::Deserialize;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use crate::graphql::escape_graphql_string;
+use crate::runtime_snapshot::{ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedTask};
+use crate::tool_call_lifecycle::subagent_request::create_subagent_request_with_request_id;
+use crate::tool_call_lifecycle::IllegalToolCallTransition;
+
+use super::{FireIntent, FireResult, TriggerKind, TriggerSource};
+
+const TOOL_CALL_COLLECTION: &str = "AgentToolCall";
+
+pub(crate) struct SubagentSource {
+    snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+    node: Arc<EmbeddedNode>,
+    subscription: Option<events::Subscription>,
+    cancel: CancellationToken,
+    collection_id_to_name: HashMap<String, String>,
+    processed_tool_calls: HashSet<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    #[serde(default)]
+    tool_call_key: Option<String>,
+    #[serde(default)]
+    request_id: Option<String>,
+    tool_call_id: String,
+    #[serde(default)]
+    args: String,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    deadline_at: Option<String>,
+    #[serde(default)]
+    child_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParentRequestRow {
+    agent_did: String,
+    #[serde(default)]
+    subagent_depth: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpawnArgs {
+    #[serde(alias = "target", alias = "target_behavior_id")]
+    behavior_id: String,
+    #[serde(alias = "message", alias = "content")]
+    prompt: String,
+    #[serde(default)]
+    deadline: Option<String>,
+}
+
+impl SubagentSource {
+    pub(crate) fn new(
+        snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+        node: Arc<EmbeddedNode>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            snapshot_rx,
+            node,
+            subscription: None,
+            cancel,
+            collection_id_to_name: HashMap::new(),
+            processed_tool_calls: HashSet::new(),
+        }
+    }
+
+    fn ensure_subscription(&mut self) {
+        if self.subscription.is_none() {
+            self.subscription = Some(self.node.subscribe(&[EventName::Update]));
+            tracing::info!("subagent source opened global Update subscription");
+        }
+    }
+
+    async fn resolve_collection_name(&mut self, collection_id: &str) -> Option<String> {
+        if let Some(name) = self.collection_id_to_name.get(collection_id) {
+            return Some(name.clone());
+        }
+
+        let names = match self.node.list_collections() {
+            Ok(names) => names,
+            Err(error) => {
+                tracing::warn!(
+                    collection_id = %collection_id,
+                    %error,
+                    "subagent source failed to list collections; dropping event"
+                );
+                return None;
+            }
+        };
+
+        for name in names {
+            let def = match self.node.get_collection(&name) {
+                Ok(Some(def)) => def,
+                Ok(None) => continue,
+                Err(error) => {
+                    tracing::warn!(
+                        collection_name = %name,
+                        %error,
+                        "subagent source failed to fetch collection definition while resolving id",
+                    );
+                    continue;
+                }
+            };
+            self.collection_id_to_name
+                .insert(def.collection_id.clone(), def.name.clone());
+        }
+
+        self.collection_id_to_name.get(collection_id).cloned()
+    }
+
+    async fn load_tool_call(&self, doc_id: &str) -> anyhow::Result<Option<ToolCallRow>> {
+        let escaped_doc_id = escape_graphql_string(doc_id);
+        let query = format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    limit: 1
+                ) {{
+                    _docID
+                    tool_call_key
+                    request_id
+                    tool_call_id
+                    args
+                    lifecycle_state
+                    deadline_at
+                    child_request_id
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "query AgentToolCall for SubagentSource failed: {:?}",
+                response.errors
+            );
+        }
+        let rows: Vec<ToolCallRow> = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get(TOOL_CALL_COLLECTION))
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn load_parent_request(
+        &self,
+        request_id: &str,
+    ) -> anyhow::Result<Option<ParentRequestRow>> {
+        let escaped_request_id = escape_graphql_string(request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                    limit: 1
+                ) {{
+                    agent_did
+                    subagent_depth
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "query parent AgentRequest for SubagentSource failed: {:?}",
+                response.errors
+            );
+        }
+        let rows: Vec<ParentRequestRow> = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("AgentRequest"))
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn child_request_exists(&self, request_id: &str) -> anyhow::Result<bool> {
+        let escaped_request_id = escape_graphql_string(request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                    limit: 1
+                ) {{ _docID }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "query child AgentRequest for SubagentSource failed: {:?}",
+                response.errors
+            );
+        }
+        Ok(response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("AgentRequest"))
+            .and_then(serde_json::Value::as_array)
+            .is_some_and(|rows| !rows.is_empty()))
+    }
+
+    async fn build_intent_for_tool_call_doc(
+        &mut self,
+        doc_id: &str,
+    ) -> anyhow::Result<Option<FireIntent>> {
+        let Some(row) = self.load_tool_call(doc_id).await? else {
+            return Ok(None);
+        };
+        let child_request_id = match non_empty(row.child_request_id.as_deref()) {
+            Some(value) => value.to_string(),
+            None => return Ok(None),
+        };
+        if row.lifecycle_state.as_deref() != Some("running") {
+            return Ok(None);
+        }
+
+        let processed_key = row
+            .tool_call_key
+            .clone()
+            .filter(|value| !value.is_empty())
+            .unwrap_or_else(|| row.doc_id.clone());
+        if self.processed_tool_calls.contains(&processed_key) {
+            return Ok(None);
+        }
+
+        let parent_request_id = match non_empty(row.request_id.as_deref()) {
+            Some(value) => value.to_string(),
+            None => return Ok(None),
+        };
+        let parent_tool_call_id = match non_empty(Some(&row.tool_call_id)) {
+            Some(value) => value.to_string(),
+            None => return Ok(None),
+        };
+        let spawn_args: SpawnArgs = serde_json::from_str(&row.args)?;
+
+        let snapshot = self.snapshot_rx.borrow().clone();
+        if snapshot.behavior(&spawn_args.behavior_id).is_none() {
+            tracing::warn!(
+                parent_request_id = %parent_request_id,
+                parent_tool_call_id = %parent_tool_call_id,
+                target_behavior_id = %spawn_args.behavior_id,
+                "subagent source target behavior is not in the active runtime snapshot; skipping spawn",
+            );
+            return Ok(None);
+        }
+
+        let Some(parent) = self.load_parent_request(&parent_request_id).await? else {
+            anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
+        };
+
+        if self.child_request_exists(&child_request_id).await? {
+            self.processed_tool_calls.insert(processed_key);
+            return Ok(None);
+        }
+
+        let parent_depth = parent
+            .subagent_depth
+            .and_then(|depth| u32::try_from(depth).ok())
+            .unwrap_or(0);
+        let deadline =
+            effective_deadline(row.deadline_at.as_deref(), spawn_args.deadline.as_deref());
+        let request_id = create_subagent_request_with_request_id(
+            &self.node,
+            child_request_id.clone(),
+            parent_request_id.clone(),
+            parent_tool_call_id.clone(),
+            parent_depth,
+            parent.agent_did,
+            spawn_args.behavior_id.clone(),
+            spawn_args.prompt.clone(),
+            deadline,
+        )
+        .await?;
+
+        self.processed_tool_calls.insert(processed_key);
+        let fired_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+        let task = ResolvedTask {
+            task_id: format!("subagent:{parent_tool_call_id}"),
+            name: Some(format!(
+                "Subagent {target}",
+                target = spawn_args.behavior_id
+            )),
+            behavior_id: spawn_args.behavior_id,
+            prompt_template: spawn_args.prompt,
+            output_schema_ref: None,
+        };
+        let event_vars = serde_json::json!({
+            "fired_at": fired_at,
+            "trigger_id": parent_tool_call_id,
+            "trigger_kind": "subagent",
+            "parent_request_id": parent_request_id,
+            "child_request_id": request_id,
+        });
+        Ok(Some(FireIntent {
+            trigger_id: None,
+            trigger_kind: TriggerKind::Manual,
+            task,
+            concurrency: ConcurrencyMode::Parallel,
+            event_vars,
+            doc_vars: None,
+            args_vars: None,
+            pre_materialized_request_id: Some(request_id),
+            on_result: Box::new(move |result| match result {
+                FireResult::Fired { request_id } => {
+                    tracing::debug!(
+                        child_request_id = %request_id,
+                        "subagent source reported pre-materialized child request fired"
+                    );
+                }
+                FireResult::Skipped { reason } => {
+                    tracing::warn!(%reason, "subagent source pre-materialized fire skipped");
+                }
+                FireResult::Errored { error } => {
+                    tracing::warn!(%error, "subagent source pre-materialized fire errored");
+                }
+            }),
+        }))
+    }
+}
+
+impl TriggerSource for SubagentSource {
+    fn next_fire(
+        &mut self,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FireIntent>> + Send + '_>> {
+        Box::pin(async move {
+            self.ensure_subscription();
+            loop {
+                let message = {
+                    let subscription = self
+                        .subscription
+                        .as_mut()
+                        .expect("subagent source subscription opened before polling");
+                    tokio::select! {
+                        biased;
+                        _ = self.cancel.cancelled() => return None,
+                        res = self.snapshot_rx.changed() => {
+                            if res.is_err() {
+                                return None;
+                            }
+                            continue;
+                        }
+                        msg = subscription.recv() => {
+                            match msg {
+                                Some(message) => message,
+                                None => {
+                                    tracing::warn!(
+                                        "subagent source subscription channel closed; source exiting",
+                                    );
+                                    return None;
+                                }
+                            }
+                        }
+                    }
+                };
+
+                let dropped = self
+                    .subscription
+                    .as_mut()
+                    .expect("subagent source subscription remains open")
+                    .check_and_reset_dropped();
+                if dropped > 0 {
+                    tracing::warn!(
+                        dropped,
+                        "subagent source dropped messages; may have missed child spawns",
+                    );
+                }
+
+                let Some(update) = message.as_update() else {
+                    continue;
+                };
+                let collection_id = update.collection_id.clone();
+                let doc_id = update.doc_id.clone();
+                let Some(collection_name) = self.resolve_collection_name(&collection_id).await
+                else {
+                    continue;
+                };
+                if collection_name != TOOL_CALL_COLLECTION {
+                    continue;
+                }
+
+                match self.build_intent_for_tool_call_doc(&doc_id).await {
+                    Ok(Some(intent)) => return Some(intent),
+                    Ok(None) => continue,
+                    Err(error) => {
+                        tracing::warn!(
+                            doc_id = %doc_id,
+                            %error,
+                            "subagent source failed to process AgentToolCall event",
+                        );
+                        continue;
+                    }
+                }
+            }
+        })
+    }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
+}
+
+fn parse_deadline(value: Option<&str>) -> Option<DateTime<Utc>> {
+    non_empty(value)
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc))
+}
+
+fn effective_deadline(
+    tool_deadline: Option<&str>,
+    args_deadline: Option<&str>,
+) -> Option<DateTime<Utc>> {
+    match (parse_deadline(tool_deadline), parse_deadline(args_deadline)) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}

--- a/crates/defra-agent/src/trigger_engine/tests.rs
+++ b/crates/defra-agent/src/trigger_engine/tests.rs
@@ -464,6 +464,7 @@ async fn trigger_engine_dispatch_matches_lean_generated_contract_cases() {
             event_vars: serde_json::json!({}),
             doc_vars: None,
             args_vars: None,
+            pre_materialized_request_id: None,
             on_result: Box::new(|_| {}),
         };
 
@@ -627,6 +628,7 @@ async fn dispatch_skips_when_schedule_not_in_active_schedules() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -639,6 +641,39 @@ async fn dispatch_skips_when_schedule_not_in_active_schedules() {
     assert!(
         materializer.calls().is_empty(),
         "materializer should not be called when the trigger is disabled"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_reports_pre_materialized_request_without_materializer_call() {
+    let snapshot = snapshot_with_schedules(HashMap::new());
+    let (_tx, rx) = watch::channel(snapshot);
+    let materializer = SpyMaterializer::new();
+    let engine = TriggerEngine::new(rx, materializer.clone());
+
+    let intent = FireIntent {
+        trigger_id: None,
+        trigger_kind: TriggerKind::Manual,
+        task: resolved_task("ignored"),
+        concurrency: ConcurrencyMode::Parallel,
+        event_vars: serde_json::json!({"trigger_kind": "subagent"}),
+        doc_vars: None,
+        args_vars: None,
+        pre_materialized_request_id: Some("child-pre-materialized".to_string()),
+        on_result: Box::new(|_| {}),
+    };
+
+    let result = engine.dispatch(intent).await;
+
+    match result {
+        FireResult::Fired { request_id } => {
+            assert_eq!(request_id, "child-pre-materialized");
+        }
+        other => panic!("expected Fired for pre-materialized intent, got {other:?}"),
+    }
+    assert!(
+        materializer.calls().is_empty(),
+        "pre-materialized dispatch must not create a second AgentRequest"
     );
 }
 
@@ -659,6 +694,7 @@ async fn dispatch_renders_and_materializes_when_schedule_active() {
         event_vars: serde_json::json!({"fired_at": "2026-04-21T00:00:00Z"}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -695,6 +731,7 @@ async fn dispatch_parallel_materializes_every_intent() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
     let intent2 = FireIntent {
@@ -705,6 +742,7 @@ async fn dispatch_parallel_materializes_every_intent() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -744,6 +782,7 @@ async fn dispatch_serial_materializes_when_no_inflight() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -780,6 +819,7 @@ async fn dispatch_serial_skips_when_inflight_exists() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -820,6 +860,7 @@ async fn dispatch_latest_only_supersedes_prior_and_fires_new() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -866,6 +907,7 @@ async fn dispatch_latest_only_lock_blocks_second_supersede_until_first_materiali
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -965,6 +1007,7 @@ async fn dispatch_errors_and_skips_materialize_on_template_render_failure() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(move |r| {
             *capture.lock().unwrap() = Some(r);
         }),
@@ -1023,6 +1066,7 @@ async fn dispatch_latest_only_serializes_parallel_fires() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: None,
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -2765,6 +2809,7 @@ async fn dispatch_manual_intent_renders_with_args_and_materializes() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: Some(serde_json::json!({"name": "Amy"})),
+        pre_materialized_request_id: None,
         on_result: Box::new(|_| {}),
     };
 
@@ -2814,6 +2859,7 @@ async fn dispatch_rejects_manual_intent_with_trigger_id() {
         event_vars: serde_json::json!({}),
         doc_vars: None,
         args_vars: Some(serde_json::json!({})),
+        pre_materialized_request_id: None,
         on_result: Box::new(move |r| {
             *capture.lock().unwrap() = Some(r);
         }),

--- a/crates/defra-agent/tests/subagent_source_conformance.rs
+++ b/crates/defra-agent/tests/subagent_source_conformance.rs
@@ -1,0 +1,401 @@
+//! Bucket 3 runtime conformance for R3 SubagentSource.
+
+mod support;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::interrupt::{fetch_interrupt_requested_at, interrupt_request};
+use defra_agent::tool_call_lifecycle::{
+    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, IllegalToolCallTransition,
+    ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
+};
+use defra_agent::{AgentIdentity, DefraAgent, DocumentRuntimeOptions, ToolCeiling};
+use serde::Deserialize;
+
+use support::fixtures::{bind_default_behavior_backend, test_identity};
+use support::interrupt::{create_runtime_request, wait_for_runtime_ready, BootedAgent};
+use support::mock_endpoint::MockModelEndpoint;
+use support::{first_optional_row, first_row, test_db};
+
+struct RunningAgent {
+    booted: BootedAgent,
+    _endpoint: MockModelEndpoint,
+    behavior_id: String,
+}
+
+async fn boot_agent(db: &support::TestDb, test_name: &str) -> RunningAgent {
+    let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity(test_name));
+    let endpoint = MockModelEndpoint::start("default").unwrap();
+    bind_default_behavior_backend(
+        db.node.as_ref(),
+        identity.did(),
+        "backend-subagent-source",
+        endpoint.endpoint(),
+    )
+    .await;
+    let agent = DefraAgent::from_default_behavior_documents(
+        db.node.clone(),
+        identity,
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let agent_did = agent.agent_did().to_string();
+    let behavior_id = agent.default_behavior_id().to_string();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(agent.run(shutdown_rx));
+    wait_for_runtime_ready(db.node.as_ref(), &agent_did).await;
+    RunningAgent {
+        booted: BootedAgent::new(shutdown_tx, handle, agent_did),
+        _endpoint: endpoint,
+        behavior_id,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildRequestRow {
+    request_id: String,
+    behavior_id: String,
+    content: String,
+    subagent_depth: Option<i64>,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
+    caused_by_trigger_id: Option<String>,
+    caused_by_trigger_kind: Option<String>,
+}
+
+async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> ChildRequestRow {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_child_request_id}" }} }},
+                limit: 1
+            ) {{
+                request_id
+                behavior_id
+                content
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+                caused_by_trigger_id
+                caused_by_trigger_kind
+            }}
+        }}"#
+    );
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let response = node.execute(&query).await;
+        if let Some(row) = first_optional_row::<ChildRequestRow>(&response, "AgentRequest") {
+            return row;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for child AgentRequest {child_request_id}"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+async fn assert_no_child_request_for_tool(
+    node: &EmbeddedNode,
+    parent_tool_call_id: &str,
+    settle: Duration,
+) {
+    tokio::time::sleep(settle).await;
+    let escaped_parent_tool_call_id = escape_graphql_string(parent_tool_call_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    caused_by_parent_tool_call_id: {{ _eq: "{escaped_parent_tool_call_id}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "query failed: {:?}",
+        response.errors
+    );
+    let count = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|rows| rows.as_array())
+        .map(Vec::len)
+        .unwrap_or(0);
+    assert_eq!(
+        count, 0,
+        "native AgentToolCall unexpectedly spawned {count} child request(s)"
+    );
+}
+
+#[tokio::test]
+async fn subagent_source_materializes_child_request_from_tool_call() {
+    let db = test_db("r3-subagent-source-spawn").await;
+    let running = boot_agent(&db, "r3-subagent-source-spawn").await;
+    let parent_request_id = "r3-parent-spawn";
+    let parent_tool_call_id = "r3-tc-spawn";
+    let child_request_id = "r3-child-spawn";
+    create_runtime_request(
+        db.node.as_ref(),
+        &running.booted.agent_did,
+        &running.behavior_id,
+        parent_request_id,
+        "r3-session-spawn",
+        "parent prompt",
+    )
+    .await;
+
+    let args = serde_json::json!({
+        "behavior_id": running.behavior_id.clone(),
+        "prompt": "child prompt from source"
+    })
+    .to_string();
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        parent_request_id.to_string(),
+        "r3-session-spawn".to_string(),
+        parent_tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        args,
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
+    assert_eq!(child.request_id, child_request_id);
+    assert_eq!(child.behavior_id, running.behavior_id);
+    assert_eq!(child.content, "child prompt from source");
+    assert_eq!(child.subagent_depth, Some(1));
+    assert_eq!(
+        child.caused_by_parent_request_id.as_deref(),
+        Some(parent_request_id)
+    );
+    assert_eq!(
+        child.caused_by_parent_tool_call_id.as_deref(),
+        Some(parent_tool_call_id)
+    );
+    assert_eq!(
+        child.caused_by_trigger_id.as_deref(),
+        Some(parent_tool_call_id)
+    );
+    assert_eq!(child.caused_by_trigger_kind.as_deref(), Some("subagent"));
+
+    running.booted.shutdown().await;
+}
+
+#[tokio::test]
+async fn subagent_source_ignores_native_tool_call_without_child_request_id() {
+    let db = test_db("r3-subagent-source-native").await;
+    let running = boot_agent(&db, "r3-subagent-source-native").await;
+    let parent_request_id = "r3-parent-native";
+    let parent_tool_call_id = "r3-tc-native";
+    create_runtime_request(
+        db.node.as_ref(),
+        &running.booted.agent_did,
+        &running.behavior_id,
+        parent_request_id,
+        "r3-session-native",
+        "parent prompt",
+    )
+    .await;
+
+    let mut lifecycle = ToolCallLifecycle::new(
+        db.node.clone(),
+        parent_request_id.to_string(),
+        "r3-session-native".to_string(),
+        parent_tool_call_id.to_string(),
+        1,
+        "read_file".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    assert_no_child_request_for_tool(
+        db.node.as_ref(),
+        parent_tool_call_id,
+        Duration::from_millis(750),
+    )
+    .await;
+
+    running.booted.shutdown().await;
+}
+
+#[tokio::test]
+async fn create_subagent_request_rejects_nonexistent_parent_request() {
+    let db = test_db("r3-subagent-source-missing-parent").await;
+    let error = create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        "r3-child-missing-parent".to_string(),
+        "missing-parent-request".to_string(),
+        "r3-tc-missing-parent".to_string(),
+        0,
+        support::AGENT_DID.to_string(),
+        "test".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("missing parent request must be rejected");
+    assert!(
+        matches!(
+            error.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::ParentLinkageIncoherent)
+        ),
+        "expected ParentLinkageIncoherent, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn create_subagent_request_enforces_depth_boundary() {
+    let db = test_db("r3-subagent-source-depth").await;
+    support::create_request(
+        db.node.as_ref(),
+        "r3-parent-depth",
+        "r3-session-depth",
+        "processing",
+        &chrono::Utc::now().to_rfc3339(),
+    )
+    .await;
+
+    let child_id = create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        "r3-child-depth-max".to_string(),
+        "r3-parent-depth".to_string(),
+        "r3-tc-depth-max".to_string(),
+        MAX_SUBAGENT_DEPTH - 1,
+        support::AGENT_DID.to_string(),
+        "test".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect("parent depth MAX-1 should create a child at MAX");
+    let escaped_child_id = escape_graphql_string(&child_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_child_id}" }} }}, limit: 1) {{
+                subagent_depth
+            }}
+        }}"#
+    );
+    #[derive(Deserialize)]
+    struct DepthRow {
+        subagent_depth: i64,
+    }
+    let row = first_row::<DepthRow>(&db.node.execute(&query).await, "AgentRequest");
+    assert_eq!(row.subagent_depth, i64::from(MAX_SUBAGENT_DEPTH));
+
+    let error = create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        "r3-child-depth-over".to_string(),
+        "r3-parent-depth".to_string(),
+        "r3-tc-depth-over".to_string(),
+        MAX_SUBAGENT_DEPTH,
+        support::AGENT_DID.to_string(),
+        "test".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("parent depth MAX should be rejected");
+    assert!(
+        matches!(
+            error.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::SubagentDepthExceeded)
+        ),
+        "expected SubagentDepthExceeded, got {error:?}"
+    );
+}
+
+#[tokio::test]
+async fn cascade_after_source_spawn_reaches_child_request() {
+    let db = test_db("r3-subagent-source-cascade").await;
+    let running = boot_agent(&db, "r3-subagent-source-cascade").await;
+    let parent_request_id = "r3-parent-cascade";
+    let parent_tool_call_id = "r3-tc-cascade";
+    let child_request_id = "r3-child-cascade";
+    create_runtime_request(
+        db.node.as_ref(),
+        &running.booted.agent_did,
+        &running.behavior_id,
+        parent_request_id,
+        "r3-session-cascade",
+        "parent prompt",
+    )
+    .await;
+
+    let args = serde_json::json!({
+        "behavior_id": running.behavior_id.clone(),
+        "prompt": "child prompt for cascade"
+    })
+    .to_string();
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        parent_request_id.to_string(),
+        "r3-session-cascade".to_string(),
+        parent_tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        args,
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Foreground,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+    let _child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
+
+    interrupt_request(db.node.as_ref(), parent_request_id)
+        .await
+        .unwrap();
+    mark_request_interrupted(db.node.as_ref(), parent_request_id).await;
+    ToolCallLifecycle::recover_all(db.node.as_ref(), &running.booted.agent_did)
+        .await
+        .unwrap();
+
+    let child_interrupt = fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_some(),
+        "cascade recovery should latch child interrupt_requested_at"
+    );
+
+    running.booted.shutdown().await;
+}
+
+async fn mark_request_interrupted(node: &EmbeddedNode, request_id: &str) {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                input: {{
+                    status: "error",
+                    lifecycle_state: "interrupted"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "mark_request_interrupted failed: {:?}",
+        response.errors
+    );
+}

--- a/crates/defra-agent/tests/subagent_source_conformance.rs
+++ b/crates/defra-agent/tests/subagent_source_conformance.rs
@@ -63,6 +63,7 @@ struct ChildRequestRow {
     request_id: String,
     behavior_id: String,
     content: String,
+    lifecycle_state: Option<String>,
     subagent_depth: Option<i64>,
     caused_by_parent_request_id: Option<String>,
     caused_by_parent_tool_call_id: Option<String>,
@@ -81,6 +82,7 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
                 request_id
                 behavior_id
                 content
+                lifecycle_state
                 subagent_depth
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
@@ -379,6 +381,59 @@ async fn cascade_after_source_spawn_reaches_child_request() {
     running.booted.shutdown().await;
 }
 
+#[tokio::test]
+async fn recovery_materializes_orphan_child_request_for_running_subagent_tool() {
+    let db = test_db("r3-subagent-source-orphan-recovery").await;
+    let parent_request_id = "r3-parent-orphan";
+    let parent_session_id = "r3-session-orphan";
+    let parent_tool_call_id = "r3-tc-orphan";
+    let child_request_id = "child-orphan-1";
+    support::create_request(
+        db.node.as_ref(),
+        parent_request_id,
+        parent_session_id,
+        "processing",
+        &chrono::Utc::now().to_rfc3339(),
+    )
+    .await;
+    create_orphan_subagent_tool_call(
+        db.node.as_ref(),
+        parent_request_id,
+        parent_session_id,
+        parent_tool_call_id,
+        child_request_id,
+    )
+    .await;
+
+    let report = ToolCallLifecycle::recover_all(db.node.as_ref(), support::AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(
+        report.tool_calls_recovered, 0,
+        "orphan backfill should not terminalize a live non-expired tool call"
+    );
+
+    let child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
+    assert_eq!(child.request_id, child_request_id);
+    assert_eq!(child.behavior_id, support::AGENT_NAME);
+    assert_eq!(child.content, "orphan child prompt");
+    assert_eq!(child.lifecycle_state.as_deref(), Some("pending"));
+    assert_eq!(child.subagent_depth, Some(1));
+    assert_eq!(
+        child.caused_by_parent_request_id.as_deref(),
+        Some(parent_request_id)
+    );
+    assert_eq!(
+        child.caused_by_parent_tool_call_id.as_deref(),
+        Some(parent_tool_call_id)
+    );
+    assert_eq!(
+        child.caused_by_trigger_id.as_deref(),
+        Some(parent_tool_call_id)
+    );
+    assert_eq!(child.caused_by_trigger_kind.as_deref(), Some("subagent"));
+}
+
 async fn mark_request_interrupted(node: &EmbeddedNode, request_id: &str) {
     let escaped_request_id = escape_graphql_string(request_id);
     let mutation = format!(
@@ -396,6 +451,59 @@ async fn mark_request_interrupted(node: &EmbeddedNode, request_id: &str) {
     assert!(
         !response.has_errors(),
         "mark_request_interrupted failed: {:?}",
+        response.errors
+    );
+}
+
+async fn create_orphan_subagent_tool_call(
+    node: &EmbeddedNode,
+    parent_request_id: &str,
+    parent_session_id: &str,
+    parent_tool_call_id: &str,
+    child_request_id: &str,
+) {
+    let escaped_parent_request_id = escape_graphql_string(parent_request_id);
+    let escaped_parent_session_id = escape_graphql_string(parent_session_id);
+    let escaped_parent_tool_call_id = escape_graphql_string(parent_tool_call_id);
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let tool_call_key = format!("{escaped_parent_session_id}:{escaped_parent_tool_call_id}");
+    let args = serde_json::json!({
+        "behavior_id": support::AGENT_NAME,
+        "prompt": "orphan child prompt"
+    })
+    .to_string();
+    let escaped_args = escape_graphql_string(&args);
+    let started_at = chrono::Utc::now().to_rfc3339();
+    let deadline_at = (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentToolCall(input: {{
+                tool_call_key: "{tool_call_key}",
+                request_id: "{escaped_parent_request_id}",
+                session_id: "{escaped_parent_session_id}",
+                message_sequence: 1,
+                tool_name: "spawn_subagent",
+                tool_call_id: "{escaped_parent_tool_call_id}",
+                args: "{escaped_args}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "{started_at}",
+                deadline_at: "{deadline_at}",
+                child_request_id: "{escaped_child_request_id}",
+                await_mode: "Foreground",
+                cancel_policy: "Cascade",
+                selected_service_id: null,
+                selected_tool_name: null,
+                tool_failure_class: null,
+                latency_ms: null
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create orphan AgentToolCall failed: {:?}",
         response.errors
     );
 }

--- a/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
@@ -990,6 +990,15 @@ async fn integration_v3_schema_defaults_populate_correctly() {
 #[tokio::test]
 async fn integration_create_subagent_request_at_max_depth_succeeds() {
     let db = test_db("tc-sa-csr-1").await;
+    support::create_request(
+        &db.node,
+        "parent-req-csr-1",
+        "parent-sess-csr-1",
+        "processing",
+        &chrono::Utc::now().to_rfc3339(),
+    )
+    .await;
+
     let new_id = create_subagent_request(
         &db.node,
         "parent-req-csr-1".to_string(),
@@ -1015,6 +1024,8 @@ async fn integration_create_subagent_request_at_max_depth_succeeds() {
                 subagent_depth
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
+                caused_by_trigger_id
+                caused_by_trigger_kind
             }}
         }}"#
     );
@@ -1038,6 +1049,11 @@ async fn integration_create_subagent_request_at_max_depth_succeeds() {
         row["caused_by_parent_tool_call_id"].as_str(),
         Some("parent-tc-csr-1")
     );
+    assert_eq!(
+        row["caused_by_trigger_id"].as_str(),
+        Some("parent-tc-csr-1")
+    );
+    assert_eq!(row["caused_by_trigger_kind"].as_str(), Some("subagent"));
 }
 
 #[tokio::test]

--- a/docs/superpowers/plans/2026-05-11-r3-rust-subagent-source.md
+++ b/docs/superpowers/plans/2026-05-11-r3-rust-subagent-source.md
@@ -1,0 +1,16 @@
+# R3 Rust SubagentSource Plan
+
+1. Add request-id-aware child request materialization while preserving the
+   existing generated-id helper API.
+2. Add parent existence validation to the shared child request creation path.
+3. Add ToolSelection target cross-reference validation in document-view apply.
+4. Add `SubagentSource` with DefraDB update subscription, AgentToolCall row
+   hydration, args parsing, target lookup, depth inheritance, and duplicate
+   spawn suppression.
+5. Add a pre-materialized request id path to `FireIntent` and
+   `TriggerEngine::dispatch`.
+6. Wire `SubagentSource` into runtime startup after the startup barrier.
+7. Add conformance coverage for source spawn, native no-op, missing parent,
+   missing target, max depth, and cascade-through-source.
+8. Run focused tests, formatting, `git diff --check`, and the relevant runtime
+   and conformance suites before pushing the stacked PR.

--- a/docs/superpowers/specs/2026-05-11-r3-rust-subagent-source-design.md
+++ b/docs/superpowers/specs/2026-05-11-r3-rust-subagent-source-design.md
@@ -1,0 +1,69 @@
+# R3 Rust SubagentSource Design
+
+## Scope
+
+R3 is runtime plumbing on top of the R2 subagent data plane and the #161
+tool-call closure work. It does not add Lean state-machine transitions. The
+existing B-theorems cover the spawn edge, depth bound, linkage coherence, and
+cascade behavior; this PR wires those invariants into Rust runtime dispatch.
+
+## SubagentSource
+
+`SubagentSource` is a `TriggerSource` sibling of `ScheduleSource`,
+`EventSource`, and `ManualSource`. It subscribes to DefraDB `Update` events,
+resolves the event collection id to a collection name, and filters for
+`AgentToolCall` rows whose `child_request_id` is non-empty and whose
+`lifecycle_state` is still `running`.
+
+The source expects `spawn_subagent` tool-call args to contain:
+
+```json
+{
+  "behavior_id": "target-behavior",
+  "prompt": "child request prompt",
+  "deadline": "optional RFC3339 deadline"
+}
+```
+
+`target` and `target_behavior_id` are accepted as aliases for
+`behavior_id`; `message` and `content` are accepted as aliases for `prompt`.
+If both the tool-call row and args carry deadlines, the child request uses the
+earlier deadline.
+
+The tool-call row already carries the child request id allocated by the spawn
+tool path. To preserve B5 link symmetry, the source materializes the child
+`AgentRequest` using that exact request id. The existing
+`create_subagent_request` helper remains available for callers that need a
+fresh id; R3 adds an internal request-id-aware variant for source dispatch.
+
+## TriggerEngine Handoff
+
+`create_subagent_request` writes the `AgentRequest` before the engine sees the
+fire. To avoid a second request materialization, `FireIntent` gains an
+optional pre-materialized request id. When present, `TriggerEngine::dispatch`
+returns `FireResult::Fired` for that id and skips enabled-gate, template,
+concurrency, and materializer steps.
+
+The persisted child request lineage is:
+
+- `caused_by_trigger_kind = "subagent"`
+- `caused_by_trigger_id = <parent_tool_call_id>`
+- `caused_by_parent_request_id = <parent request_id>`
+- `caused_by_parent_tool_call_id = <parent tool_call_id>`
+
+The formal trigger vocabulary remains unchanged; `"subagent"` is runtime
+lineage metadata for parent-linked child requests, not a new schedule/event
+dispatch transition.
+
+## Validation
+
+R3 adds the deferred cross-reference checks from R2:
+
+- `ToolSelection.subagent_targets[*]` must resolve to a behavior in the active
+  document runtime view before the selection is applied.
+- `create_subagent_request` rejects a missing parent `AgentRequest`, or a
+  parent owned by a different `agent_did`, with
+  `IllegalToolCallTransition::ParentLinkageIncoherent`.
+
+The depth bound continues to use `MAX_SUBAGENT_DEPTH`, matching Lean's
+`Subagent.maxSubagentDepth`.


### PR DESCRIPTION
## Summary

Implements the R3 runtime spawn side of the subagent bridge on top of #161:

- adds `SubagentSource` as a trigger-engine source for running `AgentToolCall` rows with `child_request_id`
- materializes linked child `AgentRequest` rows with `request_id == child_request_id` and subagent lineage metadata
- adds a pre-materialized `FireIntent` path so `TriggerEngine` reports the spawned child without creating a second request
- backfills crash-window orphan children during tool-call startup recovery when a running subagent `AgentToolCall` exists but its child `AgentRequest` does not
- validates `ToolSelection.subagent_targets` against loaded `AgentBehavior` documents during control apply
- validates subagent parent request linkage before child request creation
- adds R3 design/plan docs and Bucket 3 runtime conformance coverage

## Issue #159 phases complete in this PR

- R3 SubagentSource runtime dispatch: complete
- R3 orphan-child startup recovery: complete
- R3 cross-reference validation: complete
- R3 Bucket 3 runtime conformance: complete

No Lean transition changes are included; R3 does not add a new state-machine transition, and the existing B-theorems cover the spawn/depth/linkage/cascade semantics this wires into runtime.

## Verification

- `cargo fmt --all --check` — passed
- `git diff --check` — passed
- `cargo test -p defra-agent --test subagent_source_conformance -- --test-threads=1` — passed, 6 tests
- `cargo test -p defra-agent --test lifecycle_recovery -- --test-threads=1` — passed, 8 tests
- `cargo test --workspace --all-targets -- --test-threads=1` — passed; live credentialed tests remained ignored as configured

`cd crates/defra-agent/proofs && lake build` was not run because this PR does not change Lean proofs or conformance contract files.

## Self-review

- inspected the full diff for scope and over-broad changes
- confirmed no production manifests, schema migrations, or Lean/proof files changed
- checked lifecycle naming consistency for `subagent`, parent linkage, and `ParentLinkageIncoherent`
- checked duplicate spawn behavior via `child_request_exists` and in-source processed keys
- checked orphan-child recovery ordering before terminal recovery, so timeout/interruption sweeps can cascade into a backfilled child
- checked cascade-through-source coverage against the #161 recovery/cascade path
