### PR TITLE
Fix structured_tool_not_allowed_is_non_retryable test

### DIFF
--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -1098,13 +1098,13 @@ mod tests {
 
         assert!(!analysis.tool_result_ok);
         // After R1's failure-class collapse, "tool_not_allowed" rebuckets to
-        // ServiceUnavailable. The raw `validation_errors[0].code` field still
-        // carries the original "tool_not_allowed" string from the JSON.
+        // ServiceUnavailable, and `validation_errors[0].code` reports the
+        // bucketed class name (not the raw input string).
         assert_eq!(
             analysis.tool_failure_class,
             Some(ToolFailureClass::ServiceUnavailable)
         );
-        assert_eq!(analysis.validation_errors[0].code, "tool_not_allowed");
+        assert_eq!(analysis.validation_errors[0].code, "serviceUnavailable");
         assert_eq!(analysis.validation_errors[0].path, "/service_id");
         assert_eq!(analysis.validation_errors[0].retryable, false);
         let error = analysis.tool_error.as_ref().expect("tool error");


### PR DESCRIPTION
## Summary

- `trace_export::tests::structured_tool_not_allowed_is_non_retryable` has been failing on main since the b002af3 failure-class collapse (13 → 5 variants).
- That commit updated `failure_class_code` to return the bucketed enum's `as_str()`, and fixed the companion assertion in `structured_invalid_argument_envelope_...` to expect `"serviceUnavailable"`, but missed this test's matching `validation_errors[0].code` assertion.
- Updates the assertion from `"tool_not_allowed"` to `"serviceUnavailable"` and rewrites the inline comment to describe what the production code actually does.

The semantic intent of the test still holds: an upstream `retryable: false` flag is preserved through the structured-error path even when the bucketed failure class (ServiceUnavailable) would otherwise default to retryable. Only the code-string expectation needed to catch up with the collapsed vocabulary.

## Test Plan

- [x] `cargo test -p defra-agent --lib trace_export` — 28 passed, 0 failed
- [x] `cargo test -p defra-agent --lib` — 360 passed, 0 failed (main is clean again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)