### PR TITLE
Fix flaky interrupt isolation test

### DIFF
--- a/crates/defra-agent/tests/interruption_integration.rs
+++ b/crates/defra-agent/tests/interruption_integration.rs
@@ -207,6 +207,27 @@ async fn resend_from_stale_populates_retry_chain() {
     );
 }
 
+#[tokio::test]
+async fn inference_call_wait_observes_latest_attempt() {
+    let db = test_db("inference-call-wait-latest").await;
+    let request_id = "req-inference-call-wait-latest";
+
+    insert_inference_call(
+        db.node.as_ref(),
+        request_id,
+        1,
+        "failed",
+        Some("ProviderError: transient connect failure"),
+    )
+    .await;
+    // Regression guard: a failed historical attempt must not hide the current retry.
+    insert_inference_call(db.node.as_ref(), request_id, 2, "running", None).await;
+
+    let call = wait_for_inference_call_state(db.node.as_ref(), request_id, "running").await;
+    assert_eq!(call.call_seq, 2);
+    assert_eq!(call.call_state, "running");
+}
+
 // --- Full BehaviorDaemon streaming interruption tests ---
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -464,6 +485,62 @@ async fn upsert_streaming_backend(
     assert!(
         !response.has_errors(),
         "upsert streaming backend failed: {:?}",
+        response.errors
+    );
+}
+
+async fn insert_inference_call(
+    node: &defra_agent::defra_node::EmbeddedNode,
+    request_id: &str,
+    call_seq: i64,
+    call_state: &str,
+    failure_reason: Option<&str>,
+) {
+    let call_id = format!("call-{request_id}-{call_seq}");
+    let now = chrono::Utc::now().to_rfc3339();
+    let escaped_call_id = escape_graphql_string(&call_id);
+    let escaped_request_id = escape_graphql_string(request_id);
+    let escaped_call_state = escape_graphql_string(call_state);
+    let escaped_now = escape_graphql_string(&now);
+    let failure_reason_field = failure_reason
+        .map(|reason| format!(r#"failure_reason: "{}","#, escape_graphql_string(reason)))
+        .unwrap_or_default();
+    let ended_at_field = if matches!(call_state, "failed" | "completed" | "cancelled") {
+        format!(r#"ended_at: "{escaped_now}","#)
+    } else {
+        String::new()
+    };
+
+    // These links are plain string fields in the test schema; the helper does
+    // not need to create matching backend or behavior rows.
+    let mutation = format!(
+        r#"mutation {{
+            add_InferenceCall(input: {{
+                call_id: "{escaped_call_id}",
+                runtime_instance_id: "runtime-test",
+                request_id: "{escaped_request_id}",
+                call_seq: {call_seq},
+                backend_id: "{STREAM_BACKEND_ID}",
+                behavior_id: "{PRIMARY_BEHAVIOR}",
+                agent_did: "{AGENT_DID}",
+                call_kind: "inference",
+                attempt: {call_seq},
+                call_state: "{escaped_call_state}",
+                {failure_reason_field}
+                queued_at: "{escaped_now}",
+                started_at: "{escaped_now}",
+                {ended_at_field}
+                priority: 0,
+                queue_depth_at_enqueue: 0,
+                controller_generation: 0,
+                backend_config_fingerprint: "test"
+            }}) {{ _docID }}
+        }}"#,
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "insert inference call failed: {:?}",
         response.errors
     );
 }

--- a/crates/defra-agent/tests/support/interrupt.rs
+++ b/crates/defra-agent/tests/support/interrupt.rs
@@ -266,10 +266,15 @@ pub async fn wait_for_request_lifecycle_state(
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct InferenceCallSnapshot {
+    pub call_seq: i64,
     pub call_state: String,
     pub failure_reason: Option<String>,
 }
 
+/// Wait for the latest inference attempt for `request_id` to reach `expected`.
+///
+/// The daemon retries transient provider failures, so a historical failed
+/// attempt must not hide the current attempt's running or terminal state.
 pub async fn wait_for_inference_call_state(
     node: &EmbeddedNode,
     request_id: &str,
@@ -277,7 +282,7 @@ pub async fn wait_for_inference_call_state(
 ) -> InferenceCallSnapshot {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     loop {
-        let row = fetch_inference_call(node, request_id).await;
+        let row = fetch_latest_inference_call(node, request_id).await;
         if row
             .as_ref()
             .is_some_and(|row| row.call_state.as_str() == expected)
@@ -286,13 +291,13 @@ pub async fn wait_for_inference_call_state(
         }
         assert!(
             tokio::time::Instant::now() < deadline,
-            "timed out waiting for inference call request_id={request_id} call_state={expected}; last={row:?}"
+            "timed out waiting for latest inference call request_id={request_id} call_state={expected}; last={row:?}"
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
 }
 
-async fn fetch_inference_call(
+async fn fetch_latest_inference_call(
     node: &EmbeddedNode,
     request_id: &str,
 ) -> Option<InferenceCallSnapshot> {
@@ -304,9 +309,10 @@ async fn fetch_inference_call(
                     request_id: {{ _eq: "{escaped_request_id}" }},
                     call_kind: {{ _eq: "inference" }}
                 }},
-                order: {{ call_seq: ASC }},
+                order: {{ call_seq: DESC }},
                 limit: 1
             ) {{
+                call_seq
                 call_state
                 failure_reason
             }}


### PR DESCRIPTION
## Summary
- Fix `wait_for_inference_call_state` to observe the latest inference attempt, not the first persisted attempt.
- Add a regression test for a failed first attempt followed by a running retry.

## Root cause
The flaky test can legitimately see an earlier transient provider failure before the daemon retries and reaches the live streaming attempt. The helper queried `InferenceCall` with `call_seq ASC limit: 1`, so it kept waiting on the stale failed row even after the current attempt was running/cancelled/completed.

## Verification
- Reproduced before fix: serial loop failed on run 11 at `wait_for_inference_call_state`, with `last=failed` provider error after streamed chunks had already been observed.
- `cargo fmt --check`
- `cargo test -p defra-agent --test interruption_integration inference_call_wait_observes_latest_attempt -- --nocapture`
- `cargo test -p defra-agent --test interruption_integration interrupting_one_request_does_not_affect_another -- --nocapture`
- 30x serial loop for `interrupting_one_request_does_not_affect_another`: 30/30 passed
- 10x `cargo test -p defra-agent --test interruption_integration -- --test-threads=4`: 10/10 passed

Closes #157
