### PR TITLE
Deadline plumbing audit + execution plan

### DIFF
--- a/docs/superpowers/audits/2026-05-12-deadline-plumbing-audit.md
+++ b/docs/superpowers/audits/2026-05-12-deadline-plumbing-audit.md
@@ -1,0 +1,134 @@
+# Deadline Plumbing Audit - Issue #149
+
+Date: 2026-05-12
+
+Scope: production Rust runtime, protocol schemas, existing Rust tests, and existing Lean proof surfaces for request, tool-call, admission, trigger, and subagent lifetimes. I treated comments and specs as hints only; the verdicts below come from the Rust paths.
+
+Bottom line: PR #161 closes the cooperative async-tool version of issue #149, but it does not fully close the native `glob` failure from #149. The live deadline path still depends on the active future yielding back to `tokio::select!`; native filesystem traversal is synchronous and has no internal deadline/cancellation point. A stuck `glob` can therefore still hold the request until restart recovery.
+
+## Entities audited
+
+| Entity name | Source file:line | Deadline source | Recovery path | Lean property covering it |
+| --- | --- | --- | --- | --- |
+| Behavior request deadline policy (`InferenceProfile.deadline_duration_secs`, default 900s) | `crates/defra-agent-protocol/schemas/inference/inference_profile.graphql:9`, `crates/defra-agent/src/config.rs:16`, `crates/defra-agent/src/agent.rs:212` | Inference profile field, default `DEFAULT_DEADLINE_DURATION_SECS` | Feeds `BehaviorConfig.deadline_duration`, then `RequestLifecycle::claim_inner` writes `AgentRequest.deadline` | S4/L1/L2 via request deadline model (`crates/defra-agent/proofs/README.md:362`, `crates/defra-agent/proofs/README.md:407`) |
+| Claimed request deadline (`AgentRequest.deadline`) | `crates/defra-agent-protocol/schemas/agent/agent_request.graphql:24`, `crates/defra-agent/src/lifecycle/claim.rs:212`, `crates/defra-agent/src/agent/daemon/inference.rs:89` | Claim time plus behavior deadline duration | Live waits are wrapped by `await_with_request_deadline`; process errors call `lifecycle.fail`; startup `RequestLifecycle::recover_all` sweeps processing rows | S4 `completed_not_deadline_expired` / `deadline_structural_bound`, L1/L2/L3 (`crates/defra-agent/proofs/Proofs/Properties/Safety.lean:139`, `crates/defra-agent/proofs/README.md:407`) |
+| Pre-claim request TTL (`AgentRequest.valid_until`) | `crates/defra-agent-protocol/schemas/agent/agent_request.graphql:28`, `crates/defra-agent/src/lifecycle/claim.rs:181` | Submitter-provided RFC3339 TTL | Claim checks `valid_until`; expired pending requests transition to `dead/Stale`; watcher fallback polling re-observes missed pending rows | `claim_requires_ttl_open`, `claim_with_ttl_bounds_time` (`crates/defra-agent/proofs/Proofs/Request/Properties.lean:131`, `crates/defra-agent/proofs/Proofs/Request/Properties.lean:160`) |
+| Request interrupt lifetime (`AgentRequest.interrupt_requested_at`) | `crates/defra-agent-protocol/schemas/agent/agent_request.graphql:27`, `crates/defra-agent/src/interrupt.rs:175`, `crates/defra-agent/src/agent/daemon/inference.rs:216` | User/API writes interrupt timestamp | Per-request observer polls every 2s; daemon cancels request token and calls `cancel_in_flight_tool_calls`; startup tool recovery cancels rows whose parent is interrupted | `interrupted_request_cancels_live_linked_tools` (`crates/defra-agent/proofs/Proofs/Composed.lean:220`) |
+| Tool-call persisted deadline/lifetime (`AgentToolCall.started_at`, `deadline_at`, `completed_at`) | `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql:12`, `crates/defra-agent/src/hook/persistence.rs:207`, `crates/defra-agent/src/tool_call_lifecycle/transition.rs:76` | Hook uses active request deadline; fallback is now + default deadline if no active request | Runtime marker path maps timeout/cancel to terminal states; live request-deadline sweep calls `timeout_expired_tool_calls`; startup `ToolCallLifecycle::recover_all` sweeps expired running rows | Tool execution liveness and composed deadline theorem (`crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean:94`, `crates/defra-agent/proofs/Proofs/Composed.lean:272`) |
+| Tool runtime wrapper (`scope_request_tool_execution`, `wrap_tool`) | `crates/defra-agent/src/tool_call_lifecycle/runtime.rs:38`, `crates/defra-agent/src/tool_call_lifecycle/runtime.rs:57`, `crates/defra-agent/src/tool_call_lifecycle/runtime.rs:98` | Request task-local deadline and cancellation token | `tokio::select!` returns timeout/cancel marker; hook maps marker to `timedOut`/`cancelled` | Same as tool-call liveness; Rust tests cover pending futures (`crates/defra-agent/src/tool_call_lifecycle/runtime.rs:202`) |
+| Native filesystem traversal (`glob`, also `grep`/list traversal class) | `crates/defra-agent/src/toolset/file_tools.rs:306`, `crates/defra-agent/src/toolset/shared/filesystem.rs:226`, `crates/defra-agent/src/toolset/shared/filesystem.rs:359` | Only the outer `AgentToolCall.deadline_at` | No internal recovery while traversal is inside one synchronous poll; startup recovery can terminalize only after process restart | Lean expects live terminalization, but Rust deviates for single-poll blocking native work |
+| In-flight hook map (`DefraSessionHook.in_flight_lifecycles`) | `crates/defra-agent/src/hook.rs:230`, `crates/defra-agent/src/hook.rs:374`, `crates/defra-agent/src/hook.rs:475` | Same `ToolCallLifecycle.deadline_at` | Live timeout/cancel/fail drains map; hook `Drop` only clears memory and leaves rows for startup recovery | Tool-call recovery/liveness, but Drop is a restart-only path |
+| Stream liveness timeout | `crates/defra-agent/src/config.rs:16`, `crates/defra-agent/src/agent/daemon/inference.rs:199`, `crates/defra-agent/src/agent/daemon/inference.rs:271` | `DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS` = 300 | Inner stream wait timeout calls `fail_in_flight_tool_calls`; request surfaces stream liveness error | No dedicated Lean timeout property; terminal tool/request behavior is covered by tool/request liveness |
+| One-shot tool execution path | `crates/defra-agent/src/oneshot.rs:48`, `crates/defra-agent/src/oneshot.rs:123` | Hook fallback deadline only, because no active request deadline is set | No request-scoped `wrap_tool`, no request lifecycle, no live deadline sweep; startup can only sweep persisted rows if there is a persisted running tool row | none - deviation |
+| Native command/bash/CLI subprocess timeouts | `crates/defra-agent/src/toolset/shared/command.rs:122`, `crates/defra-agent/src/toolset/shared/command.rs:147`, `crates/defra-agent/src/toolset/cli_tool.rs:118`, `crates/defra-agent/src/toolset/bash_tools.rs:106` | Per-tool `timeout_secs`, capped by config/default | `tokio::time::timeout` around child process; `kill_on_drop(true)` for subprocesses; outer lifecycle completes/fails normally | none for local subprocess timeout; covered operationally by Rust tests (`crates/defra-agent/src/toolset/tests.rs:1097`) |
+| MCP `call_tool` and MCP preflight timeout | `crates/defra-agent/src/meta_tools/call.rs:96`, `crates/defra-agent/src/meta_tools/call.rs:115`, `crates/defra-agent/src/meta_tools/call.rs:163` | 120s when service health is stale, else 300s; 30s preflight | Local timeout returns error; outer request/tool deadline also wraps daemon calls | Tool lifecycle terminalization; backend-health cases for health gate (`crates/defra-agent/proofs/README.md:415`) |
+| MCP health checker probe/staleness lifetime | `crates/defra-agent/src/health_checker.rs:23`, `crates/defra-agent/src/health_checker.rs:247`, `crates/defra-agent/src/health_checker.rs:250` | 30s health interval, 120s heartbeat staleness, 5s probe timeout | Probe timeout marks service unreachable and evicts MCP pool connection | none - operational health path |
+| Admission `InferenceCall` queued/running/terminal lifetime | `crates/defra-agent-protocol/schemas/inference/inference_call.graphql:15`, `crates/defra-agent/src/admission/controller.rs:146`, `crates/defra-agent/src/admission/permit.rs:137` | No own deadline; bounded by surrounding request deadline/cancel token in daemon | Queued guard and permit Drop terminalize live cancelled/dropped calls; no startup sweep found for persisted `queued`/`running` rows | InferenceCall slot accounting and permit-drop terminalization (`crates/defra-agent/proofs/Proofs/InferenceCall/SlotAccounting.lean:171`, `crates/defra-agent/proofs/README.md:426`) |
+| Streaming response lifetime (`AgentResponse.status=streaming`) | `crates/defra-agent/src/streaming.rs:101`, `crates/defra-agent/src/streaming.rs:426`, `crates/defra-agent/src/lifecycle/recovery.rs:103` | Stream writer batch interval and request lifecycle terminalization | Finalize writes terminal response; startup recovery marks streaming responses `error` and creates missing error responses | L3 recovery convergence (`crates/defra-agent/proofs/README.md:409`) |
+| Watcher fallback poll and processed-request cooldown | `crates/defra-agent/src/watcher/cooldown.rs:7`, `crates/defra-agent/src/watcher/cooldown.rs:8`, `crates/defra-agent/src/watcher.rs:113` | 30s fallback poll, 30s local processed-id cooldown | Missed gossip falls back to full pending-request query; processed-id cache is pruned and capped | none - runtime observation path |
+| Interrupt observer poll cadence | `crates/defra-agent/src/interrupt.rs:175`, `crates/defra-agent/src/interrupt.rs:195` | 2s DB poll interval | Observer signals daemon; daemon cancel path reaches request/tool/admission lifecycles | `interrupted_request_cancels_live_linked_tools` |
+| Runtime control watcher debounce/settle window | `crates/defra-agent/src/agent/runtime/control_watcher.rs:14`, `crates/defra-agent/src/agent/runtime/control_watcher.rs:18`, `crates/defra-agent/src/agent/runtime/control_watcher.rs:137` | 5s debounce, 60s settle window, 1s settle retry | Dropped events force full reconcile; unresolved references keep retrying and publish error | none - operational reconcile path |
+| Schedule trigger lifetime (`Schedule.interval_secs`, `next_run_at`) | `crates/defra-agent-protocol/schemas/agent/schedule.graphql:4`, `crates/defra-agent-protocol/schemas/agent/schedule.graphql:7`, `crates/defra-agent/src/trigger_engine/schedule_source.rs:91` | Persisted `next_run_at` plus `interval_secs` | Tick loop seeds missing `next_run_at`; fired/skipped advances next run; errors do not advance so next tick retries | Trigger dispatch/serial properties, but runtime writeback convergence is outside Lean (`crates/defra-agent/proofs/README.md:491`) |
+| Event trigger runtime lifetime (`EventTrigger.last_*`, `seen_docs`) | `crates/defra-agent-protocol/schemas/agent/event_trigger.graphql:11`, `crates/defra-agent/src/trigger_engine/event_source.rs:31`, `crates/defra-agent/src/trigger_engine/event_source.rs:84` | Process-lifetime first-seen cache and best-effort runtime fields | Subscription drives fires; dropped events only log; runtime-field writes are best effort | Trigger dispatch shape is covered; event delivery/resync is explicitly operational, not proven |
+| Subagent spawn source (`AgentToolCall.child_request_id`, spawn args deadline) | `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql:21`, `crates/defra-agent/src/trigger_engine/subagent_source.rs:37`, `crates/defra-agent/src/trigger_engine/subagent_source.rs:282` | Effective deadline is min(parent tool `deadline_at`, spawn args `deadline`) | Event-driven `SubagentSource` materializes child; startup `recover_orphan_subagent_children` materializes missed children after restart | Subagent `bridge_spawn`/link invariants (`crates/defra-agent/proofs/Proofs/Subagent/Transition.lean:39`) |
+| Subagent child request deadline | `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs:130`, `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs:159`, `crates/defra-agent/src/lifecycle/claim.rs:212` | Caller passes effective deadline into child `AgentRequest.deadline` | No convergent path: watcher does not load `deadline`, claim overwrites it with now + behavior duration | none - deviation from deadline propagation |
+| Subagent bridge terminal lifetime (`await_mode`, `cancel_policy`, `child_request_id`) | `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql:19`, `crates/defra-agent/src/tool_call_lifecycle/transition.rs:306`, `crates/defra-agent/src/tool_call_lifecycle/recovery.rs:224` | Parent tool deadline plus child request terminal state | `bridge_complete`/`bridge_failure` exist but no production caller was found; recovery skips detached subagent tool rows even when an outcome exists | Subagent bridge transition model (`crates/defra-agent/proofs/Proofs/Subagent/Transition.lean:76`, `crates/defra-agent/proofs/Proofs/Subagent/Transition.lean:105`) |
+| Subagent lineage/depth (`caused_by_parent_*`, `subagent_depth`) | `crates/defra-agent-protocol/schemas/agent/agent_request.graphql:29`, `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs:162`, `crates/defra-agent/src/watcher.rs:40` | Not a deadline; it is the recovery/cascade link | Creation validates parent/depth, watcher rejects incoherent rows, recovery uses parent link for orphan children and cascade interrupt | Subagent depth/link invariants (`crates/defra-agent/proofs/Proofs/Subagent/Properties.lean:80`) |
+| Trigger lineage/concurrency (`caused_by_trigger_id`, `caused_by_trigger_kind`) | `crates/defra-agent-protocol/schemas/agent/agent_request.graphql:19`, `crates/defra-agent/src/lifecycle/materialize.rs:10`, `crates/defra-agent/src/trigger_engine/production_materializer.rs:156` | Not a deadline; it gates serial/latest-only runtime lifetimes | Trigger materializer writes lineage; serial/latest-only query or supersede active runtime requests by lineage | Trigger dispatch/lineage and serial/latest-only proofs (`crates/defra-agent/proofs/README.md:491`) |
+| Health/status observability for expired processing | `crates/defra-agent/src/hook.rs:26`, `crates/defra-agent/src/agent/runtime/startup.rs:334` | Should be active request/tool age and expired-processing counters | Existing counters cover hook persistence successes/failures and startup recovery logs only; no live active-tool/expired-processing counter found | none - deviation from #149 acceptance criteria |
+
+## Per-entity verdict
+
+- ✅ Closed - Behavior request deadline policy: the policy source is wired into `BehaviorConfig` and request claim; it is covered by request deadline properties.
+- ⚠️ Partial - Claimed request deadline: request waits are bounded in normal async paths, but a synchronous native tool poll can prevent the deadline future from being observed until restart.
+- ✅ Closed - Pre-claim request TTL: stale pending requests are converted to `dead/Stale` during claim, and watcher fallback polling makes missed pending events observable.
+- ⚠️ Partial - Request interrupt lifetime: interrupt propagation exists, but it is cooperative and has the same non-preemptive native tool gap as request deadlines.
+- ⚠️ Partial - Tool-call persisted deadline/lifetime: live timeout/cancel/recovery exists and is tested for pending async futures, but native synchronous filesystem work can still bypass live convergence.
+- ⚠️ Partial - Tool runtime wrapper: the wrapper is correct for futures that yield, but `tokio::select!` cannot interrupt an inner future during a single blocking poll.
+- ⚠️ Partial - Native filesystem traversal: `glob` has no internal timeout/cancel point, so it only converges via restart recovery if the traversal blocks indefinitely.
+- ⚠️ Partial - In-flight hook map: live drains exist, but hook drop intentionally leaves running rows for startup recovery, which is not live convergence.
+- ⚠️ Partial - Stream liveness timeout: it handles idle async streams, but it cannot fire while `stream.next()` is trapped inside a synchronous native tool poll.
+- ❌ Open - One-shot tool execution path: tools are not wrapped and no request deadline is installed, so one-shot tool calls can hang with only a fallback persisted deadline.
+- ✅ Closed - Native command/bash/CLI subprocess timeouts: subprocesses have local timeouts and `kill_on_drop`, with Rust coverage.
+- ✅ Closed - MCP `call_tool` and preflight timeout: the mutating call path has explicit timeouts and daemon request deadlines also wrap it.
+- ✅ Closed - MCP health checker probe/staleness lifetime: probes time out, mark unreachable, and evict cached connections.
+- ⚠️ Partial - Admission `InferenceCall` lifetime: live Drop paths are covered, but no startup sweep terminalizes stale persisted `queued`/`running` call rows.
+- ✅ Closed - Streaming response lifetime: normal finalize and startup recovery both converge streaming/missing response documents.
+- ✅ Closed - Watcher fallback poll/cooldown: missed gossip falls back to polling and cooldown state is bounded.
+- ⚠️ Partial - Interrupt observer poll cadence: the observer itself is bounded, but the downstream cancellation can still be blocked by a synchronous native tool.
+- ✅ Closed - Runtime control watcher debounce/settle window: dropped control events force full reconcile and unresolved references retry inside a bounded settle window.
+- ⚠️ Partial - Schedule trigger lifetime: schedule fires advance on success/skip, but post-fire runtime-field writes are spawned best-effort and can duplicate due fires if the write fails.
+- ⚠️ Partial - Event trigger runtime lifetime: dropped events only warn and there is no live resync path; runtime-field writes are explicitly best effort.
+- ⚠️ Partial - Subagent spawn source: missed `AgentToolCall` update events are repaired only by startup orphan-child recovery, not by a live scan.
+- ❌ Open - Subagent child request deadline: the effective child deadline is written to the pending row and then silently overwritten at claim.
+- ❌ Open - Subagent bridge terminal lifetime: bridge terminal transitions exist but are not wired to a production child-terminal observer, and detached rows are skipped by recovery.
+- ✅ Closed - Subagent lineage/depth: creation and watcher coherence checks match the Lean depth/link invariants.
+- ✅ Closed - Trigger lineage/concurrency: trigger lineage is written and used by serial/latest-only gates; stuck requests still inherit the request-deadline gap above.
+- ⚠️ Partial - Health/status observability for expired processing: the #149 liveness counters are not present; only persistence counters and startup recovery logs exist.
+
+## #149 specifically
+
+Verdict: #161 did not fully close #149. It added the right persisted lifecycle states and cooperative runtime paths, but the native `glob` implementation still has no preemptible execution boundary.
+
+Trace through the intended #161 path:
+
+1. Runtime construction wraps daemon tools with `runtime::wrap_tool` (`crates/defra-agent/src/agent/runtime/context.rs:84`).
+2. A request is claimed with `deadline = now + behavior.deadline_duration` (`crates/defra-agent/src/lifecycle/claim.rs:212`), and the daemon reads that as `lifecycle.claimed_deadline_at()` (`crates/defra-agent/src/agent/daemon/inference.rs:89`).
+3. Before streaming, the daemon installs the active request id and request deadline on the hook (`crates/defra-agent/src/agent/daemon/inference.rs:137`, `crates/defra-agent/src/agent/daemon/inference.rs:145`).
+4. When the model calls `glob`, the hook persists an `AgentToolCall` row and inserts the lifecycle in the in-flight map (`crates/defra-agent/src/hook/persistence.rs:223`, `crates/defra-agent/src/hook/persistence.rs:235`).
+5. Stream polling is scoped with the request deadline and cancellation token (`crates/defra-agent/src/agent/daemon/inference.rs:242`).
+6. If the wrapper observes the deadline, it returns a managed timeout marker (`crates/defra-agent/src/tool_call_lifecycle/runtime.rs:115`), and the hook maps that marker to `ToolCallLifecycle::timeout()` (`crates/defra-agent/src/hook/persistence.rs:267`).
+7. If the outer request deadline fires while waiting for a stream item, the daemon calls `timeout_expired_tool_calls()` (`crates/defra-agent/src/agent/daemon/inference.rs:253`), which drains expired lifecycles and calls `timeout()` (`crates/defra-agent/src/hook.rs:374`).
+8. The request then unwinds through `process_request`, records the failure reason, and fails the request (`crates/defra-agent/src/agent/daemon.rs:320`).
+
+That path works for a pending async tool future; the #161 runtime test uses `PendingTool` and proves the wrapper returns a timeout marker (`crates/defra-agent/src/tool_call_lifecycle/runtime.rs:202`).
+
+The actual `glob` path is different:
+
+1. `GlobTool::call` is an `async fn`, but it immediately calls `collect_glob_matches(...)` without an `.await` inside the traversal (`crates/defra-agent/src/toolset/file_tools.rs:306`).
+2. `collect_glob_matches_inner` recursively walks directories synchronously (`crates/defra-agent/src/toolset/shared/filesystem.rs:226`).
+3. Directory reads use `std::fs::read_dir` (`crates/defra-agent/src/toolset/shared/filesystem.rs:359`).
+
+Once `tokio::select!` polls the `self.inner.call(args)` branch, this native `glob` future can spend the entire poll inside synchronous filesystem code. During that poll, the deadline sleep and cancellation token cannot be observed by the wrapper, and the outer `await_with_request_deadline` around `stream.next()` cannot resume either. That reconstructs the issue #149 shape: `AgentToolCall` stays `status="called"` / `lifecycle_state="running"`, the request remains `processing`, and the single-worker queue stays occupied until the process restarts.
+
+Restart recovery is better after #161: `ToolCallLifecycle::recover_all` finds persisted running tool calls, marks expired rows `timedOut`, and cascades child interrupts where applicable (`crates/defra-agent/src/tool_call_lifecycle/recovery.rs:192`). Startup also recovers stuck processing requests and streaming responses (`crates/defra-agent/src/lifecycle/recovery.rs:15`, `crates/defra-agent/src/lifecycle/recovery.rs:103`). That is still restart convergence, not the live convergence requested by #149.
+
+Recommendation: do not close #149 yet.
+
+## Follow-up issues to file
+
+### 1. Native filesystem tools need a preemptible deadline boundary
+
+`glob` still executes synchronous recursive filesystem traversal inside a single async poll (`file_tools.rs:306`, `filesystem.rs:226`, `filesystem.rs:359`). PR #161's wrapper is cooperative, so it cannot observe the request deadline until that poll returns. Add a hard runtime boundary for native filesystem tools, especially `glob` and `grep`: the request should terminalize the `AgentToolCall` and free the worker at deadline even if the filesystem traversal continues or blocks. Include a regression test that simulates a single-poll blocking native tool, not only a pending async future.
+
+### 2. One-shot tool runs bypass request-scoped deadline enforcement
+
+`run_openai_oneshot_with_tools` builds tools directly and never maps them through `runtime::wrap_tool` (`oneshot.rs:48`), while the hook is created without an active request id or deadline (`oneshot.rs:123`). The hook fallback persists a default deadline and empty request id, but there is no request lifecycle, cancellation token, or live `timeout_expired_tool_calls` sweep. Either install a one-shot request deadline scope or make one-shot tool persistence explicitly non-lifecycle-managed.
+
+### 3. Preserve inherited subagent deadlines through claim
+
+`create_subagent_request_with_request_id` writes an effective child `deadline` from the parent tool deadline and spawn args (`subagent_request.rs:130`), but `RequestLifecycle::claim_inner` later overwrites `AgentRequest.deadline` with `now + behavior.deadline_duration` (`claim.rs:212`). The watcher also does not load the pending row's existing `deadline` (`watcher/query.rs:5`), so a queued child can start after its inherited deadline. Claim should preserve or min with an existing pending deadline, or the subagent source should encode the inherited bound as `valid_until`.
+
+### 4. Wire subagent bridge completion/failure into production recovery
+
+`bridge_complete` and `bridge_failure` exist as lifecycle transitions (`transition.rs:306`, `transition.rs:364`), but no production caller was found. `recover_stuck_running_tool_calls` also skips detached subagent tool rows (`recovery.rs:224`), even when the parent is terminal or the tool deadline expired. Add a child-terminal observer/recovery path that drives parent bridge tool rows to `completed`, `failed`, or `cancelled`, and define how detached parent bridge rows become terminal.
+
+### 5. Add a live rescan path for missed subagent spawn events
+
+`SubagentSource` only reacts to update events and logs dropped messages as "may have missed child spawns" (`subagent_source.rs:378`). Startup orphan recovery can materialize missing child requests after restart (`recovery.rs:88`), but a live daemon has no periodic scan to repair missed `AgentToolCall.child_request_id` rows. Add a bounded live rescan after dropped events or on a slow cadence.
+
+### 6. Terminalize stale persisted `InferenceCall` rows on startup
+
+Admission guards terminalize queued/running calls on normal drop (`controller.rs:282`, `permit.rs:137`), but startup recovery only calls request and tool-call recovery (`startup.rs:334`, `startup.rs:368`). A crash can leave `InferenceCall.call_state="queued"` or `"running"` indefinitely, diverging from the persisted slot-accounting model and polluting telemetry. Add startup recovery keyed by old `runtime_instance_id`, terminal parent request, or request deadline.
+
+### 7. Make trigger runtime-field writebacks convergent
+
+Schedule and event trigger result callbacks spawn best-effort DefraDB updates and only log failures (`schedule_source.rs:236`, `event_source.rs:581`). A failed schedule fired/skipped update can leave `next_run_at` unchanged and refire the same due schedule; event runtime fields can miss `last_status`/`fire_count`. Add retry, idempotent writeback reconciliation, or a periodic repair pass for trigger runtime-owned fields.
+
+### 8. Add live resync for dropped event-trigger messages
+
+`EventSource` treats dropped subscription messages as a correctness hazard and only warns (`event_source.rs:844`). Because `seen_docs` is process-local first-observation state, a dropped create event can be missed forever in the live process. Add a resync strategy after dropped messages, or persist enough event-source cursor/seen state to make "created" triggers convergent.
+
+### 9. Expose active request/tool liveness counters
+
+Issue #149 asked for `/healthz` or `/status` counters for active request id, active tool name, age since last progress, and expired-processing count. The current exposed hook stats are persistence counters only (`hook.rs:26`), and recovery counts are logged only at startup (`startup.rs:334`). Add live runtime status fields or health counters so expired processing/tool-call stalls are visible before an operator notices queue starvation.

--- a/docs/superpowers/plans/2026-05-12-deadline-audit-execution.md
+++ b/docs/superpowers/plans/2026-05-12-deadline-audit-execution.md
@@ -1,0 +1,113 @@
+# Deadline Audit Execution Plan
+
+## 1. Priority + dependency matrix
+
+| Item | Priority | Hard dependencies | Blocking relationship to R4 |
+| --- | --- | --- | --- |
+| Issue #149 | P0 | Audit follow-up #1 is required for live correctness; follow-up #9 is required if we keep the original health/status acceptance criteria. Current timeout rows write `lifecycle_state: "timedOut"` but not `tool_failure_class` (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:471`, `crates/defra-agent/src/tool_call_lifecycle/recovery.rs:479`), so the #149 closure PR must either add the class or explicitly accept `timedOut` as equivalent. | Blocks any R4 soak that uses native filesystem tools because request deadline observation is still cooperative in `RuntimeManagedTool::call` (`crates/defra-agent/src/tool_call_lifecycle/runtime.rs:115`) and a blocked request remains the active daemon work item until its future returns. |
+| Follow-up #1: native filesystem preemptible boundary | P0 | None. It should not depend on R4 or new R4 primitives; the existing daemon tool wrapping point is already present (`crates/defra-agent/src/agent/runtime/context.rs:84`). | Blocks R4 validation runs that depend on deadline guarantees. R4 must not assume native file tools are deadline-preemptible until this lands. |
+| Follow-up #2: one-shot deadline enforcement | P1 | None hard. It can reuse existing `wrap_tool` / `scope_request_tool_execution` (`crates/defra-agent/src/tool_call_lifecycle/runtime.rs:38`, `crates/defra-agent/src/tool_call_lifecycle/runtime.rs:57`). | Not a design blocker for R4 unless R4 introduces one-shot subagent test harnesses through `run_openai_oneshot_with_tools` (`crates/defra-agent/src/oneshot.rs:33`). |
+| Follow-up #3: preserve inherited subagent deadlines through claim | P0 | None hard. Current child creation already accepts a deadline (`crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs:88`); claim is the overwrite point (`crates/defra-agent/src/lifecycle/claim.rs:212`). | Blocks R4 if R4 needs inherited child deadlines or detach semantics to be truthful. R4 must not pretend the pending child `deadline` survives claim today. |
+| Follow-up #4: wire bridge completion/failure in production | P0 | Follow-up #3 is not a strict code dependency, but should land first if R4 wants bridge terminal behavior and child deadline behavior in the same release train. The transition methods already exist (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:306`, `crates/defra-agent/src/tool_call_lifecycle/transition.rs:364`). | Direct R4 blocker. R4 cannot assume parent bridge rows terminalize when children finish unless it wires this itself or waits for this PR. |
+| Follow-up #5: live rescan for missed subagent spawn events | P1 | None hard. It should reuse the running child-linked row query shape from recovery (`crates/defra-agent/src/tool_call_lifecycle/recovery.rs:88`) rather than inventing a second parser. | R4-adjacent. It is not a design prerequisite, but R4 should document that live missed-spawn recovery is restart-only until this lands. |
+| Follow-up #6: startup sweep for stale `InferenceCall` rows | P1 | None hard. Startup recovery currently invokes request and tool-call recovery only (`crates/defra-agent/src/agent/runtime/startup.rs:334`, `crates/defra-agent/src/agent/runtime/startup.rs:368`). | Not an R4 design blocker, but it affects post-crash scheduler capacity telemetry if R4 stress tests restart mid-run. |
+| Follow-up #7: trigger runtime-field writeback convergence | P1 | None hard. Schedule and event writebacks are independent code paths (`crates/defra-agent/src/trigger_engine/schedule_source.rs:236`, `crates/defra-agent/src/trigger_engine/event_source.rs:585`). | Not an R4 blocker unless R4 depends on scheduled/event-trigger subagent orchestration. |
+| Follow-up #8: event-trigger dropped-message resync | P1 | None hard, but it should reuse any durable writeback/error-reporting helpers introduced by follow-up #7 if they land first. Current dropped-event behavior is warn-only (`crates/defra-agent/src/trigger_engine/event_source.rs:844`). | Not an R4 blocker for bridge design. It is a production reliability gap for event-triggered R4 scenarios. |
+| Follow-up #9: active request/tool liveness counters | P1 | None hard for observability; if used as #149 close evidence, it should land after follow-up #1 so counters report the final active-tool model. Existing hook stats are persistence-only (`crates/defra-agent/src/hook.rs:26`). | Does not block R4 design. It should be available before R4 soak sign-off so stalls are visible without DB spelunking. |
+
+Planning correction to the audit: no finding is reversed. The plan adds one #149 nuance: the audit treated `lifecycle_state="timedOut"` as the timeout classification, but #149 also asked for `tool_failure_class` or equivalent. Current timeout transitions do not populate `tool_failure_class` (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:471`, `crates/defra-agent/src/tool_call_lifecycle/recovery.rs:479`), so the #149 PR should make that equivalence explicit in code or issue-closing notes.
+
+## 2. Sequencing
+
+| PR | Scope | Independently mergeable? | One-sentence title | Smallest first commit |
+| --- | --- | --- | --- | --- |
+| PR A | Issue #149 + follow-up #1 | Yes | Make native filesystem tool deadlines preemptible and close the live `glob` stall. | Add a test-only single-poll blocking native tool harness that proves the existing cooperative wrapper cannot meet a short request deadline without a preemptible boundary. |
+| PR B | Follow-up #3 | Yes | Preserve inherited subagent request deadlines through claim. | Add a claim-path regression that creates a pending subagent request with an earlier deadline and proves claim does not extend it past the inherited bound. |
+| PR C | Follow-up #4 | Yes, but should read R4 design before implementation | Bridge child terminal states back to parent subagent tool rows. | Add the production child-terminal scanner/observer skeleton and a DB fixture showing a completed child maps to `bridge_complete`. |
+| PR D | Follow-up #5 | Yes | Add live orphan-subagent spawn rescan after missed tool-call events. | Extract the recovery query/parsing path for running child-linked tool rows into a reusable scanner used first by startup recovery. |
+| PR E | Follow-up #6 | Yes | Recover stale admission calls on startup. | Add an `InferenceCall` startup-recovery query for old `queued`/`running` rows without mutating request/tool logic. |
+| PR F | Follow-up #2 | Yes | Enforce request-scoped deadlines for one-shot tool runs. | Wrap one-shot tools with `runtime::wrap_tool` and add a one-shot short-deadline regression before changing public behavior. |
+| PR G | Follow-up #7 | Yes | Make trigger runtime writebacks retryable and idempotent. | Introduce a small writeback worker abstraction for `Schedule` runtime fields and move the current fire-and-forget schedule update onto it. |
+| PR H | Follow-up #8 | Yes, but can reuse PR G helpers | Resync event-trigger sources after dropped subscription messages. | Add a deterministic resync entry point that can rebuild `seen_docs`/missed candidates without depending on live subscription delivery. |
+| PR I | Follow-up #9 | Yes | Expose active request/tool liveness counters in runtime status. | Add an internal `RuntimeLivenessSnapshot` query/model with active request id, active tool id/name, active ages, and expired-processing count. |
+
+Recommended merge order:
+
+1. PR A first. It is the only issue #149 correctness fix and the only one that can prove the single-worker queue no longer stalls behind native `glob`.
+2. PR B before PR C if R4 wants inherited child deadlines in the same milestone. PR C can still be developed independently, but its R4 semantics should cite whether PR B is already merged.
+3. PR C next for R4. It is the largest R4-coupled production path because the Lean bridge transitions already exist, but production currently only defines the methods.
+4. PR D can land before or after PR C. It improves missed spawn convergence but does not define bridge terminal semantics.
+5. PR E, PR F, PR G, PR H, and PR I are independently mergeable after the P0 path is moving. PR I should land before any "soak clean" claim for R4, but it does not need to block PR A's code review.
+
+## 3. R4 coupling
+
+### Follow-up #3: inherited subagent deadlines
+
+R4's design needs to assume the current runtime computes an effective child deadline before materialization (`crates/defra-agent/src/trigger_engine/subagent_source.rs:282`) and writes it at subagent request creation (`crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs:130`), but claim overwrites `AgentRequest.deadline` with `now + behavior.deadline_duration` (`crates/defra-agent/src/lifecycle/claim.rs:212`). The watcher request projection also omits `deadline`, so claim has no loaded pending-deadline value to preserve (`crates/defra-agent/src/watcher/query.rs:5`).
+
+R4 should not pretend a detached child is bounded by the parent/tool deadline today. If R4's model depends on that, R4 must either block on PR B or explicitly include deadline preservation in the R4 implementation scope.
+
+Recommendation: block R4's "deadline semantics complete" claim on PR B, but R4 design can continue with the current gap called out.
+
+### Follow-up #4: bridge completion/failure wiring
+
+R4's design needs to assume only the transition methods exist today: `bridge_complete` trusts its caller to verify child completion (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:306`), and `bridge_failure` projects failed/dead/interrupted/superseded child states (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:364`). The production source currently materializes child requests from `AgentToolCall.child_request_id` (`crates/defra-agent/src/trigger_engine/subagent_source.rs:284`), but the audit found no production caller that observes child terminal state and invokes those bridge transitions.
+
+R4 should not pretend parent bridge tool rows become terminal when child requests finish. It must wire that observer itself or list bridge terminalization as an explicit gap.
+
+Recommendation: R4 should block on PR C if it wants production bridge semantics; otherwise it can layer on top only if its design names the unwired bridge as a carried risk.
+
+### R4-adjacent: missed subagent spawn events
+
+Follow-up #5 is not a core R4 design primitive, but R4 should not assume missed `AgentToolCall` update events are live-repaired. Current `SubagentSource` warns on dropped messages (`crates/defra-agent/src/trigger_engine/subagent_source.rs:378`), while the repair path is startup-only (`crates/defra-agent/src/tool_call_lifecycle/recovery.rs:88`).
+
+Recommendation: do not block R4 design on PR D, but block production-readiness language for event-loss convergence until PR D lands.
+
+## 4. Lean obligations
+
+| Item | Obligation type | File/module | Blocks Rust fix? |
+| --- | --- | --- | --- |
+| Issue #149 / follow-up #1 | New conformance boundary for an existing property. Lean already says live calls can reach terminal and deadline-exceeded linked tools time out; the missing part is Rust's runtime assumption that tool execution is preemptible (`crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean:94`, `crates/defra-agent/proofs/Proofs/Composed.lean:272`). | Add generated contract/conformance coverage under `Proofs/Conformance/Boundaries.lean` or `Proofs/Conformance/ContractCases/BoundaryRuntime.lean`. | Rust P0 fix can land first with a Rust regression; Lean conformance should be in the same PR if small, otherwise queued immediately. |
+| Follow-up #2 | Conformance test over existing tool lifecycle behavior if one-shot remains lifecycle-managed. If one-shot is declared outside the lifecycle model, record that deviation. | `Proofs/Conformance/Deviations.lean` for an explicit exclusion, or boundary contract cases if wrapped. | Does not block Rust; Rust should define whether one-shot participates in lifecycle first. |
+| Follow-up #3 | New property: child claim must not extend an inherited subagent deadline, or inherited deadline must be encoded as TTL. | `Proofs/Subagent/Properties.lean` for bridge/deadline invariant plus request claim case in `Proofs/Request/Properties.lean`. | Rust can land first with DB tests if it preserves/mins existing deadline; Lean should follow before R4 claims proof coverage. |
+| Follow-up #4 | Conformance test for existing Lean bridge transitions, not a new transition. Lean already models `bridge_complete` and `bridge_failure` (`crates/defra-agent/proofs/Proofs/Subagent/Transition.lean:76`, `crates/defra-agent/proofs/Proofs/Subagent/Transition.lean:105`). | Add contract cases under a new `Proofs/Conformance/Subagent` module or extend `Proofs/Conformance/ContractCases/LifecycleTransitions.lean`. | Blocks R4 proof/conformance claim, but the Rust observer can land with Rust tests first if the Lean case is queued in the same milestone. |
+| Follow-up #5 | Conformance test for startup/live materialization convergence; new property only if the model wants live missed-event repair. | `Proofs/Conformance/Boundaries.lean` for DefraDB event-delivery boundary; `Proofs/Subagent/Properties.lean` only if live rescan becomes modeled. | Rust can land first; Lean should document the event-delivery boundary. |
+| Follow-up #6 | New property or conformance case: startup recovery terminalizes stale persisted `InferenceCall` rows so reconstructed slot counts do not include dead-runtime rows. Existing slot model says running rows hold slots (`crates/defra-agent/proofs/Proofs/InferenceCall/SlotAccounting.lean:97`). | `Proofs/InferenceCall/SlotAccounting.lean` and generated cases in `Proofs/Conformance/ContractCases/SlotAccounting.lean`. | Rust can land first with recovery tests; Lean should be same PR if the sweep affects slot-accounting invariants. |
+| Follow-up #7 | New conformance/liveness case if writeback retry semantics become part of runtime contract; otherwise Rust operational tests only. | `Proofs/Conformance/Triggers/Trace.lean` or `Proofs/Triggers` if modeled. | Does not block Rust. |
+| Follow-up #8 | No new Lean property unless we decide to model DefraDB event delivery. The existing README treats subscription delivery/control-source behavior as operational Rust coverage (`crates/defra-agent/proofs/README.md:514`). | Rust tests plus optional note in `Proofs/Conformance/Boundaries.lean`. | Does not block Rust. |
+| Follow-up #9 | No Lean property. This is observability over runtime state, not a state-machine transition. | none | Does not block Rust. |
+
+## 5. Verification strategy per follow-up
+
+| Item | Concrete test/repro | CI stability plan | Soak needed? |
+| --- | --- | --- | --- |
+| Issue #149 | End-to-end daemon regression: model invokes a native `glob`-class tool that blocks longer than a short request deadline; assert request terminalizes and a second queued request advances without restart. | Use a finite single-poll blocker, e.g. `std::thread::sleep(200ms)` with a 10-20ms deadline, not an infinite hang. Gate wall-clock assertions with generous bounds. | Yes. Re-run the original 70-case stress shape before closing #149. |
+| Follow-up #1 | Unit test the native execution boundary with a single-poll blocking tool; integration test that `AgentToolCall` ends as `timedOut` and has `completed_at`/`latency_ms`. | Use deterministic short sleeps and `tokio::time::timeout` around the test itself. Avoid OS/filesystem pathological hangs in CI. | Yes, same soak as #149 because the production failure involved native filesystem traversal. |
+| Follow-up #2 | One-shot regression using an extra test tool that never yields or blocks longer than a one-shot deadline; assert `run_openai_oneshot_with_tools` returns and persisted lifecycle is terminal when persistence is enabled. | Prefer a fake completion model/tool harness over networked OpenAI-compatible clients. Keep timeout under one second. | No. Unit/integration coverage is enough. |
+| Follow-up #3 | DB test: create subagent pending request with inherited deadline earlier than behavior duration, then claim; assert deadline is preserved/minned or stale request is rejected if deadline is past. | Use fixed RFC3339 values and an isolated EmbeddedNode fixture. No sleeps except unavoidable DB polling. | No. |
+| Follow-up #4 | DB integration tests for child `completed`, `failed`, `dead`, `interrupted`, and `superseded`: parent bridge row must transition via `bridge_complete` or `bridge_failure`; cascade interrupt must still call `interrupt_request` for cascade policy (`crates/defra-agent/src/hook.rs:396`). | Use direct fixture rows and call the observer/sweep once. Do not depend on real model/tool streaming. | R4 soak should cover this after unit tests, because ordering with live child requests is the risk. |
+| Follow-up #5 | Start `SubagentSource` after inserting a running child-linked tool row or simulate dropped event, then run live rescan; assert child request materializes once. | Test the scanner directly and one source-level path. Avoid relying on actual subscription buffer overflow in CI. | No dedicated soak, but include in R4 subagent stress. |
+| Follow-up #6 | Seed `InferenceCall` rows in `queued` and `running` for an old runtime or terminal parent request; run startup recovery; assert terminal states and reconstructed slot count zero. | Pure DB fixture plus recovery function. No provider/backend network calls. | No. |
+| Follow-up #7 | Fake first writeback failure and second success for schedule/event runtime fields; assert `next_run_at` advances once and fire count is idempotent. | Use an injectable writeback helper/fake or paused-time retry loop. Avoid sleeping real retry intervals. | No, unless the implementation uses background retry tasks that need fleet-level confidence. |
+| Follow-up #8 | Unit/integration test resync: seed source docs and trigger config, mark subscription drop, run resync, assert missed created doc produces one fire and already-seen docs do not duplicate. | Drive resync as a direct method; do not try to force actual mpsc dropped-message behavior. | Maybe. Event-trigger soak is useful after implementation because lost-event bugs are ordering-sensitive. |
+| Follow-up #9 | Seed one active request past deadline and one running tool; query status/liveness endpoint/model; assert active ids, ages, active tool name, and expired-processing count. | Avoid wall-clock exactness; assert nonzero/greater-than thresholds with fixed inserted timestamps. | No, but use it during #149/R4 soak as operator-facing evidence. |
+
+## 6. Out-of-scope and deferred items
+
+Do soon:
+
+- Follow-up #9 is not the live correctness fix, but it is worth doing soon because #149's operational failure was silent while health stayed OK. It should not block PR A implementation, but it should block declaring the soak operationally observable.
+- The `tool_failure_class` nuance for timeout rows should be resolved in PR A or in the #149 close comment. Current timeout code sets `lifecycle_state="timedOut"` and omits `tool_failure_class` (`crates/defra-agent/src/tool_call_lifecycle/transition.rs:471`, `crates/defra-agent/src/tool_call_lifecycle/recovery.rs:479`).
+- Follow-up #6 should land before any restart-heavy stress campaign, because persisted `InferenceCall` rows are the scheduler slot-accounting source (`crates/defra-agent/src/admission/slot_accounting.rs:16`).
+
+Defer behind P0 correctness:
+
+- Follow-up #7 writeback convergence and follow-up #8 event resync are silent operational bugs, but neither should delay PR A, PR B, or PR C.
+- Follow-up #2 is a real bug for public one-shot APIs, but it does not block R4 unless R4 starts using one-shot as a subagent execution harness.
+- Deep health/status UI work beyond the counters in follow-up #9 is out of scope. The first observability PR should expose facts already derivable from `AgentRequest` and `AgentToolCall` (`crates/defra-agent-protocol/schemas/agent/agent_request.graphql:24`, `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql:12`); dashboards can follow later.
+
+Do not include in this plan's implementation scope:
+
+- No production code changes in the audit/plan PR.
+- No issue filing until the plan is reviewed.
+- No assumptions about R4-only primitives. Every PR above is expressed in terms of code that already exists in this worktree.


### PR DESCRIPTION
- **Broken:** #161 fixed cooperative async tool timeouts, but native `glob` can still bypass live deadlines because filesystem traversal is synchronous inside one poll.
- **Worst:** #149 should stay open until native filesystem tools get a preemptible deadline boundary and a regression proves the single-worker queue advances without restart.
- **R4:** inherited subagent deadlines and bridge terminalization are not production-complete; R4 must block on those fixes or explicitly carry the gaps.
- **Ships next:** first PR should implement the native preemptible boundary plus the #149-closing test; subagent deadline preservation and bridge wiring follow as independent PRs.
- **Defers:** trigger writeback convergence, event resync, one-shot deadline wrapping, stale InferenceCall recovery, and observability counters are planned but sit behind the P0 correctness path.