### PR TITLE
Make native filesystem tool deadlines preemptible and close the live `glob` stall.

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
@@ -234,4 +234,23 @@ def backendHealthAdmissionCases : List BackendHealthAdmissionCase :=
       .stale
   ]
 
+def nativeFilesystemBoundaryCase (toolName : String) : NativeFilesystemBoundaryCase :=
+  { name := toolName ++ "_single_poll_blocker_times_out_and_queue_advances"
+  , toolName := toolName
+  , workClass := "filesystemTraversal"
+  , boundary := "spawnBlockingRuntimeBoundary"
+  , innerPollBlocks := true
+  , requestDeadlineMs := 15
+  , blockerMs := 200
+  , expectedTerminal := "timedOut"
+  , expectedFailureClass := some "external"
+  , queueAdvancesBeforeBlockerReturns := true
+  }
+
+def nativeFilesystemBoundaryCases : List NativeFilesystemBoundaryCase :=
+  [ nativeFilesystemBoundaryCase "list_files"
+  , nativeFilesystemBoundaryCase "glob"
+  , nativeFilesystemBoundaryCase "grep"
+  ]
+
 end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -154,6 +154,19 @@ structure BackendHealthAdmissionCase where
   externalEndpointFreshnessClaimed : Bool
   deriving Repr
 
+structure NativeFilesystemBoundaryCase where
+  name : String
+  toolName : String
+  workClass : String
+  boundary : String
+  innerPollBlocks : Bool
+  requestDeadlineMs : Nat
+  blockerMs : Nat
+  expectedTerminal : String
+  expectedFailureClass : Option String
+  queueAdvancesBeforeBlockerReturns : Bool
+  deriving Repr
+
 structure LifecycleTransitionCase where
   name : String
   domain : String

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -198,6 +198,23 @@ def backendHealthAdmissionCaseJson
       ++ boolString witness.externalEndpointFreshnessClaimed
     ++ "}"
 
+def nativeFilesystemBoundaryCaseJson
+    (witness : NativeFilesystemBoundaryCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"tool_name\":" ++ jsonString witness.toolName ++ ","
+    ++ "\"work_class\":" ++ jsonString witness.workClass ++ ","
+    ++ "\"boundary\":" ++ jsonString witness.boundary ++ ","
+    ++ "\"inner_poll_blocks\":" ++ boolString witness.innerPollBlocks ++ ","
+    ++ "\"request_deadline_ms\":" ++ toString witness.requestDeadlineMs ++ ","
+    ++ "\"blocker_ms\":" ++ toString witness.blockerMs ++ ","
+    ++ "\"expected_terminal\":" ++ jsonString witness.expectedTerminal ++ ","
+    ++ "\"expected_failure_class\":"
+      ++ jsonOptionalString witness.expectedFailureClass ++ ","
+    ++ "\"queue_advances_before_blocker_returns\":"
+      ++ boolString witness.queueAdvancesBeforeBlockerReturns
+    ++ "}"
+
 def toolPreflightCaseJson (witness : ToolExecution.PreflightCase) : String :=
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
@@ -339,6 +356,9 @@ def snapshotJson : String :=
     ++ "\"backend_health_admission_cases\":"
       ++ jsonArray
         (backendHealthAdmissionCases.map backendHealthAdmissionCaseJson) ++ ","
+    ++ "\"native_filesystem_boundary_cases\":"
+      ++ jsonArray
+        (nativeFilesystemBoundaryCases.map nativeFilesystemBoundaryCaseJson) ++ ","
     ++ "\"tool_preflight_cases\":"
       ++ jsonArray (ToolExecution.preflightCases.map toolPreflightCaseJson) ++ ","
     ++ "\"tool_retry_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -226,6 +226,10 @@ def caseCoverage : List CoverageEntry :=
       boundaryBackendHealthAdmissionFreshnessId
       "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy"
   , consumerCoverage
+      "native_filesystem_boundary_cases"
+      "NativeFilesystemBoundaryCases"
+      "toolset::tests::generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract"
+  , consumerCoverage
       "frontend_client_shell_cases"
       "FrontendClientShellCases"
       "apps/desktop-tauri/src/lib/chat-shell.test.ts::projectChatShell matches generated Lean ClientShell projection contracts"

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -431,6 +431,7 @@ async fn fetch_tool_call_row(
                     lifecycle_state
                     result
                     status
+                    tool_failure_class
                 }}
             }}"#
         ))
@@ -551,6 +552,11 @@ async fn hook_maps_managed_timeout_result_to_timed_out_lifecycle() {
     assert_eq!(
         row.get("lifecycle_state").and_then(|value| value.as_str()),
         Some("timedOut")
+    );
+    assert_eq!(
+        row.get("tool_failure_class")
+            .and_then(|value| value.as_str()),
+        Some("external")
     );
     assert!(row
         .get("result")

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -44,6 +44,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) persistence_failure_policy_cases: Vec<LeanPersistenceFailurePolicyCase>,
     pub(crate) storage_observation_runtime_cases: Vec<LeanStorageObservationRuntimeCase>,
     pub(crate) backend_health_admission_cases: Vec<LeanBackendHealthAdmissionCase>,
+    pub(crate) native_filesystem_boundary_cases: Vec<LeanNativeFilesystemBoundaryCase>,
     pub(crate) tool_preflight_cases: Vec<LeanToolPreflightCase>,
     pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
     pub(crate) boundaries: Vec<LeanBoundary>,
@@ -406,6 +407,20 @@ pub(crate) struct LeanBackendHealthAdmissionCase {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct LeanNativeFilesystemBoundaryCase {
+    pub(crate) name: String,
+    pub(crate) tool_name: String,
+    pub(crate) work_class: String,
+    pub(crate) boundary: String,
+    pub(crate) inner_poll_blocks: bool,
+    pub(crate) request_deadline_ms: usize,
+    pub(crate) blocker_ms: usize,
+    pub(crate) expected_terminal: String,
+    pub(crate) expected_failure_class: Option<String>,
+    pub(crate) queue_advances_before_blocker_returns: bool,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct LeanToolPreflightCase {
     pub(crate) name: String,
     pub(crate) health: String,
@@ -605,6 +620,11 @@ pub(crate) fn lean_storage_observation_runtime_cases(
 
 pub(crate) fn lean_backend_health_admission_cases() -> &'static [LeanBackendHealthAdmissionCase] {
     &lean_contract_snapshot().backend_health_admission_cases
+}
+
+pub(crate) fn lean_native_filesystem_boundary_cases() -> &'static [LeanNativeFilesystemBoundaryCase]
+{
+    &lean_contract_snapshot().native_filesystem_boundary_cases
 }
 
 pub(crate) fn lean_tool_preflight_cases() -> &'static [LeanToolPreflightCase] {

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -85,6 +85,20 @@ impl super::ToolCallLifecycle {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_recovery_persists_external_failure_class() {
+        assert_eq!(
+            RecoveryOutcome::TimedOut.failure_class(),
+            Some(FailureClass::External)
+        );
+        assert_eq!(RecoveryOutcome::Cancelled.failure_class(), None);
+    }
+}
+
 async fn recover_orphan_subagent_children(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
     let rows = load_running_tool_call_rows(node).await?;
     let mut materialized = 0;
@@ -478,8 +492,8 @@ impl RecoveryOutcome {
 
     fn failure_class(self) -> Option<FailureClass> {
         match self {
-            Self::Failed => Some(FailureClass::External),
-            Self::TimedOut | Self::Cancelled => None,
+            Self::TimedOut | Self::Failed => Some(FailureClass::External),
+            Self::Cancelled => None,
         }
     }
 

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -17,7 +17,7 @@ use defra_node::QueryResponse;
 use crate::graphql::escape_graphql_string;
 use crate::session::execute_mutation_with_retry;
 
-use super::{AwaitMode, CancelPolicy, ToolCallLifecycle, ToolCallState};
+use super::{AwaitMode, CancelPolicy, FailureClass, ToolCallLifecycle, ToolCallState};
 
 /// Error returned when a transition method is called from an illegal
 /// pre-state, or when a subagent-specific guard is violated.
@@ -467,6 +467,7 @@ impl ToolCallLifecycle {
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let failure_class = FailureClass::External.as_str();
 
         let mutation = format!(
             r#"mutation {{
@@ -476,6 +477,7 @@ impl ToolCallLifecycle {
                         result: "{escaped_result}",
                         status: "completed",
                         lifecycle_state: "timedOut",
+                        tool_failure_class: "{failure_class}",
                         started_at: "{started_at_str}",
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
@@ -490,6 +492,7 @@ impl ToolCallLifecycle {
             .context("timeout mutation")?;
 
         self.state = ToolCallState::TimedOut;
+        self.failure_class = Some(FailureClass::External);
         Ok(())
     }
 

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -19,6 +19,16 @@ use super::shared::{
 const DEFAULT_GREP_PREVIEW_CHARS: usize = 240;
 const OUTPUT_META_PREFIX: &str = "defra_fs: ";
 
+async fn run_filesystem_boundary<F, T>(operation: F) -> Result<T, ToolError>
+where
+    F: FnOnce() -> Result<T, ToolError> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| ToolError(anyhow!("filesystem tool boundary failed: {error}")))?
+}
+
 #[derive(Clone)]
 pub(super) struct ListFilesTool {
     context: ToolContext,
@@ -146,37 +156,43 @@ impl Tool for ListFilesTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let dir = self.context.resolve_existing_dir(args.path.as_deref())?;
-        let entries = collect_entries(
-            &self.context,
-            &dir,
-            args.recursive,
-            args.max_entries.max(1).min(self.default_max_entries.max(1)),
-        )?;
+        let context = self.context.clone();
+        let default_max_entries = self.default_max_entries;
 
-        let metadata = ListFilesMetadata {
-            ok: true,
-            status: "success",
-            tool: Self::NAME,
-            path: self.context.display_path(&dir),
-            recursive: args.recursive,
-            returned_count: entries.items.len(),
-            total_count: total_count(entries.items.len(), entries.truncated),
-            truncated: entries.truncated,
-            default_ignored: default_ignored_names(),
-            summary: summarize_entries(&entries.items),
-        };
-        let output = ListFilesOutput {
-            metadata,
-            entries: entries.items,
-        };
+        run_filesystem_boundary(move || {
+            let dir = context.resolve_existing_dir(args.path.as_deref())?;
+            let entries = collect_entries(
+                &context,
+                &dir,
+                args.recursive,
+                args.max_entries.max(1).min(default_max_entries.max(1)),
+            )?;
 
-        Ok(render_tool_output(
-            &output.metadata,
-            format_entries("entries", &output.entries),
-            &output,
-            args.raw_json,
-        )?)
+            let metadata = ListFilesMetadata {
+                ok: true,
+                status: "success",
+                tool: Self::NAME,
+                path: context.display_path(&dir),
+                recursive: args.recursive,
+                returned_count: entries.items.len(),
+                total_count: total_count(entries.items.len(), entries.truncated),
+                truncated: entries.truncated,
+                default_ignored: default_ignored_names(),
+                summary: summarize_entries(&entries.items),
+            };
+            let output = ListFilesOutput {
+                metadata,
+                entries: entries.items,
+            };
+
+            Ok(render_tool_output(
+                &output.metadata,
+                format_entries("entries", &output.entries),
+                &output,
+                args.raw_json,
+            )?)
+        })
+        .await
     }
 }
 
@@ -304,37 +320,43 @@ impl Tool for GlobTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let dir = self.context.resolve_existing_dir(args.path.as_deref())?;
-        let pattern = Pattern::new(&args.pattern)
-            .with_context(|| format!("invalid glob pattern {}", args.pattern))?;
-        let matches = collect_glob_matches(
-            &self.context,
-            &dir,
-            &pattern,
-            args.max_matches.min(self.default_max_matches).max(1),
-        )?;
+        let context = self.context.clone();
+        let default_max_matches = self.default_max_matches;
 
-        let output = GlobOutput {
-            metadata: GlobMetadata {
-                ok: true,
-                status: "success",
-                tool: Self::NAME,
-                pattern: args.pattern,
-                path: self.context.display_path(&dir),
-                returned_count: matches.items.len(),
-                total_count: total_count(matches.items.len(), matches.truncated),
-                truncated: matches.truncated,
-                default_ignored: default_ignored_names(),
-            },
-            matches: matches.items,
-        };
+        run_filesystem_boundary(move || {
+            let dir = context.resolve_existing_dir(args.path.as_deref())?;
+            let pattern = Pattern::new(&args.pattern)
+                .with_context(|| format!("invalid glob pattern {}", args.pattern))?;
+            let matches = collect_glob_matches(
+                &context,
+                &dir,
+                &pattern,
+                args.max_matches.min(default_max_matches).max(1),
+            )?;
 
-        Ok(render_tool_output(
-            &output.metadata,
-            format_entries("matches", &output.matches),
-            &output,
-            args.raw_json,
-        )?)
+            let output = GlobOutput {
+                metadata: GlobMetadata {
+                    ok: true,
+                    status: "success",
+                    tool: Self::NAME,
+                    pattern: args.pattern,
+                    path: context.display_path(&dir),
+                    returned_count: matches.items.len(),
+                    total_count: total_count(matches.items.len(), matches.truncated),
+                    truncated: matches.truncated,
+                    default_ignored: default_ignored_names(),
+                },
+                matches: matches.items,
+            };
+
+            Ok(render_tool_output(
+                &output.metadata,
+                format_entries("matches", &output.matches),
+                &output,
+                args.raw_json,
+            )?)
+        })
+        .await
     }
 }
 
@@ -385,53 +407,59 @@ impl Tool for GrepTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
-        let dir = self.context.resolve_existing_dir(args.path.as_deref())?;
-        let max_matches = args.max_matches.min(self.default_max_matches).max(1);
-        let collected = collect_grep_matches(
-            &self.context,
-            &dir,
-            &args.pattern,
-            args.case_sensitive,
-            max_matches,
-        )?;
+        let context = self.context.clone();
+        let default_max_matches = self.default_max_matches;
 
-        let mut files_with_matches = BTreeSet::new();
-        let matches = collected
-            .items
-            .into_iter()
-            .map(|entry| {
-                files_with_matches.insert(entry.path.clone());
-                GrepOutputMatch {
-                    path: entry.path,
-                    line_number: entry.line_number,
-                    preview: truncate_inline(&entry.line, DEFAULT_GREP_PREVIEW_CHARS),
-                }
-            })
-            .collect::<Vec<_>>();
+        run_filesystem_boundary(move || {
+            let dir = context.resolve_existing_dir(args.path.as_deref())?;
+            let max_matches = args.max_matches.min(default_max_matches).max(1);
+            let collected = collect_grep_matches(
+                &context,
+                &dir,
+                &args.pattern,
+                args.case_sensitive,
+                max_matches,
+            )?;
 
-        let output = GrepOutput {
-            metadata: GrepMetadata {
-                ok: true,
-                status: "success",
-                tool: Self::NAME,
-                pattern: args.pattern,
-                path: self.context.display_path(&dir),
-                case_sensitive: args.case_sensitive,
-                returned_count: matches.len(),
-                total_count: total_count(matches.len(), collected.truncated),
-                files_with_matches: files_with_matches.len(),
-                truncated: collected.truncated,
-                default_ignored: default_ignored_names(),
-            },
-            matches,
-        };
+            let mut files_with_matches = BTreeSet::new();
+            let matches = collected
+                .items
+                .into_iter()
+                .map(|entry| {
+                    files_with_matches.insert(entry.path.clone());
+                    GrepOutputMatch {
+                        path: entry.path,
+                        line_number: entry.line_number,
+                        preview: truncate_inline(&entry.line, DEFAULT_GREP_PREVIEW_CHARS),
+                    }
+                })
+                .collect::<Vec<_>>();
 
-        Ok(render_tool_output(
-            &output.metadata,
-            format_grep_matches(&output.matches),
-            &output,
-            args.raw_json,
-        )?)
+            let output = GrepOutput {
+                metadata: GrepMetadata {
+                    ok: true,
+                    status: "success",
+                    tool: Self::NAME,
+                    pattern: args.pattern,
+                    path: context.display_path(&dir),
+                    case_sensitive: args.case_sensitive,
+                    returned_count: matches.len(),
+                    total_count: total_count(matches.len(), collected.truncated),
+                    files_with_matches: files_with_matches.len(),
+                    truncated: collected.truncated,
+                    default_ignored: default_ignored_names(),
+                },
+                matches,
+            };
+
+            Ok(render_tool_output(
+                &output.metadata,
+                format_grep_matches(&output.matches),
+                &output,
+                args.raw_json,
+            )?)
+        })
+        .await
     }
 }
 

--- a/crates/defra-agent/src/toolset/shared.rs
+++ b/crates/defra-agent/src/toolset/shared.rs
@@ -10,12 +10,12 @@ pub(super) use command::{
 pub(super) use command::{run_command, validate_command_policy};
 pub use command::{CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode};
 pub(super) use context::{ToolContext, ToolError};
+#[cfg(test)]
+pub(super) use filesystem::block_next_sorted_children_for_test;
 pub(super) use filesystem::{
     collect_entries, collect_glob_matches, collect_grep_matches, default_ignored_names,
     render_file_contents, truncate_inline, truncate_text, FilesystemEntry,
 };
-#[cfg(test)]
-pub(super) use filesystem::block_next_sorted_children_for_test;
 
 pub(super) fn default_max_list_entries() -> usize {
     super::DEFAULT_MAX_LIST_ENTRIES

--- a/crates/defra-agent/src/toolset/shared.rs
+++ b/crates/defra-agent/src/toolset/shared.rs
@@ -14,6 +14,8 @@ pub(super) use filesystem::{
     collect_entries, collect_glob_matches, collect_grep_matches, default_ignored_names,
     render_file_contents, truncate_inline, truncate_text, FilesystemEntry,
 };
+#[cfg(test)]
+pub(super) use filesystem::block_next_sorted_children_for_test;
 
 pub(super) fn default_max_list_entries() -> usize {
     super::DEFAULT_MAX_LIST_ENTRIES

--- a/crates/defra-agent/src/toolset/shared/filesystem.rs
+++ b/crates/defra-agent/src/toolset/shared/filesystem.rs
@@ -357,6 +357,9 @@ fn collect_grep_matches_inner(
 }
 
 fn sorted_children(dir: &Path) -> Result<Vec<std::fs::DirEntry>> {
+    #[cfg(test)]
+    maybe_block_sorted_children_for_test(dir);
+
     let read_dir = match std::fs::read_dir(dir) {
         Ok(read_dir) => read_dir,
         Err(error) if should_skip_io_error(&error) => return Ok(Vec::new()),
@@ -391,3 +394,63 @@ fn should_skip_io_error(error: &std::io::Error) -> bool {
         std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::NotFound
     )
 }
+
+#[cfg(test)]
+mod blocking_test_hook {
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, OnceLock};
+    use std::time::Duration;
+
+    static BLOCKED_DIRS: OnceLock<Mutex<Vec<(PathBuf, Duration)>>> = OnceLock::new();
+
+    fn blocked_dirs() -> &'static Mutex<Vec<(PathBuf, Duration)>> {
+        BLOCKED_DIRS.get_or_init(|| Mutex::new(Vec::new()))
+    }
+
+    pub(crate) struct SortedChildrenBlockGuard {
+        dir: PathBuf,
+    }
+
+    impl Drop for SortedChildrenBlockGuard {
+        fn drop(&mut self) {
+            let mut blocked = blocked_dirs()
+                .lock()
+                .expect("sorted-children test hook mutex poisoned");
+            blocked.retain(|(dir, _)| dir != &self.dir);
+        }
+    }
+
+    pub(crate) fn block_next_sorted_children_for_test(
+        dir: impl AsRef<Path>,
+        duration: Duration,
+    ) -> SortedChildrenBlockGuard {
+        let dir = dir.as_ref().to_path_buf();
+        blocked_dirs()
+            .lock()
+            .expect("sorted-children test hook mutex poisoned")
+            .push((dir.clone(), duration));
+        SortedChildrenBlockGuard { dir }
+    }
+
+    pub(super) fn maybe_block_sorted_children_for_test(dir: &Path) {
+        let duration = {
+            let mut blocked = blocked_dirs()
+                .lock()
+                .expect("sorted-children test hook mutex poisoned");
+            blocked
+                .iter()
+                .position(|(blocked_dir, _)| blocked_dir == dir)
+                .map(|index| blocked.remove(index).1)
+        };
+
+        if let Some(duration) = duration {
+            std::thread::sleep(duration);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) use blocking_test_hook::block_next_sorted_children_for_test;
+
+#[cfg(test)]
+use blocking_test_hook::maybe_block_sorted_children_for_test;

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use defra_node::EmbeddedNode;
 
@@ -14,9 +14,9 @@ use super::file_tools::{
     EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, WriteFileTool,
 };
 use super::shared::{
-    build_shell_env_from_vars, select_sandbox_for_policy, validate_command_policy,
-    validate_read_only_command, CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode,
-    ToolContext,
+    block_next_sorted_children_for_test, build_shell_env_from_vars, select_sandbox_for_policy,
+    validate_command_policy, validate_read_only_command, CommandExecutionMode,
+    CommandExecutionPolicy, CommandNetworkMode, ToolContext,
 };
 use super::*;
 use crate::ensure_schemas;
@@ -124,6 +124,63 @@ fn compact_exec_meta(output: &str) -> serde_json::Value {
         .strip_prefix("defra_exec: ")
         .unwrap_or_else(|| panic!("missing defra_exec metadata line in output:\n{output}"));
     serde_json::from_str(raw).expect("metadata json")
+}
+
+#[tokio::test]
+async fn native_filesystem_deadline_preempts_single_poll_blocker_and_advances_queue() {
+    let root = temp_root("defra-agent-native-boundary");
+    std::fs::write(root.join("first.txt"), "first request\n").unwrap();
+    std::fs::write(root.join("second.txt"), "second request\n").unwrap();
+    let context = ToolContext::new(root.clone(), false).unwrap();
+
+    let _blocker =
+        block_next_sorted_children_for_test(context.root(), Duration::from_millis(200));
+    let blocking_tool = crate::tool_call_lifecycle::runtime::wrap_tool(Box::new(GlobTool::new(
+        context.clone(),
+        DEFAULT_MAX_MATCHES,
+    )));
+    let second_tool = crate::tool_call_lifecycle::runtime::wrap_tool(Box::new(ReadFileTool::new(
+        context,
+        DEFAULT_MAX_FILE_CHARS,
+    )));
+
+    let started = Instant::now();
+    let first_deadline = chrono::Utc::now() + chrono::Duration::milliseconds(15);
+    let first_result = crate::tool_call_lifecycle::runtime::scope_request_tool_execution(
+        Some(first_deadline),
+        tokio_util::sync::CancellationToken::new(),
+        blocking_tool.call(r#"{"pattern":"*.txt"}"#.to_string()),
+    )
+    .await
+    .expect("managed timeout is returned as tool output");
+    let first_elapsed = started.elapsed();
+
+    let second_deadline = chrono::Utc::now() + chrono::Duration::seconds(1);
+    let second_result = crate::tool_call_lifecycle::runtime::scope_request_tool_execution(
+        Some(second_deadline),
+        tokio_util::sync::CancellationToken::new(),
+        second_tool.call(r#"{"path":"second.txt"}"#.to_string()),
+    )
+    .await
+    .expect("second queued request should advance after first timeout");
+    let queue_elapsed = started.elapsed();
+
+    tokio::time::sleep(Duration::from_millis(225)).await;
+    let _ = std::fs::remove_dir_all(&root);
+
+    assert_eq!(
+        crate::tool_call_lifecycle::runtime::classify_managed_tool_result(&first_result),
+        Some(crate::tool_call_lifecycle::runtime::ManagedToolTerminal::TimedOut)
+    );
+    assert!(
+        first_elapsed < Duration::from_millis(150),
+        "blocking native tool should terminalize at the request deadline, elapsed={first_elapsed:?}"
+    );
+    assert!(
+        queue_elapsed < Duration::from_millis(150),
+        "single-worker queue should advance before the blocking native work returns, elapsed={queue_elapsed:?}"
+    );
+    assert!(second_result.contains("second request"));
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -22,7 +22,7 @@ use super::*;
 use crate::ensure_schemas;
 use crate::lean_vocab_test::{
     lean_command_env_cases, lean_command_policy_case, lean_command_policy_cases,
-    lean_command_sandbox_cases, LeanCommandPolicyCase,
+    lean_command_sandbox_cases, lean_native_filesystem_boundary_cases, LeanCommandPolicyCase,
 };
 use crate::lifecycle::DEFAULT_REQUEST_MAX_RETRIES;
 
@@ -133,8 +133,7 @@ async fn native_filesystem_deadline_preempts_single_poll_blocker_and_advances_qu
     std::fs::write(root.join("second.txt"), "second request\n").unwrap();
     let context = ToolContext::new(root.clone(), false).unwrap();
 
-    let _blocker =
-        block_next_sorted_children_for_test(context.root(), Duration::from_millis(200));
+    let _blocker = block_next_sorted_children_for_test(context.root(), Duration::from_millis(200));
     let blocking_tool = crate::tool_call_lifecycle::runtime::wrap_tool(Box::new(GlobTool::new(
         context.clone(),
         DEFAULT_MAX_MATCHES,
@@ -181,6 +180,37 @@ async fn native_filesystem_deadline_preempts_single_poll_blocker_and_advances_qu
         "single-worker queue should advance before the blocking native work returns, elapsed={queue_elapsed:?}"
     );
     assert!(second_result.contains("second request"));
+}
+
+#[test]
+fn generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract() {
+    let cases = lean_native_filesystem_boundary_cases();
+    let tool_names = cases
+        .iter()
+        .map(|case| case.tool_name.as_str())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(tool_names, BTreeSet::from(["glob", "grep", "list_files"]));
+    for case in cases {
+        assert!(
+            case.name
+                .ends_with("_single_poll_blocker_times_out_and_queue_advances"),
+            "unexpected native filesystem boundary case name: {}",
+            case.name
+        );
+        assert_eq!(case.work_class, "filesystemTraversal");
+        assert_eq!(case.boundary, "spawnBlockingRuntimeBoundary");
+        assert!(case.inner_poll_blocks);
+        assert!(case.request_deadline_ms <= 20);
+        assert!(case.blocker_ms >= 200);
+        assert!(
+            case.request_deadline_ms < case.blocker_ms,
+            "deadline must be shorter than deterministic blocker"
+        );
+        assert_eq!(case.expected_terminal, "timedOut");
+        assert_eq!(case.expected_failure_class.as_deref(), Some("external"));
+        assert!(case.queue_advances_before_blocker_returns);
+    }
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -425,6 +425,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "BackendHealthAdmissionCases".to_string(),
         ));
     }
+    if !snapshot.native_filesystem_boundary_cases.is_empty() {
+        emitted.insert((
+            "native_filesystem_boundary_cases".to_string(),
+            "NativeFilesystemBoundaryCases".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.frontend_client_shell_case_count,
         snapshot.frontend_client_shell_cases.len(),
@@ -498,6 +504,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "persistence_policy_cases",
         "storage_observation_cases",
         "backend_health_cases",
+        "native_filesystem_boundary_cases",
         "frontend_client_shell_cases",
         "desktop_client_shell_cases",
         "tool_cases",

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -259,6 +259,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_command_sandbox_cases_match_rust_selection",
         },
         ConformanceConsumer::RustTest {
+            id: "toolset::tests::generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/toolset/tests.rs",
+            module_path: "toolset::tests",
+            function: "generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/trigger_engine/tests.rs",


### PR DESCRIPTION
## Summary
- Implements PR A from [the deadline plumbing audit](docs/superpowers/audits/2026-05-12-deadline-plumbing-audit.md) and [the execution plan](docs/superpowers/plans/2026-05-12-deadline-audit-execution.md).
- Adds a deterministic 200ms single-poll native filesystem blocker regression with a 15ms request deadline; the red state on the old boundary completed `glob` normally after the blocker instead of terminalizing at timeout.
- Runs `list_files`, `glob`, and `grep` traversal work behind a `tokio::task::spawn_blocking` runtime boundary so the lifecycle wrapper can observe deadlines while synchronous filesystem traversal continues on the blocking pool.
- Persists timeout `tool_failure_class` as `external` in both direct timeout transitions and recovery.
- Includes Lean native filesystem boundary conformance cases plus the Rust consumer coverage entry.

Closes #149

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
- [x] `cargo test -p defra-agent --lib --tests`
- [x] `cargo test -p defra-agent-cli`
- [x] `lake build` in `crates/defra-agent/proofs/`

## Soak note
- The original 70-case stress shape from `crates/amygdala-evals/suites/stress/amy-tool-calling-2026-05-04` run `20260507T221328Z` was not rerun locally; this PR covers the blocking primitive deterministically and leaves soak validation as the next validation step.