### PR TITLE
Expose active request/tool liveness counters in runtime status

### DIFF
--- a/crates/defra-agent-cli/src/commands/status.rs
+++ b/crates/defra-agent-cli/src/commands/status.rs
@@ -56,6 +56,7 @@ pub(crate) async fn load_runtime_status_output(
         .and_then(|rows| rows.first())
         .cloned()
         .unwrap_or(Value::Null);
+    let liveness_value = crate::commands::status::load_liveness_value(graphql).await;
     let home_dir = resolve_home_dir(home);
     let runtime_state = read_runtime_state(&home_dir)?;
     let p2p_status = crate::commands::p2p::load_live_http_p2p_status(home, graphql).await;
@@ -65,6 +66,7 @@ pub(crate) async fn load_runtime_status_output(
         "agent_did": agent_did,
         "runtime_state": runtime_state,
         "runtime": runtime_row,
+        "liveness": liveness_value,
         "p2p": p2p_status,
         "behavior_readiness": if unavailable_behaviors.is_empty() { "ready" } else { "degraded" },
         "unavailable_behaviors": unavailable_behaviors,
@@ -91,6 +93,13 @@ pub(crate) async fn load_runtime_status_output(
         crate::commands::p2p::flatten_p2p_fields(map, &p2p_value);
     }
     Ok(output)
+}
+
+pub(crate) async fn load_liveness_value(graphql: &str) -> Value {
+    match crate::http::prometheus::load_metrics_query_data(graphql).await {
+        Ok(data) => serde_json::to_value(&data.liveness).unwrap_or(Value::Null),
+        Err(_) => Value::Null,
+    }
 }
 
 async fn load_live_unavailable_behaviors(

--- a/crates/defra-agent-cli/src/http/healthz.rs
+++ b/crates/defra-agent-cli/src/http/healthz.rs
@@ -29,10 +29,11 @@ pub(crate) fn render_healthz_payload(
                 .inference_backends
                 .iter()
                 .any(|backend| backend.enabled && backend.probe_status != "healthy");
+            let liveness_degraded = data.liveness.expired_processing_count > 0;
             let ok = runtime_ready;
             let status = if !runtime_ready {
                 "unhealthy"
-            } else if runtime_degraded || backend_degraded {
+            } else if runtime_degraded || backend_degraded || liveness_degraded {
                 "degraded"
             } else {
                 "ok"
@@ -47,6 +48,7 @@ pub(crate) fn render_healthz_payload(
                 "unhealthy"
             };
             let backend_status = if backend_degraded { "degraded" } else { "ok" };
+            let liveness_status = if liveness_degraded { "degraded" } else { "ok" };
 
             json!({
                 "status": status,
@@ -72,9 +74,16 @@ pub(crate) fn render_healthz_payload(
                         "status": backend_status,
                         "count": data.inference_backends.len(),
                     },
+                    "liveness": {
+                        "status": liveness_status,
+                        "active_request_count": data.liveness.active_request_ids.len(),
+                        "active_tool_call_count": data.liveness.active_tool_calls.len(),
+                        "expired_processing_count": data.liveness.expired_processing_count,
+                    },
                 },
                 "runtimes": data.agent_runtimes,
                 "backends": data.inference_backends,
+                "liveness": data.liveness,
             })
         }
         None => json!({
@@ -106,5 +115,123 @@ pub(crate) fn render_healthz_payload(
             "runtimes": [],
             "backends": [],
         }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::*;
+    use crate::http::liveness::{ActiveRequest, ActiveToolCall, RuntimeLivenessSnapshot};
+    use crate::http::prometheus::{MetricsBackendRow, MetricsQueryData, MetricsRuntimeRow};
+
+    fn state() -> RuntimeHttpState {
+        RuntimeHttpState {
+            graphql: "http://localhost:9181/api/v0/graphql".to_string(),
+            agent_name: "test-agent".to_string(),
+            agent_did: "did:defra-agent:test".to_string(),
+            started_at: "2026-05-13T12:00:00Z".to_string(),
+            started_instant: Instant::now(),
+        }
+    }
+
+    fn ready_runtime() -> MetricsRuntimeRow {
+        MetricsRuntimeRow {
+            agent_did: "did:defra-agent:test".to_string(),
+            process_state: defra_agent::ProcessLifecycleState::Ready
+                .as_str()
+                .to_string(),
+            reconcile_phase: "idle".to_string(),
+            active_generation: 1,
+            router_generation: 1,
+            runnable_behavior_count: 1,
+            unavailable_behavior_count: 0,
+            last_reconcile_result: "applied".to_string(),
+            last_reconcile_completed_at: "2026-05-13T11:59:00Z".to_string(),
+        }
+    }
+
+    fn healthy_backend() -> MetricsBackendRow {
+        MetricsBackendRow {
+            backend_id: "backend-1".to_string(),
+            enabled: true,
+            max_concurrent: 1,
+            max_queue_depth: 4,
+            probe_status: "healthy".to_string(),
+            last_probe: Some("2026-05-13T11:59:30Z".to_string()),
+        }
+    }
+
+    #[test]
+    fn healthz_reports_degraded_when_expired_processing_count_positive() {
+        let data = MetricsQueryData {
+            agent_runtimes: vec![ready_runtime()],
+            inference_backends: vec![healthy_backend()],
+            liveness: RuntimeLivenessSnapshot {
+                active_request_ids: vec!["req-stuck".to_string()],
+                expired_processing_count: 1,
+                requests: vec![ActiveRequest {
+                    request_id: "req-stuck".to_string(),
+                    claimed_at: Some("2026-05-13T11:55:00Z".to_string()),
+                    deadline: Some("2026-05-13T11:59:00Z".to_string()),
+                    deadline_expired: true,
+                    deadline_age_ms: Some(60_000),
+                    last_progress_age_ms: 300_000,
+                    subagent_depth: 0,
+                    caused_by_parent_request_id: None,
+                    caused_by_trigger_kind: None,
+                }],
+                active_tool_calls: vec![ActiveToolCall {
+                    request_id: "req-stuck".to_string(),
+                    tool_call_id: "tc-1".to_string(),
+                    tool_name: "glob".to_string(),
+                    started_at: Some("2026-05-13T11:55:30Z".to_string()),
+                    deadline_at: Some("2026-05-13T11:58:00Z".to_string()),
+                    await_mode: None,
+                    running_age_ms: 270_000,
+                    deadline_expired: true,
+                }],
+            },
+        };
+
+        let payload = render_healthz_payload(&state(), Some(&data), None);
+
+        assert_eq!(
+            payload.get("status").and_then(|v| v.as_str()),
+            Some("degraded"),
+            "expired processing must downgrade /healthz to degraded; payload was {payload}"
+        );
+        assert_eq!(
+            payload.get("ok").and_then(|v| v.as_bool()),
+            Some(true),
+            "degraded must keep ok=true so /healthz stays 200 OK"
+        );
+        let liveness_check = payload
+            .pointer("/checks/liveness")
+            .expect("checks.liveness must be present");
+        assert_eq!(
+            liveness_check.get("status").and_then(|v| v.as_str()),
+            Some("degraded")
+        );
+        assert_eq!(
+            liveness_check
+                .get("expired_processing_count")
+                .and_then(|v| v.as_i64()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn healthz_stays_ok_when_no_expired_processing() {
+        let data = MetricsQueryData {
+            agent_runtimes: vec![ready_runtime()],
+            inference_backends: vec![healthy_backend()],
+            liveness: RuntimeLivenessSnapshot::default(),
+        };
+
+        let payload = render_healthz_payload(&state(), Some(&data), None);
+
+        assert_eq!(payload.get("status").and_then(|v| v.as_str()), Some("ok"));
     }
 }

--- a/crates/defra-agent-cli/src/http/liveness.rs
+++ b/crates/defra-agent-cli/src/http/liveness.rs
@@ -1,0 +1,305 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LivenessRequestRow {
+    pub(crate) request_id: String,
+    #[serde(default)]
+    pub(crate) claimed_at: Option<String>,
+    #[serde(default)]
+    pub(crate) deadline: Option<String>,
+    #[serde(default)]
+    pub(crate) subagent_depth: Option<i64>,
+    #[serde(default)]
+    pub(crate) caused_by_parent_request_id: Option<String>,
+    #[serde(default)]
+    pub(crate) caused_by_trigger_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct LivenessToolCallRow {
+    pub(crate) request_id: String,
+    pub(crate) tool_call_id: String,
+    pub(crate) tool_name: String,
+    #[serde(default)]
+    pub(crate) started_at: Option<String>,
+    #[serde(default)]
+    pub(crate) deadline_at: Option<String>,
+    #[serde(default)]
+    pub(crate) await_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub(crate) struct RuntimeLivenessSnapshot {
+    pub(crate) active_request_ids: Vec<String>,
+    pub(crate) expired_processing_count: i64,
+    pub(crate) requests: Vec<ActiveRequest>,
+    pub(crate) active_tool_calls: Vec<ActiveToolCall>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ActiveRequest {
+    pub(crate) request_id: String,
+    pub(crate) claimed_at: Option<String>,
+    pub(crate) deadline: Option<String>,
+    pub(crate) deadline_expired: bool,
+    pub(crate) deadline_age_ms: Option<i64>,
+    pub(crate) last_progress_age_ms: i64,
+    pub(crate) subagent_depth: i64,
+    pub(crate) caused_by_parent_request_id: Option<String>,
+    pub(crate) caused_by_trigger_kind: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ActiveToolCall {
+    pub(crate) request_id: String,
+    pub(crate) tool_call_id: String,
+    pub(crate) tool_name: String,
+    pub(crate) started_at: Option<String>,
+    pub(crate) deadline_at: Option<String>,
+    pub(crate) await_mode: Option<String>,
+    pub(crate) running_age_ms: i64,
+    pub(crate) deadline_expired: bool,
+}
+
+pub(crate) fn compute_liveness_summary(
+    now: DateTime<Utc>,
+    requests: Vec<LivenessRequestRow>,
+    tool_calls: Vec<LivenessToolCallRow>,
+) -> RuntimeLivenessSnapshot {
+    let active_tool_calls: Vec<ActiveToolCall> = tool_calls
+        .iter()
+        .map(|row| {
+            let started_at = parse_optional_rfc3339(row.started_at.as_deref());
+            let deadline_at = parse_optional_rfc3339(row.deadline_at.as_deref());
+            let running_age_ms = started_at
+                .map(|started| millis_between(started, now).max(0))
+                .unwrap_or(0);
+            let deadline_expired = deadline_at.is_some_and(|deadline| now > deadline);
+            ActiveToolCall {
+                request_id: row.request_id.clone(),
+                tool_call_id: row.tool_call_id.clone(),
+                tool_name: row.tool_name.clone(),
+                started_at: row.started_at.clone(),
+                deadline_at: row.deadline_at.clone(),
+                await_mode: row.await_mode.clone(),
+                running_age_ms,
+                deadline_expired,
+            }
+        })
+        .collect();
+
+    let mut active_request_ids = Vec::with_capacity(requests.len());
+    let mut request_views = Vec::with_capacity(requests.len());
+    let mut expired_processing_count = 0i64;
+
+    for row in &requests {
+        active_request_ids.push(row.request_id.clone());
+        let claimed_at = parse_optional_rfc3339(row.claimed_at.as_deref());
+        let deadline = parse_optional_rfc3339(row.deadline.as_deref());
+        let deadline_expired = deadline.is_some_and(|deadline| now > deadline);
+        if deadline_expired {
+            expired_processing_count += 1;
+        }
+        let deadline_age_ms = deadline.map(|deadline| millis_between(deadline, now));
+
+        let latest_tool_activity = active_tool_calls
+            .iter()
+            .filter(|tc| tc.request_id == row.request_id)
+            .filter_map(|tc| parse_optional_rfc3339(tc.started_at.as_deref()))
+            .max();
+        let progress_at = match (claimed_at, latest_tool_activity) {
+            (Some(claimed), Some(tool)) => Some(claimed.max(tool)),
+            (Some(claimed), None) => Some(claimed),
+            (None, Some(tool)) => Some(tool),
+            (None, None) => None,
+        };
+        let last_progress_age_ms = progress_at
+            .map(|progress| millis_between(progress, now).max(0))
+            .unwrap_or(0);
+
+        request_views.push(ActiveRequest {
+            request_id: row.request_id.clone(),
+            claimed_at: row.claimed_at.clone(),
+            deadline: row.deadline.clone(),
+            deadline_expired,
+            deadline_age_ms,
+            last_progress_age_ms,
+            subagent_depth: row.subagent_depth.unwrap_or(0),
+            caused_by_parent_request_id: row.caused_by_parent_request_id.clone(),
+            caused_by_trigger_kind: row.caused_by_trigger_kind.clone(),
+        });
+    }
+
+    RuntimeLivenessSnapshot {
+        active_request_ids,
+        expired_processing_count,
+        requests: request_views,
+        active_tool_calls,
+    }
+}
+
+fn parse_optional_rfc3339(value: Option<&str>) -> Option<DateTime<Utc>> {
+    let trimmed = value?.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    DateTime::parse_from_rfc3339(trimmed)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn millis_between(earlier: DateTime<Utc>, later: DateTime<Utc>) -> i64 {
+    later.signed_duration_since(earlier).num_milliseconds()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc.with_ymd_and_hms(2026, 5, 13, 12, 0, 0).unwrap()
+    }
+
+    fn iso(offset_secs: i64) -> String {
+        (now() + chrono::Duration::seconds(offset_secs)).to_rfc3339()
+    }
+
+    fn request(
+        request_id: &str,
+        claimed_offset_secs: i64,
+        deadline_offset_secs: i64,
+    ) -> LivenessRequestRow {
+        LivenessRequestRow {
+            request_id: request_id.to_string(),
+            claimed_at: Some(iso(claimed_offset_secs)),
+            deadline: Some(iso(deadline_offset_secs)),
+            subagent_depth: None,
+            caused_by_parent_request_id: None,
+            caused_by_trigger_kind: None,
+        }
+    }
+
+    fn tool_call(
+        request_id: &str,
+        tool_call_id: &str,
+        tool_name: &str,
+        started_offset_secs: i64,
+        deadline_offset_secs: Option<i64>,
+        await_mode: Option<&str>,
+    ) -> LivenessToolCallRow {
+        LivenessToolCallRow {
+            request_id: request_id.to_string(),
+            tool_call_id: tool_call_id.to_string(),
+            tool_name: tool_name.to_string(),
+            started_at: Some(iso(started_offset_secs)),
+            deadline_at: deadline_offset_secs.map(iso),
+            await_mode: await_mode.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn expired_processing_count_counts_requests_with_past_deadline() {
+        let requests = vec![
+            request("req-expired", -120, -30), // claimed 2m ago, deadline 30s ago
+            request("req-fresh", -10, 60),     // claimed 10s ago, deadline 60s in future
+        ];
+        let snapshot = compute_liveness_summary(now(), requests, Vec::new());
+
+        assert_eq!(snapshot.expired_processing_count, 1);
+        assert!(snapshot
+            .active_request_ids
+            .iter()
+            .any(|id| id == "req-expired"));
+        let expired = snapshot
+            .requests
+            .iter()
+            .find(|r| r.request_id == "req-expired")
+            .expect("expired request must appear in snapshot");
+        assert!(
+            expired.deadline_expired,
+            "deadline should be flagged expired"
+        );
+        let fresh = snapshot
+            .requests
+            .iter()
+            .find(|r| r.request_id == "req-fresh")
+            .expect("fresh request must appear in snapshot");
+        assert!(
+            !fresh.deadline_expired,
+            "fresh deadline must not be flagged"
+        );
+    }
+
+    #[test]
+    fn active_tool_calls_carry_tool_name_and_running_age() {
+        let requests = vec![request("req-1", -45, 60)];
+        let tools = vec![tool_call("req-1", "tc-1", "glob", -30, Some(60), None)];
+        let snapshot = compute_liveness_summary(now(), requests, tools);
+
+        assert_eq!(snapshot.active_tool_calls.len(), 1);
+        let tc = &snapshot.active_tool_calls[0];
+        assert_eq!(tc.tool_name, "glob");
+        assert_eq!(tc.request_id, "req-1");
+        assert!(
+            tc.running_age_ms >= 30_000,
+            "running age must reflect 30s elapsed, got {}",
+            tc.running_age_ms
+        );
+        assert!(!tc.deadline_expired);
+    }
+
+    #[test]
+    fn subagent_bridge_tool_calls_carry_await_mode() {
+        let requests = vec![request("req-parent", -10, 300)];
+        let tools = vec![tool_call(
+            "req-parent",
+            "tc-bridge",
+            "amy-rumination",
+            -5,
+            None,
+            Some("bridge"),
+        )];
+        let snapshot = compute_liveness_summary(now(), requests, tools);
+
+        let tc = &snapshot.active_tool_calls[0];
+        assert_eq!(tc.await_mode.as_deref(), Some("bridge"));
+    }
+
+    #[test]
+    fn last_progress_age_ms_uses_most_recent_tool_activity_over_claimed_at() {
+        let requests = vec![request("req-1", -300, 60)];
+        let tools = vec![tool_call("req-1", "tc-1", "bash", -10, Some(60), None)];
+        let snapshot = compute_liveness_summary(now(), requests, tools);
+
+        let req = snapshot
+            .requests
+            .iter()
+            .find(|r| r.request_id == "req-1")
+            .unwrap();
+        assert!(
+            req.last_progress_age_ms < 60_000,
+            "tool started 10s ago must beat claimed_at 300s ago, got {}",
+            req.last_progress_age_ms
+        );
+        assert!(
+            req.last_progress_age_ms >= 10_000,
+            "progress age must reflect tool start, got {}",
+            req.last_progress_age_ms
+        );
+    }
+
+    #[test]
+    fn last_progress_age_ms_falls_back_to_claimed_at_when_no_tool_calls() {
+        let requests = vec![request("req-1", -45, 60)];
+        let snapshot = compute_liveness_summary(now(), requests, Vec::new());
+
+        let req = &snapshot.requests[0];
+        assert!(
+            req.last_progress_age_ms >= 45_000,
+            "claimed 45s ago, got {}",
+            req.last_progress_age_ms
+        );
+    }
+}

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod healthz;
+pub(crate) mod liveness;
 pub(crate) mod prometheus;
 pub(crate) mod router;
 pub(crate) mod version;

--- a/crates/defra-agent-cli/src/http/prometheus.rs
+++ b/crates/defra-agent-cli/src/http/prometheus.rs
@@ -1,18 +1,33 @@
 use anyhow::{Context, Result};
+use chrono::Utc;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
+use crate::http::liveness::{
+    compute_liveness_summary, LivenessRequestRow, LivenessToolCallRow, RuntimeLivenessSnapshot,
+};
 use crate::post_graphql;
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Serialize)]
 pub(crate) struct MetricsQueryData {
-    #[serde(rename = "AgentRuntime", default)]
     pub(crate) agent_runtimes: Vec<MetricsRuntimeRow>,
-    #[serde(rename = "InferenceBackend", default)]
     pub(crate) inference_backends: Vec<MetricsBackendRow>,
+    pub(crate) liveness: RuntimeLivenessSnapshot,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
+struct MetricsQueryEnvelope {
+    #[serde(rename = "AgentRuntime", default)]
+    agent_runtimes: Vec<MetricsRuntimeRow>,
+    #[serde(rename = "InferenceBackend", default)]
+    inference_backends: Vec<MetricsBackendRow>,
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<LivenessRequestRow>,
+    #[serde(rename = "AgentToolCall", default)]
+    tool_calls: Vec<LivenessToolCallRow>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct MetricsRuntimeRow {
     pub(crate) agent_did: String,
     #[serde(default)]
@@ -33,7 +48,7 @@ pub(crate) struct MetricsRuntimeRow {
     pub(crate) last_reconcile_completed_at: String,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub(crate) struct MetricsBackendRow {
     pub(crate) backend_id: String,
     #[serde(default)]
@@ -249,6 +264,40 @@ pub(crate) async fn render_prometheus_metrics(graphql: &str) -> Result<String> {
         }
     }
 
+    push_metric_prelude(
+        &mut lines,
+        "defra_agent_active_requests",
+        "Number of AgentRequest rows currently in processing.",
+    );
+    push_metric_sample(
+        &mut lines,
+        "defra_agent_active_requests",
+        &[],
+        data.liveness.active_request_ids.len() as i64,
+    );
+    push_metric_prelude(
+        &mut lines,
+        "defra_agent_active_tool_calls",
+        "Number of AgentToolCall rows currently running.",
+    );
+    push_metric_sample(
+        &mut lines,
+        "defra_agent_active_tool_calls",
+        &[],
+        data.liveness.active_tool_calls.len() as i64,
+    );
+    push_metric_prelude(
+        &mut lines,
+        "defra_agent_expired_processing_count",
+        "Number of processing AgentRequest rows whose deadline has already passed. Zero is healthy.",
+    );
+    push_metric_sample(
+        &mut lines,
+        "defra_agent_expired_processing_count",
+        &[],
+        data.liveness.expired_processing_count,
+    );
+
     lines.push(String::new());
     Ok(lines.join("\n"))
 }
@@ -276,6 +325,27 @@ pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQuer
                 probe_status
                 last_probe
             }
+            AgentRequest(filter: {
+                status: { _eq: "processing" },
+                lifecycle_state: { _eq: "processing" }
+            }) {
+                request_id
+                claimed_at
+                deadline
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_trigger_kind
+            }
+            AgentToolCall(filter: {
+                lifecycle_state: { _eq: "running" }
+            }) {
+                request_id
+                tool_call_id
+                tool_name
+                started_at
+                deadline_at
+                await_mode
+            }
         }"#,
     )
     .await?;
@@ -283,7 +353,14 @@ pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQuer
         .get("data")
         .cloned()
         .unwrap_or_else(|| Value::Object(Default::default()));
-    serde_json::from_value(data).context("decoding runtime HTTP query response")
+    let envelope: MetricsQueryEnvelope =
+        serde_json::from_value(data).context("decoding runtime HTTP query response")?;
+    let liveness = compute_liveness_summary(Utc::now(), envelope.requests, envelope.tool_calls);
+    Ok(MetricsQueryData {
+        agent_runtimes: envelope.agent_runtimes,
+        inference_backends: envelope.inference_backends,
+        liveness,
+    })
 }
 
 fn push_metric_prelude(lines: &mut Vec<String>, name: &str, help: &str) {
@@ -334,8 +411,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn metrics_query_data_treats_null_probe_status_as_unknown() {
-        let data: MetricsQueryData = serde_json::from_value(serde_json::json!({
+    fn metrics_query_envelope_treats_null_probe_status_as_unknown() {
+        let envelope: MetricsQueryEnvelope = serde_json::from_value(serde_json::json!({
             "AgentRuntime": [],
             "InferenceBackend": [{
                 "backend_id": "workstation-1",
@@ -344,10 +421,12 @@ mod tests {
                 "max_queue_depth": 8,
                 "probe_status": null,
                 "last_probe": null
-            }]
+            }],
+            "AgentRequest": [],
+            "AgentToolCall": []
         }))
-        .expect("metrics query data should decode null probe_status");
+        .expect("metrics query envelope should decode null probe_status");
 
-        assert_eq!(data.inference_backends[0].probe_status, "unknown");
+        assert_eq!(envelope.inference_backends[0].probe_status, "unknown");
     }
 }

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -102,6 +102,7 @@ async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
                 "runtime": runtime,
                 "runtimes": data.agent_runtimes,
                 "backends": data.inference_backends,
+                "liveness": data.liveness,
                 "p2p": p2p.clone(),
             })
         }

--- a/crates/defra-agent-cli/tests/cli_status.rs
+++ b/crates/defra-agent-cli/tests/cli_status.rs
@@ -143,3 +143,168 @@ async fn status_includes_p2p_runtime_info() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn status_liveness_surfaces_expired_processing_request_and_running_tool() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-liveness-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+
+    let port = allocate_port()?;
+    let agent_name = format!("cli-liveness-{}", Uuid::new_v4().simple());
+    let graphql = graphql_url(port);
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    // Seed an AgentRequest that is currently "processing" with a deadline well in the past.
+    // Fixed timestamps avoid wall-clock dependencies; the deadline is years before any
+    // realistic test execution time so expired_processing_count is reliably positive.
+    let stuck_request_id = format!("stuck-req-{}", Uuid::new_v4().simple());
+    let stuck_session_id = format!("stuck-session-{}", Uuid::new_v4().simple());
+    let stuck_tool_call_key = format!("stuck-tc-{}", Uuid::new_v4().simple());
+    let stuck_tool_call_id = format!("toolcall-{}", Uuid::new_v4().simple());
+
+    graphql_query(
+        &graphql,
+        &format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "default",
+                    session_id: "{session_id}",
+                    content: "stuck request seeded for liveness surface test",
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    backend_id: "studios-cluster",
+                    created_at: "2024-01-01T11:00:00Z",
+                    claimed_at: "2024-01-01T11:00:01Z",
+                    deadline: "2024-01-01T11:00:30Z",
+                    retry_count: 0
+                }}) {{ _docID }}
+            }}"#,
+            request_id = stuck_request_id,
+            session_id = stuck_session_id,
+        ),
+    )
+    .await?;
+
+    graphql_query(
+        &graphql,
+        &format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "{key}",
+                    request_id: "{request_id}",
+                    session_id: "{session_id}",
+                    message_sequence: 1,
+                    tool_name: "glob",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{{}}",
+                    status: "called",
+                    lifecycle_state: "running",
+                    started_at: "2024-01-01T11:00:05Z",
+                    deadline_at: "2024-01-01T11:00:30Z"
+                }}) {{ _docID }}
+            }}"#,
+            key = stuck_tool_call_key,
+            request_id = stuck_request_id,
+            session_id = stuck_session_id,
+            tool_call_id = stuck_tool_call_id,
+        ),
+    )
+    .await?;
+
+    let output = run_cli_json(&home_dir, &["status"])?;
+    let liveness = output
+        .get("liveness")
+        .expect("status output must include liveness block");
+    let expired = liveness
+        .get("expired_processing_count")
+        .and_then(Value::as_i64)
+        .expect("liveness must expose expired_processing_count as i64");
+    assert!(
+        expired >= 1,
+        "expired_processing_count must reflect the seeded stuck request, got {expired} in {liveness}"
+    );
+
+    let active_ids = liveness
+        .get("active_request_ids")
+        .and_then(Value::as_array)
+        .expect("liveness must expose active_request_ids array");
+    assert!(
+        active_ids
+            .iter()
+            .any(|id| id.as_str() == Some(stuck_request_id.as_str())),
+        "active_request_ids must contain seeded {stuck_request_id}, got {active_ids:?}"
+    );
+
+    let tool_calls = liveness
+        .get("active_tool_calls")
+        .and_then(Value::as_array)
+        .expect("liveness must expose active_tool_calls array");
+    let seeded_tool = tool_calls
+        .iter()
+        .find(|tc| tc.get("request_id").and_then(Value::as_str) == Some(stuck_request_id.as_str()))
+        .unwrap_or_else(|| {
+            panic!("active_tool_calls must contain a row for {stuck_request_id}: {tool_calls:?}")
+        });
+    assert_eq!(
+        seeded_tool.get("tool_name").and_then(Value::as_str),
+        Some("glob")
+    );
+    let running_age_ms = seeded_tool
+        .get("running_age_ms")
+        .and_then(Value::as_i64)
+        .expect("active tool call must report running_age_ms");
+    assert!(
+        running_age_ms > 0,
+        "running_age_ms must be positive for a row with started_at in the past, got {running_age_ms}"
+    );
+    assert_eq!(
+        seeded_tool.get("deadline_expired").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let request_view = liveness
+        .get("requests")
+        .and_then(Value::as_array)
+        .and_then(|requests| {
+            requests.iter().find(|r| {
+                r.get("request_id").and_then(Value::as_str) == Some(stuck_request_id.as_str())
+            })
+        })
+        .expect("requests array must include seeded stuck request");
+    let last_progress_age_ms = request_view
+        .get("last_progress_age_ms")
+        .and_then(Value::as_i64)
+        .expect("request view must expose last_progress_age_ms");
+    assert!(
+        last_progress_age_ms > 0,
+        "last_progress_age_ms must be positive for stale request, got {last_progress_age_ms}"
+    );
+    assert_eq!(
+        request_view
+            .get("deadline_expired")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Closes audit follow-up #9 from the [2026-05-12 deadline plumbing audit](docs/superpowers/audits/2026-05-12-deadline-plumbing-audit.md) and the matching row in the [execution plan](docs/superpowers/plans/2026-05-12-deadline-audit-execution.md) ("PR I — Expose active request/tool liveness counters in runtime status"). Moves the audit entity **"Health/status observability for expired processing"** from ❌ Open to ✅ Closed.

The original #149 stress soak left four `glob` tool calls stuck while `/healthz` stayed green for hours. PR #173 fixed the live-correctness gap; this PR closes the visibility gap.

## What changed

- **New `compute_liveness_summary` pure function** in `crates/defra-agent-cli/src/http/liveness.rs` operating on `AgentRequest{status="processing", lifecycle_state="processing"}` and `AgentToolCall{lifecycle_state="running"}` rows with an injected `now` argument. Tests assert nonzero/greater-than thresholds against fixed inserted timestamps rather than wall clock.
- **`/healthz` verdict**: `expired_processing_count > 0` flips status from `ok` to `degraded` while keeping `ok=true` (HTTP 200). Matches existing `degraded` semantics for unavailable behaviors/backends, and would have caught the #149 incident shape during a soak.
- **`/status` JSON body**: new `liveness` block (active request ids, active tool calls with `tool_name`/`started_at`/`running_age_ms`/`await_mode`, per-request `last_progress_age_ms`/`deadline_expired`, `expired_processing_count`).
- **`/metrics`**: three new Prometheus gauges — `defra_agent_active_requests`, `defra_agent_active_tool_calls`, `defra_agent_expired_processing_count`.
- **CLI `defra-agent status`**: same `liveness` block in the JSON output for operators without HTTP.

Subagent bridge rows (`lifecycle_state="running"`, `await_mode="bridge"`) appear as ordinary active tool calls with their `await_mode` surfaced — no R4 trampling.

## Audit / Lean obligations

- **No new Lean property.** This is observability over existing runtime state — execution plan Section 4 row for PR I confirms "No Lean property".
- **Doesn't touch `HookStats` in `hook.rs`.** R4 just landed there (#177); this PR extends a different surface.

## Test plan

- [x] `cargo test -p defra-agent-cli --bin defra-agent http::` — 8 unit tests (5 pure-fn + 2 healthz verdict + 1 prometheus envelope).
- [x] `cargo test -p defra-agent-cli --test cli_status` — 3 integration tests including new `status_liveness_surfaces_expired_processing_request_and_running_tool` that seeds an expired processing request and a running tool call via GraphQL, runs `defra-agent status`, and asserts active ids, tool name, running age, expired count, and `deadline_expired` flags.
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
- [x] `cargo test -p defra-agent --lib --tests` — all suites green.
- [x] `cargo test -p defra-agent-cli` — full CLI suite green.

Refs #149 (already closed; do not auto-close), refs #172.

🤖 Generated with [Claude Code](https://claude.com/claude-code)