### PR TITLE
Add recovery-action enumeration contract in Lean

### DIFF
--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -20,6 +20,7 @@ import Proofs.Subagent
 import Proofs.Properties.Safety
 import Proofs.Properties.Decidable
 import Proofs.Properties.Liveness
+import Proofs.Recovery
 import Proofs.Properties.SchedulingSafety
 import Proofs.Properties.SchedulingLiveness
 import Proofs.Conformance.DefraAgent

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -201,6 +201,20 @@ structure QueueDeadlineConformanceCase where
   explicitDeadlinePreserved : Bool
   deriving Repr
 
+structure RecoverySweepCase where
+  name : String
+  sweepId : String
+  collection : String
+  rustFunction : String
+  cadence : String
+  implementationStatus : String
+  preState : String
+  terminalState : String
+  measureBefore : Nat
+  measureAfter : Nat
+  deadlineAuditRef : String
+  deriving DecidableEq, Repr
+
 def boolString (value : Bool) : String :=
   if value then "true" else "false"
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -6,6 +6,7 @@ import Proofs.ToolExecution
 import Proofs.Conformance.Deviations
 import Proofs.CommandPolicy.Cases
 import Proofs.Conformance.CoverageLedger
+import Proofs.Recovery.ContractCases
 
 /-!
 # Conformance Snapshot JSON
@@ -357,6 +358,23 @@ def queueDeadlineConformanceCaseJson
       ++ boolString witness.explicitDeadlinePreserved
     ++ "}"
 
+def recoverySweepCaseJson (witness : RecoverySweepCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"sweep_id\":" ++ jsonString witness.sweepId ++ ","
+    ++ "\"collection\":" ++ jsonString witness.collection ++ ","
+    ++ "\"rust_function\":" ++ jsonString witness.rustFunction ++ ","
+    ++ "\"cadence\":" ++ jsonString witness.cadence ++ ","
+    ++ "\"implementation_status\":"
+      ++ jsonString witness.implementationStatus ++ ","
+    ++ "\"pre_state\":" ++ jsonString witness.preState ++ ","
+    ++ "\"terminal_state\":" ++ jsonString witness.terminalState ++ ","
+    ++ "\"measure_before\":" ++ toString witness.measureBefore ++ ","
+    ++ "\"measure_after\":" ++ toString witness.measureAfter ++ ","
+    ++ "\"deadline_audit_ref\":"
+      ++ jsonString witness.deadlineAuditRef
+    ++ "}"
+
 def snapshotJson : String :=
   "{"
     ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
@@ -421,6 +439,9 @@ def snapshotJson : String :=
     ++ "\"queue_deadline_conformance_cases\":"
       ++ jsonArray
         (queueDeadlineConformanceCases.map queueDeadlineConformanceCaseJson) ++ ","
+    ++ "\"recovery_sweep_cases\":"
+      ++ jsonArray
+        (Recovery.recoverySweepCases.map recoverySweepCaseJson) ++ ","
     ++ "\"follow_up_hooks\":[],"
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -279,6 +279,11 @@ def caseCoverage : List CoverageEntry :=
       "QueueDeadlineConformanceCases"
       "state_machine_conformance::generated_queue_deadline_cases_pin_r4a_contract_rows"
       "Runtime-backed queue/deadline consumers land in R4a Task 5 and Task 7 after the Rust claim and scheduler implementations exist."
+  , consumerWithFollowUpCoverage
+      "recovery_sweep_cases"
+      "RecoverySweepCases"
+      "state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract"
+      "Deadline audit PR E must implement InferenceCall::recover_all; the bridge terminal wiring follow-up must implement detached bridge row recovery."
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/proofs/Proofs/Recovery.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery.lean
@@ -1,0 +1,10 @@
+import Proofs.Recovery.Contract
+import Proofs.Recovery.Sweeps
+import Proofs.Recovery.ContractCases
+
+/-!
+# Recovery Action Enumeration
+
+Barrel import for persisted startup recovery sweep contracts, registered
+sweeps, convergence theorems, and conformance witness rows.
+-/

--- a/crates/defra-agent/proofs/Proofs/Recovery/Contract.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/Contract.lean
@@ -1,0 +1,150 @@
+import Proofs.Basic
+
+/-!
+# Recovery Sweep Contract
+
+Closed, finite contract for persisted startup recovery sweeps.
+-/
+
+namespace Recovery
+
+inductive RecoveryCadence where
+  | startup
+  deriving DecidableEq, Repr
+
+namespace RecoveryCadence
+
+def toContract : RecoveryCadence → String
+  | .startup => "startup"
+
+end RecoveryCadence
+
+inductive RecoveryImplementationStatus where
+  | implemented
+  | obligation
+  deriving DecidableEq, Repr
+
+namespace RecoveryImplementationStatus
+
+def toContract : RecoveryImplementationStatus → String
+  | .implemented => "implemented"
+  | .obligation => "obligation"
+
+end RecoveryImplementationStatus
+
+inductive PersistedRecoveryCollection where
+  | agentRequest
+  | agentResponse
+  | agentToolCall
+  | inferenceCall
+  deriving DecidableEq, Repr
+
+namespace PersistedRecoveryCollection
+
+def toContract : PersistedRecoveryCollection → String
+  | .agentRequest => "AgentRequest"
+  | .agentResponse => "AgentResponse"
+  | .agentToolCall => "AgentToolCall"
+  | .inferenceCall => "InferenceCall"
+
+def all : List PersistedRecoveryCollection :=
+  [ .agentRequest
+  , .agentResponse
+  , .agentToolCall
+  , .inferenceCall
+  ]
+
+theorem all_complete (collection : PersistedRecoveryCollection) :
+    collection ∈ all := by
+  cases collection <;> simp [all]
+
+end PersistedRecoveryCollection
+
+/--
+Per-sweep recovery contract.
+
+`Row` is dependent so each persisted collection can reuse its existing Lean row
+model. A sweep is intentionally a startup action over stale persisted rows, not
+a live observer loop.
+-/
+structure RecoverySweep where
+  Row : Type
+  collection : PersistedRecoveryCollection
+  sweepId : String
+  rustFunction : String
+  cadence : RecoveryCadence
+  implementationStatus : RecoveryImplementationStatus
+  stale : Row → Prop
+  recover : Row → Row
+  terminal : Row → Prop
+  measure : Row → Nat
+  h_stale_positive : ∀ row, stale row → measure row > 0
+  h_recover_terminal : ∀ row, stale row → terminal (recover row)
+  h_recover_zero : ∀ row, stale row → measure (recover row) = 0
+
+namespace RecoverySweep
+
+def recoveredRows (sweep : RecoverySweep) (rows : List sweep.Row) : List sweep.Row :=
+  rows.map sweep.recover
+
+def aggregateMeasure (sweep : RecoverySweep) (rows : List sweep.Row) : Nat :=
+  rows.foldr (fun row acc => sweep.measure row + acc) 0
+
+theorem recover_decreases_measure
+    (sweep : RecoverySweep)
+    (row : sweep.Row)
+    (h_stale : sweep.stale row) :
+    sweep.measure (sweep.recover row) < sweep.measure row := by
+  rw [sweep.h_recover_zero row h_stale]
+  exact sweep.h_stale_positive row h_stale
+
+theorem recoveredRows_length
+    (sweep : RecoverySweep)
+    (rows : List sweep.Row) :
+    (sweep.recoveredRows rows).length = rows.length := by
+  simp [recoveredRows]
+
+theorem recoveredRows_terminal
+    (sweep : RecoverySweep)
+    {rows : List sweep.Row}
+    (h_all_stale : ∀ row, row ∈ rows → sweep.stale row) :
+    ∀ row, row ∈ sweep.recoveredRows rows → sweep.terminal row := by
+  intro row h_mem
+  unfold recoveredRows at h_mem
+  rcases List.mem_map.mp h_mem with ⟨pre, h_pre_mem, h_row⟩
+  rw [← h_row]
+  exact sweep.h_recover_terminal pre (h_all_stale pre h_pre_mem)
+
+theorem aggregateMeasure_recovered_zero
+    (sweep : RecoverySweep)
+    {rows : List sweep.Row}
+    (h_all_stale : ∀ row, row ∈ rows → sweep.stale row) :
+    sweep.aggregateMeasure (sweep.recoveredRows rows) = 0 := by
+  induction rows with
+  | nil =>
+      simp [aggregateMeasure, recoveredRows]
+  | cons hd tl ih =>
+      have h_hd : sweep.measure (sweep.recover hd) = 0 :=
+        sweep.h_recover_zero hd (h_all_stale hd (by simp))
+      have h_tl : ∀ row, row ∈ tl → sweep.stale row := by
+        intro row h_mem
+        exact h_all_stale row (by simp [h_mem])
+      simp [aggregateMeasure, recoveredRows, h_hd]
+      exact ih h_tl
+
+theorem finite_stale_rows_converge
+    (sweep : RecoverySweep)
+    (rows : List sweep.Row)
+    (h_all_stale : ∀ row, row ∈ rows → sweep.stale row) :
+    ∃ results : List sweep.Row,
+      results.length = rows.length ∧
+      sweep.aggregateMeasure results = 0 ∧
+      ∀ row, row ∈ results → sweep.terminal row := by
+  refine ⟨sweep.recoveredRows rows, ?_, ?_, ?_⟩
+  · exact sweep.recoveredRows_length rows
+  · exact sweep.aggregateMeasure_recovered_zero h_all_stale
+  · exact sweep.recoveredRows_terminal h_all_stale
+
+end RecoverySweep
+
+end Recovery

--- a/crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
@@ -1,0 +1,150 @@
+import Proofs.Recovery.Sweeps
+import Proofs.Conformance.ContractCases
+
+/-!
+# Recovery Sweep Conformance Cases
+
+Finite witness rows emitted to Rust so every persisted startup recovery sweep
+has an explicit consumer or follow-up obligation.
+-/
+
+namespace Recovery
+
+open Conformance.ContractCases
+
+def recoveryCase
+    (sweep : RecoverySweep)
+    (name preState terminalState deadlineAuditRef : String)
+    (measureBefore : Nat := 1)
+    (measureAfter : Nat := 0) : RecoverySweepCase :=
+  { name := name
+  , sweepId := sweep.sweepId
+  , collection := sweep.collection.toContract
+  , rustFunction := sweep.rustFunction
+  , cadence := sweep.cadence.toContract
+  , implementationStatus := sweep.implementationStatus.toContract
+  , preState := preState
+  , terminalState := terminalState
+  , measureBefore := measureBefore
+  , measureAfter := measureAfter
+  , deadlineAuditRef := deadlineAuditRef
+  }
+
+def recoverySweepCases : List RecoverySweepCase :=
+  [ recoveryCase
+      requestRecoverySweep
+      "request_claimed_recovery_to_failed"
+      "claimed"
+      "failed"
+      "formal-coverage-audit-2026-05-13-gap-6"
+  , recoveryCase
+      requestRecoverySweep
+      "request_processing_recovery_to_failed"
+      "processing"
+      "failed"
+      "formal-coverage-audit-2026-05-13-gap-6"
+  , recoveryCase
+      responseRecoverySweep
+      "response_streaming_recovery_to_error"
+      "streaming"
+      "error"
+      "deadline-plumbing-audit-2026-05-12-streaming-response-lifetime"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_deadline_exceeded_to_timed_out"
+      "running"
+      "timedOut"
+      "deadline-plumbing-audit-2026-05-12-tool-call-persisted-deadline"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_parent_interrupted_to_cancelled"
+      "running"
+      "cancelled"
+      "deadline-plumbing-audit-2026-05-12-request-interrupt-lifetime"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_terminal_parent_to_failed"
+      "running"
+      "failed"
+      "deadline-plumbing-audit-2026-05-12-tool-call-persisted-deadline"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_child_completed_to_completed"
+      "running"
+      "completed"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_child_failed_to_failed"
+      "running"
+      "failed"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_child_interrupted_to_cancelled"
+      "running"
+      "cancelled"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      detachedBridgeRecoverySweep
+      "detached_bridge_child_completed_to_completed"
+      "running"
+      "completed"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      detachedBridgeRecoverySweep
+      "detached_bridge_child_failed_to_failed"
+      "running"
+      "failed"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      detachedBridgeRecoverySweep
+      "detached_bridge_child_interrupted_to_cancelled"
+      "running"
+      "cancelled"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      detachedBridgeRecoverySweep
+      "detached_bridge_terminal_parent_to_failed"
+      "running"
+      "failed"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      detachedBridgeRecoverySweep
+      "detached_bridge_deadline_exceeded_to_timed_out"
+      "running"
+      "timedOut"
+      "deadline-plumbing-audit-2026-05-12-subagent-bridge-terminal-lifetime"
+  , recoveryCase
+      inferenceCallRecoverySweep
+      "inference_queued_stale_to_cancelled"
+      "queued"
+      "cancelled"
+      "deadline-plumbing-audit-2026-05-12-follow-up-6-pr-e"
+  , recoveryCase
+      inferenceCallRecoverySweep
+      "inference_running_stale_to_failed"
+      "running"
+      "failed"
+      "deadline-plumbing-audit-2026-05-12-follow-up-6-pr-e"
+  , recoveryCase
+      inferenceCallRecoverySweep
+      "inference_interrupted_parent_to_cancelled"
+      "running"
+      "cancelled"
+      "deadline-plumbing-audit-2026-05-12-follow-up-6-pr-e"
+  ]
+
+theorem recoverySweepCases_registered_sweeps :
+    ∀ witness : RecoverySweepCase,
+      witness ∈ recoverySweepCases →
+      (witness.sweepId, witness.collection) ∈ registeredRecoverySweepContracts := by
+  native_decide
+
+theorem recoverySweepCases_decrease_to_zero :
+    ∀ witness,
+      witness ∈ recoverySweepCases →
+      witness.measureBefore > witness.measureAfter ∧ witness.measureAfter = 0 := by
+  native_decide
+
+end Recovery

--- a/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
@@ -1,0 +1,472 @@
+import Proofs.Recovery.Contract
+import Proofs.Properties.Liveness
+import Proofs.InferenceCall
+import Proofs.ToolExecution
+import Proofs.Subagent
+
+/-!
+# Registered Recovery Sweeps
+
+Concrete startup-recovery sweep contracts for persisted collections with
+non-terminal rows.
+-/
+
+namespace Recovery
+
+open ToolExecution
+
+/-! ## Request lifecycle recovery -/
+
+def requestRecoveryStale (row : RequestContext) : Prop :=
+  row.state = .claimed ∨ row.state = .processing
+
+instance (row : RequestContext) : Decidable (requestRecoveryStale row) := by
+  unfold requestRecoveryStale
+  infer_instance
+
+def requestRecover (row : RequestContext) : RequestContext :=
+  { row with state := .failed, admission := .released }
+
+def requestRecoveryMeasure (row : RequestContext) : Nat :=
+  if requestRecoveryStale row then 1 else 0
+
+theorem requestRecovery_stale_positive :
+    ∀ row, requestRecoveryStale row → requestRecoveryMeasure row > 0 := by
+  intro row h_stale
+  simp [requestRecoveryMeasure, h_stale]
+
+theorem requestRecover_terminal :
+    ∀ row, requestRecoveryStale row → isTerminal (requestRecover row).state := by
+  intro row _h_stale
+  simp [requestRecover, HasTerminal.isTerminal, RequestState.instHasTerminal]
+
+theorem requestRecover_zero :
+    ∀ row, requestRecoveryStale row → requestRecoveryMeasure (requestRecover row) = 0 := by
+  intro row _h_stale
+  have h_not : ¬ requestRecoveryStale (requestRecover row) := by
+    intro h_stale
+    cases h_stale with
+    | inl h_claimed =>
+        simp [requestRecover] at h_claimed
+    | inr h_processing =>
+        simp [requestRecover] at h_processing
+  simp [requestRecoveryMeasure, h_not]
+
+def requestRecoverySweep : RecoverySweep :=
+  { Row := RequestContext
+  , collection := .agentRequest
+  , sweepId := "request_lifecycle_recover_all_requests"
+  , rustFunction := "RequestLifecycle::recover_all"
+  , cadence := .startup
+  , implementationStatus := .implemented
+  , stale := requestRecoveryStale
+  , recover := requestRecover
+  , terminal := fun row => isTerminal row.state
+  , measure := requestRecoveryMeasure
+  , h_stale_positive := requestRecovery_stale_positive
+  , h_recover_terminal := requestRecover_terminal
+  , h_recover_zero := requestRecover_zero
+  }
+
+/-! ## Streaming response recovery -/
+
+inductive ResponseRecoveryStatus where
+  | streaming
+  | completed
+  | error
+  deriving DecidableEq, Repr
+
+namespace ResponseRecoveryStatus
+
+def toContract : ResponseRecoveryStatus → String
+  | .streaming => "streaming"
+  | .completed => "completed"
+  | .error => "error"
+
+instance : HasTerminal ResponseRecoveryStatus where
+  isTerminal status := status = .completed ∨ status = .error
+  isTerminal_dec status :=
+    match status with
+    | .completed => isTrue (Or.inl rfl)
+    | .error => isTrue (Or.inr rfl)
+    | .streaming => isFalse (by
+        intro h
+        cases h with
+        | inl h_completed => cases h_completed
+        | inr h_error => cases h_error)
+
+end ResponseRecoveryStatus
+
+structure ResponseRecoveryRow where
+  status : ResponseRecoveryStatus
+  deriving Repr
+
+def responseRecoveryStale (row : ResponseRecoveryRow) : Prop :=
+  row.status = .streaming
+
+instance (row : ResponseRecoveryRow) : Decidable (responseRecoveryStale row) := by
+  unfold responseRecoveryStale
+  infer_instance
+
+def responseRecover (row : ResponseRecoveryRow) : ResponseRecoveryRow :=
+  { row with status := .error }
+
+def responseRecoveryMeasure (row : ResponseRecoveryRow) : Nat :=
+  if responseRecoveryStale row then 1 else 0
+
+theorem responseRecovery_stale_positive :
+    ∀ row, responseRecoveryStale row → responseRecoveryMeasure row > 0 := by
+  intro row h_stale
+  simp [responseRecoveryMeasure, h_stale]
+
+theorem responseRecover_terminal :
+    ∀ row, responseRecoveryStale row → isTerminal (responseRecover row).status := by
+  intro row _h_stale
+  simp [responseRecover, HasTerminal.isTerminal, ResponseRecoveryStatus.instHasTerminal]
+
+theorem responseRecover_zero :
+    ∀ row, responseRecoveryStale row → responseRecoveryMeasure (responseRecover row) = 0 := by
+  intro row _h_stale
+  simp [responseRecover, responseRecoveryMeasure, responseRecoveryStale]
+
+def responseRecoverySweep : RecoverySweep :=
+  { Row := ResponseRecoveryRow
+  , collection := .agentResponse
+  , sweepId := "request_lifecycle_recover_all_streaming_responses"
+  , rustFunction := "RequestLifecycle::recover_all"
+  , cadence := .startup
+  , implementationStatus := .implemented
+  , stale := responseRecoveryStale
+  , recover := responseRecover
+  , terminal := fun row => isTerminal row.status
+  , measure := responseRecoveryMeasure
+  , h_stale_positive := responseRecovery_stale_positive
+  , h_recover_terminal := responseRecover_terminal
+  , h_recover_zero := responseRecover_zero
+  }
+
+/-! ## Tool-call recovery -/
+
+def isDetachedBridgeCall (call : ToolCallContext) : Prop :=
+  call.childRequestId.isSome ∧ call.cancelPolicy = .detach
+
+instance (call : ToolCallContext) : Decidable (isDetachedBridgeCall call) := by
+  unfold isDetachedBridgeCall
+  infer_instance
+
+inductive ToolRecoveryCause where
+  | deadlineExceeded
+  | parentInterrupted
+  | parentTerminal
+  | childCompleted
+  | childFailed
+  | childDead
+  | childInterrupted
+  | childSuperseded
+  deriving DecidableEq, Repr
+
+namespace ToolRecoveryCause
+
+def toContract : ToolRecoveryCause → String
+  | .deadlineExceeded => "deadlineExceeded"
+  | .parentInterrupted => "parentInterrupted"
+  | .parentTerminal => "parentTerminal"
+  | .childCompleted => "childCompleted"
+  | .childFailed => "childFailed"
+  | .childDead => "childDead"
+  | .childInterrupted => "childInterrupted"
+  | .childSuperseded => "childSuperseded"
+
+def terminalState : ToolRecoveryCause → ToolCallState
+  | .deadlineExceeded => .timedOut
+  | .parentInterrupted => .cancelled
+  | .parentTerminal => .failed
+  | .childCompleted => .completed
+  | .childFailed => .failed
+  | .childDead => .failed
+  | .childInterrupted => .cancelled
+  | .childSuperseded => .failed
+
+theorem terminalState_terminal (cause : ToolRecoveryCause) :
+    isTerminal cause.terminalState := by
+  cases cause <;>
+    simp [terminalState, HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+
+end ToolRecoveryCause
+
+structure ToolCallRecoveryRow where
+  call : ToolCallContext
+  cause : ToolRecoveryCause
+  deriving Repr
+
+def toolCallRecoveryStale (row : ToolCallRecoveryRow) : Prop :=
+  row.call.state = .running ∧ ¬ isDetachedBridgeCall row.call
+
+instance (row : ToolCallRecoveryRow) : Decidable (toolCallRecoveryStale row) := by
+  unfold toolCallRecoveryStale
+  infer_instance
+
+def toolCallRecover (row : ToolCallRecoveryRow) : ToolCallRecoveryRow :=
+  { row with call := { row.call with state := row.cause.terminalState } }
+
+def toolCallRecoveryMeasure (row : ToolCallRecoveryRow) : Nat :=
+  if toolCallRecoveryStale row then 1 else 0
+
+theorem toolCallRecovery_stale_positive :
+    ∀ row, toolCallRecoveryStale row → toolCallRecoveryMeasure row > 0 := by
+  intro row h_stale
+  simp [toolCallRecoveryMeasure, h_stale]
+
+theorem toolCallRecover_terminal :
+    ∀ row, toolCallRecoveryStale row → isTerminal (toolCallRecover row).call.state := by
+  intro row _h_stale
+  rcases row with ⟨call, cause⟩
+  cases cause <;>
+    simp [toolCallRecover, ToolRecoveryCause.terminalState,
+      HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+
+theorem toolCallRecover_zero :
+    ∀ row, toolCallRecoveryStale row → toolCallRecoveryMeasure (toolCallRecover row) = 0 := by
+  intro row _h_stale
+  have h_terminal_not_running : row.cause.terminalState ≠ .running := by
+    cases row.cause <;> simp [ToolRecoveryCause.terminalState]
+  have h_not : ¬ toolCallRecoveryStale (toolCallRecover row) := by
+    intro h_stale
+    rcases h_stale with ⟨h_running, _h_not_detached⟩
+    simp [toolCallRecover] at h_running
+    exact h_terminal_not_running h_running
+  simp [toolCallRecoveryMeasure, h_not]
+
+def toolCallRecoverySweep : RecoverySweep :=
+  { Row := ToolCallRecoveryRow
+  , collection := .agentToolCall
+  , sweepId := "tool_call_lifecycle_recover_all_running_calls"
+  , rustFunction := "ToolCallLifecycle::recover_all"
+  , cadence := .startup
+  , implementationStatus := .implemented
+  , stale := toolCallRecoveryStale
+  , recover := toolCallRecover
+  , terminal := fun row => isTerminal row.call.state
+  , measure := toolCallRecoveryMeasure
+  , h_stale_positive := toolCallRecovery_stale_positive
+  , h_recover_terminal := toolCallRecover_terminal
+  , h_recover_zero := toolCallRecover_zero
+  }
+
+/-! ## Detached bridge recovery obligation -/
+
+inductive DetachedBridgeRecoveryCause where
+  | deadlineExceeded
+  | terminalParent
+  | childCompleted
+  | childFailed
+  | childDead
+  | childInterrupted
+  | childSuperseded
+  deriving DecidableEq, Repr
+
+namespace DetachedBridgeRecoveryCause
+
+def toContract : DetachedBridgeRecoveryCause → String
+  | .deadlineExceeded => "deadlineExceeded"
+  | .terminalParent => "terminalParent"
+  | .childCompleted => "childCompleted"
+  | .childFailed => "childFailed"
+  | .childDead => "childDead"
+  | .childInterrupted => "childInterrupted"
+  | .childSuperseded => "childSuperseded"
+
+def terminalState : DetachedBridgeRecoveryCause → ToolCallState
+  | .deadlineExceeded => .timedOut
+  | .terminalParent => .failed
+  | .childCompleted => .completed
+  | .childFailed => .failed
+  | .childDead => .failed
+  | .childInterrupted => .cancelled
+  | .childSuperseded => .failed
+
+theorem terminalState_terminal (cause : DetachedBridgeRecoveryCause) :
+    isTerminal cause.terminalState := by
+  cases cause <;>
+    simp [terminalState, HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+
+end DetachedBridgeRecoveryCause
+
+structure DetachedBridgeRecoveryRow where
+  call : ToolCallContext
+  cause : DetachedBridgeRecoveryCause
+  deriving Repr
+
+def detachedBridgeRecoveryStale (row : DetachedBridgeRecoveryRow) : Prop :=
+  row.call.state = .running ∧ isDetachedBridgeCall row.call
+
+instance (row : DetachedBridgeRecoveryRow) : Decidable (detachedBridgeRecoveryStale row) := by
+  unfold detachedBridgeRecoveryStale
+  infer_instance
+
+def detachedBridgeRecover (row : DetachedBridgeRecoveryRow) : DetachedBridgeRecoveryRow :=
+  { row with call := { row.call with state := row.cause.terminalState } }
+
+def detachedBridgeRecoveryMeasure (row : DetachedBridgeRecoveryRow) : Nat :=
+  if detachedBridgeRecoveryStale row then 1 else 0
+
+theorem detachedBridgeRecovery_stale_positive :
+    ∀ row, detachedBridgeRecoveryStale row → detachedBridgeRecoveryMeasure row > 0 := by
+  intro row h_stale
+  simp [detachedBridgeRecoveryMeasure, h_stale]
+
+theorem detachedBridgeRecover_terminal :
+    ∀ row, detachedBridgeRecoveryStale row → isTerminal (detachedBridgeRecover row).call.state := by
+  intro row _h_stale
+  rcases row with ⟨call, cause⟩
+  cases cause <;>
+    simp [detachedBridgeRecover, DetachedBridgeRecoveryCause.terminalState,
+      HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+
+theorem detachedBridgeRecover_zero :
+    ∀ row, detachedBridgeRecoveryStale row → detachedBridgeRecoveryMeasure (detachedBridgeRecover row) = 0 := by
+  intro row _h_stale
+  have h_terminal_not_running : row.cause.terminalState ≠ .running := by
+    cases row.cause <;> simp [DetachedBridgeRecoveryCause.terminalState]
+  have h_not : ¬ detachedBridgeRecoveryStale (detachedBridgeRecover row) := by
+    intro h_stale
+    rcases h_stale with ⟨h_running, _h_detached⟩
+    simp [detachedBridgeRecover] at h_running
+    exact h_terminal_not_running h_running
+  simp [detachedBridgeRecoveryMeasure, h_not]
+
+def detachedBridgeRecoverySweep : RecoverySweep :=
+  { Row := DetachedBridgeRecoveryRow
+  , collection := .agentToolCall
+  , sweepId := "tool_call_lifecycle_recover_detached_bridge_rows"
+  , rustFunction := "ToolCallLifecycle::recover_detached_bridge_rows"
+  , cadence := .startup
+  , implementationStatus := .obligation
+  , stale := detachedBridgeRecoveryStale
+  , recover := detachedBridgeRecover
+  , terminal := fun row => isTerminal row.call.state
+  , measure := detachedBridgeRecoveryMeasure
+  , h_stale_positive := detachedBridgeRecovery_stale_positive
+  , h_recover_terminal := detachedBridgeRecover_terminal
+  , h_recover_zero := detachedBridgeRecover_zero
+  }
+
+/-! ## Inference-call recovery obligation -/
+
+inductive InferenceRecoveryCause where
+  | staleQueued
+  | staleRunning
+  | interruptedParent
+  deriving DecidableEq, Repr
+
+namespace InferenceRecoveryCause
+
+def toContract : InferenceRecoveryCause → String
+  | .staleQueued => "staleQueued"
+  | .staleRunning => "staleRunning"
+  | .interruptedParent => "interruptedParent"
+
+end InferenceRecoveryCause
+
+structure InferenceCallRecoveryRow where
+  call : InferenceCall
+  cause : InferenceRecoveryCause
+  deriving Repr
+
+def inferenceCallRecoveryStale (row : InferenceCallRecoveryRow) : Prop :=
+  match row.cause with
+  | .staleQueued => row.call.state = .queued
+  | .staleRunning => row.call.state = .running
+  | .interruptedParent => row.call.state = .queued ∨ row.call.state = .running
+
+instance (row : InferenceCallRecoveryRow) : Decidable (inferenceCallRecoveryStale row) := by
+  unfold inferenceCallRecoveryStale
+  cases row.cause <;> infer_instance
+
+def inferenceCallRecover (row : InferenceCallRecoveryRow) : InferenceCallRecoveryRow :=
+  match row.cause with
+  | .staleQueued => { row with call := { row.call with state := .cancelled } }
+  | .staleRunning => { row with call := { row.call with state := .failed } }
+  | .interruptedParent => { row with call := { row.call with state := .cancelled } }
+
+def inferenceCallRecoveryMeasure (row : InferenceCallRecoveryRow) : Nat :=
+  if inferenceCallRecoveryStale row then 1 else 0
+
+theorem inferenceCallRecovery_stale_positive :
+    ∀ row, inferenceCallRecoveryStale row → inferenceCallRecoveryMeasure row > 0 := by
+  intro row h_stale
+  simp [inferenceCallRecoveryMeasure, h_stale]
+
+theorem inferenceCallRecover_terminal :
+    ∀ row, inferenceCallRecoveryStale row → isTerminal (inferenceCallRecover row).call.state := by
+  intro row _h_stale
+  rcases row with ⟨call, cause⟩
+  cases cause <;>
+    simp [inferenceCallRecover, HasTerminal.isTerminal, InferenceCallState.instHasTerminal]
+
+theorem inferenceCallRecover_zero :
+    ∀ row, inferenceCallRecoveryStale row → inferenceCallRecoveryMeasure (inferenceCallRecover row) = 0 := by
+  intro row _h_stale
+  have h_not : ¬ inferenceCallRecoveryStale (inferenceCallRecover row) := by
+    intro h_stale
+    rcases row with ⟨call, cause⟩
+    cases cause <;>
+      simp [inferenceCallRecoveryStale, inferenceCallRecover] at h_stale
+  simp [inferenceCallRecoveryMeasure, h_not]
+
+theorem inferenceCallRecover_contributes_zero
+    (row : InferenceCallRecoveryRow)
+    (h_stale : inferenceCallRecoveryStale row)
+    (bid : BackendId) :
+    (inferenceCallRecover row).call.slotContribution bid = 0 :=
+  InferenceCall.terminal_call_contributes_zero (inferenceCallRecover_terminal row h_stale)
+
+def inferenceCallRecoverySweep : RecoverySweep :=
+  { Row := InferenceCallRecoveryRow
+  , collection := .inferenceCall
+  , sweepId := "inference_call_recover_all_stale_calls"
+  , rustFunction := "InferenceCall::recover_all"
+  , cadence := .startup
+  , implementationStatus := .obligation
+  , stale := inferenceCallRecoveryStale
+  , recover := inferenceCallRecover
+  , terminal := fun row => isTerminal row.call.state
+  , measure := inferenceCallRecoveryMeasure
+  , h_stale_positive := inferenceCallRecovery_stale_positive
+  , h_recover_terminal := inferenceCallRecover_terminal
+  , h_recover_zero := inferenceCallRecover_zero
+  }
+
+def registeredRecoverySweeps : List RecoverySweep :=
+  [ requestRecoverySweep
+  , responseRecoverySweep
+  , toolCallRecoverySweep
+  , detachedBridgeRecoverySweep
+  , inferenceCallRecoverySweep
+  ]
+
+def registeredRecoverySweepIds : List String :=
+  registeredRecoverySweeps.map fun sweep => sweep.sweepId
+
+def registeredRecoverySweepContracts : List (String × String) :=
+  registeredRecoverySweeps.map fun sweep =>
+    (sweep.sweepId, sweep.collection.toContract)
+
+theorem registered_sweeps_cover_persisted_collections :
+    ∀ collection,
+      collection ∈ PersistedRecoveryCollection.all →
+      ∃ sweep,
+        sweep ∈ registeredRecoverySweeps ∧
+        sweep.collection = collection := by
+  intro collection _h_collection
+  cases collection with
+  | agentRequest =>
+      exact ⟨requestRecoverySweep, by simp [registeredRecoverySweeps], rfl⟩
+  | agentResponse =>
+      exact ⟨responseRecoverySweep, by simp [registeredRecoverySweeps], rfl⟩
+  | agentToolCall =>
+      exact ⟨toolCallRecoverySweep, by simp [registeredRecoverySweeps], rfl⟩
+  | inferenceCall =>
+      exact ⟨inferenceCallRecoverySweep, by simp [registeredRecoverySweeps], rfl⟩
+
+end Recovery

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -54,6 +54,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) command_env_cases: Vec<LeanCommandEnvCase>,
     pub(crate) live_overlay_cases: Vec<LeanLiveOverlayCase>,
     pub(crate) queue_deadline_conformance_cases: Vec<LeanQueueDeadlineConformanceCase>,
+    pub(crate) recovery_sweep_cases: Vec<LeanRecoverySweepCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
@@ -528,6 +529,21 @@ pub(crate) struct LeanQueueDeadlineConformanceCase {
     pub(crate) explicit_deadline_preserved: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanRecoverySweepCase {
+    pub(crate) name: String,
+    pub(crate) sweep_id: String,
+    pub(crate) collection: String,
+    pub(crate) rust_function: String,
+    pub(crate) cadence: String,
+    pub(crate) implementation_status: String,
+    pub(crate) pre_state: String,
+    pub(crate) terminal_state: String,
+    pub(crate) measure_before: usize,
+    pub(crate) measure_after: usize,
+    pub(crate) deadline_audit_ref: String,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -679,6 +695,18 @@ pub(crate) fn lean_queue_deadline_case(name: &str) -> &'static LeanQueueDeadline
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean queue/deadline case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_recovery_sweep_cases() -> &'static [LeanRecoverySweepCase] {
+    &lean_contract_snapshot().recovery_sweep_cases
+}
+
+pub(crate) fn lean_recovery_sweep_case(name: &str) -> &'static LeanRecoverySweepCase {
+    lean_contract_snapshot()
+        .recovery_sweep_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean recovery sweep case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_tool_retry_case(name: &str) -> &'static LeanToolRetryCase {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -22,9 +22,10 @@ use lean_vocab_test::{
     lean_client_shell_case, lean_command_env_case, lean_command_policy_case,
     lean_command_sandbox_case, lean_contract_snapshot, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_queue_deadline_case, lean_queue_deadline_cases,
-    lean_request_transition_cases, lean_runtime_reconcile_case, lean_session_recovery_case,
-    lean_state_machine_contract, lean_tool_preflight_case, lean_tool_retry_case,
-    lean_vocabulary_values, LeanLifecycleTransitionCase,
+    lean_recovery_sweep_case, lean_recovery_sweep_cases, lean_request_transition_cases,
+    lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
+    lean_tool_preflight_case, lean_tool_retry_case, lean_vocabulary_values,
+    LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -213,6 +214,7 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);
+    assert_eq!(lean_recovery_sweep_cases().len(), 17);
 }
 
 #[test]
@@ -498,6 +500,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "QueueDeadlineConformanceCases".to_string(),
         ));
     }
+    if !lean_recovery_sweep_cases().is_empty() {
+        emitted.insert((
+            "recovery_sweep_cases".to_string(),
+            "RecoverySweepCases".to_string(),
+        ));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -523,6 +531,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "command_policy_cases",
         "live_overlay_cases",
         "queue_deadline_cases",
+        "recovery_sweep_cases",
         "follow_up_hook",
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();
@@ -599,6 +608,143 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "coverage ledger consumer registry has unreferenced entries: {:?}",
         unreferenced_consumers
     );
+}
+
+#[test]
+fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
+    let cases = lean_recovery_sweep_cases();
+    assert_eq!(
+        cases.len(),
+        17,
+        "Lean should emit one row per registered recovery predicate witness"
+    );
+
+    let expected_sweep_ids = [
+        "request_lifecycle_recover_all_requests",
+        "request_lifecycle_recover_all_streaming_responses",
+        "tool_call_lifecycle_recover_all_running_calls",
+        "tool_call_lifecycle_recover_detached_bridge_rows",
+        "inference_call_recover_all_stale_calls",
+    ]
+    .into_iter()
+    .collect::<BTreeSet<_>>();
+    let actual_sweep_ids = cases
+        .iter()
+        .map(|case| case.sweep_id.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        actual_sweep_ids, expected_sweep_ids,
+        "Lean recovery sweep registry drifted"
+    );
+
+    for case in cases {
+        assert_eq!(case.cadence.as_str(), "startup");
+        assert!(
+            case.measure_before > case.measure_after,
+            "recovery case {} must decrease its measure",
+            case.name
+        );
+        assert_eq!(
+            case.measure_after, 0,
+            "recovery case {} must reach zero measure",
+            case.name
+        );
+        assert_ne!(
+            case.terminal_state.as_str(),
+            "running",
+            "recovery case {} must not leave a stale row running",
+            case.name
+        );
+        assert!(
+            !case.deadline_audit_ref.trim().is_empty(),
+            "recovery case {} must name its audit reference",
+            case.name
+        );
+    }
+
+    let implemented = [
+        "request_lifecycle_recover_all_requests",
+        "request_lifecycle_recover_all_streaming_responses",
+        "tool_call_lifecycle_recover_all_running_calls",
+    ];
+    for sweep_id in implemented {
+        for case in cases.iter().filter(|case| case.sweep_id == sweep_id) {
+            assert_eq!(
+                case.implementation_status.as_str(),
+                "implemented",
+                "sweep {sweep_id} should be an implemented startup sweep"
+            );
+        }
+    }
+
+    let detached_cases = cases
+        .iter()
+        .filter(|case| case.sweep_id == "tool_call_lifecycle_recover_detached_bridge_rows")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        detached_cases.len(),
+        5,
+        "detached bridge recovery must have explicit obligation witnesses"
+    );
+    for case in detached_cases {
+        assert_eq!(case.collection.as_str(), "AgentToolCall");
+        assert_eq!(
+            case.rust_function.as_str(),
+            "ToolCallLifecycle::recover_detached_bridge_rows"
+        );
+        assert_eq!(case.implementation_status.as_str(), "obligation");
+        assert!(
+            case.deadline_audit_ref
+                .contains("subagent-bridge-terminal-lifetime"),
+            "detached bridge case {} must point at the bridge terminal lifetime gap",
+            case.name
+        );
+        assert!(
+            ["completed", "failed", "cancelled", "timedOut"]
+                .contains(&case.terminal_state.as_str()),
+            "detached bridge case {} must terminalize, not skip",
+            case.name
+        );
+    }
+
+    let queued = lean_recovery_sweep_case("inference_queued_stale_to_cancelled");
+    assert_eq!(queued.pre_state.as_str(), "queued");
+    assert_eq!(queued.terminal_state.as_str(), "cancelled");
+
+    let running = lean_recovery_sweep_case("inference_running_stale_to_failed");
+    assert_eq!(running.pre_state.as_str(), "running");
+    assert_eq!(running.terminal_state.as_str(), "failed");
+
+    let interrupted = lean_recovery_sweep_case("inference_interrupted_parent_to_cancelled");
+    assert_eq!(interrupted.terminal_state.as_str(), "cancelled");
+
+    for case in cases
+        .iter()
+        .filter(|case| case.sweep_id == "inference_call_recover_all_stale_calls")
+    {
+        assert_eq!(case.collection.as_str(), "InferenceCall");
+        assert_eq!(case.rust_function.as_str(), "InferenceCall::recover_all");
+        assert_eq!(case.implementation_status.as_str(), "obligation");
+        assert!(
+            case.deadline_audit_ref.contains("follow-up-6-pr-e"),
+            "InferenceCall recovery case {} must point at deadline audit PR E",
+            case.name
+        );
+        let terminal_row =
+            InferenceCallSlotRow::new("contract-backend", case.terminal_state.as_str());
+        assert_eq!(
+            slot_contribution(terminal_row, "contract-backend"),
+            0,
+            "terminal InferenceCall recovery case {} must release its backend slot",
+            case.name
+        );
+        assert_eq!(
+            reconstructed_running_slot_count([terminal_row], "contract-backend"),
+            0,
+            "terminal InferenceCall recovery case {} must reconstruct zero running slots",
+            case.name
+        );
+    }
 }
 
 #[test]

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -231,6 +231,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_queue_deadline_cases_pin_r4a_contract_rows",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_recovery_sweep_cases_pin_startup_recovery_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",

--- a/docs/superpowers/plans/2026-05-13-recovery-action-enumeration-lean.md
+++ b/docs/superpowers/plans/2026-05-13-recovery-action-enumeration-lean.md
@@ -1,0 +1,219 @@
+# Recovery-Action Enumeration in Lean - Implementation Plan
+
+> Design approved by Jack on 2026-05-13 with one refinement: split the
+> implemented tool-call startup sweep and the detached-bridge recovery
+> obligation into separate registry rows.
+
+**Goal:** Add a Lean-owned recovery-sweep registry that enumerates persisted startup recovery actions, proves each registered sweep drives stale rows to terminal in finite time, and emits conformance vectors for Rust consumers. This closes issue #189 at the model/contract layer and records the missing Rust obligations for deadline audit follow-ups #4 and #6.
+
+**Architecture:** A new `Proofs.Recovery` module owns the contract type, concrete sweep registrations, finite convergence theorems, and conformance cases. Existing request L3 liveness remains unchanged. The conformance JSON gains `recovery_sweep_cases`, and `CoverageLedger` gains `recovery_sweep_cases` entries with implemented consumers or explicit follow-up coverage.
+
+**Non-goals:**
+
+- No Rust production recovery implementation.
+- No edits to `Proofs/Session/Transcript.lean` or `Proofs/Session/State.lean`.
+- No edits under `crates/defra-agent/proofs/tla/`.
+- No full `AgentResponse` streaming lifecycle model beyond startup recovery from `streaming` to `error`.
+- No `AgentConversation` terminalization contract unless Jack changes the approved design.
+
+## Files
+
+Create:
+
+```text
+crates/defra-agent/proofs/Proofs/Recovery/Contract.lean
+crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
+crates/defra-agent/proofs/Proofs/Recovery.lean
+```
+
+Modify:
+
+```text
+crates/defra-agent/proofs/Proofs.lean
+crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+crates/defra-agent/src/lean_vocab_test.rs
+crates/defra-agent/tests/state_machine_conformance.rs
+crates/defra-agent/tests/support/conformance_consumers.rs
+```
+
+The Rust files above are test/conformance harness code only, not production recovery code.
+
+## Task 1: Confirm Approved Design Baseline
+
+- [x] Confirm Jack approves the three design questions:
+  - `InferenceCall` terminal mapping.
+  - `AgentConversation` exclusion from v1.
+  - `Proofs.lean` import placement.
+- [x] Update the design doc status from `Draft pending Jack approval` to `Approved`.
+- [x] Split tool-call recovery into two registry rows:
+  - `tool_call_lifecycle_recover_all_running_calls` with `implemented` status.
+  - `tool_call_lifecycle_recover_detached_bridge_rows` with `obligation` status.
+
+Verification:
+
+```bash
+git diff -- docs/superpowers/specs/2026-05-13-recovery-action-enumeration-lean-design.md
+```
+
+## Task 2: Add Recovery Contract Core
+
+Create `Proofs/Recovery/Contract.lean`.
+
+- [x] Define `RecoveryCadence`, `RecoveryImplementationStatus`, and `PersistedRecoveryCollection`.
+- [x] Define `PersistedRecoveryCollection.toContract`, `.all`, and completeness theorem over `.all`.
+- [x] Define dependent `RecoverySweep`.
+- [x] Define aggregate finite-list measure helpers.
+- [x] Prove generic finite convergence:
+  - single stale row recovery reaches terminal;
+  - recovered stale row measure is zero;
+  - finite list recovery reaches zero aggregate stale measure.
+
+Verification:
+
+```bash
+cd crates/defra-agent/proofs
+lake env lean Proofs/Recovery/Contract.lean
+```
+
+## Task 3: Register Concrete Sweeps
+
+Create `Proofs/Recovery/Sweeps.lean`.
+
+- [x] Request sweep:
+  - row model over `RequestContext`;
+  - stale states `claimed` and `processing`;
+  - terminal mapping to conservative `failed/released`;
+  - theorem tying the row-level terminal result to existing `isTerminal`.
+- [x] Streaming response sweep:
+  - minimal response status enum for `streaming`, `complete`, `error`;
+  - stale `streaming`;
+  - terminal mapping `error`.
+- [x] Tool-call sweep:
+  - row model over `ToolExecution.ToolCallContext` plus recovery cause;
+  - include deadline, parent interrupted, parent terminal, and child terminal bridge causes;
+  - exclude detached bridge rows from this implemented predicate;
+  - prove every actionable running row maps to a terminal tool state;
+- [x] Detached bridge obligation sweep:
+  - row model over `ToolExecution.ToolCallContext` plus detached bridge terminalizing cause;
+  - mark the sweep `RecoveryImplementationStatus.obligation`;
+  - prove detached rows with a terminalizing cause are stale and map to a terminal state;
+  - terminal mapping follows the bridge contract: child completed -> `completed`, child interrupted -> `cancelled`, other child terminal/terminal parent -> `failed`, deadline exceeded -> `timedOut`.
+- [x] Inference-call sweep obligation:
+  - row model over `InferenceCall` plus stale cause;
+  - map stale rows to terminal states per approved design;
+  - prove terminal rows contribute zero backend slots.
+- [x] Define `registeredRecoverySweeps`.
+- [x] Prove `registered_sweeps_cover_persisted_collections`.
+
+Verification:
+
+```bash
+cd crates/defra-agent/proofs
+lake env lean Proofs/Recovery/Sweeps.lean
+```
+
+## Task 4: Emit Conformance Cases
+
+Create `Proofs/Recovery/ContractCases.lean`.
+
+- [x] Define `RecoverySweepCase` rows with stable strings:
+  - sweep id;
+  - collection;
+  - Rust function;
+  - cadence;
+  - implementation status;
+  - pre state;
+  - terminal state;
+  - measure before and after;
+  - deadline audit reference.
+- [x] Emit cases for:
+  - request `claimed` and `processing`;
+  - response `streaming`;
+  - implemented tool sweep: timed out, parent interrupted, parent terminal, child completed, child failed, child interrupted;
+  - detached bridge obligation sweep: detached child completed, detached child failed, detached child interrupted, detached terminal parent, detached deadline exceeded;
+  - inference queued stale, running stale, interrupted-parent stale.
+- [x] Add a theorem that every emitted case corresponds to a registered sweep collection.
+
+Verification:
+
+```bash
+cd crates/defra-agent/proofs
+lake env lean Proofs/Recovery/ContractCases.lean
+```
+
+## Task 5: Wire Lean Imports and JSON
+
+- [x] Add `import Proofs.Recovery` to `Proofs.lean` after `Proofs.Properties.Liveness`.
+- [x] Add `RecoverySweepCase` to `Proofs/Conformance/ContractCases/Types.lean`.
+- [x] Import `Proofs.Recovery.ContractCases` in `Proofs/Conformance/Contracts/Json.lean`.
+- [x] Add `recoverySweepCaseJson`.
+- [x] Add `recovery_sweep_cases` to `snapshotJson`.
+- [x] Add `recovery_sweep_cases` coverage rows in `CoverageLedger.lean`.
+
+Verification:
+
+```bash
+cd crates/defra-agent/proofs
+lake env lean Proofs.lean
+lake env lean --run Proofs/Conformance/Contracts.lean
+```
+
+## Task 6: Update Rust Conformance Harness
+
+No production Rust changes.
+
+- [x] Add `LeanRecoverySweepCase` parsing in `crates/defra-agent/src/lean_vocab_test.rs`.
+- [x] Add accessors for recovery sweep cases.
+- [x] Add a state-machine conformance test that:
+  - asserts all expected sweep ids are present;
+  - asserts `implementation_status = obligation` for missing Rust paths;
+  - asserts detached bridge cases are represented and not marked as skipped;
+  - asserts inference terminal cases reconstruct zero slots when mapped through existing slot-accounting helpers.
+- [x] Register the new test consumer in `tests/support/conformance_consumers.rs`.
+
+Verification:
+
+```bash
+cargo test -p defra-agent state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract
+cargo test -p defra-agent state_machine_conformance::coverage_ledger_domains_are_consumed_or_explicitly_accepted
+```
+
+## Task 7: Full Verification
+
+Run the focused Lean and Rust checks first, then the broader proof command.
+
+```bash
+cd crates/defra-agent/proofs
+lake env lean Proofs.lean
+lake env lean --run Proofs/Conformance/Contracts.lean
+cd ../../..
+cargo test -p defra-agent state_machine_conformance
+cargo test -p defra-agent admission::tests::generated_inference_slot_accounting_cases_match_admission_reconstruction_logic
+```
+
+No `sorry` is allowed:
+
+```bash
+rg -n "sorry|admit" crates/defra-agent/proofs/Proofs/Recovery crates/defra-agent/proofs/Proofs/Conformance
+```
+
+## Task 8: PR
+
+Open PR:
+
+```text
+Add recovery-action enumeration contract in Lean
+```
+
+PR body must include:
+
+- `Closes #189`
+- `Refs #183`
+- `Refs #172`
+- contract type name: `RecoverySweep`;
+- registered sweep instances and finiteness witnesses;
+- deadline audit rows closed or made contractual: stale `InferenceCall` startup sweep and detached subagent bridge terminal lifetime;
+- implementation obligations for PR E and the bridge terminal wiring follow-up.

--- a/docs/superpowers/specs/2026-05-13-recovery-action-enumeration-lean-design.md
+++ b/docs/superpowers/specs/2026-05-13-recovery-action-enumeration-lean-design.md
@@ -1,0 +1,143 @@
+# Recovery-Action Enumeration in Lean - Design
+
+**Status:** Approved
+**Date:** 2026-05-13
+**Tracks:** issue #189; refs #183 and deadline audit #172 follow-ups #4 and #6
+**Scope:** Lean recovery-sweep contract and conformance vectors for persisted startup recovery. No Rust production recovery implementation changes.
+
+## Background
+
+The current L3 theorem, `Proofs/Properties/Liveness.lean` `recovery_convergence`, proves that a finite list of stuck requests reaches terminal request states. It does not enumerate the concrete startup sweeps that Rust runs today:
+
+- `RequestLifecycle::recover_all`
+- streaming `AgentResponse` recovery inside `RequestLifecycle::recover_all`
+- `ToolCallLifecycle::recover_all`
+- the missing `InferenceCall::recover_all` obligation
+
+The 2026-05-13 formal coverage audit ranks this as gap #6 because the model has no closed list of persisted collections that must participate in startup recovery. The 2026-05-12 deadline audit shows the practical failures: stale `InferenceCall.call_state` rows can survive restart, and detached subagent bridge tool rows are skipped by tool-call recovery.
+
+## Brainstorming Decisions
+
+1. **Use a closed registry, not a typeclass.** A typeclass is open-world: adding a new persisted collection without an instance would not necessarily fail a central theorem. The contract should be a finite Lean list plus coverage theorems over a sealed collection enum.
+2. **Put the contract on the recovery sweep/function, not only the collection.** The Rust surface is a sweep entry point with one or more row mappings. `RequestLifecycle::recover_all`, for example, covers request rows and streaming response rows. The registry should name both the Rust sweep and the modeled persisted collection clause.
+3. **Model startup persisted sweeps only.** Live observers such as interrupt polling are not `#189` recovery actions unless they are later promoted to a periodic persisted-row sweep. The v1 cadence is `startup`.
+4. **Missing Rust paths are obligations.** `InferenceCall::recover_all` and detached bridge terminalization are represented as Lean obligations and emitted conformance rows. PR E and the bridge terminal wiring follow-up will satisfy them in Rust later.
+5. **Detached bridge rows are not an allowed skip.** A detached subagent tool row with a terminalizing cause is stale under the contract. The current Rust skip must be made visible as an implementation gap, not encoded as an accepted exception.
+6. **Keep response recovery narrow.** This design models only the recovery clause `AgentResponse.status = streaming -> error`. It does not add the full server-side response lifecycle from follow-up #190.
+7. **Do not model `AgentConversation` in v1.** `recover_stuck_conversations` is operational repair inside `RequestLifecycle::recover_all`, but it is not a terminalizing persisted state machine in the current Lean conformance registry. Adding it would broaden #189 beyond the audit's named recovery gaps.
+8. **Keep implementation status binary by splitting tool-call predicates.** The existing tool-call startup sweep and the missing detached-bridge recovery path are separate registry rows. Each row represents one stale-row predicate, so `RecoveryImplementationStatus` only needs `implemented` and `obligation`.
+
+## Lean Contract Shape
+
+Add a recovery module under `crates/defra-agent/proofs/Proofs/Recovery/`.
+
+The core shape is a dependent record so each sweep can use the row type that already matches its model:
+
+```lean
+inductive RecoveryCadence
+  | startup
+
+inductive RecoveryImplementationStatus
+  | implemented
+  | obligation
+
+inductive PersistedRecoveryCollection
+  | agentRequest
+  | agentResponse
+  | agentToolCall
+  | inferenceCall
+
+structure RecoverySweep where
+  Row : Type
+  collection : PersistedRecoveryCollection
+  sweepId : String
+  rustFunction : String
+  cadence : RecoveryCadence
+  implementationStatus : RecoveryImplementationStatus
+  stale : Row -> Prop
+  recover : Row -> Row
+  terminal : Row -> Prop
+  measure : Row -> Nat
+  h_stale_positive : forall row, stale row -> measure row > 0
+  h_recover_terminal : forall row, stale row -> terminal (recover row)
+  h_recover_zero : forall row, stale row -> measure (recover row) = 0
+```
+
+The aggregate progress measure for a finite sweep input is the sum of row measures. Generic theorems prove:
+
+- recovering one stale row strictly decreases the aggregate measure;
+- mapping `recover` over a finite list drives the aggregate measure to zero;
+- every recovered stale row is terminal under that sweep's `terminal` predicate.
+
+The existing L3 theorem is not weakened. The request instance can cite the same stuck-row shape and terminal mapping that L3 already proves, but the generic recovery registry proves its own finite-list theorem over the registered sweep row.
+
+## Coverage Registry
+
+Add a sealed collection list:
+
+```lean
+def PersistedRecoveryCollection.all : List PersistedRecoveryCollection :=
+  [ .agentRequest, .agentResponse, .agentToolCall, .inferenceCall ]
+```
+
+Add:
+
+```lean
+def registeredRecoverySweeps : List RecoverySweep := [...]
+
+theorem registered_sweeps_cover_persisted_collections :
+  forall c, c in PersistedRecoveryCollection.all ->
+    exists sweep, sweep in registeredRecoverySweeps /\ sweep.collection = c
+```
+
+This is the Lean failure point for "new modeled persisted state machine added, no recovery sweep registered." A future collection must be added to `PersistedRecoveryCollection.all`; the coverage theorem fails until a sweep is registered.
+
+Conformance JSON should add a `recovery_sweep_cases` array. Each row includes:
+
+- `sweep_id`
+- `collection`
+- `rust_function`
+- `cadence`
+- `implementation_status`
+- `pre_state`
+- `terminal_state`
+- `measure_before`
+- `measure_after`
+- `deadline_audit_ref`
+
+Add a `CoverageLedger` category `recovery_sweep_cases`. Implemented Rust sweeps can have concrete consumers now. Missing Rust sweeps should use follow-up coverage pointing at PR E and the bridge terminal wiring follow-up until those PRs implement the obligations.
+
+## Registered Sweeps
+
+| Sweep id | Collection | Rust function | Status | Stale rows | Terminal mapping | Finiteness witness |
+| --- | --- | --- | --- | --- | --- | --- |
+| `request_lifecycle_recover_all_requests` | `AgentRequest` | `RequestLifecycle::recover_all` | implemented | request state `claimed` or `processing` | `failed` in the conservative contract; Rust may map complete response rows to `completed` | count of stuck request rows |
+| `request_lifecycle_recover_all_streaming_responses` | `AgentResponse` | `RequestLifecycle::recover_all` | implemented | response status `streaming` | `error` | count of streaming response rows |
+| `tool_call_lifecycle_recover_all_running_calls` | `AgentToolCall` | `ToolCallLifecycle::recover_all` | implemented | non-detached running tool calls with deadline exceeded, interrupted parent, terminal parent, or terminal child bridge observation | `timedOut`, `cancelled`, `failed`, or `completed` by cause | count of actionable non-detached running tool rows |
+| `tool_call_lifecycle_recover_detached_bridge_rows` | `AgentToolCall` | `ToolCallLifecycle::recover_detached_bridge_rows` | obligation | detached subagent bridge tool row with a terminalizing cause | terminal mapping per bridge contract: child completed -> `completed`, child interrupted -> `cancelled`, other child terminal/terminal parent -> `failed`, deadline exceeded -> `timedOut` | count of stale detached bridge rows |
+| `inference_call_recover_all_stale_calls` | `InferenceCall` | `InferenceCall::recover_all` | obligation | `queued` or `running` calls from dead runtime, terminal parent, interrupted parent, or expired request context | proposed: `queued -> cancelled`; `running -> failed`; interrupted parent -> `cancelled` | count of stale inference-call rows; terminal rows contribute zero slots |
+
+Tool-call recovery treats background subagent rows with no terminalizing cause as not stale. Detached rows with a terminalizing cause are stale under the sibling obligation sweep; they are not filtered out of the modeled contract.
+
+## Import Coordination
+
+Planned Lean files:
+
+```text
+crates/defra-agent/proofs/Proofs/Recovery/Contract.lean
+crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
+crates/defra-agent/proofs/Proofs/Recovery.lean
+```
+
+`Proofs/Recovery/Sweeps.lean` imports `Proofs.Properties.Liveness`, `Proofs.InferenceCall`, `Proofs.ToolExecution`, and `Proofs.Subagent`.
+
+`Proofs.lean` should import `Proofs.Recovery` after `Proofs.Properties.Liveness`. This is the only expected import-list coordination point with the #191 and #188 agents.
+
+`Proofs/Conformance/Contracts/Json.lean` should import `Proofs.Recovery.ContractCases` to emit `recovery_sweep_cases`.
+
+## Approved Questions
+
+1. `InferenceCall` terminal mapping is approved: stale `queued -> cancelled`, stale `running -> failed`, and any interrupted-parent row -> `cancelled`.
+2. `AgentConversation` is excluded from v1 because it is not a terminalizing persisted state machine in the current conformance registry.
+3. `Proofs.lean` may import `Proofs.Recovery` after `Proofs.Properties.Liveness`.


### PR DESCRIPTION
## Summary

Adds a Lean-owned persisted recovery-action contract centered on the dependent `RecoverySweep` record, plus a closed `PersistedRecoveryCollection` registry and `registeredRecoverySweeps` list. The registry proves every modeled persisted recovery collection has a registered startup sweep, and each sweep carries row-level finiteness witnesses via `h_stale_positive`, `h_recover_terminal`, and `h_recover_zero`.

Registered sweep instances:

- `request_lifecycle_recover_all_requests` (`RequestLifecycle::recover_all`, implemented): stale request rows in `claimed` or `processing`; witness is count of stuck request rows; terminal mapping is conservative `failed` / released.
- `request_lifecycle_recover_all_streaming_responses` (`RequestLifecycle::recover_all`, implemented): stale streaming response rows; witness is count of streaming response rows; terminal mapping is `error`.
- `tool_call_lifecycle_recover_all_running_calls` (`ToolCallLifecycle::recover_all`, implemented): actionable non-detached running tool rows; witness is count of such rows; terminal mapping follows deadline, parent, and child-terminal causes.
- `tool_call_lifecycle_recover_detached_bridge_rows` (`ToolCallLifecycle::recover_detached_bridge_rows`, obligation): detached bridge rows with terminalizing causes; witness is count of stale detached bridge rows; terminal mapping follows the bridge contract.
- `inference_call_recover_all_stale_calls` (`InferenceCall::recover_all`, obligation): stale queued/running inference calls; witness is count of stale inference rows; terminal mapping is `queued -> cancelled`, `running -> failed`, interrupted-parent -> `cancelled`, with terminal rows contributing zero backend slots.

Also emits `recovery_sweep_cases` into the Lean conformance JSON and adds a Rust conformance consumer that pins the registered sweep ids, implementation statuses, detached bridge obligation rows, and InferenceCall zero-slot terminal mappings.

## Deadline Audit Coverage

This makes the 2026-05-12 deadline audit gaps contractual:

- Closes the model-level side of ❌ #6: stale `InferenceCall.call_state` startup recovery is now a registered obligation row for deadline audit PR E.
- Closes the model-level side of the ❌ subagent bridge terminal lifetime gap: detached bridge rows are no longer an allowed skip; they are a separate obligation sweep.

Implementation obligations left for follow-up Rust work:

- Deadline audit PR E must implement `InferenceCall::recover_all` against the obligation sweep.
- The bridge terminal wiring follow-up must implement detached bridge row recovery against `tool_call_lifecycle_recover_detached_bridge_rows`.

## Verification

- `lake build Proofs`
- `lake env lean --run Proofs/Conformance/Contracts.lean`
- `cargo test -p defra-agent --test state_machine_conformance`
- `cargo test -p defra-agent admission::tests::generated_inference_slot_accounting_cases_match_admission_reconstruction_logic`
- `cargo fmt --check`
- `rg -n "sorry|admit" crates/defra-agent/proofs/Proofs/Recovery crates/defra-agent/proofs/Proofs/Conformance` (no matches)
- `git diff --cached --check`

Closes #189
Refs #183
Refs #172
