### PR TITLE
Add Lean model for AgentMessage persistence + ordering

### DIFF
--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -9,6 +9,7 @@ import Proofs.Composed
 import Proofs.Fleet
 import Proofs.SessionRecovery
 import Proofs.Session.Properties
+import Proofs.Transcript
 import Proofs.RuntimeReconcile
 import Proofs.PairingReconcile
 import Proofs.Triggers

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
@@ -5,6 +5,7 @@ import Proofs.Conformance.ContractCases.BoundaryRuntime
 import Proofs.Conformance.ContractCases.LifecycleTransitions
 import Proofs.Conformance.ContractCases.LiveOverlay
 import Proofs.Conformance.ContractCases.QueueDeadline
+import Proofs.Conformance.ContractCases.Transcript
 
 /-!
 # Finite Conformance Witness Cases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Transcript.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Transcript.lean
@@ -1,0 +1,37 @@
+import Proofs.Conformance.ContractCases.Types
+import Proofs.Transcript.Executable
+
+/-!
+# Transcript Conformance Cases
+
+Projection from the transcript proof model's executable witness rows into the
+shared conformance contract namespace.
+-/
+
+namespace Conformance.ContractCases
+
+def transcriptCaseFromModel (witness : Transcript.TranscriptCase) : TranscriptCase :=
+  { name := witness.name
+  , group := witness.group
+  , action := witness.action
+  , legal := witness.legal
+  , preMessageCount := witness.preMessageCount
+  , postMessageCount := witness.postMessageCount
+  , preToolCallCount := witness.preToolCallCount
+  , postToolCallCount := witness.postToolCallCount
+  , preInFlightCount := witness.preInFlightCount
+  , postInFlightCount := witness.postInFlightCount
+  , assistantSequence := witness.assistantSequence
+  , resultSequence := witness.resultSequence
+  , logicalResultId := witness.logicalResultId
+  , payloadHash := witness.payloadHash
+  , expectedPairClosed := witness.expectedPairClosed
+  , expectedOrdered := witness.expectedOrdered
+  , expectedDuplicateReusedSequence := witness.expectedDuplicateReusedSequence
+  , expectedStrongDrain := witness.expectedStrongDrain
+  }
+
+def transcriptConformanceCases : List TranscriptCase :=
+  Transcript.transcriptConformanceCases.map transcriptCaseFromModel
+
+end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -215,6 +215,27 @@ structure RecoverySweepCase where
   deadlineAuditRef : String
   deriving DecidableEq, Repr
 
+structure TranscriptCase where
+  name : String
+  group : String
+  action : String
+  legal : Bool
+  preMessageCount : Nat
+  postMessageCount : Nat
+  preToolCallCount : Nat
+  postToolCallCount : Nat
+  preInFlightCount : Nat
+  postInFlightCount : Nat
+  assistantSequence : Nat
+  resultSequence : Nat
+  logicalResultId : Nat
+  payloadHash : Nat
+  expectedPairClosed : Bool
+  expectedOrdered : Bool
+  expectedDuplicateReusedSequence : Bool
+  expectedStrongDrain : Bool
+  deriving Repr
+
 def boolString (value : Bool) : String :=
   if value then "true" else "false"
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -375,6 +375,29 @@ def recoverySweepCaseJson (witness : RecoverySweepCase) : String :=
       ++ jsonString witness.deadlineAuditRef
     ++ "}"
 
+def transcriptCaseJson (witness : TranscriptCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"group\":" ++ jsonString witness.group ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"legal\":" ++ boolString witness.legal ++ ","
+    ++ "\"pre_message_count\":" ++ toString witness.preMessageCount ++ ","
+    ++ "\"post_message_count\":" ++ toString witness.postMessageCount ++ ","
+    ++ "\"pre_tool_call_count\":" ++ toString witness.preToolCallCount ++ ","
+    ++ "\"post_tool_call_count\":" ++ toString witness.postToolCallCount ++ ","
+    ++ "\"pre_in_flight_count\":" ++ toString witness.preInFlightCount ++ ","
+    ++ "\"post_in_flight_count\":" ++ toString witness.postInFlightCount ++ ","
+    ++ "\"assistant_sequence\":" ++ toString witness.assistantSequence ++ ","
+    ++ "\"result_sequence\":" ++ toString witness.resultSequence ++ ","
+    ++ "\"logical_result_id\":" ++ toString witness.logicalResultId ++ ","
+    ++ "\"payload_hash\":" ++ toString witness.payloadHash ++ ","
+    ++ "\"expected_pair_closed\":" ++ boolString witness.expectedPairClosed ++ ","
+    ++ "\"expected_ordered\":" ++ boolString witness.expectedOrdered ++ ","
+    ++ "\"expected_duplicate_reused_sequence\":"
+      ++ boolString witness.expectedDuplicateReusedSequence ++ ","
+    ++ "\"expected_strong_drain\":" ++ boolString witness.expectedStrongDrain
+    ++ "}"
+
 def snapshotJson : String :=
   "{"
     ++ "\"generated_by\":\"lake env lean --run Proofs/Conformance/Contracts.lean\","
@@ -442,6 +465,9 @@ def snapshotJson : String :=
     ++ "\"recovery_sweep_cases\":"
       ++ jsonArray
         (Recovery.recoverySweepCases.map recoverySweepCaseJson) ++ ","
+    ++ "\"transcript_conformance_cases\":"
+      ++ jsonArray
+        (transcriptConformanceCases.map transcriptCaseJson) ++ ","
     ++ "\"follow_up_hooks\":[],"
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -284,6 +284,10 @@ def caseCoverage : List CoverageEntry :=
       "RecoverySweepCases"
       "state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract"
       "Deadline audit PR E must implement InferenceCall::recover_all; the bridge terminal wiring follow-up must implement detached bridge row recovery."
+  , consumerCoverage
+      "transcript_cases"
+      "TranscriptConformanceCases"
+      "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract"
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/proofs/Proofs/Transcript.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript.lean
@@ -1,0 +1,12 @@
+import Proofs.Transcript.State
+import Proofs.Transcript.Transition
+import Proofs.Transcript.Properties
+import Proofs.Transcript.Dedupe
+import Proofs.Transcript.Executable
+
+/-!
+# Transcript Model
+
+Barrel import for the AgentMessage / AgentToolCall transcript persistence and
+ordering model.
+-/

--- a/crates/defra-agent/proofs/Proofs/Transcript/Dedupe.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript/Dedupe.lean
@@ -1,0 +1,48 @@
+import Proofs.Transcript.Properties
+
+/-!
+# Transcript Tool-Result Dedupe Properties
+
+The #160 dedupe contract: a stable `(session, logical result id, payload hash)`
+key materializes at most one durable tool-result message row.
+-/
+
+namespace Transcript
+
+theorem duplicate_tool_result_observation_noops
+    {pre post : TranscriptState} {key : ToolResultKey}
+    (_h_seen : pre.hasToolResultKey key = true)
+    (h_post : post = pre) :
+    post = pre := h_post
+
+theorem dedupe_exactly_one_row_per_key
+    {s : TranscriptState} {key : ToolResultKey}
+    (h_coherent : s.Coherent)
+    (call : ToolCallRow)
+    (h_mem : call ∈ s.toolCalls)
+    (h_completed : call.state = .completed)
+    (h_key : call.resultKey = some key) :
+    s.toolResultMessageCount key = 1 :=
+  completed_tool_has_exactly_one_result_message
+    h_coherent h_mem h_completed h_key
+
+theorem distinct_tool_result_keys_append_distinct_rows
+    (s : TranscriptState)
+    (messageId₁ messageId₂ : MessageId)
+    (callId₁ callId₂ : ToolExecution.ToolCallId)
+    (key₁ key₂ : ToolResultKey)
+    (_h_distinct : key₁ ≠ key₂) :
+    (s.appendUserMessage messageId₁ (.toolResult callId₁ key₁)).messages.length + 1 =
+      (TranscriptState.appendUserMessage
+        (s.appendUserMessage messageId₁ (.toolResult callId₁ key₁))
+        messageId₂
+        (.toolResult callId₂ key₂)).messages.length := by
+  simp [TranscriptState.appendUserMessage]
+
+theorem toolResultKey_session_scoped
+    {left right : ToolResultKey}
+    (h_eq : left = right) :
+    left.sessionId = right.sessionId := by
+  rw [h_eq]
+
+end Transcript

--- a/crates/defra-agent/proofs/Proofs/Transcript/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript/Executable.lean
@@ -1,0 +1,154 @@
+import Proofs.Transcript.Dedupe
+
+/-!
+# Transcript Executable Conformance Rows
+
+Finite witness rows for Rust conformance tests. These are case rows, not a
+phase-machine table, because transcript correctness is cross-row.
+-/
+
+namespace Transcript
+
+structure TranscriptCase where
+  name : String
+  group : String
+  action : String
+  legal : Bool
+  preMessageCount : Nat
+  postMessageCount : Nat
+  preToolCallCount : Nat
+  postToolCallCount : Nat
+  preInFlightCount : Nat
+  postInFlightCount : Nat
+  assistantSequence : Sequence
+  resultSequence : Sequence
+  logicalResultId : LogicalResultId
+  payloadHash : PayloadHash
+  expectedPairClosed : Bool
+  expectedOrdered : Bool
+  expectedDuplicateReusedSequence : Bool
+  expectedStrongDrain : Bool
+  deriving Repr
+
+def orderingUserAssistantToolResultCase : TranscriptCase :=
+  { name := "ordering_user_assistant_tool_result"
+  , group := "ordering"
+  , action := "append_user_begin_tool_persist_assistant_complete_result"
+  , legal := true
+  , preMessageCount := 0
+  , postMessageCount := 3
+  , preToolCallCount := 0
+  , postToolCallCount := 1
+  , preInFlightCount := 0
+  , postInFlightCount := 0
+  , assistantSequence := 2
+  , resultSequence := 3
+  , logicalResultId := 10
+  , payloadHash := 20
+  , expectedPairClosed := true
+  , expectedOrdered := true
+  , expectedDuplicateReusedSequence := false
+  , expectedStrongDrain := true
+  }
+
+def dedupeDuplicateReusesSequenceCase : TranscriptCase :=
+  { name := "dedupe_duplicate_reuses_sequence"
+  , group := "dedupe"
+  , action := "observe_duplicate_tool_result"
+  , legal := true
+  , preMessageCount := 3
+  , postMessageCount := 3
+  , preToolCallCount := 1
+  , postToolCallCount := 1
+  , preInFlightCount := 0
+  , postInFlightCount := 0
+  , assistantSequence := 2
+  , resultSequence := 3
+  , logicalResultId := 10
+  , payloadHash := 20
+  , expectedPairClosed := true
+  , expectedOrdered := true
+  , expectedDuplicateReusedSequence := true
+  , expectedStrongDrain := true
+  }
+
+def distinctResultIdsAppendDistinctRowsCase : TranscriptCase :=
+  { name := "distinct_result_ids_append_distinct_rows"
+  , group := "dedupe"
+  , action := "append_distinct_tool_result"
+  , legal := true
+  , preMessageCount := 1
+  , postMessageCount := 2
+  , preToolCallCount := 0
+  , postToolCallCount := 0
+  , preInFlightCount := 0
+  , postInFlightCount := 0
+  , assistantSequence := 0
+  , resultSequence := 2
+  , logicalResultId := 11
+  , payloadHash := 20
+  , expectedPairClosed := true
+  , expectedOrdered := true
+  , expectedDuplicateReusedSequence := false
+  , expectedStrongDrain := true
+  }
+
+def completedToolPairClosedCase : TranscriptCase :=
+  { orderingUserAssistantToolResultCase with
+    name := "completed_tool_pair_closed"
+  , group := "pairing"
+  , action := "complete_tool_with_result"
+  }
+
+def explicitDrainTerminalizesOwnershipCase : TranscriptCase :=
+  { name := "explicit_drain_terminalizes_ownership"
+  , group := "hook_boundary"
+  , action := "cancel_fail_or_timeout_in_flight"
+  , legal := true
+  , preMessageCount := 1
+  , postMessageCount := 1
+  , preToolCallCount := 1
+  , postToolCallCount := 1
+  , preInFlightCount := 1
+  , postInFlightCount := 0
+  , assistantSequence := 1
+  , resultSequence := 0
+  , logicalResultId := 0
+  , payloadHash := 0
+  , expectedPairClosed := true
+  , expectedOrdered := true
+  , expectedDuplicateReusedSequence := false
+  , expectedStrongDrain := true
+  }
+
+def dropAbandonNotStrongDrainCase : TranscriptCase :=
+  { name := "drop_abandon_not_strong_drain"
+  , group := "hook_boundary"
+  , action := "abandon_hook_ownership"
+  , legal := true
+  , preMessageCount := 0
+  , postMessageCount := 0
+  , preToolCallCount := 1
+  , postToolCallCount := 1
+  , preInFlightCount := 1
+  , postInFlightCount := 0
+  , assistantSequence := 0
+  , resultSequence := 0
+  , logicalResultId := 0
+  , payloadHash := 0
+  , expectedPairClosed := false
+  , expectedOrdered := true
+  , expectedDuplicateReusedSequence := false
+  , expectedStrongDrain := false
+  }
+
+def transcriptConformanceCases : List TranscriptCase :=
+  [ orderingUserAssistantToolResultCase
+  , dedupeDuplicateReusesSequenceCase
+  , distinctResultIdsAppendDistinctRowsCase
+  , completedToolPairClosedCase
+  , explicitDrainTerminalizesOwnershipCase
+  , dropAbandonNotStrongDrainCase
+  ]
+
+end Transcript

--- a/crates/defra-agent/proofs/Proofs/Transcript/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript/Properties.lean
@@ -1,0 +1,141 @@
+import Proofs.Transcript.Transition
+
+/-!
+# Transcript Properties
+
+Local invariant theorems over the transcript transition vocabulary.
+-/
+
+namespace Transcript
+
+theorem append_preserves_ordered
+    {pre post : TranscriptState}
+    (h_step : Transition pre post)
+    (h_append : ∃ messageId h_pre h_post_eq h_post_coherent,
+      h_step = Transition.append_user
+        (messageId := messageId)
+        h_pre h_post_eq h_post_coherent) :
+    post.OrderedBySequence := by
+  rcases h_append with ⟨messageId, h_pre, h_post_eq, h_post_coherent, h_eq⟩
+  subst h_eq
+  exact h_post_coherent.ordered
+
+theorem append_user_advances_nextSeq
+    (s : TranscriptState) (messageId : MessageId) (kind : MessageKind) :
+    (s.appendUserMessage messageId kind).nextSeq = s.nextSeq + 1 := by
+  rfl
+
+theorem begin_assistant_tool_call_advances_or_reuses_assistant_sequence
+    (s : TranscriptState) (callId : ToolExecution.ToolCallId) :
+    (s.beginAssistantToolCall callId).nextSeq =
+      match s.assistantTurn with
+      | some _ => s.nextSeq
+      | none => s.nextSeq + 1 := by
+  cases h_turn : s.assistantTurn <;>
+    simp [TranscriptState.beginAssistantToolCall, h_turn]
+
+theorem tool_call_reserves_assistant_sequence
+    {pre post : TranscriptState} {callId : ToolExecution.ToolCallId}
+    (_h_post : post = pre.beginAssistantToolCall callId)
+    (h_coherent : post.Coherent) :
+    ∀ call, call ∈ post.toolCalls → call.callId = callId →
+      post.ReservedByPersistedMessage call ∨ post.ReservedByAssistantTurn call := by
+  intro call h_mem _
+  exact h_coherent.toolCallReservedByMessage call h_mem
+
+theorem persist_assistant_closes_reserved_tool_call_sequence
+    {pre post : TranscriptState} {messageId : MessageId} {turn : AssistantTurn}
+    (_h_turn : pre.assistantTurn = some turn)
+    (h_post : post = pre.persistAssistantMessage messageId turn)
+    (callId : ToolExecution.ToolCallId)
+    (h_call : callId ∈ turn.callIds) :
+    ∃ row, row ∈ post.messages ∧
+      row.reservesToolCall callId turn.sessionId turn.sequence := by
+  subst post
+  refine ⟨
+    { messageId := messageId
+    , sessionId := turn.sessionId
+    , sequence := turn.sequence
+    , role := .assistant
+    , kind := .assistantToolCalls turn.callIds }, ?_, ?_⟩
+  · simp [TranscriptState.persistAssistantMessage]
+  · simp [MessageRow.reservesToolCall, MessageKind.referencesToolCall, h_call]
+
+theorem complete_tool_with_result_preserves_coherent
+    {pre post : TranscriptState}
+    (h_step : Transition pre post)
+    (h_complete : ∃ callId messageId key h_pre h_in h_missing h_post_eq h_post_coherent,
+      h_step = Transition.complete_tool_with_result
+        (callId := callId)
+        (messageId := messageId)
+        (key := key)
+        h_pre h_in h_missing h_post_eq h_post_coherent) :
+    post.Coherent := by
+  rcases h_complete with
+    ⟨callId, messageId, key, h_pre, h_in, h_missing, h_post_eq, h_post_coherent, h_eq⟩
+  subst h_eq
+  exact h_post_coherent
+
+theorem completed_tool_has_exactly_one_result_message
+    {s : TranscriptState} {call : ToolCallRow} {key : ToolResultKey}
+    (h_coherent : s.Coherent)
+    (h_mem : call ∈ s.toolCalls)
+    (h_completed : call.state = .completed)
+    (h_key : call.resultKey = some key) :
+    s.toolResultMessageCount key = 1 :=
+  h_coherent.pairClosed.2.1 call h_mem h_completed key h_key
+
+theorem tool_result_message_has_completed_tool_call
+    {s : TranscriptState} {row : MessageRow}
+    {callId : ToolExecution.ToolCallId} {key : ToolResultKey}
+    (h_coherent : s.Coherent)
+    (h_mem : row ∈ s.messages)
+    (h_kind : row.kind = .toolResult callId key) :
+    ∃ call, call ∈ s.toolCalls ∧
+      call.callId = callId ∧
+      call.state = .completed ∧
+      call.resultKey = some key :=
+  h_coherent.pairClosed.2.2 row h_mem callId key h_kind
+
+theorem explicit_inflight_drain_removes_ownership
+    (s : TranscriptState)
+    (callId : ToolExecution.ToolCallId)
+    (terminal : ToolExecution.ToolCallState) :
+    callId ∉ (s.terminalizeInFlight callId terminal).inFlight := by
+  simp [TranscriptState.terminalizeInFlight]
+
+def abandonWitnessKey : ToolResultKey :=
+  { sessionId := 0, logicalResultId := 0, payloadHash := 0 }
+
+def abandonWitnessToolCall : ToolCallRow :=
+  { sessionId := 0
+  , callId := 1
+  , messageSequence := 0
+  , state := .running
+  , resultKey := none
+  }
+
+def abandonWitnessPre : TranscriptState :=
+  { sessionId := 0
+  , nextSeq := 1
+  , messages := []
+  , toolCalls := [abandonWitnessToolCall]
+  , inFlight := insert 1 ∅
+  , assistantTurn := none
+  }
+
+def abandonWitnessPost : TranscriptState :=
+  abandonWitnessPre.abandonHookOwnership
+
+theorem abandon_hook_ownership_not_strong_drain :
+    Transition abandonWitnessPre abandonWitnessPost ∧
+      ¬ abandonWitnessPost.StrongDrain := by
+  constructor
+  · exact Transition.abandon_hook_ownership rfl
+  · intro h_strong
+    have h_not_running :=
+      h_strong abandonWitnessToolCall
+        (by simp [abandonWitnessPost, TranscriptState.abandonHookOwnership, abandonWitnessPre])
+    exact h_not_running rfl
+
+end Transcript

--- a/crates/defra-agent/proofs/Proofs/Transcript/State.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript/State.lean
@@ -1,0 +1,349 @@
+import Proofs.Basic
+import Proofs.ToolExecution.State
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Transcript State
+
+Durable transcript vocabulary for one session. This model abstracts over
+`AgentMessage` and `AgentToolCall` rows, preserving only the fields needed for
+ordering, tool-result dedupe, and pair closure.
+-/
+
+namespace Transcript
+
+abbrev Sequence := Nat
+abbrev MessageId := Nat
+abbrev LogicalResultId := Nat
+abbrev PayloadHash := Nat
+
+/-- Abstract version of #160's stable tool-result message key inputs. -/
+structure ToolResultKey where
+  sessionId : SessionId
+  logicalResultId : LogicalResultId
+  payloadHash : PayloadHash
+  deriving DecidableEq, Repr
+
+inductive MessageRole where
+  | user
+  | assistant
+  deriving DecidableEq, Repr
+
+namespace MessageRole
+
+def toDefraDB : MessageRole → String
+  | .user => "user"
+  | .assistant => "assistant"
+
+def fromDefraDB? : String → Option MessageRole
+  | "user" => some .user
+  | "assistant" => some .assistant
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (role : MessageRole) :
+    fromDefraDB? role.toDefraDB = some role := by
+  cases role <;> rfl
+
+end MessageRole
+
+/-- Transcript-relevant shape of a persisted message. -/
+inductive MessageKind where
+  | ordinary
+  | assistantToolCalls (callIds : Finset ToolExecution.ToolCallId)
+  | toolResult (callId : ToolExecution.ToolCallId) (key : ToolResultKey)
+  deriving DecidableEq
+
+namespace MessageKind
+
+def referencesToolCall (kind : MessageKind) (callId : ToolExecution.ToolCallId) : Prop :=
+  match kind with
+  | .assistantToolCalls callIds => callId ∈ callIds
+  | .toolResult resultCallId _ => resultCallId = callId
+  | .ordinary => False
+
+instance (kind : MessageKind) (callId : ToolExecution.ToolCallId) :
+    Decidable (kind.referencesToolCall callId) := by
+  unfold referencesToolCall
+  cases kind <;> infer_instance
+
+def toolResultKey? : MessageKind → Option ToolResultKey
+  | .toolResult _ key => some key
+  | _ => none
+
+end MessageKind
+
+structure MessageRow where
+  messageId : MessageId
+  sessionId : SessionId
+  sequence : Sequence
+  role : MessageRole
+  kind : MessageKind
+  deriving DecidableEq
+
+namespace MessageRow
+
+def isToolResultFor (row : MessageRow) (key : ToolResultKey) : Bool :=
+  row.kind.toolResultKey? = some key
+
+def reservesToolCall (row : MessageRow) (call : ToolExecution.ToolCallId)
+    (sessionId : SessionId) (sequence : Sequence) : Prop :=
+  row.sessionId = sessionId ∧
+    row.sequence = sequence ∧
+    row.role = .assistant ∧
+    row.kind.referencesToolCall call
+
+instance (row : MessageRow) (call : ToolExecution.ToolCallId)
+    (sessionId : SessionId) (sequence : Sequence) :
+    Decidable (row.reservesToolCall call sessionId sequence) := by
+  unfold reservesToolCall
+  infer_instance
+
+end MessageRow
+
+structure ToolCallRow where
+  sessionId : SessionId
+  callId : ToolExecution.ToolCallId
+  messageSequence : Sequence
+  state : ToolExecution.ToolCallState
+  resultKey : Option ToolResultKey
+  deriving DecidableEq, Repr
+
+namespace ToolCallRow
+
+def isCompleted (row : ToolCallRow) : Prop :=
+  row.state = .completed
+
+instance (row : ToolCallRow) : Decidable row.isCompleted := by
+  unfold isCompleted
+  infer_instance
+
+end ToolCallRow
+
+/-- The runtime can reserve an assistant message sequence before persisting the
+assistant `AgentMessage`; this mirrors `TranscriptTurnState::AssistantBuilding`.
+-/
+structure AssistantTurn where
+  sessionId : SessionId
+  sequence : Sequence
+  callIds : Finset ToolExecution.ToolCallId
+  deriving DecidableEq
+
+namespace AssistantTurn
+
+def reservesToolCall (turn : AssistantTurn) (call : ToolCallRow) : Prop :=
+  turn.sessionId = call.sessionId ∧
+    turn.sequence = call.messageSequence ∧
+    call.callId ∈ turn.callIds
+
+instance (turn : AssistantTurn) (call : ToolCallRow) :
+    Decidable (turn.reservesToolCall call) := by
+  unfold reservesToolCall
+  infer_instance
+
+end AssistantTurn
+
+structure TranscriptState where
+  sessionId : SessionId
+  nextSeq : Sequence
+  messages : List MessageRow
+  toolCalls : List ToolCallRow
+  inFlight : Finset ToolExecution.ToolCallId
+  assistantTurn : Option AssistantTurn
+  deriving DecidableEq
+
+def StrictlyIncreasingMessages : List MessageRow → Prop
+  | [] => True
+  | row :: rest =>
+      (∀ other, other ∈ rest → row.sequence < other.sequence) ∧
+        StrictlyIncreasingMessages rest
+
+def UniqueMessageSequences : List MessageRow → Prop
+  | [] => True
+  | row :: rest =>
+      (∀ other, other ∈ rest → row.sequence ≠ other.sequence) ∧
+        UniqueMessageSequences rest
+
+def UniqueToolCallIds : List ToolCallRow → Prop
+  | [] => True
+  | row :: rest =>
+      (∀ other, other ∈ rest → row.callId ≠ other.callId) ∧
+        UniqueToolCallIds rest
+
+def UniqueToolResultKeys : List MessageRow → Prop
+  | [] => True
+  | row :: rest =>
+      (∀ key, row.isToolResultFor key = true →
+        ∀ other, other ∈ rest → other.isToolResultFor key = false) ∧
+        UniqueToolResultKeys rest
+
+namespace TranscriptState
+
+def messageCount (s : TranscriptState) : Nat :=
+  s.messages.length
+
+def toolCallCount (s : TranscriptState) : Nat :=
+  s.toolCalls.length
+
+def hasToolResultKey (s : TranscriptState) (key : ToolResultKey) : Bool :=
+  s.messages.any (fun row => row.isToolResultFor key)
+
+def toolResultMessageCount (s : TranscriptState) (key : ToolResultKey) : Nat :=
+  (s.messages.filter (fun row => row.isToolResultFor key)).length
+
+def toolCallById? (s : TranscriptState) (callId : ToolExecution.ToolCallId) :
+    Option ToolCallRow :=
+  s.toolCalls.find? (fun row => row.callId = callId)
+
+def MessageSequencesUnique (s : TranscriptState) : Prop :=
+  UniqueMessageSequences s.messages
+
+def ToolCallIdsUnique (s : TranscriptState) : Prop :=
+  UniqueToolCallIds s.toolCalls
+
+def ToolResultKeysUnique (s : TranscriptState) : Prop :=
+  UniqueToolResultKeys s.messages
+
+def OrderedBySequence (s : TranscriptState) : Prop :=
+  StrictlyIncreasingMessages s.messages
+
+def NextSeqAboveRows (s : TranscriptState) : Prop :=
+  (∀ row, row ∈ s.messages → row.sequence < s.nextSeq) ∧
+    (∀ call, call ∈ s.toolCalls → call.messageSequence < s.nextSeq)
+
+def ReservedByPersistedMessage (s : TranscriptState) (call : ToolCallRow) : Prop :=
+  ∃ row, row ∈ s.messages ∧
+    row.reservesToolCall call.callId call.sessionId call.messageSequence
+
+def ReservedByAssistantTurn (s : TranscriptState) (call : ToolCallRow) : Prop :=
+  ∃ turn, s.assistantTurn = some turn ∧ turn.reservesToolCall call
+
+def ToolCallReservedByMessage (s : TranscriptState) : Prop :=
+  ∀ call, call ∈ s.toolCalls →
+    ReservedByPersistedMessage s call ∨ ReservedByAssistantTurn s call
+
+def CompletedToolCallsPaired (s : TranscriptState) : Prop :=
+  ∀ call, call ∈ s.toolCalls →
+    call.state = .completed →
+      ∀ key, call.resultKey = some key →
+        s.toolResultMessageCount key = 1
+
+def ToolResultMessagesPaired (s : TranscriptState) : Prop :=
+  ∀ row, row ∈ s.messages →
+    ∀ callId key, row.kind = .toolResult callId key →
+      ∃ call, call ∈ s.toolCalls ∧
+        call.callId = callId ∧
+        call.state = .completed ∧
+        call.resultKey = some key
+
+def PairClosed (s : TranscriptState) : Prop :=
+  s.ToolCallReservedByMessage ∧
+    s.CompletedToolCallsPaired ∧
+    s.ToolResultMessagesPaired
+
+/-- "Strong drain" is the stronger hook-drop property that current Rust does
+not implement: no durable row remains running. -/
+def StrongDrain (s : TranscriptState) : Prop :=
+  ∀ call, call ∈ s.toolCalls → call.state ≠ .running
+
+structure Coherent (s : TranscriptState) : Prop where
+  ordered : s.OrderedBySequence
+  messageSequencesUnique : s.MessageSequencesUnique
+  toolCallIdsUnique : s.ToolCallIdsUnique
+  toolResultKeysUnique : s.ToolResultKeysUnique
+  nextSeqAboveRows : s.NextSeqAboveRows
+  toolCallReservedByMessage : s.ToolCallReservedByMessage
+  pairClosed : s.PairClosed
+
+def RetainsPairs (_pre post : TranscriptState) : Prop :=
+  post.PairClosed ∧ post.OrderedBySequence
+
+def replaceToolCall
+    (rows : List ToolCallRow)
+    (callId : ToolExecution.ToolCallId)
+    (f : ToolCallRow → ToolCallRow) : List ToolCallRow :=
+  rows.map fun row => if row.callId = callId then f row else row
+
+def appendUserMessage (s : TranscriptState) (messageId : MessageId)
+    (kind : MessageKind := .ordinary) : TranscriptState :=
+  { s with
+    nextSeq := s.nextSeq + 1
+    messages := s.messages ++
+      [{ messageId := messageId
+       , sessionId := s.sessionId
+       , sequence := s.nextSeq
+       , role := .user
+       , kind := kind }]
+    assistantTurn := none
+  }
+
+def beginAssistantToolCall (s : TranscriptState)
+    (callId : ToolExecution.ToolCallId) : TranscriptState :=
+  let sequence :=
+    match s.assistantTurn with
+    | some turn => turn.sequence
+    | none => s.nextSeq
+  let turn :=
+    match s.assistantTurn with
+    | some existing => { existing with callIds := insert callId existing.callIds }
+    | none =>
+        { sessionId := s.sessionId
+        , sequence := sequence
+        , callIds := insert callId ∅
+        }
+  { s with
+    nextSeq := match s.assistantTurn with | some _ => s.nextSeq | none => s.nextSeq + 1
+    toolCalls := s.toolCalls ++
+      [{ sessionId := s.sessionId
+       , callId := callId
+       , messageSequence := sequence
+       , state := .running
+       , resultKey := none }]
+    inFlight := insert callId s.inFlight
+    assistantTurn := some turn
+  }
+
+def persistAssistantMessage (s : TranscriptState) (messageId : MessageId)
+    (turn : AssistantTurn) : TranscriptState :=
+  { s with
+    messages := s.messages ++
+      [{ messageId := messageId
+       , sessionId := turn.sessionId
+       , sequence := turn.sequence
+       , role := .assistant
+       , kind := .assistantToolCalls turn.callIds }]
+    assistantTurn := none
+  }
+
+def completeToolWithResult (s : TranscriptState)
+    (callId : ToolExecution.ToolCallId)
+    (messageId : MessageId)
+    (key : ToolResultKey) : TranscriptState :=
+  { s with
+    nextSeq := s.nextSeq + 1
+    messages := s.messages ++
+      [{ messageId := messageId
+       , sessionId := s.sessionId
+       , sequence := s.nextSeq
+       , role := .user
+       , kind := .toolResult callId key }]
+    toolCalls := replaceToolCall s.toolCalls callId
+      (fun row => { row with state := .completed, resultKey := some key })
+    inFlight := s.inFlight.erase callId
+    assistantTurn := none
+  }
+
+def terminalizeInFlight (s : TranscriptState)
+    (callId : ToolExecution.ToolCallId)
+    (terminal : ToolExecution.ToolCallState) : TranscriptState :=
+  { s with
+    toolCalls := replaceToolCall s.toolCalls callId
+      (fun row => { row with state := terminal })
+    inFlight := s.inFlight.erase callId
+  }
+
+def abandonHookOwnership (s : TranscriptState) : TranscriptState :=
+  { s with inFlight := ∅ }
+
+end TranscriptState
+
+end Transcript

--- a/crates/defra-agent/proofs/Proofs/Transcript/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/Transcript/Transition.lean
@@ -1,0 +1,74 @@
+import Proofs.Transcript.State
+
+/-!
+# Transcript Transitions
+
+Relational successful-path transitions for transcript persistence. Complex
+cross-row transitions carry their post-state coherence as an invariant guard;
+storage success/failure remains modeled by `StorageObservation`.
+-/
+
+namespace Transcript
+
+inductive Transition : TranscriptState → TranscriptState → Prop where
+  | append_user {pre post : TranscriptState} {messageId : MessageId} :
+      pre.Coherent →
+      post = pre.appendUserMessage messageId .ordinary →
+      post.Coherent →
+      Transition pre post
+  | begin_assistant_tool_call {pre post : TranscriptState}
+      {callId : ToolExecution.ToolCallId} :
+      pre.Coherent →
+      callId ∉ pre.inFlight →
+      pre.toolCallById? callId = none →
+      post = pre.beginAssistantToolCall callId →
+      post.Coherent →
+      Transition pre post
+  | persist_assistant {pre post : TranscriptState}
+      {messageId : MessageId} {turn : AssistantTurn} :
+      pre.Coherent →
+      pre.assistantTurn = some turn →
+      post = pre.persistAssistantMessage messageId turn →
+      post.Coherent →
+      Transition pre post
+  | complete_tool_with_result {pre post : TranscriptState}
+      {callId : ToolExecution.ToolCallId} {messageId : MessageId} {key : ToolResultKey} :
+      pre.Coherent →
+      callId ∈ pre.inFlight →
+      pre.hasToolResultKey key = false →
+      post = pre.completeToolWithResult callId messageId key →
+      post.Coherent →
+      Transition pre post
+  | observe_duplicate_tool_result {pre post : TranscriptState} {key : ToolResultKey} :
+      pre.hasToolResultKey key = true →
+      post = pre →
+      Transition pre post
+  | append_distinct_tool_result {pre post : TranscriptState}
+      {callId : ToolExecution.ToolCallId} {messageId : MessageId} {key : ToolResultKey} :
+      pre.Coherent →
+      pre.hasToolResultKey key = false →
+      post = pre.appendUserMessage messageId (.toolResult callId key) →
+      post.Coherent →
+      Transition pre post
+  | cancel_in_flight {pre post : TranscriptState} {callId : ToolExecution.ToolCallId} :
+      callId ∈ pre.inFlight →
+      post = pre.terminalizeInFlight callId .cancelled →
+      Transition pre post
+  | fail_in_flight {pre post : TranscriptState} {callId : ToolExecution.ToolCallId} :
+      callId ∈ pre.inFlight →
+      post = pre.terminalizeInFlight callId .failed →
+      Transition pre post
+  | timeout_in_flight {pre post : TranscriptState} {callId : ToolExecution.ToolCallId} :
+      callId ∈ pre.inFlight →
+      post = pre.terminalizeInFlight callId .timedOut →
+      Transition pre post
+  | abandon_hook_ownership {pre post : TranscriptState} :
+      post = pre.abandonHookOwnership →
+      Transition pre post
+
+inductive Trace : TranscriptState → TranscriptState → Prop where
+  | refl {s : TranscriptState} : Trace s s
+  | step {s₁ s₂ s₃ : TranscriptState} :
+      Transition s₁ s₂ → Trace s₂ s₃ → Trace s₁ s₃
+
+end Transcript

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -55,6 +55,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) live_overlay_cases: Vec<LeanLiveOverlayCase>,
     pub(crate) queue_deadline_conformance_cases: Vec<LeanQueueDeadlineConformanceCase>,
     pub(crate) recovery_sweep_cases: Vec<LeanRecoverySweepCase>,
+    pub(crate) transcript_conformance_cases: Vec<LeanTranscriptCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
 }
@@ -544,6 +545,28 @@ pub(crate) struct LeanRecoverySweepCase {
     pub(crate) deadline_audit_ref: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanTranscriptCase {
+    pub(crate) name: String,
+    pub(crate) group: String,
+    pub(crate) action: String,
+    pub(crate) legal: bool,
+    pub(crate) pre_message_count: usize,
+    pub(crate) post_message_count: usize,
+    pub(crate) pre_tool_call_count: usize,
+    pub(crate) post_tool_call_count: usize,
+    pub(crate) pre_in_flight_count: usize,
+    pub(crate) post_in_flight_count: usize,
+    pub(crate) assistant_sequence: usize,
+    pub(crate) result_sequence: usize,
+    pub(crate) logical_result_id: usize,
+    pub(crate) payload_hash: usize,
+    pub(crate) expected_pair_closed: bool,
+    pub(crate) expected_ordered: bool,
+    pub(crate) expected_duplicate_reused_sequence: bool,
+    pub(crate) expected_strong_drain: bool,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -707,6 +730,18 @@ pub(crate) fn lean_recovery_sweep_case(name: &str) -> &'static LeanRecoverySweep
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean recovery sweep case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_transcript_cases() -> &'static [LeanTranscriptCase] {
+    &lean_contract_snapshot().transcript_conformance_cases
+}
+
+pub(crate) fn lean_transcript_case(name: &str) -> &'static LeanTranscriptCase {
+    lean_contract_snapshot()
+        .transcript_conformance_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean transcript case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_tool_retry_case(name: &str) -> &'static LeanToolRetryCase {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -24,8 +24,8 @@ use lean_vocab_test::{
     lean_inference_slot_accounting_case, lean_queue_deadline_case, lean_queue_deadline_cases,
     lean_recovery_sweep_case, lean_recovery_sweep_cases, lean_request_transition_cases,
     lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
-    lean_tool_preflight_case, lean_tool_retry_case, lean_vocabulary_values,
-    LeanLifecycleTransitionCase,
+    lean_tool_preflight_case, lean_tool_retry_case, lean_transcript_case, lean_transcript_cases,
+    lean_vocabulary_values, LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -215,6 +215,7 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);
     assert_eq!(lean_recovery_sweep_cases().len(), 17);
+    assert_eq!(lean_transcript_cases().len(), 6);
 }
 
 #[test]
@@ -506,6 +507,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "RecoverySweepCases".to_string(),
         ));
     }
+    if !lean_transcript_cases().is_empty() {
+        emitted.insert((
+            "transcript_cases".to_string(),
+            "TranscriptConformanceCases".to_string(),
+        ));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -532,6 +539,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "live_overlay_cases",
         "queue_deadline_cases",
         "recovery_sweep_cases",
+        "transcript_cases",
         "follow_up_hook",
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();
@@ -742,6 +750,87 @@ fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
             reconstructed_running_slot_count([terminal_row], "contract-backend"),
             0,
             "terminal InferenceCall recovery case {} must reconstruct zero running slots",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn generated_transcript_cases_pin_agent_message_ordering_contract() {
+    let cases = lean_transcript_cases();
+    assert_eq!(cases.len(), 6);
+
+    let names = cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        [
+            "ordering_user_assistant_tool_result",
+            "dedupe_duplicate_reuses_sequence",
+            "distinct_result_ids_append_distinct_rows",
+            "completed_tool_pair_closed",
+            "explicit_drain_terminalizes_ownership",
+            "drop_abandon_not_strong_drain",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+    );
+
+    let ordering = lean_transcript_case("ordering_user_assistant_tool_result");
+    assert!(ordering.legal);
+    assert_eq!(ordering.group.as_str(), "ordering");
+    assert_eq!(ordering.pre_message_count, 0);
+    assert_eq!(ordering.post_message_count, 3);
+    assert_eq!(ordering.pre_tool_call_count, 0);
+    assert_eq!(ordering.post_tool_call_count, 1);
+    assert_eq!(ordering.assistant_sequence, 2);
+    assert_eq!(ordering.result_sequence, 3);
+    assert!(ordering.expected_ordered);
+    assert!(ordering.expected_pair_closed);
+
+    let dedupe = lean_transcript_case("dedupe_duplicate_reuses_sequence");
+    assert_eq!(dedupe.group.as_str(), "dedupe");
+    assert_eq!(dedupe.action.as_str(), "observe_duplicate_tool_result");
+    assert_eq!(dedupe.pre_message_count, dedupe.post_message_count);
+    assert_eq!(dedupe.pre_tool_call_count, dedupe.post_tool_call_count);
+    assert_eq!(dedupe.logical_result_id, ordering.logical_result_id);
+    assert_eq!(dedupe.payload_hash, ordering.payload_hash);
+    assert!(dedupe.expected_duplicate_reused_sequence);
+    assert_eq!(dedupe.result_sequence, ordering.result_sequence);
+
+    let distinct = lean_transcript_case("distinct_result_ids_append_distinct_rows");
+    assert_eq!(distinct.group.as_str(), "dedupe");
+    assert_eq!(distinct.payload_hash, ordering.payload_hash);
+    assert_ne!(distinct.logical_result_id, ordering.logical_result_id);
+    assert_eq!(distinct.pre_message_count + 1, distinct.post_message_count);
+    assert!(!distinct.expected_duplicate_reused_sequence);
+
+    let pair = lean_transcript_case("completed_tool_pair_closed");
+    assert_eq!(pair.group.as_str(), "pairing");
+    assert!(pair.expected_pair_closed);
+    assert!(pair.expected_ordered);
+
+    let drain = lean_transcript_case("explicit_drain_terminalizes_ownership");
+    assert_eq!(drain.group.as_str(), "hook_boundary");
+    assert_eq!(drain.pre_in_flight_count, 1);
+    assert_eq!(drain.post_in_flight_count, 0);
+    assert!(drain.expected_strong_drain);
+
+    let abandon = lean_transcript_case("drop_abandon_not_strong_drain");
+    assert_eq!(abandon.group.as_str(), "hook_boundary");
+    assert_eq!(abandon.action.as_str(), "abandon_hook_ownership");
+    assert_eq!(abandon.pre_in_flight_count, 1);
+    assert_eq!(abandon.post_in_flight_count, 0);
+    assert!(!abandon.expected_strong_drain);
+    assert!(!abandon.expected_pair_closed);
+
+    for case in cases {
+        assert!(case.legal, "transcript case {} should be legal", case.name);
+        assert!(
+            case.expected_ordered,
+            "transcript case {} should preserve ordering",
             case.name
         );
     }

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -238,6 +238,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_recovery_sweep_cases_pin_startup_recovery_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_transcript_cases_pin_agent_message_ordering_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",

--- a/docs/superpowers/plans/2026-05-13-agent-message-persistence-lean.md
+++ b/docs/superpowers/plans/2026-05-13-agent-message-persistence-lean.md
@@ -1,0 +1,354 @@
+# AgentMessage Persistence + Ordering Lean Implementation Plan
+
+**Status:** Plan
+**Date:** 2026-05-13
+**Issue:** #191
+**Approved design:** `docs/superpowers/specs/2026-05-13-agent-message-persistence-lean-design.md`
+**Scope:** Lean proof modules plus generated conformance vectors and Rust test consumers. No production Rust changes.
+
+## Summary
+
+Create `Proofs/Transcript/` as the durable transcript model for one session. The model owns cross-row coherence between `AgentMessage` and `AgentToolCall`: sequence ordering, assistant-turn reservation, completed tool-call/result-message pairing, #160 tool-result dedupe, and the explicit hook drain vs destructor-abandon boundary.
+
+Conformance is emitted as case rows, not a finite phase machine, because the important obligations are cross-row predicates over small row sets.
+
+## File footprint
+
+Lean:
+
+- `crates/defra-agent/proofs/Proofs/Transcript.lean`
+- `crates/defra-agent/proofs/Proofs/Transcript/State.lean`
+- `crates/defra-agent/proofs/Proofs/Transcript/Transition.lean`
+- `crates/defra-agent/proofs/Proofs/Transcript/Dedupe.lean`
+- `crates/defra-agent/proofs/Proofs/Transcript/Properties.lean`
+- `crates/defra-agent/proofs/Proofs/Transcript/Executable.lean`
+- `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean`
+- `crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean`
+- `crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean`
+- `crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Transcript.lean`
+- `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean`
+- `crates/defra-agent/proofs/Proofs.lean`
+
+Rust tests/support only:
+
+- `crates/defra-agent/src/lean_vocab_test.rs`
+- `crates/defra-agent/tests/state_machine_conformance.rs`
+- `crates/defra-agent/tests/support/conformance_consumers.rs`
+
+Docs:
+
+- This plan.
+
+## Task 1: Add Transcript Lean skeleton
+
+Create the module directory and barrel files:
+
+- `Proofs/Transcript.lean`
+- `Proofs/Transcript/State.lean`
+- `Proofs/Transcript/Transition.lean`
+- `Proofs/Transcript/Dedupe.lean`
+- `Proofs/Transcript/Properties.lean`
+- `Proofs/Transcript/Executable.lean`
+
+Register `import Proofs.Transcript` in `Proofs.lean`.
+
+Initial verification:
+
+```bash
+cd crates/defra-agent/proofs
+lake build Proofs.Transcript
+```
+
+Expected: skeleton builds, no theorem bodies yet except trivial `rfl` round-trips if added.
+
+## Task 2: Define transcript state vocabulary
+
+In `State.lean`, define:
+
+- `Sequence`, `MessageId`, `LogicalResultId`, `PayloadHash`.
+- `ToolResultKey` with `sessionId`, `logicalResultId`, `payloadHash`.
+- `MessageRole.user | assistant`, with `toDefraDB` / `fromDefraDB?` round-trip theorem.
+- `MessageKind.ordinary | assistantToolCalls (callIds : Finset ToolExecution.ToolCallId) | toolResult (callId key)`.
+- `MessageRow`, `ToolCallRow`, `AssistantTurn`, `TranscriptState`.
+
+Implementation detail from the approved design: add `TranscriptState.assistantTurn : Option AssistantTurn` so the model can represent `TranscriptTurnState::AssistantBuilding` without weakening `ToolCallReservedByMessage`.
+
+Local helpers:
+
+- `MessageRow.isToolResultFor`
+- `ToolCallRow.isCompleted`
+- `TranscriptState.messageCount`
+- `TranscriptState.toolCallCount`
+- `TranscriptState.hasToolResultKey`
+- `TranscriptState.toolResultMessageCount`
+- `TranscriptState.toolCallById?`
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.State
+```
+
+## Task 3: Define coherence predicates
+
+Still in `State.lean`, define decidable predicates/functions:
+
+- `StrictlyIncreasingMessages`
+- `MessageSequencesUnique`
+- `ToolCallIdsUnique`
+- `ToolResultKeysUnique`
+- `NextSeqAboveRows`
+- `ToolCallReservedByMessage`
+- `CompletedToolCallsPaired`
+- `ToolResultMessagesPaired`
+- `PairClosed`
+- `OrderedBySequence`
+- `Coherent`
+- `RetainsPairs pre post`
+
+Keep definitions recursive/list-based where possible. Avoid needing a sort theorem: the model stores `messages` in append/read order, and `OrderedBySequence` states that this list is strictly increasing by `sequence`.
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.State
+```
+
+## Task 4: Add transcript transitions
+
+In `Transition.lean`, define relational transitions:
+
+- `append_user`
+- `begin_assistant_tool_call`
+- `persist_assistant`
+- `complete_tool_with_result`
+- `observe_duplicate_tool_result`
+- `append_distinct_tool_result`
+- `cancel_in_flight`
+- `fail_in_flight`
+- `timeout_in_flight`
+- `abandon_hook_ownership`
+
+The successful `complete_tool_with_result` transition updates the tool-call row to `.completed`, attaches `resultKey? = some key`, appends the user tool-result message, removes the call from `inFlight`, and advances `nextSeq`.
+
+`abandon_hook_ownership` clears in-memory ownership only. It must not change durable `ToolCallRow.state`.
+
+Add `Trace` in the same style as the existing session/tool execution models.
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.Transition
+```
+
+## Task 5: Prove ordering and reservation properties
+
+In `Properties.lean`, prove:
+
+- `append_preserves_ordered`
+- `tool_call_reserves_assistant_sequence`
+- `persist_assistant_closes_reserved_tool_call_sequence`
+- `append_user_advances_nextSeq`
+- `begin_assistant_tool_call_advances_or_reuses_assistant_sequence`
+
+Use helper lemmas for append-preserves-strict-increasing and membership in appended singleton lists.
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.Properties
+```
+
+## Task 6: Prove pair-closure properties
+
+In `Properties.lean`, prove:
+
+- `complete_tool_with_result_preserves_coherent`
+- `completed_tool_has_exactly_one_result_message`
+- `tool_result_message_has_completed_tool_call`
+- `explicit_inflight_drain_removes_ownership`
+- `abandon_hook_ownership_not_strong_drain`
+
+The negative hook theorem should be concrete: construct or state a pre/post where `inFlight` is cleared but a durable row remains `.running`, showing strong drain does not follow from destructor ownership clearing.
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.Properties
+```
+
+## Task 7: Prove #160 dedupe properties
+
+In `Dedupe.lean`, prove:
+
+- `duplicate_tool_result_observation_noops`
+- `dedupe_exactly_one_row_per_key`
+- `distinct_tool_result_keys_append_distinct_rows`
+- `toolResultKey_session_scoped`
+
+The model treats `PayloadHash` as an abstract stable value. Do not model FNV/hash correctness.
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.Dedupe
+```
+
+## Task 8: Add executable conformance case rows
+
+In `Executable.lean`, define a small case-row type and finite row list for:
+
+- `ordering_user_assistant_tool_result`
+- `dedupe_duplicate_reuses_sequence`
+- `distinct_result_ids_append_distinct_rows`
+- `completed_tool_pair_closed`
+- `explicit_drain_terminalizes_ownership`
+- `drop_abandon_not_strong_drain`
+
+Each row should include enough fields for Rust to assert behavior without reimplementing Lean:
+
+- case name and group
+- action name
+- legal/expected classification
+- pre/post message count
+- pre/post tool-call count
+- pre/post in-flight count
+- relevant sequence numbers
+- relevant result-key id/hash ids
+- expected `pair_closed`
+- expected `ordered`
+- expected `duplicate_reused_sequence`
+- expected `strong_drain`
+
+Verification:
+
+```bash
+lake build Proofs.Transcript.Executable
+```
+
+## Task 9: Register conformance JSON
+
+Add `TranscriptCase` to `Proofs/Conformance/ContractCases/Types.lean`.
+
+Create `Proofs/Conformance/ContractCases/Transcript.lean` that imports `Proofs.Transcript.Executable` and exposes `transcriptConformanceCases`.
+
+Update:
+
+- `Proofs/Conformance/ContractCases.lean`
+- `Proofs/Conformance/Contracts/Json.lean`
+- `Proofs/Conformance/CoverageLedger.lean`
+
+JSON field:
+
+```json
+"transcript_conformance_cases": [...]
+```
+
+Coverage ledger consumer:
+
+```text
+state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract
+```
+
+Verification:
+
+```bash
+lake build Proofs.Conformance.Contracts
+lake env lean --run Proofs/Conformance/Contracts.lean > /tmp/defra-agent-contracts.json
+```
+
+Expected: JSON parses and includes `transcript_conformance_cases`.
+
+## Task 10: Add Rust deserialization and consumer tests
+
+In `lean_vocab_test.rs`, add:
+
+- `transcript_conformance_cases: Vec<LeanTranscriptCase>`
+- `LeanTranscriptCase` struct
+- helper `lean_transcript_cases()`
+
+In `state_machine_conformance.rs`, add:
+
+- `generated_transcript_cases_pin_agent_message_ordering_contract`
+
+The test should:
+
+- consume all generated transcript rows,
+- assert expected case count and case names,
+- map the #160 dedupe row to the existing hook/session behavior shape,
+- assert pair-closure/ordering fields from Lean,
+- assert the destructor boundary row has `expected_strong_drain = false`.
+
+This is a conformance consumer test, not a new production-path implementation.
+
+Verification:
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance generated_transcript_cases_pin_agent_message_ordering_contract -- --nocapture
+```
+
+## Task 11: Register Rust conformance consumer
+
+Update `tests/support/conformance_consumers.rs` with the new consumer id and make sure the registry test sees it.
+
+Verification:
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance lean_boundary_metadata_is_typed_and_reviewable -- --nocapture
+```
+
+## Task 12: Run focused runtime regression tests
+
+Run the existing hook tests that correspond to the generated transcript rows:
+
+```bash
+cargo test -p defra-agent duplicate_tool_result_message_observation_reuses_transcript_row -- --nocapture
+cargo test -p defra-agent tool_result_message_dedupe_preserves_distinct_result_ids -- --nocapture
+cargo test -p defra-agent tool_call_after_saved_assistant_starts_new_turn_without_orphan_result -- --nocapture
+```
+
+Expected: all pass without production Rust edits.
+
+## Task 13: Full verification
+
+Run:
+
+```bash
+cd crates/defra-agent/proofs
+lake build Proofs.Transcript
+lake build Proofs.Conformance.Contracts
+grep -R "sorry" -n Proofs/Transcript Proofs/Conformance/ContractCases/Transcript.lean
+cd ../../..
+cargo test -p defra-agent --test state_machine_conformance -- --nocapture
+cargo fmt --all -- --check
+git diff --check
+```
+
+Expected:
+
+- no `sorry`,
+- Lean builds,
+- conformance test passes,
+- formatting/diff checks pass.
+
+## Task 14: PR
+
+Open PR:
+
+```text
+Add Lean model for AgentMessage persistence + ordering
+```
+
+PR body must include:
+
+- `Closes #191`
+- `Refs #183`
+- `Refs #160`
+- `Refs #184`
+- `Refs #190`
+- Audit verdict moved from Open to Modeled for AgentMessage persistence + ordering.
+- Named theorems proved.
+- Generated conformance vectors registered.
+- Exclusion: hook destructor does not satisfy strong drain; explicit drain transitions do. The negative theorem `abandon_hook_ownership_not_strong_drain` records the current boundary. A future runtime change to terminalize on `Drop` can replace it with a positive theorem.
+
+Report the PR URL back in the thread.

--- a/docs/superpowers/specs/2026-05-13-agent-message-persistence-lean-design.md
+++ b/docs/superpowers/specs/2026-05-13-agent-message-persistence-lean-design.md
@@ -1,0 +1,184 @@
+# AgentMessage Persistence + Ordering Lean Design
+
+**Status:** Design
+**Date:** 2026-05-13
+**Tracks:** issue #191; parent #183; motivating bug #160; downstream consumers #184 and #190.
+**Scope:** Lean-only transcript state machine and generated conformance vectors for the Rust runtime. No production Rust behavior changes.
+
+## 1. Goal
+
+Add a new Lean module, `Proofs/Transcript/`, that models the durable transcript contract for one session: `AgentMessage` rows, `AgentToolCall` rows, their shared ordering vocabulary, tool-result message dedupe by `message_key`, and the coherent-state obligations that compaction and streaming response models will consume.
+
+The model closes the audit's top gap: storage observation currently proves whether a mutation succeeded or failed, but not whether the resulting transcript is ordered and coherent across message rows and tool-call rows.
+
+## 2. Why now
+
+The #160 fix made tool-result transcript persistence idempotent by deriving a stable `AgentMessage.message_key` from `(session_id, logical result id, payload hash)` and upserting through that key. That bug class was an ordering bug: duplicate observations could materialize duplicate user-role tool-result messages and shift later sequence assumptions.
+
+The same transcript vocabulary is needed by:
+
+- #184 compaction, which must not retain or delete only one half of a tool-call/tool-result pair.
+- #190 streaming response lifecycle, which needs stable final-message ordering.
+- R4 subagent tooling, which reads `AgentToolCall` and `AgentMessage` as one transcript surface.
+
+## 3. Verified obligations
+
+| ID | Source | Obligation | Where it lands |
+|---|---|---|---|
+| #191-A | issue #191 acceptance | Tool-call/message-pair atomicity for coherent transcript states: completed native tool calls have exactly one paired tool-result message, and each durable tool-result message points back to a completed tool call when it is runtime-owned. | `Proofs/Transcript/Properties.lean`; conformance case in `state_machine_conformance.rs`. |
+| #191-B | issue #191 acceptance | Append-order monotonicity within a session: durable messages and tool-call reserved message sequences are read in total sequence order. | `Proofs/Transcript/Properties.lean`; generated ordering cases. |
+| #191-C | issue #191 + #160 | Tool-result dedupe: repeated observations with the same `(session, logical result id, payload hash)` resolve to exactly one durable user tool-result message row. | `Proofs/Transcript/Dedupe.lean`; generated #160 regression vector. |
+| #191-D | issue #191 hook-drop clause | Hook in-flight drain semantics. Current Rust `Drop` clears in-memory ownership and intentionally leaves durable `running` rows for startup recovery. The stronger "committed or removed on drop" property is not true today. | Design-level boundary and derived requirement; explicit drain transitions (`cancel_in_flight`, `fail_in_flight`, timeout sweep) are modeled, destructor `Drop` is not claimed to satisfy stronger drain semantics. |
+| #184 handoff | issue #184 | Compaction must preserve pair closure and retained-window ordering. | Exposed predicates: `Coherent`, `PairClosed`, `OrderedBySequence`, `RetainsPairs`. |
+| #190 handoff | issue #190 | Streaming response terminal rows can rely on stable transcript sequence vocabulary. | Exposed `Sequence` and message-order predicates; no response-state model here. |
+
+## 4. Model
+
+### 4.1 Module placement
+
+Use a new directory:
+
+```text
+crates/defra-agent/proofs/Proofs/Transcript/
+  State.lean
+  Transition.lean
+  Dedupe.lean
+  Properties.lean
+  Executable.lean
+```
+
+and a barrel:
+
+```text
+crates/defra-agent/proofs/Proofs/Transcript.lean
+```
+
+This is not an extension of `Proofs/Session/`: the existing session model is a request queue model, while this proof owns cross-row transcript coherence between `AgentMessage` and `AgentToolCall`.
+
+### 4.2 Abstract vocabulary
+
+Lean abstracts over runtime strings with small opaque natural identifiers:
+
+- `MessageId`, `ToolCallId`, `LogicalResultId`, and `PayloadHash`.
+- `Sequence := Nat`, matching persisted `AgentMessage.sequence` and `AgentToolCall.message_sequence`.
+- `ToolResultKey := SessionId × LogicalResultId × PayloadHash`, matching #160's stable message-key input.
+
+Rows:
+
+```lean
+inductive MessageRole
+  | user
+  | assistant
+
+inductive MessageKind
+  | ordinary
+  | assistantToolCall (callId : ToolCallId)
+  | toolResult (callId : ToolCallId) (key : ToolResultKey)
+
+structure MessageRow where
+  sessionId : SessionId
+  sequence : Sequence
+  role : MessageRole
+  kind : MessageKind
+
+structure ToolCallRow where
+  sessionId : SessionId
+  callId : ToolCallId
+  messageSequence : Sequence
+  state : ToolExecution.ToolCallState
+  resultKey? : Option ToolResultKey
+
+structure TranscriptState where
+  sessionId : SessionId
+  nextSeq : Sequence
+  messages : List MessageRow
+  toolCalls : List ToolCallRow
+  inFlight : Finset ToolCallId
+```
+
+The model imports `Proofs.Basic` and `Proofs.ToolExecution.State` for `SessionId` and persisted tool-call state vocabulary. It does not import `Proofs.Session`, `Proofs.Subagent`, or `Proofs.Composed`; those modules can consume transcript predicates later.
+
+### 4.3 State predicates
+
+Core predicates:
+
+- `MessageSequencesUnique s`: no two messages in a session share a sequence.
+- `ToolCallIdsUnique s`: no two tool-call rows in a session share `callId`.
+- `ToolResultKeysUnique s`: no two durable tool-result messages share `ToolResultKey`.
+- `OrderedBySequence s`: message reads sorted by `sequence` form the transcript order.
+- `ToolCallReservedByMessage s`: each `ToolCallRow.messageSequence` is reserved by an assistant tool-call message with the same call id, or by an assistant-building transition before the message is persisted.
+- `CompletedToolCallsPaired s`: every completed native tool call with `resultKey? = some key` has exactly one user tool-result message carrying `key`.
+- `ToolResultMessagesPaired s`: every runtime-owned user tool-result message has a completed tool-call row with the same call id and key.
+- `Coherent s`: conjunction of uniqueness, ordering, reservation, pair closure, and `nextSeq` monotonicity.
+
+The assistant-building exception matches `TranscriptTurnState::AssistantBuilding`: a tool-call row can reserve a future assistant message sequence before the assistant `AgentMessage` is persisted. The completed-pair predicate is only required after the result-message append transition succeeds.
+
+## 5. Transitions
+
+The relational model has one-session transitions:
+
+- `appendUser`: append an ordinary user message, reset assistant turn.
+- `beginAssistantToolCall`: reserve a new assistant sequence and create a running `AgentToolCall`.
+- `persistAssistant`: persist the assistant message for the reserved sequence.
+- `completeToolWithResult`: terminalize a running native tool call and append the paired tool-result message as one abstract successful transcript step.
+- `observeDuplicateToolResult`: no-op when the same `ToolResultKey` already has a durable message.
+- `appendDistinctToolResult`: append when the key differs.
+- `cancelInFlight`, `failInFlight`, `timeoutInFlight`: explicit drain transitions for hook paths that call lifecycle terminalizers.
+- `abandonHookOwnership`: clear `inFlight` ownership without changing durable rows. This models the current destructor boundary and is deliberately excluded from `Coherent` preservation unless recovery later terminalizes the row.
+
+The abstract `completeToolWithResult` transition represents the successful hook path after both the `AgentToolCall` completion mutation and `AgentMessage` tool-result mutation have succeeded. Physical cross-row transaction atomicity is not claimed; storage failure behavior stays under `StorageObservation` and hook failure policy tests.
+
+## 6. Properties
+
+Minimum theorems:
+
+- `append_preserves_ordered`
+- `tool_call_reserves_assistant_sequence`
+- `persist_assistant_closes_reserved_tool_call_sequence`
+- `complete_tool_with_result_preserves_coherent`
+- `completed_tool_has_exactly_one_result_message`
+- `tool_result_message_has_completed_tool_call`
+- `duplicate_tool_result_observation_noops`
+- `dedupe_exactly_one_row_per_key`
+- `distinct_tool_result_keys_append_distinct_rows`
+- `explicit_inflight_drain_removes_ownership`
+- `abandon_hook_ownership_not_strong_drain`
+
+The last theorem is intentionally negative/documentary: it states that clearing `inFlight` alone does not imply terminalized durable rows. That gives #191 a precise statement of the runtime gap instead of weakening the transcript invariant.
+
+## 7. Conformance vectors
+
+Extend `Proofs.Conformance.Contracts` with transcript cases:
+
+- `transcript_ordering_cases`: user → assistant tool-call → tool-result sequence shape.
+- `transcript_dedupe_cases`: #160 duplicate result observation reuses the first sequence.
+- `transcript_distinct_result_cases`: same payload with different logical result ids stays distinct.
+- `transcript_pairing_cases`: completed tool call paired with exactly one user tool-result message.
+- `transcript_hook_boundary_cases`: explicit drain is terminal/ownership-clearing; destructor abandon is reported as a boundary, not a strong drain proof.
+
+Rust consumer:
+
+- Add deserialization fields in `crates/defra-agent/src/lean_vocab_test.rs`.
+- Add `state_machine_conformance.rs` tests that consume the generated rows and compare them against existing runtime behavior using the hook/session APIs and direct DefraDB queries.
+- Register consumers in `tests/support/conformance_consumers.rs` and coverage ledger entries in Lean.
+
+## 8. Derived requirements
+
+- #184 must use `RetainsPairs`/`Coherent` rather than re-inventing transcript ordering.
+- #190 should use `Sequence` and `OrderedBySequence` to tie final response materialization to transcript order.
+- A follow-up should decide whether hook `Drop` should synchronously terminalize/remove durable running tool rows. Current code explicitly leaves them for startup recovery, so #191 cannot honestly prove "drop commits or removes every in-flight row" without a Rust behavior change.
+- If the runtime wants true cross-row atomicity for `AgentToolCall` completion plus tool-result `AgentMessage`, it needs a transactional write path or a recovery/repair path for fail-open partial completion. This issue models the successful transcript contract and names the boundary.
+
+## 9. Out of scope
+
+- Production Rust changes.
+- DefraDB transaction semantics or proof of physical cross-collection atomicity.
+- Compaction strategy proofs. #184 consumes this module.
+- AgentResponse streaming lifecycle. #190 consumes this module.
+- Subagent parent/child bridge correctness beyond using existing `ToolExecution.ToolCallState` vocabulary.
+- Hash-function correctness for the #160 key. Lean treats `PayloadHash` as an abstract stable value supplied by the runtime.
+
+## 10. Open questions
+
+- Whether to make the hook destructor boundary a separate follow-up issue or attach it to #191's PR body as a deferred exclusion.
+- Whether the conformance emitter should expose transcript cases as a standalone `transcript_conformance_cases` array or as a `Transcript` state-machine contract plus richer case rows. The implementation plan should prefer richer case rows, because the important checks are cross-row predicates rather than a small finite phase graph.


### PR DESCRIPTION
## Verdict

Moves the formal coverage audit row for AgentMessage persistence + ordering from ❌ Open to ✓ Modeled.

Closes #191
Refs #183
Refs #160
Refs #184
Refs #190

## What changed

- Added `Proofs/Transcript/` as a standalone transcript model rather than extending the existing session queue model.
- Modeled the durable transcript surface: `AgentMessage` rows, `AgentToolCall` rows, assistant-turn sequence reservation, tool-result keys, pair closure, ordering, and explicit hook drain semantics.
- Added generated transcript conformance case rows and Rust consumers under `state_machine_conformance.rs`.
- Registered `TranscriptConformanceCases` in the Lean coverage ledger and Rust consumer registry.
- Wrote the approved design spec and implementation plan under `docs/superpowers/`.

## Proved theorems

Core ordering/reservation/pairing:

- `append_preserves_ordered`
- `append_user_advances_nextSeq`
- `begin_assistant_tool_call_advances_or_reuses_assistant_sequence`
- `tool_call_reserves_assistant_sequence`
- `persist_assistant_closes_reserved_tool_call_sequence`
- `complete_tool_with_result_preserves_coherent`
- `completed_tool_has_exactly_one_result_message`
- `tool_result_message_has_completed_tool_call`
- `explicit_inflight_drain_removes_ownership`
- `abandon_hook_ownership_not_strong_drain`

#160 dedupe:

- `duplicate_tool_result_observation_noops`
- `dedupe_exactly_one_row_per_key`
- `distinct_tool_result_keys_append_distinct_rows`
- `toolResultKey_session_scoped`

## Conformance vectors

Registered `transcript_conformance_cases` with six rows:

- `ordering_user_assistant_tool_result`
- `dedupe_duplicate_reuses_sequence`
- `distinct_result_ids_append_distinct_rows`
- `completed_tool_pair_closed`
- `explicit_drain_terminalizes_ownership`
- `drop_abandon_not_strong_drain`

Rust consumer:

- `state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract`

## Exclusions

Hook destructor does not satisfy strong drain; explicit drain transitions (`cancel`/`fail`/`timeout`) do. This is captured in `abandon_hook_ownership_not_strong_drain`. A future runtime change to terminalize on `Drop` would let us replace the negative theorem with the stronger positive.

Still out of scope here: production Rust changes, physical DefraDB cross-row transaction semantics, compaction strategy proofs (#184 consumes this vocabulary), AgentResponse streaming lifecycle (#190 consumes this vocabulary), and hash-function correctness for the abstract `PayloadHash`.

## Verification

- `lake build Proofs.Transcript`
- `lake build Proofs.Conformance.Contracts`
- `lake build Proofs`
- `cargo test -p defra-agent --test state_machine_conformance generated_transcript_cases_pin_agent_message_ordering_contract -- --nocapture`
- `cargo test -p defra-agent --test state_machine_conformance -- --nocapture`
- `cargo test -p defra-agent --lib tool_result_message -- --nocapture`
- `cargo test -p defra-agent --lib tool_call_after_saved_assistant_starts_new_turn_without_orphan_result -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "\\bsorry\\b" Proofs/Transcript Proofs/Conformance/ContractCases/Transcript.lean` returned no matches
