### PR TITLE
Add MCP health probe / eviction state machine in Lean

### DIFF
--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -17,6 +17,7 @@ import Proofs.Client
 import Proofs.ClientShell
 import Proofs.CommandPolicy
 import Proofs.ToolExecution
+import Proofs.MCPHealth
 import Proofs.Subagent
 import Proofs.Properties.Safety
 import Proofs.Properties.Decidable

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -3,6 +3,7 @@ import Proofs.Conformance.Triggers.Contracts
 import Proofs.Conformance.ClientShell.Contracts
 import Proofs.ApplyReconcile.ContractCases
 import Proofs.ToolExecution
+import Proofs.MCPHealth.Executable
 import Proofs.Conformance.Deviations
 import Proofs.CommandPolicy.Cases
 import Proofs.Conformance.CoverageLedger
@@ -235,6 +236,24 @@ def toolRetryCaseJson (witness : ToolExecution.RetryCase) : String :=
     ++ "\"idempotency\":" ++ jsonString witness.idempotency.toDefraDB ++ ","
     ++ "\"failure_class\":" ++ jsonString witness.failure.toDefraDB ++ ","
     ++ "\"disposition\":" ++ jsonString witness.disposition.toDefraDB
+    ++ "}"
+
+def mcpHealthCaseJson (witness : Proofs.MCPHealth.TransitionCase) : String :=
+  let nextCountStr : String :=
+    match witness.nextCount with
+    | none => "null"
+    | some n => toString n
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"start_state\":" ++ jsonString witness.startState.toDefraDB ++ ","
+    ++ "\"start_count\":" ++ toString witness.startCount ++ ","
+    ++ "\"event\":" ++ jsonString witness.event.toDefraDB ++ ","
+    ++ "\"threshold_k\":" ++ toString witness.thresholdK ++ ","
+    ++ "\"next_state\":"
+      ++ jsonOptionalString
+          (witness.nextState.map Proofs.MCPHealth.HealthState.toDefraDB) ++ ","
+    ++ "\"next_count\":" ++ nextCountStr ++ ","
+    ++ "\"rust_projection\":" ++ jsonOptionalString witness.rustProjection
     ++ "}"
 
 def jsonStringMatrix (values : List (List String)) : String :=
@@ -470,6 +489,9 @@ def snapshotJson : String :=
     ++ "\"transcript_conformance_cases\":"
       ++ jsonArray
         (transcriptConformanceCases.map transcriptCaseJson) ++ ","
+    ++ "\"mcp_health_cases\":"
+      ++ jsonArray
+        (Proofs.MCPHealth.transitionCases.map mcpHealthCaseJson) ++ ","
     ++ "\"follow_up_hooks\":[],"
     ++ "\"event_delivery_transition_case_count\":"
       ++ toString Conformance.EventDelivery.transitionCaseCount ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -175,10 +175,6 @@ def stateMachineCoverage : List CoverageEntry :=
       "state_machine"
       "ToolCall"
       "tool_call_lifecycle::tests::tool_call_state_machine_contract_is_complete"
-  , consumerCoverage
-      "state_machine"
-      "MCPHealth"
-      "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
   , followUpCoverage
       "state_machine"
       "AwaitMode"
@@ -304,6 +300,10 @@ def caseCoverage : List CoverageEntry :=
       "event_delivery_cases"
       "EventDeliveryConvergenceTraces"
       "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation"
+  , consumerCoverage
+      "mcp_health_cases"
+      "MCPHealthCases"
+      "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -175,6 +175,10 @@ def stateMachineCoverage : List CoverageEntry :=
       "state_machine"
       "ToolCall"
       "tool_call_lifecycle::tests::tool_call_state_machine_contract_is_complete"
+  , consumerCoverage
+      "state_machine"
+      "MCPHealth"
+      "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
   , followUpCoverage
       "state_machine"
       "AwaitMode"

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -1,4 +1,5 @@
 import Proofs.MCPHealth.State
+import Proofs.MCPHealth.Transition
 
 /-!
 # MCP Health / Eviction
@@ -11,7 +12,6 @@ K ≥ 2 admits the bounded-flap regime. See
 -/
 
 -- Subsequent imports added as tasks land:
--- import Proofs.MCPHealth.Transition
 -- import Proofs.MCPHealth.Properties
 -- import Proofs.MCPHealth.Coupling
 -- import Proofs.MCPHealth.Executable

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -1,0 +1,7 @@
+import Proofs.MCPHealth.State
+
+-- Subsequent imports added as tasks land:
+-- import Proofs.MCPHealth.Transition
+-- import Proofs.MCPHealth.Properties
+-- import Proofs.MCPHealth.Coupling
+-- import Proofs.MCPHealth.Executable

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -1,5 +1,15 @@
 import Proofs.MCPHealth.State
 
+/-!
+# MCP Health / Eviction
+
+Per-service Lean state machine for the MCP connection-pool health checker.
+Four-state lifecycle (`healthy → degraded → evicted → reconnecting`)
+parameterized by a failure-count threshold K. K=1 matches today's Rust;
+K ≥ 2 admits the bounded-flap regime. See
+`docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` for the design.
+-/
+
 -- Subsequent imports added as tasks land:
 -- import Proofs.MCPHealth.Transition
 -- import Proofs.MCPHealth.Properties

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -2,6 +2,7 @@ import Proofs.MCPHealth.State
 import Proofs.MCPHealth.Transition
 import Proofs.MCPHealth.Properties
 import Proofs.MCPHealth.Coupling
+import Proofs.MCPHealth.Executable
 
 /-!
 # MCP Health / Eviction
@@ -12,6 +13,3 @@ parameterized by a failure-count threshold K. K=1 matches today's Rust;
 K ≥ 2 admits the bounded-flap regime. See
 `docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` for the design.
 -/
-
--- Subsequent imports added as tasks land:
--- import Proofs.MCPHealth.Executable

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -1,5 +1,6 @@
 import Proofs.MCPHealth.State
 import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Properties
 
 /-!
 # MCP Health / Eviction
@@ -12,6 +13,5 @@ K ≥ 2 admits the bounded-flap regime. See
 -/
 
 -- Subsequent imports added as tasks land:
--- import Proofs.MCPHealth.Properties
 -- import Proofs.MCPHealth.Coupling
 -- import Proofs.MCPHealth.Executable

--- a/crates/defra-agent/proofs/Proofs/MCPHealth.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth.lean
@@ -1,6 +1,7 @@
 import Proofs.MCPHealth.State
 import Proofs.MCPHealth.Transition
 import Proofs.MCPHealth.Properties
+import Proofs.MCPHealth.Coupling
 
 /-!
 # MCP Health / Eviction
@@ -13,5 +14,4 @@ K ≥ 2 admits the bounded-flap regime. See
 -/
 
 -- Subsequent imports added as tasks land:
--- import Proofs.MCPHealth.Coupling
 -- import Proofs.MCPHealth.Executable

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Coupling.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Coupling.lean
@@ -1,0 +1,67 @@
+import Proofs.MCPHealth.State
+import Proofs.ToolExecution.Policy
+
+/-!
+# MCP Health — Coupling to ToolExecution.Policy
+
+Projects the four-state `HealthState` down to the three-value
+`ToolExecution.Health` ADT that `preflight` already keys on. Then proves
+the four bridging lemmas (C1–C4):
+
+* Evicted / Reconnecting block dispatch as ServiceUnavailable.
+* Healthy / Degraded dispatch (when schema is valid or unchecked).
+
+This file is the **only** file in `Proofs.MCPHealth` that imports
+`Proofs.ToolExecution.Policy`. It does not modify `Policy.lean` — purely
+additive extension. See spec §5 for the rationale (preflight is the
+correct coupling axis, not `retryDisposition`).
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Project the four-state lifecycle to the three-value Health ADT.
+
+    Both flavors of `.degraded` (staleness-degraded and
+    failure-count-degraded) project to `.stale`, reflecting that both admit
+    dispatch with a longer timeout. -/
+def healthProjection : HealthState → ToolExecution.Health
+  | .healthy      => .healthy
+  | .degraded     => .stale
+  | .evicted      => .unreachable
+  | .reconnecting => .unreachable
+
+namespace Coupling
+
+/-- C1: Evicted services block dispatch as ServiceUnavailable. -/
+theorem c1_evicted_blocks_dispatch (schema : ToolExecution.SchemaStatus) :
+    ToolExecution.preflight (healthProjection .evicted) schema
+      = .block .serviceUnavailable := by
+  cases schema <;> rfl
+
+/-- C2: Reconnecting services block dispatch as ServiceUnavailable. -/
+theorem c2_reconnecting_blocks_dispatch (schema : ToolExecution.SchemaStatus) :
+    ToolExecution.preflight (healthProjection .reconnecting) schema
+      = .block .serviceUnavailable := by
+  cases schema <;> rfl
+
+/-- C3: Healthy services with valid (or unchecked) schema dispatch. -/
+theorem c3_healthy_dispatches
+    (schema : ToolExecution.SchemaStatus) (hv : schema ≠ .invalid) :
+    ToolExecution.preflight (healthProjection .healthy) schema = .dispatch := by
+  cases schema
+  · rfl
+  · rfl
+  · exact absurd rfl hv
+
+/-- C4: Degraded services dispatch (matches today's "stale services allowed
+    through with a longer timeout" behavior). -/
+theorem c4_degraded_dispatches
+    (schema : ToolExecution.SchemaStatus) (hv : schema ≠ .invalid) :
+    ToolExecution.preflight (healthProjection .degraded) schema = .dispatch := by
+  cases schema
+  · rfl
+  · rfl
+  · exact absurd rfl hv
+
+end Coupling
+end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Executable.lean
@@ -1,0 +1,91 @@
+import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Coupling
+
+/-!
+# MCP Health — Conformance witnesses
+
+Exhaustive enumeration of transitions across
+`K ∈ {1, 2, 3} × startState ∈ HealthState.all × startCount ∈ {0..K} ×
+event ∈ Event.all`. Each row is evaluated by `step?` and tagged with the
+Rust 3-state projection.
+
+`k1ProjectionCases` is the subset Rust consumes today (K=1, matching the
+current `health_checker.rs` behavior). The K ≥ 2 rows are emitted but not
+yet asserted by any Rust test — they form the formal contract for a future
+K-aware refactor.
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Witness row for a single transition. -/
+structure TransitionCase where
+  name           : String
+  startState     : HealthState
+  startCount     : Nat
+  event          : Event
+  thresholdK     : Nat
+  nextState      : Option HealthState   -- none = service removed
+  nextCount      : Option Nat
+  rustProjection : Option String         -- "healthy" | "stale" | "unreachable" | none
+  deriving Repr
+
+namespace TransitionCase
+
+/-- Build a row by applying `step?` to (startState, startCount, event, K). -/
+def build (startState : HealthState) (startCount : Nat) (event : Event)
+    (thresholdK : Nat) (hk : thresholdK ≥ 1) : TransitionCase :=
+  let K : Threshold := Threshold.ofNat thresholdK hk
+  let sm : ServiceModel := { state := startState, failureCount := startCount }
+  let next := step? sm event K
+  let nameSuffix := match next with
+    | none => "removed"
+    | some sm' => sm'.state.toDefraDB ++ "_" ++ toString sm'.failureCount
+  { name :=
+      "mcp_health_K" ++ toString thresholdK ++ "_"
+        ++ startState.toDefraDB ++ "_" ++ toString startCount ++ "_"
+        ++ event.toDefraDB ++ "_" ++ nameSuffix
+  , startState := startState
+  , startCount := startCount
+  , event := event
+  , thresholdK := thresholdK
+  , nextState := next.map (·.state)
+  , nextCount := next.map (·.failureCount)
+  , rustProjection :=
+      next.map fun sm' => (healthProjection sm'.state).toDefraDB
+  }
+
+end TransitionCase
+
+/-- Range `[0..K)` of valid starting `failureCount` values for a given K.
+    `0` for staleness-degraded / Healthy / Reconnecting; up to `K-1` for
+    failure-count-degraded; `K` only appears as a *next* count, not a start. -/
+def countRange (K : Nat) : List Nat :=
+  List.range K  -- [0, 1, ..., K-1]
+
+/-- Generate all rows for a single K. -/
+def transitionCasesFor (K : Nat) (hk : K ≥ 1) : List TransitionCase :=
+  HealthState.all.flatMap fun s =>
+    (countRange K).flatMap fun n =>
+      Event.all.map fun e =>
+        TransitionCase.build s n e K hk
+
+/-- All conformance rows for K ∈ {1, 2, 3}. -/
+def transitionCases : List TransitionCase :=
+  transitionCasesFor 1 (by decide) ++
+  transitionCasesFor 2 (by decide) ++
+  transitionCasesFor 3 (by decide)
+
+/-- K=1 subset — the rows Rust witnesses today. -/
+def k1ProjectionCases : List TransitionCase :=
+  transitionCases.filter (·.thresholdK = 1)
+
+/-- K ≥ 2 subset — emitted but not yet asserted by any Rust test. -/
+def k2PlusFutureCases : List TransitionCase :=
+  transitionCases.filter (·.thresholdK ≥ 2)
+
+/-- `k1ProjectionCases` and `k2PlusFutureCases` partition `transitionCases`. -/
+theorem k1_k2_partition :
+    k1ProjectionCases.length + k2PlusFutureCases.length = transitionCases.length := by
+  native_decide
+
+end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -104,7 +104,7 @@ theorem h6_evicted_recovers_via_backoff_then_probe
     `Reconnecting` state, so a successful probe after eviction must assign
     `Healthy` directly. See spec §7.1 for the design rationale. -/
 theorem h6'_evicted_recovers_via_probe_directly
-    (sm : ServiceModel) (K : Threshold) (h : sm.state = .evicted) :
+    (sm : ServiceModel) (K : Threshold) (_h : sm.state = .evicted) :
     (step? sm (.probeSuccess false) K).map (·.state) = some .healthy := rfl
 
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -1,0 +1,61 @@
+import Proofs.MCPHealth.Transition
+
+/-!
+# MCP Health / Eviction — Properties
+
+Safety, arithmetic, and liveness facts about `step?` / `run?`. Property
+tags (H1–H8, H6') match the spec table in §8 of
+`docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md`.
+
+This file is built additively. Task 4 adds the easy safety/arithmetic facts;
+later tasks add H7 (K=1 collapse), H6 / H6' (liveness), and H5 (anti-flapping
+inter-eviction gap, load-bearing).
+-/
+
+namespace Proofs.MCPHealth
+
+/-- H1: every legal next-state arises from a named `Event`; no spontaneous
+    transitions. Trivially structural — `step?` is a total function of
+    `Event`. Recorded as a fact for the audit's "no spontaneous transitions"
+    acceptance criterion. -/
+theorem h1_event_triggered
+    (sm sm' : ServiceModel) (K : Threshold) :
+    (∃ e, step? sm e K = some sm') ↔
+      sm' ∈ (Event.all.filterMap (fun e => step? sm e K)) := by
+  constructor
+  · rintro ⟨e, he⟩
+    have := Event.all_complete e
+    simp [List.mem_filterMap]
+    exact ⟨e, this, he⟩
+  · intro h
+    simp [List.mem_filterMap] at h
+    obtain ⟨e, _, he⟩ := h
+    exact ⟨e, he⟩
+
+/-- H2: `probeSuccess` resets `failureCount` to 0. -/
+@[simp]
+theorem h2_success_resets_failure_count
+    (sm : ServiceModel) (stale : Bool) (K : Threshold) :
+    (step? sm (.probeSuccess stale) K).map (·.failureCount) = some 0 := rfl
+
+/-- H3: `probeFail` increments `failureCount` by exactly 1. -/
+@[simp]
+theorem h3_probefail_increments_count
+    (sm : ServiceModel) (K : Threshold) :
+    (step? sm .probeFail K).map (·.failureCount) = some (sm.failureCount + 1) := by
+  simp only [step?]
+  split <;> simp
+
+/-- H4: `backoffExpiry` only changes state when starting from `.evicted`. -/
+@[simp]
+theorem h4_backoff_only_from_evicted (sm : ServiceModel) (K : Threshold) :
+    (step? sm .backoffExpiry K).map (·.state)
+      = some (if sm.state = .evicted then .reconnecting else sm.state) := rfl
+
+/-- H8: `registryAbsent` ends the per-service state machine. -/
+@[simp]
+theorem h8_registry_absent_terminates
+    (sm : ServiceModel) (K : Threshold) :
+    step? sm .registryAbsent K = none := rfl
+
+end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -107,12 +107,6 @@ theorem h6'_evicted_recovers_via_probe_directly
     (sm : ServiceModel) (K : Threshold) (_h : sm.state = .evicted) :
     (step? sm (.probeSuccess false) K).map (·.state) = some .healthy := rfl
 
-/-- Helper: `run?` unfolds across `cons` via `step?` and a recursive `run?`. -/
-theorem run?_cons (sm : ServiceModel) (e : Event) (rest : List Event) (K : Threshold) :
-    run? sm (e :: rest) K = (step? sm e K).bind (fun sm'' => run? sm'' rest K) := by
-  have := run?_append sm [e] rest K
-  simpa using this
-
 /-- Helper 1: across any successful `run?`, the gain in `failureCount` is
     bounded above by the number of `probeFail` events. Each `probeFail`
     increments `failureCount` by 1; `probeSuccess` resets to 0; `backoffExpiry`
@@ -312,12 +306,10 @@ theorem take_split_at {α : Type} (l : List α) (p1 p2 : Nat) (h12 : p1 ≤ p2) 
     contains ≥ K `probeFail` events. -/
 theorem h5_anti_flapping_inter_eviction_gap
     (events : List Event) (K : Threshold)
-    (p1 p2 : Nat) (h12 : p1 < p2) (h2le : p2 ≤ events.length)
+    (p1 p2 : Nat) (h12 : p1 < p2) (_h2le : p2 ≤ events.length)
     (h1 : (run? ServiceModel.initial (events.take p1) K).map (·.state) = some .healthy)
     (h2 : (run? ServiceModel.initial (events.take p2) K).map (·.state) = some .evicted) :
     K.val ≤ ((events.drop p1).take (p2 - p1)).countP (· = Event.probeFail) := by
-  -- Bound check: p2 ≤ events.length keeps the slice within events.
-  have _hlen_p2 : p2 ≤ events.length := h2le
   -- Extract sm1 from h1.
   rcases hsm1 : run? ServiceModel.initial (events.take p1) K with _ | sm1
   · rw [hsm1] at h1; simp at h1

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -58,4 +58,33 @@ theorem h8_registry_absent_terminates
     (sm : ServiceModel) (K : Threshold) :
     step? sm .registryAbsent K = none := rfl
 
+/-- H7: at K=1, `probeFail` from any non-removed state with `failureCount = 0`
+    goes directly to `.evicted`. Witnesses the K=1 collapse to today's Rust
+    single-failure eviction. -/
+theorem h7_k1_collapse_probefail_skips_degraded
+    (sm : ServiceModel) (h0 : sm.failureCount = 0)
+    (K : Threshold) (hk : K.val = 1) :
+    (step? sm .probeFail K).map (·.state) = some .evicted := by
+  simp [step?, h0, hk]
+
+/-- Helper: when `step?` lands in `.degraded` via `probeFail`, the new
+    `failureCount` is strictly less than K. This is the bookkeeping invariant
+    that supports H5's induction in Task 7. -/
+theorem degraded_count_lt_K
+    (sm sm' : ServiceModel) (K : Threshold)
+    (h : step? sm .probeFail K = some sm')
+    (hd : sm'.state = .degraded) :
+    sm'.failureCount < K.val := by
+  simp only [step?] at h
+  split at h
+  · -- ≥ K branch — state becomes .evicted, contradicts hd = .degraded
+    rename_i hge
+    cases h
+    exact absurd hd (by simp)
+  · -- < K branch — state becomes .degraded, failureCount = sm.failureCount + 1 < K
+    rename_i hlt
+    cases h
+    simp only [ServiceModel.mk.injEq] at *
+    omega
+
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -87,4 +87,24 @@ theorem degraded_count_lt_K
     simp only [ServiceModel.mk.injEq] at *
     omega
 
+/-- H6: from `.evicted`, the two-event sequence
+    `[backoffExpiry, probeSuccess false]` reaches `.healthy`.
+    Constructive liveness witness for the backoff-then-probe recovery path
+    (relevant under K ≥ 2 with an armed backoff). -/
+theorem h6_evicted_recovers_via_backoff_then_probe
+    (sm : ServiceModel) (K : Threshold) (h : sm.state = .evicted) :
+    (run? sm [.backoffExpiry, .probeSuccess false] K).map (·.state) = some .healthy := by
+  simp [run?, List.foldl, Option.bind, step?, h]
+
+/-- H6': from `.evicted`, a single `probeSuccess false` reaches `.healthy`
+    directly (skipping `.reconnecting`). This is the **permissive** recovery
+    path — `Reconnecting` is an optional pass-through state, not mandatory.
+
+    Required by the K=1 conformance: today's Rust has no observable
+    `Reconnecting` state, so a successful probe after eviction must assign
+    `Healthy` directly. See spec §7.1 for the design rationale. -/
+theorem h6'_evicted_recovers_via_probe_directly
+    (sm : ServiceModel) (K : Threshold) (h : sm.state = .evicted) :
+    (step? sm (.probeSuccess false) K).map (·.state) = some .healthy := rfl
+
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
@@ -107,4 +107,258 @@ theorem h6'_evicted_recovers_via_probe_directly
     (sm : ServiceModel) (K : Threshold) (_h : sm.state = .evicted) :
     (step? sm (.probeSuccess false) K).map (·.state) = some .healthy := rfl
 
+/-- Helper: `run?` unfolds across `cons` via `step?` and a recursive `run?`. -/
+theorem run?_cons (sm : ServiceModel) (e : Event) (rest : List Event) (K : Threshold) :
+    run? sm (e :: rest) K = (step? sm e K).bind (fun sm'' => run? sm'' rest K) := by
+  have := run?_append sm [e] rest K
+  simpa using this
+
+/-- Helper 1: across any successful `run?`, the gain in `failureCount` is
+    bounded above by the number of `probeFail` events. Each `probeFail`
+    increments `failureCount` by 1; `probeSuccess` resets to 0; `backoffExpiry`
+    preserves; `registryAbsent` aborts the run. -/
+theorem failureCount_le_probefail_count
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm') :
+    sm'.failureCount ≤ sm.failureCount + events.countP (· = Event.probeFail) := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      subst hrun
+      simp
+  | cons e rest ih =>
+      rw [run?_cons] at hrun
+      cases e with
+      | probeSuccess stale =>
+          -- step? sm (.probeSuccess stale) K = some { sm with state := ..., failureCount := 0 }
+          have hstep : step? sm (.probeSuccess stale) K =
+              some { state := if stale then .degraded else .healthy, failureCount := 0 } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          have hih := ih _ hrun
+          have hne : ¬ ((Event.probeSuccess stale) = Event.probeFail) := by
+            intro h; cases h
+          rw [List.countP_cons_of_neg _ _ (by simp [hne])]
+          simp at hih
+          omega
+      | probeFail =>
+          -- Either branch of step? yields some sm'' with failureCount = sm.failureCount + 1.
+          have hstep : ∃ sm'', step? sm .probeFail K = some sm'' ∧
+              sm''.failureCount = sm.failureCount + 1 := by
+            simp only [step?]
+            split
+            · refine ⟨_, rfl, ?_⟩; simp
+            · refine ⟨_, rfl, ?_⟩; simp
+          obtain ⟨sm'', hstep_eq, hfc⟩ := hstep
+          rw [hstep_eq] at hrun
+          simp [Option.bind] at hrun
+          have hih := ih _ hrun
+          rw [List.countP_cons_of_pos _ _ (by simp)]
+          rw [hfc] at hih
+          omega
+      | backoffExpiry =>
+          have hstep : step? sm .backoffExpiry K =
+              some { sm with state := if sm.state = .evicted then .reconnecting else sm.state } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          have hih := ih _ hrun
+          have hne : ¬ ((Event.backoffExpiry : Event) = Event.probeFail) := by
+            intro h; cases h
+          rw [List.countP_cons_of_neg _ _ (by simp [hne])]
+          simp at hih
+          omega
+      | registryAbsent =>
+          simp [step?] at hrun
+
+/-- Helper 2: if `run?` lands in `.evicted` and the invariant
+    `(sm.state = .evicted → sm.failureCount ≥ K.val)` holds at the start,
+    then the final `failureCount ≥ K.val`. The invariant is preserved by
+    every legal transition in `step?`. -/
+theorem evicted_failureCount_ge_K
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (hst : sm'.state = .evicted)
+    (hinv : sm.state = .evicted → sm.failureCount ≥ K.val) :
+    sm'.failureCount ≥ K.val := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      subst hrun
+      exact hinv hst
+  | cons e rest ih =>
+      rw [run?_cons] at hrun
+      cases e with
+      | probeSuccess stale =>
+          -- New state: .healthy or .degraded; new failureCount: 0.
+          have hstep : step? sm (.probeSuccess stale) K =
+              some { state := if stale then .degraded else .healthy, failureCount := 0 } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          apply ih _ hrun
+          intro hev
+          -- new state is .healthy or .degraded, never .evicted; hev is impossible.
+          cases stale <;> simp at hev
+      | probeFail =>
+          simp only [step?] at hrun
+          split at hrun
+          · -- ≥ K branch: new state = .evicted, new failureCount = sm.failureCount + 1 ≥ K
+            rename_i hge
+            simp [Option.bind] at hrun
+            apply ih _ hrun
+            intro _hev
+            -- new failureCount = sm.failureCount + 1 ≥ K
+            exact hge
+          · -- < K branch: new state = .degraded; for it to remain .evicted later, invariant must apply
+            rename_i _hlt
+            simp [Option.bind] at hrun
+            apply ih _ hrun
+            intro hev
+            -- new state is .degraded, hev says .degraded = .evicted, impossible
+            simp at hev
+      | backoffExpiry =>
+          have hstep : step? sm .backoffExpiry K =
+              some { sm with state := if sm.state = .evicted then .reconnecting else sm.state } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          apply ih _ hrun
+          intro hev
+          -- new state: .reconnecting if sm.state = .evicted, else sm.state. Neither is .evicted
+          -- when entering from a state where the invariant held (we need .evicted at the new sm).
+          by_cases hse : sm.state = .evicted
+          · simp [hse] at hev  -- new state = .reconnecting, hev: .reconnecting = .evicted is false
+          · -- new state = sm.state, hev: sm.state = .evicted, contradicts hse; simp closes the goal
+            simp [hse] at hev
+      | registryAbsent =>
+          simp [step?] at hrun
+
+/-- Helper 3: if `run?` lands in `.healthy` and the invariant
+    `(sm.state = .healthy → sm.failureCount = 0)` holds at the start,
+    then the final `failureCount = 0`. The invariant is preserved by every
+    legal transition: `probeSuccess false` sets state to `.healthy` and count
+    to 0 (preserved); `probeSuccess true` exits `.healthy`; `probeFail`
+    exits `.healthy`; `backoffExpiry` from non-`.evicted` preserves state and
+    count, so the invariant carries. -/
+theorem healthy_failureCount_eq_zero
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (hst : sm'.state = .healthy)
+    (hinv : sm.state = .healthy → sm.failureCount = 0) :
+    sm'.failureCount = 0 := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      subst hrun
+      exact hinv hst
+  | cons e rest ih =>
+      rw [run?_cons] at hrun
+      cases e with
+      | probeSuccess stale =>
+          have hstep : step? sm (.probeSuccess stale) K =
+              some { state := if stale then .degraded else .healthy, failureCount := 0 } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          apply ih _ hrun
+          intro _hh
+          rfl
+      | probeFail =>
+          simp only [step?] at hrun
+          split at hrun
+          all_goals {
+            simp [Option.bind] at hrun
+            apply ih _ hrun
+            intro hh
+            -- new state is .evicted or .degraded, not .healthy; hh is impossible
+            simp at hh
+          }
+      | backoffExpiry =>
+          have hstep : step? sm .backoffExpiry K =
+              some { sm with state := if sm.state = .evicted then .reconnecting else sm.state } := by
+            simp [step?]
+          rw [hstep] at hrun
+          simp [Option.bind] at hrun
+          apply ih _ hrun
+          intro hh
+          by_cases hse : sm.state = .evicted
+          · simp [hse] at hh  -- new state = .reconnecting, hh: .reconnecting = .healthy, false
+          · simp [hse] at hh  -- new state = sm.state, hh: sm.state = .healthy
+            -- new failureCount = sm.failureCount, and by hinv applied to hh, = 0
+            exact hinv hh
+      | registryAbsent =>
+          simp [step?] at hrun
+
+/-- List arithmetic: for `p1 ≤ p2`, the prefix of length `p2` decomposes as
+    the prefix of length `p1` appended with the next `p2 - p1` events. Direct
+    consequence of `List.take_add`. Used to slice a run at an intermediate
+    prefix in H5. -/
+theorem take_split_at {α : Type} (l : List α) (p1 p2 : Nat) (h12 : p1 ≤ p2) :
+    l.take p2 = l.take p1 ++ (l.drop p1).take (p2 - p1) := by
+  have h : p1 + (p2 - p1) = p2 := by omega
+  have := List.take_add l p1 (p2 - p1)
+  rw [h] at this
+  exact this
+
+/-- H5: load-bearing anti-flapping safety property. If the run reaches
+    `.healthy` at prefix `p1` and `.evicted` at later prefix `p2`, the events
+    between the two prefixes contain at least `K` `probeFail` events.
+
+    Proof: from the healthy prefix, the model has `failureCount = 0`. To reach
+    `.evicted` at `p2`, the slice must drive `failureCount ≥ K`. Each
+    `probeFail` raises `failureCount` by 1; nothing else does. So the slice
+    contains ≥ K `probeFail` events. -/
+theorem h5_anti_flapping_inter_eviction_gap
+    (events : List Event) (K : Threshold)
+    (p1 p2 : Nat) (h12 : p1 < p2) (h2le : p2 ≤ events.length)
+    (h1 : (run? ServiceModel.initial (events.take p1) K).map (·.state) = some .healthy)
+    (h2 : (run? ServiceModel.initial (events.take p2) K).map (·.state) = some .evicted) :
+    K.val ≤ ((events.drop p1).take (p2 - p1)).countP (· = Event.probeFail) := by
+  -- Bound check: p2 ≤ events.length keeps the slice within events.
+  have _hlen_p2 : p2 ≤ events.length := h2le
+  -- Extract sm1 from h1.
+  rcases hsm1 : run? ServiceModel.initial (events.take p1) K with _ | sm1
+  · rw [hsm1] at h1; simp at h1
+  rw [hsm1] at h1
+  simp at h1
+  -- h1 : sm1.state = .healthy
+  -- Extract sm2 from h2.
+  rcases hsm2 : run? ServiceModel.initial (events.take p2) K with _ | sm2
+  · rw [hsm2] at h2; simp at h2
+  rw [hsm2] at h2
+  simp at h2
+  -- h2 : sm2.state = .evicted
+  -- Decompose events.take p2 = events.take p1 ++ (events.drop p1).take (p2 - p1)
+  have hp12 : p1 ≤ p2 := Nat.le_of_lt h12
+  have hsplit : events.take p2 = events.take p1 ++ (events.drop p1).take (p2 - p1) :=
+    take_split_at events p1 p2 hp12
+  -- Apply run?_append: run? init (a ++ b) K = (run? init a K).bind (run? · b K)
+  rw [hsplit, run?_append] at hsm2
+  rw [hsm1] at hsm2
+  simp [Option.bind] at hsm2
+  -- hsm2 : run? sm1 ((events.drop p1).take (p2 - p1)) K = some sm2
+  -- Get sm1.failureCount = 0 from Helper 3.
+  have h_init_inv : ServiceModel.initial.state = .healthy →
+      ServiceModel.initial.failureCount = 0 := fun _ => rfl
+  have hsm1_fc : sm1.failureCount = 0 := by
+    -- Apply Helper 3 to the initial run.
+    have := healthy_failureCount_eq_zero ServiceModel.initial sm1 (events.take p1) K hsm1 h1
+              h_init_inv
+    exact this
+  -- Get sm2.failureCount ≥ K.val from Helper 2.
+  have hsm2_fc_ge : sm2.failureCount ≥ K.val := by
+    apply evicted_failureCount_ge_K sm1 sm2 ((events.drop p1).take (p2 - p1)) K hsm2 h2
+    intro hev
+    -- sm1.state = .evicted, but sm1.state = .healthy, contradiction.
+    rw [h1] at hev
+    cases hev
+  -- Get sm2.failureCount ≤ sm1.failureCount + slice probefail count from Helper 1.
+  have hbound :=
+    failureCount_le_probefail_count sm1 sm2 ((events.drop p1).take (p2 - p1)) K hsm2
+  rw [hsm1_fc] at hbound
+  -- Combine: K ≤ sm2.failureCount ≤ 0 + slice count
+  omega
+
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/State.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/State.lean
@@ -1,5 +1,119 @@
+import Proofs.Basic
+
+/-!
+# MCP Health / Eviction — Types
+
+Per-service state machine for the MCP connection-pool health checker. See
+`docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` for the design.
+
+`HealthState` is the four-state lifecycle from #186. `ServiceModel` carries the
+state plus a `failureCount` that distinguishes the two semantic flavors of
+`Degraded` (see doc comment). `Event` is the named-event vocabulary that
+drives transitions; no async tick is modeled.
+-/
+
 namespace Proofs.MCPHealth
 
--- types defined in subsequent tasks
+/-- The four-state lifecycle.
+
+    `healthy` — last probe succeeded with fresh heartbeat.
+    `degraded` — last probe succeeded but heartbeat is stale (`failureCount = 0`),
+                 or saw `failureCount ≥ 1` consecutive failures with
+                 `failureCount < K` (only under K ≥ 2).
+    `evicted` — pool connection has been removed; no calls admitted.
+    `reconnecting` — backoff expired after eviction; awaiting next probe.
+                     Unreachable at K=1 / no backoff. -/
+inductive HealthState where
+  | healthy
+  | degraded
+  | evicted
+  | reconnecting
+  deriving DecidableEq, Repr
+
+namespace HealthState
+
+def toDefraDB : HealthState → String
+  | .healthy      => "healthy"
+  | .degraded     => "degraded"
+  | .evicted      => "evicted"
+  | .reconnecting => "reconnecting"
+
+def all : List HealthState :=
+  [ .healthy, .degraded, .evicted, .reconnecting ]
+
+theorem all_complete (s : HealthState) : s ∈ all := by
+  cases s <;> simp [all]
+
+end HealthState
+
+/-- Per-service state model.
+
+    `failureCount` is the count of consecutive `probeFail` events since the
+    last `probeSuccess`. It is reset to 0 by any `probeSuccess` regardless of
+    the `staleness` flag.
+
+    The single `degraded` constructor has two semantic flavors distinguished
+    by `failureCount`:
+
+    * `failureCount = 0`: staleness-degraded (entered via
+      `probeSuccess(staleness = true)`). Equivalent to today's `Stale`
+      `HealthStatus`.
+    * `failureCount ≥ 1`: failure-count-degraded (entered via `probeFail`
+      when `failureCount + 1 < K`). Only reachable under K ≥ 2; unreachable
+      under K=1 because `failureCount + 1 ≥ 1 = K` always evicts immediately.
+
+    Both flavors share `healthProjection .degraded = .stale` and therefore
+    the same preflight dispatch decision. -/
+structure ServiceModel where
+  state        : HealthState
+  failureCount : Nat
+  deriving DecidableEq, Repr
+
+namespace ServiceModel
+
+/-- Initial model — used when the pool first observes a service. -/
+def initial : ServiceModel := { state := .healthy, failureCount := 0 }
+
+end ServiceModel
+
+/-- The four events that drive transitions.
+
+    `probeSuccess` carries a `staleness : Bool` flag derived from the
+    heartbeat age at probe time (mirrors `health_checker.rs:247`).
+
+    `probeFail` folds both probe error and probe timeout — operationally
+    identical in `health_checker.rs:268,:289` (both call `mcp_pool.remove`
+    and set `Unreachable`).
+
+    `backoffExpiry` is a no-op outside `.evicted`.
+
+    `registryAbsent` removes the service from the model entirely
+    (`step? sm .registryAbsent K = none`). -/
+inductive Event where
+  | probeSuccess (staleness : Bool)
+  | probeFail
+  | backoffExpiry
+  | registryAbsent
+  deriving DecidableEq, Repr
+
+namespace Event
+
+def toDefraDB : Event → String
+  | .probeSuccess false => "probeSuccessFresh"
+  | .probeSuccess true  => "probeSuccessStale"
+  | .probeFail          => "probeFail"
+  | .backoffExpiry      => "backoffExpiry"
+  | .registryAbsent     => "registryAbsent"
+
+def all : List Event :=
+  [ .probeSuccess false, .probeSuccess true
+  , .probeFail, .backoffExpiry, .registryAbsent ]
+
+theorem all_complete (e : Event) : e ∈ all := by
+  cases e
+  · rename_i b; cases b <;> simp [all]
+  all_goals simp [all]
+
+end Event
 
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/State.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/State.lean
@@ -1,0 +1,5 @@
+namespace Proofs.MCPHealth
+
+-- types defined in subsequent tasks
+
+end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
@@ -89,4 +89,10 @@ theorem run?_append (sm : ServiceModel) (a b : List Event) (K : Threshold) :
   simp only [run?]
   exact foldl_bind_append (some sm) a b K
 
+/-- Helper: `run?` unfolds across `cons` via `step?` and a recursive `run?`. -/
+theorem run?_cons (sm : ServiceModel) (e : Event) (rest : List Event) (K : Threshold) :
+    run? sm (e :: rest) K = (step? sm e K).bind (fun sm'' => run? sm'' rest K) := by
+  have := run?_append sm [e] rest K
+  simpa using this
+
 end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
@@ -1,0 +1,91 @@
+import Proofs.MCPHealth.State
+
+/-!
+# MCP Health / Eviction — Transitions
+
+Deterministic event-driven transitions. `step?` is total over `Event`; it
+returns `none` only on `registryAbsent` (service removed) and `some sm'`
+otherwise. `run?` short-circuits on the first `registryAbsent`.
+
+`Threshold` is the failure-count threshold K. K=1 collapses to today's Rust
+behavior (single probeFail evicts); K ≥ 2 admits the bounded-flap regime.
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Failure-count threshold. K=1 today; K ≥ 2 admits the flapping-bound regime. -/
+abbrev Threshold := { k : Nat // k ≥ 1 }
+
+namespace Threshold
+
+/-- K=1: today's Rust behavior (single probeFail → Evicted). -/
+def one : Threshold := ⟨1, Nat.le.refl⟩
+
+/-- Lift an arbitrary `Nat ≥ 1` to a `Threshold` (helpful in conformance). -/
+def ofNat (k : Nat) (h : k ≥ 1) : Threshold := ⟨k, h⟩
+
+end Threshold
+
+/-- One transition step.
+
+    `registryAbsent` returns `none` — the per-service state machine ends.
+    `backoffExpiry` is a no-op outside `.evicted`.
+    `probeSuccess stale` resets `failureCount` to 0 and routes to `.healthy`
+    (fresh) or `.degraded` (stale).
+    `probeFail` increments `failureCount` and routes to `.evicted` if the
+    new count ≥ K, else `.degraded`. -/
+def step? (sm : ServiceModel) (e : Event) (K : Threshold) : Option ServiceModel :=
+  match e with
+  | .registryAbsent => none
+  | .backoffExpiry  =>
+      some { sm with state := if sm.state = .evicted then .reconnecting else sm.state }
+  | .probeSuccess stale =>
+      some { state := if stale then .degraded else .healthy
+           , failureCount := 0 }
+  | .probeFail =>
+      let n := sm.failureCount + 1
+      if n ≥ K.val then some { state := .evicted,  failureCount := n }
+                   else some { state := .degraded, failureCount := n }
+
+/-- Sequential application of events. Short-circuits on `registryAbsent`. -/
+def run? (sm : ServiceModel) (events : List Event) (K : Threshold)
+    : Option ServiceModel :=
+  events.foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) (some sm)
+
+/-- `run? sm [] K = some sm`. -/
+@[simp]
+theorem run?_nil (sm : ServiceModel) (K : Threshold) :
+    run? sm [] K = some sm := rfl
+
+/-- One-event `run?` reduces to `step?`. -/
+@[simp]
+theorem run?_singleton (sm : ServiceModel) (e : Event) (K : Threshold) :
+    run? sm [e] K = step? sm e K := by
+  simp [run?, List.foldl, Option.bind]
+
+/-- Compose two runs: `run? sm (a ++ b) K = (run? sm a K).bind (run? · b K)`.
+    Used by `Properties.lean` to slice runs at intermediate prefixes. -/
+-- Helper: foldl bind factors over append for any starting accumulator.
+private theorem foldl_bind_append (acc : Option ServiceModel) (a b : List Event) (K : Threshold) :
+    (a ++ b).foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) acc =
+    (a.foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) acc).bind
+      (fun sm' => b.foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) (some sm')) := by
+  induction a generalizing acc with
+  | nil =>
+      simp only [List.foldl, List.nil_append, Option.bind]
+      cases acc with
+      | none =>
+          induction b with
+          | nil => rfl
+          | cons _ _ ihb => simp [List.foldl, ihb]
+      | some sm => rfl
+  | cons e rest ih =>
+      simp only [List.foldl, List.cons_append]
+      rw [ih]
+
+theorem run?_append (sm : ServiceModel) (a b : List Event) (K : Threshold) :
+    run? sm (a ++ b) K = (run? sm a K).bind (fun sm' => run? sm' b K) := by
+  simp only [run?]
+  exact foldl_bind_append (some sm) a b K
+
+end Proofs.MCPHealth

--- a/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
@@ -40,12 +40,13 @@ def step? (sm : ServiceModel) (e : Event) (K : Threshold) : Option ServiceModel 
   | .backoffExpiry  =>
       some { sm with state := if sm.state = .evicted then .reconnecting else sm.state }
   | .probeSuccess stale =>
-      some { state := if stale then .degraded else .healthy
-           , failureCount := 0 }
+      some { sm with
+                state := if stale then .degraded else .healthy
+              , failureCount := 0 }
   | .probeFail =>
       let n := sm.failureCount + 1
-      if n ≥ K.val then some { state := .evicted,  failureCount := n }
-                   else some { state := .degraded, failureCount := n }
+      if n ≥ K.val then some { sm with state := .evicted,  failureCount := n }
+                   else some { sm with state := .degraded, failureCount := n }
 
 /-- Sequential application of events. Short-circuits on `registryAbsent`. -/
 def run? (sm : ServiceModel) (events : List Event) (K : Threshold)

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -369,3 +369,83 @@ mod registry_parsing_tests {
         assert_eq!(entries[0].tailscale_ip, "100.69.4.79");
     }
 }
+
+#[cfg(test)]
+mod transitions_tests {
+    use super::HealthStatus;
+    use crate::lean_vocab_test::{lean_mcp_health_k1_cases, LeanMcpHealthCase};
+
+    /// Project a Lean K=1 case's `rust_projection` to a `HealthStatus` for
+    /// today's Rust to assert against. `None` means the service was removed
+    /// via `registryAbsent`; tests skip those rows (Rust represents removal
+    /// by dropping the map entry, not by a `HealthStatus`).
+    fn projected_health_status(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
+        case.rust_projection.as_deref().map(|s| match s {
+            "healthy" => HealthStatus::Healthy,
+            "stale" => HealthStatus::Stale,
+            "unreachable" => HealthStatus::Unreachable,
+            other => panic!(
+                "Lean MCP health case {} produced unknown rust_projection {:?}",
+                case.name, other
+            ),
+        })
+    }
+
+    /// Simulate one tick of `run_health_check`'s decision logic for a given
+    /// case: given a starting `HealthStatus` and a probe event, what does
+    /// today's Rust assign?
+    ///
+    /// Mirrors the inline logic at `health_checker.rs:247–308` but drives it
+    /// with the case's event rather than a real probe call.
+    fn rust_simulated_next(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
+        match case.event.as_str() {
+            "registryAbsent" => None,
+            "backoffExpiry" => {
+                // Today's Rust has no backoffExpiry behavior — backoff is not
+                // armed at K=1. Express this by mapping back through the
+                // starting projection (no observable change at K=1).
+                Some(start_status(case))
+            }
+            "probeSuccessFresh" => Some(HealthStatus::Healthy),
+            "probeSuccessStale" => Some(HealthStatus::Stale),
+            "probeFail" => Some(HealthStatus::Unreachable),
+            other => panic!(
+                "Lean MCP health case {} produced unknown event {:?}",
+                case.name, other
+            ),
+        }
+    }
+
+    fn start_status(case: &LeanMcpHealthCase) -> HealthStatus {
+        match case.start_state.as_str() {
+            "healthy" => HealthStatus::Healthy,
+            // K=1 collapses: degraded can only be entered via probeSuccess(stale=true),
+            // which projects to Stale.
+            "degraded" => HealthStatus::Stale,
+            "evicted" | "reconnecting" => HealthStatus::Unreachable,
+            other => panic!(
+                "Lean MCP health case {} produced unknown start_state {:?}",
+                case.name, other
+            ),
+        }
+    }
+
+    #[test]
+    fn generated_mcp_health_k1_cases_match_health_checker_transitions() {
+        let cases = lean_mcp_health_k1_cases();
+        assert!(
+            !cases.is_empty(),
+            "Lean must emit at least one K=1 MCP health case"
+        );
+
+        for case in cases {
+            let expected = projected_health_status(case);
+            let actual = rust_simulated_next(case);
+            assert_eq!(
+                actual, expected,
+                "Lean MCP health K=1 case {} must match Rust HealthStatus assignment",
+                case.name
+            );
+        }
+    }
+}

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -47,6 +47,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) native_filesystem_boundary_cases: Vec<LeanNativeFilesystemBoundaryCase>,
     pub(crate) tool_preflight_cases: Vec<LeanToolPreflightCase>,
     pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
+    pub(crate) mcp_health_cases: Vec<LeanMcpHealthCase>,
     pub(crate) boundaries: Vec<LeanBoundary>,
     pub(crate) deviations: Vec<LeanDeviation>,
     pub(crate) command_policy_cases: Vec<LeanCommandPolicyCase>,
@@ -498,6 +499,18 @@ pub(crate) struct LeanToolRetryCase {
 }
 
 #[derive(Debug, Deserialize)]
+pub(crate) struct LeanMcpHealthCase {
+    pub(crate) name: String,
+    pub(crate) start_state: String,
+    pub(crate) start_count: usize,
+    pub(crate) event: String,
+    pub(crate) threshold_k: usize,
+    pub(crate) next_state: Option<String>,
+    pub(crate) next_count: Option<usize>,
+    pub(crate) rust_projection: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub(crate) struct LeanCommandPolicyCase {
     pub(crate) name: String,
     pub(crate) category: String,
@@ -857,6 +870,18 @@ pub(crate) fn lean_tool_retry_case(name: &str) -> &'static LeanToolRetryCase {
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean tool retry case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_mcp_health_cases() -> &'static [LeanMcpHealthCase] {
+    &lean_contract_snapshot().mcp_health_cases
+}
+
+pub(crate) fn lean_mcp_health_k1_cases() -> Vec<&'static LeanMcpHealthCase> {
+    lean_contract_snapshot()
+        .mcp_health_cases
+        .iter()
+        .filter(|case| case.threshold_k == 1)
+        .collect()
 }
 
 pub(crate) fn lean_command_policy_cases() -> &'static [LeanCommandPolicyCase] {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -22,12 +22,12 @@ use lean_vocab_test::{
     lean_client_shell_case, lean_command_env_case, lean_command_policy_case,
     lean_command_sandbox_case, lean_contract_snapshot, lean_event_delivery_convergence_traces,
     lean_event_delivery_source_instances, lean_event_delivery_transition_cases,
-    lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case, lean_queue_deadline_case,
-    lean_queue_deadline_cases, lean_recovery_sweep_case, lean_recovery_sweep_cases,
-    lean_request_transition_cases, lean_runtime_reconcile_case, lean_session_recovery_case,
-    lean_state_machine_contract, lean_tool_preflight_case, lean_tool_retry_case,
-    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
-    LeanLifecycleTransitionCase,
+    lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case, lean_mcp_health_cases,
+    lean_queue_deadline_case, lean_queue_deadline_cases, lean_recovery_sweep_case,
+    lean_recovery_sweep_cases, lean_request_transition_cases, lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_state_machine_contract, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_transcript_case, lean_transcript_cases, lean_vocabulary_values,
+    LeanEventDeliveryAction, LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -539,6 +539,9 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "EventDeliveryConvergenceTraces".to_string(),
         ));
     }
+    if !lean_mcp_health_cases().is_empty() {
+        emitted.insert(("mcp_health_cases".to_string(), "MCPHealthCases".to_string()));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -567,6 +570,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "recovery_sweep_cases",
         "transcript_cases",
         "event_delivery_cases",
+        "mcp_health_cases",
         "follow_up_hook",
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -335,6 +335,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             module_path: "tool_call_lifecycle::tests",
             function: "tool_call_state_machine_contract_is_complete",
         },
+        ConformanceConsumer::RustTest {
+            id: "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/health_checker.rs",
+            module_path: "health_checker::tests",
+            function: "generated_mcp_health_k1_cases_match_health_checker_transitions",
+        },
     ]
 }
 

--- a/docs/superpowers/plans/2026-05-13-mcp-health-lean.md
+++ b/docs/superpowers/plans/2026-05-13-mcp-health-lean.md
@@ -1,0 +1,1594 @@
+# MCP Health Probe / Eviction State Machine in Lean Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land a per-service Lean state machine over `healthy → degraded → evicted → reconnecting`, parameterized by a failure-count threshold K, with a load-bearing anti-flapping inter-eviction-gap theorem, projection coupling to `Proofs/ToolExecution/Policy.lean`, conformance witnesses for today's K=1 Rust behavior, and one new `#[cfg(test)]` consumer test in `crates/defra-agent/src/health_checker.rs`.
+
+**Architecture:** Five Lean files under `crates/defra-agent/proofs/Proofs/MCPHealth/` plus one entrypoint file. JSON conformance emission via `Proofs/Conformance/Contracts/Json.lean` (additive — one new field, one new emitter helper). Rust side: one new case struct + one accessor in `crates/defra-agent/src/lean_vocab_test.rs`, plus the consumer test in `crates/defra-agent/src/health_checker.rs`. No Rust production code changes (no edits to `HealthStatus`, `ServiceHealth`, `run_health_check`, or `mcp_pool.rs`). No edits to `Proofs/ToolExecution/Policy.lean`.
+
+**Tech Stack:** Lean 4 (via `lake`); Rust (via `cargo`); `serde` + `serde_json` for the Lean→Rust JSON bridge.
+
+**Reference:** `docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` is the source of truth for shapes, names, and acceptance.
+
+---
+
+## File Structure
+
+**New files (Lean):**
+- `crates/defra-agent/proofs/Proofs/MCPHealth.lean` — entry; re-exports the namespace.
+- `crates/defra-agent/proofs/Proofs/MCPHealth/State.lean` — `HealthState`, `ServiceModel`, `Event`, vocabularies.
+- `crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean` — `Threshold`, `step?`, `run?`.
+- `crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean` — H1–H8, H6'.
+- `crates/defra-agent/proofs/Proofs/MCPHealth/Coupling.lean` — `healthProjection`, C1–C4.
+- `crates/defra-agent/proofs/Proofs/MCPHealth/Executable.lean` — `TransitionCase` + `transitionCases` + filters.
+
+**Modified files (Lean):**
+- `crates/defra-agent/proofs/Proofs.lean` — add one import line.
+- `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean` — add `mcpHealthCaseJson` + one new field in the top-level JSON emitter.
+- `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean` — add one consumer-coverage entry.
+
+**Modified files (Rust, test-only):**
+- `crates/defra-agent/src/lean_vocab_test.rs` — add `LeanMcpHealthCase` struct, add `mcp_health_cases` field on `LeanContractSnapshot`, add `lean_mcp_health_k1_cases()` accessor.
+- `crates/defra-agent/src/health_checker.rs` — add one new test inside the existing `#[cfg(test)] mod registry_parsing_tests` (or a sibling `mod transitions_tests`).
+
+---
+
+## Task 1: Scaffold the MCPHealth module and wire it into Proofs.lean
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth.lean`
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth/State.lean` (empty namespace)
+- Modify: `crates/defra-agent/proofs/Proofs.lean` (one new import)
+
+- [ ] **Step 1: Create the stub `State.lean`** (empty namespace, to establish the directory):
+
+```lean
+namespace Proofs.MCPHealth
+
+-- types defined in subsequent tasks
+
+end Proofs.MCPHealth
+```
+
+Path: `crates/defra-agent/proofs/Proofs/MCPHealth/State.lean`
+
+- [ ] **Step 2: Create the entrypoint `MCPHealth.lean`:**
+
+```lean
+import Proofs.MCPHealth.State
+
+-- Subsequent imports added as tasks land:
+-- import Proofs.MCPHealth.Transition
+-- import Proofs.MCPHealth.Properties
+-- import Proofs.MCPHealth.Coupling
+-- import Proofs.MCPHealth.Executable
+```
+
+Path: `crates/defra-agent/proofs/Proofs/MCPHealth.lean`
+
+- [ ] **Step 3: Add the new import to `Proofs.lean`:**
+
+Modify `crates/defra-agent/proofs/Proofs.lean`. Between line 18 (`import Proofs.ToolExecution`) and line 19 (`import Proofs.Subagent`), insert:
+
+```lean
+import Proofs.MCPHealth
+```
+
+Final line 19 becomes the new MCPHealth import; the old line 19 (`import Proofs.Subagent`) shifts to line 20. Verify with `head -22 crates/defra-agent/proofs/Proofs.lean`.
+
+- [ ] **Step 4: Verify `lake build` is clean.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: build succeeds with no errors, no warnings about `sorry`.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth/State.lean \
+        crates/defra-agent/proofs/Proofs.lean
+git commit -m "Scaffold Proofs.MCPHealth module (#186)"
+```
+
+---
+
+## Task 2: State.lean — HealthState, ServiceModel, Event
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth/State.lean`
+
+- [ ] **Step 1: Write the full `State.lean` body.**
+
+Replace the empty namespace from Task 1 with:
+
+```lean
+import Proofs.Basic
+
+/-!
+# MCP Health / Eviction — Types
+
+Per-service state machine for the MCP connection-pool health checker. See
+`docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` for the design.
+
+`HealthState` is the four-state lifecycle from #186. `ServiceModel` carries the
+state plus a `failureCount` that distinguishes the two semantic flavors of
+`Degraded` (see doc comment). `Event` is the named-event vocabulary that
+drives transitions; no async tick is modeled.
+-/
+
+namespace Proofs.MCPHealth
+
+/-- The four-state lifecycle.
+
+    `healthy` — last probe succeeded with fresh heartbeat.
+    `degraded` — last probe succeeded but heartbeat is stale (`failureCount = 0`),
+                 or saw `failureCount ≥ 1` consecutive failures with
+                 `failureCount < K` (only under K ≥ 2).
+    `evicted` — pool connection has been removed; no calls admitted.
+    `reconnecting` — backoff expired after eviction; awaiting next probe.
+                     Unreachable at K=1 / no backoff. -/
+inductive HealthState where
+  | healthy
+  | degraded
+  | evicted
+  | reconnecting
+  deriving DecidableEq, Repr
+
+namespace HealthState
+
+def toDefraDB : HealthState → String
+  | .healthy      => "healthy"
+  | .degraded     => "degraded"
+  | .evicted      => "evicted"
+  | .reconnecting => "reconnecting"
+
+def all : List HealthState :=
+  [ .healthy, .degraded, .evicted, .reconnecting ]
+
+theorem all_complete (s : HealthState) : s ∈ all := by
+  cases s <;> simp [all]
+
+end HealthState
+
+/-- Per-service state model.
+
+    `failureCount` is the count of consecutive `probeFail` events since the
+    last `probeSuccess`. It is reset to 0 by any `probeSuccess` regardless of
+    the `staleness` flag.
+
+    The single `degraded` constructor has two semantic flavors distinguished
+    by `failureCount`:
+
+    * `failureCount = 0`: staleness-degraded (entered via
+      `probeSuccess(staleness = true)`). Equivalent to today's `Stale`
+      `HealthStatus`.
+    * `failureCount ≥ 1`: failure-count-degraded (entered via `probeFail`
+      when `failureCount + 1 < K`). Only reachable under K ≥ 2; unreachable
+      under K=1 because `failureCount + 1 ≥ 1 = K` always evicts immediately.
+
+    Both flavors share `healthProjection .degraded = .stale` and therefore
+    the same preflight dispatch decision. -/
+structure ServiceModel where
+  state        : HealthState
+  failureCount : Nat
+  deriving DecidableEq, Repr
+
+namespace ServiceModel
+
+/-- Initial model — used when the pool first observes a service. -/
+def initial : ServiceModel := { state := .healthy, failureCount := 0 }
+
+end ServiceModel
+
+/-- The four events that drive transitions.
+
+    `probeSuccess` carries a `staleness : Bool` flag derived from the
+    heartbeat age at probe time (mirrors `health_checker.rs:247`).
+
+    `probeFail` folds both probe error and probe timeout — operationally
+    identical in `health_checker.rs:268,:289` (both call `mcp_pool.remove`
+    and set `Unreachable`).
+
+    `backoffExpiry` is a no-op outside `.evicted`.
+
+    `registryAbsent` removes the service from the model entirely
+    (`step? sm .registryAbsent K = none`). -/
+inductive Event where
+  | probeSuccess (staleness : Bool)
+  | probeFail
+  | backoffExpiry
+  | registryAbsent
+  deriving DecidableEq, Repr
+
+namespace Event
+
+def toDefraDB : Event → String
+  | .probeSuccess false => "probeSuccessFresh"
+  | .probeSuccess true  => "probeSuccessStale"
+  | .probeFail          => "probeFail"
+  | .backoffExpiry      => "backoffExpiry"
+  | .registryAbsent     => "registryAbsent"
+
+def all : List Event :=
+  [ .probeSuccess false, .probeSuccess true
+  , .probeFail, .backoffExpiry, .registryAbsent ]
+
+theorem all_complete (e : Event) : e ∈ all := by
+  cases e
+  · rename_i b; cases b <;> simp [all]
+  all_goals simp [all]
+
+end Event
+
+end Proofs.MCPHealth
+```
+
+- [ ] **Step 2: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build, no `sorry`, no warnings.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/State.lean
+git commit -m "Proofs.MCPHealth: define HealthState, ServiceModel, Event (#186)"
+```
+
+---
+
+## Task 3: Transition.lean — Threshold, step?, run?
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth.lean` (uncomment Transition import)
+
+- [ ] **Step 1: Create `Transition.lean` with the full body.**
+
+```lean
+import Proofs.MCPHealth.State
+
+/-!
+# MCP Health / Eviction — Transitions
+
+Deterministic event-driven transitions. `step?` is total over `Event`; it
+returns `none` only on `registryAbsent` (service removed) and `some sm'`
+otherwise. `run?` short-circuits on the first `registryAbsent`.
+
+`Threshold` is the failure-count threshold K. K=1 collapses to today's Rust
+behavior (single probeFail evicts); K ≥ 2 admits the bounded-flap regime.
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Failure-count threshold. K=1 today; K ≥ 2 admits the flapping-bound regime. -/
+abbrev Threshold := { k : Nat // k ≥ 1 }
+
+namespace Threshold
+
+/-- K=1: today's Rust behavior (single probeFail → Evicted). -/
+def one : Threshold := ⟨1, Nat.le.refl⟩
+
+/-- Lift an arbitrary `Nat ≥ 1` to a `Threshold` (helpful in conformance). -/
+def ofNat (k : Nat) (h : k ≥ 1) : Threshold := ⟨k, h⟩
+
+end Threshold
+
+/-- One transition step.
+
+    `registryAbsent` returns `none` — the per-service state machine ends.
+    `backoffExpiry` is a no-op outside `.evicted`.
+    `probeSuccess stale` resets `failureCount` to 0 and routes to `.healthy`
+    (fresh) or `.degraded` (stale).
+    `probeFail` increments `failureCount` and routes to `.evicted` if the
+    new count ≥ K, else `.degraded`. -/
+def step? (sm : ServiceModel) (e : Event) (K : Threshold) : Option ServiceModel :=
+  match e with
+  | .registryAbsent => none
+  | .backoffExpiry  =>
+      some { sm with state := if sm.state = .evicted then .reconnecting else sm.state }
+  | .probeSuccess stale =>
+      some { state := if stale then .degraded else .healthy
+           , failureCount := 0 }
+  | .probeFail =>
+      let n := sm.failureCount + 1
+      if n ≥ K.val then some { state := .evicted,  failureCount := n }
+                   else some { state := .degraded, failureCount := n }
+
+/-- Sequential application of events. Short-circuits on `registryAbsent`. -/
+def run? (sm : ServiceModel) (events : List Event) (K : Threshold)
+    : Option ServiceModel :=
+  events.foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) (some sm)
+
+/-- `run? sm [] K = some sm`. -/
+@[simp]
+theorem run?_nil (sm : ServiceModel) (K : Threshold) :
+    run? sm [] K = some sm := rfl
+
+/-- One-event `run?` reduces to `step?`. -/
+@[simp]
+theorem run?_singleton (sm : ServiceModel) (e : Event) (K : Threshold) :
+    run? sm [e] K = step? sm e K := by
+  simp [run?, List.foldl, Option.bind]
+
+end Proofs.MCPHealth
+```
+
+- [ ] **Step 2: Uncomment the Transition import in `MCPHealth.lean`.**
+
+Modify `crates/defra-agent/proofs/Proofs/MCPHealth.lean` — uncomment the `Transition` line so it reads:
+
+```lean
+import Proofs.MCPHealth.State
+import Proofs.MCPHealth.Transition
+
+-- Subsequent imports added as tasks land:
+-- import Proofs.MCPHealth.Properties
+-- import Proofs.MCPHealth.Coupling
+-- import Proofs.MCPHealth.Executable
+```
+
+- [ ] **Step 3: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth.lean
+git commit -m "Proofs.MCPHealth: define Threshold, step?, run? (#186)"
+```
+
+---
+
+## Task 4: Properties.lean — H1–H4 and H8 (simple safety + arithmetic)
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth.lean` (uncomment Properties import)
+
+- [ ] **Step 1: Create `Properties.lean` with H1–H4 and H8.**
+
+```lean
+import Proofs.MCPHealth.Transition
+
+/-!
+# MCP Health / Eviction — Properties
+
+Safety, arithmetic, and liveness facts about `step?` / `run?`. Property
+tags (H1–H8, H6') match the spec table in §8.
+
+This file is built additively. Task 4 adds the easy safety/arithmetic facts;
+later tasks add H7 (K=1 collapse), H6 / H6' (liveness), and H5 (anti-flapping
+inter-eviction gap, load-bearing).
+-/
+
+namespace Proofs.MCPHealth
+
+/-- H1: every legal next-state arises from a named `Event`; no spontaneous
+    transitions. Trivially structural — `step?` is a total function of
+    `Event`. Recorded as a fact for the audit's "no spontaneous transitions"
+    acceptance criterion. -/
+theorem h1_event_triggered
+    (sm sm' : ServiceModel) (K : Threshold) :
+    (∃ e, step? sm e K = some sm') ↔ sm' ∈ (Event.all.filterMap (fun e => step? sm e K)) := by
+  constructor
+  · rintro ⟨e, he⟩
+    have := Event.all_complete e
+    simp [List.mem_filterMap]
+    exact ⟨e, this, he⟩
+  · intro h
+    simp [List.mem_filterMap] at h
+    obtain ⟨e, _, he⟩ := h
+    exact ⟨e, he⟩
+
+/-- H2: `probeSuccess` resets `failureCount` to 0. -/
+@[simp]
+theorem h2_success_resets_failure_count
+    (sm : ServiceModel) (stale : Bool) (K : Threshold) :
+    (step? sm (.probeSuccess stale) K).map (·.failureCount) = some 0 := rfl
+
+/-- H3: `probeFail` increments `failureCount` by exactly 1. -/
+@[simp]
+theorem h3_probefail_increments_count
+    (sm : ServiceModel) (K : Threshold) :
+    (step? sm .probeFail K).map (·.failureCount) = some (sm.failureCount + 1) := by
+  simp [step?]
+  split <;> rfl
+
+/-- H4: `backoffExpiry` only changes state when starting from `.evicted`. -/
+@[simp]
+theorem h4_backoff_only_from_evicted (sm : ServiceModel) (K : Threshold) :
+    (step? sm .backoffExpiry K).map (·.state)
+      = some (if sm.state = .evicted then .reconnecting else sm.state) := rfl
+
+/-- H8: `registryAbsent` ends the per-service state machine. -/
+@[simp]
+theorem h8_registry_absent_terminates
+    (sm : ServiceModel) (K : Threshold) :
+    step? sm .registryAbsent K = none := rfl
+
+end Proofs.MCPHealth
+```
+
+- [ ] **Step 2: Uncomment the Properties import in `MCPHealth.lean`.**
+
+Modify the entrypoint:
+
+```lean
+import Proofs.MCPHealth.State
+import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Properties
+
+-- Subsequent imports added as tasks land:
+-- import Proofs.MCPHealth.Coupling
+-- import Proofs.MCPHealth.Executable
+```
+
+- [ ] **Step 3: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build. No `sorry`. No warnings.
+
+If any theorem step fails: check that `step?` is defined exactly as in Task 3, then re-run. The `split <;> rfl` pattern in H3 relies on the `if-then-else` inside `step?` having matching record shape on both branches.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth.lean
+git commit -m "Proofs.MCPHealth: prove H1–H4, H8 (event-triggered + arithmetic) (#186)"
+```
+
+---
+
+## Task 5: Properties.lean — H7 (K=1 collapse) and helper lemmas
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean`
+
+- [ ] **Step 1: Append H7 and a helper lemma to `Properties.lean`.**
+
+At the end of the file, before `end Proofs.MCPHealth`, insert:
+
+```lean
+/-- H7: at K=1, `probeFail` from any non-removed state with `failureCount = 0`
+    goes directly to `.evicted`. Witnesses the K=1 collapse to today's Rust
+    single-failure eviction. -/
+theorem h7_k1_collapse_probefail_skips_degraded
+    (sm : ServiceModel) (h0 : sm.failureCount = 0)
+    (K : Threshold) (hk : K.val = 1) :
+    (step? sm .probeFail K).map (·.state) = some .evicted := by
+  simp [step?, h0, hk]
+
+/-- Helper: when `step?` lands in `.degraded` via `probeFail`, the new
+    failureCount is strictly less than K. This is the bookkeeping invariant
+    that supports H5's induction. -/
+theorem degraded_count_lt_K
+    (sm sm' : ServiceModel) (K : Threshold)
+    (h : step? sm .probeFail K = some sm')
+    (hd : sm'.state = .degraded) :
+    sm'.failureCount < K.val := by
+  simp [step?] at h
+  split at h
+  · -- n ≥ K branch: state becomes .evicted, contradicts hd = .degraded
+    rename_i hge
+    obtain ⟨hstate, _⟩ := Option.some_inj.mp h |>.symm |> (fun eq => ⟨congrArg _ eq, congrArg _ eq⟩)
+    -- simpler: rewrite h, then derive state = .evicted from the record
+    cases h
+    simp at hd
+  · -- n < K branch: this is the .degraded case
+    rename_i hlt
+    cases h
+    -- sm'.failureCount = sm.failureCount + 1 = n
+    -- hlt : ¬ (sm.failureCount + 1 ≥ K.val)
+    omega
+```
+
+(Note for the executor: if the `degraded_count_lt_K` proof above doesn't compile cleanly, the structure is fine but the tactic script may need adjustment. The mathematical content is: split on the `if` inside `step?`; in the `≥ K` branch the state is `.evicted` which contradicts `hd`; in the `< K` branch the failure count is `sm.failureCount + 1` and `¬ (sm.failureCount + 1 ≥ K.val)` gives `sm.failureCount + 1 < K.val` by `omega`. Adjust to whichever Lean 4 idiom compiles.)
+
+- [ ] **Step 2: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build. If `degraded_count_lt_K` fails, fix the tactic script — the mathematical content is sound; only the proof syntax may need adjustment.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+git commit -m "Proofs.MCPHealth: prove H7 (K=1 collapse) and degraded_count_lt_K (#186)"
+```
+
+---
+
+## Task 6: Properties.lean — H6 and H6' (constructive liveness)
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean`
+
+- [ ] **Step 1: Append H6 and H6' to `Properties.lean`.**
+
+At the end of the file, before `end Proofs.MCPHealth`, insert:
+
+```lean
+/-- H6: from `.evicted`, the two-event sequence
+    `[backoffExpiry, probeSuccess false]` reaches `.healthy`.
+    Constructive liveness witness for the backoff-then-probe recovery path
+    (relevant under K ≥ 2 with an armed backoff). -/
+theorem h6_evicted_recovers_via_backoff_then_probe
+    (sm : ServiceModel) (K : Threshold) (h : sm.state = .evicted) :
+    (run? sm [.backoffExpiry, .probeSuccess false] K).map (·.state) = some .healthy := by
+  simp [run?, List.foldl, Option.bind, step?, h]
+
+/-- H6': from `.evicted`, a single `probeSuccess false` reaches `.healthy`
+    directly (skipping `.reconnecting`). This is the **permissive** recovery
+    path — `Reconnecting` is an optional pass-through state, not mandatory.
+
+    Required by the K=1 conformance: today's Rust has no observable
+    `Reconnecting` state, so a successful probe after eviction must assign
+    `Healthy` directly. See spec §7.1 for the design rationale. -/
+theorem h6'_evicted_recovers_via_probe_directly
+    (sm : ServiceModel) (K : Threshold) (h : sm.state = .evicted) :
+    (step? sm (.probeSuccess false) K).map (·.state) = some .healthy := rfl
+```
+
+- [ ] **Step 2: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build, no `sorry`.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean
+git commit -m "Proofs.MCPHealth: prove H6, H6' (liveness — both recovery paths) (#186)"
+```
+
+---
+
+## Task 7: Properties.lean — H5 (anti-flapping inter-eviction gap, load-bearing)
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean`
+
+This is the load-bearing safety theorem. The statement says: if a run reaches `.healthy` at prefix `p1` and `.evicted` at later prefix `p2`, the event slice `events[p1..p2]` contains ≥ K `probeFail` events.
+
+- [ ] **Step 1: Append helper lemmas and H5 to `Properties.lean`.**
+
+At the end of the file, before `end Proofs.MCPHealth`, insert:
+
+```lean
+/-! ## H5 — Anti-flapping inter-eviction gap (load-bearing)
+
+The contract that catches the historical flapping connection-pool bug class.
+For K=1 it's vacuously tight (1 failure suffices to evict). For K ≥ 2 it
+guarantees ≥ K probeFail events between any Healthy and any subsequent Evicted.
+-/
+
+/-- Helper: when `run? sm events K` lands in `.evicted`, then either `sm`
+    started in `.evicted`, or the events list contains at least one
+    `probeFail` whose increment landed at or above K.
+
+    More usefully for H5: the `failureCount` of a `.evicted` outcome is
+    ≥ K.val.  -/
+theorem evicted_failureCount_ge_K
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (hst : sm'.state = .evicted) :
+    sm.state = .evicted ∨ sm'.failureCount ≥ K.val := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      left
+      subst hrun
+      exact hst
+  | cons e rest ih =>
+      simp [run?, List.foldl, Option.bind] at hrun
+      cases hstep : step? sm e K with
+      | none =>
+          rw [hstep] at hrun
+          simp at hrun
+      | some sm'' =>
+          rw [hstep] at hrun
+          simp at hrun
+          -- hrun : run? sm'' rest K = some sm'
+          have := ih sm'' hrun
+          cases this with
+          | inl h =>
+              -- sm''.state = .evicted; trace back through step?
+              cases e <;> simp [step?] at hstep
+              · -- probeSuccess: contradicts h
+                rename_i b
+                obtain rfl := Option.some_inj.mp hstep
+                simp at h
+                cases b <;> simp at h
+              · -- probeFail
+                split at hstep
+                · -- ≥ K branch
+                  rename_i hge
+                  obtain rfl := Option.some_inj.mp hstep
+                  right
+                  -- sm''.failureCount = sm.failureCount + 1 ≥ K.val
+                  -- now we need to track this through `run?` to sm'
+                  -- the failureCount can change in rest events, so we instead
+                  -- prove sm'.failureCount ≥ K.val by case-splitting rest
+                  exact run_preserves_failureCount_or_resets sm'' sm' rest K hrun hst hge
+                · simp at h
+              · -- backoffExpiry
+                obtain rfl := Option.some_inj.mp hstep
+                cases sm.state <;> simp at h
+              · -- registryAbsent ruled out by hstep
+                contradiction
+          | inr h => right; exact h
+
+/-- Helper: across a `run?` that lands in `.evicted`, the failureCount is
+    preserved or reset to 0 + re-incremented above K. Either way, the final
+    `failureCount` is ≥ K.val. Used inside `evicted_failureCount_ge_K`. -/
+theorem run_preserves_failureCount_or_resets
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (hst : sm'.state = .evicted)
+    (hsm : sm.failureCount ≥ K.val) :
+    sm'.failureCount ≥ K.val := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      subst hrun
+      exact hsm
+  | cons e rest ih =>
+      simp [run?, List.foldl, Option.bind] at hrun
+      cases hstep : step? sm e K with
+      | none =>
+          rw [hstep] at hrun
+          simp at hrun
+      | some sm'' =>
+          rw [hstep] at hrun
+          simp at hrun
+          -- if sm''.state = .evicted with high count, recurse
+          -- if sm''.state ≠ .evicted at this point, the next steps may
+          -- transit through .evicted again with a fresh count
+          cases e <;> simp [step?] at hstep
+          · -- probeSuccess: resets count; sm''.state ≠ .evicted at this point
+            -- but sm''.state could become .evicted later via failures
+            -- Recurse: ih needs sm''.failureCount ≥ K.val, which is false here
+            -- So we must instead use evicted_failureCount_ge_K on sm''/sm'/rest
+            rename_i b
+            obtain rfl := Option.some_inj.mp hstep
+            have := evicted_failureCount_ge_K sm'' sm' rest K hrun hst
+            cases this with
+            | inl h => simp at h
+              -- sm''.state = .evicted, but probeSuccess gives healthy/degraded
+              cases b <;> simp at h
+            | inr h => exact h
+          · -- probeFail
+            split at hstep
+            · rename_i hge
+              obtain rfl := Option.some_inj.mp hstep
+              -- sm''.failureCount = sm.failureCount + 1 ≥ K.val ≥ K.val
+              -- so we can use ih with the new hsm
+              apply ih sm''
+              · exact hrun
+              · -- new hsm : sm''.failureCount ≥ K.val
+                exact Nat.le_of_lt (Nat.lt_succ_of_le hge)
+            · rename_i hlt
+              -- sm''.failureCount = sm.failureCount + 1 < K.val
+              -- contradicts hsm : sm.failureCount ≥ K.val ?? Not directly.
+              -- sm.failureCount ≥ K.val means sm.failureCount + 1 ≥ K.val + 1 > K.val,
+              -- which contradicts hlt.
+              exfalso
+              apply hlt
+              omega
+          · -- backoffExpiry: count unchanged
+            obtain rfl := Option.some_inj.mp hstep
+            apply ih
+            · exact hrun
+            · simp; exact hsm
+          · -- registryAbsent
+            contradiction
+
+/-- H5 anti_flapping_inter_eviction_gap.
+
+    If a run starting from `ServiceModel.initial` reaches `.healthy` at
+    prefix `p1` (after `events.take p1`) and `.evicted` at later prefix `p2`
+    (after `events.take p2`), then the slice `events[p1..p2]` contains at
+    least K `.probeFail` events.
+
+    This is the contract that catches the historical flapping bug class:
+    at K=1, one fail is enough (matches today's Rust); at K ≥ 2, the model
+    guarantees inter-eviction quiet windows.
+
+    Proof strategy: at prefix p1 the state is `.healthy`, so failureCount is 0
+    (probeSuccess resets to 0; the only way to be `.healthy` is via
+    `probeSuccess(false)`). Between p1 and p2, the state lands in `.evicted`,
+    so by `evicted_failureCount_ge_K`, the failureCount is ≥ K. Since each
+    `probeFail` increments by exactly 1 and `probeSuccess` resets to 0, the
+    count of `probeFail` events in the slice is ≥ K. -/
+theorem h5_anti_flapping_inter_eviction_gap
+    (events : List Event) (K : Threshold)
+    (p1 p2 : Nat) (h12 : p1 < p2) (h2le : p2 ≤ events.length)
+    (h1 : (run? ServiceModel.initial (events.take p1) K).map (·.state) = some .healthy)
+    (h2 : (run? ServiceModel.initial (events.take p2) K).map (·.state) = some .evicted) :
+    K.val ≤ ((events.drop p1).take (p2 - p1)).countP (· = Event.probeFail) := by
+  -- Sketch (executor: fill in the tactic script):
+  -- 1. From h1 extract sm1 with (run? init (events.take p1) K) = some sm1
+  --    and sm1.state = .healthy, hence sm1.failureCount = 0 (by H2-style fact
+  --    on the last event of the prefix being probeSuccess(false), or by initial).
+  -- 2. From h2 extract sm2 similarly with sm2.state = .evicted.
+  -- 3. Apply evicted_failureCount_ge_K to (sm1, sm2, events.drop p1 ⌢ … take (p2-p1))
+  --    to get sm2.failureCount ≥ K.val.
+  -- 4. Each .probeFail in the slice increments failureCount by 1; each
+  --    .probeSuccess resets to 0; other events don't change failureCount.
+  --    By the structure of step?, sm2.failureCount equals the count of
+  --    .probeFail events since the last .probeSuccess in the slice
+  --    (or since p1 if no probeSuccess in the slice).
+  -- 5. count_eq_failureCount: the count of probeFail events bounded below
+  --    by sm2.failureCount (any intervening probeSuccess would only INCREASE
+  --    the required count to reach ≥ K).
+  -- 6. Conclude.
+  sorry
+```
+
+**IMPORTANT**: The `sorry` here is a stand-in only for this step's draft. **Step 2 of this task MUST replace it with a complete proof — no `sorry` remains in any committed file.**
+
+- [ ] **Step 2: Complete the H5 proof.**
+
+The proof has two pieces that need to come together:
+
+**(a) `sm1.failureCount = 0` at the `.healthy` prefix.**
+
+State a helper lemma:
+
+```lean
+theorem healthy_failureCount_eq_zero
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (hst : sm'.state = .healthy) :
+    sm'.failureCount = 0 ∨ (events = [] ∧ sm.failureCount = 0 ∧ sm.state = .healthy) := by
+  -- Induction on events.
+  -- nil case: sm' = sm; if sm.state = .healthy then return the right disjunct.
+  -- cons case: the only events that produce .healthy are
+  --            probeSuccess(false) (which sets failureCount := 0) or
+  --            backoffExpiry from a .healthy starting state (preserves count;
+  --            but the prefix-induction means we can recurse to get count = 0).
+  sorry
+```
+
+Drive the proof by case analysis on the last event of the prefix. `ServiceModel.initial.failureCount = 0` and `.state = .healthy` is the base case.
+
+**(b) `sm2.failureCount` is a lower bound on the probeFail count in the slice.**
+
+State the bridge lemma:
+
+```lean
+theorem failureCount_bounded_by_probefail_count
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm')
+    (h0 : sm.failureCount = 0) :
+    sm'.failureCount ≤ events.countP (· = Event.probeFail) := by
+  induction events generalizing sm with
+  | nil => simp [run?] at hrun; subst hrun; simp [h0]
+  | cons e rest ih =>
+      simp [run?, List.foldl, Option.bind] at hrun
+      cases hstep : step? sm e K with
+      | none => rw [hstep] at hrun; simp at hrun
+      | some sm'' =>
+          rw [hstep] at hrun; simp at hrun
+          cases e <;> simp [step?] at hstep
+          · -- probeSuccess: sm''.failureCount = 0; ih applies with h0 = 0
+            rename_i b
+            obtain rfl := Option.some_inj.mp hstep
+            apply Nat.le_trans (ih sm'' hrun (by rfl))
+            simp [List.countP_cons]
+          · -- probeFail: sm''.failureCount = sm.failureCount + 1 = 1 (by h0)
+            split at hstep
+            · obtain rfl := Option.some_inj.mp hstep
+              -- sm''.failureCount = 1; recurse with new h0 = 1
+              -- But ih requires sm.failureCount = 0; here sm''.failureCount = 1
+              -- So we need a strictly stronger ih ... or a different angle.
+              sorry
+            · obtain rfl := Option.some_inj.mp hstep
+              sorry
+          · -- backoffExpiry: failureCount preserved
+            obtain rfl := Option.some_inj.mp hstep; simp
+            apply Nat.le_trans (ih sm hrun h0)
+            simp [List.countP_cons]
+          · contradiction
+```
+
+**Sharper formulation** (replace the above with this):
+
+```lean
+/-- The bridge fact: across any `run?`, the gain in `failureCount` is bounded
+    above by the count of `probeFail` events in the run. (Each probeFail
+    increments by 1; probeSuccess resets to 0; backoffExpiry preserves.) -/
+theorem failureCount_le_probefail_count
+    (sm sm' : ServiceModel) (events : List Event) (K : Threshold)
+    (hrun : run? sm events K = some sm') :
+    sm'.failureCount ≤ sm.failureCount + events.countP (· = Event.probeFail) := by
+  induction events generalizing sm with
+  | nil =>
+      simp [run?] at hrun
+      subst hrun
+      simp
+  | cons e rest ih =>
+      simp [run?, List.foldl, Option.bind] at hrun
+      cases hstep : step? sm e K with
+      | none => rw [hstep] at hrun; simp at hrun
+      | some sm'' =>
+          rw [hstep] at hrun; simp at hrun
+          have hih := ih sm'' hrun
+          cases e <;> simp [step?] at hstep
+          · rename_i b
+            obtain rfl := Option.some_inj.mp hstep
+            -- sm''.failureCount = 0
+            simp [List.countP_cons]
+            omega
+          · split at hstep
+            · obtain rfl := Option.some_inj.mp hstep
+              simp [List.countP_cons] at hih ⊢
+              omega
+            · obtain rfl := Option.some_inj.mp hstep
+              simp [List.countP_cons] at hih ⊢
+              omega
+          · obtain rfl := Option.some_inj.mp hstep
+            simp [List.countP_cons] at hih ⊢
+            cases sm.state <;> simp at hih <;> omega
+          · contradiction
+```
+
+Then H5 follows from `evicted_failureCount_ge_K` (sm2.failureCount ≥ K.val), `healthy_failureCount_eq_zero` (sm1.failureCount = 0), and `failureCount_le_probefail_count` applied to the slice between p1 and p2.
+
+Final H5 proof:
+
+```lean
+theorem h5_anti_flapping_inter_eviction_gap
+    (events : List Event) (K : Threshold)
+    (p1 p2 : Nat) (h12 : p1 < p2) (h2le : p2 ≤ events.length)
+    (h1 : (run? ServiceModel.initial (events.take p1) K).map (·.state) = some .healthy)
+    (h2 : (run? ServiceModel.initial (events.take p2) K).map (·.state) = some .evicted) :
+    K.val ≤ ((events.drop p1).take (p2 - p1)).countP (· = Event.probeFail) := by
+  -- Extract sm1 from h1, sm2 from h2.
+  obtain ⟨sm1, hsm1_run, hsm1_state⟩ := by
+    rcases hrun1 : (run? ServiceModel.initial (events.take p1) K) with _ | sm1
+    · simp [hrun1] at h1
+    · simp [hrun1] at h1; exact ⟨sm1, hrun1, h1⟩
+  obtain ⟨sm2, hsm2_run, hsm2_state⟩ := by
+    rcases hrun2 : (run? ServiceModel.initial (events.take p2) K) with _ | sm2
+    · simp [hrun2] at h2
+    · simp [hrun2] at h2; exact ⟨sm2, hrun2, h2⟩
+  -- Bridge: run? sm1 (slice) K = some sm2, where slice = events[p1..p2].
+  have hslice : run? sm1 ((events.drop p1).take (p2 - p1)) K = some sm2 := by
+    -- run? sm0 (a ++ b) K = (run? sm0 a K).bind (run? · b K) — split events.take p2.
+    -- events.take p2 = events.take p1 ++ (events.drop p1).take (p2 - p1).
+    sorry  -- executor: prove via List.take_append_drop / run? composition lemma.
+  -- sm1.failureCount = 0 because sm1.state = .healthy.
+  have hsm1_fc : sm1.failureCount = 0 := by
+    have := healthy_failureCount_eq_zero ServiceModel.initial sm1
+      (events.take p1) K hsm1_run hsm1_state
+    cases this with
+    | inl h => exact h
+    | inr h => obtain ⟨_, h_init_fc, _⟩ := h; exact h_init_fc
+  -- sm2.failureCount ≥ K.val because sm2.state = .evicted and sm1.state ≠ .evicted.
+  have hsm2_fc : sm2.failureCount ≥ K.val := by
+    have := evicted_failureCount_ge_K sm1 sm2 _ K hslice hsm2_state
+    cases this with
+    | inl h => exfalso; rw [h] at hsm1_state; cases hsm1_state
+    | inr h => exact h
+  -- Apply the bound: sm2.failureCount ≤ sm1.failureCount + slice.probeFail_count.
+  have := failureCount_le_probefail_count sm1 sm2 _ K hslice
+  omega
+```
+
+**Need: `run?` composition lemma.** Add it to `Transition.lean` (or as a private lemma in `Properties.lean`):
+
+```lean
+/-- Compose two runs: `run? sm (a ++ b) K = (run? sm a K).bind (run? · b K)`. -/
+theorem run?_append (sm : ServiceModel) (a b : List Event) (K : Threshold) :
+    run? sm (a ++ b) K = (run? sm a K).bind (fun sm' => run? sm' b K) := by
+  induction a generalizing sm with
+  | nil => simp [run?]
+  | cons e rest ih =>
+      simp [run?, List.foldl, Option.bind]
+      cases step? sm e K with
+      | none => simp
+      | some sm' => simp; exact ih sm'
+```
+
+Add `run?_append` to `Transition.lean` after the existing `run?_singleton` lemma, then use it in the H5 proof: `events.take p2 = events.take p1 ++ (events.drop p1).take (p2 - p1)` (standard `List` lemma `List.take_append_take_drop` or hand-rolled with `List.take_append_drop` and arithmetic on the lengths).
+
+- [ ] **Step 3: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build, **zero `sorry`**. If H5's proof has a residual `sorry`, the task is not complete — fix it before committing.
+
+If proof tactics need adjustment to compile under the actual Lean toolchain, the mathematical content is what's load-bearing: H5 follows from (i) the run lands in `.evicted` with `failureCount ≥ K`, (ii) it started in `.healthy` with `failureCount = 0`, (iii) every probeFail increments by ≤ 1 and probeSuccess resets to 0. Adjust tactics until `lake build` is clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Properties.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth/Transition.lean
+git commit -m "Proofs.MCPHealth: prove H5 anti-flapping inter-eviction gap (#186)"
+```
+
+---
+
+## Task 8: Coupling.lean — healthProjection + C1–C4
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth/Coupling.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth.lean` (uncomment Coupling import)
+
+- [ ] **Step 1: Create `Coupling.lean`.**
+
+```lean
+import Proofs.MCPHealth.State
+import Proofs.ToolExecution.Policy
+
+/-!
+# MCP Health — Coupling to ToolExecution.Policy
+
+Projects the four-state `HealthState` down to the three-value
+`ToolExecution.Health` ADT that `preflight` already keys on. Then proves
+the four bridging lemmas (C1–C4):
+
+* Evicted / Reconnecting block dispatch as ServiceUnavailable.
+* Healthy / Degraded dispatch (when schema is valid or unchecked).
+
+This file is the **only** file in `Proofs.MCPHealth` that imports
+`Proofs.ToolExecution.Policy`. It does not modify `Policy.lean` — purely
+additive extension. See spec §5 for the rationale (preflight is the
+correct coupling axis, not `retryDisposition`).
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Project the four-state lifecycle to the three-value Health ADT.
+
+    Both flavors of `.degraded` (staleness-degraded and
+    failure-count-degraded) project to `.stale`, reflecting that both admit
+    dispatch with a longer timeout. -/
+def healthProjection : HealthState → ToolExecution.Health
+  | .healthy      => .healthy
+  | .degraded     => .stale
+  | .evicted      => .unreachable
+  | .reconnecting => .unreachable
+
+namespace Coupling
+
+/-- C1: Evicted services block dispatch as ServiceUnavailable. -/
+theorem c1_evicted_blocks_dispatch (schema : ToolExecution.SchemaStatus) :
+    ToolExecution.preflight (healthProjection .evicted) schema
+      = .block .serviceUnavailable := by
+  cases schema <;> rfl
+
+/-- C2: Reconnecting services block dispatch as ServiceUnavailable. -/
+theorem c2_reconnecting_blocks_dispatch (schema : ToolExecution.SchemaStatus) :
+    ToolExecution.preflight (healthProjection .reconnecting) schema
+      = .block .serviceUnavailable := by
+  cases schema <;> rfl
+
+/-- C3: Healthy services with valid (or unchecked) schema dispatch. -/
+theorem c3_healthy_dispatches
+    (schema : ToolExecution.SchemaStatus) (hv : schema ≠ .invalid) :
+    ToolExecution.preflight (healthProjection .healthy) schema = .dispatch := by
+  cases schema
+  · rfl
+  · rfl
+  · exact absurd rfl hv
+
+/-- C4: Degraded services dispatch (matches today's "stale services allowed
+    through with a longer timeout" behavior). -/
+theorem c4_degraded_dispatches
+    (schema : ToolExecution.SchemaStatus) (hv : schema ≠ .invalid) :
+    ToolExecution.preflight (healthProjection .degraded) schema = .dispatch := by
+  cases schema
+  · rfl
+  · rfl
+  · exact absurd rfl hv
+
+end Coupling
+end Proofs.MCPHealth
+```
+
+- [ ] **Step 2: Uncomment the Coupling import in `MCPHealth.lean`.**
+
+```lean
+import Proofs.MCPHealth.State
+import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Properties
+import Proofs.MCPHealth.Coupling
+
+-- Subsequent imports added as tasks land:
+-- import Proofs.MCPHealth.Executable
+```
+
+- [ ] **Step 3: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build, no `sorry`.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Coupling.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth.lean
+git commit -m "Proofs.MCPHealth: project HealthState to ToolExecution.Health (#186)"
+```
+
+---
+
+## Task 9: Executable.lean — TransitionCase + transitionCases
+
+**Files:**
+- Create: `crates/defra-agent/proofs/Proofs/MCPHealth/Executable.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/MCPHealth.lean` (uncomment Executable import)
+
+- [ ] **Step 1: Create `Executable.lean`.**
+
+```lean
+import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Coupling
+
+/-!
+# MCP Health — Conformance witnesses
+
+Exhaustive enumeration of transitions across
+`K ∈ {1, 2, 3} × startState ∈ HealthState.all × startCount ∈ {0..K} ×
+event ∈ Event.all`. Each row is evaluated by `step?` and tagged with the
+Rust 3-state projection.
+
+`k1ProjectionCases` is the subset Rust consumes today (K=1, matching the
+current `health_checker.rs` behavior). The K ≥ 2 rows are emitted but not
+yet asserted by any Rust test — they form the formal contract for a future
+K-aware refactor.
+-/
+
+namespace Proofs.MCPHealth
+
+/-- Witness row for a single transition. -/
+structure TransitionCase where
+  name           : String
+  startState     : HealthState
+  startCount     : Nat
+  event          : Event
+  thresholdK     : Nat
+  nextState      : Option HealthState   -- none = service removed
+  nextCount      : Option Nat
+  rustProjection : Option String         -- "healthy" | "stale" | "unreachable" | none
+  deriving Repr
+
+namespace TransitionCase
+
+/-- Build a row by applying `step?` to (startState, startCount, event, K). -/
+def build (startState : HealthState) (startCount : Nat) (event : Event)
+    (thresholdK : Nat) (hk : thresholdK ≥ 1) : TransitionCase :=
+  let K : Threshold := Threshold.ofNat thresholdK hk
+  let sm : ServiceModel := { state := startState, failureCount := startCount }
+  let next := step? sm event K
+  let nameSuffix := match next with
+    | none => "removed"
+    | some sm' => sm'.state.toDefraDB ++ "_" ++ toString sm'.failureCount
+  { name :=
+      "mcp_health_K" ++ toString thresholdK ++ "_"
+        ++ startState.toDefraDB ++ "_" ++ toString startCount ++ "_"
+        ++ event.toDefraDB ++ "_" ++ nameSuffix
+  , startState := startState
+  , startCount := startCount
+  , event := event
+  , thresholdK := thresholdK
+  , nextState := next.map (·.state)
+  , nextCount := next.map (·.failureCount)
+  , rustProjection :=
+      next.map fun sm' => (healthProjection sm'.state).toDefraDB
+  }
+
+end TransitionCase
+
+/-- Range `[0..K]` of valid starting `failureCount` values for a given K.
+    `0` for staleness-degraded / Healthy / Reconnecting; up to `K-1` for
+    failure-count-degraded; `K` only appears as a *next* count, not a start. -/
+def countRange (K : Nat) : List Nat :=
+  (List.range K)  -- [0, 1, ..., K-1]
+
+/-- Generate all rows for a single K. -/
+def transitionCasesFor (K : Nat) (hk : K ≥ 1) : List TransitionCase :=
+  HealthState.all.flatMap fun s =>
+    (countRange K).flatMap fun n =>
+      Event.all.map fun e =>
+        TransitionCase.build s n e K hk
+
+/-- All conformance rows for K ∈ {1, 2, 3}. -/
+def transitionCases : List TransitionCase :=
+  transitionCasesFor 1 (by decide) ++
+  transitionCasesFor 2 (by decide) ++
+  transitionCasesFor 3 (by decide)
+
+/-- K=1 subset — the rows Rust witnesses today. -/
+def k1ProjectionCases : List TransitionCase :=
+  transitionCases.filter (·.thresholdK = 1)
+
+/-- K ≥ 2 subset — emitted but not yet asserted by any Rust test. -/
+def k2PlusFutureCases : List TransitionCase :=
+  transitionCases.filter (·.thresholdK ≥ 2)
+
+/-- `k1ProjectionCases` and `k2PlusFutureCases` partition `transitionCases`. -/
+theorem k1_k2_partition :
+    k1ProjectionCases.length + k2PlusFutureCases.length = transitionCases.length := by
+  simp [k1ProjectionCases, k2PlusFutureCases, transitionCases,
+        transitionCasesFor, List.filter, List.length]
+  decide
+
+end Proofs.MCPHealth
+```
+
+- [ ] **Step 2: Uncomment the Executable import in `MCPHealth.lean`.**
+
+```lean
+import Proofs.MCPHealth.State
+import Proofs.MCPHealth.Transition
+import Proofs.MCPHealth.Properties
+import Proofs.MCPHealth.Coupling
+import Proofs.MCPHealth.Executable
+```
+
+- [ ] **Step 3: Verify `lake build`.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean build, no `sorry`.
+
+If the `decide` tactic times out or fails on `k1_k2_partition`, replace with `by rfl` or `by simp [...]; norm_num` — the proof is purely computational over a finite list.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/MCPHealth/Executable.lean \
+        crates/defra-agent/proofs/Proofs/MCPHealth.lean
+git commit -m "Proofs.MCPHealth: emit conformance transition cases (K=1, K=2, K=3) (#186)"
+```
+
+---
+
+## Task 10: Wire conformance JSON emission
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean`
+
+The Lean→Rust bridge runs `lake env lean --run Proofs/Conformance/Contracts.lean` and parses the JSON between sentinel markers. We add one new field `"mcp_health_cases"` to the top-level JSON object.
+
+- [ ] **Step 1: Add the import for the new module to `Json.lean`.**
+
+Read `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean` and locate the import section near the top of the file. Add:
+
+```lean
+import Proofs.MCPHealth.Executable
+```
+
+next to the existing `Proofs.ToolExecution.Policy` (or near it).
+
+- [ ] **Step 2: Add the per-row emitter helper in `Json.lean`.**
+
+After `toolRetryCaseJson` (around line 235 in the file, locate by `grep -n "toolRetryCaseJson" crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean`), insert:
+
+```lean
+def mcpHealthCaseJson (witness : Proofs.MCPHealth.TransitionCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"start_state\":" ++ jsonString witness.startState.toDefraDB ++ ","
+    ++ "\"start_count\":" ++ toString witness.startCount ++ ","
+    ++ "\"event\":" ++ jsonString witness.event.toDefraDB ++ ","
+    ++ "\"threshold_k\":" ++ toString witness.thresholdK ++ ","
+    ++ "\"next_state\":"
+      ++ jsonOptionalString (witness.nextState.map Proofs.MCPHealth.HealthState.toDefraDB) ++ ","
+    ++ "\"next_count\":"
+      ++ (match witness.nextCount with
+          | none => "null"
+          | some n => toString n) ++ ","
+    ++ "\"rust_projection\":"
+      ++ jsonOptionalString witness.rustProjection
+    ++ "}"
+```
+
+(If `jsonOptionalString` is the helper already used for similar nullable strings, reuse it. Otherwise look up the existing helper in `Json.lean` and use whichever matches.)
+
+- [ ] **Step 3: Wire the new field into the top-level JSON emitter.**
+
+Find the closing brace of the top-level JSON (around line 427: `++ "}"`). Insert the new field **immediately before** `++ "\"follow_up_hooks\":[],"`:
+
+```lean
+    ++ "\"mcp_health_cases\":"
+      ++ jsonArray (Proofs.MCPHealth.transitionCases.map mcpHealthCaseJson) ++ ","
+    ++ "\"follow_up_hooks\":[],"
+```
+
+- [ ] **Step 4: Add a coverage-ledger entry in `CoverageLedger.lean`.**
+
+Locate the `consumerCoverage` block near line 105 (after the `ToolRetryDisposition` entry). Insert:
+
+```lean
+  , consumerCoverage
+      "state_machine"
+      "MCPHealth"
+      "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
+```
+
+The placement is between the existing entries; choose the spot that keeps the existing ordering pattern (state_machine entries are typically grouped — find a nearby state-machine row and insert next to it). If unclear, place it at the end of the `consumerCoverage` list, just before the closing `]`.
+
+- [ ] **Step 5: Verify `lake build` and JSON emission.**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean | grep -A1 mcp_health_cases | head -10
+```
+
+Expected: build is clean; the second command prints a JSON snippet showing `"mcp_health_cases":[ ... rows ...`.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean \
+        crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+git commit -m "Conformance: emit mcp_health_cases JSON; register coverage row (#186)"
+```
+
+---
+
+## Task 11: Wire LeanContractSnapshot + LeanMcpHealthCase
+
+**Files:**
+- Modify: `crates/defra-agent/src/lean_vocab_test.rs`
+
+- [ ] **Step 1: Add `LeanMcpHealthCase` struct.**
+
+In `crates/defra-agent/src/lean_vocab_test.rs`, after `LeanToolRetryCase` (around line 440, locate via `grep -n "struct LeanToolRetryCase" crates/defra-agent/src/lean_vocab_test.rs`), insert:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanMcpHealthCase {
+    pub(crate) name: String,
+    pub(crate) start_state: String,
+    pub(crate) start_count: usize,
+    pub(crate) event: String,
+    pub(crate) threshold_k: usize,
+    pub(crate) next_state: Option<String>,
+    pub(crate) next_count: Option<usize>,
+    pub(crate) rust_projection: Option<String>,
+}
+```
+
+- [ ] **Step 2: Add the field to `LeanContractSnapshot`.**
+
+Locate the `LeanContractSnapshot` struct (around line 27). Insert a new field **next to `tool_retry_cases`** (so related test surfaces stay grouped):
+
+```rust
+pub(crate) tool_retry_cases: Vec<LeanToolRetryCase>,
+pub(crate) mcp_health_cases: Vec<LeanMcpHealthCase>,
+```
+
+- [ ] **Step 3: Add the accessor functions.**
+
+After `lean_tool_retry_case` (around line 690, locate via `grep -n "lean_tool_retry_case" crates/defra-agent/src/lean_vocab_test.rs`), insert:
+
+```rust
+pub(crate) fn lean_mcp_health_cases() -> &'static [LeanMcpHealthCase] {
+    &lean_contract_snapshot().mcp_health_cases
+}
+
+pub(crate) fn lean_mcp_health_k1_cases() -> Vec<&'static LeanMcpHealthCase> {
+    lean_contract_snapshot()
+        .mcp_health_cases
+        .iter()
+        .filter(|case| case.threshold_k == 1)
+        .collect()
+}
+```
+
+- [ ] **Step 4: Verify `cargo check` (test target).**
+
+```bash
+cargo check -p defra-agent --tests
+```
+
+Expected: no errors. The new struct and field should parse cleanly. Warnings about unused functions are fine — the Rust test in Task 12 will consume them.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/defra-agent/src/lean_vocab_test.rs
+git commit -m "lean_vocab_test: wire LeanMcpHealthCase + accessors (#186)"
+```
+
+---
+
+## Task 12: Add the Rust consumer test in health_checker.rs
+
+**Files:**
+- Modify: `crates/defra-agent/src/health_checker.rs`
+
+The new test consumes the K=1 rows from Lean and asserts the projection matches today's Rust behavior. **No changes to `run_health_check` or any production code.**
+
+- [ ] **Step 1: Write the failing test first.**
+
+In `crates/defra-agent/src/health_checker.rs`, locate the existing test module (`#[cfg(test)] mod registry_parsing_tests`, around line 324). Add a **new test module** below it (sibling, not nested):
+
+```rust
+#[cfg(test)]
+mod transitions_tests {
+    use super::HealthStatus;
+    use crate::lean_vocab_test::{lean_mcp_health_k1_cases, LeanMcpHealthCase};
+
+    /// Project a Lean K=1 case's `rust_projection` to a `HealthStatus` for
+    /// today's Rust to assert against. `None` means the service was removed
+    /// via `registryAbsent`; tests skip those rows (Rust represents removal
+    /// by dropping the map entry, not by a `HealthStatus`).
+    fn projected_health_status(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
+        case.rust_projection.as_deref().map(|s| match s {
+            "healthy" => HealthStatus::Healthy,
+            "stale" => HealthStatus::Stale,
+            "unreachable" => HealthStatus::Unreachable,
+            other => panic!(
+                "Lean MCP health case {} produced unknown rust_projection {:?}",
+                case.name, other
+            ),
+        })
+    }
+
+    /// Simulate one tick of `run_health_check`'s decision logic for a given
+    /// case: given a starting `HealthStatus` and a probe event, what does
+    /// today's Rust assign?
+    ///
+    /// This mirrors the inline logic at `health_checker.rs:247–308` but
+    /// drives it with the case's event rather than a real probe call.
+    fn rust_simulated_next(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
+        match case.event.as_str() {
+            "registryAbsent" => None,
+            "backoffExpiry" => {
+                // Today's Rust has no backoffExpiry behavior — backoff is not
+                // armed at K=1. Express this by mapping the projection back
+                // (no observable change at K=1).
+                Some(start_status(case))
+            }
+            "probeSuccessFresh" => Some(HealthStatus::Healthy),
+            "probeSuccessStale" => Some(HealthStatus::Stale),
+            "probeFail" => Some(HealthStatus::Unreachable),
+            other => panic!(
+                "Lean MCP health case {} produced unknown event {:?}",
+                case.name, other
+            ),
+        }
+    }
+
+    fn start_status(case: &LeanMcpHealthCase) -> HealthStatus {
+        match case.start_state.as_str() {
+            "healthy" => HealthStatus::Healthy,
+            "degraded" => HealthStatus::Stale, // K=1: degraded only via staleness
+            "evicted" | "reconnecting" => HealthStatus::Unreachable,
+            other => panic!(
+                "Lean MCP health case {} produced unknown start_state {:?}",
+                case.name, other
+            ),
+        }
+    }
+
+    #[test]
+    fn generated_mcp_health_k1_cases_match_health_checker_transitions() {
+        let cases = lean_mcp_health_k1_cases();
+        assert!(
+            !cases.is_empty(),
+            "Lean must emit at least one K=1 MCP health case"
+        );
+
+        for case in cases {
+            let expected = projected_health_status(case);
+            let actual = rust_simulated_next(case);
+            assert_eq!(
+                actual, expected,
+                "Lean MCP health K=1 case {} must match Rust HealthStatus assignment",
+                case.name
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it compiles and either passes or fails meaningfully.**
+
+```bash
+cargo test -p defra-agent transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions -- --nocapture
+```
+
+Expected: passes. The K=1 conformance rows from Lean (`Healthy + probeFail → Evicted` projects to `Unreachable`; `Healthy + probeSuccess(true) → Degraded` projects to `Stale`; etc.) should all match `rust_simulated_next`.
+
+If it fails: the most likely cause is a row-by-row mismatch between Lean's `healthProjection` table and the Rust simulation logic. Read the assertion failure message — it names the offending case — and reconcile. Either Lean's emission is wrong (re-check `healthProjection` in `Coupling.lean`) or Rust's `rust_simulated_next` doesn't capture today's behavior accurately.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/defra-agent/src/health_checker.rs
+git commit -m "health_checker: consume Lean K=1 MCP health conformance rows (#186)"
+```
+
+---
+
+## Task 13: Final verification — full test + lake build
+
+**Files:** (no edits in this task; verification only)
+
+- [ ] **Step 1: Run the full Lean build.**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: clean build, zero `sorry`, no warnings.
+
+Verify no `sorry` anywhere in the new module:
+
+```bash
+grep -rn "sorry" crates/defra-agent/proofs/Proofs/MCPHealth/
+```
+
+Expected: no matches (or only matches inside string literals / doc comments — re-read each line; the doc strings in `Task 5/7` should not contain the word `sorry` as a placeholder. Replace any residual `sorry` placeholders with `by ...` proofs before continuing.)
+
+- [ ] **Step 2: Run the full Rust test suite for the agent crate.**
+
+```bash
+cargo test -p defra-agent
+```
+
+Expected: all existing tests pass; the new test `transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions` passes.
+
+If any unrelated test fails: investigate the root cause; don't disable or skip.
+
+- [ ] **Step 3: Verify the conformance JSON sentinel block parses end-to-end.**
+
+```bash
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean | \
+    grep -c '"mcp_health_cases"'
+```
+
+Expected: `1` (the field appears exactly once in the JSON).
+
+- [ ] **Step 4: Sanity-check the K=1 row count.**
+
+```bash
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean | \
+    grep -o '"threshold_k":1' | wc -l
+```
+
+Expected: the count equals `|HealthState.all| * K=1's countRange * |Event.all| = 4 * 1 * 5 = 20` rows at K=1. (`countRange 1 = [0]` is a one-element list.)
+
+- [ ] **Step 5: Confirm no edits to `Proofs/ToolExecution/Policy.lean` or production Rust.**
+
+```bash
+git diff main -- crates/defra-agent/proofs/Proofs/ToolExecution/Policy.lean
+git diff main -- crates/defra-agent/src/health_checker.rs | grep -v "^+#\[cfg(test)\]\|^+mod transitions_tests\|^+    \|^+}" | head
+```
+
+Expected: first command shows no diff. Second command's filtered output (anything outside the `#[cfg(test)]` block) is empty.
+
+If either shows unexpected diffs, revert those changes — production code should be untouched.
+
+- [ ] **Step 6: No new commit in this task (verification only). Move to Task 14 to open the PR.**
+
+---
+
+## Task 14: Open the pull request
+
+**Files:** (no file edits; PR creation only)
+
+- [ ] **Step 1: Confirm branch state.**
+
+```bash
+git status
+git log --oneline main..HEAD
+```
+
+Expected: clean tree (no uncommitted changes); 8–11 commits ahead of main (one per task), all signed by the implementer.
+
+- [ ] **Step 2: Push the branch.**
+
+```bash
+git push -u origin proofs/issue-186-mcp-health-eviction
+```
+
+- [ ] **Step 3: Open the PR.**
+
+```bash
+gh pr create --title "Add MCP health probe / eviction state machine in Lean" --body "$(cat <<'EOF'
+## Summary
+
+Adds a per-service Lean state machine over the four-state lifecycle
+`healthy → degraded → evicted → reconnecting`, parameterized by a failure-count
+threshold K. K=1 collapses to today's Rust single-probe-failure eviction;
+K≥2 admits the bounded-flap regime.
+
+## States and transitions
+
+- `Healthy → Degraded` on `probeSuccess(staleness=true)` (any K) or
+  `probeFail` when `failureCount + 1 < K` (K≥2 only).
+- `Degraded → Evicted` on `probeFail` when `failureCount + 1 ≥ K`.
+- `Evicted → Reconnecting` on `backoffExpiry`.
+- `Reconnecting → Healthy` on `probeSuccess(false)`.
+- Permissive direct path: `Evicted → Healthy` on `probeSuccess(false)`
+  (the `Reconnecting` pass-through is optional; this matches today's K=1 Rust
+  where no observable `Reconnecting` state exists).
+
+## Load-bearing safety property
+
+**H5 anti-flapping inter-eviction gap.** If a run reaches `.healthy` at prefix
+`p1` and `.evicted` at later prefix `p2`, the event slice `events[p1..p2]`
+contains ≥ K `.probeFail` events. At K=1 this admits today's single-failure
+eviction; at K≥2 it guarantees inter-eviction quiet windows — the contract
+that closes the flapping connection-pool bug class the audit identified.
+
+## Conformance vectors registered
+
+- `Proofs.MCPHealth.transitionCases` — exhaustive over
+  `K ∈ {1,2,3} × startState × startCount ∈ [0..K) × event`.
+- `Proofs.MCPHealth.k1ProjectionCases` — K=1 subset, consumed by the new
+  Rust test `health_checker::transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions`.
+- `Proofs.MCPHealth.k2PlusFutureCases` — K≥2 subset, emitted as the formal
+  contract for a future K-aware Rust refactor; not asserted by any Rust test
+  yet (deliberately).
+
+## Coupling to `ToolRetryDisposition`
+
+Reframed at design time (see `docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` §5).
+The load-bearing coupling is to **`preflight`**, not `retryDisposition`:
+`retryDisposition` is keyed on operation/idempotency/failure-class and
+adding `HealthState` would break that orthogonality (and conflict with the
+"additive only" rule for `Proofs/ToolExecution/Policy.lean`). Instead,
+`Proofs/MCPHealth/Coupling.lean` defines `healthProjection : HealthState →
+ToolExecution.Health` and proves four lemmas (C1–C4) that compose the
+projection with the existing `preflight` contract. `Policy.lean` is not
+modified.
+
+## Scope discipline
+
+- Zero `sorry`.
+- No Rust production code changes (no edits to `HealthStatus`, `ServiceHealth`,
+  `run_health_check`, or `mcp_pool.rs`).
+- No TLA+ artifact (cross-node coordination is not in scope).
+- No edits to `Proofs/ToolExecution/Policy.lean` (additive extension only).
+- One new line in `Proofs.lean`.
+
+## Test plan
+
+- [ ] `cd crates/defra-agent/proofs && lake build` is clean, zero `sorry`.
+- [ ] `cargo test -p defra-agent` passes; new test
+      `transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions`
+      is among the passing tests.
+- [ ] `lake env lean --run Proofs/Conformance/Contracts.lean` emits a
+      `mcp_health_cases` field with > 0 rows.
+- [ ] No diff to `Proofs/ToolExecution/Policy.lean`.
+- [ ] No production-code diff in `health_checker.rs`/`mcp_pool.rs` (only
+      `#[cfg(test)]` additions).
+
+Closes #186
+Refs #183
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens; `gh` returns the PR URL.
+
+- [ ] **Step 4: Report the PR URL back to the user.**
+
+---
+
+## Self-review notes (for the executor)
+
+Before the final PR, re-verify against the spec (`docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md`):
+
+- **§3 acceptance row coverage:** every row in the spec's acceptance table should map to a task above. Spot-check: H5 → Task 7; H6/H6' → Task 6; H7 → Task 5; H1/H2/H3/H4/H8 → Task 4; C1–C4 → Task 8; conformance vectors → Task 9; Rust consumer → Task 12; CoverageLedger → Task 10.
+- **§7.3 K=1 table:** every row in the spec's K=1 collapse table should appear as a row in `k1ProjectionCases`. Sanity-check by row count (expected: 20 rows).
+- **§14 risks:** all named risks (permissive recovery, backoff minimality, registry-absent terminal, staleness as observation) are acknowledged in code comments. The permissive-recovery risk specifically is addressed by H6' (Task 6).
+- **§12 constraints:** zero `sorry`, no production-Rust changes, no edits to `Policy.lean`, named `Proofs.lean` import — all enforced by Task 13's verification steps.
+
+If any spec requirement maps to no task, add the task before pushing.

--- a/docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md
+++ b/docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md
@@ -1,0 +1,348 @@
+# MCP health probe / eviction state machine in Lean: design
+
+**Status:** Design
+**Date:** 2026-05-13
+**Tracks:** issue #186 (this work); parent #183 (formal coverage audit follow-ups); audit `docs/superpowers/audits/2026-05-13-formal-coverage-audit.md` gap #7.
+**Scope:** A small per-service Lean state machine over `healthy → degraded → evicted → reconnecting`, parameterized by a failure-count threshold K. Includes a projection lemma that bridges the new state machine into the existing `Proofs/ToolExecution/Policy.lean` preflight contract, plus conformance witnesses for today's K=1 Rust behavior. No Rust production-code changes. No new TLA+ artifact.
+
+## 1. Goal
+
+Close audit gap #7. The audit's leverage statement:
+
+> probe interval, staleness window, eviction lifecycle, and pool eviction state machine are operational only ... modeling probe/eviction as a state machine would catch flapping-connection-pool bugs before they reach prod; leaving it open means health-driven pool eviction has no contract beyond Rust tests.
+
+The bug class the audit names — **flapping** — is what makes #186 worth doing relative to its low immediate stakes. A formal **inter-eviction gap** property gives the runtime a contract that catches "one bad probe evicts; the next call lazily reconnects; one bad probe evicts; ..." regression as a proof failure rather than an integration-test gotcha.
+
+This spec produces an implementation plan, not implementation. The plan is the next step (writing-plans skill).
+
+## 2. Why now
+
+- Every connection-pool bug shipped historically has been health-related.
+- The existing `Proofs/ToolExecution/Policy.lean` already encodes a 3-value `Health` ADT (`healthy`/`stale`/`unreachable`) and a `preflight` decision keyed on it, but **no state machine** — no transitions, no flapping property, no anti-oscillation guarantee.
+- Issue #186 explicitly chose a richer 4-state shape (`healthy → degraded → evicted → reconnecting`) than the 3-state code today. That ask is structurally inconsistent with the current Rust health checker (which evicts on a single probe failure) unless we parameterize: a failure threshold `K` lets `K=1` describe today's behavior and `K≥2` describe the anti-flapping regime.
+- The MCP boundary is increasingly central as more services move to MCP (`x-data`, `hf-data`, `coding-session`, observability, etc.); a formal probe/eviction contract scales the safety we already prove on the tool-call lifecycle out to the connection lifecycle.
+
+## 3. Acceptance against #186
+
+| Acceptance item | Where it lands |
+|---|---|
+| Four-state machine `healthy → degraded → evicted → reconnecting` with bounded transitions | `Proofs/MCPHealth/State.lean` + `Proofs/MCPHealth/Transition.lean` |
+| `Healthy → Degraded`: probe fails or staleness threshold crossed | `step?` on `probeSuccess(staleness=true)` and `probeFail` with `K≥2` |
+| `Degraded → Evicted`: N consecutive probe failures | `step?` on `probeFail` with `failureCount + 1 ≥ K` |
+| `Evicted → Reconnecting`: explicit re-add or backoff expiry | `step?` on `backoffExpiry` |
+| `Reconnecting → Healthy`: successful probe | `step?` on `probeSuccess(false)` from `.reconnecting` |
+| Coupling to `ToolRetryDisposition` | **Reframed** (§5): the load-bearing coupling is to `preflight`, not `retryDisposition`. See §5 for the rationale. |
+| Flapping bound (the load-bearing property) | `h5_anti_flapping_inter_eviction_gap` in `Proofs/MCPHealth/Properties.lean` |
+| Probe/eviction event ordering: every transition triggered by a named event | `h1_event_triggered` + the fact that `step?` is a total function over `Event` |
+| Conformance vocabulary registered | `Proofs/MCPHealth/Executable.lean` exports K=1 rows for Rust; K≥2 rows emitted but not yet consumed |
+| Rust consumer tests probe/eviction transitions against the proven model | New test in `crates/defra-agent/src/health_checker.rs` (`#[cfg(test)] mod tests`) consuming K=1 rows. **Tests only — no production-code changes.** |
+
+## 4. Architecture
+
+### 4.1 Files
+
+Module lives at `crates/defra-agent/proofs/Proofs/MCPHealth/` with the conventional 4-file split used by `Proofs/ToolExecution/`, `Proofs/Request/`, and `Proofs/Triggers/`, plus a small `Coupling.lean` to isolate the dependency on `Proofs/ToolExecution/Policy.lean`:
+
+```
+Proofs/MCPHealth.lean              -- entry: re-exports the namespace
+Proofs/MCPHealth/State.lean        -- HealthState, ServiceModel, Event
+Proofs/MCPHealth/Transition.lean   -- step?, run?
+Proofs/MCPHealth/Properties.lean   -- H1–H8
+Proofs/MCPHealth/Coupling.lean     -- healthProjection + preflight bridge
+Proofs/MCPHealth/Executable.lean   -- conformance witness rows
+```
+
+Dependency edges:
+
+```
+MCPHealth.State        --→ Proofs.Basic
+MCPHealth.Transition   --→ MCPHealth.State
+MCPHealth.Properties   --→ MCPHealth.Transition
+MCPHealth.Coupling     --→ MCPHealth.State + Proofs.ToolExecution.Policy
+MCPHealth.Executable   --→ MCPHealth.Transition + MCPHealth.Coupling
+MCPHealth (entrypoint) --→ all of the above
+```
+
+### 4.2 `Proofs.lean` import
+
+Add a single line:
+
+```lean
+import Proofs.MCPHealth
+```
+
+Insertion site: between line 18 (`import Proofs.ToolExecution`) and line 19 (`import Proofs.Subagent`). The Coupling.lean dependency on `Proofs.ToolExecution.Policy` is satisfied by ordering after the ToolExecution import.
+
+**Coordination note.** Per the brief, five sibling streams (#191, #188, #189, #187, #185) may also edit `Proofs.lean`. The only shared editing surface is the import list. Last-to-land rebases.
+
+### 4.3 Per-service scope
+
+Both the Rust connection pool (`crates/defra-agent/src/mcp_pool.rs`: `HashMap<service_id, McpConnection>`) and health map (`crates/defra-agent/src/health_checker.rs`: `HashMap<service_id, ServiceHealth>`) are keyed by `service_id` with no cross-service coupling beyond the registry retain set. The Lean state machine matches: one `ServiceModel` per service. Aggregate-pool properties would multiply bookkeeping without closing any cross-service invariant.
+
+The registry-retain rule ("services not in the online set get dropped") is modeled at the event layer (`Event.registryAbsent` returns `none` from `step?`); no separate Pool.lean wrapper.
+
+### 4.4 Parameterization over K
+
+A single `Threshold` parameter governs whether a probe failure goes straight to `Evicted` (K=1, today) or transits `Degraded` first (K≥2, future):
+
+| K | Meaning | Witnessed in Rust today? |
+|---|---|---|
+| `K = 1` | One probe failure → `Evicted` immediately. `Degraded` is reachable only via `probeSuccess(staleness=true)` (mirrors today's `Stale`). | **Yes** — conformance rows witness this against `run_health_check`. |
+| `K ≥ 2` | Probe failures accumulate in `Degraded` (`failureCount < K`) before evicting. `backoffExpiry` becomes a meaningful event. | **No** — conformance rows are emitted but not consumed; they form the formal contract for a future Rust K-aware refactor. |
+
+This is the load-bearing choice that lets the spec close #186's acceptance criteria without forcing a Rust refactor in the same PR.
+
+## 5. ToolRetryDisposition coupling
+
+Issue #186 names `ToolRetryDisposition` as the coupling target. The brief asks us to "brainstorm to confirm this is the right vocabulary." We propose **reframing the coupling target to `preflight`, not `retryDisposition`**, on these grounds:
+
+- `retryDisposition : ToolOperation → IdempotencyEvidence → FailureClass → RetryDisposition` is keyed on what kind of operation failed, not on what state the service is in. Adding `HealthState` as an input would break that orthogonality and conflict with the "additive only" coordination rule for `ToolExecution/Policy.lean`.
+- The operationally-relevant decision when a service is `Evicted` or `Reconnecting` is **dispatch admission**, not retry classification: today's `enforce_health_gate` (`crates/defra-agent/src/meta_tools/shared.rs`) blocks dispatch before any retry decision is reached. That gate's contract is `preflight`.
+- The retry behavior today (`list_tools` lazily reconnects after a pool eviction; `call_tool` does not retry) is a property of the operation and its idempotency, and is already proven by `mcp_call_without_idempotency_metadata_does_not_retry` / `list_tools_transport_retry_is_safe_read`. Nothing about that changes when we add the state machine.
+
+So the new file `Coupling.lean` defines a projection `healthProjection : HealthState → ToolExecution.Health`:
+
+```
+.healthy        ↦ .healthy
+.degraded       ↦ .stale
+.evicted        ↦ .unreachable
+.reconnecting   ↦ .unreachable
+```
+
+And proves four lemmas (C1–C4) that compose the projection with `preflight`. Nothing inside `ToolExecution/Policy.lean` changes. The retry vocabulary stays orthogonal and unchanged.
+
+The reframed coupling still discharges the spirit of #186's ask ("an evicted service implies the documented dispatch-blocking behavior") with the right vocabulary.
+
+## 6. Core types
+
+### 6.1 `HealthState`
+
+```lean
+inductive HealthState where
+  | healthy
+  | degraded
+  | evicted
+  | reconnecting
+  deriving DecidableEq, Repr
+```
+
+### 6.2 `ServiceModel`
+
+```lean
+structure ServiceModel where
+  state        : HealthState
+  failureCount : Nat
+  deriving DecidableEq, Repr
+```
+
+`failureCount` is the count of consecutive `probeFail` events since the last `probeSuccess`. Carrying it on the structure (rather than inside `.degraded`) lets `Reconnecting → probeFail → Evicted` increment without re-deriving the count from `.degraded`'s payload. `Degraded` is entered with `failureCount ∈ [0, K)`: `0` means "degraded because the last probe reported `staleness=true`"; `n ≥ 1` means "degraded because of `n` consecutive probe failures."
+
+### 6.3 `Event`
+
+```lean
+inductive Event where
+  | probeSuccess (staleness : Bool)
+  | probeFail
+  | backoffExpiry
+  | registryAbsent
+  deriving DecidableEq, Repr
+```
+
+Staleness is a probe-success modifier (mirrors `health_checker.rs:247` where `is_stale` is computed inline from the heartbeat age at probe time). `probeFail` folds both error and timeout — operationally identical in Rust (`health_checker.rs:268,:289` both `mcp_pool.remove` and set `Unreachable`). `backoffExpiry` is a no-op outside `.evicted`; `registryAbsent` removes the entity from the model entirely (returns `none` from `step?`).
+
+`Event.all` enumerates all five inhabitants (`probeSuccess false`, `probeSuccess true`, `probeFail`, `backoffExpiry`, `registryAbsent`) for use in conformance generation.
+
+## 7. Transitions
+
+### 7.1 `step?`
+
+```lean
+abbrev Threshold := { k : Nat // k ≥ 1 }
+
+def step? (sm : ServiceModel) (e : Event) (K : Threshold) : Option ServiceModel :=
+  match e with
+  | .registryAbsent => none
+  | .backoffExpiry  =>
+      some { sm with state := if sm.state = .evicted then .reconnecting else sm.state }
+  | .probeSuccess stale =>
+      some { state := if stale then .degraded else .healthy
+           , failureCount := 0 }
+  | .probeFail =>
+      let n := sm.failureCount + 1
+      if n ≥ K.val then some { state := .evicted,  failureCount := n }
+                   else some { state := .degraded, failureCount := n }
+```
+
+### 7.2 `run?`
+
+```lean
+def run? (sm : ServiceModel) (events : List Event) (K : Threshold)
+    : Option ServiceModel :=
+  events.foldl (fun acc e => acc.bind (fun sm' => step? sm' e K)) (some sm)
+```
+
+`run?` short-circuits on the first `.registryAbsent` — the per-service state machine ends, and any later events do not apply (analogous to terminal-irreversibility in the request lifecycle).
+
+### 7.3 K=1 collapse table
+
+For K=1, the matrix evaluates to:
+
+| start state | event | next state | failureCount |
+|---|---|---|---|
+| Healthy | probeSuccess false | Healthy | 0 |
+| Healthy | probeSuccess true | Degraded | 0 |
+| Healthy | probeFail | **Evicted** | 1 |
+| Healthy | backoffExpiry | Healthy | unchanged |
+| Healthy | registryAbsent | (removed) | — |
+| Degraded | probeSuccess false | Healthy | 0 |
+| Degraded | probeSuccess true | Degraded | 0 |
+| Degraded | probeFail | **Evicted** | n+1 |
+| Degraded | backoffExpiry | Degraded | unchanged |
+| Degraded | registryAbsent | (removed) | — |
+| Evicted | probeSuccess false | Healthy | 0 |
+| Evicted | probeSuccess true | Degraded | 0 |
+| Evicted | probeFail | Evicted | n+1 |
+| Evicted | backoffExpiry | **Reconnecting** | unchanged |
+| Evicted | registryAbsent | (removed) | — |
+| Reconnecting | probeSuccess false | Healthy | 0 |
+| Reconnecting | probeSuccess true | Degraded | 0 |
+| Reconnecting | probeFail | **Evicted** | n+1 |
+| Reconnecting | backoffExpiry | Reconnecting | unchanged |
+| Reconnecting | registryAbsent | (removed) | — |
+
+At K=1, every `probeFail` from a non-removed state goes to `Evicted` in one step — matching today's Rust single-failure eviction. The `Degraded`-as-stale-only path matches the `Stale` HealthStatus today.
+
+## 8. Properties
+
+| Tag | Statement | Kind | Discharged in |
+|---|---|---|---|
+| H1 | Every next-state arises from a named `Event`. No spontaneous transitions. | Safety (structural) | `Properties.lean` |
+| H2 | `probeSuccess` resets `failureCount` to 0. | Arithmetic | `Properties.lean` |
+| H3 | `probeFail` increments `failureCount` by exactly 1. | Arithmetic | `Properties.lean` |
+| H4 | `backoffExpiry` is a no-op outside `.evicted`. | Safety | `Properties.lean` |
+| **H5** | **Anti-flapping inter-eviction gap:** if `run?` reaches `.healthy` at prefix p1 and `.evicted` at later prefix p2, then the event slice `events[p1..p2]` contains ≥ K probeFail events. | **Safety (load-bearing)** | `Properties.lean` |
+| H6 | From `.evicted`, the two-event sequence `[backoffExpiry, probeSuccess false]` reaches `.healthy`. | Liveness (constructive) | `Properties.lean` |
+| H7 | At K=1, a `probeFail` from any non-degraded state with `failureCount = 0` goes directly to `.evicted` (witnesses the K=1 collapse to today's Rust). | Safety | `Properties.lean` |
+| H8 | `registryAbsent` ends the per-service state machine (`step? sm .registryAbsent K = none`). | Safety | `Properties.lean` |
+| C1 | `preflight (healthProjection .evicted) schema = .block .serviceUnavailable`. | Coupling | `Coupling.lean` |
+| C2 | `preflight (healthProjection .reconnecting) schema = .block .serviceUnavailable`. | Coupling | `Coupling.lean` |
+| C3 | `preflight (healthProjection .healthy) schema = .dispatch` when `schema ≠ .invalid`. | Coupling | `Coupling.lean` |
+| C4 | `preflight (healthProjection .degraded) schema = .dispatch` when `schema ≠ .invalid`. | Coupling | `Coupling.lean` |
+
+H5 is the **load-bearing safety property** — the contract that catches flapping regressions.
+
+## 9. Conformance witnesses
+
+`Executable.lean` emits `TransitionCase` rows:
+
+```lean
+structure TransitionCase where
+  name            : String   -- "transition_K1_healthy_probeFail_evicted_1" etc.
+  startState      : HealthState
+  startCount      : Nat
+  event           : Event
+  thresholdK      : Nat
+  nextState       : Option HealthState   -- none = service removed by registryAbsent
+  nextCount       : Option Nat
+  rustProjection  : Option String        -- "healthy" | "stale" | "unreachable" | none
+  deriving Repr
+```
+
+Generation is exhaustive over `K ∈ {1, 2, 3}`, `startState ∈ HealthState.all`, `startCount ∈ {0..K}`, `event ∈ Event.all`. The `rustProjection` field applies `healthProjection ∘ ToolExecution.Health.toDefraDB` and is `Some` whenever `nextState` is `some _`.
+
+Two derived projections are exposed:
+
+- `k1ProjectionCases : List TransitionCase` — filtered to `thresholdK = 1`. **Consumed by Rust today.**
+- `k2PlusFutureCases : List TransitionCase` — `thresholdK ≥ 2`. **Emitted but not yet consumed by a Rust assertion.** These are the formal contract for a future K-aware Rust refactor.
+
+A single Lean theorem ties the K=1 enumeration to today's Rust observable behavior:
+
+```lean
+theorem k1_cases_match_rust_health_status :
+    ∀ row ∈ k1ProjectionCases, rustProjectionAgreesWithCurrentRustBehavior row
+```
+
+`rustProjectionAgreesWithCurrentRustBehavior` is a structural predicate over the row's `rustProjection` field; the body is `rfl` on each enumerated row.
+
+## 10. Rust consumer (test-only)
+
+Add one new test to `crates/defra-agent/src/health_checker.rs` (`#[cfg(test)] mod tests`). The test is parameterized by the Lean-generated K=1 rows via the existing `lean_vocab_test` bridge module pattern (mirrors `lean_tool_preflight_cases` from `meta_tools/call.rs:367`):
+
+```rust
+#[tokio::test]
+async fn generated_mcp_health_k1_cases_match_health_checker_transitions() {
+    for case in lean_mcp_health_k1_cases() {
+        let actual = simulate_health_checker_one_event(&case).await;
+        assert_eq!(actual, case.rust_projection,
+            "Lean MCPHealth K=1 case {} must match Rust HealthStatus", case.name);
+    }
+}
+```
+
+The Rust bridge file (`crates/defra-agent/src/lean_vocab_test.rs` or a sibling) gets one new struct (`LeanMcpHealthCase`) and one new helper (`lean_mcp_health_k1_cases()`). **The bridge file is test-only (`#[cfg(test)]`)**; this is not production code.
+
+The `simulate_health_checker_one_event` helper drives a single probe outcome through a stripped-down version of `run_health_check`'s decision logic, using a `ServiceHealthMap` and a controlled probe result. **No changes to `run_health_check` itself.**
+
+### 10.1 Out of scope for the Rust test
+
+- Asserting K=2 transitions (Rust has no K≥2 behavior to assert against).
+- Asserting the `c1`–`c4` preflight lemmas in Rust (already covered by `generated_tool_preflight_cases_match_health_and_schema_gates` in `meta_tools/call.rs:385`; we don't duplicate).
+- Driving real probes against a real MCP server (the test uses a deterministic event vocabulary; integration coverage is upstream).
+
+## 11. What this spec is not
+
+- **Not a Rust refactor.** Production code in `health_checker.rs` and `mcp_pool.rs` is untouched. The K≥2 regime is described formally so that a future Rust refactor has a contract to satisfy, but the refactor itself is out of scope.
+- **Not a TLA+ artifact.** The state machine is per-service and event-driven; there is no cross-node coordination to motivate a temporal-logic spec. Sibling stream #188 is the TLA+ track.
+- **Not a backoff-timer model.** `backoffExpiry` is an external event; the model does not specify durations or backoff strategy. Future work may introduce a separate `Proofs/MCPHealth/Backoff.lean` if Rust grows a configurable backoff schedule, but that is not required by #186.
+- **Not a model of probe interval, staleness window, or probe timeout durations.** The relevant constants in `health_checker.rs:23,:24,:25` (30 s / 120 s / 5 s) are values used by `run_health_check` to compute the `staleness` flag and to issue the probe; the state machine consumes the flag and the probe outcome but doesn't itself encode durations. This mirrors how `Proofs/Request/*` treats deadlines as parameters rather than modeling wall-clock time.
+- **Not a change to `Proofs/ToolExecution/Policy.lean`.** Additive extension via `Coupling.lean` only.
+
+## 12. Hard constraints honored
+
+| Constraint (from brief) | Honored by |
+|---|---|
+| Zero `sorry` | All proofs are by `rfl` / structural induction / arithmetic. H5's induction is over the event list. |
+| No Rust production code | Only `#[cfg(test)]` additions to `health_checker.rs` and one new test-only helper in `lean_vocab_test.rs`. |
+| Don't model the network or the MCP protocol | The model treats probes as event-tagged transitions. Wire-level concerns (HTTP, transport, rmcp protocol) are out of scope. |
+| Don't conflict with `ToolExecution/Policy.lean` | `Coupling.lean` is the only file that imports `ToolExecution.Policy`. No edits to `Policy.lean`. |
+| Coordinate `Proofs.lean` imports | Named insertion site (between lines 18 and 19). Last-to-land rebases. |
+
+## 13. Coordination with sibling streams
+
+| Stream | Likely edit surface | Conflict risk with this stream |
+|---|---|---|
+| #191 (`Session/Transcript`) | New `Proofs/Session/Transcript.lean` or `Proofs/Transcript/`; `Proofs.lean` import line | Low — disjoint files; only `Proofs.lean` overlaps. |
+| #188 (TLA+) | `proofs/tla/` only | None — different artifact tree. |
+| #189 (`Liveness`/`Recovery`) | `Proofs/Properties/Liveness.lean` + `Proofs/Recovery/`; `Proofs.lean` | Low — disjoint files. |
+| #187 (`EventDelivery`) | `Proofs/EventDelivery/` or Triggers extension; `Proofs.lean` | Low — disjoint files. |
+| #185 (`Identity`) | `Proofs/Identity/`; `Proofs.lean` | Low — disjoint files. |
+
+**The only shared editing surface across all six streams is `Proofs.lean`.** This spec adds exactly one line (`import Proofs.MCPHealth`); any conflict is a trivial rebase.
+
+`Proofs/ToolExecution/Policy.lean` is named in the brief as "stable today; extension is fine; refactor is not." This spec is purely additive (a new `Coupling.lean` that imports `Policy`, never modifies it). Same rule applies symmetrically to sibling streams.
+
+## 14. Risks and known limitations
+
+- **K is a free parameter in the model but pinned at 1 in Rust today.** A future K≥2 refactor must (a) add a per-service failure counter to `ServiceHealth`, (b) introduce a `Degraded` variant to `HealthStatus`, (c) gate `mcp_pool.remove` on `failureCount ≥ K`, (d) consume the K≥2 conformance rows in a new test. This spec defines that contract; it does not deliver the refactor.
+- **`backoffExpiry` semantics are minimal.** The model only requires "evicted + backoffExpiry → reconnecting." It does not model arming, cancellation, jitter, or schedule choice. Future Rust may add backoff timers; the model accommodates that by leaving the event's timing unspecified.
+- **`registryAbsent` is modeled as terminal.** In Rust, a service can disappear from the online set and reappear later with the same `service_id`. The model treats reappearance as a fresh `ServiceModel` (i.e., `step?` returns `none`, and the pool layer would seed a new model). If we want to formalize same-id resurrection, that would need a separate Pool.lean wrapper — explicitly out of scope here.
+- **Staleness is observational, not driven by an async tick.** Today's Rust computes staleness inline from the heartbeat age at probe time, which means the model never needs an async time event. If Rust ever moves to an asynchronous staleness flagger (independent of probes), the event vocabulary would need a fifth event — this spec accepts that small future delta.
+- **H5's induction depth.** The flapping-bound theorem is a quantifier over arbitrary event lists. The proof is by induction on the suffix `events[p1..p2]`; cases are `nil` (vacuous), `probeSuccess _ :: …` (impossible to reach `.evicted` since it resets `failureCount`), `probeFail :: …` (decrement K by 1 and recurse), `backoffExpiry :: …` and `registryAbsent :: …` (vacuous transit). Lemma `failureCount_le_K_along_degraded` discharges the bookkeeping.
+
+## 15. Definition of done
+
+- [ ] All five `MCPHealth/*.lean` files written, zero `sorry`.
+- [ ] H1–H8 and C1–C4 closed.
+- [ ] `Proofs.lean` carries `import Proofs.MCPHealth` (one line).
+- [ ] `lake build` clean from `crates/defra-agent/proofs/`.
+- [ ] `Proofs/MCPHealth/Executable.lean` enumerates K∈{1,2,3} cases; `k1ProjectionCases` matches `transitionCases.filter (·.thresholdK = 1)`.
+- [ ] New `#[cfg(test)]` consumer in `health_checker.rs` passes; K=1 row count > 0 and asserted.
+- [ ] `cargo test -p defra-agent` clean (no production-code changes; only `#[cfg(test)]` additions).
+- [ ] No edits to `Proofs/ToolExecution/Policy.lean`.
+
+## 16. Out-of-scope follow-ups (not this PR)
+
+- **K≥2 Rust refactor.** When and if Rust adopts N-consecutive-failures eviction, a follow-up issue can drive the changes; the K≥2 conformance rows are pre-positioned.
+- **Backoff timer modeling.** If Rust grows a configurable backoff strategy, add `Proofs/MCPHealth/Backoff.lean` and the corresponding properties.
+- **Pool-level theorems.** If a cross-service invariant arises (e.g., "no more than M services evicted simultaneously"), a `Proofs/MCPHealth/Pool.lean` could land. Today's code has no such constraint.
+- **Cross-deployment MCP service propagation.** If MCP services start gossiping their health across deployments, that's a TLA+ track sibling to #176 and #162, not a Lean extension.

--- a/docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md
+++ b/docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md
@@ -135,7 +135,16 @@ structure ServiceModel where
   deriving DecidableEq, Repr
 ```
 
-`failureCount` is the count of consecutive `probeFail` events since the last `probeSuccess`. Carrying it on the structure (rather than inside `.degraded`) lets `Reconnecting → probeFail → Evicted` increment without re-deriving the count from `.degraded`'s payload. `Degraded` is entered with `failureCount ∈ [0, K)`: `0` means "degraded because the last probe reported `staleness=true`"; `n ≥ 1` means "degraded because of `n` consecutive probe failures."
+`failureCount` is the count of consecutive `probeFail` events since the last `probeSuccess`. Carrying it on the structure (rather than inside `.degraded`) lets `Reconnecting → probeFail → Evicted` increment without re-deriving the count from `.degraded`'s payload.
+
+**`Degraded` is a single constructor with two semantic flavors, distinguished by `failureCount`:**
+
+| `failureCount` | Flavor | Entered by |
+|---|---|---|
+| `0` | **Staleness-degraded.** The last probe succeeded but the heartbeat is older than the staleness window. Operationally equivalent to today's `Stale`. | `probeSuccess(staleness = true)` from any state. |
+| `≥ 1` | **Failure-count-degraded.** Saw `failureCount` consecutive probe failures, but `failureCount < K` so the service is not yet evicted. Only reachable under `K ≥ 2`. | `probeFail` from `Healthy`/`Degraded`/`Reconnecting` when `failureCount + 1 < K`. |
+
+The two flavors share `Degraded` (and therefore share `healthProjection .degraded = .stale`) because the operational dispatch decision is identical: both flavors admit `call_tool` with a longer timeout (matching today's "stale services allowed through with a longer timeout" behavior). The doc comment on `ServiceModel.failureCount` will state this distinction explicitly.
 
 ### 6.3 `Event`
 
@@ -173,6 +182,16 @@ def step? (sm : ServiceModel) (e : Event) (K : Threshold) : Option ServiceModel 
                    else some { state := .degraded, failureCount := n }
 ```
 
+**Design choice: `Reconnecting` is an *optional* pass-through state, not mandatory.**
+
+`probeSuccess(false)` from `Evicted` returns directly to `Healthy` (skipping `Reconnecting`) rather than `none`. We deliberately choose the **permissive** version on these grounds:
+
+- **K=1 (today) has no `Reconnecting` state in Rust.** When a service is evicted, the next health-check tick simply calls `mcp_pool.list_tools(...)`, which lazily reconnects via `get_or_connect`. A successful probe assigns `HealthStatus::Healthy` directly. There is no intermediate observable state. Forcing the path through `Reconnecting` would make every K=1 conformance row for `Evicted + probeSuccess` fail against today's Rust.
+- **`Reconnecting` is meaningful only under K≥2 with an armed backoff.** In that regime, `Evicted → backoffExpiry → Reconnecting → probeSuccess → Healthy` is the natural sequence; the backoff is what introduces the intermediate state. Without an armed backoff, there's nothing between "I was evicted" and "the next probe succeeded."
+- **Restrictive alternative considered and rejected.** Returning `none` (or holding state in `Evicted`) on `Evicted + probeSuccess` would force the path through `Reconnecting`, but at the cost of either making the K=1 path unreachable (the service can never recover without a backoff event) or requiring Rust to emit a `backoffExpiry` event before every successful reconnect (gratuitous mechanism). Neither matches today's Rust.
+
+This is documented in property **H6'** (§8) and in the doc comment on `step?`.
+
 ### 7.2 `run?`
 
 ```lean
@@ -199,8 +218,8 @@ For K=1, the matrix evaluates to:
 | Degraded | probeFail | **Evicted** | n+1 |
 | Degraded | backoffExpiry | Degraded | unchanged |
 | Degraded | registryAbsent | (removed) | — |
-| Evicted | probeSuccess false | Healthy | 0 |
-| Evicted | probeSuccess true | Degraded | 0 |
+| Evicted | probeSuccess false | Healthy [†] | 0 |
+| Evicted | probeSuccess true | Degraded [†] | 0 |
 | Evicted | probeFail | Evicted | n+1 |
 | Evicted | backoffExpiry | **Reconnecting** | unchanged |
 | Evicted | registryAbsent | (removed) | — |
@@ -212,6 +231,8 @@ For K=1, the matrix evaluates to:
 
 At K=1, every `probeFail` from a non-removed state goes to `Evicted` in one step — matching today's Rust single-failure eviction. The `Degraded`-as-stale-only path matches the `Stale` HealthStatus today.
 
+[†] The `Evicted → Healthy` and `Evicted → Degraded` rows on `probeSuccess` reflect the **permissive recovery** choice (§7.1): `Reconnecting` is an optional pass-through, not mandatory. Under K=1, Rust has no `Reconnecting` state, so a successful probe after eviction assigns `Healthy` directly. Property **H6'** formalizes this.
+
 ## 8. Properties
 
 | Tag | Statement | Kind | Discharged in |
@@ -222,6 +243,7 @@ At K=1, every `probeFail` from a non-removed state goes to `Evicted` in one step
 | H4 | `backoffExpiry` is a no-op outside `.evicted`. | Safety | `Properties.lean` |
 | **H5** | **Anti-flapping inter-eviction gap:** if `run?` reaches `.healthy` at prefix p1 and `.evicted` at later prefix p2, then the event slice `events[p1..p2]` contains ≥ K probeFail events. | **Safety (load-bearing)** | `Properties.lean` |
 | H6 | From `.evicted`, the two-event sequence `[backoffExpiry, probeSuccess false]` reaches `.healthy`. | Liveness (constructive) | `Properties.lean` |
+| H6' | From `.evicted`, a single `probeSuccess false` reaches `.healthy` directly (permissive transition; the `Reconnecting` pass-through is optional). Witnesses the K=1 collapse where Rust has no `Reconnecting` state. | Liveness (constructive) | `Properties.lean` |
 | H7 | At K=1, a `probeFail` from any non-degraded state with `failureCount = 0` goes directly to `.evicted` (witnesses the K=1 collapse to today's Rust). | Safety | `Properties.lean` |
 | H8 | `registryAbsent` ends the per-service state machine (`step? sm .registryAbsent K = none`). | Safety | `Properties.lean` |
 | C1 | `preflight (healthProjection .evicted) schema = .block .serviceUnavailable`. | Coupling | `Coupling.lean` |
@@ -325,6 +347,7 @@ The `simulate_health_checker_one_event` helper drives a single probe outcome thr
 
 - **K is a free parameter in the model but pinned at 1 in Rust today.** A future K≥2 refactor must (a) add a per-service failure counter to `ServiceHealth`, (b) introduce a `Degraded` variant to `HealthStatus`, (c) gate `mcp_pool.remove` on `failureCount ≥ K`, (d) consume the K≥2 conformance rows in a new test. This spec defines that contract; it does not deliver the refactor.
 - **`backoffExpiry` semantics are minimal.** The model only requires "evicted + backoffExpiry → reconnecting." It does not model arming, cancellation, jitter, or schedule choice. Future Rust may add backoff timers; the model accommodates that by leaving the event's timing unspecified.
+- **Permissive `Evicted → Healthy` recovery (see §7.1, H6').** The state machine admits a direct `probeSuccess` from `Evicted` to `Healthy`, skipping `Reconnecting`. This is the right model of today's Rust, but it also means the state machine does **not** enforce "every recovery must pass through `Reconnecting`." If a future Rust refactor wants `Reconnecting` to be observable (e.g., for runtime status counters), it must also change `step?` to return `none` on `Evicted + probeSuccess`, drop H6', and route every recovery through `backoffExpiry`. That refactor is out of scope here.
 - **`registryAbsent` is modeled as terminal.** In Rust, a service can disappear from the online set and reappear later with the same `service_id`. The model treats reappearance as a fresh `ServiceModel` (i.e., `step?` returns `none`, and the pool layer would seed a new model). If we want to formalize same-id resurrection, that would need a separate Pool.lean wrapper — explicitly out of scope here.
 - **Staleness is observational, not driven by an async tick.** Today's Rust computes staleness inline from the heartbeat age at probe time, which means the model never needs an async time event. If Rust ever moves to an asynchronous staleness flagger (independent of probes), the event vocabulary would need a fifth event — this spec accepts that small future delta.
 - **H5's induction depth.** The flapping-bound theorem is a quantifier over arbitrary event lists. The proof is by induction on the suffix `events[p1..p2]`; cases are `nil` (vacuous), `probeSuccess _ :: …` (impossible to reach `.evicted` since it resets `failureCount`), `probeFail :: …` (decrement K by 1 and recurse), `backoffExpiry :: …` and `registryAbsent :: …` (vacuous transit). Lemma `failureCount_le_K_along_degraded` discharges the bookkeeping.


### PR DESCRIPTION
## Summary

Adds a per-service Lean state machine over the four-state lifecycle `healthy → degraded → evicted → reconnecting`, parameterized by a failure-count threshold K. K=1 collapses to today's Rust single-probe-failure eviction; K≥2 admits the bounded-flap regime. Closes audit gap #7.

## States and transitions

- `Healthy → Degraded` on `probeSuccess(staleness=true)` (any K) or `probeFail` when `failureCount + 1 < K` (K≥2 only).
- `Degraded → Evicted` on `probeFail` when `failureCount + 1 ≥ K`.
- `Evicted → Reconnecting` on `backoffExpiry`.
- `Reconnecting → Healthy` on `probeSuccess(false)`.
- **Permissive direct path:** `Evicted → Healthy` on `probeSuccess(false)`. The `Reconnecting` pass-through is *optional*; this matches today's K=1 Rust where no observable `Reconnecting` state exists. Formalized by property H6'.

## Load-bearing safety property

**H5 anti-flapping inter-eviction gap.** If a run reaches `.healthy` at prefix `p1` and `.evicted` at later prefix `p2`, the event slice `events[p1..p2]` contains ≥ K `.probeFail` events. At K=1 this admits today's single-failure eviction; at K≥2 it guarantees inter-eviction quiet windows — the contract that closes the historical flapping connection-pool bug class.

## Conformance vectors registered

- `Proofs.MCPHealth.transitionCases` — exhaustive over `K ∈ {1,2,3} × startState × startCount ∈ [0..K) × event`. 120 rows total.
- `Proofs.MCPHealth.k1ProjectionCases` — 20-row K=1 subset, consumed by the new Rust test `health_checker::transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions`.
- `Proofs.MCPHealth.k2PlusFutureCases` — 100-row K≥2 subset, emitted as the formal contract for a future K-aware Rust refactor; not asserted by any Rust test yet (deliberately).

## Coupling to `ToolRetryDisposition`

Reframed at design time (see `docs/superpowers/specs/2026-05-13-mcp-health-lean-design.md` §5). The load-bearing coupling is to **`preflight`**, not `retryDisposition`: `retryDisposition` is keyed on operation/idempotency/failure-class, and adding `HealthState` there would break that orthogonality (and conflict with the "additive only" rule for `Proofs/ToolExecution/Policy.lean`). Instead, `Proofs/MCPHealth/Coupling.lean` defines `healthProjection : HealthState → ToolExecution.Health` and proves four lemmas (C1–C4) that compose the projection with the existing `preflight` contract. `Policy.lean` is not modified.

## Scope discipline

- Zero `sorry`.
- No Rust production code changes (`HealthStatus`, `ServiceHealth`, `run_health_check`, `mcp_pool.rs` untouched; only `#[cfg(test)]` additions in `health_checker.rs` and `lean_vocab_test.rs`).
- No TLA+ artifact (cross-node coordination is not in scope here; sibling #188 covers that).
- No edits to `Proofs/ToolExecution/Policy.lean`.
- One new line added to `Proofs.lean`.

## Test plan

- [x] `cd crates/defra-agent/proofs && lake build` is clean, zero `sorry`.
- [x] `cargo test -p defra-agent` passes; new test `transitions_tests::generated_mcp_health_k1_cases_match_health_checker_transitions` is among the 438 passing tests.
- [x] `lake env lean --run Proofs/Conformance/Contracts.lean` emits a `mcp_health_cases` field with 120 rows (20 at K=1).
- [x] No diff to `Proofs/ToolExecution/Policy.lean`.
- [x] No production-code diff in `health_checker.rs`/`mcp_pool.rs` (only `#[cfg(test)]` additions).

Closes #186
Refs #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)