### PR TITLE
Conformance bridge catch-up: repair drift + streaming + compaction + identity

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -4,6 +4,7 @@ import Proofs.Conformance.ClientShell.Contracts
 import Proofs.ApplyReconcile.ContractCases
 import Proofs.ToolExecution
 import Proofs.MCPHealth.Executable
+import Proofs.StreamingResponse.Executable
 import Proofs.Conformance.Deviations
 import Proofs.CommandPolicy.Cases
 import Proofs.Conformance.CoverageLedger
@@ -340,6 +341,30 @@ def jsonOptionalNat : Option Nat → String
   | none => "null"
   | some value => toString value
 
+def responseTransitionCaseJson
+    (witness : StreamingResponse.ResponseTransitionCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"group\":" ++ jsonString witness.group ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"legal\":" ++ boolString witness.legal ++ ","
+    ++ "\"pre_status\":" ++ jsonString witness.preStatus ++ ","
+    ++ "\"post_status\":" ++ jsonString witness.postStatus ++ ","
+    ++ "\"pre_live_tail\":" ++ jsonString witness.preLiveTail ++ ","
+    ++ "\"post_live_tail\":" ++ jsonString witness.postLiveTail ++ ","
+    ++ "\"pre_token_count\":" ++ toString witness.preTokenCount ++ ","
+    ++ "\"post_token_count\":" ++ toString witness.postTokenCount ++ ","
+    ++ "\"error_reason\":" ++ jsonOptionalString witness.errorReason ++ ","
+    ++ "\"pre_materialized_seq\":"
+      ++ jsonOptionalNat witness.preMaterializedSeq ++ ","
+    ++ "\"post_materialized_seq\":"
+      ++ jsonOptionalNat witness.postMaterializedSeq ++ ","
+    ++ "\"expected_request_state\":"
+      ++ jsonOptionalString witness.expectedRequestState ++ ","
+    ++ "\"expected_request_persistence\":"
+      ++ jsonOptionalString witness.expectedRequestPersistence
+    ++ "}"
+
 def queueDeadlineConformanceCaseJson
     (witness : QueueDeadlineConformanceCase) : String :=
   "{"
@@ -489,6 +514,9 @@ def snapshotJson : String :=
     ++ "\"transcript_conformance_cases\":"
       ++ jsonArray
         (transcriptConformanceCases.map transcriptCaseJson) ++ ","
+    ++ "\"streaming_response_cases\":"
+      ++ jsonArray
+        (StreamingResponse.responseTransitionCases.map responseTransitionCaseJson) ++ ","
     ++ "\"mcp_health_cases\":"
       ++ jsonArray
         (Proofs.MCPHealth.transitionCases.map mcpHealthCaseJson) ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -5,6 +5,7 @@ import Proofs.ApplyReconcile.ContractCases
 import Proofs.ToolExecution
 import Proofs.MCPHealth.Executable
 import Proofs.StreamingResponse.Executable
+import Proofs.Compaction.Executable
 import Proofs.Conformance.Deviations
 import Proofs.CommandPolicy.Cases
 import Proofs.Conformance.CoverageLedger
@@ -365,6 +366,22 @@ def responseTransitionCaseJson
       ++ jsonOptionalString witness.expectedRequestPersistence
     ++ "}"
 
+def compactionReducerCaseJson (witness : Compaction.CompactionReducerCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"group\":" ++ jsonString witness.group ++ ","
+    ++ "\"reducer\":" ++ jsonString witness.reducer ++ ","
+    ++ "\"legal\":" ++ boolString witness.legal ++ ","
+    ++ "\"pre_message_count\":" ++ toString witness.preMessageCount ++ ","
+    ++ "\"post_message_count\":" ++ toString witness.postMessageCount ++ ","
+    ++ "\"preserves_pairs\":" ++ boolString witness.preservesPairs ++ ","
+    ++ "\"preserves_order\":" ++ boolString witness.preservesOrder ++ ","
+    ++ "\"gate_open\":" ++ boolString witness.gateOpen ++ ","
+    ++ "\"safe_to_reduce\":" ++ boolString witness.safeToReduce ++ ","
+    ++ "\"reducer_is_identity\":"
+      ++ boolString witness.reducerIsIdentity
+    ++ "}"
+
 def queueDeadlineConformanceCaseJson
     (witness : QueueDeadlineConformanceCase) : String :=
   "{"
@@ -517,6 +534,9 @@ def snapshotJson : String :=
     ++ "\"streaming_response_cases\":"
       ++ jsonArray
         (StreamingResponse.responseTransitionCases.map responseTransitionCaseJson) ++ ","
+    ++ "\"compaction_reducer_cases\":"
+      ++ jsonArray
+        (Compaction.compactionReducerCases.map compactionReducerCaseJson) ++ ","
     ++ "\"mcp_health_cases\":"
       ++ jsonArray
         (Proofs.MCPHealth.transitionCases.map mcpHealthCaseJson) ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -288,6 +288,14 @@ def caseCoverage : List CoverageEntry :=
       "transcript_cases"
       "TranscriptConformanceCases"
       "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract"
+  , consumerCoverage
+      "identity_structural_cases"
+      "IdentityStructuralCases"
+      "identity_conformance::identity_structural_cases_match_lean_verdicts"
+  , consumerCoverage
+      "identity_contracts"
+      "IdentityContracts"
+      "identity_conformance::identity_respects_principal_contract_is_declared"
   , consumerWithFollowUpCoverage
       "streaming_response_cases"
       "ResponseTransitionCases"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -293,9 +293,11 @@ def caseCoverage : List CoverageEntry :=
       "ResponseTransitionCases"
       "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract"
       "Runtime-backed streaming response lifecycle drive remains a follow-up; this row pins the emitted Lean case shape."
-  -- compaction_reducer_cases was dropped because PR #202 added the ledger row
-  -- without the JSON emitter, Rust deserializer, or consumer test. Follow-up
-  -- issue #207 re-adds this row alongside the JSON bridge.
+  , consumerWithFollowUpCoverage
+      "compaction_reducer_cases"
+      "CompactionReducerCases"
+      "state_machine_conformance::generated_compaction_reducer_cases_pin_contract"
+      "Runtime-backed compaction reducer drive remains a follow-up; this row pins the emitted Lean case shape."
   , consumerCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -288,12 +288,14 @@ def caseCoverage : List CoverageEntry :=
       "transcript_cases"
       "TranscriptConformanceCases"
       "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract"
-  -- compaction_reducer_cases and streaming_response_cases entries were dropped
-  -- here because PRs #199 and #202 added the ledger rows without the JSON
-  -- emitter, Rust deserializer, or consumer test. See
-  -- docs/superpowers/audits/2026-05-14-conformance-pipeline-audit.md §3.
-  -- Follow-up issues #206 (streaming) and #207 (compaction) re-add these rows
-  -- alongside the JSON bridges.
+  , consumerWithFollowUpCoverage
+      "streaming_response_cases"
+      "ResponseTransitionCases"
+      "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract"
+      "Runtime-backed streaming response lifecycle drive remains a follow-up; this row pins the emitted Lean case shape."
+  -- compaction_reducer_cases was dropped because PR #202 added the ledger row
+  -- without the JSON emitter, Rust deserializer, or consumer test. Follow-up
+  -- issue #207 re-adds this row alongside the JSON bridge.
   , consumerCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -58,6 +58,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) recovery_sweep_cases: Vec<LeanRecoverySweepCase>,
     pub(crate) transcript_conformance_cases: Vec<LeanTranscriptCase>,
     pub(crate) streaming_response_cases: Vec<LeanResponseTransitionCase>,
+    pub(crate) compaction_reducer_cases: Vec<LeanCompactionReducerCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
     pub(crate) identity_structural_cases: Vec<LeanIdentityStructuralCase>,
@@ -694,6 +695,21 @@ pub(crate) struct LeanResponseTransitionCase {
     pub(crate) expected_request_persistence: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanCompactionReducerCase {
+    pub(crate) name: String,
+    pub(crate) group: String,
+    pub(crate) reducer: String,
+    pub(crate) legal: bool,
+    pub(crate) pre_message_count: usize,
+    pub(crate) post_message_count: usize,
+    pub(crate) preserves_pairs: bool,
+    pub(crate) preserves_order: bool,
+    pub(crate) gate_open: bool,
+    pub(crate) safe_to_reduce: bool,
+    pub(crate) reducer_is_identity: bool,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -881,6 +897,18 @@ pub(crate) fn lean_response_transition_case(name: &str) -> &'static LeanResponse
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean response-transition case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_compaction_reducer_cases() -> &'static [LeanCompactionReducerCase] {
+    &lean_contract_snapshot().compaction_reducer_cases
+}
+
+pub(crate) fn lean_compaction_reducer_case(name: &str) -> &'static LeanCompactionReducerCase {
+    lean_contract_snapshot()
+        .compaction_reducer_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean compaction-reducer case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_event_delivery_transition_cases() -> &'static [LeanEventDeliveryTransitionCase] {

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -57,6 +57,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) queue_deadline_conformance_cases: Vec<LeanQueueDeadlineConformanceCase>,
     pub(crate) recovery_sweep_cases: Vec<LeanRecoverySweepCase>,
     pub(crate) transcript_conformance_cases: Vec<LeanTranscriptCase>,
+    pub(crate) streaming_response_cases: Vec<LeanResponseTransitionCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
     pub(crate) identity_structural_cases: Vec<LeanIdentityStructuralCase>,
@@ -674,6 +675,25 @@ pub(crate) struct LeanTranscriptCase {
     pub(crate) expected_strong_drain: bool,
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanResponseTransitionCase {
+    pub(crate) name: String,
+    pub(crate) group: String,
+    pub(crate) action: String,
+    pub(crate) legal: bool,
+    pub(crate) pre_status: String,
+    pub(crate) post_status: String,
+    pub(crate) pre_live_tail: String,
+    pub(crate) post_live_tail: String,
+    pub(crate) pre_token_count: usize,
+    pub(crate) post_token_count: usize,
+    pub(crate) error_reason: Option<String>,
+    pub(crate) pre_materialized_seq: Option<usize>,
+    pub(crate) post_materialized_seq: Option<usize>,
+    pub(crate) expected_request_state: Option<String>,
+    pub(crate) expected_request_persistence: Option<String>,
+}
+
 #[derive(Debug, PartialEq, Eq)]
 enum LeanVocabularyParseError<'a> {
     MissingNamespace,
@@ -849,6 +869,18 @@ pub(crate) fn lean_transcript_case(name: &str) -> &'static LeanTranscriptCase {
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean transcript case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_response_transition_cases() -> &'static [LeanResponseTransitionCase] {
+    &lean_contract_snapshot().streaming_response_cases
+}
+
+pub(crate) fn lean_response_transition_case(name: &str) -> &'static LeanResponseTransitionCase {
+    lean_contract_snapshot()
+        .streaming_response_cases
+        .iter()
+        .find(|case| case.name == name)
+        .unwrap_or_else(|| panic!("Lean response-transition case {name:?} was not emitted"))
 }
 
 pub(crate) fn lean_event_delivery_transition_cases() -> &'static [LeanEventDeliveryTransitionCase] {

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -24,10 +24,11 @@ use lean_vocab_test::{
     lean_event_delivery_source_instances, lean_event_delivery_transition_cases,
     lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case, lean_mcp_health_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_recovery_sweep_case,
-    lean_recovery_sweep_cases, lean_request_transition_cases, lean_runtime_reconcile_case,
-    lean_session_recovery_case, lean_state_machine_contract, lean_tool_preflight_case,
-    lean_tool_retry_case, lean_transcript_case, lean_transcript_cases, lean_vocabulary_values,
-    LeanEventDeliveryAction, LeanLifecycleTransitionCase,
+    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_transition_case,
+    lean_response_transition_cases, lean_runtime_reconcile_case, lean_session_recovery_case,
+    lean_state_machine_contract, lean_tool_preflight_case, lean_tool_retry_case,
+    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
+    LeanLifecycleTransitionCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -516,6 +517,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "TranscriptConformanceCases".to_string(),
         ));
     }
+    if !lean_response_transition_cases().is_empty() {
+        emitted.insert((
+            "streaming_response_cases".to_string(),
+            "ResponseTransitionCases".to_string(),
+        ));
+    }
     assert_eq!(
         snapshot.event_delivery_transition_case_count,
         snapshot.event_delivery_transition_cases.len(),
@@ -881,6 +888,298 @@ fn generated_transcript_cases_pin_agent_message_ordering_contract() {
             case.name
         );
     }
+}
+
+#[test]
+fn generated_streaming_response_cases_pin_lifecycle_contract() {
+    let cases = lean_response_transition_cases();
+    assert_eq!(cases.len(), 12);
+    let expected = [
+        (
+            "begin_emits_streaming_empty",
+            "normal",
+            "begin",
+            true,
+            "streaming",
+            "streaming",
+            "empty",
+            "empty",
+            0,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "write_tokens_advances_progress",
+            "normal",
+            "write_tokens",
+            true,
+            "streaming",
+            "streaming",
+            "empty",
+            "nonEmpty",
+            0,
+            5,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "write_reasoning_no_token_bump",
+            "normal",
+            "write_reasoning",
+            true,
+            "streaming",
+            "streaming",
+            "empty",
+            "nonEmpty",
+            0,
+            0,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "flush_pending_is_abstract_noop",
+            "normal",
+            "flush",
+            true,
+            "streaming",
+            "streaming",
+            "nonEmpty",
+            "nonEmpty",
+            3,
+            3,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "reset_tail_clears_but_preserves_tokens",
+            "normal",
+            "reset_tail",
+            true,
+            "streaming",
+            "streaming",
+            "nonEmpty",
+            "empty",
+            7,
+            7,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "finalize_complete_clears_and_materializes",
+            "normal",
+            "finalize_complete",
+            true,
+            "streaming",
+            "complete",
+            "nonEmpty",
+            "empty",
+            10,
+            10,
+            None,
+            None,
+            Some(42),
+            Some("completed"),
+            Some("committed"),
+        ),
+        (
+            "finalize_error_inference_failed_clears",
+            "normal",
+            "finalize_error",
+            true,
+            "streaming",
+            "error",
+            "nonEmpty",
+            "empty",
+            8,
+            8,
+            Some("inferenceFailed"),
+            None,
+            None,
+            Some("failed"),
+            Some("committed"),
+        ),
+        (
+            "finalize_error_idle_timeout_requires_deadline",
+            "normal",
+            "finalize_error",
+            true,
+            "streaming",
+            "error",
+            "nonEmpty",
+            "empty",
+            4,
+            4,
+            Some("streamIdleTimeout"),
+            None,
+            None,
+            Some("failed"),
+            Some("committed"),
+        ),
+        (
+            "recover_interrupted_keeps_content",
+            "recovery",
+            "recover_interrupted",
+            true,
+            "streaming",
+            "error",
+            "nonEmpty",
+            "nonEmpty",
+            6,
+            6,
+            Some("daemonRestartRecovery"),
+            None,
+            None,
+            Some("failed"),
+            Some("committed"),
+        ),
+        (
+            "observe_idempotent_finalize_is_noop",
+            "idempotent",
+            "observe_idempotent_finalize",
+            true,
+            "complete",
+            "complete",
+            "empty",
+            "empty",
+            12,
+            12,
+            None,
+            Some(99),
+            Some(99),
+            None,
+            None,
+        ),
+        (
+            "set_interrupted_at_does_not_change_status",
+            "boundary",
+            "set_interrupted_at",
+            true,
+            "streaming",
+            "streaming",
+            "nonEmpty",
+            "nonEmpty",
+            2,
+            2,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "bridge_completed_pairs_request_committed",
+            "bridge",
+            "finalize_complete",
+            true,
+            "streaming",
+            "complete",
+            "nonEmpty",
+            "empty",
+            15,
+            15,
+            None,
+            None,
+            Some(88),
+            Some("completed"),
+            Some("committed"),
+        ),
+    ];
+
+    let names = cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        expected.iter().map(|case| case.0).collect::<BTreeSet<_>>()
+    );
+    for case in expected {
+        assert_response_transition_case(case);
+    }
+
+    for case in cases {
+        assert!(case.legal, "streaming case {} should be legal", case.name);
+        assert!(
+            case.post_token_count >= case.pre_token_count,
+            "streaming case {} should not decrease token count",
+            case.name
+        );
+    }
+}
+
+type ResponseTransitionExpectation = (
+    &'static str,
+    &'static str,
+    &'static str,
+    bool,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    usize,
+    usize,
+    Option<&'static str>,
+    Option<usize>,
+    Option<usize>,
+    Option<&'static str>,
+    Option<&'static str>,
+);
+
+fn assert_response_transition_case(expectation: ResponseTransitionExpectation) {
+    let (
+        name,
+        group,
+        action,
+        legal,
+        pre_status,
+        post_status,
+        pre_live_tail,
+        post_live_tail,
+        pre_token_count,
+        post_token_count,
+        error_reason,
+        pre_materialized_seq,
+        post_materialized_seq,
+        expected_request_state,
+        expected_request_persistence,
+    ) = expectation;
+    let case = lean_response_transition_case(name);
+    assert_eq!(case.group.as_str(), group);
+    assert_eq!(case.action.as_str(), action);
+    assert_eq!(case.legal, legal);
+    assert_eq!(case.pre_status.as_str(), pre_status);
+    assert_eq!(case.post_status.as_str(), post_status);
+    assert_eq!(case.pre_live_tail.as_str(), pre_live_tail);
+    assert_eq!(case.post_live_tail.as_str(), post_live_tail);
+    assert_eq!(case.pre_token_count, pre_token_count);
+    assert_eq!(case.post_token_count, post_token_count);
+    assert_eq!(case.error_reason.as_deref(), error_reason);
+    assert_eq!(case.pre_materialized_seq, pre_materialized_seq);
+    assert_eq!(case.post_materialized_seq, post_materialized_seq);
+    assert_eq!(
+        case.expected_request_state.as_deref(),
+        expected_request_state
+    );
+    assert_eq!(
+        case.expected_request_persistence.as_deref(),
+        expected_request_persistence
+    );
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -20,7 +20,8 @@ use lean_vocab_test::{
     assert_lean_transition_is_illegal, assert_lean_transition_is_legal,
     assert_lifecycle_transition_cases_partition, assert_state_machine_contract_is_complete,
     lean_client_shell_case, lean_command_env_case, lean_command_policy_case,
-    lean_command_sandbox_case, lean_contract_snapshot, lean_event_delivery_convergence_traces,
+    lean_command_sandbox_case, lean_compaction_reducer_case, lean_compaction_reducer_cases,
+    lean_contract_snapshot, lean_event_delivery_convergence_traces,
     lean_event_delivery_source_instances, lean_event_delivery_transition_cases,
     lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case, lean_mcp_health_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_recovery_sweep_case,
@@ -521,6 +522,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         emitted.insert((
             "streaming_response_cases".to_string(),
             "ResponseTransitionCases".to_string(),
+        ));
+    }
+    if !lean_compaction_reducer_cases().is_empty() {
+        emitted.insert((
+            "compaction_reducer_cases".to_string(),
+            "CompactionReducerCases".to_string(),
         ));
     }
     assert_eq!(
@@ -1180,6 +1187,205 @@ fn assert_response_transition_case(expectation: ResponseTransitionExpectation) {
         case.expected_request_persistence.as_deref(),
         expected_request_persistence
     );
+}
+
+#[test]
+fn generated_compaction_reducer_cases_pin_contract() {
+    let cases = lean_compaction_reducer_cases();
+    assert_eq!(cases.len(), 10);
+    let expected = [
+        (
+            "identity_reducer_is_no_op",
+            "witness",
+            "identity",
+            true,
+            0,
+            0,
+            true,
+            true,
+            false,
+            true,
+            true,
+        ),
+        (
+            "identity_preserves_pair_atomicity",
+            "witness",
+            "identity",
+            true,
+            2,
+            2,
+            true,
+            true,
+            false,
+            true,
+            true,
+        ),
+        (
+            "identity_preserves_message_order",
+            "witness",
+            "identity",
+            true,
+            3,
+            3,
+            true,
+            true,
+            false,
+            true,
+            true,
+        ),
+        (
+            "strip_preserves_pair_atomicity",
+            "witness",
+            "strip_tool_results",
+            true,
+            2,
+            2,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ),
+        (
+            "strip_preserves_message_order",
+            "witness",
+            "strip_tool_results",
+            true,
+            3,
+            3,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ),
+        (
+            "strip_is_strictly_idempotent",
+            "witness",
+            "strip_tool_results",
+            true,
+            2,
+            2,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ),
+        (
+            "reduction_blocked_when_response_streaming",
+            "streaming",
+            "any_valid",
+            true,
+            1,
+            1,
+            true,
+            true,
+            true,
+            false,
+            true,
+        ),
+        (
+            "reduction_allowed_when_response_terminal",
+            "streaming",
+            "any_valid",
+            true,
+            1,
+            1,
+            true,
+            true,
+            true,
+            true,
+            false,
+        ),
+        (
+            "no_orphaned_tool_results_after_strip",
+            "contract",
+            "strip_tool_results",
+            true,
+            2,
+            2,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ),
+        (
+            "reapply_preserves_view_coherent",
+            "contract",
+            "any_valid",
+            true,
+            2,
+            2,
+            true,
+            true,
+            true,
+            true,
+            true,
+        ),
+    ];
+
+    let names = cases
+        .iter()
+        .map(|case| case.name.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        expected.iter().map(|case| case.0).collect::<BTreeSet<_>>()
+    );
+    for case in expected {
+        assert_compaction_reducer_case(case);
+    }
+    for case in cases {
+        assert!(case.legal, "compaction case {} should be legal", case.name);
+        assert!(
+            case.preserves_pairs && case.preserves_order,
+            "compaction case {} should preserve transcript shape",
+            case.name
+        );
+    }
+}
+
+type CompactionReducerExpectation = (
+    &'static str,
+    &'static str,
+    &'static str,
+    bool,
+    usize,
+    usize,
+    bool,
+    bool,
+    bool,
+    bool,
+    bool,
+);
+
+fn assert_compaction_reducer_case(expectation: CompactionReducerExpectation) {
+    let (
+        name,
+        group,
+        reducer,
+        legal,
+        pre_message_count,
+        post_message_count,
+        preserves_pairs,
+        preserves_order,
+        gate_open,
+        safe_to_reduce,
+        reducer_is_identity,
+    ) = expectation;
+    let case = lean_compaction_reducer_case(name);
+    assert_eq!(case.group.as_str(), group);
+    assert_eq!(case.reducer.as_str(), reducer);
+    assert_eq!(case.legal, legal);
+    assert_eq!(case.pre_message_count, pre_message_count);
+    assert_eq!(case.post_message_count, post_message_count);
+    assert_eq!(case.preserves_pairs, preserves_pairs);
+    assert_eq!(case.preserves_order, preserves_order);
+    assert_eq!(case.gate_open, gate_open);
+    assert_eq!(case.safe_to_reduce, safe_to_reduce);
+    assert_eq!(case.reducer_is_identity, reducer_is_identity);
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -542,6 +542,18 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     if !lean_mcp_health_cases().is_empty() {
         emitted.insert(("mcp_health_cases".to_string(), "MCPHealthCases".to_string()));
     }
+    if !snapshot.identity_structural_cases.is_empty() {
+        emitted.insert((
+            "identity_structural_cases".to_string(),
+            "IdentityStructuralCases".to_string(),
+        ));
+    }
+    if !snapshot.identity_contracts.is_empty() {
+        emitted.insert((
+            "identity_contracts".to_string(),
+            "IdentityContracts".to_string(),
+        ));
+    }
     for hook in &snapshot.follow_up_hooks {
         emitted.insert(("follow_up_hook".to_string(), hook.clone()));
     }
@@ -569,8 +581,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "queue_deadline_cases",
         "recovery_sweep_cases",
         "transcript_cases",
+        "compaction_reducer_cases",
+        "streaming_response_cases",
         "event_delivery_cases",
         "mcp_health_cases",
+        "identity_structural_cases",
+        "identity_contracts",
         "follow_up_hook",
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -140,6 +140,20 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_storage_observation_cases_match_hook_runtime_classification",
         },
         ConformanceConsumer::RustTest {
+            id: "identity_conformance::identity_structural_cases_match_lean_verdicts",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/identity_conformance.rs",
+            module_path: "identity_conformance",
+            function: "identity_structural_cases_match_lean_verdicts",
+        },
+        ConformanceConsumer::RustTest {
+            id: "identity_conformance::identity_respects_principal_contract_is_declared",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/identity_conformance.rs",
+            module_path: "identity_conformance",
+            function: "identity_respects_principal_contract_is_declared",
+        },
+        ConformanceConsumer::RustTest {
             id: "lifecycle::tests::request_state_machine_contract_is_complete",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/lifecycle.rs",

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -252,6 +252,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_streaming_response_cases_pin_lifecycle_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_compaction_reducer_cases_pin_contract",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_compaction_reducer_cases_pin_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -245,6 +245,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_transcript_cases_pin_agent_message_ordering_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_streaming_response_cases_pin_lifecycle_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",


### PR DESCRIPTION
## Summary

Cites `docs/superpowers/audits/2026-05-14-conformance-pipeline-audit.md` and lands the bundled drift repair the audit calls out.

- Repairs `lean_contract_coverage_ledger_accounts_for_every_emitted_domain` drift handling for the new categories and identity-emitted fields.
- Adds the Lean JSON bridge, Rust deserializer/accessors, shape-pin test, ledger row, and consumer registry entry for `streaming_response_cases`.
- Adds the same bridge path for `compaction_reducer_cases`.
- Registers `identity_structural_cases` and `identity_contracts` in the coverage ledger and consumer registry.

## Commit shape

- `Repair lean_contract_coverage_ledger_accounts_for_every_emitted_domain drift bombs (#205)`
- `Add JSON bridge for streaming_response_cases (#206)`
- `Add JSON bridge for compaction_reducer_cases (#207)`
- `Register identity vectors in ledger + consumer registry (#208)`

## Test plan

- [x] `cd crates/defra-agent/proofs && lake build`
- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
- [x] `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain`
- [x] `cargo test -p defra-agent --test state_machine_conformance generated_streaming_response_cases_pin_lifecycle_contract`
- [x] `cargo test -p defra-agent --test state_machine_conformance generated_compaction_reducer_cases_pin_contract`
- [x] `cargo test -p defra-agent --test identity_conformance`

Closes #205
Closes #206
Closes #207
Closes #208
Refs #204
Refs #199
Refs #202
Refs #196
