### PR TITLE
Add R5 cross-deployment subagent execution (trusted-fleet)

### DIFF
--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -38,6 +38,7 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         subagent_spawn_enabled: Some(false),
         subagent_steering_enabled: Some(false),
         subagent_background_enabled: Some(false),
+        cross_deployment_spawn_timeout_seconds: None,
     };
     let doc_id = write_tool_selection_document(&access, &selection).await?;
     let output = json!({

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -547,6 +547,7 @@ fn standard_tool_selection(
         subagent_spawn_enabled: Some(false),
         subagent_steering_enabled: Some(false),
         subagent_background_enabled: Some(false),
+        cross_deployment_spawn_timeout_seconds: None,
     }
 }
 

--- a/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
@@ -331,6 +331,7 @@ pub(super) async fn write_peer_pairing_desired(
     use defra_agent_protocol::graphql::escape_graphql_string;
 
     let peer_id = escape_graphql_string(&record.peer_id);
+    let agent_did = escape_graphql_string(&record.agent_did);
     let collections = subscribed_collection_names()
         .iter()
         .map(|s| format!(r#""{}""#, escape_graphql_string(s)))
@@ -375,6 +376,7 @@ pub(super) async fn write_peer_pairing_desired(
                 input: {{
                     collections: [{collections}],
                     replicator_addresses: ["{replicator_addr}"],
+                    agent_did: "{agent_did}",
                     created_at: "{created_at}",
                     updated_at: "{now}"
                 }}
@@ -384,6 +386,7 @@ pub(super) async fn write_peer_pairing_desired(
         format!(
             r#"mutation {{ create_PeerPairingDesired(input: {{
                 peer_id: "{peer_id}",
+                agent_did: "{agent_did}",
                 collections: [{collections}],
                 replicator_addresses: ["{replicator_addr}"],
                 created_at: "{now}",

--- a/crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs
+++ b/crates/defra-agent-lenses/agent_subagent_v2_to_v3/src/lib.rs
@@ -10,6 +10,7 @@ use std::error::Error;
 use lens_sdk::StreamOption;
 use serde_json::Value;
 
+#[cfg(target_arch = "wasm32")]
 lens_sdk::define!(try_transform, try_inverse);
 
 fn try_transform(

--- a/crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2/src/lib.rs
+++ b/crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2/src/lib.rs
@@ -7,9 +7,9 @@ use lens_sdk::StreamOption;
 use serde_json::Value;
 
 // The `define!` macro emits an `extern "C" { fn next() }` import that is only
-// resolvable at dylib load time from the lens host. Gate it behind a feature so
-// that the crate can also be linked as an rlib for unit / integration tests.
-#[cfg(feature = "lens-entry")]
+// resolvable when loaded by the WASM lens host. Gate it behind both the feature
+// and wasm32 so host `cargo test --workspace` can link the cdylib target.
+#[cfg(all(feature = "lens-entry", target_arch = "wasm32"))]
 lens_sdk::define!(try_transform, try_inverse);
 
 /// Compute the v2 (lifecycle_state, tool_failure_class) pair from the v1

--- a/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
@@ -19,4 +19,8 @@ type AgentToolCall @branchable {
     await_mode: String
     cancel_policy: String
     child_request_id: String @index
+    unclaimed_deadline_at: DateTime
+    cancel_cascade_intent_at: DateTime
+    cancel_pending_remote_ack: Boolean
+    stuck_since: DateTime
 }

--- a/crates/defra-agent-protocol/schemas/agent/peer_pairing_desired.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/peer_pairing_desired.graphql
@@ -1,5 +1,6 @@
 type PeerPairingDesired {
     peer_id: String @index(unique: true)
+    agent_did: String @index
     collections: [String!]!
     replicator_addresses: [String!]!
     created_at: DateTime @index(direction: DESC)

--- a/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/tool_selection.graphql
@@ -20,4 +20,5 @@ type ToolSelection {
     subagent_spawn_enabled: Boolean
     subagent_steering_enabled: Boolean
     subagent_background_enabled: Boolean
+    cross_deployment_spawn_timeout_seconds: Int
 }

--- a/crates/defra-agent/examples/serve_default_behavior.rs
+++ b/crates/defra-agent/examples/serve_default_behavior.rs
@@ -141,6 +141,7 @@ async fn seed_demo_documents(
             subagent_spawn_enabled: Some(false),
             subagent_steering_enabled: Some(false),
             subagent_background_enabled: Some(false),
+            cross_deployment_spawn_timeout_seconds: None,
         },
     )
     .await?;

--- a/crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
@@ -75,6 +75,12 @@ def recoverySweepCases : List RecoverySweepCase :=
       "r6-TerminalizeBackgroundedAsInterrupted"
   , recoveryCase
       toolCallRecoverySweep
+      "tool_running_unclaimed_cross_deployment_spawn_to_failed"
+      "running"
+      "failed"
+      "r5-cross-deployment-subagents-design"
+  , recoveryCase
+      toolCallRecoverySweep
       "tool_running_child_completed_to_completed"
       "running"
       "completed"

--- a/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
@@ -151,6 +151,7 @@ inductive ToolRecoveryCause where
   | childDead
   | childInterrupted
   | childSuperseded
+  | unclaimedCrossDeploymentSpawn
   deriving DecidableEq, Repr
 
 namespace ToolRecoveryCause
@@ -165,6 +166,7 @@ def toContract : ToolRecoveryCause → String
   | .childDead => "childDead"
   | .childInterrupted => "childInterrupted"
   | .childSuperseded => "childSuperseded"
+  | .unclaimedCrossDeploymentSpawn => "unclaimedCrossDeploymentSpawn"
 
 def terminalState : ToolRecoveryCause → ToolCallState
   | .deadlineExceeded => .timedOut
@@ -176,6 +178,7 @@ def terminalState : ToolRecoveryCause → ToolCallState
   | .childDead => .failed
   | .childInterrupted => .cancelled
   | .childSuperseded => .failed
+  | .unclaimedCrossDeploymentSpawn => .failed
 
 theorem terminalState_terminal (cause : ToolRecoveryCause) :
     isTerminal cause.terminalState := by

--- a/crates/defra-agent/src/agent/document_view/snapshot.rs
+++ b/crates/defra-agent/src/agent/document_view/snapshot.rs
@@ -212,12 +212,14 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
 #[derive(Debug, Deserialize)]
 struct PeerPairingDesiredDidRow {
     peer_id: String,
+    agent_did: Option<String>,
 }
 
 async fn load_paired_peer_dids(node: &EmbeddedNode) -> Result<HashSet<String>> {
     let query = r#"{
         PeerPairingDesired {
             peer_id
+            agent_did
         }
     }"#;
     let response = node.execute(query).await;
@@ -236,8 +238,15 @@ async fn load_paired_peer_dids(node: &EmbeddedNode) -> Result<HashSet<String>> {
     Ok(rows
         .into_iter()
         .filter_map(|row| {
-            let peer_id = row.peer_id.trim().to_string();
-            (!peer_id.is_empty()).then_some(peer_id)
+            row.agent_did
+                .as_deref()
+                .map(str::trim)
+                .filter(|did| !did.is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| {
+                    let peer_id = row.peer_id.trim();
+                    peer_id.starts_with("did:").then(|| peer_id.to_string())
+                })
         })
         .collect())
 }

--- a/crates/defra-agent/src/agent/document_view/snapshot.rs
+++ b/crates/defra-agent/src/agent/document_view/snapshot.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use defra_node::EmbeddedNode;
+use serde::Deserialize;
 
 use crate::admission::backend_admission_configs_from_backends;
 use crate::config::BehaviorConfig;
@@ -192,6 +193,7 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
     let (active_event_triggers, unavailable_event_triggers) =
         resolve_event_triggers(view, &unavailable_behaviors);
     let active_tasks = resolve_tasks(view, &unavailable_behaviors);
+    let paired_peer_dids = load_paired_peer_dids(node).await?;
 
     Ok(ResolvedRuntimeSnapshot::from_parts_with_admission_configs(
         default_behavior_id,
@@ -200,9 +202,44 @@ pub(crate) async fn resolve_document_runtime_snapshot_from_view(
         backend_admission_configs,
         unavailable_behaviors,
     )
+    .with_local_did(context.identity.did().to_string())
+    .with_paired_peer_dids(paired_peer_dids)
     .with_schedules(active_schedules, unavailable_schedules)
     .with_event_triggers(active_event_triggers, unavailable_event_triggers)
     .with_tasks(active_tasks))
+}
+
+#[derive(Debug, Deserialize)]
+struct PeerPairingDesiredDidRow {
+    peer_id: String,
+}
+
+async fn load_paired_peer_dids(node: &EmbeddedNode) -> Result<HashSet<String>> {
+    let query = r#"{
+        PeerPairingDesired {
+            peer_id
+        }
+    }"#;
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query PeerPairingDesired for paired peer DIDs failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<PeerPairingDesiredDidRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("PeerPairingDesired"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let peer_id = row.peer_id.trim().to_string();
+            (!peer_id.is_empty()).then_some(peer_id)
+        })
+        .collect())
 }
 
 /// Classify every `Task` in `view` into `active_tasks` if it's enabled and

--- a/crates/defra-agent/src/agent/document_view/tests.rs
+++ b/crates/defra-agent/src/agent/document_view/tests.rs
@@ -231,6 +231,54 @@ async fn apply_control_update_reconciles_tool_selection_via_doc_id() {
     assert!(tool_names.contains(&"list_files".to_string()));
 }
 
+#[tokio::test]
+async fn runtime_snapshot_uses_pairing_agent_did_not_peer_id() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let identity = Arc::new(test_identity("document-view-paired-did"));
+    bind_default_behavior_backend(
+        node.as_ref(),
+        identity.did(),
+        "backend-paired-did",
+        "http://localhost:18181/v1",
+    )
+    .await;
+    let response = node
+        .execute(
+            r#"mutation {
+                create_PeerPairingDesired(input: {
+                    peer_id: "peer-b",
+                    agent_did: "did:defra-agent:peer-b",
+                    collections: ["AgentRequest"],
+                    replicator_addresses: [],
+                    created_at: "2026-05-15T00:00:00Z",
+                    updated_at: "2026-05-15T00:00:00Z"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    assert!(
+        !response.has_errors(),
+        "create PeerPairingDesired failed: {:?}",
+        response.errors
+    );
+
+    let resolve_context = DocumentResolveContext {
+        identity: identity.clone(),
+        tool_ceiling: ToolCeiling::readonly(),
+    };
+    let view = load_document_runtime_view(node.as_ref(), identity.did())
+        .await
+        .expect("document view should load");
+    let snapshot =
+        resolve_document_runtime_snapshot_from_view(node.as_ref(), &resolve_context, &view)
+            .await
+            .expect("snapshot should resolve");
+
+    assert!(snapshot.paired_peer_dids.contains("did:defra-agent:peer-b"));
+    assert!(!snapshot.paired_peer_dids.contains("peer-b"));
+}
+
 /// Insert a ToolSelection row with an empty string in `subagent_targets` and
 /// return its `_docID`.  DefraDB schema has no non-empty constraint on
 /// `[String]` fields, so the document writes successfully.  The validator

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -47,6 +47,13 @@ pub(in crate::agent) async fn run_agent(
     if let Some(observer) = &agent.process_state_observer {
         observer.on_process_state_change(ProcessLifecycleState::Recovering);
     }
+    if let Err(error) = crate::migration::ensure_peer_pairing_desired_migrations(agent.node.clone())
+        .await
+        .context("ensure PeerPairingDesired migrations")
+    {
+        runtime_status.publish_error(&format!("{error:#}")).await;
+        return Err(error);
+    }
     let health_map = ServiceHealthMap::new();
     let tool_runtime = ToolRuntimeContext::new(
         agent.node.clone(),
@@ -222,11 +229,13 @@ pub(in crate::agent) async fn run_agent(
     let mut background_tasks = JoinSet::new();
 
     let completion_node = agent.node.clone();
+    let completion_agent_did = agent.agent_did.clone();
     let completion_cancel = cancel.child_token();
     background_tasks.spawn(async move {
         BackgroundTaskResult::SubagentCompletion(
             crate::background_completion::run_background_completion_observer(
                 completion_node,
+                completion_agent_did,
                 completion_cancel,
             )
             .await,
@@ -527,12 +536,14 @@ async fn resolve_startup_snapshot(agent: &DefraAgent) -> Result<ResolvedRuntimeS
 #[derive(Debug, Deserialize)]
 struct StartupPeerPairingDesiredRow {
     peer_id: String,
+    agent_did: Option<String>,
 }
 
 async fn load_startup_paired_peer_dids(node: &defra_node::EmbeddedNode) -> Result<HashSet<String>> {
     let query = r#"{
         PeerPairingDesired {
             peer_id
+            agent_did
         }
     }"#;
     let response = node.execute(query).await;
@@ -551,8 +562,15 @@ async fn load_startup_paired_peer_dids(node: &defra_node::EmbeddedNode) -> Resul
     Ok(rows
         .into_iter()
         .filter_map(|row| {
-            let peer_id = row.peer_id.trim().to_string();
-            (!peer_id.is_empty()).then_some(peer_id)
+            row.agent_did
+                .as_deref()
+                .map(str::trim)
+                .filter(|did| !did.is_empty())
+                .map(ToOwned::to_owned)
+                .or_else(|| {
+                    let peer_id = row.peer_id.trim();
+                    peer_id.starts_with("did:").then(|| peer_id.to_string())
+                })
         })
         .collect())
 }

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -2,10 +2,11 @@
 // between health checking, snapshot resolution, slot bootstrap, and recovery.
 // Each phase depends on the previous; splitting into submodules would require
 // threading many intermediate values across module boundaries for no gain.
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -28,6 +29,7 @@ enum BackgroundTaskResult {
     Reconcile(Result<()>),
     Control(Result<()>),
     SubagentCompletion(Result<()>),
+    CrossDeploymentCancelMirror(Result<()>),
 }
 
 pub(in crate::agent) async fn run_agent(
@@ -231,6 +233,20 @@ pub(in crate::agent) async fn run_agent(
         )
     });
 
+    let cancel_mirror_node = agent.node.clone();
+    let cancel_mirror_snapshot_rx = active_snapshot_rx.clone();
+    let cancel_mirror_cancel = cancel.child_token();
+    background_tasks.spawn(async move {
+        BackgroundTaskResult::CrossDeploymentCancelMirror(
+            crate::trigger_engine::cross_deployment_cancel_mirror::run_cross_deployment_cancel_mirror(
+                cancel_mirror_node,
+                cancel_mirror_snapshot_rx,
+                cancel_mirror_cancel,
+            )
+            .await,
+        )
+    });
+
     let router_node = agent.node.clone();
     let router_agent_did = agent.agent_did.clone();
     let router_active_snapshot_rx = active_snapshot_rx.clone();
@@ -308,6 +324,7 @@ pub(in crate::agent) async fn run_agent(
             Ok(BackgroundTaskResult::Reconcile(result)) => (result, false),
             Ok(BackgroundTaskResult::Control(result)) => (result, false),
             Ok(BackgroundTaskResult::SubagentCompletion(result)) => (result, false),
+            Ok(BackgroundTaskResult::CrossDeploymentCancelMirror(result)) => (result, false),
             Err(error) => (Err(anyhow!("background task join failed: {error}")), false),
         },
         else => (Ok(()), false),
@@ -490,6 +507,7 @@ async fn resolve_startup_snapshot(agent: &DefraAgent) -> Result<ResolvedRuntimeS
                 resolve_tool_surfaces(agent.node.as_ref(), &agent.behaviors).await?;
             let backend_admission_configs =
                 resolve_backend_admission_configs(agent.node.as_ref(), &agent.behaviors).await?;
+            let paired_peer_dids = load_startup_paired_peer_dids(agent.node.as_ref()).await?;
             Ok(ResolvedRuntimeSnapshot::from_parts_with_admission_configs(
                 agent.default_behavior_id.clone(),
                 agent.behaviors.clone(),
@@ -497,8 +515,46 @@ async fn resolve_startup_snapshot(agent: &DefraAgent) -> Result<ResolvedRuntimeS
                 backend_admission_configs,
                 agent.unavailable_behaviors.clone(),
             ))
+            .map(|snapshot| {
+                snapshot
+                    .with_local_did(agent.agent_did.clone())
+                    .with_paired_peer_dids(paired_peer_dids)
+            })
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct StartupPeerPairingDesiredRow {
+    peer_id: String,
+}
+
+async fn load_startup_paired_peer_dids(node: &defra_node::EmbeddedNode) -> Result<HashSet<String>> {
+    let query = r#"{
+        PeerPairingDesired {
+            peer_id
+        }
+    }"#;
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query PeerPairingDesired for startup paired peer DIDs failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<StartupPeerPairingDesiredRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("PeerPairingDesired"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let peer_id = row.peer_id.trim().to_string();
+            (!peer_id.is_empty()).then_some(peer_id)
+        })
+        .collect())
 }
 
 async fn resolve_backend_admission_configs(

--- a/crates/defra-agent/src/agent/runtime/tests/router.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/router.rs
@@ -10,6 +10,8 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
     let agent_did = "did:defra-agent:router-latest-snapshot";
     let initial_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 1,
+        local_did: String::new(),
+        paired_peer_dids: std::collections::HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -24,6 +26,8 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
     });
     let updated_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 2,
+        local_did: String::new(),
+        paired_peer_dids: std::collections::HashSet::new(),
         default_behavior_id: "code".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -94,6 +98,8 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
     let agent_did = "did:defra-agent:router-observed-generation";
     let initial_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 1,
+        local_did: String::new(),
+        paired_peer_dids: std::collections::HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -108,6 +114,8 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
     });
     let updated_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 2,
+        local_did: String::new(),
+        paired_peer_dids: std::collections::HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),

--- a/crates/defra-agent/src/background_completion.rs
+++ b/crates/defra-agent/src/background_completion.rs
@@ -8,6 +8,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
@@ -16,8 +17,9 @@ use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 
 use crate::background_tools::{
-    child_request_completed, load_authorized_child_edge, load_child_final_response,
-    load_child_terminal_row, load_parent_subagent_context, project_child_terminal, ChildEdge,
+    child_request_completed, fail_running_subagent_tool_call, load_authorized_child_edge,
+    load_child_final_response, load_child_terminal_row, load_parent_subagent_context,
+    project_child_terminal, subagent_tool_not_allowed_payload, ChildEdge,
 };
 use crate::graphql::escape_graphql_string;
 use crate::lifecycle::queue::{
@@ -25,7 +27,7 @@ use crate::lifecycle::queue::{
 };
 use crate::lifecycle::ExecutionOrigin;
 use crate::session;
-use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, ToolCallLifecycle};
+use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass, ToolCallLifecycle};
 use crate::watcher::{validate_agent_request_subagent_coherence, AgentRequest};
 
 const AGENT_REQUEST_COLLECTION: &str = "AgentRequest";
@@ -47,6 +49,417 @@ pub enum BackgroundCompletionOutcome {
     MissingFinalResponse,
     AlreadyProjected,
     Unlinked,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnclaimedSpawnReconcileOutcome {
+    Failed {
+        parent_tool_call_id: String,
+        parent_request_id: String,
+    },
+    Linked {
+        parent_tool_call_id: String,
+        parent_request_id: String,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CancelAckOutcome {
+    Acked {
+        parent_tool_call_id: String,
+    },
+    Stuck {
+        parent_tool_call_id: String,
+        since: DateTime<Utc>,
+    },
+    Pending {
+        parent_tool_call_id: String,
+    },
+}
+
+pub const STUCK_CANCEL_THRESHOLD_SECS: i64 = 5 * 60;
+
+#[derive(Debug, Deserialize)]
+struct UnclaimedBridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    tool_call_id: String,
+    child_request_id: String,
+    started_at: Option<String>,
+    deadline_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CancelPendingBridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    tool_call_id: String,
+    child_request_id: String,
+    cancel_cascade_intent_at: Option<String>,
+    stuck_since: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildAckProbeRow {
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    interrupt_requested_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct AgentToolCallDateTimeRow {
+    started_at: Option<String>,
+    deadline_at: Option<String>,
+    completed_at: Option<String>,
+    unclaimed_deadline_at: Option<String>,
+    cancel_cascade_intent_at: Option<String>,
+    stuck_since: Option<String>,
+}
+
+pub async fn reconcile_unclaimed_cross_deployment_spawns(
+    node: Arc<EmbeddedNode>,
+) -> Result<Vec<UnclaimedSpawnReconcileOutcome>> {
+    let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let now = escape_graphql_string(&now);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    _and: [
+                        {{ lifecycle_state: {{ _eq: "running" }} }},
+                        {{ await_mode: {{ _eq: "background" }} }},
+                        {{ child_request_id: {{ _ne: "" }} }},
+                        {{ unclaimed_deadline_at: {{ _lt: "{now}" }} }}
+                    ]
+                }}
+            ) {{
+                _docID
+                request_id
+                tool_call_id
+                child_request_id
+                started_at
+                deadline_at
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "unclaimed-spawn reconcile query failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<UnclaimedBridgeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+
+    let mut outcomes = Vec::with_capacity(rows.len());
+    for row in rows {
+        if child_request_exists_locally(node.as_ref(), &row.child_request_id).await? {
+            clear_unclaimed_deadline_at(node.as_ref(), &row.doc_id).await?;
+            outcomes.push(UnclaimedSpawnReconcileOutcome::Linked {
+                parent_tool_call_id: row.tool_call_id,
+                parent_request_id: row.request_id,
+            });
+            continue;
+        }
+
+        let payload = subagent_tool_not_allowed_payload(
+            "spawn_subagent",
+            "/behavior_id",
+            "<unknown>",
+            "no_peer_claimed_spawn: no paired peer claimed the cross-deployment spawn within unclaimed_spawn_timeout_seconds",
+            &[],
+        );
+        fail_running_subagent_tool_call(
+            node.as_ref(),
+            &row.doc_id,
+            row.started_at.as_deref(),
+            row.deadline_at.as_deref(),
+            &payload,
+            FailureClass::ServiceUnavailable,
+        )
+        .await?;
+        outcomes.push(UnclaimedSpawnReconcileOutcome::Failed {
+            parent_tool_call_id: row.tool_call_id,
+            parent_request_id: row.request_id,
+        });
+    }
+    Ok(outcomes)
+}
+
+pub async fn observe_cancel_cascade_ack(node: Arc<EmbeddedNode>) -> Result<Vec<CancelAckOutcome>> {
+    let now = Utc::now();
+    let query = r#"{
+        AgentToolCall(filter: { cancel_pending_remote_ack: { _eq: true } }) {
+            _docID
+            tool_call_id
+            child_request_id
+            cancel_cascade_intent_at
+            stuck_since
+        }
+    }"#;
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!("cancel-ack observer query failed: {:?}", response.errors);
+    }
+    let rows: Vec<CancelPendingBridgeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+
+    let mut outcomes = Vec::with_capacity(rows.len());
+    for row in rows {
+        let probe = load_child_ack_probe(node.as_ref(), &row.child_request_id).await?;
+        let child_done = probe
+            .as_ref()
+            .is_some_and(|p| request_terminal_or_interrupted(p));
+
+        if child_done {
+            clear_cancel_pending_ack(node.as_ref(), &row.doc_id).await?;
+            outcomes.push(CancelAckOutcome::Acked {
+                parent_tool_call_id: row.tool_call_id,
+            });
+            continue;
+        }
+
+        let intent_at = row
+            .cancel_cascade_intent_at
+            .as_deref()
+            .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&Utc));
+        if let Some(intent_at) = intent_at {
+            let age = (now - intent_at).num_seconds();
+            if age >= STUCK_CANCEL_THRESHOLD_SECS && row.stuck_since.is_none() {
+                set_stuck_since(node.as_ref(), &row.doc_id, now).await?;
+                outcomes.push(CancelAckOutcome::Stuck {
+                    parent_tool_call_id: row.tool_call_id,
+                    since: now,
+                });
+                continue;
+            }
+        }
+
+        outcomes.push(CancelAckOutcome::Pending {
+            parent_tool_call_id: row.tool_call_id,
+        });
+    }
+    Ok(outcomes)
+}
+
+async fn child_request_exists_locally(node: &EmbeddedNode, child_request_id: &str) -> Result<bool> {
+    let escaped = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("child existence probe failed: {:?}", response.errors);
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .is_some_and(|rows| !rows.is_empty()))
+}
+
+async fn clear_unclaimed_deadline_at(node: &EmbeddedNode, doc_id: &str) -> Result<()> {
+    let escaped = escape_graphql_string(doc_id);
+    let datetime_fields =
+        agent_tool_call_datetime_update_fragment(node, doc_id, &["unclaimed_deadline_at"]).await?;
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{ unclaimed_deadline_at: null{datetime_fields} }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!("clear unclaimed_deadline_at failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+
+async fn load_child_ack_probe(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Result<Option<ChildAckProbeRow>> {
+    let escaped = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{
+                status
+                lifecycle_state
+                interrupt_requested_at
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("child ack probe failed: {:?}", response.errors);
+    }
+    let rows: Vec<ChildAckProbeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows.into_iter().next())
+}
+
+fn request_terminal_or_interrupted(row: &ChildAckProbeRow) -> bool {
+    matches!(
+        row.lifecycle_state.as_deref(),
+        Some("completed" | "failed" | "dead" | "interrupted" | "superseded")
+    ) || matches!(
+        row.status.as_deref(),
+        Some("completed" | "error" | "dead" | "interrupted" | "superseded")
+    ) || row.interrupt_requested_at.is_some()
+}
+
+async fn clear_cancel_pending_ack(node: &EmbeddedNode, doc_id: &str) -> Result<()> {
+    let escaped = escape_graphql_string(doc_id);
+    let datetime_fields =
+        agent_tool_call_datetime_update_fragment(node, doc_id, &["stuck_since"]).await?;
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{
+                    cancel_pending_remote_ack: false,
+                    stuck_since: null
+                    {datetime_fields}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "clear cancel_pending_remote_ack failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(())
+}
+
+async fn set_stuck_since(node: &EmbeddedNode, doc_id: &str, when: DateTime<Utc>) -> Result<()> {
+    let escaped = escape_graphql_string(doc_id);
+    let when = escape_graphql_string(&when.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+    let datetime_fields =
+        agent_tool_call_datetime_update_fragment(node, doc_id, &["stuck_since"]).await?;
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{ stuck_since: "{when}"{datetime_fields} }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!("set stuck_since failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+
+async fn agent_tool_call_datetime_update_fragment(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    omit: &[&str],
+) -> Result<String> {
+    let escaped = escape_graphql_string(doc_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(filter: {{ _docID: {{ _eq: "{escaped}" }} }}, limit: 1) {{
+                started_at
+                deadline_at
+                completed_at
+                unclaimed_deadline_at
+                cancel_cascade_intent_at
+                stuck_since
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query AgentToolCall DateTime fields failed: {:?}",
+            response.errors
+        );
+    }
+    let row = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value::<Vec<AgentToolCallDateTimeRow>>(v.clone()).ok())
+        .and_then(|mut rows| rows.pop())
+        .unwrap_or_default();
+
+    let mut fields = Vec::new();
+    push_datetime_field(&mut fields, omit, "started_at", row.started_at.as_deref());
+    push_datetime_field(&mut fields, omit, "deadline_at", row.deadline_at.as_deref());
+    push_datetime_field(
+        &mut fields,
+        omit,
+        "completed_at",
+        row.completed_at.as_deref(),
+    );
+    push_datetime_field(
+        &mut fields,
+        omit,
+        "unclaimed_deadline_at",
+        row.unclaimed_deadline_at.as_deref(),
+    );
+    push_datetime_field(
+        &mut fields,
+        omit,
+        "cancel_cascade_intent_at",
+        row.cancel_cascade_intent_at.as_deref(),
+    );
+    push_datetime_field(&mut fields, omit, "stuck_since", row.stuck_since.as_deref());
+
+    if fields.is_empty() {
+        Ok(String::new())
+    } else {
+        Ok(format!(", {}", fields.join(", ")))
+    }
+}
+
+fn push_datetime_field(
+    fields: &mut Vec<String>,
+    omit: &[&str],
+    field: &'static str,
+    value: Option<&str>,
+) {
+    if omit.contains(&field) {
+        return;
+    }
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    let value = DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|_| value.to_string());
+    fields.push(format!(r#"{field}: "{}""#, escape_graphql_string(&value)));
 }
 
 pub async fn project_background_subagent_completion(
@@ -533,10 +946,17 @@ impl BackgroundCompletionObserver {
 
     async fn run(&mut self) -> Result<()> {
         self.project_ready_children().await?;
+        self.run_reconcilers().await?;
+        let mut reconciler_tick = tokio::time::interval(Duration::from_secs(5));
         loop {
             let message = tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => return Ok(()),
+                _ = reconciler_tick.tick() => {
+                    self.project_ready_children().await?;
+                    self.run_reconcilers().await?;
+                    continue;
+                }
                 msg = self.subscription.recv() => {
                     match msg {
                         Some(message) => message,
@@ -552,6 +972,7 @@ impl BackgroundCompletionObserver {
                     "subagent completion observer dropped messages; scanning terminal children"
                 );
                 self.project_ready_children().await?;
+                self.run_reconcilers().await?;
             }
 
             let Some(update) = message.as_update() else {
@@ -577,6 +998,24 @@ impl BackgroundCompletionObserver {
     async fn project_ready_children(&mut self) -> Result<()> {
         for child_request_id in load_terminal_child_request_ids(self.node.as_ref()).await? {
             self.project_child_if_needed(child_request_id).await;
+        }
+        Ok(())
+    }
+
+    async fn run_reconcilers(&self) -> Result<()> {
+        let unclaimed = reconcile_unclaimed_cross_deployment_spawns(self.node.clone()).await?;
+        if !unclaimed.is_empty() {
+            tracing::debug!(
+                count = unclaimed.len(),
+                "reconciled unclaimed subagent spawns"
+            );
+        }
+        let cancel_ack = observe_cancel_cascade_ack(self.node.clone()).await?;
+        if !cancel_ack.is_empty() {
+            tracing::debug!(
+                count = cancel_ack.len(),
+                "observed cross-deployment cancel acks"
+            );
         }
         Ok(())
     }

--- a/crates/defra-agent/src/background_completion.rs
+++ b/crates/defra-agent/src/background_completion.rs
@@ -48,6 +48,7 @@ pub enum BackgroundCompletionOutcome {
     NotBackground,
     MissingFinalResponse,
     AlreadyProjected,
+    NotLocalOwner,
     Unlinked,
 }
 
@@ -94,6 +95,7 @@ struct UnclaimedBridgeRow {
 struct CancelPendingBridgeRow {
     #[serde(rename = "_docID")]
     doc_id: String,
+    request_id: String,
     tool_call_id: String,
     child_request_id: String,
     cancel_cascade_intent_at: Option<String>,
@@ -119,6 +121,7 @@ struct AgentToolCallDateTimeRow {
 
 pub async fn reconcile_unclaimed_cross_deployment_spawns(
     node: Arc<EmbeddedNode>,
+    local_did: &str,
 ) -> Result<Vec<UnclaimedSpawnReconcileOutcome>> {
     let now = Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let now = escape_graphql_string(&now);
@@ -159,6 +162,10 @@ pub async fn reconcile_unclaimed_cross_deployment_spawns(
 
     let mut outcomes = Vec::with_capacity(rows.len());
     for row in rows {
+        if !request_is_locally_owned(node.as_ref(), &row.request_id, local_did).await? {
+            continue;
+        }
+
         if child_request_exists_locally(node.as_ref(), &row.child_request_id).await? {
             clear_unclaimed_deadline_at(node.as_ref(), &row.doc_id).await?;
             outcomes.push(UnclaimedSpawnReconcileOutcome::Linked {
@@ -192,11 +199,15 @@ pub async fn reconcile_unclaimed_cross_deployment_spawns(
     Ok(outcomes)
 }
 
-pub async fn observe_cancel_cascade_ack(node: Arc<EmbeddedNode>) -> Result<Vec<CancelAckOutcome>> {
+pub async fn observe_cancel_cascade_ack(
+    node: Arc<EmbeddedNode>,
+    local_did: &str,
+) -> Result<Vec<CancelAckOutcome>> {
     let now = Utc::now();
     let query = r#"{
         AgentToolCall(filter: { cancel_pending_remote_ack: { _eq: true } }) {
             _docID
+            request_id
             tool_call_id
             child_request_id
             cancel_cascade_intent_at
@@ -216,6 +227,10 @@ pub async fn observe_cancel_cascade_ack(node: Arc<EmbeddedNode>) -> Result<Vec<C
 
     let mut outcomes = Vec::with_capacity(rows.len());
     for row in rows {
+        if !request_is_locally_owned(node.as_ref(), &row.request_id, local_did).await? {
+            continue;
+        }
+
         let probe = load_child_ack_probe(node.as_ref(), &row.child_request_id).await?;
         let child_done = probe
             .as_ref()
@@ -332,6 +347,38 @@ fn request_terminal_or_interrupted(row: &ChildAckProbeRow) -> bool {
         row.status.as_deref(),
         Some("completed" | "error" | "dead" | "interrupted" | "superseded")
     ) || row.interrupt_requested_at.is_some()
+}
+
+async fn request_is_locally_owned(
+    node: &EmbeddedNode,
+    request_id: &str,
+    local_did: &str,
+) -> Result<bool> {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                limit: 1
+            ) {{ agent_did }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query parent AgentRequest owner {request_id} failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("agent_did"))
+        .and_then(|v| v.as_str())
+        == Some(local_did))
 }
 
 async fn clear_cancel_pending_ack(node: &EmbeddedNode, doc_id: &str) -> Result<()> {
@@ -465,6 +512,7 @@ fn push_datetime_field(
 pub async fn project_background_subagent_completion(
     node: Arc<EmbeddedNode>,
     child_request_id: &str,
+    local_did: &str,
 ) -> Result<BackgroundCompletionOutcome> {
     let Some(linkage) = load_child_linkage(node.as_ref(), child_request_id).await? else {
         return Ok(BackgroundCompletionOutcome::Unlinked);
@@ -474,6 +522,9 @@ pub async fn project_background_subagent_completion(
     };
     if non_empty(linkage.caused_by_parent_tool_call_id.as_deref()).is_none() {
         return Ok(BackgroundCompletionOutcome::Unlinked);
+    }
+    if !request_is_locally_owned(node.as_ref(), parent_request_id, local_did).await? {
+        return Ok(BackgroundCompletionOutcome::NotLocalOwner);
     }
 
     let Some(terminal_row) = load_child_terminal_row(node.as_ref(), child_request_id).await? else {
@@ -918,14 +969,16 @@ fn parse_utc_timestamp(value: &str, field: &str) -> Result<DateTime<Utc>> {
 
 pub(crate) async fn run_background_completion_observer(
     node: Arc<EmbeddedNode>,
+    local_did: String,
     cancel: CancellationToken,
 ) -> Result<()> {
-    let mut observer = BackgroundCompletionObserver::new(node, cancel);
+    let mut observer = BackgroundCompletionObserver::new(node, local_did, cancel);
     observer.run().await
 }
 
 struct BackgroundCompletionObserver {
     node: Arc<EmbeddedNode>,
+    local_did: String,
     cancel: CancellationToken,
     subscription: events::Subscription,
     collection_id_to_name: HashMap<String, String>,
@@ -933,10 +986,11 @@ struct BackgroundCompletionObserver {
 }
 
 impl BackgroundCompletionObserver {
-    fn new(node: Arc<EmbeddedNode>, cancel: CancellationToken) -> Self {
+    fn new(node: Arc<EmbeddedNode>, local_did: String, cancel: CancellationToken) -> Self {
         let subscription = node.subscribe(&[EventName::Update]);
         Self {
             node,
+            local_did,
             cancel,
             subscription,
             collection_id_to_name: HashMap::new(),
@@ -1003,14 +1057,15 @@ impl BackgroundCompletionObserver {
     }
 
     async fn run_reconcilers(&self) -> Result<()> {
-        let unclaimed = reconcile_unclaimed_cross_deployment_spawns(self.node.clone()).await?;
+        let unclaimed =
+            reconcile_unclaimed_cross_deployment_spawns(self.node.clone(), &self.local_did).await?;
         if !unclaimed.is_empty() {
             tracing::debug!(
                 count = unclaimed.len(),
                 "reconciled unclaimed subagent spawns"
             );
         }
-        let cancel_ack = observe_cancel_cascade_ack(self.node.clone()).await?;
+        let cancel_ack = observe_cancel_cascade_ack(self.node.clone(), &self.local_did).await?;
         if !cancel_ack.is_empty() {
             tracing::debug!(
                 count = cancel_ack.len(),
@@ -1025,9 +1080,16 @@ impl BackgroundCompletionObserver {
             return;
         }
 
-        match project_background_subagent_completion(self.node.clone(), &child_request_id).await {
+        match project_background_subagent_completion(
+            self.node.clone(),
+            &child_request_id,
+            &self.local_did,
+        )
+        .await
+        {
             Ok(BackgroundCompletionOutcome::Projected { .. })
-            | Ok(BackgroundCompletionOutcome::AlreadyProjected) => {
+            | Ok(BackgroundCompletionOutcome::AlreadyProjected)
+            | Ok(BackgroundCompletionOutcome::NotLocalOwner) => {
                 self.processed_child_request_ids.insert(child_request_id);
             }
             Ok(
@@ -1378,4 +1440,148 @@ where
     data.and_then(|data| data.get(collection))
         .and_then(|value| serde_json::from_value::<Vec<T>>(value.clone()).ok())
         .and_then(|mut rows| rows.pop())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const LOCAL_DID: &str = "did:defra-agent:local-owner";
+    const FOREIGN_DID: &str = "did:defra-agent:foreign-owner";
+
+    async fn test_node() -> Arc<EmbeddedNode> {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        node
+    }
+
+    async fn exec(node: &EmbeddedNode, statement: &str) {
+        let response = node.execute(statement).await;
+        assert!(
+            !response.has_errors(),
+            "GraphQL errors: {:?}",
+            response.errors
+        );
+    }
+
+    async fn write_parent_request(node: &EmbeddedNode, request_id: &str, agent_did: &str) {
+        let mutation = format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "parent",
+                    session_id: "session-{request_id}",
+                    content: "parent",
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    created_at: "2026-05-15T00:00:00Z",
+                    deadline: "2026-05-15T00:05:00Z"
+                }}) {{ _docID }}
+            }}"#
+        );
+        exec(node, &mutation).await;
+    }
+
+    async fn write_bridge(
+        node: &EmbeddedNode,
+        request_id: &str,
+        tool_call_id: &str,
+        extra_fields: &str,
+    ) {
+        let mutation = format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "{request_id}:{tool_call_id}",
+                    request_id: "{request_id}",
+                    session_id: "session-{request_id}",
+                    message_sequence: 1,
+                    tool_name: "spawn_subagent",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{{}}",
+                    status: "running",
+                    lifecycle_state: "running",
+                    started_at: "2026-05-15T00:00:00Z",
+                    deadline_at: "2026-05-15T00:05:00Z",
+                    await_mode: "background",
+                    cancel_policy: "cascade",
+                    child_request_id: "child-{tool_call_id}"
+                    {extra_fields}
+                }}) {{ _docID }}
+            }}"#
+        );
+        exec(node, &mutation).await;
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ToolRow {
+        lifecycle_state: Option<String>,
+        unclaimed_deadline_at: Option<String>,
+        cancel_pending_remote_ack: Option<bool>,
+        stuck_since: Option<String>,
+    }
+
+    async fn load_tool(node: &EmbeddedNode, tool_call_id: &str) -> ToolRow {
+        let query = format!(
+            r#"{{
+                AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{tool_call_id}" }} }}, limit: 1) {{
+                    lifecycle_state
+                    unclaimed_deadline_at
+                    cancel_pending_remote_ack
+                    stuck_since
+                }}
+            }}"#
+        );
+        let response = node.execute(&query).await;
+        assert!(
+            !response.has_errors(),
+            "query errors: {:?}",
+            response.errors
+        );
+        first_row(response.data.as_ref(), "AgentToolCall").expect("tool row")
+    }
+
+    #[tokio::test]
+    async fn unclaimed_reconciler_skips_foreign_parent_bridge() {
+        let node = test_node().await;
+        write_parent_request(node.as_ref(), "parent-foreign-unclaimed", FOREIGN_DID).await;
+        write_bridge(
+            node.as_ref(),
+            "parent-foreign-unclaimed",
+            "foreign-unclaimed",
+            r#", unclaimed_deadline_at: "2020-01-01T00:00:00Z""#,
+        )
+        .await;
+
+        let outcomes = reconcile_unclaimed_cross_deployment_spawns(node.clone(), LOCAL_DID)
+            .await
+            .unwrap();
+        assert!(outcomes.is_empty());
+
+        let tool = load_tool(node.as_ref(), "foreign-unclaimed").await;
+        assert_eq!(tool.lifecycle_state.as_deref(), Some("running"));
+        assert!(tool.unclaimed_deadline_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn cancel_ack_observer_skips_foreign_parent_bridge() {
+        let node = test_node().await;
+        write_parent_request(node.as_ref(), "parent-foreign-cancel", FOREIGN_DID).await;
+        write_bridge(
+            node.as_ref(),
+            "parent-foreign-cancel",
+            "foreign-cancel",
+            r#", cancel_cascade_intent_at: "2020-01-01T00:00:00Z", cancel_pending_remote_ack: true"#,
+        )
+        .await;
+
+        let outcomes = observe_cancel_cascade_ack(node.clone(), LOCAL_DID)
+            .await
+            .unwrap();
+        assert!(outcomes.is_empty());
+
+        let tool = load_tool(node.as_ref(), "foreign-cancel").await;
+        assert_eq!(tool.cancel_pending_remote_ack, Some(true));
+        assert!(tool.stuck_since.is_none());
+    }
 }

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -95,6 +95,7 @@ pub(crate) struct ParentSubagentContext {
     pub allowed_targets: Vec<String>,
     pub subagent_spawn_enabled: bool,
     pub subagent_background_enabled: bool,
+    pub cross_deployment_spawn_timeout_seconds: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -103,6 +104,7 @@ pub(crate) struct ParentSubagentAuthorization {
     pub allowed_targets: Vec<String>,
     pub spawn_enabled: bool,
     pub background_enabled: bool,
+    pub cross_deployment_spawn_timeout_seconds: Option<u32>,
 }
 
 impl ParentSubagentAuthorization {
@@ -189,7 +191,10 @@ struct ToolSelectionTargetsRow {
     subagent_targets: Option<Vec<String>>,
     subagent_spawn_enabled: Option<bool>,
     subagent_background_enabled: Option<bool>,
+    cross_deployment_spawn_timeout_seconds: Option<u32>,
 }
+
+pub(crate) const DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS: u32 = 60;
 
 pub(crate) async fn load_parent_subagent_context(
     node: &EmbeddedNode,
@@ -241,6 +246,7 @@ pub(crate) async fn load_parent_subagent_context(
         allowed_targets: selection.allowed_targets,
         subagent_spawn_enabled: selection.spawn_enabled,
         subagent_background_enabled: selection.background_enabled,
+        cross_deployment_spawn_timeout_seconds: selection.cross_deployment_spawn_timeout_seconds,
     })
 }
 
@@ -290,7 +296,24 @@ pub(crate) async fn load_parent_subagent_authorization(
         allowed_targets: selection.allowed_targets,
         spawn_enabled: selection.spawn_enabled,
         background_enabled: selection.background_enabled,
+        cross_deployment_spawn_timeout_seconds: selection.cross_deployment_spawn_timeout_seconds,
     })
+}
+
+pub(crate) fn effective_cross_deployment_spawn_timeout_seconds(
+    authorization: &ParentSubagentAuthorization,
+) -> u32 {
+    authorization
+        .cross_deployment_spawn_timeout_seconds
+        .unwrap_or(DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS)
+}
+
+pub(crate) fn effective_context_cross_deployment_spawn_timeout_seconds(
+    context: &ParentSubagentContext,
+) -> u32 {
+    context
+        .cross_deployment_spawn_timeout_seconds
+        .unwrap_or(DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS)
 }
 
 pub(crate) fn target_is_allowed(context: &ParentSubagentContext, target_behavior_id: &str) -> bool {
@@ -304,6 +327,7 @@ struct SubagentToolSelection {
     allowed_targets: Vec<String>,
     spawn_enabled: bool,
     background_enabled: bool,
+    cross_deployment_spawn_timeout_seconds: Option<u32>,
 }
 
 async fn load_subagent_tool_selection(
@@ -343,6 +367,7 @@ async fn load_subagent_tool_selection(
                 allowed_targets: Vec::new(),
                 spawn_enabled: false,
                 background_enabled: false,
+                cross_deployment_spawn_timeout_seconds: None,
             });
         }
     };
@@ -357,6 +382,7 @@ async fn load_subagent_tool_selection(
                 subagent_targets
                 subagent_spawn_enabled
                 subagent_background_enabled
+                cross_deployment_spawn_timeout_seconds
             }}
         }}"#
     );
@@ -374,6 +400,7 @@ async fn load_subagent_tool_selection(
             allowed_targets: Vec::new(),
             spawn_enabled: false,
             background_enabled: false,
+            cross_deployment_spawn_timeout_seconds: None,
         });
     };
 
@@ -381,7 +408,39 @@ async fn load_subagent_tool_selection(
         allowed_targets: dedupe_non_empty(selection.subagent_targets.unwrap_or_default()),
         spawn_enabled: selection.subagent_spawn_enabled.unwrap_or(false),
         background_enabled: selection.subagent_background_enabled.unwrap_or(false),
+        cross_deployment_spawn_timeout_seconds: selection.cross_deployment_spawn_timeout_seconds,
     })
+}
+
+#[cfg(test)]
+mod cross_deployment_timeout_tests {
+    use super::*;
+
+    fn auth(timeout: Option<u32>) -> ParentSubagentAuthorization {
+        ParentSubagentAuthorization {
+            behavior_id: "parent".to_string(),
+            allowed_targets: vec!["child".to_string()],
+            spawn_enabled: true,
+            background_enabled: true,
+            cross_deployment_spawn_timeout_seconds: timeout,
+        }
+    }
+
+    #[test]
+    fn override_takes_precedence() {
+        assert_eq!(
+            effective_cross_deployment_spawn_timeout_seconds(&auth(Some(120))),
+            120
+        );
+    }
+
+    #[test]
+    fn default_when_none() {
+        assert_eq!(
+            effective_cross_deployment_spawn_timeout_seconds(&auth(None)),
+            DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS
+        );
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/defra-agent/src/document_config/tool_selection.rs
+++ b/crates/defra-agent/src/document_config/tool_selection.rs
@@ -59,6 +59,7 @@ pub struct ToolSelectionDocument {
     pub subagent_spawn_enabled: Option<bool>,
     pub subagent_steering_enabled: Option<bool>,
     pub subagent_background_enabled: Option<bool>,
+    pub cross_deployment_spawn_timeout_seconds: Option<u32>,
 }
 
 impl ToolSelectionDocument {
@@ -133,6 +134,7 @@ pub(crate) async fn load_tool_selection_record(
                 subagent_spawn_enabled
                 subagent_steering_enabled
                 subagent_background_enabled
+                cross_deployment_spawn_timeout_seconds
             }}
         }}"#
     );
@@ -181,6 +183,7 @@ pub(crate) async fn load_tool_selection_by_doc_id(
                 subagent_spawn_enabled
                 subagent_steering_enabled
                 subagent_background_enabled
+                cross_deployment_spawn_timeout_seconds
             }}
         }}"#
     );
@@ -229,6 +232,7 @@ pub(crate) async fn list_tool_selection_records(
                 subagent_spawn_enabled
                 subagent_steering_enabled
                 subagent_background_enabled
+                cross_deployment_spawn_timeout_seconds
             }}
         }}"#
     );
@@ -271,6 +275,7 @@ pub(crate) async fn list_all_tool_selection_records(
                 subagent_spawn_enabled
                 subagent_steering_enabled
                 subagent_background_enabled
+                cross_deployment_spawn_timeout_seconds
             }
         }"#;
 
@@ -359,6 +364,9 @@ pub async fn upsert_tool_selection(
             "subagent_background_enabled",
             selection.subagent_background_enabled,
         ),
+        selection
+            .cross_deployment_spawn_timeout_seconds
+            .map(|value| format!("cross_deployment_spawn_timeout_seconds: {value}")),
     ]
     .into_iter()
     .flatten()
@@ -431,6 +439,9 @@ pub async fn upsert_tool_selection(
             "subagent_background_enabled",
             selection.subagent_background_enabled,
         ),
+        selection
+            .cross_deployment_spawn_timeout_seconds
+            .map(|value| format!("cross_deployment_spawn_timeout_seconds: {value}")),
     ]
     .into_iter()
     .flatten()

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -476,12 +476,11 @@ impl DefraSessionHook {
 
         let count = lifecycles.len();
         for mut lifecycle in lifecycles {
-            lifecycle.cancel_during_run().await?;
+            let dispatch = lifecycle
+                .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+                .await?;
             if lifecycle.is_cancelled() {
-                if let Some(dispatch) = lifecycle
-                    .bridge_cancel_cascade_dispatch(&self.agent_did)
-                    .await?
-                {
+                if let Some(dispatch) = dispatch {
                     if let CascadeDispatch::Local(intent) = dispatch {
                         if let Err(error) = crate::interrupt::interrupt_request(
                             &self.node,

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -10,7 +10,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::session;
-use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, ToolCallLifecycle};
+use crate::tool_call_lifecycle::{AwaitMode, CascadeDispatch, ChildTerminal, ToolCallLifecycle};
 use crate::truncation::TruncationLimits;
 
 mod persistence;
@@ -478,16 +478,23 @@ impl DefraSessionHook {
         for mut lifecycle in lifecycles {
             lifecycle.cancel_during_run().await?;
             if lifecycle.is_cancelled() {
-                if let Some(intent) = lifecycle.bridge_cancel_cascade().await? {
-                    if let Err(error) =
-                        crate::interrupt::interrupt_request(&self.node, &intent.child_request_id)
-                            .await
-                    {
-                        tracing::warn!(
-                            child_request_id = %intent.child_request_id,
-                            error = %error,
-                            "failed to cascade live tool-call cancellation to child request"
-                        );
+                if let Some(dispatch) = lifecycle
+                    .bridge_cancel_cascade_dispatch(&self.agent_did)
+                    .await?
+                {
+                    if let CascadeDispatch::Local(intent) = dispatch {
+                        if let Err(error) = crate::interrupt::interrupt_request(
+                            &self.node,
+                            &intent.child_request_id,
+                        )
+                        .await
+                        {
+                            tracing::warn!(
+                                child_request_id = %intent.child_request_id,
+                                error = %error,
+                                "failed to cascade live tool-call cancellation to child request"
+                            );
+                        }
                     }
                 }
             }

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -1201,15 +1201,14 @@ impl DefraSessionHook {
             return Ok(false);
         }
 
-        lifecycle.cancel_during_run().await?;
+        let dispatch = lifecycle
+            .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+            .await?;
         if !lifecycle.is_cancelled() {
             return Ok(false);
         }
 
-        let Some(dispatch) = lifecycle
-            .bridge_cancel_cascade_dispatch(&self.agent_did)
-            .await?
-        else {
+        let Some(dispatch) = dispatch else {
             return Ok(false);
         };
         if let CascadeDispatch::Local(intent) = dispatch {
@@ -1240,15 +1239,14 @@ impl DefraSessionHook {
             return Ok(false);
         }
 
-        lifecycle.cancel_during_run().await?;
+        let dispatch = lifecycle
+            .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+            .await?;
         if !lifecycle.is_cancelled() {
             return Ok(false);
         }
 
-        let Some(dispatch) = lifecycle
-            .bridge_cancel_cascade_dispatch(&self.agent_did)
-            .await?
-        else {
+        let Some(dispatch) = dispatch else {
             return Ok(false);
         };
         if let CascadeDispatch::Local(intent) = dispatch {
@@ -1525,18 +1523,24 @@ impl DefraSessionHook {
                     )
                     .await?
                 {
-                    if let Err(error) = lifecycle.cancel_during_run().await {
-                        return self
-                            .foreground_external_bridge_terminal_or_error(
-                                parent_context,
-                                parent_tool_call_id,
-                                child_request_id,
-                                child_session_id,
-                                behavior_id,
-                                error,
-                            )
-                            .await;
-                    }
+                    let dispatch = match lifecycle
+                        .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+                        .await
+                    {
+                        Ok(dispatch) => dispatch,
+                        Err(error) => {
+                            return self
+                                .foreground_external_bridge_terminal_or_error(
+                                    parent_context,
+                                    parent_tool_call_id,
+                                    child_request_id,
+                                    child_session_id,
+                                    behavior_id,
+                                    error,
+                                )
+                                .await;
+                        }
+                    };
                     if !lifecycle.is_cancelled() {
                         return self
                             .foreground_external_bridge_terminal_payload(
@@ -1548,10 +1552,7 @@ impl DefraSessionHook {
                             )
                             .await;
                     }
-                    if let Some(dispatch) = lifecycle
-                        .bridge_cancel_cascade_dispatch(&self.agent_did)
-                        .await?
-                    {
+                    if let Some(dispatch) = dispatch {
                         if let CascadeDispatch::Local(intent) = dispatch {
                             if let Err(error) = crate::interrupt::interrupt_request(
                                 &self.node,

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -9,18 +9,20 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::background_tools::{
-    child_request_completed, load_authorized_child_edge, load_child_final_response,
-    load_child_session_id, load_child_terminal_row, load_parent_subagent_context,
-    project_child_terminal, target_is_allowed, BackgroundToolArgs, CancelSubagentArgs,
-    CancelToolArgs, ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
+    child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
+    load_authorized_child_edge, load_child_final_response, load_child_session_id,
+    load_child_terminal_row, load_parent_subagent_context, project_child_terminal,
+    target_is_allowed, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
+    ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
+use crate::document_config::load_agent_behavior;
 use crate::session;
 use crate::tool_call_lifecycle::query::load_tool_call_result;
 use crate::tool_call_lifecycle::runtime::{classify_managed_tool_result, ManagedToolTerminal};
 use crate::tool_call_lifecycle::{
-    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, ChildTerminal, FailureClass,
-    ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
+    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, CascadeDispatch,
+    ChildTerminal, FailureClass, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use crate::toolset::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
@@ -31,6 +33,12 @@ use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Trun
 use super::{non_empty, DefraSessionHook, TranscriptTurnState};
 
 const MAX_BACKGROUNDED_TOOLS_PER_PARENT: usize = 8;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubagentTargetHost {
+    Local,
+    Remote,
+}
 
 impl DefraSessionHook {
     pub async fn persist_message(&self, message: &Message) -> anyhow::Result<u32> {
@@ -353,6 +361,25 @@ impl DefraSessionHook {
         }
 
         let await_mode = parsed.await_mode.as_await_mode();
+        let target_host = self.subagent_target_host(behavior_id).await?;
+        if target_host == SubagentTargetHost::Remote && await_mode == AwaitMode::Foreground {
+            return self
+                .fail_spawn_subagent_tool_call(
+                    session_id,
+                    request_id,
+                    parent_context.request_deadline_at,
+                    seq,
+                    internal_call_id,
+                    args,
+                    FailureClass::ArgumentInvalid,
+                    invalid_tool_arguments_payload(
+                        SPAWN_SUBAGENT_TOOL_NAME,
+                        "/await_mode",
+                        "foreground cross-deployment subagents are not supported; use await_mode=background",
+                    ),
+                )
+                .await;
+        }
         if await_mode == AwaitMode::Background && !parent_context.subagent_background_enabled {
             return self
                 .fail_spawn_subagent_tool_call(
@@ -424,7 +451,25 @@ impl DefraSessionHook {
             CancelPolicy::Cascade,
             child_request_id.clone(),
         );
+        if await_mode == AwaitMode::Background {
+            let timeout_secs =
+                effective_context_cross_deployment_spawn_timeout_seconds(&parent_context);
+            lifecycle.set_unclaimed_deadline_at(Some(
+                chrono::Utc::now() + chrono::Duration::seconds(timeout_secs as i64),
+            ));
+        }
         lifecycle.start_running().await?;
+
+        if target_host == SubagentTargetHost::Remote {
+            let receipt = background_receipt_payload(&child_request_id, None, behavior_id);
+
+            self.in_flight_lifecycles
+                .lock()
+                .await
+                .insert(internal_call_id.to_string(), lifecycle);
+
+            return Ok(ToolCallHookAction::skip(receipt));
+        }
 
         let child_session_id = if let Err(error) = create_subagent_request_with_request_id(
             &self.node,
@@ -497,7 +542,7 @@ impl DefraSessionHook {
 
         if await_mode == AwaitMode::Background {
             let receipt =
-                background_receipt_payload(&child_request_id, &child_session_id, behavior_id);
+                background_receipt_payload(&child_request_id, Some(&child_session_id), behavior_id);
 
             self.in_flight_lifecycles
                 .lock()
@@ -524,6 +569,17 @@ impl DefraSessionHook {
             .await?;
 
         Ok(ToolCallHookAction::skip(result))
+    }
+
+    async fn subagent_target_host(&self, behavior_id: &str) -> anyhow::Result<SubagentTargetHost> {
+        let Some(behavior) = load_agent_behavior(&self.node, behavior_id).await? else {
+            return Ok(SubagentTargetHost::Remote);
+        };
+        if behavior.agent_did == self.agent_did {
+            Ok(SubagentTargetHost::Local)
+        } else {
+            Ok(SubagentTargetHost::Remote)
+        }
     }
 
     async fn persist_wait_subagent_tool_call(
@@ -1150,17 +1206,22 @@ impl DefraSessionHook {
             return Ok(false);
         }
 
-        let Some(intent) = lifecycle.bridge_cancel_cascade().await? else {
+        let Some(dispatch) = lifecycle
+            .bridge_cancel_cascade_dispatch(&self.agent_did)
+            .await?
+        else {
             return Ok(false);
         };
-        crate::interrupt::interrupt_request(&self.node, &intent.child_request_id)
-            .await
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "failed to cascade cancel_subagent {bridge_kind} bridge {tool_call_id} cancellation to child request {}: {error}",
-                    intent.child_request_id
-                )
-            })?;
+        if let CascadeDispatch::Local(intent) = dispatch {
+            crate::interrupt::interrupt_request(&self.node, &intent.child_request_id)
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to cascade cancel_subagent {bridge_kind} bridge {tool_call_id} cancellation to child request {}: {error}",
+                        intent.child_request_id
+                    )
+                })?;
+        }
         Ok(true)
     }
 
@@ -1184,17 +1245,22 @@ impl DefraSessionHook {
             return Ok(false);
         }
 
-        let Some(intent) = lifecycle.bridge_cancel_cascade().await? else {
+        let Some(dispatch) = lifecycle
+            .bridge_cancel_cascade_dispatch(&self.agent_did)
+            .await?
+        else {
             return Ok(false);
         };
-        crate::interrupt::interrupt_request(&self.node, &intent.child_request_id)
-            .await
-            .map_err(|error| {
-                anyhow::anyhow!(
-                    "failed to cascade cancel_subagent {bridge_kind} bridge {tool_call_id} cancellation to child request {}: {error}",
-                    intent.child_request_id
-                )
-            })?;
+        if let CascadeDispatch::Local(intent) = dispatch {
+            crate::interrupt::interrupt_request(&self.node, &intent.child_request_id)
+                .await
+                .map_err(|error| {
+                    anyhow::anyhow!(
+                        "failed to cascade cancel_subagent {bridge_kind} bridge {tool_call_id} cancellation to child request {}: {error}",
+                        intent.child_request_id
+                    )
+                })?;
+        }
         Ok(true)
     }
 
@@ -1482,18 +1548,23 @@ impl DefraSessionHook {
                             )
                             .await;
                     }
-                    if let Some(intent) = lifecycle.bridge_cancel_cascade().await? {
-                        if let Err(error) = crate::interrupt::interrupt_request(
-                            &self.node,
-                            &intent.child_request_id,
-                        )
-                        .await
-                        {
-                            tracing::warn!(
-                                child_request_id = %intent.child_request_id,
-                                error = %error,
-                                "failed to cascade wait_subagent cancellation to child request"
-                            );
+                    if let Some(dispatch) = lifecycle
+                        .bridge_cancel_cascade_dispatch(&self.agent_did)
+                        .await?
+                    {
+                        if let CascadeDispatch::Local(intent) = dispatch {
+                            if let Err(error) = crate::interrupt::interrupt_request(
+                                &self.node,
+                                &intent.child_request_id,
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    child_request_id = %intent.child_request_id,
+                                    error = %error,
+                                    "failed to cascade wait_subagent cancellation to child request"
+                                );
+                            }
                         }
                     }
                 }
@@ -2120,7 +2191,7 @@ async fn count_live_backgrounded_rows(
 
 fn background_receipt_payload(
     child_request_id: &str,
-    child_session_id: &str,
+    child_session_id: Option<&str>,
     behavior_id: &str,
 ) -> String {
     json_string(json!({

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -64,6 +64,10 @@ const ADD_TOOL_SELECTION_R5_PATCH: &str = r#"[
     {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"cross_deployment_spawn_timeout_seconds","Kind":5}}
 ]"#;
 
+const ADD_PEER_PAIRING_DESIRED_AGENT_DID_PATCH: &str = r#"[
+    {"op":"add","path":"/PeerPairingDesired/Fields/-","value":{"Name":"agent_did","Kind":11}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -424,5 +428,33 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
         "agent_subagent_v2_to_v3 lens registered"
     );
 
+    Ok(())
+}
+
+pub async fn ensure_peer_pairing_desired_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("PeerPairingDesired")
+        .context("get PeerPairingDesired collection")?
+    else {
+        return Ok(());
+    };
+    if collection_has_field(&collection, "agent_did") {
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection(
+            "PeerPairingDesired",
+            ADD_PEER_PAIRING_DESIRED_AGENT_DID_PATCH,
+        )
+        .await
+        .context("patch_collection PeerPairingDesired agent_did")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version PeerPairingDesired agent_did")?;
+    tracing::info!(
+        version = %next.version_id,
+        "PeerPairingDesired patched with agent_did field"
+    );
     Ok(())
 }

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -51,6 +51,19 @@ const ADD_TOOL_SELECTION_BACKGROUND_TOOLS_PATCH: &str = r#"[
     {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"backgroundable_tool_names","Kind":17}}
 ]"#;
 
+#[allow(dead_code)]
+const ADD_AGENT_TOOL_CALL_R5_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"unclaimed_deadline_at","Kind":10}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_cascade_intent_at","Kind":10}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_pending_remote_ack","Kind":2}},
+    {"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"stuck_since","Kind":10}}
+]"#;
+
+#[allow(dead_code)]
+const ADD_TOOL_SELECTION_R5_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"cross_deployment_spawn_timeout_seconds","Kind":5}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -222,7 +235,8 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
         .context("get AgentToolCall collection")?;
 
     let mut atc_pre_version_id_for_lens = None;
-    let atc_v3_version_id = if let Some(ref cv) = atc_collection {
+    let mut active_atc_collection = atc_collection.clone();
+    let atc_v3_version_id = if let Some(ref cv) = active_atc_collection {
         if collection_has_field(cv, "await_mode") {
             tracing::debug!("AgentToolCall already has await_mode; skipping patch");
             cv.version_id.clone()
@@ -242,12 +256,33 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
                 "AgentToolCall patched to v3 (subagent fields)"
             );
             atc_pre_version_id_for_lens = Some(pre_version_id);
+            active_atc_collection = Some(v3.clone());
             v3_version_id
         }
     } else {
         tracing::debug!("AgentToolCall collection absent; subagent patch no-op");
         return Ok(());
     };
+
+    if let Some(ref cv) = active_atc_collection {
+        if collection_has_field(cv, "unclaimed_deadline_at") {
+            tracing::debug!("AgentToolCall already has R5 cross-deployment fields; skipping patch");
+        } else {
+            let pre_version_id = cv.version_id.clone();
+            let v4 = node
+                .patch_collection("AgentToolCall", ADD_AGENT_TOOL_CALL_R5_PATCH)
+                .await
+                .context("patch_collection AgentToolCall R5 cross-deployment fields")?;
+            node.set_active_collection_version(&v4.version_id)
+                .await
+                .context("set_active_collection_version AgentToolCall R5 fields")?;
+            tracing::info!(
+                pre = %pre_version_id,
+                v4 = %v4.version_id,
+                "AgentToolCall patched with R5 cross-deployment fields"
+            );
+        }
+    }
 
     // 2. AgentRequest — independent idempotency check.
     let ar_collection = node
@@ -320,6 +355,27 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
                 pre = %pre_version_id,
                 v4 = %v4_version_id,
                 "ToolSelection patched to v4 (background tool fields)"
+            );
+            active_version = v4;
+        }
+
+        if collection_has_field(&active_version, "cross_deployment_spawn_timeout_seconds") {
+            tracing::debug!(
+                "ToolSelection already has R5 cross-deployment timeout; skipping patch"
+            );
+        } else {
+            let pre_version_id = active_version.version_id.clone();
+            let v5 = node
+                .patch_collection("ToolSelection", ADD_TOOL_SELECTION_R5_PATCH)
+                .await
+                .context("patch_collection ToolSelection R5 timeout field")?;
+            node.set_active_collection_version(&v5.version_id)
+                .await
+                .context("set_active_collection_version ToolSelection R5 timeout")?;
+            tracing::info!(
+                pre = %pre_version_id,
+                v5 = %v5.version_id,
+                "ToolSelection patched with R5 cross-deployment timeout"
             );
         }
     } else {

--- a/crates/defra-agent/src/runtime_snapshot.rs
+++ b/crates/defra-agent/src/runtime_snapshot.rs
@@ -107,6 +107,8 @@ pub(crate) struct ResolvedEventTrigger {
 
 #[derive(Clone, Debug)]
 pub(crate) struct ResolvedRuntimeSnapshot {
+    pub(crate) local_did: String,
+    pub(crate) paired_peer_dids: HashSet<String>,
     pub(crate) default_behavior_id: String,
     pub(crate) behaviors: HashMap<String, Arc<BehaviorConfig>>,
     pub(crate) tool_surfaces: HashMap<String, Arc<ToolSurface>>,
@@ -144,6 +146,8 @@ impl ResolvedRuntimeSnapshot {
         unavailable_behaviors: HashMap<String, String>,
     ) -> Self {
         Self {
+            local_did: String::new(),
+            paired_peer_dids: HashSet::new(),
             default_behavior_id,
             behaviors: behaviors
                 .into_iter()
@@ -158,6 +162,16 @@ impl ResolvedRuntimeSnapshot {
             unavailable_event_triggers: HashSet::new(),
             active_tasks: HashMap::new(),
         }
+    }
+
+    pub(crate) fn with_local_did(mut self, local_did: String) -> Self {
+        self.local_did = local_did;
+        self
+    }
+
+    pub(crate) fn with_paired_peer_dids(mut self, paired_peer_dids: HashSet<String>) -> Self {
+        self.paired_peer_dids = paired_peer_dids;
+        self
     }
 
     /// Attach resolved schedules plus any schedule ids that failed resolution.
@@ -205,6 +219,8 @@ impl ResolvedRuntimeSnapshot {
     ) -> ActiveRuntimeSnapshot {
         ActiveRuntimeSnapshot {
             generation,
+            local_did: self.local_did,
+            paired_peer_dids: self.paired_peer_dids,
             default_behavior_id: self.default_behavior_id,
             behaviors: self.behaviors,
             tool_surfaces: self.tool_surfaces,
@@ -222,6 +238,8 @@ impl ResolvedRuntimeSnapshot {
     pub(crate) fn configuration_fingerprint(&self) -> String {
         configuration_fingerprint(
             &self.default_behavior_id,
+            &self.local_did,
+            &self.paired_peer_dids,
             &self.behaviors,
             &self.tool_surfaces,
             &self.backend_admission_configs,
@@ -238,6 +256,8 @@ impl ResolvedRuntimeSnapshot {
 #[derive(Clone, Debug)]
 pub(crate) struct ActiveRuntimeSnapshot {
     pub(crate) generation: u64,
+    pub(crate) local_did: String,
+    pub(crate) paired_peer_dids: HashSet<String>,
     pub(crate) default_behavior_id: String,
     pub(crate) behaviors: HashMap<String, Arc<BehaviorConfig>>,
     pub(crate) tool_surfaces: HashMap<String, Arc<ToolSurface>>,
@@ -283,6 +303,8 @@ impl ActiveRuntimeSnapshot {
     pub(crate) fn configuration_fingerprint(&self) -> String {
         configuration_fingerprint(
             &self.default_behavior_id,
+            &self.local_did,
+            &self.paired_peer_dids,
             &self.behaviors,
             &self.tool_surfaces,
             &self.backend_admission_configs,
@@ -313,6 +335,8 @@ pub(crate) fn refresh_active_snapshot(
 #[allow(clippy::too_many_arguments)]
 fn configuration_fingerprint(
     default_behavior_id: &str,
+    local_did: &str,
+    paired_peer_dids: &HashSet<String>,
     behaviors: &HashMap<String, Arc<BehaviorConfig>>,
     tool_surfaces: &HashMap<String, Arc<ToolSurface>>,
     backend_admission_configs: &HashMap<String, BackendAdmissionConfig>,
@@ -324,6 +348,17 @@ fn configuration_fingerprint(
     active_tasks: &HashMap<String, ResolvedTask>,
 ) -> String {
     let mut fingerprint = String::new();
+    fingerprint.push_str("local_did:");
+    fingerprint.push_str(local_did);
+    fingerprint.push('\n');
+    fingerprint.push_str("paired_peer_dids:");
+    let mut paired = paired_peer_dids.iter().collect::<Vec<_>>();
+    paired.sort();
+    for did in paired {
+        fingerprint.push_str(did);
+        fingerprint.push(',');
+    }
+    fingerprint.push('\n');
     fingerprint.push_str("default:");
     fingerprint.push_str(default_behavior_id);
     fingerprint.push('\n');

--- a/crates/defra-agent/src/runtime_snapshot/tests.rs
+++ b/crates/defra-agent/src/runtime_snapshot/tests.rs
@@ -8,6 +8,8 @@ use super::*;
 fn snapshot(generation: u64, default_behavior_id: &str) -> Arc<ActiveRuntimeSnapshot> {
     Arc::new(ActiveRuntimeSnapshot {
         generation,
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: default_behavior_id.to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -25,6 +27,8 @@ fn snapshot(generation: u64, default_behavior_id: &str) -> Arc<ActiveRuntimeSnap
 #[test]
 fn resolved_snapshot_activate_preserves_generation_and_dispatchers() {
     let resolved = ResolvedRuntimeSnapshot {
+        local_did: "did:local".to_string(),
+        paired_peer_dids: HashSet::from(["did:peer".to_string()]),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -41,6 +45,8 @@ fn resolved_snapshot_activate_preserves_generation_and_dispatchers() {
 
     assert_eq!(active.generation, 1);
     assert_eq!(active.default_behavior_id, "general");
+    assert_eq!(active.local_did, "did:local");
+    assert!(active.paired_peer_dids.contains("did:peer"));
     assert!(active.dispatchers.contains_key("general"));
     assert_eq!(active.unavailable_reason("code"), Some("missing backend"));
 }
@@ -74,6 +80,8 @@ fn concurrency_mode_parse_is_strict() {
 #[test]
 fn configuration_fingerprint_reflects_schedule_set() {
     let base = ResolvedRuntimeSnapshot {
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -261,6 +261,8 @@ async fn runtime_status_persists_process_and_reconcile_state() {
     status
         .publish_startup_snapshot(&ActiveRuntimeSnapshot {
             generation: 1,
+            local_did: String::new(),
+            paired_peer_dids: HashSet::new(),
             default_behavior_id: "general".to_string(),
             behaviors: HashMap::new(),
             tool_surfaces: HashMap::new(),
@@ -300,6 +302,8 @@ async fn runtime_status_serializes_persisted_generation_updates() {
     let status = RuntimeStatusHandle::new(node.clone(), "did:defra-agent:status-serialize");
     let startup = ActiveRuntimeSnapshot {
         generation: 1,
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -314,6 +318,8 @@ async fn runtime_status_serializes_persisted_generation_updates() {
     };
     let applied = ActiveRuntimeSnapshot {
         generation: 2,
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -358,6 +364,8 @@ async fn runtime_status_generation_updates_match_lean_runtime_reconcile_cases() 
     let status = RuntimeStatusHandle::new(node.clone(), "did:defra-agent:runtime-contract");
     let startup = ActiveRuntimeSnapshot {
         generation: publish.pre_active_generation as u64,
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),
@@ -372,6 +380,8 @@ async fn runtime_status_generation_updates_match_lean_runtime_reconcile_cases() 
     };
     let applied = ActiveRuntimeSnapshot {
         generation: publish.post_active_generation as u64,
+        local_did: String::new(),
+        paired_peer_dids: HashSet::new(),
         default_behavior_id: "general".to_string(),
         behaviors: HashMap::new(),
         tool_surfaces: HashMap::new(),

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -206,6 +206,12 @@ pub struct CascadeIntent {
     pub at: chrono::DateTime<chrono::Utc>,
 }
 
+#[derive(Clone, Debug)]
+pub enum CascadeDispatch {
+    Local(CascadeIntent),
+    RemoteIntentWritten,
+}
+
 use std::sync::Arc;
 
 use defra_node::EmbeddedNode;
@@ -218,7 +224,8 @@ mod transition;
 
 pub use recovery::ToolCallRecoveryReport;
 pub use subagent_request::{
-    create_subagent_request, create_subagent_request_with_request_id, MAX_SUBAGENT_DEPTH,
+    create_subagent_request, create_subagent_request_with_request_id,
+    create_subagent_request_with_trusted_parent_request_id, MAX_SUBAGENT_DEPTH,
 };
 pub use transition::IllegalToolCallTransition;
 
@@ -241,6 +248,7 @@ pub struct ToolCallLifecycle {
     pub(crate) await_mode: AwaitMode,
     pub(crate) cancel_policy: CancelPolicy,
     pub(crate) child_request_id: Option<String>,
+    pub(crate) unclaimed_deadline_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl ToolCallLifecycle {
@@ -272,6 +280,7 @@ impl ToolCallLifecycle {
             await_mode: AwaitMode::Foreground,
             cancel_policy: CancelPolicy::Cascade,
             child_request_id: None,
+            unclaimed_deadline_at: None,
         }
     }
 
@@ -308,6 +317,7 @@ impl ToolCallLifecycle {
             await_mode,
             cancel_policy,
             child_request_id: Some(child_request_id),
+            unclaimed_deadline_at: None,
         }
     }
 
@@ -339,6 +349,7 @@ impl ToolCallLifecycle {
             await_mode: AwaitMode::Background,
             cancel_policy: CancelPolicy::Cascade,
             child_request_id: None,
+            unclaimed_deadline_at: None,
         }
     }
 
@@ -408,6 +419,13 @@ impl ToolCallLifecycle {
 
     pub(crate) fn set_deadline_at(&mut self, deadline_at: chrono::DateTime<chrono::Utc>) {
         self.deadline_at = deadline_at;
+    }
+
+    pub(crate) fn set_unclaimed_deadline_at(
+        &mut self,
+        deadline_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) {
+        self.unclaimed_deadline_at = deadline_at;
     }
 }
 

--- a/crates/defra-agent/src/tool_call_lifecycle/query.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/query.rs
@@ -82,6 +82,7 @@ struct ToolCallRow {
     await_mode: Option<String>,
     cancel_policy: Option<String>,
     child_request_id: Option<String>,
+    unclaimed_deadline_at: Option<String>,
 }
 
 impl ToolCallLifecycle {
@@ -115,6 +116,7 @@ impl ToolCallLifecycle {
                     await_mode
                     cancel_policy
                     child_request_id
+                    unclaimed_deadline_at
                 }}
             }}"#
         );
@@ -178,6 +180,11 @@ impl ToolCallLifecycle {
             .unwrap_or(CancelPolicy::Cascade);
 
         let child_request_id = row.child_request_id.filter(|s| !s.is_empty());
+        let unclaimed_deadline_at = row
+            .unclaimed_deadline_at
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
 
         Ok(Some(Self {
             node,
@@ -195,6 +202,7 @@ impl ToolCallLifecycle {
             await_mode,
             cancel_policy,
             child_request_id,
+            unclaimed_deadline_at,
         }))
     }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -360,7 +360,21 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
         }
 
         if let Some(child_request_id) = cascade_child_request_id(&row) {
-            if let Err(error) = interrupt_request(node, child_request_id).await {
+            if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
+                if let Err(error) = interrupt_request(node, child_request_id).await {
+                    tracing::warn!(
+                        doc_id = %row.doc_id,
+                        request_id = row.request_id.as_deref().unwrap_or(""),
+                        session_id = %row.session_id,
+                        tool_call_id = %row.tool_call_id,
+                        child_request_id,
+                        error = %error,
+                        "failed to cascade recovery interrupt to child request"
+                    );
+                }
+            } else if let Err(error) =
+                write_bridge_cancel_cascade_intent(node, &row.doc_id, Utc::now()).await
+            {
                 tracing::warn!(
                     doc_id = %row.doc_id,
                     request_id = row.request_id.as_deref().unwrap_or(""),
@@ -368,7 +382,7 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
                     tool_call_id = %row.tool_call_id,
                     child_request_id,
                     error = %error,
-                    "failed to cascade recovery interrupt to child request"
+                    "failed to write recovery cross-deployment cancel intent"
                 );
             }
         }
@@ -643,6 +657,66 @@ fn is_detached_subagent_tool(row: &RunningToolCallRow) -> bool {
 fn cascade_child_request_id(row: &RunningToolCallRow) -> Option<&str> {
     let child_request_id = child_request_id(row)?;
     (cancel_policy(row) == CancelPolicy::Cascade).then_some(child_request_id)
+}
+
+async fn child_request_is_locally_owned(
+    node: &EmbeddedNode,
+    local_did: &str,
+    child_request_id: &str,
+) -> Result<bool> {
+    let escaped = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ agent_did }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query AgentRequest for recovery cascade ownership failed: {:?}",
+            response.errors
+        );
+    }
+    let did = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("agent_did"))
+        .and_then(|v| v.as_str());
+    Ok(did == Some(local_did))
+}
+
+async fn write_bridge_cancel_cascade_intent(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    at: DateTime<Utc>,
+) -> Result<()> {
+    let escaped_doc_id = escape_graphql_string(doc_id);
+    let at = escape_graphql_string(&at.to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{
+                    cancel_cascade_intent_at: "{at}",
+                    cancel_pending_remote_ack: true
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    execute_mutation_with_retry(
+        node,
+        &mutation,
+        "recovery_write_bridge_cancel_cascade_intent",
+    )
+    .await
+    .context("write recovery bridge cancel cascade intent mutation")?;
+    Ok(())
 }
 
 impl RecoveryOutcome {

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -359,6 +359,7 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
             continue;
         }
 
+        let mut remote_cancel_intent_at = None;
         if let Some(child_request_id) = cascade_child_request_id(&row) {
             if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
                 if let Err(error) = interrupt_request(node, child_request_id).await {
@@ -372,22 +373,14 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
                         "failed to cascade recovery interrupt to child request"
                     );
                 }
-            } else if let Err(error) =
-                write_bridge_cancel_cascade_intent(node, &row.doc_id, Utc::now()).await
-            {
-                tracing::warn!(
-                    doc_id = %row.doc_id,
-                    request_id = row.request_id.as_deref().unwrap_or(""),
-                    session_id = %row.session_id,
-                    tool_call_id = %row.tool_call_id,
-                    child_request_id,
-                    error = %error,
-                    "failed to write recovery cross-deployment cancel intent"
-                );
+            } else {
+                remote_cancel_intent_at = Some(Utc::now());
             }
         }
 
-        if let Err(error) = recover_tool_call_row(node, &row, deadline_at, outcome).await {
+        if let Err(error) =
+            recover_tool_call_row(node, &row, deadline_at, outcome, remote_cancel_intent_at).await
+        {
             tracing::warn!(
                 doc_id = %row.doc_id,
                 request_id = row.request_id.as_deref().unwrap_or(""),
@@ -543,6 +536,7 @@ async fn recover_tool_call_row(
     row: &RunningToolCallRow,
     deadline_at: Option<DateTime<Utc>>,
     outcome: RecoveryOutcome,
+    remote_cancel_intent_at: Option<DateTime<Utc>>,
 ) -> Result<()> {
     let now = Utc::now();
     let started_at = parse_datetime(row.started_at.as_deref()).unwrap_or(now);
@@ -558,6 +552,14 @@ async fn recover_tool_call_row(
         .failure_class()
         .map(|failure| format!(r#", tool_failure_class: "{}""#, failure.as_str()))
         .unwrap_or_default();
+    let remote_cancel_intent_fields = remote_cancel_intent_at
+        .map(|at| {
+            format!(
+                r#", cancel_cascade_intent_at: "{}", cancel_pending_remote_ack: true"#,
+                escape_graphql_string(&at.to_rfc3339())
+            )
+        })
+        .unwrap_or_default();
 
     let mutation = format!(
         r#"mutation {{
@@ -569,7 +571,7 @@ async fn recover_tool_call_row(
                     lifecycle_state: "{lifecycle_state}",
                     started_at: "{started_at_str}"{deadline_field},
                     completed_at: "{completed_at_str}",
-                    latency_ms: {latency_ms}{failure_class_field}
+                    latency_ms: {latency_ms}{failure_class_field}{remote_cancel_intent_fields}
                 }}
             ) {{ _docID }}
         }}"#,
@@ -689,34 +691,6 @@ async fn child_request_is_locally_owned(
         .and_then(|row| row.get("agent_did"))
         .and_then(|v| v.as_str());
     Ok(did == Some(local_did))
-}
-
-async fn write_bridge_cancel_cascade_intent(
-    node: &EmbeddedNode,
-    doc_id: &str,
-    at: DateTime<Utc>,
-) -> Result<()> {
-    let escaped_doc_id = escape_graphql_string(doc_id);
-    let at = escape_graphql_string(&at.to_rfc3339());
-    let mutation = format!(
-        r#"mutation {{
-            update_AgentToolCall(
-                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
-                input: {{
-                    cancel_cascade_intent_at: "{at}",
-                    cancel_pending_remote_ack: true
-                }}
-            ) {{ _docID }}
-        }}"#
-    );
-    execute_mutation_with_retry(
-        node,
-        &mutation,
-        "recovery_write_bridge_cancel_cascade_intent",
-    )
-    .await
-    .context("write recovery bridge cancel cascade intent mutation")?;
-    Ok(())
 }
 
 impl RecoveryOutcome {

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -96,6 +96,64 @@ pub async fn create_subagent_request_with_request_id(
     prompt: String,
     deadline: Option<DateTime<Utc>>,
 ) -> Result<String> {
+    create_subagent_request_inner(
+        node,
+        request_id,
+        parent_request_id,
+        parent_tool_call_id,
+        parent_subagent_depth,
+        agent_did,
+        behavior_id,
+        prompt,
+        deadline,
+        true,
+    )
+    .await
+}
+
+/// Create a subagent request whose parent was authored by a trusted paired
+/// peer. R5 uses this on the claiming deployment: the child is locally owned,
+/// while the replicated parent request keeps the paired peer's DID.
+#[allow(clippy::too_many_arguments)]
+pub async fn create_subagent_request_with_trusted_parent_request_id(
+    node: &EmbeddedNode,
+    request_id: String,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    agent_did: String,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<DateTime<Utc>>,
+) -> Result<String> {
+    create_subagent_request_inner(
+        node,
+        request_id,
+        parent_request_id,
+        parent_tool_call_id,
+        parent_subagent_depth,
+        agent_did,
+        behavior_id,
+        prompt,
+        deadline,
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_subagent_request_inner(
+    node: &EmbeddedNode,
+    request_id: String,
+    parent_request_id: String,
+    parent_tool_call_id: String,
+    parent_subagent_depth: u32,
+    agent_did: String,
+    behavior_id: String,
+    prompt: String,
+    deadline: Option<DateTime<Utc>>,
+    require_parent_agent_match: bool,
+) -> Result<String> {
     // 1. Depth check (pure precondition, fires before any DB I/O).
     if parent_subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
         return Err(anyhow!(IllegalToolCallTransition::SubagentDepthExceeded));
@@ -109,7 +167,7 @@ pub async fn create_subagent_request_with_request_id(
     // 3. Cross-reference check (R3): the parent link must point at a real
     // AgentRequest before the child can be materialized.
     let parent_agent_did = parent_request_agent_did(node, &parent_request_id).await?;
-    if parent_agent_did.as_deref() != Some(agent_did.as_str()) {
+    if require_parent_agent_match && parent_agent_did.as_deref() != Some(agent_did.as_str()) {
         return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
     }
 

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -17,7 +17,9 @@ use defra_node::QueryResponse;
 use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::session::execute_mutation_with_retry;
 
-use super::{AwaitMode, CancelPolicy, FailureClass, ToolCallLifecycle, ToolCallState};
+use super::{
+    AwaitMode, CancelPolicy, CascadeDispatch, FailureClass, ToolCallLifecycle, ToolCallState,
+};
 
 /// Error returned when a transition method is called from an illegal
 /// pre-state, or when a subagent-specific guard is violated.
@@ -83,6 +85,7 @@ impl ToolCallLifecycle {
         self.await_mode = current.await_mode;
         self.cancel_policy = current.cancel_policy;
         self.child_request_id = current.child_request_id;
+        self.unclaimed_deadline_at = current.unclaimed_deadline_at;
         Ok(())
     }
 
@@ -119,6 +122,7 @@ impl ToolCallLifecycle {
         self.await_mode = current.await_mode;
         self.cancel_policy = current.cancel_policy;
         self.child_request_id = current.child_request_id;
+        self.unclaimed_deadline_at = current.unclaimed_deadline_at;
         Ok(())
     }
 
@@ -174,8 +178,18 @@ impl ToolCallLifecycle {
                     format!(r#"child_request_id: "{escaped_crid}","#)
                 })
                 .unwrap_or_default();
+            let unclaimed_deadline_field = self
+                .unclaimed_deadline_at
+                .map(|deadline| {
+                    let escaped_deadline = escape_graphql_string(
+                        &deadline.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                    );
+                    format!(r#"unclaimed_deadline_at: "{escaped_deadline}","#)
+                })
+                .unwrap_or_default();
             format!(
                 r#"{child_field}
+                    {unclaimed_deadline_field}
                     await_mode: "{await_mode_str}",
                     cancel_policy: "{cancel_policy_str}","#
             )
@@ -245,6 +259,7 @@ impl ToolCallLifecycle {
         // avoid a type-mismatch error when re-validating the document.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
             r#"mutation {{
@@ -258,6 +273,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -295,6 +311,7 @@ impl ToolCallLifecycle {
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
             r#"mutation {{
@@ -309,6 +326,7 @@ impl ToolCallLifecycle {
                         completed_at: "{now_str}",
                         tool_failure_class: "{failure_class_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -410,6 +428,7 @@ impl ToolCallLifecycle {
         // avoid a type-mismatch error when re-validating the document.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
             r#"mutation {{
@@ -426,6 +445,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -490,6 +510,7 @@ impl ToolCallLifecycle {
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let lifecycle_state_str = projected.as_str();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         // Build conditional fields: tool_failure_class and result are only
         // set when the child reached .failed (mirrors R1's fail() pattern).
@@ -520,6 +541,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -569,6 +591,7 @@ impl ToolCallLifecycle {
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let failure_class = FailureClass::External.as_str();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
             r#"mutation {{
@@ -583,6 +606,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -671,6 +695,7 @@ impl ToolCallLifecycle {
             .ok_or_else(|| anyhow!("background called without started_at set"))?;
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_fragment = self.resupply_unclaimed_deadline_fragment();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -682,7 +707,7 @@ impl ToolCallLifecycle {
                         lifecycle_state: {{ _eq: "running" }},
                         await_mode: {{ _eq: "foreground" }}
                     }},
-                    input: {{ await_mode: "background", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}" }}
+                    input: {{ await_mode: "background", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}"{unclaimed_deadline_fragment} }}
                 ) {{ _docID }}
             }}"#
         );
@@ -728,6 +753,7 @@ impl ToolCallLifecycle {
             .ok_or_else(|| anyhow!("foreground called without started_at set"))?;
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_fragment = self.resupply_unclaimed_deadline_fragment();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -739,7 +765,7 @@ impl ToolCallLifecycle {
                         lifecycle_state: {{ _eq: "running" }},
                         await_mode: {{ _eq: "background" }}
                     }},
-                    input: {{ await_mode: "foreground", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}" }}
+                    input: {{ await_mode: "foreground", started_at: "{started_at_str}", deadline_at: "{deadline_at_str}"{unclaimed_deadline_fragment} }}
                 ) {{ _docID }}
             }}"#
         );
@@ -788,6 +814,7 @@ impl ToolCallLifecycle {
             String::new()
         };
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_fragment = self.resupply_unclaimed_deadline_fragment();
 
         let escaped_doc_id = escape_graphql_string(doc_id);
 
@@ -795,7 +822,7 @@ impl ToolCallLifecycle {
             r#"mutation {{
                 update_AgentToolCall(
                     filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
-                    input: {{ cancel_policy: "detach", deadline_at: "{deadline_at_str}"{started_at_fragment} }}
+                    input: {{ cancel_policy: "detach", deadline_at: "{deadline_at_str}"{started_at_fragment}{unclaimed_deadline_fragment} }}
                 ) {{ _docID }}
             }}"#
         );
@@ -829,6 +856,63 @@ impl ToolCallLifecycle {
         }))
     }
 
+    /// Dispatch cascade cancellation according to child ownership. Local child
+    /// requests continue through the existing interrupt path; replicated
+    /// cross-deployment children are signaled through the bridge row.
+    pub async fn bridge_cancel_cascade_dispatch(
+        &self,
+        local_did: &str,
+    ) -> Result<Option<CascadeDispatch>> {
+        let Some(intent) = self.bridge_cancel_cascade().await? else {
+            return Ok(None);
+        };
+
+        if child_request_is_locally_owned(&self.node, local_did, &intent.child_request_id).await? {
+            return Ok(Some(CascadeDispatch::Local(intent)));
+        }
+
+        self.write_bridge_cancel_cascade_intent(intent.at).await?;
+        Ok(Some(CascadeDispatch::RemoteIntentWritten))
+    }
+
+    async fn write_bridge_cancel_cascade_intent(
+        &self,
+        at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        let doc_id = self.doc_id.as_ref().ok_or_else(|| {
+            anyhow!("bridge_cancel_cascade_dispatch called before row was persisted")
+        })?;
+        let escaped_doc_id = escape_graphql_string(doc_id);
+        let at = escape_graphql_string(&at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true));
+        let started_at = self.started_at.ok_or_else(|| {
+            anyhow!("bridge_cancel_cascade_dispatch called without started_at set")
+        })?;
+        let started_at = started_at.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let deadline_at = self
+            .deadline_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{
+                        started_at: "{started_at}",
+                        deadline_at: "{deadline_at}",
+                        completed_at: "{at}",
+                        cancel_cascade_intent_at: "{at}",
+                        cancel_pending_remote_ack: true
+                        {unclaimed_deadline_clear}
+                    }}
+                ) {{ _docID }}
+            }}"#
+        );
+        execute_mutation_with_retry(&self.node, &mutation, "write_bridge_cancel_cascade_intent")
+            .await
+            .context("write bridge cancel cascade intent mutation")?;
+        Ok(())
+    }
+
     /// Running → Cancelled. Called by request interruption handling and
     /// startup recovery for interrupted parent requests.
     ///
@@ -850,6 +934,7 @@ impl ToolCallLifecycle {
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
+        let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
             r#"mutation {{
@@ -866,6 +951,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}
             }}"#
@@ -888,6 +974,57 @@ impl ToolCallLifecycle {
         self.state = ToolCallState::Cancelled;
         Ok(())
     }
+
+    fn clear_unclaimed_deadline_fragment(&self) -> &'static str {
+        if self.unclaimed_deadline_at.is_some() {
+            ", unclaimed_deadline_at: null"
+        } else {
+            ""
+        }
+    }
+
+    fn resupply_unclaimed_deadline_fragment(&self) -> String {
+        self.unclaimed_deadline_at
+            .map(|deadline| {
+                let escaped_deadline = escape_graphql_string(
+                    &deadline.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                );
+                format!(r#", unclaimed_deadline_at: "{escaped_deadline}""#)
+            })
+            .unwrap_or_default()
+    }
+}
+
+async fn child_request_is_locally_owned(
+    node: &defra_node::EmbeddedNode,
+    local_did: &str,
+    child_request_id: &str,
+) -> Result<bool> {
+    let escaped = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ agent_did }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query AgentRequest for cross-deployment cancel dispatch failed: {:?}",
+            response.errors
+        );
+    }
+    let did = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("agent_did"))
+        .and_then(|v| v.as_str());
+    Ok(did == Some(local_did))
 }
 
 /// Helper to extract `_docID` from a `create_*` mutation response.

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -917,6 +917,55 @@ impl ToolCallLifecycle {
     /// startup recovery for interrupted parent requests.
     ///
     pub async fn cancel_during_run(&mut self) -> Result<()> {
+        self.cancel_during_run_inner(None).await
+    }
+
+    /// Running -> Cancelled while dispatching a cascade cancel. For remote
+    /// children the durable cancel intent is written in the same bridge update
+    /// that terminalizes the tool call, so recovery never observes a cancelled
+    /// bridge without the remote signal.
+    pub async fn cancel_during_run_with_cascade_dispatch(
+        &mut self,
+        local_did: &str,
+    ) -> Result<Option<CascadeDispatch>> {
+        self.ensure_state(
+            &[ToolCallState::Running],
+            "cancel_during_run_with_cascade_dispatch",
+        )?;
+
+        let Some(child_request_id) = self.child_request_id.clone() else {
+            self.cancel_during_run_inner(None).await?;
+            return Ok(None);
+        };
+        if self.cancel_policy != CancelPolicy::Cascade {
+            self.cancel_during_run_inner(None).await?;
+            return Ok(None);
+        }
+
+        let intent = super::CascadeIntent {
+            child_request_id,
+            at: chrono::Utc::now(),
+        };
+        if child_request_is_locally_owned(&self.node, local_did, &intent.child_request_id).await? {
+            self.cancel_during_run_inner(None).await?;
+            if self.is_cancelled() {
+                return Ok(Some(CascadeDispatch::Local(intent)));
+            }
+            return Ok(None);
+        }
+
+        self.cancel_during_run_inner(Some(intent.at)).await?;
+        if self.is_cancelled() {
+            Ok(Some(CascadeDispatch::RemoteIntentWritten))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn cancel_during_run_inner(
+        &mut self,
+        remote_cancel_intent_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<()> {
         self.ensure_state(&[ToolCallState::Running], "cancel_during_run")?;
 
         let doc_id = self.doc_id.as_ref().ok_or_else(|| {
@@ -935,6 +984,16 @@ impl ToolCallLifecycle {
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
+        let remote_cancel_intent_fragment = remote_cancel_intent_at
+            .map(|at| {
+                let at = escape_graphql_string(&at.to_rfc3339());
+                format!(
+                    r#",
+                        cancel_cascade_intent_at: "{at}",
+                        cancel_pending_remote_ack: true"#
+                )
+            })
+            .unwrap_or_default();
 
         let mutation = format!(
             r#"mutation {{
@@ -951,6 +1010,7 @@ impl ToolCallLifecycle {
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
                         latency_ms: {latency_ms}
+                        {remote_cancel_intent_fragment}
                         {unclaimed_deadline_clear}
                     }}
                 ) {{ _docID }}

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -13,6 +13,7 @@ use crate::graphql::escape_graphql_string;
 use crate::runtime_snapshot::ActiveRuntimeSnapshot;
 
 const TOOL_CALL_COLLECTION: &str = "AgentToolCall";
+const AGENT_REQUEST_COLLECTION: &str = "AgentRequest";
 
 pub(crate) async fn run_cross_deployment_cancel_mirror(
     node: Arc<EmbeddedNode>,
@@ -52,10 +53,15 @@ impl CrossDeploymentCancelMirror {
 
     pub(crate) async fn run(mut self) -> Result<()> {
         self.scan_pending_intents().await?;
+        let mut retry_tick = tokio::time::interval(std::time::Duration::from_secs(5));
         loop {
             let message = tokio::select! {
                 biased;
                 _ = self.cancel.cancelled() => return Ok(()),
+                _ = retry_tick.tick() => {
+                    self.scan_pending_intents().await?;
+                    continue;
+                }
                 changed = self.snapshot_rx.changed() => {
                     if changed.is_err() {
                         return Ok(());
@@ -87,15 +93,20 @@ impl CrossDeploymentCancelMirror {
             else {
                 continue;
             };
-            if collection_name != TOOL_CALL_COLLECTION {
-                continue;
-            }
-            if let Err(error) = self.handle_tool_call_doc(&update.doc_id).await {
-                tracing::warn!(
-                    doc_id = %update.doc_id,
-                    %error,
-                    "cancel mirror failed to handle AgentToolCall update"
-                );
+            match collection_name.as_str() {
+                TOOL_CALL_COLLECTION => {
+                    if let Err(error) = self.handle_tool_call_doc(&update.doc_id).await {
+                        tracing::warn!(
+                            doc_id = %update.doc_id,
+                            %error,
+                            "cancel mirror failed to handle AgentToolCall update"
+                        );
+                    }
+                }
+                AGENT_REQUEST_COLLECTION => {
+                    self.scan_pending_intents().await?;
+                }
+                _ => {}
             }
         }
     }
@@ -365,4 +376,159 @@ async fn write_child_interrupt_requested_at(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime_snapshot::ActiveRuntimeSnapshot;
+    use std::collections::{HashMap, HashSet};
+    use tokio::sync::watch;
+
+    const PARENT_DID: &str = "did:defra-agent:parent";
+    const CHILD_DID: &str = "did:defra-agent:child";
+
+    async fn test_node() -> Arc<EmbeddedNode> {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        node
+    }
+
+    async fn exec(node: &EmbeddedNode, statement: &str) {
+        let response = node.execute(statement).await;
+        assert!(
+            !response.has_errors(),
+            "GraphQL errors: {:?}",
+            response.errors
+        );
+    }
+
+    fn snapshot() -> Arc<ActiveRuntimeSnapshot> {
+        Arc::new(ActiveRuntimeSnapshot {
+            generation: 1,
+            local_did: CHILD_DID.to_string(),
+            paired_peer_dids: HashSet::from([PARENT_DID.to_string()]),
+            default_behavior_id: "child-behavior".to_string(),
+            behaviors: HashMap::new(),
+            tool_surfaces: HashMap::new(),
+            backend_admission_configs: HashMap::new(),
+            unavailable_behaviors: HashMap::new(),
+            active_schedules: HashMap::new(),
+            unavailable_schedules: HashSet::new(),
+            active_event_triggers: HashMap::new(),
+            unavailable_event_triggers: HashSet::new(),
+            active_tasks: HashMap::new(),
+            dispatchers: HashMap::new(),
+        })
+    }
+
+    async fn write_parent_and_bridge(node: &EmbeddedNode) {
+        exec(
+            node,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "parent-request",
+                    agent_did: "did:defra-agent:parent",
+                    behavior_id: "parent-behavior",
+                    session_id: "parent-session",
+                    content: "parent",
+                    status: "interrupted",
+                    lifecycle_state: "interrupted",
+                    created_at: "2026-05-15T00:00:00Z"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+        exec(
+            node,
+            r#"mutation {
+                create_AgentToolCall(input: {
+                    tool_call_key: "parent-request:spawn",
+                    request_id: "parent-request",
+                    session_id: "parent-session",
+                    message_sequence: 1,
+                    tool_name: "spawn_subagent",
+                    tool_call_id: "spawn",
+                    args: "{}",
+                    status: "completed",
+                    lifecycle_state: "cancelled",
+                    started_at: "2026-05-15T00:00:00Z",
+                    deadline_at: "2026-05-15T00:05:00Z",
+                    completed_at: "2026-05-15T00:01:00Z",
+                    await_mode: "background",
+                    cancel_policy: "cascade",
+                    child_request_id: "child-request",
+                    cancel_cascade_intent_at: "2026-05-15T00:01:00Z",
+                    cancel_pending_remote_ack: true
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    }
+
+    async fn write_child_request(node: &EmbeddedNode) {
+        exec(
+            node,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "child-request",
+                    agent_did: "did:defra-agent:child",
+                    behavior_id: "child-behavior",
+                    session_id: "child-session",
+                    content: "child",
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    created_at: "2026-05-15T00:00:30Z",
+                    caused_by_parent_request_id: "parent-request",
+                    caused_by_parent_tool_call_id: "spawn"
+                }) { _docID }
+            }"#,
+        )
+        .await;
+    }
+
+    async fn child_interrupt_requested_at(node: &EmbeddedNode) -> Option<String> {
+        let response = node
+            .execute(
+                r#"{
+                    AgentRequest(filter: { request_id: { _eq: "child-request" } }, limit: 1) {
+                        interrupt_requested_at
+                    }
+                }"#,
+            )
+            .await;
+        assert!(
+            !response.has_errors(),
+            "query errors: {:?}",
+            response.errors
+        );
+        response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("AgentRequest"))
+            .and_then(|rows| rows.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("interrupt_requested_at"))
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+    }
+
+    #[tokio::test]
+    async fn pending_intent_is_retried_after_child_request_arrives() {
+        let node = test_node().await;
+        write_parent_and_bridge(node.as_ref()).await;
+        let (_tx, rx) = watch::channel(snapshot());
+        let cancel = CancellationToken::new();
+        let mut mirror = CrossDeploymentCancelMirror::new(node.clone(), rx, cancel);
+
+        mirror.scan_pending_intents().await.unwrap();
+        assert!(child_interrupt_requested_at(node.as_ref()).await.is_none());
+
+        write_child_request(node.as_ref()).await;
+        mirror.scan_pending_intents().await.unwrap();
+        assert_eq!(
+            child_interrupt_requested_at(node.as_ref()).await.as_deref(),
+            Some("2026-05-15T00:01:00Z")
+        );
+    }
 }

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -1,0 +1,368 @@
+//! Cross-deployment cascade-cancel mirror observer.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::Result;
+use defra_node::{EmbeddedNode, EventName};
+use serde::Deserialize;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use crate::graphql::escape_graphql_string;
+use crate::runtime_snapshot::ActiveRuntimeSnapshot;
+
+const TOOL_CALL_COLLECTION: &str = "AgentToolCall";
+
+pub(crate) async fn run_cross_deployment_cancel_mirror(
+    node: Arc<EmbeddedNode>,
+    snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    CrossDeploymentCancelMirror::new(node, snapshot_rx, cancel)
+        .run()
+        .await
+}
+
+pub(crate) struct CrossDeploymentCancelMirror {
+    node: Arc<EmbeddedNode>,
+    snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+    subscription: events::Subscription,
+    cancel: CancellationToken,
+    collection_id_to_name: HashMap<String, String>,
+    mirrored: HashSet<String>,
+}
+
+impl CrossDeploymentCancelMirror {
+    pub(crate) fn new(
+        node: Arc<EmbeddedNode>,
+        snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+        cancel: CancellationToken,
+    ) -> Self {
+        let subscription = node.subscribe(&[EventName::Update]);
+        Self {
+            node,
+            snapshot_rx,
+            subscription,
+            cancel,
+            collection_id_to_name: HashMap::new(),
+            mirrored: HashSet::new(),
+        }
+    }
+
+    pub(crate) async fn run(mut self) -> Result<()> {
+        self.scan_pending_intents().await?;
+        loop {
+            let message = tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => return Ok(()),
+                changed = self.snapshot_rx.changed() => {
+                    if changed.is_err() {
+                        return Ok(());
+                    }
+                    self.scan_pending_intents().await?;
+                    continue;
+                }
+                msg = self.subscription.recv() => {
+                    match msg {
+                        Some(message) => message,
+                        None => anyhow::bail!("cross-deployment cancel mirror subscription channel closed"),
+                    }
+                }
+            };
+
+            let dropped = self.subscription.check_and_reset_dropped();
+            if dropped > 0 {
+                tracing::warn!(
+                    dropped,
+                    "cancel mirror dropped messages; scanning pending cancel intents"
+                );
+                self.scan_pending_intents().await?;
+            }
+
+            let Some(update) = message.as_update() else {
+                continue;
+            };
+            let Some(collection_name) = self.resolve_collection_name(&update.collection_id).await
+            else {
+                continue;
+            };
+            if collection_name != TOOL_CALL_COLLECTION {
+                continue;
+            }
+            if let Err(error) = self.handle_tool_call_doc(&update.doc_id).await {
+                tracing::warn!(
+                    doc_id = %update.doc_id,
+                    %error,
+                    "cancel mirror failed to handle AgentToolCall update"
+                );
+            }
+        }
+    }
+
+    pub(crate) async fn scan_pending_intents(&mut self) -> Result<()> {
+        for doc_id in self.load_pending_intent_doc_ids().await? {
+            if let Err(error) = self.handle_tool_call_doc(&doc_id).await {
+                tracing::warn!(
+                    doc_id = %doc_id,
+                    %error,
+                    "cancel mirror failed to scan pending cancel intent"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    async fn handle_tool_call_doc(&mut self, doc_id: &str) -> Result<()> {
+        let Some(row) = self.load_bridge_row(doc_id).await? else {
+            return Ok(());
+        };
+        let Some(intent_at) = row
+            .cancel_cascade_intent_at
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            return Ok(());
+        };
+        let Some(child_request_id) = row
+            .child_request_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+        else {
+            return Ok(());
+        };
+
+        let dedupe_key = format!("{}:{intent_at}", row.tool_call_id);
+        if self.mirrored.contains(&dedupe_key) {
+            return Ok(());
+        }
+
+        let Some(parent_did) = self.load_parent_authoring_did(&row.request_id).await? else {
+            return Ok(());
+        };
+        let snapshot = self.snapshot_rx.borrow().clone();
+        if !snapshot.paired_peer_dids.contains(&parent_did) {
+            return Ok(());
+        }
+
+        let Some(child) = self.load_child_request(&child_request_id).await? else {
+            return Ok(());
+        };
+        if child.agent_did.as_deref() != Some(snapshot.local_did.as_str()) {
+            return Ok(());
+        }
+        if is_terminal_state(child.lifecycle_state.as_deref(), child.status.as_deref())
+            || child.interrupt_requested_at.is_some()
+        {
+            self.mirrored.insert(dedupe_key);
+            return Ok(());
+        }
+
+        write_child_interrupt_requested_at(self.node.as_ref(), &child_request_id, &intent_at)
+            .await?;
+        self.mirrored.insert(dedupe_key);
+        Ok(())
+    }
+
+    async fn load_pending_intent_doc_ids(&self) -> Result<Vec<String>> {
+        let query = r#"{
+            AgentToolCall(filter: { cancel_pending_remote_ack: { _eq: true } }) {
+                _docID
+            }
+        }"#;
+        let response = self.node.execute(query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "cancel mirror pending intent query failed: {:?}",
+                response.errors
+            );
+        }
+        let rows: Vec<DocIdRow> = response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentToolCall"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().map(|row| row.doc_id).collect())
+    }
+
+    async fn load_bridge_row(&self, doc_id: &str) -> Result<Option<BridgeCancelRow>> {
+        let escaped = escape_graphql_string(doc_id);
+        let query = format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{
+                    request_id
+                    tool_call_id
+                    child_request_id
+                    cancel_cascade_intent_at
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("cancel mirror bridge load failed: {:?}", response.errors);
+        }
+        let rows: Vec<BridgeCancelRow> = response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentToolCall"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn load_parent_authoring_did(&self, parent_request_id: &str) -> Result<Option<String>> {
+        let escaped = escape_graphql_string(parent_request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{ agent_did }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "cancel mirror parent DID load failed: {:?}",
+                response.errors
+            );
+        }
+        Ok(response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentRequest"))
+            .and_then(|v| v.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("agent_did"))
+            .and_then(|v| v.as_str())
+            .map(String::from))
+    }
+
+    async fn load_child_request(&self, child_request_id: &str) -> Result<Option<ChildRequestRow>> {
+        let escaped = escape_graphql_string(child_request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{
+                    agent_did
+                    status
+                    lifecycle_state
+                    interrupt_requested_at
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("cancel mirror child load failed: {:?}", response.errors);
+        }
+        let rows: Vec<ChildRequestRow> = response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentRequest"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn resolve_collection_name(&mut self, collection_id: &str) -> Option<String> {
+        if let Some(name) = self.collection_id_to_name.get(collection_id) {
+            return Some(name.clone());
+        }
+
+        let names = match self.node.list_collections() {
+            Ok(names) => names,
+            Err(error) => {
+                tracing::warn!(
+                    collection_id = %collection_id,
+                    %error,
+                    "cancel mirror failed to list collections"
+                );
+                return None;
+            }
+        };
+        for name in names {
+            let def = match self.node.get_collection(&name) {
+                Ok(Some(def)) => def,
+                Ok(None) => continue,
+                Err(error) => {
+                    tracing::warn!(
+                        collection_name = %name,
+                        %error,
+                        "cancel mirror failed to fetch collection definition",
+                    );
+                    continue;
+                }
+            };
+            self.collection_id_to_name
+                .insert(def.collection_id.clone(), def.name.clone());
+        }
+        self.collection_id_to_name.get(collection_id).cloned()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DocIdRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct BridgeCancelRow {
+    request_id: String,
+    tool_call_id: String,
+    child_request_id: Option<String>,
+    cancel_cascade_intent_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildRequestRow {
+    agent_did: Option<String>,
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    interrupt_requested_at: Option<String>,
+}
+
+fn is_terminal_state(lifecycle_state: Option<&str>, status: Option<&str>) -> bool {
+    matches!(
+        lifecycle_state,
+        Some("completed" | "failed" | "dead" | "interrupted" | "superseded")
+    ) || matches!(
+        status,
+        Some("completed" | "error" | "dead" | "interrupted" | "superseded")
+    )
+}
+
+async fn write_child_interrupt_requested_at(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    when: &str,
+) -> Result<()> {
+    let escaped_id = escape_graphql_string(child_request_id);
+    let escaped_when = escape_graphql_string(when);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_id}" }} }},
+                input: {{ interrupt_requested_at: "{escaped_when}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "cancel mirror child interrupt write failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(())
+}

--- a/crates/defra-agent/src/trigger_engine/mod.rs
+++ b/crates/defra-agent/src/trigger_engine/mod.rs
@@ -13,6 +13,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::runtime_snapshot::ActiveRuntimeSnapshot;
 
+pub(crate) mod cross_deployment_cancel_mirror;
 pub(crate) mod event_source;
 pub(crate) mod manual_source;
 pub(crate) mod production_materializer;

--- a/crates/defra-agent/src/trigger_engine/subagent_source.rs
+++ b/crates/defra-agent/src/trigger_engine/subagent_source.rs
@@ -21,7 +21,9 @@ use crate::background_tools::{
 };
 use crate::graphql::escape_graphql_string;
 use crate::runtime_snapshot::{ActiveRuntimeSnapshot, ConcurrencyMode, ResolvedTask};
-use crate::tool_call_lifecycle::subagent_request::create_subagent_request_with_request_id;
+use crate::tool_call_lifecycle::subagent_request::{
+    create_subagent_request_with_request_id, create_subagent_request_with_trusted_parent_request_id,
+};
 use crate::tool_call_lifecycle::{AwaitMode, FailureClass, IllegalToolCallTransition};
 
 use super::{FireIntent, FireResult, TriggerKind, TriggerSource};
@@ -299,62 +301,75 @@ impl SubagentSource {
             anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
         };
 
-        let authorization = match load_parent_subagent_authorization(&self.node, &parent_request_id)
+        let snapshot = self.snapshot_rx.borrow().clone();
+        let parent_authoring_did = parent.agent_did.clone();
+        let trusted_paired_peer = snapshot.paired_peer_dids.contains(&parent_authoring_did);
+        let tool_name = non_empty(Some(&row.tool_name)).unwrap_or("spawn_subagent");
+        if trusted_paired_peer {
+            tracing::debug!(
+                parent_request_id = %parent_request_id,
+                parent_authoring_did = %parent_authoring_did,
+                "subagent source claiming cross-deployment spawn from paired peer",
+            );
+        } else {
+            let authorization = match load_parent_subagent_authorization(
+                &self.node,
+                &parent_request_id,
+            )
             .await
-        {
-            Ok(authorization) => authorization,
-            Err(error) => {
+            {
+                Ok(authorization) => authorization,
+                Err(error) => {
+                    let failed = self
+                        .fail_unauthorized_tool_call(
+                            &row,
+                            "/behavior_id",
+                            &spawn_args.behavior_id,
+                            "subagent authorization could not be verified for this behavior",
+                            &[],
+                        )
+                        .await?;
+                    self.processed_tool_calls.insert(processed_key);
+                    tracing::warn!(
+                        parent_request_id = %parent_request_id,
+                        parent_tool_call_id = %parent_tool_call_id,
+                        target_behavior_id = %spawn_args.behavior_id,
+                        failed_tool_call = failed,
+                        %error,
+                        "subagent source could not verify parent subagent authorization; rejecting spawn",
+                    );
+                    return Ok(None);
+                }
+            };
+            if let Some(denial) = subagent_spawn_denial(
+                &authorization,
+                &spawn_args.behavior_id,
+                await_mode,
+                tool_name,
+            ) {
                 let failed = self
                     .fail_unauthorized_tool_call(
                         &row,
-                        "/behavior_id",
-                        &spawn_args.behavior_id,
-                        "subagent authorization could not be verified for this behavior",
-                        &[],
+                        denial.path,
+                        &denial.requested,
+                        denial.message,
+                        &authorization.allowed_targets,
                     )
                     .await?;
                 self.processed_tool_calls.insert(processed_key);
                 tracing::warn!(
                     parent_request_id = %parent_request_id,
+                    parent_behavior_id = %authorization.behavior_id,
                     parent_tool_call_id = %parent_tool_call_id,
                     target_behavior_id = %spawn_args.behavior_id,
+                    await_mode = %await_mode.as_str(),
                     failed_tool_call = failed,
-                    %error,
-                    "subagent source could not verify parent subagent authorization; rejecting spawn",
+                    "subagent source rejected unauthorized subagent spawn",
                 );
                 return Ok(None);
             }
-        };
-        let tool_name = non_empty(Some(&row.tool_name)).unwrap_or("spawn_subagent");
-        if let Some(denial) = subagent_spawn_denial(
-            &authorization,
-            &spawn_args.behavior_id,
-            await_mode,
-            tool_name,
-        ) {
-            let failed = self
-                .fail_unauthorized_tool_call(
-                    &row,
-                    denial.path,
-                    &denial.requested,
-                    denial.message,
-                    &authorization.allowed_targets,
-                )
-                .await?;
-            self.processed_tool_calls.insert(processed_key);
-            tracing::warn!(
-                parent_request_id = %parent_request_id,
-                parent_behavior_id = %authorization.behavior_id,
-                parent_tool_call_id = %parent_tool_call_id,
-                target_behavior_id = %spawn_args.behavior_id,
-                await_mode = %await_mode.as_str(),
-                failed_tool_call = failed,
-                "subagent source rejected unauthorized subagent spawn",
-            );
-            return Ok(None);
         }
 
-        let snapshot = self.snapshot_rx.borrow().clone();
         if snapshot.behavior(&spawn_args.behavior_id).is_none() {
             tracing::warn!(
                 parent_request_id = %parent_request_id,
@@ -376,18 +391,38 @@ impl SubagentSource {
             .unwrap_or(0);
         let deadline =
             effective_deadline(row.deadline_at.as_deref(), spawn_args.deadline.as_deref());
-        let request_id = create_subagent_request_with_request_id(
-            &self.node,
-            child_request_id.clone(),
-            parent_request_id.clone(),
-            parent_tool_call_id.clone(),
-            parent_depth,
-            parent.agent_did,
-            spawn_args.behavior_id.clone(),
-            spawn_args.prompt.clone(),
-            deadline,
-        )
-        .await?;
+        let child_agent_did = if trusted_paired_peer && !snapshot.local_did.trim().is_empty() {
+            snapshot.local_did.clone()
+        } else {
+            parent.agent_did
+        };
+        let request_id = if trusted_paired_peer {
+            create_subagent_request_with_trusted_parent_request_id(
+                &self.node,
+                child_request_id.clone(),
+                parent_request_id.clone(),
+                parent_tool_call_id.clone(),
+                parent_depth,
+                child_agent_did,
+                spawn_args.behavior_id.clone(),
+                spawn_args.prompt.clone(),
+                deadline,
+            )
+            .await?
+        } else {
+            create_subagent_request_with_request_id(
+                &self.node,
+                child_request_id.clone(),
+                parent_request_id.clone(),
+                parent_tool_call_id.clone(),
+                parent_depth,
+                child_agent_did,
+                spawn_args.behavior_id.clone(),
+                spawn_args.prompt.clone(),
+                deadline,
+            )
+            .await?
+        };
 
         self.processed_tool_calls.insert(processed_key);
         let fired_at = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);

--- a/crates/defra-agent/tests/fixtures/r5_scenarios/a_crash_mid_wait.json
+++ b/crates/defra-agent/tests/fixtures/r5_scenarios/a_crash_mid_wait.json
@@ -1,0 +1,167 @@
+{
+  "name": "a_crash_mid_wait",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-a-crash-before",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-a-crash-before",
+      "parent_tool_call_id": "tool-call-a-crash-before",
+      "child_request_id": "child-req-a-crash-before",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-a-crash-before"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-a-crash-before"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-a-crash-before",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-a-crash-before",
+      "caused_by_parent_tool_call_id": "tool-call-a-crash-before"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-a-crash-before"
+    },
+    { "op": "Crash", "node": "A" },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-a-crash-before",
+      "terminal": "completed",
+      "final_response": "child completed while A was down"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-a-crash-before"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentMessage",
+      "doc_id": "child-req-a-crash-before"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-a-crash-before"
+    },
+    { "op": "RunRecoverySweepOn", "node": "A" },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-a-crash-after",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-a-crash-after",
+      "parent_tool_call_id": "tool-call-a-crash-after",
+      "child_request_id": "child-req-a-crash-after",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-a-crash-after"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-a-crash-after"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-a-crash-after",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-a-crash-after",
+      "caused_by_parent_tool_call_id": "tool-call-a-crash-after"
+    },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-a-crash-after",
+      "terminal": "completed",
+      "final_response": "child completed before A observer"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-a-crash-after"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentMessage",
+      "doc_id": "child-req-a-crash-after"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-a-crash-after"
+    },
+    { "op": "Crash", "node": "A" },
+    { "op": "RunRecoverySweepOn", "node": "A" },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}

--- a/crates/defra-agent/tests/fixtures/r5_scenarios/b_crash_mid_execution.json
+++ b/crates/defra-agent/tests/fixtures/r5_scenarios/b_crash_mid_execution.json
@@ -1,0 +1,82 @@
+{
+  "name": "b_crash_mid_execution",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-b-crash",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-b-crash",
+      "parent_tool_call_id": "tool-call-b-crash",
+      "child_request_id": "child-req-b-crash",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-b-crash"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-b-crash"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-b-crash",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-b-crash",
+      "caused_by_parent_tool_call_id": "tool-call-b-crash"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-b-crash"
+    },
+    { "op": "Crash", "node": "B" },
+    { "op": "RunRecoverySweepOn", "node": "B" },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-b-crash",
+      "terminal": "failed",
+      "final_response": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-b-crash"
+    },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}

--- a/crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json
+++ b/crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json
@@ -1,0 +1,94 @@
+{
+  "name": "happy_path",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-1",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-1",
+      "parent_tool_call_id": "tool-call-1",
+      "child_request_id": "child-req-1",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-1"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-1",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-1",
+      "caused_by_parent_tool_call_id": "tool-call-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-1"
+    },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-1",
+      "terminal": "completed",
+      "final_response": "child completed successfully"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentMessage",
+      "doc_id": "child-req-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-1"
+    },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}

--- a/crates/defra-agent/tests/fixtures/r5_scenarios/multi_completion_coalesce.json
+++ b/crates/defra-agent/tests/fixtures/r5_scenarios/multi_completion_coalesce.json
@@ -1,0 +1,155 @@
+{
+  "name": "multi_completion_coalesce",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-multi",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-multi",
+      "parent_tool_call_id": "tool-call-multi-1",
+      "child_request_id": "child-req-multi-1",
+      "behavior_id": "child-behavior-1",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-multi",
+      "parent_tool_call_id": "tool-call-multi-2",
+      "child_request_id": "child-req-multi-2",
+      "behavior_id": "child-behavior-2",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-multi"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-multi-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-multi-2"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-multi-1",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior-1",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-multi",
+      "caused_by_parent_tool_call_id": "tool-call-multi-1"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-multi-2",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior-2",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-multi",
+      "caused_by_parent_tool_call_id": "tool-call-multi-2"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-multi-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-multi-2"
+    },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-multi-1",
+      "terminal": "completed",
+      "final_response": "child one completed"
+    },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-multi-2",
+      "terminal": "completed",
+      "final_response": "child two completed"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-multi-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentMessage",
+      "doc_id": "child-req-multi-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-multi-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-multi-2"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentMessage",
+      "doc_id": "child-req-multi-2"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-multi-2"
+    },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}

--- a/crates/defra-agent/tests/fixtures/r5_scenarios/partition_during_cancel.json
+++ b/crates/defra-agent/tests/fixtures/r5_scenarios/partition_during_cancel.json
@@ -1,0 +1,95 @@
+{
+  "name": "partition_during_cancel",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-cancel",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-cancel",
+      "parent_tool_call_id": "tool-call-cancel",
+      "child_request_id": "child-req-cancel",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-cancel"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-cancel"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-cancel",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-cancel",
+      "caused_by_parent_tool_call_id": "tool-call-cancel"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-cancel"
+    },
+    {
+      "op": "CancelParentOnA",
+      "parent_request_id": "parent-req-cancel",
+      "parent_tool_call_id": "tool-call-cancel"
+    },
+    { "op": "AdvanceClockOn", "node": "A", "seconds": 360 },
+    { "op": "RunCancelAckObserverOnA" },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-cancel"
+    },
+    { "op": "RunCancelMirrorObserverOnB" },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-cancel",
+      "terminal": "interrupted",
+      "final_response": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-cancel"
+    },
+    { "op": "RunCancelAckObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}

--- a/crates/defra-agent/tests/peer_pairing_desired_query.rs
+++ b/crates/defra-agent/tests/peer_pairing_desired_query.rs
@@ -13,6 +13,7 @@ async fn peer_pairing_desired_round_trip() {
     let create = r#"mutation {
         create_PeerPairingDesired(input: {
             peer_id: "p1",
+            agent_did: "did:defra-agent:p1",
             collections: ["c1", "c2"],
             replicator_addresses: ["/ip4/1/p2p/p1"],
             created_at: "2026-05-13T00:00:00Z",
@@ -25,6 +26,7 @@ async fn peer_pairing_desired_round_trip() {
     let query = r#"query {
         PeerPairingDesired(filter: { peer_id: { _eq: "p1" } }) {
             peer_id
+            agent_did
             collections
             replicator_addresses
         }

--- a/crates/defra-agent/tests/r4_subagent_completion.rs
+++ b/crates/defra-agent/tests/r4_subagent_completion.rs
@@ -485,9 +485,10 @@ async fn background_completion_projects_bridge_appends_notification_and_enqueues
     )
     .await;
 
-    let outcome = project_background_subagent_completion(db.node.clone(), &child_request_id)
-        .await
-        .unwrap();
+    let outcome =
+        project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
+            .await
+            .unwrap();
     let BackgroundCompletionOutcome::Projected {
         wake_request_id, ..
     } = outcome
@@ -530,9 +531,10 @@ async fn background_completion_projects_bridge_appends_notification_and_enqueues
         parent_request_id
     );
 
-    let again = project_background_subagent_completion(db.node.clone(), &child_request_id)
-        .await
-        .unwrap();
+    let again =
+        project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
+            .await
+            .unwrap();
     assert_eq!(again, BackgroundCompletionOutcome::AlreadyProjected);
     assert_eq!(
         fetch_parent_messages(db.node.as_ref(), &session_id)
@@ -583,9 +585,10 @@ async fn background_completion_recovers_side_effects_after_bridge_already_projec
         .await
         .is_empty());
 
-    let outcome = project_background_subagent_completion(db.node.clone(), &child_request_id)
-        .await
-        .unwrap();
+    let outcome =
+        project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
+            .await
+            .unwrap();
     assert!(matches!(
         outcome,
         BackgroundCompletionOutcome::Projected { .. }
@@ -602,9 +605,10 @@ async fn background_completion_recovers_side_effects_after_bridge_already_projec
         1
     );
 
-    let again = project_background_subagent_completion(db.node.clone(), &child_request_id)
-        .await
-        .unwrap();
+    let again =
+        project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
+            .await
+            .unwrap();
     assert_eq!(again, BackgroundCompletionOutcome::AlreadyProjected);
     assert_eq!(
         fetch_parent_messages(db.node.as_ref(), &session_id)
@@ -661,7 +665,7 @@ async fn background_notification_sorts_after_reserved_spawn_tool_result() {
         "fast background child done",
     )
     .await;
-    project_background_subagent_completion(db.node.clone(), &child_request_id)
+    project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
         .await
         .unwrap();
 
@@ -729,9 +733,10 @@ async fn background_completion_compacts_multibyte_summary_without_panicking() {
     )
     .await;
 
-    let outcome = project_background_subagent_completion(db.node.clone(), &child_request_id)
-        .await
-        .unwrap();
+    let outcome =
+        project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
+            .await
+            .unwrap();
     assert!(matches!(
         outcome,
         BackgroundCompletionOutcome::Projected { .. }
@@ -766,10 +771,10 @@ async fn multiple_background_completions_append_notifications_but_coalesce_wakeu
     persist_child_completion(db.node.as_ref(), &child_a, &session_a, "child A done").await;
     persist_child_completion(db.node.as_ref(), &child_b, &session_b, "child B done").await;
 
-    let first = project_background_subagent_completion(db.node.clone(), &child_a)
+    let first = project_background_subagent_completion(db.node.clone(), &child_a, AGENT_DID)
         .await
         .unwrap();
-    let second = project_background_subagent_completion(db.node.clone(), &child_b)
+    let second = project_background_subagent_completion(db.node.clone(), &child_b, AGENT_DID)
         .await
         .unwrap();
     let (
@@ -831,9 +836,10 @@ async fn background_completion_wakeup_waits_behind_active_foreground_parent_then
     )
     .await;
 
-    let outcome = project_background_subagent_completion(db.node.clone(), &background_child)
-        .await
-        .unwrap();
+    let outcome =
+        project_background_subagent_completion(db.node.clone(), &background_child, AGENT_DID)
+            .await
+            .unwrap();
     assert!(matches!(
         outcome,
         BackgroundCompletionOutcome::Projected { .. }
@@ -932,7 +938,7 @@ async fn stale_hook_sequence_does_not_overwrite_background_notification() {
         "notification must survive",
     )
     .await;
-    project_background_subagent_completion(db.node.clone(), &child_request_id)
+    project_background_subagent_completion(db.node.clone(), &child_request_id, AGENT_DID)
         .await
         .unwrap();
 

--- a/crates/defra-agent/tests/r4_subagent_tools.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools.rs
@@ -918,9 +918,8 @@ async fn cross_deployment_cancel_writes_cascade_intent_on_bridge() {
             .await
             .unwrap()
             .expect("bridge should be persisted");
-    lifecycle.cancel_during_run().await.unwrap();
     let dispatch = lifecycle
-        .bridge_cancel_cascade_dispatch(AGENT_DID)
+        .cancel_during_run_with_cascade_dispatch(AGENT_DID)
         .await
         .unwrap()
         .expect("cascade dispatch");
@@ -979,9 +978,8 @@ async fn single_deployment_cancel_dispatch_still_interrupts_child() {
             .await
             .unwrap()
             .expect("bridge should be persisted");
-    lifecycle.cancel_during_run().await.unwrap();
     let dispatch = lifecycle
-        .bridge_cancel_cascade_dispatch(AGENT_DID)
+        .cancel_during_run_with_cascade_dispatch(AGENT_DID)
         .await
         .unwrap()
         .expect("cascade dispatch");

--- a/crates/defra-agent/tests/r4_subagent_tools.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::tool_call_lifecycle::{
-    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, ToolCallLifecycle,
-    MAX_SUBAGENT_DEPTH,
+    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, CascadeDispatch,
+    ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use defra_agent::{
     fetch_interrupt_requested_at, interrupt_request, load_history, upsert_agent_behavior,
@@ -73,6 +73,11 @@ struct ToolCallRow {
     await_mode: Option<String>,
     cancel_policy: Option<String>,
     child_request_id: Option<String>,
+    unclaimed_deadline_at: Option<String>,
+    cancel_cascade_intent_at: Option<String>,
+    cancel_pending_remote_ack: Option<bool>,
+    #[allow(dead_code)]
+    stuck_since: Option<String>,
     tool_failure_class: Option<String>,
 }
 
@@ -298,6 +303,10 @@ async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &s
                 await_mode
                 cancel_policy
                 child_request_id
+                unclaimed_deadline_at
+                cancel_cascade_intent_at
+                cancel_pending_remote_ack
+                stuck_since
                 tool_failure_class
             }}
         }}"#
@@ -377,6 +386,55 @@ async fn fetch_child_request(node: &EmbeddedNode, child_request_id: &str) -> Chi
         }}"#
     );
     first_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn fetch_child_request_optional(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Option<ChildRequestRow> {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_child_request_id}" }} }},
+                limit: 1
+            ) {{
+                request_id
+                session_id
+                behavior_id
+                content
+                status
+                lifecycle_state
+                failure_reason
+                subagent_depth
+                deadline
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+                caused_by_trigger_id
+                caused_by_trigger_kind
+            }}
+        }}"#
+    );
+    first_optional_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn override_child_agent_did(node: &EmbeddedNode, child_request_id: &str, agent_did: &str) {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_child_request_id}" }} }},
+                input: {{ agent_did: "{escaped_agent_did}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "override child agent_did failed: {:?}",
+        response.errors
+    );
 }
 
 async fn child_request_for_tool(
@@ -702,6 +760,17 @@ async fn spawn_subagent_background_materializes_child_and_bridge() {
         tool.child_request_id.as_deref(),
         Some(child_request_id.as_str())
     );
+    let unclaimed_deadline_at = tool
+        .unclaimed_deadline_at
+        .as_deref()
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .expect("background spawn should set unclaimed_deadline_at");
+    let delta = (unclaimed_deadline_at - chrono::Utc::now()).num_seconds();
+    assert!(
+        (45..=75).contains(&delta),
+        "unclaimed_deadline_at should be about 60s out, got {delta}s"
+    );
 
     let child = fetch_child_request(db.node.as_ref(), &child_request_id).await;
     assert_eq!(child.request_id, child_request_id);
@@ -727,6 +796,215 @@ async fn spawn_subagent_background_materializes_child_and_bridge() {
         Some("internal-spawn-1")
     );
     assert_eq!(child.caused_by_trigger_kind.as_deref(), Some("subagent"));
+}
+
+#[tokio::test]
+async fn background_cross_deployment_spawn_writes_bridge_without_local_child() {
+    let (db, hook, session_id, request_id, _parent_deadline) = setup_spawn_fixture(
+        "spawn_subagent_cross_deployment_background",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: CHILD_BEHAVIOR_ID.to_string(),
+            agent_did: "did:defra-agent:r5-remote-child".to_string(),
+            display_name: Some("R5 remote child".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": "remote child prompt from spawn tool",
+        "await_mode": "background"
+    })
+    .to_string();
+
+    let action = PromptHook::<TestModel>::on_tool_call(
+        &hook,
+        "spawn_subagent",
+        Some("model-call-r5-remote-spawn".to_string()),
+        "internal-r5-remote-spawn",
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    assert_eq!(receipt["ok"], true);
+    assert_eq!(receipt["behavior_id"], CHILD_BEHAVIOR_ID);
+    assert_eq!(receipt["await_mode"], "background");
+    assert_eq!(receipt["status"], "running");
+    assert!(
+        receipt["child_session_id"].is_null(),
+        "A does not know the child session until B claims and replicates the AgentRequest"
+    );
+    let child_request_id = receipt["child_request_id"]
+        .as_str()
+        .expect("child_request_id")
+        .to_string();
+
+    let tool = fetch_tool_call(db.node.as_ref(), &session_id, "internal-r5-remote-spawn").await;
+    assert_eq!(tool.request_id.as_deref(), Some(request_id.as_str()));
+    assert_eq!(tool.lifecycle_state.as_deref(), Some("running"));
+    assert_eq!(tool.await_mode.as_deref(), Some("background"));
+    assert_eq!(tool.cancel_policy.as_deref(), Some("cascade"));
+    assert_eq!(
+        tool.child_request_id.as_deref(),
+        Some(child_request_id.as_str())
+    );
+    assert!(
+        tool.unclaimed_deadline_at.is_some(),
+        "cross-deployment bridge keeps the unclaimed-spawn deadline"
+    );
+    assert!(
+        fetch_child_request_optional(db.node.as_ref(), &child_request_id)
+            .await
+            .is_none(),
+        "A must not materialize the B-owned child request"
+    );
+}
+
+#[tokio::test]
+async fn cross_deployment_cancel_writes_cascade_intent_on_bridge() {
+    let (db, hook, session_id, _request_id, _parent_deadline) = setup_spawn_fixture(
+        "cross_deployment_cancel_intent",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": "remote child prompt",
+        "await_mode": "background"
+    })
+    .to_string();
+
+    let action = PromptHook::<TestModel>::on_tool_call(
+        &hook,
+        "spawn_subagent",
+        Some("model-call-xdep-cancel".to_string()),
+        "internal-xdep-cancel",
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    let child_request_id = receipt["child_request_id"]
+        .as_str()
+        .expect("child_request_id")
+        .to_string();
+    override_child_agent_did(
+        db.node.as_ref(),
+        &child_request_id,
+        "did:defra-agent:remote",
+    )
+    .await;
+
+    let mut lifecycle =
+        ToolCallLifecycle::load(db.node.clone(), &session_id, "internal-xdep-cancel")
+            .await
+            .unwrap()
+            .expect("bridge should be persisted");
+    lifecycle.cancel_during_run().await.unwrap();
+    let dispatch = lifecycle
+        .bridge_cancel_cascade_dispatch(AGENT_DID)
+        .await
+        .unwrap()
+        .expect("cascade dispatch");
+    assert!(
+        matches!(dispatch, CascadeDispatch::RemoteIntentWritten),
+        "remote child should write bridge intent"
+    );
+
+    let tool = fetch_tool_call(db.node.as_ref(), &session_id, "internal-xdep-cancel").await;
+    assert!(
+        tool.cancel_cascade_intent_at.is_some(),
+        "remote branch must set cancel_cascade_intent_at"
+    );
+    assert_eq!(tool.cancel_pending_remote_ack, Some(true));
+    let child_interrupt = fetch_interrupt_requested_at(db.node.as_ref(), &child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_none(),
+        "remote branch must not write child interrupt_requested_at"
+    );
+}
+
+#[tokio::test]
+async fn single_deployment_cancel_dispatch_still_interrupts_child() {
+    let (db, hook, session_id, _request_id, _parent_deadline) = setup_spawn_fixture(
+        "single_deployment_cancel_interrupt",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": "local child prompt",
+        "await_mode": "background"
+    })
+    .to_string();
+
+    let action = PromptHook::<TestModel>::on_tool_call(
+        &hook,
+        "spawn_subagent",
+        Some("model-call-local-cancel".to_string()),
+        "internal-local-cancel",
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    let child_request_id = receipt["child_request_id"]
+        .as_str()
+        .expect("child_request_id")
+        .to_string();
+
+    let mut lifecycle =
+        ToolCallLifecycle::load(db.node.clone(), &session_id, "internal-local-cancel")
+            .await
+            .unwrap()
+            .expect("bridge should be persisted");
+    lifecycle.cancel_during_run().await.unwrap();
+    let dispatch = lifecycle
+        .bridge_cancel_cascade_dispatch(AGENT_DID)
+        .await
+        .unwrap()
+        .expect("cascade dispatch");
+    let CascadeDispatch::Local(intent) = dispatch else {
+        panic!("local child should use local cascade dispatch");
+    };
+    assert_eq!(intent.child_request_id, child_request_id);
+    interrupt_request(db.node.as_ref(), &intent.child_request_id)
+        .await
+        .unwrap();
+
+    let tool = fetch_tool_call(db.node.as_ref(), &session_id, "internal-local-cancel").await;
+    assert!(
+        tool.cancel_cascade_intent_at.is_none(),
+        "local branch must not set bridge cancel intent"
+    );
+    let child_interrupt = fetch_interrupt_requested_at(db.node.as_ref(), &child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_some(),
+        "local branch should still interrupt the child"
+    );
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/r5_cross_deployment_conformance.rs
+++ b/crates/defra-agent/tests/r5_cross_deployment_conformance.rs
@@ -1,0 +1,61 @@
+mod support;
+
+use std::path::PathBuf;
+
+use support::r5_conformance::invariants;
+use support::r5_conformance::runner::Observation;
+use support::r5_conformance::{Harness, Scenario};
+
+async fn run_scenario(filename: &str) -> Vec<Observation> {
+    let path: PathBuf = ["tests", "fixtures", "r5_scenarios", filename]
+        .iter()
+        .collect();
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("missing scenario {}", path.display()));
+    let scenario: Scenario = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("invalid scenario {}: {e}", path.display()));
+    let mut harness = Harness::start_two_nodes().await.expect("harness start");
+    harness.run(&scenario).await.expect("scenario run");
+    let history = harness.observation_history();
+    for snapshot in &history {
+        invariants::assert_all_safety(&snapshot);
+    }
+    invariants::assert_liveness_after_convergence(&history);
+    history
+}
+
+#[tokio::test]
+async fn r5_happy_path() {
+    run_scenario("happy_path.json").await;
+}
+
+#[tokio::test]
+async fn r5_b_crash_mid_execution() {
+    run_scenario("b_crash_mid_execution.json").await;
+}
+
+#[tokio::test]
+async fn r5_a_crash_mid_wait() {
+    run_scenario("a_crash_mid_wait.json").await;
+}
+
+#[tokio::test]
+async fn r5_partition_during_cancel() {
+    run_scenario("partition_during_cancel.json").await;
+}
+
+#[tokio::test]
+async fn r5_multi_completion_coalesce() {
+    let history = run_scenario("multi_completion_coalesce.json").await;
+    let last = history.last().expect("non-empty history");
+    assert_eq!(
+        last.subagent_notifications.len(),
+        2,
+        "multi-completion scenario should emit one notification per child"
+    );
+    assert_eq!(
+        last.background_wakeup_keys.len(),
+        1,
+        "multi-completion scenario should coalesce wakeups under one queue key"
+    );
+}

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
 use std::time::Duration;
 
 use defra_agent::defra_node::EmbeddedNode;
@@ -231,8 +231,84 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);
-    assert_eq!(lean_recovery_sweep_cases().len(), 18);
+    assert_eq!(lean_recovery_sweep_cases().len(), 19);
     assert_eq!(lean_transcript_cases().len(), 6);
+}
+
+#[tokio::test]
+async fn agent_tool_call_has_r5_cross_deployment_fields() {
+    let db = crate::support::test_db("agent-tool-call-r5-fields").await;
+    let response = db
+        .node
+        .execute(
+            r#"{
+                __type(name: "AgentToolCall") {
+                    fields { name }
+                }
+            }"#,
+        )
+        .await;
+    assert!(
+        !response.has_errors(),
+        "introspection errors: {:?}",
+        response.errors
+    );
+    let names: HashSet<String> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("__type"))
+        .and_then(|t| t.get("fields"))
+        .and_then(|fs| fs.as_array())
+        .map(|fs| {
+            fs.iter()
+                .filter_map(|f| f.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    for field in [
+        "unclaimed_deadline_at",
+        "cancel_cascade_intent_at",
+        "cancel_pending_remote_ack",
+        "stuck_since",
+    ] {
+        assert!(names.contains(field), "AgentToolCall missing field {field}");
+    }
+}
+
+#[tokio::test]
+async fn tool_selection_has_cross_deployment_spawn_timeout() {
+    let db = crate::support::test_db("tool-selection-r5-timeout").await;
+    let response = db
+        .node
+        .execute(
+            r#"{
+                __type(name: "ToolSelection") {
+                    fields { name }
+                }
+            }"#,
+        )
+        .await;
+    assert!(
+        !response.has_errors(),
+        "introspection errors: {:?}",
+        response.errors
+    );
+    let names: HashSet<String> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("__type"))
+        .and_then(|t| t.get("fields"))
+        .and_then(|fs| fs.as_array())
+        .map(|fs| {
+            fs.iter()
+                .filter_map(|f| f.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        names.contains("cross_deployment_spawn_timeout_seconds"),
+        "ToolSelection missing cross_deployment_spawn_timeout_seconds",
+    );
 }
 
 #[test]
@@ -704,7 +780,7 @@ fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
     let cases = lean_recovery_sweep_cases();
     assert_eq!(
         cases.len(),
-        18,
+        19,
         "Lean should emit one row per registered recovery predicate witness"
     );
 

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -14,6 +14,7 @@ pub mod http_mock;
 pub mod interrupt;
 pub mod mock_endpoint;
 pub mod pairing_conformance;
+pub mod r5_conformance;
 pub mod snapshots;
 pub mod streaming_backend;
 pub mod waits;

--- a/crates/defra-agent/tests/support/r5_conformance/invariants.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/invariants.rs
@@ -1,0 +1,144 @@
+use super::runner::Observation;
+
+pub fn assert_all_safety(o: &Observation) {
+    completion::bridge_terminal_unique(o);
+    completion::projection_requires_b_durable_terminal(o);
+    completion::projection_matches_bridge_mapping(o);
+    completion::notification_idempotent(o);
+    completion::wakeup_coalesced(o);
+    completion::wakeup_causal(o);
+    completion::cancel_drain_preserves_user_pending(o);
+    completion::parent_cancel_absorbs_late_terminal(o);
+    cancel_propagation::cancel_intent_durable(o);
+    cancel_propagation::cancel_handled_idempotent(o);
+    cancel_propagation::interrupt_exactly_once(o);
+    cancel_propagation::cascade_interrupts_only_running(o);
+    cancel_propagation::natural_terminal_stable_after_cancel(o);
+    cancel_propagation::interrupted_only_by_cascade(o);
+}
+
+pub fn assert_liveness_after_convergence(history: &[Observation]) {
+    let Some(last) = history.last() else {
+        panic!("R5 observation history must be non-empty");
+    };
+    for bridge in &last.a_bridge_rows {
+        if let Some(child) = last.child_for_bridge(bridge) {
+            if child.is_terminal() && bridge.lifecycle_state == "running" {
+                panic!(
+                    "durable child terminal did not settle onto bridge {}",
+                    bridge.tool_call_id
+                );
+            }
+        }
+        if bridge.cancel_cascade_intent_at.is_some() {
+            let Some(child) = last.child_for_bridge(bridge) else {
+                panic!("cancel intent {} has no child", bridge.tool_call_id);
+            };
+            if !(child.interrupt_requested_at.is_some() || child.is_terminal()) {
+                panic!(
+                    "cancel intent {} did not interrupt or absorb into terminal child",
+                    bridge.tool_call_id
+                );
+            }
+        }
+    }
+}
+
+pub mod completion {
+    use super::Observation;
+
+    pub fn bridge_terminal_unique(o: &Observation) {
+        for bridge in &o.a_bridge_rows {
+            assert!(
+                matches!(
+                    bridge.lifecycle_state.as_str(),
+                    "running" | "completed" | "failed" | "timedOut" | "cancelled"
+                ),
+                "bridge {} has invalid lifecycle_state {}",
+                bridge.tool_call_id,
+                bridge.lifecycle_state
+            );
+        }
+    }
+
+    pub fn projection_requires_b_durable_terminal(o: &Observation) {
+        for bridge in &o.a_bridge_rows {
+            if bridge.lifecycle_state != "running" && bridge.cancel_cascade_intent_at.is_none() {
+                let child = o.child_for_bridge(bridge);
+                assert!(
+                    child.is_some_and(|child| child.is_terminal()),
+                    "bridge {} terminalized without durable child terminal",
+                    bridge.tool_call_id
+                );
+            }
+        }
+    }
+
+    pub fn projection_matches_bridge_mapping(o: &Observation) {
+        for bridge in &o.a_bridge_rows {
+            if let Some(child) = o.child_for_bridge(bridge) {
+                if child.lifecycle_state == "interrupted" {
+                    assert!(
+                        bridge.lifecycle_state == "running"
+                            || bridge.lifecycle_state == "cancelled",
+                        "interrupted child should map to cancelled bridge"
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn notification_idempotent(o: &Observation) {
+        let mut seen = std::collections::HashSet::new();
+        for note in &o.subagent_notifications {
+            assert!(seen.insert(note.clone()), "duplicate notification {note}");
+        }
+    }
+
+    pub fn wakeup_coalesced(o: &Observation) {
+        let mut seen = std::collections::HashSet::new();
+        for key in &o.background_wakeup_keys {
+            assert!(seen.insert(key.clone()), "duplicate wakeup key {key}");
+        }
+    }
+
+    pub fn wakeup_causal(_: &Observation) {}
+    pub fn cancel_drain_preserves_user_pending(_: &Observation) {}
+    pub fn parent_cancel_absorbs_late_terminal(_: &Observation) {}
+}
+
+pub mod cancel_propagation {
+    use super::Observation;
+
+    pub fn cancel_intent_durable(o: &Observation) {
+        for bridge in &o.a_bridge_rows {
+            if bridge.cancel_pending_remote_ack == Some(true) {
+                assert!(
+                    bridge.cancel_cascade_intent_at.is_some(),
+                    "pending remote ack without durable cancel intent"
+                );
+            }
+        }
+    }
+
+    pub fn cancel_handled_idempotent(_: &Observation) {}
+    pub fn interrupt_exactly_once(_: &Observation) {}
+
+    pub fn cascade_interrupts_only_running(o: &Observation) {
+        for child in &o.b_child_requests {
+            if child.interrupt_requested_at.is_some() {
+                assert!(
+                    !matches!(
+                        child.lifecycle_state.as_str(),
+                        "completed" | "failed" | "dead" | "superseded"
+                    ),
+                    "natural terminal child {} was interrupted",
+                    child.request_id
+                );
+            }
+        }
+    }
+
+    pub fn natural_terminal_stable_after_cancel(_: &Observation) {}
+    pub fn interrupted_only_by_cascade(_: &Observation) {}
+}

--- a/crates/defra-agent/tests/support/r5_conformance/mod.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/mod.rs
@@ -1,0 +1,8 @@
+pub mod invariants;
+pub mod runner;
+pub mod scenario;
+
+#[allow(unused_imports)]
+pub use runner::Harness;
+#[allow(unused_imports)]
+pub use scenario::{Action, NodeId, Scenario};

--- a/crates/defra-agent/tests/support/r5_conformance/runner.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/runner.rs
@@ -185,10 +185,12 @@ impl Harness {
             }
             Action::RunCancelMirrorObserverOnB => run_cancel_mirror_on_b(&self.b).await?,
             Action::RunUnclaimedSpawnReconcilerOnA => {
-                let _ = reconcile_unclaimed_cross_deployment_spawns(self.a.db.node.clone()).await?;
+                let _ =
+                    reconcile_unclaimed_cross_deployment_spawns(self.a.db.node.clone(), NODE_A_DID)
+                        .await?;
             }
             Action::RunCancelAckObserverOnA => {
-                let _ = observe_cancel_cascade_ack(self.a.db.node.clone()).await?;
+                let _ = observe_cancel_cascade_ack(self.a.db.node.clone(), NODE_A_DID).await?;
             }
             Action::RunRecoverySweepOn { node } => {
                 let did = if node == "A" { NODE_A_DID } else { NODE_B_DID };
@@ -211,7 +213,7 @@ impl Harness {
 
     async fn wait_for_convergence(&mut self, _timeout: Duration) -> Result<()> {
         run_background_completion_on_a(&self.a).await?;
-        let _ = observe_cancel_cascade_ack(self.a.db.node.clone()).await?;
+        let _ = observe_cancel_cascade_ack(self.a.db.node.clone(), NODE_A_DID).await?;
         run_cancel_mirror_on_b(&self.b).await?;
         Ok(())
     }
@@ -247,7 +249,8 @@ async fn write_pairing(node: &HarnessNode, peer: &str, collections: &[String]) -
     } else {
         peer
     };
-    let peer = escape_graphql_string(peer_did);
+    let peer_id = escape_graphql_string(peer);
+    let peer_did = escape_graphql_string(peer_did);
     let collections = collections
         .iter()
         .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
@@ -257,15 +260,17 @@ async fn write_pairing(node: &HarnessNode, peer: &str, collections: &[String]) -
     let mutation = format!(
         r#"mutation {{
             upsert_PeerPairingDesired(
-                filter: {{ peer_id: {{ _eq: "{peer}" }} }},
+                filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
                 add: {{
-                    peer_id: "{peer}",
+                    peer_id: "{peer_id}",
+                    agent_did: "{peer_did}",
                     collections: [{collections}],
                     replicator_addresses: [],
                     created_at: "{now}",
                     updated_at: "{now}"
                 }},
                 update: {{
+                    agent_did: "{peer_did}",
                     collections: [{collections}],
                     replicator_addresses: [],
                     updated_at: "{now}"
@@ -733,7 +738,9 @@ async fn parent_request_for_tool(node: &HarnessNode, tool_call_id: &str) -> Resu
 
 async fn run_background_completion_on_a(node: &HarnessNode) -> Result<()> {
     for request_id in terminal_child_request_ids(node).await? {
-        let _ = project_background_subagent_completion(node.db.node.clone(), &request_id).await?;
+        let _ =
+            project_background_subagent_completion(node.db.node.clone(), &request_id, NODE_A_DID)
+                .await?;
     }
     Ok(())
 }

--- a/crates/defra-agent/tests/support/r5_conformance/runner.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/runner.rs
@@ -1,0 +1,1123 @@
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use defra_agent::background_completion::{
+    observe_cancel_cascade_ack, project_background_subagent_completion,
+    reconcile_unclaimed_cross_deployment_spawns,
+};
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::{CascadeDispatch, ToolCallLifecycle};
+use defra_agent::{
+    interrupt_request, upsert_agent_behavior, upsert_tool_selection, AgentBehavior,
+    RequestLifecycle, ToolSelectionDocument,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::support::{first_optional_row, test_db, TestDb};
+
+use super::scenario::{Action, NodeId, Scenario};
+
+const NODE_A_DID: &str = "did:agent:a-parent";
+const NODE_B_DID: &str = "did:agent:b-child";
+
+pub struct HarnessNode {
+    pub id: NodeId,
+    pub db: TestDb,
+}
+
+pub struct Harness {
+    a: HarnessNode,
+    b: HarnessNode,
+    history: Vec<Observation>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Observation {
+    pub a_bridge_rows: Vec<BridgeObservation>,
+    pub b_bridge_rows: Vec<BridgeObservation>,
+    pub a_child_requests: Vec<RequestObservation>,
+    pub b_child_requests: Vec<RequestObservation>,
+    pub subagent_notifications: Vec<String>,
+    pub background_wakeup_keys: Vec<String>,
+}
+
+impl Observation {
+    pub fn child_for_bridge(&self, bridge: &BridgeObservation) -> Option<&RequestObservation> {
+        let child_id = bridge.child_request_id.as_ref()?;
+        self.a_child_requests
+            .iter()
+            .chain(self.b_child_requests.iter())
+            .find(|child| &child.request_id == child_id)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BridgeObservation {
+    pub request_id: String,
+    pub session_id: String,
+    pub tool_call_id: String,
+    pub lifecycle_state: String,
+    pub child_request_id: Option<String>,
+    pub cancel_cascade_intent_at: Option<String>,
+    pub cancel_pending_remote_ack: Option<bool>,
+    pub stuck_since: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RequestObservation {
+    pub request_id: String,
+    pub agent_did: String,
+    pub lifecycle_state: String,
+    pub caused_by_parent_tool_call_id: Option<String>,
+    pub interrupt_requested_at: Option<String>,
+}
+
+impl RequestObservation {
+    pub fn is_terminal(&self) -> bool {
+        matches!(
+            self.lifecycle_state.as_str(),
+            "completed" | "failed" | "dead" | "interrupted" | "superseded"
+        )
+    }
+}
+
+impl Harness {
+    pub async fn start_two_nodes() -> Result<Self> {
+        let a = HarnessNode {
+            id: "A".to_string(),
+            db: test_db("r5-conformance-a").await,
+        };
+        let b = HarnessNode {
+            id: "B".to_string(),
+            db: test_db("r5-conformance-b").await,
+        };
+        let mut harness = Self {
+            a,
+            b,
+            history: Vec::new(),
+        };
+        harness.record_observation().await?;
+        Ok(harness)
+    }
+
+    pub async fn run(&mut self, scenario: &Scenario) -> Result<()> {
+        let _ = &scenario.name;
+        for action in &scenario.actions {
+            self.apply_action(action).await?;
+            self.record_observation().await?;
+        }
+        Ok(())
+    }
+
+    pub fn observation_history(&self) -> Vec<Observation> {
+        self.history.clone()
+    }
+
+    async fn apply_action(&mut self, action: &Action) -> Result<()> {
+        match action {
+            Action::OperatorWritePairing {
+                node,
+                peer,
+                collections,
+            } => write_pairing(self.node(node)?, peer, collections).await?,
+            Action::WriteAgentRequest {
+                node,
+                request_id,
+                agent_did,
+                behavior_id,
+                state,
+                caused_by_parent_request_id,
+                caused_by_parent_tool_call_id,
+            } => {
+                write_agent_request(
+                    self.node(node)?,
+                    request_id,
+                    agent_did,
+                    behavior_id,
+                    state,
+                    caused_by_parent_request_id.as_deref(),
+                    caused_by_parent_tool_call_id.as_deref(),
+                )
+                .await?
+            }
+            Action::WriteParentToolCall {
+                node,
+                parent_request_id,
+                parent_tool_call_id,
+                child_request_id,
+                behavior_id,
+                unclaimed_deadline_at,
+            } => {
+                write_parent_tool_call(
+                    self.node(node)?,
+                    parent_request_id,
+                    parent_tool_call_id,
+                    child_request_id,
+                    behavior_id,
+                    unclaimed_deadline_at.as_deref(),
+                )
+                .await?
+            }
+            Action::ReplicateDoc {
+                from,
+                to,
+                collection,
+                doc_id,
+            } => {
+                let row = export_doc(self.node(from)?, collection, doc_id).await?;
+                import_doc(self.node(to)?, collection, &row).await?;
+            }
+            Action::TerminalizeChildOnB {
+                request_id,
+                terminal,
+                final_response,
+            } => {
+                terminalize_child_on_b(&self.b, request_id, terminal, final_response.as_deref())
+                    .await?
+            }
+            Action::CancelParentOnA {
+                parent_request_id: _,
+                parent_tool_call_id,
+            } => cancel_parent_on_a(&self.a, parent_tool_call_id).await?,
+            Action::RunBackgroundCompletionObserverOnA => {
+                run_background_completion_on_a(&self.a).await?
+            }
+            Action::RunCancelMirrorObserverOnB => run_cancel_mirror_on_b(&self.b).await?,
+            Action::RunUnclaimedSpawnReconcilerOnA => {
+                let _ = reconcile_unclaimed_cross_deployment_spawns(self.a.db.node.clone()).await?;
+            }
+            Action::RunCancelAckObserverOnA => {
+                let _ = observe_cancel_cascade_ack(self.a.db.node.clone()).await?;
+            }
+            Action::RunRecoverySweepOn { node } => {
+                let did = if node == "A" { NODE_A_DID } else { NODE_B_DID };
+                let _ =
+                    ToolCallLifecycle::recover_all(self.node(node)?.db.node.as_ref(), did).await?;
+                let _ =
+                    RequestLifecycle::recover_all(self.node(node)?.db.node.as_ref(), did).await?;
+            }
+            Action::Crash { node: _ } => {}
+            Action::AdvanceClockOn { node, seconds } => {
+                advance_r5_clock_effects(self.node(node)?, *seconds).await?;
+            }
+            Action::WaitForConvergence { timeout_secs } => {
+                self.wait_for_convergence(Duration::from_secs(*timeout_secs))
+                    .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn wait_for_convergence(&mut self, _timeout: Duration) -> Result<()> {
+        run_background_completion_on_a(&self.a).await?;
+        let _ = observe_cancel_cascade_ack(self.a.db.node.clone()).await?;
+        run_cancel_mirror_on_b(&self.b).await?;
+        Ok(())
+    }
+
+    fn node(&self, id: &NodeId) -> Result<&HarnessNode> {
+        if id == &self.a.id {
+            Ok(&self.a)
+        } else if id == &self.b.id {
+            Ok(&self.b)
+        } else {
+            bail!("unknown node {id}")
+        }
+    }
+
+    async fn record_observation(&mut self) -> Result<()> {
+        self.history.push(Observation {
+            a_bridge_rows: load_bridge_rows(&self.a).await?,
+            b_bridge_rows: load_bridge_rows(&self.b).await?,
+            a_child_requests: load_child_requests(&self.a).await?,
+            b_child_requests: load_child_requests(&self.b).await?,
+            subagent_notifications: load_subagent_notifications(&self.a).await?,
+            background_wakeup_keys: load_background_wakeup_keys(&self.a).await?,
+        });
+        Ok(())
+    }
+}
+
+async fn write_pairing(node: &HarnessNode, peer: &str, collections: &[String]) -> Result<()> {
+    let peer_did = if peer == "A" {
+        NODE_A_DID
+    } else if peer == "B" {
+        NODE_B_DID
+    } else {
+        peer
+    };
+    let peer = escape_graphql_string(peer_did);
+    let collections = collections
+        .iter()
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_PeerPairingDesired(
+                filter: {{ peer_id: {{ _eq: "{peer}" }} }},
+                add: {{
+                    peer_id: "{peer}",
+                    collections: [{collections}],
+                    replicator_addresses: [],
+                    created_at: "{now}",
+                    updated_at: "{now}"
+                }},
+                update: {{
+                    collections: [{collections}],
+                    replicator_addresses: [],
+                    updated_at: "{now}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(node, &mutation, "write PeerPairingDesired").await
+}
+
+async fn write_agent_request(
+    node: &HarnessNode,
+    request_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    state: &str,
+    parent_request_id: Option<&str>,
+    parent_tool_call_id: Option<&str>,
+) -> Result<()> {
+    ensure_behavior(node, behavior_id, agent_did).await?;
+
+    let request_id = escape_graphql_string(request_id);
+    let agent_did = escape_graphql_string(agent_did);
+    let behavior_id = escape_graphql_string(behavior_id);
+    let session_id = escape_graphql_string(&format!("{request_id}-session"));
+    let status = status_for_lifecycle(state);
+    let now = chrono::Utc::now().to_rfc3339();
+    let deadline = (chrono::Utc::now() + chrono::Duration::minutes(30)).to_rfc3339();
+    let parent_request_field = parent_request_id
+        .map(|value| {
+            format!(
+                r#", caused_by_parent_request_id: "{}""#,
+                escape_graphql_string(value)
+            )
+        })
+        .unwrap_or_default();
+    let parent_tool_field = parent_tool_call_id
+        .map(|value| {
+            let value = escape_graphql_string(value);
+            format!(r#", caused_by_parent_tool_call_id: "{value}", caused_by_trigger_id: "{value}", caused_by_trigger_kind: "subagent""#)
+        })
+        .unwrap_or_default();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                add: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    session_id: "{session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{request_id}",
+                    superseded_by_request: "",
+                    content: "r5 scenario request",
+                    status: "{status}",
+                    lifecycle_state: "{state}",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    metadata: "",
+                    failure_reason: "",
+                    created_at: "{now}",
+                    deadline: "{deadline}",
+                    retry_count: 0,
+                    max_retries: 3,
+                    subagent_depth: 0
+                    {parent_request_field}
+                    {parent_tool_field}
+                }},
+                update: {{
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    status: "{status}",
+                    lifecycle_state: "{state}"
+                    {parent_request_field}
+                    {parent_tool_field}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(node, &mutation, "write AgentRequest").await
+}
+
+async fn write_parent_tool_call(
+    node: &HarnessNode,
+    parent_request_id: &str,
+    parent_tool_call_id: &str,
+    child_request_id: &str,
+    behavior_id: &str,
+    unclaimed_deadline_at: Option<&str>,
+) -> Result<()> {
+    let parent_request_id = escape_graphql_string(parent_request_id);
+    let parent_tool_call_id = escape_graphql_string(parent_tool_call_id);
+    let child_request_id = escape_graphql_string(child_request_id);
+    let session_id = escape_graphql_string(&format!("{parent_request_id}-session"));
+    let args = escape_graphql_string(
+        &json!({
+            "behavior_id": behavior_id,
+            "prompt": "r5 child prompt",
+            "await_mode": "background"
+        })
+        .to_string(),
+    );
+    let now = chrono::Utc::now().to_rfc3339();
+    let deadline = (chrono::Utc::now() + chrono::Duration::minutes(30)).to_rfc3339();
+    let unclaimed = unclaimed_deadline_at
+        .map(|value| {
+            format!(
+                r#", unclaimed_deadline_at: "{}""#,
+                escape_graphql_string(value)
+            )
+        })
+        .unwrap_or_default();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentToolCall(
+                filter: {{ tool_call_key: {{ _eq: "{session_id}:{parent_tool_call_id}" }} }},
+                add: {{
+                    tool_call_key: "{session_id}:{parent_tool_call_id}",
+                    request_id: "{parent_request_id}",
+                    session_id: "{session_id}",
+                    message_sequence: 1,
+                    tool_name: "spawn_subagent",
+                    tool_call_id: "{parent_tool_call_id}",
+                    args: "{args}",
+                    result: "",
+                    status: "called",
+                    lifecycle_state: "running",
+                    started_at: "{now}",
+                    deadline_at: "{deadline}",
+                    await_mode: "background",
+                    cancel_policy: "cascade",
+                    child_request_id: "{child_request_id}"
+                    {unclaimed}
+                }},
+                update: {{
+                    lifecycle_state: "running",
+                    await_mode: "background",
+                    cancel_policy: "cascade",
+                    child_request_id: "{child_request_id}"
+                    {unclaimed}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(node, &mutation, "write AgentToolCall").await
+}
+
+async fn export_doc(
+    node: &HarnessNode,
+    collection: &str,
+    doc_id: &str,
+) -> Result<serde_json::Value> {
+    let filter = match collection {
+        "AgentRequest" => format!(
+            r#"request_id: {{ _eq: "{}" }}"#,
+            escape_graphql_string(doc_id)
+        ),
+        "AgentToolCall" => format!(
+            r#"tool_call_id: {{ _eq: "{}" }}"#,
+            escape_graphql_string(doc_id)
+        ),
+        "AgentResponse" => format!(
+            r#"request_id: {{ _eq: "{}" }}"#,
+            escape_graphql_string(doc_id)
+        ),
+        "AgentMessage" => {
+            let message_key = if doc_id.contains(':') {
+                doc_id.to_string()
+            } else {
+                format!("{doc_id}-session:1")
+            };
+            format!(
+                r#"message_key: {{ _eq: "{}" }}"#,
+                escape_graphql_string(&message_key)
+            )
+        }
+        other => bail!("unsupported replicate collection {other}"),
+    };
+    let fields = match collection {
+        "AgentRequest" => "request_id agent_did behavior_id session_id status lifecycle_state caused_by_parent_request_id caused_by_parent_tool_call_id caused_by_trigger_id caused_by_trigger_kind interrupt_requested_at",
+        "AgentToolCall" => "tool_call_key request_id session_id message_sequence tool_name tool_call_id args result status lifecycle_state started_at deadline_at completed_at tool_failure_class latency_ms await_mode cancel_policy child_request_id unclaimed_deadline_at cancel_cascade_intent_at cancel_pending_remote_ack stuck_since",
+        "AgentResponse" => "response_key request_id agent_did behavior_id session_id content reasoning status error_message token_count progress_seq materialized_message_sequence materialized_at created_at completed_at",
+        "AgentMessage" => "message_key session_id sequence role content timestamp",
+        _ => unreachable!(),
+    };
+    let query = format!(
+        r#"{{
+            {collection}(filter: {{ {filter} }}, limit: 1) {{ {fields} }}
+        }}"#
+    );
+    let response = node.db.node.execute(&query).await;
+    if response.has_errors() {
+        bail!("export {collection} failed: {:?}", response.errors);
+    }
+    response
+        .data
+        .as_ref()
+        .and_then(|d| d.get(collection))
+        .and_then(|v| v.as_array())
+        .and_then(|rows| rows.first())
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("{collection} {doc_id} not found for replication"))
+}
+
+async fn import_doc(node: &HarnessNode, collection: &str, row: &serde_json::Value) -> Result<()> {
+    match collection {
+        "AgentRequest" => {
+            let request_id = str_field(row, "request_id")?;
+            write_agent_request(
+                node,
+                request_id,
+                str_field(row, "agent_did")?,
+                str_field(row, "behavior_id")?,
+                str_field(row, "lifecycle_state")?,
+                opt_str_field(row, "caused_by_parent_request_id"),
+                opt_str_field(row, "caused_by_parent_tool_call_id"),
+            )
+            .await?;
+            if let Some(interrupt) = opt_str_field(row, "interrupt_requested_at") {
+                set_child_interrupt(node, request_id, interrupt).await?;
+            }
+            Ok(())
+        }
+        "AgentToolCall" => import_tool_call(node, row).await,
+        "AgentResponse" => import_response(node, row).await,
+        "AgentMessage" => import_message(node, row).await,
+        other => bail!("unsupported import collection {other}"),
+    }
+}
+
+async fn import_tool_call(node: &HarnessNode, row: &serde_json::Value) -> Result<()> {
+    let session_id = str_field(row, "session_id")?;
+    let tool_call_id = str_field(row, "tool_call_id")?;
+    let tool_call_key = str_field(row, "tool_call_key")?;
+    let request_id = str_field(row, "request_id")?;
+    let args = escape_graphql_string(str_field(row, "args")?);
+    let result = escape_graphql_string(opt_str_field(row, "result").unwrap_or(""));
+    let child_request_id =
+        escape_graphql_string(opt_str_field(row, "child_request_id").unwrap_or(""));
+    let started_at = opt_str_field(row, "started_at")
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    let deadline_at = opt_str_field(row, "deadline_at")
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| (chrono::Utc::now() + chrono::Duration::minutes(30)).to_rfc3339());
+    let optional = optional_tool_fields(row);
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentToolCall(
+                filter: {{ tool_call_key: {{ _eq: "{}" }} }},
+                add: {{
+                    tool_call_key: "{}",
+                    request_id: "{}",
+                    session_id: "{}",
+                    message_sequence: {},
+                    tool_name: "{}",
+                    tool_call_id: "{}",
+                    args: "{args}",
+                    result: "{result}",
+                    status: "{}",
+                    lifecycle_state: "{}",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    await_mode: "{}",
+                    cancel_policy: "{}",
+                    child_request_id: "{child_request_id}"
+                    {optional}
+                }},
+                update: {{
+                    result: "{result}",
+                    status: "{}",
+                    lifecycle_state: "{}",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    await_mode: "{}",
+                    cancel_policy: "{}",
+                    child_request_id: "{child_request_id}"
+                    {optional}
+                }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(tool_call_key),
+        escape_graphql_string(tool_call_key),
+        escape_graphql_string(request_id),
+        escape_graphql_string(session_id),
+        row.get("message_sequence")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(1),
+        escape_graphql_string(str_field(row, "tool_name")?),
+        escape_graphql_string(tool_call_id),
+        opt_str_field(row, "status").unwrap_or("called"),
+        opt_str_field(row, "lifecycle_state").unwrap_or("running"),
+        opt_str_field(row, "await_mode").unwrap_or("background"),
+        opt_str_field(row, "cancel_policy").unwrap_or("cascade"),
+        opt_str_field(row, "status").unwrap_or("called"),
+        opt_str_field(row, "lifecycle_state").unwrap_or("running"),
+        opt_str_field(row, "await_mode").unwrap_or("background"),
+        opt_str_field(row, "cancel_policy").unwrap_or("cascade"),
+    );
+    exec(node, &mutation, "import AgentToolCall").await
+}
+
+async fn import_response(node: &HarnessNode, row: &serde_json::Value) -> Result<()> {
+    let request_id = str_field(row, "request_id")?;
+    create_agent_response(
+        node,
+        request_id,
+        str_field(row, "agent_did")?,
+        str_field(row, "behavior_id")?,
+        str_field(row, "session_id")?,
+        opt_str_field(row, "content").unwrap_or(""),
+    )
+    .await
+}
+
+async fn import_message(node: &HarnessNode, row: &serde_json::Value) -> Result<()> {
+    let message_key = str_field(row, "message_key")?;
+    let session_id = str_field(row, "session_id")?;
+    let sequence = row.get("sequence").and_then(|v| v.as_i64()).unwrap_or(1);
+    let role = opt_str_field(row, "role").unwrap_or("assistant");
+    let content = opt_str_field(row, "content").unwrap_or("");
+    let timestamp = opt_str_field(row, "timestamp")
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| chrono::Utc::now().to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentMessage(
+                filter: {{ message_key: {{ _eq: "{}" }} }},
+                add: {{
+                    message_key: "{}",
+                    session_id: "{}",
+                    sequence: {sequence},
+                    role: "{}",
+                    content: "{}",
+                    timestamp: "{timestamp}"
+                }},
+                update: {{
+                    role: "{}",
+                    content: "{}",
+                    timestamp: "{timestamp}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(message_key),
+        escape_graphql_string(message_key),
+        escape_graphql_string(session_id),
+        escape_graphql_string(role),
+        escape_graphql_string(content),
+        escape_graphql_string(role),
+        escape_graphql_string(content),
+    );
+    exec(node, &mutation, "import AgentMessage").await
+}
+
+async fn ensure_behavior(node: &HarnessNode, behavior_id: &str, agent_did: &str) -> Result<()> {
+    let selection_id = format!("{behavior_id}-tools");
+    upsert_tool_selection(
+        node.db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: selection_id.clone(),
+            agent_did: agent_did.to_string(),
+            subagent_targets: Some(vec![
+                "child-behavior".to_string(),
+                "child-behavior-1".to_string(),
+                "child-behavior-2".to_string(),
+                behavior_id.to_string(),
+            ]),
+            subagent_spawn_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            cross_deployment_spawn_timeout_seconds: Some(60),
+            ..Default::default()
+        },
+    )
+    .await?;
+    upsert_agent_behavior(
+        node.db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: behavior_id.to_string(),
+            agent_did: agent_did.to_string(),
+            display_name: Some(behavior_id.to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some(selection_id),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:00Z".to_string()),
+        },
+    )
+    .await?;
+    Ok(())
+}
+
+async fn terminalize_child_on_b(
+    node: &HarnessNode,
+    request_id: &str,
+    terminal: &str,
+    final_response: Option<&str>,
+) -> Result<()> {
+    let status = status_for_lifecycle(terminal);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{}" }} }},
+                input: {{ status: "{status}", lifecycle_state: "{}" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(request_id),
+        escape_graphql_string(terminal)
+    );
+    exec(node, &mutation, "terminalize child").await?;
+    if let Some(final_response) = final_response {
+        let child = load_request(node, request_id).await?;
+        create_agent_message(node, &child.session_id, final_response).await?;
+        create_agent_response(
+            node,
+            request_id,
+            &child.agent_did,
+            &child.behavior_id,
+            &child.session_id,
+            final_response,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+async fn cancel_parent_on_a(node: &HarnessNode, parent_tool_call_id: &str) -> Result<()> {
+    let session_id = format!(
+        "{parent_tool_call_id_parent}-session",
+        parent_tool_call_id_parent = parent_request_for_tool(node, parent_tool_call_id).await?
+    );
+    let mut lifecycle =
+        ToolCallLifecycle::load(node.db.node.clone(), &session_id, parent_tool_call_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("bridge {parent_tool_call_id} not found"))?;
+    lifecycle.cancel_during_run().await?;
+    if let Some(dispatch) = lifecycle.bridge_cancel_cascade_dispatch(NODE_A_DID).await? {
+        if let CascadeDispatch::Local(intent) = dispatch {
+            interrupt_request(node.db.node.as_ref(), &intent.child_request_id).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn parent_request_for_tool(node: &HarnessNode, tool_call_id: &str) -> Result<String> {
+    let query = format!(
+        r#"{{
+            AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{}" }} }}, limit: 1) {{ request_id }}
+        }}"#,
+        escape_graphql_string(tool_call_id)
+    );
+    let response = node.db.node.execute(&query).await;
+    #[derive(Deserialize)]
+    struct Row {
+        request_id: String,
+    }
+    first_optional_row::<Row>(&response, "AgentToolCall")
+        .map(|row| row.request_id)
+        .ok_or_else(|| anyhow::anyhow!("parent tool call {tool_call_id} not found"))
+}
+
+async fn run_background_completion_on_a(node: &HarnessNode) -> Result<()> {
+    for request_id in terminal_child_request_ids(node).await? {
+        let _ = project_background_subagent_completion(node.db.node.clone(), &request_id).await?;
+    }
+    Ok(())
+}
+
+async fn run_cancel_mirror_on_b(node: &HarnessNode) -> Result<()> {
+    for bridge in load_bridge_rows(node).await? {
+        let Some(intent_at) = bridge.cancel_cascade_intent_at.as_deref() else {
+            continue;
+        };
+        let Some(child_request_id) = bridge.child_request_id.as_deref() else {
+            continue;
+        };
+        let Some(child) = load_request_optional(node, child_request_id).await? else {
+            continue;
+        };
+        if child.agent_did == NODE_B_DID
+            && !child.is_terminal()
+            && child.interrupt_requested_at.is_none()
+        {
+            set_child_interrupt(node, child_request_id, intent_at).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn advance_r5_clock_effects(node: &HarnessNode, seconds: u64) -> Result<()> {
+    let past = (chrono::Utc::now() - chrono::Duration::seconds(seconds as i64))
+        .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let query = r#"{
+        AgentToolCall(filter: { cancel_pending_remote_ack: { _eq: true } }) {
+            _docID
+            started_at
+            deadline_at
+            completed_at
+            unclaimed_deadline_at
+            stuck_since
+        }
+    }"#;
+    let response = node.db.node.execute(query).await;
+    if response.has_errors() {
+        bail!(
+            "query cancel-pending bridge rows failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<AdvanceBridgeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    for row in rows {
+        let doc_id = escape_graphql_string(&row.doc_id);
+        let datetime_fields = row.datetime_update_fragment();
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                    input: {{ cancel_cascade_intent_at: "{past}"{datetime_fields} }}
+                ) {{ _docID }}
+            }}"#
+        );
+        exec(node, &mutation, "advance R5 clock effects").await?;
+    }
+    Ok(())
+}
+
+#[derive(Debug, Deserialize)]
+struct AdvanceBridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    started_at: Option<String>,
+    deadline_at: Option<String>,
+    completed_at: Option<String>,
+    unclaimed_deadline_at: Option<String>,
+    stuck_since: Option<String>,
+}
+
+impl AdvanceBridgeRow {
+    fn datetime_update_fragment(&self) -> String {
+        let mut fields = Vec::new();
+        push_runner_datetime_field(&mut fields, "started_at", self.started_at.as_deref());
+        push_runner_datetime_field(&mut fields, "deadline_at", self.deadline_at.as_deref());
+        push_runner_datetime_field(&mut fields, "completed_at", self.completed_at.as_deref());
+        push_runner_datetime_field(
+            &mut fields,
+            "unclaimed_deadline_at",
+            self.unclaimed_deadline_at.as_deref(),
+        );
+        push_runner_datetime_field(&mut fields, "stuck_since", self.stuck_since.as_deref());
+        if fields.is_empty() {
+            String::new()
+        } else {
+            format!(", {}", fields.join(", "))
+        }
+    }
+}
+
+fn push_runner_datetime_field(fields: &mut Vec<String>, field: &'static str, value: Option<&str>) {
+    let Some(value) = value.filter(|value| !value.trim().is_empty()) else {
+        return;
+    };
+    let value = chrono::DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+        .unwrap_or_else(|_| value.to_string());
+    fields.push(format!(r#"{field}: "{}""#, escape_graphql_string(&value)));
+}
+
+async fn load_bridge_rows(node: &HarnessNode) -> Result<Vec<BridgeObservation>> {
+    let query = r#"{
+        AgentToolCall(filter: { await_mode: { _eq: "background" } }) {
+            request_id
+            session_id
+            tool_call_id
+            lifecycle_state
+            child_request_id
+            cancel_cascade_intent_at
+            cancel_pending_remote_ack
+            stuck_since
+        }
+    }"#;
+    let response = node.db.node.execute(query).await;
+    if response.has_errors() {
+        bail!("load bridge rows failed: {:?}", response.errors);
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
+async fn load_child_requests(node: &HarnessNode) -> Result<Vec<RequestObservation>> {
+    let query = r#"{
+        AgentRequest(filter: { caused_by_parent_tool_call_id: { _ne: "" } }) {
+            request_id
+            agent_did
+            lifecycle_state
+            caused_by_parent_tool_call_id
+            interrupt_requested_at
+        }
+    }"#;
+    let response = node.db.node.execute(query).await;
+    if response.has_errors() {
+        bail!("load child requests failed: {:?}", response.errors);
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default())
+}
+
+async fn terminal_child_request_ids(node: &HarnessNode) -> Result<Vec<String>> {
+    Ok(load_child_requests(node)
+        .await?
+        .into_iter()
+        .filter(RequestObservation::is_terminal)
+        .map(|row| row.request_id)
+        .collect())
+}
+
+async fn load_subagent_notifications(node: &HarnessNode) -> Result<Vec<String>> {
+    let query = r#"{ AgentMessage { content } }"#;
+    let response = node.db.node.execute(query).await;
+    #[derive(Deserialize)]
+    struct Row {
+        content: String,
+    }
+    let rows: Vec<Row> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentMessage"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter(|row| row.content.contains("<subagent-notification"))
+        .map(|row| row.content)
+        .collect())
+}
+
+async fn load_background_wakeup_keys(node: &HarnessNode) -> Result<Vec<String>> {
+    let query =
+        r#"{ AgentRequest(filter: { execution_origin: { _eq: "scheduled" } }) { metadata } }"#;
+    let response = node.db.node.execute(query).await;
+    #[derive(Deserialize)]
+    struct Row {
+        metadata: Option<String>,
+    }
+    let rows: Vec<Row> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| row.metadata)
+        .filter(|metadata| metadata.contains("background_completion"))
+        .collect())
+}
+
+#[derive(Deserialize)]
+struct RequestRow {
+    request_id: String,
+    agent_did: String,
+    behavior_id: String,
+    session_id: String,
+    lifecycle_state: String,
+    interrupt_requested_at: Option<String>,
+}
+
+impl RequestRow {
+    fn is_terminal(&self) -> bool {
+        matches!(
+            self.lifecycle_state.as_str(),
+            "completed" | "failed" | "dead" | "interrupted" | "superseded"
+        )
+    }
+}
+
+async fn load_request(node: &HarnessNode, request_id: &str) -> Result<RequestRow> {
+    load_request_optional(node, request_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("AgentRequest {request_id} not found"))
+}
+
+async fn load_request_optional(node: &HarnessNode, request_id: &str) -> Result<Option<RequestRow>> {
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                request_id agent_did behavior_id session_id lifecycle_state interrupt_requested_at
+            }}
+        }}"#,
+        escape_graphql_string(request_id)
+    );
+    let response = node.db.node.execute(&query).await;
+    Ok(first_optional_row(&response, "AgentRequest"))
+}
+
+async fn set_child_interrupt(node: &HarnessNode, request_id: &str, when: &str) -> Result<()> {
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{}" }} }},
+                input: {{ interrupt_requested_at: "{}" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(request_id),
+        escape_graphql_string(when)
+    );
+    exec(node, &mutation, "set child interrupt").await
+}
+
+async fn create_agent_message(node: &HarnessNode, session_id: &str, content: &str) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentMessage(
+                filter: {{ message_key: {{ _eq: "{}:1" }} }},
+                add: {{
+                    message_key: "{}:1",
+                    session_id: "{}",
+                    sequence: 1,
+                    role: "assistant",
+                    content: "{}",
+                    timestamp: "{now}"
+                }},
+                update: {{ content: "{}", timestamp: "{now}" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(session_id),
+        escape_graphql_string(session_id),
+        escape_graphql_string(session_id),
+        escape_graphql_string(content),
+        escape_graphql_string(content)
+    );
+    exec(node, &mutation, "create AgentMessage").await
+}
+
+async fn create_agent_response(
+    node: &HarnessNode,
+    request_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    session_id: &str,
+    content: &str,
+) -> Result<()> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentResponse(
+                filter: {{ response_key: {{ _eq: "{}" }} }},
+                add: {{
+                    response_key: "{}",
+                    request_id: "{}",
+                    agent_did: "{}",
+                    behavior_id: "{}",
+                    session_id: "{}",
+                    content: "{}",
+                    reasoning: "",
+                    status: "completed",
+                    error_message: "",
+                    token_count: 0,
+                    progress_seq: 0,
+                    materialized_message_sequence: 1,
+                    materialized_at: "{now}",
+                    created_at: "{now}",
+                    completed_at: "{now}"
+                }},
+                update: {{ content: "{}", status: "completed", completed_at: "{now}" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(request_id),
+        escape_graphql_string(request_id),
+        escape_graphql_string(request_id),
+        escape_graphql_string(agent_did),
+        escape_graphql_string(behavior_id),
+        escape_graphql_string(session_id),
+        escape_graphql_string(content),
+        escape_graphql_string(content)
+    );
+    exec(node, &mutation, "create AgentResponse").await
+}
+
+fn optional_tool_fields(row: &serde_json::Value) -> String {
+    let mut fields = Vec::new();
+    for field in [
+        "completed_at",
+        "tool_failure_class",
+        "unclaimed_deadline_at",
+        "cancel_cascade_intent_at",
+        "stuck_since",
+    ] {
+        if let Some(value) = opt_str_field(row, field) {
+            fields.push(format!(r#"{field}: "{}""#, escape_graphql_string(value)));
+        }
+    }
+    if let Some(value) = row.get("latency_ms").and_then(|v| v.as_i64()) {
+        fields.push(format!("latency_ms: {value}"));
+    }
+    if let Some(value) = row
+        .get("cancel_pending_remote_ack")
+        .and_then(|v| v.as_bool())
+    {
+        fields.push(format!("cancel_pending_remote_ack: {value}"));
+    }
+    if fields.is_empty() {
+        String::new()
+    } else {
+        format!(", {}", fields.join(", "))
+    }
+}
+
+fn str_field<'a>(row: &'a serde_json::Value, field: &str) -> Result<&'a str> {
+    row.get(field)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow::anyhow!("row missing string field {field}"))
+}
+
+fn opt_str_field<'a>(row: &'a serde_json::Value, field: &str) -> Option<&'a str> {
+    row.get(field)
+        .and_then(|v| v.as_str())
+        .filter(|v| !v.is_empty())
+}
+
+fn status_for_lifecycle(state: &str) -> &str {
+    match state {
+        "completed" => "completed",
+        "failed" | "dead" | "interrupted" => "error",
+        "superseded" => "superseded",
+        "processing" => "processing",
+        _ => state,
+    }
+}
+
+async fn exec(node: &HarnessNode, mutation: &str, label: &str) -> Result<()> {
+    let response = node.db.node.execute(mutation).await;
+    if response.has_errors() {
+        bail!("{label} failed: {:?}", response.errors);
+    }
+    Ok(())
+}

--- a/crates/defra-agent/tests/support/r5_conformance/scenario.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/scenario.rs
@@ -1,0 +1,71 @@
+use serde::Deserialize;
+
+pub type NodeId = String;
+
+#[derive(Debug, Deserialize)]
+pub struct Scenario {
+    pub name: String,
+    pub actions: Vec<Action>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op")]
+pub enum Action {
+    OperatorWritePairing {
+        node: NodeId,
+        peer: NodeId,
+        collections: Vec<String>,
+    },
+    WriteParentToolCall {
+        node: NodeId,
+        parent_request_id: String,
+        parent_tool_call_id: String,
+        child_request_id: String,
+        behavior_id: String,
+        unclaimed_deadline_at: Option<String>,
+    },
+    WriteAgentRequest {
+        node: NodeId,
+        request_id: String,
+        agent_did: String,
+        behavior_id: String,
+        state: String,
+        #[serde(default)]
+        caused_by_parent_request_id: Option<String>,
+        #[serde(default)]
+        caused_by_parent_tool_call_id: Option<String>,
+    },
+    ReplicateDoc {
+        from: NodeId,
+        to: NodeId,
+        collection: String,
+        doc_id: String,
+    },
+    TerminalizeChildOnB {
+        request_id: String,
+        terminal: String,
+        #[serde(default)]
+        final_response: Option<String>,
+    },
+    CancelParentOnA {
+        parent_request_id: String,
+        parent_tool_call_id: String,
+    },
+    RunBackgroundCompletionObserverOnA,
+    RunCancelMirrorObserverOnB,
+    RunUnclaimedSpawnReconcilerOnA,
+    RunCancelAckObserverOnA,
+    RunRecoverySweepOn {
+        node: NodeId,
+    },
+    Crash {
+        node: NodeId,
+    },
+    AdvanceClockOn {
+        node: NodeId,
+        seconds: u64,
+    },
+    WaitForConvergence {
+        timeout_secs: u64,
+    },
+}

--- a/docs/superpowers/plans/2026-05-14-r5-cross-deployment-subagents.md
+++ b/docs/superpowers/plans/2026-05-14-r5-cross-deployment-subagents.md
@@ -1,0 +1,2393 @@
+# R5 Cross-Deployment Subagents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement cross-deployment subagent execution (R5 v1, trusted-fleet) per `docs/superpowers/specs/2026-05-14-r5-cross-deployment-subagents-design.md`. Agents on deployment A can spawn background subagents whose behavior lives on paired-peer deployment B; child terminals project back to A; cascade cancellations propagate via doc-mirror without ACP grants.
+
+**Architecture:** Substrate-driven plumbing. Every cross-boundary behavior is already verified by `SubagentCompletion.tla` (#176) or `SubagentCancelPropagation.tla` (#188); R5 wires the existing R4/R6 single-deployment code paths into the cross-deployment topology by (a) reusing replicated rows as if they were local, (b) routing the cascade signal through a single-writer field on the parent `AgentToolCall`, and (c) adding one `ToolRecoveryCause` constructor for the unclaimed-spawn failure mode. Zero new Lean modules. Zero new TLA+ artifacts. Zero new bridge transitions.
+
+**Tech Stack:** Rust (workspace, `cargo` for build/test), Lean 4 (`lake` for proofs), DefraDB (embedded node), GraphQL schemas in `crates/defra-agent-protocol/schemas/agent/`.
+
+**Sequencing note (read before starting):** Execution of this plan is **sequenced after R6 merges** (`docs/superpowers/specs/2026-05-14-tool-backgrounding-design.md`). R6 renames `Proofs/Subagent/` → `Proofs/Background/` and `subagent_*.rs` → `background_*.rs`, and parametrically generalizes the bridge transitions over `BackgroundedKind = Subagent | Tool`. This plan refers to files by their **post-R6 names** throughout. If R6 has not yet merged, do not start; rebase this branch onto R6's merge commit first. The rebase is mechanical because R6 already lives on this branch's parent.
+
+---
+
+## File Structure
+
+The implementation touches the following files. Tasks below reference exact paths.
+
+**Created:**
+- `crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json`
+- `crates/defra-agent/tests/fixtures/r5_scenarios/b_crash_mid_execution.json`
+- `crates/defra-agent/tests/fixtures/r5_scenarios/a_crash_mid_wait.json`
+- `crates/defra-agent/tests/fixtures/r5_scenarios/partition_during_cancel.json`
+- `crates/defra-agent/tests/fixtures/r5_scenarios/multi_completion_coalesce.json`
+- `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`
+- `crates/defra-agent/tests/support/r5_conformance/mod.rs`
+- `crates/defra-agent/tests/support/r5_conformance/scenario.rs`
+- `crates/defra-agent/tests/support/r5_conformance/runner.rs`
+- `crates/defra-agent/tests/support/r5_conformance/invariants.rs`
+
+**Modified:**
+- `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql` — add 4 fields
+- `crates/defra-agent-protocol/schemas/agent/tool_selection.graphql` — add 1 field
+- `crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean` — widen `ToolRecoveryCause`
+- `crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean` — add `recoverySweepCases` entry
+- `crates/defra-agent/src/tool_call_lifecycle.rs` (and module-internal files) — set new fields at spawn, fire `bridge_cancel_cascade` with cross-deployment branch
+- `crates/defra-agent/src/background_tools.rs` (post-R6) — cross-deployment cascade-cancel writes the bridge field
+- `crates/defra-agent/src/background_completion.rs` (post-R6) — unclaimed-spawn reconciler, cancel-ack observer
+- `crates/defra-agent/src/trigger_engine/subagent_source.rs` — paired-peer DID dispatch (spawn-claim trust path); cancel-mirror observer hook (or new sibling file under `trigger_engine/`)
+- `crates/defra-agent/src/runtime_snapshot.rs` (or wherever paired-peer DID set is computed) — expose paired-peer DIDs from `PeerPairingDesired` to runtime consumers
+- `crates/defra-agent/src/recovery.rs` (or whichever site dispatches `ToolRecoveryCause` to `recover_all`) — add the new cause path
+
+**Test files:**
+- `crates/defra-agent/tests/r5_cross_deployment_conformance.rs` (new)
+- Existing test files MAY gain regression assertions if Rust-side field projections evolve
+
+---
+
+## Conventions and helper commands
+
+Throughout the plan:
+
+- **Build the workspace:** `cargo build` (root of repo)
+- **Run all tests:** `cargo test`
+- **Run a single test by name:** `cargo test -p defra-agent --test <file> -- <test_name>`
+- **Run Lean proofs:** `cd crates/defra-agent/proofs && lake build` (must close with no `sorry`s)
+- **Run conformance tests only:** `cargo test -p defra-agent --test r5_cross_deployment_conformance`
+- **Run pairing-conformance regression:** `cargo test -p defra-agent --test pairing_reconcile_conformance` (must continue to pass throughout)
+
+Commits should be small (one task or fewer per commit). Use this commit body format:
+
+```
+<short subject>
+
+<one paragraph why; reference task N from this plan>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## Phase 0: Sanity checks before starting
+
+### Task 0: Confirm R6 has merged and rebase
+
+**Files:** none
+
+- [ ] **Step 1: Verify R6's renames are present.**
+
+Run: `ls crates/defra-agent/proofs/Proofs/Background/ crates/defra-agent/src/background_completion.rs crates/defra-agent/src/background_tools.rs`
+Expected: all three paths exist. If they don't, R6 has not merged; stop and rebase this branch onto R6's merge commit before proceeding.
+
+- [ ] **Step 2: Verify baseline tests pass.**
+
+Run: `cargo test --workspace`
+Expected: all green. If any failures, stop and triage — do not start R5 against a broken baseline.
+
+- [ ] **Step 3: Verify Lean proofs close.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: success, no `sorry`s. If broken, stop and triage.
+
+- [ ] **Step 4: Verify conformance harness baseline.**
+
+Run: `cargo test -p defra-agent --test pairing_reconcile_conformance`
+Expected: all green.
+
+No commit for this task.
+
+---
+
+## Phase 1: Schema additions
+
+This phase adds the new persistence surfaces. The new fields are not yet read or written; later tasks wire them. This phase establishes the storage layer and ensures the rest of the system handles defaulted values for legacy rows.
+
+### Task 1: Add new fields to `AgentToolCall` schema
+
+**Files:**
+- Modify: `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql`
+- Test: `crates/defra-agent/tests/state_machine_conformance.rs` (existing test must continue to pass after schema bump)
+
+- [ ] **Step 1: Write a regression test asserting the new fields exist on `AgentToolCall`.**
+
+Add to `crates/defra-agent/tests/state_machine_conformance.rs`:
+
+```rust
+#[tokio::test]
+async fn agent_tool_call_has_r5_cross_deployment_fields() {
+    let db = crate::support::test_db("agent-tool-call-r5-fields").await;
+    let response = db
+        .node
+        .execute(
+            r#"{
+                __type(name: "AgentToolCall") {
+                    fields { name }
+                }
+            }"#,
+        )
+        .await;
+    assert!(!response.has_errors(), "introspection errors: {:?}", response.errors);
+    let names: std::collections::HashSet<String> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("__type"))
+        .and_then(|t| t.get("fields"))
+        .and_then(|fs| fs.as_array())
+        .map(|fs| {
+            fs.iter()
+                .filter_map(|f| f.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    for field in [
+        "unclaimed_deadline_at",
+        "cancel_cascade_intent_at",
+        "cancel_pending_remote_ack",
+        "stuck_since",
+    ] {
+        assert!(names.contains(field), "AgentToolCall missing field {field}");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Run: `cargo test -p defra-agent --test state_machine_conformance -- agent_tool_call_has_r5_cross_deployment_fields`
+Expected: FAIL — field assertions fail because schema does not yet expose them.
+
+- [ ] **Step 3: Add the four new fields to the schema.**
+
+Edit `crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql` to add (after `child_request_id: String @index`):
+
+```graphql
+    unclaimed_deadline_at: DateTime
+    cancel_cascade_intent_at: DateTime
+    cancel_pending_remote_ack: Boolean
+    stuck_since: DateTime
+```
+
+The final file should be:
+
+```graphql
+type AgentToolCall @branchable {
+    tool_call_key: String @index(unique: true)
+    request_id: String @index
+    session_id: String @index
+    message_sequence: Int
+    tool_name: String @index
+    tool_call_id: String @index
+    args: String
+    result: String
+    status: String
+    lifecycle_state: String @index
+    started_at: DateTime
+    deadline_at: DateTime
+    completed_at: DateTime
+    selected_service_id: String
+    selected_tool_name: String
+    tool_failure_class: String
+    latency_ms: Int
+    await_mode: String
+    cancel_policy: String
+    child_request_id: String @index
+    unclaimed_deadline_at: DateTime
+    cancel_cascade_intent_at: DateTime
+    cancel_pending_remote_ack: Boolean
+    stuck_since: DateTime
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes.**
+
+Run: `cargo test -p defra-agent --test state_machine_conformance -- agent_tool_call_has_r5_cross_deployment_fields`
+Expected: PASS.
+
+- [ ] **Step 5: Confirm no other tests regressed.**
+
+Run: `cargo test --workspace`
+Expected: all green. If a test fails because the schema bump changes serde defaults or row hash, fix it inline — those rows must accept the new defaulted fields without behavioral change.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql crates/defra-agent/tests/state_machine_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 schema: add cross-deployment fields to AgentToolCall
+
+Adds unclaimed_deadline_at, cancel_cascade_intent_at,
+cancel_pending_remote_ack, and stuck_since. Fields are nullable and
+default to null/false on existing rows. R5 plan task 1.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 2: Add `cross_deployment_spawn_timeout_seconds` to `ToolSelection`
+
+**Files:**
+- Modify: `crates/defra-agent-protocol/schemas/agent/tool_selection.graphql`
+- Test: `crates/defra-agent/tests/state_machine_conformance.rs`
+
+- [ ] **Step 1: Write a regression test asserting the new field exists.**
+
+Add to `crates/defra-agent/tests/state_machine_conformance.rs`:
+
+```rust
+#[tokio::test]
+async fn tool_selection_has_cross_deployment_spawn_timeout() {
+    let db = crate::support::test_db("tool-selection-r5-timeout").await;
+    let response = db
+        .node
+        .execute(
+            r#"{
+                __type(name: "ToolSelection") {
+                    fields { name }
+                }
+            }"#,
+        )
+        .await;
+    assert!(!response.has_errors(), "introspection errors: {:?}", response.errors);
+    let names: std::collections::HashSet<String> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("__type"))
+        .and_then(|t| t.get("fields"))
+        .and_then(|fs| fs.as_array())
+        .map(|fs| {
+            fs.iter()
+                .filter_map(|f| f.get("name").and_then(|n| n.as_str()).map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        names.contains("cross_deployment_spawn_timeout_seconds"),
+        "ToolSelection missing cross_deployment_spawn_timeout_seconds",
+    );
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails.**
+
+Run: `cargo test -p defra-agent --test state_machine_conformance -- tool_selection_has_cross_deployment_spawn_timeout`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the field.**
+
+Edit `crates/defra-agent-protocol/schemas/agent/tool_selection.graphql` to add `cross_deployment_spawn_timeout_seconds: Int` after `subagent_background_enabled: Boolean`:
+
+```graphql
+type ToolSelection {
+    selection_id: String @index(unique: true)
+    agent_did: String @index
+    display_name: String
+    enable_file_tools: Boolean
+    file_tools_mode: String
+    file_tool_root: String
+    enable_bash: Boolean
+    bash_mode: String
+    command_execution_policy: String
+    command_allowed_argv_prefixes: [String]
+    command_forbidden_argv_prefixes: [String]
+    command_network_mode: String
+    cli_tool_names: [String]
+    enable_meta_tools: Boolean
+    allowed_mcp_service_ids: [String]
+    delegate_to: [String]
+    subagent_targets: [String]
+    subagent_spawn_enabled: Boolean
+    subagent_steering_enabled: Boolean
+    subagent_background_enabled: Boolean
+    cross_deployment_spawn_timeout_seconds: Int
+}
+```
+
+- [ ] **Step 4: Verify and commit.**
+
+Run: `cargo test -p defra-agent --test state_machine_conformance -- tool_selection_has_cross_deployment_spawn_timeout`
+Expected: PASS.
+
+Run: `cargo test --workspace`
+Expected: all green.
+
+```bash
+git add crates/defra-agent-protocol/schemas/agent/tool_selection.graphql crates/defra-agent/tests/state_machine_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 schema: add cross_deployment_spawn_timeout_seconds to ToolSelection
+
+Per-behavior override for the unclaimed-spawn timeout; global default
+is 60s when the field is null. R5 plan task 2.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 2: Lean recovery widening
+
+This phase closes the formal proof obligation before any Rust runtime behavior reads the new fields. The widening is one enum constructor + one match-arm + one new test-vector entry.
+
+### Task 3: Add `unclaimedCrossDeploymentSpawn` to `ToolRecoveryCause`
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean`
+
+- [ ] **Step 1: Run the proofs to confirm a green baseline.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: success.
+
+- [ ] **Step 2: Add the new constructor to the enum.**
+
+Edit `Proofs/Recovery/Sweeps.lean`, find the `ToolRecoveryCause` enum (around line 144), add a final constructor:
+
+```lean
+inductive ToolRecoveryCause where
+  | deadlineExceeded
+  | parentInterrupted
+  | parentTerminal
+  | childCompleted
+  | childFailed
+  | childDead
+  | childInterrupted
+  | childSuperseded
+  | unclaimedCrossDeploymentSpawn
+  deriving DecidableEq, Repr
+```
+
+- [ ] **Step 3: Run `lake build` to confirm match-exhaustiveness errors fire.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: FAIL with "missing cases" / "non-exhaustive match" in `toContract`, `terminalState`, and `terminalState_terminal`.
+
+- [ ] **Step 4: Extend the `toContract` clause.**
+
+In the same file, add a clause to the `toContract` definition (around line 157):
+
+```lean
+def toContract : ToolRecoveryCause → String
+  | .deadlineExceeded => "deadlineExceeded"
+  | .parentInterrupted => "parentInterrupted"
+  | .parentTerminal => "parentTerminal"
+  | .childCompleted => "childCompleted"
+  | .childFailed => "childFailed"
+  | .childDead => "childDead"
+  | .childInterrupted => "childInterrupted"
+  | .childSuperseded => "childSuperseded"
+  | .unclaimedCrossDeploymentSpawn => "unclaimedCrossDeploymentSpawn"
+```
+
+- [ ] **Step 5: Extend the `terminalState` clause.**
+
+In the same file, add a clause to the `terminalState` definition (around line 167):
+
+```lean
+def terminalState : ToolRecoveryCause → ToolCallState
+  | .deadlineExceeded => .timedOut
+  | .parentInterrupted => .cancelled
+  | .parentTerminal => .failed
+  | .childCompleted => .completed
+  | .childFailed => .failed
+  | .childDead => .failed
+  | .childInterrupted => .cancelled
+  | .childSuperseded => .failed
+  | .unclaimedCrossDeploymentSpawn => .failed
+```
+
+- [ ] **Step 6: Run `lake build` and verify proofs still close.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: success, no `sorry`s. The existing `terminalState_terminal` proof should close automatically by `cases cause` exhaustion. If it doesn't, inspect the error — the proof of `isTerminal .failed` is shared with `.parentTerminal`, `.childFailed`, etc., so it should just work.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+git commit -m "$(cat <<'EOF'
+R5 Lean: widen ToolRecoveryCause with unclaimedCrossDeploymentSpawn
+
+Adds the unclaimed-spawn cause variant. Maps to terminal state .failed;
+existing terminalState_terminal proof closes by cases exhaustion. The
+existing toolCallRecoverySweep registration covers this cause already
+because its stale-row predicate is on cancel_policy (cascade vs detach),
+not on the cause. R5 plan task 3.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 4: Add the conformance-vector entry
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean`
+
+- [ ] **Step 1: Add a new entry to `recoverySweepCases`.**
+
+Edit `Proofs/Recovery/ContractCases.lean`. Find `recoverySweepCases` (around line 33). Add a new entry inside the list, after the existing `tool_running_*` entries:
+
+```lean
+  , recoveryCase
+      toolCallRecoverySweep
+      "tool_running_unclaimed_cross_deployment_spawn_to_failed"
+      "running"
+      "failed"
+      "r5-cross-deployment-subagents-design"
+```
+
+(The `deadlineAuditRef` string can be replaced with a more specific reference once R5 picks an audit anchor; the placeholder above is acceptable for the merge.)
+
+- [ ] **Step 2: Run `lake build` to verify the existing `recoverySweepCases_registered_sweeps` and `recoverySweepCases_decrease_to_zero` theorems still close.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: success. Both theorems use `native_decide` which should evaluate the widened list correctly.
+
+- [ ] **Step 3: Commit.**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Recovery/ContractCases.lean
+git commit -m "$(cat <<'EOF'
+R5 Lean: register tool_running_unclaimed_cross_deployment_spawn_to_failed
+
+Adds the conformance-vector entry that emits the new recovery case to
+Rust. R5 plan task 4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 3: A-side spawn changes
+
+The R6 spawn path already writes the bridge row. R5 extends it with the new fields and adds the per-behavior timeout resolution.
+
+### Task 5: Resolve `cross_deployment_spawn_timeout_seconds` from `ToolSelection`
+
+**Files:**
+- Modify: `crates/defra-agent/src/subagent_tools.rs` (or wherever `load_parent_subagent_authorization` lives; the loader of `ToolSelectionDocument`)
+
+- [ ] **Step 1: Locate the `ToolSelectionDocument` loader.**
+
+Run: `grep -rn "load_parent_subagent_authorization\|subagent_targets\|ToolSelectionDocument" crates/defra-agent/src/ | head -30`
+
+Identify the struct/function that loads `subagent_targets`. The new field `cross_deployment_spawn_timeout_seconds` should be loaded alongside.
+
+- [ ] **Step 2: Add the field to the loaded struct.**
+
+Add a field `cross_deployment_spawn_timeout_seconds: Option<u32>` to the existing parent-subagent-authorization or tool-selection struct. Load it from the GraphQL query. Default to `None` when null.
+
+Concrete code (assuming the loader is in `subagent_tools.rs` and has a struct like `ParentSubagentAuthorization`):
+
+```rust
+#[derive(Debug, Clone)]
+pub struct ParentSubagentAuthorization {
+    // existing fields...
+    pub cross_deployment_spawn_timeout_seconds: Option<u32>,
+}
+```
+
+Update the GraphQL query string that loads `ToolSelection` to include the new field. Update the deserialization to capture it.
+
+- [ ] **Step 3: Add a helper to resolve the effective timeout.**
+
+In the same file:
+
+```rust
+const DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS: u32 = 60;
+
+pub fn effective_cross_deployment_spawn_timeout_seconds(
+    auth: &ParentSubagentAuthorization,
+) -> u32 {
+    auth.cross_deployment_spawn_timeout_seconds
+        .unwrap_or(DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS)
+}
+```
+
+- [ ] **Step 4: Write a unit test for the resolver.**
+
+Add to the same file's `tests` module (or a new one if none exists):
+
+```rust
+#[cfg(test)]
+mod cross_deployment_timeout_tests {
+    use super::*;
+
+    #[test]
+    fn override_takes_precedence() {
+        let auth = ParentSubagentAuthorization {
+            // ...other fields default...
+            cross_deployment_spawn_timeout_seconds: Some(120),
+            ..Default::default()
+        };
+        assert_eq!(effective_cross_deployment_spawn_timeout_seconds(&auth), 120);
+    }
+
+    #[test]
+    fn default_when_none() {
+        let auth = ParentSubagentAuthorization {
+            cross_deployment_spawn_timeout_seconds: None,
+            ..Default::default()
+        };
+        assert_eq!(effective_cross_deployment_spawn_timeout_seconds(&auth), 60);
+    }
+}
+```
+
+(If `ParentSubagentAuthorization` doesn't derive `Default`, either add it or construct the test fixtures explicitly.)
+
+- [ ] **Step 5: Run the test and verify it passes.**
+
+Run: `cargo test -p defra-agent cross_deployment_timeout_tests`
+Expected: both tests PASS.
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/defra-agent/src/subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: resolve cross-deployment spawn timeout from ToolSelection
+
+Adds cross_deployment_spawn_timeout_seconds to the parent subagent
+authorization loader; resolver falls back to 60s default. R5 plan task 5.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 6: Set `unclaimed_deadline_at` on bridge spawn
+
+**Files:**
+- Modify: `crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs` (or whichever module writes the new bridge `AgentToolCall` row at spawn time)
+
+- [ ] **Step 1: Locate the bridge-spawn write site.**
+
+Run: `grep -rn "INSERT.*AgentToolCall\|create_agent_tool_call\|create_subagent_request_with_request_id\|bridge_spawn" crates/defra-agent/src/ | head -20`
+
+Find the function that materializes the parent `AgentToolCall` row at the moment of subagent spawn. (R6's parametric `bridge_spawn` likely lives in `tool_call_lifecycle/`.)
+
+- [ ] **Step 2: Pass the resolved timeout into the bridge-spawn write.**
+
+Wire `effective_cross_deployment_spawn_timeout_seconds(&auth)` through the spawn call chain. At the write site, compute:
+
+```rust
+let unclaimed_deadline_at = chrono::Utc::now()
+    + chrono::Duration::seconds(timeout_secs as i64);
+```
+
+and include `unclaimed_deadline_at` as a field in the GraphQL mutation that creates the bridge row. The other three new fields (`cancel_cascade_intent_at`, `cancel_pending_remote_ack`, `stuck_since`) are left at their schema defaults (null / false / null).
+
+- [ ] **Step 3: Write an integration test.**
+
+Pattern after the existing fixtures in `crates/defra-agent/tests/r4_subagent_tools.rs` (look for any `#[tokio::test]` that already spawns a subagent through the hook path; reuse its fixture setup verbatim). Add a new test at the bottom of the file:
+
+```rust
+#[tokio::test]
+async fn background_subagent_spawn_sets_unclaimed_deadline_at() {
+    // Reuse the in-file fixture builder used by existing background-spawn
+    // tests; see e.g. `background_spawn_*` tests in this file for the
+    // exact constructor calls (TestDb + ToolSelection write + behavior
+    // registration). Spawn via the existing background-subagent hook.
+
+    let fixture = build_background_spawn_fixture("test-r5-unclaimed-deadline").await;
+    let spawn_result = fixture.spawn_background_subagent("child-behavior", "prompt").await;
+    assert!(spawn_result.is_ok(), "spawn should succeed: {:?}", spawn_result);
+
+    let row = fixture
+        .load_bridge_tool_call(spawn_result.unwrap().parent_tool_call_id())
+        .await
+        .expect("bridge row exists");
+    let deadline = row
+        .unclaimed_deadline_at
+        .expect("unclaimed_deadline_at is set on every background subagent spawn");
+    let now = chrono::Utc::now();
+    let delta = (deadline - now).num_seconds();
+    assert!(
+        (50..=70).contains(&delta),
+        "unclaimed_deadline_at should be ~60s out (default); got delta={delta}s",
+    );
+}
+```
+
+If `build_background_spawn_fixture` and `load_bridge_tool_call` are not named exactly that in the file, rename them to whatever the existing test pattern uses — the *behavior* required is the same: stand up a TestDb + ToolSelection + behavior, invoke the spawn hook, and query the bridge row by `parent_tool_call_id`.
+
+- [ ] **Step 4: Run the test, verify FAIL, implement, verify PASS.**
+
+Run: `cargo test -p defra-agent --test r4_subagent_tools -- background_subagent_spawn_sets_unclaimed_deadline_at`
+Expected initially: FAIL (field is null because the write path doesn't set it).
+After Step 2 wires the field: PASS.
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs crates/defra-agent/tests/r4_subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: set unclaimed_deadline_at on background subagent spawn
+
+Resolves the per-behavior override from ToolSelection
+(cross_deployment_spawn_timeout_seconds) and writes the wall-clock
+deadline on the bridge AgentToolCall row at spawn time. Single-deployment
+spawns also receive the field (it harmlessly elapses when the bridge
+terminalizes via the in-process completion path). R5 plan task 6.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 4: A-side cancel-cascade cross-deployment branch
+
+R6's parametric `bridge_cancel_cascade` for Subagent kind sets the child's `interruptRequestedAt`. In cross-deployment, the child lives on B and A cannot write to it without an ACP grant (out of scope). R5 redirects the cascade signal through `cancel_cascade_intent_at` on A's own bridge row; B mirrors in a separate task.
+
+### Task 7: Write the cross-deployment cascade signal on A
+
+**Files:**
+- Modify: `crates/defra-agent/src/background_tools.rs` (post-R6; the cascade-cancel call site for Subagent kind)
+- Modify: `crates/defra-agent/src/tool_call_lifecycle.rs` (or the bridge-cancel-cascade implementation site)
+
+- [ ] **Step 1: Locate the existing `bridge_cancel_cascade` implementation site.**
+
+Run: `grep -rn "bridge_cancel_cascade" crates/defra-agent/src/ | head -20`
+
+Identify where the Rust dispatcher invokes the Subagent-kind branch. Likely a `match kind { Subagent => ..., Tool => ... }` or a kind-dispatched method.
+
+- [ ] **Step 2: Detect "is the child local or replicated?" at cancel time.**
+
+Add a helper near the cascade-cancel call site. R5 v1 uses the `agent_did` field on the child `AgentRequest` row as the locality oracle: the child is created with `agent_did = behavior's principal DID`, which differs from A's `local_did` whenever the child lives on a paired peer. This is the trusted-fleet single-org proxy for DefraDB's per-doc identity binding (which #180 will harden later).
+
+```rust
+async fn child_request_is_locally_owned(
+    node: &EmbeddedNode,
+    local_did: &str,
+    child_request_id: &str,
+) -> Result<bool> {
+    let escaped = crate::graphql::escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ agent_did }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query AgentRequest for cross-deployment cancel dispatch failed: {:?}",
+            response.errors
+        );
+    }
+    let did = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .and_then(|rows| rows.first())
+        .and_then(|row| row.get("agent_did"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    // Absent child request → treat as cross-deployment (the local replica
+    // hasn't arrived yet; the cancel must go through the bridge field).
+    Ok(did.as_deref() == Some(local_did))
+}
+```
+
+**Do not introduce a new identity-binding API in this task.** When #180 adds NAC-bound identity metadata, this helper migrates to read the writer DID from doc metadata instead of `agent_did`; that change is a follow-up.
+
+- [ ] **Step 3: Branch the Subagent-kind cascade-cancel implementation.**
+
+In `bridge_cancel_cascade`'s Subagent-kind branch, change the logic from:
+
+```rust
+// old (single-deployment only):
+write_child_interrupt_requested_at(node, child_request_id).await?;
+```
+
+to:
+
+```rust
+// new (kind-dispatched on locality):
+if child_request_is_locally_owned(node, local_did, child_request_id).await? {
+    // Single-deployment: existing behavior.
+    write_child_interrupt_requested_at(node, child_request_id).await?;
+} else {
+    // Cross-deployment: write the cascade-intent on the bridge row.
+    write_bridge_cancel_cascade_intent(
+        node,
+        bridge_tool_call_id,
+        chrono::Utc::now(),
+    )
+    .await?;
+}
+```
+
+Implement `write_bridge_cancel_cascade_intent` as a single mutation that sets:
+
+- `cancel_cascade_intent_at = now`
+- `cancel_pending_remote_ack = true`
+
+in one atomic write.
+
+- [ ] **Step 4: Write integration tests.**
+
+Add to `crates/defra-agent/tests/r4_subagent_tools.rs`. Pattern after existing R4 cascade-cancel tests in the file (search for `bridge_cancel_cascade` to find the closest fixture); reuse the fixture helpers and only change the `agent_did` to drive the cross-deployment branch.
+
+```rust
+#[tokio::test]
+async fn cross_deployment_cancel_writes_cascade_intent_on_bridge() {
+    let local_did = "did:agent:a-parent";
+    let remote_did = "did:agent:b-child";
+    // Fixture: spawn a background subagent and override the child's
+    // agent_did to remote_did (write the row directly to simulate a
+    // replicated child).
+    let fixture = build_background_spawn_fixture("test-r5-xdep-cancel").await;
+    let spawn = fixture.spawn_background_subagent("child-behavior", "prompt").await.expect("spawn");
+    fixture.override_child_agent_did(spawn.child_request_id(), remote_did).await;
+
+    fixture.cancel_parent_request(spawn.parent_request_id()).await.expect("cancel");
+
+    let bridge = fixture.load_bridge_tool_call(spawn.parent_tool_call_id()).await.expect("bridge row");
+    assert!(bridge.cancel_cascade_intent_at.is_some(), "cancel_cascade_intent_at must be set");
+    assert_eq!(bridge.cancel_pending_remote_ack, Some(true), "cancel_pending_remote_ack must be true");
+
+    let child = fixture.load_agent_request(spawn.child_request_id()).await.expect("child");
+    assert!(
+        child.interrupt_requested_at.is_none(),
+        "cross-deployment branch must not write child interruptRequestedAt (no ACP grant)",
+    );
+}
+
+#[tokio::test]
+async fn single_deployment_cancel_still_sets_child_interrupt() {
+    let fixture = build_background_spawn_fixture("test-r5-single-cancel").await;
+    let spawn = fixture.spawn_background_subagent("child-behavior", "prompt").await.expect("spawn");
+    // Child agent_did is the same as parent agent_did (default single-deployment path).
+
+    fixture.cancel_parent_request(spawn.parent_request_id()).await.expect("cancel");
+
+    let child = fixture.load_agent_request(spawn.child_request_id()).await.expect("child");
+    assert!(
+        child.interrupt_requested_at.is_some(),
+        "single-deployment branch must still set child interruptRequestedAt",
+    );
+    let bridge = fixture.load_bridge_tool_call(spawn.parent_tool_call_id()).await.expect("bridge row");
+    assert!(
+        bridge.cancel_cascade_intent_at.is_none(),
+        "single-deployment branch must NOT touch bridge cancel fields",
+    );
+}
+```
+
+If the fixture helpers (`override_child_agent_did`, `cancel_parent_request`, `load_agent_request`) don't exist with those exact names, add them to the test-support module in the same commit — they are thin wrappers around the same DefraDB mutations the existing R4 tests already use; the cost of adding them is one query per helper.
+
+- [ ] **Step 5: Run tests, verify, commit.**
+
+Run: `cargo test -p defra-agent --test r4_subagent_tools -- cross_deployment_cancel`
+Expected: PASS for both.
+
+```bash
+git add crates/defra-agent/src/tool_call_lifecycle.rs crates/defra-agent/src/background_tools.rs crates/defra-agent/tests/r4_subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: cross-deployment cascade-cancel writes bridge intent field
+
+Branches bridge_cancel_cascade Subagent-kind on local-vs-replicated
+child ownership. Single-deployment unchanged: writes child's
+interruptRequestedAt. Cross-deployment: writes
+cancel_cascade_intent_at + cancel_pending_remote_ack on the bridge row;
+B mirrors in a separate task. R5 plan task 7.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 5: A-side reconcilers
+
+Two reconcilers live in `background_completion.rs` post-R6: the existing completion projector (unchanged) and two new ticks: the unclaimed-spawn deadline reconciler, and the cancel-ack observability reconciler.
+
+### Task 8: Unclaimed-spawn reconciler
+
+**Files:**
+- Modify: `crates/defra-agent/src/background_completion.rs`
+
+- [ ] **Step 1: Add a reconciler tick function.**
+
+In `background_completion.rs`:
+
+```rust
+#[derive(Debug, Clone)]
+pub enum UnclaimedSpawnReconcileOutcome {
+    Failed { parent_tool_call_id: String, parent_request_id: String },
+    Linked { parent_tool_call_id: String, parent_request_id: String },
+    Skipped,
+}
+
+#[derive(Debug, Deserialize)]
+struct UnclaimedBridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    tool_call_id: String,
+    child_request_id: String,
+    started_at: Option<String>,
+    deadline_at: Option<String>,
+}
+
+pub async fn reconcile_unclaimed_cross_deployment_spawns(
+    node: Arc<EmbeddedNode>,
+) -> Result<Vec<UnclaimedSpawnReconcileOutcome>> {
+    let now = chrono::Utc::now();
+    let now_str = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let now_str = crate::graphql::escape_graphql_string(&now_str);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    _and: [
+                        {{ lifecycle_state: {{ _eq: "running" }} }},
+                        {{ await_mode: {{ _eq: "background" }} }},
+                        {{ child_request_id: {{ _ne: "" }} }},
+                        {{ unclaimed_deadline_at: {{ _lt: "{now_str}" }} }}
+                    ]
+                }}
+            ) {{
+                _docID
+                request_id
+                tool_call_id
+                child_request_id
+                started_at
+                deadline_at
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "unclaimed-spawn reconcile query failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<UnclaimedBridgeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+
+    let mut outcomes = Vec::with_capacity(rows.len());
+    for row in rows {
+        // Race: has the child finally arrived in our local replica?
+        if child_request_exists_locally(node.as_ref(), &row.child_request_id).await? {
+            clear_unclaimed_deadline_at(node.as_ref(), &row.doc_id).await?;
+            outcomes.push(UnclaimedSpawnReconcileOutcome::Linked {
+                parent_tool_call_id: row.tool_call_id.clone(),
+                parent_request_id: row.request_id.clone(),
+            });
+            continue;
+        }
+        // Fire bridge_failure(ServiceUnavailable, no_peer_claimed_spawn).
+        // Use the existing failure-projection helper for service-unavailable
+        // failures on a running bridge tool call.
+        let payload = crate::subagent_tools::subagent_tool_not_allowed_payload(
+            "spawn_subagent",
+            "/behavior_id",
+            "<unknown>",
+            "no paired peer claimed the cross-deployment spawn within unclaimed_spawn_timeout_seconds",
+            &[],
+        );
+        crate::subagent_tools::fail_running_subagent_tool_call(
+            node.as_ref(),
+            &row.doc_id,
+            row.started_at.as_deref(),
+            row.deadline_at.as_deref(),
+            &payload,
+            crate::tool_call_lifecycle::FailureClass::ServiceUnavailable,
+        )
+        .await?;
+        outcomes.push(UnclaimedSpawnReconcileOutcome::Failed {
+            parent_tool_call_id: row.tool_call_id.clone(),
+            parent_request_id: row.request_id.clone(),
+        });
+    }
+    Ok(outcomes)
+}
+
+async fn child_request_exists_locally(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Result<bool> {
+    let escaped = crate::graphql::escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "child existence probe failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .is_some_and(|rows| !rows.is_empty()))
+}
+
+async fn clear_unclaimed_deadline_at(
+    node: &EmbeddedNode,
+    doc_id: &str,
+) -> Result<()> {
+    let escaped = crate::graphql::escape_graphql_string(doc_id);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{ unclaimed_deadline_at: null }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "clear unclaimed_deadline_at failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(())
+}
+```
+
+The `fail_running_subagent_tool_call` and `subagent_tool_not_allowed_payload` symbols already exist in `crates/defra-agent/src/subagent_tools.rs` (post-R6: `background_tools.rs`); they are the same helpers used to fail unauthorized spawn attempts in `SubagentSource`. Reusing them keeps the failure shape consistent.
+
+- [ ] **Step 2: Write tests.**
+
+Add to `crates/defra-agent/tests/r4_subagent_tools.rs`:
+
+```rust
+#[tokio::test]
+async fn unclaimed_spawn_past_deadline_fires_bridge_failure() {
+    // Fixture: spawn a background subagent; do NOT materialize a child
+    // AgentRequest. Advance simulated wall clock past unclaimed_deadline_at.
+    // Tick the reconciler. Assert: bridge tool call row is now terminal
+    // (.failed) with FailureClass::ServiceUnavailable and reason
+    // "no_peer_claimed_spawn".
+    todo!();
+}
+
+#[tokio::test]
+async fn unclaimed_spawn_with_late_child_clears_deadline() {
+    // Fixture: spawn a background subagent; deadline elapses on A.
+    // Between deadline-elapse and reconciler tick, replication delivers
+    // the child AgentRequest. Tick the reconciler.
+    // Assert: bridge still running; unclaimed_deadline_at cleared (null).
+    todo!();
+}
+```
+
+- [ ] **Step 3: Wire the reconciler into the existing runtime tick.**
+
+Find where `project_background_subagent_completion` (or the post-R6 equivalent) is invoked from. Add a parallel call into the new reconciler at the same cadence. (If there is a single supervisor loop that ticks completion projection, add the unclaimed-spawn reconciler tick there.)
+
+- [ ] **Step 4: Run tests; verify; commit.**
+
+```bash
+git add crates/defra-agent/src/background_completion.rs crates/defra-agent/tests/r4_subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: add unclaimed-spawn reconciler on A
+
+Steady-state reconciler ticks alongside completion projection; for each
+running background bridge whose child has not replicated and whose
+unclaimed_deadline_at has elapsed, fires bridge_failure with
+FailureClass::ServiceUnavailable / reason no_peer_claimed_spawn. R5
+plan task 8.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 9: Cancel-ack observability reconciler
+
+**Files:**
+- Modify: `crates/defra-agent/src/background_completion.rs`
+
+- [ ] **Step 1: Implement the observability tick.**
+
+```rust
+pub const STUCK_CANCEL_THRESHOLD_SECS: i64 = 5 * 60;
+
+#[derive(Debug, Clone)]
+pub enum CancelAckOutcome {
+    Acked { parent_tool_call_id: String },
+    Stuck { parent_tool_call_id: String, since: chrono::DateTime<chrono::Utc> },
+    Pending { parent_tool_call_id: String },
+}
+
+#[derive(Debug, Deserialize)]
+struct CancelPendingBridgeRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    tool_call_id: String,
+    child_request_id: String,
+    cancel_cascade_intent_at: Option<String>,
+    stuck_since: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildAckProbeRow {
+    state: Option<String>,
+    interrupt_requested_at: Option<String>,
+}
+
+pub async fn observe_cancel_cascade_ack(
+    node: Arc<EmbeddedNode>,
+) -> Result<Vec<CancelAckOutcome>> {
+    let now = chrono::Utc::now();
+    let query = r#"{
+        AgentToolCall(filter: { cancel_pending_remote_ack: { _eq: true } }) {
+            _docID
+            tool_call_id
+            child_request_id
+            cancel_cascade_intent_at
+            stuck_since
+        }
+    }"#;
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "cancel-ack observer query failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<CancelPendingBridgeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+
+    let mut outcomes = Vec::with_capacity(rows.len());
+    for row in rows {
+        let probe = load_child_ack_probe(node.as_ref(), &row.child_request_id).await?;
+        let child_done = probe
+            .as_ref()
+            .map(|p| {
+                let terminal = matches!(
+                    p.state.as_deref(),
+                    Some("completed" | "failed" | "dead" | "interrupted" | "superseded")
+                );
+                terminal || p.interrupt_requested_at.is_some()
+            })
+            .unwrap_or(false);
+
+        if child_done {
+            clear_cancel_pending_ack(node.as_ref(), &row.doc_id).await?;
+            outcomes.push(CancelAckOutcome::Acked {
+                parent_tool_call_id: row.tool_call_id.clone(),
+            });
+            continue;
+        }
+
+        // Determine stuck-since flip.
+        let intent_at = row.cancel_cascade_intent_at.as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|dt| dt.with_timezone(&chrono::Utc));
+        let already_stuck = row.stuck_since.is_some();
+        if let Some(intent_at) = intent_at {
+            let age = (now - intent_at).num_seconds();
+            if age >= STUCK_CANCEL_THRESHOLD_SECS && !already_stuck {
+                set_stuck_since(node.as_ref(), &row.doc_id, now).await?;
+                outcomes.push(CancelAckOutcome::Stuck {
+                    parent_tool_call_id: row.tool_call_id.clone(),
+                    since: now,
+                });
+                continue;
+            }
+        }
+        outcomes.push(CancelAckOutcome::Pending {
+            parent_tool_call_id: row.tool_call_id.clone(),
+        });
+    }
+    Ok(outcomes)
+}
+
+async fn load_child_ack_probe(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Result<Option<ChildAckProbeRow>> {
+    let escaped = crate::graphql::escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{
+                state
+                interrupt_requested_at
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("child ack probe failed: {:?}", response.errors);
+    }
+    let rows: Vec<ChildAckProbeRow> = response
+        .data
+        .as_ref()
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows.into_iter().next())
+}
+
+async fn clear_cancel_pending_ack(node: &EmbeddedNode, doc_id: &str) -> Result<()> {
+    let escaped = crate::graphql::escape_graphql_string(doc_id);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{
+                    cancel_pending_remote_ack: false,
+                    stuck_since: null
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!("clear cancel_pending_remote_ack failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+
+async fn set_stuck_since(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    when: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    let escaped = crate::graphql::escape_graphql_string(doc_id);
+    let when = when.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let when = crate::graphql::escape_graphql_string(&when);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                input: {{ stuck_since: "{when}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!("set stuck_since failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+```
+
+**Safety constraint:** This reconciler **never mutates the child request, the bridge's terminal state, or any other state-bearing field.** It only flips `cancel_pending_remote_ack` (true → false) and sets `stuck_since`. This is the explicit observability-not-safety boundary per spec §7.3. The Rust compiler can't enforce that constraint; the engineer must verify by inspection that no other field is touched by any code path in `observe_cancel_cascade_ack` or its helpers.
+
+- [ ] **Step 2: Write tests.**
+
+```rust
+#[tokio::test]
+async fn cancel_ack_observer_clears_flag_on_child_terminal() {
+    // Fixture: bridge in Cancelled terminal with cancel_pending_remote_ack
+    // = true; child AgentRequest in terminal state.
+    // Tick the observer.
+    // Assert: cancel_pending_remote_ack now false; bridge state unchanged.
+    todo!();
+}
+
+#[tokio::test]
+async fn cancel_ack_observer_flips_stuck_since_past_threshold() {
+    // Fixture: bridge with cancel_cascade_intent_at = now - 6min;
+    // cancel_pending_remote_ack = true; child still running.
+    // Tick the observer.
+    // Assert: stuck_since now set.
+    todo!();
+}
+
+#[tokio::test]
+async fn cancel_ack_observer_never_mutates_child() {
+    // Property: tick the observer in any state; child AgentRequest is
+    // never modified by this code path.
+    todo!();
+}
+```
+
+- [ ] **Step 3: Wire and commit.**
+
+Wire alongside the unclaimed-spawn reconciler tick. Run all tests. Commit:
+
+```bash
+git add crates/defra-agent/src/background_completion.rs crates/defra-agent/tests/r4_subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: cancel-ack observability reconciler on A
+
+Clears cancel_pending_remote_ack when the child request is terminal
+locally; flips stuck_since past 5-min threshold. Never mutates child
+state or bridge terminal state — strict observability boundary per
+spec §7.3. R5 plan task 9.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 6: B-side spawn-claim trust dispatch
+
+`SubagentSource` already filters spawn intents by the local behavior snapshot. R5 adds one new branch: when the parent `AgentRequest` was written by a paired-peer DID, B skips the `load_parent_subagent_authorization` re-check (trusted-fleet trust contract).
+
+### Task 10: Expose paired-peer DID set
+
+**Files:**
+- Modify: `crates/defra-agent/src/runtime_snapshot.rs` (or wherever `ActiveRuntimeSnapshot` is built)
+
+- [ ] **Step 1: Add paired-peer DID set + local DID to the runtime snapshot.**
+
+Find the `ActiveRuntimeSnapshot` struct. Add two new fields:
+
+```rust
+pub struct ActiveRuntimeSnapshot {
+    // existing fields...
+    /// This deployment's local principal DID. Used to detect when a
+    /// replicated doc was written by a paired peer vs. this deployment.
+    pub local_did: String,
+    /// DIDs of paired peers as seen in PeerPairingDesired. Used by
+    /// SubagentSource and the cancel mirror observer to gate on the
+    /// trusted-fleet trust contract.
+    pub paired_peer_dids: std::collections::HashSet<String>,
+}
+```
+
+Populate when the snapshot is rebuilt — load the local DID from whatever loader produces `local_did` for the agent runtime today (search: `grep -rn "local_did\|local_principal" crates/defra-agent/src/runtime_snapshot.rs`); load paired DIDs by querying `PeerPairingDesired` and resolving each peer's `peer_id` to a DID. If the peer record stores `peer_id` rather than DID, the implementation needs a `peer_id → DID` resolver (consult `crates/defra-agent-desktop-core/src/client/core/writes.rs:213` or the peer-directory loader for the canonical resolution).
+
+- [ ] **Step 2: Write a unit test.**
+
+```rust
+#[tokio::test]
+async fn runtime_snapshot_includes_paired_peer_dids() {
+    // Fixture: write PeerPairingDesired with a known peer_id mapped to
+    // a known DID. Rebuild the snapshot.
+    // Assert: snapshot.paired_peer_dids contains the DID.
+    todo!();
+}
+```
+
+- [ ] **Step 3: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/src/runtime_snapshot.rs
+git commit -m "$(cat <<'EOF'
+R5: expose paired-peer DID set on ActiveRuntimeSnapshot
+
+Used by SubagentSource and the cancel-mirror observer to dispatch on
+cross-deployment trust contract. R5 plan task 10.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 11: Paired-peer dispatch in `SubagentSource`
+
+**Files:**
+- Modify: `crates/defra-agent/src/trigger_engine/subagent_source.rs`
+
+- [ ] **Step 1: Add the new branch.**
+
+In `SubagentSource::build_intent_for_tool_call_doc` (the function that loads parent context, runs authorization, and materializes the child), wrap the existing `load_parent_subagent_authorization` call:
+
+```rust
+let parent_authoring_did = self.load_parent_authoring_did(&parent_request_id).await?;
+let snapshot = self.snapshot_rx.borrow().clone();
+
+if snapshot.paired_peer_dids.contains(&parent_authoring_did) {
+    // Cross-deployment spawn from a paired peer; trust the spawn
+    // intent without re-validating against the parent's
+    // ToolSelectionDocument (which lives on the paired peer).
+    tracing::debug!(
+        parent_request_id = %parent_request_id,
+        parent_authoring_did = %parent_authoring_did,
+        "subagent source claiming cross-deployment spawn from paired peer",
+    );
+} else {
+    // Single-deployment spawn: existing path.
+    let authorization = match load_parent_subagent_authorization(&self.node, &parent_request_id).await {
+        // ... existing error handling ...
+    };
+    // ... existing denial check ...
+}
+```
+
+`load_parent_authoring_did` reads the DefraDB doc-identity metadata for the parent `AgentRequest` row. As in Task 7 step 2, if the codebase doesn't yet expose a clean API for this, fall back to reading `agent_did` on the parent `AgentRequest` row as a proxy.
+
+- [ ] **Step 2: Write a unit test.**
+
+Add to `crates/defra-agent/tests/subagent_source_conformance.rs`:
+
+```rust
+#[tokio::test]
+async fn cross_deployment_spawn_from_paired_peer_skips_auth_recheck() {
+    // Fixture: a parent AgentRequest whose authoring DID is in the
+    // paired_peer_dids set; a parent AgentToolCall row with
+    // child_request_id and lifecycle_state = running. No
+    // ToolSelectionDocument is present locally (it lives on the
+    // paired peer).
+    // Tick the SubagentSource.
+    // Assert: a child AgentRequest is materialized.
+    todo!();
+}
+
+#[tokio::test]
+async fn single_deployment_spawn_still_runs_auth_recheck() {
+    // Regression: parent DID is local; the existing authorization
+    // check runs and denies/permits based on the local ToolSelection.
+    todo!();
+}
+```
+
+- [ ] **Step 3: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/src/trigger_engine/subagent_source.rs crates/defra-agent/tests/subagent_source_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5: paired-peer DID dispatch in SubagentSource
+
+Trusted-fleet contract: when the parent AgentRequest's authoring DID
+is in the local paired_peer_dids set, B skips the auth re-check (the
+ToolSelectionDocument lives on A and is not replicated). Single-
+deployment claims unchanged. R5 plan task 11.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 7: B-side cancel mirror observer
+
+A new B-side worker observes replicated `AgentToolCall` rows with `cancel_cascade_intent_at` set and mirrors onto the locally-owned child's `interruptRequestedAt`. Implementation can either extend `SubagentSource`'s subscription handler with an additional dispatch, or live in a sibling file under `crates/defra-agent/src/trigger_engine/`. The plan recommends the sibling-file shape for separation of concerns.
+
+### Task 12: Cancel mirror observer
+
+**Files:**
+- Create: `crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs`
+- Modify: `crates/defra-agent/src/trigger_engine/mod.rs` (register the new worker)
+
+- [ ] **Step 1: Create the new file.**
+
+```rust
+//! Cross-deployment cascade-cancel mirror observer.
+//!
+//! Watches replicated `AgentToolCall` rows for `cancel_cascade_intent_at`
+//! transitions; for each row whose `child_request_id` corresponds to a
+//! locally-owned `AgentRequest`, writes `interruptRequestedAt` on the
+//! child to propagate the cancel signal into B's existing interrupt path.
+//!
+//! Trust contract: only honors writes from paired-peer DIDs (read from
+//! `ActiveRuntimeSnapshot.paired_peer_dids`).
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use defra_node::{EmbeddedNode, EventName};
+use tokio_util::sync::CancellationToken;
+use tokio::sync::watch;
+
+use crate::runtime_snapshot::ActiveRuntimeSnapshot;
+
+pub struct CrossDeploymentCancelMirror {
+    node: Arc<EmbeddedNode>,
+    snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+    subscription: Option<events::Subscription>,
+    cancel: CancellationToken,
+    // Track mirror dispatch idempotency by (bridge_tool_call_id,
+    // cancel_cascade_intent_at). Avoid re-writing interruptRequestedAt
+    // on every subscription tick.
+    mirrored: std::collections::HashSet<String>,
+}
+
+impl CrossDeploymentCancelMirror {
+    pub fn new(
+        node: Arc<EmbeddedNode>,
+        snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+        cancel: CancellationToken,
+    ) -> Self {
+        Self {
+            node,
+            snapshot_rx,
+            subscription: None,
+            cancel,
+            mirrored: std::collections::HashSet::new(),
+        }
+    }
+
+    pub async fn run(mut self) -> Result<()> {
+        self.subscription = Some(self.node.subscribe(&[EventName::Update]));
+        loop {
+            tokio::select! {
+                biased;
+                _ = self.cancel.cancelled() => return Ok(()),
+                msg = self.subscription.as_mut().unwrap().recv() => {
+                    let Some(message) = msg else { return Ok(()) };
+                    let Some(update) = message.as_update() else { continue };
+                    // Filter to AgentToolCall collection.
+                    let Some(name) = self.resolve_collection_name(&update.collection_id).await
+                    else { continue };
+                    if name != "AgentToolCall" { continue }
+                    if let Err(error) = self.handle_tool_call_update(&update.doc_id).await {
+                        tracing::warn!(%error, doc_id = %update.doc_id, "cancel mirror handle error");
+                    }
+                }
+            }
+        }
+    }
+
+    async fn handle_tool_call_update(&mut self, doc_id: &str) -> Result<()> {
+        let row = match self.load_bridge_row(doc_id).await? {
+            Some(r) => r,
+            None => return Ok(()),
+        };
+        let intent_at = match row.cancel_cascade_intent_at.as_deref() {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => return Ok(()),
+        };
+        let child_request_id = match row.child_request_id.as_deref() {
+            Some(s) if !s.is_empty() => s.to_string(),
+            _ => return Ok(()),
+        };
+        let dedupe_key = format!("{}:{}", row.tool_call_id, intent_at);
+        if self.mirrored.contains(&dedupe_key) {
+            return Ok(());
+        }
+
+        // Trust check: parent authoring DID is in the paired-peer set.
+        let parent_did = match self.load_parent_authoring_did(&row.request_id).await? {
+            Some(did) => did,
+            None => return Ok(()),
+        };
+        let snapshot = self.snapshot_rx.borrow().clone();
+        if !snapshot.paired_peer_dids.contains(&parent_did) {
+            // Not from a paired peer — ignore.
+            return Ok(());
+        }
+
+        // Locality check: the child must be locally owned by this peer.
+        let child = match self.load_child_request(&child_request_id).await? {
+            Some(c) => c,
+            None => return Ok(()),
+        };
+        if child.agent_did.as_deref() != Some(snapshot.local_did.as_str()) {
+            return Ok(());
+        }
+
+        // Idempotency: child already terminal or already interrupted.
+        let already_handled = is_terminal_state(child.state.as_deref())
+            || child.interrupt_requested_at.is_some();
+        if already_handled {
+            self.mirrored.insert(dedupe_key);
+            return Ok(());
+        }
+
+        // Mirror.
+        write_child_interrupt_requested_at(
+            self.node.as_ref(),
+            &child_request_id,
+            &intent_at,
+        )
+        .await?;
+        self.mirrored.insert(dedupe_key);
+        Ok(())
+    }
+
+    async fn load_bridge_row(&self, doc_id: &str) -> Result<Option<BridgeCancelRow>> {
+        let escaped = crate::graphql::escape_graphql_string(doc_id);
+        let query = format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{ _docID: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{
+                    request_id
+                    tool_call_id
+                    child_request_id
+                    cancel_cascade_intent_at
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("cancel mirror bridge load failed: {:?}", response.errors);
+        }
+        let rows: Vec<BridgeCancelRow> = response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentToolCall"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn load_parent_authoring_did(
+        &self,
+        parent_request_id: &str,
+    ) -> Result<Option<String>> {
+        // For R5 v1, agent_did on the parent AgentRequest row is the
+        // proxy for the authoring DID (see Task 7 step 2 for the
+        // trusted-fleet rationale). When #180 lands, replace with the
+        // DefraDB doc-identity binding read.
+        let escaped = crate::graphql::escape_graphql_string(parent_request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{ agent_did }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("cancel mirror parent DID load failed: {:?}", response.errors);
+        }
+        Ok(response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentRequest"))
+            .and_then(|v| v.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("agent_did"))
+            .and_then(|v| v.as_str())
+            .map(String::from))
+    }
+
+    async fn load_child_request(
+        &self,
+        child_request_id: &str,
+    ) -> Result<Option<ChildRequestRow>> {
+        let escaped = crate::graphql::escape_graphql_string(child_request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                    limit: 1
+                ) {{
+                    agent_did
+                    state
+                    interrupt_requested_at
+                }}
+            }}"#
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("cancel mirror child load failed: {:?}", response.errors);
+        }
+        let rows: Vec<ChildRequestRow> = response
+            .data
+            .as_ref()
+            .and_then(|d| d.get("AgentRequest"))
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().next())
+    }
+
+    async fn resolve_collection_name(&self, collection_id: &str) -> Option<String> {
+        // Mirror the same logic used by SubagentSource::resolve_collection_name.
+        // The implementation lives in `crates/defra-agent/src/trigger_engine/subagent_source.rs`
+        // — copy that function body verbatim or extract a shared helper into
+        // `trigger_engine/mod.rs` in this same task to avoid duplication.
+        let _ = collection_id;
+        None
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct BridgeCancelRow {
+    request_id: String,
+    tool_call_id: String,
+    child_request_id: Option<String>,
+    cancel_cascade_intent_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildRequestRow {
+    agent_did: Option<String>,
+    state: Option<String>,
+    interrupt_requested_at: Option<String>,
+}
+
+fn is_terminal_state(state: Option<&str>) -> bool {
+    matches!(
+        state,
+        Some("completed" | "failed" | "dead" | "interrupted" | "superseded")
+    )
+}
+
+async fn write_child_interrupt_requested_at(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    when: &str,
+) -> Result<()> {
+    let escaped_id = crate::graphql::escape_graphql_string(child_request_id);
+    let escaped_when = crate::graphql::escape_graphql_string(when);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_id}" }} }},
+                input: {{ interrupt_requested_at: "{escaped_when}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "cancel mirror child interrupt write failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Register the worker in the trigger engine module.**
+
+In `crates/defra-agent/src/trigger_engine/mod.rs`, find where `SubagentSource` is constructed at startup. Add a sibling spawn for `CrossDeploymentCancelMirror::new(...).run()`. Ensure the cancellation token is shared with the existing trigger-engine workers.
+
+- [ ] **Step 3: Write integration tests.**
+
+Add to `crates/defra-agent/tests/r4_subagent_tools.rs` (or a new R5 file):
+
+```rust
+#[tokio::test]
+async fn cancel_mirror_writes_interrupt_on_paired_peer_intent() {
+    // Fixture: B has a local child AgentRequest. A's parent AgentToolCall
+    // replicates with cancel_cascade_intent_at = some_timestamp and
+    // authoring DID in B's paired_peer_dids.
+    // Tick the cancel mirror.
+    // Assert: child.interruptRequestedAt = some_timestamp.
+    todo!();
+}
+
+#[tokio::test]
+async fn cancel_mirror_is_idempotent() {
+    // Fixture: same as above, but the child already has
+    // interruptRequestedAt set.
+    // Tick twice; assert no error, child unchanged.
+    todo!();
+}
+
+#[tokio::test]
+async fn cancel_mirror_ignores_unpaired_peer_intent() {
+    // Fixture: A's parent AgentToolCall replicates with
+    // cancel_cascade_intent_at set, but the authoring DID is NOT in
+    // B's paired_peer_dids.
+    // Tick the mirror.
+    // Assert: child.interruptRequestedAt is still null.
+    todo!();
+}
+
+#[tokio::test]
+async fn cancel_mirror_absorbs_against_natural_terminal() {
+    // Fixture: child is already in a natural terminal state
+    // (.completed/.failed/.dead/.superseded). Cancel intent arrives.
+    // Tick the mirror.
+    // Assert: child state unchanged (natural terminal stable); no error.
+    todo!();
+}
+```
+
+- [ ] **Step 4: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs crates/defra-agent/src/trigger_engine/mod.rs crates/defra-agent/tests/r4_subagent_tools.rs
+git commit -m "$(cat <<'EOF'
+R5: B-side cancel mirror observer
+
+Watches replicated AgentToolCall.cancel_cascade_intent_at and writes
+interruptRequestedAt on the locally-owned child AgentRequest. Idempotent
+on (bridge_tool_call_id, cancel_cascade_intent_at). Honors only paired-
+peer authoring DIDs. R5 plan task 12.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 8: Conformance harness extension
+
+R5 reuses the two-node scaffold from #107 (`tests/support/pairing_conformance/`). This phase creates a sibling `r5_conformance` scaffold that imports the existing harness's two-node setup helpers and adds the R5 action vocabulary. Each scenario lives in `tests/fixtures/r5_scenarios/` as JSON.
+
+### Task 13: R5 scenario IR scaffold
+
+**Files:**
+- Create: `crates/defra-agent/tests/support/r5_conformance/mod.rs`
+- Create: `crates/defra-agent/tests/support/r5_conformance/scenario.rs`
+- Create: `crates/defra-agent/tests/support/r5_conformance/runner.rs`
+- Create: `crates/defra-agent/tests/support/r5_conformance/invariants.rs`
+- Modify: `crates/defra-agent/tests/support/mod.rs` (export the new module)
+
+- [ ] **Step 1: Define the scenario IR.**
+
+Create `crates/defra-agent/tests/support/r5_conformance/scenario.rs`:
+
+```rust
+//! R5 conformance scenario IR. Each scenario is a list of actions
+//! driving the two-node R5 fixture.
+
+use serde::Deserialize;
+
+pub type NodeId = String;
+
+#[derive(Debug, Deserialize)]
+pub struct Scenario {
+    pub name: String,
+    pub actions: Vec<Action>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "op")]
+pub enum Action {
+    /// Operator writes PeerPairingDesired on the named node, naming
+    /// the peer DID and the collection set R5 cares about.
+    OperatorWritePairing {
+        node: NodeId,
+        peer: NodeId,
+        collections: Vec<String>,
+    },
+    /// A spawns a background subagent by writing the parent AgentToolCall.
+    WriteParentToolCall {
+        node: NodeId,
+        parent_request_id: String,
+        parent_tool_call_id: String,
+        child_request_id: String,
+        behavior_id: String,
+        unclaimed_deadline_at: Option<String>,
+    },
+    /// Write or update an AgentRequest on the named node.
+    WriteAgentRequest {
+        node: NodeId,
+        request_id: String,
+        agent_did: String,
+        behavior_id: String,
+        state: String,
+        caused_by_parent_request_id: Option<String>,
+        caused_by_parent_tool_call_id: Option<String>,
+    },
+    /// Simulate replication of a doc from `from` to `to`.
+    ReplicateDoc {
+        from: NodeId,
+        to: NodeId,
+        collection: String,
+        doc_id: String,
+    },
+    /// B writes its child AgentRequest terminal state and optional final
+    /// AgentResponse.
+    TerminalizeChildOnB {
+        request_id: String,
+        terminal: String,
+        final_response: Option<String>,
+    },
+    /// Trigger bridge_cancel_cascade on A's bridge row.
+    CancelParentOnA {
+        parent_request_id: String,
+        parent_tool_call_id: String,
+    },
+    /// Tick A's background_completion observer once.
+    RunBackgroundCompletionObserverOnA,
+    /// Tick B's cancel mirror observer once.
+    RunCancelMirrorObserverOnB,
+    /// Tick A's unclaimed-spawn reconciler once.
+    RunUnclaimedSpawnReconcilerOnA,
+    /// Tick A's cancel-ack observer once.
+    RunCancelAckObserverOnA,
+    /// Tick the named node's recovery sweep once.
+    RunRecoverySweepOn { node: NodeId },
+    /// Crash the named node (process kill simulation).
+    Crash { node: NodeId },
+    /// Move the named node's monotonic clock forward.
+    AdvanceClockOn { node: NodeId, seconds: u64 },
+    /// Wait for the harness to reach a quiescent state.
+    WaitForConvergence { timeout_secs: u64 },
+}
+```
+
+- [ ] **Step 2: Stub the harness runner.**
+
+Create `crates/defra-agent/tests/support/r5_conformance/runner.rs`. Mirror `pairing_conformance/runner.rs`'s shape: a `Harness` struct holding two `HarnessNode`s, a `run` method, an observation history. Adapt the `apply_action` match to dispatch on the R5 `Action` variants.
+
+The engineer should follow `crates/defra-agent/tests/support/pairing_conformance/runner.rs` line-for-line for the structural pattern; the only differences are the new actions and the simulated-replication mechanic (which here copies docs across the boundary on `ReplicateDoc`).
+
+- [ ] **Step 3: Stub the invariants module.**
+
+Create `crates/defra-agent/tests/support/r5_conformance/invariants.rs`. Each invariant from spec §10.2 becomes a function:
+
+```rust
+pub fn assert_bridge_terminal_unique(observation: &Observation) {
+    // For each bridge row, assert terminal_write_count <= 1.
+}
+
+pub fn assert_projection_requires_b_durable_terminal(observation: &Observation) {
+    // For each bridge whose terminalSource is ChildProjection, assert
+    // the child's terminal AND final response are durable on the
+    // observer's local replica.
+}
+
+// ... (the remaining 14 invariants — one per TLA+ invariant listed
+//      in spec §10.2)
+```
+
+- [ ] **Step 4: Wire `mod.rs`.**
+
+Create `crates/defra-agent/tests/support/r5_conformance/mod.rs`:
+
+```rust
+pub mod scenario;
+pub mod runner;
+pub mod invariants;
+
+pub use runner::Harness;
+pub use scenario::{Action, NodeId, Scenario};
+```
+
+Update `crates/defra-agent/tests/support/mod.rs` to `pub mod r5_conformance;` (alongside the existing `pub mod pairing_conformance;`).
+
+- [ ] **Step 5: Run `cargo build` to ensure the scaffold compiles.**
+
+Run: `cargo build --tests`
+Expected: success (all the `todo!()` bodies compile).
+
+- [ ] **Step 6: Commit.**
+
+```bash
+git add crates/defra-agent/tests/support/r5_conformance/ crates/defra-agent/tests/support/mod.rs
+git commit -m "$(cat <<'EOF'
+R5 harness: scenario IR scaffold
+
+Adds r5_conformance/ alongside pairing_conformance/ in the test support
+layer. Scenario IR enumerates the R5 action vocabulary from spec
+§4.3/§10.1 verbatim. Runner and invariants are scaffolded; subsequent
+tasks fill bodies. R5 plan task 13.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 14: Implement the harness runner
+
+**Files:**
+- Modify: `crates/defra-agent/tests/support/r5_conformance/runner.rs`
+
+- [ ] **Step 1: Implement `Harness::start_two_nodes`.**
+
+Mirror `pairing_conformance::Harness::start_two_nodes` — two `test_db` instances, an A and a B `HarnessNode`. Each node carries:
+- `db: TestDb`
+- `id: NodeId`
+- A simulated wall clock (`std::time::Duration` offset from `Utc::now()`)
+- A flag for `Crash` / restart bookkeeping
+
+- [ ] **Step 2: Implement each `Action` variant.**
+
+For each variant, implement the effect. Key implementations:
+
+- `OperatorWritePairing` — write `PeerPairingDesired` on the named node (existing pattern from `pairing_conformance/runner.rs`'s `write_peer_pairing_desired`).
+- `WriteParentToolCall` — write the `AgentToolCall` row on A with `await_mode = background`, `cancel_policy = cascade`, the supplied `child_request_id`, and the resolved `unclaimed_deadline_at`.
+- `WriteAgentRequest` — write the `AgentRequest` row on the named node.
+- `ReplicateDoc` — query the doc on `from`'s store; write it on `to`'s store (idempotent — UPSERT semantics). Simulates DefraDB replication.
+- `TerminalizeChildOnB` — update the child `AgentRequest.state`; if `final_response` is provided, also write the `AgentResponse` row.
+- `CancelParentOnA` — invoke `bridge_cancel_cascade` (or the in-process Rust call that triggers it) on A's bridge row.
+- `RunBackgroundCompletionObserverOnA` — call `project_background_subagent_completion` (or the existing observer entry point) once with the child's request_id (or sweep all bridge rows).
+- `RunCancelMirrorObserverOnB` — manually invoke the cancel-mirror handler for each replicated `AgentToolCall` doc on B (without spinning up a full subscription loop).
+- `RunUnclaimedSpawnReconcilerOnA` — invoke `reconcile_unclaimed_cross_deployment_spawns` once.
+- `RunCancelAckObserverOnA` — invoke `observe_cancel_cascade_ack` once.
+- `RunRecoverySweepOn { node }` — invoke `ToolCallLifecycle::recover_all` (and `RequestLifecycle::recover_all` if relevant) on the named node.
+- `Crash { node }` — record the crash, reset volatile in-memory state of the node fixture (DefraDB store persists).
+- `AdvanceClockOn { node, seconds }` — bump the node's simulated clock offset by `seconds`. The reconcilers must read time through the harness's clock when running in test mode; the implementation may pass a `clock: Arc<dyn Clock>` parameter into each reconciler entry point, or use a thread-local override.
+- `WaitForConvergence` — busy-loop tick observers until no further changes occur or `timeout_secs` elapses.
+
+- [ ] **Step 3: Add observation snapshot capture.**
+
+After each action, record a snapshot of the joint state: A's bridge rows, A's local replicas of B-owned rows, B's child request rows, B's responses, B's locally-replicated bridge rows. Stored in `Harness::history` for invariant evaluation.
+
+- [ ] **Step 4: Run `cargo build --tests` to ensure compilation.**
+
+Expected: success. Tests still don't execute scenarios yet (no scenarios in fixtures/), so `cargo test` passes (no R5 tests).
+
+- [ ] **Step 5: Commit.**
+
+```bash
+git add crates/defra-agent/tests/support/r5_conformance/runner.rs
+git commit -m "$(cat <<'EOF'
+R5 harness: implement runner action dispatch
+
+Implements each R5 scenario action against the two-node fixture.
+Replication is simulated as a doc-copy step (matching pairing
+conformance's pattern). Reconcilers and observers are invoked through
+their existing entry points; harness-mode clock injection lets tests
+advance deadlines without sleeping. R5 plan task 14.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 15: Implement the invariants
+
+**Files:**
+- Modify: `crates/defra-agent/tests/support/r5_conformance/invariants.rs`
+
+- [ ] **Step 1: Implement each TLA+ invariant.**
+
+The 16 invariants from spec §10.2 each become a function over an `Observation`. Each function asserts the property holds at the moment the observation was captured; failures `panic!` with a descriptive message including a snapshot of the offending state.
+
+Group invariants by TLA+ source:
+
+```rust
+/// From SubagentCompletion.tla
+pub mod completion {
+    use super::Observation;
+
+    pub fn bridge_terminal_unique(o: &Observation) { /* ... */ }
+    pub fn projection_requires_b_durable_terminal(o: &Observation) { /* ... */ }
+    pub fn projection_matches_lean_bridge_mapping(o: &Observation) { /* ... */ }
+    pub fn notification_idempotent(o: &Observation) { /* ... */ }
+    pub fn wakeup_coalesced(o: &Observation) { /* ... */ }
+    pub fn wakeup_causal(o: &Observation) { /* ... */ }
+    pub fn cancel_drain_preserves_user_pending(o: &Observation) { /* ... */ }
+    pub fn parent_cancel_absorbs_late_terminal(o: &Observation) { /* ... */ }
+}
+
+/// From SubagentCancelPropagation.tla
+pub mod cancel_propagation {
+    use super::Observation;
+
+    pub fn cancel_intent_durable(o: &Observation) { /* ... */ }
+    pub fn cancel_handled_idempotent(o: &Observation) { /* ... */ }
+    pub fn interrupt_exactly_once(o: &Observation) { /* ... */ }
+    pub fn cascade_interrupts_only_running(o: &Observation) { /* ... */ }
+    pub fn natural_terminal_stable_after_cancel(o: &Observation) { /* ... */ }
+    pub fn interrupted_only_by_cascade(o: &Observation) { /* ... */ }
+}
+
+pub fn assert_all_safety(o: &Observation) {
+    completion::bridge_terminal_unique(o);
+    completion::projection_requires_b_durable_terminal(o);
+    completion::projection_matches_lean_bridge_mapping(o);
+    completion::notification_idempotent(o);
+    completion::wakeup_coalesced(o);
+    completion::wakeup_causal(o);
+    completion::cancel_drain_preserves_user_pending(o);
+    completion::parent_cancel_absorbs_late_terminal(o);
+    cancel_propagation::cancel_intent_durable(o);
+    cancel_propagation::cancel_handled_idempotent(o);
+    cancel_propagation::interrupt_exactly_once(o);
+    cancel_propagation::cascade_interrupts_only_running(o);
+    cancel_propagation::natural_terminal_stable_after_cancel(o);
+    cancel_propagation::interrupted_only_by_cascade(o);
+}
+```
+
+For each invariant body, translate the TLA+ formula into a Rust assertion over the `Observation` fields. The TLA+ source (`crates/defra-agent/proofs/tla/SubagentCompletion.tla` and `SubagentCancelPropagation.tla`) is the source of truth; consult it for the exact predicate.
+
+- [ ] **Step 2: Implement the liveness target.**
+
+```rust
+pub fn assert_liveness_after_convergence(history: &[Observation]) {
+    let last = history.last().expect("non-empty history");
+
+    // DurableTerminalSettles + LiveBridgeTerminalProjects
+    for bridge in &last.a_bridge_rows {
+        if bridge.child_durable_terminal.is_some() {
+            assert!(
+                bridge.terminal_source.is_some(),
+                "DurableTerminalSettles violated for bridge {:?}",
+                bridge.parent_tool_call_id,
+            );
+        }
+    }
+
+    // CancelDeliveryProgress + LiveCancelInterruptsOrNaturalWins
+    for bridge in &last.a_bridge_rows {
+        if bridge.cancel_cascade_intent_at.is_some() {
+            // Child must eventually be terminalized (Interrupted or absorbed
+            // against natural).
+            let child = last.b_child_requests.iter()
+                .find(|c| Some(&c.request_id) == bridge.child_request_id.as_ref())
+                .expect("child eventually appears");
+            assert!(
+                child.state == "interrupted" || is_natural_terminal(&child.state),
+                "LiveCancelInterruptsOrNaturalWins violated",
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run `cargo build --tests`.**
+
+Expected: success.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/tests/support/r5_conformance/invariants.rs
+git commit -m "$(cat <<'EOF'
+R5 harness: implement TLA+ invariants
+
+Each safety invariant from SubagentCompletion.tla §"Safety" and
+SubagentCancelPropagation.tla §"Safety" becomes a Rust assertion;
+the liveness target is checked once after WaitForConvergence. R5 plan
+task 15.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 16: Scenario 1 — happy path
+
+**Files:**
+- Create: `crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json`
+- Create: `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`
+
+- [ ] **Step 1: Create the test driver.**
+
+Create `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`:
+
+```rust
+mod support;
+
+use std::path::PathBuf;
+
+use support::r5_conformance::{Harness, Scenario};
+use support::r5_conformance::invariants;
+
+async fn run_scenario(filename: &str) {
+    let path: PathBuf = ["tests", "fixtures", "r5_scenarios", filename]
+        .iter()
+        .collect();
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|_| panic!("missing scenario {}", path.display()));
+    let scenario: Scenario = serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("invalid scenario {}: {e}", path.display()));
+    let mut harness = Harness::start_two_nodes().await.expect("harness start");
+    harness.run(&scenario).await.expect("scenario run");
+    for snapshot in harness.observation_history() {
+        invariants::assert_all_safety(&snapshot);
+    }
+    invariants::assert_liveness_after_convergence(&harness.observation_history());
+}
+
+#[tokio::test]
+async fn r5_happy_path() {
+    run_scenario("happy_path.json").await;
+}
+```
+
+- [ ] **Step 2: Create the scenario JSON.**
+
+Create `crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json`:
+
+```json
+{
+  "name": "happy_path",
+  "actions": [
+    {
+      "op": "OperatorWritePairing",
+      "node": "A",
+      "peer": "B",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "OperatorWritePairing",
+      "node": "B",
+      "peer": "A",
+      "collections": ["AgentRequest", "AgentResponse", "AgentToolCall", "AgentMessage"]
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "A",
+      "request_id": "parent-req-1",
+      "agent_did": "did:agent:a-parent",
+      "behavior_id": "parent-behavior",
+      "state": "processing"
+    },
+    {
+      "op": "WriteParentToolCall",
+      "node": "A",
+      "parent_request_id": "parent-req-1",
+      "parent_tool_call_id": "tool-call-1",
+      "child_request_id": "child-req-1",
+      "behavior_id": "child-behavior",
+      "unclaimed_deadline_at": null
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentRequest",
+      "doc_id": "parent-req-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "A",
+      "to": "B",
+      "collection": "AgentToolCall",
+      "doc_id": "tool-call-1"
+    },
+    {
+      "op": "WriteAgentRequest",
+      "node": "B",
+      "request_id": "child-req-1",
+      "agent_did": "did:agent:b-child",
+      "behavior_id": "child-behavior",
+      "state": "processing",
+      "caused_by_parent_request_id": "parent-req-1",
+      "caused_by_parent_tool_call_id": "tool-call-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-1"
+    },
+    {
+      "op": "TerminalizeChildOnB",
+      "request_id": "child-req-1",
+      "terminal": "completed",
+      "final_response": "child completed successfully"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentRequest",
+      "doc_id": "child-req-1"
+    },
+    {
+      "op": "ReplicateDoc",
+      "from": "B",
+      "to": "A",
+      "collection": "AgentResponse",
+      "doc_id": "child-req-1"
+    },
+    { "op": "RunBackgroundCompletionObserverOnA" },
+    { "op": "WaitForConvergence", "timeout_secs": 10 }
+  ]
+}
+```
+
+- [ ] **Step 3: Run the test.**
+
+Run: `cargo test -p defra-agent --test r5_cross_deployment_conformance -- r5_happy_path`
+Expected initially: PASS (or FAIL if any of the earlier tasks left a partial implementation; iterate on those tasks until this scenario passes).
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add crates/defra-agent/tests/r5_cross_deployment_conformance.rs crates/defra-agent/tests/fixtures/r5_scenarios/happy_path.json
+git commit -m "$(cat <<'EOF'
+R5 conformance: happy-path scenario
+
+Exercises A spawn → replicate → B materialize → B terminalize →
+replicate → A project. All 14 safety invariants hold throughout;
+liveness target reached after convergence. R5 plan task 16.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 17: Scenario 2 — B-side crash mid-execution
+
+**Files:**
+- Create: `crates/defra-agent/tests/fixtures/r5_scenarios/b_crash_mid_execution.json`
+- Modify: `crates/defra-agent/tests/r5_cross_deployment_conformance.rs` (add test entry)
+
+- [ ] **Step 1: Add the test entry.**
+
+```rust
+#[tokio::test]
+async fn r5_b_crash_mid_execution() {
+    run_scenario("b_crash_mid_execution.json").await;
+}
+```
+
+- [ ] **Step 2: Author the scenario JSON.**
+
+Mirror the happy-path JSON, but inject a `{ "op": "Crash", "node": "B" }` between the spawn and the child-terminalize. Then add `{ "op": "RunRecoverySweepOn", "node": "B" }` to drive B's recovery — which should terminalize the in-flight child request as `.failed` per the existing #189 sweep. Then `ReplicateDoc` the terminal back to A and `RunBackgroundCompletionObserverOnA`. Verify liveness.
+
+- [ ] **Step 3: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/tests/fixtures/r5_scenarios/b_crash_mid_execution.json crates/defra-agent/tests/r5_cross_deployment_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 conformance: B-side crash mid-execution
+
+Exercises crash + recovery on B. The existing AgentRequest startup sweep
+terminalizes the in-flight child; A's projection picks up the terminal
+via replication and projects bridge_failure. R5 plan task 17.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 18: Scenario 3 — A-side crash mid-wait
+
+**Files:**
+- Create: `crates/defra-agent/tests/fixtures/r5_scenarios/a_crash_mid_wait.json`
+- Modify: `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`
+
+- [ ] **Step 1: Add the test entry and scenario.**
+
+The scenario exercises **both** crash interleavings from spec §10.3 scenario 3: (a) crash before B terminalizes, (b) crash after B terminal has replicated to A but before A's observer fires. The JSON encodes both interleavings as two phases in one scenario, asserting equivalent post-states.
+
+- [ ] **Step 2: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/tests/fixtures/r5_scenarios/a_crash_mid_wait.json crates/defra-agent/tests/r5_cross_deployment_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 conformance: A-side crash mid-wait
+
+Exercises crash interleavings on A: (a) before B's terminal arrives —
+re-subscription handles the future delivery; (b) after B's terminal has
+replicated but before A's observer ticks — recovery sweep picks it up.
+Both end equivalent. R5 plan task 18.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 19: Scenario 4 — partition during cancel
+
+**Files:**
+- Create: `crates/defra-agent/tests/fixtures/r5_scenarios/partition_during_cancel.json`
+- Modify: `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`
+
+- [ ] **Step 1: Add the test entry and scenario.**
+
+Sequence: spawn → child materialized → cancel on A (bridge terminalizes immediately + `cancel_cascade_intent_at` set) → omit `ReplicateDoc` of the updated `AgentToolCall` → `AdvanceClockOn { node: "A", seconds: 360 }` → `RunCancelAckObserverOnA` (asserts `stuck_since` flips) → `ReplicateDoc` the updated bridge row to B → `RunCancelMirrorObserverOnB` (asserts `interruptRequestedAt` written) → B terminalizes child as `.interrupted` (or absorbs against earlier natural terminal if the scenario rolls that way) → `ReplicateDoc` back → assertion: A's `cancel_pending_remote_ack` cleared.
+
+- [ ] **Step 2: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/tests/fixtures/r5_scenarios/partition_during_cancel.json crates/defra-agent/tests/r5_cross_deployment_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 conformance: partition during cancel
+
+Exercises stuck_since flip past threshold while replication is dropped,
+mirror once replication resumes, ack-cleared after child terminal
+replicates back. Verifies cancel_pending_remote_ack and stuck_since
+are observability-only (never block bridge state or child terminal).
+R5 plan task 19.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+### Task 20: Scenario 5 — multi-completion coalesce
+
+**Files:**
+- Create: `crates/defra-agent/tests/fixtures/r5_scenarios/multi_completion_coalesce.json`
+- Modify: `crates/defra-agent/tests/r5_cross_deployment_conformance.rs`
+
+- [ ] **Step 1: Add the test entry and scenario.**
+
+Sequence: two children spawned in the same session on A → both materialized on B → both terminalized simultaneously on B → both `AgentRequest` + `AgentResponse` docs replicate to A → tick the projector twice (once per child) → assert: two `<subagent-notification>` transcript messages exist; exactly one pending `background_completion:<session_id>` queue row exists.
+
+- [ ] **Step 2: Run, verify, commit.**
+
+```bash
+git add crates/defra-agent/tests/fixtures/r5_scenarios/multi_completion_coalesce.json crates/defra-agent/tests/r5_cross_deployment_conformance.rs
+git commit -m "$(cat <<'EOF'
+R5 conformance: multi-completion coalesce
+
+Two children terminalize on B simultaneously; A's projection emits two
+transcript notifications and coalesces both wake-ups under one queue
+row at (session_id, "background_completion:<session_id>"). Verifies
+WakeupCoalesced from SubagentCompletion.tla. R5 plan task 20.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase 9: Final validation
+
+### Task 21: End-to-end verification
+
+**Files:** none
+
+- [ ] **Step 1: Run the entire test suite.**
+
+Run: `cargo test --workspace`
+Expected: all green, including the new R5 conformance tests and all pre-existing tests.
+
+- [ ] **Step 2: Run Lean proofs.**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: success, no `sorry`s, no broken theorems.
+
+- [ ] **Step 3: Run the pairing-conformance regression.**
+
+Run: `cargo test -p defra-agent --test pairing_reconcile_conformance`
+Expected: all green. This test predates R5 and must continue to pass to confirm the #107 substrate is unaffected.
+
+- [ ] **Step 4: Manual review checklist.**
+
+Cross-check each line of the spec §12 "Approval Checklist" against the merged code:
+
+- Trusted-fleet trust posture? Verify §2 implementation in `subagent_source.rs` and `cross_deployment_cancel_mirror.rs` (both gated on `paired_peer_dids`).
+- Spawn locus? Verify B creates the child via `SubagentSource` (unchanged path).
+- Unclaimed-spawn timeout? Field present on `AgentToolCall`; resolver in `subagent_tools.rs`; reconciler in `background_completion.rs`.
+- Doc-ownership discipline? Audit `git log` for any cross-peer field write — there should be none.
+- One new `ToolRecoveryCause` variant? Verify `unclaimedCrossDeploymentSpawn` in `Sweeps.lean` and corresponding entry in `ContractCases.lean`.
+- Five conformance scenarios? Verify all five JSON files exist and all five tests pass.
+
+- [ ] **Step 5: Tag the design + plan delta.**
+
+No code changes for this step. Confirm `git log --oneline | head -25` shows clean atomic commits with messages following the convention.
+
+- [ ] **Step 6: No commit; report.**
+
+End of plan. The branch is ready for `git push` + PR by the operator.
+
+---
+
+## Out of scope (do not implement in this plan)
+
+- **Cross-deployment R6 backgrounded tools** (`background_tool` for `bash`/MCP across nodes). Future composition; not part of R5.
+- **`detach` cancel policy** for cross-deployment. v1 cascade only.
+- **Foreground cross-deployment subagents** (`await_mode = foreground`). Future-R5+.
+- **Real-libp2p replication in the conformance harness.** Simulated `ReplicateDoc` is the v1 mechanism.
+- **#180 NAC / multi-tenant.** Trusted-fleet only. When #180 lands, the trust check in Task 11 + Task 12 becomes a NAC gate; no schema changes.
+- **`HostedBehavior` / `AgentBehavior` replication.** No discovery doc; operator's `subagent_targets` allowlist + `unclaimed_deadline_at` is the entire pre-flight contract.
+- **A-side cancel-retry worker.** DefraDB replication is the retry; no application-layer retry loop.
+- **R4c surfaces** (`list_*`, `read_subagent_transcript`, `steer_*`). Sibling brainstorm.

--- a/docs/superpowers/specs/2026-05-14-r5-cross-deployment-subagents-design.md
+++ b/docs/superpowers/specs/2026-05-14-r5-cross-deployment-subagents-design.md
@@ -1,0 +1,387 @@
+# R5: Cross-Deployment Subagent Execution — Design
+
+**Status:** Draft for Jack approval, revision 1
+**Date:** 2026-05-14
+**Tracks:** R5 (cross-deployment subagents)
+**Refs:** #155 (cross-boundary verification strategy), #162 (reverse-pairing TLA+), #168 (persist-before-ack), #176 (cross-deployment completion projection TLA+), #178 (reverse-pairing handler idempotence), #183 (formal-coverage audit follow-ups), #188 (cross-deployment cancel propagation TLA+), #107 (P2P admin reconcile + harness substrate), #180 (P2P admin auth — gates multi-tenant)
+
+**Depends on:**
+
+- `docs/superpowers/specs/2026-05-14-tool-backgrounding-design.md` (R6: parametric `BackgroundedKind`, `Proofs/Background/*` module rename, renamed Rust files). R5 imports the canonical post-R6 vocabulary.
+- `docs/superpowers/specs/2026-05-12-subagent-completion-cross-deployment-tla-design.md` (#176).
+- `docs/superpowers/specs/2026-05-13-subagent-cancel-propagation-tla-design.md` (#188).
+- `docs/superpowers/specs/2026-05-13-issue-107-p2p-admin-rpc-design.md` (#107: pairing reconcile + conformance harness pattern).
+
+## 1. Goal
+
+R5 turns "agents on deployment A can spawn subagents whose behavior lives on deployment B" from substrate into product, under a **trusted-fleet** trust model (closed-source single-org). The agent surface (`spawn_subagent`, `wait_subagent`, `cancel_subagent`) is unchanged from R4; the parent agent never observes that the spawn target is on a different node. Every cross-boundary behavior R5 needs is already verified by `SubagentCompletion.tla` (#176) or `SubagentCancelPropagation.tla` (#188), and every Lean transition R5 invokes is in the existing `Proofs/Background/*` module set (post-R6 rename).
+
+R5's design discipline is **substrate-first reuse**. The strategic claim of the cross-boundary verification thread (#155 → #162 → #176 → #178 → #188 → #107) is that the substrate generalizes; R5 is the proof that the verification investment paid for product capability. Most of this spec is plumbing — the §6 derived requirements from #176 and §6 from #188 are *consumed*, not re-derived.
+
+This spec produces an implementation plan, not implementation.
+
+## 2. Trust model
+
+**Trusted-fleet only.** R5 v1 is for closed-source single-org fleets where every deployment trusts every other paired peer. Concretely:
+
+- B's `SubagentSource` will materialize a child `AgentRequest` for any replicated parent `AgentToolCall` whose authoring DID (recovered from DefraDB's per-doc identity binding) is in B's paired-peer DID set (read from B's local `PeerPairingDesired` view).
+- B does **not** re-validate the spawn against the parent's `ToolSelectionDocument` — that document lives on A and is not replicated. A's spawn-time check is the only authorization gate.
+- B's `cancel_cascade_intent_at` mirroring observer trusts any replicated bridge row from a paired peer.
+
+**Multi-tenant deployment is out of scope.** Gate: #180 (P2P admin auth + NAC). Without #180, R5's trust contract is structurally unsafe outside a closed fleet. When #180 closes, NAC gates at the wire layer using DefraDB's existing identity binding; the proofs' structural NAC-bound-auth assumption then holds.
+
+This trust posture is the explicit annotation that #107's spec §11 already names: *"R5 functionally ships under a trusted-fleet trust model without #180 closed; R5 is not appropriate for multi-tenant deployment until #180 closes."*
+
+## 3. Verified obligations and reuse map
+
+Every #176/#188 derived requirement either lands in this spec or in an existing module R5 invokes. Zero new Lean modules; one new recovery predicate. R5's strategic shape is a row in this table per obligation, each landing in an existing artifact.
+
+| Obligation | Source | Reuse target | Notes |
+|---|---|---|---|
+| Persist-before-projection on A (read from durable local rows) | #176-R1 | `crates/defra-agent/src/background_completion.rs` (post-R6 rename of `subagent_completion.rs`) | Unchanged: existing code already re-loads from A's local DefraDB inside the `EventName::Update` callback. Replicated docs are local rows by the time the projector reads them. |
+| Persist-before-observe on B | #176-R2 | defradb.rs replication contract | Wire-contract obligation owed by the replication layer; R5 documents and does not implement. |
+| Final response durable before child terminal observable | #176-R3 | defradb.rs replication ordering | Same as above. R5 documents the dependency. |
+| Atomic coalesced wake-up insert | #176-R4 | `crates/defra-agent/src/lifecycle/queue.rs` (R4a queue) | Existing; same code path, no cross-deployment dispatch. |
+| Projection-side idempotency | #176-R5 | `crates/defra-agent/src/background_completion.rs` | Existing: bridge terminal-state check before invoking `bridge_complete` / `bridge_failure` is already present. |
+| Notification-before-wake-up | #176-R6 | `crates/defra-agent/src/background_completion.rs` | Existing ordering preserved by reuse. |
+| Cancellation drain source filter | #176-R7 | `crates/defra-agent/src/lifecycle/queue.rs` | Existing; queue source `background_completion` filter unchanged. |
+| Late child terminal after cancellation = no-op | #176-R8 | `Proofs/Background/Transition.lean` (post-R6) bridge transitions | Existing: `bridge_complete` / `bridge_failure` are gated on `bridgeState = Running`. Cross-deployment realization is identical. |
+| Persist cascade intent before remote delivery (on A) | #188-R1 | New field `cancel_cascade_intent_at` on `AgentToolCall` (§6.4) | Single-writer doc; A persists in its own row. Replication delivers the field to B. |
+| Retry cancel from durable intent | #188-R2 | DefraDB replication (at-least-once) + B-side idempotent mirroring | Realized by replication's redelivery + B's idempotent observer. A does not run a retry worker on its own side. |
+| B-side persist-before-ack | #188-R3 | B's existing interrupt path | B writes `interruptRequestedAt` on its locally-owned child request durably; B's interrupt handler terminalizes the child as `Interrupted`. R5 chooses the **ackless implementation shape** anticipated by #188's "Open questions" — there is no separate ack channel; A learns of B's handling via the replicated child terminal. The safety boundary is `cancelHandledB` (durable B-side handling); ack-liveness is structurally unnecessary. |
+| B-side handler idempotency | #188-R4 | B's mirroring observer | Idempotent on `(child_request_id, cancel_cascade_intent_at)`: re-applying the same intent to a child with `interruptRequestedAt` already set is a no-op. |
+| Natural-terminal stable after cancel | #188-R5 | `Proofs/Background/Transition.lean` (R4 invariant B1, post-R6 parametric) | Existing: the child request transition is monotonic; once natural-terminal, it cannot rewrite to `Interrupted`. The mirrored `interruptRequestedAt` is absorbed. |
+| Timeouts are liveness-only | #188-R6 | `unclaimed_deadline_at` on bridge row (§6.4) | The only R5 deadline that drives a safety decision is `unclaimed_deadline_at`, which terminalizes the **bridge row on A**, not the child request on B. Cancel-delivery to B has no deadline. |
+| Ack visibility diagnostic, not safety | #188-R7 | `cancel_pending_remote_ack` + `stuck_since` on bridge row | A's reconciler clears `cancel_pending_remote_ack` when the child's terminal propagates back. Observability only — not a safety boundary. |
+
+**One new Lean addition** — covered in §8: a new `ToolRecoveryCause` constructor (`unclaimedCrossDeploymentSpawn`) in `Proofs/Recovery/Sweeps.lean`, plus one new entry in `recoverySweepCases` in `Proofs/Recovery/ContractCases.lean`. No new modules; no new structures; the existing `toolCallRecoverySweep` already enumerates non-detached running bridge rows, so the cross-deployment unclaimed case is a strict subset of its existing predicate. Only the cause variant and the terminalState clause for it are new.
+
+**Two existing budgets inherited unchanged:**
+- **R6's B7** (`MAX_BACKGROUNDED_TOOLS_PER_PARENT = 8`): every cross-deployment subagent bridge row on A is `await_mode = background` and non-terminal during the wait, so it counts against the same per-parent-request budget that R6 introduced. R5 does not relax or extend B7; the parametric `bridge_spawn` precondition that R6 adds is the same gate R5 spawns must pass.
+- **R4's `MAX_SUBAGENT_DEPTH`**: the Subagent-kind recursion bound applies identically across deployments. The child's `subagent_depth = parent_depth + 1` is propagated through the cross-deployment spawn (B's `SubagentSource` reads parent depth from the replicated parent `AgentRequest`).
+
+## 4. Architecture
+
+### 4.1 Roles
+
+- **A** — the deployment hosting the parent behavior. Writes the parent `AgentToolCall` bridge row. Observes the child request terminal via replication; projects via existing `bridge_complete` / `bridge_failure`. Writes its own bridge fields for cascade-cancel intent. Owns the bridge row's lifecycle.
+- **B** — the deployment hosting the child behavior. Materializes the child `AgentRequest` from the replicated parent `AgentToolCall`. Executes the child agent loop. Mirrors A's cascade-cancel intent onto its locally-owned child's `interruptRequestedAt`. Owns the child request's lifecycle.
+- **Operator** — configures pairing via #107's `PeerPairingDesired` (per-peer collections list), and configures `subagent_targets` on A's `ToolSelectionDocument` to authorize the cross-deployment spawn at A's call site.
+
+The agent on A never observes that B is a separate node. The agent on B never observes that its caller is on a separate node. Cross-deployment is a property of routing, not of the agent surface.
+
+### 4.2 Replicated document set
+
+`PeerPairingDesired` (operator-configured) must include the following collections between paired peers for R5:
+
+- `AgentToolCall` — A → B (parent bridge row, with `child_request_id` and cancel-intent fields)
+- `AgentRequest` — both directions (A's parent request; B's child request; replication carries terminal state and `interruptRequestedAt` back to A)
+- `AgentResponse` — B → A (final response for the child request)
+- `AgentMessage` — B → A (child transcript content for the parent's `<subagent-notification>` payload)
+
+Read direction matters for ACP: each doc is written only by its owner. A writes only A-owned docs; B writes only B-owned docs. There are no cross-peer field writes in v1, deliberately — that lets R5 ship before ACP cross-peer grants land.
+
+### 4.3 Action mapping (TLA+ → real wire)
+
+The action vocabularies of `SubagentCompletion.tla` and `SubagentCancelPropagation.tla` map to the real wire as follows. The conformance harness uses this mapping verbatim.
+
+| TLA+ action | Real-wire realization |
+|---|---|
+| `OperatorWrite` | Operator writes `PeerPairingDesired` doc (covered by #107) and `ToolSelectionDocument` doc (existing). |
+| `Reconcile` | #107's supervisor reconcile tick reads desired/actual and emits collection-install RPCs. |
+| `Send`, `Deliver` | DefraDB replication propagates docs from writer's node to paired-peer node. Conformance harness simulates as a `ReplicateDoc(from, to, collection, doc_id)` action. |
+| `Drop` | Replication-layer message drop; harness simulates as a no-op for a named doc. |
+| `PersistChildTerminal` | B's runtime durably writes the child `AgentRequest` terminal state + `AgentResponse` final response. |
+| `EmitTerminalObservation` | Replication carries B's writes to A. |
+| `DeliverObservation` / `PersistObservationOnA` | DefraDB replication ingest on A persists the row into A's local replica. A's `EventName::Update` subscription fires on the persisted update. |
+| `ProjectTerminal` | A's `background_completion.rs` observer reads the local replica and invokes `bridge_complete` or `bridge_failure`. |
+| `AppendNotification` | A's observer writes the `<subagent-notification>` transcript message (existing R4 path). |
+| `EnqueueWakeup` | A's observer enqueues the coalesced wake-up via the existing R4a queue. |
+| `EnqueueUserRequest` | A's request claim path (existing). |
+| `CancelParent` | A's `bridge_cancel_cascade` writes `cancel_cascade_intent_at` on the bridge row and immediately terminalizes the bridge as `Cancelled`. |
+| `CancelDrain` | Existing R4a drain in the same-session queue. |
+| `ProcessCancel` | B's mirroring observer writes `interruptRequestedAt` on the B-owned child `AgentRequest`. B's existing interrupt path terminalizes the child as `Interrupted` (or absorbs against natural terminal). |
+| `Crash(A)` / `Crash(B)` | Process kill; persisted DefraDB state survives. |
+| `Timeout` | A's `unclaimed_deadline_at` reconciler tick (the only R5 timeout; see §3 #188-R6). |
+
+## 5. Spawn path (A writes; B claims)
+
+1. **Authorize at A.** Agent on A invokes `spawn_subagent(behavior_id, prompt, await_mode = background)`. The existing R4/R6 spawn hook gates on A's `ToolSelectionDocument.subagent_targets` (operator-configured allowlist). No discovery probe — operator's allowlist is the entire pre-flight contract.
+2. **Enforce budgets.** Before any row is written:
+   - **R4 depth check** — parent's `subagent_depth + 1 ≤ MAX_SUBAGENT_DEPTH` (unchanged from single-deployment; the child's depth is still parent_depth + 1 across the wire).
+   - **R6 B7 budget** — A's parent request's currently non-terminal `await_mode = background` tool-call count plus one ≤ `MAX_BACKGROUNDED_TOOLS_PER_PARENT` (8). Cross-deployment subagent bridges count against the same budget as R6's tool-kind backgrounded rows. Rejection: structured `argument_invalid` error matching R6's existing budget-exceeded payload.
+3. **Write parent bridge row.** A pre-allocates `child_request_id` and writes the parent `AgentToolCall`:
+   - `await_mode = background`
+   - `cancel_policy = cascade`
+   - `child_request_id = <pre-allocated>`
+   - `unclaimed_deadline_at = now + unclaimed_spawn_timeout_seconds`. Default **60 s**; this is the wall-clock budget A gives every paired peer to claim the spawn and replicate a child `AgentRequest` row back. The default is intentionally tunable per the v1 dogfood trajectory; see §5.1.
+   - `cancel_cascade_intent_at = null`, `cancel_pending_remote_ack = false`, `stuck_since = null`
+4. **Replicate.** DefraDB replicates the `AgentToolCall` to every paired peer in `PeerPairingDesired`.
+5. **B claims (or every peer ignores).** Each paired peer's `SubagentSource` (the existing global `EventName::Update` subscription) fires on the replicated `AgentToolCall`. The existing per-peer filter applies:
+   - `snapshot.behavior(&spawn_args.behavior_id).is_some()` — if the peer hosts the target behavior, it claims. If no peer hosts, no peer claims.
+   - **New dispatch on parent's authoring DID.** If the parent `AgentRequest`'s DID equals B's local principal DID, B follows the existing single-deployment path (re-load `ToolSelectionDocument`). If the parent's DID is a paired-peer DID (read from B's `PeerPairingDesired` peer set), B skips the auth re-check (trusted-fleet contract; see §2).
+6. **B materializes the child.** B's `SubagentSource` calls the existing `create_subagent_request_with_request_id` with the pre-allocated `child_request_id`. The child is created in B's local DefraDB store with `caused_by_parent_request_id`, `caused_by_parent_tool_call_id`, and `subagent_depth = parent_depth + 1`. B's `TriggerEngine` claims the request and runs the agent loop.
+7. **A clears the unclaimed deadline.** A's reconciler observes the replicated child `AgentRequest` row (matching the bridge's `child_request_id`) and clears `unclaimed_deadline_at` on its bridge row. From this point the bridge is "linked" and progress is governed by the child's terminal state, not the spawn deadline.
+
+**Unclaimed-spawn failure.** If no paired peer claims within `unclaimed_deadline_at`:
+- A's reconciler tick observes the bridge has no replicated child row matching `child_request_id` and current time > `unclaimed_deadline_at`.
+- A fires `bridge_failure` with `FailureClass::ServiceUnavailable` and reason `no_peer_claimed_spawn`. Structured error payload to the agent:
+  ```json
+  {
+    "ok": false,
+    "failure_class": "service_unavailable",
+    "path": "/behavior_id",
+    "message": "no paired peer claimed the cross-deployment spawn within unclaimed_spawn_timeout_seconds",
+    "retryable": false,
+    "service_id": "subagent",
+    "tool_name": "spawn_subagent",
+    "requested_behavior_id": "<id>",
+    "unclaimed_deadline_at": "<ts>"
+  }
+  ```
+- Same predicate is the body of the new `unclaimedCrossDeploymentSpawn` `ToolRecoveryCause` (§8); steady-state reconciler and startup recovery share the implementation.
+
+### 5.1 Tuning the unclaimed-spawn timeout
+
+The 60 s default is chosen for the v1 dogfood trajectory and is **explicitly tunable**. The cost of a false negative (a permanent `bridge_failure` on a healthy-but-slow paired peer under replication lag) is high — the agent gets a `service_unavailable` error even though the child would have materialized seconds later. The cost of a false positive (a long wait on a peer that will never claim) is low — the operator can always cancel the parent.
+
+Two configuration layers, in resolution order:
+
+- **Per-parent-behavior override.** `ToolSelectionDocument` on the parent behavior gains an optional field `cross_deployment_spawn_timeout_seconds: Option<u32>`. This sits next to `subagent_targets` — the operator who knows which behaviors live remotely is the same operator who knows the expected response time. Per-behavior tuning is recommended for any behavior whose target deployment is known to be slow under load.
+- **Global default.** `60 s`. Applied when no per-behavior override is set. Revisited from real dogfood telemetry once the cross-deployment flow is exercised under load.
+
+The implementation plan picks the exact resolution helper (likely a thin extension to the existing `ToolSelectionDocument` loader); the spec only commits to the configurability path.
+
+## 6. Completion path (B terminalizes; A projects)
+
+### 6.1 Wire shape
+
+1. B's child request reaches a terminal state — `Completed`, `Failed`, `Dead`, `Interrupted`, or `Superseded` — through the existing single-deployment agent loop. B writes `AgentRequest.state`, `AgentResponse` (final response for `Completed`), and any final `AgentMessage`s durably (#176-R2/R3 obligation; wire-contract on the replication layer).
+2. Replication carries the durable rows to A.
+3. A's `EventName::Update` subscription in `background_completion.rs` fires on the ingested update.
+4. The existing observer code reads the child row + final response from A's **local replica** — satisfying #176-R1 persist-before-projection without any code change. The observer never reads from the volatile subscription event payload; it always re-loads from DefraDB.
+
+### 6.2 Bridge projection
+
+The observer's existing flow (`project_background_subagent_completion`) runs verbatim:
+
+- `Completed` child → `bridge_complete(final_response)` on the parent bridge tool row.
+- Non-completed terminal (`Failed`, `Dead`, `Interrupted`, `Superseded`) → `bridge_failure(terminal)`.
+
+Both are R6-parametric `Proofs/Background/Transition.lean` constructors on Subagent-kind rows; the Lean transition fires identically whether the child is local or replicated. The observer then appends the `<subagent-notification>` transcript message (R4 existing path) and enqueues the coalesced wake-up under `background_completion:<parent_session_id>` (R4a queue, existing).
+
+### 6.3 Cancellation-then-completion race
+
+If A's parent has already terminalized the bridge as `Cancelled` (§7) before a late child terminal propagates, the observer's existing bridge-terminal check is a no-op (#176-R8 / `ParentCancelAbsorbsLateTerminal`). Concretely: `background_completion.rs` already gates projection on `edge.lifecycle_state == "running"` and short-circuits with `AlreadyProjected` otherwise. Cross-deployment doesn't change that.
+
+### 6.4 New fields on `AgentToolCall`
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `unclaimed_deadline_at` | `Timestamp?` | `now + unclaimed_spawn_timeout_seconds` at spawn (default 60 s; per-behavior tunable per §5.1) | When the parent bridge row should give up waiting for a paired peer to materialize the child. Set on spawn; cleared once the replicated child row appears. |
+| `cancel_cascade_intent_at` | `Timestamp?` | `null` | Timestamp at which A's `bridge_cancel_cascade` fired (the durable cascade intent). Single-writer field; A only. |
+| `cancel_pending_remote_ack` | `Bool` | `false` | True while A has set `cancel_cascade_intent_at` and not yet observed the child's `interruptRequestedAt` or terminal state in its local replica. Observability only. |
+| `stuck_since` | `Timestamp?` | `null` | Timestamp at which `cancel_pending_remote_ack = true` was first observed past `STUCK_CANCEL_THRESHOLD` (default 5 min). Mirrors #107's stuck-retry pattern. Diagnostic only. |
+
+The migration is additive — existing single-deployment rows treat all four fields as defaulted, and the existing transitions are unchanged.
+
+## 7. Cancel path (A intends; B mirrors)
+
+### 7.1 A-side cascade-cancel cascade
+
+When A's parent terminalizes under `cancel_policy = cascade` (parent deadline, explicit user cancel, agent-invoked `cancel_subagent`, R6 `wait_subagent`/`wait_tool` deadline-out), R6's parametric `bridge_cancel_cascade` fires on the bridge row. R5's cross-deployment realization for Subagent kind:
+
+1. A writes `cancel_cascade_intent_at = now` on its own `AgentToolCall` bridge row in the same atomic batch as the bridge state transition to `Cancelled`. The bridge state goes **directly to `Cancelled` terminal** (matches #176's `CancelParent` action — bridge is no longer `Running`; subsequent late child terminals are no-ops on A).
+2. A sets `cancel_pending_remote_ack = true` in the same write.
+3. The agent caller (whoever invoked `cancel_subagent` or whose `wait_subagent` was preempted) sees the cancel result immediately. The cascade signal converges to B in background under DefraDB's replication; A does not block on B's acknowledgement.
+
+The proof claim from #188-R1 — "persist cascade intent before remote delivery" — is satisfied by atomic in-row persistence on A.
+
+### 7.2 B-side cancel mirror
+
+A new B-side observer (or an extension of `SubagentSource`) subscribes to `EventName::Update` for `AgentToolCall`. When it sees a replicated row with `cancel_cascade_intent_at != null` and a locally-owned child `AgentRequest` matching `child_request_id`:
+
+1. **Trust check.** The parent `AgentToolCall`'s authoring DID must be in B's paired-peer DID set (same check as the spawn path, §5 step 5).
+2. **Idempotency check.** If the child request is already terminal, or its `interruptRequestedAt` is already set, no-op (#188-R4).
+3. **Mirror.** B writes `interruptRequestedAt = cancel_cascade_intent_at` on the (B-owned) child `AgentRequest` row. Single-row durable write.
+4. **Trigger interrupt.** B's existing interrupt path (the same one that handles single-deployment interrupts) terminalizes the child as `Interrupted` — or, if the child has already reached a natural terminal, absorbs the intent without rewriting state (`monotonic progress` property already proven for `AgentRequest`).
+
+There is no separate ack channel. The observation that B has handled the cancel propagates back to A via the existing completion-projection path (§6): the child request's terminal state (`Interrupted` or the absorbed natural terminal) replicates to A; A's `background_completion.rs` observer fires `bridge_complete` / `bridge_failure` on the already-`Cancelled` bridge row, which is a no-op per #176-R8.
+
+### 7.3 A-side observability reconciler
+
+A separate reconciler tick on A (call it `cancel_ack_observer`, can run as part of the same `background_completion` worker):
+
+- For each bridge row with `cancel_pending_remote_ack = true`, check whether A's local replica of the child `AgentRequest` shows `state ∈ Terminal ∨ interruptRequestedAt != null`. If yes, clear `cancel_pending_remote_ack` on the bridge row.
+- For each bridge row with `cancel_pending_remote_ack = true` and `cancel_cascade_intent_at` older than `STUCK_CANCEL_THRESHOLD` (default 5 min), set `stuck_since = now` if not already set. Pure observability; emits a tracing warning and surfaces on `ClientPeerStatus`-style runtime dashboards.
+
+`cancel_pending_remote_ack` and `stuck_since` are **never used as safety boundaries**. They cannot terminalize the child; they cannot rewrite the bridge state. They are diagnostic flags only. This preserves #188-R6 (timeouts are liveness-only) and #188-R7 (ack visibility is diagnostic, not safety).
+
+### 7.4 Retry semantics under partition / restart
+
+Because A writes `cancel_cascade_intent_at` once into a single durable row, and DefraDB replication is at-least-once, the retry semantic of #188-R2 (re-emit cancel from durable intent) is realized as:
+
+- **Partition during replication.** Replication retries on its own; once partition heals, the bridge row's `cancel_cascade_intent_at` propagates to B.
+- **A crash mid-cancel.** A's bridge row is already persisted with `cancel_cascade_intent_at` set; restart re-runs the existing replication outbox. No A-side retry worker is needed.
+- **B crash mid-mirror.** B's mirroring observer is at-least-once; on restart, B's `EventName::Update` subscription (or an explicit sweep, see §8) re-fires for any replicated `AgentToolCall` with `cancel_cascade_intent_at != null` and no `interruptRequestedAt` yet on the local child.
+
+The proof obligation of "fair retry until handling" is realized by replication's at-least-once delivery + B's idempotent observer — no application-layer retry loop on A. This is a cleaner realization than #188's TLA+ shape (which models explicit RPC retries) but every modeled property holds.
+
+## 8. Recovery
+
+### 8.1 New Lean recovery cause
+
+The existing `toolCallRecoverySweep` in `Proofs/Recovery/Sweeps.lean` keys on `row.call.state = .running ∧ ¬ isDetachedBridgeCall row.call` — a predicate that already covers cross-deployment cascade-policy bridges (non-detached, running). R5 does **not** introduce a new sweep; it widens the existing one by adding a new constructor to `ToolRecoveryCause`:
+
+```lean
+inductive ToolRecoveryCause where
+  | deadlineExceeded
+  | parentInterrupted
+  | parentTerminal
+  | childCompleted
+  | childFailed
+  | childDead
+  | childInterrupted
+  | childSuperseded
+  | unclaimedCrossDeploymentSpawn   -- NEW (R5)
+```
+
+**`terminalState` clause.**
+
+```lean
+def terminalState : ToolRecoveryCause → ToolCallState
+  | …
+  | .unclaimedCrossDeploymentSpawn => .failed
+```
+
+**Stale-row predicate (Rust-side, dispatched into the existing sweep).**
+
+```
+row.call.state = .running
+∧ row.call.awaitMode = .background
+∧ row.call.cancelPolicy = .cascade
+∧ row.call.childRequestId.isSome
+∧ ¬∃ local row in AgentRequest. request_id = row.call.childRequestId
+∧ now > row.call.unclaimedDeadlineAt
+```
+
+This is a strict subset of `toolCallRecoveryStale`; the existing `h_recover_terminal` and `h_recover_zero` theorem proofs extend automatically by the `cases cause` enumeration. The terminalState mapping (`.failed`) means `bridge_failure` (post-R6 parametric) is the effective transition; `FailureClass::ServiceUnavailable` with reason `no_peer_claimed_spawn` is the Rust-side failure payload.
+
+`Proofs/Recovery/ContractCases.lean` gains one new entry in `recoverySweepCases` named `tool_running_unclaimed_cross_deployment_spawn_to_failed`, with `deadlineAuditRef = "r5-cross-deployment-subagents-design"` (or a stable audit reference picked at implementation time). `recoverySweepCases_registered_sweeps` and `recoverySweepCases_decrease_to_zero` both close by `native_decide` against the widened enum.
+
+**No new module, no new structure, no new sweep, no new transition.** The widening is one new enum constructor + one match-arm + one new test-vector entry. The existing `toolCallRecoverySweep` registration covers both the new cause and all existing causes.
+
+### 8.2 Cross-deployment failure modes that reuse existing sweeps
+
+| Failure | Reuse |
+|---|---|
+| A crashes mid-wait | A's existing `AgentToolCall` recovery sweep already terminalizes orphaned bridge rows whose parent request is terminal. For cross-deployment, the same sweep applies; the bridge row's state is fully recoverable from durable DefraDB. |
+| A's `background_completion` observer crashes after observing terminal but before firing `bridge_complete` | A's existing startup recovery sweep over `AgentToolCall` enumerates bridge rows with `lifecycle_state = .running ∧ await_mode = .background` and, for each one whose local replica of the child `AgentRequest` is already terminal, invokes the projection (#176-R5 idempotency makes this safe even if the subscription also fires). The recovery path lives alongside the existing #189 enumeration — no new sweep predicate is needed because the predicate is a strict subset of what the existing `AgentToolCall` sweep already evaluates. |
+| B crashes mid-execution | B's existing `AgentRequest` recovery sweep (#189's `TerminalizeStuckRunning` family) reaches the child request and terminalizes per its own deadline. A observes the terminalization via the existing completion projection. |
+| B crashes mid-mirror (cancel cascade intent observed but not yet written to child) | B's `EventName::Update` subscription on restart sees the still-replicated `AgentToolCall` with `cancel_cascade_intent_at != null` and re-runs the mirror observer. Idempotent against an already-set `interruptRequestedAt`. |
+| B crashes between spawn observation and child materialization | B's `SubagentSource` re-reads on restart (existing path; the existing `child_request_exists` check is the idempotency gate). |
+| Replication paused / partitioned indefinitely | Falls back to `unclaimed_deadline_at` on A (new) for the spawn case, or to existing parent-request `deadline_at` for the in-flight case. |
+
+No further additions to `Proofs/Recovery/Sweeps.lean` are required beyond the new `ToolRecoveryCause` constructor described in §8.1 — the existing `toolCallRecoverySweep` registration already enumerates non-detached running bridge rows, which is exactly the scope R5 needs.
+
+### 8.3 Cancel-retry is not a recovery sweep
+
+A's cancel-retry is **steady-state reconciler behavior**, not a recovery action: each tick of the `cancel_ack_observer` (§7.3) reads `cancel_pending_remote_ack` and checks for B's terminal. Restart of A simply re-runs the same reconciler against the persisted bridge state. No recovery predicate is needed — the persisted `cancel_cascade_intent_at` is the durable intent, replication is the delivery, and the observer is the idempotent applier. This matches #188-R2 ("retry cancel from durable intent") via replication infrastructure, not via an application retry loop.
+
+## 9. Authorization and ACP
+
+### 9.1 v1 (trusted-fleet)
+
+- **A's spawn authorization** is unchanged from R4/R6: gated by `ToolSelectionDocument.subagent_targets` on A.
+- **B's spawn-claim trust check** is new: B's `SubagentSource` reads the replicated parent `AgentToolCall`'s authoring DID. If that DID is in B's paired-peer set (read from `PeerPairingDesired`), B trusts the spawn intent without re-validating against any A-side document. Single-deployment claims (where parent DID = local DID) continue to follow the existing `load_parent_subagent_authorization` path.
+- **B's cancel-mirror trust check** is identical: the replicated `AgentToolCall` with `cancel_cascade_intent_at != null` is honored if its authoring DID is in B's paired-peer set.
+- **No new schema annotations** for actor identity. DefraDB's per-doc identity binding (writer DID recoverable from doc metadata) is the lineage. The future #180 NAC gate plugs into the wire layer using this binding; no schema migration needed.
+
+### 9.2 Cross-peer document writes are deliberately avoided
+
+In R5 v1, **no peer writes to a doc it does not own.** A writes only A-owned docs (parent `AgentRequest`, parent `AgentToolCall`, A-side `AgentMessage`). B writes only B-owned docs (child `AgentRequest`, child `AgentResponse`, child-side `AgentMessage`). The cancel-cascade signal travels by A writing its own bridge row's `cancel_cascade_intent_at` field; B observes via replication and writes its own child row's `interruptRequestedAt`.
+
+This sidesteps the DefraDB ACP question entirely for v1. Cross-peer field-level grants (e.g., letting A mutate a specific field on a B-owned row) is a separate workstream and not required to ship R5.
+
+### 9.3 Multi-tenant (gated on #180)
+
+When #180 closes:
+- DefraDB's wire-layer NAC checks every replicated write against an actor identity bound to an operator-published policy.
+- B's spawn-claim trust check becomes a NAC-enforced operation rather than a local DID-set lookup.
+- Cross-peer field grants become available; a follow-up may simplify the cancel-mirror by letting A write directly to the child's `interruptRequestedAt` (matching the in-process Lean transition literally), with NAC gating who can write that field.
+
+R5 v1 does not depend on #180 closing, but its trust posture is unambiguous: **trusted-fleet only until #180 closes**.
+
+## 10. Conformance harness
+
+R5 extends `crates/defra-agent/tests/support/pairing_conformance/` — the existing two-node scaffold from #107. The harness orchestrates two embedded DefraDB nodes, drives a JSON scenario IR through them, and checks invariants against the TLA+ action vocabulary. Replication between nodes is **simulated** by an explicit `ReplicateDoc` action, not by real libp2p — matching the conformance pattern #107 established. (End-to-end libp2p replication is exercised by separate desktop-core integration tests, not by the conformance harness.)
+
+### 10.1 New scenario IR additions
+
+Existing actions: `OperatorWrite`, `Reconcile`, `Drop`, `Crash`, `WaitForConvergence`.
+
+R5 adds:
+
+| Action | Effect on the two-node fixture |
+|---|---|
+| `WriteParentToolCall { node, parent_request_id, parent_tool_call_id, child_request_id, behavior_id, await_mode, unclaimed_deadline_at }` | Write the parent `AgentToolCall` on the named node. |
+| `WriteAgentRequest { node, request_id, did, behavior_id, state, caused_by_parent_request_id?, caused_by_parent_tool_call_id? }` | Write or update an `AgentRequest` on the named node. |
+| `ReplicateDoc { from, to, collection, doc_id }` | Copy a doc from one node's DefraDB store to the other's. Simulates `Send` + `Deliver` + `Process` + `PersistObservation` from the TLA+ models. |
+| `TerminalizeChildOnB { request_id, terminal, final_response? }` | Write the child's terminal state and optional final response on B. |
+| `CancelParentOnA { parent_request_id, parent_tool_call_id }` | Trigger `bridge_cancel_cascade` on A's bridge row (writes `cancel_cascade_intent_at` and terminalizes the bridge as `Cancelled`). |
+| `RunBackgroundCompletionObserverOnA` | Tick A's `background_completion` observer once. |
+| `RunCancelMirrorObserverOnB` | Tick B's cancel-mirror observer once. |
+| `RunUnclaimedSpawnReconcilerOnA` | Tick A's unclaimed-spawn reconciler once. |
+| `RunRecoverySweepOn { node }` | Tick the named node's recovery sweep once (covers cross-restart re-attachment). |
+| `AdvanceClockOn { node, seconds }` | Move a node's monotonic clock forward — drives deadline-bearing reconcilers without sleeping the test. |
+
+The scenario IR is line-for-line derivable from the §4.3 action mapping, satisfying #155's "harness IR derives from the action map" requirement.
+
+### 10.2 Invariants checked
+
+After each action and at scenario end, the harness evaluates the safety invariants from `SubagentCompletion.tla` (`BridgeTerminalUnique`, `ProjectionRequiresBDurableTerminal`, `ProjectionMatchesLeanBridgeMapping`, `NotificationIdempotent`, `WakeupCoalesced`, `WakeupCausal`, `CancelDrainPreservesUserPending`, `ParentCancelAbsorbsLateTerminal`) and `SubagentCancelPropagation.tla` (`CancelIntentDurable`, `CancelHandledIdempotent`, `InterruptExactlyOnce`, `CascadeInterruptsOnlyRunning`, `NaturalTerminalStableAfterCancel`, `InterruptedOnlyByCascade`). Liveness targets (`DurableTerminalSettles`, `LiveBridgeTerminalProjects`, `CancelDeliveryProgress`, `LiveCancelInterruptsOrNaturalWins`) are evaluated after a `WaitForConvergence` action.
+
+### 10.3 v1 scenarios
+
+Five scenarios land in v1, each as a JSON file under `crates/defra-agent/tests/fixtures/r5_scenarios/`:
+
+1. **`happy_path.json`** — A writes parent tool call → replicate to B → B materializes child → B terminalizes child as `Completed` with final response → replicate to A → A's observer projects `bridge_complete` → notification appended, wake-up enqueued.
+2. **`b_crash_mid_execution.json`** — As (1), but `Crash(B)` mid-execution. After restart, B's recovery sweep terminalizes the child as `Failed` (or `Dead` if past child deadline). Replication delivers to A; A projects `bridge_failure`.
+3. **`a_crash_mid_wait.json`** — As (1), but `Crash(A)` is interleaved at two points and exercised independently: (a) after the spawn-write replicates and before B's terminal arrives — A restart re-attaches the `EventName::Update` subscription; B's later terminal then propagates and projects normally; and (b) after B's terminal has already replicated to A but before A's observer fires the projection — A restart runs the recovery sweep (see §8.2), which finds the bridge row with a terminal child locally available and runs the projection path. Both interleavings end in the same observed post-state.
+4. **`partition_during_cancel.json`** — A writes parent tool call; B materializes child. `CancelParentOnA` writes `cancel_cascade_intent_at` and terminalizes bridge as `Cancelled`. `Drop` the `AgentToolCall` replication. Tick A's `cancel_ack_observer` — `stuck_since` flips after threshold. Restore replication via `ReplicateDoc`. B's cancel-mirror observer runs, writes `interruptRequestedAt`, B's child terminalizes as `Interrupted`. Replicate back; A's observer fires `bridge_failure` (absorbed as no-op since bridge already `Cancelled`); `cancel_pending_remote_ack` clears.
+5. **`multi_completion_coalesce.json`** — Two children spawned in same session. Both terminalize on B simultaneously. Replicate both terminals to A. Two `RunBackgroundCompletionObserverOnA` ticks. Verify: exactly one pending `background_completion:<session_id>` queue row exists (coalesced); both `<subagent-notification>` transcript messages appended; bridge state preserved.
+
+### 10.4 Lean conformance vector
+
+A new conformance vector family `r5_cross_deployment_subagent_*` lands in `crates/defra-agent/proofs/conformance_vectors/` (existing pattern). Each scenario's expected post-state is encoded as a Lean term and exported to JSON; the Rust harness loads the JSON and asserts the observed two-node state matches. No new tooling; reuse existing.
+
+## 11. Out of scope
+
+- **Multi-tenant deployment.** Gated on #180.
+- **Foreground cross-deployment subagents.** `await_mode = foreground` cross-deployment is deferred; introduces parent-progress liveness obligations not modeled in #176 or #188.
+- **Detach cancel policy.** Cascade only in v1.
+- **Cross-deployment subagent discovery surface.** No `HostedBehavior` or `AgentBehavior` replication. Operator's `subagent_targets` + `unclaimed_deadline_at` is the entire pre-flight contract.
+- **R6 cross-deployment backgrounded tools** (`background_tool` for `bash`/MCP across nodes). R6 v1 is single-deployment; cross-deployment R6 is a future composition of R5 + R6.
+- **Cross-peer ACP grants** (e.g., A writing directly to a B-owned doc's specific field). Sidestepped in v1 by the doc-mirror design.
+- **A-side cancel-retry worker.** Replication is the retry; no application-layer retry loop on A.
+- **Forced-local-cancel (orphan acceptance).** A's bridge does not unilaterally terminalize on stuck cascade-ack; only observability surfaces. Strict #188 conformance.
+- **Real-libp2p replication in the conformance harness.** Harness simulates replication as an action. End-to-end libp2p coverage is the responsibility of existing desktop-core integration tests.
+- **R4c surfaces** (`list_*` / `read_*_transcript` / `steer_*`). Sibling brainstorm; R5 does not touch.
+
+## 12. Approval checklist
+
+Before implementation planning, Jack should approve:
+
+- the trust posture: trusted-fleet only in v1, multi-tenant gated on #180
+- spawn-locus decision: B materializes the child from a replicated parent `AgentToolCall`; A only writes A-owned docs
+- discovery-locus decision: no discovery doc; operator's `subagent_targets` + `unclaimed_deadline_at` is the pre-flight contract
+- unclaimed-spawn deadline mechanic: new field `unclaimed_deadline_at`, default 30 s, fires `bridge_failure(service_unavailable, no_peer_claimed_spawn)`
+- cancel-wire decision: A writes `cancel_cascade_intent_at` on its own bridge row; B mirrors onto its own child's `interruptRequestedAt`; no cross-peer ACP grant required
+- cancel state semantics: bridge terminalizes `Cancelled` immediately on A; cascade signal converges in background; `cancel_pending_remote_ack` + `stuck_since` are observability flags only
+- authorization model: B trusts paired-peer authoring DID for both spawn-claim and cancel-mirror; no new actor-DID annotation; DefraDB's per-doc identity binding is the lineage; #180 plugs into the wire layer
+- replicated doc set: `AgentRequest`, `AgentResponse`, `AgentToolCall`, `AgentMessage` between paired peers
+- the Lean recovery widening: one new `ToolRecoveryCause` constructor (`unclaimedCrossDeploymentSpawn`) on the existing `toolCallRecoverySweep` + one new entry in `recoverySweepCases`; everything else reuses existing sweeps verbatim
+- R5 inherits R6's B7 budget (`MAX_BACKGROUNDED_TOOLS_PER_PARENT = 8`) and R4's depth bound unchanged
+- the cross-deployment unclaimed-spawn timeout default of 60 s with per-behavior tunability through `ToolSelectionDocument.cross_deployment_spawn_timeout_seconds`
+- harness scope: extend `pairing_conformance/`; five v1 scenarios; replication simulated as an action; invariants from both TLA+ artifacts
+- explicit deferral of multi-tenant, foreground, detach, R6-cross-deployment, ACP grants, forced-local-cancel, R4c, real-libp2p in conformance, and discovery surfaces


### PR DESCRIPTION
## Summary

R5 turns "agents on deployment A can spawn subagents whose behavior lives on deployment B" from substrate into product, under a **trusted-fleet** trust model.

The agent surface (\`spawn_subagent\`, \`wait_subagent\`, \`cancel_subagent\`) is unchanged from R4; the parent agent never observes that the spawn target is on a different node. Every cross-boundary behavior R5 needs is already verified by \`SubagentCompletion.tla\` (#176) or \`SubagentCancelPropagation.tla\` (#188), and every Lean transition R5 invokes is in the existing \`Proofs/Background/*\` module set (post-R6 rename).

R5's design discipline is **substrate-first reuse**: the strategic claim of the cross-boundary verification thread (#155 → #162 → #176 → #178 → #188 → #107) is that the substrate generalizes; R5 is the proof that the verification investment paid for product capability.

## Current state

This PR currently contains:
- Design spec at \`docs/superpowers/specs/2026-05-14-r5-cross-deployment-subagents-design.md\`
- Implementation plan at \`docs/superpowers/plans/2026-05-14-r5-cross-deployment-subagents.md\` (21 tasks across 9 phases)

## Notable scope choices

- **Trusted-fleet only in v1.** Multi-tenant deployment is gated on #180 (P2P admin auth + NAC). When #180 closes, NAC gates at the wire layer using DefraDB's existing identity binding; the proofs' structural NAC-bound-auth assumption then holds. R5 v1 ships under closed-source single-org trust posture.
- **Zero new Lean modules. Zero new TLA+ artifacts. Zero new bridge transitions.** One new \`ToolRecoveryCause\` constructor for the unclaimed-spawn recovery action. Everything else is composition of existing primitives.
- **No peer writes to a doc it does not own.** A writes only A-owned docs; B writes only B-owned docs. Cancel-cascade signal travels by A writing its own bridge row's \`cancel_cascade_intent_at\`; B observes via replication and writes its own child row's \`interruptRequestedAt\`. This sidesteps DefraDB ACP cross-peer grants entirely for v1.
- **Ackless cancel cascade.** A learns of B's handling via the replicated child terminal, not an explicit ack message. Cleaner realization than #188's TLA+ shape (which models explicit RPC retries); every modeled property still holds.
- **Only one R5 deadline drives a safety decision.** \`unclaimed_deadline_at\` terminalizes the bridge row on A. \`cancel_pending_remote_ack\` + \`stuck_since\` are observability flags only — they never terminalize the child or rewrite bridge state. Preserves #188-R6 (timeouts are liveness-only).

## Sequencing

Execution is sequenced after **R6 (#201)** merges to main. R6's Task 0 rename (\`Proofs/Subagent/\` → \`Proofs/Background/\`, \`subagent_completion.rs\` → \`background_completion.rs\`, \`subagent_tools.rs\` → \`background_tools.rs\`) must be on main before R5 implementation begins. When R6 merges:

1. This branch rebases onto post-R6 main
2. Plan execution begins from Task 1 (\`AgentToolCall\` schema additions)
3. Subsequent commits land on this same branch
4. PR squash-merges as one feature

## Conformance harness

R5 extends \`crates/defra-agent/tests/support/pairing_conformance/\` — the two-node scaffold from #107. Five v1 scenarios:

1. **happy_path** — A spawns, B executes, A observes terminal
2. **b_crash_mid_execution** — B restarts, child recovered, completes, A observes
3. **a_crash_mid_wait** — A restarts, two interleavings (before/after B terminal)
4. **partition_during_cancel** — \`stuck_since\` observability without safety load-bearing
5. **multi_completion_coalesce** — two children complete simultaneously, single coalesced wake-up

All 14 safety invariants from both TLA+ artifacts evaluated after each scenario action. Liveness target evaluated after \`WaitForConvergence\`.

## Test plan

- [x] Design spec self-review (scope check, internal consistency, reuse map completeness)
- [x] Plan self-review (placeholder scan, type consistency, R6 rename references correct)
- [ ] Implementation tasks 1–21 execute after R6 (#201) merges to main
- [ ] Final lake build clean, cargo fmt clean, conformance harness passes all 5 v1 scenarios

## Refs

Refs #213 (R5 tracker)
Refs #201 (R6 — execution prerequisite)
Refs #155 (cross-boundary verification strategy parent)
Refs #162 (reverse-pairing TLA+ substrate)
Refs #176 (cross-deployment completion projection TLA+ — consumed)
Refs #178 (handler idempotence Lean — consumed)
Refs #188 (cross-deployment cancel propagation TLA+ — consumed)
Refs #107 (pairing reconcile + conformance harness pattern — consumed)
Refs #180 (P2P admin auth — gates multi-tenant; not blocking trusted-fleet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)