### PR TITLE
Promote transcript_conformance_cases from shape-pin to runtime drive

### DIFF
--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -403,7 +403,7 @@ impl DefraSessionHook {
         Ok(count)
     }
 
-    pub(crate) async fn cancel_in_flight_tool_calls(&self) -> anyhow::Result<usize> {
+    pub async fn cancel_in_flight_tool_calls(&self) -> anyhow::Result<usize> {
         let lifecycles = {
             let mut map = self.in_flight_lifecycles.lock().await;
             map.drain()

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -4,8 +4,20 @@ use std::time::Duration;
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::lifecycle::{ClaimOutcome, ExecutionOrigin, TriggerLineage};
-use defra_agent::{write_manual_agent_request, DefraStreamWriter, RequestLifecycle};
+use defra_agent::{
+    write_manual_agent_request, DefraSessionHook, DefraStreamWriter, FailurePolicy,
+    RequestLifecycle,
+};
+use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
+use rig::completion::message::{
+    AssistantContent, Message, Text, ToolCall, ToolFunction, ToolResult, ToolResultContent,
+    UserContent,
+};
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::one_or_many::OneOrMany;
+use rig::streaming::StreamingCompletionResponse;
 use serde::Deserialize;
+use serde_json::json;
 
 #[path = "../src/admission/slot_accounting.rs"]
 mod admission_slot_accounting;
@@ -31,11 +43,12 @@ use lean_vocab_test::{
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
-    fetch_conversation_snapshot, fetch_request_lineage_snapshot,
-    fetch_request_lineage_snapshot_by_tuple, fetch_request_snapshot, fetch_request_snapshot_raw,
-    fetch_response_content, fetch_response_interrupted_at, fetch_response_snapshot,
-    fetch_session_snapshot, ConversationSnapshot, RequestLineageSnapshot, RequestSnapshot,
-    ResponseSnapshot, SessionSnapshot,
+    fetch_conversation_snapshot, fetch_message_snapshots_for_session,
+    fetch_request_lineage_snapshot, fetch_request_lineage_snapshot_by_tuple,
+    fetch_request_snapshot, fetch_request_snapshot_raw, fetch_response_content,
+    fetch_response_interrupted_at, fetch_response_snapshot, fetch_session_snapshot,
+    fetch_tool_call_snapshots_for_session, ConversationSnapshot, MessageSnapshot,
+    RequestLineageSnapshot, RequestSnapshot, ResponseSnapshot, SessionSnapshot, ToolCallSnapshot,
 };
 use support::{
     build_request, create_agent_session, create_request, create_response_with_content_and_status,
@@ -786,8 +799,280 @@ fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
     }
 }
 
-#[test]
-fn generated_transcript_cases_pin_agent_message_ordering_contract() {
+#[derive(Clone, Default)]
+struct TranscriptConformanceModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TranscriptConformanceModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in transcript conformance tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in transcript conformance tests".to_string(),
+        ))
+    }
+}
+
+fn transcript_user_message(text: &str) -> Message {
+    Message::User {
+        content: OneOrMany::one(UserContent::Text(Text {
+            text: text.to_string(),
+        })),
+    }
+}
+
+fn transcript_assistant_tool_call_message(model_call_id: &str) -> Message {
+    Message::Assistant {
+        id: None,
+        content: OneOrMany::one(AssistantContent::ToolCall(ToolCall {
+            id: model_call_id.to_string(),
+            call_id: Some(model_call_id.to_string()),
+            function: ToolFunction {
+                name: "read".to_string(),
+                arguments: json!({ "file_path": "/tmp/transcript-contract.txt" }),
+            },
+            signature: None,
+            additional_params: None,
+        })),
+    }
+}
+
+fn transcript_tool_result_message(result_id: &str, text: &str) -> Message {
+    Message::User {
+        content: OneOrMany::one(UserContent::ToolResult(ToolResult {
+            id: result_id.to_string(),
+            call_id: Some(result_id.to_string()),
+            content: OneOrMany::one(ToolResultContent::Text(Text {
+                text: text.to_string(),
+            })),
+        })),
+    }
+}
+
+async fn transcript_hook_fixture(test_name: &str) -> (support::TestDb, DefraSessionHook, String) {
+    let db = test_db(test_name).await;
+    let session_id = format!("{test_name}-session");
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        &session_id,
+        AGENT_NAME,
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .expect("resume transcript hook");
+    hook.set_active_request_id(Some(format!("{test_name}-request")))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::minutes(5)))
+        .await;
+    (db, hook, session_id)
+}
+
+async fn transcript_messages_and_calls(
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> (Vec<MessageSnapshot>, Vec<ToolCallSnapshot>, Vec<Message>) {
+    let messages = fetch_message_snapshots_for_session(node, session_id).await;
+    let tool_calls = fetch_tool_call_snapshots_for_session(node, session_id).await;
+    let history = defra_agent::load_history(node, session_id)
+        .await
+        .expect("load transcript history");
+    (messages, tool_calls, history)
+}
+
+fn transcript_tool_result_count(history: &[Message]) -> usize {
+    history
+        .iter()
+        .filter(|message| {
+            matches!(
+                message,
+                Message::User { content }
+                    if matches!(content.first_ref(), UserContent::ToolResult(_))
+            )
+        })
+        .count()
+}
+
+fn transcript_ordered(messages: &[MessageSnapshot]) -> bool {
+    messages
+        .windows(2)
+        .all(|window| window[0].sequence < window[1].sequence)
+}
+
+fn transcript_strong_drain(tool_calls: &[ToolCallSnapshot]) -> bool {
+    tool_calls
+        .iter()
+        .all(|call| call.lifecycle_state.as_deref() != Some("running"))
+}
+
+fn transcript_pair_closed(
+    messages: &[MessageSnapshot],
+    tool_calls: &[ToolCallSnapshot],
+    history: &[Message],
+) -> bool {
+    let tool_calls_reserved_by_assistant_message = tool_calls.iter().all(|call| {
+        messages.iter().any(|message| {
+            message.sequence == call.message_sequence && message.role.as_str() == "assistant"
+        })
+    });
+    let no_running_tool_calls = transcript_strong_drain(tool_calls);
+    let completed_tool_call_count = tool_calls
+        .iter()
+        .filter(|call| call.lifecycle_state.as_deref() == Some("completed"))
+        .count();
+    let completed_calls_have_results = completed_tool_call_count == 0
+        || transcript_tool_result_count(history) == completed_tool_call_count;
+
+    tool_calls_reserved_by_assistant_message
+        && no_running_tool_calls
+        && completed_calls_have_results
+}
+
+async fn assert_transcript_counts(
+    label: &str,
+    node: &EmbeddedNode,
+    session_id: &str,
+    expected_messages: usize,
+    expected_tool_calls: usize,
+) {
+    let (messages, tool_calls, _) = transcript_messages_and_calls(node, session_id).await;
+    assert_eq!(
+        messages.len(),
+        expected_messages,
+        "{label}: AgentMessage count"
+    );
+    assert_eq!(
+        tool_calls.len(),
+        expected_tool_calls,
+        "{label}: AgentToolCall count"
+    );
+}
+
+async fn assert_transcript_post_state(
+    case: &lean_vocab_test::LeanTranscriptCase,
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> (Vec<MessageSnapshot>, Vec<ToolCallSnapshot>, Vec<Message>) {
+    let (messages, tool_calls, history) = transcript_messages_and_calls(node, session_id).await;
+    assert_eq!(
+        messages.len(),
+        case.post_message_count,
+        "{}: post_message_count",
+        case.name
+    );
+    assert_eq!(
+        tool_calls.len(),
+        case.post_tool_call_count,
+        "{}: post_tool_call_count",
+        case.name
+    );
+    assert_eq!(
+        transcript_ordered(&messages),
+        case.expected_ordered,
+        "{}: expected_ordered",
+        case.name
+    );
+    assert_eq!(
+        transcript_pair_closed(&messages, &tool_calls, &history),
+        case.expected_pair_closed,
+        "{}: expected_pair_closed",
+        case.name
+    );
+    assert_eq!(
+        transcript_strong_drain(&tool_calls),
+        case.expected_strong_drain,
+        "{}: expected_strong_drain",
+        case.name
+    );
+    (messages, tool_calls, history)
+}
+
+async fn persist_completed_tool_sequence(
+    test_name: &str,
+    case: &lean_vocab_test::LeanTranscriptCase,
+) -> (support::TestDb, DefraSessionHook, String, u32) {
+    let (db, hook, session_id) = transcript_hook_fixture(test_name).await;
+    assert_transcript_counts(
+        &format!("{} pre-state", case.name),
+        &db.node,
+        &session_id,
+        case.pre_message_count,
+        case.pre_tool_call_count,
+    )
+    .await;
+
+    assert!(matches!(
+        PromptHook::<TranscriptConformanceModel>::on_completion_call(
+            &hook,
+            &transcript_user_message("run transcript conformance tool"),
+            &[],
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    let model_call_id = format!("result-{}", case.logical_result_id);
+    let internal_call_id = format!("internal-{}", case.logical_result_id);
+    let payload = format!("payload-{}", case.payload_hash);
+    let tool_args = r#"{"file_path":"/tmp/transcript-contract.txt"}"#;
+
+    assert!(matches!(
+        PromptHook::<TranscriptConformanceModel>::on_tool_call(
+            &hook,
+            "read",
+            Some(model_call_id.clone()),
+            &internal_call_id,
+            tool_args,
+        )
+        .await,
+        ToolCallHookAction::Continue
+    ));
+
+    let assistant_sequence = hook
+        .persist_message(&transcript_assistant_tool_call_message(&model_call_id))
+        .await
+        .expect("persist assistant tool-call message");
+    assert_eq!(
+        assistant_sequence as usize, case.assistant_sequence,
+        "{}: assistant_sequence",
+        case.name
+    );
+
+    assert!(matches!(
+        PromptHook::<TranscriptConformanceModel>::on_tool_result(
+            &hook,
+            "read",
+            Some(model_call_id.clone()),
+            &internal_call_id,
+            tool_args,
+            &payload,
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    (db, hook, session_id, case.result_sequence as u32)
+}
+
+fn assert_transcript_case_shape() {
     let cases = lean_transcript_cases();
     assert_eq!(cases.len(), 6);
 
@@ -865,6 +1150,239 @@ fn generated_transcript_cases_pin_agent_message_ordering_contract() {
             case.name
         );
     }
+}
+
+#[tokio::test]
+async fn generated_transcript_cases_pin_agent_message_ordering_contract() {
+    assert_transcript_case_shape();
+
+    let ordering = lean_transcript_case("ordering_user_assistant_tool_result");
+    let (db, hook, session_id, result_sequence) =
+        persist_completed_tool_sequence("transcript-ordering", ordering).await;
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        ordering.post_in_flight_count,
+        "{}: post_in_flight_count",
+        ordering.name
+    );
+    let (messages, tool_calls, history) =
+        assert_transcript_post_state(ordering, &db.node, &session_id).await;
+    assert_eq!(result_sequence as usize, ordering.result_sequence);
+    assert_eq!(
+        messages
+            .iter()
+            .find(|message| message.role.as_str() == "user" && message.sequence > 1)
+            .map(|message| message.sequence as usize),
+        Some(ordering.result_sequence),
+        "{}: result_sequence",
+        ordering.name
+    );
+    assert_eq!(
+        tool_calls
+            .first()
+            .map(|call| call.message_sequence as usize),
+        Some(ordering.assistant_sequence),
+        "{}: tool call reserves assistant sequence",
+        ordering.name
+    );
+    assert_eq!(
+        transcript_tool_result_count(&history),
+        1,
+        "{}",
+        ordering.name
+    );
+
+    let dedupe = lean_transcript_case("dedupe_duplicate_reuses_sequence");
+    let (db, hook, session_id, first_result_sequence) =
+        persist_completed_tool_sequence("transcript-dedupe", ordering).await;
+    assert_transcript_counts(
+        "dedupe duplicate pre-state",
+        &db.node,
+        &session_id,
+        dedupe.pre_message_count,
+        dedupe.pre_tool_call_count,
+    )
+    .await;
+    let duplicate_sequence = hook
+        .persist_message(&transcript_tool_result_message(
+            &format!("result-{}", dedupe.logical_result_id),
+            &format!("payload-{}", dedupe.payload_hash),
+        ))
+        .await
+        .expect("persist duplicate tool-result message");
+    assert_eq!(
+        duplicate_sequence as usize, dedupe.result_sequence,
+        "{}: duplicate reused sequence",
+        dedupe.name
+    );
+    assert_eq!(
+        first_result_sequence as usize, dedupe.result_sequence,
+        "{}: original sequence",
+        dedupe.name
+    );
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        dedupe.post_in_flight_count,
+        "{}: post_in_flight_count",
+        dedupe.name
+    );
+    let (messages, _, history) = assert_transcript_post_state(dedupe, &db.node, &session_id).await;
+    assert_eq!(messages.len(), dedupe.pre_message_count, "{}", dedupe.name);
+    assert_eq!(transcript_tool_result_count(&history), 1, "{}", dedupe.name);
+
+    let distinct = lean_transcript_case("distinct_result_ids_append_distinct_rows");
+    let (db, hook, session_id) = transcript_hook_fixture("transcript-distinct").await;
+    let seed_result_id = format!("result-{}", ordering.logical_result_id);
+    let payload = format!("payload-{}", distinct.payload_hash);
+    let first_sequence = hook
+        .persist_message(&transcript_tool_result_message(&seed_result_id, &payload))
+        .await
+        .expect("persist seed tool-result message");
+    assert_eq!(first_sequence, 1, "{}: seed sequence", distinct.name);
+    assert_transcript_counts(
+        "distinct result-id pre-state",
+        &db.node,
+        &session_id,
+        distinct.pre_message_count,
+        distinct.pre_tool_call_count,
+    )
+    .await;
+    let distinct_sequence = hook
+        .persist_message(&transcript_tool_result_message(
+            &format!("result-{}", distinct.logical_result_id),
+            &payload,
+        ))
+        .await
+        .expect("persist distinct tool-result message");
+    assert_eq!(
+        distinct_sequence as usize, distinct.result_sequence,
+        "{}: result_sequence",
+        distinct.name
+    );
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        distinct.post_in_flight_count,
+        "{}: post_in_flight_count",
+        distinct.name
+    );
+    let (_, _, history) = assert_transcript_post_state(distinct, &db.node, &session_id).await;
+    assert_eq!(
+        transcript_tool_result_count(&history),
+        distinct.post_message_count,
+        "{}: distinct result rows",
+        distinct.name
+    );
+
+    let pair = lean_transcript_case("completed_tool_pair_closed");
+    let (db, hook, session_id, _) =
+        persist_completed_tool_sequence("transcript-pair-closed", pair).await;
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        pair.post_in_flight_count,
+        "{}: post_in_flight_count",
+        pair.name
+    );
+    let (_, tool_calls, history) = assert_transcript_post_state(pair, &db.node, &session_id).await;
+    assert_eq!(
+        tool_calls
+            .first()
+            .and_then(|call| call.lifecycle_state.as_deref()),
+        Some("completed"),
+        "{}: completed tool call",
+        pair.name
+    );
+    assert_eq!(transcript_tool_result_count(&history), 1, "{}", pair.name);
+
+    let drain = lean_transcript_case("explicit_drain_terminalizes_ownership");
+    let (db, hook, session_id) = transcript_hook_fixture("transcript-explicit-drain").await;
+    assert!(matches!(
+        PromptHook::<TranscriptConformanceModel>::on_tool_call(
+            &hook,
+            "read",
+            Some("result-drain".to_string()),
+            "internal-drain",
+            r#"{"file_path":"/tmp/transcript-contract.txt"}"#,
+        )
+        .await,
+        ToolCallHookAction::Continue
+    ));
+    let assistant_sequence = hook
+        .persist_message(&transcript_assistant_tool_call_message("result-drain"))
+        .await
+        .expect("persist drain assistant message");
+    assert_eq!(
+        assistant_sequence as usize, drain.assistant_sequence,
+        "{}: assistant_sequence",
+        drain.name
+    );
+    assert_transcript_counts(
+        "explicit drain pre-state",
+        &db.node,
+        &session_id,
+        drain.pre_message_count,
+        drain.pre_tool_call_count,
+    )
+    .await;
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        drain.pre_in_flight_count,
+        "{}: explicit drain count",
+        drain.name
+    );
+    assert_eq!(
+        hook.cancel_in_flight_tool_calls().await.unwrap(),
+        drain.post_in_flight_count,
+        "{}: post_in_flight_count",
+        drain.name
+    );
+    let (_, tool_calls, _) = assert_transcript_post_state(drain, &db.node, &session_id).await;
+    assert_eq!(
+        tool_calls
+            .first()
+            .and_then(|call| call.lifecycle_state.as_deref()),
+        Some("cancelled"),
+        "{}: durable row terminalized",
+        drain.name
+    );
+
+    let abandon = lean_transcript_case("drop_abandon_not_strong_drain");
+    let (db, hook, session_id) = transcript_hook_fixture("transcript-drop-abandon").await;
+    assert!(matches!(
+        PromptHook::<TranscriptConformanceModel>::on_tool_call(
+            &hook,
+            "read",
+            Some("result-abandon".to_string()),
+            "internal-abandon",
+            r#"{"file_path":"/tmp/transcript-contract.txt"}"#,
+        )
+        .await,
+        ToolCallHookAction::Continue
+    ));
+    assert_transcript_counts(
+        "drop abandon pre-state",
+        &db.node,
+        &session_id,
+        abandon.pre_message_count,
+        abandon.pre_tool_call_count,
+    )
+    .await;
+    let observer = hook.clone();
+    drop(hook);
+    assert_eq!(
+        observer.cancel_in_flight_tool_calls().await.unwrap(),
+        abandon.post_in_flight_count,
+        "{}: drop abandons in-memory ownership",
+        abandon.name
+    );
+    let (_, tool_calls, _) = assert_transcript_post_state(abandon, &db.node, &session_id).await;
+    assert_eq!(
+        tool_calls
+            .first()
+            .and_then(|call| call.lifecycle_state.as_deref()),
+        Some("running"),
+        "{}: durable row remains running after Drop",
+        abandon.name
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #209. Refs #204, #191, #160.

This promotes `state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract` from shape-pinning to a runtime drive against `DefraSessionHook` / `hook::persistence` and durable `AgentMessage` + `AgentToolCall` rows.

Context: `docs/superpowers/audits/2026-05-14-conformance-pipeline-audit.md` §⚠️ Partial identified `transcript_conformance_cases` as registered `consumerCoverage` while only checking Lean row shape. Follow-up draft #5 calls for driving `append_message`, duplicate tool-result observation, explicit drain, and hook-drop abandon behavior. This also closes the formal-coverage audit's #1 ranked gap: AgentMessage persistence + ordering, including the #160 tool-result dedupe bug class.

## Runtime paths driven

- `ordering_user_assistant_tool_result`: resumes a real hook, persists a user message, starts a tool call, persists the assistant tool-call message, completes the tool result, and asserts message/tool-call counts, ordering, pair closure, result sequence, and strong drain.
- `dedupe_duplicate_reuses_sequence`: seeds the completed sequence, re-persists the same logical tool result payload through `persist_message`, and asserts the original result sequence is reused with no extra row.
- `distinct_result_ids_append_distinct_rows`: persists two tool-result messages with the same payload and distinct logical result ids, asserting both durable rows remain.
- `completed_tool_pair_closed`: drives the completed tool-call path and asserts the completed durable tool call is paired with exactly one result message.
- `explicit_drain_terminalizes_ownership`: starts an in-flight tool call, persists its assistant reservation, calls the hook's explicit cancel drain, and asserts ownership drains plus the durable row is terminalized.
- `drop_abandon_not_strong_drain`: starts an in-flight tool call, drops the hook owner, asserts a later drain sees no ownership, and asserts the durable row remains `running` to match `abandon_hook_ownership_not_strong_drain`.

## Notes

The integration test needs to call the real explicit drain method, so `DefraSessionHook::cancel_in_flight_tool_calls` is made public. No hook persistence logic is reimplemented in the test.

## Test plan

- `cd crates/defra-agent/proofs && lake build`
- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
- `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain -- --nocapture`
- `cargo test -p defra-agent --test state_machine_conformance generated_transcript_cases_pin_agent_message_ordering_contract -- --nocapture`
