### PR TITLE
Add R4c agent-facing background work management tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,4 @@ opt-level = 1
 opt-level = 1
 debug = 0
 split-debuginfo = "off"
+incremental = false

--- a/crates/defra-agent/proofs/Proofs/Background/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/Background/Properties.lean
@@ -962,5 +962,58 @@ theorem bridge_link_symmetric
     post.linked :=
   inv_link pre post h_init h_trace
 
+/-- B5 invariant survives the `steer_subagent(interrupt=true)` composition.
+    On the current R6 surface, bridge reachability is represented as a
+    `BridgedState.Trace`; queue drain/append work is outside `BridgedState`
+    and cannot mutate bridge link fields. -/
+theorem steer_subagent_interrupt_preserves_link_symmetry
+    {pre post : BridgedState}
+    {childSessionId : SessionId}
+    {queuePre queueDrained queuePost : SessionQueue.SessionQueueState}
+    {transcriptPre transcriptPost : Transcript.TranscriptState}
+    {childRequestId steeringRequestId : RequestId}
+    {message : String}
+    (h_step : SteerWithInterrupt
+      pre post
+      childSessionId
+      queuePre queueDrained queuePost
+      transcriptPre transcriptPost
+      childRequestId steeringRequestId message)
+    (h_pre  : pre.linked) :
+    post.linked := by
+  rcases h_step.h_bridge_compose with
+    ⟨cascaded, interrupted, h_cascade, h_interrupt, _h_child_id, h_tail⟩
+  have _h_queue_session : queuePost.sessionId = childSessionId :=
+    h_step.h_queue_post_session
+  have _h_drain_uses_child_key :
+      queueDrained =
+        queuePre.drainAutomatedWakeups
+          SessionQueue.QueueSource.backgroundCompletion
+          (some (backgroundCompletionQueueKey childSessionId)) :=
+    h_step.h_drain_shape
+  rcases h_step.h_append_compose with
+    ⟨entry, _h_append_transition, _h_append_shape,
+      h_entry_request, h_entry_source, h_entry_policy, _h_entry_key⟩
+  have _h_append_is_steering :
+      entry.source = SessionQueue.QueueSource.steering ∧
+      entry.policy = SessionQueue.QueuePolicy.append ∧
+      entry.requestId = steeringRequestId :=
+    ⟨h_entry_source, h_entry_policy, h_entry_request⟩
+  have _h_transcript_session : transcriptPost.sessionId = childSessionId :=
+    h_step.h_transcript_post_session
+  rcases h_step.h_transcript_append with
+    ⟨messageId, _h_message_nonempty, _h_transcript_transition, h_transcript_shape⟩
+  have _h_transcript_is_user_append :
+      transcriptPost =
+        transcriptPre.appendUserMessage
+          messageId
+          Transcript.MessageKind.ordinary :=
+    h_transcript_shape
+  have h_trace : Trace pre post :=
+    Trace.step
+      (BridgeCancelCascadeStep.to_transition h_cascade)
+      (Trace.step (ChildInterruptStep.to_transition h_interrupt) h_tail)
+  exact bridge_link_symmetric pre post h_pre h_trace
+
 end BridgedState
 end Subagent

--- a/crates/defra-agent/proofs/Proofs/Background/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/Background/Transition.lean
@@ -1,5 +1,7 @@
 import Proofs.Background.State
 import Proofs.Background.Bridge
+import Proofs.Session.Transition
+import Proofs.Transcript.Transition
 
 /-!
 # Subagent Bridge Transitions
@@ -163,6 +165,193 @@ inductive Trace : BridgedState → BridgedState → Prop where
   | refl {s : BridgedState} : Trace s s
   | step {s₁ s₂ s₃ : BridgedState} :
       Transition s₁ s₂ → Trace s₂ s₃ → Trace s₁ s₃
+
+/-- Named wrapper around the existing `bridge_cancel_cascade` constructor.
+    This is not a new transition; it packages the constructor arguments so
+    higher-level composed witnesses can identify that the cascade arm fired. -/
+structure BridgeCancelCascadeStep
+    (pre post : BridgedState) : Prop where
+  h_parent_term   : isTerminal pre.parent.request.state ∨
+                    (∃ t ∈ pre.parent.tools,
+                       t.callId = pre.bridgeCallId ∧
+                       t.state = .cancelled)
+  h_cascade_pol   : ∃ t ∈ pre.parent.tools,
+                      t.callId = pre.bridgeCallId ∧
+                      t.cancelPolicy = .cascade
+  h_interrupt_set : post.child.request.interruptRequestedAt.isSome
+  h_child_request_eq :
+    post.child.request =
+      { pre.child.request with
+        interruptRequestedAt := post.child.request.interruptRequestedAt }
+  h_parent_eq     : post.parent = pre.parent
+  h_bridgeId_eq   : post.bridgeCallId = pre.bridgeCallId
+  h_child_id_eq   : post.child.requestId = pre.child.requestId
+  h_child_caused_req_eq :
+    post.child.request.causedByParentRequestId =
+      pre.child.request.causedByParentRequestId
+  h_child_caused_tool_eq :
+    post.child.request.causedByParentToolCallId =
+      pre.child.request.causedByParentToolCallId
+  h_child_depth_eq :
+    post.child.request.subagentDepth = pre.child.request.subagentDepth
+  h_child_tools_eq : post.child.tools = pre.child.tools
+
+theorem BridgeCancelCascadeStep.to_transition
+    {pre post : BridgedState}
+    (h : BridgeCancelCascadeStep pre post) :
+    Transition pre post :=
+  Transition.bridge_cancel_cascade
+    h.h_parent_term
+    h.h_cascade_pol
+    h.h_interrupt_set
+    h.h_parent_eq
+    h.h_bridgeId_eq
+    h.h_child_id_eq
+    h.h_child_caused_req_eq
+    h.h_child_caused_tool_eq
+    h.h_child_depth_eq
+    h.h_child_tools_eq
+
+/-- The request-level interrupt transition used by
+    `steer_subagent(interrupt=true)`. This mirrors the existing
+    `RequestContext.Transition.interrupt_*` constructors so future request
+    transitions cannot accidentally satisfy the steering witness just because
+    they also end in `.interrupted`. -/
+inductive RequestInterruptStep : RequestContext → RequestContext → Prop where
+  | before_claim {pre post : RequestContext} :
+      pre.state = .pending →
+      pre.admission = .released →
+      pre.interruptRequestedAt.isSome →
+      post = { pre with state := .interrupted, admission := .released } →
+      RequestInterruptStep pre post
+  | claimed {pre post : RequestContext} :
+      pre.state = .claimed →
+      (pre.admission = .waiting ∨ pre.admission = .acquired) →
+      pre.interruptRequestedAt.isSome →
+      post = { pre with state := .interrupted, admission := .released } →
+      RequestInterruptStep pre post
+  | processing {pre post : RequestContext} :
+      pre.state = .processing →
+      pre.admission = .executing →
+      pre.interruptRequestedAt.isSome →
+      post = { pre with state := .interrupted, admission := .released } →
+      RequestInterruptStep pre post
+
+theorem RequestInterruptStep.to_transition
+    {pre post : RequestContext}
+    (h : RequestInterruptStep pre post) :
+    RequestContext.Transition pre post := by
+  cases h with
+  | before_claim h_state h_admission h_interrupt h_post =>
+      exact RequestContext.Transition.interrupt_before_claim
+        h_state h_admission h_interrupt h_post
+  | claimed h_state h_admission h_interrupt h_post =>
+      exact RequestContext.Transition.interrupt_claimed
+        h_state h_admission h_interrupt h_post
+  | processing h_state h_admission h_interrupt h_post =>
+      exact RequestContext.Transition.interrupt_processing
+        h_state h_admission h_interrupt h_post
+
+/-- Named wrapper for the child-side request interrupt after cascade has set
+    `interruptRequestedAt`. It lifts one of the existing request-level
+    interrupt constructors through `ComposedState.request_step`; no new
+    transition logic is introduced here. -/
+structure ChildInterruptStep
+    (pre post : BridgedState) : Prop where
+  h_request_interrupt :
+    RequestInterruptStep pre.child.request post.child.request
+  h_process_eq : post.child.process = pre.child.process
+  h_call_eq : post.child.call = pre.child.call
+  h_tools_eq : post.child.tools = pre.child.tools
+  h_requestId_eq : post.child.requestId = pre.child.requestId
+  h_pending_accepts :
+    pre.child.request.state = .pending → pre.child.process.acceptsWork
+  h_no_foreground_block :
+    post.child.request.progressSeq > pre.child.request.progressSeq ∨
+      (pre.child.request.state = .claimed ∧
+       post.child.request.state = .processing) →
+      ¬ ∃ t ∈ pre.child.tools, t.awaitMode = .foreground ∧
+                            ¬ isTerminal t.state
+  h_parent_eq : post.parent = pre.parent
+  h_bridgeId_eq : post.bridgeCallId = pre.bridgeCallId
+  h_link_pre : pre.linked
+  h_link_post : post.linked
+
+theorem ChildInterruptStep.to_transition
+    {pre post : BridgedState}
+    (h : ChildInterruptStep pre post) :
+    Transition pre post :=
+  Transition.child_step
+    (ComposedState.Transition.request_step
+      (RequestInterruptStep.to_transition h.h_request_interrupt)
+      h.h_process_eq
+      h.h_call_eq
+      h.h_tools_eq
+      h.h_requestId_eq
+      h.h_pending_accepts
+      h.h_no_foreground_block)
+    h.h_parent_eq
+    h.h_bridgeId_eq
+    h.h_link_pre
+    h.h_link_post
+
+/-- Canonical proof-model key for a child session's background-completion
+    wake-up queue. Runtime encodes this as `background_completion:<session>`;
+    the Lean queue key is opaque Nat, so the session id itself is the stable
+    representative. -/
+def backgroundCompletionQueueKey (childSessionId : SessionId) :
+    SessionQueue.QueueKey :=
+  childSessionId
+
+/-- Current-surface witness for `steer_subagent(interrupt=true)`.
+    The bridge-affecting part is the existing cancel cascade plus the child
+    interrupt transition. The concrete queue/transcript states are parameters
+    of the witness because those models live outside `BridgedState`. -/
+structure SteerWithInterrupt
+    (pre post : BridgedState)
+    (childSessionId : SessionId)
+    (queuePre queueDrained queuePost : SessionQueue.SessionQueueState)
+    (transcriptPre transcriptPost : Transcript.TranscriptState)
+    (childRequestId : RequestId)
+    (steeringRequestId : RequestId)
+    (steeringMessage : String) : Prop where
+  h_child_active :
+    pre.child.requestId = childRequestId ∧
+    ¬ isTerminal pre.child.request.state
+  h_bridge_compose :
+    ∃ cascaded interrupted : BridgedState,
+      BridgeCancelCascadeStep pre cascaded ∧
+      ChildInterruptStep cascaded interrupted ∧
+      interrupted.child.requestId = childRequestId ∧
+      Trace interrupted post
+  h_queue_pre_session : queuePre.sessionId = childSessionId
+  h_queue_drained_session : queueDrained.sessionId = childSessionId
+  h_queue_post_session : queuePost.sessionId = childSessionId
+  h_drain_transition :
+    SessionQueue.Transition queuePre queueDrained
+  h_drain_shape :
+    queueDrained =
+      queuePre.drainAutomatedWakeups
+        SessionQueue.QueueSource.backgroundCompletion
+        (some (backgroundCompletionQueueKey childSessionId))
+  h_append_compose :
+    ∃ entry : SessionQueue.QueueEntry,
+      SessionQueue.Transition queueDrained queuePost ∧
+      queuePost = queueDrained.appendPending entry ∧
+      entry.requestId = steeringRequestId ∧
+      entry.source = SessionQueue.QueueSource.steering ∧
+      entry.policy = SessionQueue.QueuePolicy.append ∧
+      entry.queueKey = none
+  h_transcript_pre_session : transcriptPre.sessionId = childSessionId
+  h_transcript_post_session : transcriptPost.sessionId = childSessionId
+  h_transcript_append :
+    ∃ messageId : Transcript.MessageId,
+      steeringMessage ≠ "" ∧
+      Transcript.Transition transcriptPre transcriptPost ∧
+      transcriptPost =
+        transcriptPre.appendUserMessage
+          messageId
+          Transcript.MessageKind.ordinary
 
 end BridgedState
 end Subagent

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -233,6 +233,62 @@ structure R6BackgroundingCase where
   queueKey : Option String
   deriving Repr
 
+namespace R4cWitnesses
+
+structure ListSubagentsLineageRejects where
+  callerRequestId : String
+  siblingRequestId : String
+  siblingChildId : String
+  callerSeesSiblingChild : Bool
+  deriving Repr
+
+structure ReadTranscriptCursorAdvances where
+  childSessionId : String
+  firstSinceSequence : Nat
+  firstThroughSequence : Nat
+  firstNextSequence : Nat
+  secondSinceSequence : Nat
+  secondThroughSequence : Nat
+  noGap : Bool
+  noOverlap : Bool
+  deriving Repr
+
+structure ReadTranscriptHidesBridgeRows where
+  childSessionId : String
+  bridgeCallId : String
+  renderedTranscript : String
+  deriving Repr
+
+structure ReadToolOutputDispatchesByState where
+  toolCallId : String
+  runningSource : String
+  terminalSource : String
+  runningPayload : String
+  staleRunningPayload : String
+  terminalPayload : String
+  deriving Repr
+
+structure SteerAppendPreservesLineage where
+  callerRequestId : String
+  childSessionId : String
+  queuedRequestId : String
+  causedByParentRequestId : String
+  queueSource : String
+  queuePolicy : String
+  deriving Repr
+
+structure SteerInterruptComposes where
+  callerRequestId : String
+  childSessionId : String
+  interruptedActiveRequestId : String
+  drainedWakeUpRequestIds : List String
+  drainedWakeUpQueueKey : String
+  queuedRequestId : String
+  queueInterruptedRequestId : String
+  deriving Repr
+
+end R4cWitnesses
+
 structure TranscriptCase where
   name : String
   group : String

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean
@@ -438,6 +438,157 @@ def recoverySweepCaseJson (witness : RecoverySweepCase) : String :=
     ++ jsonString witness.deadlineAuditRef
     ++ "}"
 
+def r4cListSubagentsLineageRejectsJson
+    (witness : R4cWitnesses.ListSubagentsLineageRejects) : String :=
+  "{"
+    ++ "\"witness\":" ++ jsonString "r4c.list_subagents.lineage_rejects" ++ ","
+    ++ "\"caller_request_id\":" ++ jsonString witness.callerRequestId ++ ","
+    ++ "\"sibling_request_id\":" ++ jsonString witness.siblingRequestId ++ ","
+    ++ "\"sibling_child_id\":" ++ jsonString witness.siblingChildId ++ ","
+    ++ "\"caller_sees_sibling_child\":"
+      ++ boolString witness.callerSeesSiblingChild
+    ++ "}"
+
+def r4cReadTranscriptCursorAdvancesJson
+    (witness : R4cWitnesses.ReadTranscriptCursorAdvances) : String :=
+  "{"
+    ++ "\"witness\":"
+      ++ jsonString "r4c.read_subagent_transcript.cursor_advances" ++ ","
+    ++ "\"child_session_id\":" ++ jsonString witness.childSessionId ++ ","
+    ++ "\"first_since_sequence\":" ++ toString witness.firstSinceSequence ++ ","
+    ++ "\"first_through_sequence\":"
+      ++ toString witness.firstThroughSequence ++ ","
+    ++ "\"first_next_sequence\":" ++ toString witness.firstNextSequence ++ ","
+    ++ "\"second_since_sequence\":"
+      ++ toString witness.secondSinceSequence ++ ","
+    ++ "\"second_through_sequence\":"
+      ++ toString witness.secondThroughSequence ++ ","
+    ++ "\"no_gap\":" ++ boolString witness.noGap ++ ","
+    ++ "\"no_overlap\":" ++ boolString witness.noOverlap
+    ++ "}"
+
+def r4cReadTranscriptHidesBridgeRowsJson
+    (witness : R4cWitnesses.ReadTranscriptHidesBridgeRows) : String :=
+  "{"
+    ++ "\"witness\":"
+      ++ jsonString "r4c.read_subagent_transcript.hides_bridge_rows" ++ ","
+    ++ "\"child_session_id\":" ++ jsonString witness.childSessionId ++ ","
+    ++ "\"bridge_call_id\":" ++ jsonString witness.bridgeCallId ++ ","
+    ++ "\"rendered_transcript\":" ++ jsonString witness.renderedTranscript
+    ++ "}"
+
+def r4cReadToolOutputDispatchesByStateJson
+    (witness : R4cWitnesses.ReadToolOutputDispatchesByState) : String :=
+  "{"
+    ++ "\"witness\":"
+      ++ jsonString "r4c.read_tool_output.dispatch_by_state" ++ ","
+    ++ "\"tool_call_id\":" ++ jsonString witness.toolCallId ++ ","
+    ++ "\"running_source\":" ++ jsonString witness.runningSource ++ ","
+    ++ "\"terminal_source\":" ++ jsonString witness.terminalSource ++ ","
+    ++ "\"running_payload\":" ++ jsonString witness.runningPayload ++ ","
+    ++ "\"stale_running_payload\":"
+      ++ jsonString witness.staleRunningPayload ++ ","
+    ++ "\"terminal_payload\":" ++ jsonString witness.terminalPayload
+    ++ "}"
+
+def r4cSteerAppendPreservesLineageJson
+    (witness : R4cWitnesses.SteerAppendPreservesLineage) : String :=
+  "{"
+    ++ "\"witness\":"
+      ++ jsonString "r4c.steer_subagent.append_preserves_lineage" ++ ","
+    ++ "\"caller_request_id\":" ++ jsonString witness.callerRequestId ++ ","
+    ++ "\"child_session_id\":" ++ jsonString witness.childSessionId ++ ","
+    ++ "\"queued_request_id\":" ++ jsonString witness.queuedRequestId ++ ","
+    ++ "\"caused_by_parent_request_id\":"
+      ++ jsonString witness.causedByParentRequestId ++ ","
+    ++ "\"queue_source\":" ++ jsonString witness.queueSource ++ ","
+    ++ "\"queue_policy\":" ++ jsonString witness.queuePolicy
+    ++ "}"
+
+def r4cSteerInterruptComposesJson
+    (witness : R4cWitnesses.SteerInterruptComposes) : String :=
+  "{"
+    ++ "\"witness\":" ++ jsonString "r4c.steer_subagent.interrupt_composes" ++ ","
+    ++ "\"caller_request_id\":" ++ jsonString witness.callerRequestId ++ ","
+    ++ "\"child_session_id\":" ++ jsonString witness.childSessionId ++ ","
+    ++ "\"interrupted_active_request_id\":"
+      ++ jsonString witness.interruptedActiveRequestId ++ ","
+    ++ "\"drained_wake_up_request_ids\":"
+      ++ jsonStringArray witness.drainedWakeUpRequestIds ++ ","
+    ++ "\"drained_wake_up_queue_key\":"
+      ++ jsonString witness.drainedWakeUpQueueKey ++ ","
+    ++ "\"queued_request_id\":" ++ jsonString witness.queuedRequestId ++ ","
+    ++ "\"queue_interrupted_request_id\":"
+      ++ jsonString witness.queueInterruptedRequestId
+    ++ "}"
+
+def r4cListSubagentsLineageRejects :
+    R4cWitnesses.ListSubagentsLineageRejects :=
+  { callerRequestId := "r4c-w1-caller"
+  , siblingRequestId := "r4c-w1-sibling"
+  , siblingChildId := "r4c-w1-sibling-child"
+  , callerSeesSiblingChild := false
+  }
+
+def r4cReadTranscriptCursorAdvances :
+    R4cWitnesses.ReadTranscriptCursorAdvances :=
+  { childSessionId := "r4c-w2-session"
+  , firstSinceSequence := 0
+  , firstThroughSequence := 5
+  , firstNextSequence := 6
+  , secondSinceSequence := 6
+  , secondThroughSequence := 10
+  , noGap := true
+  , noOverlap := true
+  }
+
+def r4cReadTranscriptHidesBridgeRows :
+    R4cWitnesses.ReadTranscriptHidesBridgeRows :=
+  { childSessionId := "r4c-w3-session"
+  , bridgeCallId := "r4c-w3-bridge-call"
+  , renderedTranscript := "[assistant seq=2]\nplain assistant message\n"
+  }
+
+def r4cReadToolOutputDispatchesByState :
+    R4cWitnesses.ReadToolOutputDispatchesByState :=
+  { toolCallId := "r4c-w4-tool-call"
+  , runningSource := "ring_buffer"
+  , terminalSource := "persisted_tool_completion"
+  , runningPayload := "ring-buffer-live-tail"
+  , staleRunningPayload := "stale-ring-buffer-tail"
+  , terminalPayload := "persisted-completion-stdout"
+  }
+
+def r4cSteerAppendPreservesLineage :
+    R4cWitnesses.SteerAppendPreservesLineage :=
+  { callerRequestId := "r4c-w5-caller"
+  , childSessionId := "r4c-w5-child-session"
+  , queuedRequestId := "r4c-w5-queued"
+  , causedByParentRequestId := "r4c-w5-caller"
+  , queueSource := "steering"
+  , queuePolicy := "append"
+  }
+
+def r4cSteerInterruptComposes :
+    R4cWitnesses.SteerInterruptComposes :=
+  { callerRequestId := "r4c-w6-caller"
+  , childSessionId := "r4c-w6-child-session"
+  , interruptedActiveRequestId := "r4c-w6-interrupted"
+  , drainedWakeUpRequestIds := ["r4c-w6-wake-1", "r4c-w6-wake-2"]
+  , drainedWakeUpQueueKey := "background_completion:r4c-w6-child-session"
+  , queuedRequestId := "r4c-w6-queued"
+  , queueInterruptedRequestId := "r4c-w6-interrupted"
+  }
+
+def r4cBackgroundWorkCasesJson : List String :=
+  [ r4cListSubagentsLineageRejectsJson r4cListSubagentsLineageRejects
+  , r4cReadTranscriptCursorAdvancesJson r4cReadTranscriptCursorAdvances
+  , r4cReadTranscriptHidesBridgeRowsJson r4cReadTranscriptHidesBridgeRows
+  , r4cReadToolOutputDispatchesByStateJson r4cReadToolOutputDispatchesByState
+  , r4cSteerAppendPreservesLineageJson r4cSteerAppendPreservesLineage
+  , r4cSteerInterruptComposesJson r4cSteerInterruptComposes
+  ]
+
 def r6BackgroundingCaseJson (witness : R6BackgroundingCase) : String :=
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
@@ -547,6 +698,8 @@ def snapshotJson : String :=
     ++ "\"recovery_sweep_cases\":"
       ++ jsonArray
         (Recovery.recoverySweepCases.map recoverySweepCaseJson) ++ ","
+    ++ "\"r4c_background_work_cases\":"
+      ++ jsonArray r4cBackgroundWorkCasesJson ++ ","
     ++ "\"r6_backgrounding_cases\":"
       ++ jsonArray
         (r6BackgroundingCases.map r6BackgroundingCaseJson) ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -289,6 +289,10 @@ def caseCoverage : List CoverageEntry :=
       "R6BackgroundingCases"
       "state_machine_conformance::generated_r6_backgrounding_cases_pin_tool_backgrounding_contract"
   , consumerCoverage
+      "r4c_background_work_cases"
+      "R4cBackgroundWorkCases"
+      "state_machine_conformance::generated_r4c_background_work_cases_pin_observable_shapes"
+  , consumerCoverage
       "transcript_cases"
       "TranscriptConformanceCases"
       "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract"

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -321,6 +321,7 @@ pub(crate) fn subagent_tool_config_from_document(
     SubagentToolConfig {
         targets: selection.subagent_targets.clone().unwrap_or_default(),
         spawn_enabled: selection.subagent_spawn_enabled.unwrap_or(false),
+        steering_enabled: selection.subagent_steering_enabled.unwrap_or(false),
         background_enabled: selection.subagent_background_enabled.unwrap_or(false),
     }
 }

--- a/crates/defra-agent/src/agent/tests/document_loading.rs
+++ b/crates/defra-agent/src/agent/tests/document_loading.rs
@@ -217,8 +217,8 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
     let tool_names = tool_surface.tool_names();
     assert!(tool_names.contains(&"spawn_subagent".to_string()));
     assert!(tool_names.contains(&"wait_subagent".to_string()));
+    assert!(tool_names.contains(&"list_subagents".to_string()));
     assert!(tool_names.contains(&"cancel_subagent".to_string()));
-    assert!(!tool_names.contains(&"list_subagents".to_string()));
     assert!(!tool_names.contains(&"read_subagent_transcript".to_string()));
     assert!(!tool_names.contains(&"steer_subagent".to_string()));
 }

--- a/crates/defra-agent/src/agent/tests/document_loading.rs
+++ b/crates/defra-agent/src/agent/tests/document_loading.rs
@@ -134,6 +134,7 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
             delegate_to: Some(vec!["did:defra-agent:amy-code".to_string()]),
             subagent_targets: Some(vec!["researcher".to_string(), "researcher".to_string()]),
             subagent_spawn_enabled: Some(true),
+            subagent_steering_enabled: Some(true),
             subagent_background_enabled: Some(true),
             ..Default::default()
         },
@@ -203,6 +204,7 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
         ["researcher".to_string()]
     );
     assert!(behavior.tools.subagent_tools().spawn_enabled);
+    assert!(behavior.tools.subagent_tools().steering_enabled);
     assert!(behavior.tools.subagent_tools().background_enabled);
     let snapshot = resolve_document_runtime_snapshot(
         agent.node.as_ref(),
@@ -219,8 +221,8 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
     assert!(tool_names.contains(&"wait_subagent".to_string()));
     assert!(tool_names.contains(&"list_subagents".to_string()));
     assert!(tool_names.contains(&"read_subagent_transcript".to_string()));
+    assert!(tool_names.contains(&"steer_subagent".to_string()));
     assert!(tool_names.contains(&"cancel_subagent".to_string()));
-    assert!(!tool_names.contains(&"steer_subagent".to_string()));
 }
 
 #[tokio::test]

--- a/crates/defra-agent/src/agent/tests/document_loading.rs
+++ b/crates/defra-agent/src/agent/tests/document_loading.rs
@@ -218,8 +218,8 @@ async fn from_default_behavior_documents_resolves_tool_selection_with_ceiling() 
     assert!(tool_names.contains(&"spawn_subagent".to_string()));
     assert!(tool_names.contains(&"wait_subagent".to_string()));
     assert!(tool_names.contains(&"list_subagents".to_string()));
+    assert!(tool_names.contains(&"read_subagent_transcript".to_string()));
     assert!(tool_names.contains(&"cancel_subagent".to_string()));
-    assert!(!tool_names.contains(&"read_subagent_transcript".to_string()));
     assert!(!tool_names.contains(&"steer_subagent".to_string()));
 }
 

--- a/crates/defra-agent/src/background_completion.rs
+++ b/crates/defra-agent/src/background_completion.rs
@@ -684,6 +684,7 @@ pub(crate) async fn append_background_tool_completion(
             policy: QueuePolicy::Coalesce,
             key: Some(queue_key),
             queued_after_request_id: Some(parent_request_id.to_string()),
+            interrupted_request_id: None,
         },
     )
     .await?;
@@ -744,6 +745,7 @@ async fn ensure_projection_side_effects(
             policy: QueuePolicy::Coalesce,
             key: Some(queue_key),
             queued_after_request_id: Some(parent_request_id.to_string()),
+            interrupted_request_id: None,
         },
     )
     .await?;

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -14,14 +14,21 @@ use serde::Deserialize;
 use serde_json::json;
 
 use crate::graphql::{escape_graphql_string, response_has_documents};
+use crate::lifecycle::queue::{
+    drain_automated_wakeups, enqueue_session_request, is_automated_wakeup, QueueHints, QueuePolicy,
+    QueueSource,
+};
+use crate::lifecycle::ExecutionOrigin;
+use crate::session;
 use crate::session::execute_mutation_with_retry;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
+use crate::watcher::{validate_agent_request_subagent_coherence, AgentRequest};
 
 use self::r4c_args::{
     ListBackgroundToolsArgs, ListBackgroundToolsEntry, ListBackgroundToolsResponse,
     ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
     ReadSubagentTranscriptArgs, ReadSubagentTranscriptResponse, ReadToolOutputArgs,
-    ReadToolOutputResponse, ReadToolOutputStream,
+    ReadToolOutputResponse, ReadToolOutputStream, SteerSubagentResponse,
 };
 use self::transcript_render::{
     render_transcript, MessageKindView, MessageRoleView, MessageView, RenderOptions,
@@ -268,10 +275,51 @@ struct ReadToolOutputRow {
     result: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct AgentRequestQueueRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    request_id: String,
+    agent_did: String,
+    behavior_id: Option<String>,
+    session_id: String,
+    content: String,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    top_k: Option<i64>,
+    max_tokens: Option<i64>,
+    metadata: Option<String>,
+    execution_origin: Option<String>,
+    created_at: String,
+    deadline: Option<String>,
+    subagent_depth: Option<u32>,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActiveSessionRequestRow {
+    request_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PendingWakeupRow {
+    request_id: Option<String>,
+    execution_origin: Option<String>,
+    metadata: Option<String>,
+}
+
 pub(crate) enum ReadToolOutputOutcome {
     Found(ReadToolOutputResponse),
     NotAuthorized,
     NotBackgrounded,
+}
+
+pub(crate) enum SteerSubagentTarget {
+    Found(ChildEdge),
+    NotAuthorized,
+    NotBackgrounded,
+    Terminal(String),
 }
 
 pub(crate) async fn handle_list_subagents(
@@ -762,6 +810,250 @@ pub(crate) async fn handle_read_tool_output(
         },
         exit_code: None,
     }))
+}
+
+pub(crate) async fn load_steer_subagent_target(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    child_request_id: &str,
+) -> Result<SteerSubagentTarget> {
+    if child_request_id.trim().is_empty() {
+        return Ok(SteerSubagentTarget::NotAuthorized);
+    }
+    let parent_context = load_parent_subagent_context(node, caller_request_id).await?;
+    let edge = match load_authorized_child_edge(node, &parent_context, child_request_id).await {
+        Ok(edge) => edge,
+        Err(error) if authorization_lookup_error(&error, caller_request_id, child_request_id) => {
+            return Ok(SteerSubagentTarget::NotAuthorized);
+        }
+        Err(error) => return Err(error),
+    };
+    if edge.await_mode != AwaitMode::Background {
+        return Ok(SteerSubagentTarget::NotBackgrounded);
+    }
+    let Some(terminal_row) = load_child_terminal_row(node, &edge.child_request_id).await? else {
+        return Ok(SteerSubagentTarget::NotAuthorized);
+    };
+    if let Some(state) = child_terminal_state_name(&terminal_row) {
+        return Ok(SteerSubagentTarget::Terminal(state));
+    }
+
+    Ok(SteerSubagentTarget::Found(edge))
+}
+
+pub(crate) async fn append_steering_request(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    edge: &ChildEdge,
+    message: &str,
+    interrupted_request_id: Option<String>,
+    drained_wake_up_request_ids: Vec<String>,
+) -> Result<SteerSubagentResponse> {
+    session::append_message(node, &edge.child_session_id, "user", message).await?;
+    let child_request = load_agent_request_for_queue(node, &edge.child_request_id)
+        .await?
+        .ok_or_else(|| anyhow!("child AgentRequest {} not found", edge.child_request_id))?;
+    if child_request.caused_by_parent_request_id.as_deref() != Some(caller_request_id) {
+        anyhow::bail!(
+            "child AgentRequest {} no longer links to caller request {caller_request_id}",
+            edge.child_request_id
+        );
+    }
+    let enqueued = enqueue_session_request(
+        node,
+        &child_request,
+        message,
+        ExecutionOrigin::Interactive,
+        QueueHints {
+            source: QueueSource::Steering,
+            policy: QueuePolicy::Append,
+            key: None,
+            queued_after_request_id: None,
+            interrupted_request_id: interrupted_request_id.clone(),
+        },
+    )
+    .await?;
+
+    Ok(SteerSubagentResponse {
+        child_request_id: edge.child_request_id.clone(),
+        child_session_id: edge.child_session_id.clone(),
+        queued_request_id: enqueued.request_id,
+        interrupted_active_request_id: interrupted_request_id,
+        drained_wake_up_request_ids,
+    })
+}
+
+pub(crate) async fn active_session_request_id(
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> Result<Option<String>> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    session_id: {{ _eq: "{escaped_session_id}" }},
+                    status: {{ _eq: "processing" }},
+                    lifecycle_state: {{ _in: ["claimed", "processing"] }}
+                }},
+                order: [{{ created_at: ASC }}, {{ request_id: ASC }}],
+                limit: 1
+            ) {{
+                request_id
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query active request for session {session_id} failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(
+        first_row::<ActiveSessionRequestRow>(response.data.as_ref(), "AgentRequest")
+            .map(|row| row.request_id),
+    )
+}
+
+pub(crate) async fn drain_automated_wakeups_returning_ids(
+    node: &EmbeddedNode,
+    session_id: &str,
+    reason: &str,
+) -> Result<Vec<String>> {
+    let request_ids = pending_automated_wakeup_request_ids(node, session_id).await?;
+    drain_automated_wakeups(node, session_id, reason).await?;
+    Ok(request_ids)
+}
+
+pub(crate) async fn pending_automated_wakeup_request_ids(
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> Result<Vec<String>> {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    session_id: {{ _eq: "{escaped_session_id}" }},
+                    status: {{ _eq: "pending" }},
+                    lifecycle_state: {{ _eq: "pending" }}
+                }},
+                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
+            ) {{
+                request_id
+                execution_origin
+                metadata
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query pending automated wake-ups for session {session_id} failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<PendingWakeupRow> = rows(response.data.as_ref(), "AgentRequest")?;
+    Ok(rows
+        .into_iter()
+        .filter(|row| {
+            row.execution_origin.as_deref() == Some("scheduled")
+                && is_automated_wakeup(row.metadata.as_deref())
+        })
+        .filter_map(|row| non_empty_string(row.request_id.as_deref()))
+        .collect())
+}
+
+async fn load_agent_request_for_queue(
+    node: &EmbeddedNode,
+    request_id: &str,
+) -> Result<Option<AgentRequest>> {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                limit: 1
+            ) {{
+                _docID
+                request_id
+                agent_did
+                behavior_id
+                session_id
+                content
+                temperature
+                top_p
+                top_k
+                max_tokens
+                metadata
+                execution_origin
+                created_at
+                deadline
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query AgentRequest {request_id} for steering queue failed: {:?}",
+            response.errors
+        );
+    }
+    let Some(row) = first_row::<AgentRequestQueueRow>(response.data.as_ref(), "AgentRequest")
+    else {
+        return Ok(None);
+    };
+    let request = AgentRequest {
+        doc_id: row.doc_id,
+        request_id: row.request_id,
+        agent_did: row.agent_did,
+        behavior_id: normalize_optional_string(row.behavior_id),
+        session_id: row.session_id,
+        content: row.content,
+        temperature: row.temperature,
+        top_p: row.top_p,
+        top_k: row.top_k,
+        max_tokens: row.max_tokens,
+        metadata: row.metadata,
+        execution_origin: normalize_optional_string(row.execution_origin),
+        created_at: row.created_at,
+        deadline: normalize_optional_string(row.deadline),
+        subagent_depth: row.subagent_depth.unwrap_or(0),
+        caused_by_parent_request_id: normalize_optional_string(row.caused_by_parent_request_id),
+        caused_by_parent_tool_call_id: normalize_optional_string(row.caused_by_parent_tool_call_id),
+    };
+    validate_agent_request_subagent_coherence(&request)?;
+    Ok(Some(request))
+}
+
+fn child_terminal_state_name(row: &ChildRequestTerminalRow) -> Option<String> {
+    if child_request_completed(row) {
+        return Some(
+            row.lifecycle_state
+                .as_deref()
+                .or(row.status.as_deref())
+                .unwrap_or("completed")
+                .to_string(),
+        );
+    }
+    project_child_terminal(row).map(|_| {
+        row.lifecycle_state
+            .as_deref()
+            .or(row.status.as_deref())
+            .unwrap_or("terminal")
+            .to_string()
+    })
+}
+
+fn normalize_optional_string(value: Option<String>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
 }
 
 fn read_tool_output_stream(value: &str, max_bytes: usize) -> ReadToolOutputStream {

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)] // R4b lands these helpers one task ahead of their tool integrations.
 
+mod r4c_args;
+
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
 use defra_agent_protocol::transcript::decode_persisted_message;

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -20,7 +20,8 @@ use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
 use self::r4c_args::{
     ListBackgroundToolsArgs, ListBackgroundToolsEntry, ListBackgroundToolsResponse,
     ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
-    ReadSubagentTranscriptArgs, ReadSubagentTranscriptResponse,
+    ReadSubagentTranscriptArgs, ReadSubagentTranscriptResponse, ReadToolOutputArgs,
+    ReadToolOutputResponse, ReadToolOutputStream,
 };
 use self::transcript_render::{
     render_transcript, MessageKindView, MessageRoleView, MessageView, RenderOptions,
@@ -254,6 +255,23 @@ struct TranscriptToolCallRow {
     tool_call_id: String,
     tool_name: String,
     child_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReadToolOutputRow {
+    tool_call_id: String,
+    tool_name: String,
+    request_id: Option<String>,
+    await_mode: Option<String>,
+    lifecycle_state: Option<String>,
+    child_request_id: Option<String>,
+    result: Option<String>,
+}
+
+pub(crate) enum ReadToolOutputOutcome {
+    Found(ReadToolOutputResponse),
+    NotAuthorized,
+    NotBackgrounded,
 }
 
 pub(crate) async fn handle_list_subagents(
@@ -670,6 +688,101 @@ fn tool_result_identities(message: &Message) -> Vec<String> {
         }
     }
     ids
+}
+
+pub(crate) async fn handle_read_tool_output(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    args: ReadToolOutputArgs,
+) -> Result<ReadToolOutputOutcome> {
+    let tool_call_id = args.tool_call_id.trim();
+    if tool_call_id.is_empty() {
+        return Ok(ReadToolOutputOutcome::NotAuthorized);
+    }
+
+    let escaped_tool_call_id = escape_graphql_string(tool_call_id);
+    let escaped_caller = escape_graphql_string(caller_request_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _eq: "{escaped_caller}" }},
+                    tool_call_id: {{ _eq: "{escaped_tool_call_id}" }}
+                }},
+                limit: 1
+            ) {{
+                tool_call_id
+                tool_name
+                request_id
+                await_mode
+                lifecycle_state
+                child_request_id
+                result
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("read_tool_output query failed: {:?}", response.errors);
+    }
+    let Some(row) = first_row::<ReadToolOutputRow>(response.data.as_ref(), "AgentToolCall") else {
+        return Ok(ReadToolOutputOutcome::NotAuthorized);
+    };
+    if row.request_id.as_deref() != Some(caller_request_id) {
+        return Ok(ReadToolOutputOutcome::NotAuthorized);
+    }
+    if row.await_mode.as_deref() != Some("background")
+        || non_empty_string(row.child_request_id.as_deref()).is_some()
+    {
+        return Ok(ReadToolOutputOutcome::NotBackgrounded);
+    }
+
+    let status = row
+        .lifecycle_state
+        .as_deref()
+        .filter(|state| !state.trim().is_empty())
+        .unwrap_or("running")
+        .to_string();
+    let max_bytes = args.validated_max_bytes() as usize;
+    let result = if status == "running" {
+        ""
+    } else {
+        row.result.as_deref().unwrap_or_default()
+    };
+    let stdout = read_tool_output_stream(result, max_bytes);
+    Ok(ReadToolOutputOutcome::Found(ReadToolOutputResponse {
+        tool_call_id: row.tool_call_id,
+        tool_name: row.tool_name,
+        status,
+        stdout,
+        stderr: ReadToolOutputStream {
+            bytes: String::new(),
+            truncated: false,
+            total_bytes_seen: 0,
+        },
+        exit_code: None,
+    }))
+}
+
+fn read_tool_output_stream(value: &str, max_bytes: usize) -> ReadToolOutputStream {
+    let total_bytes_seen = value.as_bytes().len() as u64;
+    let (bytes, truncated) = truncate_utf8_prefix(value, max_bytes);
+    ReadToolOutputStream {
+        bytes,
+        truncated,
+        total_bytes_seen,
+    }
+}
+
+fn truncate_utf8_prefix(value: &str, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value.to_string(), false);
+    }
+    let mut end = max_bytes.min(value.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    (value[..end].to_string(), true)
 }
 
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -11,7 +11,7 @@ use defra_agent_protocol::transcript::{decode_persisted_message, present_persist
 use defra_node::EmbeddedNode;
 use rig::completion::message::{AssistantContent, Message, Text, UserContent};
 use serde::Deserialize;
-use serde_json::json;
+use serde_json::{json, Value};
 
 use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::lifecycle::queue::{
@@ -261,6 +261,7 @@ struct TranscriptToolCallRow {
     message_sequence: u64,
     tool_call_id: String,
     tool_name: String,
+    await_mode: Option<String>,
     child_request_id: Option<String>,
 }
 
@@ -561,6 +562,7 @@ pub(crate) async fn handle_read_subagent_transcript(
                 message_sequence
                 tool_call_id
                 tool_name
+                await_mode
                 child_request_id
             }}
         }}"#
@@ -641,7 +643,9 @@ fn decode_transcript_message_views(
     for row in tool_call_rows {
         if let Some(tool_call_id) = non_empty_string(Some(&row.tool_call_id)) {
             tool_names_by_call_id.insert(tool_call_id.clone(), row.tool_name);
-            if non_empty_string(row.child_request_id.as_deref()).is_some() {
+            let is_background_bridge = non_empty_string(row.child_request_id.as_deref()).is_some()
+                || row.await_mode.as_deref().map(str::trim) == Some("background");
+            if is_background_bridge {
                 bridge_call_ids_by_sequence
                     .entry(row.message_sequence)
                     .or_default()
@@ -797,18 +801,24 @@ pub(crate) async fn handle_read_tool_output(
     } else {
         row.result.as_deref().unwrap_or_default()
     };
-    let stdout = read_tool_output_stream(result, max_bytes);
+    let persisted = persisted_tool_output_streams(&row.tool_name, result);
+    let stdout = read_tool_output_stream(
+        &persisted.stdout,
+        max_bytes,
+        persisted.stdout_total_bytes_seen,
+    );
+    let stderr = read_tool_output_stream(
+        &persisted.stderr,
+        max_bytes,
+        persisted.stderr_total_bytes_seen,
+    );
     Ok(ReadToolOutputOutcome::Found(ReadToolOutputResponse {
         tool_call_id: row.tool_call_id,
         tool_name: row.tool_name,
         status,
         stdout,
-        stderr: ReadToolOutputStream {
-            bytes: String::new(),
-            truncated: false,
-            total_bytes_seen: 0,
-        },
-        exit_code: None,
+        stderr,
+        exit_code: persisted.exit_code,
     }))
 }
 
@@ -850,7 +860,7 @@ pub(crate) async fn append_steering_request(
     drained_wake_up_request_ids: Vec<String>,
 ) -> Result<SteerSubagentResponse> {
     session::append_message(node, &edge.child_session_id, "user", message).await?;
-    let child_request = load_agent_request_for_queue(node, &edge.child_request_id)
+    let mut child_request = load_agent_request_for_queue(node, &edge.child_request_id)
         .await?
         .ok_or_else(|| anyhow!("child AgentRequest {} not found", edge.child_request_id))?;
     if child_request.caused_by_parent_request_id.as_deref() != Some(caller_request_id) {
@@ -859,6 +869,8 @@ pub(crate) async fn append_steering_request(
             edge.child_request_id
         );
     }
+    child_request.caused_by_parent_request_id = Some(caller_request_id.to_string());
+    child_request.caused_by_parent_tool_call_id = None;
     let enqueued = enqueue_session_request(
         node,
         &child_request,
@@ -1056,9 +1068,82 @@ fn normalize_optional_string(value: Option<String>) -> Option<String> {
     })
 }
 
-fn read_tool_output_stream(value: &str, max_bytes: usize) -> ReadToolOutputStream {
-    let total_bytes_seen = value.as_bytes().len() as u64;
-    let (bytes, truncated) = truncate_utf8_prefix(value, max_bytes);
+#[derive(Debug, Default)]
+struct PersistedToolOutputStreams {
+    stdout: String,
+    stderr: String,
+    exit_code: Option<i32>,
+    stdout_total_bytes_seen: Option<u64>,
+    stderr_total_bytes_seen: Option<u64>,
+}
+
+fn persisted_tool_output_streams(tool_name: &str, result: &str) -> PersistedToolOutputStreams {
+    parse_native_command_output_streams(tool_name, result).unwrap_or_else(|| {
+        PersistedToolOutputStreams {
+            stdout: result.to_string(),
+            stdout_total_bytes_seen: Some(result.as_bytes().len() as u64),
+            ..Default::default()
+        }
+    })
+}
+
+fn parse_native_command_output_streams(
+    tool_name: &str,
+    result: &str,
+) -> Option<PersistedToolOutputStreams> {
+    if !matches!(tool_name, "bash" | "bash_unrestricted") {
+        return None;
+    }
+
+    let trimmed = result.trim_start();
+    let (metadata_line, body) = trimmed.split_once('\n')?;
+    let metadata = metadata_line.trim().strip_prefix("defra_exec: ")?;
+    let metadata = serde_json::from_str::<Value>(metadata).ok()?;
+    let body = body.strip_prefix("stdout:\n")?;
+    let (stdout, stderr) = body.rsplit_once("\nstderr:\n")?;
+    let stdout = persisted_stream_body(stdout);
+    let stderr = persisted_stream_body(stderr);
+    let stdout_total_bytes_seen = stream_total_seen(&metadata, "stdout_truncation", &stdout);
+    let stderr_total_bytes_seen = stream_total_seen(&metadata, "stderr_truncation", &stderr);
+    let exit_code = metadata
+        .get("exit_code")
+        .and_then(Value::as_i64)
+        .and_then(|code| i32::try_from(code).ok());
+
+    Some(PersistedToolOutputStreams {
+        stdout,
+        stderr,
+        exit_code,
+        stdout_total_bytes_seen: Some(stdout_total_bytes_seen),
+        stderr_total_bytes_seen: Some(stderr_total_bytes_seen),
+    })
+}
+
+fn persisted_stream_body(value: &str) -> String {
+    if value == "(empty)" {
+        String::new()
+    } else {
+        value.to_string()
+    }
+}
+
+fn stream_total_seen(metadata: &Value, key: &str, returned: &str) -> u64 {
+    metadata
+        .get(key)
+        .and_then(|value| value.get("total_chars"))
+        .and_then(Value::as_u64)
+        .unwrap_or_else(|| returned.as_bytes().len() as u64)
+        .max(returned.as_bytes().len() as u64)
+}
+
+fn read_tool_output_stream(
+    value: &str,
+    max_bytes: usize,
+    total_bytes_seen: Option<u64>,
+) -> ReadToolOutputStream {
+    let value_bytes = value.as_bytes().len() as u64;
+    let total_bytes_seen = total_bytes_seen.unwrap_or(value_bytes).max(value_bytes);
+    let (bytes, truncated) = truncate_utf8_tail(value, max_bytes);
     ReadToolOutputStream {
         bytes,
         truncated,
@@ -1066,15 +1151,15 @@ fn read_tool_output_stream(value: &str, max_bytes: usize) -> ReadToolOutputStrea
     }
 }
 
-fn truncate_utf8_prefix(value: &str, max_bytes: usize) -> (String, bool) {
+fn truncate_utf8_tail(value: &str, max_bytes: usize) -> (String, bool) {
     if value.len() <= max_bytes {
         return (value.to_string(), false);
     }
-    let mut end = max_bytes.min(value.len());
-    while end > 0 && !value.is_char_boundary(end) {
-        end -= 1;
+    let mut start = value.len().saturating_sub(max_bytes);
+    while start < value.len() && !value.is_char_boundary(start) {
+        start += 1;
     }
-    (value[..end].to_string(), true)
+    (value[start..].to_string(), true)
 }
 
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {
@@ -1086,7 +1171,13 @@ fn list_status_matches(filter: ListStatusFilter, status: &str) -> bool {
         ListStatusFilter::Running => status == "running",
         ListStatusFilter::Terminal => matches!(
             status,
-            "completed" | "failed" | "timedOut" | "cancelled" | "dead" | "interrupted"
+            "completed"
+                | "failed"
+                | "timedOut"
+                | "cancelled"
+                | "dead"
+                | "interrupted"
+                | "superseded"
         ),
         ListStatusFilter::All => !status.trim().is_empty(),
     }

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -18,6 +18,7 @@ use crate::session::execute_mutation_with_retry;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
 
 use self::r4c_args::{
+    ListBackgroundToolsArgs, ListBackgroundToolsEntry, ListBackgroundToolsResponse,
     ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
 };
 
@@ -224,6 +225,18 @@ struct ListSubagentChildRow {
     subagent_depth: Option<u32>,
 }
 
+#[derive(Debug, Deserialize)]
+struct ListBackgroundToolRow {
+    tool_call_id: String,
+    tool_name: String,
+    await_mode: Option<String>,
+    lifecycle_state: Option<String>,
+    child_request_id: Option<String>,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+    result: Option<String>,
+}
+
 pub(crate) async fn handle_list_subagents(
     node: &EmbeddedNode,
     caller_request_id: &str,
@@ -337,7 +350,94 @@ pub(crate) async fn handle_list_subagents(
     })
 }
 
+pub(crate) async fn handle_list_background_tools(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    local_deployment_id: &str,
+    args: ListBackgroundToolsArgs,
+) -> Result<ListBackgroundToolsResponse> {
+    let limit = args.validated_limit() as usize;
+    let escaped_caller = escape_graphql_string(caller_request_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _eq: "{escaped_caller}" }},
+                    await_mode: {{ _eq: "background" }}
+                }},
+                order: {{ started_at: ASC }}
+            ) {{
+                tool_call_id
+                tool_name
+                await_mode
+                lifecycle_state
+                child_request_id
+                started_at
+                completed_at
+                result
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!("list_background_tools query failed: {:?}", response.errors);
+    }
+    let rows: Vec<ListBackgroundToolRow> = rows(response.data.as_ref(), "AgentToolCall")?;
+
+    let mut entries = Vec::new();
+    for row in rows {
+        if non_empty_string(row.child_request_id.as_deref()).is_some() {
+            continue;
+        }
+        if row.await_mode.as_deref() != Some("background") {
+            continue;
+        }
+        let Some(tool_call_id) = non_empty_string(Some(&row.tool_call_id)) else {
+            continue;
+        };
+        let status = row
+            .lifecycle_state
+            .as_deref()
+            .filter(|state| !state.trim().is_empty())
+            .unwrap_or("running");
+        if !list_status_matches(args.status, status) {
+            continue;
+        }
+        let created_at = parse_rfc3339(row.started_at.as_deref())
+            .ok_or_else(|| anyhow!("background tool call {tool_call_id} has invalid started_at"))?;
+        let last_update = parse_rfc3339(row.completed_at.as_deref()).unwrap_or(created_at);
+        let stdout_bytes = row
+            .result
+            .as_deref()
+            .map_or(0, |result| result.len() as u64);
+
+        entries.push(ListBackgroundToolsEntry {
+            tool_call_id,
+            tool_name: row.tool_name,
+            deployment_id: local_deployment_id.to_string(),
+            await_mode: "background".to_string(),
+            status: status.to_string(),
+            created_at,
+            last_update,
+            stdout_bytes,
+            stderr_bytes: 0,
+        });
+    }
+
+    let truncated = entries.len() > limit;
+    entries.truncate(limit);
+    Ok(ListBackgroundToolsResponse {
+        read_at: Utc::now(),
+        truncated,
+        entries,
+    })
+}
+
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {
+    list_status_matches(filter, status)
+}
+
+fn list_status_matches(filter: ListStatusFilter, status: &str) -> bool {
     match filter {
         ListStatusFilter::Running => status == "running",
         ListStatusFilter::Terminal => matches!(

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -1,7 +1,9 @@
 #![allow(dead_code)] // R4b lands these helpers one task ahead of their tool integrations.
 
-mod r4c_args;
+pub(crate) mod r4c_args;
 mod transcript_render;
+
+use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
@@ -14,6 +16,10 @@ use serde_json::json;
 use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::session::execute_mutation_with_retry;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
+
+use self::r4c_args::{
+    ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
+};
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SpawnSubagentArgs {
@@ -198,6 +204,149 @@ struct ToolSelectionTargetsRow {
 }
 
 pub(crate) const DEFAULT_CROSS_DEPLOYMENT_SPAWN_TIMEOUT_SECONDS: u32 = 60;
+
+#[derive(Debug, Deserialize)]
+struct ListSubagentBridgeRow {
+    tool_call_id: String,
+    child_request_id: Option<String>,
+    lifecycle_state: Option<String>,
+    await_mode: Option<String>,
+    started_at: Option<String>,
+    completed_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListSubagentChildRow {
+    request_id: String,
+    session_id: String,
+    behavior_id: Option<String>,
+    created_at: String,
+    subagent_depth: Option<u32>,
+}
+
+pub(crate) async fn handle_list_subagents(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    local_deployment_id: &str,
+    args: ListSubagentsArgs,
+) -> Result<ListSubagentsResponse> {
+    let limit = args.validated_limit() as usize;
+    let escaped_caller = escape_graphql_string(caller_request_id);
+    let escaped_spawn_tool = escape_graphql_string("spawn_subagent");
+    let bridge_query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _eq: "{escaped_caller}" }},
+                    tool_name: {{ _eq: "{escaped_spawn_tool}" }}
+                }},
+                order: {{ started_at: ASC }}
+            ) {{
+                tool_call_id
+                child_request_id
+                lifecycle_state
+                await_mode
+                started_at
+                completed_at
+            }}
+        }}"#
+    );
+    let bridge_response = node.execute(&bridge_query).await;
+    if bridge_response.has_errors() {
+        anyhow::bail!(
+            "list_subagents bridge query failed: {:?}",
+            bridge_response.errors
+        );
+    }
+    let bridges: Vec<ListSubagentBridgeRow> = rows(bridge_response.data.as_ref(), "AgentToolCall")?;
+
+    let child_query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    caused_by_parent_request_id: {{ _eq: "{escaped_caller}" }}
+                }},
+                order: {{ created_at: ASC }}
+            ) {{
+                request_id
+                session_id
+                behavior_id
+                created_at
+                subagent_depth
+            }}
+        }}"#
+    );
+    let child_response = node.execute(&child_query).await;
+    if child_response.has_errors() {
+        anyhow::bail!(
+            "list_subagents child query failed: {:?}",
+            child_response.errors
+        );
+    }
+    let children_by_request =
+        rows::<ListSubagentChildRow>(child_response.data.as_ref(), "AgentRequest")?
+            .into_iter()
+            .map(|row| (row.request_id.clone(), row))
+            .collect::<HashMap<_, _>>();
+
+    let mut entries = Vec::new();
+    for bridge in bridges {
+        if bridge.await_mode.as_deref() != Some("background") {
+            continue;
+        }
+        let Some(child_request_id) = non_empty_string(bridge.child_request_id.as_deref()) else {
+            continue;
+        };
+        let status = bridge
+            .lifecycle_state
+            .as_deref()
+            .filter(|state| !state.trim().is_empty())
+            .unwrap_or("running");
+        if !list_subagent_status_matches(args.status, status) {
+            continue;
+        }
+        let Some(child) = children_by_request.get(&child_request_id) else {
+            continue;
+        };
+        let created_at = parse_rfc3339(Some(&child.created_at)).ok_or_else(|| {
+            anyhow!("child AgentRequest {child_request_id} has invalid created_at")
+        })?;
+        let last_update = parse_rfc3339(bridge.completed_at.as_deref())
+            .or_else(|| parse_rfc3339(bridge.started_at.as_deref()))
+            .unwrap_or(created_at);
+
+        entries.push(ListSubagentsEntry {
+            child_request_id,
+            child_session_id: child.session_id.clone(),
+            behavior_id: non_empty_string(child.behavior_id.as_deref()).unwrap_or_default(),
+            deployment_id: local_deployment_id.to_string(),
+            await_mode: "background".to_string(),
+            status: status.to_string(),
+            created_at,
+            last_update,
+            depth: child.subagent_depth.unwrap_or_default(),
+        });
+    }
+
+    let truncated = entries.len() > limit;
+    entries.truncate(limit);
+    Ok(ListSubagentsResponse {
+        read_at: Utc::now(),
+        truncated,
+        entries,
+    })
+}
+
+fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {
+    match filter {
+        ListStatusFilter::Running => status == "running",
+        ListStatusFilter::Terminal => matches!(
+            status,
+            "completed" | "failed" | "timedOut" | "cancelled" | "dead" | "interrupted"
+        ),
+        ListStatusFilter::All => !status.trim().is_empty(),
+    }
+}
 
 pub(crate) async fn load_parent_subagent_context(
     node: &EmbeddedNode,
@@ -854,6 +1003,16 @@ where
     data.and_then(|data| data.get(collection))
         .and_then(|value| serde_json::from_value::<Vec<T>>(value.clone()).ok())
         .and_then(|mut rows| rows.pop())
+}
+
+fn rows<T>(data: Option<&serde_json::Value>, collection: &str) -> Result<Vec<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let Some(value) = data.and_then(|data| data.get(collection)) else {
+        anyhow::bail!("{collection} field missing from query response");
+    };
+    serde_json::from_value(value.clone()).map_err(|error| anyhow!("parse {collection}: {error}"))
 }
 
 fn dedupe_non_empty(values: Vec<String>) -> Vec<String> {

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -3,13 +3,13 @@
 pub(crate) mod r4c_args;
 mod transcript_render;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};
-use defra_agent_protocol::transcript::decode_persisted_message;
+use defra_agent_protocol::transcript::{decode_persisted_message, present_persisted_message};
 use defra_node::EmbeddedNode;
-use rig::completion::message::{AssistantContent, Message, Text};
+use rig::completion::message::{AssistantContent, Message, Text, UserContent};
 use serde::Deserialize;
 use serde_json::json;
 
@@ -20,6 +20,10 @@ use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
 use self::r4c_args::{
     ListBackgroundToolsArgs, ListBackgroundToolsEntry, ListBackgroundToolsResponse,
     ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
+    ReadSubagentTranscriptArgs, ReadSubagentTranscriptResponse,
+};
+use self::transcript_render::{
+    render_transcript, MessageKindView, MessageRoleView, MessageView, RenderOptions,
 };
 
 #[derive(Debug, Clone, Deserialize)]
@@ -237,6 +241,21 @@ struct ListBackgroundToolRow {
     result: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct TranscriptMessageRow {
+    sequence: u64,
+    role: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TranscriptToolCallRow {
+    message_sequence: u64,
+    tool_call_id: String,
+    tool_name: String,
+    child_request_id: Option<String>,
+}
+
 pub(crate) async fn handle_list_subagents(
     node: &EmbeddedNode,
     caller_request_id: &str,
@@ -431,6 +450,226 @@ pub(crate) async fn handle_list_background_tools(
         truncated,
         entries,
     })
+}
+
+pub(crate) async fn handle_read_subagent_transcript(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    args: ReadSubagentTranscriptArgs,
+) -> Result<Option<ReadSubagentTranscriptResponse>> {
+    let child_request_id = args.child_request_id.trim();
+    let Some(edge) =
+        load_readable_background_child_edge(node, caller_request_id, child_request_id).await?
+    else {
+        return Ok(None);
+    };
+
+    let escaped_session_id = escape_graphql_string(&edge.child_session_id);
+    let messages_query = format!(
+        r#"{{
+            AgentMessage(
+                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
+                order: {{ sequence: ASC }}
+            ) {{
+                sequence
+                role
+                content
+            }}
+        }}"#
+    );
+    let messages_response = node.execute(&messages_query).await;
+    if messages_response.has_errors() {
+        anyhow::bail!(
+            "read_subagent_transcript AgentMessage query failed: {:?}",
+            messages_response.errors
+        );
+    }
+    let message_rows: Vec<TranscriptMessageRow> =
+        rows(messages_response.data.as_ref(), "AgentMessage")?;
+
+    let tool_calls_query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }}
+            ) {{
+                message_sequence
+                tool_call_id
+                tool_name
+                child_request_id
+            }}
+        }}"#
+    );
+    let tool_calls_response = node.execute(&tool_calls_query).await;
+    if tool_calls_response.has_errors() {
+        anyhow::bail!(
+            "read_subagent_transcript AgentToolCall query failed: {:?}",
+            tool_calls_response.errors
+        );
+    }
+    let tool_call_rows: Vec<TranscriptToolCallRow> =
+        rows(tool_calls_response.data.as_ref(), "AgentToolCall")?;
+
+    let views = decode_transcript_message_views(message_rows, tool_call_rows);
+    let rendered = render_transcript(
+        &views,
+        args.since_sequence,
+        RenderOptions {
+            include_user_messages: args.include_user_messages,
+            include_tool_results: args.include_tool_results,
+            limit: args.validated_limit(),
+            max_chars: args.validated_max_chars(),
+        },
+    );
+
+    Ok(Some(ReadSubagentTranscriptResponse {
+        child_request_id: edge.child_request_id,
+        child_session_id: edge.child_session_id,
+        from_sequence: rendered.from_sequence,
+        through_sequence: rendered.through_sequence,
+        next_sequence: rendered.next_sequence,
+        truncated: rendered.truncated,
+        transcript: rendered.transcript,
+    }))
+}
+
+async fn load_readable_background_child_edge(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    child_request_id: &str,
+) -> Result<Option<ChildEdge>> {
+    if child_request_id.is_empty() {
+        return Ok(None);
+    }
+    let parent_context = load_parent_subagent_context(node, caller_request_id).await?;
+    match load_authorized_child_edge(node, &parent_context, child_request_id).await {
+        Ok(edge) if edge.await_mode == AwaitMode::Background => Ok(Some(edge)),
+        Ok(_) => Ok(None),
+        Err(error) if authorization_lookup_error(&error, caller_request_id, child_request_id) => {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn authorization_lookup_error(
+    error: &anyhow::Error,
+    caller_request_id: &str,
+    child_request_id: &str,
+) -> bool {
+    let message = error.to_string();
+    message.contains(&format!("child AgentRequest {child_request_id} not found"))
+        || message.contains(&format!(
+            "child AgentRequest {child_request_id} is not linked to parent request {caller_request_id}"
+        ))
+        || (message.contains("parent AgentToolCall") && message.contains("not found for child"))
+        || message.contains("has no parent tool-call link")
+        || message.contains("does not point at child")
+}
+
+fn decode_transcript_message_views(
+    message_rows: Vec<TranscriptMessageRow>,
+    tool_call_rows: Vec<TranscriptToolCallRow>,
+) -> Vec<MessageView> {
+    let mut bridge_call_ids_by_sequence = HashMap::<u64, HashSet<String>>::new();
+    let mut tool_names_by_call_id = HashMap::<String, String>::new();
+    for row in tool_call_rows {
+        if let Some(tool_call_id) = non_empty_string(Some(&row.tool_call_id)) {
+            tool_names_by_call_id.insert(tool_call_id.clone(), row.tool_name);
+            if non_empty_string(row.child_request_id.as_deref()).is_some() {
+                bridge_call_ids_by_sequence
+                    .entry(row.message_sequence)
+                    .or_default()
+                    .insert(tool_call_id);
+            }
+        }
+    }
+
+    message_rows
+        .into_iter()
+        .map(|row| {
+            let presentation = present_persisted_message(&row.role, &row.content);
+            let message = decode_persisted_message(&row.role, &row.content);
+            let role = if row.role == "assistant" {
+                MessageRoleView::Assistant
+            } else {
+                MessageRoleView::User
+            };
+            let body = presentation.body_markdown;
+            let kind = if presentation.has_tool_results {
+                let tool_name = tool_result_identities(&message)
+                    .into_iter()
+                    .find_map(|id| tool_names_by_call_id.get(&id).cloned())
+                    .unwrap_or_else(|| "tool".to_string());
+                MessageKindView::ToolResult { tool_name, body }
+            } else if presentation.has_tool_calls {
+                let bridge_call_ids = bridge_call_ids_by_sequence
+                    .get(&row.sequence)
+                    .map(|ids| ids.iter().cloned().collect::<Vec<_>>())
+                    .unwrap_or_default();
+                let bridge_set = bridge_call_ids.iter().cloned().collect::<HashSet<_>>();
+                let tool_call_identities = assistant_tool_call_identities(&message);
+                let non_bridge_tool_call_count = tool_call_identities
+                    .iter()
+                    .filter(|ids| ids.iter().all(|id| !bridge_set.contains(id)))
+                    .count() as u32;
+                MessageKindView::AssistantWithToolCalls {
+                    body,
+                    tool_call_count: tool_call_identities.len() as u32,
+                    bridge_call_ids,
+                    non_bridge_tool_call_count,
+                }
+            } else {
+                MessageKindView::Ordinary { body }
+            };
+
+            MessageView {
+                sequence: row.sequence,
+                role,
+                kind,
+            }
+        })
+        .collect()
+}
+
+fn assistant_tool_call_identities(message: &Message) -> Vec<Vec<String>> {
+    let Message::Assistant { content, .. } = message else {
+        return Vec::new();
+    };
+    content
+        .iter()
+        .filter_map(|item| {
+            let AssistantContent::ToolCall(tool_call) = item else {
+                return None;
+            };
+            let mut ids = Vec::new();
+            if let Some(id) = non_empty_string(Some(&tool_call.id)) {
+                ids.push(id);
+            }
+            if let Some(call_id) = non_empty_string(tool_call.call_id.as_deref()) {
+                ids.push(call_id);
+            }
+            (!ids.is_empty()).then_some(ids)
+        })
+        .collect()
+}
+
+fn tool_result_identities(message: &Message) -> Vec<String> {
+    let Message::User { content } = message else {
+        return Vec::new();
+    };
+    let mut ids = Vec::new();
+    for item in content.iter() {
+        let UserContent::ToolResult(tool_result) = item else {
+            continue;
+        };
+        if let Some(id) = non_empty_string(Some(&tool_result.id)) {
+            ids.push(id);
+        }
+        if let Some(call_id) = non_empty_string(tool_result.call_id.as_deref()) {
+            ids.push(call_id);
+        }
+    }
+    ids
 }
 
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)] // R4b lands these helpers one task ahead of their tool integrations.
 
 mod r4c_args;
+mod transcript_render;
 
 use anyhow::{anyhow, Result};
 use chrono::{DateTime, Utc};

--- a/crates/defra-agent/src/background_tools/r4c_args.rs
+++ b/crates/defra-agent/src/background_tools/r4c_args.rs
@@ -1,0 +1,315 @@
+//! Argument and envelope types for the R4c agent-facing background-work tools.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_LIST_LIMIT: u32 = 20;
+const MAX_LIST_LIMIT: u32 = 50;
+const DEFAULT_TRANSCRIPT_LIMIT: u32 = 20;
+const MAX_TRANSCRIPT_LIMIT: u32 = 100;
+const DEFAULT_TRANSCRIPT_MAX_CHARS: u32 = 6000;
+const MAX_TRANSCRIPT_MAX_CHARS: u32 = 24000;
+const DEFAULT_READ_TOOL_OUTPUT_BYTES: u32 = 16384;
+const MAX_READ_TOOL_OUTPUT_BYTES: u32 = 262144;
+
+pub(crate) const PER_TOOL_RESULT_SNIPPET_BYTES: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ListStatusFilter {
+    #[default]
+    Running,
+    Terminal,
+    All,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ListSubagentsArgs {
+    #[serde(default)]
+    pub(crate) status: ListStatusFilter,
+    #[serde(default = "default_list_limit")]
+    pub(crate) limit: u32,
+}
+
+fn default_list_limit() -> u32 {
+    DEFAULT_LIST_LIMIT
+}
+
+impl ListSubagentsArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.clamp(1, MAX_LIST_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ListBackgroundToolsArgs {
+    #[serde(default)]
+    pub(crate) status: ListStatusFilter,
+    #[serde(default = "default_list_limit")]
+    pub(crate) limit: u32,
+}
+
+impl ListBackgroundToolsArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.clamp(1, MAX_LIST_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ReadSubagentTranscriptArgs {
+    pub(crate) child_request_id: String,
+    #[serde(default)]
+    pub(crate) since_sequence: u64,
+    #[serde(default = "default_transcript_limit")]
+    pub(crate) limit: u32,
+    #[serde(default = "default_transcript_max_chars")]
+    pub(crate) max_chars: u32,
+    #[serde(default)]
+    pub(crate) include_user_messages: bool,
+    #[serde(default)]
+    pub(crate) include_tool_results: bool,
+}
+
+fn default_transcript_limit() -> u32 {
+    DEFAULT_TRANSCRIPT_LIMIT
+}
+
+fn default_transcript_max_chars() -> u32 {
+    DEFAULT_TRANSCRIPT_MAX_CHARS
+}
+
+impl ReadSubagentTranscriptArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.clamp(1, MAX_TRANSCRIPT_LIMIT)
+    }
+
+    pub(crate) fn validated_max_chars(&self) -> u32 {
+        self.max_chars.clamp(64, MAX_TRANSCRIPT_MAX_CHARS)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ReadToolOutputArgs {
+    pub(crate) tool_call_id: String,
+    #[serde(default = "default_read_tool_output_bytes")]
+    pub(crate) max_bytes_per_stream: u32,
+}
+
+fn default_read_tool_output_bytes() -> u32 {
+    DEFAULT_READ_TOOL_OUTPUT_BYTES
+}
+
+impl ReadToolOutputArgs {
+    pub(crate) fn validated_max_bytes(&self) -> u32 {
+        self.max_bytes_per_stream
+            .clamp(256, MAX_READ_TOOL_OUTPUT_BYTES)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SteerSubagentArgs {
+    pub(crate) child_request_id: String,
+    pub(crate) message: String,
+    #[serde(default)]
+    pub(crate) interrupt: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListSubagentsEntry {
+    pub(crate) child_request_id: String,
+    pub(crate) child_session_id: String,
+    pub(crate) behavior_id: String,
+    pub(crate) deployment_id: String,
+    pub(crate) await_mode: String,
+    pub(crate) status: String,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) last_update: DateTime<Utc>,
+    pub(crate) depth: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListSubagentsResponse {
+    pub(crate) read_at: DateTime<Utc>,
+    pub(crate) truncated: bool,
+    pub(crate) entries: Vec<ListSubagentsEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListBackgroundToolsEntry {
+    pub(crate) tool_call_id: String,
+    pub(crate) tool_name: String,
+    pub(crate) deployment_id: String,
+    pub(crate) await_mode: String,
+    pub(crate) status: String,
+    pub(crate) created_at: DateTime<Utc>,
+    pub(crate) last_update: DateTime<Utc>,
+    pub(crate) stdout_bytes: u64,
+    pub(crate) stderr_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListBackgroundToolsResponse {
+    pub(crate) read_at: DateTime<Utc>,
+    pub(crate) truncated: bool,
+    pub(crate) entries: Vec<ListBackgroundToolsEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadSubagentTranscriptResponse {
+    pub(crate) child_request_id: String,
+    pub(crate) child_session_id: String,
+    pub(crate) from_sequence: u64,
+    pub(crate) through_sequence: u64,
+    pub(crate) next_sequence: u64,
+    pub(crate) truncated: bool,
+    pub(crate) transcript: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadToolOutputStream {
+    pub(crate) bytes: String,
+    pub(crate) truncated: bool,
+    pub(crate) total_bytes_seen: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadToolOutputResponse {
+    pub(crate) tool_call_id: String,
+    pub(crate) tool_name: String,
+    pub(crate) status: String,
+    pub(crate) stdout: ReadToolOutputStream,
+    pub(crate) stderr: ReadToolOutputStream,
+    pub(crate) exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SteerSubagentResponse {
+    pub(crate) child_request_id: String,
+    pub(crate) child_session_id: String,
+    pub(crate) queued_request_id: String,
+    pub(crate) interrupted_active_request_id: Option<String>,
+    pub(crate) drained_wake_up_request_ids: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn list_subagents_args_round_trip() {
+        let args: ListSubagentsArgs = serde_json::from_value(json!({
+            "status": "running",
+            "limit": 20
+        }))
+        .expect("parse");
+        assert_eq!(args.status, ListStatusFilter::Running);
+        assert_eq!(args.limit, 20);
+        assert_eq!(args.validated_limit(), 20);
+    }
+
+    #[test]
+    fn list_subagents_args_defaults_and_caps() {
+        let args: ListSubagentsArgs = serde_json::from_value(json!({})).expect("parse");
+        assert_eq!(args.status, ListStatusFilter::Running);
+        assert_eq!(args.limit, DEFAULT_LIST_LIMIT);
+
+        let capped: ListSubagentsArgs =
+            serde_json::from_value(json!({ "status": "all", "limit": 500 })).expect("parse");
+        assert_eq!(capped.status, ListStatusFilter::All);
+        assert_eq!(capped.validated_limit(), MAX_LIST_LIMIT);
+
+        let floored: ListSubagentsArgs =
+            serde_json::from_value(json!({ "limit": 0 })).expect("parse");
+        assert_eq!(floored.validated_limit(), 1);
+    }
+
+    #[test]
+    fn list_background_tools_args_round_trip_and_defaults() {
+        let defaults: ListBackgroundToolsArgs =
+            serde_json::from_value(json!({})).expect("parse defaults");
+        assert_eq!(defaults.status, ListStatusFilter::Running);
+        assert_eq!(defaults.limit, DEFAULT_LIST_LIMIT);
+
+        let explicit: ListBackgroundToolsArgs = serde_json::from_value(json!({
+            "status": "terminal",
+            "limit": 51
+        }))
+        .expect("parse explicit");
+        assert_eq!(explicit.status, ListStatusFilter::Terminal);
+        assert_eq!(explicit.validated_limit(), MAX_LIST_LIMIT);
+    }
+
+    #[test]
+    fn read_subagent_transcript_args_round_trip_and_defaults() {
+        let defaults: ReadSubagentTranscriptArgs = serde_json::from_value(json!({
+            "child_request_id": "child-1"
+        }))
+        .expect("parse defaults");
+        assert_eq!(defaults.child_request_id, "child-1");
+        assert_eq!(defaults.since_sequence, 0);
+        assert_eq!(defaults.limit, DEFAULT_TRANSCRIPT_LIMIT);
+        assert_eq!(defaults.max_chars, DEFAULT_TRANSCRIPT_MAX_CHARS);
+        assert!(!defaults.include_user_messages);
+        assert!(!defaults.include_tool_results);
+
+        let explicit: ReadSubagentTranscriptArgs = serde_json::from_value(json!({
+            "child_request_id": "child-2",
+            "since_sequence": 7,
+            "limit": 200,
+            "max_chars": 30000,
+            "include_user_messages": true,
+            "include_tool_results": true
+        }))
+        .expect("parse explicit");
+        assert_eq!(explicit.child_request_id, "child-2");
+        assert_eq!(explicit.since_sequence, 7);
+        assert_eq!(explicit.validated_limit(), MAX_TRANSCRIPT_LIMIT);
+        assert_eq!(explicit.validated_max_chars(), MAX_TRANSCRIPT_MAX_CHARS);
+        assert!(explicit.include_user_messages);
+        assert!(explicit.include_tool_results);
+    }
+
+    #[test]
+    fn read_tool_output_args_round_trip_and_defaults() {
+        let defaults: ReadToolOutputArgs = serde_json::from_value(json!({
+            "tool_call_id": "tool-1"
+        }))
+        .expect("parse defaults");
+        assert_eq!(defaults.tool_call_id, "tool-1");
+        assert_eq!(
+            defaults.max_bytes_per_stream,
+            DEFAULT_READ_TOOL_OUTPUT_BYTES
+        );
+
+        let explicit: ReadToolOutputArgs = serde_json::from_value(json!({
+            "tool_call_id": "tool-2",
+            "max_bytes_per_stream": 1
+        }))
+        .expect("parse explicit");
+        assert_eq!(explicit.tool_call_id, "tool-2");
+        assert_eq!(explicit.validated_max_bytes(), 256);
+    }
+
+    #[test]
+    fn steer_subagent_args_round_trip_and_defaults() {
+        let defaults: SteerSubagentArgs = serde_json::from_value(json!({
+            "child_request_id": "child-1",
+            "message": "continue"
+        }))
+        .expect("parse defaults");
+        assert_eq!(defaults.child_request_id, "child-1");
+        assert_eq!(defaults.message, "continue");
+        assert!(!defaults.interrupt);
+
+        let explicit: SteerSubagentArgs = serde_json::from_value(json!({
+            "child_request_id": "child-2",
+            "message": "restart with this",
+            "interrupt": true
+        }))
+        .expect("parse explicit");
+        assert_eq!(explicit.child_request_id, "child-2");
+        assert_eq!(explicit.message, "restart with this");
+        assert!(explicit.interrupt);
+    }
+}

--- a/crates/defra-agent/src/background_tools/transcript_render.rs
+++ b/crates/defra-agent/src/background_tools/transcript_render.rs
@@ -1,0 +1,343 @@
+//! Pure-function transcript renderer for read_subagent_transcript.
+
+use crate::background_tools::r4c_args::PER_TOOL_RESULT_SNIPPET_BYTES;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MessageRoleView {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MessageKindView {
+    Ordinary {
+        body: String,
+    },
+    AssistantWithToolCalls {
+        body: String,
+        tool_call_count: u32,
+        bridge_call_ids: Vec<String>,
+        non_bridge_tool_call_count: u32,
+    },
+    ToolResult {
+        tool_name: String,
+        body: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MessageView {
+    pub(crate) sequence: u64,
+    pub(crate) role: MessageRoleView,
+    pub(crate) kind: MessageKindView,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RenderOptions {
+    pub(crate) include_user_messages: bool,
+    pub(crate) include_tool_results: bool,
+    pub(crate) limit: u32,
+    pub(crate) max_chars: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RenderOutput {
+    pub(crate) transcript: String,
+    pub(crate) from_sequence: u64,
+    pub(crate) through_sequence: u64,
+    pub(crate) next_sequence: u64,
+    pub(crate) truncated: bool,
+}
+
+pub(crate) fn render_transcript(
+    messages: &[MessageView],
+    since_sequence: u64,
+    opts: RenderOptions,
+) -> RenderOutput {
+    let mut transcript = String::new();
+    let mut first_included: Option<u64> = None;
+    let mut last_included = since_sequence;
+    let mut included_count = 0;
+    let mut truncated = false;
+
+    for msg in messages {
+        if msg.sequence <= since_sequence {
+            continue;
+        }
+        if !opts.include_user_messages
+            && msg.role == MessageRoleView::User
+            && !matches!(&msg.kind, MessageKindView::ToolResult { .. })
+        {
+            continue;
+        }
+
+        let Some(block) = render_block(msg, opts) else {
+            continue;
+        };
+        let projected_len = transcript.len() + block.len() + usize::from(!transcript.is_empty());
+        if included_count + 1 > opts.limit || projected_len > opts.max_chars as usize {
+            truncated = true;
+            break;
+        }
+
+        if !transcript.is_empty() {
+            transcript.push('\n');
+        }
+        transcript.push_str(&block);
+        included_count += 1;
+        first_included.get_or_insert(msg.sequence);
+        last_included = msg.sequence;
+    }
+
+    let from_sequence = first_included.unwrap_or(since_sequence);
+    RenderOutput {
+        transcript,
+        from_sequence,
+        through_sequence: last_included,
+        next_sequence: last_included
+            .saturating_add(1)
+            .max(since_sequence.saturating_add(1)),
+        truncated,
+    }
+}
+
+fn render_block(msg: &MessageView, opts: RenderOptions) -> Option<String> {
+    match (&msg.role, &msg.kind) {
+        (MessageRoleView::User, MessageKindView::Ordinary { body }) => {
+            Some(format!("[user seq={}]\n{}", msg.sequence, body))
+        }
+        (MessageRoleView::Assistant, MessageKindView::Ordinary { body }) => {
+            Some(format!("[assistant seq={}]\n{}", msg.sequence, body))
+        }
+        (
+            MessageRoleView::Assistant,
+            MessageKindView::AssistantWithToolCalls {
+                body,
+                non_bridge_tool_call_count,
+                ..
+            },
+        ) => {
+            if *non_bridge_tool_call_count == 0 {
+                Some(format!("[assistant seq={}]\n{}", msg.sequence, body))
+            } else {
+                Some(format!(
+                    "[assistant seq={} tool_calls={}]\n{}",
+                    msg.sequence, non_bridge_tool_call_count, body
+                ))
+            }
+        }
+        (MessageRoleView::User, MessageKindView::ToolResult { tool_name, body }) => {
+            if !opts.include_tool_results {
+                None
+            } else {
+                let snippet: String = body.chars().take(PER_TOOL_RESULT_SNIPPET_BYTES).collect();
+                Some(format!(
+                    "[tool-result seq={} tool={}]\n{}",
+                    msg.sequence, tool_name, snippet
+                ))
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OPTS_DEFAULT: RenderOptions = RenderOptions {
+        include_user_messages: false,
+        include_tool_results: false,
+        limit: 20,
+        max_chars: 6000,
+    };
+
+    fn assistant(sequence: u64, body: &str) -> MessageView {
+        MessageView {
+            sequence,
+            role: MessageRoleView::Assistant,
+            kind: MessageKindView::Ordinary {
+                body: body.to_string(),
+            },
+        }
+    }
+
+    fn user(sequence: u64, body: &str) -> MessageView {
+        MessageView {
+            sequence,
+            role: MessageRoleView::User,
+            kind: MessageKindView::Ordinary {
+                body: body.to_string(),
+            },
+        }
+    }
+
+    fn assistant_with_tool_calls(
+        sequence: u64,
+        body: &str,
+        bridge_call_ids: Vec<&str>,
+        non_bridge_tool_call_count: u32,
+    ) -> MessageView {
+        MessageView {
+            sequence,
+            role: MessageRoleView::Assistant,
+            kind: MessageKindView::AssistantWithToolCalls {
+                body: body.to_string(),
+                tool_call_count: bridge_call_ids.len() as u32 + non_bridge_tool_call_count,
+                bridge_call_ids: bridge_call_ids
+                    .into_iter()
+                    .map(ToString::to_string)
+                    .collect(),
+                non_bridge_tool_call_count,
+            },
+        }
+    }
+
+    fn tool_result(sequence: u64, tool: &str, body: &str) -> MessageView {
+        MessageView {
+            sequence,
+            role: MessageRoleView::User,
+            kind: MessageKindView::ToolResult {
+                tool_name: tool.to_string(),
+                body: body.to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn assistant_only_default() {
+        let msgs = vec![
+            assistant(1, "hello"),
+            user(2, "ignored"),
+            assistant(3, "world"),
+        ];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(out.transcript.contains("[assistant seq=1]"));
+        assert!(out.transcript.contains("[assistant seq=3]"));
+        assert!(!out.transcript.contains("[user"));
+        assert_eq!(out.from_sequence, 1);
+        assert_eq!(out.through_sequence, 3);
+        assert_eq!(out.next_sequence, 4);
+        assert!(!out.truncated);
+    }
+
+    #[test]
+    fn include_user_messages_when_opted_in() {
+        let msgs = vec![
+            assistant(1, "hello"),
+            user(2, "real input"),
+            assistant(3, "ok"),
+        ];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions {
+                include_user_messages: true,
+                ..OPTS_DEFAULT
+            },
+        );
+        assert!(out.transcript.contains("[user seq=2]"));
+        assert!(out.transcript.contains("real input"));
+    }
+
+    #[test]
+    fn bridge_only_assistant_renders_plain() {
+        let msgs = vec![assistant_with_tool_calls(
+            5,
+            "spawning child",
+            vec!["bridge-1"],
+            0,
+        )];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(out.transcript.contains("[assistant seq=5]"));
+        assert!(!out.transcript.contains("tool_calls="));
+        assert!(!out.transcript.contains("bridge-1"));
+    }
+
+    #[test]
+    fn non_bridge_tool_calls_render_count_suffix() {
+        let msgs = vec![assistant_with_tool_calls(
+            5,
+            "using visible tool",
+            vec!["bridge-1"],
+            2,
+        )];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(out.transcript.contains("[assistant seq=5 tool_calls=2]"));
+        assert!(!out.transcript.contains("bridge-1"));
+    }
+
+    #[test]
+    fn tool_result_hidden_by_default() {
+        let msgs = vec![assistant(1, "hi"), tool_result(2, "bash", "stdout")];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(!out.transcript.contains("[tool-result"));
+    }
+
+    #[test]
+    fn tool_result_snippet_capped() {
+        let big_body = "x".repeat(1024);
+        let msgs = vec![tool_result(1, "bash", &big_body)];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions {
+                include_tool_results: true,
+                ..OPTS_DEFAULT
+            },
+        );
+        assert!(out.transcript.contains("[tool-result seq=1 tool=bash]"));
+        let snippet_len = out
+            .transcript
+            .split("[tool-result seq=1 tool=bash]\n")
+            .nth(1)
+            .expect("snippet body")
+            .len();
+        assert!(snippet_len <= PER_TOOL_RESULT_SNIPPET_BYTES);
+    }
+
+    #[test]
+    fn since_sequence_skips_earlier() {
+        let msgs = vec![assistant(1, "a"), assistant(2, "b"), assistant(3, "c")];
+        let out = render_transcript(&msgs, 1, OPTS_DEFAULT);
+        assert!(!out.transcript.contains("[assistant seq=1]"));
+        assert!(out.transcript.contains("[assistant seq=2]"));
+        assert_eq!(out.from_sequence, 2);
+    }
+
+    #[test]
+    fn truncated_when_limit_hit() {
+        let msgs = vec![assistant(1, "a"), assistant(2, "b"), assistant(3, "c")];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions {
+                limit: 2,
+                ..OPTS_DEFAULT
+            },
+        );
+        assert!(out.truncated);
+        assert_eq!(out.through_sequence, 2);
+        assert_eq!(out.next_sequence, 3);
+    }
+
+    #[test]
+    fn truncated_when_max_chars_hit() {
+        let long = "x".repeat(200);
+        let msgs = vec![
+            assistant(1, &long),
+            assistant(2, &long),
+            assistant(3, &long),
+        ];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions {
+                max_chars: 250,
+                ..OPTS_DEFAULT
+            },
+        );
+        assert!(out.truncated);
+        assert!(out.transcript.len() <= 250);
+    }
+}

--- a/crates/defra-agent/src/background_tools/transcript_render.rs
+++ b/crates/defra-agent/src/background_tools/transcript_render.rs
@@ -61,7 +61,7 @@ pub(crate) fn render_transcript(
     let mut truncated = false;
 
     for msg in messages {
-        if msg.sequence <= since_sequence {
+        if msg.sequence < since_sequence {
             continue;
         }
         if !opts.include_user_messages
@@ -299,7 +299,7 @@ mod tests {
     #[test]
     fn since_sequence_skips_earlier() {
         let msgs = vec![assistant(1, "a"), assistant(2, "b"), assistant(3, "c")];
-        let out = render_transcript(&msgs, 1, OPTS_DEFAULT);
+        let out = render_transcript(&msgs, 2, OPTS_DEFAULT);
         assert!(!out.transcript.contains("[assistant seq=1]"));
         assert!(out.transcript.contains("[assistant seq=2]"));
         assert_eq!(out.from_sequence, 2);

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -9,15 +9,16 @@ use serde_json::json;
 use tracing::Instrument;
 
 use crate::background_tools::r4c_args::{
-    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs,
+    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs, ReadToolOutputArgs,
 };
 use crate::background_tools::{
     child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
     handle_list_background_tools, handle_list_subagents, handle_read_subagent_transcript,
-    load_authorized_child_edge, load_child_final_response, load_child_session_id,
-    load_child_terminal_row, load_parent_subagent_context, project_child_terminal,
-    target_is_allowed, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
-    ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
+    handle_read_tool_output, load_authorized_child_edge, load_child_final_response,
+    load_child_session_id, load_child_terminal_row, load_parent_subagent_context,
+    project_child_terminal, target_is_allowed, BackgroundToolArgs, CancelSubagentArgs,
+    CancelToolArgs, ParentSubagentContext, ReadToolOutputOutcome, SpawnSubagentArgs,
+    WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::load_agent_behavior;
@@ -31,7 +32,7 @@ use crate::tool_call_lifecycle::{
 use crate::toolset::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
     LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
@@ -1190,6 +1191,69 @@ impl DefraSessionHook {
             anyhow::anyhow!("serialize list_background_tools response: {error}")
         })?;
         Ok(ToolCallHookAction::skip(json_string(result)))
+    }
+
+    async fn persist_read_tool_output_tool_call(
+        &self,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> anyhow::Result<ToolCallHookAction> {
+        let (_session_id, request_id, _deadline_at, _seq) =
+            self.ensure_assistant_turn_sequence().await?;
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            None,
+            tool_call_id.as_deref(),
+        );
+
+        let parsed = match serde_json::from_str::<ReadToolOutputArgs>(args) {
+            Ok(args) => args,
+            Err(error) => {
+                return Ok(ToolCallHookAction::skip(
+                    background_invalid_tool_arguments_payload(
+                        READ_TOOL_OUTPUT_TOOL_NAME,
+                        "/",
+                        format!("invalid read_tool_output arguments: {error}"),
+                    ),
+                ));
+            }
+        };
+        let background_tool_call_id = parsed.tool_call_id.trim().to_string();
+        if background_tool_call_id.is_empty() {
+            return Ok(ToolCallHookAction::skip(
+                background_invalid_tool_arguments_payload(
+                    READ_TOOL_OUTPUT_TOOL_NAME,
+                    "/tool_call_id",
+                    "tool_call_id is required",
+                ),
+            ));
+        }
+
+        match handle_read_tool_output(&self.node, &request_id, parsed).await? {
+            ReadToolOutputOutcome::Found(response) => {
+                let result = serde_json::to_value(response).map_err(|error| {
+                    anyhow::anyhow!("serialize read_tool_output response: {error}")
+                })?;
+                Ok(ToolCallHookAction::skip(json_string(result)))
+            }
+            ReadToolOutputOutcome::NotBackgrounded => Ok(ToolCallHookAction::skip(
+                background_invalid_tool_arguments_payload(
+                    READ_TOOL_OUTPUT_TOOL_NAME,
+                    "/tool_call_id",
+                    "tool_call_id must identify an ordinary backgrounded tool call",
+                ),
+            )),
+            ReadToolOutputOutcome::NotAuthorized => Ok(ToolCallHookAction::skip(
+                background_tool_not_allowed_payload(
+                    READ_TOOL_OUTPUT_TOOL_NAME,
+                    "/tool_call_id",
+                    &background_tool_call_id,
+                    "background tool call is not owned by this parent request",
+                    Vec::new(),
+                ),
+            )),
+        }
     }
 
     async fn persist_cancel_tool_call(
@@ -2616,6 +2680,24 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 Err(e) => {
                     self.on_tool_persistence_error("persist list_background_tools tool call", &e)
                 }
+            };
+        }
+        if tool_name == READ_TOOL_OUTPUT_TOOL_NAME {
+            let result = self
+                .persist_read_tool_output_tool_call(tool_call_id, internal_call_id, args)
+                .instrument(tracing::info_span!(
+                    "tool.call",
+                    tool_name = %tool_name,
+                    tool_call_id = %internal_call_id,
+                ))
+                .await;
+
+            return match result {
+                Ok(action) => {
+                    self.record_success();
+                    action
+                }
+                Err(e) => self.on_tool_persistence_error("persist read_tool_output tool call", &e),
             };
         }
         if tool_name == CANCEL_TOOL_NAME {

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -8,14 +8,16 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
-use crate::background_tools::r4c_args::{ListBackgroundToolsArgs, ListSubagentsArgs};
+use crate::background_tools::r4c_args::{
+    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs,
+};
 use crate::background_tools::{
     child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
-    handle_list_background_tools, handle_list_subagents, load_authorized_child_edge,
-    load_child_final_response, load_child_session_id, load_child_terminal_row,
-    load_parent_subagent_context, project_child_terminal, target_is_allowed, BackgroundToolArgs,
-    CancelSubagentArgs, CancelToolArgs, ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs,
-    WaitToolArgs,
+    handle_list_background_tools, handle_list_subagents, handle_read_subagent_transcript,
+    load_authorized_child_edge, load_child_final_response, load_child_session_id,
+    load_child_terminal_row, load_parent_subagent_context, project_child_terminal,
+    target_is_allowed, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
+    ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::load_agent_behavior;
@@ -28,8 +30,8 @@ use crate::tool_call_lifecycle::{
 };
 use crate::toolset::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
-    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
-    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
@@ -693,6 +695,56 @@ impl DefraSessionHook {
             handle_list_subagents(&self.node, &request_id, &self.agent_did, parsed).await?;
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize list_subagents response: {error}"))?;
+        Ok(ToolCallHookAction::skip(json_string(result)))
+    }
+
+    async fn persist_read_subagent_transcript_tool_call(
+        &self,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> anyhow::Result<ToolCallHookAction> {
+        let (_session_id, request_id, _deadline_at, _seq) =
+            self.ensure_assistant_turn_sequence().await?;
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            None,
+            tool_call_id.as_deref(),
+        );
+
+        let parsed = match serde_json::from_str::<ReadSubagentTranscriptArgs>(args) {
+            Ok(args) => args,
+            Err(error) => {
+                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                    READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                    "/",
+                    format!("invalid read_subagent_transcript arguments: {error}"),
+                )));
+            }
+        };
+        let child_request_id = parsed.child_request_id.trim().to_string();
+        if child_request_id.is_empty() {
+            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                "/child_request_id",
+                "child_request_id is required",
+            )));
+        }
+
+        let Some(response) =
+            handle_read_subagent_transcript(&self.node, &request_id, parsed).await?
+        else {
+            return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                "/child_request_id",
+                &child_request_id,
+                "child is not a background subagent owned by this parent request",
+                Vec::new(),
+            )));
+        };
+        let result = serde_json::to_value(response).map_err(|error| {
+            anyhow::anyhow!("serialize read_subagent_transcript response: {error}")
+        })?;
         Ok(ToolCallHookAction::skip(json_string(result)))
     }
 
@@ -2470,6 +2522,26 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                     action
                 }
                 Err(e) => self.on_tool_persistence_error("persist list_subagents tool call", &e),
+            };
+        }
+        if tool_name == READ_SUBAGENT_TRANSCRIPT_TOOL_NAME {
+            let result = self
+                .persist_read_subagent_transcript_tool_call(tool_call_id, internal_call_id, args)
+                .instrument(tracing::info_span!(
+                    "tool.call",
+                    tool_name = %tool_name,
+                    tool_call_id = %internal_call_id,
+                ))
+                .await;
+
+            return match result {
+                Ok(action) => {
+                    self.record_success();
+                    action
+                }
+                Err(e) => {
+                    self.on_tool_persistence_error("persist read_subagent_transcript tool call", &e)
+                }
             };
         }
         if tool_name == CANCEL_SUBAGENT_TOOL_NAME {

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -10,15 +10,18 @@ use tracing::Instrument;
 
 use crate::background_tools::r4c_args::{
     ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs, ReadToolOutputArgs,
+    SteerSubagentArgs,
 };
 use crate::background_tools::{
-    child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
-    handle_list_background_tools, handle_list_subagents, handle_read_subagent_transcript,
-    handle_read_tool_output, load_authorized_child_edge, load_child_final_response,
-    load_child_session_id, load_child_terminal_row, load_parent_subagent_context,
-    project_child_terminal, target_is_allowed, BackgroundToolArgs, CancelSubagentArgs,
-    CancelToolArgs, ParentSubagentContext, ReadToolOutputOutcome, SpawnSubagentArgs,
-    WaitSubagentArgs, WaitToolArgs,
+    active_session_request_id, append_steering_request, child_request_completed,
+    drain_automated_wakeups_returning_ids,
+    effective_context_cross_deployment_spawn_timeout_seconds, handle_list_background_tools,
+    handle_list_subagents, handle_read_subagent_transcript, handle_read_tool_output,
+    load_authorized_child_edge, load_child_final_response, load_child_session_id,
+    load_child_terminal_row, load_parent_subagent_context, load_steer_subagent_target,
+    pending_automated_wakeup_request_ids, project_child_terminal, target_is_allowed,
+    BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, ParentSubagentContext,
+    ReadToolOutputOutcome, SpawnSubagentArgs, SteerSubagentTarget, WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::load_agent_behavior;
@@ -32,7 +35,8 @@ use crate::tool_call_lifecycle::{
 use crate::toolset::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
     LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, STEER_SUBAGENT_TOOL_NAME,
+    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
@@ -746,6 +750,122 @@ impl DefraSessionHook {
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize read_subagent_transcript response: {error}")
         })?;
+        Ok(ToolCallHookAction::skip(json_string(result)))
+    }
+
+    async fn persist_steer_subagent_tool_call(
+        &self,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> anyhow::Result<ToolCallHookAction> {
+        let (_session_id, request_id, _deadline_at, _seq) =
+            self.ensure_assistant_turn_sequence().await?;
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            None,
+            tool_call_id.as_deref(),
+        );
+
+        let parsed = match serde_json::from_str::<SteerSubagentArgs>(args) {
+            Ok(args) => args,
+            Err(error) => {
+                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/",
+                    format!("invalid steer_subagent arguments: {error}"),
+                )));
+            }
+        };
+        let child_request_id = parsed.child_request_id.trim().to_string();
+        if child_request_id.is_empty() {
+            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                STEER_SUBAGENT_TOOL_NAME,
+                "/child_request_id",
+                "child_request_id is required",
+            )));
+        }
+        let message = parsed.message.trim().to_string();
+        if message.is_empty() {
+            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                STEER_SUBAGENT_TOOL_NAME,
+                "/message",
+                "message is required",
+            )));
+        }
+
+        let edge = match load_steer_subagent_target(&self.node, &request_id, &child_request_id)
+            .await?
+        {
+            SteerSubagentTarget::Found(edge) => edge,
+            SteerSubagentTarget::NotAuthorized => {
+                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    &child_request_id,
+                    "child not owned by this parent request",
+                    Vec::new(),
+                )));
+            }
+            SteerSubagentTarget::NotBackgrounded => {
+                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    &child_request_id,
+                    "foreground subagents cannot be steered; call cancel_subagent first",
+                    Vec::new(),
+                )));
+            }
+            SteerSubagentTarget::Terminal(state) => {
+                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    format!("child is in terminal state '{state}'; spawn a new subagent instead"),
+                )));
+            }
+        };
+
+        let mut interrupted_active_request_id = None;
+        let mut drained_wake_up_request_ids = Vec::new();
+        if parsed.interrupt {
+            drained_wake_up_request_ids =
+                pending_automated_wakeup_request_ids(&self.node, &edge.child_session_id).await?;
+            if let Some(active_request_id) =
+                active_session_request_id(&self.node, &edge.child_session_id).await?
+            {
+                crate::interrupt::interrupt_request(&self.node, &active_request_id).await?;
+                let _descendants_cancelled = self
+                    .cancel_live_subagent_descendants(&edge.child_session_id)
+                    .await?;
+                interrupted_active_request_id = Some(active_request_id);
+            }
+            let post_interrupt_drained = drain_automated_wakeups_returning_ids(
+                &self.node,
+                &edge.child_session_id,
+                "automated wake-up drained because subagent was steered with interrupt=true",
+            )
+            .await?;
+            for request_id in post_interrupt_drained {
+                if !drained_wake_up_request_ids
+                    .iter()
+                    .any(|existing| existing == &request_id)
+                {
+                    drained_wake_up_request_ids.push(request_id);
+                }
+            }
+        }
+
+        let response = append_steering_request(
+            &self.node,
+            &request_id,
+            &edge,
+            &message,
+            interrupted_active_request_id,
+            drained_wake_up_request_ids,
+        )
+        .await?;
+        let result = serde_json::to_value(response)
+            .map_err(|error| anyhow::anyhow!("serialize steer_subagent response: {error}"))?;
         Ok(ToolCallHookAction::skip(json_string(result)))
     }
 
@@ -2606,6 +2726,24 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 Err(e) => {
                     self.on_tool_persistence_error("persist read_subagent_transcript tool call", &e)
                 }
+            };
+        }
+        if tool_name == STEER_SUBAGENT_TOOL_NAME {
+            let result = self
+                .persist_steer_subagent_tool_call(tool_call_id, internal_call_id, args)
+                .instrument(tracing::info_span!(
+                    "tool.call",
+                    tool_name = %tool_name,
+                    tool_call_id = %internal_call_id,
+                ))
+                .await;
+
+            return match result {
+                Ok(action) => {
+                    self.record_success();
+                    action
+                }
+                Err(e) => self.on_tool_persistence_error("persist steer_subagent tool call", &e),
             };
         }
         if tool_name == CANCEL_SUBAGENT_TOOL_NAME {

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -8,12 +8,13 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
+use crate::background_tools::r4c_args::ListSubagentsArgs;
 use crate::background_tools::{
     child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
-    load_authorized_child_edge, load_child_final_response, load_child_session_id,
-    load_child_terminal_row, load_parent_subagent_context, project_child_terminal,
-    target_is_allowed, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
-    ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
+    handle_list_subagents, load_authorized_child_edge, load_child_final_response,
+    load_child_session_id, load_child_terminal_row, load_parent_subagent_context,
+    project_child_terminal, target_is_allowed, BackgroundToolArgs, CancelSubagentArgs,
+    CancelToolArgs, ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::load_agent_behavior;
@@ -25,8 +26,8 @@ use crate::tool_call_lifecycle::{
     ChildTerminal, FailureClass, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use crate::toolset::{
-    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
-    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME,
+    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
@@ -660,6 +661,37 @@ impl DefraSessionHook {
             .await?;
 
         Ok(ToolCallHookAction::skip(result))
+    }
+
+    async fn persist_list_subagents_tool_call(
+        &self,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> anyhow::Result<ToolCallHookAction> {
+        let (_session_id, request_id, _deadline_at, _seq) =
+            self.ensure_assistant_turn_sequence().await?;
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            None,
+            tool_call_id.as_deref(),
+        );
+
+        let parsed = match serde_json::from_str::<ListSubagentsArgs>(args) {
+            Ok(args) => args,
+            Err(error) => {
+                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                    LIST_SUBAGENTS_TOOL_NAME,
+                    "/",
+                    format!("invalid list_subagents arguments: {error}"),
+                )));
+            }
+        };
+        let response =
+            handle_list_subagents(&self.node, &request_id, &self.agent_did, parsed).await?;
+        let result = serde_json::to_value(response)
+            .map_err(|error| anyhow::anyhow!("serialize list_subagents response: {error}"))?;
+        Ok(ToolCallHookAction::skip(json_string(result)))
     }
 
     async fn persist_cancel_subagent_tool_call(
@@ -2384,6 +2416,24 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                     action
                 }
                 Err(e) => self.on_tool_persistence_error("persist wait_subagent tool call", &e),
+            };
+        }
+        if tool_name == LIST_SUBAGENTS_TOOL_NAME {
+            let result = self
+                .persist_list_subagents_tool_call(tool_call_id, internal_call_id, args)
+                .instrument(tracing::info_span!(
+                    "tool.call",
+                    tool_name = %tool_name,
+                    tool_call_id = %internal_call_id,
+                ))
+                .await;
+
+            return match result {
+                Ok(action) => {
+                    self.record_success();
+                    action
+                }
+                Err(e) => self.on_tool_persistence_error("persist list_subagents tool call", &e),
             };
         }
         if tool_name == CANCEL_SUBAGENT_TOOL_NAME {

--- a/crates/defra-agent/src/hook/persistence.rs
+++ b/crates/defra-agent/src/hook/persistence.rs
@@ -8,13 +8,14 @@ use serde::Deserialize;
 use serde_json::json;
 use tracing::Instrument;
 
-use crate::background_tools::r4c_args::ListSubagentsArgs;
+use crate::background_tools::r4c_args::{ListBackgroundToolsArgs, ListSubagentsArgs};
 use crate::background_tools::{
     child_request_completed, effective_context_cross_deployment_spawn_timeout_seconds,
-    handle_list_subagents, load_authorized_child_edge, load_child_final_response,
-    load_child_session_id, load_child_terminal_row, load_parent_subagent_context,
-    project_child_terminal, target_is_allowed, BackgroundToolArgs, CancelSubagentArgs,
-    CancelToolArgs, ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs, WaitToolArgs,
+    handle_list_background_tools, handle_list_subagents, load_authorized_child_edge,
+    load_child_final_response, load_child_session_id, load_child_terminal_row,
+    load_parent_subagent_context, project_child_terminal, target_is_allowed, BackgroundToolArgs,
+    CancelSubagentArgs, CancelToolArgs, ParentSubagentContext, SpawnSubagentArgs, WaitSubagentArgs,
+    WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::load_agent_behavior;
@@ -26,8 +27,9 @@ use crate::tool_call_lifecycle::{
     ChildTerminal, FailureClass, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use crate::toolset::{
-    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME,
-    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
+    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
+    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 use crate::truncation::{truncate_text, DefraSpillTruncator, TruncationMode, Truncator};
 
@@ -1102,6 +1104,40 @@ impl DefraSessionHook {
             .await_background_tool(&request_id, background_tool_call_id, parent_deadline_at)
             .await?;
         Ok(ToolCallHookAction::skip(result))
+    }
+
+    async fn persist_list_background_tools_tool_call(
+        &self,
+        tool_call_id: Option<String>,
+        internal_call_id: &str,
+        args: &str,
+    ) -> anyhow::Result<ToolCallHookAction> {
+        let (_session_id, request_id, _deadline_at, _seq) =
+            self.ensure_assistant_turn_sequence().await?;
+        self.state.lock().await.register_tool_result_identity(
+            internal_call_id,
+            None,
+            tool_call_id.as_deref(),
+        );
+
+        let parsed = match serde_json::from_str::<ListBackgroundToolsArgs>(args) {
+            Ok(args) => args,
+            Err(error) => {
+                return Ok(ToolCallHookAction::skip(
+                    background_invalid_tool_arguments_payload(
+                        LIST_BACKGROUND_TOOLS_TOOL_NAME,
+                        "/",
+                        format!("invalid list_background_tools arguments: {error}"),
+                    ),
+                ));
+            }
+        };
+        let response =
+            handle_list_background_tools(&self.node, &request_id, &self.agent_did, parsed).await?;
+        let result = serde_json::to_value(response).map_err(|error| {
+            anyhow::anyhow!("serialize list_background_tools response: {error}")
+        })?;
+        Ok(ToolCallHookAction::skip(json_string(result)))
     }
 
     async fn persist_cancel_tool_call(
@@ -2488,6 +2524,26 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                     action
                 }
                 Err(e) => self.on_tool_persistence_error("persist wait_tool tool call", &e),
+            };
+        }
+        if tool_name == LIST_BACKGROUND_TOOLS_TOOL_NAME {
+            let result = self
+                .persist_list_background_tools_tool_call(tool_call_id, internal_call_id, args)
+                .instrument(tracing::info_span!(
+                    "tool.call",
+                    tool_name = %tool_name,
+                    tool_call_id = %internal_call_id,
+                ))
+                .await;
+
+            return match result {
+                Ok(action) => {
+                    self.record_success();
+                    action
+                }
+                Err(e) => {
+                    self.on_tool_persistence_error("persist list_background_tools tool call", &e)
+                }
             };
         }
         if tool_name == CANCEL_TOOL_NAME {

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -56,6 +56,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) live_overlay_cases: Vec<LeanLiveOverlayCase>,
     pub(crate) queue_deadline_conformance_cases: Vec<LeanQueueDeadlineConformanceCase>,
     pub(crate) recovery_sweep_cases: Vec<LeanRecoverySweepCase>,
+    #[serde(default)]
+    pub(crate) r4c_background_work_cases: Vec<LeanR4cBackgroundWorkCase>,
     pub(crate) r6_backgrounding_cases: Vec<LeanR6BackgroundingCase>,
     pub(crate) transcript_conformance_cases: Vec<LeanTranscriptCase>,
     pub(crate) streaming_response_cases: Vec<LeanResponseTransitionCase>,
@@ -656,6 +658,84 @@ pub(crate) struct LeanRecoverySweepCase {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(tag = "witness", deny_unknown_fields)]
+pub(crate) enum LeanR4cBackgroundWorkCase {
+    #[serde(rename = "r4c.list_subagents.lineage_rejects")]
+    ListSubagentsLineageRejects {
+        caller_request_id: String,
+        sibling_request_id: String,
+        sibling_child_id: String,
+        caller_sees_sibling_child: bool,
+    },
+    #[serde(rename = "r4c.read_subagent_transcript.cursor_advances")]
+    ReadTranscriptCursorAdvances {
+        child_session_id: String,
+        first_since_sequence: usize,
+        first_through_sequence: usize,
+        first_next_sequence: usize,
+        second_since_sequence: usize,
+        second_through_sequence: usize,
+        no_gap: bool,
+        no_overlap: bool,
+    },
+    #[serde(rename = "r4c.read_subagent_transcript.hides_bridge_rows")]
+    ReadTranscriptHidesBridgeRows {
+        child_session_id: String,
+        bridge_call_id: String,
+        rendered_transcript: String,
+    },
+    #[serde(rename = "r4c.read_tool_output.dispatch_by_state")]
+    ReadToolOutputDispatchesByState {
+        tool_call_id: String,
+        running_source: String,
+        terminal_source: String,
+        running_payload: String,
+        stale_running_payload: String,
+        terminal_payload: String,
+    },
+    #[serde(rename = "r4c.steer_subagent.append_preserves_lineage")]
+    SteerAppendPreservesLineage {
+        caller_request_id: String,
+        child_session_id: String,
+        queued_request_id: String,
+        caused_by_parent_request_id: String,
+        queue_source: String,
+        queue_policy: String,
+    },
+    #[serde(rename = "r4c.steer_subagent.interrupt_composes")]
+    SteerInterruptComposes {
+        caller_request_id: String,
+        child_session_id: String,
+        interrupted_active_request_id: String,
+        drained_wake_up_request_ids: Vec<String>,
+        drained_wake_up_queue_key: String,
+        queued_request_id: String,
+        queue_interrupted_request_id: String,
+    },
+}
+
+impl LeanR4cBackgroundWorkCase {
+    pub(crate) fn witness(&self) -> &'static str {
+        match self {
+            Self::ListSubagentsLineageRejects { .. } => "r4c.list_subagents.lineage_rejects",
+            Self::ReadTranscriptCursorAdvances { .. } => {
+                "r4c.read_subagent_transcript.cursor_advances"
+            }
+            Self::ReadTranscriptHidesBridgeRows { .. } => {
+                "r4c.read_subagent_transcript.hides_bridge_rows"
+            }
+            Self::ReadToolOutputDispatchesByState { .. } => {
+                "r4c.read_tool_output.dispatch_by_state"
+            }
+            Self::SteerAppendPreservesLineage { .. } => {
+                "r4c.steer_subagent.append_preserves_lineage"
+            }
+            Self::SteerInterruptComposes { .. } => "r4c.steer_subagent.interrupt_composes",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct LeanR6BackgroundingCase {
     pub(crate) name: String,
     pub(crate) group: String,
@@ -893,6 +973,18 @@ pub(crate) fn lean_recovery_sweep_case(name: &str) -> &'static LeanRecoverySweep
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean recovery sweep case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_r4c_background_work_cases() -> &'static [LeanR4cBackgroundWorkCase] {
+    &lean_contract_snapshot().r4c_background_work_cases
+}
+
+pub(crate) fn lean_r4c_background_work_case(witness: &str) -> &'static LeanR4cBackgroundWorkCase {
+    lean_contract_snapshot()
+        .r4c_background_work_cases
+        .iter()
+        .find(|case| case.witness() == witness)
+        .unwrap_or_else(|| panic!("Lean R4c background-work witness {witness:?} was not emitted"))
 }
 
 pub(crate) fn lean_r6_backgrounding_cases() -> &'static [LeanR6BackgroundingCase] {

--- a/crates/defra-agent/src/lifecycle/queue.rs
+++ b/crates/defra-agent/src/lifecycle/queue.rs
@@ -22,6 +22,8 @@ pub(crate) struct QueueHints {
     pub policy: QueuePolicy,
     pub key: Option<String>,
     pub queued_after_request_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interrupted_request_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -564,6 +566,7 @@ mod tests {
             policy,
             key: Some("session:sess-1".to_string()),
             queued_after_request_id: Some("req-1".to_string()),
+            interrupted_request_id: None,
         }
     }
 
@@ -735,6 +738,7 @@ mod tests {
                     policy: QueuePolicy::Append,
                     key: None,
                     queued_after_request_id: None,
+                    interrupted_request_id: None,
                 })
             );
         }
@@ -773,6 +777,7 @@ mod tests {
             policy: QueuePolicy::Coalesce,
             key: Some("agent:did:key:z123".to_string()),
             queued_after_request_id: None,
+            interrupted_request_id: None,
         });
 
         let value: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -798,6 +803,7 @@ mod tests {
                 policy: QueuePolicy::Append,
                 key: None,
                 queued_after_request_id: None,
+                interrupted_request_id: None,
             }
         ))));
         assert!(is_automated_wakeup(Some(&queue_metadata_json(
@@ -806,6 +812,7 @@ mod tests {
                 policy: QueuePolicy::Coalesce,
                 key: Some("background_completion:session-1".to_string()),
                 queued_after_request_id: None,
+                interrupted_request_id: None,
             }
         ))));
         assert!(!is_automated_wakeup(Some(&queue_metadata_json(
@@ -814,6 +821,7 @@ mod tests {
                 policy: QueuePolicy::Append,
                 key: Some("background_completion:session-1".to_string()),
                 queued_after_request_id: None,
+                interrupted_request_id: None,
             }
         ))));
         assert!(!is_automated_wakeup(Some(&queue_metadata_json(
@@ -822,6 +830,7 @@ mod tests {
                 policy: QueuePolicy::Coalesce,
                 key: None,
                 queued_after_request_id: None,
+                interrupted_request_id: None,
             }
         ))));
         assert!(!is_automated_wakeup(Some(&queue_metadata_json(
@@ -830,6 +839,7 @@ mod tests {
                 policy: QueuePolicy::Coalesce,
                 key: None,
                 queued_after_request_id: None,
+                interrupted_request_id: None,
             }
         ))));
     }
@@ -844,6 +854,7 @@ mod tests {
             policy: QueuePolicy::Coalesce,
             key: Some(format!("background_completion:{session_id}")),
             queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
         };
 
         let first = enqueue_session_request(
@@ -902,6 +913,7 @@ mod tests {
             policy: QueuePolicy::Append,
             key: Some(format!("background_completion:{session_id}")),
             queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
         };
         insert_raw_queue_request(
             &db.node,
@@ -947,6 +959,7 @@ mod tests {
             policy: QueuePolicy::Coalesce,
             key: Some(format!("background_completion:{session_id}")),
             queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
         };
         let key = hints.key.clone().unwrap();
         let survivor = enqueue_session_request(
@@ -1007,6 +1020,7 @@ mod tests {
             policy: QueuePolicy::Coalesce,
             key: Some(format!("background_completion:{session_id}")),
             queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
         };
         let survivor_doc_id = insert_raw_queue_request(
             &db.node,
@@ -1061,6 +1075,7 @@ mod tests {
             policy: QueuePolicy::Coalesce,
             key: None,
             queued_after_request_id: Some(parent.request_id.clone()),
+            interrupted_request_id: None,
         };
 
         let first = enqueue_session_request(

--- a/crates/defra-agent/src/lifecycle/queue.rs
+++ b/crates/defra-agent/src/lifecycle/queue.rs
@@ -385,6 +385,13 @@ fn parent_linkage_graphql_fields(parent: &AgentRequest) -> String {
                 escape_graphql_string(parent_tool_call_id),
             )
         }
+        (Some(parent_request_id), None) if !parent_request_id.trim().is_empty() => {
+            format!(
+                r#",
+                caused_by_parent_request_id: "{}""#,
+                escape_graphql_string(parent_request_id),
+            )
+        }
         _ => String::new(),
     }
 }

--- a/crates/defra-agent/src/tool_surface/behavior_config.rs
+++ b/crates/defra-agent/src/tool_surface/behavior_config.rs
@@ -103,6 +103,7 @@ impl BehaviorToolConfig {
             subagent_tools: SubagentToolConfig {
                 targets: dedupe_strings(subagent_tools.targets),
                 spawn_enabled: subagent_tools.spawn_enabled,
+                steering_enabled: subagent_tools.steering_enabled,
                 background_enabled: subagent_tools.background_enabled,
             },
             background_tools: BackgroundToolConfig {

--- a/crates/defra-agent/src/tool_surface/selection.rs
+++ b/crates/defra-agent/src/tool_surface/selection.rs
@@ -13,12 +13,21 @@ use crate::toolset::CommandExecutionPolicy;
 pub(crate) struct SubagentToolConfig {
     pub targets: Vec<String>,
     pub spawn_enabled: bool,
+    pub steering_enabled: bool,
     pub background_enabled: bool,
 }
 
 impl SubagentToolConfig {
     pub(crate) fn tools_enabled(&self) -> bool {
         self.spawn_enabled && !self.targets.is_empty()
+    }
+
+    pub(crate) fn steering_tools_enabled(&self) -> bool {
+        self.tools_enabled() && self.steering_enabled
+    }
+
+    pub(crate) fn steer_subagent_enabled(&self) -> bool {
+        self.steering_tools_enabled() && self.background_enabled
     }
 }
 

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -25,7 +25,7 @@ use file_tools::{EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, 
 use shared::ToolContext;
 use subagent::{
     BackgroundTool, CancelSubagentTool, CancelTool, ListBackgroundToolsTool, ListSubagentsTool,
-    SpawnSubagentTool, WaitSubagentTool, WaitTool,
+    ReadSubagentTranscriptTool, SpawnSubagentTool, WaitSubagentTool, WaitTool,
 };
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
@@ -48,6 +48,7 @@ pub const DELEGATE_TOOL_NAME: &str = "delegate_to_agent";
 pub(crate) const SPAWN_SUBAGENT_TOOL_NAME: &str = "spawn_subagent";
 pub(crate) const WAIT_SUBAGENT_TOOL_NAME: &str = "wait_subagent";
 pub(crate) const LIST_SUBAGENTS_TOOL_NAME: &str = "list_subagents";
+pub(crate) const READ_SUBAGENT_TRANSCRIPT_TOOL_NAME: &str = "read_subagent_transcript";
 pub(crate) const CANCEL_SUBAGENT_TOOL_NAME: &str = "cancel_subagent";
 pub(crate) const BACKGROUND_TOOL_NAME: &str = "background_tool";
 pub(crate) const WAIT_TOOL_NAME: &str = "wait_tool";
@@ -410,6 +411,7 @@ pub(crate) fn subagent_tool_names(config: &SubagentToolConfig) -> Vec<String> {
         SPAWN_SUBAGENT_TOOL_NAME,
         WAIT_SUBAGENT_TOOL_NAME,
         LIST_SUBAGENTS_TOOL_NAME,
+        READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
         CANCEL_SUBAGENT_TOOL_NAME,
     ]
     .into_iter()
@@ -426,6 +428,7 @@ pub(crate) fn build_subagent_tools(config: SubagentToolConfig) -> Vec<Box<dyn To
         Box::new(SpawnSubagentTool::new(config.clone())),
         Box::new(WaitSubagentTool),
         Box::new(ListSubagentsTool),
+        Box::new(ReadSubagentTranscriptTool),
         Box::new(CancelSubagentTool),
     ]
 }

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -25,7 +25,7 @@ use file_tools::{EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, 
 use shared::ToolContext;
 use subagent::{
     BackgroundTool, CancelSubagentTool, CancelTool, ListBackgroundToolsTool, ListSubagentsTool,
-    ReadSubagentTranscriptTool, SpawnSubagentTool, WaitSubagentTool, WaitTool,
+    ReadSubagentTranscriptTool, ReadToolOutputTool, SpawnSubagentTool, WaitSubagentTool, WaitTool,
 };
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
@@ -53,6 +53,7 @@ pub(crate) const CANCEL_SUBAGENT_TOOL_NAME: &str = "cancel_subagent";
 pub(crate) const BACKGROUND_TOOL_NAME: &str = "background_tool";
 pub(crate) const WAIT_TOOL_NAME: &str = "wait_tool";
 pub(crate) const LIST_BACKGROUND_TOOLS_TOOL_NAME: &str = "list_background_tools";
+pub(crate) const READ_TOOL_OUTPUT_TOOL_NAME: &str = "read_tool_output";
 pub(crate) const CANCEL_TOOL_NAME: &str = "cancel_tool";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -442,6 +443,7 @@ pub(crate) fn background_tool_names(config: &BackgroundToolConfig) -> Vec<String
         BACKGROUND_TOOL_NAME,
         WAIT_TOOL_NAME,
         LIST_BACKGROUND_TOOLS_TOOL_NAME,
+        READ_TOOL_OUTPUT_TOOL_NAME,
         CANCEL_TOOL_NAME,
     ]
     .into_iter()
@@ -458,6 +460,7 @@ pub(crate) fn build_background_tools(config: BackgroundToolConfig) -> Vec<Box<dy
         Box::new(BackgroundTool::new(config.clone())),
         Box::new(WaitTool),
         Box::new(ListBackgroundToolsTool),
+        Box::new(ReadToolOutputTool),
         Box::new(CancelTool),
     ]
 }

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -24,8 +24,8 @@ use delegate::DelegateToAgentTool;
 use file_tools::{EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, WriteFileTool};
 use shared::ToolContext;
 use subagent::{
-    BackgroundTool, CancelSubagentTool, CancelTool, ListSubagentsTool, SpawnSubagentTool,
-    WaitSubagentTool, WaitTool,
+    BackgroundTool, CancelSubagentTool, CancelTool, ListBackgroundToolsTool, ListSubagentsTool,
+    SpawnSubagentTool, WaitSubagentTool, WaitTool,
 };
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
@@ -51,6 +51,7 @@ pub(crate) const LIST_SUBAGENTS_TOOL_NAME: &str = "list_subagents";
 pub(crate) const CANCEL_SUBAGENT_TOOL_NAME: &str = "cancel_subagent";
 pub(crate) const BACKGROUND_TOOL_NAME: &str = "background_tool";
 pub(crate) const WAIT_TOOL_NAME: &str = "wait_tool";
+pub(crate) const LIST_BACKGROUND_TOOLS_TOOL_NAME: &str = "list_background_tools";
 pub(crate) const CANCEL_TOOL_NAME: &str = "cancel_tool";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -434,10 +435,15 @@ pub(crate) fn background_tool_names(config: &BackgroundToolConfig) -> Vec<String
         return Vec::new();
     }
 
-    [BACKGROUND_TOOL_NAME, WAIT_TOOL_NAME, CANCEL_TOOL_NAME]
-        .into_iter()
-        .map(str::to_string)
-        .collect()
+    [
+        BACKGROUND_TOOL_NAME,
+        WAIT_TOOL_NAME,
+        LIST_BACKGROUND_TOOLS_TOOL_NAME,
+        CANCEL_TOOL_NAME,
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
 }
 
 pub(crate) fn build_background_tools(config: BackgroundToolConfig) -> Vec<Box<dyn ToolDyn>> {
@@ -448,6 +454,7 @@ pub(crate) fn build_background_tools(config: BackgroundToolConfig) -> Vec<Box<dy
     vec![
         Box::new(BackgroundTool::new(config.clone())),
         Box::new(WaitTool),
+        Box::new(ListBackgroundToolsTool),
         Box::new(CancelTool),
     ]
 }

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -25,7 +25,8 @@ use file_tools::{EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, 
 use shared::ToolContext;
 use subagent::{
     BackgroundTool, CancelSubagentTool, CancelTool, ListBackgroundToolsTool, ListSubagentsTool,
-    ReadSubagentTranscriptTool, ReadToolOutputTool, SpawnSubagentTool, WaitSubagentTool, WaitTool,
+    ReadSubagentTranscriptTool, ReadToolOutputTool, SpawnSubagentTool, SteerSubagentTool,
+    WaitSubagentTool, WaitTool,
 };
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
@@ -49,6 +50,7 @@ pub(crate) const SPAWN_SUBAGENT_TOOL_NAME: &str = "spawn_subagent";
 pub(crate) const WAIT_SUBAGENT_TOOL_NAME: &str = "wait_subagent";
 pub(crate) const LIST_SUBAGENTS_TOOL_NAME: &str = "list_subagents";
 pub(crate) const READ_SUBAGENT_TRANSCRIPT_TOOL_NAME: &str = "read_subagent_transcript";
+pub(crate) const STEER_SUBAGENT_TOOL_NAME: &str = "steer_subagent";
 pub(crate) const CANCEL_SUBAGENT_TOOL_NAME: &str = "cancel_subagent";
 pub(crate) const BACKGROUND_TOOL_NAME: &str = "background_tool";
 pub(crate) const WAIT_TOOL_NAME: &str = "wait_tool";
@@ -408,16 +410,27 @@ pub(crate) fn subagent_tool_names(config: &SubagentToolConfig) -> Vec<String> {
         return Vec::new();
     }
 
-    [
+    let mut names = [
         SPAWN_SUBAGENT_TOOL_NAME,
         WAIT_SUBAGENT_TOOL_NAME,
         LIST_SUBAGENTS_TOOL_NAME,
-        READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
         CANCEL_SUBAGENT_TOOL_NAME,
     ]
     .into_iter()
     .map(str::to_string)
-    .collect()
+    .collect::<Vec<_>>();
+    if config.steering_tools_enabled() {
+        names.insert(3, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME.to_string());
+    }
+    if config.steer_subagent_enabled() {
+        let insert_at = if config.steering_tools_enabled() {
+            4
+        } else {
+            3
+        };
+        names.insert(insert_at, STEER_SUBAGENT_TOOL_NAME.to_string());
+    }
+    names
 }
 
 pub(crate) fn build_subagent_tools(config: SubagentToolConfig) -> Vec<Box<dyn ToolDyn>> {
@@ -425,13 +438,19 @@ pub(crate) fn build_subagent_tools(config: SubagentToolConfig) -> Vec<Box<dyn To
         return Vec::new();
     }
 
-    vec![
+    let mut tools: Vec<Box<dyn ToolDyn>> = vec![
         Box::new(SpawnSubagentTool::new(config.clone())),
         Box::new(WaitSubagentTool),
         Box::new(ListSubagentsTool),
-        Box::new(ReadSubagentTranscriptTool),
-        Box::new(CancelSubagentTool),
-    ]
+    ];
+    if config.steering_tools_enabled() {
+        tools.push(Box::new(ReadSubagentTranscriptTool));
+    }
+    if config.steer_subagent_enabled() {
+        tools.push(Box::new(SteerSubagentTool));
+    }
+    tools.push(Box::new(CancelSubagentTool));
+    tools
 }
 
 pub(crate) fn background_tool_names(config: &BackgroundToolConfig) -> Vec<String> {

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -24,7 +24,8 @@ use delegate::DelegateToAgentTool;
 use file_tools::{EditFileTool, GlobTool, GrepTool, ListFilesTool, ReadFileTool, WriteFileTool};
 use shared::ToolContext;
 use subagent::{
-    BackgroundTool, CancelSubagentTool, CancelTool, SpawnSubagentTool, WaitSubagentTool, WaitTool,
+    BackgroundTool, CancelSubagentTool, CancelTool, ListSubagentsTool, SpawnSubagentTool,
+    WaitSubagentTool, WaitTool,
 };
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
@@ -46,6 +47,7 @@ const DELEGATE_WAIT_TIMEOUT_SECS: u64 = 30;
 pub const DELEGATE_TOOL_NAME: &str = "delegate_to_agent";
 pub(crate) const SPAWN_SUBAGENT_TOOL_NAME: &str = "spawn_subagent";
 pub(crate) const WAIT_SUBAGENT_TOOL_NAME: &str = "wait_subagent";
+pub(crate) const LIST_SUBAGENTS_TOOL_NAME: &str = "list_subagents";
 pub(crate) const CANCEL_SUBAGENT_TOOL_NAME: &str = "cancel_subagent";
 pub(crate) const BACKGROUND_TOOL_NAME: &str = "background_tool";
 pub(crate) const WAIT_TOOL_NAME: &str = "wait_tool";
@@ -406,6 +408,7 @@ pub(crate) fn subagent_tool_names(config: &SubagentToolConfig) -> Vec<String> {
     [
         SPAWN_SUBAGENT_TOOL_NAME,
         WAIT_SUBAGENT_TOOL_NAME,
+        LIST_SUBAGENTS_TOOL_NAME,
         CANCEL_SUBAGENT_TOOL_NAME,
     ]
     .into_iter()
@@ -421,6 +424,7 @@ pub(crate) fn build_subagent_tools(config: SubagentToolConfig) -> Vec<Box<dyn To
     vec![
         Box::new(SpawnSubagentTool::new(config.clone())),
         Box::new(WaitSubagentTool),
+        Box::new(ListSubagentsTool),
         Box::new(CancelSubagentTool),
     ]
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -3,7 +3,7 @@ use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
 use crate::background_tools::r4c_args::{
-    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs,
+    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs, ReadToolOutputArgs,
 };
 use crate::background_tools::{
     BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, SpawnSubagentArgs, WaitSubagentArgs,
@@ -16,7 +16,7 @@ use super::shared::ToolError;
 use super::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
     LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 
 const SUBAGENT_SERVICE_ID: &str = "subagent";
@@ -131,6 +131,9 @@ pub(super) struct WaitTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct ListBackgroundToolsTool;
+
+#[derive(Clone, Copy)]
+pub(super) struct ReadToolOutputTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct CancelTool;
@@ -468,6 +471,45 @@ impl Tool for ListBackgroundToolsTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let _ = args.validated_limit();
+        Err(background_not_yet_executable_error(Self::NAME))
+    }
+}
+
+impl Tool for ReadToolOutputTool {
+    const NAME: &'static str = READ_TOOL_OUTPUT_TOOL_NAME;
+
+    type Error = ToolError;
+    type Args = ReadToolOutputArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Read stdout and stderr snapshots for a visible background tool call."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "tool_call_id": {
+                        "type": "string",
+                        "description": "Tool call ID returned by background_tool or list_background_tools."
+                    },
+                    "max_bytes_per_stream": {
+                        "type": "integer",
+                        "minimum": 256,
+                        "maximum": 262144,
+                        "default": 16384,
+                        "description": "Maximum bytes to return per stream."
+                    }
+                },
+                "required": ["tool_call_id"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        validate_tool_call_id(Self::NAME, &args.tool_call_id)?;
+        let _ = args.validated_max_bytes();
         Err(background_not_yet_executable_error(Self::NAME))
     }
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -2,7 +2,9 @@ use anyhow::anyhow;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
-use crate::background_tools::r4c_args::{ListBackgroundToolsArgs, ListSubagentsArgs};
+use crate::background_tools::r4c_args::{
+    ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs,
+};
 use crate::background_tools::{
     BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, SpawnSubagentArgs, WaitSubagentArgs,
     WaitToolArgs,
@@ -13,8 +15,8 @@ use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
 use super::shared::ToolError;
 use super::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
-    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
-    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 
 const SUBAGENT_SERVICE_ID: &str = "subagent";
@@ -117,6 +119,9 @@ pub(super) struct WaitSubagentTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct ListSubagentsTool;
+
+#[derive(Clone, Copy)]
+pub(super) struct ReadSubagentTranscriptTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct CancelSubagentTool;
@@ -295,6 +300,69 @@ impl Tool for ListSubagentsTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let _ = args.validated_limit();
+        Err(not_yet_executable_error(Self::NAME))
+    }
+}
+
+impl Tool for ReadSubagentTranscriptTool {
+    const NAME: &'static str = READ_SUBAGENT_TRANSCRIPT_TOOL_NAME;
+
+    type Error = ToolError;
+    type Args = ReadSubagentTranscriptArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Read a compact transcript snapshot from a visible background subagent."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "child_request_id": {
+                        "type": "string",
+                        "description": "Child request ID returned by spawn_subagent or list_subagents."
+                    },
+                    "since_sequence": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "default": 0,
+                        "description": "First transcript sequence to include."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100,
+                        "default": 20,
+                        "description": "Maximum rendered message blocks to return."
+                    },
+                    "max_chars": {
+                        "type": "integer",
+                        "minimum": 64,
+                        "maximum": 24000,
+                        "default": 6000,
+                        "description": "Maximum rendered transcript characters to return."
+                    },
+                    "include_user_messages": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Include ordinary user messages from the child session."
+                    },
+                    "include_tool_results": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Include capped tool-result snippets from the child session."
+                    }
+                },
+                "required": ["child_request_id"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        validate_child_request_id(Self::NAME, &args.child_request_id)?;
+        let _ = args.validated_limit();
+        let _ = args.validated_max_chars();
         Err(not_yet_executable_error(Self::NAME))
     }
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -2,6 +2,7 @@ use anyhow::anyhow;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
+use crate::background_tools::r4c_args::ListSubagentsArgs;
 use crate::background_tools::{
     BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, SpawnSubagentArgs, WaitSubagentArgs,
     WaitToolArgs,
@@ -11,8 +12,8 @@ use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
 
 use super::shared::ToolError;
 use super::{
-    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
-    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME,
+    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 
 const SUBAGENT_SERVICE_ID: &str = "subagent";
@@ -112,6 +113,9 @@ impl BackgroundTool {
 
 #[derive(Clone, Copy)]
 pub(super) struct WaitSubagentTool;
+
+#[derive(Clone, Copy)]
+pub(super) struct ListSubagentsTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct CancelSubagentTool;
@@ -248,6 +252,45 @@ impl Tool for CancelSubagentTool {
                 "reason must be omitted or non-empty",
             ));
         }
+        Err(not_yet_executable_error(Self::NAME))
+    }
+}
+
+impl Tool for ListSubagentsTool {
+    const NAME: &'static str = LIST_SUBAGENTS_TOOL_NAME;
+
+    type Error = ToolError;
+    type Args = ListSubagentsArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "List this parent request's visible background child subagents."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["running", "terminal", "all"],
+                        "default": "running",
+                        "description": "Filter child subagents by bridge lifecycle state."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "default": 20,
+                        "description": "Maximum entries to return."
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let _ = args.validated_limit();
         Err(not_yet_executable_error(Self::NAME))
     }
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -4,6 +4,7 @@ use rig::tool::Tool;
 
 use crate::background_tools::r4c_args::{
     ListBackgroundToolsArgs, ListSubagentsArgs, ReadSubagentTranscriptArgs, ReadToolOutputArgs,
+    SteerSubagentArgs,
 };
 use crate::background_tools::{
     BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, SpawnSubagentArgs, WaitSubagentArgs,
@@ -16,7 +17,8 @@ use super::shared::ToolError;
 use super::{
     BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
     LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    READ_TOOL_OUTPUT_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME, STEER_SUBAGENT_TOOL_NAME,
+    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 
 const SUBAGENT_SERVICE_ID: &str = "subagent";
@@ -122,6 +124,9 @@ pub(super) struct ListSubagentsTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct ReadSubagentTranscriptTool;
+
+#[derive(Clone, Copy)]
+pub(super) struct SteerSubagentTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct CancelSubagentTool;
@@ -366,6 +371,53 @@ impl Tool for ReadSubagentTranscriptTool {
         validate_child_request_id(Self::NAME, &args.child_request_id)?;
         let _ = args.validated_limit();
         let _ = args.validated_max_chars();
+        Err(not_yet_executable_error(Self::NAME))
+    }
+}
+
+impl Tool for SteerSubagentTool {
+    const NAME: &'static str = STEER_SUBAGENT_TOOL_NAME;
+
+    type Error = ToolError;
+    type Args = SteerSubagentArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Append a steering message to a visible background subagent, optionally interrupting its active request first."
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "child_request_id": {
+                        "type": "string",
+                        "description": "Child request ID returned by spawn_subagent or list_subagents."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "User-role steering message to append to the child session."
+                    },
+                    "interrupt": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Interrupt the child session's active request before appending the steering request."
+                    }
+                },
+                "required": ["child_request_id", "message"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        validate_child_request_id(Self::NAME, &args.child_request_id)?;
+        if args.message.trim().is_empty() {
+            return Err(invalid_arguments_error(
+                Self::NAME,
+                "/message",
+                "message is required",
+            ));
+        }
         Err(not_yet_executable_error(Self::NAME))
     }
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -2,7 +2,7 @@ use anyhow::anyhow;
 use rig::completion::ToolDefinition;
 use rig::tool::Tool;
 
-use crate::background_tools::r4c_args::ListSubagentsArgs;
+use crate::background_tools::r4c_args::{ListBackgroundToolsArgs, ListSubagentsArgs};
 use crate::background_tools::{
     BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, SpawnSubagentArgs, WaitSubagentArgs,
     WaitToolArgs,
@@ -12,8 +12,9 @@ use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
 
 use super::shared::ToolError;
 use super::{
-    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME,
-    SPAWN_SUBAGENT_TOOL_NAME, WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
+    BACKGROUND_TOOL_NAME, CANCEL_SUBAGENT_TOOL_NAME, CANCEL_TOOL_NAME,
+    LIST_BACKGROUND_TOOLS_TOOL_NAME, LIST_SUBAGENTS_TOOL_NAME, SPAWN_SUBAGENT_TOOL_NAME,
+    WAIT_SUBAGENT_TOOL_NAME, WAIT_TOOL_NAME,
 };
 
 const SUBAGENT_SERVICE_ID: &str = "subagent";
@@ -122,6 +123,9 @@ pub(super) struct CancelSubagentTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct WaitTool;
+
+#[derive(Clone, Copy)]
+pub(super) struct ListBackgroundToolsTool;
 
 #[derive(Clone, Copy)]
 pub(super) struct CancelTool;
@@ -358,6 +362,44 @@ impl Tool for WaitTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         validate_tool_call_id(WAIT_TOOL_NAME, &args.tool_call_id)?;
+        Err(background_not_yet_executable_error(Self::NAME))
+    }
+}
+
+impl Tool for ListBackgroundToolsTool {
+    const NAME: &'static str = LIST_BACKGROUND_TOOLS_TOOL_NAME;
+
+    type Error = ToolError;
+    type Args = ListBackgroundToolsArgs;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "List this parent request's visible background tool calls.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["running", "terminal", "all"],
+                        "default": "running",
+                        "description": "Filter background tool calls by lifecycle state."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 50,
+                        "default": 20,
+                        "description": "Maximum entries to return."
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let _ = args.validated_limit();
         Err(background_not_yet_executable_error(Self::NAME))
     }
 }

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -169,6 +169,7 @@ fn background_tool_names_are_gated_by_allowlist() {
         vec![
             BACKGROUND_TOOL_NAME.to_string(),
             WAIT_TOOL_NAME.to_string(),
+            LIST_BACKGROUND_TOOLS_TOOL_NAME.to_string(),
             CANCEL_TOOL_NAME.to_string()
         ]
     );

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -170,6 +170,7 @@ fn background_tool_names_are_gated_by_allowlist() {
             BACKGROUND_TOOL_NAME.to_string(),
             WAIT_TOOL_NAME.to_string(),
             LIST_BACKGROUND_TOOLS_TOOL_NAME.to_string(),
+            READ_TOOL_OUTPUT_TOOL_NAME.to_string(),
             CANCEL_TOOL_NAME.to_string()
         ]
     );

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -132,10 +132,10 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
             SPAWN_SUBAGENT_TOOL_NAME.to_string(),
             WAIT_SUBAGENT_TOOL_NAME.to_string(),
             LIST_SUBAGENTS_TOOL_NAME.to_string(),
+            READ_SUBAGENT_TRANSCRIPT_TOOL_NAME.to_string(),
             CANCEL_SUBAGENT_TOOL_NAME.to_string()
         ]
     );
-    assert!(!names.contains(&"read_subagent_transcript".to_string()));
     assert!(!names.contains(&"steer_subagent".to_string()));
 }
 
@@ -190,6 +190,7 @@ async fn subagent_tool_definitions_register_expected_surface() {
             SPAWN_SUBAGENT_TOOL_NAME.to_string(),
             WAIT_SUBAGENT_TOOL_NAME.to_string(),
             LIST_SUBAGENTS_TOOL_NAME.to_string(),
+            READ_SUBAGENT_TRANSCRIPT_TOOL_NAME.to_string(),
             CANCEL_SUBAGENT_TOOL_NAME.to_string()
         ]
     );

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -131,10 +131,10 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
         vec![
             SPAWN_SUBAGENT_TOOL_NAME.to_string(),
             WAIT_SUBAGENT_TOOL_NAME.to_string(),
+            LIST_SUBAGENTS_TOOL_NAME.to_string(),
             CANCEL_SUBAGENT_TOOL_NAME.to_string()
         ]
     );
-    assert!(!names.contains(&"list_subagents".to_string()));
     assert!(!names.contains(&"read_subagent_transcript".to_string()));
     assert!(!names.contains(&"steer_subagent".to_string()));
 }
@@ -175,7 +175,7 @@ fn background_tool_names_are_gated_by_allowlist() {
 }
 
 #[tokio::test]
-async fn subagent_tool_definitions_register_only_r4b_surface() {
+async fn subagent_tool_definitions_register_expected_surface() {
     let config = SubagentToolConfig {
         targets: vec!["research".to_string()],
         spawn_enabled: true,
@@ -188,6 +188,7 @@ async fn subagent_tool_definitions_register_only_r4b_surface() {
         vec![
             SPAWN_SUBAGENT_TOOL_NAME.to_string(),
             WAIT_SUBAGENT_TOOL_NAME.to_string(),
+            LIST_SUBAGENTS_TOOL_NAME.to_string(),
             CANCEL_SUBAGENT_TOOL_NAME.to_string()
         ]
     );

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -109,6 +109,7 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
     let disabled = SubagentToolConfig {
         targets: vec!["worker".to_string()],
         spawn_enabled: false,
+        steering_enabled: false,
         background_enabled: true,
     };
     assert!(subagent_tool_names(&disabled).is_empty());
@@ -116,6 +117,7 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
     let no_targets = SubagentToolConfig {
         targets: Vec::new(),
         spawn_enabled: true,
+        steering_enabled: true,
         background_enabled: true,
     };
     assert!(subagent_tool_names(&no_targets).is_empty());
@@ -123,6 +125,7 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
     let enabled = SubagentToolConfig {
         targets: vec!["worker".to_string()],
         spawn_enabled: true,
+        steering_enabled: true,
         background_enabled: false,
     };
     let names = subagent_tool_names(&enabled);
@@ -137,6 +140,40 @@ fn subagent_tool_names_are_gated_by_spawn_and_targets() {
         ]
     );
     assert!(!names.contains(&"steer_subagent".to_string()));
+
+    let steering_disabled = SubagentToolConfig {
+        targets: vec!["worker".to_string()],
+        spawn_enabled: true,
+        steering_enabled: false,
+        background_enabled: true,
+    };
+    assert_eq!(
+        subagent_tool_names(&steering_disabled),
+        vec![
+            SPAWN_SUBAGENT_TOOL_NAME.to_string(),
+            WAIT_SUBAGENT_TOOL_NAME.to_string(),
+            LIST_SUBAGENTS_TOOL_NAME.to_string(),
+            CANCEL_SUBAGENT_TOOL_NAME.to_string()
+        ]
+    );
+
+    let steering_and_background = SubagentToolConfig {
+        targets: vec!["worker".to_string()],
+        spawn_enabled: true,
+        steering_enabled: true,
+        background_enabled: true,
+    };
+    assert_eq!(
+        subagent_tool_names(&steering_and_background),
+        vec![
+            SPAWN_SUBAGENT_TOOL_NAME.to_string(),
+            WAIT_SUBAGENT_TOOL_NAME.to_string(),
+            LIST_SUBAGENTS_TOOL_NAME.to_string(),
+            READ_SUBAGENT_TRANSCRIPT_TOOL_NAME.to_string(),
+            STEER_SUBAGENT_TOOL_NAME.to_string(),
+            CANCEL_SUBAGENT_TOOL_NAME.to_string()
+        ]
+    );
 }
 
 #[test]
@@ -181,6 +218,7 @@ async fn subagent_tool_definitions_register_expected_surface() {
     let config = SubagentToolConfig {
         targets: vec!["research".to_string()],
         spawn_enabled: true,
+        steering_enabled: true,
         background_enabled: false,
     };
     let tools = build_subagent_tools(config);
@@ -212,6 +250,7 @@ async fn spawn_subagent_definition_exposes_background_mode_when_enabled() {
     let config = SubagentToolConfig {
         targets: vec!["research".to_string()],
         spawn_enabled: true,
+        steering_enabled: true,
         background_enabled: true,
     };
     let tools = build_subagent_tools(config);

--- a/crates/defra-agent/src/watcher.rs
+++ b/crates/defra-agent/src/watcher.rs
@@ -40,13 +40,16 @@ pub struct AgentRequest {
 }
 
 /// Coherence check on AgentRequest's subagent fields:
-/// - caused_by_parent_request_id and caused_by_parent_tool_call_id must be
-///   set together (both Some) or together (both None).
-/// - subagent_depth = 0 ↔ both parent fields are None.
+/// - caused_by_parent_tool_call_id requires caused_by_parent_request_id.
+/// - caused_by_parent_request_id without caused_by_parent_tool_call_id is only
+///   valid for queued steering requests, which preserve lineage without
+///   claiming a bridge call.
+/// - subagent_depth = 0 ↔ no parent lineage is present.
 pub fn validate_agent_request_subagent_coherence(req: &AgentRequest) -> Result<()> {
     let has_parent_req = req.caused_by_parent_request_id.is_some();
     let has_parent_tc = req.caused_by_parent_tool_call_id.is_some();
-    if has_parent_req != has_parent_tc {
+    let request_only_steering_link = has_parent_req && !has_parent_tc && is_steering_queue(req);
+    if has_parent_req != has_parent_tc && !request_only_steering_link {
         return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
     }
     let is_top_level = !has_parent_req; // both None
@@ -57,6 +60,25 @@ pub fn validate_agent_request_subagent_coherence(req: &AgentRequest) -> Result<(
         return Err(IllegalToolCallTransition::ParentLinkageIncoherent.into());
     }
     Ok(())
+}
+
+fn is_steering_queue(req: &AgentRequest) -> bool {
+    let Some(metadata) = req
+        .metadata
+        .as_deref()
+        .map(str::trim)
+        .filter(|m| !m.is_empty())
+    else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(metadata) else {
+        return false;
+    };
+    value
+        .get("queue")
+        .and_then(|queue| queue.get("source"))
+        .and_then(serde_json::Value::as_str)
+        == Some("steering")
 }
 
 pub trait Watcher: Send + Sync {

--- a/crates/defra-agent/src/watcher/tests.rs
+++ b/crates/defra-agent/src/watcher/tests.rs
@@ -22,6 +22,21 @@ fn validate_rejects_mixed_parent_linkage_request_id_only() {
 }
 
 #[test]
+fn validate_accepts_steering_request_lineage_without_tool_call_link() {
+    let req = AgentRequest {
+        subagent_depth: 1,
+        metadata: Some(
+            r#"{"queue":{"source":"steering","policy":"append","key":null,"queued_after_request_id":null}}"#
+                .to_string(),
+        ),
+        caused_by_parent_request_id: Some("parent-req-1".to_string()),
+        caused_by_parent_tool_call_id: None,
+        ..base_request()
+    };
+    assert!(validate_agent_request_subagent_coherence(&req).is_ok());
+}
+
+#[test]
 fn validate_rejects_mixed_parent_linkage_tool_call_id_only() {
     let req = AgentRequest {
         subagent_depth: 1,

--- a/crates/defra-agent/tests/r4c_list_background_tools.rs
+++ b/crates/defra-agent/tests/r4c_list_background_tools.rs
@@ -1,0 +1,396 @@
+//! Integration tests for R4c list_background_tools.
+
+mod support;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::ToolCallLifecycle;
+use defra_agent::{BackgroundToolRegistry, DefraSessionHook, FailurePolicy};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::ToolDefinition;
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::streaming::StreamingCompletionResponse;
+use rig::tool::{ToolDyn, ToolError};
+use rig::wasm_compat::WasmBoxedFuture;
+use serde_json::{json, Value};
+
+use support::{test_db, AGENT_DID};
+
+#[derive(Clone, Default)]
+struct TestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R4c list_background_tools tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R4c list_background_tools tests".to_string(),
+        ))
+    }
+}
+
+struct StaticTool {
+    name: &'static str,
+    result: &'static str,
+}
+
+impl ToolDyn for StaticTool {
+    fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+        Box::pin(async move {
+            ToolDefinition {
+                name: self.name.to_string(),
+                description: "test tool".to_string(),
+                parameters: json!({"type":"object"}),
+            }
+        })
+    }
+
+    fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move { Ok(self.result.to_string()) })
+    }
+}
+
+struct PendingTool;
+
+impl ToolDyn for PendingTool {
+    fn name(&self) -> String {
+        "slow_tool".to_string()
+    }
+
+    fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+        Box::pin(async {
+            ToolDefinition {
+                name: "slow_tool".to_string(),
+                description: "test tool".to_string(),
+                parameters: json!({"type":"object"}),
+            }
+        })
+    }
+
+    fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(std::future::pending())
+    }
+}
+
+async fn setup_hook(
+    test_name: &str,
+    registry: BackgroundToolRegistry,
+) -> (support::TestDb, DefraSessionHook, String, String) {
+    let db = test_db(test_name).await;
+    let session_id = format!("{test_name}-session");
+    let request_id = format!("{test_name}-request");
+    support::create_request(
+        db.node.as_ref(),
+        &request_id,
+        &session_id,
+        "processing",
+        "2026-05-14T00:00:00Z",
+    )
+    .await;
+
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        &session_id,
+        "r4c-background-tools",
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap()
+    .with_background_tool_registry(registry);
+    hook.set_active_request_id(Some(request_id.clone())).await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::seconds(5)))
+        .await;
+    (db, hook, session_id, request_id)
+}
+
+fn registry(tools: Vec<Box<dyn ToolDyn>>, allowlist: &[&str]) -> BackgroundToolRegistry {
+    BackgroundToolRegistry::from_tools(
+        tools,
+        &allowlist
+            .iter()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+async fn background_tool(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    tool_name: &str,
+) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "background_tool",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &json!({"tool_name": tool_name, "args": {}}).to_string(),
+        )
+        .await,
+    )
+}
+
+async fn wait_tool(hook: &DefraSessionHook, internal_call_id: &str, tool_call_id: &str) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "wait_tool",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &json!({ "tool_call_id": tool_call_id }).to_string(),
+        )
+        .await,
+    )
+}
+
+async fn list_background_tools(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    args: Value,
+) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "list_background_tools",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &args.to_string(),
+        )
+        .await,
+    )
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_name: &str) -> usize {
+    let session_id = escape_graphql_string(session_id);
+    let tool_name = escape_graphql_string(tool_name);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_name: {{ _eq: "{tool_name}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "count AgentToolCall by name failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map_or(0, Vec::len)
+}
+
+async fn create_foreground_tool_call(db: &support::TestDb, request_id: &str, session_id: &str) {
+    let mut lifecycle = ToolCallLifecycle::new(
+        db.node.clone(),
+        request_id.to_string(),
+        session_id.to_string(),
+        "foreground-call".to_string(),
+        99,
+        "foreground_tool".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+    );
+    lifecycle.start_running().await.unwrap();
+    lifecycle.complete("foreground result").await.unwrap();
+}
+
+#[tokio::test]
+async fn list_background_tools_returns_running_bg_tools() {
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-list-bg-running",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let handle_a = background_tool(&hook, "bg-a", "slow_tool").await;
+    let handle_b = background_tool(&hook, "bg-b", "slow_tool").await;
+
+    let result = list_background_tools(&hook, "list-running", json!({})).await;
+    let entries = result["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 2);
+    let ids = entries
+        .iter()
+        .map(|entry| entry["tool_call_id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(ids.contains(&handle_a["tool_call_id"].as_str().unwrap()));
+    assert!(ids.contains(&handle_b["tool_call_id"].as_str().unwrap()));
+    for entry in entries {
+        assert_eq!(entry["tool_name"].as_str(), Some("slow_tool"));
+        assert_eq!(entry["await_mode"].as_str(), Some("background"));
+        assert_eq!(entry["status"].as_str(), Some("running"));
+        assert_eq!(entry["stdout_bytes"].as_u64(), Some(0));
+        assert_eq!(entry["stderr_bytes"].as_u64(), Some(0));
+    }
+}
+
+#[tokio::test]
+async fn list_background_tools_rejects_sibling_requests() {
+    let db = test_db("r4c-list-bg-sibling").await;
+    let (hook_1, _session_1, _request_1) = setup_hook_on_db(
+        &db,
+        "parent-one",
+        "session-one",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let (hook_2, _session_2, _request_2) = setup_hook_on_db(
+        &db,
+        "parent-two",
+        "session-two",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    background_tool(&hook_2, "sibling-bg", "slow_tool").await;
+
+    let result = list_background_tools(&hook_1, "list-sibling", json!({})).await;
+    assert!(result["entries"].as_array().unwrap().is_empty());
+}
+
+async fn setup_hook_on_db(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+    registry: BackgroundToolRegistry,
+) -> (DefraSessionHook, String, String) {
+    support::create_request(
+        db.node.as_ref(),
+        request_id,
+        session_id,
+        "processing",
+        "2026-05-14T00:00:00Z",
+    )
+    .await;
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        session_id,
+        "r4c-background-tools",
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap()
+    .with_background_tool_registry(registry);
+    hook.set_active_request_id(Some(request_id.to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::seconds(5)))
+        .await;
+    (hook, session_id.to_string(), request_id.to_string())
+}
+
+#[tokio::test]
+async fn list_background_tools_excludes_foreground_calls() {
+    let (db, hook, session_id, request_id) = setup_hook(
+        "r4c-list-bg-foreground",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    create_foreground_tool_call(&db, &request_id, &session_id).await;
+    background_tool(&hook, "bg-visible", "slow_tool").await;
+
+    let result = list_background_tools(&hook, "list-foreground", json!({})).await;
+    let entries = result["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["tool_name"].as_str(), Some("slow_tool"));
+}
+
+#[tokio::test]
+async fn list_background_tools_status_filter() {
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-list-bg-status",
+        registry(
+            vec![Box::new(StaticTool {
+                name: "complete_tool",
+                result: "terminal output",
+            })],
+            &["complete_tool"],
+        ),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-terminal", "complete_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+    let waited = wait_tool(&hook, "wait-terminal", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
+
+    let running =
+        list_background_tools(&hook, "list-status-running", json!({"status": "running"})).await;
+    assert_eq!(running["entries"].as_array().unwrap().len(), 0);
+
+    let terminal =
+        list_background_tools(&hook, "list-status-terminal", json!({"status": "terminal"})).await;
+    assert_eq!(terminal["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(terminal["entries"][0]["status"].as_str(), Some("completed"));
+    assert_eq!(
+        terminal["entries"][0]["stdout_bytes"].as_u64(),
+        Some("terminal output".len() as u64)
+    );
+}
+
+#[tokio::test]
+async fn list_background_tools_limit_truncates() {
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-list-bg-limit",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    for index in 0..5 {
+        background_tool(&hook, &format!("bg-limit-{index}"), "slow_tool").await;
+    }
+
+    let result = list_background_tools(&hook, "list-limit", json!({"limit": 3})).await;
+    assert_eq!(result["entries"].as_array().unwrap().len(), 3);
+    assert_eq!(result["truncated"].as_bool(), Some(true));
+}
+
+#[tokio::test]
+async fn list_background_tools_no_parent_tool_call_row_written() {
+    let (db, hook, session_id, _request_id) = setup_hook(
+        "r4c-list-bg-no-row",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    background_tool(&hook, "bg-no-row", "slow_tool").await;
+    let _ = list_background_tools(&hook, "list-no-row", json!({})).await;
+
+    assert_eq!(
+        count_tool_calls_by_name(db.node.as_ref(), &session_id, "list_background_tools").await,
+        0
+    );
+}

--- a/crates/defra-agent/tests/r4c_list_subagents.rs
+++ b/crates/defra-agent/tests/r4c_list_subagents.rs
@@ -257,6 +257,74 @@ async fn bridge_complete(db: &support::TestDb, session_id: &str, tool_call_id: &
     assert!(projected);
 }
 
+async fn create_superseded_child_edge(
+    node: &EmbeddedNode,
+    parent_request_id: &str,
+    session_id: &str,
+    tool_call_id: &str,
+) {
+    let child_request_id = format!("{tool_call_id}-child");
+    let child_session_id = format!("{tool_call_id}-child-session");
+    let parent_request_id = escape_graphql_string(parent_request_id);
+    let session_id = escape_graphql_string(session_id);
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let child_request_id = escape_graphql_string(&child_request_id);
+    let child_session_id = escape_graphql_string(&child_session_id);
+    let agent_did = escape_graphql_string(AGENT_DID);
+    let behavior_id = escape_graphql_string(CHILD_BEHAVIOR_ID);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{child_request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{child_session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{child_request_id}",
+                superseded_by_request: "",
+                content: "superseded child",
+                status: "superseded",
+                lifecycle_state: "superseded",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "2026-05-14T00:01:00Z",
+                deadline: "2026-05-14T00:06:00Z",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 1,
+                caused_by_parent_request_id: "{parent_request_id}",
+                caused_by_parent_tool_call_id: "{tool_call_id}"
+            }}) {{ _docID }}
+            create_AgentToolCall(input: {{
+                tool_call_key: "{session_id}:{tool_call_id}",
+                request_id: "{parent_request_id}",
+                session_id: "{session_id}",
+                message_sequence: 1,
+                tool_name: "spawn_subagent",
+                tool_call_id: "{tool_call_id}",
+                args: "{{}}",
+                result: "",
+                status: "superseded",
+                lifecycle_state: "superseded",
+                started_at: "2026-05-14T00:01:00Z",
+                completed_at: "2026-05-14T00:02:00Z",
+                deadline_at: "2026-05-14T00:06:00Z",
+                await_mode: "background",
+                cancel_policy: "propagate",
+                child_request_id: "{child_request_id}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create superseded child edge failed: {:?}",
+        response.errors
+    );
+}
+
 #[tokio::test]
 async fn list_subagents_returns_running_children() {
     let db = setup_db("r4c-list-running").await;
@@ -314,6 +382,27 @@ async fn list_subagents_status_filter() {
 
     let all = list_subagents(&hook, "list-status-all", json!({"status": "all"})).await;
     assert_eq!(all["entries"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn list_subagents_terminal_includes_superseded_children() {
+    let db = setup_db("r4c-list-superseded").await;
+    let session_id = "session-superseded";
+    let hook = create_parent_hook(&db, "parent-superseded", session_id).await;
+    create_superseded_child_edge(
+        db.node.as_ref(),
+        "parent-superseded",
+        session_id,
+        "spawn-superseded",
+    )
+    .await;
+
+    let terminal = list_subagents(&hook, "list-superseded", json!({"status": "terminal"})).await;
+    assert_eq!(terminal["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        terminal["entries"][0]["status"].as_str(),
+        Some("superseded")
+    );
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/r4c_list_subagents.rs
+++ b/crates/defra-agent/tests/r4c_list_subagents.rs
@@ -1,0 +1,363 @@
+//! Integration tests for R4c list_subagents.
+
+mod support;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::ToolCallLifecycle;
+use defra_agent::{
+    upsert_agent_behavior, upsert_tool_selection, AgentBehavior, DefraSessionHook, FailurePolicy,
+    ToolSelectionDocument,
+};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::streaming::StreamingCompletionResponse;
+use serde_json::{json, Value};
+
+use support::test_db;
+
+const AGENT_DID: &str = "did:defra-agent:r4c-list-subagents";
+const PARENT_BEHAVIOR_ID: &str = "r4c-parent";
+const CHILD_BEHAVIOR_ID: &str = "r4c-child";
+
+#[derive(Clone, Default)]
+struct TestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R4c list_subagents tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R4c list_subagents tests".to_string(),
+        ))
+    }
+}
+
+async fn setup_db(name: &str) -> support::TestDb {
+    let db = test_db(name).await;
+    upsert_tool_selection(
+        db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: "r4c-parent-tools".to_string(),
+            agent_did: AGENT_DID.to_string(),
+            subagent_targets: Some(vec![CHILD_BEHAVIOR_ID.to_string()]),
+            subagent_spawn_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: PARENT_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c parent".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some("r4c-parent-tools".to_string()),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: CHILD_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c child".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:01Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    db
+}
+
+async fn create_parent_hook(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+) -> DefraSessionHook {
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    create_parent_request(db.node.as_ref(), request_id, session_id, deadline).await;
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        session_id,
+        PARENT_BEHAVIOR_ID,
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap();
+    hook.set_active_request_id(Some(request_id.to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(deadline)).await;
+    hook
+}
+
+async fn create_parent_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    deadline: chrono::DateTime<chrono::Utc>,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let behavior_id = escape_graphql_string(PARENT_BEHAVIOR_ID);
+    let agent_did = escape_graphql_string(AGENT_DID);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let deadline = deadline.to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "parent prompt",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "{created_at}",
+                deadline: "{deadline}",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create parent AgentRequest failed: {:?}",
+        response.errors
+    );
+}
+
+async fn spawn_background_child(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    prompt: &str,
+) -> Value {
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": prompt,
+        "await_mode": "background"
+    })
+    .to_string();
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "spawn_subagent",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    assert_eq!(receipt["ok"], true);
+    receipt
+}
+
+async fn list_subagents(hook: &DefraSessionHook, internal_call_id: &str, args: Value) -> Value {
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "list_subagents",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args.to_string(),
+    )
+    .await;
+    skip_reason_json(action)
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_name: &str) -> usize {
+    let escaped_session_id = escape_graphql_string(session_id);
+    let escaped_tool_name = escape_graphql_string(tool_name);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{escaped_session_id}" }},
+                    tool_name: {{ _eq: "{escaped_tool_name}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "count AgentToolCall by name failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map_or(0, Vec::len)
+}
+
+async fn bridge_complete(db: &support::TestDb, session_id: &str, tool_call_id: &str) {
+    let mut lifecycle = ToolCallLifecycle::load(db.node.clone(), session_id, tool_call_id)
+        .await
+        .expect("load lifecycle")
+        .expect("bridge lifecycle should exist");
+    let projected = lifecycle
+        .bridge_complete("child final answer".to_string())
+        .await
+        .expect("bridge complete");
+    assert!(projected);
+}
+
+#[tokio::test]
+async fn list_subagents_returns_running_children() {
+    let db = setup_db("r4c-list-running").await;
+    let hook = create_parent_hook(&db, "parent-running", "session-running").await;
+    let child_a = spawn_background_child(&hook, "spawn-a", "do A").await;
+    let child_b = spawn_background_child(&hook, "spawn-b", "do B").await;
+
+    let result = list_subagents(&hook, "list-running", json!({})).await;
+    let entries = result["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 2);
+    let ids = entries
+        .iter()
+        .map(|entry| entry["child_request_id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert!(ids.contains(&child_a["child_request_id"].as_str().unwrap()));
+    assert!(ids.contains(&child_b["child_request_id"].as_str().unwrap()));
+    for entry in entries {
+        assert_eq!(entry["deployment_id"].as_str(), Some(AGENT_DID));
+        assert_eq!(entry["await_mode"].as_str(), Some("background"));
+        assert_eq!(entry["status"].as_str(), Some("running"));
+        assert_eq!(entry["behavior_id"].as_str(), Some(CHILD_BEHAVIOR_ID));
+    }
+}
+
+#[tokio::test]
+async fn list_subagents_rejects_sibling_children() {
+    let db = setup_db("r4c-list-sibling").await;
+    let hook_1 = create_parent_hook(&db, "parent-one", "session-one").await;
+    let hook_2 = create_parent_hook(&db, "parent-two", "session-two").await;
+    spawn_background_child(&hook_2, "spawn-sibling", "do sibling work").await;
+
+    let result = list_subagents(&hook_1, "list-sibling", json!({})).await;
+    let entries = result["entries"].as_array().expect("entries");
+    assert!(
+        entries.is_empty(),
+        "parent one must not see parent two's child"
+    );
+}
+
+#[tokio::test]
+async fn list_subagents_status_filter() {
+    let db = setup_db("r4c-list-status").await;
+    let session_id = "session-status";
+    let hook = create_parent_hook(&db, "parent-status", session_id).await;
+    spawn_background_child(&hook, "spawn-terminal", "terminal child").await;
+    bridge_complete(&db, session_id, "spawn-terminal").await;
+
+    let running = list_subagents(&hook, "list-status-running", json!({"status": "running"})).await;
+    assert_eq!(running["entries"].as_array().unwrap().len(), 0);
+
+    let terminal =
+        list_subagents(&hook, "list-status-terminal", json!({"status": "terminal"})).await;
+    assert_eq!(terminal["entries"].as_array().unwrap().len(), 1);
+    assert_eq!(terminal["entries"][0]["status"].as_str(), Some("completed"));
+
+    let all = list_subagents(&hook, "list-status-all", json!({"status": "all"})).await;
+    assert_eq!(all["entries"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn list_subagents_limit_truncates() {
+    let db = setup_db("r4c-list-limit").await;
+    let hook = create_parent_hook(&db, "parent-limit", "session-limit").await;
+    for index in 0..5 {
+        spawn_background_child(&hook, &format!("spawn-limit-{index}"), "limited child").await;
+    }
+
+    let result = list_subagents(&hook, "list-limit", json!({"limit": 3})).await;
+    assert_eq!(result["entries"].as_array().unwrap().len(), 3);
+    assert_eq!(result["truncated"].as_bool(), Some(true));
+}
+
+#[tokio::test]
+async fn list_subagents_no_parent_tool_call_row_written() {
+    let db = setup_db("r4c-list-no-row").await;
+    let session_id = "session-no-row";
+    let hook = create_parent_hook(&db, "parent-no-row", session_id).await;
+    spawn_background_child(&hook, "spawn-no-row", "child").await;
+    let _ = list_subagents(&hook, "list-no-row", json!({})).await;
+
+    assert_eq!(
+        count_tool_calls_by_name(db.node.as_ref(), session_id, "list_subagents").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn list_subagents_lineage_matches_r4c_witness_shape() {
+    let db = setup_db("r4c-list-witness").await;
+    let hook_1 = create_parent_hook(&db, "r4c-w1-caller", "r4c-w1-caller-session").await;
+    let hook_2 = create_parent_hook(&db, "r4c-w1-sibling", "r4c-w1-sibling-session").await;
+    let sibling_child =
+        spawn_background_child(&hook_2, "r4c-w1-sibling-tool-call", "sibling child").await;
+    let sibling_child_id = sibling_child["child_request_id"].as_str().unwrap();
+
+    let result = list_subagents(&hook_1, "r4c-w1-list", json!({})).await;
+    let entries = result["entries"].as_array().unwrap();
+    assert!(
+        !entries
+            .iter()
+            .any(|entry| entry["child_request_id"].as_str() == Some(sibling_child_id)),
+        "caller must not see sibling child"
+    );
+}

--- a/crates/defra-agent/tests/r4c_read_subagent_transcript.rs
+++ b/crates/defra-agent/tests/r4c_read_subagent_transcript.rs
@@ -243,6 +243,7 @@ async fn append_assistant_tool_call_message(
     sequence: u32,
     body: &str,
     tool_call_id: &str,
+    tool_name: &str,
 ) {
     let message = Message::Assistant {
         id: None,
@@ -254,7 +255,7 @@ async fn append_assistant_tool_call_message(
                 id: tool_call_id.to_string(),
                 call_id: Some(tool_call_id.to_string()),
                 function: ToolFunction {
-                    name: "spawn_subagent".to_string(),
+                    name: tool_name.to_string(),
                     arguments: json!({"behavior_id": CHILD_BEHAVIOR_ID}),
                 },
                 signature: None,
@@ -309,6 +310,45 @@ async fn create_child_bridge_tool_call(
     assert!(
         !response.has_errors(),
         "create child bridge AgentToolCall failed: {:?}",
+        response.errors
+    );
+}
+
+async fn create_background_tool_call(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    child_session_id: &str,
+    message_sequence: u32,
+    tool_call_id: &str,
+) {
+    let child_request_id = escape_graphql_string(child_request_id);
+    let child_session_id = escape_graphql_string(child_session_id);
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let tool_call_key = format!("{child_session_id}:{tool_call_id}");
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentToolCall(input: {{
+                tool_call_key: "{tool_call_key}",
+                request_id: "{child_request_id}",
+                session_id: "{child_session_id}",
+                message_sequence: {message_sequence},
+                tool_name: "bash",
+                tool_call_id: "{tool_call_id}",
+                args: "{{}}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "2026-05-14T00:01:00Z",
+                deadline_at: "2026-05-14T00:06:00Z",
+                await_mode: "background",
+                cancel_policy: "propagate"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create background AgentToolCall failed: {:?}",
         response.errors
     );
 }
@@ -414,6 +454,7 @@ async fn read_transcript_hides_bridge_rows() {
         1,
         "plain assistant message",
         "bridge-tc-1",
+        "spawn_subagent",
     )
     .await;
     create_child_bridge_tool_call(
@@ -434,6 +475,43 @@ async fn read_transcript_hides_bridge_rows() {
     let transcript = result["transcript"].as_str().unwrap();
     assert!(transcript.contains("plain assistant message"));
     assert!(!transcript.contains("bridge-tc-1"));
+    assert!(!transcript.contains("tool_calls="));
+}
+
+#[tokio::test]
+async fn read_transcript_hides_tool_kind_background_bridge_rows() {
+    let db = setup_db("r4c-read-tool-bridge").await;
+    let hook = create_parent_hook(&db, "parent-tool-bridge", "session-tool-bridge").await;
+    let child = spawn_background_child(&hook, "spawn-tool-bridge", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    append_assistant_tool_call_message(
+        db.node.as_ref(),
+        child_session_id,
+        1,
+        "checking files",
+        "background-tc-1",
+        "bash",
+    )
+    .await;
+    create_background_tool_call(
+        db.node.as_ref(),
+        child_request_id,
+        child_session_id,
+        1,
+        "background-tc-1",
+    )
+    .await;
+
+    let result = read_transcript(
+        &hook,
+        "read-tool-bridge",
+        json!({ "child_request_id": child_request_id }),
+    )
+    .await;
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("checking files"));
+    assert!(!transcript.contains("background-tc-1"));
     assert!(!transcript.contains("tool_calls="));
 }
 

--- a/crates/defra-agent/tests/r4c_read_subagent_transcript.rs
+++ b/crates/defra-agent/tests/r4c_read_subagent_transcript.rs
@@ -1,0 +1,537 @@
+//! Integration tests for R4c read_subagent_transcript.
+
+mod support;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{
+    upsert_agent_behavior, upsert_tool_selection, AgentBehavior, DefraSessionHook, FailurePolicy,
+    ToolSelectionDocument,
+};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::message::{AssistantContent, Message, Text, ToolCall, ToolFunction};
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::one_or_many::OneOrMany;
+use rig::streaming::StreamingCompletionResponse;
+use serde_json::{json, Value};
+
+use support::test_db;
+
+const AGENT_DID: &str = "did:defra-agent:r4c-read-transcript";
+const PARENT_BEHAVIOR_ID: &str = "r4c-parent";
+const CHILD_BEHAVIOR_ID: &str = "r4c-child";
+
+#[derive(Clone, Default)]
+struct TestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R4c read_subagent_transcript tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R4c read_subagent_transcript tests".to_string(),
+        ))
+    }
+}
+
+async fn setup_db(name: &str) -> support::TestDb {
+    let db = test_db(name).await;
+    upsert_tool_selection(
+        db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: "r4c-parent-tools".to_string(),
+            agent_did: AGENT_DID.to_string(),
+            subagent_targets: Some(vec![CHILD_BEHAVIOR_ID.to_string()]),
+            subagent_spawn_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: PARENT_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c parent".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some("r4c-parent-tools".to_string()),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: CHILD_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c child".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:01Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    db
+}
+
+async fn create_parent_hook(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+) -> DefraSessionHook {
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    create_parent_request(db.node.as_ref(), request_id, session_id, deadline).await;
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        session_id,
+        PARENT_BEHAVIOR_ID,
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap();
+    hook.set_active_request_id(Some(request_id.to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(deadline)).await;
+    hook
+}
+
+async fn create_parent_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    deadline: chrono::DateTime<chrono::Utc>,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let behavior_id = escape_graphql_string(PARENT_BEHAVIOR_ID);
+    let agent_did = escape_graphql_string(AGENT_DID);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let deadline = deadline.to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "parent prompt",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "{created_at}",
+                deadline: "{deadline}",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create parent AgentRequest failed: {:?}",
+        response.errors
+    );
+}
+
+async fn spawn_background_child(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    prompt: &str,
+) -> Value {
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": prompt,
+        "await_mode": "background"
+    })
+    .to_string();
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "spawn_subagent",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    assert_eq!(receipt["ok"], true);
+    receipt
+}
+
+async fn read_transcript(hook: &DefraSessionHook, internal_call_id: &str, args: Value) -> Value {
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "read_subagent_transcript",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args.to_string(),
+    )
+    .await;
+    skip_reason_json(action)
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn append_message(
+    node: &EmbeddedNode,
+    session_id: &str,
+    sequence: u32,
+    role: &str,
+    content: &str,
+) {
+    support::create_agent_message(
+        node,
+        session_id,
+        sequence,
+        role,
+        content,
+        &format!("2026-05-14T00:00:{sequence:02}Z"),
+    )
+    .await;
+}
+
+async fn append_assistant_tool_call_message(
+    node: &EmbeddedNode,
+    session_id: &str,
+    sequence: u32,
+    body: &str,
+    tool_call_id: &str,
+) {
+    let message = Message::Assistant {
+        id: None,
+        content: OneOrMany::many(vec![
+            AssistantContent::Text(Text {
+                text: body.to_string(),
+            }),
+            AssistantContent::ToolCall(ToolCall {
+                id: tool_call_id.to_string(),
+                call_id: Some(tool_call_id.to_string()),
+                function: ToolFunction {
+                    name: "spawn_subagent".to_string(),
+                    arguments: json!({"behavior_id": CHILD_BEHAVIOR_ID}),
+                },
+                signature: None,
+                additional_params: None,
+            }),
+        ])
+        .unwrap(),
+    };
+    append_message(
+        node,
+        session_id,
+        sequence,
+        "assistant",
+        &serde_json::to_string(&message).unwrap(),
+    )
+    .await;
+}
+
+async fn create_child_bridge_tool_call(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    child_session_id: &str,
+    message_sequence: u32,
+    tool_call_id: &str,
+) {
+    let child_request_id = escape_graphql_string(child_request_id);
+    let child_session_id = escape_graphql_string(child_session_id);
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let tool_call_key = format!("{child_session_id}:{tool_call_id}");
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentToolCall(input: {{
+                tool_call_key: "{tool_call_key}",
+                request_id: "{child_request_id}",
+                session_id: "{child_session_id}",
+                message_sequence: {message_sequence},
+                tool_name: "spawn_subagent",
+                tool_call_id: "{tool_call_id}",
+                args: "{{}}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "2026-05-14T00:01:00Z",
+                deadline_at: "2026-05-14T00:06:00Z",
+                await_mode: "background",
+                cancel_policy: "propagate",
+                child_request_id: "grandchild-request"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create child bridge AgentToolCall failed: {:?}",
+        response.errors
+    );
+}
+
+async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_name: &str) -> usize {
+    let session_id = escape_graphql_string(session_id);
+    let tool_name = escape_graphql_string(tool_name);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_name: {{ _eq: "{tool_name}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "count AgentToolCall by name failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map_or(0, Vec::len)
+}
+
+#[tokio::test]
+async fn read_transcript_assistant_only_default() {
+    let db = setup_db("r4c-read-default").await;
+    let hook = create_parent_hook(&db, "parent-default", "session-default").await;
+    let child = spawn_background_child(&hook, "spawn-default", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    append_message(
+        db.node.as_ref(),
+        child_session_id,
+        1,
+        "assistant",
+        "first thought",
+    )
+    .await;
+    append_message(db.node.as_ref(), child_session_id, 2, "user", "feedback").await;
+    append_message(
+        db.node.as_ref(),
+        child_session_id,
+        3,
+        "assistant",
+        "second thought",
+    )
+    .await;
+
+    let result = read_transcript(
+        &hook,
+        "read-default",
+        json!({ "child_request_id": child_request_id }),
+    )
+    .await;
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("first thought"));
+    assert!(transcript.contains("second thought"));
+    assert!(!transcript.contains("feedback"));
+}
+
+#[tokio::test]
+async fn read_transcript_includes_user_when_opted_in() {
+    let db = setup_db("r4c-read-user").await;
+    let hook = create_parent_hook(&db, "parent-user", "session-user").await;
+    let child = spawn_background_child(&hook, "spawn-user", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    append_message(db.node.as_ref(), child_session_id, 1, "assistant", "a1").await;
+    append_message(db.node.as_ref(), child_session_id, 2, "user", "u1").await;
+
+    let result = read_transcript(
+        &hook,
+        "read-user",
+        json!({
+            "child_request_id": child_request_id,
+            "include_user_messages": true
+        }),
+    )
+    .await;
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("a1"));
+    assert!(transcript.contains("u1"));
+}
+
+#[tokio::test]
+async fn read_transcript_hides_bridge_rows() {
+    let db = setup_db("r4c-read-bridge").await;
+    let hook = create_parent_hook(&db, "parent-bridge", "session-bridge").await;
+    let child = spawn_background_child(&hook, "spawn-bridge", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    append_assistant_tool_call_message(
+        db.node.as_ref(),
+        child_session_id,
+        1,
+        "plain assistant message",
+        "bridge-tc-1",
+    )
+    .await;
+    create_child_bridge_tool_call(
+        db.node.as_ref(),
+        child_request_id,
+        child_session_id,
+        1,
+        "bridge-tc-1",
+    )
+    .await;
+
+    let result = read_transcript(
+        &hook,
+        "read-bridge",
+        json!({ "child_request_id": child_request_id }),
+    )
+    .await;
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("plain assistant message"));
+    assert!(!transcript.contains("bridge-tc-1"));
+    assert!(!transcript.contains("tool_calls="));
+}
+
+#[tokio::test]
+async fn read_transcript_cursor_advances_cleanly() {
+    let db = setup_db("r4c-read-cursor").await;
+    let hook = create_parent_hook(&db, "parent-cursor", "session-cursor").await;
+    let child = spawn_background_child(&hook, "spawn-cursor", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    for sequence in 1..=10 {
+        append_message(
+            db.node.as_ref(),
+            child_session_id,
+            sequence,
+            "assistant",
+            &format!("turn {sequence}"),
+        )
+        .await;
+    }
+
+    let first = read_transcript(
+        &hook,
+        "read-cursor-first",
+        json!({
+            "child_request_id": child_request_id,
+            "limit": 5
+        }),
+    )
+    .await;
+    assert_eq!(first["truncated"].as_bool(), Some(true));
+    assert_eq!(first["through_sequence"].as_u64(), Some(5));
+    let next = first["next_sequence"].as_u64().unwrap();
+    assert_eq!(next, 6);
+
+    let second = read_transcript(
+        &hook,
+        "read-cursor-second",
+        json!({
+            "child_request_id": child_request_id,
+            "since_sequence": next,
+            "limit": 5
+        }),
+    )
+    .await;
+    assert_eq!(second["through_sequence"].as_u64(), Some(10));
+    let combined = format!(
+        "{}\n{}",
+        first["transcript"].as_str().unwrap(),
+        second["transcript"].as_str().unwrap()
+    );
+    for sequence in 1..=10 {
+        assert!(
+            combined.contains(&format!("turn {sequence}")),
+            "missing turn {sequence}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn read_transcript_rejects_unauthorized_child() {
+    let db = setup_db("r4c-read-unauthorized").await;
+    let hook_1 = create_parent_hook(&db, "parent-one", "session-one").await;
+    let hook_2 = create_parent_hook(&db, "parent-two", "session-two").await;
+    let child = spawn_background_child(&hook_2, "spawn-sibling", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+
+    let result = read_transcript(
+        &hook_1,
+        "read-unauthorized",
+        json!({ "child_request_id": child_request_id }),
+    )
+    .await;
+    assert_eq!(result["ok"].as_bool(), Some(false));
+    assert_eq!(result["failure_class"].as_str(), Some("tool_not_allowed"));
+}
+
+#[tokio::test]
+async fn read_transcript_no_parent_tool_call_row_written() {
+    let db = setup_db("r4c-read-no-row").await;
+    let parent_session_id = "session-no-row";
+    let hook = create_parent_hook(&db, "parent-no-row", parent_session_id).await;
+    let child = spawn_background_child(&hook, "spawn-no-row", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+
+    let _ = read_transcript(
+        &hook,
+        "read-no-row",
+        json!({ "child_request_id": child_request_id }),
+    )
+    .await;
+    assert_eq!(
+        count_tool_calls_by_name(
+            db.node.as_ref(),
+            parent_session_id,
+            "read_subagent_transcript"
+        )
+        .await,
+        0
+    );
+}

--- a/crates/defra-agent/tests/r4c_read_tool_output.rs
+++ b/crates/defra-agent/tests/r4c_read_tool_output.rs
@@ -1,0 +1,425 @@
+//! Integration tests for R4c read_tool_output.
+
+mod support;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::ToolCallLifecycle;
+use defra_agent::{BackgroundToolRegistry, DefraSessionHook, FailurePolicy};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::ToolDefinition;
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::streaming::StreamingCompletionResponse;
+use rig::tool::{ToolDyn, ToolError};
+use rig::wasm_compat::WasmBoxedFuture;
+use serde_json::{json, Value};
+
+use support::{test_db, AGENT_DID};
+
+#[derive(Clone, Default)]
+struct TestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R4c read_tool_output tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R4c read_tool_output tests".to_string(),
+        ))
+    }
+}
+
+struct StaticTool {
+    name: &'static str,
+    result: String,
+}
+
+impl ToolDyn for StaticTool {
+    fn name(&self) -> String {
+        self.name.to_string()
+    }
+
+    fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+        Box::pin(async move {
+            ToolDefinition {
+                name: self.name.to_string(),
+                description: "test tool".to_string(),
+                parameters: json!({"type":"object"}),
+            }
+        })
+    }
+
+    fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(async move { Ok(self.result.clone()) })
+    }
+}
+
+struct PendingTool;
+
+impl ToolDyn for PendingTool {
+    fn name(&self) -> String {
+        "slow_tool".to_string()
+    }
+
+    fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+        Box::pin(async {
+            ToolDefinition {
+                name: "slow_tool".to_string(),
+                description: "test tool".to_string(),
+                parameters: json!({"type":"object"}),
+            }
+        })
+    }
+
+    fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        Box::pin(std::future::pending())
+    }
+}
+
+async fn setup_hook(
+    test_name: &str,
+    registry: BackgroundToolRegistry,
+) -> (support::TestDb, DefraSessionHook, String, String) {
+    let db = test_db(test_name).await;
+    let session_id = format!("{test_name}-session");
+    let request_id = format!("{test_name}-request");
+    support::create_request(
+        db.node.as_ref(),
+        &request_id,
+        &session_id,
+        "processing",
+        "2026-05-14T00:00:00Z",
+    )
+    .await;
+
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        &session_id,
+        "r4c-read-tool-output",
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap()
+    .with_background_tool_registry(registry);
+    hook.set_active_request_id(Some(request_id.clone())).await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::seconds(5)))
+        .await;
+    (db, hook, session_id, request_id)
+}
+
+async fn setup_hook_on_db(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+    registry: BackgroundToolRegistry,
+) -> (DefraSessionHook, String, String) {
+    support::create_request(
+        db.node.as_ref(),
+        request_id,
+        session_id,
+        "processing",
+        "2026-05-14T00:00:00Z",
+    )
+    .await;
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        session_id,
+        "r4c-read-tool-output",
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap()
+    .with_background_tool_registry(registry);
+    hook.set_active_request_id(Some(request_id.to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::seconds(5)))
+        .await;
+    (hook, session_id.to_string(), request_id.to_string())
+}
+
+fn registry(tools: Vec<Box<dyn ToolDyn>>, allowlist: &[&str]) -> BackgroundToolRegistry {
+    BackgroundToolRegistry::from_tools(
+        tools,
+        &allowlist
+            .iter()
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>(),
+    )
+}
+
+async fn background_tool(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    tool_name: &str,
+) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "background_tool",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &json!({"tool_name": tool_name, "args": {}}).to_string(),
+        )
+        .await,
+    )
+}
+
+async fn wait_tool(hook: &DefraSessionHook, internal_call_id: &str, tool_call_id: &str) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "wait_tool",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &json!({ "tool_call_id": tool_call_id }).to_string(),
+        )
+        .await,
+    )
+}
+
+async fn read_tool_output(hook: &DefraSessionHook, internal_call_id: &str, args: Value) -> Value {
+    skip_reason_json(
+        PromptHook::<TestModel>::on_tool_call(
+            hook,
+            "read_tool_output",
+            Some(format!("model-{internal_call_id}")),
+            internal_call_id,
+            &args.to_string(),
+        )
+        .await,
+    )
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn create_foreground_tool_call(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+) -> String {
+    let tool_call_id = "foreground-call".to_string();
+    let mut lifecycle = ToolCallLifecycle::new(
+        db.node.clone(),
+        request_id.to_string(),
+        session_id.to_string(),
+        tool_call_id.clone(),
+        99,
+        "foreground_tool".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+    );
+    lifecycle.start_running().await.unwrap();
+    lifecycle.complete("foreground result").await.unwrap();
+    tool_call_id
+}
+
+async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_name: &str) -> usize {
+    let session_id = escape_graphql_string(session_id);
+    let tool_name = escape_graphql_string(tool_name);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_name: {{ _eq: "{tool_name}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "count AgentToolCall by name failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map_or(0, Vec::len)
+}
+
+#[tokio::test]
+async fn read_tool_output_running_returns_empty_live_stream_without_ring_buffer() {
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-read-output-running",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-running", "slow_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+
+    let result = read_tool_output(
+        &hook,
+        "read-running",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+    assert_eq!(result["status"].as_str(), Some("running"));
+    assert_eq!(result["tool_name"].as_str(), Some("slow_tool"));
+    assert_eq!(result["stdout"]["bytes"].as_str(), Some(""));
+    assert_eq!(result["stdout"]["truncated"].as_bool(), Some(false));
+    assert_eq!(result["stdout"]["total_bytes_seen"].as_u64(), Some(0));
+    assert!(result["exit_code"].is_null());
+}
+
+#[tokio::test]
+async fn read_tool_output_terminal_reads_persisted_result() {
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-read-output-terminal",
+        registry(
+            vec![Box::new(StaticTool {
+                name: "complete_tool",
+                result: "done\n".to_string(),
+            })],
+            &["complete_tool"],
+        ),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-terminal", "complete_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+    let waited = wait_tool(&hook, "wait-terminal", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
+
+    let result = read_tool_output(
+        &hook,
+        "read-terminal",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+    assert_eq!(result["status"].as_str(), Some("completed"));
+    assert_eq!(result["stdout"]["bytes"].as_str(), Some("done\n"));
+    assert_eq!(result["stdout"]["total_bytes_seen"].as_u64(), Some(5));
+    assert!(result["exit_code"].is_null());
+}
+
+#[tokio::test]
+async fn read_tool_output_truncated_flag_on_overflow() {
+    let large = "x".repeat(300);
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-read-output-truncate",
+        registry(
+            vec![Box::new(StaticTool {
+                name: "large_tool",
+                result: large,
+            })],
+            &["large_tool"],
+        ),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-large", "large_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+    let waited = wait_tool(&hook, "wait-large", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
+
+    let result = read_tool_output(
+        &hook,
+        "read-large",
+        json!({
+            "tool_call_id": tool_call_id,
+            "max_bytes_per_stream": 256
+        }),
+    )
+    .await;
+    assert_eq!(result["stdout"]["truncated"].as_bool(), Some(true));
+    assert_eq!(result["stdout"]["total_bytes_seen"].as_u64(), Some(300));
+    assert_eq!(result["stdout"]["bytes"].as_str().unwrap().len(), 256);
+}
+
+#[tokio::test]
+async fn read_tool_output_rejects_non_backgrounded() {
+    let (db, hook, session_id, request_id) = setup_hook(
+        "r4c-read-output-foreground",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let foreground_call_id = create_foreground_tool_call(&db, &request_id, &session_id).await;
+
+    let result = read_tool_output(
+        &hook,
+        "read-foreground",
+        json!({ "tool_call_id": foreground_call_id }),
+    )
+    .await;
+    assert_eq!(result["ok"].as_bool(), Some(false));
+    assert_eq!(result["failure_class"].as_str(), Some("argument_invalid"));
+}
+
+#[tokio::test]
+async fn read_tool_output_rejects_unauthorized() {
+    let db = test_db("r4c-read-output-unauthorized").await;
+    let (hook_1, _session_1, _request_1) = setup_hook_on_db(
+        &db,
+        "parent-one",
+        "session-one",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let (hook_2, _session_2, _request_2) = setup_hook_on_db(
+        &db,
+        "parent-two",
+        "session-two",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let handle = background_tool(&hook_2, "sibling-bg", "slow_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+
+    let result = read_tool_output(
+        &hook_1,
+        "read-unauthorized",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+    assert_eq!(result["ok"].as_bool(), Some(false));
+    assert_eq!(result["failure_class"].as_str(), Some("tool_not_allowed"));
+}
+
+#[tokio::test]
+async fn read_tool_output_no_parent_tool_call_row_written() {
+    let (db, hook, session_id, _request_id) = setup_hook(
+        "r4c-read-output-no-row",
+        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-no-row", "slow_tool").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+    let _ = read_tool_output(
+        &hook,
+        "read-no-row",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+
+    assert_eq!(
+        count_tool_calls_by_name(db.node.as_ref(), &session_id, "read_tool_output").await,
+        0
+    );
+}

--- a/crates/defra-agent/tests/r4c_read_tool_output.rs
+++ b/crates/defra-agent/tests/r4c_read_tool_output.rs
@@ -321,14 +321,63 @@ async fn read_tool_output_terminal_reads_persisted_result() {
 }
 
 #[tokio::test]
+async fn read_tool_output_terminal_parses_native_command_streams() {
+    let persisted = concat!(
+        "defra_exec: {\"ok\":false,\"status\":\"exit_nonzero\",",
+        "\"command\":\"grep -P foo README.md\",\"argv\":[\"grep\",\"-P\",\"foo\",\"README.md\"],",
+        "\"cwd\":\".\",\"exit_code\":2,\"timed_out\":false,\"duration_ms\":4,",
+        "\"timeout_ms\":10000,\"execution_mode\":\"read_only\",",
+        "\"network_mode\":\"inherit\",\"sandbox\":\"policy_read_only\",",
+        "\"stdout_truncation\":{\"returned_chars\":7,\"total_chars\":7,",
+        "\"max_chars\":16000,\"truncated\":false},",
+        "\"stderr_truncation\":{\"returned_chars\":25,\"total_chars\":25,",
+        "\"max_chars\":16000,\"truncated\":false}}\n",
+        "stdout:\n",
+        "matches\n",
+        "stderr:\n",
+        "grep: invalid option -- P"
+    );
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-read-output-native",
+        registry(
+            vec![Box::new(StaticTool {
+                name: "bash",
+                result: persisted.to_string(),
+            })],
+            &["bash"],
+        ),
+    )
+    .await;
+    let handle = background_tool(&hook, "bg-native", "bash").await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+    let waited = wait_tool(&hook, "wait-native", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
+
+    let result = read_tool_output(
+        &hook,
+        "read-native",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+    assert_eq!(result["stdout"]["bytes"].as_str(), Some("matches"));
+    assert_eq!(result["stdout"]["total_bytes_seen"].as_u64(), Some(7));
+    assert_eq!(
+        result["stderr"]["bytes"].as_str(),
+        Some("grep: invalid option -- P")
+    );
+    assert_eq!(result["stderr"]["total_bytes_seen"].as_u64(), Some(25));
+    assert_eq!(result["exit_code"].as_i64(), Some(2));
+}
+
+#[tokio::test]
 async fn read_tool_output_truncated_flag_on_overflow() {
-    let large = "x".repeat(300);
+    let large = format!("{}tail", "prefix".repeat(60));
     let (_db, hook, _session_id, _request_id) = setup_hook(
         "r4c-read-output-truncate",
         registry(
             vec![Box::new(StaticTool {
                 name: "large_tool",
-                result: large,
+                result: large.clone(),
             })],
             &["large_tool"],
         ),
@@ -349,8 +398,16 @@ async fn read_tool_output_truncated_flag_on_overflow() {
     )
     .await;
     assert_eq!(result["stdout"]["truncated"].as_bool(), Some(true));
-    assert_eq!(result["stdout"]["total_bytes_seen"].as_u64(), Some(300));
+    assert_eq!(
+        result["stdout"]["total_bytes_seen"].as_u64(),
+        Some(large.len() as u64)
+    );
     assert_eq!(result["stdout"]["bytes"].as_str().unwrap().len(), 256);
+    assert!(result["stdout"]["bytes"]
+        .as_str()
+        .unwrap()
+        .ends_with("tail"));
+    assert_ne!(result["stdout"]["bytes"].as_str().unwrap(), &large[..256]);
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/r4c_steer_subagent.rs
+++ b/crates/defra-agent/tests/r4c_steer_subagent.rs
@@ -1,0 +1,690 @@
+//! Integration tests for R4c steer_subagent.
+
+mod support;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::{
+    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, ToolCallLifecycle,
+};
+use defra_agent::{
+    fetch_interrupt_requested_at, upsert_agent_behavior, upsert_tool_selection, AgentBehavior,
+    DefraSessionHook, FailurePolicy, ToolSelectionDocument,
+};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::streaming::StreamingCompletionResponse;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use support::test_db;
+
+const AGENT_DID: &str = "did:defra-agent:r4c-steer";
+const PARENT_BEHAVIOR_ID: &str = "r4c-parent";
+const CHILD_BEHAVIOR_ID: &str = "r4c-child";
+
+#[derive(Clone, Default)]
+struct TestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for TestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R4c steer_subagent tests".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R4c steer_subagent tests".to_string(),
+        ))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RequestRow {
+    session_id: String,
+    behavior_id: Option<String>,
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    metadata: Option<String>,
+    subagent_depth: Option<u32>,
+    caused_by_parent_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessageRow {
+    role: String,
+    content: String,
+}
+
+async fn setup_db(name: &str) -> support::TestDb {
+    let db = test_db(name).await;
+    upsert_tool_selection(
+        db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: "r4c-parent-tools".to_string(),
+            agent_did: AGENT_DID.to_string(),
+            subagent_targets: Some(vec![CHILD_BEHAVIOR_ID.to_string()]),
+            subagent_spawn_enabled: Some(true),
+            subagent_steering_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: PARENT_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c parent".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some("r4c-parent-tools".to_string()),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehavior {
+            behavior_id: CHILD_BEHAVIOR_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("R4c child".to_string()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: None,
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-14T00:00:01Z".to_string()),
+        },
+    )
+    .await
+    .unwrap();
+    db
+}
+
+async fn create_parent_hook(
+    db: &support::TestDb,
+    request_id: &str,
+    session_id: &str,
+) -> DefraSessionHook {
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    create_parent_request(db.node.as_ref(), request_id, session_id, deadline).await;
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        session_id,
+        PARENT_BEHAVIOR_ID,
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .unwrap();
+    hook.set_active_request_id(Some(request_id.to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(deadline)).await;
+    hook
+}
+
+async fn create_parent_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    deadline: chrono::DateTime<chrono::Utc>,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let behavior_id = escape_graphql_string(PARENT_BEHAVIOR_ID);
+    let agent_did = escape_graphql_string(AGENT_DID);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let deadline = deadline.to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "parent prompt",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "{created_at}",
+                deadline: "{deadline}",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create parent AgentRequest failed: {:?}",
+        response.errors
+    );
+}
+
+async fn spawn_background_child(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    prompt: &str,
+) -> Value {
+    let args = json!({
+        "behavior_id": CHILD_BEHAVIOR_ID,
+        "prompt": prompt,
+        "await_mode": "background"
+    })
+    .to_string();
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "spawn_subagent",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    assert_eq!(receipt["ok"], true);
+    receipt
+}
+
+async fn steer_subagent(hook: &DefraSessionHook, internal_call_id: &str, args: Value) -> Value {
+    let action = PromptHook::<TestModel>::on_tool_call(
+        hook,
+        "steer_subagent",
+        Some(format!("model-{internal_call_id}")),
+        internal_call_id,
+        &args.to_string(),
+    )
+    .await;
+    skip_reason_json(action)
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn fetch_request(node: &EmbeddedNode, request_id: &str) -> RequestRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                session_id
+                behavior_id
+                status
+                lifecycle_state
+                metadata
+                subagent_depth
+                caused_by_parent_request_id
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    support::first_row(&response, "AgentRequest")
+}
+
+async fn latest_user_message(node: &EmbeddedNode, session_id: &str) -> MessageRow {
+    let session_id = escape_graphql_string(session_id);
+    let query = format!(
+        r#"{{
+            AgentMessage(
+                filter: {{ session_id: {{ _eq: "{session_id}" }}, role: {{ _eq: "user" }} }},
+                order: {{ sequence: DESC }},
+                limit: 1
+            ) {{
+                role
+                content
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    support::first_row(&response, "AgentMessage")
+}
+
+async fn update_request_state(
+    node: &EmbeddedNode,
+    request_id: &str,
+    status: &str,
+    lifecycle_state: &str,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let status = escape_graphql_string(status);
+    let lifecycle_state = escape_graphql_string(lifecycle_state);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                input: {{
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "update AgentRequest state failed: {:?}",
+        response.errors
+    );
+}
+
+async fn create_child_session_queued_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    execution_origin: &str,
+    metadata: &str,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let agent_did = escape_graphql_string(AGENT_DID);
+    let behavior_id = escape_graphql_string(CHILD_BEHAVIOR_ID);
+    let session_id = escape_graphql_string(session_id);
+    let execution_origin = escape_graphql_string(execution_origin);
+    let metadata = escape_graphql_string(metadata);
+    let now = chrono::Utc::now();
+    let created_at = escape_graphql_string(&now.to_rfc3339());
+    let deadline = escape_graphql_string(&(now + chrono::Duration::minutes(5)).to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "queued child session request",
+                status: "pending",
+                lifecycle_state: "pending",
+                backend_id: "",
+                execution_origin: "{execution_origin}",
+                metadata: "{metadata}",
+                failure_reason: "",
+                created_at: "{created_at}",
+                deadline: "{deadline}",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 1
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create queued child AgentRequest failed: {:?}",
+        response.errors
+    );
+}
+
+async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_name: &str) -> usize {
+    let session_id = escape_graphql_string(session_id);
+    let tool_name = escape_graphql_string(tool_name);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_name: {{ _eq: "{tool_name}" }}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "count AgentToolCall by name failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map_or(0, Vec::len)
+}
+
+fn queue_metadata(
+    source: &str,
+    policy: &str,
+    key: Option<&str>,
+    queued_after_request_id: Option<&str>,
+) -> String {
+    json!({
+        "queue": {
+            "source": source,
+            "policy": policy,
+            "key": key,
+            "queued_after_request_id": queued_after_request_id
+        }
+    })
+    .to_string()
+}
+
+#[tokio::test]
+async fn steer_subagent_append_enqueues_with_steering_source() {
+    let db = setup_db("r4c-steer-append").await;
+    let hook = create_parent_hook(&db, "parent-append", "session-append").await;
+    let child = spawn_background_child(&hook, "spawn-append", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+
+    let result = steer_subagent(
+        &hook,
+        "steer-append",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "also check the staging config",
+            "interrupt": false
+        }),
+    )
+    .await;
+    let queued_request_id = result["queued_request_id"].as_str().unwrap();
+    assert_eq!(result["interrupted_active_request_id"], Value::Null);
+    assert!(result["drained_wake_up_request_ids"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let queued = fetch_request(db.node.as_ref(), queued_request_id).await;
+    assert_eq!(queued.session_id, child_session_id);
+    assert_eq!(queued.behavior_id.as_deref(), Some(CHILD_BEHAVIOR_ID));
+    assert_eq!(queued.subagent_depth, Some(1));
+    assert_eq!(
+        queued.caused_by_parent_request_id.as_deref(),
+        Some("parent-append")
+    );
+    assert_eq!(queued.status.as_deref(), Some("pending"));
+    assert_eq!(queued.lifecycle_state.as_deref(), Some("pending"));
+    let metadata: Value = serde_json::from_str(queued.metadata.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["queue"]["source"], "steering");
+    assert_eq!(metadata["queue"]["policy"], "append");
+}
+
+#[tokio::test]
+async fn steer_subagent_append_writes_user_message() {
+    let db = setup_db("r4c-steer-message").await;
+    let hook = create_parent_hook(&db, "parent-message", "session-message").await;
+    let child = spawn_background_child(&hook, "spawn-message", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+
+    let _ = steer_subagent(
+        &hook,
+        "steer-message",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "also check the staging config"
+        }),
+    )
+    .await;
+
+    let message = latest_user_message(db.node.as_ref(), child_session_id).await;
+    assert_eq!(message.role, "user");
+    assert!(message.content.contains("also check the staging config"));
+}
+
+#[tokio::test]
+async fn steer_subagent_rejects_terminal_child() {
+    let db = setup_db("r4c-steer-terminal").await;
+    let hook = create_parent_hook(&db, "parent-terminal", "session-terminal").await;
+    let child = spawn_background_child(&hook, "spawn-terminal", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    update_request_state(db.node.as_ref(), child_request_id, "completed", "completed").await;
+
+    let result = steer_subagent(
+        &hook,
+        "steer-terminal",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "do more"
+        }),
+    )
+    .await;
+    assert_eq!(result["ok"].as_bool(), Some(false));
+    assert_eq!(
+        result["failure_class"].as_str(),
+        Some("invalid_tool_arguments")
+    );
+}
+
+#[tokio::test]
+async fn steer_subagent_rejects_unauthorized_child() {
+    let db = setup_db("r4c-steer-unauthorized").await;
+    let hook_1 = create_parent_hook(&db, "parent-one", "session-one").await;
+    let hook_2 = create_parent_hook(&db, "parent-two", "session-two").await;
+    let child = spawn_background_child(&hook_2, "spawn-sibling", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+
+    let result = steer_subagent(
+        &hook_1,
+        "steer-unauthorized",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "hi"
+        }),
+    )
+    .await;
+    assert_eq!(result["ok"].as_bool(), Some(false));
+    assert_eq!(result["failure_class"].as_str(), Some("tool_not_allowed"));
+}
+
+#[tokio::test]
+async fn steer_subagent_no_parent_tool_call_row_written() {
+    let db = setup_db("r4c-steer-no-row").await;
+    let parent_session_id = "session-no-row";
+    let hook = create_parent_hook(&db, "parent-no-row", parent_session_id).await;
+    let child = spawn_background_child(&hook, "spawn-no-row", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+
+    let _ = steer_subagent(
+        &hook,
+        "steer-no-row",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "x"
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        count_tool_calls_by_name(db.node.as_ref(), parent_session_id, "steer_subagent").await,
+        0
+    );
+}
+
+#[tokio::test]
+async fn steer_subagent_interrupt_latches_active_child_request() {
+    let db = setup_db("r4c-steer-interrupt").await;
+    let hook = create_parent_hook(&db, "parent-interrupt", "session-interrupt").await;
+    let child = spawn_background_child(&hook, "spawn-interrupt", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    update_request_state(
+        db.node.as_ref(),
+        child_request_id,
+        "processing",
+        "processing",
+    )
+    .await;
+
+    let result = steer_subagent(
+        &hook,
+        "steer-interrupt",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "stop, do this instead",
+            "interrupt": true
+        }),
+    )
+    .await;
+
+    assert_eq!(
+        result["interrupted_active_request_id"].as_str(),
+        Some(child_request_id)
+    );
+    assert!(
+        fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    let queued = fetch_request(
+        db.node.as_ref(),
+        result["queued_request_id"].as_str().unwrap(),
+    )
+    .await;
+    let metadata: Value = serde_json::from_str(queued.metadata.as_deref().unwrap()).unwrap();
+    assert_eq!(
+        metadata["queue"]["interrupted_request_id"].as_str(),
+        Some(child_request_id)
+    );
+}
+
+#[tokio::test]
+async fn steer_subagent_interrupt_drains_automated_wakeups() {
+    let db = setup_db("r4c-steer-drain").await;
+    let hook = create_parent_hook(&db, "parent-drain", "session-drain").await;
+    let child = spawn_background_child(&hook, "spawn-drain", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap();
+    let child_session_id = child["child_session_id"].as_str().unwrap();
+    update_request_state(
+        db.node.as_ref(),
+        child_request_id,
+        "processing",
+        "processing",
+    )
+    .await;
+    let wake_request_id = "r4c-steer-drain-wake";
+    create_child_session_queued_request(
+        db.node.as_ref(),
+        wake_request_id,
+        child_session_id,
+        "scheduled",
+        &queue_metadata(
+            "background_completion",
+            "coalesce",
+            Some(&format!("background_completion:{child_session_id}")),
+            Some(child_request_id),
+        ),
+    )
+    .await;
+
+    let result = steer_subagent(
+        &hook,
+        "steer-drain",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "redirect",
+            "interrupt": true
+        }),
+    )
+    .await;
+
+    let drained = result["drained_wake_up_request_ids"].as_array().unwrap();
+    assert!(drained
+        .iter()
+        .any(|id| id.as_str() == Some(wake_request_id)));
+    let wake = fetch_request(db.node.as_ref(), wake_request_id).await;
+    assert_eq!(wake.status.as_deref(), Some("interrupted"));
+    assert_eq!(wake.lifecycle_state.as_deref(), Some("interrupted"));
+}
+
+#[tokio::test]
+async fn steer_subagent_interrupt_cascades_to_grandchild_subagents() {
+    let db = setup_db("r4c-steer-cascade").await;
+    let hook = create_parent_hook(&db, "parent-cascade", "session-cascade").await;
+    let parent_deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    let child = spawn_background_child(&hook, "spawn-cascade", "do work").await;
+    let child_request_id = child["child_request_id"].as_str().unwrap().to_string();
+    let child_session_id = child["child_session_id"].as_str().unwrap().to_string();
+    update_request_state(
+        db.node.as_ref(),
+        &child_request_id,
+        "processing",
+        "processing",
+    )
+    .await;
+
+    let grandchild_request_id = "r4c-steer-grandchild";
+    let mut descendant_bridge = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        child_request_id.clone(),
+        child_session_id.clone(),
+        "internal-steer-descendant".to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        parent_deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        grandchild_request_id.to_string(),
+    );
+    descendant_bridge.start_running().await.unwrap();
+    let _grandchild_session_id = create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        grandchild_request_id.to_string(),
+        child_request_id.clone(),
+        "internal-steer-descendant".to_string(),
+        1,
+        AGENT_DID.to_string(),
+        CHILD_BEHAVIOR_ID.to_string(),
+        "grandchild prompt".to_string(),
+        Some(parent_deadline - chrono::Duration::minutes(1)),
+    )
+    .await
+    .unwrap();
+
+    let _ = steer_subagent(
+        &hook,
+        "steer-cascade",
+        json!({
+            "child_request_id": child_request_id,
+            "message": "redirect",
+            "interrupt": true
+        }),
+    )
+    .await;
+
+    assert!(
+        fetch_interrupt_requested_at(db.node.as_ref(), grandchild_request_id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+}

--- a/crates/defra-agent/tests/r4c_steer_subagent.rs
+++ b/crates/defra-agent/tests/r4c_steer_subagent.rs
@@ -64,6 +64,7 @@ struct RequestRow {
     metadata: Option<String>,
     subagent_depth: Option<u32>,
     caused_by_parent_request_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -251,6 +252,7 @@ async fn fetch_request(node: &EmbeddedNode, request_id: &str) -> RequestRow {
                 metadata
                 subagent_depth
                 caused_by_parent_request_id
+                caused_by_parent_tool_call_id
             }}
         }}"#
     );
@@ -430,6 +432,7 @@ async fn steer_subagent_append_enqueues_with_steering_source() {
         queued.caused_by_parent_request_id.as_deref(),
         Some("parent-append")
     );
+    assert_eq!(queued.caused_by_parent_tool_call_id.as_deref(), None);
     assert_eq!(queued.status.as_deref(), Some("pending"));
     assert_eq!(queued.lifecycle_state.as_deref(), Some("pending"));
     let metadata: Value = serde_json::from_str(queued.metadata.as_deref().unwrap()).unwrap();

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -36,12 +36,13 @@ use lean_vocab_test::{
     lean_contract_snapshot, lean_event_delivery_convergence_traces,
     lean_event_delivery_source_instances, lean_event_delivery_transition_cases,
     lean_fleet_slot_accounting_case, lean_inference_slot_accounting_case, lean_mcp_health_cases,
-    lean_queue_deadline_case, lean_queue_deadline_cases, lean_r6_backgrounding_case,
-    lean_r6_backgrounding_cases, lean_recovery_sweep_case, lean_recovery_sweep_cases,
-    lean_request_transition_cases, lean_response_transition_case, lean_response_transition_cases,
-    lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
-    lean_tool_preflight_case, lean_tool_retry_case, lean_transcript_case, lean_transcript_cases,
-    lean_vocabulary_values, LeanEventDeliveryAction, LeanLifecycleTransitionCase,
+    lean_queue_deadline_case, lean_queue_deadline_cases, lean_r4c_background_work_case,
+    lean_r4c_background_work_cases, lean_r6_backgrounding_case, lean_r6_backgrounding_cases,
+    lean_recovery_sweep_case, lean_recovery_sweep_cases, lean_request_transition_cases,
+    lean_response_transition_case, lean_response_transition_cases, lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_state_machine_contract, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_transcript_case, lean_transcript_cases, lean_vocabulary_values,
+    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -657,6 +658,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "IdentityContracts".to_string(),
         ));
     }
+    if !lean_r4c_background_work_cases().is_empty() {
+        emitted.insert((
+            "r4c_background_work_cases".to_string(),
+            "R4cBackgroundWorkCases".to_string(),
+        ));
+    }
     if !lean_r6_backgrounding_cases().is_empty() {
         emitted.insert((
             "r6_background_cases".to_string(),
@@ -696,6 +703,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "mcp_health_cases",
         "identity_structural_cases",
         "identity_contracts",
+        "r4c_background_work_cases",
         "r6_background_cases",
         "follow_up_hook",
     ];
@@ -1342,6 +1350,162 @@ fn generated_r6_backgrounding_cases_pin_tool_backgrounding_contract() {
         lean_r6_backgrounding_case("legacy_subagent_completion_source_aliases_canonical_key");
     assert_eq!(legacy.queue_source.as_deref(), Some("subagent_completion"));
     assert_eq!(legacy.queue_key.as_deref(), canonical.queue_key.as_deref());
+}
+
+#[test]
+fn generated_r4c_background_work_cases_pin_observable_shapes() {
+    let cases = lean_r4c_background_work_cases();
+    assert_eq!(cases.len(), 6);
+
+    let names = cases
+        .iter()
+        .map(LeanR4cBackgroundWorkCase::witness)
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        names,
+        [
+            "r4c.list_subagents.lineage_rejects",
+            "r4c.read_subagent_transcript.cursor_advances",
+            "r4c.read_subagent_transcript.hides_bridge_rows",
+            "r4c.read_tool_output.dispatch_by_state",
+            "r4c.steer_subagent.append_preserves_lineage",
+            "r4c.steer_subagent.interrupt_composes",
+        ]
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+    );
+
+    match lean_r4c_background_work_case("r4c.list_subagents.lineage_rejects") {
+        LeanR4cBackgroundWorkCase::ListSubagentsLineageRejects {
+            caller_request_id,
+            sibling_request_id,
+            sibling_child_id,
+            caller_sees_sibling_child,
+        } => {
+            assert_eq!(caller_request_id, "r4c-w1-caller");
+            assert_eq!(sibling_request_id, "r4c-w1-sibling");
+            assert_eq!(sibling_child_id, "r4c-w1-sibling-child");
+            assert!(!*caller_sees_sibling_child);
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    match lean_r4c_background_work_case("r4c.read_subagent_transcript.cursor_advances") {
+        LeanR4cBackgroundWorkCase::ReadTranscriptCursorAdvances {
+            child_session_id,
+            first_since_sequence,
+            first_through_sequence,
+            first_next_sequence,
+            second_since_sequence,
+            second_through_sequence,
+            no_gap,
+            no_overlap,
+        } => {
+            assert_eq!(child_session_id, "r4c-w2-session");
+            assert_eq!(*first_since_sequence, 0);
+            assert_eq!(*first_through_sequence, 5);
+            assert_eq!(*first_next_sequence, 6);
+            assert_eq!(*second_since_sequence, 6);
+            assert_eq!(*second_through_sequence, 10);
+            assert_eq!(first_next_sequence, second_since_sequence);
+            assert!(*no_gap);
+            assert!(*no_overlap);
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    match lean_r4c_background_work_case("r4c.read_subagent_transcript.hides_bridge_rows") {
+        LeanR4cBackgroundWorkCase::ReadTranscriptHidesBridgeRows {
+            child_session_id,
+            bridge_call_id,
+            rendered_transcript,
+        } => {
+            assert_eq!(child_session_id, "r4c-w3-session");
+            assert_eq!(bridge_call_id, "r4c-w3-bridge-call");
+            assert_eq!(
+                rendered_transcript,
+                "[assistant seq=2]\nplain assistant message\n"
+            );
+            assert!(
+                !rendered_transcript.contains(bridge_call_id),
+                "rendered transcript must hide bridge tool-call rows"
+            );
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    match lean_r4c_background_work_case("r4c.read_tool_output.dispatch_by_state") {
+        LeanR4cBackgroundWorkCase::ReadToolOutputDispatchesByState {
+            tool_call_id,
+            running_source,
+            terminal_source,
+            running_payload,
+            stale_running_payload,
+            terminal_payload,
+        } => {
+            assert_eq!(tool_call_id, "r4c-w4-tool-call");
+            assert_eq!(running_source, "ring_buffer");
+            assert_eq!(terminal_source, "persisted_tool_completion");
+            assert_eq!(running_payload, "ring-buffer-live-tail");
+            assert_eq!(stale_running_payload, "stale-ring-buffer-tail");
+            assert_eq!(terminal_payload, "persisted-completion-stdout");
+            assert_ne!(
+                terminal_payload, stale_running_payload,
+                "terminal reads must not replay a stale live buffer"
+            );
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    match lean_r4c_background_work_case("r4c.steer_subagent.append_preserves_lineage") {
+        LeanR4cBackgroundWorkCase::SteerAppendPreservesLineage {
+            caller_request_id,
+            child_session_id,
+            queued_request_id,
+            caused_by_parent_request_id,
+            queue_source,
+            queue_policy,
+        } => {
+            assert_eq!(caller_request_id, "r4c-w5-caller");
+            assert_eq!(child_session_id, "r4c-w5-child-session");
+            assert_eq!(queued_request_id, "r4c-w5-queued");
+            assert_eq!(caused_by_parent_request_id, caller_request_id);
+            assert_eq!(queue_source, "steering");
+            assert_eq!(queue_policy, "append");
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    match lean_r4c_background_work_case("r4c.steer_subagent.interrupt_composes") {
+        LeanR4cBackgroundWorkCase::SteerInterruptComposes {
+            caller_request_id,
+            child_session_id,
+            interrupted_active_request_id,
+            drained_wake_up_request_ids,
+            drained_wake_up_queue_key,
+            queued_request_id,
+            queue_interrupted_request_id,
+        } => {
+            assert_eq!(caller_request_id, "r4c-w6-caller");
+            assert_eq!(child_session_id, "r4c-w6-child-session");
+            assert_eq!(interrupted_active_request_id, "r4c-w6-interrupted");
+            assert_eq!(
+                drained_wake_up_request_ids,
+                &vec!["r4c-w6-wake-1".to_string(), "r4c-w6-wake-2".to_string()]
+            );
+            assert_eq!(
+                drained_wake_up_queue_key,
+                "background_completion:r4c-w6-child-session"
+            );
+            assert_eq!(
+                drained_wake_up_queue_key,
+                &format!("background_completion:{child_session_id}")
+            );
+            assert_eq!(queued_request_id, "r4c-w6-queued");
+            assert_eq!(queue_interrupted_request_id, interrupted_active_request_id);
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -259,6 +259,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_r6_backgrounding_cases_pin_tool_backgrounding_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_r4c_background_work_cases_pin_observable_shapes",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_r4c_background_work_cases_pin_observable_shapes",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",

--- a/docs/superpowers/plans/2026-05-14-r4c-background-work-management.md
+++ b/docs/superpowers/plans/2026-05-14-r4c-background-work-management.md
@@ -1,0 +1,3103 @@
+# R4c Agent-Facing Background Work Management Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` for this plan. Execute one task at a time with a fresh implementation subagent, then a spec-compliance reviewer, then a code-quality reviewer. Do not start a later task until the current task is reviewed, formatted, verified, and committed.
+
+**Goal:** Implement the approved R4c design in `docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md` — five agent-facing tools (`list_subagents`, `list_background_tools`, `read_subagent_transcript`, `read_tool_output`, `steer_subagent`) plus one new Lean theorem and six conformance witnesses.
+
+**Architecture:** Hook-intercepted Rig tools with zero new `AgentToolCall` rows. Reuses R6's `Proofs/Background/*`, R4a's `Proofs/Session/*` (`QueueSource.steering`, `pendingAfterDrain`), R4's `interrupt` transition, and #191's `Proofs/Transcript/*`. One new theorem (`steer_subagent_interrupt_preserves_link_symmetry`) discharges B5 preservation across the `interrupt+cascade+drain+append` composition.
+
+**Tech Stack:** Rust 2024 edition, Rig (LLM tools), DefraDB (GraphQL document store), Lean 4 / Lake, the existing conformance witness pipeline.
+
+Do not start coding until Jack approves this plan.
+
+---
+
+## Sequencing Prerequisite
+
+R4c implementation **must not begin until R6 (tool backgrounding, design `docs/superpowers/specs/2026-05-14-tool-backgrounding-design.md`) is merged to main.** R4c imports `Proofs.Background.*` (R6's rename target), writes against `background_tools.rs`/`background_completion.rs` (R6's rename targets), and reads the `<tool-completion>` payload R6's projector persists.
+
+Confirm at kickoff:
+
+```bash
+git log --oneline main | rg -i "Proofs/Subagent -> Proofs/Background|background_tool meta-tool|tool_backgrounding"
+git log --oneline main | rg -i "#191|transcript persistence model"
+```
+
+The first command must show R6's Task 0 rename commit AND at least one substantive R6 commit. The second command must show #191 merged.
+
+If R6 has not merged, **stop and surface the blocker to Jack**. Do not attempt to land R4c against the pre-rename surface.
+
+R4c ships as one PR with substantive commits per task. No "pure rename" no-op commit (R6 owns that).
+
+---
+
+## Cadence
+
+For every task:
+
+1. Spawn a fresh implementation subagent with the task section as its prompt.
+2. Tell the worker: "You are not alone in the codebase. Do not revert edits made by others. Own only the files listed in this task unless you discover a blocker."
+3. After the implementation pass, run:
+
+```bash
+cargo fmt --all
+```
+
+4. Spawn a fresh spec-compliance reviewer. Ask it to compare the diff against the approved R4c spec and this task.
+5. Spawn a fresh code-quality reviewer. Ask it to review only bugs, regressions, maintainability risks, and missing tests.
+6. Address reviewer findings.
+7. Run the task's focused verify commands.
+8. Before commit, run the broader CI commands:
+
+```bash
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+cargo test -p defra-agent --lib --tests
+cargo test -p defra-agent-cli
+```
+
+9. Commit one task at a time.
+
+---
+
+## Lean Properties To Re-Verify
+
+After every Lean task, the following must remain green:
+
+- **B1–B7** in `Proofs/Background/Properties.lean` (R6 parametric set)
+- **S1, S3, S4, S5, S6** in `Proofs/Request/Properties.lean`
+- **L1, L3** bounded termination / recovery convergence
+- R4a session-queue invariants (`Proofs/Session/Properties.lean`)
+- #189 recovery enumeration coverage in `Proofs/Recovery/Properties.lean`
+- #191 transcript pair atomicity in `Proofs/Transcript/Properties.lean`
+- **New (Task 1):** `steer_subagent_interrupt_preserves_link_symmetry` in `Proofs/Background/Properties.lean`
+
+Verify after every Lean task:
+
+```bash
+cd crates/defra-agent/proofs && lake build
+cd crates/defra-agent/proofs && lake build Proofs.Conformance.Contracts
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean >/tmp/r4c-lean-contract.json
+```
+
+---
+
+## File Structure
+
+R4c is glue and rendering. New files are minimal; most work edits the post-R6 surface.
+
+**New files:**
+
+- `crates/defra-agent/src/background_tools/transcript_render.rs` — pure-function transcript renderer. Unit-testable in isolation.
+- `crates/defra-agent/src/background_tools/r4c_args.rs` — argument/envelope types for the five R4c tools. Keeps `background_tools.rs` itself focused on hook-interceptor wiring.
+- `crates/defra-agent/tests/r4c_list_subagents.rs` — integration tests for `list_subagents`.
+- `crates/defra-agent/tests/r4c_list_background_tools.rs` — integration tests for `list_background_tools`.
+- `crates/defra-agent/tests/r4c_read_subagent_transcript.rs` — integration tests for `read_subagent_transcript`.
+- `crates/defra-agent/tests/r4c_read_tool_output.rs` — integration tests for `read_tool_output`.
+- `crates/defra-agent/tests/r4c_steer_subagent.rs` — integration tests for both `steer_subagent` modes.
+
+**Modified files:**
+
+- `crates/defra-agent/proofs/Proofs/Background/Transition.lean` — add a `SteerWithInterrupt` derived transition that composes existing primitives.
+- `crates/defra-agent/proofs/Proofs/Background/Properties.lean` — add the new theorem.
+- `crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean` — emit six R4c witness rows.
+- `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean` — JSON encoders for new witness types.
+- `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Types.lean` — Lean structs for the new witness types.
+- `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean` — six new ledger rows.
+- `crates/defra-agent/src/background_tools.rs` — add five new tool definitions and their hook interceptors.
+- `crates/defra-agent/src/hook.rs` — register the five new interceptor entries.
+- `crates/defra-agent/src/hook/persistence.rs` — branch on the five new tool names before ordinary `AgentToolCall` persistence (R4 pattern carried forward).
+- `crates/defra-agent/src/tool_surface/selection.rs` — register the five new tools per the per-tool gate rules (Section "Tool Surface > Registration gates" of the spec).
+- `crates/defra-agent/tests/support/conformance_consumers.rs` — Rust consumers for the new witnesses.
+- `crates/defra-agent/tests/state_machine_conformance.rs` — register the new consumers and assert ledger coverage.
+
+---
+
+## R4c Task 0: Kickoff Gate — Confirm R6 Prerequisite
+
+**Purpose:** Verify R6 is fully merged to main before starting. This task does not write code or commit; it is a hard gate.
+
+**Steps:**
+
+- [ ] **Step 1: Confirm R6 rename commit on main**
+
+Run:
+
+```bash
+git log --oneline main | rg -i "Rename Proofs/Subagent -> Proofs/Background|pure no-op rename"
+```
+
+Expected: one or more lines showing R6's Task 0 rename commit.
+
+- [ ] **Step 2: Confirm R6 substance landed**
+
+Run:
+
+```bash
+git log --oneline main | rg -i "background_tool meta-tool|wait_tool|cancel_tool"
+```
+
+Expected: at least three commit lines matching R6 Tasks 7, 8, 9.
+
+- [ ] **Step 3: Confirm rename in current branch's working tree**
+
+Run:
+
+```bash
+ls crates/defra-agent/src/background_tools.rs crates/defra-agent/src/background_completion.rs
+ls crates/defra-agent/proofs/Proofs/Background/
+```
+
+Expected: all three exist; no `subagent_tools.rs` or `subagent_completion.rs` remain.
+
+- [ ] **Step 4: If any of the above fails, stop**
+
+If R6 is not on main or this branch isn't rebased onto post-R6 main, report the blocker to Jack and halt. Do not proceed.
+
+**Verify:** None. This task gates the rest.
+
+**Commit:** None. Move to Task 1 only if all checks pass.
+
+---
+
+## R4c Task 1: Add Lean Theorem `steer_subagent_interrupt_preserves_link_symmetry`
+
+**Purpose:** Ship the one new R4c theorem. Discharge B5 preservation across the `interrupt + bridge_cancel_cascade + pendingAfterDrain + appendPending` composition that `steer_subagent(interrupt=true)` uses. This makes future regressions of the composition trip `lake build` before they trip Rust.
+
+**Files:**
+
+- Modify: `crates/defra-agent/proofs/Proofs/Background/Transition.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Background/Properties.lean`
+
+**Steps:**
+
+- [ ] **Step 1: Define the composed transition in `Transition.lean`**
+
+Add (after the existing `bridge_cancel_cascade` constructor):
+
+```lean
+/-- Composed transition for steer_subagent(interrupt=true). Sequences the
+    existing interrupt + bridge_cancel_cascade + pendingAfterDrain +
+    appendPending primitives. Not a new transition; a witness that the
+    composition is reachable from `pre` and well-formed at `post`. -/
+structure SteerWithInterrupt
+    (pre post : BackgroundedState)
+    (childRequestId : RequestId)
+    (steeringRequestId : RequestId)
+    (steeringMessage : String) : Prop where
+  -- 1. The child has an active running request that the interrupt targets.
+  h_child_active : ∃ child : BackgroundedRow,
+    child ∈ pre.parent.children ∧
+    child.requestId = childRequestId ∧
+    ¬ terminal child.requestState
+  -- 2. The post-state reflects the interrupt + cascade + drain + append
+  --    composition (witness: any execution path that fires
+  --    Request.interrupt then bridge_cancel_cascade on live edges then
+  --    SessionQueue.drainAutomatedWakeups on the child session then
+  --    SessionQueue.appendPending with QueueSource.steering produces
+  --    `post`). The transition shape lives in `Background/Executable.lean`
+  --    as the canonical executor; this Prop carries the witness for the
+  --    properties layer.
+  h_compose : ∃ mid₁ mid₂ mid₃ : BackgroundedState,
+    Request.interruptStep pre mid₁ childRequestId ∧
+    BridgeCancelCascade mid₁ mid₂ childRequestId ∧
+    SessionQueue.drainAutomatedWakeupsStep mid₂ mid₃
+      (childSessionOf pre childRequestId) ∧
+    SessionQueue.appendPendingStep mid₃ post
+      { requestId := steeringRequestId
+      , source := .steering
+      , policy := .append
+      , queueKey := none
+      , queuedAfter := none
+      }
+```
+
+The four helper `*Step` propositions are thin wrappers around existing
+transitions; if they do not exist in `Background/Executable.lean` yet,
+add minimal ones that simply assert "the existing transition fires with
+the listed arguments." Do not introduce new transition logic.
+
+- [ ] **Step 2: State the theorem in `Properties.lean`**
+
+Add (after the existing `link_symmetry` theorem, B5):
+
+```lean
+/-- B5 invariant survives the `steer_subagent(interrupt=true)` composition.
+    Discharged from existing B5 plus the invariants of the four sub-steps. -/
+theorem steer_subagent_interrupt_preserves_link_symmetry
+    {pre post : BackgroundedState}
+    {childRequestId steeringRequestId : RequestId}
+    {message : String}
+    (h_step : SteerWithInterrupt pre post childRequestId steeringRequestId message)
+    (h_pre  : link_symmetry pre) :
+    link_symmetry post := by
+  rcases h_step.h_compose with ⟨mid₁, mid₂, mid₃, h_int, h_casc, h_drain, h_app⟩
+  -- Step A: interrupt preserves B5 (existing lemma on Request.interruptStep)
+  have h1 : link_symmetry mid₁ := link_symmetry_of_interrupt h_pre h_int
+  -- Step B: bridge_cancel_cascade preserves B5 (existing B3 corollary)
+  have h2 : link_symmetry mid₂ := link_symmetry_of_cascade h1 h_casc
+  -- Step C: drainAutomatedWakeups touches only queue, not bridge rows
+  have h3 : link_symmetry mid₃ := link_symmetry_of_drain h2 h_drain
+  -- Step D: appendPending writes a new request with caused_by_parent_request_id
+  --         pointing at the steering parent; B5 lifts directly.
+  exact link_symmetry_of_appendPending h3 h_app
+```
+
+If any of `link_symmetry_of_interrupt`, `link_symmetry_of_cascade`,
+`link_symmetry_of_drain`, `link_symmetry_of_appendPending` do not exist,
+add them as small lemmas in `Properties.lean` proven by unfolding
+`link_symmetry` and case-analyzing the sub-step. Each is a few lines.
+
+- [ ] **Step 3: Run Lean and observe the new theorem compile**
+
+Run:
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: build succeeds. The new theorem is discharged.
+
+- [ ] **Step 4: Confirm no existing theorem regressed**
+
+Run:
+
+```bash
+cd crates/defra-agent/proofs && lake build Proofs.Conformance.Contracts
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Background/Properties.lean
+```
+
+Expected: both succeed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Background/Transition.lean \
+       crates/defra-agent/proofs/Proofs/Background/Properties.lean
+git commit -m "$(cat <<'EOF'
+Add steer_subagent_interrupt_preserves_link_symmetry theorem
+
+R4c's only new Lean theorem. Discharges B5 preservation across the
+interrupt + bridge_cancel_cascade + pendingAfterDrain + appendPending
+composition that steer_subagent(interrupt=true) uses.
+
+No new transitions; the SteerWithInterrupt prop is a witness over
+existing primitives.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 2: Emit R4c Conformance Witnesses
+
+**Purpose:** Emit six deterministic Lean witnesses so Rust tests detect drift in the observable shapes that the R4c spec promises. No new Lean module; additions to the existing contracts surface.
+
+**Files:**
+
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Types.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/Contracts.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean`
+- Modify: `crates/defra-agent/tests/support/conformance_consumers.rs`
+- Modify: `crates/defra-agent/tests/state_machine_conformance.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Define the six witness types in `Types.lean`**
+
+Add:
+
+```lean
+namespace R4cWitnesses
+
+structure ListSubagentsLineageRejects where
+  callerRequestId : String
+  siblingRequestId : String
+  siblingChildId : String
+  callerSeesSiblingChild : Bool  -- always false in emitted witness
+
+structure ReadTranscriptCursorAdvances where
+  childSessionId : String
+  firstSinceSequence : Nat
+  firstThroughSequence : Nat
+  firstNextSequence : Nat
+  secondSinceSequence : Nat       -- = firstNextSequence
+  secondThroughSequence : Nat
+  noGap : Bool                    -- always true
+  noOverlap : Bool                -- always true
+
+structure ReadTranscriptHidesBridgeRows where
+  childSessionId : String
+  bridgeCallId : String
+  renderedTranscript : String     -- bridge call id absent from rendering
+
+structure ReadToolOutputDispatchesByState where
+  toolCallId : String
+  runningSource : String          -- "ring_buffer"
+  terminalSource : String         -- "persisted_tool_completion"
+
+structure SteerAppendPreservesLineage where
+  callerRequestId : String
+  childSessionId : String
+  queuedRequestId : String
+  causedByParentRequestId : String  -- = callerRequestId
+  queueSource : String              -- "steering"
+  queuePolicy : String              -- "append"
+
+structure SteerInterruptComposes where
+  callerRequestId : String
+  childSessionId : String
+  interruptedActiveRequestId : String
+  drainedWakeUpRequestIds : List String
+  queuedRequestId : String
+  queueInterruptedRequestId : String  -- = interruptedActiveRequestId
+
+end R4cWitnesses
+```
+
+- [ ] **Step 2: Add JSON encoders in `Json.lean`**
+
+For each of the six structs, add a `ToJson` instance that emits a stable field order. Follow the convention already established in this file (look at the R4/R6 encoders and mirror).
+
+Example for the first:
+
+```lean
+instance : ToJson R4cWitnesses.ListSubagentsLineageRejects where
+  toJson w :=
+    Json.mkObj
+      [ ("witness", Json.str "list_subagents_lineage_rejects")
+      , ("caller_request_id", Json.str w.callerRequestId)
+      , ("sibling_request_id", Json.str w.siblingRequestId)
+      , ("sibling_child_id", Json.str w.siblingChildId)
+      , ("caller_sees_sibling_child", Json.bool w.callerSeesSiblingChild)
+      ]
+```
+
+Repeat for the other five with parallel field-order discipline.
+
+- [ ] **Step 3: Emit the six witnesses in `Contracts.lean`**
+
+Add (in the `emit` function or its equivalent):
+
+```lean
+-- R4c witness emissions
+let r4c_w1 : R4cWitnesses.ListSubagentsLineageRejects :=
+  { callerRequestId := "r4c-w1-caller"
+  , siblingRequestId := "r4c-w1-sibling"
+  , siblingChildId := "r4c-w1-sibling-child"
+  , callerSeesSiblingChild := false
+  }
+emit_witness "r4c.list_subagents.lineage_rejects" r4c_w1
+
+let r4c_w2 : R4cWitnesses.ReadTranscriptCursorAdvances :=
+  { childSessionId := "r4c-w2-session"
+  , firstSinceSequence := 0
+  , firstThroughSequence := 5
+  , firstNextSequence := 6
+  , secondSinceSequence := 6
+  , secondThroughSequence := 10
+  , noGap := true
+  , noOverlap := true
+  }
+emit_witness "r4c.read_subagent_transcript.cursor_advances" r4c_w2
+
+let r4c_w3 : R4cWitnesses.ReadTranscriptHidesBridgeRows :=
+  { childSessionId := "r4c-w3-session"
+  , bridgeCallId := "r4c-w3-bridge-call"
+  , renderedTranscript := "[assistant seq=2]\nplain assistant message\n"
+  }
+emit_witness "r4c.read_subagent_transcript.hides_bridge_rows" r4c_w3
+
+let r4c_w4 : R4cWitnesses.ReadToolOutputDispatchesByState :=
+  { toolCallId := "r4c-w4-tool-call"
+  , runningSource := "ring_buffer"
+  , terminalSource := "persisted_tool_completion"
+  }
+emit_witness "r4c.read_tool_output.dispatch_by_state" r4c_w4
+
+let r4c_w5 : R4cWitnesses.SteerAppendPreservesLineage :=
+  { callerRequestId := "r4c-w5-caller"
+  , childSessionId := "r4c-w5-child-session"
+  , queuedRequestId := "r4c-w5-queued"
+  , causedByParentRequestId := "r4c-w5-caller"
+  , queueSource := "steering"
+  , queuePolicy := "append"
+  }
+emit_witness "r4c.steer_subagent.append_preserves_lineage" r4c_w5
+
+let r4c_w6 : R4cWitnesses.SteerInterruptComposes :=
+  { callerRequestId := "r4c-w6-caller"
+  , childSessionId := "r4c-w6-child-session"
+  , interruptedActiveRequestId := "r4c-w6-interrupted"
+  , drainedWakeUpRequestIds := ["r4c-w6-wake-1", "r4c-w6-wake-2"]
+  , queuedRequestId := "r4c-w6-queued"
+  , queueInterruptedRequestId := "r4c-w6-interrupted"
+  }
+emit_witness "r4c.steer_subagent.interrupt_composes" r4c_w6
+```
+
+- [ ] **Step 4: Register six ledger rows in `CoverageLedger.lean`**
+
+Add (in the ledger constant):
+
+```lean
+, "r4c.list_subagents.lineage_rejects"
+, "r4c.read_subagent_transcript.cursor_advances"
+, "r4c.read_subagent_transcript.hides_bridge_rows"
+, "r4c.read_tool_output.dispatch_by_state"
+, "r4c.steer_subagent.append_preserves_lineage"
+, "r4c.steer_subagent.interrupt_composes"
+```
+
+- [ ] **Step 5: Add Rust consumers in `tests/support/conformance_consumers.rs`**
+
+For each witness, add a consumer struct mirroring the Lean type and a parse-from-JSON impl. Follow the R4/R6 consumer patterns already in this file:
+
+```rust
+#[derive(Debug, serde::Deserialize)]
+pub struct ListSubagentsLineageRejectsWitness {
+    pub caller_request_id: String,
+    pub sibling_request_id: String,
+    pub sibling_child_id: String,
+    pub caller_sees_sibling_child: bool,
+}
+
+// ... repeat for the other five
+```
+
+Register each in the `consumers!` macro or its equivalent so the contracts test discovers them.
+
+- [ ] **Step 6: Write Rust assertions in `state_machine_conformance.rs`**
+
+Add one test per witness that:
+1. Parses the witness JSON.
+2. Sets up the corresponding Rust scenario (real `EmbeddedNode`, behaviors, requests).
+3. Calls the R4c tool path that should match the witness.
+4. Asserts the observable Rust shape matches the witness.
+
+Example for w1:
+
+```rust
+#[tokio::test]
+async fn r4c_list_subagents_lineage_rejects_matches_witness() {
+    let witness: ListSubagentsLineageRejectsWitness =
+        load_witness("r4c.list_subagents.lineage_rejects");
+
+    let ctx = TestContext::new().await;
+    let caller = ctx.spawn_request(&witness.caller_request_id).await;
+    let sibling = ctx.spawn_request(&witness.sibling_request_id).await;
+    ctx.spawn_subagent(&sibling, &witness.sibling_child_id).await;
+
+    // Caller's list_subagents must not return sibling's child.
+    let result = ctx.list_subagents(&caller).await.expect("list ok");
+    assert!(
+        !result.entries.iter().any(|e| e.child_request_id == witness.sibling_child_id),
+        "caller saw sibling's child; expected lineage scoping to reject"
+    );
+}
+```
+
+The other five tests follow the same pattern: load witness, set up scenario, call R4c tool, assert envelope matches witness expectations.
+
+**Note:** The R4c tool implementations don't exist yet (Tasks 3-10). These tests will compile-error or fail until the corresponding tool tasks land. That's the intended TDD flow.
+
+- [ ] **Step 7: Verify Lean compiles and witnesses emit**
+
+Run:
+
+```bash
+cd crates/defra-agent/proofs && lake build
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean >/tmp/r4c-witnesses.json
+jq '.[] | select(.witness | startswith("r4c."))' /tmp/r4c-witnesses.json | head -60
+```
+
+Expected: six R4c witness objects appear in the JSON output.
+
+- [ ] **Step 8: Verify ledger coverage**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain
+```
+
+Expected: PASS. The ledger accounts for every emitted witness.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Conformance/ \
+       crates/defra-agent/tests/support/conformance_consumers.rs \
+       crates/defra-agent/tests/state_machine_conformance.rs
+git commit -m "$(cat <<'EOF'
+Emit R4c conformance witnesses for the six observable shapes
+
+Witnesses cover:
+- list_subagents lineage scoping rejects siblings
+- read_subagent_transcript cursor advances cleanly across pages
+- read_subagent_transcript hides bridge rows
+- read_tool_output dispatches buffer vs persisted by state
+- steer_subagent(interrupt=false) preserves lineage
+- steer_subagent(interrupt=true) composes interrupt+cascade+drain+append
+
+Rust consumers fail-fast for unimplemented tools; that drives the TDD
+flow for the next eight tasks.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 3: Define R4c Argument And Envelope Types
+
+**Purpose:** Create the strongly-typed argument and return envelopes for the five R4c tools in a single focused module. Keeps `background_tools.rs` itself focused on hook-interceptor wiring.
+
+**Files:**
+
+- Create: `crates/defra-agent/src/background_tools/r4c_args.rs`
+- Modify: `crates/defra-agent/src/background_tools.rs` (`mod r4c_args;`)
+
+**Steps:**
+
+- [ ] **Step 1: Write a failing serialization test**
+
+Add at the bottom of `r4c_args.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn list_subagents_args_round_trip() {
+        let args: ListSubagentsArgs = serde_json::from_value(json!({
+            "status": "running",
+            "limit": 20
+        })).expect("parse");
+        assert_eq!(args.status, ListStatusFilter::Running);
+        assert_eq!(args.limit, 20);
+    }
+
+    #[test]
+    fn list_subagents_args_defaults() {
+        let args: ListSubagentsArgs = serde_json::from_value(json!({})).expect("parse");
+        assert_eq!(args.status, ListStatusFilter::Running);
+        assert_eq!(args.limit, 20);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p defra-agent --lib background_tools::r4c_args
+```
+
+Expected: compile error (the types don't exist yet).
+
+- [ ] **Step 3: Define the types**
+
+Write the module body:
+
+```rust
+//! Argument and envelope types for the five R4c agent-facing tools.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_LIST_LIMIT: u32 = 20;
+const MAX_LIST_LIMIT: u32 = 50;
+const DEFAULT_TRANSCRIPT_LIMIT: u32 = 20;
+const MAX_TRANSCRIPT_LIMIT: u32 = 100;
+const DEFAULT_TRANSCRIPT_MAX_CHARS: u32 = 6000;
+const MAX_TRANSCRIPT_MAX_CHARS: u32 = 24000;
+const DEFAULT_READ_TOOL_OUTPUT_BYTES: u32 = 16384;
+const MAX_READ_TOOL_OUTPUT_BYTES: u32 = 262144;
+pub(crate) const PER_TOOL_RESULT_SNIPPET_BYTES: usize = 256;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ListStatusFilter {
+    #[default]
+    Running,
+    Terminal,
+    All,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ListSubagentsArgs {
+    #[serde(default)]
+    pub status: ListStatusFilter,
+    #[serde(default = "default_list_limit")]
+    pub limit: u32,
+}
+
+fn default_list_limit() -> u32 { DEFAULT_LIST_LIMIT }
+
+impl ListSubagentsArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.min(MAX_LIST_LIMIT).max(1)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ListBackgroundToolsArgs {
+    #[serde(default)]
+    pub status: ListStatusFilter,
+    #[serde(default = "default_list_limit")]
+    pub limit: u32,
+}
+
+impl ListBackgroundToolsArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.min(MAX_LIST_LIMIT).max(1)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ReadSubagentTranscriptArgs {
+    pub child_request_id: String,
+    #[serde(default)]
+    pub since_sequence: u64,
+    #[serde(default = "default_transcript_limit")]
+    pub limit: u32,
+    #[serde(default = "default_transcript_max_chars")]
+    pub max_chars: u32,
+    #[serde(default)]
+    pub include_user_messages: bool,
+    #[serde(default)]
+    pub include_tool_results: bool,
+}
+
+fn default_transcript_limit() -> u32 { DEFAULT_TRANSCRIPT_LIMIT }
+fn default_transcript_max_chars() -> u32 { DEFAULT_TRANSCRIPT_MAX_CHARS }
+
+impl ReadSubagentTranscriptArgs {
+    pub(crate) fn validated_limit(&self) -> u32 {
+        self.limit.min(MAX_TRANSCRIPT_LIMIT).max(1)
+    }
+    pub(crate) fn validated_max_chars(&self) -> u32 {
+        self.max_chars.min(MAX_TRANSCRIPT_MAX_CHARS).max(64)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ReadToolOutputArgs {
+    pub tool_call_id: String,
+    #[serde(default = "default_read_tool_output_bytes")]
+    pub max_bytes_per_stream: u32,
+}
+
+fn default_read_tool_output_bytes() -> u32 { DEFAULT_READ_TOOL_OUTPUT_BYTES }
+
+impl ReadToolOutputArgs {
+    pub(crate) fn validated_max_bytes(&self) -> u32 {
+        self.max_bytes_per_stream.min(MAX_READ_TOOL_OUTPUT_BYTES).max(256)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct SteerSubagentArgs {
+    pub child_request_id: String,
+    pub message: String,
+    #[serde(default)]
+    pub interrupt: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListSubagentsEntry {
+    pub child_request_id: String,
+    pub child_session_id: String,
+    pub behavior_id: String,
+    pub deployment_id: String,
+    pub await_mode: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub last_update: DateTime<Utc>,
+    pub depth: u32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListSubagentsResponse {
+    pub read_at: DateTime<Utc>,
+    pub truncated: bool,
+    pub entries: Vec<ListSubagentsEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListBackgroundToolsEntry {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub deployment_id: String,
+    pub await_mode: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub last_update: DateTime<Utc>,
+    pub stdout_bytes: u64,
+    pub stderr_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ListBackgroundToolsResponse {
+    pub read_at: DateTime<Utc>,
+    pub truncated: bool,
+    pub entries: Vec<ListBackgroundToolsEntry>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadSubagentTranscriptResponse {
+    pub child_request_id: String,
+    pub child_session_id: String,
+    pub from_sequence: u64,
+    pub through_sequence: u64,
+    pub next_sequence: u64,
+    pub truncated: bool,
+    pub transcript: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadToolOutputStream {
+    pub bytes: String,
+    pub truncated: bool,
+    pub total_bytes_seen: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ReadToolOutputResponse {
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub status: String,
+    pub stdout: ReadToolOutputStream,
+    pub stderr: ReadToolOutputStream,
+    pub exit_code: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct SteerSubagentResponse {
+    pub child_request_id: String,
+    pub child_session_id: String,
+    pub queued_request_id: String,
+    pub interrupted_active_request_id: Option<String>,
+    pub drained_wake_up_request_ids: Vec<String>,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p defra-agent --lib background_tools::r4c_args
+```
+
+Expected: PASS (both `list_subagents_args_round_trip` and `list_subagents_args_defaults`).
+
+- [ ] **Step 5: Add round-trip tests for the other arg types**
+
+Add four more `#[test]` blocks mirroring `list_subagents_args_round_trip` for `ListBackgroundToolsArgs`, `ReadSubagentTranscriptArgs`, `ReadToolOutputArgs`, `SteerSubagentArgs`. Each should verify the field defaults and an explicit-fields round trip.
+
+Run:
+
+```bash
+cargo test -p defra-agent --lib background_tools::r4c_args
+```
+
+Expected: all five round-trip tests PASS.
+
+- [ ] **Step 6: Wire `mod r4c_args;` into `background_tools.rs`**
+
+Add at the top of `background_tools.rs`:
+
+```rust
+mod r4c_args;
+```
+
+Run:
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean compile.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/defra-agent/src/background_tools/r4c_args.rs \
+       crates/defra-agent/src/background_tools.rs
+git commit -m "$(cat <<'EOF'
+Add R4c argument and envelope types
+
+Centralizes the strongly-typed arg/return shapes for list_subagents,
+list_background_tools, read_subagent_transcript, read_tool_output, and
+steer_subagent in background_tools/r4c_args.rs. Hard caps and defaults
+mirror the R4c spec.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 4: Implement Transcript Renderer
+
+**Purpose:** Pure-function transcript renderer in its own module. Unit-testable without DB plumbing. Owns the compact-text formatting, filtering pipeline, and snippet caps.
+
+**Files:**
+
+- Create: `crates/defra-agent/src/background_tools/transcript_render.rs`
+- Modify: `crates/defra-agent/src/background_tools.rs` (`mod transcript_render;`)
+
+**Steps:**
+
+- [ ] **Step 1: Define the inputs and outputs**
+
+Add the file:
+
+```rust
+//! Pure-function transcript renderer for read_subagent_transcript.
+
+use crate::background_tools::r4c_args::PER_TOOL_RESULT_SNIPPET_BYTES;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MessageRoleView {
+    User,
+    Assistant,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MessageKindView {
+    Ordinary { body: String },
+    AssistantWithToolCalls {
+        body: String,
+        tool_call_count: u32,
+        /// Bridge call ids that must be hidden from rendering.
+        bridge_call_ids: Vec<String>,
+        /// Non-bridge tool calls (visible to renderer for the count suffix).
+        non_bridge_tool_call_count: u32,
+    },
+    ToolResult { tool_name: String, body: String },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MessageView {
+    pub sequence: u64,
+    pub role: MessageRoleView,
+    pub kind: MessageKindView,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RenderOptions {
+    pub include_user_messages: bool,
+    pub include_tool_results: bool,
+    pub limit: u32,
+    pub max_chars: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RenderOutput {
+    pub transcript: String,
+    pub from_sequence: u64,
+    pub through_sequence: u64,
+    pub next_sequence: u64,
+    pub truncated: bool,
+}
+
+pub(crate) fn render_transcript(
+    messages: &[MessageView],
+    since_sequence: u64,
+    opts: RenderOptions,
+) -> RenderOutput {
+    let mut transcript = String::new();
+    let mut first_included: Option<u64> = None;
+    let mut last_included: u64 = since_sequence;
+    let mut included_count: u32 = 0;
+    let mut truncated = false;
+
+    for msg in messages {
+        if msg.sequence <= since_sequence {
+            continue;
+        }
+        if !opts.include_user_messages && msg.role == MessageRoleView::User {
+            continue;
+        }
+        let block = match render_block(msg, opts) {
+            Some(b) => b,
+            None => continue, // bridge-only assistant messages or filtered rows
+        };
+        let projected_len = transcript.len()
+            + block.len()
+            + if transcript.is_empty() { 0 } else { 1 };
+        if included_count + 1 > opts.limit
+            || projected_len > opts.max_chars as usize
+        {
+            truncated = true;
+            break;
+        }
+        if !transcript.is_empty() {
+            transcript.push('\n');
+        }
+        transcript.push_str(&block);
+        included_count += 1;
+        if first_included.is_none() {
+            first_included = Some(msg.sequence);
+        }
+        last_included = msg.sequence;
+    }
+
+    let from_sequence = first_included.unwrap_or(since_sequence);
+    RenderOutput {
+        transcript,
+        from_sequence,
+        through_sequence: last_included,
+        next_sequence: last_included.saturating_add(1).max(since_sequence + 1),
+        truncated,
+    }
+}
+
+fn render_block(msg: &MessageView, opts: RenderOptions) -> Option<String> {
+    match (&msg.role, &msg.kind) {
+        (MessageRoleView::User, MessageKindView::Ordinary { body }) => {
+            Some(format!("[user seq={}]\n{}", msg.sequence, body))
+        }
+        (MessageRoleView::Assistant, MessageKindView::Ordinary { body }) => {
+            Some(format!("[assistant seq={}]\n{}", msg.sequence, body))
+        }
+        (MessageRoleView::Assistant, MessageKindView::AssistantWithToolCalls {
+            body,
+            non_bridge_tool_call_count,
+            ..
+        }) => {
+            // Bridge call ids hidden by construction (filtered out before render).
+            // If all tool calls in this message are bridge calls, render as plain assistant.
+            if *non_bridge_tool_call_count == 0 {
+                Some(format!("[assistant seq={}]\n{}", msg.sequence, body))
+            } else {
+                Some(format!(
+                    "[assistant seq={} tool_calls={}]\n{}",
+                    msg.sequence, non_bridge_tool_call_count, body
+                ))
+            }
+        }
+        (MessageRoleView::User, MessageKindView::ToolResult { tool_name, body }) => {
+            if !opts.include_tool_results {
+                None
+            } else {
+                let snippet: String = body
+                    .chars()
+                    .take(PER_TOOL_RESULT_SNIPPET_BYTES)
+                    .collect();
+                Some(format!(
+                    "[tool-result seq={} tool={}]\n{}",
+                    msg.sequence, tool_name, snippet
+                ))
+            }
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assistant(seq: u64, body: &str) -> MessageView {
+        MessageView {
+            sequence: seq,
+            role: MessageRoleView::Assistant,
+            kind: MessageKindView::Ordinary { body: body.to_string() },
+        }
+    }
+
+    fn user(seq: u64, body: &str) -> MessageView {
+        MessageView {
+            sequence: seq,
+            role: MessageRoleView::User,
+            kind: MessageKindView::Ordinary { body: body.to_string() },
+        }
+    }
+
+    fn assistant_with_bridge_calls(
+        seq: u64,
+        body: &str,
+        bridge_call_ids: Vec<&str>,
+    ) -> MessageView {
+        MessageView {
+            sequence: seq,
+            role: MessageRoleView::Assistant,
+            kind: MessageKindView::AssistantWithToolCalls {
+                body: body.to_string(),
+                tool_call_count: bridge_call_ids.len() as u32,
+                bridge_call_ids: bridge_call_ids.iter().map(|s| s.to_string()).collect(),
+                non_bridge_tool_call_count: 0,
+            },
+        }
+    }
+
+    fn tool_result(seq: u64, tool: &str, body: &str) -> MessageView {
+        MessageView {
+            sequence: seq,
+            role: MessageRoleView::User,
+            kind: MessageKindView::ToolResult { tool_name: tool.to_string(), body: body.to_string() },
+        }
+    }
+
+    const OPTS_DEFAULT: RenderOptions = RenderOptions {
+        include_user_messages: false,
+        include_tool_results: false,
+        limit: 20,
+        max_chars: 6000,
+    };
+
+    #[test]
+    fn assistant_only_default() {
+        let msgs = vec![assistant(1, "hello"), user(2, "ignored"), assistant(3, "world")];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(out.transcript.contains("[assistant seq=1]"));
+        assert!(out.transcript.contains("[assistant seq=3]"));
+        assert!(!out.transcript.contains("[user"));
+        assert_eq!(out.from_sequence, 1);
+        assert_eq!(out.through_sequence, 3);
+        assert_eq!(out.next_sequence, 4);
+        assert!(!out.truncated);
+    }
+
+    #[test]
+    fn include_user_messages_when_opted_in() {
+        let msgs = vec![assistant(1, "hello"), user(2, "real input"), assistant(3, "ok")];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions { include_user_messages: true, ..OPTS_DEFAULT },
+        );
+        assert!(out.transcript.contains("[user seq=2]"));
+        assert!(out.transcript.contains("real input"));
+    }
+
+    #[test]
+    fn bridge_only_assistant_renders_plain() {
+        let msgs = vec![assistant_with_bridge_calls(5, "spawning child", vec!["bridge-1"])];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(out.transcript.contains("[assistant seq=5]"));
+        assert!(!out.transcript.contains("tool_calls="));
+        assert!(!out.transcript.contains("bridge-1"));
+    }
+
+    #[test]
+    fn tool_result_hidden_by_default() {
+        let msgs = vec![assistant(1, "hi"), tool_result(2, "bash", "stdout")];
+        let out = render_transcript(&msgs, 0, OPTS_DEFAULT);
+        assert!(!out.transcript.contains("[tool-result"));
+    }
+
+    #[test]
+    fn tool_result_snippet_capped() {
+        let big_body = "x".repeat(1024);
+        let msgs = vec![tool_result(1, "bash", &big_body)];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions { include_tool_results: true, ..OPTS_DEFAULT },
+        );
+        assert!(out.transcript.contains("[tool-result seq=1 tool=bash]"));
+        let snippet_len = out.transcript
+            .split("[tool-result seq=1 tool=bash]\n")
+            .nth(1).expect("snippet body").len();
+        assert!(snippet_len <= PER_TOOL_RESULT_SNIPPET_BYTES);
+    }
+
+    #[test]
+    fn since_sequence_skips_earlier() {
+        let msgs = vec![assistant(1, "a"), assistant(2, "b"), assistant(3, "c")];
+        let out = render_transcript(&msgs, 1, OPTS_DEFAULT);
+        assert!(!out.transcript.contains("[assistant seq=1]"));
+        assert!(out.transcript.contains("[assistant seq=2]"));
+        assert_eq!(out.from_sequence, 2);
+    }
+
+    #[test]
+    fn truncated_when_limit_hit() {
+        let msgs = vec![assistant(1, "a"), assistant(2, "b"), assistant(3, "c")];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions { limit: 2, ..OPTS_DEFAULT },
+        );
+        assert!(out.truncated);
+        assert_eq!(out.through_sequence, 2);
+        assert_eq!(out.next_sequence, 3);
+    }
+
+    #[test]
+    fn truncated_when_max_chars_hit() {
+        let long = "x".repeat(200);
+        let msgs = vec![assistant(1, &long), assistant(2, &long), assistant(3, &long)];
+        let out = render_transcript(
+            &msgs,
+            0,
+            RenderOptions { max_chars: 250, ..OPTS_DEFAULT },
+        );
+        assert!(out.truncated);
+        assert!(out.transcript.len() <= 250);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test -p defra-agent --lib background_tools::transcript_render
+```
+
+Expected: all eight tests PASS.
+
+- [ ] **Step 3: Wire `mod transcript_render;` into `background_tools.rs`**
+
+Add near the existing `mod r4c_args;`:
+
+```rust
+mod transcript_render;
+```
+
+Run:
+
+```bash
+cargo check -p defra-agent
+```
+
+Expected: clean compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/src/background_tools/transcript_render.rs \
+       crates/defra-agent/src/background_tools.rs
+git commit -m "$(cat <<'EOF'
+Add pure-function transcript renderer for read_subagent_transcript
+
+Renders compact LLM-facing text from a slice of MessageView rows.
+Assistant-only by default; opt-in user messages and tool-result snippets
+(256-byte cap). Bridge call rows hidden by construction. Pagination via
+since_sequence; truncation when limit or max_chars hits.
+
+Tests cover defaults, opt-in flags, bridge hiding, snippet caps, and
+both truncation modes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 5: Implement `list_subagents` Tool
+
+**Purpose:** First R4c tool. Hook-intercepted; per-parent-request lineage query; returns a snapshot envelope.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/src/hook.rs`
+- Modify: `crates/defra-agent/src/hook/persistence.rs`
+- Create: `crates/defra-agent/tests/r4c_list_subagents.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Write the integration test (failing)**
+
+Create `crates/defra-agent/tests/r4c_list_subagents.rs`:
+
+```rust
+//! Integration tests for R4c list_subagents.
+
+mod support;
+
+use defra_agent::test_support::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn list_subagents_returns_running_children() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p1", "Solve X").await;
+    let child_a = ctx.spawn_subagent(&parent, "amy-code", "do A", "background").await;
+    let child_b = ctx.spawn_subagent(&parent, "amy-code", "do B", "background").await;
+
+    let result = ctx.call_tool(&parent, "list_subagents", json!({})).await
+        .expect("ok");
+
+    let entries = result["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 2);
+    let ids: Vec<&str> = entries.iter()
+        .map(|e| e["child_request_id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&child_a.request_id.as_str()));
+    assert!(ids.contains(&child_b.request_id.as_str()));
+    for e in entries {
+        assert_eq!(e["deployment_id"].as_str().unwrap(), ctx.local_deployment_id());
+        assert_eq!(e["await_mode"].as_str().unwrap(), "background");
+        assert_eq!(e["status"].as_str().unwrap(), "running");
+    }
+}
+
+#[tokio::test]
+async fn list_subagents_rejects_sibling_children() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent1 = ctx.spawn_parent_request("p1", "first").await;
+    let parent2 = ctx.spawn_parent_request("p2", "second").await;
+    let _child_of_p2 = ctx.spawn_subagent(&parent2, "amy-code", "do X", "background").await;
+
+    let result = ctx.call_tool(&parent1, "list_subagents", json!({})).await
+        .expect("ok");
+    let entries = result["entries"].as_array().expect("entries");
+    assert!(entries.is_empty(), "parent1 must not see parent2's children");
+}
+
+#[tokio::test]
+async fn list_subagents_status_filter() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "task", "background").await;
+    ctx.terminalize_child(&child, "completed", "result").await;
+
+    let running = ctx.call_tool(&parent, "list_subagents", json!({"status": "running"})).await
+        .expect("ok");
+    assert_eq!(running["entries"].as_array().unwrap().len(), 0);
+
+    let terminal = ctx.call_tool(&parent, "list_subagents", json!({"status": "terminal"})).await
+        .expect("ok");
+    assert_eq!(terminal["entries"].as_array().unwrap().len(), 1);
+
+    let all = ctx.call_tool(&parent, "list_subagents", json!({"status": "all"})).await
+        .expect("ok");
+    assert_eq!(all["entries"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn list_subagents_limit_truncates() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    for i in 0..5 {
+        ctx.spawn_subagent(&parent, "amy-code", &format!("task {i}"), "background").await;
+    }
+    let result = ctx.call_tool(&parent, "list_subagents", json!({"limit": 3})).await
+        .expect("ok");
+    assert_eq!(result["entries"].as_array().unwrap().len(), 3);
+    assert_eq!(result["truncated"].as_bool().unwrap(), true);
+}
+
+#[tokio::test]
+async fn list_subagents_no_parent_tool_call_row_written() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    ctx.spawn_subagent(&parent, "amy-code", "task", "background").await;
+    let _ = ctx.call_tool(&parent, "list_subagents", json!({})).await;
+
+    let tool_call_rows = ctx.fetch_tool_calls(&parent).await;
+    assert!(
+        !tool_call_rows.iter().any(|r| r.tool_name == "list_subagents"),
+        "no AgentToolCall row should exist for list_subagents"
+    );
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test r4c_list_subagents
+```
+
+Expected: compile error (`call_tool("list_subagents", ...)` returns an error because the tool is not registered).
+
+- [ ] **Step 3: Add the implementation in `background_tools.rs`**
+
+Add (alongside the R4 subagent tool helpers):
+
+```rust
+use crate::background_tools::r4c_args::{
+    ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse, ListStatusFilter,
+};
+use chrono::Utc;
+use defra_node::EmbeddedNode;
+
+pub(crate) async fn handle_list_subagents(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    local_deployment_id: &str,
+    args: ListSubagentsArgs,
+) -> Result<ListSubagentsResponse> {
+    let limit = args.validated_limit();
+
+    let status_clause = match args.status {
+        ListStatusFilter::Running => "status: { _eq: \"processing\" }",
+        ListStatusFilter::Terminal => {
+            "_or: [\
+                { status: { _eq: \"completed\" } }, \
+                { status: { _eq: \"failed\" } }, \
+                { status: { _eq: \"dead\" } }, \
+                { status: { _eq: \"interrupted\" } }, \
+                { status: { _eq: \"superseded\" } } \
+            ]"
+        }
+        ListStatusFilter::All => "_or: [{ status: { _neq: \"\" } }]",
+    };
+
+    let query = format!(
+        r#"
+        query {{
+            AgentRequest(
+                filter: {{
+                    caused_by_parent_request_id: {{ _eq: "{caller}" }},
+                    {status}
+                }},
+                order: {{ created_at: ASC }},
+                limit: {limit_plus_one}
+            ) {{
+                _docID
+                session_id
+                behavior_id
+                await_mode
+                status
+                created_at
+                updated_at
+                subagent_depth
+            }}
+        }}
+        "#,
+        caller = escape_graphql_string(caller_request_id),
+        status = status_clause,
+        limit_plus_one = limit + 1,
+    );
+
+    let raw = node.execute_query(&query).await
+        .map_err(|e| anyhow!("list_subagents query failed: {e}"))?;
+
+    let rows: Vec<RawSubagentRow> = parse_subagent_rows(&raw)?;
+    let truncated = rows.len() > limit as usize;
+    let entries: Vec<ListSubagentsEntry> = rows.into_iter()
+        .take(limit as usize)
+        .map(|r| ListSubagentsEntry {
+            child_request_id: r.id,
+            child_session_id: r.session_id,
+            behavior_id: r.behavior_id,
+            deployment_id: local_deployment_id.to_string(),
+            await_mode: r.await_mode,
+            status: r.status,
+            created_at: r.created_at,
+            last_update: r.updated_at,
+            depth: r.subagent_depth,
+        })
+        .collect();
+
+    Ok(ListSubagentsResponse {
+        read_at: Utc::now(),
+        truncated,
+        entries,
+    })
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawSubagentRow {
+    #[serde(rename = "_docID")]
+    id: String,
+    session_id: String,
+    behavior_id: String,
+    await_mode: String,
+    status: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    subagent_depth: u32,
+}
+
+fn parse_subagent_rows(raw: &serde_json::Value) -> Result<Vec<RawSubagentRow>> {
+    let rows = raw
+        .get("data")
+        .and_then(|d| d.get("AgentRequest"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("AgentRequest field missing in list_subagents query"))?;
+    rows.iter().cloned()
+        .map(serde_json::from_value)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow!("parse subagent rows: {e}"))
+}
+```
+
+- [ ] **Step 4: Register the tool in `tool_surface/selection.rs`**
+
+Locate the existing R4 subagent tool registrations and add (gated by the same `subagent_targets` non-empty check that gates `spawn_subagent`):
+
+```rust
+if !selection.subagent_targets.is_empty() {
+    register_native_tool("list_subagents", list_subagents_tool_definition());
+}
+```
+
+Where `list_subagents_tool_definition()` constructs the Rig tool struct with the JSON schema for `ListSubagentsArgs`.
+
+- [ ] **Step 5: Intercept `list_subagents` in `hook/persistence.rs`**
+
+Locate the existing branch that intercepts `wait_subagent` and `cancel_subagent` before ordinary tool-call persistence (R4 pattern). Add an analogous branch for `list_subagents`:
+
+```rust
+"list_subagents" => {
+    let args: ListSubagentsArgs = serde_json::from_value(call.args.clone())
+        .map_err(|e| structured_argument_invalid_error("list_subagents", "/", &e.to_string()))?;
+    let response = background_tools::handle_list_subagents(
+        node,
+        &caller_request_id,
+        &local_deployment_id,
+        args,
+    ).await?;
+    return Ok(HookOutcome::ReturnedWithoutPersistence {
+        result: serde_json::to_value(response)?,
+    });
+}
+```
+
+The key invariant: this branch returns `HookOutcome::ReturnedWithoutPersistence`, which prevents the ordinary tool-call lifecycle from creating an `AgentToolCall` row.
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test r4c_list_subagents
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 7: Run the conformance witness test for w1**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_list_subagents_lineage_rejects
+```
+
+Expected: PASS. The witness from Task 2 now resolves against the running implementation.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/src/hook.rs \
+       crates/defra-agent/src/hook/persistence.rs \
+       crates/defra-agent/src/tool_surface/selection.rs \
+       crates/defra-agent/tests/r4c_list_subagents.rs
+git commit -m "$(cat <<'EOF'
+Implement list_subagents agent-facing tool
+
+Per-parent-request lineage scope; status filter (running|terminal|all);
+limit hard cap 50; snapshot envelope with read_at and truncated flag.
+Hook-intercepted before persistence; no AgentToolCall row written.
+
+Resolves the r4c.list_subagents.lineage_rejects conformance witness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 6: Implement `list_background_tools` Tool
+
+**Purpose:** Symmetric to `list_subagents` for the Tool kind. Queries `AgentToolCall` rows where `request_id = caller AND await_mode = .background`.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/src/hook/persistence.rs`
+- Modify: `crates/defra-agent/src/tool_surface/selection.rs`
+- Create: `crates/defra-agent/tests/r4c_list_background_tools.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Write integration tests (failing)**
+
+Create `crates/defra-agent/tests/r4c_list_background_tools.rs` with five tests mirroring Task 5's test structure:
+
+```rust
+mod support;
+
+use defra_agent::test_support::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn list_background_tools_returns_running_bg_tools() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let h1 = ctx.background_tool(&parent, "bash", json!({"cmd": "sleep 10"})).await;
+    let h2 = ctx.background_tool(&parent, "bash", json!({"cmd": "sleep 20"})).await;
+
+    let result = ctx.call_tool(&parent, "list_background_tools", json!({})).await
+        .expect("ok");
+
+    let entries = result["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 2);
+    let ids: Vec<&str> = entries.iter()
+        .map(|e| e["tool_call_id"].as_str().unwrap())
+        .collect();
+    assert!(ids.contains(&h1.tool_call_id.as_str()));
+    assert!(ids.contains(&h2.tool_call_id.as_str()));
+    for e in entries {
+        assert_eq!(e["tool_name"].as_str().unwrap(), "bash");
+        assert_eq!(e["await_mode"].as_str().unwrap(), "background");
+        assert_eq!(e["status"].as_str().unwrap(), "running");
+    }
+}
+
+#[tokio::test]
+async fn list_background_tools_rejects_sibling_requests() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let p1 = ctx.spawn_parent_request("p1", "first").await;
+    let p2 = ctx.spawn_parent_request("p2", "second").await;
+    ctx.background_tool(&p2, "bash", json!({"cmd": "sleep 5"})).await;
+
+    let result = ctx.call_tool(&p1, "list_background_tools", json!({})).await
+        .expect("ok");
+    assert!(result["entries"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_background_tools_excludes_foreground_calls() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    ctx.run_foreground_tool(&parent, "read_file", json!({"path": "/etc/hostname"})).await;
+    ctx.background_tool(&parent, "bash", json!({"cmd": "sleep 5"})).await;
+
+    let result = ctx.call_tool(&parent, "list_background_tools", json!({})).await
+        .expect("ok");
+    let entries = result["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["tool_name"].as_str().unwrap(), "bash");
+}
+
+#[tokio::test]
+async fn list_background_tools_status_filter() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let h = ctx.background_tool(&parent, "bash", json!({"cmd": "true"})).await;
+    ctx.wait_for_terminal(&h).await;
+
+    let running = ctx.call_tool(&parent, "list_background_tools", json!({"status": "running"})).await
+        .expect("ok");
+    assert!(running["entries"].as_array().unwrap().is_empty());
+    let terminal = ctx.call_tool(&parent, "list_background_tools", json!({"status": "terminal"})).await
+        .expect("ok");
+    assert_eq!(terminal["entries"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn list_background_tools_no_parent_tool_call_row_written() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    ctx.background_tool(&parent, "bash", json!({"cmd": "sleep 5"})).await;
+    let _ = ctx.call_tool(&parent, "list_background_tools", json!({})).await;
+
+    let tool_calls = ctx.fetch_tool_calls(&parent).await;
+    assert!(!tool_calls.iter().any(|r| r.tool_name == "list_background_tools"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test r4c_list_background_tools
+```
+
+Expected: compile error / tool not registered.
+
+- [ ] **Step 3: Add `handle_list_background_tools` in `background_tools.rs`**
+
+Mirror the structure of `handle_list_subagents`. The query targets `AgentToolCall`:
+
+```rust
+pub(crate) async fn handle_list_background_tools(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    local_deployment_id: &str,
+    args: ListBackgroundToolsArgs,
+) -> Result<ListBackgroundToolsResponse> {
+    let limit = args.validated_limit();
+    let status_clause = match args.status {
+        ListStatusFilter::Running => "state: { _eq: \"running\" }",
+        ListStatusFilter::Terminal => {
+            "_or: [\
+                { state: { _eq: \"completed\" } }, \
+                { state: { _eq: \"failed\" } }, \
+                { state: { _eq: \"cancelled\" } }, \
+                { state: { _eq: \"interrupted\" } } \
+            ]"
+        }
+        ListStatusFilter::All => "state: { _neq: \"\" }",
+    };
+    let query = format!(
+        r#"
+        query {{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _eq: "{caller}" }},
+                    await_mode: {{ _eq: "background" }},
+                    {status}
+                }},
+                order: {{ created_at: ASC }},
+                limit: {limit_plus_one}
+            ) {{
+                _docID
+                tool_name
+                await_mode
+                state
+                created_at
+                updated_at
+                stdout_bytes
+                stderr_bytes
+            }}
+        }}
+        "#,
+        caller = escape_graphql_string(caller_request_id),
+        status = status_clause,
+        limit_plus_one = limit + 1,
+    );
+    let raw = node.execute_query(&query).await
+        .map_err(|e| anyhow!("list_background_tools query failed: {e}"))?;
+    let rows: Vec<RawBgToolRow> = parse_bg_tool_rows(&raw)?;
+    let truncated = rows.len() > limit as usize;
+    let entries: Vec<ListBackgroundToolsEntry> = rows.into_iter()
+        .take(limit as usize)
+        .map(|r| ListBackgroundToolsEntry {
+            tool_call_id: r.id,
+            tool_name: r.tool_name,
+            deployment_id: local_deployment_id.to_string(),
+            await_mode: r.await_mode,
+            status: r.state,
+            created_at: r.created_at,
+            last_update: r.updated_at,
+            stdout_bytes: r.stdout_bytes,
+            stderr_bytes: r.stderr_bytes,
+        })
+        .collect();
+    Ok(ListBackgroundToolsResponse { read_at: Utc::now(), truncated, entries })
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct RawBgToolRow {
+    #[serde(rename = "_docID")]
+    id: String,
+    tool_name: String,
+    await_mode: String,
+    state: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    stdout_bytes: u64,
+    stderr_bytes: u64,
+}
+
+fn parse_bg_tool_rows(raw: &serde_json::Value) -> Result<Vec<RawBgToolRow>> {
+    let rows = raw.get("data").and_then(|d| d.get("AgentToolCall"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("AgentToolCall field missing"))?;
+    rows.iter().cloned().map(serde_json::from_value).collect::<Result<Vec<_>, _>>()
+        .map_err(|e| anyhow!("parse bg tool rows: {e}"))
+}
+```
+
+**Note on `stdout_bytes`/`stderr_bytes`:** R6's `background_completion.rs` persists these on `AgentToolCall` rows when terminal. For running rows the schema must surface the ring buffer's current occupancy. If R6 did not add these fields to the `AgentToolCall` schema, this task absorbs the migration: add `stdout_bytes: Int` and `stderr_bytes: Int` to the `AgentToolCall` GraphQL schema with default 0, and update R6's executor to write them as the buffer grows. Coordinate with the R6 implementation; if the schema fields exist, no migration needed.
+
+- [ ] **Step 4: Register and intercept**
+
+In `tool_surface/selection.rs`:
+
+```rust
+if !selection.backgroundable_tool_names.is_empty() {
+    register_native_tool("list_background_tools", list_background_tools_tool_definition());
+}
+```
+
+In `hook/persistence.rs`, add a branch analogous to `list_subagents` that calls `handle_list_background_tools` and returns without persistence.
+
+- [ ] **Step 5: Run integration tests**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test r4c_list_background_tools
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/src/hook/persistence.rs \
+       crates/defra-agent/src/tool_surface/selection.rs \
+       crates/defra-agent/tests/r4c_list_background_tools.rs \
+       crates/defra-agent-protocol/schemas/  # if schema migration needed
+git commit -m "$(cat <<'EOF'
+Implement list_background_tools agent-facing tool
+
+Symmetric to list_subagents for Tool kind. Per-parent-request lineage;
+filters await_mode = background; status filter; snapshot envelope.
+Hook-intercepted; no AgentToolCall row written.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 7: Implement `read_subagent_transcript` Tool
+
+**Purpose:** Query the child session's transcript, hide bridge calls, render via the Task 4 renderer, return compact text.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/src/hook/persistence.rs`
+- Modify: `crates/defra-agent/src/tool_surface/selection.rs`
+- Create: `crates/defra-agent/tests/r4c_read_subagent_transcript.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Write integration tests (failing)**
+
+Create the test file. Key scenarios from the spec:
+
+```rust
+mod support;
+
+use defra_agent::test_support::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn read_transcript_assistant_only_default() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    ctx.append_assistant_message(&child.session_id, "first thought").await;
+    ctx.append_user_message(&child.session_id, "feedback").await;
+    ctx.append_assistant_message(&child.session_id, "second thought").await;
+
+    let result = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+    })).await.expect("ok");
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("first thought"));
+    assert!(transcript.contains("second thought"));
+    assert!(!transcript.contains("feedback"));
+}
+
+#[tokio::test]
+async fn read_transcript_includes_user_when_opted_in() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    ctx.append_assistant_message(&child.session_id, "a1").await;
+    ctx.append_user_message(&child.session_id, "u1").await;
+
+    let result = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+        "include_user_messages": true,
+    })).await.expect("ok");
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("u1"));
+}
+
+#[tokio::test]
+async fn read_transcript_hides_bridge_rows() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    // Child backgrounds a tool (creates a bridge AgentToolCall row).
+    ctx.append_assistant_with_bridge_call(&child.session_id, "spawning child", "bridge-tc-1").await;
+
+    let result = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+    })).await.expect("ok");
+    let transcript = result["transcript"].as_str().unwrap();
+    assert!(transcript.contains("spawning child"));
+    assert!(!transcript.contains("bridge-tc-1"));
+    assert!(!transcript.contains("tool_calls="));
+}
+
+#[tokio::test]
+async fn read_transcript_cursor_advances_cleanly() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    for i in 1..=10 {
+        ctx.append_assistant_message(&child.session_id, &format!("turn {i}")).await;
+    }
+
+    let first = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+        "limit": 5,
+    })).await.expect("ok");
+    let next = first["next_sequence"].as_u64().unwrap();
+    assert_eq!(first["truncated"].as_bool().unwrap(), true);
+
+    let second = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+        "since_sequence": next,
+        "limit": 5,
+    })).await.expect("ok");
+    let combined = format!(
+        "{}\n{}",
+        first["transcript"].as_str().unwrap(),
+        second["transcript"].as_str().unwrap()
+    );
+    for i in 1..=10 {
+        assert!(combined.contains(&format!("turn {i}")), "missing turn {i}");
+    }
+}
+
+#[tokio::test]
+async fn read_transcript_rejects_unauthorized_child() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent1 = ctx.spawn_parent_request("p1", "first").await;
+    let parent2 = ctx.spawn_parent_request("p2", "second").await;
+    let child = ctx.spawn_subagent(&parent2, "amy-code", "do X", "background").await;
+
+    let result = ctx.call_tool(&parent1, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+    })).await;
+    assert!(result.is_err() || result.as_ref().unwrap()["ok"] == false);
+}
+
+#[tokio::test]
+async fn read_transcript_no_parent_tool_call_row_written() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    let _ = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": child.request_id,
+    })).await;
+    let tool_calls = ctx.fetch_tool_calls(&parent).await;
+    assert!(!tool_calls.iter().any(|r| r.tool_name == "read_subagent_transcript"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p defra-agent --test r4c_read_subagent_transcript
+```
+
+Expected: compile error / tool not registered.
+
+- [ ] **Step 3: Implement the handler**
+
+In `background_tools.rs`, add `handle_read_subagent_transcript`:
+
+```rust
+use crate::background_tools::transcript_render::{
+    MessageKindView, MessageRoleView, MessageView, RenderOptions, render_transcript,
+};
+use crate::background_tools::r4c_args::{
+    ReadSubagentTranscriptArgs, ReadSubagentTranscriptResponse,
+};
+
+pub(crate) async fn handle_read_subagent_transcript(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    args: ReadSubagentTranscriptArgs,
+) -> Result<ReadSubagentTranscriptResponse> {
+    // 1. Authorize: child_request_id must be owned by caller.
+    let child = fetch_child_subagent_row(node, caller_request_id, &args.child_request_id).await?
+        .ok_or_else(|| structured_tool_not_allowed_error(
+            "read_subagent_transcript",
+            "/child_request_id",
+            "child not owned by this parent request",
+        ))?;
+
+    // 2. Query child session messages above since_sequence.
+    let limit = args.validated_limit();
+    let max_chars = args.validated_max_chars();
+    let query_limit = limit * 2 + 10; // overhead for filtered rows
+    let query = format!(
+        r#"
+        query {{
+            AgentMessage(
+                filter: {{
+                    session_id: {{ _eq: "{session}" }},
+                    sequence: {{ _gt: {since} }}
+                }},
+                order: {{ sequence: ASC }},
+                limit: {limit}
+            ) {{
+                sequence
+                role
+                kind
+                content
+                tool_call_ids
+                tool_name
+                bridge_call_ids
+            }}
+        }}
+        "#,
+        session = escape_graphql_string(&child.session_id),
+        since = args.since_sequence,
+        limit = query_limit,
+    );
+    let raw = node.execute_query(&query).await
+        .map_err(|e| anyhow!("read_subagent_transcript query failed: {e}"))?;
+
+    // 3. Decode rows into MessageView, hiding bridge calls.
+    let views = decode_message_views(&raw)?;
+
+    // 4. Render.
+    let out = render_transcript(
+        &views,
+        args.since_sequence,
+        RenderOptions {
+            include_user_messages: args.include_user_messages,
+            include_tool_results: args.include_tool_results,
+            limit,
+            max_chars,
+        },
+    );
+
+    Ok(ReadSubagentTranscriptResponse {
+        child_request_id: args.child_request_id,
+        child_session_id: child.session_id,
+        from_sequence: out.from_sequence,
+        through_sequence: out.through_sequence,
+        next_sequence: out.next_sequence,
+        truncated: out.truncated,
+        transcript: out.transcript,
+    })
+}
+
+fn decode_message_views(raw: &serde_json::Value) -> Result<Vec<MessageView>> {
+    let rows = raw.get("data").and_then(|d| d.get("AgentMessage"))
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| anyhow!("AgentMessage missing"))?;
+    let mut views = Vec::with_capacity(rows.len());
+    for row in rows {
+        let sequence = row["sequence"].as_u64().unwrap_or(0);
+        let role_str = row["role"].as_str().unwrap_or("");
+        let kind_str = row["kind"].as_str().unwrap_or("ordinary");
+        let body = row["content"].as_str().unwrap_or("").to_string();
+        let role = match role_str {
+            "user" => MessageRoleView::User,
+            _ => MessageRoleView::Assistant,
+        };
+        let kind = match kind_str {
+            "tool_result" => {
+                MessageKindView::ToolResult {
+                    tool_name: row["tool_name"].as_str().unwrap_or("").to_string(),
+                    body,
+                }
+            }
+            "assistant_with_tool_calls" => {
+                let bridge_ids: Vec<String> = row["bridge_call_ids"].as_array()
+                    .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .unwrap_or_default();
+                let all_ids: Vec<String> = row["tool_call_ids"].as_array()
+                    .map(|a| a.iter().filter_map(|v| v.as_str().map(String::from)).collect())
+                    .unwrap_or_default();
+                let non_bridge_count = all_ids.iter()
+                    .filter(|id| !bridge_ids.contains(id))
+                    .count() as u32;
+                MessageKindView::AssistantWithToolCalls {
+                    body,
+                    tool_call_count: all_ids.len() as u32,
+                    bridge_call_ids: bridge_ids,
+                    non_bridge_tool_call_count: non_bridge_count,
+                }
+            }
+            _ => MessageKindView::Ordinary { body },
+        };
+        views.push(MessageView { sequence, role, kind });
+    }
+    Ok(views)
+}
+```
+
+`fetch_child_subagent_row` is a helper that queries `AgentRequest` for `child_request_id` and checks `caused_by_parent_request_id = caller_request_id`. Likely already exists from R4; reuse if so.
+
+**Schema note on `bridge_call_ids`:** This task assumes `AgentMessage` carries a `bridge_call_ids` field that names which `tool_call_ids` are bridge rows. If that field does not exist, this task absorbs the migration: add `bridge_call_ids: [String!]` to the `AgentMessage` schema, populate it from `hook/persistence.rs` when an assistant message reserves a bridge call, and backfill via a script (the alternative is a second query against `AgentToolCall` per message, which is slower but does not require migration; pick based on prod data volume).
+
+- [ ] **Step 4: Register and intercept**
+
+In `tool_surface/selection.rs`:
+
+```rust
+if !selection.subagent_targets.is_empty() && selection.subagent_steering_enabled {
+    register_native_tool("read_subagent_transcript", read_subagent_transcript_tool_definition());
+}
+```
+
+In `hook/persistence.rs`, add the interception branch returning without persistence.
+
+- [ ] **Step 5: Run integration tests**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test r4c_read_subagent_transcript
+```
+
+Expected: all six tests PASS.
+
+- [ ] **Step 6: Run conformance witness tests w2, w3**
+
+Run:
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_read_subagent_transcript
+```
+
+Expected: both `cursor_advances` and `hides_bridge_rows` witness tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/src/hook/persistence.rs \
+       crates/defra-agent/src/tool_surface/selection.rs \
+       crates/defra-agent/tests/r4c_read_subagent_transcript.rs \
+       crates/defra-agent-protocol/schemas/  # if migration applied
+git commit -m "$(cat <<'EOF'
+Implement read_subagent_transcript agent-facing tool
+
+Renders child session messages as compact text. Assistant-only by
+default; opt-in user messages and tool-result snippets (256-byte cap).
+Bridge call rows always hidden. Pagination via since_sequence cursor;
+truncated flag when limit or max_chars hit.
+
+Resolves r4c.read_subagent_transcript.cursor_advances and
+r4c.read_subagent_transcript.hides_bridge_rows witnesses.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 8: Implement `read_tool_output` Tool
+
+**Purpose:** Snapshot a backgrounded tool's stdout/stderr. Dispatch by row state: ring buffer for running, persisted `<tool-completion>` payload for terminal.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/src/hook/persistence.rs`
+- Modify: `crates/defra-agent/src/tool_surface/selection.rs`
+- Create: `crates/defra-agent/tests/r4c_read_tool_output.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Write integration tests (failing)**
+
+Create the test file:
+
+```rust
+mod support;
+
+use defra_agent::test_support::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn read_tool_output_running_reads_ring_buffer() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let h = ctx.background_tool(&parent, "bash", json!({
+        "cmd": "for i in 1 2 3; do echo line$i; sleep 0.1; done; sleep 5"
+    })).await;
+    ctx.wait_for_buffer_bytes(&h, "stdout", 18).await; // "line1\nline2\nline3\n"
+
+    let result = ctx.call_tool(&parent, "read_tool_output", json!({
+        "tool_call_id": h.tool_call_id,
+    })).await.expect("ok");
+
+    assert_eq!(result["status"].as_str().unwrap(), "running");
+    assert!(result["stdout"]["bytes"].as_str().unwrap().contains("line1"));
+    assert!(result["stdout"]["bytes"].as_str().unwrap().contains("line3"));
+    assert_eq!(result["stdout"]["truncated"].as_bool().unwrap(), false);
+    assert!(result["stdout"]["total_bytes_seen"].as_u64().unwrap() >= 18);
+    assert!(result["exit_code"].is_null());
+}
+
+#[tokio::test]
+async fn read_tool_output_terminal_reads_persisted() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let h = ctx.background_tool(&parent, "bash", json!({
+        "cmd": "echo done"
+    })).await;
+    ctx.wait_for_terminal(&h).await;
+
+    let result = ctx.call_tool(&parent, "read_tool_output", json!({
+        "tool_call_id": h.tool_call_id,
+    })).await.expect("ok");
+
+    assert_eq!(result["status"].as_str().unwrap(), "completed");
+    assert!(result["stdout"]["bytes"].as_str().unwrap().contains("done"));
+    assert_eq!(result["exit_code"].as_i64().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn read_tool_output_truncated_flag_on_overflow() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let h = ctx.background_tool(&parent, "bash", json!({
+        "cmd": format!("head -c 300000 /dev/urandom | base64 ; sleep 5")
+    })).await;
+    ctx.wait_for_buffer_bytes(&h, "stdout", 262144).await; // 256 KB cap
+
+    let result = ctx.call_tool(&parent, "read_tool_output", json!({
+        "tool_call_id": h.tool_call_id,
+        "max_bytes_per_stream": 262144,
+    })).await.expect("ok");
+
+    assert_eq!(result["stdout"]["truncated"].as_bool().unwrap(), true);
+    assert!(result["stdout"]["total_bytes_seen"].as_u64().unwrap() > 262144);
+}
+
+#[tokio::test]
+async fn read_tool_output_rejects_non_backgrounded() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let fg_call_id = ctx.run_foreground_tool(&parent, "read_file",
+        json!({"path": "/etc/hostname"})).await.tool_call_id;
+
+    let result = ctx.call_tool(&parent, "read_tool_output", json!({
+        "tool_call_id": fg_call_id,
+    })).await.expect("ok");
+    assert_eq!(result["ok"].as_bool().unwrap(), false);
+    assert_eq!(result["failure_class"].as_str().unwrap(), "argument_invalid");
+}
+
+#[tokio::test]
+async fn read_tool_output_rejects_unauthorized() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let p1 = ctx.spawn_parent_request("p1", "go").await;
+    let p2 = ctx.spawn_parent_request("p2", "go").await;
+    let h = ctx.background_tool(&p2, "bash", json!({"cmd": "sleep 5"})).await;
+
+    let result = ctx.call_tool(&p1, "read_tool_output", json!({
+        "tool_call_id": h.tool_call_id,
+    })).await.expect("ok");
+    assert_eq!(result["ok"].as_bool().unwrap(), false);
+    assert_eq!(result["failure_class"].as_str().unwrap(), "tool_not_allowed");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p defra-agent --test r4c_read_tool_output
+```
+
+Expected: compile error / not registered.
+
+- [ ] **Step 3: Implement the handler**
+
+```rust
+use crate::background_tools::r4c_args::{
+    ReadToolOutputArgs, ReadToolOutputResponse, ReadToolOutputStream,
+};
+
+pub(crate) async fn handle_read_tool_output(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    args: ReadToolOutputArgs,
+    buffer_registry: &BackgroundToolBufferRegistry, // R6's buffer registry
+) -> Result<ReadToolOutputResponse> {
+    // 1. Authorize: tool_call_id must be owned by caller AND await_mode=background.
+    let row = fetch_tool_call_row(node, &args.tool_call_id).await?
+        .ok_or_else(|| structured_tool_not_allowed_error(
+            "read_tool_output",
+            "/tool_call_id",
+            "tool call not found",
+        ))?;
+    if row.request_id != caller_request_id {
+        return Err(structured_tool_not_allowed_error(
+            "read_tool_output",
+            "/tool_call_id",
+            "tool call not owned by this parent request",
+        ));
+    }
+    if row.await_mode != "background" {
+        return Err(structured_argument_invalid_error(
+            "read_tool_output",
+            "/tool_call_id",
+            "tool call is not backgrounded",
+        ));
+    }
+
+    let max_bytes = args.validated_max_bytes() as usize;
+    let (stdout, stderr, exit_code, status) = match row.state.as_str() {
+        "running" => {
+            let snapshot = buffer_registry.snapshot(&args.tool_call_id, max_bytes)
+                .ok_or_else(|| anyhow!("buffer registry missing tool_call_id"))?;
+            (
+                ReadToolOutputStream {
+                    bytes: utf8_tail_trim(&snapshot.stdout_tail),
+                    truncated: snapshot.stdout_truncated,
+                    total_bytes_seen: snapshot.stdout_total_bytes_seen,
+                },
+                ReadToolOutputStream {
+                    bytes: utf8_tail_trim(&snapshot.stderr_tail),
+                    truncated: snapshot.stderr_truncated,
+                    total_bytes_seen: snapshot.stderr_total_bytes_seen,
+                },
+                None,
+                "running".to_string(),
+            )
+        }
+        terminal_state => {
+            let persisted = fetch_persisted_tool_completion(node, &args.tool_call_id).await?
+                .ok_or_else(|| anyhow!("no persisted tool completion for terminal row"))?;
+            let stdout_bytes = persisted.stdout
+                .chars().rev().take(max_bytes).collect::<String>()
+                .chars().rev().collect::<String>();
+            let stderr_bytes = persisted.stderr
+                .chars().rev().take(max_bytes).collect::<String>()
+                .chars().rev().collect::<String>();
+            (
+                ReadToolOutputStream {
+                    bytes: stdout_bytes,
+                    truncated: persisted.stdout_truncated,
+                    total_bytes_seen: persisted.stdout_total_bytes_seen,
+                },
+                ReadToolOutputStream {
+                    bytes: stderr_bytes,
+                    truncated: persisted.stderr_truncated,
+                    total_bytes_seen: persisted.stderr_total_bytes_seen,
+                },
+                persisted.exit_code,
+                terminal_state.to_string(),
+            )
+        }
+    };
+
+    Ok(ReadToolOutputResponse {
+        tool_call_id: args.tool_call_id,
+        tool_name: row.tool_name,
+        status,
+        stdout,
+        stderr,
+        exit_code,
+    })
+}
+
+/// Trim partial UTF-8 sequences at the head and tail of a byte slice's UTF-8 decoding.
+fn utf8_tail_trim(bytes: &[u8]) -> String {
+    // Walk forward from start to first valid UTF-8 boundary.
+    let mut start = 0;
+    while start < bytes.len() {
+        if std::str::from_utf8(&bytes[start..]).is_ok() {
+            break;
+        }
+        start += 1;
+    }
+    // Walk backward from end to last valid UTF-8 boundary.
+    let mut end = bytes.len();
+    while end > start {
+        if std::str::from_utf8(&bytes[start..end]).is_ok() {
+            break;
+        }
+        end -= 1;
+    }
+    String::from_utf8_lossy(&bytes[start..end]).into_owned()
+}
+
+#[cfg(test)]
+mod utf8_trim_tests {
+    use super::utf8_tail_trim;
+
+    #[test]
+    fn ascii_unchanged() {
+        assert_eq!(utf8_tail_trim(b"hello world"), "hello world");
+    }
+
+    #[test]
+    fn trims_partial_at_tail() {
+        let s = "abc🎉".as_bytes();
+        let trimmed = utf8_tail_trim(&s[..s.len() - 1]);
+        assert_eq!(trimmed, "abc");
+    }
+}
+```
+
+`BackgroundToolBufferRegistry::snapshot` is R6's API for reading the ring buffer; if R6 named it differently, adapt to that name. `fetch_persisted_tool_completion` queries the `<tool-completion>` payload R6's projector writes — likely a DB read against an `AgentMessage` kind `tool_completion` or a side-table; consult R6's `background_completion.rs` for the exact storage.
+
+- [ ] **Step 4: Register and intercept**
+
+In `tool_surface/selection.rs`:
+
+```rust
+if !selection.backgroundable_tool_names.is_empty() {
+    register_native_tool("read_tool_output", read_tool_output_tool_definition());
+}
+```
+
+In `hook/persistence.rs`, add the interception branch.
+
+- [ ] **Step 5: Run integration tests**
+
+```bash
+cargo test -p defra-agent --test r4c_read_tool_output
+```
+
+Expected: all five tests PASS.
+
+- [ ] **Step 6: Run conformance witness w4**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_read_tool_output_dispatch
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/src/hook/persistence.rs \
+       crates/defra-agent/src/tool_surface/selection.rs \
+       crates/defra-agent/tests/r4c_read_tool_output.rs
+git commit -m "$(cat <<'EOF'
+Implement read_tool_output agent-facing tool
+
+Snapshot of stdout/stderr for a backgrounded tool. Dispatches by row
+state: ring buffer for running, persisted <tool-completion> payload for
+terminal. Per-stream byte cap (16 KB default, 256 KB hard cap).
+total_bytes_seen monotonic counter. UTF-8 safe tail trim.
+
+Resolves r4c.read_tool_output.dispatch_by_state witness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 9: Implement `steer_subagent` (`interrupt=false` Mode)
+
+**Purpose:** Append the steering message to the child session as a queued `AgentRequest` with `QueueSource.steering, QueuePolicy.append`. Plus the durable `user`-role `AgentMessage` in child history.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/src/hook/persistence.rs`
+- Modify: `crates/defra-agent/src/tool_surface/selection.rs`
+- Create: `crates/defra-agent/tests/r4c_steer_subagent.rs`
+
+**Steps:**
+
+- [ ] **Step 1: Write integration tests for append mode (failing)**
+
+Create the test file:
+
+```rust
+mod support;
+
+use defra_agent::test_support::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn steer_subagent_append_enqueues_with_steering_source() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+
+    let result = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "also check the staging config",
+        "interrupt": false,
+    })).await.expect("ok");
+
+    let queued_id = result["queued_request_id"].as_str().unwrap();
+    assert!(result["interrupted_active_request_id"].is_null());
+    assert!(result["drained_wake_up_request_ids"].as_array().unwrap().is_empty());
+
+    let queued = ctx.fetch_request(queued_id).await;
+    assert_eq!(queued.session_id, child.session_id);
+    assert_eq!(queued.behavior_id, child.behavior_id);
+    assert_eq!(queued.subagent_depth, child.subagent_depth);
+    assert_eq!(queued.caused_by_parent_request_id.as_deref(), Some(parent.request_id.as_str()));
+    assert!(queued.caused_by_parent_tool_call_id.is_none());
+    assert_eq!(queued.metadata["queue"]["source"].as_str(), Some("steering"));
+    assert_eq!(queued.metadata["queue"]["policy"].as_str(), Some("append"));
+    assert_eq!(queued.status, "pending");
+}
+
+#[tokio::test]
+async fn steer_subagent_append_writes_user_message() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+
+    let _ = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "also check the staging config",
+    })).await.expect("ok");
+
+    let messages = ctx.fetch_messages(&child.session_id).await;
+    let last_user = messages.iter().rev().find(|m| m.role == "user")
+        .expect("user message appended");
+    assert!(last_user.content.contains("also check the staging config"));
+}
+
+#[tokio::test]
+async fn steer_subagent_rejects_terminal_child() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    ctx.terminalize_child(&child, "completed", "result").await;
+
+    let result = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "do more",
+    })).await.expect("ok");
+    assert_eq!(result["ok"].as_bool().unwrap(), false);
+    assert_eq!(result["failure_class"].as_str().unwrap(), "argument_invalid");
+}
+
+#[tokio::test]
+async fn steer_subagent_rejects_unauthorized() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let p1 = ctx.spawn_parent_request("p1", "go").await;
+    let p2 = ctx.spawn_parent_request("p2", "go").await;
+    let child = ctx.spawn_subagent(&p2, "amy-code", "do X", "background").await;
+
+    let result = ctx.call_tool(&p1, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "hi",
+    })).await.expect("ok");
+    assert_eq!(result["ok"].as_bool().unwrap(), false);
+    assert_eq!(result["failure_class"].as_str().unwrap(), "tool_not_allowed");
+}
+
+#[tokio::test]
+async fn steer_subagent_no_parent_tool_call_row_written() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    let _ = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "x",
+    })).await.expect("ok");
+    let tool_calls = ctx.fetch_tool_calls(&parent).await;
+    assert!(!tool_calls.iter().any(|r| r.tool_name == "steer_subagent"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p defra-agent --test r4c_steer_subagent
+```
+
+Expected: compile error / tool not registered.
+
+- [ ] **Step 3: Implement the append handler**
+
+```rust
+use crate::background_tools::r4c_args::{SteerSubagentArgs, SteerSubagentResponse};
+use crate::lifecycle::queue::{QueueHints, QueuePolicy, QueueSource};
+
+pub(crate) async fn handle_steer_subagent(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    args: SteerSubagentArgs,
+) -> Result<SteerSubagentResponse> {
+    // 1. Authorize: child owned by caller.
+    let child = fetch_child_subagent_row(node, caller_request_id, &args.child_request_id).await?
+        .ok_or_else(|| structured_tool_not_allowed_error(
+            "steer_subagent", "/child_request_id",
+            "child not owned by this parent request",
+        ))?;
+
+    // 2. Reject terminal child.
+    if is_terminal_status(&child.status) {
+        return Err(structured_argument_invalid_error(
+            "steer_subagent", "/child_request_id",
+            &format!("child is in terminal state '{}'; spawn a new subagent instead", child.status),
+        ));
+    }
+
+    // 3. Reject foreground child.
+    if child.await_mode != "background" {
+        return Err(structured_tool_not_allowed_error(
+            "steer_subagent", "/child_request_id",
+            "foreground subagents cannot be steered; call cancel_subagent first",
+        ));
+    }
+
+    let (interrupted_id, drained_ids) = if args.interrupt {
+        // Task 10 fills this in. For Task 9 (interrupt=false only), return None/empty.
+        return Err(anyhow!("interrupt=true not yet implemented; landing in R4c Task 10"));
+    } else {
+        (None::<String>, Vec::<String>::new())
+    };
+
+    // 4. Append durable user-role message to child session transcript.
+    let message_id = append_user_message_to_session(node, &child.session_id, &args.message).await?;
+
+    // 5. Compose new AgentRequest in child session.
+    let queued_request_id = generate_request_id();
+    create_steering_request(
+        node,
+        &child.session_id,
+        &child.behavior_id,
+        child.subagent_depth,
+        caller_request_id,
+        &queued_request_id,
+        &args.message,
+        QueueHints {
+            source: QueueSource::Steering,
+            policy: QueuePolicy::Append,
+            key: None,
+            queued_after_request_id: None,
+        },
+        interrupted_id.clone(),
+    ).await?;
+
+    Ok(SteerSubagentResponse {
+        child_request_id: args.child_request_id,
+        child_session_id: child.session_id,
+        queued_request_id,
+        interrupted_active_request_id: interrupted_id,
+        drained_wake_up_request_ids: drained_ids,
+    })
+}
+
+fn is_terminal_status(s: &str) -> bool {
+    matches!(s, "completed" | "failed" | "dead" | "interrupted" | "superseded")
+}
+```
+
+The helper functions `append_user_message_to_session`, `create_steering_request`, and `QueueSource::Steering` already exist or have R4a-equivalent surface — wire to whatever the codebase exposes today. The `QueueSource::Steering` enum variant is already in the Lean model (`Proofs/Session/State.lean`) and likely already in Rust via R4a; if not, add it as a one-line enum addition.
+
+- [ ] **Step 4: Register and intercept**
+
+In `tool_surface/selection.rs`:
+
+```rust
+if !selection.subagent_targets.is_empty()
+    && selection.subagent_steering_enabled
+    && selection.subagent_background_enabled
+{
+    register_native_tool("steer_subagent", steer_subagent_tool_definition());
+}
+```
+
+In `hook/persistence.rs`, add the interception branch.
+
+- [ ] **Step 5: Run append tests**
+
+```bash
+cargo test -p defra-agent --test r4c_steer_subagent steer_subagent_append
+cargo test -p defra-agent --test r4c_steer_subagent steer_subagent_rejects
+cargo test -p defra-agent --test r4c_steer_subagent steer_subagent_no_parent
+```
+
+Expected: PASS for all append-mode tests.
+
+- [ ] **Step 6: Run conformance witness w5**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_steer_subagent_append
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/src/hook/persistence.rs \
+       crates/defra-agent/src/tool_surface/selection.rs \
+       crates/defra-agent/tests/r4c_steer_subagent.rs \
+       crates/defra-agent/src/lifecycle/queue.rs  # if Steering source added
+git commit -m "$(cat <<'EOF'
+Implement steer_subagent append mode (interrupt=false)
+
+Authorizes through parent-child edge; rejects terminal/foreground
+children. Appends a durable user-role AgentMessage to child session;
+enqueues a new AgentRequest with QueueSource.steering and
+QueuePolicy.append, preserving lineage and depth. Hook-intercepted; no
+parent-side AgentToolCall row.
+
+interrupt=true mode lands in the next task.
+
+Resolves r4c.steer_subagent.append_preserves_lineage witness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 10: Add `interrupt=true` Mode To `steer_subagent`
+
+**Purpose:** Compose existing primitives — `interrupt` transition + `bridge_cancel_cascade` + `pendingAfterDrain` + steering append — to interrupt the child's active request and queue the steering message as replacement.
+
+**Files:**
+
+- Modify: `crates/defra-agent/src/background_tools.rs`
+- Modify: `crates/defra-agent/tests/r4c_steer_subagent.rs` (add the interrupt-mode tests)
+
+**Steps:**
+
+- [ ] **Step 1: Add the interrupt-mode integration tests**
+
+Append to `r4c_steer_subagent.rs`:
+
+```rust
+#[tokio::test]
+async fn steer_subagent_interrupt_cancels_active_child_request() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    let active = ctx.start_child_request(&child).await; // child claims its first request
+
+    let result = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "stop, do this instead",
+        "interrupt": true,
+    })).await.expect("ok");
+
+    assert_eq!(
+        result["interrupted_active_request_id"].as_str().unwrap(),
+        active.request_id.as_str(),
+    );
+    let queued_id = result["queued_request_id"].as_str().unwrap();
+
+    let interrupted = ctx.fetch_request(&active.request_id).await;
+    assert_eq!(interrupted.status, "interrupted");
+
+    let queued = ctx.fetch_request(queued_id).await;
+    assert_eq!(queued.metadata["queue"]["source"].as_str(), Some("steering"));
+    assert_eq!(
+        queued.metadata["queue"]["interrupted_request_id"].as_str().unwrap(),
+        active.request_id.as_str(),
+    );
+}
+
+#[tokio::test]
+async fn steer_subagent_interrupt_drains_automated_wakeups() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    let _active = ctx.start_child_request(&child).await;
+    let grandchild = ctx.spawn_subagent_inside(&child, "amy-code", "deep", "background").await;
+    ctx.terminalize_child(&grandchild, "completed", "g done").await;
+    // The grandchild terminal projects a coalesced wake-up into the child session.
+
+    let result = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "redirect",
+        "interrupt": true,
+    })).await.expect("ok");
+
+    let drained = result["drained_wake_up_request_ids"].as_array().unwrap();
+    assert!(!drained.is_empty(), "expected at least one drained wake-up");
+}
+
+#[tokio::test]
+async fn steer_subagent_interrupt_cascades_to_grandchild_tools() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "go").await;
+    let child = ctx.spawn_subagent(&parent, "amy-code", "do X", "background").await;
+    let _active = ctx.start_child_request(&child).await;
+    let gh_bash = ctx.background_tool_inside(&child, "bash", json!({"cmd": "sleep 30"})).await;
+
+    let _ = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": child.request_id,
+        "message": "redirect",
+        "interrupt": true,
+    })).await.expect("ok");
+
+    let bash_row = ctx.fetch_tool_call(&gh_bash.tool_call_id).await;
+    assert_eq!(bash_row.state, "cancelled");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test -p defra-agent --test r4c_steer_subagent steer_subagent_interrupt
+```
+
+Expected: tests FAIL (Task 9's handler returns the "not yet implemented" error).
+
+- [ ] **Step 3: Replace the placeholder branch in `handle_steer_subagent`**
+
+Replace:
+
+```rust
+let (interrupted_id, drained_ids) = if args.interrupt {
+    return Err(anyhow!("interrupt=true not yet implemented; landing in R4c Task 10"));
+} else {
+    (None::<String>, Vec::<String>::new())
+};
+```
+
+With:
+
+```rust
+let (interrupted_id, drained_ids) = if args.interrupt {
+    // Find the child's active request, if any.
+    let active = fetch_active_request_in_session(node, &child.session_id).await?;
+    let interrupted = if let Some(a) = active {
+        // Fire request interrupt (existing transition).
+        interrupt_request(node, &a.request_id).await?;
+        // Cascade through live tool/subagent edges (existing parametric path).
+        cascade_cancel_request_descendants(node, &a.request_id).await?;
+        Some(a.request_id)
+    } else {
+        None
+    };
+
+    // Drain pending automated wake-ups for child session.
+    let queue_key = format!("background_completion:{}", child.session_id);
+    let drained = drain_automated_wakeups(
+        node,
+        &child.session_id,
+        QueueSource::SubagentCompletion, // back-compat alias of BackgroundCompletion per R6
+        Some(&queue_key),
+    ).await?;
+
+    (interrupted, drained)
+} else {
+    (None::<String>, Vec::<String>::new())
+};
+```
+
+Then, when constructing `QueueHints` for the steering request, set the `metadata.queue.interrupted_request_id` field if `interrupted_id` is `Some`. This means extending `QueueHints` with an optional field or writing the metadata directly. The cleanest path: extend `QueueHints` once and pass `interrupted_request_id: interrupted_id.clone()` into it.
+
+The helpers `interrupt_request`, `cascade_cancel_request_descendants`, `fetch_active_request_in_session`, `drain_automated_wakeups` already exist or have direct R4/R6 surface equivalents. Wire to whatever the codebase exposes; if any is missing, add it as a thin adapter over the existing transition path, do not invent a new transition.
+
+- [ ] **Step 4: Run interrupt-mode tests**
+
+```bash
+cargo test -p defra-agent --test r4c_steer_subagent steer_subagent_interrupt
+```
+
+Expected: all three interrupt-mode tests PASS.
+
+- [ ] **Step 5: Re-run all r4c_steer_subagent tests**
+
+```bash
+cargo test -p defra-agent --test r4c_steer_subagent
+```
+
+Expected: all eight tests (5 from Task 9 + 3 from Task 10) PASS.
+
+- [ ] **Step 6: Run conformance witness w6**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_steer_subagent_interrupt_composes
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run Lean to confirm the Task 1 theorem still holds**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+```
+
+Expected: PASS. The composition the theorem covers is now exercised by the Rust path.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/src/background_tools.rs \
+       crates/defra-agent/tests/r4c_steer_subagent.rs \
+       crates/defra-agent/src/lifecycle/queue.rs  # if QueueHints extended
+git commit -m "$(cat <<'EOF'
+Add steer_subagent interrupt mode (interrupt=true)
+
+Composes existing primitives: interrupt request transition,
+bridge_cancel_cascade over the interrupted request's live edges,
+pendingAfterDrain for child-session automated wake-ups, then
+appendPending with QueueSource.steering. Zero new transitions; B5
+preservation already verified by Task 1's
+steer_subagent_interrupt_preserves_link_symmetry theorem.
+
+Resolves r4c.steer_subagent.interrupt_composes witness.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 11: End-To-End R4c Integration Coverage
+
+**Purpose:** Cover the integrated path across all five tools, registration gates, lineage scoping, and the conformance witness round-trip.
+
+**Files:**
+
+- Modify: `crates/defra-agent/tests/r4c_list_subagents.rs`
+- Modify: `crates/defra-agent/tests/r4c_list_background_tools.rs`
+- Modify: `crates/defra-agent/tests/r4c_read_subagent_transcript.rs`
+- Modify: `crates/defra-agent/tests/r4c_read_tool_output.rs`
+- Modify: `crates/defra-agent/tests/r4c_steer_subagent.rs`
+- Modify: `crates/defra-agent/tests/support/mod.rs`
+
+**Scenarios to add (extend existing test files; do not create new ones):**
+
+- [ ] **Registration matrix in a new test under any existing file (place in `r4c_list_subagents.rs`):**
+
+```rust
+#[tokio::test]
+async fn registration_matrix_subagent_family() {
+    use defra_agent::test_support::*;
+
+    let ctx_empty = TestContext::start_with_selection(json!({
+        "subagent_targets": [],
+        "subagent_spawn_enabled": false,
+        "subagent_steering_enabled": false,
+        "subagent_background_enabled": false,
+        "backgroundable_tool_names": [],
+    })).await;
+    assert!(!ctx_empty.tool_registered("list_subagents"));
+    assert!(!ctx_empty.tool_registered("read_subagent_transcript"));
+    assert!(!ctx_empty.tool_registered("steer_subagent"));
+
+    let ctx_targets = TestContext::start_with_selection(json!({
+        "subagent_targets": ["amy-code"],
+        "subagent_spawn_enabled": true,
+        "subagent_steering_enabled": false,
+        "subagent_background_enabled": false,
+        "backgroundable_tool_names": [],
+    })).await;
+    assert!(ctx_targets.tool_registered("list_subagents"));
+    assert!(!ctx_targets.tool_registered("read_subagent_transcript"));
+    assert!(!ctx_targets.tool_registered("steer_subagent"));
+
+    let ctx_steering = TestContext::start_with_selection(json!({
+        "subagent_targets": ["amy-code"],
+        "subagent_spawn_enabled": true,
+        "subagent_steering_enabled": true,
+        "subagent_background_enabled": true,
+        "backgroundable_tool_names": [],
+    })).await;
+    assert!(ctx_steering.tool_registered("list_subagents"));
+    assert!(ctx_steering.tool_registered("read_subagent_transcript"));
+    assert!(ctx_steering.tool_registered("steer_subagent"));
+}
+
+#[tokio::test]
+async fn registration_matrix_tool_family() {
+    use defra_agent::test_support::*;
+
+    let ctx_empty = TestContext::start_with_selection(json!({
+        "subagent_targets": [],
+        "backgroundable_tool_names": [],
+    })).await;
+    assert!(!ctx_empty.tool_registered("list_background_tools"));
+    assert!(!ctx_empty.tool_registered("read_tool_output"));
+
+    let ctx_bg = TestContext::start_with_selection(json!({
+        "subagent_targets": [],
+        "backgroundable_tool_names": ["bash"],
+    })).await;
+    assert!(ctx_bg.tool_registered("list_background_tools"));
+    assert!(ctx_bg.tool_registered("read_tool_output"));
+}
+```
+
+- [ ] **End-to-end scenario in `r4c_steer_subagent.rs`:**
+
+```rust
+#[tokio::test]
+async fn end_to_end_supervise_then_steer() {
+    let ctx = TestContext::start_with_default_behavior().await;
+    let parent = ctx.spawn_parent_request("p", "supervise a worker").await;
+    let worker = ctx.spawn_subagent(&parent, "amy-code", "long-running task", "background").await;
+    let _ = ctx.background_tool_inside(&worker, "bash", json!({"cmd": "sleep 30"})).await;
+
+    // 1. Parent lists; sees the worker.
+    let list = ctx.call_tool(&parent, "list_subagents", json!({})).await.expect("ok");
+    let entries = list["entries"].as_array().unwrap();
+    assert_eq!(entries.len(), 1);
+
+    // 2. Parent reads transcript; gets compact text.
+    ctx.append_assistant_message(&worker.session_id, "I'm working on it").await;
+    let transcript = ctx.call_tool(&parent, "read_subagent_transcript", json!({
+        "child_request_id": worker.request_id,
+    })).await.expect("ok");
+    assert!(transcript["transcript"].as_str().unwrap().contains("working on it"));
+
+    // 3. Parent steers; new request enqueued.
+    let steer = ctx.call_tool(&parent, "steer_subagent", json!({
+        "child_request_id": worker.request_id,
+        "message": "actually focus on Y first",
+    })).await.expect("ok");
+    let queued_id = steer["queued_request_id"].as_str().unwrap();
+
+    // 4. Parent re-lists; sees worker still running and the new pending request as part of lineage.
+    let list2 = ctx.call_tool(&parent, "list_subagents", json!({"status": "all"})).await
+        .expect("ok");
+    let ids: Vec<&str> = list2["entries"].as_array().unwrap().iter()
+        .map(|e| e["child_request_id"].as_str().unwrap()).collect();
+    assert!(ids.contains(&worker.request_id.as_str()));
+    assert!(ids.contains(&queued_id)); // steering request is also a child of parent
+}
+```
+
+- [ ] **Run all R4c integration tests**
+
+```bash
+cargo test -p defra-agent --test r4c_list_subagents
+cargo test -p defra-agent --test r4c_list_background_tools
+cargo test -p defra-agent --test r4c_read_subagent_transcript
+cargo test -p defra-agent --test r4c_read_tool_output
+cargo test -p defra-agent --test r4c_steer_subagent
+```
+
+Expected: all green.
+
+- [ ] **Run all conformance witness tests**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance r4c_
+```
+
+Expected: six witness tests PASS.
+
+- [ ] **Commit**
+
+```bash
+cargo fmt --all
+git add crates/defra-agent/tests/r4c_*.rs \
+       crates/defra-agent/tests/support/mod.rs
+git commit -m "$(cat <<'EOF'
+Add end-to-end R4c coverage: registration matrix and supervise-and-steer
+
+Verifies the five-tool registration matrix per the spec's gate rules,
+and an end-to-end supervise-then-steer scenario that exercises list,
+read, and steer in one parent session.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## R4c Task 12: Final Polish And Full CI
+
+**Purpose:** Run broad verification, sanity-check that no out-of-scope surface accidentally landed, update docs if code drifted from the approved design.
+
+**Files:**
+
+- Modify only if needed:
+  - `docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md`
+  - `docs/superpowers/plans/2026-05-14-r4c-background-work-management.md`
+  - `crates/defra-agent/proofs/README.md`
+  - `CLAUDE.md` (if the architecture summary needs an R4c mention)
+
+**Steps:**
+
+- [ ] **Step 1: Format and diff check**
+
+```bash
+cargo fmt --all
+git diff --check
+```
+
+Expected: no whitespace errors.
+
+- [ ] **Step 2: Run Lean**
+
+```bash
+cd crates/defra-agent/proofs && lake build
+cd crates/defra-agent/proofs && lake build Proofs.Conformance.Contracts
+cd crates/defra-agent/proofs && lake env lean --run Proofs/Conformance/Contracts.lean >/tmp/r4c-final-contract.json
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Broader CI**
+
+```bash
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+cargo test -p defra-agent --lib --tests
+cargo test -p defra-agent-cli
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Sanity-check no accidental out-of-scope surface landed**
+
+```bash
+rg -n "list_background_work|read_background_transcript|since_byte|replace_subagent" crates/defra-agent/src crates/defra-agent/tests
+```
+
+Expected: no live tool registrations, no since_byte protocol, no replace_subagent verb. Only doc references in the spec/plan files (which discuss them as out-of-scope) are acceptable.
+
+```bash
+rg -n "deployment_id" crates/defra-agent/src
+```
+
+Expected: present in `r4c_args.rs` envelopes; populated with the local deployment id in the list handlers; no cross-deployment routing.
+
+- [ ] **Step 5: Sanity-check no accidental subagent-named ghosts**
+
+```bash
+rg -n "subagent_completion\.rs|subagent_tools\.rs|Proofs\.Subagent" crates/defra-agent
+```
+
+Expected: zero hits in code (only in older doc files, which are immutable references).
+
+- [ ] **Step 6: Verify ledger coverage**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Update `CLAUDE.md` architecture summary if needed**
+
+If the State Machines or Document-Driven Control Plane sections summarize the bridge model, add a one-line mention of R4c management tools as glue over the existing model. Do not add a section about R4c itself; the spec and plan files are the canonical reference.
+
+- [ ] **Step 8: Final commit**
+
+```bash
+git add docs/ CLAUDE.md crates/defra-agent/proofs/README.md
+git commit -m "$(cat <<'EOF'
+Polish R4c background work management implementation
+
+Final CI, no out-of-scope surface, ledger coverage confirmed.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+If no documentation changes were needed, skip the commit; there is no value in an empty polish commit.

--- a/docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md
+++ b/docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md
@@ -1,0 +1,755 @@
+# R4c Agent-Facing Background Work Management Tools Design
+
+Status: draft for Jack approval, revision 1
+Date: 2026-05-14
+Tracking: TBD (suggested title: "R4c: agent-facing background work management")
+Refs: R4 (#177), R6 (this branch), #191, #189, #190, #184, #160
+
+Depends on:
+
+- `docs/superpowers/specs/2026-05-12-r4-agent-facing-tools-design.md` (R4 spawn/wait/cancel surface and the originally-deferred R4c sketches)
+- `docs/superpowers/specs/2026-05-14-tool-backgrounding-design.md` (R6 parametric `BackgroundedKind`, rename of `Proofs/Subagent/` → `Proofs/Background/`, `<tool-completion>` transcript element)
+- `docs/superpowers/plans/2026-05-14-tool-backgrounding.md` (R6 implementation plan, including the Task 0 rename)
+
+## Goal
+
+R4c adds five agent-facing tools that let a parent agent observe and steer the
+background work it spawned. The five tools split per `BackgroundedKind`:
+
+- **Subagent kind:** `list_subagents`, `read_subagent_transcript`, `steer_subagent`
+- **Tool kind:** `list_background_tools`, `read_tool_output`
+
+There is no unified `list_background_work` / `read_background_transcript`. The
+envelopes differ per kind, the LLM gets typed tool names, and we don't pay for
+a `kind` discriminator field.
+
+R4c was originally deferred by R4 with "first-90-days won't need them." Jack
+has now reversed that. The design is sized as small as honestly possible:
+these are management tools, not new state machines.
+
+## Strategic Claim
+
+R4c adds **zero new Lean transitions** and **possibly zero new theorems**.
+Every primitive R4c uses already exists in the verified model:
+
+- the parent-child edge for authorization (R4)
+- `Proofs/Background/*` bridge rows for listing (R6 parametric `BridgedState`)
+- `Proofs/Transcript/*` rows for transcript rendering (#191)
+- `Proofs/Session/*` queue (`QueueSource.steering` variant already present) for
+  steering append semantics (R4a)
+- `interrupt` (in `Proofs/Request/Transition.lean`) +
+  `bridge_cancel_cascade` (R6 parametric) + `pendingAfterDrain` for
+  `steer_subagent(interrupt=true)`
+
+R4c is glue plus rendering. The Lean obligation is composition correctness,
+not new modules. Conformance witnesses (Section "Verified Obligations") cover
+the six observable shapes Rust must not drift on.
+
+## Scope And Sequencing
+
+R4c sequences after R6 merges to main. Concretely:
+
+1. **R6 prerequisite (kickoff gate):** R6 merged to main. R6 Task 0's rename
+   (`Proofs/Subagent/` → `Proofs/Background/`, `subagent_completion.rs` →
+   `background_completion.rs`, `subagent_tools.rs` → `background_tools.rs`)
+   must be on `main` before R4c implementation begins. R4c imports
+   `Proofs.Background.*` and edits `background_tools.rs`.
+2. **Rebase on merge:** when R6 merges, R4c rebases. Conflicts expected in
+   `background_tools.rs` (R4c adds five new tool entries to a file R6 will
+   have substantively touched), `hook.rs` and `hook/persistence.rs`
+   (interceptor wiring), and `tool_surface/selection.rs` (registration gates).
+3. **R5 sibling:** R5 brainstorms cross-deployment in parallel. R4c and R5
+   share no file surface. If R5 lands an `R5/Cross/` proof module that lists
+   remote work, R4c's v2 cross-deployment lift folds it in as a pure additive
+   change to the same five tool envelopes.
+4. **PR shape:** R4c is one PR with substantive commits per task. No "pure
+   rename" no-op commit (R6 owns that).
+
+### What R4c reuses (unchanged)
+
+- The parametric bridge transitions (R6 — `Proofs/Background/*`).
+- The session queue / coalesced wake-up infrastructure (R4a).
+- The transcript model and dedupe (#191).
+- The R4 hook-intercepted no-`AgentToolCall`-row pattern (carried forward
+  from `wait_subagent` / `cancel_subagent`).
+- Authorization via the parent-child edge (R4 + R6).
+
+### What R4c adds (new surface only)
+
+- Five new tool definitions in `background_tools.rs`.
+- A pure-function transcript renderer in `background_tools/transcript_render.rs`.
+- Hook interceptor entries for the five new tools.
+- Conformance witnesses in `Proofs/Conformance/Contracts.lean` (no new Lean
+  modules — additions to the existing contract surface).
+- Registration gate wiring against existing `ToolSelectionDocument` fields.
+
+## Tool Surface
+
+All five tools register as native Rig tools and are hook-intercepted before
+ordinary `AgentToolCall` persistence. None of the five writes a parent-side
+tool-call row.
+
+### Registration gates
+
+- `list_subagents`: registers when behavior has at least one
+  `subagent_targets` entry. (Discovery surface for spawn; same gate as
+  `spawn_subagent`.)
+- `read_subagent_transcript`: requires `subagent_targets` non-empty AND
+  `subagent_steering_enabled = true`.
+- `steer_subagent`: requires `subagent_targets` non-empty AND
+  `subagent_steering_enabled = true`. Additionally requires
+  `subagent_background_enabled = true` because steering is only meaningful
+  for backgrounded children.
+- `list_background_tools`: registers when behavior's
+  `backgroundable_tool_names` is non-empty. (Discovery surface for
+  `background_tool`; same gate as R6's three tool-kind tools.)
+- `read_tool_output`: same gate as `list_background_tools`. R6 noted this
+  tool would land bundled with R4c.
+
+### `list_subagents`
+
+Arguments:
+
+```json
+{
+  "status": "running",
+  "limit": 20
+}
+```
+
+Defaults: `status = "running"`, `limit = 20`. `status` accepts
+`"running" | "terminal" | "all"`. `limit` hard cap is 50.
+
+Returns an array of compact entries reachable from **this parent request's**
+authorized subagent edges:
+
+```json
+{
+  "read_at": "2026-05-14T17:30:00Z",
+  "truncated": false,
+  "entries": [
+    {
+      "child_request_id": "...",
+      "child_session_id": "...",
+      "behavior_id": "...",
+      "deployment_id": "...",
+      "await_mode": "background",
+      "status": "running",
+      "created_at": "...",
+      "last_update": "...",
+      "depth": 1
+    }
+  ]
+}
+```
+
+`status` values match the R2 `ChildTerminal` vocabulary plus `"running"`:
+`"running" | "completed" | "failed" | "dead" | "interrupted" | "superseded"`.
+
+`deployment_id` carries the local deployment in v1. The field is reserved so
+the v2 cross-deployment lift is additive.
+
+### `list_background_tools`
+
+Arguments:
+
+```json
+{
+  "status": "running",
+  "limit": 20
+}
+```
+
+Same defaults and caps as `list_subagents`.
+
+Returns:
+
+```json
+{
+  "read_at": "...",
+  "truncated": false,
+  "entries": [
+    {
+      "tool_call_id": "...",
+      "tool_name": "bash",
+      "deployment_id": "...",
+      "await_mode": "background",
+      "status": "running",
+      "created_at": "...",
+      "last_update": "...",
+      "stdout_bytes": 12345,
+      "stderr_bytes": 678
+    }
+  ]
+}
+```
+
+`status` values: `"running" | "completed" | "failed" | "cancelled" | "interrupted"`.
+
+`stdout_bytes` / `stderr_bytes` are the ring buffer's current occupancy for
+running rows and the persisted captured payload size for terminal rows.
+
+### `read_subagent_transcript`
+
+Arguments:
+
+```json
+{
+  "child_request_id": "...",
+  "since_sequence": 0,
+  "limit": 20,
+  "max_chars": 6000,
+  "include_user_messages": false,
+  "include_tool_results": false
+}
+```
+
+Defaults: `since_sequence = 0`, `limit = 20`, `max_chars = 6000`,
+`include_user_messages = false`, `include_tool_results = false`.
+
+Hard caps: `limit ≤ 100`, `max_chars ≤ 24000`, per-tool-result body snippet
+≤ 256 bytes (the rendered snippet, not the underlying row).
+
+Returns:
+
+```json
+{
+  "child_request_id": "...",
+  "child_session_id": "...",
+  "from_sequence": 1,
+  "through_sequence": 12,
+  "next_sequence": 13,
+  "truncated": false,
+  "transcript": "[assistant seq=1]\n...\n[assistant seq=4]\n..."
+}
+```
+
+`next_sequence = last_included_sequence + 1` so a follow-up call with
+`since_sequence = next_sequence` is correct.
+
+`truncated = true` iff rendering stopped before consuming all matching rows
+because `limit` or `max_chars` was hit.
+
+Render rules (Section "`read_subagent_transcript` Render Rules") detail what
+goes into the `transcript` blob.
+
+### `read_tool_output`
+
+Arguments:
+
+```json
+{
+  "tool_call_id": "...",
+  "max_bytes_per_stream": 16384
+}
+```
+
+Defaults: `max_bytes_per_stream = 16384`. Hard cap: 262144 (256 KB).
+
+Returns:
+
+```json
+{
+  "tool_call_id": "...",
+  "tool_name": "bash",
+  "status": "running",
+  "stdout": {
+    "bytes": "...",
+    "truncated": false,
+    "total_bytes_seen": 12345
+  },
+  "stderr": {
+    "bytes": "...",
+    "truncated": false,
+    "total_bytes_seen": 678
+  },
+  "exit_code": null
+}
+```
+
+`exit_code` is `null` when `status = "running"`; otherwise the captured exit
+code for tools that produce one (bash) or `null` for tools that don't (MCP).
+
+Source dispatch by row state:
+
+- **Running:** in-memory ring buffer maintained by R6 (256 KB per stream, see
+  R6 §"Streaming Output Behavior").
+- **Terminal:** the persisted `<tool-completion>` payload R6 writes on bridge
+  projection.
+
+Caller-facing semantics are identical regardless of state.
+
+`stdout.bytes` is the **tail** of the available buffer — the most recent
+`max_bytes_per_stream` bytes. Best-effort UTF-8 cleaning trims partial
+multibyte sequences at the head/tail. Binary streams may have non-printable
+characters in the cleaned tail.
+
+`truncated = true` iff older bytes were dropped (running: ring buffer
+overflowed; terminal: R6's terminal envelope already had `truncated = true`).
+
+`total_bytes_seen` is monotonic: it counts every byte that has flowed
+through the stream, including bytes the ring buffer subsequently dropped.
+Use it to detect "still making progress".
+
+### `steer_subagent`
+
+Arguments:
+
+```json
+{
+  "child_request_id": "...",
+  "message": "...",
+  "interrupt": false
+}
+```
+
+Default: `interrupt = false`.
+
+Returns (success):
+
+```json
+{
+  "child_request_id": "...",
+  "child_session_id": "...",
+  "queued_request_id": "...",
+  "interrupted_active_request_id": null,
+  "drained_wake_up_request_ids": []
+}
+```
+
+`interrupted_active_request_id` is present (non-null) iff `interrupt = true`
+and there was an active child request to interrupt.
+
+`drained_wake_up_request_ids` is the list of automated wake-up `AgentRequest`
+ids terminalized as part of the `interrupt = true` drain.
+
+Two operating modes detailed in Section "`steer_subagent` Semantics" below.
+
+## Authorization
+
+Authorization is per-parent-request lineage for all five tools.
+
+### Operand lineage check
+
+- **Subagent operand (`child_request_id`):** must satisfy
+  `AgentRequest.caused_by_parent_request_id = caller.request_id`. R4's
+  spawn/wait/cancel already authorize through this; R4c reuses verbatim.
+- **Tool operand (`tool_call_id`):** must satisfy
+  `AgentToolCall.request_id = caller.request_id` AND
+  `await_mode = .background`. R6's `wait_tool`/`cancel_tool` already check
+  this; R4c reuses verbatim.
+
+No tool re-authorizes against `subagent_targets` or
+`backgroundable_tool_names` — the row's existence is the authorization
+witness. R6's pattern for the wait/cancel surface carries forward.
+
+### Listing scope
+
+`list_subagents` and `list_background_tools` scope to the caller's parent
+request lineage:
+
+- `list_subagents` returns rows with
+  `AgentRequest.caused_by_parent_request_id = caller.request_id`.
+- `list_background_tools` returns rows with
+  `AgentToolCall.request_id = caller.request_id` AND
+  `await_mode = .background`.
+
+A reissued parent request (same session, new `request_id`) does **not** see
+the prior request's children. This is the strictest least-privilege scope and
+matches the parent-child edge that R4 already authorizes through.
+
+The `status` filter (`"running" | "terminal" | "all"`) further selects within
+the lineage scope.
+
+### Failure shapes
+
+All five tools use the structured error envelope R4 established:
+
+```json
+{
+  "ok": false,
+  "failure_class": "tool_not_allowed",
+  "path": "/child_request_id",
+  "message": "child not owned by this parent request",
+  "retryable": false,
+  "service_id": "background_management",
+  "tool_name": "read_subagent_transcript"
+}
+```
+
+Persisted lifecycle failure class:
+
+- `FailureClass::ServiceUnavailable` for authorization failures
+  (consistent with R4 and R6).
+- `FailureClass::ArgumentInvalid` for malformed arguments and for
+  state-mismatch rejections.
+
+### Specific authorization failures
+
+- `child_request_id` not owned by caller → `tool_not_allowed`,
+  `"child not owned by this parent request"`.
+- `tool_call_id` not owned by caller → `tool_not_allowed`, same shape.
+- `tool_call_id` is not backgrounded (foreground row) →
+  `argument_invalid`, `"tool call is not backgrounded"`. An agent that calls
+  `read_tool_output` on an ordinary `read_file` row hits this.
+- `steer_subagent` called on terminal child → `argument_invalid`,
+  `"child is in terminal state '<x>'; spawn a new subagent instead"`.
+- `steer_subagent` called on foreground child → `tool_not_allowed`,
+  `"foreground subagents cannot be steered; call cancel_subagent first"`.
+  This closes the loophole if hooks reorder somehow; in practice the parent
+  is blocked inside `spawn_subagent`/`wait_subagent` and cannot call
+  `steer_subagent`.
+- `read_subagent_transcript` `since_sequence` exceeds child session's
+  current `max_sequence` → returns empty `transcript` with
+  `from_sequence = through_sequence = next_sequence = since_sequence`,
+  `truncated = false`. Not an error; the agent has caught up.
+
+### Recovery-time validation
+
+R4c tools are pure read/observe/steer surfaces. There is no row to
+terminalize at recovery — these tools don't write authorization-bound state.
+No recovery sweep changes.
+
+## `read_subagent_transcript` Render Rules
+
+The `transcript` field is a single text blob, never a structured array. Each
+rendered message is one line-prefixed block.
+
+### Default (assistant-only) shape
+
+```
+[assistant seq=4]
+I'll start by reading the config file to see the current backend.
+
+[assistant seq=7]
+The config has three backends. I'll bench all three.
+```
+
+Blocks are separated by a blank line.
+
+### `include_user_messages = true`
+
+User messages interleave with `[user seq=N]` prefix:
+
+```
+[user seq=6]
+make sure you also check the staging config
+
+[assistant seq=7]
+...
+```
+
+### `include_tool_results = true`
+
+Tool-result rows render as snippets capped at 256 bytes:
+
+```
+[tool-result seq=8 tool=bash]
+... up to 256 bytes of stdout/stderr summary ...
+```
+
+Tool-call XML envelopes from assistant messages are **never** rendered.
+Assistant messages that emitted tool calls render with a compact suffix:
+
+```
+[assistant seq=7 tool_calls=2]
+I'll check the config and then run the benchmark.
+```
+
+### Bridge call hiding
+
+Bridge `AgentToolCall` rows (Subagent kind and Tool kind both) are always
+hidden from this view. The parent doesn't need to see "child spawned
+subagent X" or "child backgrounded bash Y" in this transcript — it's the
+child's internal mechanism, and listing it would mislead the parent into
+trying to operate on rows it doesn't own. The bridge row renders as nothing.
+
+### Filtering pipeline
+
+Order of operations:
+
+1. Query `AgentMessage` rows where `session_id = child_session_id` AND
+   `sequence > since_sequence`, ordered by `sequence` ascending.
+2. Drop tool-call/tool-result message rows unless
+   `include_tool_results = true`.
+3. Drop `user`-role rows unless `include_user_messages = true`.
+4. Drop bridge call references (`AgentMessage` rows that name a bridge
+   `AgentToolCall`).
+5. Accumulate rendered blocks until the next block would exceed `limit`
+   messages OR `max_chars` total characters.
+6. Emit the envelope with `from_sequence` = first rendered row's sequence,
+   `through_sequence` = last rendered row's sequence,
+   `next_sequence = through_sequence + 1`,
+   `truncated = (rows_remaining > 0)`.
+
+Compaction (#184) running concurrently could reshape history between calls.
+The `next_sequence` cursor stays valid because compaction preserves sequence
+numbers.
+
+## `read_tool_output` Buffer Source
+
+Source dispatch by row state, restated for completeness:
+
+- **Running:** in-memory ring buffer keyed by `tool_call_id`, maintained by
+  R6's executor (R6 §"Streaming Output Behavior"). The buffer holds the most
+  recent 256 KB per stream; older bytes are dropped on overflow.
+- **Terminal:** the persisted `<tool-completion>` payload R6's projector
+  writes (R6 §"Streaming Output Behavior"). The payload carries the same
+  byte cap and `truncated` flag.
+
+The caller doesn't distinguish. R4c's hook reads from whichever source the
+row state selects.
+
+### Concurrency
+
+For running rows, R4c locks the ring buffer for the duration of the snapshot
+(already done by R6's buffer; R4c reuses the existing read lock). For
+terminal rows, the persisted payload is immutable.
+
+### Best-effort UTF-8
+
+The ring buffer is byte-oriented. On read, R4c trims partial multibyte
+sequences at the head and tail of the returned slice. A stream that is
+fundamentally binary produces a cleaned tail with non-printable bytes
+preserved within whole UTF-8 sequences only. This is the right tradeoff for
+the common case (bash producing text output); binary streams should not be
+backgrounded in practice.
+
+## `steer_subagent` Semantics
+
+Both modes compose existing primitives. Zero new Lean transitions.
+
+### `interrupt = false` (append)
+
+1. Resolve `child_request_id` through the parent-child edge (Section
+   "Authorization").
+2. Refuse if the child is in any terminal state (`argument_invalid`).
+3. Refuse if the child is foreground (`tool_not_allowed`).
+4. Append a user-role `AgentMessage` row to the child session transcript
+   with the steering `message` as its content. This makes the steering
+   message durable model-visible context, symmetric with how ordinary user
+   input lands in a session.
+5. Compose a new `AgentRequest` row in the child session:
+   - `session_id` = child session
+   - `behavior_id` = child behavior (preserved)
+   - `subagent_depth` = child's depth (preserved)
+   - `caused_by_parent_request_id` = caller's `request_id` (the steering
+     parent), preserving lineage
+   - `caused_by_parent_tool_call_id` = `null` (no bridge edge; this is a
+     session-queue append, not a spawn)
+   - `metadata.queue.source = "steering"`
+   - `metadata.queue.policy = "append"`
+   - prompt = the steering `message`
+6. Return the envelope with `queued_request_id` set to the new request id;
+   `interrupted_active_request_id` = `null`;
+   `drained_wake_up_request_ids` = `[]`.
+
+The child claims the steering request when its current active request
+terminalizes (per R4a queue semantics).
+
+### `interrupt = true` (replace)
+
+1. Resolve and refuse-if-terminal-or-foreground as above.
+2. Fire the existing **request interrupt** transition on the child's active
+   `AgentRequest`. This is the same `interrupt` transition that user-cancel
+   uses (`Proofs/Request/Transition.lean`).
+3. The interrupt cascades through any live tool/subagent edges on the
+   interrupted request via the existing R6-parametric
+   `bridge_cancel_cascade`. Same cascade vector as user-cancel of the
+   child's active request.
+4. Drain pending automated wake-ups in the child session: call
+   `pendingAfterDrain` with `source = .subagentCompletion` (post-R6 alias:
+   `.backgroundCompletion`) and `queueKey =
+   subagent_completion:<child_session_id>` (post-R6 alias:
+   `background_completion:<child_session_id>`). The drained wake-ups are
+   terminalized into the queue's `terminal` set per R4a; rows are not
+   deleted.
+5. Append a user-role `AgentMessage` to the child session transcript with
+   the steering `message` (same as step 4 of `interrupt = false`).
+6. Compose a new `AgentRequest` row in the child session (same fields as
+   step 5 of `interrupt = false`), plus one extra metadata field:
+   `metadata.queue.interrupted_request_id = <interrupted_active_request_id>`
+   for trace clarity.
+7. Return the envelope with `queued_request_id`,
+   `interrupted_active_request_id` set to the interrupted active request's
+   id, and `drained_wake_up_request_ids` set to the list of terminalized
+   wake-up ids.
+
+### Invariant preservation by reuse
+
+Because `interrupt = true` uses the existing `interrupt` transition, the
+existing `bridge_cancel_cascade`, the existing `pendingAfterDrain`, and an
+ordinary `AgentRequest` append, every B-theorem on `Proofs/Background/*`
+and every S-theorem on `Proofs/Request/*` carries through. The Lean
+obligation is composition correctness, not a new transition.
+
+The implementation plan may optionally add a derived property
+`steer_with_interrupt_preserves_link_symmetry` discharged from existing B5
+and the interrupt transition's invariants. Belt-and-suspenders; not strictly
+required.
+
+### Why no transcript element for the steering act
+
+The steering message IS the agent-visible signal — it's the user-role
+`AgentMessage` written in step 4/5. No `<steering-notification>` synthetic
+element is required. The parent has no agent-visible record of having
+steered (no parent-side `AgentToolCall` row by design); the audit trail is
+the child session's transcript plus the queue metadata
+(`metadata.queue.source = "steering"`).
+
+## Concurrency And Hook Integration
+
+### No parent-side tool-call rows
+
+All five R4c tools are hook-intercepted **before** ordinary tool-call
+persistence. None of them creates a parent-side `AgentToolCall` row.
+
+This carries forward R4's pattern for `wait_subagent` and `cancel_subagent`:
+management tools that operate on existing rows must not pollute the parent's
+own transcript with management-tool noise, and must not invent extra bridge
+edges. The Lean single-live-foreground invariant from R4 is preserved.
+
+### Snapshot semantics
+
+All five tools are point-in-time reads or one-shot writes. None blocks. None
+long-polls.
+
+- `list_subagents` / `list_background_tools`: single DB query. The response
+  carries `read_at: ISO8601`. A row that terminalizes between query and
+  response shows as its earlier status; the next call sees the update.
+- `read_subagent_transcript`: single DB query against `AgentMessage`.
+  Concurrent compaction is safe because the `next_sequence` cursor is stable
+  under sequence-preserving compaction (#184).
+- `read_tool_output`: ring buffer read for running rows (locked snapshot);
+  immutable persisted payload for terminal rows.
+- `steer_subagent`: one-shot write composing atomic existing transitions.
+
+### File ownership
+
+- `crates/defra-agent/src/background_tools.rs` (post-R6 rename): adds the
+  five new tool definitions and their hook interceptors. ~300-500 new LoC
+  over R4+R6 baseline.
+- `crates/defra-agent/src/background_completion.rs` (post-R6 rename):
+  unchanged. R4c does not extend the projector.
+- New file: `crates/defra-agent/src/background_tools/transcript_render.rs`
+  — pure-function transcript renderer (compact text from
+  `Transcript.MessageRow` list). Unit-testable in isolation.
+- `crates/defra-agent/src/hook.rs` and
+  `crates/defra-agent/src/hook/persistence.rs`: hook interceptor entries for
+  the five new tools.
+- `crates/defra-agent/src/tool_surface/selection.rs`: registration gate
+  wiring. `subagent_steering_enabled` flag governs
+  `read_subagent_transcript` and `steer_subagent`. `subagent_targets`
+  non-empty governs `list_subagents`. `backgroundable_tool_names` non-empty
+  governs `list_background_tools` and `read_tool_output`.
+
+## Verified Obligations
+
+R4c expects **zero new Lean modules** and **zero new Lean transitions**.
+
+### Possible derived property (deferred unless reviewer surfaces it)
+
+- `steer_subagent_interrupt_preserves_link_symmetry`: after the
+  `interrupt = true` composition (interrupt + cascade + drain + append),
+  every bridge row's `parent_request_id` still points at a request whose
+  `caused_by_parent_*` symmetry is intact. This is mechanically discharged
+  from existing B5 plus the existing `interrupt` transition's invariants.
+  Belt-and-suspenders; the implementation plan flags it for the
+  spec-compliance reviewer to confirm whether to ship.
+
+### Conformance witnesses (required)
+
+R4c emits Lean conformance witnesses for these scenarios so Rust tests
+detect drift:
+
+1. **`list_subagents` lineage scoping rejects a `child_request_id` from a
+   sibling parent request.** Two siblings of the same parent request P1 and
+   P2; P1's `list_subagents` does not return P2's children.
+2. **`read_subagent_transcript` `next_sequence` cursor advances correctly
+   across a paged call.** Two consecutive calls with the second's
+   `since_sequence` = first's `next_sequence` cover the full transcript
+   without overlap or gap.
+3. **`read_subagent_transcript` rejects bridge call rows from the rendered
+   output.** A child session containing a backgrounded tool call has the
+   bridge row hidden in the rendered transcript.
+4. **`read_tool_output` for a terminal row reads the persisted
+   `<tool-completion>` payload, not a stale buffer.** After bridge
+   projection, the in-memory buffer is gone; the read returns the persisted
+   payload.
+5. **`steer_subagent(interrupt=false)` appends with
+   `caused_by_parent_request_id = caller`.** The new child-session
+   `AgentRequest` preserves caller lineage.
+6. **`steer_subagent(interrupt=true)` interrupts the active child request,
+   drains automated wake-ups under the right queue key, and appends the
+   steering message.** All three effects observable in one composition.
+
+Witnesses register in `Proofs/Conformance/Contracts.lean` and Rust
+consumers parse them in `state_machine_conformance.rs`. No new Lean module
+is required.
+
+### Lean properties to re-verify
+
+After R4c, the following must remain green:
+
+- All R4 request-lifecycle theorems S1, S3, S4, S5, S6.
+- All R6-parametric bridge theorems B1, B2, B3, B4, B5, B6, B7.
+- The R4a session-queue invariants (created-ordered pending list, unique
+  coalesced queue keys).
+- L1 bounded termination, L3 recovery convergence.
+- #189 recovery enumeration coverage (unchanged by R4c).
+- #191 transcript pair atomicity (unchanged by R4c).
+
+R4c does not change any of these; it reuses them.
+
+## Out Of Scope
+
+Explicit non-goals; the implementation plan should not absorb them:
+
+- A unified `list_background_work` / `read_background_transcript`.
+  Explicitly chosen against in Section "Tool Surface".
+- A `read_tool_output` `since_byte` incremental protocol. Snapshot per call.
+- Foreground-steering surface (no tool to steer a foreground subagent; the
+  parent is blocked anyway).
+- Cross-deployment listing / reading / steering. v1 is local-only; the
+  envelopes carry `deployment_id` so v2 lift is additive. R5's domain.
+- A separate `replace_subagent` verb. We picked the boolean knob
+  (`interrupt = false | true`).
+- A new Lean transition for steering. Reuse-only.
+- Per-DID / per-behavior list scopes. R4c is per-parent-request only.
+- Operator/supervisor UI tools that show every behavior's live work. Future
+  surface, not LLM-facing.
+- Mid-execution tool steering (e.g., "send a SIGUSR1 to the running bash
+  and let it keep running"). There is no design for this; if it ever lands,
+  it's a separate tool.
+- Live transcript tail / long-poll variants. Snapshot posture is canonical.
+
+## Approval Checklist
+
+Before implementation planning, Jack should approve:
+
+- The five-tool surface, split per kind: `list_subagents`,
+  `list_background_tools`, `read_subagent_transcript`, `read_tool_output`,
+  `steer_subagent`.
+- Registration gates: `subagent_targets` non-empty for the subagent family,
+  `subagent_steering_enabled` for `read_subagent_transcript` and
+  `steer_subagent`, `subagent_background_enabled` additionally for
+  `steer_subagent`, `backgroundable_tool_names` non-empty for the tool
+  family.
+- Per-parent-request lineage scope for the two list tools.
+- `read_subagent_transcript` defaults: compact text, assistant-only,
+  `since_sequence` paged, hard caps 100 messages / 24000 chars / 256-byte
+  tool-result snippets; bridge call rows always hidden.
+- `read_tool_output` defaults: snapshot per call, tail of ring buffer for
+  running rows, persisted `<tool-completion>` payload for terminal rows;
+  per-stream cap 16 KB default / 256 KB hard cap; best-effort UTF-8 trim;
+  `total_bytes_seen` monotonic counter.
+- `steer_subagent` ships both modes in v1: `interrupt = false` (append)
+  and `interrupt = true` (interrupt + cascade + drain + append). Composes
+  existing primitives — zero new Lean transitions.
+- No parent-side `AgentToolCall` rows for any of the five tools.
+- Zero new Lean modules. Possibly zero new theorems. Six conformance
+  witnesses cover observable Rust shapes.
+- Cross-deployment deferred to v2 (R5's domain). `deployment_id` on
+  envelopes for additive v2 lift.
+- Sequencing: R4c executes after R6 merges to main; PR rebases on R6 merge;
+  no "pure rename" no-op commit in R4c (R6 owns that).

--- a/docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md
+++ b/docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md
@@ -29,8 +29,10 @@ these are management tools, not new state machines.
 
 ## Strategic Claim
 
-R4c adds **zero new Lean transitions** and **possibly zero new theorems**.
-Every primitive R4c uses already exists in the verified model:
+R4c adds **zero new Lean transitions** and **one new theorem** (B5
+preservation under the `steer_subagent(interrupt=true)` composition, see
+"Verified Obligations"). Every primitive R4c uses already exists in the
+verified model:
 
 - the parent-child edge for authorization (R4)
 - `Proofs/Background/*` bridge rows for listing (R6 parametric `BridgedState`)
@@ -290,6 +292,25 @@ overflowed; terminal: R6's terminal envelope already had `truncated = true`).
 `total_bytes_seen` is monotonic: it counts every byte that has flowed
 through the stream, including bytes the ring buffer subsequently dropped.
 Use it to detect "still making progress".
+
+### Tail-only snapshot limitation
+
+The snapshot posture has a real cost callers must understand: an agent
+polling `read_tool_output` every N seconds **will miss any line the tool
+emits that gets pushed out of the ring buffer between polls**. Concretely,
+if a bash subprocess produces 300 KB of stdout between two polls and the
+buffer is 256 KB, ~44 KB of intermediate output is gone — the agent sees
+the most recent 256 KB only.
+
+This is the right tradeoff for v1: the common case is "what is bash doing
+right now?", not "give me the complete log." `total_bytes_seen` lets the
+caller detect that bytes were dropped (`total_bytes_seen > buffer_size`
+implies older bytes are gone), but cannot recover them.
+
+If a future caller needs lossless tail-following, v2 may add a
+`since_byte` incremental protocol or persist the full stream to disk; both
+are out of scope for v1. Callers that need the full output today should
+not background the tool — they should run it foreground.
 
 ### `steer_subagent`
 
@@ -646,16 +667,31 @@ long-polls.
 ## Verified Obligations
 
 R4c expects **zero new Lean modules** and **zero new Lean transitions**.
+R4c ships **one new theorem**.
 
-### Possible derived property (deferred unless reviewer surfaces it)
+### New theorem (required)
 
-- `steer_subagent_interrupt_preserves_link_symmetry`: after the
-  `interrupt = true` composition (interrupt + cascade + drain + append),
-  every bridge row's `parent_request_id` still points at a request whose
-  `caused_by_parent_*` symmetry is intact. This is mechanically discharged
-  from existing B5 plus the existing `interrupt` transition's invariants.
-  Belt-and-suspenders; the implementation plan flags it for the
-  spec-compliance reviewer to confirm whether to ship.
+`steer_subagent_interrupt_preserves_link_symmetry`: after the
+`interrupt = true` composition (interrupt + cascade + drain + append),
+every bridge row's `parent_request_id` still points at a request whose
+`caused_by_parent_*` symmetry is intact (B5 invariant preserved).
+
+Statement (informal):
+
+```lean
+theorem steer_with_interrupt_preserves_link_symmetry
+    (pre post : BackgroundedState)
+    (steer : SteerWithInterrupt pre post)
+    (h_pre : B5 pre) :
+    B5 post
+```
+
+Discharged mechanically from existing B5 plus the existing `interrupt`
+transition's invariants. The composition (interrupt + cascade + drain +
+append) is the operationally-touchiest R4c path; the theorem makes future
+regressions of the composition trip Lean before they trip Rust. Cost is one
+short proof; gain is that any future steering refactor that breaks lineage
+symmetry fails `lake build`. R4c is the cheapest place to add it.
 
 ### Conformance witnesses (required)
 
@@ -711,7 +747,8 @@ Explicit non-goals; the implementation plan should not absorb them:
 - Foreground-steering surface (no tool to steer a foreground subagent; the
   parent is blocked anyway).
 - Cross-deployment listing / reading / steering. v1 is local-only; the
-  envelopes carry `deployment_id` so v2 lift is additive. R5's domain.
+  envelopes carry `deployment_id` so v2 lift is additive. R5's domain
+  (see "Cross-Deployment v2 Coordination" below).
 - A separate `replace_subagent` verb. We picked the boolean knob
   (`interrupt = false | true`).
 - A new Lean transition for steering. Reuse-only.
@@ -722,6 +759,33 @@ Explicit non-goals; the implementation plan should not absorb them:
   and let it keep running"). There is no design for this; if it ever lands,
   it's a separate tool.
 - Live transcript tail / long-poll variants. Snapshot posture is canonical.
+
+## Cross-Deployment v2 Coordination
+
+R4c v1 is local-only: `list_subagents` and `list_background_tools` enumerate
+work whose lineage lives on this deployment. The envelopes carry
+`deployment_id` (set to the local deployment in v1) so a v2 lift to
+cross-deployment is additive — the field is reserved, not invented later.
+
+The v2 coordination point is not decided in R4c. R5's current spec covers
+cross-deployment subagent **cancel propagation** and **completion
+projection**, but does not address cross-deployment **listing**. Two
+plausible v2 paths, both deferred:
+
+1. **R4c v2 extends in place.** `list_subagents` and `list_background_tools`
+   follow lineage across deployments via whatever cross-deployment query
+   primitive R5 establishes. The envelopes don't change; the
+   `deployment_id` field starts carrying remote values. Requires R5 to
+   surface a "list children visible to this parent across deployments"
+   query that R4c can call.
+2. **A separate cross-deployment list tool supersedes R4c's.** R5 (or a
+   later iteration) ships `list_remote_subagents` / `list_remote_background_tools`
+   as new tools alongside R4c's, with their own envelopes. R4c's tools
+   remain strictly local. Larger surface; clearer coordinate-system split.
+
+R4c does not pick. The `deployment_id` field is the seam that lets either
+path land additively. When R5 has consensus on the cross-deployment query
+surface, the v2 decision becomes mechanical.
 
 ## Approval Checklist
 
@@ -747,9 +811,13 @@ Before implementation planning, Jack should approve:
   and `interrupt = true` (interrupt + cascade + drain + append). Composes
   existing primitives — zero new Lean transitions.
 - No parent-side `AgentToolCall` rows for any of the five tools.
-- Zero new Lean modules. Possibly zero new theorems. Six conformance
-  witnesses cover observable Rust shapes.
+- Zero new Lean modules. One new theorem
+  (`steer_subagent_interrupt_preserves_link_symmetry`, B5 preservation
+  under the interrupt + cascade + drain + append composition). Six
+  conformance witnesses cover observable Rust shapes.
 - Cross-deployment deferred to v2 (R5's domain). `deployment_id` on
-  envelopes for additive v2 lift.
+  envelopes for additive v2 lift. R4c does not pick between v2 extending
+  in place vs. a separate cross-deployment list tool; the `deployment_id`
+  seam supports either.
 - Sequencing: R4c executes after R6 merges to main; PR rebases on R6 merge;
   no "pure rename" no-op commit in R4c (R6 owns that).


### PR DESCRIPTION
## Summary

R4c adds five agent-facing tools that let a parent agent observe and steer the background work it spawned. R4 originally deferred these with "first-90-days won't need them"; that decision is now reversed.

Five tools, split per \`BackgroundedKind\`:
- **Subagent kind:** \`list_subagents\`, \`read_subagent_transcript\`, \`steer_subagent\`
- **Tool kind:** \`list_background_tools\`, \`read_tool_output\`

No unified surface, no \`kind\` discriminator. Typed tool names and typed envelopes throughout. Authorization is per-parent-request lineage for all five tools (strictest least-privilege scope).

## Current state

This PR currently contains:
- Design spec at \`docs/superpowers/specs/2026-05-14-r4c-background-work-management-design.md\`
- Implementation plan at \`docs/superpowers/plans/2026-05-14-r4c-background-work-management.md\` (13 tasks, 0–12)

## Notable scope choices

- **Zero new Lean modules.** One new theorem (\`steer_subagent_interrupt_preserves_link_symmetry\`) discharges B5 preservation across the \`interrupt + cascade + drain + append\` composition. Six conformance witnesses cover observable Rust shapes.
- **\`read_subagent_transcript\`** — compact rendered text, assistant-only by default, paged by \`since_sequence\`, bridge call rows always hidden. Hard caps: 100 messages / 24000 chars / 256-byte tool-result snippets.
- **\`read_tool_output\`** — snapshot per call with explicit tail-only-snapshot limitation: bytes pushed out of R6's 256 KB ring buffer between polls are gone. \`total_bytes_seen\` monotonic counter for "still making progress" signal.
- **\`steer_subagent\` ships both modes in v1.** \`interrupt=false\` (append a steering message to the child session queue) and \`interrupt=true\` (interrupt + cascade + drain + append). Both compose existing primitives — zero new Lean transitions.
- **Cross-deployment listing deferred to v2 (R5's domain).** \`deployment_id\` reserved on every envelope as the additive seam between "R4c v2 extends in place" and "R5 ships a separate cross-deployment list tool."

## Sequencing

Execution is sequenced after **R6 (#201)** merges to main. R6's Task 0 rename (\`Proofs/Subagent/\` → \`Proofs/Background/\`) must be on main before R4c implementation begins. When R6 merges:

1. This branch rebases onto post-R6 main
2. Plan execution begins from Task 0 (spec self-review checkpoint)
3. Subsequent commits land on this same branch
4. PR squash-merges as one feature

R5 (#214) is a sibling brainstorm — also sequenced after R6 — and shares no file surface with R4c.

## Test plan

- [x] Design spec self-review (scope check, three tightenings addressed inline)
- [x] Plan self-review (placeholder scan, type consistency across tasks)
- [ ] Implementation tasks 0–12 execute after R6 (#201) merges to main
- [ ] Final lake build clean, cargo fmt clean, six conformance witnesses pass

## Refs

Refs #216 (R4c tracker)
Refs #201 (R6 — execution prerequisite)
Refs #213 (R5 — sibling sequencing; cross-deployment lift target for R4c v2)
Refs #177 (R4 — closest prior art; the spec R4c was originally deferred from)
Refs #191 (Lean transcript model — used by \`read_subagent_transcript\` renderer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)