### PR TITLE
Fence production apply boundary with Lean cases

### DIFF
--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -19,6 +19,10 @@ use crate::{
     CONFIG_EXPORT_FORMAT, CONFIG_EXPORT_FORMAT_V1,
 };
 
+#[cfg(test)]
+#[path = "../../defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
 const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 
 // Topological desired-state write order. Every prefix is safe to observe: a
@@ -778,5 +782,824 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
             "expected create field, got {}",
             field.field
         );
+    }
+}
+
+#[cfg(test)]
+mod lean_apply_write_boundary_tests {
+    use super::lean_vocab_test::{
+        lean_apply_reconcile_cases, LeanApplyDesiredDoc, LeanApplyDocRef, LeanApplyReconcileCase,
+        LeanApplySelectedDoc,
+    };
+    use super::*;
+    use axum::{extract::State, routing::post, Json, Router};
+    use defra_agent::BackendProviderKind;
+    use regex::Regex;
+    use serde_json::{json, Map};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    const DEFAULT_AGENT_DID: &str = "did:example:agent";
+    const DEFAULT_BEHAVIOR_ID: &str = "behavior-a";
+    const DEFAULT_TASK_ID: &str = "task-a";
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct ObservedWrite {
+        collection: Collection,
+        unique_value: String,
+    }
+
+    #[derive(Clone, Default)]
+    struct RecordingGraphqlState {
+        queries: Arc<Mutex<Vec<String>>>,
+        writes: Arc<Mutex<Vec<ObservedWrite>>>,
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn generated_apply_reconcile_cases_fence_production_apply_write_boundary() {
+        let cases = lean_apply_reconcile_cases();
+        assert!(
+            cases
+                .iter()
+                .any(|case| case.name == "production_write_boundary_all_collections"),
+            "Lean must emit a production write-boundary case covering every collection"
+        );
+
+        for case in cases {
+            assert_write_order_projection_matches_production(case);
+            assert!(case.write_order_prefix_safe);
+            assert!(case.production_prefixes_referrers_closed);
+
+            let desired_manifest = desired_manifest_from_lean(case);
+            let desired_bundle =
+                desired_state::export_bundle_from_manifest(&desired_manifest, "graphql")
+                    .unwrap_or_else(|error| {
+                        panic!(
+                            "failed to build desired apply bundle for Lean case {}: {error}",
+                            case.name
+                        )
+                    });
+            let planned = diff_report_from_lean(case);
+            assert_selected_documents_match_lean(case, desired_bundle.as_bundle(), &planned);
+
+            let (graphql, recorder) = start_recording_graphql().await;
+            let counts = apply_desired_state_changes(
+                &ConfigAccess::Graphql(graphql),
+                &desired_bundle,
+                &planned,
+            )
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "production apply_desired_state_changes failed for Lean case {}: {error}",
+                    case.name
+                )
+            });
+
+            assert_counts_match_lean(case, &counts);
+
+            let observed = recorder.writes.lock().expect("writes lock").clone();
+            let expected = case
+                .expected_selected_writes
+                .iter()
+                .map(observed_write_from_lean)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                observed, expected,
+                "production mutation sequence drifted from Lean write-boundary projection for case {}",
+                case.name
+            );
+            assert_observed_prefixes_are_referrer_closed(case, &observed);
+            assert_live_payloads_not_written(case, &recorder);
+        }
+    }
+
+    fn assert_write_order_projection_matches_production(case: &LeanApplyReconcileCase) {
+        let expected_order = case
+            .expected_write_order
+            .iter()
+            .map(|entry| {
+                let collection = collection_from_lean_name(&entry.collection);
+                assert_eq!(
+                    entry.graphql_type,
+                    collection.graphql_type(),
+                    "Lean GraphQL type mapping drifted for {:?}",
+                    collection
+                );
+                assert_eq!(
+                    entry.unique_field,
+                    collection.unique_field(),
+                    "Lean unique-field mapping drifted for {:?}",
+                    collection
+                );
+                assert_eq!(
+                    entry.apply_order,
+                    collection.apply_order() as usize,
+                    "Lean apply-order mapping drifted for {:?}",
+                    collection
+                );
+                collection
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            expected_order, CONFIG_APPLY_ORDER,
+            "CONFIG_APPLY_ORDER must match Lean's production write order projection for case {}",
+            case.name
+        );
+    }
+
+    fn assert_selected_documents_match_lean(
+        case: &LeanApplyReconcileCase,
+        desired_bundle: &ConfigExportBundle,
+        planned: &desired_state::DesiredStateDiffReport,
+    ) {
+        let create_docs = case
+            .expected_selected_create_docs
+            .iter()
+            .map(observed_write_from_lean)
+            .collect::<Vec<_>>();
+        let update_docs = case
+            .expected_selected_update_docs
+            .iter()
+            .map(observed_write_from_lean)
+            .collect::<Vec<_>>();
+
+        for collection in Collection::ALL {
+            let diff = planned.collections.get(collection);
+            assert_eq!(
+                diff.create,
+                ids_for_collection(&create_docs, collection),
+                "planned create ids must match Lean selected-create docs for case {} / {:?}",
+                case.name,
+                collection
+            );
+            assert_eq!(
+                diff.update,
+                ids_for_collection(&update_docs, collection),
+                "planned update ids must match Lean selected-update docs for case {} / {:?}",
+                case.name,
+                collection
+            );
+
+            let selected = select_apply_docs_for_collection(desired_bundle, planned, collection)
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "production selection failed for Lean case {} / {:?}: {error}",
+                        case.name, collection
+                    )
+                });
+            let actual_ids = selected
+                .iter()
+                .map(|doc| unique_value_from_doc(doc, collection))
+                .collect::<Vec<_>>();
+            let expected = case
+                .expected_selected_writes
+                .iter()
+                .filter(|doc| collection_from_lean_ref(&doc.target) == collection)
+                .collect::<Vec<_>>();
+            let expected_ids = expected
+                .iter()
+                .map(|doc| doc.unique_value.clone())
+                .collect::<Vec<_>>();
+
+            assert_eq!(
+                actual_ids, expected_ids,
+                "selected production docs must match Lean selected writes for case {} / {:?}",
+                case.name, collection
+            );
+            assert_no_live_only_doc_selected(case, collection, &actual_ids);
+            assert_selected_docs_carry_lean_content(case, collection, &selected, &expected);
+            assert_selected_docs_keep_live_fields_out(case, collection, &selected);
+        }
+    }
+
+    fn assert_selected_docs_carry_lean_content(
+        case: &LeanApplyReconcileCase,
+        collection: Collection,
+        selected: &[Value],
+        expected: &[&LeanApplySelectedDoc],
+    ) {
+        let by_id = selected
+            .iter()
+            .map(|doc| (unique_value_from_doc(doc, collection), doc))
+            .collect::<BTreeMap<_, _>>();
+        for expected_doc in expected {
+            let selected_doc = by_id.get(&expected_doc.unique_value).unwrap_or_else(|| {
+                panic!(
+                    "selected production docs missing {} for Lean case {} / {:?}",
+                    expected_doc.unique_value, case.name, collection
+                )
+            });
+            let encoded = serde_json::to_string(selected_doc).expect("selected doc JSON");
+            assert!(
+                encoded.contains(&expected_doc.content),
+                "selected production doc for Lean case {} / {:?} / {} did not carry Lean content {:?}: {}",
+                case.name,
+                collection,
+                expected_doc.unique_value,
+                expected_doc.content,
+                encoded
+            );
+        }
+    }
+
+    fn assert_selected_docs_keep_live_fields_out(
+        case: &LeanApplyReconcileCase,
+        collection: Collection,
+        selected: &[Value],
+    ) {
+        let prepared = prepare_import_documents(
+            collection.graphql_type(),
+            collection.unique_field(),
+            selected,
+            true,
+        )
+        .unwrap_or_else(|error| {
+            panic!(
+                "failed to prepare selected docs for Lean case {} / {:?}: {error}",
+                case.name, collection
+            )
+        });
+        for doc in prepared {
+            for field in runtime_owned_fields(collection) {
+                assert!(
+                    doc.add_doc.get(field).is_none(),
+                    "add document for Lean case {} / {:?} / {} contains live-owned field {field}",
+                    case.name,
+                    collection,
+                    doc.unique_value
+                );
+                let update_doc = doc.update_doc.as_ref().expect("override update doc");
+                assert!(
+                    update_doc.get(field).is_none(),
+                    "update document for Lean case {} / {:?} / {} contains live-owned field {field}",
+                    case.name,
+                    collection,
+                    doc.unique_value
+                );
+            }
+        }
+    }
+
+    fn assert_no_live_only_doc_selected(
+        case: &LeanApplyReconcileCase,
+        collection: Collection,
+        actual_ids: &[String],
+    ) {
+        let actual_ids = actual_ids.iter().collect::<BTreeSet<_>>();
+        for live_only in &case.expected_live_only {
+            if collection_from_lean_ref(live_only) == collection {
+                assert!(
+                    !actual_ids.contains(&live_only.id),
+                    "live-only doc was selected for production write in Lean case {} / {:?}: {}",
+                    case.name,
+                    collection,
+                    live_only.id
+                );
+            }
+        }
+    }
+
+    fn assert_counts_match_lean(case: &LeanApplyReconcileCase, counts: &ConfigApplyCounts) {
+        for collection in Collection::ALL {
+            let expected = case
+                .expected_selected_writes
+                .iter()
+                .filter(|doc| collection_from_lean_ref(&doc.target) == collection)
+                .count();
+            assert_eq!(
+                count_for_collection(counts, collection),
+                expected,
+                "apply_desired_state_changes count mismatch for Lean case {} / {:?}",
+                case.name,
+                collection
+            );
+        }
+    }
+
+    fn assert_observed_prefixes_are_referrer_closed(
+        case: &LeanApplyReconcileCase,
+        observed: &[ObservedWrite],
+    ) {
+        let manifest_refs = case
+            .manifest
+            .iter()
+            .map(|doc| {
+                (
+                    doc_key_from_desired(doc),
+                    doc.refs.iter().map(doc_key).collect(),
+                )
+            })
+            .collect::<BTreeMap<_, Vec<_>>>();
+        let mut present = case
+            .pre_desired
+            .iter()
+            .map(doc_key_from_desired)
+            .collect::<BTreeSet<_>>();
+
+        for prefix_len in 0..=observed.len() {
+            if prefix_len > 0 {
+                let written = &observed[prefix_len - 1];
+                present.insert((written.collection, written.unique_value.clone()));
+            }
+
+            for written in &observed[..prefix_len] {
+                let key = (written.collection, written.unique_value.clone());
+                let refs = manifest_refs.get(&key).unwrap_or_else(|| {
+                    panic!(
+                        "observed production write is not in Lean manifest for case {}: {:?}",
+                        case.name, key
+                    )
+                });
+                for reference in refs {
+                    assert!(
+                        present.contains(reference),
+                        "production prefix {prefix_len} leaves referrer {:?} dangling on {:?} in Lean case {}",
+                        key,
+                        reference,
+                        case.name
+                    );
+                }
+            }
+        }
+    }
+
+    fn assert_live_payloads_not_written(
+        case: &LeanApplyReconcileCase,
+        recorder: &RecordingGraphqlState,
+    ) {
+        let queries = recorder.queries.lock().expect("queries lock").join("\n");
+        for live in &case.pre_live {
+            assert!(
+                !queries.contains(&live.content),
+                "production write boundary leaked live payload {:?} into GraphQL for Lean case {}",
+                live.content,
+                case.name
+            );
+        }
+    }
+
+    async fn start_recording_graphql() -> (String, RecordingGraphqlState) {
+        let state = RecordingGraphqlState::default();
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind recording GraphQL listener");
+        let addr = listener.local_addr().expect("recording GraphQL addr");
+        let app = Router::new()
+            .route("/", post(recording_graphql_handler))
+            .with_state(state.clone());
+        tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("recording GraphQL server");
+        });
+        (format!("http://{addr}/"), state)
+    }
+
+    async fn recording_graphql_handler(
+        State(state): State<RecordingGraphqlState>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let query = body
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        state
+            .queries
+            .lock()
+            .expect("queries lock")
+            .push(query.clone());
+
+        if query.contains("mutation") {
+            let writes = parse_mutation_writes(&query);
+            state.writes.lock().expect("writes lock").extend(writes);
+            Json(json!({ "data": aliased_mutation_response(&query) }))
+        } else {
+            Json(json!({ "data": empty_collection_query_response(&query) }))
+        }
+    }
+
+    fn aliased_mutation_response(query: &str) -> Value {
+        let alias_re = Regex::new(r"\b(doc_\d+)\s*:").expect("alias regex");
+        let mut data = Map::new();
+        for capture in alias_re.captures_iter(query) {
+            let alias = capture[1].to_string();
+            data.insert(alias.clone(), json!({ "_docID": format!("{alias}-id") }));
+        }
+        Value::Object(data)
+    }
+
+    fn empty_collection_query_response(query: &str) -> Value {
+        let mut data = Map::new();
+        for collection in Collection::ALL {
+            if query.contains(&format!("{}(", collection.graphql_type())) {
+                data.insert(
+                    collection.graphql_type().to_string(),
+                    Value::Array(Vec::new()),
+                );
+            }
+        }
+        Value::Object(data)
+    }
+
+    fn parse_mutation_writes(query: &str) -> Vec<ObservedWrite> {
+        let field_re =
+            Regex::new(r"(?:\bdoc_\d+\s*:\s*)?(?:create|update|upsert)_([A-Za-z]+)\s*\(")
+                .expect("mutation field regex");
+        let matches = field_re
+            .captures_iter(query)
+            .map(|capture| {
+                let whole = capture.get(0).expect("whole match");
+                let collection_name = capture.get(1).expect("collection match").as_str();
+                (whole.start(), collection_from_lean_name(collection_name))
+            })
+            .collect::<Vec<_>>();
+
+        let mut writes = Vec::new();
+        for (index, (start, collection)) in matches.iter().copied().enumerate() {
+            let end = matches
+                .get(index + 1)
+                .map(|(next_start, _)| *next_start)
+                .unwrap_or(query.len());
+            let segment = &query[start..end];
+            let value_re = Regex::new(&format!(
+                r#"\b{}\s*:\s*"([^"]+)""#,
+                regex::escape(collection.unique_field())
+            ))
+            .expect("unique-field regex");
+            let unique_value = value_re
+                .captures(segment)
+                .and_then(|capture| capture.get(1))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "mutation segment for {:?} did not carry unique field {}: {}",
+                        collection,
+                        collection.unique_field(),
+                        segment
+                    )
+                })
+                .as_str()
+                .to_string();
+            writes.push(ObservedWrite {
+                collection,
+                unique_value,
+            });
+        }
+        writes
+    }
+
+    fn desired_manifest_from_lean(
+        case: &LeanApplyReconcileCase,
+    ) -> desired_state::DesiredStateManifest {
+        let agent_did = agent_did_for_case(case);
+        let principal_doc = docs_for_collection(case, Collection::AgentPrincipal)
+            .into_iter()
+            .next();
+        desired_state::DesiredStateManifest {
+            agent_principal: principal_doc
+                .map(|doc| desired_principal(doc))
+                .unwrap_or_else(|| desired_state::DesiredAgentPrincipal {
+                    agent_did: agent_did.clone(),
+                    display_name: Some("default-principal".to_string()),
+                    default_behavior_id: first_manifest_id(case, Collection::AgentBehavior),
+                    enabled: true,
+                }),
+            agent_behaviors: docs_for_collection(case, Collection::AgentBehavior)
+                .into_iter()
+                .map(|doc| desired_behavior(doc, &agent_did))
+                .collect(),
+            tool_selections: docs_for_collection(case, Collection::ToolSelection)
+                .into_iter()
+                .map(|doc| desired_tool_selection(doc, &agent_did))
+                .collect(),
+            inference_backends: docs_for_collection(case, Collection::InferenceBackend)
+                .into_iter()
+                .map(desired_backend)
+                .collect(),
+            inference_profiles: docs_for_collection(case, Collection::InferenceProfile)
+                .into_iter()
+                .map(desired_profile)
+                .collect(),
+            tool_service_registries: docs_for_collection(case, Collection::ToolServiceRegistry)
+                .into_iter()
+                .map(desired_tool_service)
+                .collect(),
+            tasks: docs_for_collection(case, Collection::Task)
+                .into_iter()
+                .map(desired_task)
+                .collect(),
+            schedules: docs_for_collection(case, Collection::Schedule)
+                .into_iter()
+                .map(desired_schedule)
+                .collect(),
+            event_triggers: docs_for_collection(case, Collection::EventTrigger)
+                .into_iter()
+                .map(desired_event_trigger)
+                .collect(),
+        }
+    }
+
+    fn desired_principal(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredAgentPrincipal {
+        desired_state::DesiredAgentPrincipal {
+            agent_did: doc.id.clone(),
+            display_name: Some(doc.content.clone()),
+            default_behavior_id: ref_id(doc, Collection::AgentBehavior),
+            enabled: true,
+        }
+    }
+
+    fn desired_behavior(
+        doc: &LeanApplyDesiredDoc,
+        agent_did: &str,
+    ) -> desired_state::DesiredAgentBehavior {
+        desired_state::DesiredAgentBehavior {
+            behavior_id: doc.id.clone(),
+            agent_did: agent_did.to_string(),
+            display_name: Some(doc.content.clone()),
+            system_prompt: Some(doc.content.clone()),
+            backend_id: ref_id(doc, Collection::InferenceBackend),
+            model_name: Some(format!("model-{}", doc.id)),
+            tool_selection_id: ref_id(doc, Collection::ToolSelection),
+            inference_profile_id: ref_id(doc, Collection::InferenceProfile),
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+        }
+    }
+
+    fn desired_tool_selection(
+        doc: &LeanApplyDesiredDoc,
+        agent_did: &str,
+    ) -> desired_state::DesiredToolSelection {
+        desired_state::DesiredToolSelection {
+            selection_id: doc.id.clone(),
+            agent_did: agent_did.to_string(),
+            display_name: Some(doc.content.clone()),
+            enable_file_tools: false,
+            file_tools_mode: "disabled".to_string(),
+            file_tool_root: None,
+            enable_bash: false,
+            bash_mode: "disabled".to_string(),
+            command_execution_policy: None,
+            command_allowed_argv_prefixes: Vec::new(),
+            command_forbidden_argv_prefixes: Vec::new(),
+            command_network_mode: None,
+            cli_tool_names: Vec::new(),
+            enable_meta_tools: false,
+            allowed_mcp_service_ids: doc
+                .refs
+                .iter()
+                .filter(|reference| {
+                    collection_from_lean_ref(reference) == Collection::ToolServiceRegistry
+                })
+                .map(|reference| reference.id.clone())
+                .collect(),
+            delegate_to: Vec::new(),
+            backgroundable_tool_names: Vec::new(),
+        }
+    }
+
+    fn desired_backend(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredInferenceBackend {
+        desired_state::DesiredInferenceBackend {
+            backend_id: doc.id.clone(),
+            name: doc.content.clone(),
+            provider_kind: BackendProviderKind::OpenAiCompatible,
+            endpoint: format!("http://127.0.0.1/{}/v1", doc.id),
+            api_key: None,
+            api_key_env_var: None,
+            max_concurrent: 1,
+            max_queue_depth: 10,
+            enabled: true,
+            models: vec![doc.content.clone()],
+        }
+    }
+
+    fn desired_profile(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredInferenceProfile {
+        desired_state::DesiredInferenceProfile {
+            profile_id: doc.id.clone(),
+            display_name: Some(doc.content.clone()),
+            context_window: None,
+            max_output_tokens: None,
+            max_turns: None,
+            temperature: None,
+            stream_batch_ms: None,
+            deadline_duration_secs: None,
+        }
+    }
+
+    fn desired_tool_service(
+        doc: &LeanApplyDesiredDoc,
+    ) -> desired_state::DesiredToolServiceRegistry {
+        desired_state::DesiredToolServiceRegistry {
+            service_id: doc.id.clone(),
+            display_name: Some(doc.content.clone()),
+            description: Some(doc.content.clone()),
+            hostname: None,
+            tailscale_ip: None,
+            lan_ip: None,
+            mcp_port: None,
+            mcp_path: None,
+        }
+    }
+
+    fn desired_task(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredTask {
+        desired_state::DesiredTask {
+            task_id: doc.id.clone(),
+            name: doc.content.clone(),
+            description: Some(doc.content.clone()),
+            behavior_id: ref_id(doc, Collection::AgentBehavior)
+                .unwrap_or_else(|| DEFAULT_BEHAVIOR_ID.to_string()),
+            prompt_template: doc.content.clone(),
+            enabled: true,
+            output_schema_ref: None,
+        }
+    }
+
+    fn desired_schedule(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredSchedule {
+        desired_state::DesiredSchedule {
+            schedule_id: doc.id.clone(),
+            task_id: ref_id(doc, Collection::Task).unwrap_or_else(|| DEFAULT_TASK_ID.to_string()),
+            interval_secs: 60,
+            enabled: true,
+            concurrency: doc.content.clone(),
+        }
+    }
+
+    fn desired_event_trigger(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredEventTrigger {
+        desired_state::DesiredEventTrigger {
+            trigger_id: doc.id.clone(),
+            task_id: ref_id(doc, Collection::Task).unwrap_or_else(|| DEFAULT_TASK_ID.to_string()),
+            source_collection: "Task".to_string(),
+            event_kind: "created".to_string(),
+            filter: Some(doc.content.clone()),
+            enabled: true,
+            concurrency: "serial".to_string(),
+        }
+    }
+
+    fn diff_report_from_lean(
+        case: &LeanApplyReconcileCase,
+    ) -> desired_state::DesiredStateDiffReport {
+        let collections = desired_state::DesiredStateDiffCollections {
+            agent_principal: diff_for_collection(case, Collection::AgentPrincipal),
+            agent_behaviors: diff_for_collection(case, Collection::AgentBehavior),
+            tool_selections: diff_for_collection(case, Collection::ToolSelection),
+            inference_backends: diff_for_collection(case, Collection::InferenceBackend),
+            inference_profiles: diff_for_collection(case, Collection::InferenceProfile),
+            tool_service_registries: diff_for_collection(case, Collection::ToolServiceRegistry),
+            tasks: diff_for_collection(case, Collection::Task),
+            schedules: diff_for_collection(case, Collection::Schedule),
+            event_triggers: diff_for_collection(case, Collection::EventTrigger),
+        };
+        let counts = collections.counts();
+        let ok = counts.is_exact_match();
+        desired_state::DesiredStateDiffReport {
+            status: "diffed",
+            ok,
+            root: format!("lean://{}", case.name),
+            access_mode: "graphql".to_string(),
+            agent_did: agent_did_for_case(case),
+            counts,
+            collections,
+        }
+    }
+
+    fn diff_for_collection(
+        case: &LeanApplyReconcileCase,
+        collection: Collection,
+    ) -> desired_state::DesiredStateCollectionDiff {
+        desired_state::DesiredStateCollectionDiff {
+            create: ref_ids_for_collection(&case.expected_create, collection),
+            update: ref_ids_for_collection(&case.expected_update, collection),
+            unchanged: ref_ids_for_collection(&case.expected_unchanged, collection),
+            live_only: ref_ids_for_collection(&case.expected_live_only, collection),
+        }
+    }
+
+    fn collection_from_lean_name(name: &str) -> Collection {
+        Collection::ALL
+            .into_iter()
+            .find(|collection| collection.graphql_type() == name)
+            .unwrap_or_else(|| panic!("unknown Lean collection name {name:?}"))
+    }
+
+    fn collection_from_lean_ref(reference: &LeanApplyDocRef) -> Collection {
+        collection_from_lean_name(&reference.collection)
+    }
+
+    fn docs_for_collection(
+        case: &LeanApplyReconcileCase,
+        collection: Collection,
+    ) -> Vec<&LeanApplyDesiredDoc> {
+        case.manifest
+            .iter()
+            .filter(|doc| collection_from_lean_name(&doc.collection) == collection)
+            .collect()
+    }
+
+    fn first_manifest_id(case: &LeanApplyReconcileCase, collection: Collection) -> Option<String> {
+        docs_for_collection(case, collection)
+            .into_iter()
+            .next()
+            .map(|doc| doc.id.clone())
+    }
+
+    fn agent_did_for_case(case: &LeanApplyReconcileCase) -> String {
+        first_manifest_id(case, Collection::AgentPrincipal)
+            .unwrap_or_else(|| DEFAULT_AGENT_DID.to_string())
+    }
+
+    fn ref_id(doc: &LeanApplyDesiredDoc, collection: Collection) -> Option<String> {
+        doc.refs
+            .iter()
+            .find(|reference| collection_from_lean_ref(reference) == collection)
+            .map(|reference| reference.id.clone())
+    }
+
+    fn ref_ids_for_collection(refs: &[LeanApplyDocRef], collection: Collection) -> Vec<String> {
+        refs.iter()
+            .filter(|reference| collection_from_lean_ref(reference) == collection)
+            .map(|reference| reference.id.clone())
+            .collect()
+    }
+
+    fn ids_for_collection(writes: &[ObservedWrite], collection: Collection) -> Vec<String> {
+        writes
+            .iter()
+            .filter(|write| write.collection == collection)
+            .map(|write| write.unique_value.clone())
+            .collect()
+    }
+
+    fn observed_write_from_lean(doc: &LeanApplySelectedDoc) -> ObservedWrite {
+        assert_eq!(doc.unique_value, doc.target.id);
+        assert_eq!(doc.graphql_type, doc.target.collection);
+        let collection = collection_from_lean_ref(&doc.target);
+        assert_eq!(doc.unique_field, collection.unique_field());
+        ObservedWrite {
+            collection,
+            unique_value: doc.unique_value.clone(),
+        }
+    }
+
+    fn unique_value_from_doc(doc: &Value, collection: Collection) -> String {
+        doc.get(collection.unique_field())
+            .and_then(Value::as_str)
+            .unwrap_or_else(|| {
+                panic!(
+                    "selected {:?} document is missing unique field {}: {}",
+                    collection,
+                    collection.unique_field(),
+                    doc
+                )
+            })
+            .to_string()
+    }
+
+    fn count_for_collection(counts: &ConfigApplyCounts, collection: Collection) -> usize {
+        match collection {
+            Collection::AgentPrincipal => counts.agent_principal,
+            Collection::AgentBehavior => counts.agent_behaviors,
+            Collection::ToolSelection => counts.tool_selections,
+            Collection::InferenceBackend => counts.inference_backends,
+            Collection::InferenceProfile => counts.inference_profiles,
+            Collection::ToolServiceRegistry => counts.tool_service_registries,
+            Collection::Task => counts.tasks,
+            Collection::Schedule => counts.schedules,
+            Collection::EventTrigger => counts.event_triggers,
+        }
+    }
+
+    fn runtime_owned_fields(collection: Collection) -> &'static [&'static str] {
+        match collection {
+            Collection::InferenceBackend => &["probe_status"],
+            Collection::ToolServiceRegistry => &["tools", "version"],
+            Collection::Schedule => &[
+                "next_run_at",
+                "last_attempt_at",
+                "last_status",
+                "last_error",
+                "fire_count",
+            ],
+            Collection::EventTrigger => &[
+                "last_attempt_at",
+                "last_fired_source_doc_id",
+                "last_status",
+                "last_error",
+                "fire_count",
+            ],
+            _ => &[],
+        }
+    }
+
+    fn doc_key(reference: &LeanApplyDocRef) -> (Collection, String) {
+        (collection_from_lean_ref(reference), reference.id.clone())
+    }
+
+    fn doc_key_from_desired(doc: &LeanApplyDesiredDoc) -> (Collection, String) {
+        (collection_from_lean_name(&doc.collection), doc.id.clone())
     }
 }

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean
@@ -35,6 +35,21 @@ structure ContractStep where
   content : String
   refs : List DocRef
 
+structure ContractCollectionWrite where
+  collection : Collection
+  graphqlType : String
+  uniqueField : String
+  applyOrder : Nat
+
+structure ContractSelectedDoc where
+  action : String
+  target : DocRef
+  graphqlType : String
+  uniqueField : String
+  uniqueValue : String
+  content : String
+  refs : List DocRef
+
 structure ApplyReconcileScenario where
   name : String
   manifest : List ContractDoc
@@ -52,6 +67,10 @@ structure ApplyReconcileCase where
   expectedUnchanged : List DocRef
   expectedLiveOnly : List DocRef
   expectedSteps : List ContractStep
+  expectedWriteOrder : List ContractCollectionWrite
+  expectedSelectedCreateDocs : List ContractSelectedDoc
+  expectedSelectedUpdateDocs : List ContractSelectedDoc
+  expectedSelectedWrites : List ContractSelectedDoc
   prefixLen : Nat
   expectedPrefixDesired : List ContractDoc
   expectedAfterDesired : List ContractDoc
@@ -62,6 +81,8 @@ structure ApplyReconcileCase where
   manifestRealizedAfter : Bool
   retryConverges : Bool
   idempotentAfter : Bool
+  writeOrderPrefixSafe : Bool
+  productionPrefixesReferrersClosed : Bool
   prefixReferrersClosed : Bool
   desiredReferencesClosedAfterPrefix : Bool
 
@@ -78,6 +99,39 @@ def collectionName : Collection → String
   | .task => "Task"
   | .schedule => "Schedule"
   | .eventTrigger => "EventTrigger"
+
+def collectionUniqueField : Collection → String
+  | .agentPrincipal => "agent_did"
+  | .agentBehavior => "behavior_id"
+  | .toolSelection => "selection_id"
+  | .inferenceBackend => "backend_id"
+  | .inferenceProfile => "profile_id"
+  | .toolServiceRegistry => "service_id"
+  | .task => "task_id"
+  | .schedule => "schedule_id"
+  | .eventTrigger => "trigger_id"
+
+def productionWriteOrder : List Collection :=
+  [ .inferenceBackend
+  , .inferenceProfile
+  , .toolServiceRegistry
+  , .toolSelection
+  , .agentBehavior
+  , .task
+  , .schedule
+  , .eventTrigger
+  , .agentPrincipal
+  ]
+
+def collectionWriteProjection (collection : Collection) : ContractCollectionWrite :=
+  { collection := collection
+  , graphqlType := collectionName collection
+  , uniqueField := collectionUniqueField collection
+  , applyOrder := collection.applyOrder
+  }
+
+def collectionBEq (a b : Collection) : Bool :=
+  if a = b then true else false
 
 def docRefBEq (a b : DocRef) : Bool :=
   if a = b then true else false
@@ -120,8 +174,31 @@ def sortedDocs (docs : List ContractDoc) : List ContractDoc :=
 def sortedSteps (steps : List ContractStep) : List ContractStep :=
   steps.mergeSort contractStepLe
 
+def productionOrderedSteps (steps : List ContractStep) : List ContractStep :=
+  productionWriteOrder.flatMap fun collection =>
+    steps.filter fun step => collectionBEq step.target.collection collection
+
 def stepToDoc (step : ContractStep) : ContractDoc :=
   { ref := step.target, content := step.content, refs := step.refs }
+
+def stepToSelectedDoc (step : ContractStep) : ContractSelectedDoc :=
+  { action := step.action
+  , target := step.target
+  , graphqlType := collectionName step.target.collection
+  , uniqueField := collectionUniqueField step.target.collection
+  , uniqueValue := step.target.id
+  , content := step.content
+  , refs := step.refs
+  }
+
+def selectedDocsByAction
+    (action : String)
+    (steps : List ContractStep) : List ContractSelectedDoc :=
+  (productionOrderedSteps steps).filterMap fun step =>
+    if step.action == action then some (stepToSelectedDoc step) else none
+
+def selectedWriteDocs (steps : List ContractStep) : List ContractSelectedDoc :=
+  (productionOrderedSteps steps).map stepToSelectedDoc
 
 def createStep (doc : ContractDoc) : ContractStep :=
   { action := "create", target := doc.ref, content := doc.content, refs := doc.refs }
@@ -200,8 +277,25 @@ def prefixReferrersClosed
     | some doc => doc.refs.all fun ref => containsDoc desired ref
     | none => false
 
+def adjacentCollectionsPrefixSafe : List Collection → Bool
+  | [] => true
+  | [_] => true
+  | left :: right :: rest =>
+      (left.applyOrder <= right.applyOrder) &&
+        adjacentCollectionsPrefixSafe (right :: rest)
+
+def allProductionPrefixesReferrersClosed
+    (preDesired : List ContractDoc)
+    (steps : List ContractStep) : Bool :=
+  (List.range (steps.length + 1)).all fun prefixLen =>
+    let prefixSteps := steps.take prefixLen
+    let prefixDesired := applyAll preDesired prefixSteps
+    prefixReferrersClosed prefixDesired prefixSteps &&
+      desiredReferencesClosed prefixDesired
+
 def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   let steps := diffSteps scenario.manifest scenario.preDesired
+  let productionSteps := productionOrderedSteps steps
   let prefixSteps := steps.take scenario.prefixLen
   let prefixDesired := applyAll scenario.preDesired prefixSteps
   let after := applyAll scenario.preDesired steps
@@ -218,6 +312,10 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   , expectedUnchanged := diffUnchanged scenario
   , expectedLiveOnly := diffLiveOnly scenario
   , expectedSteps := steps
+  , expectedWriteOrder := productionWriteOrder.map collectionWriteProjection
+  , expectedSelectedCreateDocs := selectedDocsByAction "create" steps
+  , expectedSelectedUpdateDocs := selectedDocsByAction "update" steps
+  , expectedSelectedWrites := selectedWriteDocs steps
   , prefixLen := scenario.prefixLen
   , expectedPrefixDesired := sortedDocs prefixDesired
   , expectedAfterDesired := sortedDocs after
@@ -230,6 +328,9 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   , manifestRealizedAfter := manifestRealizedBool scenario.manifest after
   , retryConverges := desiredDocsEq retry after
   , idempotentAfter := desiredDocsEq reapplied after
+  , writeOrderPrefixSafe := adjacentCollectionsPrefixSafe productionWriteOrder
+  , productionPrefixesReferrersClosed :=
+      allProductionPrefixesReferrersClosed scenario.preDesired productionSteps
   , prefixReferrersClosed :=
       prefixReferrersClosed prefixDesired prefixSteps
   , desiredReferencesClosedAfterPrefix := desiredReferencesClosed prefixDesired
@@ -253,8 +354,11 @@ def backendA : DocRef := doc .inferenceBackend "backend-a"
 def backendB : DocRef := doc .inferenceBackend "backend-b"
 def selectionA : DocRef := doc .toolSelection "selection-a"
 def profileA : DocRef := doc .inferenceProfile "profile-a"
+def serviceA : DocRef := doc .toolServiceRegistry "service-a"
 def behaviorA : DocRef := doc .agentBehavior "behavior-a"
 def taskA : DocRef := doc .task "task-a"
+def scheduleA : DocRef := doc .schedule "schedule-a"
+def eventTriggerA : DocRef := doc .eventTrigger "trigger-a"
 def principalA : DocRef := doc .agentPrincipal "did:example:agent"
 
 def applyReconcileScenarios : List ApplyReconcileScenario :=
@@ -309,6 +413,23 @@ def applyReconcileScenarios : List ApplyReconcileScenario :=
     , preLive := []
     , prefixLen := 4
     }
+  , { name := "production_write_boundary_all_collections"
+    , manifest :=
+        [ desired .inferenceBackend "backend-a" "backend-desired"
+        , desired .inferenceProfile "profile-a" "profile-desired"
+        , desired .toolServiceRegistry "service-a" "service-desired"
+        , desired .toolSelection "selection-a" "selection-desired"
+        , desired .agentBehavior "behavior-a" "behavior-desired"
+            [backendA, selectionA, profileA, serviceA]
+        , desired .task "task-a" "task-desired" [behaviorA]
+        , desired .schedule "schedule-a" "schedule-desired"
+        , desired .eventTrigger "trigger-a" "trigger-desired" [taskA]
+        , desired .agentPrincipal "did:example:agent" "principal-desired" [behaviorA]
+        ]
+    , preDesired := []
+    , preLive := []
+    , prefixLen := 6
+    }
   ]
 
 def applyReconcileCases : List ApplyReconcileCase :=
@@ -345,6 +466,26 @@ def stepJson (step : ContractStep) : String :=
       ++ jsonArray ((sortedDocRefs step.refs).map docRefJson)
     ++ "}"
 
+def collectionWriteJson (entry : ContractCollectionWrite) : String :=
+  "{"
+    ++ "\"collection\":" ++ jsonString (collectionName entry.collection) ++ ","
+    ++ "\"graphql_type\":" ++ jsonString entry.graphqlType ++ ","
+    ++ "\"unique_field\":" ++ jsonString entry.uniqueField ++ ","
+    ++ "\"apply_order\":" ++ toString entry.applyOrder
+    ++ "}"
+
+def selectedDocJson (entry : ContractSelectedDoc) : String :=
+  "{"
+    ++ "\"action\":" ++ jsonString entry.action ++ ","
+    ++ "\"target\":" ++ docRefJson entry.target ++ ","
+    ++ "\"graphql_type\":" ++ jsonString entry.graphqlType ++ ","
+    ++ "\"unique_field\":" ++ jsonString entry.uniqueField ++ ","
+    ++ "\"unique_value\":" ++ jsonString entry.uniqueValue ++ ","
+    ++ "\"content\":" ++ jsonString entry.content ++ ","
+    ++ "\"refs\":"
+      ++ jsonArray ((sortedDocRefs entry.refs).map docRefJson)
+    ++ "}"
+
 def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
   "{"
     ++ "\"name\":" ++ jsonString witness.name ++ ","
@@ -361,6 +502,14 @@ def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
       ++ jsonArray (witness.expectedLiveOnly.map docRefJson) ++ ","
     ++ "\"expected_steps\":"
       ++ jsonArray (witness.expectedSteps.map stepJson) ++ ","
+    ++ "\"expected_write_order\":"
+      ++ jsonArray (witness.expectedWriteOrder.map collectionWriteJson) ++ ","
+    ++ "\"expected_selected_create_docs\":"
+      ++ jsonArray (witness.expectedSelectedCreateDocs.map selectedDocJson) ++ ","
+    ++ "\"expected_selected_update_docs\":"
+      ++ jsonArray (witness.expectedSelectedUpdateDocs.map selectedDocJson) ++ ","
+    ++ "\"expected_selected_writes\":"
+      ++ jsonArray (witness.expectedSelectedWrites.map selectedDocJson) ++ ","
     ++ "\"prefix_len\":" ++ toString witness.prefixLen ++ ","
     ++ "\"expected_prefix_desired\":"
       ++ jsonArray (witness.expectedPrefixDesired.map desiredDocJson) ++ ","
@@ -377,6 +526,10 @@ def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
       ++ boolString witness.manifestRealizedAfter ++ ","
     ++ "\"retry_converges\":" ++ boolString witness.retryConverges ++ ","
     ++ "\"idempotent_after\":" ++ boolString witness.idempotentAfter ++ ","
+    ++ "\"write_order_prefix_safe\":"
+      ++ boolString witness.writeOrderPrefixSafe ++ ","
+    ++ "\"production_prefixes_referrers_closed\":"
+      ++ boolString witness.productionPrefixesReferrersClosed ++ ","
     ++ "\"prefix_referrers_closed\":"
       ++ boolString witness.prefixReferrersClosed ++ ","
     ++ "\"desired_references_closed_after_prefix\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -209,7 +209,7 @@ def caseCoverage : List CoverageEntry :=
   , consumerCoverage
       "apply_reconcile_cases"
       "ApplyReconcileCases"
-      "apply_conformance::generated_apply_reconcile_cases_drive_apply_model_and_production_ordering"
+      "config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary"
   , consumerCoverage
       "session_recovery_cases"
       "SessionRecoveryCases"

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -285,6 +285,25 @@ pub(crate) struct LeanApplyStep {
     pub(crate) refs: Vec<LeanApplyDocRef>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplyCollectionWrite {
+    pub(crate) collection: String,
+    pub(crate) graphql_type: String,
+    pub(crate) unique_field: String,
+    pub(crate) apply_order: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanApplySelectedDoc {
+    pub(crate) action: String,
+    pub(crate) target: LeanApplyDocRef,
+    pub(crate) graphql_type: String,
+    pub(crate) unique_field: String,
+    pub(crate) unique_value: String,
+    pub(crate) content: String,
+    pub(crate) refs: Vec<LeanApplyDocRef>,
+}
+
 #[derive(Debug, Deserialize)]
 pub(crate) struct LeanApplyReconcileCase {
     pub(crate) name: String,
@@ -296,6 +315,10 @@ pub(crate) struct LeanApplyReconcileCase {
     pub(crate) expected_unchanged: Vec<LeanApplyDocRef>,
     pub(crate) expected_live_only: Vec<LeanApplyDocRef>,
     pub(crate) expected_steps: Vec<LeanApplyStep>,
+    pub(crate) expected_write_order: Vec<LeanApplyCollectionWrite>,
+    pub(crate) expected_selected_create_docs: Vec<LeanApplySelectedDoc>,
+    pub(crate) expected_selected_update_docs: Vec<LeanApplySelectedDoc>,
+    pub(crate) expected_selected_writes: Vec<LeanApplySelectedDoc>,
     pub(crate) prefix_len: usize,
     pub(crate) expected_prefix_desired: Vec<LeanApplyDesiredDoc>,
     pub(crate) expected_after_desired: Vec<LeanApplyDesiredDoc>,
@@ -306,6 +329,8 @@ pub(crate) struct LeanApplyReconcileCase {
     pub(crate) manifest_realized_after: bool,
     pub(crate) retry_converges: bool,
     pub(crate) idempotent_after: bool,
+    pub(crate) write_order_prefix_safe: bool,
+    pub(crate) production_prefixes_referrers_closed: bool,
     pub(crate) prefix_referrers_closed: bool,
     pub(crate) desired_references_closed_after_prefix: bool,
 }

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -180,7 +180,7 @@ fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().request_transition_cases.len(), 81);
     assert_eq!(lean_contract_snapshot().process_transition_cases.len(), 25);
-    assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 6);
+    assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 7);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 18);
     assert_eq!(
         lean_contract_snapshot()

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -105,11 +105,11 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             test: "matches generated Lean ClientShell projection contracts",
         },
         ConformanceConsumer::RustTest {
-            id: "apply_conformance::generated_apply_reconcile_cases_drive_apply_model_and_production_ordering",
-            package: "defra-agent",
-            source_path: "crates/defra-agent/tests/apply_conformance.rs",
-            module_path: "apply_conformance",
-            function: "generated_apply_reconcile_cases_drive_apply_model_and_production_ordering",
+            id: "config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary",
+            package: "defra-agent-cli",
+            source_path: "crates/defra-agent-cli/src/config_import.rs",
+            module_path: "config_import::lean_apply_write_boundary_tests",
+            function: "generated_apply_reconcile_cases_fence_production_apply_write_boundary",
         },
         ConformanceConsumer::RustTest {
             id: "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy",

--- a/docs/superpowers/audits/2026-05-15-lean-spec-gap-audit.md
+++ b/docs/superpowers/audits/2026-05-15-lean-spec-gap-audit.md
@@ -209,6 +209,7 @@ The case model includes:
 - `ContractDoc`, `ContractLiveDoc`, `ContractStep`, `ApplyReconcileScenario`, and `ApplyReconcileCase` in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:23`.
 - `diffSteps`, which computes expected steps from desired/live input, in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:132`.
 - `buildCase`, which computes expected buckets, steps, prefix behavior, retry behavior, idempotence, and reference closure flags, in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:203`.
+- #220 extends the same `apply_reconcile_cases` rows in place with production write-boundary projections: expected collection write order, GraphQL type and unique-field metadata, selected create/update/write docs, and production-prefix referrer-closure flags.
 
 The emitted scenario set includes:
 
@@ -218,6 +219,7 @@ The emitted scenario set includes:
 - `live_only_no_op` in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:282`.
 - `prefix_retry_convergence_idempotence` in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:288`.
 - `referrer_closure` in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:298`.
+- `production_write_boundary_all_collections`, added by #220, exercises selected writes across every production apply collection while keeping delete semantics out of scope.
 
 The cases are serialized by `applyReconcileCasesJson` in `crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases.lean:348`.
 
@@ -227,13 +229,9 @@ The JSON snapshot includes `apply_reconcile_cases` in `crates/defra-agent/proofs
 
 The ledger currently says:
 
-- `apply_reconcile_cases` has `consumerCoverage` with Rust consumer `apply_conformance::generated_apply_reconcile_cases_drive_apply_model_and_production_ordering` in `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean:209`.
+- `apply_reconcile_cases` has `consumerCoverage` with Rust consumer `config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary` in `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean:209`.
 
-That is accurate for the current emitted domain. The Rust test consumes every Lean ApplyReconcile case and checks both the Rust reference model and production ordering constants.
-
-The caveat is that the production CLI write boundary is not fully Lean-driven yet. The ledger row does not mean `defra-agent-cli config apply` is transactionally fenced by Lean rows. It means the Lean cases drive `defra_agent::apply_model`, and the same test cross-checks the production collection ordering constant.
-
-I filed #220 because the next operational boundary for #56 needs its own Lean-backed production consumer.
+That is accurate for the current emitted domain after #220. The reference-model consumer remains useful and still consumes the same rows in `apply_conformance.rs`, but the ledger now points at the production-boundary consumer because that is the stronger #56 gate.
 
 ### Rust consumer state
 
@@ -264,13 +262,12 @@ The production CLI surface is separate:
 - `CONFIG_APPLY_ORDER` lives in `crates/defra-agent-cli/src/config_import.rs:24`.
 - `apply_desired_state_changes` iterates that order and applies selected documents in `crates/defra-agent-cli/src/config_import.rs:591`.
 - `select_apply_docs_for_collection` selects the create/update documents for one collection in `crates/defra-agent-cli/src/config_import.rs:615`.
-- Existing CLI tests pin order and retry-safe prefixes in `crates/defra-agent-cli/src/config_import.rs:642` and `crates/defra-agent-cli/tests/cli_config_apply_order.rs:4`.
+- `generated_apply_reconcile_cases_fence_production_apply_write_boundary` consumes the Lean rows next to `apply_desired_state_changes`, checks production order and selection, validates GraphQL type / unique-field mapping, keeps live-owned fields out of prepared writes, and records the real mutation sequence against a fake GraphQL endpoint.
+- Existing CLI tests still pin order and retry-safe prefixes in `crates/defra-agent-cli/src/config_import.rs:642` and `crates/defra-agent-cli/tests/cli_config_apply_order.rs:4`.
 
 ### Is this a Rust-catches-up-to-Lean candidate?
 
-Yes for the reference model and collection ordering.
-
-Not yet for the production write boundary.
+Yes for the reference model, collection ordering, and production write boundary.
 
 The current Lean cases are strong enough to catch regressions in:
 
@@ -283,34 +280,21 @@ The current Lean cases are strong enough to catch regressions in:
 - idempotence,
 - lower-rank reference closure.
 
-They are not yet enough to catch bugs in:
+They now also catch bugs in:
 
 - actual `config apply` write sequencing,
 - production document selection per collection,
+- GraphQL type / unique-field projection drift,
+- live-field leakage at the write boundary,
+
+They are still not intended to catch:
+
 - transactional rollback behavior for #56,
 - future delete behavior for #57.
 
-### Smallest additions to make ApplyReconcile production-ready
+### Production-boundary status
 
-Issue #220 is the next narrow addition.
-
-Minimum useful addition:
-
-1. Either reuse existing `apply_reconcile_cases` directly in `defra-agent-cli`, or add production-facing expected fields only if the existing rows are too model-shaped.
-
-2. Add a `defra-agent-cli` conformance test that consumes Lean rows and checks:
-   - `CONFIG_APPLY_ORDER` matches Lean `Collection.applyOrder`;
-   - selected create/update documents match expected Lean buckets;
-   - no live-only document is selected for write;
-   - prefixes are retry-safe and lower-rank references appear before referrers.
-
-3. Keep delete behavior out of this task.
-   - Lean and Rust currently model create/update/no-op only.
-   - #57 should own live-only deletion semantics and any new Lean rows for delete.
-
-4. Use #56 for the transactional implementation once the production boundary is fenced.
-
-This is smaller than a Lean refactor because the existing rows already contain most of the needed data. The main gap is consumer placement: `defra-agent-cli`, not `defra_agent::apply_model`.
+#220 reused the existing `apply_reconcile_cases` domain and extended it in place rather than adding a sibling emitted domain. That keeps the reference-model consumer green while giving `defra-agent-cli` a production-facing projection. Delete behavior remains out of scope; Lean and Rust still model create/update/no-op only, and #57 should own live-only deletion semantics and any new delete rows. #56 can now use the production-boundary conformance test as the pre-transactional gate.
 
 ## Other shape-pin or follow-up ledger entries
 


### PR DESCRIPTION
## Summary
- extend existing `apply_reconcile_cases` rows with production write-boundary projections for write order, selected create/update docs, unique fields, and prefix safety
- add a `defra-agent-cli` conformance consumer around `apply_desired_state_changes` that records production GraphQL writes against Lean rows
- repoint the coverage ledger to the production-boundary consumer while keeping the reference-model consumer active

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo fmt --all`
- `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
- `cargo test -p defra-agent --lib --tests`
- `cargo test -p defra-agent-cli`

Closes #220.