### PR TITLE
Tighten identity permission conformance mirrors

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Identity/Conformance.lean
+++ b/crates/defra-agent/proofs/Proofs/Identity/Conformance.lean
@@ -330,6 +330,20 @@ def identityPermissionCases : List IdentityPermissionCase :=
 theorem identityPermissionCases_count :
     identityPermissionCases.length = 4 := rfl
 
+def stringListContains (values : List String) (value : String) : Bool :=
+  values.any (fun candidate => candidate == value)
+
+def identityPermissionCaseReferencesDeclared
+    (c : IdentityPermissionCase) : Bool :=
+  let behaviorIds := c.behaviors.map (fun behavior => behavior.id)
+  let deploymentIds := c.deployments.map (fun deployment => deployment.id)
+  stringListContains behaviorIds c.actorBehavior &&
+    stringListContains behaviorIds c.peerBehavior &&
+    stringListContains deploymentIds c.hostDeployment
+
+theorem identityPermissionCases_reference_declared_ids :
+    identityPermissionCases.all identityPermissionCaseReferencesDeclared = true := rfl
+
 open Conformance.Contracts
 open Conformance.ContractCases (boolString)
 

--- a/crates/defra-agent/tests/identity_conformance.rs
+++ b/crates/defra-agent/tests/identity_conformance.rs
@@ -88,14 +88,10 @@ fn rust_canonical_permission_decision(case: &LeanIdentityPermissionCase, princip
 }
 
 fn rust_hostability_decision(
-    case: &LeanIdentityPermissionCase,
     deployment: &LeanIdentityDeployment,
     behavior: &LeanIdentityBehavior,
 ) -> bool {
-    let principal_dids: HashSet<&str> = case.principals.iter().map(|p| p.did.as_str()).collect();
-    principal_dids.contains(deployment.principal.as_str())
-        && principal_dids.contains(behavior.principal.as_str())
-        && deployment.principal == behavior.principal
+    deployment.principal == behavior.principal
 }
 
 #[test]
@@ -223,13 +219,13 @@ fn identity_permission_cases_pin_runtime_permission_contract_shape() {
 
         let host = deployment_for_id(case, &case.host_deployment);
         assert_eq!(
-            rust_hostability_decision(case, host, actor),
+            rust_hostability_decision(host, actor),
             case.expected_actor_hostable,
             "case {:?}: actor hostability decision drifted",
             case.name
         );
         assert_eq!(
-            rust_hostability_decision(case, host, peer),
+            rust_hostability_decision(host, peer),
             case.expected_peer_hostable,
             "case {:?}: peer hostability decision drifted",
             case.name


### PR DESCRIPTION
## Summary
- make the Rust hostability mirror match Lean `Deployment.canHostBehavior` exactly
- add a Lean compile-time fence that every emitted identity permission row references declared behavior and deployment ids

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo fmt --all`
- `cargo test -p defra-agent --test identity_conformance`

Follow-up to #222 / review feedback for #219.