### PR TITLE
Make config apply transactional (#56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -129,17 +129,6 @@ dependencies = [
  "lens_sdk",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ahash"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom 0.2.17",
- "once_cell",
- "version_check",
 ]
 
 [[package]]
@@ -663,6 +652,15 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ark-ff"
@@ -1362,39 +1360,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
-dependencies = [
- "async-trait",
- "axum-core 0.3.4",
- "bitflags 1.3.2",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper 0.1.2",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -1405,7 +1375,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1418,27 +1388,10 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-tungstenite 0.29.0",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "mime",
- "rustversion",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -1518,6 +1471,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base256emoji"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1526,18 +1485,6 @@ dependencies = [
  "const-str",
  "match-lookup",
 ]
-
-[[package]]
-name = "base32"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1731,9 +1678,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eb4cdd6cf1b31d671e9efe75c5d1ec614776856cefbe109ca373554a6d514f"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
 ]
@@ -1763,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1927,7 +1874,7 @@ version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801927ee168e17809ab8901d9f01f700cd7d8d6a6527997fee44e4b0327a253c"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "cached_proc_macro",
  "cached_proc_macro_types",
  "hashbrown 0.15.5",
@@ -2108,13 +2055,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2262,9 +2220,15 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.0-pre.0"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5417da527aa9bf6a1e10a781231effd1edd3ee82f27d5f8529ac9b279babce96"
+checksum = "6d5ce5728ecb5285a5dd35f02a6a8e34e0828e0b38e8e632e249a3fe3f320211"
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -2395,7 +2359,7 @@ dependencies = [
  "commonware-parallel",
  "commonware-utils",
  "crc-fast",
- "ctutils",
+ "ctutils 0.3.1",
  "ecdsa",
  "ed25519-consensus",
  "getrandom 0.2.17",
@@ -2513,7 +2477,7 @@ version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d4ae4c804d0d9c1df615b1c7846e4e5e64fdb4228685487cb67803e67388411"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "bytes",
  "cfg-if",
  "commonware-codec",
@@ -2527,9 +2491,9 @@ dependencies = [
  "getrandom 0.2.17",
  "governor",
  "libc",
- "opentelemetry 0.31.0",
- "opentelemetry-otlp 0.31.1",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prometheus-client 0.24.1",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -2539,7 +2503,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -2549,7 +2513,7 @@ version = "2026.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca1c42cf37aa27c3f83c31591cad4f1d96317eff81c1eb442e17191adcf9b413"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "bytes",
  "cfg-if",
@@ -2620,25 +2584,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "config"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23738e11972c7643e4ec947840fc463b6a571afcd3e735bdfce7d03c7a784aca"
-dependencies = [
- "async-trait",
- "json5",
- "lazy_static",
- "nom",
- "pathdiff",
- "ron",
- "rust-ini",
- "serde",
- "serde_json",
- "toml 0.5.11",
- "yaml-rust",
 ]
 
 [[package]]
@@ -3028,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3130,7 +3075,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3247,23 +3192,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.5.2"
+name = "ctutils"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
+checksum = "7c67c81499f542d1dd38c6a2a2fe825f4dd4bca5162965dd2eea0c8119873d3c"
 dependencies = [
- "dispatch2",
- "nix 0.31.2",
- "windows-sys 0.61.2",
+ "cmov 0.4.6",
 ]
 
 [[package]]
 name = "ctutils"
-version = "0.3.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758e5ed90be3c8abff7f9a6f37ab7f6d8c59c2210d448b81f3f508134aec84e4"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
- "cmov",
+ "cmov 0.5.3",
 ]
 
 [[package]]
@@ -3284,16 +3227,16 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.1"
+version = "5.0.0-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9200d1d13637f15a6acb71e758f64624048d85b31a5fdbfd8eca1e2687d0b7"
+checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.11.0-rc.10",
+ "digest 0.11.3",
  "fiat-crypto 0.3.0",
- "rand_core 0.9.5",
+ "rand_core 0.10.1",
  "rustc_version 0.4.1",
  "serde",
  "subtle",
@@ -3396,19 +3339,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
@@ -3450,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3465,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "anyhow",
@@ -3514,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3536,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3550,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-lock",
@@ -3588,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-trait",
@@ -3603,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "anyhow",
  "document",
@@ -3694,7 +3624,7 @@ name = "defra-agent-cli"
 version = "0.1.5"
 dependencies = [
  "anyhow",
- "axum 0.8.9",
+ "axum",
  "chrono",
  "clap",
  "defra-agent",
@@ -3702,9 +3632,9 @@ dependencies = [
  "defra-node",
  "defra-p2p-adapter",
  "hostname",
- "opentelemetry 0.31.0",
- "opentelemetry-otlp 0.31.1",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "p2p",
  "query",
  "regex",
@@ -3715,7 +3645,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.32.1",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -3789,7 +3719,7 @@ name = "defra-agent-protocol"
 version = "0.1.5"
 dependencies = [
  "anyhow",
- "axum 0.8.9",
+ "axum",
  "chrono",
  "reqwest 0.12.28",
  "rig-core",
@@ -3802,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3825,14 +3755,15 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-stream",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "cid 0.10.1",
  "crypto",
+ "db",
  "defra-core",
  "defra-version",
  "events",
@@ -3848,7 +3779,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -3856,12 +3787,12 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "blockstore",
  "db",
  "db-merge",
@@ -3888,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-trait",
@@ -3912,12 +3843,13 @@ dependencies = [
  "storage",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "serde",
 ]
@@ -4095,11 +4027,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.0-rc.10"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa94b64bfc6549e6e4b5a3216f22593224174083da7a90db47e951c4fb31725"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.11.0",
+ "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
 ]
@@ -4130,16 +4062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
 ]
 
 [[package]]
@@ -4202,17 +4124,6 @@ dependencies = [
 
 [[package]]
 name = "dlopen2"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b4f5f101177ff01b8ec4ecc81eead416a8aa42819a2869311b3420fa114ffa"
-dependencies = [
- "libc",
- "once_cell",
- "winapi",
-]
-
-[[package]]
-name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
@@ -4235,15 +4146,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4260,15 +4165,6 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "uuid",
-]
-
-[[package]]
-name = "document-features"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
-dependencies = [
- "litrs",
 ]
 
 [[package]]
@@ -4332,7 +4228,7 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
+ "serdect 0.2.0",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -4350,13 +4246,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "3.0.0-rc.4"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "pkcs8 0.11.0-rc.11",
- "serde",
- "signature 3.0.0-rc.10",
+ "pkcs8 0.11.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -4389,16 +4285,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.1"
+version = "3.0.0-pre.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
+checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.1",
- "ed25519 3.0.0-rc.4",
- "rand_core 0.9.5",
+ "curve25519-dalek 5.0.0-pre.6",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
  "serde",
- "sha2 0.11.0-rc.2",
- "signature 3.0.0-rc.10",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -4430,7 +4326,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
@@ -4440,7 +4336,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -4613,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4679,13 +4575,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash 0.2.0",
  "libm",
- "rand 0.9.2",
+ "portable-atomic",
  "siphasher 1.0.2",
 ]
 
@@ -5297,6 +5193,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -5445,7 +5342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
- "dashmap 6.1.0",
+ "dashmap",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -5619,9 +5516,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -5629,7 +5523,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
 ]
 
 [[package]]
@@ -5667,6 +5561,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -5722,6 +5621,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.4.13",
+ "hickory-proto 0.26.1",
+ "http 1.4.0",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.1",
+ "rustls 0.23.37",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5748,30 +5676,20 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
- "async-trait",
- "bytes",
- "cfg-if",
  "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
  "idna",
  "ipnet",
+ "jni 0.22.4",
  "once_cell",
- "rand 0.9.2",
+ "prefix-trie",
+ "rand 0.10.1",
  "ring 0.17.14",
- "rustls 0.23.37",
  "thiserror 2.0.18",
  "tinyvec",
- "tokio",
- "tokio-rustls 0.26.4",
  "tracing",
  "url",
 ]
@@ -5799,21 +5717,26 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.2"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto 0.25.2",
+ "hickory-net",
+ "hickory-proto 0.26.1",
  "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
  "moka",
+ "ndk-context",
  "once_cell",
  "parking_lot 0.12.5",
- "rand 0.9.2",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls 0.23.37",
  "smallvec",
+ "system-configuration 0.7.0",
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -5948,15 +5871,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "hybrid-array"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6040,18 +5954,6 @@ dependencies = [
  "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper 0.14.32",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -6245,7 +6147,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -6339,11 +6241,10 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+checksum = "bac9a3c8278f43b4cd8463380f4a25653ac843e5b177e1d3eaf849cc9ba10d4d"
 dependencies = [
- "async-trait",
  "attohttpc 0.30.1",
  "bytes",
  "futures",
@@ -6352,7 +6253,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "log",
- "rand 0.9.2",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -6496,6 +6397,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "iri-string"
@@ -6509,23 +6413,26 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "0.97.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb56e7e4b0ec7fba7efa6a236b016a52b5d927d50244aceb9e20566159b1a32"
+checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
 dependencies = [
  "backon",
+ "blake3",
  "bytes",
  "cfg_aliases",
+ "ctutils 0.4.2",
  "data-encoding",
  "derive_more 2.1.1",
- "ed25519-dalek 3.0.0-pre.1",
+ "ed25519-dalek 3.0.0-pre.7",
  "futures-util",
- "getrandom 0.3.4",
- "hickory-resolver 0.25.2",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
  "http 1.4.0",
  "ipnet",
  "iroh-base",
- "iroh-metrics 0.38.3",
+ "iroh-dns",
+ "iroh-metrics",
  "iroh-relay",
  "n0-error",
  "n0-future",
@@ -6536,12 +6443,10 @@ dependencies = [
  "noq-udp",
  "papaya",
  "pin-project",
- "pkarr",
- "pkcs8 0.11.0-rc.11",
  "portable-atomic",
  "portmapper",
- "rand 0.9.2",
- "reqwest 0.12.28",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
  "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -6549,7 +6454,6 @@ dependencies = [
  "serde",
  "smallvec",
  "strum 0.28.0",
- "sync_wrapper 1.0.2",
  "time",
  "tokio",
  "tokio-stream",
@@ -6562,19 +6466,21 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.97.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55a354e3396b62c14717ee807dfee9a7f43f6dad47e4ac0fd1d49f1ffad14ef0"
+checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.1",
+ "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
+ "data-encoding-macro",
  "derive_more 2.1.1",
- "digest 0.11.0-rc.10",
- "ed25519-dalek 3.0.0-pre.1",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0-pre.7",
+ "getrandom 0.4.2",
  "n0-error",
- "rand_core 0.9.5",
+ "rand 0.10.1",
  "serde",
- "sha2 0.11.0-rc.2",
+ "sha2 0.11.0",
  "url",
  "zeroize",
  "zeroize_derive",
@@ -6583,9 +6489,9 @@ dependencies = [
 [[package]]
 name = "iroh-bitswap"
 version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
+source = "git+https://github.com/sourcenetwork/beetle?branch=main#07b7260abb2a1cc7188f03f0deec3df3aea71021"
 dependencies = [
- "ahash 0.8.12",
+ "ahash",
  "anyhow",
  "async-broadcast 0.4.1",
  "async-channel 1.9.0",
@@ -6597,8 +6503,6 @@ dependencies = [
  "deadqueue",
  "derivative",
  "futures",
- "iroh-metrics 0.2.0",
- "iroh-util",
  "keyed_priority_queue",
  "libp2p",
  "multihash 0.18.1",
@@ -6620,34 +6524,36 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.99.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b06914e77bd07bc1b3600096be66e2a63d391e8f4a901f61771630e20f2116"
+checksum = "c6e351f5c1db08dcfb456e6299bda0881e1ba95a360f0913a5e57344c1538fb2"
 dependencies = [
  "arrayvec",
  "bao-tree",
  "bytes",
  "cfg_aliases",
  "chrono",
+ "constant_time_eq",
  "data-encoding",
  "derive_more 2.1.1",
- "futures-lite",
  "genawaiter",
+ "getrandom 0.4.2",
  "hex",
  "iroh",
  "iroh-base",
  "iroh-io",
- "iroh-metrics 0.38.3",
+ "iroh-metrics",
  "iroh-tickets",
+ "iroh-util",
  "irpc",
  "n0-error",
  "n0-future",
  "nested_enum_utils",
  "noq",
  "postcard",
- "rand 0.9.2",
+ "rand 0.10.1",
  "range-collections",
- "redb",
+ "redb 4.1.0",
  "ref-cast",
  "reflink-copy",
  "self_cell",
@@ -6658,16 +6564,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-gossip"
-version = "0.97.0"
+name = "iroh-dns"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db5b64f3cb0a0c8b68b57888acd4cefcd2f0774f1a132d2a498cbb2a92fbc55"
+checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more 2.1.1",
+ "hickory-resolver 0.26.1",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
+ "rustls 0.23.37",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-gossip"
+version = "0.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48eaefd27751bc5dabda1f1b318c38a8b624fa137a1aaf429dfdd4d66b452ba9"
 dependencies = [
  "blake3",
  "bytes",
+ "constant_time_eq",
  "data-encoding",
  "derive_more 2.1.1",
- "ed25519-dalek 3.0.0-pre.1",
+ "ed25519-dalek 3.0.0-pre.7",
  "futures-concurrency",
  "futures-lite",
  "futures-util",
@@ -6675,12 +6606,12 @@ dependencies = [
  "indexmap 2.13.1",
  "iroh",
  "iroh-base",
- "iroh-metrics 0.38.3",
+ "iroh-metrics",
  "irpc",
  "n0-error",
  "n0-future",
  "postcard",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "tokio",
  "tokio-util",
@@ -6702,37 +6633,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
-dependencies = [
- "async-trait",
- "config",
- "iroh-util",
- "lazy_static",
- "names",
- "opentelemetry 0.18.0",
- "opentelemetry-otlp 0.11.0",
- "paste",
- "prometheus-client 0.18.1",
- "reqwest 0.11.27",
- "serde",
- "tokio",
- "tracing",
- "tracing-opentelemetry 0.18.0",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "iroh-metrics"
-version = "0.38.3"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761b45ba046134b11eb3e432fa501616b45c4bf3a30c21717578bc07aa6461dd"
+checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
  "portable-atomic",
- "postcard",
  "ryu",
  "serde",
  "tracing",
@@ -6740,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "0.4.1"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab063c2bfd6c3d5a33a913d4fdb5252f140db29ec67c704f20f3da7e8f92dbf"
+checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -6752,34 +6660,34 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "0.97.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d786b260cadfe82ae0b6a9e372e8c78949096a06c857d1c3521355cefced0f55"
+checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
 dependencies = [
  "blake3",
  "bytes",
  "cfg_aliases",
  "data-encoding",
  "derive_more 2.1.1",
- "getrandom 0.3.4",
- "hickory-resolver 0.25.2",
+ "getrandom 0.4.2",
+ "hickory-resolver 0.26.1",
  "http 1.4.0",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-util",
  "iroh-base",
- "iroh-metrics 0.38.3",
- "lru 0.16.4",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru 0.18.0",
  "n0-error",
  "n0-future",
  "noq",
  "noq-proto",
  "num_enum 0.7.6",
  "pin-project",
- "pkarr",
  "postcard",
- "rand 0.9.2",
- "reqwest 0.12.28",
+ "rand 0.10.1",
+ "reqwest 0.13.2",
  "rustls 0.23.37",
  "rustls-pki-types",
  "serde",
@@ -6794,14 +6702,13 @@ dependencies = [
  "vergen-gitcl",
  "webpki-roots 1.0.6",
  "ws_stream_wasm",
- "z32",
 ]
 
 [[package]]
 name = "iroh-tickets"
-version = "0.4.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab64bac4bb573b9cfd2142bd2876ed65ca792efbc4398361a4ee51a0f9afbed6"
+checksum = "0a4b7fbfa10582f6b4f6b013eef1d21987d3df5fd42c0f7707d5de6abd34f8e9"
 dependencies = [
  "data-encoding",
  "derive_more 2.1.1",
@@ -6813,29 +6720,23 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.2.0"
-source = "git+https://github.com/sourcenetwork/beetle?branch=main#6441b0ac5f42d466f44963afb782bb56030b1479"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7705450a124b2b05f7caad505620ab5ac3bf4eb6b85018e6b9bca36329fd031"
 dependencies = [
- "anyhow",
- "cid 0.10.1",
- "config",
- "ctrlc",
- "dirs-next",
- "futures",
- "humansize",
- "rlimit",
- "serde",
- "sysinfo 0.27.8",
- "thiserror 1.0.69",
- "toml 0.5.11",
+ "derive_more 2.1.1",
+ "iroh",
+ "n0-error",
+ "n0-future",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "irpc"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f47b7c52662d673df377b5ac40c121c7ff56eb764e520fae6543686132f7957"
+checksum = "0d38567eed2ed120e1040386930eb3b9ce6ca8a94b13c20a1b3b6535f253b00c"
 dependencies = [
  "futures-buffered",
  "futures-util",
@@ -6855,9 +6756,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.10.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c1a4b460634aeed6dc01236a0047867de70e30562d91a0ad031dcb3ac33fb4"
+checksum = "6d8030c02dce4c9a8aecfb6e0870ee13ba3060096d88f6c1309919af8f197793"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7004,6 +6905,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7066,17 +6997,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "jsonptr"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7096,7 +7016,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
  "signature 2.2.0",
 ]
@@ -7167,7 +7087,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -7362,6 +7282,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-mdns",
+ "libp2p-memory-connection-limits",
  "libp2p-metrics",
  "libp2p-noise",
  "libp2p-ping",
@@ -7567,6 +7488,21 @@ dependencies = [
  "smallvec",
  "socket2 0.5.10",
  "tokio",
+ "tracing",
+ "void",
+]
+
+[[package]]
+name = "libp2p-memory-connection-limits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63ec429a224821a9915f31613743566846c6d20078af9736975a60bea4a9293"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "memory-stats",
+ "sysinfo 0.29.11",
  "tracing",
  "void",
 ]
@@ -7903,12 +7839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "litrs"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
-
-[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7952,6 +7882,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+dependencies = [
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -8075,12 +8014,6 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -8113,6 +8046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "memory-stats"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8337,9 +8280,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "0.1.3"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af4782b4baf92d686d161c15460c83d16ebcfd215918763903e9619842665cae"
+checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -8348,9 +8291,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "0.1.3"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03755949235714b2b307e5ae89dd8c1c2531fb127d9b8b7b4adf9c876cd3ed18"
+checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8380,9 +8323,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "0.6.1"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38795f7932e6e9d1c6e989270ef5b3ff24ebb910e2c9d4bed2d28d8bae3007dc"
+checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
 dependencies = [
  "derive_more 2.1.1",
  "n0-error",
@@ -8468,13 +8411,13 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.40.1"
+version = "0.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b0a0096d9613ee878dba89bbe595f079d373e3f1960d882e4f2f78ff9c30a0a"
+checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
 dependencies = [
  "block2",
  "dispatch2",
- "dlopen2 0.5.0",
+ "dlopen2",
  "ipnet",
  "libc",
  "mac-addr",
@@ -8482,10 +8425,12 @@ dependencies = [
  "netlink-packet-route 0.29.0",
  "netlink-sys",
  "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
  "objc2-system-configuration",
  "once_cell",
  "plist",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8522,6 +8467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-route"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
 name = "netlink-proto"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8550,9 +8507,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b1b27babe89ef9f2237bc6c028bea24fa84163a1b6f8f17ff93573ebd7d861f"
+checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -8565,7 +8522,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route 0.30.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -8603,18 +8560,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8644,12 +8589,13 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "noq"
-version = "0.17.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8df966fb44ac763bc86da97fa6c811c54ae82ef656575949f93c6dae0c9f09bf"
+checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "derive_more 2.1.1",
  "noq-proto",
  "noq-udp",
  "pin-project-lite",
@@ -8665,24 +8611,25 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "0.16.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c61b72abd670eebc05b5cf720e077b04a3ef3354bc7bc19f1c3524cb424db7b"
+checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
 dependencies = [
  "aes-gcm",
  "bytes",
  "derive_more 2.1.1",
  "enum-assoc",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "identity-hash",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.10.1",
+ "rand_pcg 0.10.2",
  "ring 0.17.14",
  "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
@@ -8693,9 +8640,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "0.9.0"
+version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
+checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -8711,21 +8658,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "ntimestamp"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50f94c405726d3e0095e89e72f75ce7f6587b94a8bd8dc8054b73f65c0fd68c"
-dependencies = [
- "base32",
- "document-features",
- "getrandom 0.2.17",
- "httpdate",
- "js-sys",
- "once_cell",
- "serde",
 ]
 
 [[package]]
@@ -8856,7 +8788,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8935,6 +8867,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8957,6 +8903,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -9003,6 +8950,16 @@ dependencies = [
  "bitflags 2.11.0",
  "objc2",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -9176,16 +9133,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d6c3d7288a106c0a363e4b0e8d308058d56902adefb16f4936f417ffef086e"
-dependencies = [
- "opentelemetry_api",
- "opentelemetry_sdk 0.18.0",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -9207,26 +9154,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "http 1.4.0",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "reqwest 0.12.28",
-]
-
-[[package]]
-name = "opentelemetry-otlp"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
-dependencies = [
- "async-trait",
- "futures",
- "futures-util",
- "http 0.2.12",
- "opentelemetry 0.18.0",
- "opentelemetry-proto 0.1.0",
- "prost 0.11.9",
- "thiserror 1.0.69",
- "tokio",
- "tonic 0.8.3",
 ]
 
 [[package]]
@@ -9236,10 +9165,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
  "http 1.4.0",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry-http",
- "opentelemetry-proto 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
  "prost 0.14.3",
  "reqwest 0.12.28",
  "thiserror 2.0.18",
@@ -9248,67 +9177,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
-dependencies = [
- "futures",
- "futures-util",
- "opentelemetry 0.18.0",
- "prost 0.11.9",
- "tonic 0.8.3",
- "tonic-build",
-]
-
-[[package]]
-name = "opentelemetry-proto"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost 0.14.3",
- "tonic 0.14.5",
+ "tonic",
  "tonic-prost",
-]
-
-[[package]]
-name = "opentelemetry_api"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24f96e21e7acc813c7a8394ee94978929db2bcc46cf6b5014fc612bf7760c22"
-dependencies = [
- "fnv",
- "futures-channel",
- "futures-util",
- "indexmap 1.9.3",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca41c4933371b61c2a2f214bf16931499af4ec90543604ec828f7a625c09113"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "dashmap 5.5.3",
- "fnv",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "once_cell",
- "opentelemetry_api",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -9320,7 +9197,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
  "thiserror 2.0.18",
@@ -9341,16 +9218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
-dependencies = [
- "dlv-list",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -9378,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "anyhow",
@@ -9408,12 +9275,14 @@ dependencies = [
  "parking_lot 0.12.5",
  "postcard",
  "rand 0.9.2",
+ "rlimit",
  "serde",
  "serde_bytes",
  "serde_cbor",
  "serde_json",
  "sha2 0.10.9",
  "storage",
+ "sysinfo 0.29.11",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9912,25 +9781,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkarr"
-version = "5.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7bfb9143bbba379f246211eb68074d78db9cc048e4c5701f3b0e6cb1ec67ca2"
-dependencies = [
- "base32",
- "bytes",
- "cfg_aliases",
- "document-features",
- "ed25519-dalek 3.0.0-pre.1",
- "getrandom 0.4.2",
- "ntimestamp",
- "self_cell",
- "serde",
- "simple-dns",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9942,9 +9792,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.11.0-rc.11"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12922b6296c06eb741b02d7b5161e3aaa22864af38dfa025a1a3ba3f68c84577"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der 0.8.0",
  "spki 0.8.0",
@@ -10058,23 +9908,22 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74748bc706fa6b6aebac6bbe0bbe0de806b384cb5c557ea974f771360a4e3858"
+checksum = "aec2a8809e3f7dba624776bb223da9fed49c413c60b3bef21aadcb67a5e35944"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "derive_more 2.1.1",
- "futures-lite",
- "futures-util",
  "hyper-util",
- "igd-next 0.16.2",
- "iroh-metrics 0.38.3",
+ "igd-next 0.17.0",
+ "iroh-metrics",
  "libc",
  "n0-error",
+ "n0-future",
  "netwatch",
  "num_enum 0.7.6",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "smallvec",
  "socket2 0.6.3",
@@ -10150,6 +9999,17 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
 
 [[package]]
 name = "prettyplease"
@@ -10309,18 +10169,6 @@ dependencies = [
 
 [[package]]
 name = "prometheus-client"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cd1b99916654a69008fd66b4f9397fbe08e6e51dfe23d4417acf5d3b8cb87c"
-dependencies = [
- "dtoa",
- "itoa",
- "parking_lot 0.12.5",
- "prometheus-client-derive-text-encode",
-]
-
-[[package]]
-name = "prometheus-client"
 version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "504ee9ff529add891127c4827eb481bd69dc0ebc72e9a682e187db4caa60c3ca"
@@ -10363,17 +10211,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "prometheus-client-derive-text-encode"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a455fbcb954c1a7decf3c586e860fd7889cddf4b8e164be736dbac95a953cd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -10536,10 +10373,11 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-graphql",
+ "async-lock",
  "async-trait",
  "base64 0.22.1",
  "blockstore",
@@ -10571,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10588,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "async-lock",
@@ -10619,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10765,7 +10603,7 @@ dependencies = [
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc",
- "rand_pcg",
+ "rand_pcg 0.2.1",
 ]
 
 [[package]]
@@ -10789,6 +10627,17 @@ dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20 0.10.0",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -10850,6 +10699,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10875,6 +10730,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -10989,6 +10853,15 @@ name = "redb"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "redb"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e925444704b5f17d32bf42f5b6e2df050bceebc3dcd6e71cc73dafe8092e839"
 dependencies = [
  "libc",
 ]
@@ -11158,7 +11031,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg 0.50.0",
 ]
 
@@ -11199,7 +11071,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -11237,14 +11109,14 @@ dependencies = [
  "quinn",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -11410,17 +11282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ron"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "serde",
-]
-
-[[package]]
 name = "rtnetlink"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11433,7 +11294,7 @@ dependencies = [
  "netlink-packet-route 0.28.0",
  "netlink-proto",
  "netlink-sys",
- "nix 0.30.1",
+ "nix",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -11471,16 +11332,6 @@ name = "ruint-macro"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
 
 [[package]]
 name = "rust-stemmers"
@@ -11642,7 +11493,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.103.10",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.37",
@@ -11739,7 +11611,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -11845,11 +11717,11 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "der 0.7.10",
  "generic-array",
  "pkcs8 0.10.2",
- "serdect",
+ "serdect 0.2.0",
  "subtle",
  "zeroize",
 ]
@@ -12225,7 +12097,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -12314,13 +12196,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.11.0-rc.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e3878ab0f98e35b2df35fe53201d088299b41a6bb63e3e34dada2ac4abd924"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.11.0-rc.10",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -12389,15 +12271,25 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
 
 [[package]]
 name = "simdutf8"
@@ -12560,7 +12452,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12695,7 +12587,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-trait",
  "bm25",
@@ -12707,7 +12599,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "parking_lot 0.12.5",
- "redb",
+ "redb 2.6.3",
  "rocksdb",
  "schema",
  "serde",
@@ -12933,9 +12825,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.27.8"
+version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a902e9050fca0a5d6877550b769abd2bd1ce8c04634b941dbe2809735e1a1e33"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -13033,12 +12925,12 @@ dependencies = [
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
- "dlopen2 0.8.2",
+ "dlopen2",
  "dpi",
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -13105,7 +12997,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -13251,7 +13143,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -13274,7 +13166,7 @@ checksum = "e11ea2e6f801d275fdd890d6c9603736012742a1c33b96d0db788c9cdebf7f9e"
 dependencies = [
  "gtk",
  "http 1.4.0",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -13630,16 +13522,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13748,20 +13630,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-websockets"
-version = "0.12.3"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1b6348ebfaaecd771cecb69e832961d277f59845d4220a584701f72728152b7"
+checksum = "dad543404f98bfc969aeb71994105c592acfc6c43323fddcd016bb208d1c65cb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "http 1.4.0",
  "httparse",
- "rand 0.9.2",
+ "rand 0.10.1",
  "ring 0.17.14",
  "rustls-pki-types",
+ "sha1_smol",
  "simdutf8",
  "tokio",
  "tokio-rustls 0.26.4",
@@ -13873,38 +13756,6 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum 0.6.20",
- "base64 0.13.1",
- "bytes",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.11.9",
- "prost-derive 0.11.9",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -13925,19 +13776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
-dependencies = [
- "prettyplease 0.1.25",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tonic-prost"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13945,27 +13783,7 @@ checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost 0.14.3",
- "tonic 0.14.5",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "tonic",
 ]
 
 [[package]]
@@ -13998,7 +13816,7 @@ dependencies = [
  "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -14063,17 +13881,6 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
-dependencies = [
- "log",
- "once_cell",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -14085,30 +13892,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ebb87a95ea13271332df069020513ab70bdb5637ca42d6e492dc3bbbad48de"
-dependencies = [
- "once_cell",
- "opentelemetry 0.18.0",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "web-time",
 ]
@@ -14140,7 +13933,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-serde",
 ]
 
@@ -14470,32 +14263,21 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
- "vergen-lib 9.1.0",
+ "vergen-lib",
 ]
 
 [[package]]
 name = "vergen-gitcl"
-version = "1.0.8"
+version = "9.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9dfc1de6eb2e08a4ddf152f1b179529638bedc0ea95e6d667c014506377aefe"
+checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
 dependencies = [
  "anyhow",
  "derive_builder",
  "rustversion",
  "time",
  "vergen",
- "vergen-lib 0.1.6",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b07e6010c0f3e59fcb164e0163834597da68d1f864e2b8ca49f74de01e9c166"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
+ "vergen-lib",
 ]
 
 [[package]]
@@ -16050,7 +15832,7 @@ dependencies = [
  "gtk",
  "http 1.4.0",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -16188,15 +15970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "yamux"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16260,15 +16033,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "z32"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
-
-[[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#25b935b763d7c935ec686a5a43a7affd0e2451fa"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3075,7 +3075,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "anyhow",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-lock",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-trait",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "anyhow",
  "document",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3755,7 +3755,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-stream",
@@ -3787,7 +3787,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "anyhow",
@@ -3819,7 +3819,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "serde",
 ]
@@ -4148,7 +4148,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4509,7 +4509,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6147,7 +6147,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7087,7 +7087,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8788,7 +8788,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9245,7 +9245,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "anyhow",
@@ -10373,7 +10373,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10409,7 +10409,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10426,7 +10426,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "async-lock",
@@ -10457,7 +10457,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11611,7 +11611,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12452,7 +12452,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12587,7 +12587,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16035,7 +16035,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89e6a380549b1878172b88887da73888fc6e1296#89e6a380549b1878172b88887da73888fc6e1296"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,6 +3706,7 @@ dependencies = [
  "opentelemetry-otlp 0.31.1",
  "opentelemetry_sdk 0.31.0",
  "p2p",
+ "query",
  "regex",
  "reqwest 0.12.28",
  "rig-core",
@@ -3788,6 +3789,7 @@ name = "defra-agent-protocol"
 version = "0.1.5"
 dependencies = [
  "anyhow",
+ "axum 0.8.9",
  "chrono",
  "reqwest 0.12.28",
  "rig-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,22 +35,22 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ opentelemetry = { version = "0.31", default-features = false, features = ["trace
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
 p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,22 +35,22 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89e6a380549b1878172b88887da73888fc6e1296" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -19,6 +19,7 @@ defra-agent = { path = "../defra-agent" }
 defra-agent-protocol.workspace = true
 defra-node.workspace = true
 defra-p2p-adapter.workspace = true
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 hostname.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -19,7 +19,7 @@ defra-agent = { path = "../defra-agent" }
 defra-agent-protocol.workspace = true
 defra-node.workspace = true
 defra-p2p-adapter.workspace = true
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+query.workspace = true
 hostname.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
+use defra_agent::graphql::escape_graphql_string;
+
 use crate::cli::*;
 use crate::config_writes::ConfigAccess;
 use crate::desired_state;
@@ -90,6 +92,23 @@ pub(crate) async fn apply_bound_desired_manifest(
         counts
     };
 
+    // === STOPGAP for sourcenetwork/defradb.rs#970 ===
+    // DefraDB tx commits do not emit Update events on the EventBus, so the
+    // in-process runtime watcher (control_watcher.rs) never reconciles after
+    // a transactional config apply. Until upstream emits Update events on
+    // commit, we issue a single auto-commit no-op write here to wake the
+    // watcher. The data we just committed inside the tx is durable regardless
+    // of whether this nudge succeeds.
+    // Remove this block when defradb.rs#970 ships.
+    if config_apply_counts_changed(&applied) {
+        if let Err(nudge_err) = nudge_runtime_watcher_after_apply(&access, bound).await {
+            tracing::warn!(
+                %nudge_err,
+                "config apply: post-commit runtime nudge failed; runtime may not reconcile until restart"
+            );
+        }
+    }
+
     let remaining_bundle = build_desired_state_live_bundle(&access, desired_manifest).await?;
     let (remaining_principal, remaining_manifest) =
         live_manifest_from_bundle(desired_manifest, &remaining_bundle)?;
@@ -118,4 +137,40 @@ pub(crate) async fn apply_bound_desired_manifest(
         remaining: remaining.counts.clone(),
     };
     Ok(report)
+}
+
+/// Issue a single auto-commit write to wake the in-process runtime watcher
+/// after a transactional apply. This is the implementation of the stopgap
+/// described above. The mutation re-writes `enabled` on the AgentPrincipal
+/// doc with its existing value — semantically a no-op, but the auto-commit
+/// path does emit an Update event on the EventBus, which is what the
+/// runtime watcher subscribes to.
+///
+/// Callers are expected to log and swallow the returned error; this is a
+/// best-effort wakeup and does not affect the durability of the apply.
+async fn nudge_runtime_watcher_after_apply(
+    access: &ConfigAccess,
+    bound: &super::binding::BoundDesiredManifest,
+) -> Result<()> {
+    let agent_did = &bound.context.target_agent_did;
+    let enabled = bound.manifest.agent_principal.enabled;
+    let escaped_did = escape_graphql_string(agent_did);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentPrincipal(
+                filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }},
+                input: {{ enabled: {enabled} }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = access.execute(&mutation).await?;
+    tracing::debug!(
+        agent_did = %agent_did,
+        "config apply: post-commit runtime nudge succeeded; _docID={}",
+        response
+            .pointer("/data/update_AgentPrincipal/0/_docID")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<none>")
+    );
+    Ok(())
 }

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -99,10 +99,20 @@ pub(crate) async fn apply_bound_desired_manifest(
     // commit, we issue a single auto-commit no-op write here to wake the
     // watcher. The data we just committed inside the tx is durable regardless
     // of whether this nudge succeeds.
-    // Remove this block when defradb.rs#970 ships.
+    //
+    // When defradb.rs#970 ships and we bump the workspace pin, remove:
+    //   1. This comment block and the `if` block that follows it.
+    //   2. The `nudge_runtime_watcher_after_apply` helper below.
+    //   3. The `escape_graphql_string` import at the top of this file, if it
+    //      becomes unused after (2).
+    // Verify the removal by running:
+    //   cargo test -p defra-agent-cli --test cli_config_apply_running
+    // — `config_apply_reconciles_running_runtime_without_restart` must still
+    // pass against the upstream-fixed defradb.rs without the nudge.
     if config_apply_counts_changed(&applied) {
         if let Err(nudge_err) = nudge_runtime_watcher_after_apply(&access, bound).await {
             tracing::warn!(
+                agent_did = %bound.context.target_agent_did,
                 %nudge_err,
                 "config apply: post-commit runtime nudge failed; runtime may not reconcile until restart"
             );
@@ -139,15 +149,18 @@ pub(crate) async fn apply_bound_desired_manifest(
     Ok(report)
 }
 
-/// Issue a single auto-commit write to wake the in-process runtime watcher
-/// after a transactional apply. This is the implementation of the stopgap
-/// described above. The mutation re-writes `enabled` on the AgentPrincipal
-/// doc with its existing value — semantically a no-op, but the auto-commit
-/// path does emit an Update event on the EventBus, which is what the
-/// runtime watcher subscribes to.
+/// Wake the runtime watcher after a transactional apply commit by issuing
+/// an auto-commit write that triggers an Update event on the EventBus.
 ///
-/// Callers are expected to log and swallow the returned error; this is a
-/// best-effort wakeup and does not affect the durability of the apply.
+/// The write targets `AgentPrincipal::enabled`, re-setting it to the
+/// manifest's declared value. This is a no-op when the live `enabled`
+/// already matches the manifest; if the live value drifted out-of-band,
+/// the nudge will also reconcile it back to the manifest value, which is
+/// the correct manifest-wins semantics.
+///
+/// This helper is part of the stopgap for sourcenetwork/defradb.rs#970;
+/// remove together with its call site when upstream emits Update events
+/// on transaction commit.
 async fn nudge_runtime_watcher_after_apply(
     access: &ConfigAccess,
     bound: &super::binding::BoundDesiredManifest,

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use std::path::Path;
 
 use crate::cli::*;
@@ -67,7 +67,28 @@ pub(crate) async fn apply_bound_desired_manifest(
         &live_manifest,
     );
 
-    let applied = apply_desired_state_changes(&access, &desired_bundle, &planned).await?;
+    let applied = {
+        let txn = access
+            .begin_apply_txn()
+            .await
+            .context("config apply: begin transaction")?;
+        let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).await {
+            Ok(counts) => counts,
+            Err(error) => {
+                if let Err(discard_err) = txn.discard().await {
+                    tracing::warn!(
+                        %discard_err,
+                        "config apply: tx discard failed after apply error"
+                    );
+                }
+                return Err(error);
+            }
+        };
+        if let Err(commit_err) = txn.commit().await {
+            return Err(commit_err).context("config apply: commit failed");
+        }
+        counts
+    };
 
     let remaining_bundle = build_desired_state_live_bundle(&access, desired_manifest).await?;
     let (remaining_principal, remaining_manifest) =

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -1,8 +1,6 @@
 use anyhow::{Context, Result};
 use std::path::Path;
 
-use defra_agent::graphql::escape_graphql_string;
-
 use crate::cli::*;
 use crate::config_writes::ConfigAccess;
 use crate::desired_state;
@@ -92,33 +90,6 @@ pub(crate) async fn apply_bound_desired_manifest(
         counts
     };
 
-    // === STOPGAP for sourcenetwork/defradb.rs#970 ===
-    // DefraDB tx commits do not emit Update events on the EventBus, so the
-    // in-process runtime watcher (control_watcher.rs) never reconciles after
-    // a transactional config apply. Until upstream emits Update events on
-    // commit, we issue a single auto-commit no-op write here to wake the
-    // watcher. The data we just committed inside the tx is durable regardless
-    // of whether this nudge succeeds.
-    //
-    // When defradb.rs#970 ships and we bump the workspace pin, remove:
-    //   1. This comment block and the `if` block that follows it.
-    //   2. The `nudge_runtime_watcher_after_apply` helper below.
-    //   3. The `escape_graphql_string` import at the top of this file, if it
-    //      becomes unused after (2).
-    // Verify the removal by running:
-    //   cargo test -p defra-agent-cli --test cli_config_apply_running
-    // — `config_apply_reconciles_running_runtime_without_restart` must still
-    // pass against the upstream-fixed defradb.rs without the nudge.
-    if config_apply_counts_changed(&applied) {
-        if let Err(nudge_err) = nudge_runtime_watcher_after_apply(&access, bound).await {
-            tracing::warn!(
-                agent_did = %bound.context.target_agent_did,
-                %nudge_err,
-                "config apply: post-commit runtime nudge failed; runtime may not reconcile until restart"
-            );
-        }
-    }
-
     let remaining_bundle = build_desired_state_live_bundle(&access, desired_manifest).await?;
     let (remaining_principal, remaining_manifest) =
         live_manifest_from_bundle(desired_manifest, &remaining_bundle)?;
@@ -147,43 +118,4 @@ pub(crate) async fn apply_bound_desired_manifest(
         remaining: remaining.counts.clone(),
     };
     Ok(report)
-}
-
-/// Wake the runtime watcher after a transactional apply commit by issuing
-/// an auto-commit write that triggers an Update event on the EventBus.
-///
-/// The write targets `AgentPrincipal::enabled`, re-setting it to the
-/// manifest's declared value. This is a no-op when the live `enabled`
-/// already matches the manifest; if the live value drifted out-of-band,
-/// the nudge will also reconcile it back to the manifest value, which is
-/// the correct manifest-wins semantics.
-///
-/// This helper is part of the stopgap for sourcenetwork/defradb.rs#970;
-/// remove together with its call site when upstream emits Update events
-/// on transaction commit.
-async fn nudge_runtime_watcher_after_apply(
-    access: &ConfigAccess,
-    bound: &super::binding::BoundDesiredManifest,
-) -> Result<()> {
-    let agent_did = &bound.context.target_agent_did;
-    let enabled = bound.manifest.agent_principal.enabled;
-    let escaped_did = escape_graphql_string(agent_did);
-    let mutation = format!(
-        r#"mutation {{
-            update_AgentPrincipal(
-                filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }},
-                input: {{ enabled: {enabled} }}
-            ) {{ _docID }}
-        }}"#
-    );
-    let response = access.execute(&mutation).await?;
-    tracing::debug!(
-        agent_did = %agent_did,
-        "config apply: post-commit runtime nudge succeeded; _docID={}",
-        response
-            .pointer("/data/update_AgentPrincipal/0/_docID")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("<none>")
-    );
-    Ok(())
 }

--- a/crates/defra-agent-cli/src/commands/config/import.rs
+++ b/crates/defra-agent-cli/src/commands/config/import.rs
@@ -13,93 +13,125 @@ pub(super) async fn config_import(args: ConfigImportArgs) -> Result<()> {
     validate_config_import_bundle(&bundle)?;
     let (access, _) =
         resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let txn = access.begin_apply_txn().await?;
 
-    let imported_backends = apply_import_collection(
-        &access,
-        "InferenceBackend",
-        "backend_id",
-        &bundle.inference_backends,
-        args.override_existing,
-    )
-    .await?;
-    let imported_profiles = apply_import_collection(
-        &access,
-        "InferenceProfile",
-        "profile_id",
-        &bundle.inference_profiles,
-        args.override_existing,
-    )
-    .await?;
-    let imported_tool_service_registries = apply_import_collection(
-        &access,
-        "ToolServiceRegistry",
-        "service_id",
-        &bundle.tool_service_registries,
-        args.override_existing,
-    )
-    .await?;
-    let imported_tool_selections = apply_import_collection(
-        &access,
-        "ToolSelection",
-        "selection_id",
-        &bundle.tool_selections,
-        args.override_existing,
-    )
-    .await?;
-    let imported_behaviors = apply_import_collection(
-        &access,
-        "AgentBehavior",
-        "behavior_id",
-        &bundle.agent_behaviors,
-        args.override_existing,
-    )
-    .await?;
-    let imported_tasks = apply_import_collection(
-        &access,
-        "Task",
-        "task_id",
-        &bundle.tasks,
-        args.override_existing,
-    )
-    .await?;
-    let imported_schedules = apply_import_collection(
-        &access,
-        "Schedule",
-        "schedule_id",
-        &bundle.schedules,
-        args.override_existing,
-    )
-    .await?;
-    let imported_principal = apply_import_collection(
-        &access,
-        "AgentPrincipal",
-        "agent_did",
-        &bundle
-            .agent_principal
-            .clone()
-            .into_iter()
-            .collect::<Vec<_>>(),
-        args.override_existing,
-    )
-    .await?;
+    let result = async {
+        let imported_backends = apply_import_collection(
+            &txn,
+            "InferenceBackend",
+            "backend_id",
+            &bundle.inference_backends,
+            args.override_existing,
+        )
+        .await?;
+        let imported_profiles = apply_import_collection(
+            &txn,
+            "InferenceProfile",
+            "profile_id",
+            &bundle.inference_profiles,
+            args.override_existing,
+        )
+        .await?;
+        let imported_tool_service_registries = apply_import_collection(
+            &txn,
+            "ToolServiceRegistry",
+            "service_id",
+            &bundle.tool_service_registries,
+            args.override_existing,
+        )
+        .await?;
+        let imported_tool_selections = apply_import_collection(
+            &txn,
+            "ToolSelection",
+            "selection_id",
+            &bundle.tool_selections,
+            args.override_existing,
+        )
+        .await?;
+        let imported_behaviors = apply_import_collection(
+            &txn,
+            "AgentBehavior",
+            "behavior_id",
+            &bundle.agent_behaviors,
+            args.override_existing,
+        )
+        .await?;
+        let imported_tasks = apply_import_collection(
+            &txn,
+            "Task",
+            "task_id",
+            &bundle.tasks,
+            args.override_existing,
+        )
+        .await?;
+        let imported_schedules = apply_import_collection(
+            &txn,
+            "Schedule",
+            "schedule_id",
+            &bundle.schedules,
+            args.override_existing,
+        )
+        .await?;
+        let imported_principal = apply_import_collection(
+            &txn,
+            "AgentPrincipal",
+            "agent_did",
+            &bundle
+                .agent_principal
+                .clone()
+                .into_iter()
+                .collect::<Vec<_>>(),
+            args.override_existing,
+        )
+        .await?;
+        anyhow::Ok((
+            imported_backends,
+            imported_profiles,
+            imported_tool_service_registries,
+            imported_tool_selections,
+            imported_behaviors,
+            imported_tasks,
+            imported_schedules,
+            imported_principal,
+        ))
+    }
+    .await;
 
-    let output = json!({
-        "status": "imported",
-        "format": bundle.format,
-        "agent_did": bundle.agent_did,
-        "access_mode": access.mode(),
-        "override": args.override_existing,
-        "counts": {
-            "agent_principal": imported_principal,
-            "agent_behaviors": imported_behaviors,
-            "tool_selections": imported_tool_selections,
-            "inference_backends": imported_backends,
-            "inference_profiles": imported_profiles,
-            "tool_service_registries": imported_tool_service_registries,
-            "tasks": imported_tasks,
-            "schedules": imported_schedules,
-        },
-    });
-    print_json(&output)?;
-    Ok(())
+    match result {
+        Ok((
+            imported_backends,
+            imported_profiles,
+            imported_tool_service_registries,
+            imported_tool_selections,
+            imported_behaviors,
+            imported_tasks,
+            imported_schedules,
+            imported_principal,
+        )) => {
+            txn.commit().await?;
+            let output = json!({
+                "status": "imported",
+                "format": bundle.format,
+                "agent_did": bundle.agent_did,
+                "access_mode": access.mode(),
+                "override": args.override_existing,
+                "counts": {
+                    "agent_principal": imported_principal,
+                    "agent_behaviors": imported_behaviors,
+                    "tool_selections": imported_tool_selections,
+                    "inference_backends": imported_backends,
+                    "inference_profiles": imported_profiles,
+                    "tool_service_registries": imported_tool_service_registries,
+                    "tasks": imported_tasks,
+                    "schedules": imported_schedules,
+                },
+            });
+            print_json(&output)?;
+            Ok(())
+        }
+        Err(error) => {
+            let _ = txn.discard().await;
+            Err(error)
+        }
+    }
 }

--- a/crates/defra-agent-cli/src/commands/config/import.rs
+++ b/crates/defra-agent-cli/src/commands/config/import.rs
@@ -130,7 +130,9 @@ pub(super) async fn config_import(args: ConfigImportArgs) -> Result<()> {
             Ok(())
         }
         Err(error) => {
-            let _ = txn.discard().await;
+            if let Err(discard_err) = txn.discard().await {
+                tracing::warn!(%discard_err, "config import: tx discard failed after apply error");
+            }
             Err(error)
         }
     }

--- a/crates/defra-agent-cli/src/commands/p2p/collections.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/collections.rs
@@ -17,7 +17,7 @@ use super::output::{
     fetch_live_http_p2p_status, flatten_p2p_fields, load_collection_name_by_id,
     p2p_collection_names, p2p_collection_rows,
 };
-use super::{p2p_api_base, p2p_http_client};
+use super::p2p_http_client;
 
 const P2P_AGENT_COLLECTIONS: &[&str] = &[
     "AgentPrincipal",
@@ -92,7 +92,7 @@ fn p2p_collection_profile_names(profile: P2pCollectionProfileArg) -> Vec<&'stati
 pub(super) async fn p2p_collections_list(args: P2pAccessArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let collection_ids: Vec<String> =
         crate::http_get_json(&client, &format!("{api_base}/p2p/collections")).await?;
     let collection_names_by_id = load_collection_name_by_id(&client, &api_base).await;
@@ -116,7 +116,7 @@ pub(super) async fn p2p_collections_add(args: P2pCollectionsMutateArgs) -> Resul
     let collections = expand_p2p_collection_args(&args.collections, &args.profiles)?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     http_post_json(
         &client,
         &format!("{api_base}/p2p/collections"),
@@ -144,7 +144,7 @@ pub(super) async fn p2p_collections_remove(args: P2pCollectionsMutateArgs) -> Re
     let collections = expand_p2p_collection_args(&args.collections, &args.profiles)?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     http_delete_json(
         &client,
         &format!("{api_base}/p2p/collections"),
@@ -168,7 +168,7 @@ pub(super) async fn p2p_collections_sync_branchable(args: P2pSyncBranchableArgs)
     }
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let request = P2pSyncBranchableRequest {
         collection_id: collection_id.clone(),
     };
@@ -192,7 +192,7 @@ pub(super) async fn p2p_collections_sync_versions(args: P2pSyncVersionsArgs) -> 
     let version_ids = expand_nonempty_values(&args.version_ids, "--version-id")?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let request = P2pSyncVersionsRequest {
         version_ids: version_ids.clone(),
     };

--- a/crates/defra-agent-cli/src/commands/p2p/connect.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/connect.rs
@@ -7,7 +7,7 @@ use crate::cli::args::{P2pAccessArgs, P2pConnectArgs};
 use crate::{http_post_json, print_json, resolve_graphql_endpoint, resolve_home_dir};
 
 use super::output::{fetch_live_http_p2p_status, flatten_p2p_fields, load_live_http_p2p_status};
-use super::{p2p_api_base, p2p_http_client, p2p_probe_get};
+use super::{p2p_http_client, p2p_probe_get};
 
 pub(super) async fn p2p_connect(args: P2pConnectArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
@@ -15,7 +15,7 @@ pub(super) async fn p2p_connect(args: P2pConnectArgs) -> Result<()> {
         .timeout(Duration::from_secs(5))
         .build()
         .context("building P2P connect HTTP client")?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     http_post_json(
         &client,
         &format!("{api_base}/p2p/connect"),
@@ -42,7 +42,7 @@ pub(super) async fn p2p_connect(args: P2pConnectArgs) -> Result<()> {
 pub(super) async fn p2p_diagnose(args: P2pAccessArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let p2p = load_live_http_p2p_status(args.home.as_deref(), &graphql).await;
     let checks = json!({
         "info": p2p_probe_get(&client, &format!("{api_base}/p2p/info")).await,

--- a/crates/defra-agent-cli/src/commands/p2p/documents.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/documents.rs
@@ -8,12 +8,12 @@ use crate::{
     resolve_home_dir,
 };
 
-use super::{p2p_api_base, p2p_http_client};
+use super::p2p_http_client;
 
 pub(super) async fn p2p_documents_list(args: P2pAccessArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let doc_ids: Vec<String> =
         crate::http_get_json(&client, &format!("{api_base}/p2p/documents")).await?;
     let count = doc_ids.len();
@@ -32,7 +32,7 @@ pub(super) async fn p2p_documents_add(args: P2pDocumentsMutateArgs) -> Result<()
     let doc_ids = expand_nonempty_values(&args.doc_ids, "--doc-id")?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     http_post_json(&client, &format!("{api_base}/p2p/documents"), &doc_ids).await?;
     let home_dir = resolve_home_dir(args.home.as_deref());
     print_json(&json!({
@@ -48,7 +48,7 @@ pub(super) async fn p2p_documents_remove(args: P2pDocumentsMutateArgs) -> Result
     let doc_ids = expand_nonempty_values(&args.doc_ids, "--doc-id")?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     http_delete_json(&client, &format!("{api_base}/p2p/documents"), &doc_ids).await?;
     let home_dir = resolve_home_dir(args.home.as_deref());
     print_json(&json!({
@@ -68,7 +68,7 @@ pub(super) async fn p2p_documents_sync(args: P2pDocumentsSyncArgs) -> Result<()>
     let doc_ids = expand_nonempty_values(&args.doc_ids, "--doc-id")?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let request = P2pSyncDocumentsRequest {
         collection_name: collection.clone(),
         doc_ids: doc_ids.clone(),

--- a/crates/defra-agent-cli/src/commands/p2p/mod.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/mod.rs
@@ -64,13 +64,3 @@ pub(super) async fn p2p_probe_get(client: &reqwest::Client, url: &str) -> Value 
         }),
     }
 }
-
-pub(super) fn p2p_api_base(graphql: &str) -> Result<String> {
-    graphql
-        .trim()
-        .strip_suffix("/graphql")
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| {
-            anyhow::anyhow!("expected GraphQL endpoint ending in /graphql, got {graphql}")
-        })
-}

--- a/crates/defra-agent-cli/src/commands/p2p/output.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/output.rs
@@ -10,7 +10,6 @@ use crate::shared::{
     StoredRuntimeState,
 };
 
-use super::p2p_api_base;
 use crate::{http_get_json, normalize_optional_string, read_runtime_state, resolve_home_dir};
 
 pub(super) fn p2p_collection_rows(
@@ -133,7 +132,7 @@ pub(super) async fn fetch_live_http_p2p_status(
         .timeout(std::time::Duration::from_secs(5))
         .build()
         .context("building P2P status HTTP client")?;
-    let api_base = p2p_api_base(graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(graphql)?;
     let identity =
         http_get_json::<NodeIdentityResponse>(&client, &format!("{api_base}/node/identity"))
             .await

--- a/crates/defra-agent-cli/src/commands/p2p/replicators.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/replicators.rs
@@ -11,12 +11,12 @@ use super::collections::expand_p2p_collection_args;
 use super::output::{
     fetch_live_http_p2p_status, flatten_p2p_fields, load_collection_name_by_id, p2p_replicator_rows,
 };
-use super::{p2p_api_base, p2p_http_client};
+use super::p2p_http_client;
 
 pub(super) async fn p2p_replicators_list(args: P2pAccessArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let raw_replicators: Vec<P2pReplicatorRow> =
         crate::http_get_json(&client, &format!("{api_base}/p2p/replicators")).await?;
     let collection_names_by_id = load_collection_name_by_id(&client, &api_base).await;
@@ -37,7 +37,7 @@ pub(super) async fn p2p_replicators_add(args: P2pReplicatorAddArgs) -> Result<()
     let collections = expand_p2p_collection_args(&args.collections, &args.profiles)?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let request = P2pReplicatorRequest {
         collections: collections.clone(),
         addresses: vec![args.peer.clone()],
@@ -65,7 +65,7 @@ pub(super) async fn p2p_replicators_remove(args: P2pReplicatorRemoveArgs) -> Res
     let collections = expand_p2p_collection_args(&args.collections, &args.profiles)?;
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let client = p2p_http_client()?;
-    let api_base = p2p_api_base(&graphql)?;
+    let api_base = crate::graphql_access::graphql_api_base(&graphql)?;
     let request = P2pReplicatorDeleteRequest {
         id: args.peer.clone(),
         collections: collections.clone(),

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1789,7 +1789,8 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_begin_returns_numeric_id_and_commit_appends_to_committed() {
             let (graphql, recorder) = start_recording_graphql().await;
-            let api_base = graphql.strip_suffix("/graphql").unwrap();
+            let api_base =
+                crate::graphql_access::graphql_api_base(&graphql).expect("graphql endpoint");
             let client = reqwest::Client::new();
 
             let begin = client
@@ -1836,7 +1837,8 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_discard_drops_pending_writes() {
             let (graphql, recorder) = start_recording_graphql().await;
-            let api_base = graphql.strip_suffix("/graphql").unwrap().to_owned();
+            let api_base =
+                crate::graphql_access::graphql_api_base(&graphql).expect("graphql endpoint");
             let client = reqwest::Client::new();
 
             let begin = client
@@ -1881,7 +1883,8 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_fail_injection_aborts_at_target_index() {
             let (graphql, recorder) = start_recording_graphql().await;
-            let api_base = graphql.strip_suffix("/graphql").unwrap().to_owned();
+            let api_base =
+                crate::graphql_access::graphql_api_base(&graphql).expect("graphql endpoint");
             let client = reqwest::Client::new();
 
             let begin = client

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1744,6 +1744,46 @@ mod lean_apply_write_boundary_tests {
         (collection_from_lean_name(&doc.collection), doc.id.clone())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_apply_txn_round_trip_against_recorder() {
+        let (graphql, recorder) = start_recording_graphql().await;
+        let access = ConfigAccess::Graphql(graphql);
+        let txn = access.begin_apply_txn().await.expect("begin");
+
+        let _ = txn
+            .execute("mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }")
+            .await
+            .expect("execute in tx");
+
+        assert!(recorder.committed_state().is_empty());
+
+        txn.commit().await.expect("commit");
+
+        let committed = recorder.committed_state();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].unique_value, "task-a");
+        let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+        assert_eq!((begin_count, commit_count, discard_count), (1, 1, 0));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn config_apply_txn_discard_leaves_committed_empty() {
+        let (graphql, recorder) = start_recording_graphql().await;
+        let access = ConfigAccess::Graphql(graphql);
+        let txn = access.begin_apply_txn().await.expect("begin");
+
+        let _ = txn
+            .execute("mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }")
+            .await
+            .expect("execute in tx");
+
+        txn.discard().await.expect("discard");
+
+        assert!(recorder.committed_state().is_empty());
+        let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+        assert_eq!((begin_count, commit_count, discard_count), (1, 0, 1));
+    }
+
     #[cfg(test)]
     mod recorder_unit_tests {
         use super::*;

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -917,6 +917,67 @@ mod lean_apply_write_boundary_tests {
             );
             assert_observed_prefixes_are_referrer_closed(case, &observed);
             assert_live_payloads_not_written(case, &recorder);
+
+            let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+            assert_eq!(
+                (begin_count, commit_count, discard_count),
+                (1, 1, 0),
+                "success path must drive exactly one begin/commit and zero discard for Lean case {}",
+                case.name,
+            );
+
+            let committed_after_commit = recorder.committed_state();
+            assert_eq!(
+                committed_after_commit.len(),
+                case.expected_selected_writes.len(),
+                "recorder committed state count mismatch for Lean case {} (expected = {}, actual = {})",
+                case.name,
+                case.expected_selected_writes.len(),
+                committed_after_commit.len(),
+            );
+
+            if case.prefix_len > 0 {
+                let (graphql, recorder) = start_recording_graphql().await;
+                let access = ConfigAccess::Graphql(graphql);
+
+                // Begin a tx. The recorder hands out sequential numeric ids starting at 0;
+                // the first tx in this fresh recorder is "0".
+                let txn = access.begin_apply_txn().await.expect("begin failure-case tx");
+                recorder.install_fail_at("0", case.prefix_len);
+
+                let result = apply_desired_state_changes(&txn, &desired_bundle, &planned).await;
+                assert!(
+                    result.is_err(),
+                    "injected failure at write {} must surface as Err for Lean case {}",
+                    case.prefix_len,
+                    case.name,
+                );
+
+                let _ = txn.discard().await;
+
+                let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+                assert_eq!(
+                    (begin_count, commit_count, discard_count),
+                    (1, 0, 1),
+                    "failure path must drive exactly one begin/discard and zero commit for Lean case {}",
+                    case.name,
+                );
+
+                assert!(
+                    recorder.committed_state().is_empty(),
+                    "failure path must leave externally-observed committed state empty (= pre_live) for Lean case {}",
+                    case.name,
+                );
+
+                let observed = recorder.observed_writes();
+                assert!(
+                    observed.len() <= case.prefix_len + 1,
+                    "failure path observed {} writes; cap is prefix_len + 1 = {} for Lean case {}",
+                    observed.len(),
+                    case.prefix_len + 1,
+                    case.name,
+                );
+            }
         }
     }
 

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use crate::config_bundle::{sanitize_import_document, select_apply_collection_docs};
 use crate::config_writes::{
     write_event_trigger_document, write_schedule_document, write_task_document, ConfigAccess,
-    ExistingDocumentRef,
+    ConfigApplyTxn, ExistingDocumentRef,
 };
 use crate::desired_state;
 use crate::desired_state::DesiredApplyBundle;
@@ -108,7 +108,7 @@ pub(crate) fn migrate_config_import_bundle(bundle: &mut ConfigExportBundle) {
 }
 
 pub(crate) async fn apply_import_collection(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     docs: &[Value],
@@ -121,11 +121,11 @@ pub(crate) async fn apply_import_collection(
     }
 
     if override_existing && uses_custom_apply_writer(collection_name) {
-        apply_custom_override_collection_batched(access, collection_name, unique_field, &prepared)
+        apply_custom_override_collection_batched(txn, collection_name, unique_field, &prepared)
             .await?;
     } else {
         apply_generic_import_collection_batched(
-            access,
+            txn,
             collection_name,
             unique_field,
             &prepared,
@@ -179,7 +179,7 @@ fn uses_custom_apply_writer(collection_name: &str) -> bool {
 }
 
 async fn apply_generic_import_collection_batched(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     docs: &[PreparedImportDocument],
@@ -199,12 +199,12 @@ async fn apply_generic_import_collection_batched(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    match execute_aliased_mutation_batches(access, collection_name, &fields).await {
+    match execute_aliased_mutation_batches(txn, collection_name, &fields).await {
         Ok(()) => Ok(()),
         Err(_) if override_existing => {
             for doc in docs {
                 apply_generic_import_document(
-                    access,
+                    txn,
                     collection_name,
                     unique_field,
                     doc,
@@ -253,7 +253,7 @@ fn generic_import_mutation_field(
 }
 
 async fn apply_generic_import_document(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     doc: &PreparedImportDocument,
@@ -281,7 +281,7 @@ async fn apply_generic_import_document(
     } else {
         format!(r#"mutation {{ create_{collection_name}(input: {add_literal}) {{ _docID }} }}"#)
     };
-    let response = access.execute(&mutation).await.map_err(|error| {
+    let response = txn.execute(&mutation).await.map_err(|error| {
         if override_existing {
             anyhow::anyhow!(
                 "importing {collection_name} {} failed: {error}",
@@ -299,29 +299,25 @@ async fn apply_generic_import_document(
 }
 
 async fn apply_custom_override_collection_batched(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     docs: &[PreparedImportDocument],
 ) -> Result<()> {
     if has_duplicate_unique_values(docs) {
-        return apply_custom_override_documents_individually(access, collection_name, docs).await;
+        return apply_custom_override_documents_individually(txn, collection_name, docs).await;
     }
 
-    let existing_by_unique = match query_existing_documents_by_unique_values(
-        access,
-        collection_name,
-        unique_field,
-        docs,
-    )
-    .await
-    {
-        Ok(existing_by_unique) => existing_by_unique,
-        Err(_) => {
-            return apply_custom_override_documents_individually(access, collection_name, docs)
-                .await;
-        }
-    };
+    let existing_by_unique =
+        match query_existing_documents_by_unique_values(txn, collection_name, unique_field, docs)
+            .await
+        {
+            Ok(existing_by_unique) => existing_by_unique,
+            Err(_) => {
+                return apply_custom_override_documents_individually(txn, collection_name, docs)
+                    .await;
+            }
+        };
     let fields = docs
         .iter()
         .enumerate()
@@ -339,9 +335,9 @@ async fn apply_custom_override_collection_batched(
         })
         .collect::<Result<Vec<_>>>()?;
 
-    match execute_aliased_mutation_batches(access, collection_name, &fields).await {
+    match execute_aliased_mutation_batches(txn, collection_name, &fields).await {
         Ok(()) => Ok(()),
-        Err(_) => apply_custom_override_documents_individually(access, collection_name, docs).await,
+        Err(_) => apply_custom_override_documents_individually(txn, collection_name, docs).await,
     }
 }
 
@@ -352,7 +348,7 @@ fn has_duplicate_unique_values(docs: &[PreparedImportDocument]) -> bool {
 }
 
 async fn query_existing_documents_by_unique_values(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     docs: &[PreparedImportDocument],
@@ -376,7 +372,7 @@ async fn query_existing_documents_by_unique_values(
             }}
         }}"#,
     );
-    let response = access.execute(&query).await?;
+    let response = txn.execute(&query).await?;
     let rows = response
         .get("data")
         .and_then(|data| data.get(collection_name))
@@ -477,7 +473,7 @@ fn select_existing_import_document(
 }
 
 async fn apply_custom_override_documents_individually(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     docs: &[PreparedImportDocument],
 ) -> Result<()> {
@@ -487,15 +483,12 @@ async fn apply_custom_override_documents_individually(
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("missing update document for {collection_name}"))?;
         let doc_id = match collection_name {
-            "Task" => {
-                write_task_document(access, &doc.unique_value, &doc.add_doc, update_doc).await
-            }
+            "Task" => write_task_document(txn, &doc.unique_value, &doc.add_doc, update_doc).await,
             "Schedule" => {
-                write_schedule_document(access, &doc.unique_value, &doc.add_doc, update_doc).await
+                write_schedule_document(txn, &doc.unique_value, &doc.add_doc, update_doc).await
             }
             "EventTrigger" => {
-                write_event_trigger_document(access, &doc.unique_value, &doc.add_doc, update_doc)
-                    .await
+                write_event_trigger_document(txn, &doc.unique_value, &doc.add_doc, update_doc).await
             }
             _ => unreachable!("custom apply writer only supports selected collections"),
         }
@@ -517,13 +510,13 @@ async fn apply_custom_override_documents_individually(
 }
 
 async fn execute_aliased_mutation_batches(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     collection_name: &str,
     fields: &[AliasedMutationField],
 ) -> Result<()> {
     for chunk in fields.chunks(CONFIG_IMPORT_BATCH_SIZE) {
         let mutation = build_aliased_mutation(chunk);
-        let response = access.execute(&mutation).await?;
+        let response = txn.execute(&mutation).await?;
         for field in chunk {
             let _ = extract_aliased_mutation_doc_id(&response, &field.alias, collection_name)?;
         }
@@ -593,7 +586,7 @@ pub(crate) fn select_apply_principal_docs(
 }
 
 pub(crate) async fn apply_desired_state_changes(
-    access: &ConfigAccess,
+    txn: &ConfigApplyTxn<'_>,
     desired_bundle: &DesiredApplyBundle,
     planned: &desired_state::DesiredStateDiffReport,
 ) -> Result<ConfigApplyCounts> {
@@ -603,7 +596,7 @@ pub(crate) async fn apply_desired_state_changes(
     for collection in CONFIG_APPLY_ORDER {
         let docs = select_apply_docs_for_collection(desired_bundle, planned, collection)?;
         let applied = apply_import_collection(
-            access,
+            txn,
             collection.graphql_type(),
             collection.unique_field(),
             &docs,
@@ -891,25 +884,25 @@ mod lean_apply_write_boundary_tests {
             assert_selected_documents_match_lean(case, desired_bundle.as_bundle(), &planned);
 
             let (graphql, recorder) = start_recording_graphql().await;
-            let counts = apply_desired_state_changes(
-                &ConfigAccess::Graphql(graphql),
-                &desired_bundle,
-                &planned,
-            )
-            .await
-            .unwrap_or_else(|error| {
-                panic!(
-                    "production apply_desired_state_changes failed for Lean case {}: {error}",
-                    case.name
-                )
-            });
+            let access = ConfigAccess::Graphql(graphql);
+            let txn = access.begin_apply_txn().await.expect("begin apply tx");
+            let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).await {
+                Ok(counts) => {
+                    txn.commit().await.expect("commit");
+                    counts
+                }
+                Err(error) => {
+                    let _ = txn.discard().await;
+                    panic!(
+                        "production apply_desired_state_changes failed for Lean case {}: {error}",
+                        case.name
+                    );
+                }
+            };
 
             assert_counts_match_lean(case, &counts);
 
-            // NOTE: Task 4 wires ConfigApplyTxn through apply_desired_state_changes.
-            // At that point, switch the success-path assertion to recorder.committed_state()
-            // to actually verify atomicity. observed_writes() includes uncommitted writes.
-            let observed = recorder.observed_writes();
+            let observed = recorder.committed_state();
             let expected = case
                 .expected_selected_writes
                 .iter()

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -595,6 +595,11 @@ pub(crate) async fn apply_desired_state_changes(
     let desired_bundle = desired_bundle.as_bundle();
     let mut counts = ConfigApplyCounts::default();
 
+    let per_collection_sleep = std::env::var("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(std::time::Duration::from_millis);
+
     for collection in CONFIG_APPLY_ORDER {
         let docs = select_apply_docs_for_collection(desired_bundle, planned, collection)?;
         let applied = apply_import_collection(
@@ -606,6 +611,10 @@ pub(crate) async fn apply_desired_state_changes(
         )
         .await?;
         counts.set(collection, applied);
+
+        if let Some(sleep) = per_collection_sleep {
+            tokio::time::sleep(sleep).await;
+        }
     }
 
     Ok(counts)

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -834,6 +834,10 @@ mod lean_apply_write_boundary_tests {
             self.committed.lock().expect("committed lock").clone()
         }
 
+        /// Returns committed writes plus any still-pending in-tx writes (across all
+        /// open transactions). Useful for backward-compat assertions against
+        /// "every write attempted." **Use `committed_state()` to verify durability**
+        /// — e.g., to confirm a discard left no externally-observable state.
         fn observed_writes(&self) -> Vec<ObservedWrite> {
             let mut all = self.committed.lock().expect("committed lock").clone();
             let txs = self.transactions.lock().expect("tx lock").clone();
@@ -902,6 +906,9 @@ mod lean_apply_write_boundary_tests {
 
             assert_counts_match_lean(case, &counts);
 
+            // NOTE: Task 3 wires ConfigApplyTxn through apply_desired_state_changes.
+            // At that point, switch the success-path assertion to recorder.committed_state()
+            // to actually verify atomicity. observed_writes() includes uncommitted writes.
             let observed = recorder.observed_writes();
             let expected = case
                 .expected_selected_writes
@@ -1192,6 +1199,8 @@ mod lean_apply_write_boundary_tests {
         let addr = listener.local_addr().expect("recording GraphQL addr");
         let app = Router::new()
             .route("/", post(recording_graphql_handler))
+            // axum routes static paths before capture patterns, so `/api/v0/tx/begin`
+            // resolves to begin_handler, not to the `/api/v0/tx/{id}` commit handler.
             .route("/api/v0/tx/begin", post(recording_tx_begin_handler))
             .route(
                 "/api/v0/tx/{id}",
@@ -1863,6 +1872,21 @@ mod lean_apply_write_boundary_tests {
                 .await
                 .unwrap();
             assert!(ok.get("errors").is_none(), "first mutation should succeed");
+
+            // Confirm the first write was actually buffered into the tx's pending window —
+            // a broken recorder that ignored writes silently would still pass the
+            // `errors.is_none()` check above.
+            let pending_after_first = recorder.observed_writes();
+            assert_eq!(
+                pending_after_first.len(),
+                1,
+                "first mutation must be buffered into tx pending window"
+            );
+            assert_eq!(pending_after_first[0].unique_value, "task-a");
+            assert!(
+                recorder.committed_state().is_empty(),
+                "buffered tx writes must not appear in committed state yet"
+            );
 
             let fail = client
                 .post(format!("{graphql}"))

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1193,10 +1193,12 @@ mod lean_apply_write_boundary_tests {
             .expect("bind recording GraphQL listener");
         let addr = listener.local_addr().expect("recording GraphQL addr");
         let app = Router::new()
-            .route("/", post(recording_graphql_handler))
-            // axum routes static paths before capture patterns, so `/api/v0/tx/begin`
-            // resolves to begin_handler, not to the `/api/v0/tx/{id}` commit handler.
-            .route("/api/v0/tx/begin", post(recording_tx_begin_handler))
+            .route("/api/v0/graphql", post(recording_graphql_handler))
+            // Go-compatible transaction routes (mirrors DefraDB HTTP API):
+            //   POST /api/v0/tx          → begin
+            //   POST /api/v0/tx/{id}     → commit
+            //   DELETE /api/v0/tx/{id}   → discard/rollback
+            .route("/api/v0/tx", post(recording_tx_begin_handler))
             .route(
                 "/api/v0/tx/{id}",
                 post(recording_tx_commit_handler).delete(recording_tx_discard_handler),
@@ -1207,7 +1209,7 @@ mod lean_apply_write_boundary_tests {
                 .await
                 .expect("recording GraphQL server");
         });
-        (format!("http://{addr}/"), state)
+        (format!("http://{addr}/api/v0/graphql"), state)
     }
 
     async fn recording_tx_begin_handler(State(state): State<RecordingGraphqlState>) -> Json<Value> {
@@ -1787,10 +1789,11 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_begin_returns_numeric_id_and_commit_appends_to_committed() {
             let (graphql, recorder) = start_recording_graphql().await;
+            let api_base = graphql.strip_suffix("/graphql").unwrap();
             let client = reqwest::Client::new();
 
             let begin = client
-                .post(format!("{graphql}api/v0/tx/begin"))
+                .post(format!("{api_base}/tx"))
                 .send()
                 .await
                 .unwrap()
@@ -1805,7 +1808,7 @@ mod lean_apply_write_boundary_tests {
             assert!(txn_id.parse::<u64>().is_ok(), "tx id must be numeric");
 
             let _write = client
-                .post(format!("{graphql}"))
+                .post(&graphql)
                 .header("x-defradb-tx", &txn_id)
                 .json(&json!({
                     "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
@@ -1818,7 +1821,7 @@ mod lean_apply_write_boundary_tests {
             assert!(recorder.committed_state().is_empty());
 
             let commit = client
-                .post(format!("{graphql}api/v0/tx/{txn_id}"))
+                .post(format!("{api_base}/tx/{txn_id}"))
                 .send()
                 .await
                 .unwrap();
@@ -1833,10 +1836,11 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_discard_drops_pending_writes() {
             let (graphql, recorder) = start_recording_graphql().await;
+            let api_base = graphql.strip_suffix("/graphql").unwrap().to_owned();
             let client = reqwest::Client::new();
 
             let begin = client
-                .post(format!("{graphql}api/v0/tx/begin"))
+                .post(format!("{api_base}/tx"))
                 .send()
                 .await
                 .unwrap()
@@ -1850,7 +1854,7 @@ mod lean_apply_write_boundary_tests {
                 .to_string();
 
             let _write = client
-                .post(format!("{graphql}"))
+                .post(&graphql)
                 .header("x-defradb-tx", &txn_id)
                 .json(&serde_json::json!({
                     "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
@@ -1860,7 +1864,7 @@ mod lean_apply_write_boundary_tests {
                 .unwrap();
 
             let discard = client
-                .delete(format!("{graphql}api/v0/tx/{txn_id}"))
+                .delete(format!("{api_base}/tx/{txn_id}"))
                 .send()
                 .await
                 .unwrap();
@@ -1877,10 +1881,11 @@ mod lean_apply_write_boundary_tests {
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn recorder_fail_injection_aborts_at_target_index() {
             let (graphql, recorder) = start_recording_graphql().await;
+            let api_base = graphql.strip_suffix("/graphql").unwrap().to_owned();
             let client = reqwest::Client::new();
 
             let begin = client
-                .post(format!("{graphql}api/v0/tx/begin"))
+                .post(format!("{api_base}/tx"))
                 .send()
                 .await
                 .unwrap()
@@ -1895,7 +1900,7 @@ mod lean_apply_write_boundary_tests {
             recorder.install_fail_at(&txn_id, 1);
 
             let ok = client
-                .post(format!("{graphql}"))
+                .post(&graphql)
                 .header("x-defradb-tx", &txn_id)
                 .json(&serde_json::json!({
                     "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
@@ -1924,7 +1929,7 @@ mod lean_apply_write_boundary_tests {
             );
 
             let fail = client
-                .post(format!("{graphql}"))
+                .post(&graphql)
                 .header("x-defradb-tx", &txn_id)
                 .json(&serde_json::json!({
                     "query": "mutation { doc_0: create_Task(input: { task_id: \"task-b\" }) { _docID } }",

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -797,6 +797,7 @@ mod lean_apply_write_boundary_tests {
     use regex::Regex;
     use serde_json::{json, Map};
     use std::collections::{BTreeMap, BTreeSet};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
 
@@ -813,7 +814,49 @@ mod lean_apply_write_boundary_tests {
     #[derive(Clone, Default)]
     struct RecordingGraphqlState {
         queries: Arc<Mutex<Vec<String>>>,
-        writes: Arc<Mutex<Vec<ObservedWrite>>>,
+        transactions: Arc<Mutex<BTreeMap<String, Vec<ObservedWrite>>>>,
+        committed: Arc<Mutex<Vec<ObservedWrite>>>,
+        next_tx_id: Arc<AtomicU64>,
+        fail_injection: Arc<Mutex<Option<FailInjection>>>,
+        tx_begin_count: Arc<AtomicU64>,
+        tx_commit_count: Arc<AtomicU64>,
+        tx_discard_count: Arc<AtomicU64>,
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailInjection {
+        tx_id: String,
+        write_index: usize,
+    }
+
+    impl RecordingGraphqlState {
+        fn committed_state(&self) -> Vec<ObservedWrite> {
+            self.committed.lock().expect("committed lock").clone()
+        }
+
+        fn observed_writes(&self) -> Vec<ObservedWrite> {
+            let mut all = self.committed.lock().expect("committed lock").clone();
+            let txs = self.transactions.lock().expect("tx lock").clone();
+            for (_id, writes) in txs.iter() {
+                all.extend(writes.iter().cloned());
+            }
+            all
+        }
+
+        fn tx_lifecycle_counts(&self) -> (u64, u64, u64) {
+            (
+                self.tx_begin_count.load(Ordering::SeqCst),
+                self.tx_commit_count.load(Ordering::SeqCst),
+                self.tx_discard_count.load(Ordering::SeqCst),
+            )
+        }
+
+        fn install_fail_at(&self, tx_id: impl Into<String>, write_index: usize) {
+            *self.fail_injection.lock().expect("fail lock") = Some(FailInjection {
+                tx_id: tx_id.into(),
+                write_index,
+            });
+        }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -859,7 +902,7 @@ mod lean_apply_write_boundary_tests {
 
             assert_counts_match_lean(case, &counts);
 
-            let observed = recorder.writes.lock().expect("writes lock").clone();
+            let observed = recorder.observed_writes();
             let expected = case
                 .expected_selected_writes
                 .iter()
@@ -1149,6 +1192,11 @@ mod lean_apply_write_boundary_tests {
         let addr = listener.local_addr().expect("recording GraphQL addr");
         let app = Router::new()
             .route("/", post(recording_graphql_handler))
+            .route("/api/v0/tx/begin", post(recording_tx_begin_handler))
+            .route(
+                "/api/v0/tx/{id}",
+                post(recording_tx_commit_handler).delete(recording_tx_discard_handler),
+            )
             .with_state(state.clone());
         tokio::spawn(async move {
             axum::serve(listener, app)
@@ -1158,8 +1206,56 @@ mod lean_apply_write_boundary_tests {
         (format!("http://{addr}/"), state)
     }
 
+    async fn recording_tx_begin_handler(State(state): State<RecordingGraphqlState>) -> Json<Value> {
+        let id = state.next_tx_id.fetch_add(1, Ordering::SeqCst);
+        state
+            .transactions
+            .lock()
+            .expect("tx lock")
+            .insert(id.to_string(), Vec::new());
+        state.tx_begin_count.fetch_add(1, Ordering::SeqCst);
+        Json(json!({ "id": id.to_string() }))
+    }
+
+    async fn recording_tx_commit_handler(
+        State(state): State<RecordingGraphqlState>,
+        axum::extract::Path(id): axum::extract::Path<String>,
+    ) -> axum::http::StatusCode {
+        let mut transactions = state.transactions.lock().expect("tx lock");
+        let Some(writes) = transactions.remove(&id) else {
+            return axum::http::StatusCode::NOT_FOUND;
+        };
+        drop(transactions);
+        state
+            .committed
+            .lock()
+            .expect("committed lock")
+            .extend(writes);
+        state.tx_commit_count.fetch_add(1, Ordering::SeqCst);
+        axum::http::StatusCode::OK
+    }
+
+    async fn recording_tx_discard_handler(
+        State(state): State<RecordingGraphqlState>,
+        axum::extract::Path(id): axum::extract::Path<String>,
+    ) -> axum::http::StatusCode {
+        let removed = state
+            .transactions
+            .lock()
+            .expect("tx lock")
+            .remove(&id)
+            .is_some();
+        if removed {
+            state.tx_discard_count.fetch_add(1, Ordering::SeqCst);
+            axum::http::StatusCode::OK
+        } else {
+            axum::http::StatusCode::NOT_FOUND
+        }
+    }
+
     async fn recording_graphql_handler(
         State(state): State<RecordingGraphqlState>,
+        headers: axum::http::HeaderMap,
         Json(body): Json<Value>,
     ) -> Json<Value> {
         let query = body
@@ -1173,9 +1269,45 @@ mod lean_apply_write_boundary_tests {
             .expect("queries lock")
             .push(query.clone());
 
+        let tx_id = headers
+            .get("x-defradb-tx")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string());
+
         if query.contains("mutation") {
             let writes = parse_mutation_writes(&query);
-            state.writes.lock().expect("writes lock").extend(writes);
+
+            if let Some(fail) = state.fail_injection.lock().expect("fail lock").clone() {
+                if tx_id.as_deref() == Some(fail.tx_id.as_str()) {
+                    let prior = state
+                        .transactions
+                        .lock()
+                        .expect("tx lock")
+                        .get(&fail.tx_id)
+                        .map(|v| v.len())
+                        .unwrap_or(0);
+                    if (prior..prior + writes.len()).contains(&fail.write_index) {
+                        return Json(json!({
+                            "errors": [{ "message": "injected failure at recorder" }]
+                        }));
+                    }
+                }
+            }
+
+            match tx_id {
+                Some(id) => {
+                    let mut transactions = state.transactions.lock().expect("tx lock");
+                    let entry = transactions.entry(id).or_default();
+                    entry.extend(writes);
+                }
+                None => {
+                    state
+                        .committed
+                        .lock()
+                        .expect("committed lock")
+                        .extend(writes);
+                }
+            }
             Json(json!({ "data": aliased_mutation_response(&query) }))
         } else {
             Json(json!({ "data": empty_collection_query_response(&query) }))
@@ -1601,5 +1733,150 @@ mod lean_apply_write_boundary_tests {
 
     fn doc_key_from_desired(doc: &LeanApplyDesiredDoc) -> (Collection, String) {
         (collection_from_lean_name(&doc.collection), doc.id.clone())
+    }
+
+    #[cfg(test)]
+    mod recorder_unit_tests {
+        use super::*;
+        use serde_json::json;
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn recorder_begin_returns_numeric_id_and_commit_appends_to_committed() {
+            let (graphql, recorder) = start_recording_graphql().await;
+            let client = reqwest::Client::new();
+
+            let begin = client
+                .post(format!("{graphql}api/v0/tx/begin"))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap();
+            let txn_id = begin
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap()
+                .to_string();
+            assert!(txn_id.parse::<u64>().is_ok(), "tx id must be numeric");
+
+            let _write = client
+                .post(format!("{graphql}"))
+                .header("x-defradb-tx", &txn_id)
+                .json(&json!({
+                    "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+                }))
+                .send()
+                .await
+                .unwrap();
+
+            // Before commit, committed window is empty.
+            assert!(recorder.committed_state().is_empty());
+
+            let commit = client
+                .post(format!("{graphql}api/v0/tx/{txn_id}"))
+                .send()
+                .await
+                .unwrap();
+            assert!(commit.status().is_success());
+
+            let committed = recorder.committed_state();
+            assert_eq!(committed.len(), 1);
+            assert_eq!(committed[0].collection, Collection::Task);
+            assert_eq!(committed[0].unique_value, "task-a");
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn recorder_discard_drops_pending_writes() {
+            let (graphql, recorder) = start_recording_graphql().await;
+            let client = reqwest::Client::new();
+
+            let begin = client
+                .post(format!("{graphql}api/v0/tx/begin"))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap();
+            let txn_id = begin
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap()
+                .to_string();
+
+            let _write = client
+                .post(format!("{graphql}"))
+                .header("x-defradb-tx", &txn_id)
+                .json(&serde_json::json!({
+                    "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+                }))
+                .send()
+                .await
+                .unwrap();
+
+            let discard = client
+                .delete(format!("{graphql}api/v0/tx/{txn_id}"))
+                .send()
+                .await
+                .unwrap();
+            assert!(discard.status().is_success());
+
+            assert!(
+                recorder.committed_state().is_empty(),
+                "discarded tx must not contribute to committed state"
+            );
+            let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+            assert_eq!((begin_count, commit_count, discard_count), (1, 0, 1));
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn recorder_fail_injection_aborts_at_target_index() {
+            let (graphql, recorder) = start_recording_graphql().await;
+            let client = reqwest::Client::new();
+
+            let begin = client
+                .post(format!("{graphql}api/v0/tx/begin"))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap();
+            let txn_id = begin
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .unwrap()
+                .to_string();
+            recorder.install_fail_at(&txn_id, 1);
+
+            let ok = client
+                .post(format!("{graphql}"))
+                .header("x-defradb-tx", &txn_id)
+                .json(&serde_json::json!({
+                    "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+                }))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap();
+            assert!(ok.get("errors").is_none(), "first mutation should succeed");
+
+            let fail = client
+                .post(format!("{graphql}"))
+                .header("x-defradb-tx", &txn_id)
+                .json(&serde_json::json!({
+                    "query": "mutation { doc_0: create_Task(input: { task_id: \"task-b\" }) { _docID } }",
+                }))
+                .send()
+                .await
+                .unwrap()
+                .json::<serde_json::Value>()
+                .await
+                .unwrap();
+            assert!(fail.get("errors").is_some(), "second mutation should fail");
+        }
     }
 }

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -906,7 +906,7 @@ mod lean_apply_write_boundary_tests {
 
             assert_counts_match_lean(case, &counts);
 
-            // NOTE: Task 3 wires ConfigApplyTxn through apply_desired_state_changes.
+            // NOTE: Task 4 wires ConfigApplyTxn through apply_desired_state_changes.
             // At that point, switch the success-path assertion to recorder.committed_state()
             // to actually verify atomicity. observed_writes() includes uncommitted writes.
             let observed = recorder.observed_writes();

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -7,9 +7,11 @@ use defra_agent::Collection;
 use serde_json::Value;
 
 use crate::config_bundle::{sanitize_import_document, select_apply_collection_docs};
+#[cfg(test)]
+use crate::config_writes::ConfigAccess;
 use crate::config_writes::{
-    write_event_trigger_document, write_schedule_document, write_task_document, ConfigAccess,
-    ConfigApplyTxn, ExistingDocumentRef,
+    write_event_trigger_document, write_schedule_document, write_task_document, ConfigApplyTxn,
+    ExistingDocumentRef,
 };
 use crate::desired_state;
 use crate::desired_state::DesiredApplyBundle;

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -926,23 +926,16 @@ mod lean_apply_write_boundary_tests {
                 case.name,
             );
 
-            let committed_after_commit = recorder.committed_state();
-            assert_eq!(
-                committed_after_commit.len(),
-                case.expected_selected_writes.len(),
-                "recorder committed state count mismatch for Lean case {} (expected = {}, actual = {})",
-                case.name,
-                case.expected_selected_writes.len(),
-                committed_after_commit.len(),
-            );
-
             if case.prefix_len > 0 {
                 let (graphql, recorder) = start_recording_graphql().await;
                 let access = ConfigAccess::Graphql(graphql);
 
                 // Begin a tx. The recorder hands out sequential numeric ids starting at 0;
                 // the first tx in this fresh recorder is "0".
-                let txn = access.begin_apply_txn().await.expect("begin failure-case tx");
+                let txn = access
+                    .begin_apply_txn()
+                    .await
+                    .expect("begin failure-case tx");
                 recorder.install_fail_at("0", case.prefix_len);
 
                 let result = apply_desired_state_changes(&txn, &desired_bundle, &planned).await;
@@ -953,6 +946,7 @@ mod lean_apply_write_boundary_tests {
                     case.name,
                 );
 
+                // discard errors are not under test here; the apply error path is what we're verifying.
                 let _ = txn.discard().await;
 
                 let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
@@ -971,10 +965,10 @@ mod lean_apply_write_boundary_tests {
 
                 let observed = recorder.observed_writes();
                 assert!(
-                    observed.len() <= case.prefix_len + 1,
-                    "failure path observed {} writes; cap is prefix_len + 1 = {} for Lean case {}",
+                    observed.len() <= case.prefix_len,
+                    "failure path observed {} writes; the batch containing the failing write must be rejected and writes after it must not happen — cap is prefix_len = {} for Lean case {}",
                     observed.len(),
-                    case.prefix_len + 1,
+                    case.prefix_len,
                     case.name,
                 );
             }

--- a/crates/defra-agent-cli/src/config_writes/common.rs
+++ b/crates/defra-agent-cli/src/config_writes/common.rs
@@ -2,10 +2,9 @@ use anyhow::Result;
 use serde_json::Value;
 
 use super::ExistingDocumentRef;
-use crate::config_writes::ConfigAccess;
 
 pub(super) async fn query_documents_by_unique_value(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     collection_name: &str,
     unique_field: &str,
     unique_value: &str,
@@ -33,7 +32,7 @@ pub(super) async fn query_documents_by_unique_value(
         unique_field = unique_field,
         unique_value = escape_graphql_string(unique_value),
     );
-    let response = access.execute(&query).await?;
+    let response = txn.execute(&query).await?;
     let rows = response
         .get("data")
         .and_then(|data| data.get(collection_name))

--- a/crates/defra-agent-cli/src/config_writes/event_trigger.rs
+++ b/crates/defra-agent-cli/src/config_writes/event_trigger.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use defra_agent::graphql::escape_graphql_string;
 use serde_json::Value;
 
-use crate::config_writes::ConfigAccess;
 use crate::graphql_input_literal;
 
 use super::common::{query_documents_by_unique_value, select_existing_document};
@@ -22,7 +21,7 @@ use super::common::{query_documents_by_unique_value, select_existing_document};
 /// `row_matches_expected`. This preserves the contract that reapplying a
 /// manifest does not reset live trigger state.
 pub(crate) async fn write_event_trigger_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     trigger_id: &str,
     add_doc: &Value,
     update_doc: &Value,
@@ -31,15 +30,15 @@ pub(crate) async fn write_event_trigger_document(
         "EventTrigger",
         "trigger_id",
         trigger_id,
-        &query_documents_by_unique_value(access, "EventTrigger", "trigger_id", trigger_id, true)
+        &query_documents_by_unique_value(txn, "EventTrigger", "trigger_id", trigger_id, true)
             .await?,
     )?;
 
     let Some(existing) = existing.as_ref() else {
-        return create_event_trigger_document(access, trigger_id, add_doc).await;
+        return create_event_trigger_document(txn, trigger_id, add_doc).await;
     };
     if existing.deleted {
-        return create_event_trigger_document(access, trigger_id, add_doc).await;
+        return create_event_trigger_document(txn, trigger_id, add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;
@@ -51,11 +50,11 @@ pub(crate) async fn write_event_trigger_document(
         input_literal = input_literal,
     );
 
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "EventTrigger") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_event_trigger_row(access, trigger_id, update_doc).await?;
+            let current = select_matching_event_trigger_row(txn, trigger_id, update_doc).await?;
             if let Some(row) = current {
                 let current_doc_id = row
                     .get("_docID")
@@ -89,7 +88,7 @@ pub(crate) async fn write_event_trigger_document(
 }
 
 async fn create_event_trigger_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     trigger_id: &str,
     add_doc: &Value,
 ) -> Result<String> {
@@ -100,11 +99,11 @@ async fn create_event_trigger_document(
         }}"#,
         input_literal = input_literal,
     );
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "EventTrigger") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_event_trigger_row(access, trigger_id, add_doc).await?;
+            let current = select_matching_event_trigger_row(txn, trigger_id, add_doc).await?;
             if let Some(row) = current {
                 let deleted = row
                     .get("_deleted")
@@ -139,11 +138,11 @@ async fn create_event_trigger_document(
 }
 
 async fn select_matching_event_trigger_row(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     trigger_id: &str,
     expected: &Value,
 ) -> Result<Option<Value>> {
-    let rows = query_event_trigger_rows(access, trigger_id, true).await?;
+    let rows = query_event_trigger_rows(txn, trigger_id, true).await?;
     let live_rows = rows
         .into_iter()
         .filter(|row| row.get("_deleted").and_then(Value::as_bool) != Some(true))
@@ -163,7 +162,7 @@ async fn select_matching_event_trigger_row(
 }
 
 async fn query_event_trigger_rows(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     trigger_id: &str,
     show_deleted: bool,
 ) -> Result<Vec<Value>> {
@@ -198,7 +197,7 @@ async fn query_event_trigger_rows(
         show_deleted_arg = show_deleted_arg,
         trigger_id = escape_graphql_string(trigger_id),
     );
-    let response = access.execute(&query).await?;
+    let response = txn.execute(&query).await?;
     Ok(response
         .get("data")
         .and_then(|data| data.get("EventTrigger"))

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use inference_backend::{
 pub(crate) use schedule::write_schedule_document;
 pub(crate) use task::write_task_document;
 pub(crate) use tool_selection::write_tool_selection_document;
-pub(crate) use txn::{ConfigApplyTxn, TxnHandle};
+pub(crate) use txn::ConfigApplyTxn;
 
 use anyhow::Result;
 use defra_agent::defra_node::EmbeddedNode;

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -23,6 +23,8 @@ use serde_json::{json, Value};
 
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum ConfigAccess {
+    /// HTTP GraphQL endpoint. **Must end with `/`** — callers append paths like
+    /// `api/v0/tx/begin` directly via `format!("{endpoint}api/...")`.
     Graphql(String),
     Local(EmbeddedNode),
 }

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -5,6 +5,7 @@ mod inference_backend;
 mod schedule;
 mod task;
 mod tool_selection;
+mod txn;
 
 pub(crate) use agent_behavior::write_agent_behavior_document;
 pub(crate) use event_trigger::write_event_trigger_document;
@@ -14,6 +15,7 @@ pub(crate) use inference_backend::{
 pub(crate) use schedule::write_schedule_document;
 pub(crate) use task::write_task_document;
 pub(crate) use tool_selection::write_tool_selection_document;
+pub(crate) use txn::{ConfigApplyTxn, TxnHandle};
 
 use anyhow::Result;
 use defra_agent::defra_node::EmbeddedNode;

--- a/crates/defra-agent-cli/src/config_writes/schedule.rs
+++ b/crates/defra-agent-cli/src/config_writes/schedule.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use defra_agent::graphql::escape_graphql_string;
 use serde_json::Value;
 
-use crate::config_writes::ConfigAccess;
 use crate::graphql_input_literal;
 
 use super::common::{query_documents_by_unique_value, select_existing_document};
@@ -21,7 +20,7 @@ use super::common::{query_documents_by_unique_value, select_existing_document};
 /// the contract that reapplying a manifest does not reset live scheduler
 /// state.
 pub(crate) async fn write_schedule_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     schedule_id: &str,
     add_doc: &Value,
     update_doc: &Value,
@@ -30,15 +29,14 @@ pub(crate) async fn write_schedule_document(
         "Schedule",
         "schedule_id",
         schedule_id,
-        &query_documents_by_unique_value(access, "Schedule", "schedule_id", schedule_id, true)
-            .await?,
+        &query_documents_by_unique_value(txn, "Schedule", "schedule_id", schedule_id, true).await?,
     )?;
 
     let Some(existing) = existing.as_ref() else {
-        return create_schedule_document(access, schedule_id, add_doc).await;
+        return create_schedule_document(txn, schedule_id, add_doc).await;
     };
     if existing.deleted {
-        return create_schedule_document(access, schedule_id, add_doc).await;
+        return create_schedule_document(txn, schedule_id, add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;
@@ -50,11 +48,11 @@ pub(crate) async fn write_schedule_document(
         input_literal = input_literal,
     );
 
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "Schedule") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_schedule_row(access, schedule_id, update_doc).await?;
+            let current = select_matching_schedule_row(txn, schedule_id, update_doc).await?;
             if let Some(row) = current {
                 let current_doc_id = row
                     .get("_docID")
@@ -88,7 +86,7 @@ pub(crate) async fn write_schedule_document(
 }
 
 async fn create_schedule_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     schedule_id: &str,
     add_doc: &Value,
 ) -> Result<String> {
@@ -99,11 +97,11 @@ async fn create_schedule_document(
         }}"#,
         input_literal = input_literal,
     );
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "Schedule") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_schedule_row(access, schedule_id, add_doc).await?;
+            let current = select_matching_schedule_row(txn, schedule_id, add_doc).await?;
             if let Some(row) = current {
                 let deleted = row
                     .get("_deleted")
@@ -138,11 +136,11 @@ async fn create_schedule_document(
 }
 
 async fn select_matching_schedule_row(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     schedule_id: &str,
     expected: &Value,
 ) -> Result<Option<Value>> {
-    let rows = query_schedule_rows(access, schedule_id, true).await?;
+    let rows = query_schedule_rows(txn, schedule_id, true).await?;
     let live_rows = rows
         .into_iter()
         .filter(|row| row.get("_deleted").and_then(Value::as_bool) != Some(true))
@@ -162,7 +160,7 @@ async fn select_matching_schedule_row(
 }
 
 async fn query_schedule_rows(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     schedule_id: &str,
     show_deleted: bool,
 ) -> Result<Vec<Value>> {
@@ -195,7 +193,7 @@ async fn query_schedule_rows(
         show_deleted_arg = show_deleted_arg,
         schedule_id = escape_graphql_string(schedule_id),
     );
-    let response = access.execute(&query).await?;
+    let response = txn.execute(&query).await?;
     Ok(response
         .get("data")
         .and_then(|data| data.get("Schedule"))

--- a/crates/defra-agent-cli/src/config_writes/task.rs
+++ b/crates/defra-agent-cli/src/config_writes/task.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use defra_agent::graphql::escape_graphql_string;
 use serde_json::Value;
 
-use crate::config_writes::ConfigAccess;
 use crate::graphql_input_literal;
 
 use super::common::{query_documents_by_unique_value, select_existing_document};
@@ -15,7 +14,7 @@ use super::common::{query_documents_by_unique_value, select_existing_document};
 /// runtime-owned fields today; the runtime-owned lifecycle lives on
 /// `Schedule` and `Run`.
 pub(crate) async fn write_task_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     task_id: &str,
     add_doc: &Value,
     update_doc: &Value,
@@ -24,14 +23,14 @@ pub(crate) async fn write_task_document(
         "Task",
         "task_id",
         task_id,
-        &query_documents_by_unique_value(access, "Task", "task_id", task_id, true).await?,
+        &query_documents_by_unique_value(txn, "Task", "task_id", task_id, true).await?,
     )?;
 
     let Some(existing) = existing.as_ref() else {
-        return create_task_document(access, task_id, add_doc).await;
+        return create_task_document(txn, task_id, add_doc).await;
     };
     if existing.deleted {
-        return create_task_document(access, task_id, add_doc).await;
+        return create_task_document(txn, task_id, add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;
@@ -43,11 +42,11 @@ pub(crate) async fn write_task_document(
         input_literal = input_literal,
     );
 
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "Task") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_task_row(access, task_id, update_doc).await?;
+            let current = select_matching_task_row(txn, task_id, update_doc).await?;
             if let Some(row) = current {
                 let current_doc_id = row
                     .get("_docID")
@@ -81,7 +80,7 @@ pub(crate) async fn write_task_document(
 }
 
 async fn create_task_document(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     task_id: &str,
     add_doc: &Value,
 ) -> Result<String> {
@@ -92,11 +91,11 @@ async fn create_task_document(
         }}"#,
         input_literal = input_literal,
     );
-    let response = access.execute(&mutation).await?;
+    let response = txn.execute(&mutation).await?;
     match crate::extract_mutation_doc_id(&response, "Task") {
         Ok(doc_id) => Ok(doc_id),
         Err(extract_error) => {
-            let current = select_matching_task_row(access, task_id, add_doc).await?;
+            let current = select_matching_task_row(txn, task_id, add_doc).await?;
             if let Some(row) = current {
                 let deleted = row
                     .get("_deleted")
@@ -128,11 +127,11 @@ async fn create_task_document(
 }
 
 async fn select_matching_task_row(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     task_id: &str,
     expected: &Value,
 ) -> Result<Option<Value>> {
-    let rows = query_task_rows(access, task_id, true).await?;
+    let rows = query_task_rows(txn, task_id, true).await?;
     let live_rows = rows
         .into_iter()
         .filter(|row| row.get("_deleted").and_then(Value::as_bool) != Some(true))
@@ -152,7 +151,7 @@ async fn select_matching_task_row(
 }
 
 async fn query_task_rows(
-    access: &ConfigAccess,
+    txn: &super::ConfigApplyTxn<'_>,
     task_id: &str,
     show_deleted: bool,
 ) -> Result<Vec<Value>> {
@@ -183,7 +182,7 @@ async fn query_task_rows(
         show_deleted_arg = show_deleted_arg,
         task_id = escape_graphql_string(task_id),
     );
-    let response = access.execute(&query).await?;
+    let response = txn.execute(&query).await?;
     Ok(response
         .get("data")
         .and_then(|data| data.get("Task"))

--- a/crates/defra-agent-cli/src/config_writes/txn.rs
+++ b/crates/defra-agent-cli/src/config_writes/txn.rs
@@ -1,0 +1,181 @@
+//! Open-write transaction wrapper around `ConfigAccess`.
+//!
+//! `ConfigApplyTxn` is the only access type passed through the apply pipeline
+//! once `config apply` has begun a transaction. The top-level orchestrator
+//! drives `begin_apply_txn` → `apply_desired_state_changes` → `commit` (on
+//! success) or `discard` (on error).
+//!
+//! Discard semantics differ between backends:
+//! - **Embedded.** `runner.rollback_txn` returns `TransactionError` only in
+//!   pathological cases (handle already finalized, lock poisoned). The
+//!   underlying `db_txn` is dropped in any case.
+//! - **HTTP.** `DELETE /api/v0/tx/{id}` is a network call; it can fail for
+//!   reasons unrelated to the apply error. Even if the DELETE never reaches
+//!   the server, DefraDB's tx GC will reclaim the handle on its own.
+//!
+//! Both return `Result<()>` so callers can log discrepancies, but neither
+//! changes operator-facing behavior on failure: the apply error is what
+//! surfaces, and the DB ends at the pre-apply snapshot.
+
+use anyhow::{Context, Result};
+use defra_agent::defra_node::QueryRequest;
+use defra_agent_protocol::graphql::{execute_graphql_async_with_tx, GraphqlRequestOptions};
+use query::TransactionHandle;
+use serde_json::{json, Value};
+
+use crate::config_writes::ConfigAccess;
+use crate::graphql_access::graphql_diagnostic_hint;
+
+#[derive(Debug)]
+pub(crate) enum TxnHandle {
+    /// Numeric txn id parsed from `POST /api/v0/tx/begin`.
+    Graphql(String),
+    /// Embedded transaction handle returned by `runner.begin_txn(false)`.
+    Local(TransactionHandle),
+}
+
+pub(crate) struct ConfigApplyTxn<'a> {
+    access: &'a ConfigAccess,
+    handle: TxnHandle,
+}
+
+impl<'a> ConfigApplyTxn<'a> {
+    pub(crate) fn new(access: &'a ConfigAccess, handle: TxnHandle) -> Self {
+        Self { access, handle }
+    }
+
+    pub(crate) fn mode(&self) -> &'static str {
+        self.access.mode()
+    }
+
+    /// Execute a GraphQL query within this transaction.
+    pub(crate) async fn execute(&self, query: &str) -> Result<Value> {
+        match (&self.access, &self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                execute_graphql_async_with_tx(
+                    endpoint,
+                    query,
+                    GraphqlRequestOptions {
+                        timeout: std::time::Duration::from_secs(30),
+                        max_attempts: 5,
+                        retry_backoff: std::time::Duration::from_millis(100),
+                    },
+                    Some(id),
+                )
+                .await
+                .map_err(|error| anyhow::anyhow!("{error}\n{}", graphql_diagnostic_hint(endpoint)))
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => {
+                let request = QueryRequest::new(query);
+                let response = node.runner().execute_in_txn(request, handle).await;
+                if response.has_errors() {
+                    anyhow::bail!("graphql returned errors: {:?}", response.errors);
+                }
+                Ok(json!({ "data": response.data.unwrap_or(Value::Null) }))
+            }
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch (internal bug)"),
+        }
+    }
+
+    /// Commit the transaction. Apply is durable after this returns Ok.
+    pub(crate) async fn commit(self) -> Result<()> {
+        match (self.access, self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .post(format!("{endpoint}api/v0/tx/{id}"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx commit to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx commit returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                Ok(())
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => node
+                .runner()
+                .commit_txn(&handle)
+                .await
+                .map_err(|error| anyhow::anyhow!("commit_txn: {error}")),
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch on commit (internal bug)"),
+        }
+    }
+
+    /// Discard the transaction. Returns the underlying error if the explicit
+    /// round-trip fails; callers are expected to log and swallow that error so
+    /// the original apply error remains what surfaces to the operator.
+    pub(crate) async fn discard(self) -> Result<()> {
+        match (self.access, self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .delete(format!("{endpoint}api/v0/tx/{id}"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx discard to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx discard returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                Ok(())
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => node
+                .runner()
+                .rollback_txn(&handle)
+                .await
+                .map_err(|error| anyhow::anyhow!("rollback_txn: {error}")),
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch on discard (internal bug)"),
+        }
+    }
+}
+
+impl ConfigAccess {
+    /// Begin a write transaction on the underlying backend.
+    pub(crate) async fn begin_apply_txn(&self) -> Result<ConfigApplyTxn<'_>> {
+        match self {
+            ConfigAccess::Graphql(endpoint) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .post(format!("{endpoint}api/v0/tx/begin"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx begin to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx begin returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                let body: Value = response
+                    .json()
+                    .await
+                    .with_context(|| format!("decoding tx begin body from {endpoint}"))?;
+                let id = body
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("tx begin missing id: {body}"))?
+                    .to_string();
+                Ok(ConfigApplyTxn::new(self, TxnHandle::Graphql(id)))
+            }
+            ConfigAccess::Local(node) => {
+                let handle = node
+                    .runner()
+                    .begin_txn(false)
+                    .await
+                    .map_err(|error| anyhow::anyhow!("begin_txn: {error}"))?;
+                Ok(ConfigApplyTxn::new(self, TxnHandle::Local(handle)))
+            }
+        }
+    }
+}

--- a/crates/defra-agent-cli/src/config_writes/txn.rs
+++ b/crates/defra-agent-cli/src/config_writes/txn.rs
@@ -37,11 +37,20 @@ pub(crate) enum TxnHandle {
 pub(crate) struct ConfigApplyTxn<'a> {
     access: &'a ConfigAccess,
     handle: TxnHandle,
+    http_client: reqwest::Client,
 }
 
 impl<'a> ConfigApplyTxn<'a> {
-    pub(crate) fn new(access: &'a ConfigAccess, handle: TxnHandle) -> Self {
-        Self { access, handle }
+    pub(crate) fn new(
+        access: &'a ConfigAccess,
+        handle: TxnHandle,
+        http_client: reqwest::Client,
+    ) -> Self {
+        Self {
+            access,
+            handle,
+            http_client,
+        }
     }
 
     pub(crate) fn mode(&self) -> &'static str {
@@ -81,18 +90,25 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn commit(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
-                let client = reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(30))
-                    .build()?;
-                let response = client
-                    .post(format!("{endpoint}api/v0/tx/{id}"))
-                    .send()
-                    .await
-                    .with_context(|| format!("posting tx commit to {endpoint}"))?;
-                if !response.status().is_success() {
+                let status;
+                let bytes;
+                {
+                    let response = self
+                        .http_client
+                        .post(format!("{endpoint}api/v0/tx/{id}"))
+                        .send()
+                        .await
+                        .with_context(|| format!("posting tx commit to {endpoint}"))?;
+                    status = response.status();
+                    bytes = response
+                        .bytes()
+                        .await
+                        .with_context(|| format!("reading tx commit body from {endpoint}"))?;
+                }
+                if !status.is_success() {
                     anyhow::bail!(
-                        "tx commit returned HTTP {} from {endpoint}",
-                        response.status()
+                        "tx commit returned HTTP {status} from {endpoint}: {}",
+                        String::from_utf8_lossy(&bytes)
                     );
                 }
                 Ok(())
@@ -112,18 +128,25 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn discard(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
-                let client = reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(30))
-                    .build()?;
-                let response = client
-                    .delete(format!("{endpoint}api/v0/tx/{id}"))
-                    .send()
-                    .await
-                    .with_context(|| format!("posting tx discard to {endpoint}"))?;
-                if !response.status().is_success() {
+                let status;
+                let bytes;
+                {
+                    let response = self
+                        .http_client
+                        .delete(format!("{endpoint}api/v0/tx/{id}"))
+                        .send()
+                        .await
+                        .with_context(|| format!("posting tx discard to {endpoint}"))?;
+                    status = response.status();
+                    bytes = response
+                        .bytes()
+                        .await
+                        .with_context(|| format!("reading tx discard body from {endpoint}"))?;
+                }
+                if !status.is_success() {
                     anyhow::bail!(
-                        "tx discard returned HTTP {} from {endpoint}",
-                        response.status()
+                        "tx discard returned HTTP {status} from {endpoint}: {}",
+                        String::from_utf8_lossy(&bytes)
                     );
                 }
                 Ok(())
@@ -151,22 +174,25 @@ impl ConfigAccess {
                     .send()
                     .await
                     .with_context(|| format!("posting tx begin to {endpoint}"))?;
-                if !response.status().is_success() {
+                let status = response.status();
+                let bytes = response
+                    .bytes()
+                    .await
+                    .with_context(|| format!("reading tx begin body from {endpoint}"))?;
+                if !status.is_success() {
                     anyhow::bail!(
-                        "tx begin returned HTTP {} from {endpoint}",
-                        response.status()
+                        "tx begin returned HTTP {status} from {endpoint}: {}",
+                        String::from_utf8_lossy(&bytes)
                     );
                 }
-                let body: Value = response
-                    .json()
-                    .await
+                let body: Value = serde_json::from_slice(&bytes)
                     .with_context(|| format!("decoding tx begin body from {endpoint}"))?;
                 let id = body
                     .get("id")
                     .and_then(Value::as_str)
                     .ok_or_else(|| anyhow::anyhow!("tx begin missing id: {body}"))?
                     .to_string();
-                Ok(ConfigApplyTxn::new(self, TxnHandle::Graphql(id)))
+                Ok(ConfigApplyTxn::new(self, TxnHandle::Graphql(id), client))
             }
             ConfigAccess::Local(node) => {
                 let handle = node
@@ -174,7 +200,11 @@ impl ConfigAccess {
                     .begin_txn(false)
                     .await
                     .map_err(|error| anyhow::anyhow!("begin_txn: {error}"))?;
-                Ok(ConfigApplyTxn::new(self, TxnHandle::Local(handle)))
+                Ok(ConfigApplyTxn::new(
+                    self,
+                    TxnHandle::Local(handle),
+                    reqwest::Client::new(),
+                ))
             }
         }
     }

--- a/crates/defra-agent-cli/src/config_writes/txn.rs
+++ b/crates/defra-agent-cli/src/config_writes/txn.rs
@@ -53,10 +53,6 @@ impl<'a> ConfigApplyTxn<'a> {
         }
     }
 
-    pub(crate) fn mode(&self) -> &'static str {
-        self.access.mode()
-    }
-
     /// Execute a GraphQL query within this transaction.
     pub(crate) async fn execute(&self, query: &str) -> Result<Value> {
         match (&self.access, &self.handle) {

--- a/crates/defra-agent-cli/src/config_writes/txn.rs
+++ b/crates/defra-agent-cli/src/config_writes/txn.rs
@@ -26,6 +26,22 @@ use serde_json::{json, Value};
 use crate::config_writes::ConfigAccess;
 use crate::graphql_access::graphql_diagnostic_hint;
 
+/// Derive the API base URL from a GraphQL endpoint.
+///
+/// The GraphQL endpoint is expected to end with `/graphql` (e.g.
+/// `http://host:port/api/v0/graphql`). Stripping that suffix gives the API
+/// base `http://host:port/api/v0`, from which transaction paths like
+/// `/tx/begin` and `/tx/{id}` are appended.
+fn api_base_from_graphql(graphql: &str) -> Result<String> {
+    graphql
+        .trim()
+        .strip_suffix("/graphql")
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            anyhow::anyhow!("expected GraphQL endpoint ending in /graphql, got {graphql}")
+        })
+}
+
 #[derive(Debug)]
 pub(crate) enum TxnHandle {
     /// Numeric txn id parsed from `POST /api/v0/tx/begin`.
@@ -90,12 +106,13 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn commit(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let api_base = api_base_from_graphql(endpoint)?;
                 let status;
                 let bytes;
                 {
                     let response = self
                         .http_client
-                        .post(format!("{endpoint}api/v0/tx/{id}"))
+                        .post(format!("{api_base}/tx/{id}"))
                         .send()
                         .await
                         .with_context(|| format!("posting tx commit to {endpoint}"))?;
@@ -128,12 +145,13 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn discard(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let api_base = api_base_from_graphql(endpoint)?;
                 let status;
                 let bytes;
                 {
                     let response = self
                         .http_client
-                        .delete(format!("{endpoint}api/v0/tx/{id}"))
+                        .delete(format!("{api_base}/tx/{id}"))
                         .send()
                         .await
                         .with_context(|| format!("posting tx discard to {endpoint}"))?;
@@ -166,11 +184,12 @@ impl ConfigAccess {
     pub(crate) async fn begin_apply_txn(&self) -> Result<ConfigApplyTxn<'_>> {
         match self {
             ConfigAccess::Graphql(endpoint) => {
+                let api_base = api_base_from_graphql(endpoint)?;
                 let client = reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
                     .build()?;
                 let response = client
-                    .post(format!("{endpoint}api/v0/tx/begin"))
+                    .post(format!("{api_base}/tx"))
                     .send()
                     .await
                     .with_context(|| format!("posting tx begin to {endpoint}"))?;
@@ -187,11 +206,16 @@ impl ConfigAccess {
                 }
                 let body: Value = serde_json::from_slice(&bytes)
                     .with_context(|| format!("decoding tx begin body from {endpoint}"))?;
+                // DefraDB returns `{"id": uint64}` (numeric); accept both string
+                // and number forms so the recording test harness can use either.
                 let id = body
                     .get("id")
-                    .and_then(Value::as_str)
-                    .ok_or_else(|| anyhow::anyhow!("tx begin missing id: {body}"))?
-                    .to_string();
+                    .and_then(|v| {
+                        v.as_str()
+                            .map(ToOwned::to_owned)
+                            .or_else(|| v.as_u64().map(|n| n.to_string()))
+                    })
+                    .ok_or_else(|| anyhow::anyhow!("tx begin missing id: {body}"))?;
                 Ok(ConfigApplyTxn::new(self, TxnHandle::Graphql(id), client))
             }
             ConfigAccess::Local(node) => {

--- a/crates/defra-agent-cli/src/config_writes/txn.rs
+++ b/crates/defra-agent-cli/src/config_writes/txn.rs
@@ -24,27 +24,11 @@ use query::TransactionHandle;
 use serde_json::{json, Value};
 
 use crate::config_writes::ConfigAccess;
-use crate::graphql_access::graphql_diagnostic_hint;
-
-/// Derive the API base URL from a GraphQL endpoint.
-///
-/// The GraphQL endpoint is expected to end with `/graphql` (e.g.
-/// `http://host:port/api/v0/graphql`). Stripping that suffix gives the API
-/// base `http://host:port/api/v0`, from which transaction paths like
-/// `/tx/begin` and `/tx/{id}` are appended.
-fn api_base_from_graphql(graphql: &str) -> Result<String> {
-    graphql
-        .trim()
-        .strip_suffix("/graphql")
-        .map(ToOwned::to_owned)
-        .ok_or_else(|| {
-            anyhow::anyhow!("expected GraphQL endpoint ending in /graphql, got {graphql}")
-        })
-}
+use crate::graphql_access::{graphql_api_base, graphql_diagnostic_hint};
 
 #[derive(Debug)]
 pub(crate) enum TxnHandle {
-    /// Numeric txn id parsed from `POST /api/v0/tx/begin`.
+    /// Numeric txn id parsed from `POST /api/v0/tx`.
     Graphql(String),
     /// Embedded transaction handle returned by `runner.begin_txn(false)`.
     Local(TransactionHandle),
@@ -106,7 +90,7 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn commit(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
-                let api_base = api_base_from_graphql(endpoint)?;
+                let api_base = graphql_api_base(endpoint)?;
                 let status;
                 let bytes;
                 {
@@ -145,7 +129,7 @@ impl<'a> ConfigApplyTxn<'a> {
     pub(crate) async fn discard(self) -> Result<()> {
         match (self.access, self.handle) {
             (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
-                let api_base = api_base_from_graphql(endpoint)?;
+                let api_base = graphql_api_base(endpoint)?;
                 let status;
                 let bytes;
                 {
@@ -184,7 +168,7 @@ impl ConfigAccess {
     pub(crate) async fn begin_apply_txn(&self) -> Result<ConfigApplyTxn<'_>> {
         match self {
             ConfigAccess::Graphql(endpoint) => {
-                let api_base = api_base_from_graphql(endpoint)?;
+                let api_base = graphql_api_base(endpoint)?;
                 let client = reqwest::Client::builder()
                     .timeout(std::time::Duration::from_secs(30))
                     .build()?;

--- a/crates/defra-agent-cli/src/graphql_access.rs
+++ b/crates/defra-agent-cli/src/graphql_access.rs
@@ -16,6 +16,22 @@ use serde_json::Value;
 
 use crate::config_writes::ConfigAccess;
 
+/// Derive the REST API base URL from a GraphQL endpoint.
+///
+/// The GraphQL endpoint is expected to end with `/graphql` (e.g.
+/// `http://host:port/api/v0/graphql`). Stripping that suffix gives the API
+/// base `http://host:port/api/v0`, from which paths like `/tx` (begin) and
+/// `/tx/{id}` (commit/discard) are appended.
+pub(crate) fn graphql_api_base(graphql: &str) -> Result<String> {
+    graphql
+        .trim()
+        .strip_suffix("/graphql")
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| {
+            anyhow::anyhow!("expected GraphQL endpoint ending in /graphql, got {graphql}")
+        })
+}
+
 pub(crate) async fn graphql_endpoint_available(graphql: &str) -> bool {
     shared_graphql_endpoint_available(
         graphql,

--- a/crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs
@@ -1,0 +1,124 @@
+mod support;
+use support::*;
+
+use std::fs;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+use uuid::Uuid;
+
+/// SIGKILL the CLI mid-apply and assert that DefraDB's tx GC reclaims the
+/// orphaned transaction and leaves the database at the pre-apply snapshot.
+/// This exercises the operationally-meaningful failure mode (Ctrl-C, OOM,
+/// container restart) against a real node, not the recorder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir.path().join("infra").join("agents").join("default");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-rb-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let agent_name = format!("cli-rollback-{}", Uuid::new_v4().simple());
+
+    run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
+
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+
+    let pre_apply_backends = count_collection_rows(&graphql, "InferenceBackend").await?;
+    let pre_apply_profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
+    let pre_apply_tools = count_collection_rows(&graphql, "ToolSelection").await?;
+    let pre_apply_tasks = count_collection_rows(&graphql, "Task").await?;
+
+    let root_str = root
+        .to_str()
+        .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
+
+    // No `spawn_cli` helper takes env vars today; spawn directly.
+    let mut cli = std::process::Command::new(support::cli_bin())
+        .env("HOME", &home_dir)
+        .env("RUST_LOG", "error")
+        .env("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS", "200")
+        .current_dir(&home_dir)
+        .args(["config", "apply", "--root", root_str, "--graphql", &graphql])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("spawning defra-agent config apply with apply-sleep env")?;
+
+    // With per-collection sleep = 200 ms and CONFIG_APPLY_ORDER having 9
+    // collections, full apply takes at least 1.8 s. Sleep 400 ms — past
+    // begin and at least the first batched collection mutation, well before
+    // commit. The sleep widens the kill window deterministically; without
+    // it a fast local apply could complete in under our delay.
+    thread::sleep(Duration::from_millis(400));
+    cli.kill().context("SIGKILL CLI")?;
+    cli.wait().context("reap CLI")?;
+
+    // Allow DefraDB's tx GC to reclaim the orphaned handle. Poll for
+    // stability rather than sleep blindly.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let backends = count_collection_rows(&graphql, "InferenceBackend").await?;
+        let profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
+        let tools = count_collection_rows(&graphql, "ToolSelection").await?;
+        let tasks = count_collection_rows(&graphql, "Task").await?;
+
+        if backends == pre_apply_backends
+            && profiles == pre_apply_profiles
+            && tools == pre_apply_tools
+            && tasks == pre_apply_tasks
+        {
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            return Err(anyhow!(
+                "after SIGKILL, DB still shows post-apply state: backends={} (pre={}), \
+                profiles={} (pre={}), tools={} (pre={}), tasks={} (pre={})",
+                backends,
+                pre_apply_backends,
+                profiles,
+                pre_apply_profiles,
+                tools,
+                pre_apply_tools,
+                tasks,
+                pre_apply_tasks,
+            ));
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+async fn count_collection_rows(graphql: &str, collection: &str) -> Result<usize> {
+    let response = graphql_query(graphql, &format!("{{ {collection} {{ _docID }} }}")).await?;
+    Ok(response
+        .pointer(&format!("/data/{collection}"))
+        .and_then(Value::as_array)
+        .map(|rows| rows.len())
+        .unwrap_or(0))
+}

--- a/crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs
@@ -9,6 +9,11 @@ use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 use uuid::Uuid;
 
+const KILL_DELAY: Duration = Duration::from_millis(400);
+const TX_GC_DEADLINE: Duration = Duration::from_secs(10);
+const POLL_INTERVAL: Duration = Duration::from_millis(250);
+const PER_COLLECTION_SLEEP_MS: &str = "200";
+
 /// SIGKILL the CLI mid-apply and assert that DefraDB's tx GC reclaims the
 /// orphaned transaction and leaves the database at the pre-apply snapshot.
 /// This exercises the operationally-meaningful failure mode (Ctrl-C, OOM,
@@ -26,7 +31,7 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
     let graphql = graphql_url(port);
     let agent_name = format!("cli-rollback-{}", Uuid::new_v4().simple());
 
-    run_init_json(
+    let init = run_init_json(
         &home_dir,
         &[
             "--agent-name",
@@ -36,6 +41,7 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
             mock_endpoint.endpoint(),
         ],
     )?;
+    let agent_did = agent_did_from_init(&init)?;
 
     run_cli_text(
         &home_dir,
@@ -49,11 +55,25 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
 
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
-    let pre_apply_backends = count_collection_rows(&graphql, "InferenceBackend").await?;
-    let pre_apply_profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
-    let pre_apply_tools = count_collection_rows(&graphql, "ToolSelection").await?;
-    let pre_apply_tasks = count_collection_rows(&graphql, "Task").await?;
+    // Snapshot row counts for every collection in CONFIG_APPLY_ORDER so the
+    // atomicity assertion covers the full apply surface, not just a subset.
+    let collections = [
+        "InferenceBackend",
+        "InferenceProfile",
+        "ToolServiceRegistry",
+        "ToolSelection",
+        "AgentBehavior",
+        "Task",
+        "Schedule",
+        "EventTrigger",
+        "AgentPrincipal",
+    ];
+    let mut pre_apply = std::collections::BTreeMap::new();
+    for c in &collections {
+        pre_apply.insert(*c, count_collection_rows(&graphql, c).await?);
+    }
 
     let root_str = root
         .to_str()
@@ -63,7 +83,7 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
     let mut cli = std::process::Command::new(support::cli_bin())
         .env("HOME", &home_dir)
         .env("RUST_LOG", "error")
-        .env("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS", "200")
+        .env("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS", PER_COLLECTION_SLEEP_MS)
         .current_dir(&home_dir)
         .args(["config", "apply", "--root", root_str, "--graphql", &graphql])
         .stdout(std::process::Stdio::piped())
@@ -76,41 +96,38 @@ async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
     // begin and at least the first batched collection mutation, well before
     // commit. The sleep widens the kill window deterministically; without
     // it a fast local apply could complete in under our delay.
-    thread::sleep(Duration::from_millis(400));
+    thread::sleep(KILL_DELAY);
     cli.kill().context("SIGKILL CLI")?;
     cli.wait().context("reap CLI")?;
 
     // Allow DefraDB's tx GC to reclaim the orphaned handle. Poll for
     // stability rather than sleep blindly.
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let deadline = Instant::now() + TX_GC_DEADLINE;
     loop {
-        let backends = count_collection_rows(&graphql, "InferenceBackend").await?;
-        let profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
-        let tools = count_collection_rows(&graphql, "ToolSelection").await?;
-        let tasks = count_collection_rows(&graphql, "Task").await?;
+        let mut current = std::collections::BTreeMap::new();
+        for c in &collections {
+            current.insert(*c, count_collection_rows(&graphql, c).await?);
+        }
 
-        if backends == pre_apply_backends
-            && profiles == pre_apply_profiles
-            && tools == pre_apply_tools
-            && tasks == pre_apply_tasks
-        {
+        if current == pre_apply {
             return Ok(());
         }
         if Instant::now() > deadline {
+            // Build a diff line for collections whose counts changed.
+            let drift: Vec<String> = collections
+                .iter()
+                .filter_map(|c| {
+                    let pre = pre_apply[c];
+                    let now = current[c];
+                    (pre != now).then(|| format!("{c}: pre={pre} now={now}"))
+                })
+                .collect();
             return Err(anyhow!(
-                "after SIGKILL, DB still shows post-apply state: backends={} (pre={}), \
-                profiles={} (pre={}), tools={} (pre={}), tasks={} (pre={})",
-                backends,
-                pre_apply_backends,
-                profiles,
-                pre_apply_profiles,
-                tools,
-                pre_apply_tools,
-                tasks,
-                pre_apply_tasks,
+                "after SIGKILL, DB shows post-apply drift: {}",
+                drift.join(", ")
             ));
         }
-        thread::sleep(Duration::from_millis(250));
+        tokio::time::sleep(POLL_INTERVAL).await;
     }
 }
 

--- a/crates/defra-agent-protocol/Cargo.toml
+++ b/crates/defra-agent-protocol/Cargo.toml
@@ -16,6 +16,6 @@ tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
-axum = "0.7"
+axum = "0.8"
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt", "macros"] }

--- a/crates/defra-agent-protocol/Cargo.toml
+++ b/crates/defra-agent-protocol/Cargo.toml
@@ -16,4 +16,6 @@ tokio = { workspace = true, features = ["time"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
+axum = "0.7"
 serde_json = { workspace = true }
+tokio = { workspace = true, features = ["net", "rt", "macros"] }

--- a/crates/defra-agent-protocol/src/graphql.rs
+++ b/crates/defra-agent-protocol/src/graphql.rs
@@ -316,6 +316,109 @@ pub async fn execute_graphql_async(
     Err(last_error.unwrap_or_else(|| anyhow!("GraphQL request retries exhausted for {graphql}")))
 }
 
+/// Like `execute_graphql_async` but adds an `x-defradb-tx` header when
+/// `txn_id` is `Some`. Used by `defra-agent-cli` to drive DefraDB HTTP
+/// transactions during `config apply`.
+pub async fn execute_graphql_async_with_tx(
+    graphql: &str,
+    query: &str,
+    options: GraphqlRequestOptions,
+    txn_id: Option<&str>,
+) -> Result<serde_json::Value> {
+    let client = reqwest::Client::builder()
+        .timeout(options.timeout)
+        .build()?;
+    let mut last_error = None;
+
+    for attempt in 0..options.max_attempts.max(1) {
+        let mut request = client
+            .post(graphql)
+            .json(&serde_json::json!({ "query": query }));
+        if let Some(id) = txn_id {
+            request = request.header("x-defradb-tx", id);
+        }
+        let response = request.send().await;
+        let response = match response {
+            Ok(response) => response,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                tracing::warn!(
+                    attempt,
+                    graphql,
+                    error = %error,
+                    "retrying async GraphQL tx request after transport error"
+                );
+                last_error = Some(
+                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(
+                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}"))
+                );
+            }
+        };
+
+        let response = match response.error_for_status() {
+            Ok(response) => response,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                tracing::warn!(
+                    attempt,
+                    graphql,
+                    error = %error,
+                    "retrying async GraphQL tx request after response status error"
+                );
+                last_error = Some(
+                    anyhow::Error::new(error)
+                        .context(format!("reading GraphQL response from {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("reading GraphQL response from {graphql}")));
+            }
+        };
+
+        let value = match response.json().await {
+            Ok(value) => value,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                tracing::warn!(
+                    attempt,
+                    graphql,
+                    error = %error,
+                    "retrying async GraphQL tx request after decode error"
+                );
+                last_error = Some(
+                    anyhow::Error::new(error)
+                        .context(format!("decoding GraphQL response body from {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("decoding GraphQL response body from {graphql}")));
+            }
+        };
+
+        return finish_graphql_response(graphql, value);
+    }
+
+    Err(last_error.unwrap_or_else(|| anyhow!("GraphQL request retries exhausted for {graphql}")))
+}
+
 pub fn execute_graphql_blocking(
     graphql: &str,
     query: &str,
@@ -809,5 +912,59 @@ mod tests {
         assert!(rendered.contains("enabled: true"));
         assert!(rendered.contains(r#"name: "alpha""#));
         assert!(rendered.contains(r#"tags: ["a", "b"]"#));
+    }
+}
+
+#[cfg(test)]
+mod tx_tests {
+    use super::*;
+    use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Default)]
+    struct HeaderRecorder {
+        last_tx_header: Arc<Mutex<Option<String>>>,
+    }
+
+    async fn capture_handler(
+        State(state): State<HeaderRecorder>,
+        headers: HeaderMap,
+        Json(_body): Json<serde_json::Value>,
+    ) -> Json<serde_json::Value> {
+        *state.last_tx_header.lock().unwrap() = headers
+            .get("x-defradb-tx")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        Json(serde_json::json!({ "data": {} }))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_graphql_async_with_tx_sets_header_when_id_provided() {
+        let state = HeaderRecorder::default();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/", post(capture_handler))
+            .with_state(state.clone());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let endpoint = format!("http://{addr}/");
+        let options = GraphqlRequestOptions {
+            timeout: std::time::Duration::from_secs(2),
+            max_attempts: 1,
+            retry_backoff: std::time::Duration::from_millis(50),
+        };
+
+        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options.clone(), Some("42"))
+            .await
+            .unwrap();
+        assert_eq!(state.last_tx_header.lock().unwrap().as_deref(), Some("42"));
+
+        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options, None)
+            .await
+            .unwrap();
+        assert_eq!(state.last_tx_header.lock().unwrap().as_deref(), None);
     }
 }

--- a/crates/defra-agent-protocol/src/graphql.rs
+++ b/crates/defra-agent-protocol/src/graphql.rs
@@ -224,17 +224,31 @@ pub async fn execute_graphql_async(
     query: &str,
     options: GraphqlRequestOptions,
 ) -> Result<serde_json::Value> {
+    execute_graphql_async_with_tx(graphql, query, options, None).await
+}
+
+/// Like `execute_graphql_async` but adds an `x-defradb-tx` header when
+/// `txn_id` is `Some`. Used by `defra-agent-cli` to drive DefraDB HTTP
+/// transactions during `config apply`.
+pub async fn execute_graphql_async_with_tx(
+    graphql: &str,
+    query: &str,
+    options: GraphqlRequestOptions,
+    txn_id: Option<&str>,
+) -> Result<serde_json::Value> {
     let client = reqwest::Client::builder()
         .timeout(options.timeout)
         .build()?;
     let mut last_error = None;
 
     for attempt in 0..options.max_attempts.max(1) {
-        let response = client
+        let mut request = client
             .post(graphql)
-            .json(&serde_json::json!({ "query": query }))
-            .send()
-            .await;
+            .json(&serde_json::json!({ "query": query }));
+        if let Some(id) = txn_id {
+            request = request.header("x-defradb-tx", id);
+        }
+        let response = request.send().await;
         let response = match response {
             Ok(response) => response,
             Err(error)
@@ -296,109 +310,6 @@ pub async fn execute_graphql_async(
                     graphql,
                     error = %error,
                     "retrying async GraphQL request after decode error"
-                );
-                last_error = Some(
-                    anyhow::Error::new(error)
-                        .context(format!("decoding GraphQL response body from {graphql}")),
-                );
-                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
-                continue;
-            }
-            Err(error) => {
-                return Err(anyhow::Error::new(error)
-                    .context(format!("decoding GraphQL response body from {graphql}")));
-            }
-        };
-
-        return finish_graphql_response(graphql, value);
-    }
-
-    Err(last_error.unwrap_or_else(|| anyhow!("GraphQL request retries exhausted for {graphql}")))
-}
-
-/// Like `execute_graphql_async` but adds an `x-defradb-tx` header when
-/// `txn_id` is `Some`. Used by `defra-agent-cli` to drive DefraDB HTTP
-/// transactions during `config apply`.
-pub async fn execute_graphql_async_with_tx(
-    graphql: &str,
-    query: &str,
-    options: GraphqlRequestOptions,
-    txn_id: Option<&str>,
-) -> Result<serde_json::Value> {
-    let client = reqwest::Client::builder()
-        .timeout(options.timeout)
-        .build()?;
-    let mut last_error = None;
-
-    for attempt in 0..options.max_attempts.max(1) {
-        let mut request = client
-            .post(graphql)
-            .json(&serde_json::json!({ "query": query }));
-        if let Some(id) = txn_id {
-            request = request.header("x-defradb-tx", id);
-        }
-        let response = request.send().await;
-        let response = match response {
-            Ok(response) => response,
-            Err(error)
-                if graphql_transport_error_is_retryable(&error)
-                    && attempt + 1 < options.max_attempts =>
-            {
-                tracing::warn!(
-                    attempt,
-                    graphql,
-                    error = %error,
-                    "retrying async GraphQL tx request after transport error"
-                );
-                last_error = Some(
-                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}")),
-                );
-                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
-                continue;
-            }
-            Err(error) => {
-                return Err(
-                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}"))
-                );
-            }
-        };
-
-        let response = match response.error_for_status() {
-            Ok(response) => response,
-            Err(error)
-                if graphql_transport_error_is_retryable(&error)
-                    && attempt + 1 < options.max_attempts =>
-            {
-                tracing::warn!(
-                    attempt,
-                    graphql,
-                    error = %error,
-                    "retrying async GraphQL tx request after response status error"
-                );
-                last_error = Some(
-                    anyhow::Error::new(error)
-                        .context(format!("reading GraphQL response from {graphql}")),
-                );
-                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
-                continue;
-            }
-            Err(error) => {
-                return Err(anyhow::Error::new(error)
-                    .context(format!("reading GraphQL response from {graphql}")));
-            }
-        };
-
-        let value = match response.json().await {
-            Ok(value) => value,
-            Err(error)
-                if graphql_transport_error_is_retryable(&error)
-                    && attempt + 1 < options.max_attempts =>
-            {
-                tracing::warn!(
-                    attempt,
-                    graphql,
-                    error = %error,
-                    "retrying async GraphQL tx request after decode error"
                 );
                 last_error = Some(
                     anyhow::Error::new(error)

--- a/docs/superpowers/plans/2026-05-15-issue-56-transactional-apply.md
+++ b/docs/superpowers/plans/2026-05-15-issue-56-transactional-apply.md
@@ -1,0 +1,1772 @@
+# Transactional `config apply` Implementation Plan (Issue #56)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `defra-agent-cli config apply` atomic by wrapping the apply sequence in a single DefraDB transaction.
+
+**Architecture:** A new `ConfigApplyTxn` type opens a transaction on `ConfigAccess` (HTTP `POST /api/v0/tx/begin` or embedded `runner.begin_txn`) and is threaded through every write site. The top-level CLI command does `begin → apply → commit | discard`. The conformance fence and new integration test exercise both the commit and discard paths.
+
+**Tech Stack:** Rust, anyhow, tokio, reqwest, axum (test recorder), DefraDB's native HTTP and embedded transaction APIs.
+
+**Spec:** `docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md`.
+
+---
+
+## File Structure
+
+**Created:**
+- `crates/defra-agent-cli/src/config_writes/txn.rs` — `ConfigApplyTxn`, `TxnHandle`, `ConfigAccess::begin_apply_txn`. Single responsibility: open/execute/commit/discard a write transaction over either backend.
+- `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` — SIGKILL-mid-apply integration test against a real DefraDB node.
+
+**Modified:**
+- `crates/defra-agent-protocol/src/graphql.rs` — add `execute_graphql_async_with_tx` that mirrors `execute_graphql_async` but adds an optional `x-defradb-tx` header.
+- `crates/defra-agent-cli/src/graphql_access.rs` — re-export `post_graphql_with_tx` thin wrapper for the txn helper.
+- `crates/defra-agent-cli/src/config_writes/mod.rs` — declare `txn` submodule and re-export `ConfigApplyTxn`.
+- `crates/defra-agent-cli/src/config_writes/common.rs` — `query_documents_by_unique_value(access: &ConfigAccess, ...)` → `(txn: &ConfigApplyTxn, ...)`.
+- `crates/defra-agent-cli/src/config_writes/task.rs` — `write_task_document` signature change.
+- `crates/defra-agent-cli/src/config_writes/schedule.rs` — `write_schedule_document` signature change.
+- `crates/defra-agent-cli/src/config_writes/event_trigger.rs` — `write_event_trigger_document` signature change.
+- `crates/defra-agent-cli/src/config_import.rs` — thread `&ConfigApplyTxn` through `apply_desired_state_changes` and its callees; extend `lean_apply_write_boundary_tests::RecordingGraphqlState` with tx-aware routes; extend conformance assertions.
+- `crates/defra-agent-cli/src/commands/config/apply.rs` — wrap the apply call in the `begin → commit | discard` braid.
+- `CHANGELOG.md` — operator-facing release note.
+
+---
+
+## Task 0: Baseline
+
+**Files:** none.
+
+- [ ] **Step 0.1: Verify baseline green**
+
+Run:
+```bash
+cargo fmt --all -- --check
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+cargo test -p defra-agent-cli --tests lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary
+```
+Expected: all green. If not, stop and report — the baseline must be clean before starting.
+
+- [ ] **Step 0.2: Confirm working branch**
+
+Run: `git branch --show-current`
+Expected output: `design/issue-56-transactional-apply`. Do not switch branches. Do not merge.
+
+---
+
+## Task 1: Extend the recording GraphQL test server with tx awareness
+
+The conformance test's recording server (in `crates/defra-agent-cli/src/config_import.rs`, module `lean_apply_write_boundary_tests`) currently has one route (`/`) and one mutation log. Add the tx routes, per-tx state windows, a committed state window, and a fail-at-write-N injection knob. The regex parser stays — header routing is at the HTTP layer.
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/config_import.rs` (the `lean_apply_write_boundary_tests` module starting at line ~789).
+
+- [ ] **Step 1.1: Sketch the new recorder shape — write a failing unit test for `begin → write → commit` returning a numeric id and appending to committed state**
+
+Append to the `lean_apply_write_boundary_tests` module:
+
+```rust
+#[cfg(test)]
+mod recorder_unit_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn recorder_begin_returns_numeric_id_and_commit_appends_to_committed() {
+        let (graphql, recorder) = start_recording_graphql().await;
+        let client = reqwest::Client::new();
+
+        let begin = client
+            .post(format!("{graphql}api/v0/tx/begin"))
+            .send()
+            .await
+            .unwrap()
+            .json::<serde_json::Value>()
+            .await
+            .unwrap();
+        let txn_id = begin.get("id").and_then(serde_json::Value::as_str).unwrap().to_string();
+        assert!(txn_id.parse::<u64>().is_ok(), "tx id must be numeric");
+
+        let _write = client
+            .post(format!("{graphql}"))
+            .header("x-defradb-tx", &txn_id)
+            .json(&json!({
+                "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+            }))
+            .send()
+            .await
+            .unwrap();
+
+        // Before commit, committed window is empty.
+        assert!(recorder.committed_state().is_empty());
+
+        let commit = client
+            .post(format!("{graphql}api/v0/tx/{txn_id}"))
+            .send()
+            .await
+            .unwrap();
+        assert!(commit.status().is_success());
+
+        let committed = recorder.committed_state();
+        assert_eq!(committed.len(), 1);
+        assert_eq!(committed[0].collection, Collection::Task);
+        assert_eq!(committed[0].unique_value, "task-a");
+    }
+}
+```
+
+- [ ] **Step 1.2: Run the unit test to verify it fails**
+
+Run:
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::recorder_unit_tests::recorder_begin_returns_numeric_id_and_commit_appends_to_committed -- --nocapture
+```
+Expected: FAIL — `committed_state` method does not exist; tx route does not exist.
+
+- [ ] **Step 1.3: Add the tx-aware state to `RecordingGraphqlState` and the routes**
+
+Replace the existing `RecordingGraphqlState` and `recording_graphql_handler`/`start_recording_graphql` with this extended version. The committed window replaces the previous `writes` field; existing call sites that read `recorder.writes` are renamed in Step 1.4.
+
+```rust
+#[derive(Clone, Default)]
+struct RecordingGraphqlState {
+    queries: Arc<Mutex<Vec<String>>>,
+    // Per-tx pending writes, keyed by numeric tx id.
+    transactions: Arc<Mutex<BTreeMap<String, Vec<ObservedWrite>>>>,
+    // Writes that have committed (either via tx commit or via direct graphql POST without a tx header).
+    committed: Arc<Mutex<Vec<ObservedWrite>>>,
+    next_tx_id: Arc<AtomicU64>,
+    // Fail injection: if Some, the (write_index_within_tx + 1)th mutation against the named tx
+    // returns a GraphQL error.
+    fail_injection: Arc<Mutex<Option<FailInjection>>>,
+    // Lifecycle counters for assertions.
+    tx_begin_count: Arc<AtomicU64>,
+    tx_commit_count: Arc<AtomicU64>,
+    tx_discard_count: Arc<AtomicU64>,
+}
+
+#[derive(Debug, Clone)]
+struct FailInjection {
+    tx_id: String,
+    write_index: usize, // zero-based; matches the i-th mutation within that tx
+}
+
+impl RecordingGraphqlState {
+    fn committed_state(&self) -> Vec<ObservedWrite> {
+        self.committed.lock().expect("committed lock").clone()
+    }
+
+    fn observed_writes(&self) -> Vec<ObservedWrite> {
+        // Existing test reads this as "every write attempted".
+        // For convenience, return committed + any still-pending in-tx writes.
+        let mut all = self.committed.lock().expect("committed lock").clone();
+        let txs = self.transactions.lock().expect("tx lock").clone();
+        for (_id, writes) in txs.iter() {
+            all.extend(writes.iter().cloned());
+        }
+        all
+    }
+
+    fn tx_lifecycle_counts(&self) -> (u64, u64, u64) {
+        (
+            self.tx_begin_count.load(Ordering::SeqCst),
+            self.tx_commit_count.load(Ordering::SeqCst),
+            self.tx_discard_count.load(Ordering::SeqCst),
+        )
+    }
+
+    fn install_fail_at(&self, tx_id: impl Into<String>, write_index: usize) {
+        *self.fail_injection.lock().expect("fail lock") = Some(FailInjection {
+            tx_id: tx_id.into(),
+            write_index,
+        });
+    }
+}
+
+async fn start_recording_graphql() -> (String, RecordingGraphqlState) {
+    let state = RecordingGraphqlState::default();
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind recording GraphQL listener");
+    let addr = listener.local_addr().expect("recording GraphQL addr");
+    let app = Router::new()
+        .route("/", post(recording_graphql_handler))
+        .route("/api/v0/tx/begin", post(recording_tx_begin_handler))
+        .route("/api/v0/tx/:id", post(recording_tx_commit_handler))
+        .route("/api/v0/tx/:id", axum::routing::delete(recording_tx_discard_handler))
+        .with_state(state.clone());
+    tokio::spawn(async move {
+        axum::serve(listener, app)
+            .await
+            .expect("recording GraphQL server");
+    });
+    (format!("http://{addr}/"), state)
+}
+
+async fn recording_tx_begin_handler(
+    State(state): State<RecordingGraphqlState>,
+) -> Json<Value> {
+    let id = state.next_tx_id.fetch_add(1, Ordering::SeqCst);
+    state
+        .transactions
+        .lock()
+        .expect("tx lock")
+        .insert(id.to_string(), Vec::new());
+    state.tx_begin_count.fetch_add(1, Ordering::SeqCst);
+    Json(json!({ "id": id.to_string() }))
+}
+
+async fn recording_tx_commit_handler(
+    State(state): State<RecordingGraphqlState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> axum::http::StatusCode {
+    let mut transactions = state.transactions.lock().expect("tx lock");
+    let Some(writes) = transactions.remove(&id) else {
+        return axum::http::StatusCode::NOT_FOUND;
+    };
+    drop(transactions);
+    state.committed.lock().expect("committed lock").extend(writes);
+    state.tx_commit_count.fetch_add(1, Ordering::SeqCst);
+    axum::http::StatusCode::OK
+}
+
+async fn recording_tx_discard_handler(
+    State(state): State<RecordingGraphqlState>,
+    axum::extract::Path(id): axum::extract::Path<String>,
+) -> axum::http::StatusCode {
+    let removed = state
+        .transactions
+        .lock()
+        .expect("tx lock")
+        .remove(&id)
+        .is_some();
+    if removed {
+        state.tx_discard_count.fetch_add(1, Ordering::SeqCst);
+        axum::http::StatusCode::OK
+    } else {
+        axum::http::StatusCode::NOT_FOUND
+    }
+}
+
+async fn recording_graphql_handler(
+    State(state): State<RecordingGraphqlState>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<Value>,
+) -> Json<Value> {
+    let query = body
+        .get("query")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    state.queries.lock().expect("queries lock").push(query.clone());
+
+    let tx_id = headers
+        .get("x-defradb-tx")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+
+    if query.contains("mutation") {
+        let writes = parse_mutation_writes(&query);
+
+        // Fail injection: if installed, check whether this batch crosses the failing index.
+        if let Some(fail) = state.fail_injection.lock().expect("fail lock").clone() {
+            if tx_id.as_deref() == Some(fail.tx_id.as_str()) {
+                let prior = state
+                    .transactions
+                    .lock()
+                    .expect("tx lock")
+                    .get(&fail.tx_id)
+                    .map(|v| v.len())
+                    .unwrap_or(0);
+                if (prior..prior + writes.len()).contains(&fail.write_index) {
+                    return Json(json!({
+                        "errors": [{ "message": "injected failure at recorder" }]
+                    }));
+                }
+            }
+        }
+
+        match tx_id {
+            Some(id) => {
+                let mut transactions = state.transactions.lock().expect("tx lock");
+                let entry = transactions.entry(id).or_default();
+                entry.extend(writes);
+            }
+            None => {
+                state.committed.lock().expect("committed lock").extend(writes);
+            }
+        }
+        Json(json!({ "data": aliased_mutation_response(&query) }))
+    } else {
+        Json(json!({ "data": empty_collection_query_response(&query) }))
+    }
+}
+```
+
+Add the required imports at the top of `lean_apply_write_boundary_tests`:
+
+```rust
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+```
+
+- [ ] **Step 1.4: Update existing assertions that read `recorder.writes` to use `recorder.observed_writes()` and `recorder.committed_state()` as appropriate**
+
+In `generated_apply_reconcile_cases_fence_production_apply_write_boundary`, find this block (around line 862):
+```rust
+let observed = recorder.writes.lock().expect("writes lock").clone();
+```
+Replace with:
+```rust
+let observed = recorder.observed_writes();
+```
+
+Find `assert_observed_prefixes_are_referrer_closed(case, &observed);` — no change needed beyond the binding rename above.
+
+Find `assert_live_payloads_not_written(case, &recorder);` — body of that helper reads `recorder.queries`, no change.
+
+- [ ] **Step 1.5: Run the new unit test to verify it passes**
+
+Run:
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::recorder_unit_tests::recorder_begin_returns_numeric_id_and_commit_appends_to_committed -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 1.6: Verify the existing conformance test still passes (recording-server refactor preserves behavior)**
+
+Run:
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary -- --nocapture
+```
+Expected: PASS. The existing test path goes through the no-header branch, which the new recorder routes into `committed` directly — observationally identical to the old behavior.
+
+- [ ] **Step 1.7: Add a unit test for discard-not-committed**
+
+Append inside the `recorder_unit_tests` module:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recorder_discard_drops_pending_writes() {
+    let (graphql, recorder) = start_recording_graphql().await;
+    let client = reqwest::Client::new();
+
+    let begin = client
+        .post(format!("{graphql}api/v0/tx/begin"))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let txn_id = begin.get("id").and_then(serde_json::Value::as_str).unwrap().to_string();
+
+    let _write = client
+        .post(format!("{graphql}"))
+        .header("x-defradb-tx", &txn_id)
+        .json(&serde_json::json!({
+            "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let discard = client
+        .delete(format!("{graphql}api/v0/tx/{txn_id}"))
+        .send()
+        .await
+        .unwrap();
+    assert!(discard.status().is_success());
+
+    assert!(
+        recorder.committed_state().is_empty(),
+        "discarded tx must not contribute to committed state"
+    );
+    let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+    assert_eq!((begin_count, commit_count, discard_count), (1, 0, 1));
+}
+```
+
+- [ ] **Step 1.8: Add a unit test for fail-at-write-N injection**
+
+Append:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn recorder_fail_injection_aborts_at_target_index() {
+    let (graphql, recorder) = start_recording_graphql().await;
+    let client = reqwest::Client::new();
+
+    let begin = client
+        .post(format!("{graphql}api/v0/tx/begin"))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    let txn_id = begin.get("id").and_then(serde_json::Value::as_str).unwrap().to_string();
+    recorder.install_fail_at(&txn_id, 1); // fail the SECOND mutation (zero-based)
+
+    let ok = client
+        .post(format!("{graphql}"))
+        .header("x-defradb-tx", &txn_id)
+        .json(&serde_json::json!({
+            "query": "mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(ok.get("errors").is_none(), "first mutation should succeed");
+
+    let fail = client
+        .post(format!("{graphql}"))
+        .header("x-defradb-tx", &txn_id)
+        .json(&serde_json::json!({
+            "query": "mutation { doc_0: create_Task(input: { task_id: \"task-b\" }) { _docID } }",
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json::<serde_json::Value>()
+        .await
+        .unwrap();
+    assert!(fail.get("errors").is_some(), "second mutation should fail");
+}
+```
+
+- [ ] **Step 1.9: Run all recorder unit tests**
+
+Run:
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::recorder_unit_tests -- --nocapture
+```
+Expected: all PASS.
+
+- [ ] **Step 1.10: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/config_import.rs
+git commit -m "$(cat <<'EOF'
+Extend test recording GraphQL server with tx awareness for #56
+
+Add per-tx state windows, /api/v0/tx/{begin,commit,discard} routes,
+x-defradb-tx header routing, and a fail-at-write-N injection knob.
+Existing conformance assertions still pass — direct-GraphQL writes
+(no header) flow into the same committed window as before.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Add `execute_graphql_async_with_tx` to the protocol crate
+
+**Files:**
+- Modify: `crates/defra-agent-protocol/src/graphql.rs:222-317`.
+
+- [ ] **Step 2.1: Write a failing test for the new function**
+
+Append to `crates/defra-agent-protocol/src/graphql.rs` (inside an existing `#[cfg(test)] mod tests { ... }` block; if no `tests` mod exists, add one at the bottom of the file):
+
+```rust
+#[cfg(test)]
+mod tx_tests {
+    use super::*;
+    use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    #[derive(Clone, Default)]
+    struct HeaderRecorder {
+        last_tx_header: Arc<Mutex<Option<String>>>,
+    }
+
+    async fn capture_handler(
+        State(state): State<HeaderRecorder>,
+        headers: HeaderMap,
+        Json(_body): Json<serde_json::Value>,
+    ) -> Json<serde_json::Value> {
+        *state.last_tx_header.lock().unwrap() = headers
+            .get("x-defradb-tx")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
+        Json(serde_json::json!({ "data": {} }))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn execute_graphql_async_with_tx_sets_header_when_id_provided() {
+        let state = HeaderRecorder::default();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/", post(capture_handler))
+            .with_state(state.clone());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        let endpoint = format!("http://{addr}/");
+        let options = GraphqlRequestOptions {
+            timeout: std::time::Duration::from_secs(2),
+            max_attempts: 1,
+            retry_backoff: std::time::Duration::from_millis(50),
+        };
+
+        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options.clone(), Some("42"))
+            .await
+            .unwrap();
+        assert_eq!(state.last_tx_header.lock().unwrap().as_deref(), Some("42"));
+
+        execute_graphql_async_with_tx(&endpoint, "{ __typename }", options, None)
+            .await
+            .unwrap();
+        assert_eq!(state.last_tx_header.lock().unwrap().as_deref(), None);
+    }
+}
+```
+
+- [ ] **Step 2.2: Run to verify it fails**
+
+Run:
+```bash
+cargo test -p defra-agent-protocol graphql::tx_tests -- --nocapture
+```
+Expected: FAIL — `execute_graphql_async_with_tx` is not defined.
+
+- [ ] **Step 2.3: Implement `execute_graphql_async_with_tx`**
+
+Add this function next to `execute_graphql_async` in `crates/defra-agent-protocol/src/graphql.rs` (right after the existing function ends at line 317):
+
+```rust
+/// Like `execute_graphql_async` but adds an `x-defradb-tx` header when
+/// `txn_id` is `Some`. Used by `defra-agent-cli` to drive DefraDB HTTP
+/// transactions during `config apply`.
+pub async fn execute_graphql_async_with_tx(
+    graphql: &str,
+    query: &str,
+    options: GraphqlRequestOptions,
+    txn_id: Option<&str>,
+) -> Result<serde_json::Value> {
+    let client = reqwest::Client::builder()
+        .timeout(options.timeout)
+        .build()?;
+    let mut last_error = None;
+
+    for attempt in 0..options.max_attempts.max(1) {
+        let mut request = client
+            .post(graphql)
+            .json(&serde_json::json!({ "query": query }));
+        if let Some(id) = txn_id {
+            request = request.header("x-defradb-tx", id);
+        }
+        let response = request.send().await;
+        let response = match response {
+            Ok(response) => response,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                tracing::warn!(
+                    attempt,
+                    graphql,
+                    error = %error,
+                    "retrying async GraphQL tx request after transport error"
+                );
+                last_error = Some(
+                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(
+                    anyhow::Error::new(error).context(format!("posting GraphQL to {graphql}"))
+                );
+            }
+        };
+
+        let response = match response.error_for_status() {
+            Ok(response) => response,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                last_error = Some(
+                    anyhow::Error::new(error)
+                        .context(format!("reading GraphQL response from {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("reading GraphQL response from {graphql}")));
+            }
+        };
+
+        let value = match response.json().await {
+            Ok(value) => value,
+            Err(error)
+                if graphql_transport_error_is_retryable(&error)
+                    && attempt + 1 < options.max_attempts =>
+            {
+                last_error = Some(
+                    anyhow::Error::new(error)
+                        .context(format!("decoding GraphQL response body from {graphql}")),
+                );
+                tokio::time::sleep(scale_backoff(options.retry_backoff, attempt)).await;
+                continue;
+            }
+            Err(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("decoding GraphQL response body from {graphql}")));
+            }
+        };
+
+        return finish_graphql_response(graphql, value);
+    }
+
+    Err(last_error
+        .unwrap_or_else(|| anyhow::anyhow!("GraphQL request retries exhausted for {graphql}")))
+}
+```
+
+- [ ] **Step 2.4: Run to verify it passes**
+
+Run:
+```bash
+cargo test -p defra-agent-protocol graphql::tx_tests -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 2.5: Format and check**
+
+```bash
+cargo fmt --all
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+```
+Expected: no errors.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add crates/defra-agent-protocol/src/graphql.rs
+git commit -m "$(cat <<'EOF'
+Add execute_graphql_async_with_tx for DefraDB HTTP transactions
+
+Mirrors execute_graphql_async with optional x-defradb-tx header. Used
+by defra-agent-cli to drive transactional config apply (#56).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add `ConfigApplyTxn` and `ConfigAccess::begin_apply_txn`
+
+**Files:**
+- Create: `crates/defra-agent-cli/src/config_writes/txn.rs`.
+- Modify: `crates/defra-agent-cli/src/config_writes/mod.rs`.
+- Modify: `crates/defra-agent-cli/src/graphql_access.rs` — thin re-export wrapper for `post_graphql_with_tx`.
+
+- [ ] **Step 3.1: Create the new module with the type definitions**
+
+Create `crates/defra-agent-cli/src/config_writes/txn.rs`:
+
+```rust
+//! Open-write transaction wrapper around `ConfigAccess`.
+//!
+//! `ConfigApplyTxn` is the only access type passed through the apply pipeline
+//! once `config apply` has begun a transaction. The top-level orchestrator
+//! drives `begin_apply_txn` → `apply_desired_state_changes` → `commit` (on
+//! success) or `discard` (on error).
+//!
+//! Discard semantics differ between backends:
+//! - **Embedded.** `runner.rollback_txn` returns `TransactionError` only in
+//!   pathological cases (handle already finalized, lock poisoned). The
+//!   underlying `db_txn` is dropped in any case.
+//! - **HTTP.** `DELETE /api/v0/tx/{id}` is a network call; it can fail for
+//!   reasons unrelated to the apply error. Even if the DELETE never reaches
+//!   the server, DefraDB's tx GC will reclaim the handle on its own.
+//!
+//! Both return `Result<()>` so callers can log discrepancies, but neither
+//! changes operator-facing behavior on failure: the apply error is what
+//! surfaces, and the DB ends at the pre-apply snapshot.
+
+use anyhow::{Context, Result};
+use defra_agent_protocol::graphql::{execute_graphql_async_with_tx, GraphqlRequestOptions};
+use serde_json::{json, Value};
+
+use crate::config_writes::ConfigAccess;
+use crate::graphql_access::graphql_diagnostic_hint;
+
+#[derive(Debug)]
+pub(crate) enum TxnHandle {
+    /// Numeric txn id parsed from `POST /api/v0/tx/begin`.
+    Graphql(String),
+    /// Embedded transaction handle returned by `runner.begin_txn(false)`.
+    Local(defra_agent::defra_node::TransactionHandle),
+}
+
+pub(crate) struct ConfigApplyTxn<'a> {
+    access: &'a ConfigAccess,
+    handle: TxnHandle,
+}
+
+impl<'a> ConfigApplyTxn<'a> {
+    pub(crate) fn new(access: &'a ConfigAccess, handle: TxnHandle) -> Self {
+        Self { access, handle }
+    }
+
+    pub(crate) fn mode(&self) -> &'static str {
+        self.access.mode()
+    }
+
+    /// Execute a GraphQL query within this transaction.
+    pub(crate) async fn execute(&self, query: &str) -> Result<Value> {
+        match (&self.access, &self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                execute_graphql_async_with_tx(
+                    endpoint,
+                    query,
+                    GraphqlRequestOptions {
+                        timeout: std::time::Duration::from_secs(30),
+                        max_attempts: 5,
+                        retry_backoff: std::time::Duration::from_millis(100),
+                    },
+                    Some(id),
+                )
+                .await
+                .map_err(|error| anyhow::anyhow!("{error}\n{}", graphql_diagnostic_hint(endpoint)))
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => {
+                let request = defra_agent::defra_node::QueryRequest {
+                    query: query.to_string(),
+                    operation_name: None,
+                    variables: None,
+                    identity: None,
+                };
+                let response = node.runner().execute_in_txn(request, handle).await;
+                if response.has_errors() {
+                    anyhow::bail!("graphql returned errors: {:?}", response.errors);
+                }
+                Ok(json!({ "data": response.data.unwrap_or(Value::Null) }))
+            }
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch (internal bug)"),
+        }
+    }
+
+    /// Commit the transaction. Apply is durable after this returns Ok.
+    pub(crate) async fn commit(self) -> Result<()> {
+        match (self.access, self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .post(format!("{endpoint}api/v0/tx/{id}"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx commit to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx commit returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                Ok(())
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => node
+                .runner()
+                .commit_txn(&handle)
+                .await
+                .map_err(|error| anyhow::anyhow!("commit_txn: {error}")),
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch on commit (internal bug)"),
+        }
+    }
+
+    /// Discard the transaction. Returns the underlying error if the explicit
+    /// round-trip fails; callers are expected to log and swallow that error so
+    /// the original apply error remains what surfaces to the operator.
+    pub(crate) async fn discard(self) -> Result<()> {
+        match (self.access, self.handle) {
+            (ConfigAccess::Graphql(endpoint), TxnHandle::Graphql(id)) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .delete(format!("{endpoint}api/v0/tx/{id}"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx discard to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx discard returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                Ok(())
+            }
+            (ConfigAccess::Local(node), TxnHandle::Local(handle)) => node
+                .runner()
+                .rollback_txn(&handle)
+                .await
+                .map_err(|error| anyhow::anyhow!("rollback_txn: {error}")),
+            _ => anyhow::bail!("ConfigApplyTxn backend/handle mismatch on discard (internal bug)"),
+        }
+    }
+}
+
+impl ConfigAccess {
+    /// Begin a write transaction on the underlying backend.
+    pub(crate) async fn begin_apply_txn(&self) -> Result<ConfigApplyTxn<'_>> {
+        match self {
+            ConfigAccess::Graphql(endpoint) => {
+                let client = reqwest::Client::builder()
+                    .timeout(std::time::Duration::from_secs(30))
+                    .build()?;
+                let response = client
+                    .post(format!("{endpoint}api/v0/tx/begin"))
+                    .send()
+                    .await
+                    .with_context(|| format!("posting tx begin to {endpoint}"))?;
+                if !response.status().is_success() {
+                    anyhow::bail!(
+                        "tx begin returned HTTP {} from {endpoint}",
+                        response.status()
+                    );
+                }
+                let body: Value = response
+                    .json()
+                    .await
+                    .with_context(|| format!("decoding tx begin body from {endpoint}"))?;
+                let id = body
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| anyhow::anyhow!("tx begin missing id: {body}"))?
+                    .to_string();
+                Ok(ConfigApplyTxn::new(self, TxnHandle::Graphql(id)))
+            }
+            ConfigAccess::Local(node) => {
+                let handle = node
+                    .runner()
+                    .begin_txn(false)
+                    .await
+                    .map_err(|error| anyhow::anyhow!("begin_txn: {error}"))?;
+                Ok(ConfigApplyTxn::new(self, TxnHandle::Local(handle)))
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 3.2: Wire the module in `config_writes/mod.rs`**
+
+Modify `crates/defra-agent-cli/src/config_writes/mod.rs`. Add the new module declaration and re-exports near the top, after the other `mod` lines:
+
+```rust
+mod agent_behavior;
+mod common;
+mod event_trigger;
+mod inference_backend;
+mod schedule;
+mod task;
+mod tool_selection;
+mod txn;  // NEW
+
+pub(crate) use agent_behavior::write_agent_behavior_document;
+pub(crate) use event_trigger::write_event_trigger_document;
+pub(crate) use inference_backend::{
+    write_inference_backend_document, InferenceBackendUpsertDocument,
+};
+pub(crate) use schedule::write_schedule_document;
+pub(crate) use task::write_task_document;
+pub(crate) use tool_selection::write_tool_selection_document;
+pub(crate) use txn::{ConfigApplyTxn, TxnHandle};  // NEW
+```
+
+- [ ] **Step 3.3: Verify the `EmbeddedNode::runner()` accessor exists, or add it if not**
+
+Run:
+```bash
+grep -n "pub fn runner\|pub.*runner" /Users/johnzampolin/.cargo/git/checkouts/defradb.rs-4ab0524bccc74f29/25b935b/crates/defra-node/src/lib.rs | head -5
+```
+Expected: `pub fn runner(&self) -> &Arc<dyn QueryExecutor>` or equivalent. If missing — the `EmbeddedNode` struct exposes `runner` only through the existing `execute` method — fall back to using `node.execute(...)` for the read-committed path and adding a sibling `EmbeddedNode::begin_txn`/`commit_txn`/`rollback_txn`/`execute_in_txn` set of wrappers locally in `defra-agent` (in `crates/defra-agent/src/lib.rs`). Pause and report if the accessor needs adding — that is a small but non-trivial sub-task.
+
+- [ ] **Step 3.4: Write a round-trip test for `ConfigApplyTxn` against the recording server**
+
+This test lives in the existing `lean_apply_write_boundary_tests` module so it can reuse `start_recording_graphql`. Append to that module:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_apply_txn_round_trip_against_recorder() {
+    let (graphql, recorder) = start_recording_graphql().await;
+    let access = ConfigAccess::Graphql(graphql);
+    let txn = access.begin_apply_txn().await.expect("begin");
+
+    let _ = txn
+        .execute("mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }")
+        .await
+        .expect("execute in tx");
+
+    // Before commit, committed window must be empty.
+    assert!(recorder.committed_state().is_empty());
+
+    txn.commit().await.expect("commit");
+
+    let committed = recorder.committed_state();
+    assert_eq!(committed.len(), 1);
+    assert_eq!(committed[0].unique_value, "task-a");
+    let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+    assert_eq!((begin_count, commit_count, discard_count), (1, 1, 0));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_apply_txn_discard_leaves_committed_empty() {
+    let (graphql, recorder) = start_recording_graphql().await;
+    let access = ConfigAccess::Graphql(graphql);
+    let txn = access.begin_apply_txn().await.expect("begin");
+
+    let _ = txn
+        .execute("mutation { doc_0: create_Task(input: { task_id: \"task-a\" }) { _docID } }")
+        .await
+        .expect("execute in tx");
+
+    txn.discard().await.expect("discard");
+
+    assert!(recorder.committed_state().is_empty());
+    let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+    assert_eq!((begin_count, commit_count, discard_count), (1, 0, 1));
+}
+```
+
+Also add `use crate::config_writes::ConfigApplyTxn;` near the top of the `lean_apply_write_boundary_tests` module imports if needed (the helper resolves it via `super::*` and `super::lean_vocab_test::...`, but `ConfigApplyTxn` is brought in via `super::*` since the lean test mod is inside `config_import.rs` which imports from `config_writes`).
+
+- [ ] **Step 3.5: Run the round-trip tests**
+
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::config_apply_txn_round_trip_against_recorder lean_apply_write_boundary_tests::config_apply_txn_discard_leaves_committed_empty -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 3.6: Format and check**
+
+```bash
+cargo fmt --all
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+```
+Expected: no errors.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/config_writes/
+git commit -m "$(cat <<'EOF'
+Add ConfigApplyTxn for transactional config apply (#56)
+
+New module wraps ConfigAccess with a DefraDB transaction handle and
+exposes execute / commit / discard. Begins a tx on POST /api/v0/tx/begin
+(HTTP) or runner.begin_txn (embedded), threads through every write,
+commits on success or discards on error.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4a: Thread `&ConfigApplyTxn` through `config_writes/`
+
+Mechanical signature change. The compiler is the source of truth for what to touch.
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/config_writes/common.rs:7`.
+- Modify: `crates/defra-agent-cli/src/config_writes/task.rs:17-22`.
+- Modify: `crates/defra-agent-cli/src/config_writes/schedule.rs:23` (use `grep -n "pub.*fn write_schedule_document" crates/defra-agent-cli/src/config_writes/schedule.rs` if line drifted).
+- Modify: `crates/defra-agent-cli/src/config_writes/event_trigger.rs:24`.
+
+- [ ] **Step 4a.1: Change `query_documents_by_unique_value` signature in `common.rs`**
+
+In `crates/defra-agent-cli/src/config_writes/common.rs`, find:
+```rust
+pub(super) async fn query_documents_by_unique_value(
+    access: &ConfigAccess,
+    ...
+```
+Replace with:
+```rust
+pub(super) async fn query_documents_by_unique_value(
+    txn: &super::ConfigApplyTxn<'_>,
+    ...
+```
+Then inside the body, replace `access.execute(&query).await` with `txn.execute(&query).await`. Remove the unused `use crate::config_writes::ConfigAccess;` if it becomes orphan; rely on the compiler.
+
+- [ ] **Step 4a.2: Change `write_task_document` signature in `task.rs`**
+
+In `crates/defra-agent-cli/src/config_writes/task.rs`:
+```rust
+pub(crate) async fn write_task_document(
+    txn: &super::ConfigApplyTxn<'_>,
+    task_id: &str,
+    add_doc: &Value,
+    update_doc: &Value,
+) -> Result<String> {
+```
+Inside, replace every `access.execute(...)` with `txn.execute(...)` and every `query_documents_by_unique_value(access, ...)` with `query_documents_by_unique_value(txn, ...)`. Update `select_matching_task_row(access, ...)` etc. — the function in this same file — recursively in the same step (if it takes `access: &ConfigAccess`, change to `txn: &super::ConfigApplyTxn<'_>` and update its calls likewise).
+
+- [ ] **Step 4a.3: Same change for `schedule.rs`**
+
+`write_schedule_document(access: &ConfigAccess, ...)` → `write_schedule_document(txn: &super::ConfigApplyTxn<'_>, ...)`. Cascade `access.execute` → `txn.execute`. Cascade local helpers.
+
+- [ ] **Step 4a.4: Same change for `event_trigger.rs`**
+
+`write_event_trigger_document(access: &ConfigAccess, ...)` → `write_event_trigger_document(txn: &super::ConfigApplyTxn<'_>, ...)`. Cascade as above.
+
+- [ ] **Step 4a.5: `cargo check` to see what's still broken**
+
+```bash
+cargo check -p defra-agent-cli --tests
+```
+Expected: errors in `config_import.rs` and possibly `commands/config/apply.rs` (still passing `&ConfigAccess` to the renamed-signature functions). These are handled in Tasks 4b and 5.
+
+- [ ] **Step 4a.6: (No commit yet — wait until 4b compiles)**
+
+Leave the working tree dirty for Task 4b.
+
+---
+
+## Task 4b: Thread `&ConfigApplyTxn` through `config_import.rs`
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/config_import.rs:110-617`.
+
+- [ ] **Step 4b.1: Switch `apply_desired_state_changes` signature**
+
+Find (line ~595):
+```rust
+pub(crate) async fn apply_desired_state_changes(
+    access: &ConfigAccess,
+    desired_bundle: &DesiredApplyBundle,
+    planned: &desired_state::DesiredStateDiffReport,
+) -> Result<ConfigApplyCounts> {
+```
+Replace with:
+```rust
+pub(crate) async fn apply_desired_state_changes(
+    txn: &ConfigApplyTxn<'_>,
+    desired_bundle: &DesiredApplyBundle,
+    planned: &desired_state::DesiredStateDiffReport,
+) -> Result<ConfigApplyCounts> {
+```
+And update the `apply_import_collection(access, ...)` call inside to `apply_import_collection(txn, ...)`.
+
+- [ ] **Step 4b.2: Switch `apply_import_collection` signature**
+
+Find (line ~110):
+```rust
+pub(crate) async fn apply_import_collection(
+    access: &ConfigAccess,
+    collection_name: &str,
+    unique_field: &str,
+    docs: &[Value],
+    override_existing: bool,
+) -> Result<usize> {
+```
+Replace `access: &ConfigAccess` with `txn: &ConfigApplyTxn<'_>`. Cascade body: `apply_custom_override_collection_batched(access, ...)` → `(txn, ...)`; `apply_generic_import_collection_batched(access, ...)` → `(txn, ...)`.
+
+- [ ] **Step 4b.3: Switch `apply_generic_import_collection_batched` (line ~181), `apply_generic_import_document` (line ~255), `apply_custom_override_collection_batched` (line ~301), `query_existing_documents_by_unique_values` (line ~354), `apply_custom_override_documents_individually` (line ~479), `execute_aliased_mutation_batches` (line ~519)**
+
+Each: change `access: &ConfigAccess` to `txn: &ConfigApplyTxn<'_>`, cascade body, change `access.execute` to `txn.execute`. For `apply_custom_override_documents_individually`, change the calls to `write_task_document(access, ...)` → `write_task_document(txn, ...)`, same for schedule and event_trigger.
+
+- [ ] **Step 4b.4: Update the import**
+
+At the top of `config_import.rs`, replace:
+```rust
+use crate::config_writes::{
+    write_event_trigger_document, write_schedule_document, write_task_document, ConfigAccess,
+    ExistingDocumentRef,
+};
+```
+with:
+```rust
+use crate::config_writes::{
+    write_event_trigger_document, write_schedule_document, write_task_document, ConfigAccess,
+    ConfigApplyTxn, ExistingDocumentRef,
+};
+```
+Keep `ConfigAccess` — `select_apply_principal_docs` and other helpers that don't touch the write path still take `&ConfigAccess` for read queries.
+
+Verify by grep: `select_apply_principal_docs` does NOT call `execute`, so it stays on `&ConfigAccess` (a `Value` accessor).
+
+- [ ] **Step 4b.5: Update the lean_apply_write_boundary_tests test body**
+
+The existing call inside `generated_apply_reconcile_cases_fence_production_apply_write_boundary` was:
+```rust
+let counts = apply_desired_state_changes(
+    &ConfigAccess::Graphql(graphql),
+    &desired_bundle,
+    &planned,
+)
+.await
+```
+Replace with:
+```rust
+let access = ConfigAccess::Graphql(graphql);
+let txn = access.begin_apply_txn().await.expect("begin apply tx");
+let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).await {
+    Ok(counts) => {
+        txn.commit().await.expect("commit");
+        counts
+    }
+    Err(error) => {
+        let _ = txn.discard().await;
+        panic!(
+            "production apply_desired_state_changes failed for Lean case {}: {error}",
+            case.name
+        );
+    }
+};
+```
+
+- [ ] **Step 4b.6: `cargo check` to find remaining call sites**
+
+```bash
+cargo check -p defra-agent-cli --tests
+```
+Expected: maybe one remaining error in `commands/config/apply.rs:70` — handled in Task 5. Otherwise no errors.
+
+- [ ] **Step 4b.7: Run existing apply-related tests (production conformance + property + e2e basics)**
+
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests -- --nocapture
+```
+Expected: PASS — the existing assertions hold because the recorder treats begin/commit transparently (writes flow into committed window after commit).
+
+- [ ] **Step 4b.8: Commit Task 4a + 4b together**
+
+```bash
+git add crates/defra-agent-cli/src/config_writes/ crates/defra-agent-cli/src/config_import.rs
+git commit -m "$(cat <<'EOF'
+Thread ConfigApplyTxn through config_apply write path (#56)
+
+Switch the apply pipeline and the three custom collection writers from
+&ConfigAccess to &ConfigApplyTxn<'_>. Production write_*_document and
+existence probes now read through the same transaction as the writes,
+so create-vs-update branch decisions see in-tx state instead of stale
+committed state.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: Orchestrator braid in `commands/config/apply.rs`
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/commands/config/apply.rs:70`.
+
+- [ ] **Step 5.1: Replace the apply call with the braid**
+
+Find (line ~70):
+```rust
+    let applied = apply_desired_state_changes(&access, &desired_bundle, &planned).await?;
+```
+Replace with:
+```rust
+    let applied = {
+        let txn = access
+            .begin_apply_txn()
+            .await
+            .context("config apply: begin transaction")?;
+        let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).await {
+            Ok(counts) => counts,
+            Err(error) => {
+                if let Err(discard_err) = txn.discard().await {
+                    tracing::warn!(
+                        %discard_err,
+                        "config apply: tx discard failed after apply error"
+                    );
+                }
+                return Err(error);
+            }
+        };
+        if let Err(commit_err) = txn.commit().await {
+            return Err(commit_err).context("config apply: commit failed");
+        }
+        counts
+    };
+```
+
+Add `use anyhow::Context;` to the file's imports if not already present (it already imports `anyhow::Result` — add `Context` to that line).
+
+- [ ] **Step 5.2: Format and check**
+
+```bash
+cargo fmt --all
+cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
+```
+Expected: no errors.
+
+- [ ] **Step 5.3: Run a representative integration test to verify the braid works end-to-end against a real DefraDB embedded node**
+
+```bash
+cargo test -p defra-agent-cli --test cli_config_apply_local -- --nocapture
+```
+Expected: PASS. This test uses `Local` backend; if it fails, the embedded `begin_txn`/`commit_txn` plumbing is broken.
+
+- [ ] **Step 5.4: Run the GraphQL-backed apply test**
+
+```bash
+cargo test -p defra-agent-cli --test cli_config_apply_graphql -- --nocapture
+```
+Expected: PASS. This test uses `Graphql` backend.
+
+- [ ] **Step 5.5: Run the production-boundary conformance test**
+
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/commands/config/apply.rs
+git commit -m "$(cat <<'EOF'
+Wrap config apply in transactional begin/commit/discard braid (#56)
+
+Apply errors trigger discard and surface the original error; commit
+errors are surfaced as apply errors with discard implicit (DB tx is
+already gone). Per-collection progress logging unchanged.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Extend the production-boundary conformance test with the injected-failure flavor
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/config_import.rs` `lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary`.
+
+- [ ] **Step 6.1: Add the success-path tx-count assertion**
+
+At the end of the existing per-case block in `generated_apply_reconcile_cases_fence_production_apply_write_boundary`, after the existing `assert_live_payloads_not_written(case, &recorder);` line, append:
+
+```rust
+let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+assert_eq!(
+    (begin_count, commit_count, discard_count),
+    (1, 1, 0),
+    "success path must drive exactly one begin/commit and zero discard for Lean case {}",
+    case.name,
+);
+
+// Externally-observed committed state on the recorder must match the success-path
+// projection: every selected write landed in committed exactly once.
+let committed_after_commit = recorder.committed_state();
+assert_eq!(
+    committed_after_commit.len(),
+    case.expected_selected_writes.len(),
+    "recorder committed state count mismatch for Lean case {} (expected = {}, actual = {})",
+    case.name,
+    case.expected_selected_writes.len(),
+    committed_after_commit.len(),
+);
+```
+
+- [ ] **Step 6.2: Add the injected-failure flavor for cases with `prefix_len > 0`**
+
+After the above block, append:
+
+```rust
+if case.prefix_len > 0 {
+    let (graphql, recorder) = start_recording_graphql().await;
+    let access = ConfigAccess::Graphql(graphql);
+
+    // Begin a tx; install fail-at-write-(prefix_len) injection on its id.
+    let txn = access.begin_apply_txn().await.expect("begin");
+    // The recorder hands out sequential numeric ids starting at 0; the
+    // first tx in this fresh recorder is "0".
+    recorder.install_fail_at("0", case.prefix_len);
+
+    let result = apply_desired_state_changes(&txn, &desired_bundle, &planned).await;
+    assert!(
+        result.is_err(),
+        "injected failure at write {} must surface as Err for Lean case {}",
+        case.prefix_len,
+        case.name,
+    );
+
+    let _ = txn.discard().await;
+
+    let (begin_count, commit_count, discard_count) = recorder.tx_lifecycle_counts();
+    assert_eq!(
+        (begin_count, commit_count, discard_count),
+        (1, 0, 1),
+        "failure path must drive exactly one begin/discard and zero commit for Lean case {}",
+        case.name,
+    );
+
+    assert!(
+        recorder.committed_state().is_empty(),
+        "failure path must leave externally-observed committed state empty (== pre_live) for Lean case {}",
+        case.name,
+    );
+
+    let observed = recorder.observed_writes();
+    assert!(
+        observed.len() <= case.prefix_len + 1,
+        "failure path observed {} writes; cap is prefix_len + 1 = {} for Lean case {}",
+        observed.len(),
+        case.prefix_len + 1,
+        case.name,
+    );
+}
+```
+
+Note: this assertion uses `case.pre_live.is_empty()` is_not_required because every Lean case in the current set has `preLive` either empty or representing pre-existing live docs the test does not need to compare against (those preexisting docs are not what the apply mutates). The fence is "committed state contains nothing new from this apply" — equivalent to "post-failure committed equals pre_live" given the recorder begins each scenario with empty committed.
+
+- [ ] **Step 6.3: Run the extended conformance test**
+
+```bash
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary -- --nocapture
+```
+Expected: PASS.
+
+- [ ] **Step 6.4: Verify red→green by temporary revert (optional manual check)**
+
+Optional sanity check; do not commit this:
+```bash
+git stash
+git revert --no-commit HEAD~2  # revert Task 5's braid commit
+cargo test -p defra-agent-cli --lib lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary -- --nocapture 2>&1 | head -50
+# Expect FAIL: tx_begin_count is 0, committed_state has writes, etc.
+git revert --abort 2>/dev/null || true
+git checkout -- .
+git stash pop
+```
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/config_import.rs
+git commit -m "$(cat <<'EOF'
+Fence transactional apply with injected-failure conformance flavor (#56)
+
+For every Lean case with prefix_len > 0, inject a fail-at-write-N at the
+recording server, run apply through ConfigApplyTxn, and assert:
+- the call returned Err,
+- exactly one begin and one discard (zero commit),
+- externally-observed committed state stayed empty,
+- observed writes did not exceed prefix_len + 1.
+
+Lean surface unwidened — the assertion uses prefix_len, expected_selected_writes,
+and the recorder's committed window.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: SIGKILL-mid-apply integration test against a real DefraDB node
+
+A naive timed kill races: on a fast local node, apply finishes in under the timeout and SIGKILL lands after commit, falsely failing the test. To make the kill deterministically land between `begin` and `commit`, the apply pipeline reads an env-gated per-collection sleep. Production sets nothing; the test sets a small value to widen the kill window.
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/config_import.rs:595-617` (`apply_desired_state_changes`).
+- Create: `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs`.
+
+- [ ] **Step 7.0: Add the env-gated per-collection slowdown to `apply_desired_state_changes`**
+
+In `crates/defra-agent-cli/src/config_import.rs`, replace `apply_desired_state_changes` with:
+
+```rust
+pub(crate) async fn apply_desired_state_changes(
+    txn: &ConfigApplyTxn<'_>,
+    desired_bundle: &DesiredApplyBundle,
+    planned: &desired_state::DesiredStateDiffReport,
+) -> Result<ConfigApplyCounts> {
+    let desired_bundle = desired_bundle.as_bundle();
+    let mut counts = ConfigApplyCounts::default();
+
+    let per_collection_sleep = std::env::var("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(std::time::Duration::from_millis);
+
+    for collection in CONFIG_APPLY_ORDER {
+        let docs = select_apply_docs_for_collection(desired_bundle, planned, collection)?;
+        let applied = apply_import_collection(
+            txn,
+            collection.graphql_type(),
+            collection.unique_field(),
+            &docs,
+            true,
+        )
+        .await?;
+        counts.set(collection, applied);
+
+        if let Some(sleep) = per_collection_sleep {
+            tokio::time::sleep(sleep).await;
+        }
+    }
+
+    Ok(counts)
+}
+```
+
+The env var is undocumented and intended for tests only. It's not gated behind `cfg(test)` because integration tests run as a separate binary and don't see `cfg(test)` from the lib.
+
+- [ ] **Step 7.1: Author the test**
+
+Create `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs`:
+
+```rust
+mod support;
+use support::*;
+
+use std::fs;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+use uuid::Uuid;
+
+/// SIGKILL the CLI mid-apply and assert that DefraDB's tx GC reclaims the
+/// orphaned transaction and leaves the database at the pre-apply snapshot.
+/// This exercises the operationally-meaningful failure mode (Ctrl-C, OOM,
+/// container restart) against a real node, not the recorder.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_apply_sigkill_mid_apply_leaves_db_unchanged() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir.path().join("infra").join("agents").join("default");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-rb-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let agent_name = format!("cli-rollback-{}", Uuid::new_v4().simple());
+
+    run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+
+    // Bootstrap a non-trivial manifest via export of the initialized state,
+    // then duplicate the foundational collections to make apply visibly
+    // multi-step on the wire.
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
+
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+
+    // Snapshot the existing committed state.
+    let pre_apply_backends = count_collection_rows(&graphql, "InferenceBackend").await?;
+    let pre_apply_profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
+    let pre_apply_tools = count_collection_rows(&graphql, "ToolSelection").await?;
+    let pre_apply_tasks = count_collection_rows(&graphql, "Task").await?;
+
+    // Spawn the CLI; let it run for a short window long enough to begin the tx
+    // and ship at least one batch, then SIGKILL.
+    let root_str = root
+        .to_str()
+        .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
+    // No `spawn_cli` helper takes env vars today; spawn directly.
+    let mut cli = std::process::Command::new(support::cli_bin())
+        .env("HOME", &home_dir)
+        .env("RUST_LOG", "error")
+        .env("DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS", "200")
+        .current_dir(&home_dir)
+        .args([
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--graphql",
+            &graphql,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("spawning defra-agent config apply with apply-sleep env")?;
+
+    // With per-collection sleep = 200 ms and CONFIG_APPLY_ORDER having 9
+    // collections, full apply takes at least 1.8 s. Sleep 400 ms — past
+    // begin and at least the first batched collection mutation, well before
+    // commit. The sleep widens the kill window deterministically; without
+    // it a fast local apply could complete in under our delay.
+    thread::sleep(Duration::from_millis(400));
+    cli.kill().context("SIGKILL CLI")?;
+    cli.wait().context("reap CLI")?;
+
+    // Allow DefraDB's tx GC to reclaim the orphaned handle and any in-tx
+    // writes to be discarded. Poll for stability rather than sleep blindly.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let backends = count_collection_rows(&graphql, "InferenceBackend").await?;
+        let profiles = count_collection_rows(&graphql, "InferenceProfile").await?;
+        let tools = count_collection_rows(&graphql, "ToolSelection").await?;
+        let tasks = count_collection_rows(&graphql, "Task").await?;
+
+        if backends == pre_apply_backends
+            && profiles == pre_apply_profiles
+            && tools == pre_apply_tools
+            && tasks == pre_apply_tasks
+        {
+            // External state has converged to pre-apply: tx GC succeeded.
+            return Ok(());
+        }
+        if Instant::now() > deadline {
+            return Err(anyhow!(
+                "after SIGKILL, DB still shows post-apply state: backends={} (pre={}), \
+                profiles={} (pre={}), tools={} (pre={}), tasks={} (pre={})",
+                backends, pre_apply_backends,
+                profiles, pre_apply_profiles,
+                tools, pre_apply_tools,
+                tasks, pre_apply_tasks,
+            ));
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+async fn count_collection_rows(graphql: &str, collection: &str) -> Result<usize> {
+    let response = graphql_query(
+        graphql,
+        &format!("{{ {collection} {{ _docID }} }}"),
+    )
+    .await?;
+    Ok(response
+        .pointer(&format!("/data/{collection}"))
+        .and_then(Value::as_array)
+        .map(|rows| rows.len())
+        .unwrap_or(0))
+}
+```
+
+- [ ] **Step 7.2: Format and run the test**
+
+```bash
+cargo fmt --all
+cargo test -p defra-agent-cli --test cli_config_apply_transactional_rollback -- --nocapture
+```
+Expected: PASS. The env-gated 200 ms per-collection sleep introduced in Step 7.0 guarantees a minimum apply runtime of ~1.8 s (9 collections × 200 ms), so the 400 ms kill timing is reliably mid-apply on any hardware.
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/config_import.rs crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs
+git commit -m "$(cat <<'EOF'
+Integration test: SIGKILL mid-apply leaves DB at pre-apply state (#56)
+
+Adds an env-gated per-collection apply sleep (DEFRA_AGENT_CONFIG_APPLY_SLEEP_MS)
+to widen the kill window deterministically, then spawns `defra-agent-cli
+config apply` against a real DefraDB node, kills it ~400 ms into the apply
+(after begin and at least one batched mutation ship), waits for tx GC to
+reclaim the orphaned transaction, then asserts external state matches the
+pre-apply snapshot across every operator-controlled collection.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: CHANGELOG and follow-up issues
+
+**Files:**
+- Modify: `CHANGELOG.md` (or whatever release-notes file the repo uses; check first).
+
+- [ ] **Step 8.1: Locate the CHANGELOG**
+
+Run:
+```bash
+ls CHANGELOG* RELEASES* RELEASE_NOTES* 2>/dev/null
+```
+If a CHANGELOG exists, add an entry. If not, skip the file edit and only file the issues.
+
+- [ ] **Step 8.2: Add an entry under "Unreleased" (or appropriate section)**
+
+If `CHANGELOG.md` exists, prepend the following under the unreleased section:
+
+```markdown
+- `defra-agent-cli config apply` is now atomic: any failure during apply leaves the database at the pre-apply snapshot, with no operator cleanup required. Closes #56.
+```
+
+- [ ] **Step 8.3: Commit CHANGELOG (if changed)**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+Note atomic config apply in CHANGELOG (#56)
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 8.4: File the Lean external-abort projection follow-up issue**
+
+Run:
+```bash
+gh issue create \
+  --title "Lean: emit expected_external_state_after_abort for apply_reconcile_cases" \
+  --body "$(cat <<'EOF'
+## Context
+
+#56 made `defra-agent-cli config apply` atomic. The production-boundary
+conformance test in `crates/defra-agent-cli/src/config_import.rs`
+(`lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary`)
+asserts that after an injected mid-apply failure, externally-observed
+committed state equals `pre_live`. That equality is enforced from Rust
+against the recorder's committed window; Lean does not emit an explicit
+field describing "what external observers see after the tx aborts."
+
+## Acceptance
+
+- Add `expected_external_state_after_abort` (a list of `pre_live` docs
+  in every current case) to `Proofs/ApplyReconcile/ContractCases.lean`'s
+  `ApplyReconcileCase` and to its JSON projection.
+- Update `crates/defra-agent-cli/src/config_import.rs::lean_apply_write_boundary_tests`
+  to assert recorder committed state equals the emitted projection
+  directly, replacing the current "committed must be empty" Rust-side
+  restatement.
+- Becomes load-bearing when #57 (delete semantics) introduces apply
+  steps that mutate pre-existing live state — at that point the post-abort
+  projection diverges from `pre_live` and the explicit Lean field is
+  required.
+
+## Related
+
+- #56 (closed)
+- #57 (delete semantics)
+EOF
+)"
+```
+
+- [ ] **Step 8.5: Decide whether to file the tx idle-timeout audit issue**
+
+Run:
+```bash
+grep -rn "idle\|timeout\|tx.*ttl\|cleanup_stale" /Users/johnzampolin/.cargo/git/checkouts/defradb.rs-4ab0524bccc74f29/*/crates/db/src/txn_registry.rs 2>/dev/null | head -10
+```
+If a fixed idle timeout exists in DefraDB that could plausibly be hit by a large `config apply`, file:
+
+```bash
+gh issue create \
+  --title "Audit DefraDB tx idle timeout against real config-apply runtimes" \
+  --body "$(cat <<'EOF'
+## Context
+
+#56 wraps the entire `config apply` in a single DefraDB transaction. If
+the open-tx idle timeout is tight and apply runtime against a slow
+remote node could approach it, the tx may be reclaimed mid-apply.
+
+## Acceptance
+
+- Identify the configurable upper bound on an open DefraDB tx.
+- Measure typical and worst-case `config apply` runtime against
+  representative manifest sizes on a `Graphql` backend.
+- Either document the safe envelope, extend the timeout, or chunk per
+  collection (last resort — loses single-tx atomicity).
+
+EOF
+)"
+```
+
+Otherwise, skip filing this issue.
+
+---
+
+## Task 9: Push and open the PR
+
+- [ ] **Step 9.1: Push the branch**
+
+```bash
+git push -u origin design/issue-56-transactional-apply
+```
+
+- [ ] **Step 9.2: Open the PR**
+
+```bash
+gh pr create --title "Make config apply transactional (#56)" --body "$(cat <<'EOF'
+## Summary
+
+Closes #56. Wraps `defra-agent-cli config apply` in a single DefraDB
+transaction. Apply errors discard, success commits. SIGKILL mid-apply
+is reclaimed by DefraDB's tx GC. Lean surface unwidened.
+
+## Test plan
+
+- [ ] `cargo fmt --all` clean
+- [ ] `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens` clean
+- [ ] `cargo test -p defra-agent-cli` green (extended production-boundary consumer + new SIGKILL integration test)
+- [ ] `cargo test -p defra-agent --lib --tests` green (reference-model apply_conformance unchanged)
+- [ ] `cd crates/defra-agent/proofs && lake build` clean (no Lean changes; sanity check)
+- [ ] Manual revert of the orchestrator braid + rerun the conformance test → observe red (proves the fence is load-bearing)
+
+## Spec
+
+`docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 9.3: Report**
+
+Stop and report to the controller:
+- commit list (`git log main..HEAD --oneline`)
+- test status (output of the final `cargo test -p defra-agent-cli`)
+- CI status if available (`gh pr checks` if it's been a minute)
+- conformance test red→green confirmation
+- any open follow-up issues filed
+
+Do not merge.
+
+---
+
+## Verification (end-of-plan)
+
+After Task 9:
+
+- `cargo fmt --all` — clean.
+- `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens` — clean.
+- `cargo test -p defra-agent-cli` — all green, including `lean_apply_write_boundary_tests::*`, `cli_config_apply_*`, and the new `cli_config_apply_transactional_rollback`.
+- `cargo test -p defra-agent --lib --tests` — all green; `apply_conformance.rs` untouched.
+- `cd crates/defra-agent/proofs && lake build` — zero `sorry`s.
+- Conformance fence behaves as red→green: reverting Task 5 turns Task 6's assertions red.
+- One follow-up issue filed (Lean external-abort projection); the tx idle-timeout audit issue filed only if implementation surfaced a concrete gap.

--- a/docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md
@@ -85,15 +85,29 @@ let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).
         return Err(error);
     }
 };
-txn.commit().await.context("config apply: commit failed")?;
+if let Err(commit_err) = txn.commit().await {
+    return Err(commit_err).context("config apply: commit failed");
+}
 Ok(counts)
 ```
+
+(Bound `counts` in the success arm; explicit `commit` block keeps the success/failure paths visually parallel for a scan-read.)
 
 Properties of the braid:
 
 - **Any error from any write aborts the whole apply.** No per-collection commits, no partial successes. Inner per-mutation retry loops in `defra-agent`'s retry classification are unchanged; what changes is that an exhausted retry discards the entire apply rather than continuing past the failure.
 - **Apply error wins.** A `discard` failure after an apply error is logged, not surfaced. The user needs to act on the apply error; the transaction will be reclaimed by DefraDB.
 - **Commit failure is propagated** as an apply error. From the user's perspective a commit failure is operationally identical to any other apply failure: the DB stayed at pre-apply state.
+- **Per-collection progress logging is unchanged.** The existing tracing lines that emit one entry per collection apply remain; transactional wrapping does not alter the user-visible progress surface.
+
+### Backend error asymmetry for `discard`
+
+Discard semantics differ between the two backends and the implementation should not paper that over:
+
+- **Embedded.** `runner.rollback_txn(handle)` returns `TransactionError` only in pathological cases (handle already finalized, lock poisoned). The underlying `db_txn` is dropped in any case. `discard` on the embedded path is effectively infallible from the operator's perspective.
+- **HTTP.** `DELETE /api/v0/tx/{id}` is a network call. It can fail for network reasons unrelated to the apply error — connection reset, server restart, timeout. Even if the DELETE never reaches the server, DefraDB's tx GC will reclaim the handle on its own.
+
+Both variants return `Result<()>` so the orchestrator can log the discrepancy when it occurs (useful telemetry). Neither return changes operator-facing behavior: the apply error is what surfaces, and the DB state ends at pre-apply regardless of whether the explicit `discard` round-trip succeeded.
 
 ### Crash semantics
 
@@ -131,17 +145,36 @@ The success-path flavor (already implemented today) keeps the existing assertion
 
 Cases with `prefix_len = 0` (`empty_manifest`, `update_existing_backend`, `live_only_no_op`) skip the injected-failure flavor; there is no meaningful interior failure point. The success-path flavor still runs for every case.
 
+#### Recording-server extension — scope note
+
+This is meaningfully more than a tweak to the existing recorder. The current `RecordingGraphqlState` is a single mutation log behind a regex parser, with only the `/` route. The tx-aware extension is roughly:
+
+- Three new routes (`POST /api/v0/tx/begin`, `POST /api/v0/tx/{id}`, `DELETE /api/v0/tx/{id}`) returning numeric ids and `204`-style success/failure on commit/discard.
+- A header-routed dispatch on the existing `/` (or `/api/v0/graphql`, whichever the production CLI calls) that reads `x-defradb-tx` and steers the write into the per-tx window vs. committed state.
+- A per-tx state struct keyed by id, plus the "committed" snapshot it merges into on `commit`.
+- A "fail at write N within tx M" injection knob.
+
+The regex-based mutation parser stays — header routing is at the HTTP layer and does not need a real GraphQL parser. The implementation plan calls this out as its own task (estimated 150–250 LOC, with focused unit tests against the recorder itself before any apply-side test consumes it). Doing the recorder before the production threading change keeps the red→green pivot clean: write the new conformance assertions first, watch them go red against today's production, then turn green as the threading lands.
+
 ### Reference-model consumer
 
 `crates/defra-agent/tests/apply_conformance.rs` is unchanged. It consumes the same Lean rows against `defra_agent::apply_model`, which is a pure reference implementation with no DB and no transaction semantics. It stays green by construction.
 
 ### Targeted integration test
 
-A new file `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` exercises the braid against a real DefraDB node, not the mock recorder:
+A new file `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` exercises the braid against a real DefraDB node, not the mock recorder. The earlier draft of this section was vague about *how* the apply fails; pinning the mechanism here so the implementer is not chasing "why doesn't my failing manifest fail at the right step."
 
-- Construct a manifest whose 4th apply step will fail (e.g., a behavior referencing a profile id that the manifest builder will deliberately omit at write time).
-- Run `defra-agent-cli config apply` against a running node.
-- Assert: command exits non-zero, query the node for every operator-controlled collection, observe zero new rows.
+**Mechanism: mid-apply process termination.** The test exercises the real-node crash recovery path:
+
+1. Build a manifest with at least three documents in each foundational collection (InferenceBackend, InferenceProfile, ToolSelection) plus enough downstream behaviors/tasks/schedules/triggers to make the apply visibly multi-step. The goal is a non-trivial write sequence on the wire so the kill can land mid-stream.
+2. Spawn `defra-agent-cli config apply` as a subprocess, pointed at the real DefraDB node via the `Graphql` backend.
+3. Tail the node's `Update` event stream (via the existing event-bus subscription used elsewhere in tests) and count incoming document-create events. Once at least one but fewer than all expected create events have arrived, SIGKILL the CLI subprocess.
+4. Wait for DefraDB's tx GC to reclaim the orphaned transaction (poll-on-query is enough — querying for the committed state directly).
+5. Query the node for every operator-controlled collection. Assert **zero new rows** across every collection that the manifest would have added. SIGKILL between `begin` and `commit` means no write the CLI made in-tx ever becomes committed.
+
+This is more operationally meaningful than synthesizing a manifest that fails apply-time validation: it exercises the real tx-GC path on a real node, which is the actual failure mode operators will hit (`Ctrl-C`, OOM kill, ssh disconnect, container restart).
+
+**Why not a fail-at-write-N mechanism against the real node?** It would require either (a) a passthrough proxy that's a second copy of the recording-server extension above, or (b) deliberately constructing a manifest that passes pre-apply validation but trips a server-side constraint at a specific step — which is brittle (validators and DefraDB GraphQL type checks both move). The recording-server flavor of the conformance fence already covers fail-at-write-N. The integration test's job is to verify the real tx GC behaves as the design assumes.
 
 The existing `cli_config_apply_order.rs` covers prefix-safe ordering and is orthogonal to atomicity — it stays as-is.
 
@@ -168,13 +201,14 @@ The fence is expressed entirely in terms of fields already emitted by `apply_rec
 
 ## Deliverables
 
-- [ ] `ConfigApplyTxn<'a>` and `TxnHandle` defined in `crates/defra-agent-cli/src/config_writes/mod.rs`.
-- [ ] `ConfigAccess::begin_apply_txn` implementations for both `Graphql` and `Local` variants.
+- [ ] `ConfigApplyTxn<'a>` and `TxnHandle` defined in `crates/defra-agent-cli/src/config_writes/mod.rs`, with backend-asymmetric discard semantics noted in doc comments.
+- [ ] `ConfigAccess::begin_apply_txn` implementations for both `Graphql` (POST `/api/v0/tx/begin`, parse numeric id) and `Local` (`runner.begin_txn(false)`) variants.
 - [ ] Threading change: `&ConfigAccess` → `&ConfigApplyTxn` through `apply_desired_state_changes`, `apply_import_collection`, `apply_generic_import_collection_batched`, `apply_custom_override_collection_batched`, `apply_custom_override_documents_individually`, `query_existing_documents_by_unique_values`, and the three `write_*_document` custom writers.
-- [ ] Top-level CLI command path braid: `begin_apply_txn` → `apply_desired_state_changes` → `commit` (success) | `discard` (error).
-- [ ] Extend `generated_apply_reconcile_cases_fence_production_apply_write_boundary` with the injected-failure / no-commit / pre-live-preservation flavor (recording server gains `begin / commit / discard` endpoints and a per-tx state window).
-- [ ] New `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` integration test against a real DefraDB node.
-- [ ] Two follow-up issues filed.
+- [ ] Top-level CLI command path braid: `begin_apply_txn` → `apply_desired_state_changes` → `commit` (success) | `discard` (error). Per-collection progress logging preserved.
+- [ ] Recording-server extension (its own task): three new tx routes, header-routed dispatch on the GraphQL endpoint, per-tx state window keyed by id, fail-at-write-N injection knob, focused recorder-only unit tests.
+- [ ] Extend `generated_apply_reconcile_cases_fence_production_apply_write_boundary` with the injected-failure / no-commit / pre-live-preservation flavor against the extended recorder, plus the success-path `begin`/`commit` count assertion.
+- [ ] New `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` integration test against a real DefraDB node, exercising the SIGKILL-mid-apply / tx-GC path.
+- [ ] Two follow-up issues filed (Lean external-abort projection; defra-node tx idle-timeout audit if implementation surfaces a gap).
 - [ ] CHANGELOG / release-note entry.
 
 ## Verification

--- a/docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md
+++ b/docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md
@@ -1,0 +1,186 @@
+# Transactional `defra-agent-cli config apply` (Issue #56)
+
+**Date:** 2026-05-15
+**Status:** Draft — brainstormed and approved by controller; awaiting written review
+**Scope:** Make `defra-agent-cli config apply` atomic: either every manifest write commits or none do, with no operator intervention required after a mid-apply failure.
+**Tracker:** #56 (parent #53; out-of-scope sibling #57). Lean precondition: #220/#223 (production write-boundary conformance test).
+
+## Summary
+
+Today `apply_desired_state_changes` in `crates/defra-agent-cli/src/config_import.rs` is best-effort: it iterates `CONFIG_APPLY_ORDER` (nine collections, foundational → behavior → task/schedule/trigger → principal) and applies each collection's batched mutations directly against `ConfigAccess::execute`. A failure midway leaves the DB in a partial state visible to every other observer (agent runtime watcher, P2P peers reading local CRDT state, ad-hoc operator queries). T-Conv (`Proofs/ApplyReconcile/Convergence.lean`) assumes apply runs to completion; today, nothing enforces that assumption from the outside.
+
+This spec wraps the entire apply sequence in a single DefraDB transaction. DefraDB already exposes first-class transactions at both backends the CLI talks to: the HTTP server (`POST /api/v0/tx/begin` plus the `x-defradb-tx` header on every GraphQL request, `POST /api/v0/tx/{id}` to commit, `DELETE /api/v0/tx/{id}` to discard) and the embedded node (`QueryExecutor::begin_txn / execute_in_txn / commit_txn / rollback_txn`). The work is to thread a transaction handle through `apply_desired_state_changes` and its per-collection writers, drive commit-or-discard at the top level, and fence the new atomicity property with a conformance test extension. No Lean changes ship in this PR.
+
+## Why this scope
+
+The PROMPT for #56 names three candidate recovery models: rollback, two-phase commit, and write-ahead log. The brainstorm settled on **DefraDB-native single transaction** (the "rollback" framing, but mechanically implemented via the DB's own transaction primitive rather than an application-level compensating log). Reasoning summarized:
+
+- It is the only candidate that delivers **atomic visibility** to external observers. WAL gives crash recovery but does not hide mid-apply partial state. Application-level compensating-log rollback would race with other writers and can't undo creates without delete semantics (which #57 owns).
+- It uses an existing, well-tested DB primitive instead of building parallel infrastructure. The HTTP `tx` endpoints have been in defra-node since well before this work; `EmbeddedNode.runner` is `Arc<dyn QueryExecutor>` and already implements `begin_txn / execute_in_txn / commit_txn / rollback_txn`.
+- It survives process crashes trivially: an open transaction held by a CLI process that dies is dropped by DefraDB without committing, so external state stays at the pre-apply snapshot. No on-disk WAL is required because no in-flight apply ever produces externally-observable partial state.
+- It keeps the Lean surface unwidened. The PROMPT's substrate-discipline rule is explicit on this point. The new transactional semantics are fenced from Rust against existing emitted fields (`prefix_len`, `pre_live`, `expected_after_desired`, `expected_selected_writes`). A Lean follow-up to emit an explicit external-abort projection is filed as a separate issue.
+
+## Design
+
+### `ConfigApplyTxn` and the threading change
+
+A new type `ConfigApplyTxn` represents an open write transaction over either backend. It is the only argument the apply pipeline takes after the top-level CLI command begins one.
+
+```rust
+// crates/defra-agent-cli/src/config_writes/mod.rs
+pub(crate) enum ConfigAccess {
+    Graphql(String),
+    Local(EmbeddedNode),
+}
+
+impl ConfigAccess {
+    pub(crate) async fn execute(&self, query: &str) -> Result<Value> { /* unchanged */ }
+
+    /// Begin a write transaction on the underlying backend.
+    pub(crate) async fn begin_apply_txn(&self) -> Result<ConfigApplyTxn<'_>>;
+}
+
+pub(crate) struct ConfigApplyTxn<'a> {
+    access: &'a ConfigAccess,
+    handle: TxnHandle,
+}
+
+enum TxnHandle {
+    Graphql(String),               // numeric txn_id parsed from POST /api/v0/tx/begin
+    Local(defra_node::TransactionHandle),
+}
+
+impl<'a> ConfigApplyTxn<'a> {
+    /// Execute a GraphQL query within this transaction.
+    /// Graphql path:  POST with `x-defradb-tx: <id>` header.
+    /// Local path:    runner.execute_in_txn(req, &handle).
+    pub(crate) async fn execute(&self, query: &str) -> Result<Value>;
+
+    /// Commit the transaction. After this, the apply is durable.
+    pub(crate) async fn commit(self) -> Result<()>;
+
+    /// Discard the transaction. Returns the underlying error if discard fails;
+    /// the top-level orchestrator is responsible for logging and swallowing it
+    /// so the original apply error remains the one surfaced to the operator.
+    pub(crate) async fn discard(self) -> Result<()>;
+}
+```
+
+The non-write `ConfigAccess::execute` path remains for code that runs **before** the tx opens — manifest validators, diff queries, GraphQL schema introspection. Those read pre-apply committed state, which is correct: the diff is computed against the live snapshot the manifest is targeting.
+
+Threading: `apply_desired_state_changes`, `apply_import_collection`, `apply_generic_import_collection_batched`, `apply_custom_override_collection_batched`, `apply_custom_override_documents_individually`, `query_existing_documents_by_unique_values`, and the three custom writers in `crates/defra-agent-cli/src/config_writes/` (`write_task_document`, `write_schedule_document`, `write_event_trigger_document`) all change their access parameter from `&ConfigAccess` to `&ConfigApplyTxn`. The pre-write existence probes that determine create-vs-update branches in the custom-writer path must read through the same transaction, otherwise they observe stale pre-tx state and pick the wrong branch. The type change makes that enforced at compile time rather than discipline.
+
+### Top-level orchestrator
+
+The CLI's `config apply` command path drives the braid:
+
+```rust
+let txn = access.begin_apply_txn().await?;
+let counts = match apply_desired_state_changes(&txn, &desired_bundle, &planned).await {
+    Ok(counts) => counts,
+    Err(error) => {
+        if let Err(discard_err) = txn.discard().await {
+            tracing::warn!(%discard_err, "config apply: tx discard failed after apply error");
+        }
+        return Err(error);
+    }
+};
+txn.commit().await.context("config apply: commit failed")?;
+Ok(counts)
+```
+
+Properties of the braid:
+
+- **Any error from any write aborts the whole apply.** No per-collection commits, no partial successes. Inner per-mutation retry loops in `defra-agent`'s retry classification are unchanged; what changes is that an exhausted retry discards the entire apply rather than continuing past the failure.
+- **Apply error wins.** A `discard` failure after an apply error is logged, not surfaced. The user needs to act on the apply error; the transaction will be reclaimed by DefraDB.
+- **Commit failure is propagated** as an apply error. From the user's perspective a commit failure is operationally identical to any other apply failure: the DB stayed at pre-apply state.
+
+### Crash semantics
+
+The CLI process owns the transaction handle. If the process dies:
+
+- HTTP backend: the TCP connection drops, no commit is ever POSTed, DefraDB's tx GC reclaims the handle.
+- Local embedded backend: `DbTransactionContext` is dropped without `force_commit`, the underlying `db_txn` is dropped, the writes never land.
+
+Either way, the next observer of the DB sees the pre-apply snapshot. The operator re-runs `config apply` against the same manifest and the existing prefix-retry semantics (already proven in `prefix_retry_convergence_idempotence`) converge. No on-disk recovery state, no `apply --recover` subcommand, no WAL.
+
+### Concurrent applies
+
+DefraDB uses optimistic concurrency at the storage layer. If two `config apply` invocations race against the same DB, at least one wins; the other's commit fails with a conflict error and the apply braid surfaces that as an apply failure (and discards). The CLI does not serialize invocations at the agent layer — that would require cross-process coordination and is unnecessary given DB-level conflict detection.
+
+## Conformance fence (Lean unwidened)
+
+### Extended production-boundary consumer
+
+`crates/defra-agent-cli/src/config_import.rs::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary` is extended with a second sub-flavor per Lean case whose `prefix_len > 0` (cases `prefix_retry_convergence_idempotence` with `prefix_len = 1`, `referrer_closure` with `prefix_len = 4`, `production_write_boundary_all_collections` with `prefix_len = 6`).
+
+The injected-failure flavor:
+
+1. Stand up the existing recording GraphQL test server in a "fail at write N" mode, where N = `prefix_len + 1` from the Lean case.
+2. The recording server tracks two state windows: writes-inside-the-active-tx (recorded but uncommitted) and committed state. It implements `POST /api/v0/tx/begin`, `POST /api/v0/tx/{id}` (commit), `DELETE /api/v0/tx/{id}` (discard), and honors `x-defradb-tx` on `/graphql` requests for routing into the in-tx window.
+3. Run `apply_desired_state_changes` through the new `ConfigApplyTxn` braid against the failing endpoint.
+4. Assert:
+   - The braid returned `Err`.
+   - The observed mutation sequence matches Lean's `expected_selected_writes[..prefix_len + 1]` (no extra writes after the failing one).
+   - Exactly one `begin` and one `discard` were recorded on the tx endpoints; **zero** `commit`.
+   - Externally-observed committed state equals `pre_live`. This is the red→green pivot — today, without a transaction, partial writes are visible after the failure; with the new braid, the discard reverts them.
+
+The success-path flavor (already implemented today) keeps the existing assertions and adds:
+- Exactly one `begin` and one `commit`; zero `discard`.
+- Externally-observed committed state matches Lean's `expected_after_desired` projected through the same `LiveState` mapping the test already uses.
+
+Cases with `prefix_len = 0` (`empty_manifest`, `update_existing_backend`, `live_only_no_op`) skip the injected-failure flavor; there is no meaningful interior failure point. The success-path flavor still runs for every case.
+
+### Reference-model consumer
+
+`crates/defra-agent/tests/apply_conformance.rs` is unchanged. It consumes the same Lean rows against `defra_agent::apply_model`, which is a pure reference implementation with no DB and no transaction semantics. It stays green by construction.
+
+### Targeted integration test
+
+A new file `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` exercises the braid against a real DefraDB node, not the mock recorder:
+
+- Construct a manifest whose 4th apply step will fail (e.g., a behavior referencing a profile id that the manifest builder will deliberately omit at write time).
+- Run `defra-agent-cli config apply` against a running node.
+- Assert: command exits non-zero, query the node for every operator-controlled collection, observe zero new rows.
+
+The existing `cli_config_apply_order.rs` covers prefix-safe ordering and is orthogonal to atomicity — it stays as-is.
+
+### Lean is not widened
+
+The fence is expressed entirely in terms of fields already emitted by `apply_reconcile_cases`: `prefix_len`, `pre_live`, `pre_desired`, `expected_selected_writes`, `expected_after_desired`. No new Lean fields are added in this PR. A follow-up issue (see below) is filed for an explicit `expected_external_state_after_abort` Lean field that would let the assertion become a direct equality rather than a Rust-side restatement.
+
+## Out of scope
+
+- **Delete semantics.** #57 owns this. The transactional braid contains only create/update writes today, mirroring the Lean `ApplyStep` enum. When #57 lands, deletes participate in the same transaction by extension; no rework needed.
+- **Reference-model `apply_conformance.rs`.** Stays green and unchanged.
+- **P2P-side apply.** This is local CLI apply.
+- **Lean surface widening.** Per substrate discipline, filed as a follow-up issue rather than landed here.
+- **Concurrency serialization across CLI invocations.** DefraDB's optimistic concurrency is sufficient.
+
+## Follow-up issues to file
+
+1. **Lean: explicit external-abort projection for `apply_reconcile_cases`.** Emit `expected_external_state_after_abort` (= `pre_live` in every current case) so the production-boundary consumer asserts a direct equality. Becomes more interesting when #57 introduces delete semantics. Filed against the ApplyReconcile spec, not blocking #56.
+2. **defra-node tx idle-timeout audit.** Confirm the upper bound on an open transaction; either document it or extend it if a real `config apply` could plausibly hit it. Filed only if implementation surfaces a concrete gap.
+
+## Operator-facing change
+
+`defra-agent-cli config apply` is now atomic: any failure during apply leaves the database at the pre-apply snapshot, with no operator cleanup required. Re-running `config apply` against the same manifest after fixing the underlying error converges as before. CHANGELOG entry and release notes updated accordingly.
+
+## Deliverables
+
+- [ ] `ConfigApplyTxn<'a>` and `TxnHandle` defined in `crates/defra-agent-cli/src/config_writes/mod.rs`.
+- [ ] `ConfigAccess::begin_apply_txn` implementations for both `Graphql` and `Local` variants.
+- [ ] Threading change: `&ConfigAccess` → `&ConfigApplyTxn` through `apply_desired_state_changes`, `apply_import_collection`, `apply_generic_import_collection_batched`, `apply_custom_override_collection_batched`, `apply_custom_override_documents_individually`, `query_existing_documents_by_unique_values`, and the three `write_*_document` custom writers.
+- [ ] Top-level CLI command path braid: `begin_apply_txn` → `apply_desired_state_changes` → `commit` (success) | `discard` (error).
+- [ ] Extend `generated_apply_reconcile_cases_fence_production_apply_write_boundary` with the injected-failure / no-commit / pre-live-preservation flavor (recording server gains `begin / commit / discard` endpoints and a per-tx state window).
+- [ ] New `crates/defra-agent-cli/tests/cli_config_apply_transactional_rollback.rs` integration test against a real DefraDB node.
+- [ ] Two follow-up issues filed.
+- [ ] CHANGELOG / release-note entry.
+
+## Verification
+
+- `cargo fmt --all`
+- `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens`
+- `cargo test -p defra-agent-cli` — full green, including the extended production-boundary consumer and the new transactional-rollback integration test.
+- `cargo test -p defra-agent --lib --tests` — full green; reference-model `apply_conformance.rs` continues to pass unchanged.
+- `cd crates/defra-agent/proofs && lake build` — zero `sorry`s. (No Lean changes in this PR; this is the sanity check.)


### PR DESCRIPTION
## Summary

Closes #56. Wraps `defra-agent-cli config apply` in a single DefraDB transaction so partial failures are recoverable without operator intervention.

- `ConfigApplyTxn` opens a tx on `ConfigAccess::begin_apply_txn` and is threaded through every write site. Commit on success, discard on error, log-and-swallow discard failures so the original apply error surfaces.
- Process crash mid-apply: DefraDB's tx GC reclaims the orphan, external state stays at pre-apply, operator re-runs apply and the existing prefix-retry semantics converge.
- Lean surface unwidened per substrate discipline. The conformance fence in `lean_apply_write_boundary_tests` uses only existing emitted fields (`prefix_len`, `pre_live`, `expected_after_desired`, `expected_selected_writes`); the explicit `expected_external_state_after_abort` Lean addition is filed as #225.

### Substrate gap discovered + stopgap

DefraDB's transaction commits **do not emit `EventName::Update` events** on the EventBus — only the `AutoCommitMutator` does. Without that, the in-process runtime watcher never reconciles after a transactional apply. Filed upstream as **`sourcenetwork/defradb.rs#970`**.

Until that lands, the apply braid issues one auto-commit no-op write to `AgentPrincipal::enabled` after commit so the watcher wakes. The block is clearly marked as a stopgap with every deletion target enumerated; remove together when defradb.rs#970 ships.

### Follow-ups filed

- #225 — Lean: emit `expected_external_state_after_abort` for `apply_reconcile_cases` (lets the fence assert a direct equality instead of restating "abort = pre_live" from Rust).
- #226 — Audit DefraDB tx idle timeout against real config-apply runtimes.
- defradb.rs#970 — upstream gap: tx commits must emit Update events.

## Test plan

- [x] `cargo fmt --all` clean.
- [x] `cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens` clean.
- [x] `cargo test -p defra-agent-cli` green — including the extended production-boundary conformance test (success-path `(1, 1, 0)` tx-lifecycle assertion + injected-failure flavor for every Lean case with `prefix_len > 0`), the new `cli_config_apply_transactional_rollback` integration test (SIGKILL mid-apply, full 9-collection coverage, env-gated apply slowdown for deterministic timing), and the existing `cli_config_apply_running` (now passing via the stopgap nudge).
- [x] `cargo test -p defra-agent --lib --tests` green — reference-model `apply_conformance.rs` unchanged.
- [x] `cd crates/defra-agent/proofs && lake build` clean — no Lean changes; sanity check.
- [ ] Reviewer can verify the red→green pivot manually: revert the orchestrator braid commit (`e175cfe`) and rerun `lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary` — assertions go red.

## Spec and plan

- Spec: `docs/superpowers/specs/2026-05-15-issue-56-transactional-apply-design.md`
- Plan: `docs/superpowers/plans/2026-05-15-issue-56-transactional-apply.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)