### PR TITLE
Promote recovery sweep runtime drive

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -278,11 +278,10 @@ def caseCoverage : List CoverageEntry :=
       "queue_deadline_cases"
       "QueueDeadlineConformanceCases"
       "state_machine_conformance::generated_queue_deadline_cases_pin_r4a_contract_rows"
-  , consumerWithFollowUpCoverage
+  , consumerCoverage
       "recovery_sweep_cases"
       "RecoverySweepCases"
-      "state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract"
-      "Deadline audit PR E must implement InferenceCall::recover_all; the bridge terminal wiring follow-up must implement detached bridge row recovery."
+      "state_machine_conformance::generated_recovery_sweep_cases_drive_startup_recovery_contract"
   , consumerCoverage
       "r6_background_cases"
       "R6BackgroundingCases"

--- a/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
+++ b/crates/defra-agent/proofs/Proofs/Recovery/Sweeps.lean
@@ -343,9 +343,9 @@ def detachedBridgeRecoverySweep : RecoverySweep :=
   { Row := DetachedBridgeRecoveryRow
   , collection := .agentToolCall
   , sweepId := "tool_call_lifecycle_recover_detached_bridge_rows"
-  , rustFunction := "ToolCallLifecycle::recover_detached_bridge_rows"
+  , rustFunction := "ToolCallLifecycle::recover_all"
   , cadence := .startup
-  , implementationStatus := .obligation
+  , implementationStatus := .implemented
   , stale := detachedBridgeRecoveryStale
   , recover := detachedBridgeRecover
   , terminal := fun row => isTerminal row.call.state
@@ -431,7 +431,7 @@ def inferenceCallRecoverySweep : RecoverySweep :=
   , sweepId := "inference_call_recover_all_stale_calls"
   , rustFunction := "InferenceCall::recover_all"
   , cadence := .startup
-  , implementationStatus := .obligation
+  , implementationStatus := .implemented
   , stale := inferenceCallRecoveryStale
   , recover := inferenceCallRecover
   , terminal := fun row => isTerminal row.call.state

--- a/crates/defra-agent/src/admission/mod.rs
+++ b/crates/defra-agent/src/admission/mod.rs
@@ -3,6 +3,7 @@ mod config;
 mod controller;
 mod permit;
 mod persistence;
+mod recovery;
 mod registry;
 #[cfg(test)]
 mod slot_accounting;
@@ -13,6 +14,7 @@ pub(crate) use client::{
     AdmittedCompletionClient, CallKind,
 };
 pub(crate) use config::{backend_admission_configs_from_backends, BackendAdmissionConfig};
+pub use recovery::{InferenceCall, InferenceCallRecoveryReport};
 pub(crate) use registry::AdmissionRegistry;
 
 #[cfg(test)]

--- a/crates/defra-agent/src/admission/recovery.rs
+++ b/crates/defra-agent/src/admission/recovery.rs
@@ -1,0 +1,210 @@
+use anyhow::{Context, Result};
+use defra_node::EmbeddedNode;
+use serde::Deserialize;
+
+use crate::graphql::escape_graphql_string;
+use crate::session::execute_mutation_with_retry;
+
+#[derive(Debug, Default)]
+pub struct InferenceCallRecoveryReport {
+    pub calls_recovered: usize,
+}
+
+pub struct InferenceCall;
+
+#[derive(Debug, Deserialize)]
+struct StaleInferenceCallRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    call_id: String,
+    request_id: String,
+    call_state: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ParentRequestRow {
+    status: String,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+}
+
+enum InferenceRecoveryOutcome {
+    Cancelled,
+    Failed,
+}
+
+impl InferenceCall {
+    pub async fn recover_all(
+        node: &EmbeddedNode,
+        agent_did: &str,
+    ) -> Result<InferenceCallRecoveryReport> {
+        let rows = load_stale_inference_calls(node, agent_did).await?;
+        let mut calls_recovered = 0;
+
+        for row in rows {
+            let Some(parent) = lookup_parent_request(node, agent_did, &row.request_id).await?
+            else {
+                continue;
+            };
+            let Some(outcome) = recovery_outcome(&row, &parent) else {
+                continue;
+            };
+
+            if let Err(error) = recover_inference_call_row(node, &row, outcome).await {
+                tracing::warn!(
+                    call_id = %row.call_id,
+                    request_id = %row.request_id,
+                    call_state = %row.call_state,
+                    error = %error,
+                    "failed to recover stale inference call"
+                );
+                continue;
+            }
+
+            calls_recovered += 1;
+            tracing::info!(
+                call_id = %row.call_id,
+                request_id = %row.request_id,
+                "recovered stale inference call"
+            );
+        }
+
+        Ok(InferenceCallRecoveryReport { calls_recovered })
+    }
+}
+
+async fn load_stale_inference_calls(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<Vec<StaleInferenceCallRow>> {
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let query = format!(
+        r#"{{
+            InferenceCall(
+                filter: {{
+                    agent_did: {{ _eq: "{escaped_agent_did}" }},
+                    call_state: {{ _in: ["queued", "running"] }}
+                }}
+            ) {{
+                _docID
+                call_id
+                request_id
+                call_state
+            }}
+        }}"#
+    );
+
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!("querying stale InferenceCall rows: {:?}", resp.errors);
+    }
+
+    let rows = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceCall"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows)
+}
+
+async fn lookup_parent_request(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    request_id: &str,
+) -> Result<Option<ParentRequestRow>> {
+    let escaped_agent_did = escape_graphql_string(agent_did);
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{
+                    agent_did: {{ _eq: "{escaped_agent_did}" }},
+                    request_id: {{ _eq: "{escaped_request_id}" }}
+                }},
+                limit: 1
+            ) {{
+                status
+                lifecycle_state
+            }}
+        }}"#
+    );
+
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "querying parent request for inference recovery request_id={request_id}: {:?}",
+            resp.errors
+        );
+    }
+
+    let rows: Vec<ParentRequestRow> = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows.into_iter().next())
+}
+
+fn recovery_outcome(
+    row: &StaleInferenceCallRow,
+    parent: &ParentRequestRow,
+) -> Option<InferenceRecoveryOutcome> {
+    if request_is_interrupted(parent) {
+        return Some(InferenceRecoveryOutcome::Cancelled);
+    }
+    if !request_is_terminal(parent) {
+        return None;
+    }
+
+    match row.call_state.as_str() {
+        "queued" => Some(InferenceRecoveryOutcome::Cancelled),
+        "running" => Some(InferenceRecoveryOutcome::Failed),
+        _ => None,
+    }
+}
+
+async fn recover_inference_call_row(
+    node: &EmbeddedNode,
+    row: &StaleInferenceCallRow,
+    outcome: InferenceRecoveryOutcome,
+) -> Result<()> {
+    let escaped_doc_id = escape_graphql_string(&row.doc_id);
+    let ended_at = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    let (call_state, failure_reason) = match outcome {
+        InferenceRecoveryOutcome::Cancelled => ("cancelled", "Cancelled"),
+        InferenceRecoveryOutcome::Failed => ("failed", "StreamDroppedBeforeTerminalResponse"),
+    };
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceCall(
+                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                input: {{
+                    call_state: "{call_state}",
+                    failure_reason: "{failure_reason}",
+                    ended_at: "{ended_at}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+    );
+
+    execute_mutation_with_retry(node, &mutation, "recover_inference_call")
+        .await
+        .context("recover inference call mutation")?;
+    Ok(())
+}
+
+fn request_is_interrupted(parent: &ParentRequestRow) -> bool {
+    parent.status == "interrupted" || parent.lifecycle_state.as_deref() == Some("interrupted")
+}
+
+fn request_is_terminal(parent: &ParentRequestRow) -> bool {
+    matches!(
+        parent.status.as_str(),
+        "completed" | "error" | "superseded" | "dead" | "interrupted"
+    ) || matches!(
+        parent.lifecycle_state.as_deref(),
+        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
+    )
+}

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -12,7 +12,7 @@ use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use super::context::{RuntimeContext, StartupBarrier};
-use crate::admission::{AdmissionRegistry, BackendAdmissionConfig};
+use crate::admission::{AdmissionRegistry, BackendAdmissionConfig, InferenceCall};
 use crate::agent::reconcile::GenerationSupervisor;
 use crate::agent::{DefraAgent, DocumentResolveContext, ProcessLifecycleState};
 use crate::backend_registry;
@@ -374,6 +374,47 @@ pub(in crate::agent) async fn run_agent(
 
 async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_behavior_id: &str) {
     let mut recovered_any = false;
+
+    match ToolCallLifecycle::recover_all(node, agent_did).await {
+        Ok(report) => {
+            if report.tool_calls_recovered > 0 {
+                recovered_any = true;
+                tracing::info!(
+                    agent_did = %agent_did,
+                    count = report.tool_calls_recovered,
+                    "recovered stuck tool calls"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                agent_did = %agent_did,
+                error = %error,
+                "startup tool-call recovery failed"
+            );
+        }
+    }
+
+    match InferenceCall::recover_all(node, agent_did).await {
+        Ok(report) => {
+            if report.calls_recovered > 0 {
+                recovered_any = true;
+                tracing::info!(
+                    agent_did = %agent_did,
+                    count = report.calls_recovered,
+                    "recovered stale inference calls"
+                );
+            }
+        }
+        Err(error) => {
+            tracing::warn!(
+                agent_did = %agent_did,
+                error = %error,
+                "startup inference-call recovery failed"
+            );
+        }
+    }
+
     match RequestLifecycle::recover_all(node, agent_did).await {
         Ok(report) => {
             if report.requests_recovered > 0 {
@@ -403,26 +444,6 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
         }
         Err(error) => {
             tracing::warn!(agent_did = %agent_did, error = %error, "startup recovery failed");
-        }
-    }
-
-    match ToolCallLifecycle::recover_all(node, agent_did).await {
-        Ok(report) => {
-            if report.tool_calls_recovered > 0 {
-                recovered_any = true;
-                tracing::info!(
-                    agent_did = %agent_did,
-                    count = report.tool_calls_recovered,
-                    "recovered stuck tool calls"
-                );
-            }
-        }
-        Err(error) => {
-            tracing::warn!(
-                agent_did = %agent_did,
-                error = %error,
-                "startup tool-call recovery failed"
-            );
         }
     }
 

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -49,6 +49,7 @@ pub mod watcher;
 
 pub use collection::Collection;
 
+pub use admission::{InferenceCall, InferenceCallRecoveryReport};
 pub use agent::{
     BehaviorBuilder, DefraAgent, DefraAgentBuilder, DocumentRuntimeOptions,
     ProcessLifecycleObserver, ProcessLifecycleState,

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -6,8 +6,8 @@ use defra_node::EmbeddedNode;
 use serde::Deserialize;
 
 use crate::background_tools::{
-    fail_running_subagent_tool_call, load_parent_subagent_authorization, subagent_spawn_denial,
-    subagent_tool_not_allowed_payload,
+    child_request_completed, fail_running_subagent_tool_call, load_parent_subagent_authorization,
+    project_child_terminal, subagent_spawn_denial, subagent_tool_not_allowed_payload,
 };
 use crate::graphql::escape_graphql_string;
 use crate::interrupt::interrupt_request;
@@ -15,7 +15,7 @@ use crate::session::execute_mutation_with_retry;
 
 use super::{
     subagent_request::create_subagent_request_with_request_id, AwaitMode, CancelPolicy,
-    FailureClass, ToolCallState,
+    ChildTerminal, FailureClass, ToolCallState,
 };
 
 #[derive(Debug, Default)]
@@ -45,6 +45,8 @@ struct RunningToolCallRow {
     cancel_policy: Option<String>,
     #[serde(default)]
     child_request_id: Option<String>,
+    #[serde(default)]
+    unclaimed_deadline_at: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -73,6 +75,7 @@ enum RecoveryOutcome {
     Cancelled,
     Failed,
     BackgroundInterrupted,
+    UnclaimedCrossDeploymentSpawn,
 }
 
 impl super::ToolCallLifecycle {
@@ -117,6 +120,13 @@ async fn recover_orphan_subagent_children(node: &EmbeddedNode, agent_did: &str) 
             continue;
         };
         if child_request_exists(node, &child_request_id).await? {
+            continue;
+        }
+        if row
+            .unclaimed_deadline_at
+            .as_deref()
+            .is_some_and(|deadline| !deadline.is_empty())
+        {
             continue;
         }
 
@@ -299,6 +309,7 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
     let mut recovered = 0;
     for row in rows {
         let deadline_at = parse_datetime(row.deadline_at.as_deref());
+        let unclaimed_deadline_at = parse_datetime(row.unclaimed_deadline_at.as_deref());
         let parent = match row
             .request_id
             .as_deref()
@@ -308,30 +319,27 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
             None => None,
         };
 
-        if is_background_subagent_tool(&row)
-            && !parent
-                .as_ref()
-                .is_some_and(|parent| request_is_interrupted(parent))
-        {
-            tracing::info!(
-                doc_id = %row.doc_id,
-                request_id = row.request_id.as_deref().unwrap_or(""),
-                session_id = %row.session_id,
-                tool_call_id = %row.tool_call_id,
-                child_request_id = row.child_request_id.as_deref().unwrap_or(""),
-                "leaving background subagent tool call running during recovery"
-            );
+        if recover_bridge_terminal_child(node, &row).await? {
+            recovered += 1;
             continue;
         }
 
-        let outcome = if is_background_tool_row(&row)
+        let outcome = if deadline_at.is_some_and(|deadline| Utc::now() >= deadline) {
+            Some(RecoveryOutcome::TimedOut)
+        } else if unclaimed_deadline_at.is_some_and(|deadline| Utc::now() >= deadline) {
+            Some(RecoveryOutcome::UnclaimedCrossDeploymentSpawn)
+        } else if is_background_tool_row(&row)
             && parent
                 .as_ref()
                 .is_some_and(|parent| !request_is_terminal(parent))
         {
             Some(RecoveryOutcome::BackgroundInterrupted)
-        } else if deadline_at.is_some_and(|deadline| Utc::now() >= deadline) {
-            Some(RecoveryOutcome::TimedOut)
+        } else if is_detached_subagent_tool(&row)
+            && parent
+                .as_ref()
+                .is_some_and(|parent| request_is_interrupted(parent))
+        {
+            None
         } else if parent
             .as_ref()
             .is_some_and(|parent| request_is_interrupted(parent))
@@ -344,37 +352,37 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
         };
 
         let Some(outcome) = outcome else {
+            if is_background_subagent_tool(&row) {
+                tracing::info!(
+                    doc_id = %row.doc_id,
+                    request_id = row.request_id.as_deref().unwrap_or(""),
+                    session_id = %row.session_id,
+                    tool_call_id = %row.tool_call_id,
+                    child_request_id = row.child_request_id.as_deref().unwrap_or(""),
+                    "leaving background subagent tool call running during recovery"
+                );
+            }
             continue;
         };
 
-        if is_detached_subagent_tool(&row) {
-            tracing::info!(
-                doc_id = %row.doc_id,
-                request_id = row.request_id.as_deref().unwrap_or(""),
-                session_id = %row.session_id,
-                tool_call_id = %row.tool_call_id,
-                child_request_id = row.child_request_id.as_deref().unwrap_or(""),
-                "leaving detached subagent tool call running during recovery"
-            );
-            continue;
-        }
-
         let mut remote_cancel_intent_at = None;
-        if let Some(child_request_id) = cascade_child_request_id(&row) {
-            if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
-                if let Err(error) = interrupt_request(node, child_request_id).await {
-                    tracing::warn!(
-                        doc_id = %row.doc_id,
-                        request_id = row.request_id.as_deref().unwrap_or(""),
-                        session_id = %row.session_id,
-                        tool_call_id = %row.tool_call_id,
-                        child_request_id,
-                        error = %error,
-                        "failed to cascade recovery interrupt to child request"
-                    );
+        if outcome != RecoveryOutcome::UnclaimedCrossDeploymentSpawn {
+            if let Some(child_request_id) = cascade_child_request_id(&row) {
+                if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
+                    if let Err(error) = interrupt_request(node, child_request_id).await {
+                        tracing::warn!(
+                            doc_id = %row.doc_id,
+                            request_id = row.request_id.as_deref().unwrap_or(""),
+                            session_id = %row.session_id,
+                            tool_call_id = %row.tool_call_id,
+                            child_request_id,
+                            error = %error,
+                            "failed to cascade recovery interrupt to child request"
+                        );
+                    }
+                } else {
+                    remote_cancel_intent_at = Some(Utc::now());
                 }
-            } else {
-                remote_cancel_intent_at = Some(Utc::now());
             }
         }
 
@@ -448,6 +456,7 @@ async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningT
             await_mode
             cancel_policy
             child_request_id
+            unclaimed_deadline_at
         }
     }"#;
 
@@ -531,6 +540,171 @@ async fn child_request_exists(node: &EmbeddedNode, request_id: &str) -> Result<b
         .is_some_and(|rows| !rows.is_empty()))
 }
 
+async fn recover_bridge_terminal_child(
+    node: &EmbeddedNode,
+    row: &RunningToolCallRow,
+) -> Result<bool> {
+    let Some(child_request_id) = child_request_id(row) else {
+        return Ok(false);
+    };
+    let Some(child) =
+        crate::background_tools::load_child_terminal_row(node, child_request_id).await?
+    else {
+        return Ok(false);
+    };
+
+    if child_request_completed(&child) {
+        let result = load_child_completion_result(node, child_request_id)
+            .await?
+            .unwrap_or_else(|| format!("child request {child_request_id} completed"));
+        recover_bridge_completed_row(node, row, &result).await?;
+        return Ok(true);
+    }
+
+    let Some(terminal) = project_child_terminal(&child) else {
+        return Ok(false);
+    };
+    recover_bridge_failed_row(node, row, &terminal).await?;
+    Ok(true)
+}
+
+async fn load_child_completion_result(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Result<Option<String>> {
+    #[derive(Deserialize)]
+    struct ResponseRow {
+        content: Option<String>,
+    }
+
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{ request_id: {{ _eq: "{escaped_child_request_id}" }} }},
+                order: {{ created_at: DESC }},
+                limit: 1
+            ) {{
+                content
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query child AgentResponse {child_request_id} for bridge recovery failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<ResponseRow> = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentResponse"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .next()
+        .and_then(|row| row.content)
+        .filter(|content| !content.trim().is_empty()))
+}
+
+async fn recover_bridge_completed_row(
+    node: &EmbeddedNode,
+    row: &RunningToolCallRow,
+    child_result: &str,
+) -> Result<()> {
+    let now = Utc::now();
+    let started_at = parse_datetime(row.started_at.as_deref()).unwrap_or(now);
+    let deadline_at = parse_datetime(row.deadline_at.as_deref()).unwrap_or(now);
+    let latency_ms = (now - started_at).num_milliseconds().max(0);
+    let escaped_doc_id = escape_graphql_string(&row.doc_id);
+    let escaped_result = escape_graphql_string(child_result);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{
+                    _docID: {{ _eq: "{escaped_doc_id}" }},
+                    lifecycle_state: {{ _eq: "running" }}
+                }},
+                input: {{
+                    result: "{escaped_result}",
+                    status: "completed",
+                    lifecycle_state: "completed",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    completed_at: "{completed_at}",
+                    latency_ms: {latency_ms},
+                    unclaimed_deadline_at: null
+                }}
+            ) {{ _docID }}
+        }}"#,
+        started_at = started_at.to_rfc3339(),
+        deadline_at = deadline_at.to_rfc3339(),
+        completed_at = now.to_rfc3339(),
+    );
+
+    execute_mutation_with_retry(node, &mutation, "recover_bridge_completed_child")
+        .await
+        .context("recover bridge completed child mutation")?;
+    Ok(())
+}
+
+async fn recover_bridge_failed_row(
+    node: &EmbeddedNode,
+    row: &RunningToolCallRow,
+    terminal: &ChildTerminal,
+) -> Result<()> {
+    let now = Utc::now();
+    let started_at = parse_datetime(row.started_at.as_deref()).unwrap_or(now);
+    let deadline_at = parse_datetime(row.deadline_at.as_deref()).unwrap_or(now);
+    let latency_ms = (now - started_at).num_milliseconds().max(0);
+    let escaped_doc_id = escape_graphql_string(&row.doc_id);
+    let projected = terminal.projected_state().as_str();
+    let optional_fields = match terminal {
+        ChildTerminal::Failed {
+            reason,
+            failure_class,
+        } => {
+            let escaped_reason = escape_graphql_string(reason);
+            let failure_class = failure_class.as_str();
+            format!(
+                r#"result: "{escaped_reason}",
+                    tool_failure_class: "{failure_class}","#
+            )
+        }
+        _ => String::new(),
+    };
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{
+                    _docID: {{ _eq: "{escaped_doc_id}" }},
+                    lifecycle_state: {{ _eq: "running" }}
+                }},
+                input: {{
+                    {optional_fields}
+                    status: "completed",
+                    lifecycle_state: "{projected}",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    completed_at: "{completed_at}",
+                    latency_ms: {latency_ms},
+                    unclaimed_deadline_at: null
+                }}
+            ) {{ _docID }}
+        }}"#,
+        started_at = started_at.to_rfc3339(),
+        deadline_at = deadline_at.to_rfc3339(),
+        completed_at = now.to_rfc3339(),
+    );
+
+    execute_mutation_with_retry(node, &mutation, "recover_bridge_terminal_child")
+        .await
+        .context("recover bridge terminal child mutation")?;
+    Ok(())
+}
+
 async fn recover_tool_call_row(
     node: &EmbeddedNode,
     row: &RunningToolCallRow,
@@ -571,7 +745,8 @@ async fn recover_tool_call_row(
                     lifecycle_state: "{lifecycle_state}",
                     started_at: "{started_at_str}"{deadline_field},
                     completed_at: "{completed_at_str}",
-                    latency_ms: {latency_ms}{failure_class_field}{remote_cancel_intent_fields}
+                    latency_ms: {latency_ms},
+                    unclaimed_deadline_at: null{failure_class_field}{remote_cancel_intent_fields}
                 }}
             ) {{ _docID }}
         }}"#,
@@ -698,13 +873,14 @@ impl RecoveryOutcome {
         match self {
             Self::TimedOut => ToolCallState::TimedOut,
             Self::Cancelled | Self::BackgroundInterrupted => ToolCallState::Cancelled,
-            Self::Failed => ToolCallState::Failed,
+            Self::Failed | Self::UnclaimedCrossDeploymentSpawn => ToolCallState::Failed,
         }
     }
 
     fn failure_class(self) -> Option<FailureClass> {
         match self {
             Self::TimedOut | Self::Failed => Some(FailureClass::External),
+            Self::UnclaimedCrossDeploymentSpawn => Some(FailureClass::ServiceUnavailable),
             Self::Cancelled | Self::BackgroundInterrupted => None,
         }
     }
@@ -728,6 +904,9 @@ impl RecoveryOutcome {
             }
             Self::Failed => {
                 "tool call failed because parent request was already terminal".to_string()
+            }
+            Self::UnclaimedCrossDeploymentSpawn => {
+                "no peer claimed subagent spawn before the unclaimed spawn deadline".to_string()
             }
         }
     }

--- a/crates/defra-agent/tests/r4_subagent_completion.rs
+++ b/crates/defra-agent/tests/r4_subagent_completion.rs
@@ -877,7 +877,7 @@ async fn background_completion_wakeup_waits_behind_active_foreground_parent_then
 }
 
 #[tokio::test]
-async fn recovery_leaves_running_background_bridge_alive_after_parent_completes() {
+async fn recovery_fails_running_background_bridge_after_parent_completes() {
     let (db, session_id, parent_request_id) =
         setup_fixture("background_completion_recovery_skip").await;
     let (child_request_id, _) = create_child_and_bridge(
@@ -895,17 +895,23 @@ async fn recovery_leaves_running_background_bridge_alive_after_parent_completes(
     let report = ToolCallLifecycle::recover_all(db.node.as_ref(), AGENT_DID)
         .await
         .unwrap();
-    assert_eq!(report.tool_calls_recovered, 0);
+    assert_eq!(report.tool_calls_recovered, 1);
 
     let tool = fetch_tool_call(db.node.as_ref(), &session_id, "spawn-bg-recovery-skip").await;
-    assert_eq!(tool.lifecycle_state.as_deref(), Some("running"));
+    assert_eq!(tool.lifecycle_state.as_deref(), Some("failed"));
     assert_eq!(tool.await_mode.as_deref(), Some("background"));
+    assert!(
+        tool.result
+            .as_deref()
+            .is_some_and(|result| result.contains("parent request was already terminal")),
+        "background bridge failure should explain the terminal parent"
+    );
     let interrupt = fetch_interrupt_requested_at(db.node.as_ref(), &child_request_id)
         .await
         .unwrap();
     assert!(
-        interrupt.is_none(),
-        "background child should not be interrupted merely because the parent completed"
+        interrupt.is_some(),
+        "cascade background child should be interrupted once recovery fails the parent bridge"
     );
 }
 

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -7,8 +7,9 @@ use defra_agent::event_delivery_contract::{
 };
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::lifecycle::{ClaimOutcome, ExecutionOrigin, TriggerLineage};
+use defra_agent::tool_call_lifecycle::{AwaitMode, CancelPolicy, ToolCallLifecycle};
 use defra_agent::{
-    write_manual_agent_request, DefraSessionHook, DefraStreamWriter, FailurePolicy,
+    write_manual_agent_request, DefraSessionHook, DefraStreamWriter, FailurePolicy, InferenceCall,
     RequestLifecycle,
 };
 use rig::agent::{HookAction, PromptHook, ToolCallHookAction};
@@ -40,12 +41,11 @@ use lean_vocab_test::{
     lean_event_delivery_transition_cases, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_mcp_health_cases, lean_queue_deadline_case,
     lean_queue_deadline_cases, lean_r4c_background_work_case, lean_r4c_background_work_cases,
-    lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_sweep_case,
-    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_transition_cases,
-    lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
-    lean_tool_preflight_case, lean_tool_retry_case, lean_transcript_case, lean_transcript_cases,
-    lean_vocabulary_values, LeanEventDeliveryAction, LeanLifecycleTransitionCase,
-    LeanR4cBackgroundWorkCase,
+    lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_sweep_cases,
+    lean_request_transition_cases, lean_response_transition_cases, lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_state_machine_contract, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_transcript_case, lean_transcript_cases, lean_vocabulary_values,
+    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -58,7 +58,7 @@ use support::snapshots::{
 };
 use support::{
     build_request, create_agent_session, create_request, create_response_with_content_and_status,
-    create_response_with_status, first_optional_row, set_interrupt_requested_at,
+    create_response_with_status, first_optional_row, first_row, set_interrupt_requested_at,
     set_request_lifecycle_state, set_valid_until, test_db, upsert_conversation, AGENT_DID,
     AGENT_NAME, BACKEND_ID, DEADLINE_SECS,
 };
@@ -91,9 +91,9 @@ fn lean_executable_contracts_cover_initial_domains() {
     coverage::lean_executable_contracts_cover_initial_domains();
 }
 
-#[test]
-fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
-    recovery_sweeps::generated_recovery_sweep_cases_pin_startup_recovery_contract();
+#[tokio::test]
+async fn generated_recovery_sweep_cases_drive_startup_recovery_contract() {
+    recovery_sweeps::generated_recovery_sweep_cases_drive_startup_recovery_contract().await;
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance/recovery_sweeps.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/recovery_sweeps.rs
@@ -1,6 +1,9 @@
 use super::*;
+use std::sync::Arc;
 
-pub(super) fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
+const RECOVERY_CREATED_AT: &str = "2026-03-23T00:00:00Z";
+
+pub(super) async fn generated_recovery_sweep_cases_drive_startup_recovery_contract() {
     let cases = lean_recovery_sweep_cases();
     assert_eq!(
         cases.len(),
@@ -27,111 +30,594 @@ pub(super) fn generated_recovery_sweep_cases_pin_startup_recovery_contract() {
     );
 
     for case in cases {
-        assert_eq!(case.cadence.as_str(), "startup");
-        assert!(
-            case.measure_before > case.measure_after,
-            "recovery case {} must decrease its measure",
-            case.name
-        );
-        assert_eq!(
-            case.measure_after, 0,
-            "recovery case {} must reach zero measure",
-            case.name
-        );
-        assert_ne!(
-            case.terminal_state.as_str(),
-            "running",
-            "recovery case {} must not leave a stale row running",
-            case.name
-        );
-        assert!(
-            !case.deadline_audit_ref.trim().is_empty(),
-            "recovery case {} must name its audit reference",
-            case.name
-        );
+        assert_recovery_case_metadata(case);
+        drive_recovery_sweep_case(case).await;
     }
+}
 
-    let implemented = [
-        "request_lifecycle_recover_all_requests",
-        "request_lifecycle_recover_all_streaming_responses",
-        "tool_call_lifecycle_recover_all_running_calls",
-    ];
-    for sweep_id in implemented {
-        for case in cases.iter().filter(|case| case.sweep_id == sweep_id) {
-            assert_eq!(
-                case.implementation_status.as_str(),
-                "implemented",
-                "sweep {sweep_id} should be an implemented startup sweep"
-            );
-        }
-    }
-
-    let detached_cases = cases
-        .iter()
-        .filter(|case| case.sweep_id == "tool_call_lifecycle_recover_detached_bridge_rows")
-        .collect::<Vec<_>>();
+fn assert_recovery_case_metadata(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    assert_eq!(case.cadence.as_str(), "startup");
     assert_eq!(
-        detached_cases.len(),
-        5,
-        "detached bridge recovery must have explicit obligation witnesses"
+        case.implementation_status.as_str(),
+        "implemented",
+        "recovery case {} must be implemented before the runtime drive can consume it",
+        case.name
     );
-    for case in detached_cases {
-        assert_eq!(case.collection.as_str(), "AgentToolCall");
+    assert!(
+        case.measure_before > case.measure_after,
+        "recovery case {} must decrease its measure",
+        case.name
+    );
+    assert_eq!(
+        case.measure_after, 0,
+        "recovery case {} must reach zero measure",
+        case.name
+    );
+    assert_ne!(
+        case.terminal_state.as_str(),
+        "running",
+        "recovery case {} must not leave a stale row running",
+        case.name
+    );
+    assert!(
+        !case.deadline_audit_ref.trim().is_empty(),
+        "recovery case {} must name its audit reference",
+        case.name
+    );
+}
+
+async fn drive_recovery_sweep_case(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    match case.collection.as_str() {
+        "AgentRequest" => drive_request_recovery_case(case).await,
+        "AgentResponse" => drive_response_recovery_case(case).await,
+        "AgentToolCall" => drive_tool_call_recovery_case(case).await,
+        "InferenceCall" => drive_inference_call_recovery_case(case).await,
+        other => panic!("unhandled recovery collection {other} for {}", case.name),
+    }
+}
+
+async fn drive_request_recovery_case(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    let db = test_db(&format!("recovery-sweep-{}", case.name)).await;
+    let request_id = format!("{}-request", case.name);
+    let session_id = format!("{}-session", case.name);
+    let doc_id = create_request(
+        &db.node,
+        &request_id,
+        &session_id,
+        "processing",
+        RECOVERY_CREATED_AT,
+    )
+    .await;
+    set_request_lifecycle_state(&db.node, &doc_id, case.pre_state.as_str()).await;
+
+    let report = RequestLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(
+        report.requests_recovered, 1,
+        "request recovery case {} should recover one request",
+        case.name
+    );
+
+    let row = fetch_request_recovery_row(&db.node, &request_id).await;
+    assert_eq!(
+        row.lifecycle_state.as_str(),
+        case.terminal_state.as_str(),
+        "request recovery case {} terminal state drifted",
+        case.name
+    );
+}
+
+async fn drive_response_recovery_case(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    let db = test_db(&format!("recovery-sweep-{}", case.name)).await;
+    let request_id = format!("{}-request", case.name);
+    let session_id = format!("{}-session", case.name);
+    create_response_with_status(
+        &db.node,
+        &request_id,
+        &request_id,
+        &session_id,
+        case.pre_state.as_str(),
+    )
+    .await;
+
+    let report = RequestLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(
+        report.responses_recovered, 1,
+        "response recovery case {} should recover one response",
+        case.name
+    );
+
+    let row = fetch_response_recovery_row(&db.node, &request_id).await;
+    assert_eq!(
+        row.status.as_str(),
+        case.terminal_state.as_str(),
+        "response recovery case {} terminal state drifted",
+        case.name
+    );
+}
+
+async fn drive_tool_call_recovery_case(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    let db = test_db(&format!("recovery-sweep-{}", case.name)).await;
+    let parent_request_id = format!("{}-parent", case.name);
+    let parent_session_id = format!("{}-parent-session", case.name);
+    let tool_call_id = format!("{}-tool", case.name);
+    seed_tool_parent_and_row(
+        db.node.clone(),
+        case,
+        &parent_request_id,
+        &parent_session_id,
+        &tool_call_id,
+    )
+    .await;
+
+    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(
+        report.tool_calls_recovered, 1,
+        "tool recovery case {} should recover one tool call",
+        case.name
+    );
+
+    let row = fetch_tool_recovery_row(&db.node, &tool_call_id).await;
+    assert_eq!(
+        row.lifecycle_state.as_deref(),
+        Some(case.terminal_state.as_str()),
+        "tool recovery case {} terminal state drifted",
+        case.name
+    );
+    assert_eq!(
+        row.status.as_deref(),
+        Some("completed"),
+        "tool recovery case {} must persist completed status with terminal lifecycle_state",
+        case.name
+    );
+    if case.terminal_state == "timedOut" {
         assert_eq!(
-            case.rust_function.as_str(),
-            "ToolCallLifecycle::recover_detached_bridge_rows"
-        );
-        assert_eq!(case.implementation_status.as_str(), "obligation");
-        assert!(
-            case.deadline_audit_ref
-                .contains("subagent-bridge-terminal-lifetime"),
-            "detached bridge case {} must point at the bridge terminal lifetime gap",
-            case.name
-        );
-        assert!(
-            ["completed", "failed", "cancelled", "timedOut"]
-                .contains(&case.terminal_state.as_str()),
-            "detached bridge case {} must terminalize, not skip",
-            case.name
+            row.tool_failure_class.as_deref(),
+            Some("external"),
+            "timeout recovery should persist external failure class"
         );
     }
+}
 
-    let queued = lean_recovery_sweep_case("inference_queued_stale_to_cancelled");
-    assert_eq!(queued.pre_state.as_str(), "queued");
-    assert_eq!(queued.terminal_state.as_str(), "cancelled");
-
-    let running = lean_recovery_sweep_case("inference_running_stale_to_failed");
-    assert_eq!(running.pre_state.as_str(), "running");
-    assert_eq!(running.terminal_state.as_str(), "failed");
-
-    let interrupted = lean_recovery_sweep_case("inference_interrupted_parent_to_cancelled");
-    assert_eq!(interrupted.terminal_state.as_str(), "cancelled");
-
-    for case in cases
-        .iter()
-        .filter(|case| case.sweep_id == "inference_call_recover_all_stale_calls")
-    {
-        assert_eq!(case.collection.as_str(), "InferenceCall");
-        assert_eq!(case.rust_function.as_str(), "InferenceCall::recover_all");
-        assert_eq!(case.implementation_status.as_str(), "obligation");
-        assert!(
-            case.deadline_audit_ref.contains("follow-up-6-pr-e"),
-            "InferenceCall recovery case {} must point at deadline audit PR E",
-            case.name
-        );
-        let terminal_row =
-            InferenceCallSlotRow::new("contract-backend", case.terminal_state.as_str());
-        assert_eq!(
-            slot_contribution(terminal_row, "contract-backend"),
-            0,
-            "terminal InferenceCall recovery case {} must release its backend slot",
-            case.name
-        );
-        assert_eq!(
-            reconstructed_running_slot_count([terminal_row], "contract-backend"),
-            0,
-            "terminal InferenceCall recovery case {} must reconstruct zero running slots",
-            case.name
-        );
+async fn drive_inference_call_recovery_case(case: &lean_vocab_test::LeanRecoverySweepCase) {
+    let db = test_db(&format!("recovery-sweep-{}", case.name)).await;
+    let request_id = format!("{}-request", case.name);
+    let session_id = format!("{}-session", case.name);
+    let parent_doc_id = create_request(
+        &db.node,
+        &request_id,
+        &session_id,
+        "processing",
+        RECOVERY_CREATED_AT,
+    )
+    .await;
+    match case.name.as_str() {
+        "inference_interrupted_parent_to_cancelled" => {
+            set_request_status_and_lifecycle(
+                &db.node,
+                &parent_doc_id,
+                "interrupted",
+                "interrupted",
+            )
+            .await;
+        }
+        "inference_queued_stale_to_cancelled" | "inference_running_stale_to_failed" => {
+            set_request_status_and_lifecycle(&db.node, &parent_doc_id, "completed", "completed")
+                .await;
+        }
+        other => panic!("unhandled inference recovery case {other}"),
     }
+    insert_inference_call(&db.node, &request_id, case.pre_state.as_str()).await;
+
+    let report = InferenceCall::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(
+        report.calls_recovered, 1,
+        "inference recovery case {} should recover one call",
+        case.name
+    );
+
+    let row = fetch_inference_recovery_row(&db.node, &request_id).await;
+    assert_eq!(
+        row.call_state.as_str(),
+        case.terminal_state.as_str(),
+        "inference recovery case {} terminal state drifted",
+        case.name
+    );
+    let terminal_row = InferenceCallSlotRow::new(BACKEND_ID, row.call_state.as_str());
+    assert_eq!(slot_contribution(terminal_row, BACKEND_ID), 0);
+    assert_eq!(
+        reconstructed_running_slot_count([terminal_row], BACKEND_ID),
+        0,
+        "terminal InferenceCall recovery case {} must reconstruct zero running slots",
+        case.name
+    );
+}
+
+async fn seed_tool_parent_and_row(
+    node: Arc<EmbeddedNode>,
+    case: &lean_vocab_test::LeanRecoverySweepCase,
+    parent_request_id: &str,
+    parent_session_id: &str,
+    tool_call_id: &str,
+) {
+    let parent_doc_id = create_request(
+        &node,
+        parent_request_id,
+        parent_session_id,
+        "processing",
+        RECOVERY_CREATED_AT,
+    )
+    .await;
+    let future_deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+    let past_deadline = chrono::Utc::now() - chrono::Duration::seconds(5);
+    let mut lifecycle = match case.name.as_str() {
+        "tool_backgrounded_running_live_parent_to_cancelled" => {
+            ToolCallLifecycle::new_background_tool(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "background_tool".to_string(),
+                "{}".to_string(),
+                future_deadline,
+            )
+        }
+        "tool_running_child_completed_to_completed"
+        | "tool_running_child_failed_to_failed"
+        | "tool_running_child_interrupted_to_cancelled" => {
+            let child_request_id = format!("{tool_call_id}-child");
+            let child_state = match case.name.as_str() {
+                "tool_running_child_completed_to_completed" => "completed",
+                "tool_running_child_failed_to_failed" => "failed",
+                "tool_running_child_interrupted_to_cancelled" => "interrupted",
+                _ => unreachable!(),
+            };
+            seed_child_request(&node, &child_request_id, child_state).await;
+            ToolCallLifecycle::new_subagent(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "spawn_subagent".to_string(),
+                "{}".to_string(),
+                future_deadline,
+                AwaitMode::Foreground,
+                CancelPolicy::Cascade,
+                child_request_id,
+            )
+        }
+        "detached_bridge_child_completed_to_completed"
+        | "detached_bridge_child_failed_to_failed"
+        | "detached_bridge_child_interrupted_to_cancelled"
+        | "detached_bridge_terminal_parent_to_failed"
+        | "detached_bridge_deadline_exceeded_to_timed_out" => {
+            let child_request_id = format!("{tool_call_id}-child");
+            let child_state = match case.name.as_str() {
+                "detached_bridge_child_completed_to_completed" => "completed",
+                "detached_bridge_child_failed_to_failed" => "failed",
+                "detached_bridge_child_interrupted_to_cancelled" => "interrupted",
+                _ => "processing",
+            };
+            seed_child_request(&node, &child_request_id, child_state).await;
+            if case.name == "detached_bridge_terminal_parent_to_failed" {
+                set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed")
+                    .await;
+            }
+            ToolCallLifecycle::new_subagent(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "spawn_subagent".to_string(),
+                "{}".to_string(),
+                if case.name == "detached_bridge_deadline_exceeded_to_timed_out" {
+                    past_deadline
+                } else {
+                    future_deadline
+                },
+                AwaitMode::Background,
+                CancelPolicy::Detach,
+                child_request_id,
+            )
+        }
+        "tool_running_deadline_exceeded_to_timed_out" => ToolCallLifecycle::new(
+            node.clone(),
+            parent_request_id.to_string(),
+            parent_session_id.to_string(),
+            tool_call_id.to_string(),
+            1,
+            "slow_tool".to_string(),
+            "{}".to_string(),
+            past_deadline,
+        ),
+        "tool_running_parent_interrupted_to_cancelled" => {
+            set_request_status_and_lifecycle(&node, &parent_doc_id, "interrupted", "interrupted")
+                .await;
+            ToolCallLifecycle::new(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "slow_tool".to_string(),
+                "{}".to_string(),
+                future_deadline,
+            )
+        }
+        "tool_running_terminal_parent_to_failed" => {
+            set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed").await;
+            ToolCallLifecycle::new(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "slow_tool".to_string(),
+                "{}".to_string(),
+                future_deadline,
+            )
+        }
+        "tool_running_unclaimed_cross_deployment_spawn_to_failed" => {
+            let child_request_id = format!("{tool_call_id}-remote-child");
+            ToolCallLifecycle::new_subagent(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                tool_call_id.to_string(),
+                1,
+                "spawn_subagent".to_string(),
+                "{}".to_string(),
+                future_deadline,
+                AwaitMode::Background,
+                CancelPolicy::Cascade,
+                child_request_id,
+            )
+        }
+        other => panic!("unhandled tool recovery case {other}"),
+    };
+    lifecycle.start_running().await.unwrap();
+
+    if case.name == "tool_running_unclaimed_cross_deployment_spawn_to_failed" {
+        set_tool_unclaimed_deadline(&node, tool_call_id, "2020-01-01T00:00:00Z").await;
+    }
+}
+
+async fn seed_child_request(node: &EmbeddedNode, request_id: &str, lifecycle_state: &str) {
+    let session_id = format!("{request_id}-session");
+    match lifecycle_state {
+        "completed" => {
+            create_request(
+                node,
+                request_id,
+                &session_id,
+                "completed",
+                RECOVERY_CREATED_AT,
+            )
+            .await;
+            create_response_with_content_and_status(
+                node,
+                request_id,
+                request_id,
+                &session_id,
+                "child final answer",
+                "complete",
+            )
+            .await;
+        }
+        "failed" => {
+            create_request(node, request_id, &session_id, "error", RECOVERY_CREATED_AT).await;
+        }
+        "interrupted" => {
+            let doc_id = create_request(
+                node,
+                request_id,
+                &session_id,
+                "processing",
+                RECOVERY_CREATED_AT,
+            )
+            .await;
+            set_request_status_and_lifecycle(node, &doc_id, "interrupted", "interrupted").await;
+        }
+        "processing" => {
+            create_request(
+                node,
+                request_id,
+                &session_id,
+                "processing",
+                RECOVERY_CREATED_AT,
+            )
+            .await;
+        }
+        other => panic!("unsupported child lifecycle state {other}"),
+    };
+}
+
+async fn set_request_status_and_lifecycle(
+    node: &EmbeddedNode,
+    doc_id: &str,
+    status: &str,
+    lifecycle_state: &str,
+) {
+    let doc_id = escape_graphql_string(doc_id);
+    let status = escape_graphql_string(status);
+    let lifecycle_state = escape_graphql_string(lifecycle_state);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                input: {{ status: "{status}", lifecycle_state: "{lifecycle_state}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "set request status/lifecycle failed: {:?}",
+        resp.errors
+    );
+}
+
+async fn set_tool_unclaimed_deadline(node: &EmbeddedNode, tool_call_id: &str, at: &str) {
+    #[derive(Debug, Deserialize)]
+    struct ToolDateTimeRow {
+        started_at: Option<String>,
+        deadline_at: Option<String>,
+    }
+
+    let escaped_tool_call_id = escape_graphql_string(tool_call_id);
+    let read_query = format!(
+        r#"{{
+            AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{escaped_tool_call_id}" }} }}, limit: 1) {{
+                started_at
+                deadline_at
+            }}
+        }}"#
+    );
+    let row: ToolDateTimeRow = first_row(&node.execute(&read_query).await, "AgentToolCall");
+    let started_at = datetime_update_field("started_at", row.started_at.as_deref());
+    let deadline_at = datetime_update_field("deadline_at", row.deadline_at.as_deref());
+    let at = escape_graphql_string(at);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentToolCall(
+                filter: {{ tool_call_id: {{ _eq: "{escaped_tool_call_id}" }} }},
+                input: {{ unclaimed_deadline_at: "{at}"{started_at}{deadline_at} }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "set tool unclaimed deadline failed: {:?}",
+        resp.errors
+    );
+}
+
+fn datetime_update_field(field: &str, value: Option<&str>) -> String {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .map(|value| format!(r#", {field}: "{}""#, escape_graphql_string(value)))
+        .unwrap_or_default()
+}
+
+async fn insert_inference_call(node: &EmbeddedNode, request_id: &str, call_state: &str) {
+    let call_id = format!("{request_id}-call");
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            add_InferenceCall(input: {{
+                call_id: "{call_id}",
+                runtime_instance_id: "runtime-recovery-test",
+                request_id: "{request_id}",
+                call_seq: 1,
+                backend_id: "{BACKEND_ID}",
+                behavior_id: "{AGENT_NAME}",
+                agent_did: "{AGENT_DID}",
+                call_kind: "inference",
+                attempt: 1,
+                call_state: "{call_state}",
+                queued_at: "{now}",
+                started_at: "{now}",
+                priority: 0,
+                queue_depth_at_enqueue: 0,
+                controller_generation: 0,
+                backend_config_fingerprint: "test"
+            }}) {{ _docID }}
+        }}"#,
+        call_id = escape_graphql_string(&call_id),
+        request_id = escape_graphql_string(request_id),
+        call_state = escape_graphql_string(call_state),
+        now = escape_graphql_string(&now),
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "insert inference call failed: {:?}",
+        resp.errors
+    );
+}
+
+#[derive(Debug, Deserialize)]
+struct RequestRecoveryRow {
+    lifecycle_state: String,
+}
+
+async fn fetch_request_recovery_row(node: &EmbeddedNode, request_id: &str) -> RequestRecoveryRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                lifecycle_state
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentRequest")
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseRecoveryRow {
+    status: String,
+}
+
+async fn fetch_response_recovery_row(node: &EmbeddedNode, request_id: &str) -> ResponseRecoveryRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                status
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentResponse")
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolRecoveryRow {
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    tool_failure_class: Option<String>,
+}
+
+async fn fetch_tool_recovery_row(node: &EmbeddedNode, tool_call_id: &str) -> ToolRecoveryRow {
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{tool_call_id}" }} }}, limit: 1) {{
+                status
+                lifecycle_state
+                tool_failure_class
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentToolCall")
+}
+
+#[derive(Debug, Deserialize)]
+struct InferenceRecoveryRow {
+    call_state: String,
+}
+
+async fn fetch_inference_recovery_row(
+    node: &EmbeddedNode,
+    request_id: &str,
+) -> InferenceRecoveryRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            InferenceCall(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                call_state
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "InferenceCall")
 }

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -259,11 +259,11 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_queue_deadline_cases_pin_r4a_contract_rows",
         },
         ConformanceConsumer::RustTest {
-            id: "state_machine_conformance::generated_recovery_sweep_cases_pin_startup_recovery_contract",
+            id: "state_machine_conformance::generated_recovery_sweep_cases_drive_startup_recovery_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
             module_path: "state_machine_conformance",
-            function: "generated_recovery_sweep_cases_pin_startup_recovery_contract",
+            function: "generated_recovery_sweep_cases_drive_startup_recovery_contract",
         },
         ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_r6_backgrounding_cases_pin_tool_backgrounding_contract",


### PR DESCRIPTION
## Summary
- add startup recovery for stale queued/running InferenceCall rows
- recover detached/background bridge rows with terminal children through tool-call recovery
- promote recovery_sweep_cases from a shape pin to a DB-backed runtime drive and update the Lean coverage ledger

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo fmt --all
- cargo check --workspace --all-targets --exclude agent-subagent-v2-to-v3-lens --exclude agent-tool-call-lifecycle-v1-to-v2-lens
- cargo test -p defra-agent --test state_machine_conformance generated_recovery_sweep_cases_drive_startup_recovery_contract -- --nocapture
- cargo test -p defra-agent --test r4_subagent_completion recovery_fails_running_background_bridge_after_parent_completes -- --nocapture
- cargo test -p defra-agent --lib --tests