### PR TITLE
Record defradb.rs P2P subscription persistence gap as Lean deviation (#166)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
@@ -6,8 +6,6 @@ import Proofs.Conformance.Boundaries
 This file is reserved for real unresolved mismatches between the Lean product
 specification and the Rust/DefraDB implementation.
 
-There are currently no known active spec deviations.
-
 Closed historical issues, intentional product policies, reserved vocabulary,
 and external storage/operational assumptions are documented in
 `Proofs.Conformance.Boundaries` instead of being listed as deviations.
@@ -47,6 +45,19 @@ def deviations : List Deviation :=
     , acceptedFailureMode := some "missed_subagent_spawn_observation_in_live_process"
     , acceptedFollowUp :=
         some "Track at #187 PR description; deadline-audit followup #5."
+    }
+  , { id := "defradb_rs_p2p_subscription_state_not_durable"
+    , domain := "reverse_pairing"
+    , subject := "DefraDB P2P subscription persistence"
+    , statement :=
+        "Reverse-pairing convergence assumes receiver-side P2P gossipsub " ++
+        "subscription state survives process restart. Go DefraDB persists that " ++
+        "state, but defradb.rs currently keeps iroh/libp2p subscription " ++
+        "registration in memory unless a higher-level path re-installs it."
+    , acceptedFailureMode :=
+        some "receiver_restart_drops_subscription_delivery_contract"
+    , acceptedFollowUp :=
+        some "Track upstream at sourcenetwork/defradb.rs#957; downstream at sourcenetwork/defra-agent#166."
     }
   ]
 

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -654,8 +654,11 @@ Current boundaries:
   failed mutations, stale reads/events, and minimum visibility paths. DefraDB
   storage-engine correctness remains external.
 
-`Proofs/Conformance/Deviations.lean` is now reserved only for real unresolved
-Rust/spec mismatches. There are currently no known active spec deviations.
+`Proofs/Conformance/Deviations.lean` is reserved only for real unresolved
+Rust/spec mismatches. Active deviations are expected to name an accepted failure
+mode or a follow-up tracker. Current entries cover live event-source rescan gaps
+and the defradb.rs durable P2P subscription-state gap tracked upstream at
+sourcenetwork/defradb.rs#957.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

- Adds a `Deviation` entry in `Proofs/Conformance/Deviations.lean` capturing the upstream defradb.rs in-memory gossipsub subscription state (vs. the Go DefraDB durable persistence behavior).
- Updates `proofs/README.md` so the deviations section no longer claims "no known active spec deviations" and points at the upstream tracker.

## Why

Surfaced from the reverse-pairing convergence work: receiver-side P2P subscription state in defradb.rs currently lives in memory unless a higher-level path re-installs it. That breaks the steady-state delivery contract assumed by the Lean spec on receiver restart.

- Upstream: sourcenetwork/defradb.rs#957
- Downstream tracker: #166

## Test plan

- [ ] `cd crates/defra-agent/proofs && lake build` succeeds locally