### PR TITLE
Lean: emit expected_external_state_after_abort for apply_reconcile_cases (#225)

### DIFF
--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -792,8 +792,8 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
 #[cfg(test)]
 mod lean_apply_write_boundary_tests {
     use super::lean_vocab_test::{
-        lean_apply_reconcile_cases, LeanApplyDesiredDoc, LeanApplyDocRef, LeanApplyReconcileCase,
-        LeanApplySelectedDoc,
+        lean_apply_reconcile_cases, LeanApplyDesiredDoc, LeanApplyDocRef, LeanApplyLiveDoc,
+        LeanApplyReconcileCase, LeanApplySelectedDoc,
     };
     use super::*;
     use axum::{extract::State, routing::post, Json, Router};
@@ -849,6 +849,15 @@ mod lean_apply_write_boundary_tests {
                 all.extend(writes.iter().cloned());
             }
             all
+        }
+
+        fn pending_state(&self) -> Vec<ObservedWrite> {
+            self.transactions
+                .lock()
+                .expect("tx lock")
+                .values()
+                .flat_map(|writes| writes.iter().cloned())
+                .collect()
         }
 
         fn tx_lifecycle_counts(&self) -> (u64, u64, u64) {
@@ -936,7 +945,13 @@ mod lean_apply_write_boundary_tests {
             );
 
             if case.prefix_len > 0 {
-                let (graphql, recorder) = start_recording_graphql().await;
+                let initial_external_state = case
+                    .pre_live
+                    .iter()
+                    .map(observed_write_from_lean_live_doc)
+                    .collect::<Vec<_>>();
+                let (graphql, recorder) =
+                    start_recording_graphql_with_committed_state(initial_external_state).await;
                 let access = ConfigAccess::Graphql(graphql);
 
                 // Begin a tx. The recorder hands out sequential numeric ids starting at 0;
@@ -954,6 +969,7 @@ mod lean_apply_write_boundary_tests {
                     case.prefix_len,
                     case.name,
                 );
+                let pending_after_failure = recorder.pending_state();
 
                 // discard errors are not under test here; the apply error path is what we're verifying.
                 let _ = txn.discard().await;
@@ -966,17 +982,22 @@ mod lean_apply_write_boundary_tests {
                     case.name,
                 );
 
-                assert!(
-                    recorder.committed_state().is_empty(),
-                    "failure path must leave externally-observed committed state empty (= pre_live) for Lean case {}",
+                let observed = recorder.committed_state();
+                let expected = case
+                    .expected_external_state_after_abort
+                    .iter()
+                    .map(observed_write_from_lean_live_doc)
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    observed, expected,
+                    "failure path must leave externally-observed committed state equal to Lean expected_external_state_after_abort for case {}",
                     case.name,
                 );
 
-                let observed = recorder.observed_writes();
                 assert!(
-                    observed.len() <= case.prefix_len,
+                    pending_after_failure.len() <= case.prefix_len,
                     "failure path observed {} writes; the batch containing the failing write must be rejected and writes after it must not happen — cap is prefix_len = {} for Lean case {}",
-                    observed.len(),
+                    pending_after_failure.len(),
                     case.prefix_len,
                     case.name,
                 );
@@ -1251,7 +1272,14 @@ mod lean_apply_write_boundary_tests {
     }
 
     async fn start_recording_graphql() -> (String, RecordingGraphqlState) {
+        start_recording_graphql_with_committed_state(Vec::new()).await
+    }
+
+    async fn start_recording_graphql_with_committed_state(
+        committed: Vec<ObservedWrite>,
+    ) -> (String, RecordingGraphqlState) {
         let state = RecordingGraphqlState::default();
+        *state.committed.lock().expect("committed lock") = committed;
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind recording GraphQL listener");
@@ -1744,6 +1772,13 @@ mod lean_apply_write_boundary_tests {
         ObservedWrite {
             collection,
             unique_value: doc.unique_value.clone(),
+        }
+    }
+
+    fn observed_write_from_lean_live_doc(doc: &LeanApplyLiveDoc) -> ObservedWrite {
+        ObservedWrite {
+            collection: collection_from_lean_name(&doc.collection),
+            unique_value: doc.id.clone(),
         }
     }
 

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -853,7 +853,9 @@ mod lean_apply_write_boundary_tests {
 
         /// Returns in-flight writes across open transactions only. This excludes
         /// committed state, so failure-path caps can measure per-tx writes after
-        /// an injected error and before discard removes the transaction.
+        /// an injected error and before discard removes the transaction. Callers
+        /// should use this when at most one transaction is open, or when an
+        /// aggregate across all open transactions is explicitly intended.
         fn pending_state(&self) -> Vec<ObservedWrite> {
             self.transactions
                 .lock()
@@ -988,7 +990,8 @@ mod lean_apply_write_boundary_tests {
                 let observed = recorder.committed_state();
                 // Today Lean emits `pre_live` here because apply has no live-write
                 // constructor; #57 can make this projection diverge without
-                // changing the Rust assertion shape.
+                // changing the Rust assertion shape. Lean's list order is the
+                // canonical order for this exact doc-for-doc comparison.
                 let expected = case
                     .expected_external_state_after_abort
                     .iter()

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -851,6 +851,9 @@ mod lean_apply_write_boundary_tests {
             all
         }
 
+        /// Returns in-flight writes across open transactions only. This excludes
+        /// committed state, so failure-path caps can measure per-tx writes after
+        /// an injected error and before discard removes the transaction.
         fn pending_state(&self) -> Vec<ObservedWrite> {
             self.transactions
                 .lock()
@@ -983,6 +986,9 @@ mod lean_apply_write_boundary_tests {
                 );
 
                 let observed = recorder.committed_state();
+                // Today Lean emits `pre_live` here because apply has no live-write
+                // constructor; #57 can make this projection diverge without
+                // changing the Rust assertion shape.
                 let expected = case
                     .expected_external_state_after_abort
                     .iter()

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
@@ -1,4 +1,5 @@
 import Proofs.ApplyReconcile.ContractCases.Types
+import Proofs.ApplyReconcile.Prefix
 
 /-! Diff, retry, and prefix projections for apply/reconcile contract cases. -/
 
@@ -121,6 +122,24 @@ def allProductionPrefixesReferrersClosed
     prefixReferrersClosed prefixDesired prefixSteps &&
       desiredReferencesClosed prefixDesired
 
+/-- Contract-case projection for externally visible state after an aborted
+    apply prefix. Today this is exactly `preLive`, mirroring the model
+    theorems `ApplyReconcile.applyPrefix_preserves_live` and
+    `ApplyReconcile.retry_after_prefix_preserves_live`: current apply steps
+    have no live-write/delete constructor. #57 should replace this helper
+    when external-state mutation semantics become non-trivial. -/
+def expectedExternalStateAfterAbort
+    (scenario : ApplyReconcileScenario) : List ContractLiveDoc :=
+  scenario.preLive
+
+/-- Semantic theorem behind `expectedExternalStateAfterAbort`: in the current
+    apply model, aborting any prefix leaves the external/live projection equal
+    to the state before the prefix. -/
+theorem abort_prefix_preserves_external_state
+    {M : Manifest} {L : LiveState} (p : ApplyPrefix M L) :
+    p.state.live = L.live :=
+  applyPrefix_preserves_live p
+
 def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   let steps := diffSteps scenario.manifest scenario.preDesired
   let productionSteps := productionOrderedSteps steps
@@ -135,7 +154,7 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   , manifest := scenario.manifest
   , preDesired := scenario.preDesired
   , preLive := scenario.preLive
-  , expected_external_state_after_abort := scenario.preLive
+  , expectedExternalStateAfterAbort := expectedExternalStateAfterAbort scenario
   , expectedCreate := diffCreate scenario
   , expectedUpdate := diffUpdate scenario
   , expectedUnchanged := diffUnchanged scenario
@@ -164,5 +183,14 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
       prefixReferrersClosed prefixDesired prefixSteps
   , desiredReferencesClosedAfterPrefix := desiredReferencesClosed prefixDesired
   }
+
+/-- Current finite witnesses expose the same external state after abort that
+    they started with. This theorem is intentionally small: it names the
+    current no-live-write coupling so #57 can update one projection point when
+    delete semantics introduce divergent abort expectations. -/
+theorem buildCase_expectedExternalStateAfterAbort_eq_preLive
+    (scenario : ApplyReconcileScenario) :
+    (buildCase scenario).expectedExternalStateAfterAbort = scenario.preLive := by
+  rfl
 
 end ApplyReconcile.ContractCases

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
@@ -135,6 +135,7 @@ def buildCase (scenario : ApplyReconcileScenario) : ApplyReconcileCase :=
   , manifest := scenario.manifest
   , preDesired := scenario.preDesired
   , preLive := scenario.preLive
+  , expected_external_state_after_abort := scenario.preLive
   , expectedCreate := diffCreate scenario
   , expectedUpdate := diffUpdate scenario
   , expectedUnchanged := diffUnchanged scenario

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Json.lean
@@ -63,6 +63,8 @@ def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
     ++ "\"manifest\":" ++ jsonArray (witness.manifest.map desiredDocJson) ++ ","
     ++ "\"pre_desired\":" ++ jsonArray (witness.preDesired.map desiredDocJson) ++ ","
     ++ "\"pre_live\":" ++ jsonArray (witness.preLive.map liveDocJson) ++ ","
+    ++ "\"expected_external_state_after_abort\":"
+      ++ jsonArray (witness.expected_external_state_after_abort.map liveDocJson) ++ ","
     ++ "\"expected_create\":"
       ++ jsonArray (witness.expectedCreate.map docRefJson) ++ ","
     ++ "\"expected_update\":"

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Json.lean
@@ -64,7 +64,7 @@ def applyReconcileCaseJson (witness : ApplyReconcileCase) : String :=
     ++ "\"pre_desired\":" ++ jsonArray (witness.preDesired.map desiredDocJson) ++ ","
     ++ "\"pre_live\":" ++ jsonArray (witness.preLive.map liveDocJson) ++ ","
     ++ "\"expected_external_state_after_abort\":"
-      ++ jsonArray (witness.expected_external_state_after_abort.map liveDocJson) ++ ","
+      ++ jsonArray (witness.expectedExternalStateAfterAbort.map liveDocJson) ++ ","
     ++ "\"expected_create\":"
       ++ jsonArray (witness.expectedCreate.map docRefJson) ++ ","
     ++ "\"expected_update\":"

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
@@ -49,7 +49,7 @@ structure ApplyReconcileCase where
   manifest : List ContractDoc
   preDesired : List ContractDoc
   preLive : List ContractLiveDoc
-  expected_external_state_after_abort : List ContractLiveDoc
+  expectedExternalStateAfterAbort : List ContractLiveDoc
   expectedCreate : List DocRef
   expectedUpdate : List DocRef
   expectedUnchanged : List DocRef

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
@@ -49,6 +49,7 @@ structure ApplyReconcileCase where
   manifest : List ContractDoc
   preDesired : List ContractDoc
   preLive : List ContractLiveDoc
+  expected_external_state_after_abort : List ContractLiveDoc
   expectedCreate : List DocRef
   expectedUpdate : List DocRef
   expectedUnchanged : List DocRef

--- a/crates/defra-agent/src/lean_vocab_test/triggers_runtime_apply.rs
+++ b/crates/defra-agent/src/lean_vocab_test/triggers_runtime_apply.rs
@@ -108,6 +108,7 @@ pub(crate) struct LeanApplyReconcileCase {
     pub(crate) manifest: Vec<LeanApplyDesiredDoc>,
     pub(crate) pre_desired: Vec<LeanApplyDesiredDoc>,
     pub(crate) pre_live: Vec<LeanApplyLiveDoc>,
+    pub(crate) expected_external_state_after_abort: Vec<LeanApplyLiveDoc>,
     pub(crate) expected_create: Vec<LeanApplyDocRef>,
     pub(crate) expected_update: Vec<LeanApplyDocRef>,
     pub(crate) expected_unchanged: Vec<LeanApplyDocRef>,


### PR DESCRIPTION
## Summary
- add Lean apply-reconcile expected_external_state_after_abort cases and JSON emission
- deserialize the new field in Rust contract fixtures
- assert the production failure path committed state against the Lean-emitted abort projection

## Verification
- cargo fmt --check
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent-cli
- cargo test -p defra-agent-cli lean_apply_write_boundary_tests