### PR TITLE
ToolCall: introduce CancelCause and tighten composition theorems (#153)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/Catalog.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/Catalog.lean
@@ -39,6 +39,7 @@ def vocabularies : List VocabularyContract :=
         ].map InferenceCallTerminalReason.toDefraDB
     }
   , { domain := "ToolCallState", values := toolCallStateNames }
+  , { domain := "CancelCause", values := toolCallCancelCauseNames }
   , { domain := "ManagedExecState", values := managedExecStateNames }
   , { domain := "ToolFailureClass", values := failureClassNames }
   , { domain := "ToolRetryDisposition", values := toolRetryDispositionNames }

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/ToolCall.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/ToolCall.lean
@@ -13,15 +13,25 @@ def toolCallStates : List ToolExecution.ToolCallState :=
 def toolCallStateNames : List String :=
   toolCallStates.map ToolExecution.ToolCallState.toDefraDB
 
+def toolCallCancelCauses : List ToolExecution.CancelCause :=
+  ToolExecution.CancelCause.all
+
+def toolCallCancelCauseNames : List String :=
+  toolCallCancelCauses.map ToolExecution.CancelCause.toDefraDB
+
+def toolCallCancelActions : List (String × ToolExecution.ToolCallContext.Action) :=
+  toolCallCancelCauses.flatMap fun cause =>
+    [ ("cancelBeforeDispatch_" ++ cause.toDefraDB, .cancelBeforeDispatch cause)
+    , ("cancelDuringRun_" ++ cause.toDefraDB, .cancelDuringRun cause)
+    ]
+
 def toolCallActions : List (String × ToolExecution.ToolCallContext.Action) :=
   [ ("dispatch", .dispatch)
   , ("spawnFailed_external", .spawnFailed .external)
   , ("complete", .complete)
   , ("fail_external", .fail .external)
   , ("timeout", .timeout)
-  , ("cancelBeforeDispatch", .cancelBeforeDispatch)
-  , ("cancelDuringRun", .cancelDuringRun)
-  ]
+  ] ++ toolCallCancelActions
 
 def toolCallWithState (state : ToolExecution.ToolCallState) : ToolExecution.ToolCallContext :=
   { callId := 1

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -110,6 +110,10 @@ def vocabularyCoverage : List CoverageEntry :=
       "tool_call_lifecycle::tests::rust_tool_call_state_vocabulary_matches_lean_model"
   , consumerCoverage
       "vocabulary"
+      "CancelCause"
+      "tool_call_lifecycle::tests::rust_cancel_cause_vocabulary_matches_lean_model"
+  , consumerCoverage
+      "vocabulary"
       "ManagedExecState"
       "managed_exec::tests::rust_managed_exec_state_vocabulary_matches_lean_model"
   , consumerCoverage

--- a/crates/defra-agent/proofs/Proofs/CrossMachineComposed/Foreground.lean
+++ b/crates/defra-agent/proofs/Proofs/CrossMachineComposed/Foreground.lean
@@ -152,12 +152,12 @@ theorem invFG_preserved
       intro h_post_p
       simp [hp, h_post] at h_post_p
       exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inr (Or.inl rfl))))
-    | cancelBeforeDispatch h_state h_post =>
+    | cancelBeforeDispatch _ h_state h_post =>
       refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
       intro h_post_p
       simp [hp, h_post] at h_post_p
       exact absurd h_post_p.2 (fun h => h (Or.inr (Or.inr (Or.inr rfl))))
-    | cancelDuringRun h_state h_post =>
+    | cancelDuringRun _ h_state h_post =>
       refine le_trans (length_filter_set_le p pre.tools idx toolPre toolPost h_idx ?_) h_inv
       intro h_post_p
       simp [hp, h_post] at h_post_p

--- a/crates/defra-agent/proofs/Proofs/CrossMachineComposed/ToolTermination.lean
+++ b/crates/defra-agent/proofs/Proofs/CrossMachineComposed/ToolTermination.lean
@@ -45,7 +45,12 @@ theorem interrupted_request_cancels_live_linked_call
   · exact InferenceCall.cancel_state pre.call
 
 
-/-- C2: An interrupted request cancels every live linked tool call. -/
+/-- C2: An interrupted request cancels every live linked tool call.
+
+The witness preserves the parent request and re-emits its `.interrupted`
+state before the tool-membership/cancelled/linkage facts. The inner tool
+transition is tagged with `CancelCause.interrupted`; a future composed
+`CauseCoherent` invariant can make that tag/state agreement global. -/
 theorem interrupted_request_cancels_live_linked_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
     (h_in           : toolPre ∈ pre.tools)
@@ -149,7 +154,11 @@ theorem deadline_exceeded_request_timesOut_running_tools
     .cancelled rather than .timedOut. The inner cancellation is tagged with
     `.deadline`, tying this composed path to the deadline hypothesis even
     though the single-machine pending-cancel transition itself has no deadline
-    guard. -/
+    guard.
+
+    The witness preserves the parent request and re-emits
+    `post.request.deadlineExceeded` before the tool-membership/cancelled/linkage
+    facts. -/
 theorem deadline_exceeded_request_cancels_pending_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
     (h_in        : toolPre ∈ pre.tools)

--- a/crates/defra-agent/proofs/Proofs/CrossMachineComposed/ToolTermination.lean
+++ b/crates/defra-agent/proofs/Proofs/CrossMachineComposed/ToolTermination.lean
@@ -49,11 +49,13 @@ theorem interrupted_request_cancels_live_linked_call
 theorem interrupted_request_cancels_live_linked_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
     (h_in           : toolPre ∈ pre.tools)
-    (h_interrupted  : pre.request.state = .interrupted)  -- documentary, tracked by #153
+    (h_interrupted  : pre.request.state = .interrupted)
     (h_live         : toolPre.cancellable)
     (h_coherent     : Coherent pre toolPre) :
     ∃ post toolPost,
       Trace pre post ∧
+      post.request = pre.request ∧
+      post.request.state = .interrupted ∧
       toolPost ∈ post.tools ∧
       toolPost.state = .cancelled ∧
       toolPost.requestId = pre.requestId := by
@@ -64,10 +66,10 @@ theorem interrupted_request_cancels_live_linked_tools
   | inl h_pending =>
     have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
                       { toolPre with state := .cancelled } :=
-      ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+      ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch .interrupted h_pending rfl
     let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
     let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
-    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    refine ⟨post, toolPost, ?_, rfl, h_interrupted, ?_, rfl, h_linked⟩
     · refine Trace.step ?_ Trace.refl
       -- Discharge the foreground-flip guard: `cancelBeforeDispatch` only changes
       -- `state`, so `toolPost.awaitMode = toolPre.awaitMode`. If `toolPre` is
@@ -81,10 +83,10 @@ theorem interrupted_request_cancels_live_linked_tools
   | inr h_running =>
     have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
                       { toolPre with state := .cancelled } :=
-      ToolExecution.ToolCallContext.Transition.cancelDuringRun h_running rfl
+      ToolExecution.ToolCallContext.Transition.cancelDuringRun .interrupted h_running rfl
     let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
     let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
-    refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+    refine ⟨post, toolPost, ?_, rfl, h_interrupted, ?_, rfl, h_linked⟩
     · refine Trace.step ?_ Trace.refl
       refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
               ⟨h_linked, h_deadline_eq, h_time_eq⟩
@@ -144,13 +146,10 @@ theorem deadline_exceeded_request_timesOut_running_tools
 
 /-- C1': A request whose deadline is exceeded cancels every Pending linked
     tool. Companion to C1 — a Pending tool never ran, so it reaches
-    .cancelled rather than .timedOut.
-
-    Note: `h_deadline` is documentary — `cancelBeforeDispatch` has no deadline
-    guard. The hypothesis captures the operational context (deadline-driven
-    cancellation path) rather than a proof-relevant constraint. Tracked under
-    issue #153 alongside C2/C3's documentary hypotheses for a future
-    CancelCause tightening pass. -/
+    .cancelled rather than .timedOut. The inner cancellation is tagged with
+    `.deadline`, tying this composed path to the deadline hypothesis even
+    though the single-machine pending-cancel transition itself has no deadline
+    guard. -/
 theorem deadline_exceeded_request_cancels_pending_tools
     {pre : ComposedState} {toolPre : ToolExecution.ToolCallContext}
     (h_in        : toolPre ∈ pre.tools)
@@ -159,6 +158,8 @@ theorem deadline_exceeded_request_cancels_pending_tools
     (h_coherent  : Coherent pre toolPre) :
     ∃ post toolPost,
       Trace pre post ∧
+      post.request = pre.request ∧
+      post.request.deadlineExceeded ∧
       toolPost ∈ post.tools ∧
       toolPost.state = .cancelled ∧
       toolPost.requestId = pre.requestId := by
@@ -167,10 +168,10 @@ theorem deadline_exceeded_request_cancels_pending_tools
   -- Inner cancelBeforeDispatch transition
   have h_t_step : ToolExecution.ToolCallContext.Transition toolPre
                     { toolPre with state := .cancelled } :=
-    ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch h_pending rfl
+    ToolExecution.ToolCallContext.Transition.cancelBeforeDispatch .deadline h_pending rfl
   let toolPost : ToolExecution.ToolCallContext := { toolPre with state := .cancelled }
   let post : ComposedState := { pre with tools := pre.tools.set idx toolPost }
-  refine ⟨post, toolPost, ?_, ?_, rfl, h_linked⟩
+  refine ⟨post, toolPost, ?_, rfl, h_deadline, ?_, rfl, h_linked⟩
   · refine Trace.step ?_ Trace.refl
     refine Transition.tool_step h_idx h_t_step rfl rfl rfl rfl rfl
             ⟨h_linked, h_deadline_eq, h_time_eq⟩
@@ -184,7 +185,11 @@ theorem deadline_exceeded_request_cancels_pending_tools
 /-- C3: A request whose linked tools are all terminal can resume making progress.
     Multi-flight form: ∀-quantified over `pre.tools`. Semantic complement of
     issue #149: when every linked tool is terminal, the foreground-blocking
-    guard on `request_step` is satisfied and the request can `advance`. -/
+    guard on `request_step` is satisfied and the request can `advance`.
+
+    This theorem performs no tool-call cancellation, so `CancelCause` has no
+    natural role here; future causal audit work should introduce a separate
+    progress-unblock witness rather than forcing a cancel cause into C3. -/
 theorem all_tools_terminal_unblocks_request_progress
     {pre : ComposedState}
     (h_all_terminal : ∀ t ∈ pre.tools, isTerminal t.state)

--- a/crates/defra-agent/proofs/Proofs/ToolExecution.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution.lean
@@ -1,4 +1,5 @@
 import Proofs.ToolExecution.Policy
+import Proofs.ToolExecution.CancelCause
 import Proofs.ToolExecution.State
 import Proofs.ToolExecution.Transition
 import Proofs.ToolExecution.Properties

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/CancelCause.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/CancelCause.lean
@@ -1,0 +1,43 @@
+import Proofs.Basic
+
+/-!
+# Tool Call Cancel Causes
+
+Daemon-visible vocabulary for why a tool call was cancelled. The cause is
+carried by cancellation transitions so cross-machine proofs can distinguish
+request-interruption, deadline, and explicit operator/user cancellation paths.
+-/
+
+namespace ToolExecution
+
+inductive CancelCause where
+  | interrupted
+  | deadline
+  | userCancelled
+  deriving DecidableEq, Repr
+
+namespace CancelCause
+
+def toDefraDB : CancelCause → String
+  | .interrupted => "interrupted"
+  | .deadline => "deadline"
+  | .userCancelled => "userCancelled"
+
+def fromDefraDB? : String → Option CancelCause
+  | "interrupted" => some .interrupted
+  | "deadline" => some .deadline
+  | "userCancelled" => some .userCancelled
+  | _ => none
+
+theorem fromDefraDB_toDefraDB (cause : CancelCause) :
+    fromDefraDB? cause.toDefraDB = some cause := by
+  cases cause <;> rfl
+
+def all : List CancelCause :=
+  [ .interrupted, .deadline, .userCancelled ]
+
+theorem all_complete (cause : CancelCause) : cause ∈ all := by
+  cases cause <;> simp [all]
+
+end CancelCause
+end ToolExecution

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
@@ -20,8 +20,8 @@ inductive Action where
   | complete
   | fail (failure : FailureClass)
   | timeout
-  | cancelBeforeDispatch
-  | cancelDuringRun
+  | cancelBeforeDispatch (cause : CancelCause)
+  | cancelDuringRun (cause : CancelCause)
   deriving DecidableEq, Repr
 
 /-- Executable transition function for the tool-call layer. -/
@@ -51,12 +51,12 @@ def step? (pre : ToolCallContext) : Action → Option ToolCallContext
         some { pre with state := .timedOut }
       else
         none
-  | .cancelBeforeDispatch =>
+  | .cancelBeforeDispatch _ =>
       if pre.state = .pending then
         some { pre with state := .cancelled }
       else
         none
-  | .cancelDuringRun =>
+  | .cancelDuringRun _ =>
       if pre.state = .running then
         some { pre with state := .cancelled }
       else
@@ -88,14 +88,14 @@ theorem step_refines_transition
       simp [step?] at h_step
       rcases h_step with ⟨⟨h_state, h_deadline⟩, h_post⟩
       exact Transition.timeout (h_state := h_state) (h_deadline := h_deadline) (h_post := h_post.symm)
-  | cancelBeforeDispatch =>
+  | cancelBeforeDispatch cause =>
       simp [step?] at h_step
       rcases h_step with ⟨h_state, h_post⟩
-      exact Transition.cancelBeforeDispatch (h_state := h_state) (h_post := h_post.symm)
-  | cancelDuringRun =>
+      exact Transition.cancelBeforeDispatch cause (h_state := h_state) (h_post := h_post.symm)
+  | cancelDuringRun cause =>
       simp [step?] at h_step
       rcases h_step with ⟨h_state, h_post⟩
-      exact Transition.cancelDuringRun (h_state := h_state) (h_post := h_post.symm)
+      exact Transition.cancelDuringRun cause (h_state := h_state) (h_post := h_post.symm)
 
 end ToolCallContext
 end ToolExecution

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Executable.lean
@@ -13,7 +13,11 @@ namespace ToolCallContext
 /-- Executable tool-call actions mirroring the state-changing constructors of
     `Transition`. The two non-state constructors (`timeAdvance`,
     `persistenceStep`) are not exposed here; they are internal to trace
-    construction in liveness proofs. -/
+    construction in liveness proofs.
+
+    Cancel causes are transition metadata: `step?` returns the same post-state
+    for each cause, while `step_refines_transition` carries the selected cause
+    into the relational witness. -/
 inductive Action where
   | dispatch
   | spawnFailed (failure : FailureClass)

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Properties.lean
@@ -23,8 +23,8 @@ theorem terminal_irreversible
   | complete h_state _ _ _          => simp_all [isTerminal]
   | fail _ h_state _                => simp_all [isTerminal]
   | timeout h_state _ _             => simp_all [isTerminal]
-  | cancelBeforeDispatch h_state _  => simp_all [isTerminal]
-  | cancelDuringRun h_state _       => simp_all [isTerminal]
+  | cancelBeforeDispatch _ h_state _ => simp_all [isTerminal]
+  | cancelDuringRun _ h_state _      => simp_all [isTerminal]
   | background h_state _ _          => simp_all [isTerminal]
   | foreground h_state _ _          => simp_all [isTerminal]
   | detach h_live _ _               => simp_all [isTerminal]
@@ -56,8 +56,8 @@ theorem timedOut_requires_deadline_exceeded
   | complete _ _ _ h_post'          => simp_all
   | fail _ _ h_post'                => simp_all
   | timeout _ h_deadline _          => exact h_deadline
-  | cancelBeforeDispatch _ h_post'  => simp_all
-  | cancelDuringRun _ h_post'       => simp_all
+  | cancelBeforeDispatch _ _ h_post' => simp_all
+  | cancelDuringRun _ _ h_post'      => simp_all
   | background _ _ h_post'          => simp_all
   | foreground _ _ h_post'          => simp_all
   | detach _ _ h_post'              => simp_all
@@ -79,8 +79,8 @@ theorem completed_implies_committed
   | complete _ h_persist _ h_post'  => simp_all
   | fail _ _ h_post'                => simp_all
   | timeout _ _ h_post'             => simp_all
-  | cancelBeforeDispatch _ h_post'  => simp_all
-  | cancelDuringRun _ h_post'       => simp_all
+  | cancelBeforeDispatch _ _ h_post' => simp_all
+  | cancelDuringRun _ _ h_post'      => simp_all
   | background _ _ h_post'          => simp_all
   | foreground _ _ h_post'          => simp_all
   | detach _ _ h_post'              => simp_all
@@ -102,7 +102,7 @@ theorem live_call_reaches_terminal
   | .pending =>
       let post : ToolCallContext := { c with state := .cancelled }
       have h_trans : Transition c post :=
-        Transition.cancelBeforeDispatch (h_state := h_state) (h_post := rfl)
+        Transition.cancelBeforeDispatch .userCancelled (h_state := h_state) (h_post := rfl)
       exact ⟨post, Trace.step h_trans Trace.refl, Or.inr (Or.inr (Or.inr rfl))⟩
   | .running =>
       -- If deadline is already exceeded, timeout in 1 step; otherwise advance time first.
@@ -150,8 +150,8 @@ theorem transition_preserves_requestId
   | complete _ _ _ h_post          => rw [h_post]
   | fail _ _ h_post                => rw [h_post]
   | timeout _ _ h_post             => rw [h_post]
-  | cancelBeforeDispatch _ h_post  => rw [h_post]
-  | cancelDuringRun _ h_post       => rw [h_post]
+  | cancelBeforeDispatch _ _ h_post => rw [h_post]
+  | cancelDuringRun _ _ h_post      => rw [h_post]
   | background _ _ h_post          => rw [h_post]
   | foreground _ _ h_post          => rw [h_post]
   | detach _ _ h_post              => rw [h_post]
@@ -172,8 +172,8 @@ theorem transition_preserves_callId
   | complete _ _ _ h_post          => rw [h_post]
   | fail _ _ h_post                => rw [h_post]
   | timeout _ _ h_post             => rw [h_post]
-  | cancelBeforeDispatch _ h_post  => rw [h_post]
-  | cancelDuringRun _ h_post       => rw [h_post]
+  | cancelBeforeDispatch _ _ h_post => rw [h_post]
+  | cancelDuringRun _ _ h_post      => rw [h_post]
   | background _ _ h_post          => rw [h_post]
   | foreground _ _ h_post          => rw [h_post]
   | detach _ _ h_post              => rw [h_post]
@@ -193,8 +193,8 @@ theorem dispatch_sets_startedAt
   | complete h_state _ _ h_post'    => exfalso; simp_all
   | fail _ h_state h_post'           => exfalso; simp_all
   | timeout h_state _ h_post'       => exfalso; simp_all
-  | cancelBeforeDispatch _ h_post'  => exfalso; rw [h_post'] at h_post; simp at h_post
-  | cancelDuringRun h_state h_post' => exfalso; simp_all
+  | cancelBeforeDispatch _ _ h_post' => exfalso; rw [h_post'] at h_post; simp at h_post
+  | cancelDuringRun _ h_state h_post' => exfalso; simp_all
   | background h_state _ h_post'    => exfalso; simp_all
   | foreground h_state _ h_post'    => exfalso; simp_all
   | detach h_live _ h_post'         => exfalso; rw [h_post'] at h_post; simp_all
@@ -217,8 +217,8 @@ theorem startedAt_preserved_outside_dispatch
   | complete _ _ _ h_post'          => rw [h_post']
   | fail _ _ h_post'                => rw [h_post']
   | timeout _ _ h_post'             => rw [h_post']
-  | cancelBeforeDispatch _ h_post'  => rw [h_post']
-  | cancelDuringRun _ h_post'       => rw [h_post']
+  | cancelBeforeDispatch _ _ h_post' => rw [h_post']
+  | cancelDuringRun _ _ h_post'      => rw [h_post']
   | background _ _ h_post'          => rw [h_post']
   | foreground _ _ h_post'          => rw [h_post']
   | detach _ _ h_post'              => rw [h_post']

--- a/crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/ToolExecution/Transition.lean
@@ -1,3 +1,4 @@
+import Proofs.ToolExecution.CancelCause
 import Proofs.ToolExecution.State
 
 /-!
@@ -44,12 +45,12 @@ inductive Transition : ToolCallContext → ToolCallContext → Prop where
       (h_post     : post = { pre with state := .timedOut })
       : Transition pre post
 
-  | cancelBeforeDispatch {pre post : ToolCallContext}
+  | cancelBeforeDispatch {pre post : ToolCallContext} (cause : CancelCause)
       (h_state : pre.state = .pending)
       (h_post  : post = { pre with state := .cancelled })
       : Transition pre post
 
-  | cancelDuringRun {pre post : ToolCallContext}
+  | cancelDuringRun {pre post : ToolCallContext} (cause : CancelCause)
       (h_state : pre.state = .running)
       (h_post  : post = { pre with state := .cancelled })
       : Transition pre post

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -168,6 +168,39 @@ impl CancelPolicy {
     pub const ALL: &'static [CancelPolicy] = &[CancelPolicy::Cascade, CancelPolicy::Detach];
 }
 
+/// Why a tool-call cancellation was requested at the state-machine boundary.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum CancelCause {
+    Interrupted,
+    Deadline,
+    UserCancelled,
+}
+
+impl CancelCause {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CancelCause::Interrupted => "interrupted",
+            CancelCause::Deadline => "deadline",
+            CancelCause::UserCancelled => "userCancelled",
+        }
+    }
+
+    pub fn from_persisted(s: &str) -> Option<Self> {
+        match s {
+            "interrupted" => Some(CancelCause::Interrupted),
+            "deadline" => Some(CancelCause::Deadline),
+            "userCancelled" => Some(CancelCause::UserCancelled),
+            _ => None,
+        }
+    }
+
+    pub const ALL: &'static [CancelCause] = &[
+        CancelCause::Interrupted,
+        CancelCause::Deadline,
+        CancelCause::UserCancelled,
+    ];
+}
+
 /// The four non-.completed terminal states a child AgentRequest can reach.
 /// Used as the argument shape to bridge_failure to project the child terminal
 /// onto a parent ToolCallState (.failed for most, .cancelled for .interrupted).
@@ -502,6 +535,20 @@ mod tests {
     }
 
     #[test]
+    fn rust_cancel_cause_vocabulary_matches_lean_model() {
+        let rust_causes = CancelCause::ALL
+            .iter()
+            .copied()
+            .map(CancelCause::as_str)
+            .collect::<Vec<_>>();
+        assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
+            domain: "CancelCause",
+            rust_source: "CancelCause::ALL",
+            rust_values: &rust_causes,
+        });
+    }
+
+    #[test]
     fn rust_failure_class_vocabulary_matches_lean_model() {
         let rust_classes = FailureClass::ALL
             .iter()
@@ -576,6 +623,23 @@ mod bucket_1_subagent_vocabulary {
     #[test]
     fn cancel_policy_from_persisted_unknown_returns_none() {
         assert_eq!(CancelPolicy::from_persisted("unknown"), None);
+    }
+
+    #[test]
+    fn cancel_cause_round_trip_via_persisted_vocab() {
+        for &cause in CancelCause::ALL {
+            assert_eq!(CancelCause::from_persisted(cause.as_str()), Some(cause));
+        }
+    }
+
+    #[test]
+    fn cancel_cause_all_has_three_variants() {
+        assert_eq!(CancelCause::ALL.len(), 3);
+    }
+
+    #[test]
+    fn cancel_cause_from_persisted_unknown_returns_none() {
+        assert_eq!(CancelCause::from_persisted("unknown"), None);
     }
 
     #[test]

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -169,6 +169,9 @@ impl CancelPolicy {
 }
 
 /// Why a tool-call cancellation was requested at the state-machine boundary.
+///
+/// This is mirrored from Lean for conformance first. Runtime methods still
+/// need to accept and persist it on AgentToolCall; tracked by #249.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CancelCause {
     Interrupted,

--- a/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
@@ -302,6 +302,8 @@ impl ToolCallLifecycle {
         &mut self,
         remote_cancel_intent_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<()> {
+        // TODO(#249): accept and persist `CancelCause` once AgentToolCall has
+        // a cancel_cause field.
         self.ensure_state(&[ToolCallState::Running], "cancel_during_run")?;
 
         let doc_id = self.doc_id.as_ref().ok_or_else(|| {

--- a/crates/defra-agent/src/tool_call_lifecycle/transition/native.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition/native.rs
@@ -310,6 +310,9 @@ impl ToolCallLifecycle {
 
     /// Pending → Cancelled. Used when a tool call is cancelled before
     /// dispatch creates a running row.
+    ///
+    /// TODO(#249): accept and persist `CancelCause` once AgentToolCall has a
+    /// cancel_cause field.
     pub async fn cancel_before_dispatch(&mut self) -> Result<()> {
         self.ensure_state(&[ToolCallState::Pending], "cancel_before_dispatch")?;
 

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -210,6 +210,11 @@ fn lean_emits_child_terminal_vocabulary_and_projections() {
 }
 
 #[test]
+fn lean_tool_call_cancel_actions_name_cancel_cause() {
+    tool_call::lean_tool_call_cancel_actions_name_cancel_cause();
+}
+
+#[test]
 fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts() {
     tooling_slots_queue_command::generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
     );

--- a/crates/defra-agent/tests/state_machine_conformance/tool_call.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/tool_call.rs
@@ -123,6 +123,33 @@ pub(super) fn lean_emits_child_terminal_vocabulary_and_projections() {
 }
 
 #[test]
+pub(super) fn lean_tool_call_cancel_actions_name_cancel_cause() {
+    let machine = lean_state_machine_contract("ToolCall");
+    let causes = lean_vocabulary_values("CancelCause");
+
+    for cause in causes {
+        let before = format!("cancelBeforeDispatch_{cause}");
+        let during = format!("cancelDuringRun_{cause}");
+        assert!(
+            machine.actions.iter().any(|action| action == &before),
+            "ToolCall actions must include cause-qualified action {before:?}"
+        );
+        assert!(
+            machine.actions.iter().any(|action| action == &during),
+            "ToolCall actions must include cause-qualified action {during:?}"
+        );
+    }
+
+    assert!(
+        !machine
+            .actions
+            .iter()
+            .any(|action| action == "cancelBeforeDispatch" || action == "cancelDuringRun"),
+        "ToolCall cancel actions must name the CancelCause vocabulary string"
+    );
+}
+
+#[test]
 fn lean_emits_bridge_transitions_in_tool_call_machine() {
     let machine = lean_state_machine_contract("ToolCall");
     let bridge_names: Vec<&str> = vec![

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -420,6 +420,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "rust_tool_call_state_vocabulary_matches_lean_model",
         },
         ConformanceConsumer::RustTest {
+            id: "tool_call_lifecycle::tests::rust_cancel_cause_vocabulary_matches_lean_model",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/tool_call_lifecycle.rs",
+            module_path: "tool_call_lifecycle::tests",
+            function: "rust_cancel_cause_vocabulary_matches_lean_model",
+        },
+        ConformanceConsumer::RustTest {
             id: "tool_call_lifecycle::tests::rust_failure_class_vocabulary_matches_lean_model",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/tool_call_lifecycle.rs",


### PR DESCRIPTION
## Summary
- Add Lean ToolExecution.CancelCause vocabulary with DefraDB round-trip support.
- Thread CancelCause through ToolCall cancel transitions, executable actions, and downstream composed proofs.
- Expose CancelCause through the conformance bridge and add Rust vocabulary/action coverage.
- Document the staged runtime/persistence follow-up in #249.

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent --lib tool_call_lifecycle