### PR TITLE
Issue #149 R3: define soak closeout gate for native tool preemptibility (#235)

### DIFF
--- a/crates/defra-agent/src/managed_exec/tests.rs
+++ b/crates/defra-agent/src/managed_exec/tests.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use tokio_util::sync::CancellationToken;
@@ -35,20 +35,47 @@ fn managed_exec_state_machine_contract_is_complete() {
 #[cfg(unix)]
 #[tokio::test]
 async fn managed_exec_deadline_kills_process_group() {
-    let outcome = run_managed_exec(ManagedExecRequest {
-        argv: vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            "echo started; trap '' TERM; sleep 5".to_string(),
-        ],
-        cwd: PathBuf::from("/"),
-        deadline_at: Some(Utc::now() + chrono::Duration::milliseconds(30)),
-        cancellation_token: CancellationToken::new(),
-        max_output_bytes: 1024,
-        stdin: Vec::new(),
-        tool_name: Some("test".to_string()),
-    })
-    .await;
+    let tool_name = "r3-soak-blocker";
+    let handle = tokio::spawn(async move {
+        run_managed_exec(ManagedExecRequest {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "echo started; trap '' TERM; sleep 5".to_string(),
+            ],
+            cwd: PathBuf::from("/"),
+            deadline_at: Some(Utc::now() + chrono::Duration::milliseconds(500)),
+            cancellation_token: CancellationToken::new(),
+            max_output_bytes: 1024,
+            stdin: Vec::new(),
+            tool_name: Some(tool_name.to_string()),
+        })
+        .await
+    });
+
+    let snapshot = wait_for_native_executor(tool_name).await;
+    assert!(snapshot.pid > 0, "active executor snapshot must expose pid");
+    assert_eq!(snapshot.tool_name.as_deref(), Some(tool_name));
+    assert!(
+        snapshot.argv0.ends_with("sh"),
+        "active executor snapshot must expose argv0, got {:?}",
+        snapshot.argv0
+    );
+    chrono::DateTime::parse_from_rfc3339(&snapshot.started_at)
+        .expect("active executor snapshot must expose RFC3339 started_at");
+    let snapshot_id = snapshot.id;
+    let first_age = snapshot.age_ms;
+    tokio::time::sleep(Duration::from_millis(25)).await;
+    let aged_snapshot = crate::active_native_executors()
+        .into_iter()
+        .find(|snapshot| snapshot.id == snapshot_id)
+        .expect("executor should remain visible before deadline");
+    assert!(
+        aged_snapshot.age_ms >= first_age,
+        "executor age must not move backwards"
+    );
+
+    let outcome = handle.await.expect("managed exec task should join");
 
     match outcome {
         ManagedExecOutcome::TimedOut { stdout, kill, .. } => {
@@ -59,7 +86,32 @@ async fn managed_exec_deadline_kills_process_group() {
         }
         other => panic!("expected timeout outcome, got {other:?}"),
     }
-    assert!(active_executor_snapshots().is_empty());
+    assert!(
+        crate::active_native_executors()
+            .into_iter()
+            .all(|snapshot| snapshot.tool_name.as_deref() != Some(tool_name)),
+        "timed-out native executor snapshot must clear after reap"
+    );
+
+    let next = run_managed_exec(ManagedExecRequest {
+        argv: vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            "printf next".to_string(),
+        ],
+        cwd: PathBuf::from("/"),
+        deadline_at: Some(Utc::now() + chrono::Duration::seconds(1)),
+        cancellation_token: CancellationToken::new(),
+        max_output_bytes: 1024,
+        stdin: Vec::new(),
+        tool_name: Some("r3-soak-next".to_string()),
+    })
+    .await;
+
+    match next {
+        ManagedExecOutcome::Exited { stdout, .. } => assert_eq!(stdout, b"next"),
+        other => panic!("expected next managed exec to run after timeout, got {other:?}"),
+    }
 }
 
 #[cfg(unix)]
@@ -96,6 +148,23 @@ async fn managed_exec_cancellation_kills_process_group() {
             assert!(kill.reaped);
         }
         other => panic!("expected cancelled outcome, got {other:?}"),
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_native_executor(tool_name: &str) -> crate::NativeExecutorStatus {
+    let timeout_at = Instant::now() + Duration::from_millis(200);
+    loop {
+        if let Some(snapshot) = crate::active_native_executors()
+            .into_iter()
+            .find(|snapshot| snapshot.tool_name.as_deref() == Some(tool_name))
+        {
+            return snapshot;
+        }
+        if Instant::now() >= timeout_at {
+            panic!("timed out waiting for active native executor snapshot for {tool_name}");
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
     }
 }
 

--- a/crates/defra-agent/src/managed_exec/tests.rs
+++ b/crates/defra-agent/src/managed_exec/tests.rs
@@ -56,11 +56,7 @@ async fn managed_exec_deadline_kills_process_group() {
     let snapshot = wait_for_native_executor(tool_name).await;
     assert!(snapshot.pid > 0, "active executor snapshot must expose pid");
     assert_eq!(snapshot.tool_name.as_deref(), Some(tool_name));
-    assert!(
-        snapshot.argv0.ends_with("sh"),
-        "active executor snapshot must expose argv0, got {:?}",
-        snapshot.argv0
-    );
+    assert_eq!(snapshot.argv0, "/bin/sh");
     chrono::DateTime::parse_from_rfc3339(&snapshot.started_at)
         .expect("active executor snapshot must expose RFC3339 started_at");
     let snapshot_id = snapshot.id;
@@ -117,6 +113,7 @@ async fn managed_exec_deadline_kills_process_group() {
 #[cfg(unix)]
 #[tokio::test]
 async fn managed_exec_cancellation_kills_process_group() {
+    let tool_name = "r3-cancel-blocker";
     let token = CancellationToken::new();
     let child_token = token.clone();
     let handle = tokio::spawn(async move {
@@ -131,15 +128,12 @@ async fn managed_exec_cancellation_kills_process_group() {
             cancellation_token: child_token,
             max_output_bytes: 1024,
             stdin: Vec::new(),
-            tool_name: Some("test".to_string()),
+            tool_name: Some(tool_name.to_string()),
         })
         .await
     });
-    tokio::time::sleep(Duration::from_millis(20)).await;
-    assert!(
-        !active_executor_snapshots().is_empty(),
-        "executor should be visible while child is running"
-    );
+    let snapshot = wait_for_native_executor(tool_name).await;
+    assert!(snapshot.pid > 0, "active executor snapshot must expose pid");
     token.cancel();
 
     match handle.await.expect("managed exec task should join") {

--- a/docs/superpowers/specs/2026-05-19-issue-149-r3-soak-closeout-gate.md
+++ b/docs/superpowers/specs/2026-05-19-issue-149-r3-soak-closeout-gate.md
@@ -1,0 +1,133 @@
+# Issue #149 R3 Soak Closeout Gate
+
+Status: proposed closeout gate
+Date: 2026-05-19
+Tracking: #149, #235
+Design reference: `docs/superpowers/specs/2026-05-18-issue-149-native-tool-preemptibility-design.md`
+
+This gate defines the operational evidence required before #149/R3 is treated
+as closed in production. It does not replace the design spec; it is the replay
+and evidence checklist for the native filesystem preemptibility fix.
+
+## Replay Shape
+
+Run the replay on a Unix deployment. Windows process-tree termination remains
+out of scope for this gate and is tracked by #236.
+
+The blocking request must use a native filesystem traversal tool routed through
+the native runner: `glob`, `list_files`, or `grep`. `glob` is the preferred
+replay because it matches the original #149 stall shape. The target must be a
+directory tree that takes longer than the request deadline to traverse. In local
+regression tests, the deterministic substitute is
+`DEFRA_NATIVE_FS_RUNNER_BLOCK_DIR` plus `DEFRA_NATIVE_FS_RUNNER_BLOCK_MS`, with
+the block duration longer than the request deadline.
+
+The runtime must be configured as a single-worker deployment:
+`max_concurrent = 1`. Submit:
+
+1. A first `AgentRequest` that invokes the blocking native filesystem tool with
+   a tight deadline.
+2. A second `AgentRequest` queued behind it, using any quick tool or prompt that
+   proves the worker advances after the first request times out.
+
+While the blocker is in flight, poll `/status`, `/healthz`, and Prometheus often
+enough to capture the active request/tool/executor window. If the timeout path
+is too fast to sample manually, rerun with a deterministic blocker that survives
+long enough to capture the degraded sample; missing observability evidence is
+not closure evidence.
+
+## Required Assertions
+
+- No `AgentToolCall` row remains `running` or legacy `called` after its
+  deadline plus the bounded timeout/kill window.
+- No `AgentRequest` row remains `processing` after its deadline plus the bounded
+  timeout/kill window.
+- The single-worker queue picks up the second request without a daemon restart.
+- `/healthz` reports `status = degraded` while
+  `expired_processing_count > 0`, then returns to `ok` after timeout recovery.
+- `/status` exposes the active request, active tool call, active native
+  executor, and executor age while the blocker is in flight.
+- Prometheus exposes the same liveness shape through
+  `defra_agent_expired_processing_count`,
+  `defra_agent_active_tool_calls`, and
+  `defra_agent_active_native_executors`.
+
+The row assertions are the closure boundary. Health/status/metrics are the
+operator visibility boundary that prevents a future #149-style stall from being
+silent.
+
+## Automated Regression Coverage
+
+The checked-in CI gate is intentionally unit-level plus deterministic native
+runner replay, not a full live DefraDB/HTTP soak harness.
+
+- `crates/defra-agent/src/toolset/tests.rs`:
+  `native_filesystem_deadline_preempts_single_poll_blocker_and_advances_queue`
+  runs `glob` through `defra-native-fs-runner`, blocks traversal longer than
+  the request deadline, asserts the managed timeout marker, and proves the next
+  queued tool can run before the blocker duration elapses.
+- `crates/defra-agent/src/managed_exec/tests.rs`:
+  `managed_exec_deadline_kills_process_group` proves the process-group kill
+  path, active native executor snapshot fields (`pid`, tool name, `argv0`,
+  `started_at`, age), snapshot cleanup after reap, and successful execution of
+  a second managed process after the timeout.
+- `crates/defra-agent-cli/src/http/liveness.rs` and `healthz.rs` cover
+  `expired_processing_count`, active tool-call liveness, and `/healthz`
+  degradation from expired processing rows.
+
+This split is sufficient for CI because it pins the native runner boundary, the
+managed-exec preemption boundary, and the HTTP liveness projection separately.
+The full DB/HTTP queue proof is required as soak evidence below rather than as a
+slow ignored integration test in this repository.
+
+Local verification command:
+
+```bash
+cargo test -p defra-agent native_filesystem_deadline_preempts_single_poll_blocker_and_advances_queue
+cargo test -p defra-agent managed_exec_deadline_kills_process_group
+```
+
+When changing the HTTP liveness surface, also run:
+
+```bash
+cargo test -p defra-agent-cli healthz_reports_degraded_when_expired_processing_count_positive
+```
+
+## Evidence Required For Closure
+
+Before the controller treats #149/R3 as operationally closed, attach these
+artifacts to the closeout thread or PR:
+
+- A green CI run that includes `cd crates/defra-agent/proofs && lake build`,
+  `cargo check -p defra-agent`, and `cargo test -p defra-agent`.
+- A documented Unix soak replay with the exact request IDs, tool call IDs,
+  deadlines, and the single-worker backend configuration.
+- DefraDB row snapshots before, during, and after the blocker showing the
+  blocking `AgentToolCall` and `AgentRequest` become terminal and do not remain
+  `running`/`called` or `processing` past the bounded timeout window.
+- `/healthz` payloads showing degraded while
+  `expired_processing_count > 0` and recovery to `ok`.
+- `/status` payloads showing the active request, active tool call, active native
+  executor, and executor age while the blocker is in flight.
+- A Prometheus snapshot covering
+  `defra_agent_expired_processing_count`,
+  `defra_agent_active_tool_calls`, and
+  `defra_agent_active_native_executors`.
+- Daemon logs, if available, showing timeout classification and managed-exec
+  kill/reap completion without a daemon restart.
+
+## Acceptance: What Re-Opens #149
+
+Re-open #149, or file a direct regression child linked to #149, if any later
+soak run shows one of these failures on Unix:
+
+- A native filesystem `glob`, `list_files`, or `grep` call remains
+  `running`/`called` past the bounded timeout window.
+- An `AgentRequest` remains `processing` past the bounded timeout window.
+- A single-worker queue requires daemon restart before the next request runs.
+- `/healthz` stays `ok` while expired processing work is visible.
+- `/status` or Prometheus no longer expose the active native executor and age
+  during the blocking window.
+
+Operational closure means this replay is covered and observable. It does not
+mean the bug class can never regress.


### PR DESCRIPTION
## Summary
- Add the #149/R3 Unix soak closeout gate document with replay shape, assertions, evidence, and reopen criteria.
- Extend the managed-exec deadline regression test to assert active native executor observability, timeout cleanup, and post-timeout executor reuse.

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent
- cargo test -p defra-agent native_filesystem_deadline_preempts_single_poll_blocker_and_advances_queue
- cargo test -p defra-agent managed_exec_deadline_kills_process_group
- cargo test -p defra-agent-cli healthz_reports_degraded_when_expired_processing_count_positive