### PR TITLE
Release: add keychain-access-groups entitlement for Secure Enclave (#245)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -325,6 +325,13 @@ jobs:
               exit 1
             fi
 
+            entitlements_output="$(codesign -d --entitlements - "${binary_path}" 2>&1)"
+            printf '%s\n' "${entitlements_output}"
+            if ! grep -q 'keychain-access-groups' <<< "${entitlements_output}"; then
+              echo "::error::Signed release artifact missing keychain-access-groups entitlement."
+              exit 1
+            fi
+
             spctl_required="${REQUIRE_SPCTL_VAR:-false}"
             if [[ "${spctl_required}" == "true" ]]; then
               spctl --assess --type execute --verbose=4 "${binary_path}"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -251,11 +251,20 @@ jobs:
           keychain_path="${SIGNING_KEYCHAIN}"
           signing_identity="${SIGNING_IDENTITY_NAME}"
           timestamp_mode="${TIMESTAMP_MODE_INPUT:-${TIMESTAMP_MODE_VAR:-auto}}"
+          apple_team_id="$(sed -nE 's/^.*\(([A-Za-z0-9]+)\)$/\1/p' <<< "${signing_identity}" | tail -n 1)"
+          entitlements_path="${RUNNER_TEMP}/entitlements.rendered.plist"
 
           if [[ -z "${keychain_path}" || -z "${signing_identity}" ]]; then
             echo "::error::Native signing keychain preflight did not provide SIGNING_KEYCHAIN/SIGNING_IDENTITY_NAME."
             exit 1
           fi
+          if [[ -z "${apple_team_id}" ]]; then
+            echo "::error::Could not extract Apple Team ID from SIGNING_IDENTITY_NAME '${signing_identity}'."
+            exit 1
+          fi
+          sed "s/__APPLE_TEAM_ID__/${apple_team_id}/g" release/entitlements.plist > "${entitlements_path}"
+          plutil -lint "${entitlements_path}"
+
           security unlock-keychain -p "${MACOS_CODESIGN_KEYCHAIN_PASSWORD}" "${keychain_path}"
           echo "Signing with native macOS identity from ${keychain_path}."
 
@@ -265,6 +274,8 @@ jobs:
               --force \
               --sign "${signing_identity}" \
               --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
+              --options runtime \
+              --entitlements "${entitlements_path}" \
               "${timestamp_arg}" \
               "${binary_path}"
           }

--- a/release/entitlements.plist
+++ b/release/entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>keychain-access-groups</key>
+    <array>
+        <string>__APPLE_TEAM_ID__.org.sourcenetwork.defra-agent</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Adds release/entitlements.plist with the keychain-access-groups access group rendered from the Apple Team ID.
- Passes the rendered entitlements and explicit hardened runtime through the production macOS codesign step.
- Verifies the signed release artifact includes keychain-access-groups.

## Notes
- Needed for the macos-secure-enclave identity backend to function.
- The actual proof-of-fix requires a tagged release; this PR only updates the workflow.
- Recommend validating post-merge with a tag such as v0.1.6-rc1.

Fixes #245.