### PR TITLE
EventDelivery: demote simulator-backed ledger rows to followUpCoverage

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -331,18 +331,28 @@ def caseCoverage : List CoverageEntry :=
       "compaction_reducer_cases"
       "CompactionReducerCases"
       "state_machine_conformance::generated_compaction_reducer_cases_pin_contract"
-  , consumerCoverage
+  -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
+  -- and follow-up issue #252: this consumer still drives the Lean rows
+  -- through InMemoryEventDeliverySource rather than the production
+  -- DefraWatcher/EventSource/SubagentSource loops.
+  , consumerWithFollowUpCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"
       "state_machine_conformance::event_delivery_transition_cases_match_contract"
+      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops."
   , consumerCoverage
       "event_delivery_cases"
       "EventDeliverySourceInstances"
       "state_machine_conformance::event_delivery_source_instances_match_runtime"
-  , consumerCoverage
+  -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
+  -- and follow-up issue #252: this consumer still drives the Lean traces
+  -- through InMemoryEventDeliverySource rather than the production
+  -- DefraWatcher/EventSource/SubagentSource loops.
+  , consumerWithFollowUpCoverage
       "event_delivery_cases"
       "EventDeliveryConvergenceTraces"
       "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation"
+      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops."
   , consumerCoverage
       "mcp_health_cases"
       "MCPHealthCases"


### PR DESCRIPTION
## Summary

- Demotes the simulator-backed `EventDeliveryTransitionCases` and `EventDeliveryConvergenceTraces` ledger rows to `consumerWithFollowUpCoverage`.
- Leaves `EventDeliverySourceInstances` as `consumerCoverage` because it is already production-bound through `EventDeliveryRuntimeContract`.
- Adds ledger comments and follow-up text pointing to #252 for the future production-source driver.

## Audit links

- [2026-05-19 conformance audit, section 15 EventDelivery](docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery)
- [Recommended next-impl order, item 1](docs/superpowers/audits/2026-05-19-conformance-audit.md#recommended-next-impl-order)

## Strategy

Strategy B. Strategy A needs a production test seam for `EmbeddedNode` / `events::Subscription`: the production sources currently own concrete subscriptions and the dependency constructors are private, so the existing conformance test cannot deterministically inject Lean-emitted subscription actions without a larger driver refactor.

Follow-up: #252

## Verification

- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent`
- `cargo test -p defra-agent --test state_machine_conformance`