### PR TITLE
Background properties: add followUpCoverage rows to expose Lean-only gap (#4 ledger half)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -110,7 +110,8 @@ def snapshotJson : String :=
     ++ "\"mcp_health_cases\":"
       ++ jsonArray
         (Proofs.MCPHealth.transitionCases.map mcpHealthCaseJson) ++ ","
-    ++ "\"follow_up_hooks\":[],"
+    ++ "\"follow_up_hooks\":"
+      ++ followUpHooksJson ++ ","
     ++ "\"event_delivery_transition_case_count\":"
       ++ toString Conformance.EventDelivery.transitionCaseCount ++ ","
     ++ "\"event_delivery_transition_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -350,7 +350,37 @@ def caseCoverage : List CoverageEntry :=
   ]
 
 def followUpHookCoverage : List CoverageEntry :=
-  []
+  [ followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.backgrounded_budget_bounded"
+      "Subagent.BridgedState.backgrounded_budget_bounded proves that reachable bridged states keep live backgrounded tools at or below maxBackgroundedPerParent. Follow-up: emit witness row via `theorem_witness` discriminator in `Proofs/Conformance/ContractCases/R6Background.lean`."
+  , followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.cascade_cancels_child"
+      "Subagent.BridgedState.cascade_cancels_child proves cascade parent termination interrupts a linked processing child; related Lean-only negative form: Subagent.BridgedState.detach_does_not_cancel_child. Follow-up: emit witness row via `theorem_witness` discriminator in `Proofs/Conformance/ContractCases/R6Background.lean`."
+  , followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.foreground_blocks_parent_advance"
+      "Subagent.BridgedState.foreground_blocks_parent_advance proves live foreground tools block parent progress/message advance; related aliases: Subagent.BridgedState.subagent_depth_bounded and Subagent.BridgedState.bridge_link_symmetric. Accepted Lean-only today because the invariant is a proof-layer bridge guard rather than an emitted runtime witness."
+  , followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.bridged_child_completion_propagates"
+      "Subagent.BridgedState.bridged_child_completion_propagates proves child completion projects to parent bridge-tool completion; related failure projection: Subagent.BridgedState.bridged_child_failure_projects. Accepted Lean-only today because R6Background emits data-shape cases and this theorem remains a formal trace projection."
+  , followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.inv_depth"
+      "Subagent.BridgedState.inv_depth proves bridged traces preserve max subagent depth; related link invariant: Subagent.BridgedState.inv_link. Accepted Lean-only today because these are structural trace invariants with no current Rust witness surface."
+  , followUpCoverage
+      "follow_up_hook"
+      "Subagent.BridgedState.bridgedUniqueCallIds_preserved"
+      "Subagent.BridgedState.bridgedUniqueCallIds_preserved proves parent and child tool call ids remain unique across bridged traces. Accepted Lean-only today because the theorem lifts a structural uniqueness proof rather than an operational R6 witness."
+  ]
+
+def followUpHookIds : List String :=
+  followUpHookCoverage.map (fun entry => entry.domain)
+
+def followUpHooksJson : String :=
+  jsonArray (followUpHookIds.map jsonString)
 
 def coverageLedger : List CoverageEntry :=
   vocabularyCoverage ++ stateMachineCoverage ++ caseCoverage ++ followUpHookCoverage


### PR DESCRIPTION
## Summary
- Add six `followUpCoverage` rows for the audited Background property theorem groups.
- Emit matching `follow_up_hooks` from the Lean conformance snapshot so the coverage drift test can see the deferred properties.
- Keep the runtime-drive half (`theorem_witness` discriminator plus Rust witnesses for `cascade_cancels_child` and `backgrounded_budget_bounded`) as a separate follow-up.

## References
- `docs/superpowers/audits/2026-05-19-conformance-audit.md` §8 Background
- `docs/superpowers/audits/2026-05-19-conformance-audit.md` Recommended next-impl order item #4

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent`
- `cargo test -p defra-agent --test state_machine_conformance`