### PR TITLE
Conformance: cosmetic naming + file-mapping cleanup (#5 audit follow-up)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/Catalog.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/Catalog.lean
@@ -3,7 +3,8 @@ import Proofs.Conformance.Contracts.Machines.Process
 import Proofs.Conformance.Contracts.Machines.Persistence
 import Proofs.Conformance.Contracts.Machines.StorageObservation
 import Proofs.Conformance.Contracts.Machines.RuntimeReconcile
-import Proofs.Conformance.Contracts.Machines.PairingSession
+import Proofs.Conformance.Contracts.Machines.PairingReconcile
+import Proofs.Conformance.Contracts.Machines.SessionRecovery
 import Proofs.Conformance.Contracts.Machines.InferenceCall
 import Proofs.Conformance.Contracts.Machines.ToolCall
 import Proofs.Conformance.Contracts.Machines.ManagedExec

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/PairingReconcile.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/PairingReconcile.lean
@@ -1,14 +1,11 @@
 import Proofs.PairingReconcile
-import Proofs.Conformance.Contracts.Machines.Request
-import Proofs.Conformance.ContractCases.SessionRecovery
+import Proofs.Conformance.ContractTypes
 
 /-!
-# Pairing and Session-Recovery Conformance Machines
+# Pairing-Reconcile Conformance Machine
 -/
 
 namespace Conformance.Contracts
-
-open Conformance.ContractCases
 
 def pairingReconcileStates : List PairingReconcile.PairingPhase :=
   [ .idle, .diverged, .converged, .crashed ]
@@ -34,20 +31,5 @@ def pairingReconcileMachine : StateMachineContract :=
       pairingReconcileActions
       PairingReconcile.step?
       PairingReconcile.PairingPhase.toContract)
-
-def sessionRecoveryLegalTransitions : List TransitionPair :=
-  sessionRecoveryCases.filterMap fun witness =>
-    if witness.legal then
-      some { source := witness.preLatestState, target := witness.postLatestState }
-    else
-      none
-
-def sessionRecoveryMachine : StateMachineContract :=
-  machineContract
-    "SessionRecovery"
-    requestStateNames
-    []
-    ["reissueFailed"]
-    sessionRecoveryLegalTransitions
 
 end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/SessionRecovery.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Machines/SessionRecovery.lean
@@ -1,0 +1,27 @@
+import Proofs.Conformance.Contracts.Machines.Request
+import Proofs.Conformance.ContractCases.SessionRecovery
+
+/-!
+# Session-Recovery Conformance Machine
+-/
+
+namespace Conformance.Contracts
+
+open Conformance.ContractCases
+
+def sessionRecoveryLegalTransitions : List TransitionPair :=
+  sessionRecoveryCases.filterMap fun witness =>
+    if witness.legal then
+      some { source := witness.preLatestState, target := witness.postLatestState }
+    else
+      none
+
+def sessionRecoveryMachine : StateMachineContract :=
+  machineContract
+    "SessionRecovery"
+    requestStateNames
+    []
+    ["reissueFailed"]
+    sessionRecoveryLegalTransitions
+
+end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -166,7 +166,7 @@ def stateMachineCoverage : List CoverageEntry :=
   , consumerCoverage
       "state_machine"
       "RuntimeReconcile"
-      "runtime_status::tests::rust_reconcile_phase_vocabulary_matches_lean_model"
+      "runtime_status::tests::runtime_reconcile_state_machine_contract_is_complete"
   , consumerCoverage
       "state_machine"
       "PairingReconcile"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -309,7 +309,7 @@ def caseCoverage : List CoverageEntry :=
   , consumerCoverage
       "transcript_cases"
       "TranscriptConformanceCases"
-      "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract"
+      "state_machine_conformance::generated_transcript_cases_drive_agent_message_ordering_contract"
   , consumerCoverage
       "identity_structural_cases"
       "IdentityStructuralCases"

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -244,6 +244,10 @@ fn rust_reconcile_phase_vocabulary_matches_lean_model() {
         rust_source: "ReconcilePhase::{Idle, Debouncing, Resolving, Diffing, Applying}",
         rust_values: &rust_phases,
     });
+}
+
+#[test]
+fn runtime_reconcile_state_machine_contract_is_complete() {
     assert_state_machine_contract_is_complete("RuntimeReconcile");
     assert_lean_transition_is_legal("RuntimeReconcile", "applying", "idle");
 }

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -108,8 +108,8 @@ fn generated_r4c_background_work_cases_pin_observable_shapes() {
 }
 
 #[tokio::test]
-async fn generated_transcript_cases_pin_agent_message_ordering_contract() {
-    transcript_background::generated_transcript_cases_pin_agent_message_ordering_contract().await;
+async fn generated_transcript_cases_drive_agent_message_ordering_contract() {
+    transcript_background::generated_transcript_cases_drive_agent_message_ordering_contract().await;
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/state_machine_conformance/transcript_background.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/transcript_background.rs
@@ -586,7 +586,7 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
     }
 }
 
-pub(super) async fn generated_transcript_cases_pin_agent_message_ordering_contract() {
+pub(super) async fn generated_transcript_cases_drive_agent_message_ordering_contract() {
     assert_transcript_case_shape();
 
     let ordering = lean_transcript_case("ordering_user_assistant_tool_result");

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -294,11 +294,11 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_r4c_background_work_cases_pin_observable_shapes",
         },
         ConformanceConsumer::RustTest {
-            id: "state_machine_conformance::generated_transcript_cases_pin_agent_message_ordering_contract",
+            id: "state_machine_conformance::generated_transcript_cases_drive_agent_message_ordering_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
             module_path: "state_machine_conformance",
-            function: "generated_transcript_cases_pin_agent_message_ordering_contract",
+            function: "generated_transcript_cases_drive_agent_message_ordering_contract",
         },
         ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract",

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -252,6 +252,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "rust_reconcile_phase_vocabulary_matches_lean_model",
         },
         ConformanceConsumer::RustTest {
+            id: "runtime_status::tests::runtime_reconcile_state_machine_contract_is_complete",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/runtime_status/tests.rs",
+            module_path: "runtime_status::tests",
+            function: "runtime_reconcile_state_machine_contract_is_complete",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",


### PR DESCRIPTION
## Summary

Follow-up for audit item #5 in docs/superpowers/audits/2026-05-19-conformance-audit.md §6.

- Rename the PairingReconcile contract machine file from PairingSession.lean to PairingReconcile.lean and split SessionRecovery into its own machine file.
- Rename the transcript conformance test consumer from *_pin_agent_message_ordering_contract to *_drive_agent_message_ordering_contract for the runtime-backed convention.
- Split RuntimeReconcile vocab coverage from the state-machine completeness assertion so each test has one purpose.

## Verification

- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance