### PR TITLE
MCPHealth: drive K=1 cases through run_health_check (#2 stage 1)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -353,10 +353,14 @@ def caseCoverage : List CoverageEntry :=
       "EventDeliveryConvergenceTraces"
       "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation"
       "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops."
-  , consumerCoverage
+  -- 2026-05-19 conformance audit section 10 / section 6 item #2:
+  -- Stage 1 drives the K=1 runtime health-check path; Stage 2 issue #253
+  -- must add K>=2 backoff behavior and drop the lean_mcp_health_k1_cases filter.
+  , consumerWithFollowUpCoverage
       "mcp_health_cases"
       "MCPHealthCases"
       "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
+      "Issue #253 adds K>=2 MCPHealth backoff behavior in Rust and drops the lean_mcp_health_k1_cases() filter so the full emitted mcp_health_cases domain is consumed."
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -189,7 +189,26 @@ async fn run_health_check(
     let services: Vec<RegistryServiceEntry> =
         serde_json::from_value(raw_services).context("parsing ToolServiceRegistry entries")?;
 
-    let now = Utc::now();
+    run_health_check_cycle(
+        services,
+        Utc::now(),
+        mcp_pool,
+        health_map,
+        local_hostname,
+        local_subnet,
+    )
+    .await
+}
+
+// Production transition step once the registry query has supplied online rows.
+async fn run_health_check_cycle(
+    services: Vec<RegistryServiceEntry>,
+    now: DateTime<Utc>,
+    mcp_pool: &McpPool,
+    health_map: &ServiceHealthMap,
+    local_hostname: &str,
+    local_subnet: Option<&str>,
+) -> Result<()> {
     let mut online_service_ids = HashSet::new();
 
     for service in services {
@@ -372,8 +391,15 @@ mod registry_parsing_tests {
 
 #[cfg(test)]
 mod transitions_tests {
-    use super::HealthStatus;
+    use chrono::Duration as ChronoDuration;
+    use rmcp::model::ListToolsResult;
+
+    use super::{
+        run_health_check_cycle, HealthStatus, RegistryServiceEntry, ServiceHealth,
+        ServiceHealthMap, STALENESS_THRESHOLD_SECS,
+    };
     use crate::lean_vocab_test::{lean_mcp_health_k1_cases, LeanMcpHealthCase};
+    use crate::mcp_pool::McpPool;
 
     /// Project a Lean K=1 case's `rust_projection` to a `HealthStatus` for
     /// today's Rust to assert against. `None` means the service was removed
@@ -391,31 +417,6 @@ mod transitions_tests {
         })
     }
 
-    /// Simulate one tick of `run_health_check`'s decision logic for a given
-    /// case: given a starting `HealthStatus` and a probe event, what does
-    /// today's Rust assign?
-    ///
-    /// Mirrors the inline logic at `health_checker.rs:247–308` but drives it
-    /// with the case's event rather than a real probe call.
-    fn rust_simulated_next(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
-        match case.event.as_str() {
-            "registryAbsent" => None,
-            "backoffExpiry" => {
-                // Today's Rust has no backoffExpiry behavior — backoff is not
-                // armed at K=1. Express this by mapping back through the
-                // starting projection (no observable change at K=1).
-                Some(start_status(case))
-            }
-            "probeSuccessFresh" => Some(HealthStatus::Healthy),
-            "probeSuccessStale" => Some(HealthStatus::Stale),
-            "probeFail" => Some(HealthStatus::Unreachable),
-            other => panic!(
-                "Lean MCP health case {} produced unknown event {:?}",
-                case.name, other
-            ),
-        }
-    }
-
     fn start_status(case: &LeanMcpHealthCase) -> HealthStatus {
         match case.start_state.as_str() {
             "healthy" => HealthStatus::Healthy,
@@ -430,8 +431,82 @@ mod transitions_tests {
         }
     }
 
-    #[test]
-    fn generated_mcp_health_k1_cases_match_health_checker_transitions() {
+    async fn run_health_check_projection(case: &LeanMcpHealthCase) -> Option<HealthStatus> {
+        const SERVICE_ID: &str = "lean-mcp-health-service";
+
+        let now = chrono::Utc::now();
+        let health_map = ServiceHealthMap::new();
+        health_map
+            .set_for_test(
+                SERVICE_ID,
+                ServiceHealth {
+                    status: start_status(case),
+                    last_seen: now,
+                    last_error: None,
+                },
+            )
+            .await;
+
+        let services = match case.event.as_str() {
+            "registryAbsent" => Vec::new(),
+            "probeSuccessFresh" | "probeFail" => vec![registry_entry(SERVICE_ID, now)],
+            "probeSuccessStale" => vec![registry_entry(
+                SERVICE_ID,
+                now - ChronoDuration::seconds(STALENESS_THRESHOLD_SECS + 30),
+            )],
+            "backoffExpiry" => {
+                // At K=1 Rust does not arm a backoff timer, so there is no
+                // runtime health-check tick to drive for this Lean event. The
+                // observable production state is unchanged until Stage 2 adds
+                // K>=2 backoff behavior.
+                return Some(start_status(case));
+            }
+            other => panic!(
+                "Lean MCP health case {} produced unknown event {:?}",
+                case.name, other
+            ),
+        };
+
+        let pool = mcp_pool_for_event(&case.event);
+        run_health_check_cycle(services, now, &pool, &health_map, "local-host", None)
+            .await
+            .unwrap_or_else(|error| {
+                panic!(
+                    "run_health_check_cycle failed for Lean MCP health case {}: {error}",
+                    case.name
+                )
+            });
+
+        health_map.get(SERVICE_ID).await.map(|health| health.status)
+    }
+
+    fn mcp_pool_for_event(event: &str) -> McpPool {
+        let probe_fails = event == "probeFail";
+        McpPool::new_with_list_tools_handler(move |_service_id, _endpoint| async move {
+            if probe_fails {
+                anyhow::bail!("Lean probeFail")
+            }
+            Ok(ListToolsResult::default())
+        })
+    }
+
+    fn registry_entry(
+        service_id: &str,
+        updated_at: chrono::DateTime<chrono::Utc>,
+    ) -> RegistryServiceEntry {
+        RegistryServiceEntry {
+            service_id: service_id.to_string(),
+            hostname: "remote-host".to_string(),
+            tailscale_ip: "100.64.0.1".to_string(),
+            lan_ip: String::new(),
+            mcp_port: Some(9201),
+            mcp_path: "/mcp".to_string(),
+            updated_at: Some(updated_at.to_rfc3339()),
+        }
+    }
+
+    #[tokio::test]
+    async fn generated_mcp_health_k1_cases_match_health_checker_transitions() {
         let cases = lean_mcp_health_k1_cases();
         assert!(
             !cases.is_empty(),
@@ -439,8 +514,14 @@ mod transitions_tests {
         );
 
         for case in cases {
+            assert_eq!(case.threshold_k, 1, "test must only consume K=1 rows");
+            assert_eq!(
+                case.start_count, 0,
+                "K=1 Lean MCP health rows must start at failureCount=0"
+            );
+
             let expected = projected_health_status(case);
-            let actual = rust_simulated_next(case);
+            let actual = run_health_check_projection(case).await;
             assert_eq!(
                 actual, expected,
                 "Lean MCP health K=1 case {} must match Rust HealthStatus assignment",

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -177,6 +177,34 @@ impl McpPool {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn new_with_list_tools_handler<F, Fut>(handler: F) -> Self
+    where
+        F: Fn(String, String) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<ListToolsResult>> + Send + 'static,
+    {
+        let handler = Arc::new(handler);
+        Self::new_with_connector(move |service_id, endpoint| {
+            let handler = Arc::clone(&handler);
+            async move {
+                let service_id_for_list = service_id.clone();
+                let endpoint_for_list = endpoint.clone();
+                Ok(McpConnection {
+                    endpoint,
+                    list_tools_fn: Box::new(move || {
+                        let handler = Arc::clone(&handler);
+                        let service_id = service_id_for_list.clone();
+                        let endpoint = endpoint_for_list.clone();
+                        Box::pin(async move { handler(service_id, endpoint).await })
+                    }),
+                    call_tool_fn: Box::new(|_params| {
+                        Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                    }),
+                })
+            }
+        })
+    }
+
     /// List the tools exposed by the MCP server at `endpoint`.
     ///
     /// Connects lazily — if no cached connection exists for `service_id`, one is


### PR DESCRIPTION
Implements Stage 1 for audit item #2 from `docs/superpowers/audits/2026-05-19-conformance-audit.md` §10 and §6 recommended implementation item #2.

Changes:
- Extract the production MCP health-check transition step behind `run_health_check_cycle`, still called by `run_health_check`, and drive the Lean K=1 consumer through that production path.
- Add a test-only MCP pool list-tools seam so K=1 probe success/failure rows do not duplicate the health-check state machine.
- Demote `mcp_health_cases` from `consumerCoverage` to `consumerWithFollowUpCoverage` with Stage 2 tracked in #253 for K>=2 backoff behavior and dropping the `lean_mcp_health_k1_cases()` filter.

Verification:
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent`
- `cargo test -p defra-agent mcp_health -- --nocapture`
- `cargo test -p defra-agent --lib`
- `RUST_TEST_THREADS=1 cargo test -p defra-agent`
- `cargo test -p defra-agent`