### PR TITLE
ManagedExec: add Windows process termination via Job Object (#236)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3620,6 +3620,7 @@ dependencies = [
  "toml 0.8.2",
  "tracing",
  "uuid",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -43,6 +43,15 @@ tempfile = "3"
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = { version = "3.7.0", features = ["OSX_10_15"] }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_JobObjects",
+    "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
 proptest = "1"

--- a/crates/defra-agent/src/managed_exec/process.rs
+++ b/crates/defra-agent/src/managed_exec/process.rs
@@ -10,11 +10,15 @@ use tokio_util::sync::CancellationToken;
 use super::output::ManagedExecOutcome;
 
 mod capture;
+#[cfg(windows)]
+mod job_object;
 #[cfg(unix)]
 mod process_group;
 mod registry;
 
 use capture::{join_capture, join_capture_with_timeout, read_optional_capped};
+#[cfg(windows)]
+use job_object::{terminate_job, ManagedChildJob};
 #[cfg(unix)]
 use process_group::{terminate_process_group, ManagedChild};
 use registry::ActiveExecGuard;
@@ -152,10 +156,120 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExecOutcome {
+    let Some((program, args)) = request.argv.split_first() else {
+        return ManagedExecOutcome::SpawnFailed {
+            error: "managed exec argv must not be empty".to_string(),
+        };
+    };
+
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(&request.cwd)
+        .stdin(if request.stdin.is_empty() {
+            Stdio::null()
+        } else {
+            Stdio::piped()
+        })
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+
+    let mut child = match ManagedChildJob::spawn(&mut command) {
+        Ok(child) => child,
+        Err(error) => {
+            return ManagedExecOutcome::SpawnFailed {
+                error: error.to_string(),
+            };
+        }
+    };
+
+    let pid = child.pid();
+    let _active =
+        pid.map(|pid| ActiveExecGuard::insert(pid, program.clone(), request.tool_name.clone()));
+
+    if !request.stdin.is_empty() {
+        if let Some(mut stdin) = child.inner.stdin.take() {
+            let input = request.stdin;
+            tokio::spawn(async move {
+                let _ = stdin.write_all(&input).await;
+            });
+        }
+    }
+
+    let stdout = child.inner.stdout.take();
+    let stderr = child.inner.stderr.take();
+    let max_output_bytes = request.max_output_bytes;
+    let stdout_task = tokio::spawn(read_optional_capped(stdout, max_output_bytes));
+    let stderr_task = tokio::spawn(read_optional_capped(stderr, max_output_bytes));
+
+    let job = child.job();
+    let mut wait = Box::pin(child.inner.wait());
+    let deadline = sleep_until_deadline(request.deadline_at);
+    tokio::pin!(deadline);
+
+    let outcome_kind = tokio::select! {
+        biased;
+        _ = request.cancellation_token.cancelled() => OutcomeKind::Cancelled,
+        _ = &mut deadline => OutcomeKind::TimedOut,
+        status = &mut wait => {
+            match status {
+                Ok(status) => {
+                    drop(wait);
+                    child.mark_finished(true);
+                    let stdout = join_capture(stdout_task).await;
+                    let stderr = join_capture(stderr_task).await;
+                    return ManagedExecOutcome::Exited {
+                        code: status.code(),
+                        stdout: stdout.bytes,
+                        stderr: stderr.bytes,
+                        stdout_truncated: stdout.truncated,
+                        stderr_truncated: stderr.truncated,
+                    };
+                }
+                Err(error) => {
+                    drop(wait);
+                    child.mark_finished(true);
+                    return ManagedExecOutcome::SpawnFailed {
+                        error: format!("waiting for managed exec failed: {error}"),
+                    };
+                }
+            }
+        }
+    };
+
+    let kill = terminate_job(job, &mut wait).await;
+    drop(wait);
+    child.mark_finished(kill.reaped);
+    let capture_timeout = (!kill.reaped).then_some(CAPTURE_DRAIN_AFTER_FAILED_REAP);
+    let stdout = join_capture_with_timeout(stdout_task, capture_timeout).await;
+    let stderr = join_capture_with_timeout(stderr_task, capture_timeout).await;
+
+    match outcome_kind {
+        OutcomeKind::TimedOut => ManagedExecOutcome::TimedOut {
+            stdout: stdout.bytes,
+            stderr: stderr.bytes,
+            stdout_truncated: stdout.truncated,
+            stderr_truncated: stderr.truncated,
+            kill,
+        },
+        OutcomeKind::Cancelled => ManagedExecOutcome::Cancelled {
+            stdout: stdout.bytes,
+            stderr: stderr.bytes,
+            stdout_truncated: stdout.truncated,
+            stderr_truncated: stderr.truncated,
+            kill,
+        },
+    }
+}
+
+#[cfg(all(not(unix), not(windows)))]
 pub(crate) async fn run_managed_exec(_request: ManagedExecRequest) -> ManagedExecOutcome {
     ManagedExecOutcome::SpawnFailed {
-        error: "ManagedExec process-group termination is not yet supported on non-Unix platforms; see #236".to_string(),
+        error: "ManagedExec process-tree termination is not yet supported on this platform"
+            .to_string(),
     }
 }
 

--- a/crates/defra-agent/src/managed_exec/process/job_object.rs
+++ b/crates/defra-agent/src/managed_exec/process/job_object.rs
@@ -1,0 +1,253 @@
+#![cfg(windows)]
+
+use std::io;
+use std::os::windows::io::RawHandle;
+use std::time::Duration;
+
+use tokio::process::{Child, Command};
+
+use crate::managed_exec::output::KillReport;
+
+use windows_sys::Win32::Foundation::{CloseHandle, HANDLE, INVALID_HANDLE_VALUE};
+use windows_sys::Win32::System::Diagnostics::ToolHelp::{
+    CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
+};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+};
+use windows_sys::Win32::System::Threading::{
+    OpenThread, ResumeThread, CREATE_SUSPENDED, THREAD_SUSPEND_RESUME,
+};
+
+const JOB_REAP_GRACE: Duration = Duration::from_millis(250);
+const TERMINATED_BY_MANAGED_EXEC: u32 = 1;
+const RESUME_THREAD_FAILED: u32 = u32::MAX;
+
+pub(super) struct ManagedChildJob {
+    pub(super) inner: Child,
+    job: OwnedHandle,
+    pid: Option<i32>,
+    finished: bool,
+}
+
+impl ManagedChildJob {
+    pub(super) fn spawn(command: &mut Command) -> io::Result<Self> {
+        let job = OwnedHandle::new_job_with_kill_on_close()?;
+        command.creation_flags(CREATE_SUSPENDED);
+
+        let mut child = command.spawn()?;
+        let pid_u32 = child.id();
+        let pid = pid_u32.and_then(|pid| i32::try_from(pid).ok());
+        let process = child_process_handle(&child)?;
+
+        if let Err(error) = job.assign_process(process) {
+            let _ = child.start_kill();
+            return Err(io::Error::new(
+                error.kind(),
+                format!("assigning managed exec to Windows Job Object failed: {error}"),
+            ));
+        }
+
+        if let Some(pid) = pid_u32 {
+            if let Err(error) = resume_process_threads(pid) {
+                let _ = job.terminate();
+                let _ = child.start_kill();
+                return Err(io::Error::new(
+                    error.kind(),
+                    format!("resuming suspended managed exec process failed: {error}"),
+                ));
+            }
+        } else {
+            let _ = job.terminate();
+            let _ = child.start_kill();
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "spawned managed exec child did not expose a process id",
+            ));
+        }
+
+        Ok(Self {
+            inner: child,
+            job,
+            pid,
+            finished: false,
+        })
+    }
+
+    pub(super) fn pid(&self) -> Option<i32> {
+        self.pid
+    }
+
+    pub(super) fn job(&self) -> JobHandle {
+        JobHandle {
+            raw: self.job.raw,
+            pid: self.pid,
+        }
+    }
+
+    pub(super) fn mark_finished(&mut self, finished: bool) {
+        self.finished = finished;
+    }
+}
+
+impl Drop for ManagedChildJob {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.job.terminate();
+            let _ = self.inner.start_kill();
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct JobHandle {
+    raw: HANDLE,
+    pid: Option<i32>,
+}
+
+unsafe impl Send for JobHandle {}
+unsafe impl Sync for JobHandle {}
+
+pub(super) async fn terminate_job<F>(job: JobHandle, wait: &mut F) -> KillReport
+where
+    F: std::future::Future<Output = io::Result<std::process::ExitStatus>> + Unpin,
+{
+    let mut report = KillReport {
+        pid: job.pid,
+        term_signal_sent: false,
+        kill_signal_sent: false,
+        reaped: false,
+    };
+
+    report.kill_signal_sent = terminate_job_now(job.raw).is_ok();
+    if tokio::time::timeout(JOB_REAP_GRACE, &mut *wait)
+        .await
+        .is_ok()
+    {
+        report.reaped = true;
+    }
+    report
+}
+
+struct OwnedHandle {
+    raw: HANDLE,
+}
+
+unsafe impl Send for OwnedHandle {}
+unsafe impl Sync for OwnedHandle {}
+
+impl OwnedHandle {
+    fn new_job_with_kill_on_close() -> io::Result<Self> {
+        let raw = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if raw.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let job = Self { raw };
+
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let result = unsafe {
+            SetInformationJobObject(
+                job.raw,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if result == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(job)
+    }
+
+    fn assign_process(&self, process: HANDLE) -> io::Result<()> {
+        let result = unsafe { AssignProcessToJobObject(self.raw, process) };
+        if result == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn terminate(&self) -> io::Result<()> {
+        terminate_job_now(self.raw)
+    }
+}
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        unsafe {
+            CloseHandle(self.raw);
+        }
+    }
+}
+
+fn terminate_job_now(job: HANDLE) -> io::Result<()> {
+    let result = unsafe { TerminateJobObject(job, TERMINATED_BY_MANAGED_EXEC) };
+    if result == 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+fn child_process_handle(child: &Child) -> io::Result<HANDLE> {
+    child
+        .raw_handle()
+        .map(raw_handle_to_handle)
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "spawned managed exec child exited"))
+}
+
+fn raw_handle_to_handle(raw: RawHandle) -> HANDLE {
+    raw as HANDLE
+}
+
+fn resume_process_threads(pid: u32) -> io::Result<()> {
+    let snapshot = unsafe { CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0) };
+    if snapshot == INVALID_HANDLE_VALUE {
+        return Err(io::Error::last_os_error());
+    }
+    let snapshot = OwnedHandle { raw: snapshot };
+
+    let mut entry = THREADENTRY32 {
+        dwSize: std::mem::size_of::<THREADENTRY32>() as u32,
+        ..THREADENTRY32::default()
+    };
+    let mut has_entry = unsafe { Thread32First(snapshot.raw, &mut entry) } != 0;
+    let mut resumed = false;
+
+    while has_entry {
+        if entry.th32OwnerProcessID == pid {
+            resume_thread(entry.th32ThreadID)?;
+            resumed = true;
+        }
+        has_entry = unsafe { Thread32Next(snapshot.raw, &mut entry) } != 0;
+    }
+
+    if resumed {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("no suspended threads found for managed exec process {pid}"),
+        ))
+    }
+}
+
+fn resume_thread(thread_id: u32) -> io::Result<()> {
+    let raw = unsafe { OpenThread(THREAD_SUSPEND_RESUME, 0, thread_id) };
+    if raw.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let thread = OwnedHandle { raw };
+
+    let result = unsafe { ResumeThread(thread.raw) };
+    if result == RESUME_THREAD_FAILED {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}

--- a/crates/defra-agent/src/managed_exec/tests.rs
+++ b/crates/defra-agent/src/managed_exec/tests.rs
@@ -145,9 +145,88 @@ async fn managed_exec_cancellation_kills_process_group() {
     }
 }
 
-#[cfg(unix)]
+#[cfg(windows)]
+#[tokio::test]
+async fn managed_exec_deadline_kills_job_object() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let pid_file = temp.path().join("deadline-grandchild.pid");
+    let tool_name = "r3-windows-job-deadline";
+    let handle = tokio::spawn({
+        let cwd = temp.path().to_path_buf();
+        let argv = windows_grandchild_argv(&pid_file);
+        async move {
+            run_managed_exec(ManagedExecRequest {
+                argv,
+                cwd,
+                deadline_at: Some(Utc::now() + chrono::Duration::seconds(8)),
+                cancellation_token: CancellationToken::new(),
+                max_output_bytes: 1024,
+                stdin: Vec::new(),
+                tool_name: Some(tool_name.to_string()),
+            })
+            .await
+        }
+    });
+
+    let snapshot = wait_for_native_executor(tool_name).await;
+    assert!(snapshot.pid > 0, "active executor snapshot must expose pid");
+    let grandchild_pid = wait_for_windows_grandchild_pid(&pid_file).await;
+
+    match handle.await.expect("managed exec task should join") {
+        ManagedExecOutcome::TimedOut { kill, .. } => {
+            assert!(kill.kill_signal_sent);
+            assert!(kill.reaped);
+        }
+        other => panic!("expected timeout outcome, got {other:?}"),
+    }
+
+    assert_windows_process_exited(grandchild_pid).await;
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn managed_exec_cancellation_kills_job_object() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let pid_file = temp.path().join("cancel-grandchild.pid");
+    let tool_name = "r3-windows-job-cancel";
+    let token = CancellationToken::new();
+    let child_token = token.clone();
+    let handle = tokio::spawn({
+        let cwd = temp.path().to_path_buf();
+        let argv = windows_grandchild_argv(&pid_file);
+        async move {
+            run_managed_exec(ManagedExecRequest {
+                argv,
+                cwd,
+                deadline_at: None,
+                cancellation_token: child_token,
+                max_output_bytes: 1024,
+                stdin: Vec::new(),
+                tool_name: Some(tool_name.to_string()),
+            })
+            .await
+        }
+    });
+
+    let snapshot = wait_for_native_executor(tool_name).await;
+    assert!(snapshot.pid > 0, "active executor snapshot must expose pid");
+    let grandchild_pid = wait_for_windows_grandchild_pid(&pid_file).await;
+    token.cancel();
+
+    match handle.await.expect("managed exec task should join") {
+        ManagedExecOutcome::Cancelled { kill, .. } => {
+            assert!(kill.kill_signal_sent);
+            assert!(kill.reaped);
+        }
+        other => panic!("expected cancelled outcome, got {other:?}"),
+    }
+
+    assert_windows_process_exited(grandchild_pid).await;
+}
+
+#[cfg(any(unix, windows))]
 async fn wait_for_native_executor(tool_name: &str) -> crate::NativeExecutorStatus {
-    let timeout_at = Instant::now() + Duration::from_millis(200);
+    let timeout_at = Instant::now() + Duration::from_secs(5);
     loop {
         if let Some(snapshot) = crate::active_native_executors()
             .into_iter()
@@ -159,6 +238,86 @@ async fn wait_for_native_executor(tool_name: &str) -> crate::NativeExecutorStatu
             panic!("timed out waiting for active native executor snapshot for {tool_name}");
         }
         tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+#[cfg(windows)]
+fn windows_grandchild_argv(pid_file: &std::path::Path) -> Vec<String> {
+    let pid_file = powershell_single_quoted(pid_file);
+    let script = format!(
+        "$p = Start-Process -FilePath powershell.exe -ArgumentList '-NoProfile -NonInteractive -Command \"Start-Sleep -Seconds 30\"' -PassThru; Set-Content -Path {pid_file} -Value $p.Id; Write-Output \"grandchild=$($p.Id)\"; Start-Sleep -Seconds 30"
+    );
+    vec![
+        "powershell.exe".to_string(),
+        "-NoProfile".to_string(),
+        "-NonInteractive".to_string(),
+        "-Command".to_string(),
+        script,
+    ]
+}
+
+#[cfg(windows)]
+fn powershell_single_quoted(path: &std::path::Path) -> String {
+    format!("'{}'", path.display().to_string().replace('\'', "''"))
+}
+
+#[cfg(windows)]
+async fn wait_for_windows_grandchild_pid(pid_file: &std::path::Path) -> u32 {
+    let timeout_at = Instant::now() + Duration::from_secs(6);
+    loop {
+        if let Ok(contents) = std::fs::read_to_string(pid_file) {
+            if let Ok(pid) = contents.trim().parse::<u32>() {
+                return pid;
+            }
+        }
+        if Instant::now() >= timeout_at {
+            panic!(
+                "timed out waiting for managed exec grandchild pid file {}",
+                pid_file.display()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[cfg(windows)]
+async fn assert_windows_process_exited(pid: u32) {
+    let timeout_at = Instant::now() + Duration::from_secs(2);
+    loop {
+        match windows_process_is_running(pid) {
+            Ok(false) => return,
+            Ok(true) => {}
+            Err(error) => panic!("checking Windows process {pid} failed: {error}"),
+        }
+        if Instant::now() >= timeout_at {
+            panic!("managed exec grandchild process {pid} survived job termination");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[cfg(windows)]
+fn windows_process_is_running(pid: u32) -> std::io::Result<bool> {
+    use windows_sys::Win32::Foundation::{CloseHandle, WAIT_OBJECT_0, WAIT_TIMEOUT};
+    use windows_sys::Win32::System::Threading::{
+        OpenProcess, WaitForSingleObject, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    const SYNCHRONIZE: u32 = 0x0010_0000;
+
+    let handle = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE, 0, pid) };
+    if handle.is_null() {
+        return Ok(false);
+    }
+    let wait = unsafe { WaitForSingleObject(handle, 0) };
+    unsafe {
+        CloseHandle(handle);
+    }
+
+    match wait {
+        WAIT_OBJECT_0 => Ok(false),
+        WAIT_TIMEOUT => Ok(true),
+        _ => Err(std::io::Error::last_os_error()),
     }
 }
 


### PR DESCRIPTION
Closes #236.

## Summary
- Add a Windows ManagedExec Job Object wrapper using CREATE_SUSPENDED assignment and JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE.
- Route Windows timeout/cancel cleanup through TerminateJobObject while leaving the Unix process-group implementation unchanged.
- Add Windows deadline/cancellation tests that assert a spawned grandchild is terminated with the managed runner.
- Verified ManagedExec conformance witness rows are platform-neutral; no Lean row changes needed.

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p defra-agent`
- `cargo test -p defra-agent --lib managed_exec::tests -- --nocapture`
- `cargo test -p defra-agent --test trigger_conformance`
- `cargo test -p defra-agent --lib -- --test-threads=1`

Local Windows cross-check was blocked by workstation tooling:
- `cargo check -p defra-agent --target x86_64-pc-windows-gnu` fails before crate code because `x86_64-w64-mingw32-gcc` is missing.
- `cargo check -p defra-agent --target x86_64-pc-windows-msvc` is blocked by a stale rustup target manifest / incompatible target std on this host.

CI should run on a Windows runner:
- `cargo check -p defra-agent`
- `cargo test -p defra-agent managed_exec::tests::managed_exec_deadline_kills_job_object`
- `cargo test -p defra-agent managed_exec::tests::managed_exec_cancellation_kills_job_object`
- Full `cargo test -p defra-agent` if runner time allows.

Note: plain local `cargo test -p defra-agent` twice aborted the lib test binary with SIGABRT under default parallel test execution after the Unix ManagedExec tests had passed. The same lib tests pass serially with `-- --test-threads=1`, and the failing trigger conformance timeout from one full run passed on focused retry.