### PR TITLE
Feature matrix: implement ledger extension + drift test (#264 impl)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -125,6 +125,10 @@ def snapshotJson : String :=
       ++ Conformance.EventDelivery.convergenceTracesJson ++ ","
     ++ "\"coverage_ledger\":"
       ++ coverageLedgerJson
+    ++ ",\"feature_surface_requirements\":"
+      ++ featureSurfaceRequirementsJson
+    ++ ",\"feature_matrix\":"
+      ++ featureMatrixJson
     ++ ",\"identity_structural_cases\":"
       ++ Identity.Conformance.structuralCasesJson
     ++ ",\"identity_permission_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -11,12 +11,43 @@ against the generated JSON so new Lean contracts cannot remain advisory-only.
 
 namespace Conformance.Contracts
 
+inductive Surface where
+  | agentFacing
+  | operatorCli
+  | operatorUi
+  | api
+  | runtimeInternal
+  deriving Repr, DecidableEq
+
+def Surface.toString : Surface → String
+  | Surface.agentFacing => "agentFacing"
+  | Surface.operatorCli => "operatorCli"
+  | Surface.operatorUi => "operatorUi"
+  | Surface.api => "api"
+  | Surface.runtimeInternal => "runtimeInternal"
+
+def Surface.toJson (surface : Surface) : String :=
+  jsonString surface.toString
+
+def surfacesJson (surfaces : List Surface) : String :=
+  jsonArray (surfaces.map Surface.toJson)
+
+def allSurfaces : List Surface :=
+  [ Surface.agentFacing
+  , Surface.operatorCli
+  , Surface.operatorUi
+  , Surface.api
+  , Surface.runtimeInternal
+  ]
+
 structure CoverageEntry where
   category : String
   domain : String
   consumer : String
   acceptedBoundary : String
   acceptedFollowUp : String
+  feature : String := ""
+  surfaces : List Surface := []
   deriving Repr
 
 -- Consumer strings are registered Rust/TypeScript test pointers. The Rust
@@ -59,334 +90,554 @@ def consumerWithFollowUpCoverage
   , acceptedFollowUp := acceptedFollowUp
   }
 
+def tagged (entry : CoverageEntry)
+    (feature : String) (surfaces : List Surface) : CoverageEntry :=
+  { entry with feature := feature, surfaces := surfaces }
+
+structure FeatureSurfaceRequirement where
+  feature : String
+  required : List Surface
+  deferred : List (Surface × String)
+  deriving Repr
+
+def featureSurfaceDeferralJson (deferred : Surface × String) : String :=
+  "{"
+    ++ "\"surface\":" ++ Surface.toJson deferred.1 ++ ","
+    ++ "\"note\":" ++ jsonString deferred.2
+    ++ "}"
+
+def FeatureSurfaceRequirement.toJson (req : FeatureSurfaceRequirement) : String :=
+  "{"
+    ++ "\"feature\":" ++ jsonString req.feature ++ ","
+    ++ "\"required\":" ++ surfacesJson req.required ++ ","
+    ++ "\"deferred\":" ++ jsonArray (req.deferred.map featureSurfaceDeferralJson)
+    ++ "}"
+
+def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
+  [ { feature := "request-lifecycle"
+    , required := [Surface.agentFacing, Surface.runtimeInternal]
+    , deferred := [(Surface.operatorUi, "#TBD-request-lifecycle-ui-dedicated-row")]
+    }
+  , { feature := "process-lifecycle"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "inference-call"
+    , required := [Surface.agentFacing, Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "tool-call"
+    , required := [Surface.agentFacing, Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "managed-exec"
+    , required := [Surface.agentFacing]
+    , deferred := []
+    }
+  , { feature := "pairing-reconcile"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "runtime-reconcile"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "session-recovery"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "background-tools"
+    , required := [Surface.agentFacing]
+    , deferred :=
+        [ (Surface.operatorCli, "#TBD-cli-bg-listing")
+        , (Surface.operatorUi, "#TBD-ui-bg-panel")
+        ]
+    }
+  , { feature := "subagents-cross-deployment"
+    , required := []
+    , deferred :=
+        [ (Surface.api, "#TBD-r5-api-row")
+        , (Surface.agentFacing, "#TBD-r5-lean-witness")
+        , (Surface.operatorUi, "#TBD-r5-ui-routing")
+        ]
+    }
+  , { feature := "interrupt-and-cancel"
+    , required := [Surface.agentFacing]
+    , deferred :=
+        [ (Surface.operatorCli, "#TBD-cli-cancel")
+        , (Surface.operatorUi, "#TBD-ui-cancel-button")
+        ]
+    }
+  , { feature := "mcp-health"
+    , required := [Surface.runtimeInternal]
+    , deferred :=
+        [ (Surface.operatorUi, "#TBD-ui-mcp-status")
+        , (Surface.operatorCli, "#TBD-cli-mcp-probe")
+        ]
+    }
+  , { feature := "identity-permission"
+    , required := [Surface.runtimeInternal]
+    , deferred := [(Surface.api, "#TBD-identity-graphql-decide")]
+    }
+  , { feature := "apply-reconcile"
+    , required := [Surface.operatorCli]
+    , deferred := [(Surface.operatorUi, "#TBD-ui-apply-preview")]
+    }
+  , { feature := "event-delivery"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "triggers"
+    , required := [Surface.runtimeInternal]
+    , deferred :=
+        [ (Surface.operatorCli, "#TBD-cli-task-run-lean")
+        , (Surface.operatorUi, "#TBD-ui-recent-runs-lean")
+        ]
+    }
+  , { feature := "compaction"
+    , required := [Surface.agentFacing]
+    , deferred := []
+    }
+  , { feature := "transcript"
+    , required := [Surface.agentFacing]
+    , deferred := [(Surface.operatorUi, "#TBD-ui-transcript-lean")]
+    }
+  , { feature := "streaming-response"
+    , required := [Surface.agentFacing]
+    , deferred := [(Surface.operatorUi, "#TBD-ui-stream-render-lean")]
+    }
+  , { feature := "client-shell"
+    , required := [Surface.operatorUi]
+    , deferred := []
+    }
+  , { feature := "command-policy"
+    , required := [Surface.agentFacing]
+    , deferred := [(Surface.operatorUi, "#TBD-ui-command-denial")]
+    }
+  , { feature := "recovery"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "fleet-slot-accounting"
+    , required := [Surface.runtimeInternal]
+    , deferred := [(Surface.api, "#TBD-fleet-graphql-introspect")]
+    }
+  , { feature := "storage-observation"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "persistence-failure-policy"
+    , required := [Surface.runtimeInternal]
+    , deferred := []
+    }
+  , { feature := "backend-health"
+    , required := [Surface.runtimeInternal]
+    , deferred := [(Surface.operatorUi, "#TBD-ui-backend-status")]
+    }
+  ]
+
 def vocabularyCoverage : List CoverageEntry :=
-  [ consumerCoverage
+  [ tagged (consumerCoverage
       "vocabulary"
       "RequestState"
-      "lifecycle::tests::rust_request_lifecycle_state_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "lifecycle::tests::rust_request_lifecycle_state_vocabulary_matches_lean_model")
+      "request-lifecycle" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "ExecutionOrigin"
-      "lifecycle::tests::rust_execution_origin_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "lifecycle::tests::rust_execution_origin_vocabulary_matches_lean_model")
+      "request-lifecycle" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "ProcessState"
-      "runtime_status::tests::rust_process_state_vocabulary_matches_lean_model"
-  , boundaryCoverage
+      "runtime_status::tests::rust_process_state_vocabulary_matches_lean_model")
+      "process-lifecycle" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "vocabulary"
       "PersistenceState"
-      boundaryPersistenceAbstractLifecycleId
-  , boundaryCoverage
+      boundaryPersistenceAbstractLifecycleId)
+      "persistence-failure-policy" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "vocabulary"
       "PersistenceFailurePolicy"
-      boundaryStorageHookFailurePolicyId
-  , consumerCoverage
+      boundaryStorageHookFailurePolicyId)
+      "persistence-failure-policy" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "ReconcilePhase"
-      "runtime_status::tests::rust_reconcile_phase_vocabulary_matches_lean_model"
-  , boundaryCoverage
+      "runtime_status::tests::rust_reconcile_phase_vocabulary_matches_lean_model")
+      "runtime-reconcile" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "vocabulary"
       "StorageObservation"
-      boundaryStorageObservationDaemonVisibleId
-  , consumerCoverage
+      boundaryStorageObservationDaemonVisibleId)
+      "storage-observation" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "SessionRecoveryLatestRequestState"
-      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract")
+      "session-recovery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "InferenceCallState"
-      "admission::tests::rust_inference_call_state_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "admission::tests::rust_inference_call_state_vocabulary_matches_lean_model")
+      "inference-call" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "InferenceCallTerminalReason"
-      "admission::tests::rust_inference_call_terminal_reason_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "admission::tests::rust_inference_call_terminal_reason_vocabulary_matches_lean_model")
+      "inference-call" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "vocabulary"
       "ToolRetryDisposition"
-      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy"
-  , consumerCoverage
+      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "ToolCallState"
-      "tool_call_lifecycle::tests::rust_tool_call_state_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "tool_call_lifecycle::tests::rust_tool_call_state_vocabulary_matches_lean_model")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "CancelCause"
-      "tool_call_lifecycle::tests::rust_cancel_cause_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "tool_call_lifecycle::tests::rust_cancel_cause_vocabulary_matches_lean_model")
+      "interrupt-and-cancel" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "ManagedExecState"
-      "managed_exec::tests::rust_managed_exec_state_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "managed_exec::tests::rust_managed_exec_state_vocabulary_matches_lean_model")
+      "managed-exec" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "ToolFailureClass"
-      "tool_call_lifecycle::tests::rust_failure_class_vocabulary_matches_lean_model"
-  , consumerCoverage
+      "tool_call_lifecycle::tests::rust_failure_class_vocabulary_matches_lean_model")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "AwaitMode"
-      "state_machine_conformance::lean_emits_await_mode_vocabulary"
-  , consumerCoverage
+      "state_machine_conformance::lean_emits_await_mode_vocabulary")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "CancelPolicy"
-      "state_machine_conformance::lean_emits_cancel_policy_vocabulary"
-  , consumerCoverage
+      "state_machine_conformance::lean_emits_cancel_policy_vocabulary")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "vocabulary"
       "ChildTerminal"
-      "state_machine_conformance::lean_emits_child_terminal_vocabulary_and_projections"
+      "state_machine_conformance::lean_emits_child_terminal_vocabulary_and_projections")
+      "background-tools" [Surface.agentFacing]
   ]
 
 def stateMachineCoverage : List CoverageEntry :=
-  [ consumerCoverage
+  [ tagged (consumerCoverage
       "state_machine"
       "Request"
-      "lifecycle::tests::request_state_machine_contract_is_complete"
-  , consumerCoverage
+      "lifecycle::tests::request_state_machine_contract_is_complete")
+      "request-lifecycle" [Surface.agentFacing, Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "Process"
-      "runtime_status::tests::rust_process_state_transitions_match_lean_contract"
-  , boundaryCoverage
+      "runtime_status::tests::rust_process_state_transitions_match_lean_contract")
+      "process-lifecycle" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "state_machine"
       "Persistence.failClosed"
       boundaryStorageHookFailurePolicyId
-      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
-  , boundaryCoverage
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains")
+      "persistence-failure-policy" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "state_machine"
       "Persistence.failOpen"
       boundaryStorageHookFailurePolicyId
-      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
-  , boundaryCoverage
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains")
+      "persistence-failure-policy" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "state_machine"
       "StorageObservation.failClosed"
       boundaryStorageObservationDaemonVisibleId
-      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
-  , boundaryCoverage
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains")
+      "storage-observation" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "state_machine"
       "StorageObservation.failOpen"
       boundaryStorageObservationDaemonVisibleId
-      "state_machine_conformance::lean_executable_contracts_cover_initial_domains"
-  , consumerCoverage
+      "state_machine_conformance::lean_executable_contracts_cover_initial_domains")
+      "storage-observation" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "RuntimeReconcile"
-      "runtime_status::tests::runtime_reconcile_state_machine_contract_is_complete"
-  , consumerCoverage
+      "runtime_status::tests::runtime_reconcile_state_machine_contract_is_complete")
+      "runtime-reconcile" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "PairingReconcile"
-      "agent::reconcile::tests::pairing_reconcile_state_machine_contract_is_complete"
-  , consumerCoverage
+      "agent::reconcile::tests::pairing_reconcile_state_machine_contract_is_complete")
+      "pairing-reconcile" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "SessionRecovery"
-      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract")
+      "session-recovery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "InferenceCall"
-      "admission::tests::rust_inference_call_transition_table_matches_lean_contract"
-  , consumerCoverage
+      "admission::tests::rust_inference_call_transition_table_matches_lean_contract")
+      "inference-call" [Surface.agentFacing, Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "ToolCall"
-      "tool_call_lifecycle::tests::tool_call_state_machine_contract_is_complete"
-  , consumerCoverage
+      "tool_call_lifecycle::tests::tool_call_state_machine_contract_is_complete")
+      "tool-call" [Surface.agentFacing, Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "state_machine"
       "ManagedExec"
-      "managed_exec::tests::managed_exec_state_machine_contract_is_complete"
-  , consumerCoverage
+      "managed_exec::tests::managed_exec_state_machine_contract_is_complete")
+      "managed-exec" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "state_machine"
       "AwaitMode"
-      "state_machine_conformance::lean_emits_await_mode_vocabulary"
-  , consumerCoverage
+      "state_machine_conformance::lean_emits_await_mode_vocabulary")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "state_machine"
       "CancelPolicy"
-      "state_machine_conformance::lean_emits_cancel_policy_vocabulary"
-  , consumerCoverage
+      "state_machine_conformance::lean_emits_cancel_policy_vocabulary")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "state_machine"
       "ChildTerminal"
-      "state_machine_conformance::lean_emits_child_terminal_vocabulary_and_projections"
+      "state_machine_conformance::lean_emits_child_terminal_vocabulary_and_projections")
+      "background-tools" [Surface.agentFacing]
   ]
 
 def caseCoverage : List CoverageEntry :=
-  [ consumerCoverage
+  [ tagged (consumerCoverage
       "lifecycle_transition_cases"
       "RequestTransitions"
-      "state_machine_conformance::generated_request_transition_cases_cover_lifecycle_policy"
-  , consumerCoverage
+      "state_machine_conformance::generated_request_transition_cases_cover_lifecycle_policy")
+      "request-lifecycle" [Surface.agentFacing, Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "lifecycle_transition_cases"
       "ProcessTransitions"
-      "runtime_status::tests::generated_process_transition_cases_match_runtime_status_policy"
-  , consumerCoverage
+      "runtime_status::tests::generated_process_transition_cases_match_runtime_status_policy")
+      "process-lifecycle" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "trigger_cases"
       "TriggerDispatch"
-      "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases"
-  , consumerCoverage
+      "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases")
+      "triggers" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "runtime_cases"
       "RuntimeReconcileCases"
-      "runtime_status::tests::runtime_status_generation_updates_match_lean_runtime_reconcile_cases"
-  , consumerCoverage
+      "runtime_status::tests::runtime_status_generation_updates_match_lean_runtime_reconcile_cases")
+      "runtime-reconcile" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "apply_reconcile_cases"
       "ApplyReconcileCases"
-      "config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary"
-  , consumerCoverage
+      "config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary")
+      "apply-reconcile" [Surface.operatorCli]
+  , tagged (consumerCoverage
       "session_recovery_cases"
       "SessionRecoveryCases"
-      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_session_recovery_cases_drive_db_backed_reissue_contract")
+      "session-recovery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "slot_cases"
       "InferenceCallSlotAccounting"
-      "admission::tests::generated_inference_slot_accounting_cases_match_admission_reconstruction_logic"
-  , boundaryCoverage
+      "admission::tests::generated_inference_slot_accounting_cases_match_admission_reconstruction_logic")
+      "inference-call" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "fleet_cases"
       "FleetSlotAccounting"
       boundaryFleetSlotAccountingDerivedViewId
-      "admission::tests::generated_slot_accounting_fleet_cases_match_admission_runtime_boundary"
-  , boundaryCoverage
+      "admission::tests::generated_slot_accounting_fleet_cases_match_admission_runtime_boundary")
+      "fleet-slot-accounting" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "persistence_policy_cases"
       "PersistenceFailurePolicyCases"
       boundaryStorageHookFailurePolicyId
-      "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions"
-  , boundaryCoverage
+      "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions")
+      "persistence-failure-policy" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "storage_observation_cases"
       "StorageObservationRuntimeCases"
       boundaryStorageObservationDaemonVisibleId
-      "hook::tests::generated_storage_observation_cases_match_hook_runtime_classification"
-  , boundaryCoverage
+      "hook::tests::generated_storage_observation_cases_match_hook_runtime_classification")
+      "storage-observation" [Surface.runtimeInternal]
+  , tagged (boundaryCoverage
       "backend_health_cases"
       "BackendHealthAdmissionCases"
       boundaryBackendHealthAdmissionFreshnessId
-      "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy"
-  , consumerCoverage
+      "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy")
+      "backend-health" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "native_filesystem_boundary_cases"
       "NativeFilesystemBoundaryCases"
-      "toolset::tests::generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract"
-  , consumerCoverage
+      "toolset::tests::generated_native_filesystem_boundary_cases_match_preemptible_boundary_contract")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "managed_exec_cases"
       "ManagedExecLivenessCases"
-      "state_machine_conformance::managed_exec_liveness_cases_pin_native_process_boundary"
-  , consumerCoverage
+      "state_machine_conformance::managed_exec_liveness_cases_pin_native_process_boundary")
+      "managed-exec" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "frontend_client_shell_cases"
       "FrontendClientShellCases"
-      "apps/desktop-tauri/src/lib/chat-shell.test.ts::projectChatShell matches generated Lean ClientShell projection contracts"
-  , consumerCoverage
+      "apps/desktop-tauri/src/lib/chat-shell.test.ts::projectChatShell matches generated Lean ClientShell projection contracts")
+      "client-shell" [Surface.operatorUi]
+  , tagged (consumerCoverage
       "desktop_client_shell_cases"
       "DesktopClientShellCases"
-      "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_projection_consumes_generated_client_shell_contract_cases"
-  , consumerCoverage
+      "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_projection_consumes_generated_client_shell_contract_cases")
+      "client-shell" [Surface.operatorUi]
+  , tagged (consumerCoverage
       "live_overlay_cases"
       "LiveOverlayCases"
-      "live_overlay_conformance::live_overlay_cases_match_lean_table"
-  , consumerCoverage
+      "live_overlay_conformance::live_overlay_cases_match_lean_table")
+      "client-shell" [Surface.operatorUi]
+  , tagged (consumerCoverage
       "tool_cases"
       "ToolExecutionPreflight"
-      "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts"
-  , consumerCoverage
+      "state_machine_conformance::generated_tool_execution_cases_cover_preflight_and_retry_contracts")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "tool_cases"
       "ToolExecutionRetry"
-      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy"
-  , consumerCoverage
+      "mcp_pool::tests::tool_retry_disposition_contract_cases_match_mcp_pool_policy")
+      "tool-call" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "command_policy_cases"
       "CommandPolicyValidation"
-      "toolset::tests::generated_command_policy_cases_match_rust_validation"
-  , consumerCoverage
+      "toolset::tests::generated_command_policy_cases_match_rust_validation")
+      "command-policy" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "command_policy_cases"
       "CommandPolicySandbox"
-      "toolset::tests::generated_command_sandbox_cases_match_rust_selection"
-  , consumerCoverage
+      "toolset::tests::generated_command_sandbox_cases_match_rust_selection")
+      "command-policy" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "command_policy_cases"
       "CommandPolicyEnv"
-      "toolset::tests::generated_command_env_cases_match_rust_filtering"
-  , consumerCoverage
+      "toolset::tests::generated_command_env_cases_match_rust_filtering")
+      "command-policy" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "queue_deadline_cases"
       "QueueDeadlineConformanceCases"
-      "state_machine_conformance::generated_queue_deadline_cases_pin_r4a_contract_rows"
-  , consumerCoverage
+      "state_machine_conformance::generated_queue_deadline_cases_pin_r4a_contract_rows")
+      "request-lifecycle" [Surface.agentFacing, Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "recovery_sweep_cases"
       "RecoverySweepCases"
-      "state_machine_conformance::generated_recovery_sweep_cases_drive_startup_recovery_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_recovery_sweep_cases_drive_startup_recovery_contract")
+      "recovery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "r6_background_cases"
       "R6BackgroundingCases"
-      "state_machine_conformance::generated_r6_backgrounding_cases_pin_tool_backgrounding_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_r6_backgrounding_cases_pin_tool_backgrounding_contract")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "r6_background_theorem_witnesses"
       "BackgroundBudgetBoundedTheoremWitness"
-      "state_machine_conformance::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant"
-  , consumerCoverage
+      "state_machine_conformance::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant")
+      "background-tools" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "r6_background_theorem_witnesses"
       "CascadeCancelsChildTheoremWitness"
-      "state_machine_conformance::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace"
-  , consumerCoverage
+      "state_machine_conformance::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "r4c_background_work_cases"
       "R4cBackgroundWorkCases"
-      "state_machine_conformance::generated_r4c_background_work_cases_pin_observable_shapes"
-  , consumerCoverage
+      "state_machine_conformance::generated_r4c_background_work_cases_pin_observable_shapes")
+      "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "transcript_cases"
       "TranscriptConformanceCases"
-      "state_machine_conformance::generated_transcript_cases_drive_agent_message_ordering_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_transcript_cases_drive_agent_message_ordering_contract")
+      "transcript" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "identity_structural_cases"
       "IdentityStructuralCases"
-      "identity_conformance::identity_structural_cases_match_lean_verdicts"
-  , consumerCoverage
+      "identity_conformance::identity_structural_cases_match_lean_verdicts")
+      "identity-permission" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "identity_permission_cases"
       "IdentityPermissionCases"
-      "identity_conformance::identity_permission_cases_pin_runtime_permission_contract_shape"
-  , consumerCoverage
+      "identity_conformance::identity_permission_cases_pin_runtime_permission_contract_shape")
+      "identity-permission" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "identity_contracts"
       "IdentityContracts"
-      "identity_conformance::identity_respects_principal_contract_enforced_by_runtime_routing"
-  , consumerCoverage
+      "identity_conformance::identity_respects_principal_contract_enforced_by_runtime_routing")
+      "identity-permission" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "streaming_response_cases"
       "ResponseTransitionCases"
-      "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract"
-  , consumerCoverage
+      "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract")
+      "streaming-response" [Surface.agentFacing]
+  , tagged (consumerCoverage
       "compaction_reducer_cases"
       "CompactionReducerCases"
-      "state_machine_conformance::generated_compaction_reducer_cases_pin_contract"
+      "state_machine_conformance::generated_compaction_reducer_cases_pin_contract")
+      "compaction" [Surface.agentFacing]
   -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
   -- and follow-up issue #252: this consumer still drives the Lean rows
   -- through InMemoryEventDeliverySource rather than the production
   -- DefraWatcher/EventSource/SubagentSource loops.
-  , consumerWithFollowUpCoverage
+  , tagged (consumerWithFollowUpCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"
       "state_machine_conformance::event_delivery_transition_cases_match_contract"
-      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops."
-  , consumerCoverage
+      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops.")
+      "event-delivery" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "event_delivery_cases"
       "EventDeliverySourceInstances"
-      "state_machine_conformance::event_delivery_source_instances_match_runtime"
+      "state_machine_conformance::event_delivery_source_instances_match_runtime")
+      "event-delivery" [Surface.runtimeInternal]
   -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
   -- and follow-up issue #252: this consumer still drives the Lean traces
   -- through InMemoryEventDeliverySource rather than the production
   -- DefraWatcher/EventSource/SubagentSource loops.
-  , consumerWithFollowUpCoverage
+  , tagged (consumerWithFollowUpCoverage
       "event_delivery_cases"
       "EventDeliveryConvergenceTraces"
       "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation"
-      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops."
+      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops.")
+      "event-delivery" [Surface.runtimeInternal]
   -- 2026-05-19 conformance audit section 10 / section 6 item #2:
   -- Stage 1 drives the K=1 runtime health-check path; Stage 2 issue #253
   -- must add K>=2 backoff behavior and drop the lean_mcp_health_k1_cases filter.
-  , consumerWithFollowUpCoverage
+  , tagged (consumerWithFollowUpCoverage
       "mcp_health_cases"
       "MCPHealthCases"
       "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
-      "Issue #253 adds K>=2 MCPHealth backoff behavior in Rust and drops the lean_mcp_health_k1_cases() filter so the full emitted mcp_health_cases domain is consumed."
+      "Issue #253 adds K>=2 MCPHealth backoff behavior in Rust and drops the lean_mcp_health_k1_cases() filter so the full emitted mcp_health_cases domain is consumed.")
+      "mcp-health" [Surface.runtimeInternal]
   ]
 
 def followUpHookCoverage : List CoverageEntry :=
-  [ followUpCoverage
+  [ tagged (followUpCoverage
       "follow_up_hook"
       "Subagent.BridgedState.foreground_blocks_parent_advance"
-      "Subagent.BridgedState.foreground_blocks_parent_advance proves live foreground tools block parent progress/message advance; related aliases: Subagent.BridgedState.subagent_depth_bounded and Subagent.BridgedState.bridge_link_symmetric. Accepted Lean-only today because the invariant is a proof-layer bridge guard rather than an emitted runtime witness."
-  , followUpCoverage
+      "Subagent.BridgedState.foreground_blocks_parent_advance proves live foreground tools block parent progress/message advance; related aliases: Subagent.BridgedState.subagent_depth_bounded and Subagent.BridgedState.bridge_link_symmetric. Accepted Lean-only today because the invariant is a proof-layer bridge guard rather than an emitted runtime witness.")
+      "background-tools" []
+  , tagged (followUpCoverage
       "follow_up_hook"
       "Subagent.BridgedState.bridged_child_completion_propagates"
-      "Subagent.BridgedState.bridged_child_completion_propagates proves child completion projects to parent bridge-tool completion; related failure projection: Subagent.BridgedState.bridged_child_failure_projects. Accepted Lean-only today because R6Background emits data-shape cases and this theorem remains a formal trace projection."
-  , followUpCoverage
+      "Subagent.BridgedState.bridged_child_completion_propagates proves child completion projects to parent bridge-tool completion; related failure projection: Subagent.BridgedState.bridged_child_failure_projects. Accepted Lean-only today because R6Background emits data-shape cases and this theorem remains a formal trace projection.")
+      "background-tools" []
+  , tagged (followUpCoverage
       "follow_up_hook"
       "Subagent.BridgedState.inv_depth"
-      "Subagent.BridgedState.inv_depth proves bridged traces preserve max subagent depth; related link invariant: Subagent.BridgedState.inv_link. Accepted Lean-only today because these are structural trace invariants with no current Rust witness surface."
-  , followUpCoverage
+      "Subagent.BridgedState.inv_depth proves bridged traces preserve max subagent depth; related link invariant: Subagent.BridgedState.inv_link. Accepted Lean-only today because these are structural trace invariants with no current Rust witness surface.")
+      "background-tools" []
+  , tagged (followUpCoverage
       "follow_up_hook"
       "Subagent.BridgedState.bridgedUniqueCallIds_preserved"
-      "Subagent.BridgedState.bridgedUniqueCallIds_preserved proves parent and child tool call ids remain unique across bridged traces. Accepted Lean-only today because the theorem lifts a structural uniqueness proof rather than an operational R6 witness."
+      "Subagent.BridgedState.bridgedUniqueCallIds_preserved proves parent and child tool call ids remain unique across bridged traces. Accepted Lean-only today because the theorem lifts a structural uniqueness proof rather than an operational R6 witness.")
+      "background-tools" []
   ]
 
 def followUpHookIds : List String :=
@@ -398,13 +649,141 @@ def followUpHooksJson : String :=
 def coverageLedger : List CoverageEntry :=
   vocabularyCoverage ++ stateMachineCoverage ++ caseCoverage ++ followUpHookCoverage
 
+structure FeatureMatrixCell where
+  feature : String
+  surface : Surface
+  coverageStrength : String
+  rowCount : Nat
+  pendingFollowUps : Nat
+  deferredNote : String
+  deriving Repr
+
+def featureSurfaceRequirementsJson : String :=
+  jsonArray (featureSurfaceRequirements.map FeatureSurfaceRequirement.toJson)
+
+def stringPresent (value : String) : Bool :=
+  !(value == "")
+
+def rowCoverageStrength (entry : CoverageEntry) : String :=
+  let hasConsumer := stringPresent entry.consumer
+  let hasBoundary := stringPresent entry.acceptedBoundary
+  let hasFollowUp := stringPresent entry.acceptedFollowUp
+  if hasConsumer && !hasFollowUp then
+    "consumer"
+  else if hasConsumer && hasFollowUp then
+    "consumer_with_follow_up"
+  else if !hasConsumer && hasBoundary then
+    "boundary"
+  else if !hasConsumer && !hasBoundary && hasFollowUp then
+    "follow_up_only"
+  else
+    "missing"
+
+def rowHasSurface (surface : Surface) (entry : CoverageEntry) : Bool :=
+  entry.surfaces.any (fun candidate => candidate == surface)
+
+def matchingFeatureSurfaceRows (feature : String) (surface : Surface) : List CoverageEntry :=
+  coverageLedger.filter (fun entry =>
+    (entry.feature == feature) && rowHasSurface surface entry)
+
+def rowsHaveStrength (rows : List CoverageEntry) (strength : String) : Bool :=
+  rows.any (fun entry => rowCoverageStrength entry == strength)
+
+def strongestCoverageStrength (rows : List CoverageEntry) : String :=
+  if rowsHaveStrength rows "consumer" then
+    "consumer"
+  else if rowsHaveStrength rows "consumer_with_follow_up" then
+    "consumer_with_follow_up"
+  else if rowsHaveStrength rows "boundary" then
+    "boundary"
+  else if rowsHaveStrength rows "follow_up_only" then
+    "follow_up_only"
+  else
+    "missing"
+
+def pendingFollowUpCount (rows : List CoverageEntry) : Nat :=
+  (rows.filter (fun entry => stringPresent entry.acceptedFollowUp)).length
+
+def requiredSurface (req : FeatureSurfaceRequirement) (surface : Surface) : Bool :=
+  req.required.any (fun candidate => candidate == surface)
+
+def deferredSurfaceNote (req : FeatureSurfaceRequirement) (surface : Surface) : Option String :=
+  match req.deferred.find? (fun deferred => deferred.1 == surface) with
+  | some deferred => some deferred.2
+  | none => none
+
+def featureMatrixCell? (req : FeatureSurfaceRequirement)
+    (surface : Surface) : Option FeatureMatrixCell :=
+  let rows := matchingFeatureSurfaceRows req.feature surface
+  match rows with
+  | [] =>
+      match deferredSurfaceNote req surface with
+      | some note =>
+          some
+            { feature := req.feature
+            , surface := surface
+            , coverageStrength := "deferred"
+            , rowCount := 0
+            , pendingFollowUps := 0
+            , deferredNote := note
+            }
+      | none =>
+          if requiredSurface req surface then
+            some
+              { feature := req.feature
+              , surface := surface
+              , coverageStrength := "missing"
+              , rowCount := 0
+              , pendingFollowUps := 0
+              , deferredNote := ""
+              }
+          else
+            none
+  | _ :: _ =>
+      some
+        { feature := req.feature
+        , surface := surface
+        , coverageStrength := strongestCoverageStrength rows
+        , rowCount := rows.length
+        , pendingFollowUps := pendingFollowUpCount rows
+        , deferredNote := ""
+        }
+
+def FeatureMatrixCell.toJson (cell : FeatureMatrixCell) : String :=
+  "{"
+    ++ "\"coverage_strength\":" ++ jsonString cell.coverageStrength ++ ","
+    ++ "\"row_count\":" ++ toString cell.rowCount ++ ","
+    ++ "\"pending_follow_ups\":" ++ toString cell.pendingFollowUps ++ ","
+    ++ "\"deferred_note\":" ++ jsonString cell.deferredNote
+    ++ "}"
+
+def featureMatrixSurfaceCellJson? (req : FeatureSurfaceRequirement)
+    (surface : Surface) : Option String :=
+  match featureMatrixCell? req surface with
+  | some cell => some (Surface.toJson surface ++ ":" ++ FeatureMatrixCell.toJson cell)
+  | none => none
+
+def featureMatrixFeatureJson (req : FeatureSurfaceRequirement) : String :=
+  jsonString req.feature ++ ":"
+    ++ "{"
+    ++ String.intercalate ","
+      (allSurfaces.filterMap (fun surface => featureMatrixSurfaceCellJson? req surface))
+    ++ "}"
+
+def featureMatrixJson : String :=
+  "{"
+    ++ String.intercalate "," (featureSurfaceRequirements.map featureMatrixFeatureJson)
+    ++ "}"
+
 def CoverageEntry.toJson (entry : CoverageEntry) : String :=
   "{"
     ++ "\"category\":" ++ jsonString entry.category ++ ","
     ++ "\"domain\":" ++ jsonString entry.domain ++ ","
     ++ "\"consumer\":" ++ jsonString entry.consumer ++ ","
     ++ "\"accepted_boundary\":" ++ jsonString entry.acceptedBoundary ++ ","
-    ++ "\"accepted_follow_up\":" ++ jsonString entry.acceptedFollowUp
+    ++ "\"accepted_follow_up\":" ++ jsonString entry.acceptedFollowUp ++ ","
+    ++ "\"feature\":" ++ jsonString entry.feature ++ ","
+    ++ "\"surfaces\":" ++ surfacesJson entry.surfaces
     ++ "}"
 
 def coverageLedgerJson : String :=

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -116,7 +116,7 @@ def FeatureSurfaceRequirement.toJson (req : FeatureSurfaceRequirement) : String 
 def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
   [ { feature := "request-lifecycle"
     , required := [Surface.agentFacing, Surface.runtimeInternal]
-    , deferred := [(Surface.operatorUi, "#TBD-request-lifecycle-ui-dedicated-row")]
+    , deferred := [(Surface.operatorUi, "#275")]
     }
   , { feature := "process-lifecycle"
     , required := [Surface.runtimeInternal]
@@ -149,39 +149,39 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
   , { feature := "background-tools"
     , required := [Surface.agentFacing]
     , deferred :=
-        [ (Surface.operatorCli, "#TBD-cli-bg-listing")
-        , (Surface.operatorUi, "#TBD-ui-bg-panel")
+        [ (Surface.operatorCli, "#268")
+        , (Surface.operatorUi, "#276")
         ]
     }
   , { feature := "subagents-cross-deployment"
     , required := []
     , deferred :=
-        [ (Surface.api, "#TBD-r5-api-row")
-        , (Surface.agentFacing, "#TBD-r5-lean-witness")
-        , (Surface.operatorUi, "#TBD-r5-ui-routing")
+        [ (Surface.api, "#272")
+        , (Surface.agentFacing, "#273")
+        , (Surface.operatorUi, "#274")
         ]
     }
   , { feature := "interrupt-and-cancel"
     , required := [Surface.agentFacing]
     , deferred :=
-        [ (Surface.operatorCli, "#TBD-cli-cancel")
-        , (Surface.operatorUi, "#TBD-ui-cancel-button")
+        [ (Surface.operatorCli, "#266")
+        , (Surface.operatorUi, "#277")
         ]
     }
   , { feature := "mcp-health"
     , required := [Surface.runtimeInternal]
     , deferred :=
-        [ (Surface.operatorUi, "#TBD-ui-mcp-status")
-        , (Surface.operatorCli, "#TBD-cli-mcp-probe")
+        [ (Surface.operatorUi, "#278")
+        , (Surface.operatorCli, "#279")
         ]
     }
   , { feature := "identity-permission"
     , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.api, "#TBD-identity-graphql-decide")]
+    , deferred := [(Surface.api, "#280")]
     }
   , { feature := "apply-reconcile"
     , required := [Surface.operatorCli]
-    , deferred := [(Surface.operatorUi, "#TBD-ui-apply-preview")]
+    , deferred := [(Surface.operatorUi, "#281")]
     }
   , { feature := "event-delivery"
     , required := [Surface.runtimeInternal]
@@ -190,8 +190,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
   , { feature := "triggers"
     , required := [Surface.runtimeInternal]
     , deferred :=
-        [ (Surface.operatorCli, "#TBD-cli-task-run-lean")
-        , (Surface.operatorUi, "#TBD-ui-recent-runs-lean")
+        [ (Surface.operatorCli, "#282")
+        , (Surface.operatorUi, "#283")
         ]
     }
   , { feature := "compaction"
@@ -200,11 +200,11 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     }
   , { feature := "transcript"
     , required := [Surface.agentFacing]
-    , deferred := [(Surface.operatorUi, "#TBD-ui-transcript-lean")]
+    , deferred := [(Surface.operatorUi, "#284")]
     }
   , { feature := "streaming-response"
     , required := [Surface.agentFacing]
-    , deferred := [(Surface.operatorUi, "#TBD-ui-stream-render-lean")]
+    , deferred := [(Surface.operatorUi, "#285")]
     }
   , { feature := "client-shell"
     , required := [Surface.operatorUi]
@@ -212,7 +212,7 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     }
   , { feature := "command-policy"
     , required := [Surface.agentFacing]
-    , deferred := [(Surface.operatorUi, "#TBD-ui-command-denial")]
+    , deferred := [(Surface.operatorUi, "#286")]
     }
   , { feature := "recovery"
     , required := [Surface.runtimeInternal]
@@ -220,7 +220,7 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     }
   , { feature := "fleet-slot-accounting"
     , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.api, "#TBD-fleet-graphql-introspect")]
+    , deferred := [(Surface.api, "#287")]
     }
   , { feature := "storage-observation"
     , required := [Surface.runtimeInternal]
@@ -232,7 +232,7 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     }
   , { feature := "backend-health"
     , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.operatorUi, "#TBD-ui-backend-status")]
+    , deferred := [(Surface.operatorUi, "#288")]
     }
   ]
 

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -1,11 +1,13 @@
 #![allow(dead_code)]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 
 use serde::Deserialize;
+
+pub(crate) type LeanFeatureMatrix = BTreeMap<String, BTreeMap<String, LeanFeatureMatrixCell>>;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct LeanVocabulary<'a> {
@@ -66,6 +68,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) compaction_reducer_cases: Vec<LeanCompactionReducerCase>,
     pub(crate) follow_up_hooks: Vec<String>,
     pub(crate) coverage_ledger: Vec<LeanCoverageEntry>,
+    pub(crate) feature_surface_requirements: Vec<LeanFeatureSurfaceRequirement>,
+    pub(crate) feature_matrix: LeanFeatureMatrix,
     pub(crate) identity_structural_cases: Vec<LeanIdentityStructuralCase>,
     pub(crate) identity_permission_cases: Vec<LeanIdentityPermissionCase>,
     pub(crate) identity_contracts: Vec<LeanIdentityContract>,
@@ -120,6 +124,53 @@ pub(crate) struct LeanCoverageEntry {
     pub(crate) consumer: String,
     pub(crate) accepted_boundary: String,
     pub(crate) accepted_follow_up: String,
+    #[serde(default)]
+    pub(crate) feature: String,
+    #[serde(default)]
+    pub(crate) surfaces: Vec<LeanSurface>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum LeanSurface {
+    AgentFacing,
+    OperatorCli,
+    OperatorUi,
+    Api,
+    RuntimeInternal,
+}
+
+impl LeanSurface {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::AgentFacing => "agentFacing",
+            Self::OperatorCli => "operatorCli",
+            Self::OperatorUi => "operatorUi",
+            Self::Api => "api",
+            Self::RuntimeInternal => "runtimeInternal",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanFeatureSurfaceRequirement {
+    pub(crate) feature: String,
+    pub(crate) required: Vec<LeanSurface>,
+    pub(crate) deferred: Vec<LeanFeatureSurfaceDeferral>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanFeatureSurfaceDeferral {
+    pub(crate) surface: LeanSurface,
+    pub(crate) note: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanFeatureMatrixCell {
+    pub(crate) coverage_strength: String,
+    pub(crate) row_count: usize,
+    pub(crate) pending_follow_ups: usize,
+    pub(crate) deferred_note: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -213,6 +264,14 @@ pub(crate) fn lean_state_machine_contract(domain: &str) -> &'static LeanStateMac
         .iter()
         .find(|contract| contract.domain == domain)
         .unwrap_or_else(|| panic!("Lean state-machine contract {domain:?} was not emitted"))
+}
+
+pub(crate) fn lean_feature_surface_requirements() -> &'static [LeanFeatureSurfaceRequirement] {
+    &lean_contract_snapshot().feature_surface_requirements
+}
+
+pub(crate) fn lean_feature_matrix() -> &'static LeanFeatureMatrix {
+    &lean_contract_snapshot().feature_matrix
 }
 
 pub(crate) fn lean_request_transition_cases() -> &'static [LeanLifecycleTransitionCase] {

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -387,6 +387,79 @@ fn lean_deviation_metadata_is_empty_or_explicitly_classified() {
     }
 }
 
+const REQUIRE_FEATURE_TAG_FOR_ALL_ROWS: bool = true;
+
+#[test]
+fn lean_feature_matrix_covers_every_declared_required_surface() {
+    let snapshot = lean_contract_snapshot();
+    let valid_features: BTreeSet<&str> = snapshot
+        .feature_surface_requirements
+        .iter()
+        .map(|req| req.feature.as_str())
+        .collect();
+
+    for entry in &snapshot.coverage_ledger {
+        if REQUIRE_FEATURE_TAG_FOR_ALL_ROWS {
+            assert!(
+                !entry.feature.is_empty(),
+                "coverage ledger row is untagged: {:?}",
+                entry
+            );
+        }
+        if !entry.feature.is_empty() {
+            assert!(
+                valid_features.contains(entry.feature.as_str()),
+                "coverage ledger row tags unknown feature: {:?}",
+                entry
+            );
+            if entry.category != "follow_up_hook" {
+                assert!(
+                    !entry.surfaces.is_empty(),
+                    "coverage ledger row carries feature {:?} but no surfaces; \
+                     each tagged non-follow-up hook row must declare at least one surface: {:?}",
+                    entry.feature,
+                    entry
+                );
+            }
+        }
+    }
+
+    for req in &snapshot.feature_surface_requirements {
+        for surface in &req.required {
+            let covered = snapshot.coverage_ledger.iter().any(|entry| {
+                entry.feature == req.feature
+                    && entry.surfaces.iter().any(|candidate| candidate == surface)
+            });
+            assert!(
+                covered,
+                "feature {:?} declares required surface {:?} but no \
+                 ledger row tags this (feature, surface). Either add a \
+                 ledger row, or move this surface to `deferred` with a \
+                 follow-up note.",
+                req.feature, surface
+            );
+        }
+    }
+
+    for req in &snapshot.feature_surface_requirements {
+        for surface in &req.required {
+            let cell = snapshot
+                .feature_matrix
+                .get(&req.feature)
+                .and_then(|surfaces| surfaces.get(surface.as_str()));
+            let strength = cell
+                .map(|cell| cell.coverage_strength.as_str())
+                .unwrap_or("missing");
+            assert!(
+                strength != "missing",
+                "feature_matrix[{}][{:?}] is `missing` but required",
+                req.feature,
+                surface
+            );
+        }
+    }
+}
+
 #[test]
 fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     let snapshot = lean_contract_snapshot();

--- a/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
@@ -389,7 +389,7 @@ existing ledger rows the worked example (§7) tags with this feature.
 
 | Feature | Required | Deferred | Tag count |
 |---|---|---|---|
-| `request-lifecycle` | `agentFacing`, `runtimeInternal` | `operatorUi` (#TBD-request-lifecycle-ui-dedicated-row, see §7.6) | 5 |
+| `request-lifecycle` | `agentFacing`, `runtimeInternal` | `operatorUi` (#275, see §7.6) | 5 |
 | `process-lifecycle` | `runtimeInternal` | — | 3 |
 | `inference-call` | `agentFacing`, `runtimeInternal` | — | 4 |
 | `tool-call` | `agentFacing`, `runtimeInternal` | — | 7 |
@@ -397,24 +397,24 @@ existing ledger rows the worked example (§7) tags with this feature.
 | `pairing-reconcile` | `runtimeInternal` | — | 1 |
 | `runtime-reconcile` | `runtimeInternal` | — | 3 |
 | `session-recovery` | `runtimeInternal` | — | 3 |
-| `background-tools` | `agentFacing` | `operatorCli` (#TBD-cli-bg-listing), `operatorUi` (#TBD-ui-bg-panel) | 14 |
-| `subagents-cross-deployment` | — | `api` (#TBD-r5-api-row), `agentFacing` (#TBD-r5-lean-witness), `operatorUi` (#TBD-r5-ui-routing) | 0 (see §3.1) |
-| `interrupt-and-cancel` | `agentFacing` | `operatorCli` (#TBD-cli-cancel), `operatorUi` (#TBD-ui-cancel-button) | 1 |
-| `mcp-health` | `runtimeInternal` | `operatorUi` (#TBD-ui-mcp-status), `operatorCli` (#TBD-cli-mcp-probe) | 1 |
-| `identity-permission` | `runtimeInternal` | `api` (#TBD-identity-graphql-decide) | 3 |
-| `apply-reconcile` | `operatorCli` | `operatorUi` (#TBD-ui-apply-preview) | 1 |
+| `background-tools` | `agentFacing` | `operatorCli` (#268), `operatorUi` (#276) | 14 |
+| `subagents-cross-deployment` | — | `api` (#272), `agentFacing` (#273), `operatorUi` (#274) | 0 (see §3.1) |
+| `interrupt-and-cancel` | `agentFacing` | `operatorCli` (#266), `operatorUi` (#277) | 1 |
+| `mcp-health` | `runtimeInternal` | `operatorUi` (#278), `operatorCli` (#279) | 1 |
+| `identity-permission` | `runtimeInternal` | `api` (#280) | 3 |
+| `apply-reconcile` | `operatorCli` | `operatorUi` (#281) | 1 |
 | `event-delivery` | `runtimeInternal` | — | 3 |
-| `triggers` | `runtimeInternal` | `operatorCli` (#TBD-cli-task-run-lean), `operatorUi` (#TBD-ui-recent-runs-lean) | 1 |
+| `triggers` | `runtimeInternal` | `operatorCli` (#282), `operatorUi` (#283) | 1 |
 | `compaction` | `agentFacing` | — | 1 |
-| `transcript` | `agentFacing` | `operatorUi` (#TBD-ui-transcript-lean) | 1 |
-| `streaming-response` | `agentFacing` | `operatorUi` (#TBD-ui-stream-render-lean) | 1 |
+| `transcript` | `agentFacing` | `operatorUi` (#284) | 1 |
+| `streaming-response` | `agentFacing` | `operatorUi` (#285) | 1 |
 | `client-shell` | `operatorUi` | — | 3 |
-| `command-policy` | `agentFacing` | `operatorUi` (#TBD-ui-command-denial) | 3 |
+| `command-policy` | `agentFacing` | `operatorUi` (#286) | 3 |
 | `recovery` | `runtimeInternal` | — | 1 |
-| `fleet-slot-accounting` | `runtimeInternal` | `api` (#TBD-fleet-graphql-introspect) | 1 |
+| `fleet-slot-accounting` | `runtimeInternal` | `api` (#287) | 1 |
 | `storage-observation` | `runtimeInternal` | — | 4 |
 | `persistence-failure-policy` | `runtimeInternal` | — | 5 |
-| `backend-health` | `runtimeInternal` | `operatorUi` (#TBD-ui-backend-status) | 1 |
+| `backend-health` | `runtimeInternal` | `operatorUi` (#288) | 1 |
 
 Tag-count totals: 74 row-tags across 74 distinct ledger rows. Under the
 single-tag rule (§3.2 / §6.2), each existing row is tagged exactly once.
@@ -438,13 +438,13 @@ Three follow-ups, all `deferred`:
 - **`api`.** Promote the existing schema introspection tests to ledger
   consumers by adding a row pointing at them with
   `category := "api_schema_cases"` (a new category). Tracked as
-  #TBD-r5-api-row.
+  #272.
 - **`agentFacing`.** Land an `r5_cross_deployment_cases` Lean domain
   emitting per-field witnesses (Lean already has the R5 model), then bind
-  it from a runtime-tool consumer. Tracked as #TBD-r5-lean-witness.
+  it from a runtime-tool consumer. Tracked as #273.
 - **`operatorUi`.** Surface cross-deployment routing in the desktop
   shell — a deployment badge or routing diagnostic on the chat shell.
-  Tracked as #TBD-r5-ui-routing.
+  Tracked as #274.
 
 The matrix v1 lists all three as `deferred` (no `required` slot) so the
 implementation PR ships without immediately failing the new drift test
@@ -567,10 +567,10 @@ serialized as:
                          "deferred_note": "" },
     "agentFacing":     { "coverage_strength": "deferred",
                          "row_count": 0, "pending_follow_ups": 0,
-                         "deferred_note": "#TBD-r5-lean-witness" },
+                         "deferred_note": "#273" },
     "operatorUi":      { "coverage_strength": "deferred",
                          "row_count": 0, "pending_follow_ups": 0,
-                         "deferred_note": "#TBD-r5-ui-routing" }
+                         "deferred_note": "#274" }
   },
   ...
 }
@@ -1084,7 +1084,7 @@ Two ways to resolve:
 The worked example chooses the soft option for v1. §3's table already
 reflects this: `request-lifecycle.required = [agentFacing,
 runtimeInternal]` and
-`deferred = [operatorUi (#TBD-request-lifecycle-ui-dedicated-row)]`.
+`deferred = [operatorUi (#275)]`.
 
 This is the only required-surface that the worked example downgrades
 to deferred during the v1 tagging pass. Every other `required` surface


### PR DESCRIPTION
Closes #264

## Summary
- extend CoverageEntry with feature and surface annotations plus feature surface requirements
- tag the existing coverage ledger rows and emit feature_surface_requirements plus feature_matrix in the Lean snapshot
- add Rust snapshot types and the feature-matrix drift test

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance