### PR TITLE
runtime: persist CancelCause on AgentToolCall (#249)

### DIFF
--- a/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
+++ b/crates/defra-agent-protocol/schemas/agent/agent_tool_call.graphql
@@ -18,6 +18,7 @@ type AgentToolCall @branchable {
     latency_ms: Int
     await_mode: String
     cancel_policy: String
+    cancel_cause: String
     child_request_id: String @index
     unclaimed_deadline_at: DateTime
     cancel_cascade_intent_at: DateTime

--- a/crates/defra-agent-protocol/src/graphql.rs
+++ b/crates/defra-agent-protocol/src/graphql.rs
@@ -612,11 +612,14 @@ pub fn session_shape_query(session_id: &str) -> String {
                 tool_name
                 tool_call_id
                 status
+                lifecycle_state
                 args
                 result
+                deadline_at
                 selected_service_id
                 selected_tool_name
                 tool_failure_class
+                cancel_cause
                 latency_ms
             }}
             AgentToolResult(filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }}, order: {{ created_at: ASC }}) {{
@@ -808,6 +811,7 @@ mod tests {
         assert!(session_query.contains("selected_service_id"));
         assert!(session_query.contains("selected_tool_name"));
         assert!(session_query.contains("tool_failure_class"));
+        assert!(session_query.contains("cancel_cause"));
         assert!(session_query.contains("latency_ms"));
         assert!(session_query.contains("discarded_because_interrupted"));
     }

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -304,7 +304,11 @@ pub struct AgentToolCallRow {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub lifecycle_state: Option<String>,
+    #[serde(default)]
     pub started_at: Option<String>,
+    #[serde(default)]
+    pub deadline_at: Option<String>,
     #[serde(default)]
     pub completed_at: Option<String>,
     #[serde(default)]
@@ -313,6 +317,8 @@ pub struct AgentToolCallRow {
     pub selected_tool_name: Option<String>,
     #[serde(default)]
     pub tool_failure_class: Option<String>,
+    #[serde(default)]
+    pub cancel_cause: Option<String>,
     #[serde(default)]
     pub latency_ms: Option<i64>,
 }

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -10,7 +10,9 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 use crate::session;
-use crate::tool_call_lifecycle::{AwaitMode, CascadeDispatch, ChildTerminal, ToolCallLifecycle};
+use crate::tool_call_lifecycle::{
+    AwaitMode, CancelCause, CascadeDispatch, ChildTerminal, ToolCallLifecycle,
+};
 use crate::truncation::TruncationLimits;
 
 mod persistence;
@@ -477,7 +479,7 @@ impl DefraSessionHook {
         let count = lifecycles.len();
         for mut lifecycle in lifecycles {
             let dispatch = lifecycle
-                .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+                .cancel_during_run_with_cascade_dispatch(CancelCause::Interrupted, &self.agent_did)
                 .await?;
             if lifecycle.is_cancelled() {
                 if let Some(dispatch) = dispatch {

--- a/crates/defra-agent/src/hook/persistence/background_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/background_tools.rs
@@ -465,7 +465,8 @@ impl DefraSessionHook {
         }
 
         let notification_tool_name = lifecycle.tool_name().to_string();
-        self.cancel_background_tool_lifecycle(lifecycle).await?;
+        self.cancel_background_tool_lifecycle(lifecycle, CancelCause::UserCancelled)
+            .await?;
         let notification_reason = parsed
             .reason
             .as_deref()

--- a/crates/defra-agent/src/hook/persistence/mod.rs
+++ b/crates/defra-agent/src/hook/persistence/mod.rs
@@ -29,7 +29,7 @@ use crate::session;
 use crate::tool_call_lifecycle::query::load_tool_call_result;
 use crate::tool_call_lifecycle::runtime::{classify_managed_tool_result, ManagedToolTerminal};
 use crate::tool_call_lifecycle::{
-    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, CascadeDispatch,
+    create_subagent_request_with_request_id, AwaitMode, CancelCause, CancelPolicy, CascadeDispatch,
     ChildTerminal, FailureClass, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use crate::toolset::{

--- a/crates/defra-agent/src/hook/persistence/prompt_hook.rs
+++ b/crates/defra-agent/src/hook/persistence/prompt_hook.rs
@@ -326,7 +326,9 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 if let Some(mut lc) = lifecycle {
                     match terminal {
                         ManagedToolTerminal::TimedOut => lc.timeout().await?,
-                        ManagedToolTerminal::Cancelled => lc.cancel_during_run().await?,
+                        ManagedToolTerminal::Cancelled => {
+                            lc.cancel_during_run(CancelCause::Interrupted).await?
+                        }
                     }
                 } else {
                     tracing::debug!(

--- a/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
@@ -4,6 +4,7 @@ impl DefraSessionHook {
     pub(super) async fn cancel_live_subagent_descendants(
         &self,
         child_session_id: &str,
+        cause: CancelCause,
     ) -> anyhow::Result<usize> {
         let tool_call_ids = running_subagent_bridge_ids(&self.node, child_session_id).await?;
         let mut cancelled = 0;
@@ -13,6 +14,7 @@ impl DefraSessionHook {
                     child_session_id,
                     &tool_call_id,
                     "descendant",
+                    cause,
                 )
                 .await?
             {
@@ -27,6 +29,7 @@ impl DefraSessionHook {
         session_id: &str,
         tool_call_id: &str,
         bridge_kind: &str,
+        cause: CancelCause,
     ) -> anyhow::Result<bool> {
         let Some(mut lifecycle) = self
             .take_or_load_in_flight_lifecycle(session_id, tool_call_id)
@@ -39,7 +42,7 @@ impl DefraSessionHook {
         }
 
         let dispatch = lifecycle
-            .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+            .cancel_during_run_with_cascade_dispatch(cause, &self.agent_did)
             .await?;
         if !lifecycle.is_cancelled() {
             return Ok(false);
@@ -66,6 +69,7 @@ impl DefraSessionHook {
         session_id: &str,
         tool_call_id: &str,
         bridge_kind: &str,
+        cause: CancelCause,
     ) -> anyhow::Result<bool> {
         let Some(mut lifecycle) =
             ToolCallLifecycle::load(self.node.clone(), session_id, tool_call_id).await?
@@ -77,7 +81,7 @@ impl DefraSessionHook {
         }
 
         let dispatch = lifecycle
-            .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+            .cancel_during_run_with_cascade_dispatch(cause, &self.agent_did)
             .await?;
         if !lifecycle.is_cancelled() {
             return Ok(false);
@@ -361,7 +365,10 @@ impl DefraSessionHook {
                     .await?
                 {
                     let dispatch = match lifecycle
-                        .cancel_during_run_with_cascade_dispatch(&self.agent_did)
+                        .cancel_during_run_with_cascade_dispatch(
+                            CancelCause::Interrupted,
+                            &self.agent_did,
+                        )
                         .await
                     {
                         Ok(dispatch) => dispatch,
@@ -847,7 +854,8 @@ impl DefraSessionHook {
                 .await?
                 .is_some()
             {
-                self.cancel_background_tool_lifecycle(lifecycle).await?;
+                self.cancel_background_tool_lifecycle(lifecycle, CancelCause::Interrupted)
+                    .await?;
                 let lifecycle = self
                     .load_authorized_background_tool(parent_request_id, tool_call_id)
                     .await?;
@@ -857,7 +865,8 @@ impl DefraSessionHook {
             }
 
             if now >= parent_deadline_at {
-                self.cancel_background_tool_lifecycle(lifecycle).await?;
+                self.cancel_background_tool_lifecycle(lifecycle, CancelCause::Deadline)
+                    .await?;
                 let lifecycle = self
                     .load_authorized_background_tool(parent_request_id, tool_call_id)
                     .await?;
@@ -876,6 +885,7 @@ impl DefraSessionHook {
     pub(super) async fn cancel_background_tool_lifecycle(
         &self,
         mut lifecycle: ToolCallLifecycle,
+        cause: CancelCause,
     ) -> anyhow::Result<()> {
         if let Some(execution) = self
             .background_executions
@@ -887,7 +897,7 @@ impl DefraSessionHook {
             execution.cancellation_token.cancel();
         }
         if lifecycle.is_running() {
-            lifecycle.cancel_during_run().await?;
+            lifecycle.cancel_during_run(cause).await?;
         }
         Ok(())
     }

--- a/crates/defra-agent/src/hook/persistence/subagent_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_tools.rs
@@ -244,7 +244,10 @@ impl DefraSessionHook {
             {
                 crate::interrupt::interrupt_request(&self.node, &active_request_id).await?;
                 let _descendants_cancelled = self
-                    .cancel_live_subagent_descendants(&edge.child_session_id)
+                    .cancel_live_subagent_descendants(
+                        &edge.child_session_id,
+                        CancelCause::UserCancelled,
+                    )
                     .await?;
                 interrupted_active_request_id = Some(active_request_id);
             }
@@ -355,13 +358,14 @@ impl DefraSessionHook {
             &parent_context.session_id,
             &edge.parent_tool_call_id,
             "root",
+            CancelCause::UserCancelled,
         )
         .await?;
         let active_interrupted =
             crate::interrupt::interrupt_active_session_request(&self.node, &edge.child_session_id)
                 .await?;
         let descendants_cancelled = self
-            .cancel_live_subagent_descendants(&edge.child_session_id)
+            .cancel_live_subagent_descendants(&edge.child_session_id, CancelCause::UserCancelled)
             .await?;
         queued_drained += crate::interrupt::cancel_subagent_session_queue(
             &self.node,

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -167,6 +167,11 @@ pub async fn ensure_tool_call_migrations(node: Arc<EmbeddedNode>) -> Result<()> 
             r#"{"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"deadline_at","Kind":10}}"#,
         );
     }
+    if !collection_has_field(collection, "cancel_cause") {
+        field_patches.push(
+            r#"{"op":"add","path":"/AgentToolCall/Fields/-","value":{"Name":"cancel_cause","Kind":11}}"#,
+        );
+    }
 
     if field_patches.is_empty() {
         tracing::debug!("AgentToolCall already has all runtime lifecycle fields; migration no-op");

--- a/crates/defra-agent/src/session/fork.rs
+++ b/crates/defra-agent/src/session/fork.rs
@@ -337,7 +337,7 @@ async fn copy_tool_calls(
             ) {{
                 message_sequence tool_name tool_call_id args result status lifecycle_state
                 started_at completed_at selected_service_id selected_tool_name tool_failure_class
-                latency_ms
+                cancel_cause latency_ms
             }}
         }}"#
     );
@@ -376,6 +376,7 @@ async fn copy_tool_calls(
         let selected_service_id = row.get("selected_service_id").and_then(|v| v.as_str());
         let selected_tool_name = row.get("selected_tool_name").and_then(|v| v.as_str());
         let tool_failure_class = row.get("tool_failure_class").and_then(|v| v.as_str());
+        let cancel_cause = row.get("cancel_cause").and_then(|v| v.as_str());
         let latency_ms = row.get("latency_ms").and_then(json_i64);
         let tool_call_id_escaped = escape_graphql_string(tool_call_id);
         let tool_call_key = format!("{child_session_escaped}:{tool_call_id_escaped}");
@@ -395,6 +396,7 @@ async fn copy_tool_calls(
                     selected_service_id: {selected_service_id},
                     selected_tool_name: {selected_tool_name},
                     tool_failure_class: {tool_failure_class},
+                    cancel_cause: {cancel_cause},
                     latency_ms: {latency_ms}
                 }}) {{ _docID }}
             "#,
@@ -408,6 +410,7 @@ async fn copy_tool_calls(
             selected_service_id = nullable_string_literal(selected_service_id),
             selected_tool_name = nullable_string_literal(selected_tool_name),
             tool_failure_class = nullable_string_literal(tool_failure_class),
+            cancel_cause = nullable_string_literal(cancel_cause),
             latency_ms = nullable_i64_literal(latency_ms),
         ));
     }

--- a/crates/defra-agent/src/tool_call_lifecycle.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle.rs
@@ -169,9 +169,6 @@ impl CancelPolicy {
 }
 
 /// Why a tool-call cancellation was requested at the state-machine boundary.
-///
-/// This is mirrored from Lean for conformance first. Runtime methods still
-/// need to accept and persist it on AgentToolCall; tracked by #249.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum CancelCause {
     Interrupted,
@@ -281,6 +278,7 @@ pub struct ToolCallLifecycle {
     state: ToolCallState,
     started_at: Option<chrono::DateTime<chrono::Utc>>,
     failure_class: Option<FailureClass>,
+    cancel_cause: Option<CancelCause>,
     pub(crate) await_mode: AwaitMode,
     pub(crate) cancel_policy: CancelPolicy,
     pub(crate) child_request_id: Option<String>,
@@ -313,6 +311,7 @@ impl ToolCallLifecycle {
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
+            cancel_cause: None,
             await_mode: AwaitMode::Foreground,
             cancel_policy: CancelPolicy::Cascade,
             child_request_id: None,
@@ -350,6 +349,7 @@ impl ToolCallLifecycle {
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
+            cancel_cause: None,
             await_mode,
             cancel_policy,
             child_request_id: Some(child_request_id),
@@ -382,6 +382,7 @@ impl ToolCallLifecycle {
             state: ToolCallState::Pending,
             started_at: None,
             failure_class: None,
+            cancel_cause: None,
             await_mode: AwaitMode::Background,
             cancel_policy: CancelPolicy::Cascade,
             child_request_id: None,

--- a/crates/defra-agent/src/tool_call_lifecycle/query.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/query.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
 
-use super::{AwaitMode, CancelPolicy, FailureClass, ToolCallLifecycle, ToolCallState};
+use super::{AwaitMode, CancelCause, CancelPolicy, FailureClass, ToolCallLifecycle, ToolCallState};
 
 #[derive(Debug, Clone, Deserialize)]
 struct ToolCallResultRow {
@@ -78,6 +78,7 @@ struct ToolCallRow {
     #[serde(default)]
     deadline_at: Option<String>,
     tool_failure_class: Option<String>,
+    cancel_cause: Option<String>,
     // v3 subagent fields — nullable for v2 rows that pre-date the schema migration.
     await_mode: Option<String>,
     cancel_policy: Option<String>,
@@ -113,6 +114,7 @@ impl ToolCallLifecycle {
                     started_at
                     deadline_at
                     tool_failure_class
+                    cancel_cause
                     await_mode
                     cancel_policy
                     child_request_id
@@ -165,6 +167,11 @@ impl ToolCallLifecycle {
             .as_deref()
             .and_then(FailureClass::from_persisted);
 
+        let cancel_cause = row
+            .cancel_cause
+            .as_deref()
+            .and_then(CancelCause::from_persisted);
+
         // v3 subagent fields. v2 rows (where these columns are null) fall back
         // to the same defaults that Self::new() uses, preserving backwards compat.
         let await_mode = row
@@ -199,6 +206,7 @@ impl ToolCallLifecycle {
             state,
             started_at,
             failure_class,
+            cancel_cause,
             await_mode,
             cancel_policy,
             child_request_id,

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -14,8 +14,8 @@ use crate::interrupt::interrupt_request;
 use crate::session::execute_mutation_with_retry;
 
 use super::{
-    subagent_request::create_subagent_request_with_request_id, AwaitMode, CancelPolicy,
-    ChildTerminal, FailureClass, ToolCallState,
+    subagent_request::create_subagent_request_with_request_id, AwaitMode, CancelCause,
+    CancelPolicy, ChildTerminal, FailureClass, ToolCallState,
 };
 
 #[derive(Debug, Default)]
@@ -43,6 +43,8 @@ struct RunningToolCallRow {
     await_mode: Option<String>,
     #[serde(default)]
     cancel_policy: Option<String>,
+    #[serde(default)]
+    cancel_cause: Option<String>,
     #[serde(default)]
     child_request_id: Option<String>,
     #[serde(default)]
@@ -455,6 +457,7 @@ async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningT
             deadline_at
             await_mode
             cancel_policy
+            cancel_cause
             child_request_id
             unclaimed_deadline_at
         }
@@ -661,6 +664,17 @@ async fn recover_bridge_failed_row(
     let latency_ms = (now - started_at).num_milliseconds().max(0);
     let escaped_doc_id = escape_graphql_string(&row.doc_id);
     let projected = terminal.projected_state().as_str();
+    let cancel_cause_field = if terminal.projected_state() == ToolCallState::Cancelled {
+        let cause = row
+            .cancel_cause
+            .as_deref()
+            .and_then(CancelCause::from_persisted)
+            .unwrap_or(CancelCause::Interrupted)
+            .as_str();
+        format!(r#"cancel_cause: "{cause}","#)
+    } else {
+        String::new()
+    };
     let optional_fields = match terminal {
         ChildTerminal::Failed {
             reason,
@@ -684,6 +698,7 @@ async fn recover_bridge_failed_row(
                 }},
                 input: {{
                     {optional_fields}
+                    {cancel_cause_field}
                     status: "completed",
                     lifecycle_state: "{projected}",
                     started_at: "{started_at}",
@@ -726,6 +741,10 @@ async fn recover_tool_call_row(
         .failure_class()
         .map(|failure| format!(r#", tool_failure_class: "{}""#, failure.as_str()))
         .unwrap_or_default();
+    let cancel_cause_field = outcome
+        .cancel_cause(row.cancel_cause.as_deref())
+        .map(|cause| format!(r#", cancel_cause: "{}""#, cause.as_str()))
+        .unwrap_or_default();
     let remote_cancel_intent_fields = remote_cancel_intent_at
         .map(|at| {
             format!(
@@ -746,7 +765,7 @@ async fn recover_tool_call_row(
                     started_at: "{started_at_str}"{deadline_field},
                     completed_at: "{completed_at_str}",
                     latency_ms: {latency_ms},
-                    unclaimed_deadline_at: null{failure_class_field}{remote_cancel_intent_fields}
+                    unclaimed_deadline_at: null{failure_class_field}{cancel_cause_field}{remote_cancel_intent_fields}
                 }}
             ) {{ _docID }}
         }}"#,
@@ -909,5 +928,15 @@ impl RecoveryOutcome {
                 "no peer claimed subagent spawn before the unclaimed spawn deadline".to_string()
             }
         }
+    }
+
+    fn cancel_cause(self, persisted: Option<&str>) -> Option<CancelCause> {
+        persisted
+            .and_then(CancelCause::from_persisted)
+            .or(match self {
+                Self::TimedOut => Some(CancelCause::Deadline),
+                Self::Cancelled | Self::BackgroundInterrupted => Some(CancelCause::Interrupted),
+                Self::Failed | Self::UnclaimedCrossDeploymentSpawn => None,
+            })
     }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/transition.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition.rs
@@ -18,8 +18,8 @@ use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::session::execute_mutation_with_retry;
 
 use super::{
-    AwaitMode, CancelPolicy, CascadeDispatch, CascadeIntent, ChildTerminal, FailureClass,
-    ToolCallLifecycle, ToolCallState,
+    AwaitMode, CancelCause, CancelPolicy, CascadeDispatch, CascadeIntent, ChildTerminal,
+    FailureClass, ToolCallLifecycle, ToolCallState,
 };
 
 /// Error returned when a transition method is called from an illegal
@@ -83,6 +83,7 @@ impl ToolCallLifecycle {
         self.state = current.state;
         self.started_at = current.started_at;
         self.failure_class = current.failure_class;
+        self.cancel_cause = current.cancel_cause;
         self.await_mode = current.await_mode;
         self.cancel_policy = current.cancel_policy;
         self.child_request_id = current.child_request_id;
@@ -120,6 +121,7 @@ impl ToolCallLifecycle {
         self.state = current.state;
         self.started_at = current.started_at;
         self.failure_class = current.failure_class;
+        self.cancel_cause = current.cancel_cause;
         self.await_mode = current.await_mode;
         self.cancel_policy = current.cancel_policy;
         self.child_request_id = current.child_request_id;

--- a/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
@@ -116,6 +116,10 @@ impl ToolCallLifecycle {
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let lifecycle_state_str = projected.as_str();
         let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
+        // If an upstream cascade already cancelled this bridge with a more
+        // specific cause, this running-state compare fails and preserves that
+        // earlier write. A successful cancelled projection here only observes
+        // the child terminal .interrupted evidence.
         let cancel_cause_field = (projected == ToolCallState::Cancelled)
             .then(|| format!(r#"cancel_cause: "{}","#, CancelCause::Interrupted.as_str()))
             .unwrap_or_default();

--- a/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition/bridge.rs
@@ -116,6 +116,9 @@ impl ToolCallLifecycle {
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let lifecycle_state_str = projected.as_str();
         let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
+        let cancel_cause_field = (projected == ToolCallState::Cancelled)
+            .then(|| format!(r#"cancel_cause: "{}","#, CancelCause::Interrupted.as_str()))
+            .unwrap_or_default();
 
         // Build conditional fields: tool_failure_class and result are only
         // set when the child reached .failed (mirrors R1's fail() pattern).
@@ -140,6 +143,7 @@ impl ToolCallLifecycle {
                     }},
                     input: {{
                         {optional_fields}
+                        {cancel_cause_field}
                         status: "completed",
                         lifecycle_state: "{lifecycle_state_str}",
                         started_at: "{started_at_str}",
@@ -168,6 +172,8 @@ impl ToolCallLifecycle {
 
         self.state = projected;
         self.failure_class = failure_class_for_persist;
+        self.cancel_cause =
+            (projected == ToolCallState::Cancelled).then_some(CancelCause::Interrupted);
         Ok(true)
     }
 
@@ -252,8 +258,8 @@ impl ToolCallLifecycle {
     /// Running → Cancelled. Called by request interruption handling and
     /// startup recovery for interrupted parent requests.
     ///
-    pub async fn cancel_during_run(&mut self) -> Result<()> {
-        self.cancel_during_run_inner(None).await
+    pub async fn cancel_during_run(&mut self, cause: CancelCause) -> Result<()> {
+        self.cancel_during_run_inner(cause, None).await
     }
 
     /// Running -> Cancelled while dispatching a cascade cancel. For remote
@@ -262,6 +268,7 @@ impl ToolCallLifecycle {
     /// bridge without the remote signal.
     pub async fn cancel_during_run_with_cascade_dispatch(
         &mut self,
+        cause: CancelCause,
         local_did: &str,
     ) -> Result<Option<CascadeDispatch>> {
         self.ensure_state(
@@ -270,11 +277,11 @@ impl ToolCallLifecycle {
         )?;
 
         let Some(child_request_id) = self.child_request_id.clone() else {
-            self.cancel_during_run_inner(None).await?;
+            self.cancel_during_run_inner(cause, None).await?;
             return Ok(None);
         };
         if self.cancel_policy != CancelPolicy::Cascade {
-            self.cancel_during_run_inner(None).await?;
+            self.cancel_during_run_inner(cause, None).await?;
             return Ok(None);
         }
 
@@ -283,14 +290,14 @@ impl ToolCallLifecycle {
             at: chrono::Utc::now(),
         };
         if child_request_is_locally_owned(&self.node, local_did, &intent.child_request_id).await? {
-            self.cancel_during_run_inner(None).await?;
+            self.cancel_during_run_inner(cause, None).await?;
             if self.is_cancelled() {
                 return Ok(Some(CascadeDispatch::Local(intent)));
             }
             return Ok(None);
         }
 
-        self.cancel_during_run_inner(Some(intent.at)).await?;
+        self.cancel_during_run_inner(cause, Some(intent.at)).await?;
         if self.is_cancelled() {
             Ok(Some(CascadeDispatch::RemoteIntentWritten))
         } else {
@@ -300,10 +307,9 @@ impl ToolCallLifecycle {
 
     async fn cancel_during_run_inner(
         &mut self,
+        cause: CancelCause,
         remote_cancel_intent_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<()> {
-        // TODO(#249): accept and persist `CancelCause` once AgentToolCall has
-        // a cancel_cause field.
         self.ensure_state(&[ToolCallState::Running], "cancel_during_run")?;
 
         let doc_id = self.doc_id.as_ref().ok_or_else(|| {
@@ -318,6 +324,7 @@ impl ToolCallLifecycle {
         let escaped_doc_id = escape_graphql_string(doc_id);
         let escaped_result = escape_graphql_string("tool call cancelled");
         let now_str = now.to_rfc3339();
+        let cancel_cause = cause.as_str();
         // DefraDB requires DateTime fields to be re-supplied on update.
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
@@ -344,6 +351,7 @@ impl ToolCallLifecycle {
                         result: "{escaped_result}",
                         status: "completed",
                         lifecycle_state: "cancelled",
+                        cancel_cause: "{cancel_cause}",
                         started_at: "{started_at_str}",
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
@@ -370,6 +378,7 @@ impl ToolCallLifecycle {
         }
 
         self.state = ToolCallState::Cancelled;
+        self.cancel_cause = Some(cause);
         Ok(())
     }
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/transition/native.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/transition/native.rs
@@ -278,6 +278,7 @@ impl ToolCallLifecycle {
         let started_at_str = started_at.to_rfc3339();
         let deadline_at_str = self.deadline_at.to_rfc3339();
         let failure_class = FailureClass::External.as_str();
+        let cancel_cause = CancelCause::Deadline.as_str();
         let unclaimed_deadline_clear = self.clear_unclaimed_deadline_fragment();
 
         let mutation = format!(
@@ -289,6 +290,7 @@ impl ToolCallLifecycle {
                         status: "completed",
                         lifecycle_state: "timedOut",
                         tool_failure_class: "{failure_class}",
+                        cancel_cause: "{cancel_cause}",
                         started_at: "{started_at_str}",
                         deadline_at: "{deadline_at_str}",
                         completed_at: "{now_str}",
@@ -305,15 +307,14 @@ impl ToolCallLifecycle {
 
         self.state = ToolCallState::TimedOut;
         self.failure_class = Some(FailureClass::External);
+        self.cancel_cause = Some(CancelCause::Deadline);
         Ok(())
     }
 
     /// Pending → Cancelled. Used when a tool call is cancelled before
     /// dispatch creates a running row.
     ///
-    /// TODO(#249): accept and persist `CancelCause` once AgentToolCall has a
-    /// cancel_cause field.
-    pub async fn cancel_before_dispatch(&mut self) -> Result<()> {
+    pub async fn cancel_before_dispatch(&mut self, cause: CancelCause) -> Result<()> {
         self.ensure_state(&[ToolCallState::Pending], "cancel_before_dispatch")?;
 
         // Pending: row may not exist yet. Create directly in Cancelled.
@@ -327,6 +328,7 @@ impl ToolCallLifecycle {
         let escaped_args = escape_graphql_string(&self.args);
         let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
         let message_sequence = self.message_sequence;
+        let cancel_cause = cause.as_str();
 
         let escaped_result = escape_graphql_string("tool call cancelled before dispatch");
 
@@ -343,6 +345,7 @@ impl ToolCallLifecycle {
                     result: "{escaped_result}",
                     status: "completed",
                     lifecycle_state: "cancelled",
+                    cancel_cause: "{cancel_cause}",
                     started_at: null,
                     deadline_at: "{deadline_at_str}",
                     completed_at: "{started_at_str}",
@@ -359,6 +362,7 @@ impl ToolCallLifecycle {
 
         self.doc_id = Some(doc_id);
         self.state = ToolCallState::Cancelled;
+        self.cancel_cause = Some(cause);
         Ok(())
     }
 }

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -453,6 +453,7 @@ mod tests {
                     args: "{}",
                     status: "completed",
                     lifecycle_state: "cancelled",
+                    cancel_cause: "interrupted",
                     started_at: "2026-05-15T00:00:00Z",
                     deadline_at: "2026-05-15T00:05:00Z",
                     completed_at: "2026-05-15T00:01:00Z",

--- a/crates/defra-agent/tests/lifecycle_recovery.rs
+++ b/crates/defra-agent/tests/lifecycle_recovery.rs
@@ -292,6 +292,7 @@ async fn recover_all_times_out_expired_running_tool_calls() {
     let snapshots = fetch_tool_call_snapshots_for_session(&db.node, "tool-timeout-session").await;
     assert_eq!(snapshots.len(), 1);
     assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("timedOut"));
+    assert_eq!(snapshots[0].cancel_cause.as_deref(), Some("deadline"));
     assert_eq!(snapshots[0].status, "completed");
     assert!(snapshots[0].result.contains("deadline exceeded"));
 }
@@ -352,6 +353,10 @@ async fn recover_all_cancels_running_tool_call_for_interrupted_parent_only() {
     assert_eq!(
         cancelled_snapshots[0].lifecycle_state.as_deref(),
         Some("cancelled")
+    );
+    assert_eq!(
+        cancelled_snapshots[0].cancel_cause.as_deref(),
+        Some("interrupted")
     );
 
     let unrelated_snapshots =

--- a/crates/defra-agent/tests/r4_subagent_tools.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::tool_call_lifecycle::{
-    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, CascadeDispatch,
+    create_subagent_request_with_request_id, AwaitMode, CancelCause, CancelPolicy, CascadeDispatch,
     ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use defra_agent::{
@@ -73,6 +73,7 @@ struct ToolCallRow {
     lifecycle_state: Option<String>,
     await_mode: Option<String>,
     cancel_policy: Option<String>,
+    cancel_cause: Option<String>,
     child_request_id: Option<String>,
     unclaimed_deadline_at: Option<String>,
     cancel_cascade_intent_at: Option<String>,
@@ -303,6 +304,7 @@ async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &s
                 lifecycle_state
                 await_mode
                 cancel_policy
+                cancel_cause
                 child_request_id
                 unclaimed_deadline_at
                 cancel_cascade_intent_at

--- a/crates/defra-agent/tests/r4_subagent_tools/background_cancel.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools/background_cancel.rs
@@ -210,7 +210,7 @@ async fn cross_deployment_cancel_writes_cascade_intent_on_bridge() {
             .unwrap()
             .expect("bridge should be persisted");
     let dispatch = lifecycle
-        .cancel_during_run_with_cascade_dispatch(AGENT_DID)
+        .cancel_during_run_with_cascade_dispatch(CancelCause::Interrupted, AGENT_DID)
         .await
         .unwrap()
         .expect("cascade dispatch");
@@ -220,6 +220,7 @@ async fn cross_deployment_cancel_writes_cascade_intent_on_bridge() {
     );
 
     let tool = fetch_tool_call(db.node.as_ref(), &session_id, "internal-xdep-cancel").await;
+    assert_eq!(tool.cancel_cause.as_deref(), Some("interrupted"));
     assert!(
         tool.cancel_cascade_intent_at.is_some(),
         "remote branch must set cancel_cascade_intent_at"
@@ -270,7 +271,7 @@ async fn single_deployment_cancel_dispatch_still_interrupts_child() {
             .unwrap()
             .expect("bridge should be persisted");
     let dispatch = lifecycle
-        .cancel_during_run_with_cascade_dispatch(AGENT_DID)
+        .cancel_during_run_with_cascade_dispatch(CancelCause::Interrupted, AGENT_DID)
         .await
         .unwrap()
         .expect("cascade dispatch");
@@ -278,6 +279,8 @@ async fn single_deployment_cancel_dispatch_still_interrupts_child() {
         panic!("local child should use local cascade dispatch");
     };
     assert_eq!(intent.child_request_id, child_request_id);
+    let tool = fetch_tool_call(db.node.as_ref(), &session_id, "internal-local-cancel").await;
+    assert_eq!(tool.cancel_cause.as_deref(), Some("interrupted"));
     interrupt_request(db.node.as_ref(), &intent.child_request_id)
         .await
         .unwrap();

--- a/crates/defra-agent/tests/r4_subagent_tools/cancel_subagent.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools/cancel_subagent.rs
@@ -132,6 +132,7 @@ async fn cancel_subagent_cancels_bridge_active_descendants_and_owned_queue() {
 
     let root_bridge = fetch_tool_call(db.node.as_ref(), &session_id, "internal-cancel-spawn").await;
     assert_eq!(root_bridge.lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(root_bridge.cancel_cause.as_deref(), Some("userCancelled"));
     let descendant = fetch_tool_call(
         db.node.as_ref(),
         &child_session_id,
@@ -139,6 +140,7 @@ async fn cancel_subagent_cancels_bridge_active_descendants_and_owned_queue() {
     )
     .await;
     assert_eq!(descendant.lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(descendant.cancel_cause.as_deref(), Some("userCancelled"));
     let parent_collision =
         fetch_tool_call(db.node.as_ref(), &session_id, "internal-cancel-descendant").await;
     assert_eq!(

--- a/crates/defra-agent/tests/r4_subagent_tools/foreground_spawn.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools/foreground_spawn.rs
@@ -121,7 +121,10 @@ async fn foreground_spawn_subagent_cancellation_cascades_to_child_and_unblocks_w
             .await
             .unwrap()
             .expect("foreground bridge should be persisted");
-    lifecycle.cancel_during_run().await.unwrap();
+    lifecycle
+        .cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
     let intent = lifecycle
         .bridge_cancel_cascade()
         .await

--- a/crates/defra-agent/tests/r6_background_recovery.rs
+++ b/crates/defra-agent/tests/r6_background_recovery.rs
@@ -10,6 +10,7 @@ use support::{create_request, first_row, test_db, AGENT_DID};
 #[derive(Debug, Deserialize)]
 struct ToolCallRow {
     lifecycle_state: Option<String>,
+    cancel_cause: Option<String>,
     result: String,
 }
 
@@ -32,6 +33,7 @@ async fn load_tool_call(
         r#"{{
             AgentToolCall(filter: {{ tool_call_id: {{ _eq: "{tool_call_id}" }} }}, limit: 1) {{
                 lifecycle_state
+                cancel_cause
                 result
             }}
         }}"#
@@ -126,6 +128,7 @@ async fn recover_all_interrupts_backgrounded_running_tool_with_live_parent() {
 
     let row = load_tool_call(db.node.as_ref(), "r6-recovery-tool").await;
     assert_eq!(row.lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(row.cancel_cause.as_deref(), Some("interrupted"));
     assert!(row.result.contains("interrupted on restart"));
 
     let messages = load_messages(db.node.as_ref(), "r6-recovery-session").await;

--- a/crates/defra-agent/tests/r6_background_tools.rs
+++ b/crates/defra-agent/tests/r6_background_tools.rs
@@ -100,6 +100,7 @@ struct ToolCallRow {
     tool_name: Option<String>,
     result: Option<String>,
     lifecycle_state: Option<String>,
+    cancel_cause: Option<String>,
     await_mode: Option<String>,
     child_request_id: Option<String>,
 }
@@ -247,6 +248,7 @@ async fn load_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &st
                 tool_name
                 result
                 lifecycle_state
+                cancel_cause
                 await_mode
                 child_request_id
             }}
@@ -499,6 +501,7 @@ async fn cancel_tool_cancels_running_background_row_without_persisting_cancel_to
 
     let row = load_tool_call(db.node.as_ref(), &session_id, &tool_call_id).await;
     assert_eq!(row.lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(row.cancel_cause.as_deref(), Some("userCancelled"));
     assert_eq!(
         count_tool_calls_by_name(db.node.as_ref(), &session_id, "cancel_tool").await,
         0

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -8,7 +8,7 @@ use defra_agent::event_delivery_contract::{
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::lifecycle::{ClaimOutcome, ExecutionOrigin, TriggerLineage};
 use defra_agent::tool_call_lifecycle::{
-    AwaitMode, CancelPolicy, CascadeDispatch, ToolCallLifecycle,
+    AwaitMode, CancelCause, CancelPolicy, CascadeDispatch, ToolCallLifecycle,
 };
 use defra_agent::{
     fetch_interrupt_requested_at, interrupt_request, upsert_agent_behavior, upsert_tool_selection,

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -209,6 +209,7 @@ async fn agent_tool_call_has_r5_cross_deployment_fields() {
         "unclaimed_deadline_at",
         "cancel_cascade_intent_at",
         "cancel_pending_remote_ack",
+        "cancel_cause",
         "stuck_since",
     ] {
         assert!(names.contains(field), "AgentToolCall missing field {field}");

--- a/crates/defra-agent/tests/state_machine_conformance/recovery_sweeps.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/recovery_sweeps.rs
@@ -181,6 +181,18 @@ async fn drive_tool_call_recovery_case(case: &lean_vocab_test::LeanRecoverySweep
             Some("external"),
             "timeout recovery should persist external failure class"
         );
+        assert_eq!(
+            row.cancel_cause.as_deref(),
+            Some("deadline"),
+            "timeout recovery should persist cancel_cause=deadline"
+        );
+    }
+    if case.terminal_state == "cancelled" {
+        assert_eq!(
+            row.cancel_cause.as_deref(),
+            Some("interrupted"),
+            "cancel recovery should persist cancel_cause=interrupted"
+        );
     }
 }
 
@@ -586,6 +598,7 @@ struct ToolRecoveryRow {
     status: Option<String>,
     lifecycle_state: Option<String>,
     tool_failure_class: Option<String>,
+    cancel_cause: Option<String>,
 }
 
 async fn fetch_tool_recovery_row(node: &EmbeddedNode, tool_call_id: &str) -> ToolRecoveryRow {
@@ -596,6 +609,7 @@ async fn fetch_tool_recovery_row(node: &EmbeddedNode, tool_call_id: &str) -> Too
                 status
                 lifecycle_state
                 tool_failure_class
+                cancel_cause
             }}
         }}"#
     );

--- a/crates/defra-agent/tests/state_machine_conformance/transcript_background.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/transcript_background.rs
@@ -62,6 +62,7 @@ struct BackgroundTheoremToolCallRow {
     await_mode: Option<String>,
     cancel_policy: Option<String>,
     child_request_id: Option<String>,
+    cancel_cause: Option<String>,
     cancel_cascade_intent_at: Option<String>,
 }
 
@@ -281,6 +282,7 @@ async fn fetch_background_theorem_tool_call(
                 await_mode
                 cancel_policy
                 child_request_id
+                cancel_cause
                 cancel_cascade_intent_at
             }}
         }}"#
@@ -917,7 +919,7 @@ pub(super) async fn generated_r6_background_theorem_witnesses_drive_cascade_canc
             .expect("load bridge lifecycle")
             .expect("bridge should be persisted");
     let dispatch = lifecycle
-        .cancel_during_run_with_cascade_dispatch(AGENT_DID)
+        .cancel_during_run_with_cascade_dispatch(CancelCause::Interrupted, AGENT_DID)
         .await
         .expect("cancel bridge with cascade dispatch")
         .expect("cascade dispatch");
@@ -936,6 +938,7 @@ pub(super) async fn generated_r6_background_theorem_witnesses_drive_cascade_canc
         "internal-theorem-cascade",
     )
     .await;
+    assert_eq!(tool.cancel_cause.as_deref(), Some("interrupted"));
     assert!(
         tool.cancel_cascade_intent_at.is_none(),
         "local cascade dispatch must not leave a remote bridge intent"

--- a/crates/defra-agent/tests/support/r5_conformance/runner.rs
+++ b/crates/defra-agent/tests/support/r5_conformance/runner.rs
@@ -6,7 +6,7 @@ use defra_agent::background_completion::{
     reconcile_unclaimed_cross_deployment_spawns,
 };
 use defra_agent::graphql::escape_graphql_string;
-use defra_agent::tool_call_lifecycle::{CascadeDispatch, ToolCallLifecycle};
+use defra_agent::tool_call_lifecycle::{CancelCause, CascadeDispatch, ToolCallLifecycle};
 use defra_agent::{
     interrupt_request, upsert_agent_behavior, upsert_tool_selection, AgentBehaviorDocument,
     RequestLifecycle, ToolSelectionDocument,
@@ -59,6 +59,7 @@ pub struct BridgeObservation {
     pub tool_call_id: String,
     pub lifecycle_state: String,
     pub child_request_id: Option<String>,
+    pub cancel_cause: Option<String>,
     pub cancel_cascade_intent_at: Option<String>,
     pub cancel_pending_remote_ack: Option<bool>,
     pub stuck_since: Option<String>,
@@ -452,7 +453,7 @@ async fn export_doc(
     };
     let fields = match collection {
         "AgentRequest" => "request_id agent_did behavior_id session_id status lifecycle_state caused_by_parent_request_id caused_by_parent_tool_call_id caused_by_trigger_id caused_by_trigger_kind interrupt_requested_at",
-        "AgentToolCall" => "tool_call_key request_id session_id message_sequence tool_name tool_call_id args result status lifecycle_state started_at deadline_at completed_at tool_failure_class latency_ms await_mode cancel_policy child_request_id unclaimed_deadline_at cancel_cascade_intent_at cancel_pending_remote_ack stuck_since",
+        "AgentToolCall" => "tool_call_key request_id session_id message_sequence tool_name tool_call_id args result status lifecycle_state started_at deadline_at completed_at tool_failure_class cancel_cause latency_ms await_mode cancel_policy child_request_id unclaimed_deadline_at cancel_cascade_intent_at cancel_pending_remote_ack stuck_since",
         "AgentResponse" => "response_key request_id agent_did behavior_id session_id content reasoning status error_message token_count progress_seq materialized_message_sequence materialized_at created_at completed_at",
         "AgentMessage" => "message_key session_id sequence role content timestamp",
         _ => unreachable!(),
@@ -710,7 +711,9 @@ async fn cancel_parent_on_a(node: &HarnessNode, parent_tool_call_id: &str) -> Re
         ToolCallLifecycle::load(node.db.node.clone(), &session_id, parent_tool_call_id)
             .await?
             .ok_or_else(|| anyhow::anyhow!("bridge {parent_tool_call_id} not found"))?;
-    lifecycle.cancel_during_run().await?;
+    lifecycle
+        .cancel_during_run(CancelCause::Interrupted)
+        .await?;
     if let Some(dispatch) = lifecycle.bridge_cancel_cascade_dispatch(NODE_A_DID).await? {
         if let CascadeDispatch::Local(intent) = dispatch {
             interrupt_request(node.db.node.as_ref(), &intent.child_request_id).await?;
@@ -858,6 +861,7 @@ async fn load_bridge_rows(node: &HarnessNode) -> Result<Vec<BridgeObservation>> 
             tool_call_id
             lifecycle_state
             child_request_id
+            cancel_cause
             cancel_cascade_intent_at
             cancel_pending_remote_ack
             stuck_since
@@ -1075,6 +1079,7 @@ fn optional_tool_fields(row: &serde_json::Value) -> String {
     for field in [
         "completed_at",
         "tool_failure_class",
+        "cancel_cause",
         "unclaimed_deadline_at",
         "cancel_cascade_intent_at",
         "stuck_since",

--- a/crates/defra-agent/tests/support/snapshots.rs
+++ b/crates/defra-agent/tests/support/snapshots.rs
@@ -523,6 +523,8 @@ pub struct ToolCallSnapshot {
     #[serde(default)]
     pub tool_failure_class: Option<String>,
     #[serde(default)]
+    pub cancel_cause: Option<String>,
+    #[serde(default)]
     pub latency_ms: Option<i64>,
 }
 
@@ -539,7 +541,7 @@ pub async fn fetch_tool_call_snapshots_for_session(
             ) {{
                 tool_call_key request_id session_id message_sequence tool_name tool_call_id
                 args result status lifecycle_state started_at deadline_at completed_at
-                selected_service_id selected_tool_name tool_failure_class latency_ms
+                selected_service_id selected_tool_name tool_failure_class cancel_cause latency_ms
             }}
         }}"#
     );

--- a/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
@@ -8,7 +8,7 @@
 
 mod support;
 
-use defra_agent::tool_call_lifecycle::{FailureClass, ToolCallLifecycle};
+use defra_agent::tool_call_lifecycle::{CancelCause, FailureClass, ToolCallLifecycle};
 use support::snapshots::fetch_tool_call_snapshots_for_session;
 use support::test_db;
 
@@ -260,4 +260,60 @@ async fn lifecycle_load_preserves_deadline_for_terminal_update() {
         observed_deadline, deadline,
         "deadline_at should survive load and terminal update"
     );
+    assert_eq!(
+        snapshots[0].cancel_cause.as_deref(),
+        Some("deadline"),
+        "timeout() should persist cancel_cause=deadline"
+    );
+}
+
+#[tokio::test]
+async fn lifecycle_cancel_during_run_persists_cancel_cause() {
+    let db = test_db("tc-lc-cancel-cause-run").await;
+
+    let mut lc = ToolCallLifecycle::new(
+        db.node.clone(),
+        "request-cancel-run".into(),
+        "test-session-cancel-run".into(),
+        "tool-call-cancel-run".into(),
+        0,
+        "test_tool".into(),
+        r#"{}"#.into(),
+        test_deadline(),
+    );
+
+    lc.start_running().await.unwrap();
+    lc.cancel_during_run(CancelCause::UserCancelled)
+        .await
+        .unwrap();
+
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "test-session-cancel-run").await;
+    assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(snapshots[0].cancel_cause.as_deref(), Some("userCancelled"));
+}
+
+#[tokio::test]
+async fn lifecycle_cancel_before_dispatch_persists_cancel_cause() {
+    let db = test_db("tc-lc-cancel-cause-pending").await;
+
+    let mut lc = ToolCallLifecycle::new(
+        db.node.clone(),
+        "request-cancel-pending".into(),
+        "test-session-cancel-pending".into(),
+        "tool-call-cancel-pending".into(),
+        0,
+        "test_tool".into(),
+        r#"{}"#.into(),
+        test_deadline(),
+    );
+
+    lc.cancel_before_dispatch(CancelCause::Interrupted)
+        .await
+        .unwrap();
+
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "test-session-cancel-pending").await;
+    assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(snapshots[0].cancel_cause.as_deref(), Some("interrupted"));
 }

--- a/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_lifecycle_conformance.rs
@@ -294,6 +294,45 @@ async fn lifecycle_cancel_during_run_persists_cancel_cause() {
 }
 
 #[tokio::test]
+async fn lifecycle_load_with_null_cancel_cause_can_persist_cancel_cause() {
+    let db = test_db("tc-lc-cancel-cause-load").await;
+
+    let mut lc = ToolCallLifecycle::new(
+        db.node.clone(),
+        "request-cancel-load".into(),
+        "test-session-cancel-load".into(),
+        "tool-call-cancel-load".into(),
+        0,
+        "test_tool".into(),
+        r#"{}"#.into(),
+        test_deadline(),
+    );
+
+    lc.start_running().await.unwrap();
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "test-session-cancel-load").await;
+    assert_eq!(snapshots[0].cancel_cause, None);
+
+    let mut loaded = ToolCallLifecycle::load(
+        db.node.clone(),
+        "test-session-cancel-load",
+        "tool-call-cancel-load",
+    )
+    .await
+    .unwrap()
+    .expect("tool call lifecycle should load");
+    loaded
+        .cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
+
+    let snapshots =
+        fetch_tool_call_snapshots_for_session(&db.node, "test-session-cancel-load").await;
+    assert_eq!(snapshots[0].lifecycle_state.as_deref(), Some("cancelled"));
+    assert_eq!(snapshots[0].cancel_cause.as_deref(), Some("interrupted"));
+}
+
+#[tokio::test]
 async fn lifecycle_cancel_before_dispatch_persists_cancel_cause() {
     let db = test_db("tc-lc-cancel-cause-pending").await;
 

--- a/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
+++ b/crates/defra-agent/tests/tool_call_subagent_lifecycle_conformance.rs
@@ -16,8 +16,8 @@ mod support;
 // remainder of Bucket 3 is filled in.
 #[allow(unused_imports)]
 use defra_agent::tool_call_lifecycle::{
-    create_subagent_request, AwaitMode, CancelPolicy, CascadeIntent, ChildTerminal, FailureClass,
-    IllegalToolCallTransition, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
+    create_subagent_request, AwaitMode, CancelCause, CancelPolicy, CascadeIntent, ChildTerminal,
+    FailureClass, IllegalToolCallTransition, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use support::test_db;
 
@@ -771,7 +771,10 @@ async fn integration_bridge_complete_does_not_overwrite_externally_terminal_brid
         .await
         .unwrap()
         .expect("external owner should reload running bridge");
-    external.cancel_during_run().await.unwrap();
+    external
+        .cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
 
     let transitioned = bridge
         .bridge_complete("late child answer".to_string())
@@ -970,7 +973,9 @@ async fn integration_cascade_intent_for_cascade_subagent_returns_some() {
         "child-req-cas-1".to_string(),
     );
     lc.start_running().await.unwrap();
-    lc.cancel_during_run().await.unwrap();
+    lc.cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
     let intent = lc.bridge_cancel_cascade().await.unwrap();
     assert!(intent.is_some());
     assert_eq!(intent.unwrap().child_request_id, "child-req-cas-1");
@@ -993,7 +998,9 @@ async fn integration_cascade_intent_for_detached_subagent_returns_none() {
         "child-req-cas-2".to_string(),
     );
     lc.start_running().await.unwrap();
-    lc.cancel_during_run().await.unwrap();
+    lc.cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
     let intent = lc.bridge_cancel_cascade().await.unwrap();
     assert!(intent.is_none(), "Detach policy returns None");
 }
@@ -1012,7 +1019,9 @@ async fn integration_cascade_intent_for_native_returns_none() {
         test_deadline(),
     );
     lc.start_running().await.unwrap();
-    lc.cancel_during_run().await.unwrap();
+    lc.cancel_during_run(CancelCause::Interrupted)
+        .await
+        .unwrap();
     let intent = lc.bridge_cancel_cascade().await.unwrap();
     assert!(
         intent.is_none(),


### PR DESCRIPTION
## Summary
- add nullable AgentToolCall.cancel_cause schema/migration support
- thread ToolExecution CancelCause through runtime cancellation paths and persist the Lean DefraDB vocabulary (`interrupted`, `deadline`, `userCancelled`)
- carry cancel_cause through recovery, fork/session shape snapshots, import/export fixtures, and conformance tests
- extend the session-shape query with AgentToolCall `lifecycle_state`, `deadline_at`, and `cancel_cause` for runtime snapshot observability

Lean source of truth: `crates/defra-agent/proofs/Proofs/ToolExecution/CancelCause.lean`.

Closes #249.

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent`
- `cargo test -p defra-agent --test state_machine_conformance`
- `cargo test -p defra-agent`
- `cargo test -p defra-agent --test tool_call_lifecycle_conformance`