### PR TITLE
CLI: request interrupt (#266)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1039,16 +1039,6 @@ pub(crate) enum RequestInterruptCauseArg {
     UserCancelled,
 }
 
-impl RequestInterruptCauseArg {
-    pub(crate) fn as_str(self) -> &'static str {
-        match self {
-            Self::Interrupted => "interrupted",
-            Self::Deadline => "deadline",
-            Self::UserCancelled => "userCancelled",
-        }
-    }
-}
-
 impl From<RequestInterruptCauseArg> for defra_agent::tool_call_lifecycle::CancelCause {
     fn from(value: RequestInterruptCauseArg) -> Self {
         match value {
@@ -1112,7 +1102,12 @@ pub(crate) struct RequestInterruptArgs {
     pub(crate) home: Option<PathBuf>,
     #[arg(long)]
     pub(crate) graphql: Option<String>,
-    #[arg(long, value_enum, default_value_t = RequestInterruptCauseArg::UserCancelled)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = RequestInterruptCauseArg::UserCancelled,
+        help = "Reason for the interrupt: userCancelled for operator action, deadline for timeout-driven cancellation, interrupted for propagated runtime interruption"
+    )]
     pub(crate) cause: RequestInterruptCauseArg,
     #[arg(long, default_value_t = false)]
     pub(crate) wait: bool,
@@ -1123,7 +1118,12 @@ pub(crate) struct RequestInterruptArgs {
         help = "Maximum time to wait for a terminal request state when --wait is set"
     )]
     pub(crate) timeout: String,
-    #[arg(long, value_enum, default_value_t = RequestInterruptOutputFormat::Text)]
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = RequestInterruptOutputFormat::Text,
+        help = "Output format; use json for scripts"
+    )]
     pub(crate) output: RequestInterruptOutputFormat,
     #[arg(long = "request-id")]
     pub(crate) request_id_flag: Option<String>,

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1029,6 +1029,42 @@ pub(crate) enum RequestCommand {
     Resend(RequestResendArgs),
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum RequestInterruptCauseArg {
+    #[value(name = "interrupted")]
+    Interrupted,
+    #[value(name = "deadline")]
+    Deadline,
+    #[value(name = "userCancelled")]
+    UserCancelled,
+}
+
+impl RequestInterruptCauseArg {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Interrupted => "interrupted",
+            Self::Deadline => "deadline",
+            Self::UserCancelled => "userCancelled",
+        }
+    }
+}
+
+impl From<RequestInterruptCauseArg> for defra_agent::tool_call_lifecycle::CancelCause {
+    fn from(value: RequestInterruptCauseArg) -> Self {
+        match value {
+            RequestInterruptCauseArg::Interrupted => Self::Interrupted,
+            RequestInterruptCauseArg::Deadline => Self::Deadline,
+            RequestInterruptCauseArg::UserCancelled => Self::UserCancelled,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum RequestInterruptOutputFormat {
+    Text,
+    Json,
+}
+
 #[derive(clap::Args)]
 pub(crate) struct RequestSubmitArgs {
     #[arg(long)]
@@ -1076,6 +1112,19 @@ pub(crate) struct RequestInterruptArgs {
     pub(crate) home: Option<PathBuf>,
     #[arg(long)]
     pub(crate) graphql: Option<String>,
+    #[arg(long, value_enum, default_value_t = RequestInterruptCauseArg::UserCancelled)]
+    pub(crate) cause: RequestInterruptCauseArg,
+    #[arg(long, default_value_t = false)]
+    pub(crate) wait: bool,
+    #[arg(
+        long,
+        value_name = "DURATION",
+        default_value = "30s",
+        help = "Maximum time to wait for a terminal request state when --wait is set"
+    )]
+    pub(crate) timeout: String,
+    #[arg(long, value_enum, default_value_t = RequestInterruptOutputFormat::Text)]
+    pub(crate) output: RequestInterruptOutputFormat,
     #[arg(long = "request-id")]
     pub(crate) request_id_flag: Option<String>,
     #[arg(value_name = "REQUEST_ID")]

--- a/crates/defra-agent-cli/src/commands/request.rs
+++ b/crates/defra-agent-cli/src/commands/request.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use anyhow::{Context, Result};
-use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{graphql::escape_graphql_string, tool_call_lifecycle::CancelCause};
 use serde_json::{json, Value};
 use tokio::time::Instant;
 
@@ -135,12 +135,13 @@ async fn request_interrupt(args: RequestInterruptArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let request_id =
         resolve_request_id(args.request_id.as_deref(), args.request_id_flag.as_deref())?;
-    let _cancel_cause: defra_agent::tool_call_lifecycle::CancelCause = args.cause.into();
+    let cancel_cause: CancelCause = args.cause.into();
 
     let before = fetch_interrupt_request_row(&graphql, &request_id).await?;
     let already_interrupted = request_row_string(&before, "interrupt_requested_at").is_some();
+    let already_terminal = request_row_is_terminal(&before);
 
-    if !already_interrupted {
+    if !already_interrupted && !already_terminal {
         let now = chrono::Utc::now().to_rfc3339();
         let mutation = format!(
             r#"mutation {{
@@ -156,10 +157,10 @@ async fn request_interrupt(args: RequestInterruptArgs) -> Result<()> {
     }
 
     let mut row = fetch_interrupt_request_row(&graphql, &request_id).await?;
-    let interrupt_landed_at =
-        request_row_string(&row, "interrupt_requested_at").ok_or_else(|| {
-            anyhow::anyhow!("request {request_id} did not persist interrupt_requested_at")
-        })?;
+    let interrupt_landed_at = request_row_string(&row, "interrupt_requested_at");
+    if !already_terminal && interrupt_landed_at.is_none() {
+        anyhow::bail!("request {request_id} did not persist interrupt_requested_at");
+    }
 
     if args.wait && !request_row_is_terminal(&row) {
         let timeout = parse_duration_suffix(&args.timeout)?;
@@ -168,9 +169,10 @@ async fn request_interrupt(args: RequestInterruptArgs) -> Result<()> {
 
     let summary = request_interrupt_summary(
         &row,
-        args.cause.as_str(),
-        &interrupt_landed_at,
+        cancel_cause.as_str(),
+        interrupt_landed_at.as_deref(),
         already_interrupted,
+        already_terminal,
     );
     match args.output {
         RequestInterruptOutputFormat::Json => print_json(&summary)?,
@@ -180,6 +182,8 @@ async fn request_interrupt(args: RequestInterruptArgs) -> Result<()> {
 }
 
 async fn fetch_interrupt_request_row(graphql: &str, request_id: &str) -> Result<Value> {
+    // request_id is expected to be unique; keep DESC+limit defensive for older
+    // data and consistent with `request show`.
     let query = format!(
         r#"{{
             AgentRequest(
@@ -255,8 +259,9 @@ fn request_row_string(row: &Value, key: &str) -> Option<String> {
 fn request_interrupt_summary(
     row: &Value,
     cause: &str,
-    interrupt_landed_at: &str,
+    interrupt_landed_at: Option<&str>,
     already_interrupted: bool,
+    already_terminal: bool,
 ) -> Value {
     let lifecycle_state = request_row_string(row, "lifecycle_state").unwrap_or_default();
     json!({
@@ -271,6 +276,7 @@ fn request_interrupt_summary(
         "interrupt_landed_at": interrupt_landed_at,
         "cause": cause,
         "already_interrupted": already_interrupted,
+        "already_terminal": already_terminal,
         "terminal": is_terminal_lifecycle_state(&lifecycle_state),
         "created_at": request_row_string(row, "created_at"),
         "claimed_at": request_row_string(row, "claimed_at"),
@@ -301,12 +307,29 @@ fn print_interrupt_text(summary: &Value) -> Result<()> {
             .unwrap_or(false)
     );
     println!(
+        "already_terminal: {}",
+        summary
+            .get("already_terminal")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    );
+    println!(
         "terminal: {}",
         summary
             .get("terminal")
             .and_then(Value::as_bool)
             .unwrap_or(false)
     );
+    if summary
+        .get("already_terminal")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        && summary
+            .get("interrupt_landed_at")
+            .is_none_or(Value::is_null)
+    {
+        println!("note: request was already terminal; interrupt was not latched");
+    }
     if let Some(reason) = summary
         .get("failure_reason")
         .and_then(Value::as_str)

--- a/crates/defra-agent-cli/src/commands/request.rs
+++ b/crates/defra-agent-cli/src/commands/request.rs
@@ -1,11 +1,17 @@
+use std::time::Duration;
+
 use anyhow::{Context, Result};
 use defra_agent::graphql::escape_graphql_string;
-use serde_json::json;
+use serde_json::{json, Value};
+use tokio::time::Instant;
 
 use crate::cli::args::{
-    RequestCommand, RequestInterruptArgs, RequestResendArgs, RequestShowArgs, RequestSubmitArgs,
+    RequestCommand, RequestInterruptArgs, RequestInterruptOutputFormat, RequestResendArgs,
+    RequestShowArgs, RequestSubmitArgs,
 };
-use crate::request_helpers::{fetch_request_view, parse_valid_until_flag};
+use crate::request_helpers::{
+    fetch_request_view, is_terminal_lifecycle_state, parse_duration_suffix, parse_valid_until_flag,
+};
 use crate::{
     create_agent_request, post_graphql, print_json, resolve_agent_did, resolve_graphql_endpoint,
     resolve_request_content, resolve_request_id, wait_for_terminal_response,
@@ -129,61 +135,185 @@ async fn request_interrupt(args: RequestInterruptArgs) -> Result<()> {
     let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
     let request_id =
         resolve_request_id(args.request_id.as_deref(), args.request_id_flag.as_deref())?;
-    // Combined existence + latch-status check. We distinguish "no row" from
-    // "row with empty field" so that interrupting a bogus request id reports
-    // an error instead of silently succeeding with a no-op mutation.
-    // Idempotent: if the field is already set, leave the original latch in place
-    // so the runtime observes a single canonical interrupt timestamp.
-    let existing_query = format!(
+    let _cancel_cause: defra_agent::tool_call_lifecycle::CancelCause = args.cause.into();
+
+    let before = fetch_interrupt_request_row(&graphql, &request_id).await?;
+    let already_interrupted = request_row_string(&before, "interrupt_requested_at").is_some();
+
+    if !already_interrupted {
+        let now = chrono::Utc::now().to_rfc3339();
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                    input: {{ interrupt_requested_at: "{now_escaped}" }}
+                ) {{ _docID }}
+            }}"#,
+            request_id = escape_graphql_string(&request_id),
+            now_escaped = escape_graphql_string(&now),
+        );
+        post_graphql(&graphql, &mutation).await?;
+    }
+
+    let mut row = fetch_interrupt_request_row(&graphql, &request_id).await?;
+    let interrupt_landed_at =
+        request_row_string(&row, "interrupt_requested_at").ok_or_else(|| {
+            anyhow::anyhow!("request {request_id} did not persist interrupt_requested_at")
+        })?;
+
+    if args.wait && !request_row_is_terminal(&row) {
+        let timeout = parse_duration_suffix(&args.timeout)?;
+        row = wait_for_terminal_request_state(&graphql, &request_id, timeout, row).await?;
+    }
+
+    let summary = request_interrupt_summary(
+        &row,
+        args.cause.as_str(),
+        &interrupt_landed_at,
+        already_interrupted,
+    );
+    match args.output {
+        RequestInterruptOutputFormat::Json => print_json(&summary)?,
+        RequestInterruptOutputFormat::Text => print_interrupt_text(&summary)?,
+    }
+    Ok(())
+}
+
+async fn fetch_interrupt_request_row(graphql: &str, request_id: &str) -> Result<Value> {
+    let query = format!(
         r#"{{
             AgentRequest(
                 filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                order: {{ created_at: DESC }},
                 limit: 1
             ) {{
                 request_id
+                agent_did
+                behavior_id
+                session_id
+                status
+                lifecycle_state
+                failure_reason
+                retry_count
+                max_retries
+                created_at
+                claimed_at
+                deadline
+                valid_until
                 interrupt_requested_at
             }}
         }}"#,
-        request_id = escape_graphql_string(&request_id),
+        request_id = escape_graphql_string(request_id),
     );
-    let existing = post_graphql(&graphql, &existing_query).await?;
-    let existing_row = existing.pointer("/data/AgentRequest/0");
-    let Some(existing_row) = existing_row else {
-        anyhow::bail!("request {request_id} not found");
-    };
-    let already = existing_row
-        .get("interrupt_requested_at")
-        .and_then(|v| v.as_str())
-        .filter(|s| !s.is_empty())
-        .map(ToOwned::to_owned);
-    if let Some(existing_at) = already {
-        let summary = json!({
-            "request_id": request_id,
-            "interrupt_requested_at": existing_at,
-            "already_interrupted": true,
-        });
-        print_json(&summary)?;
-        return Ok(());
-    }
+    let response = post_graphql(graphql, &query).await?;
+    response
+        .pointer("/data/AgentRequest")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("request {request_id} not found"))
+}
 
-    let now = chrono::Utc::now().to_rfc3339();
-    let mutation = format!(
-        r#"mutation {{
-            update_AgentRequest(
-                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
-                input: {{ interrupt_requested_at: "{now_escaped}" }}
-            ) {{ _docID }}
-        }}"#,
-        request_id = escape_graphql_string(&request_id),
-        now_escaped = escape_graphql_string(&now),
+async fn wait_for_terminal_request_state(
+    graphql: &str,
+    request_id: &str,
+    timeout: Duration,
+    mut last_row: Value,
+) -> Result<Value> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if request_row_is_terminal(&last_row) {
+            return Ok(last_row);
+        }
+        if Instant::now() >= deadline {
+            let state = request_row_string(&last_row, "lifecycle_state")
+                .unwrap_or_else(|| "<missing>".to_string());
+            anyhow::bail!(
+                "timed out waiting for request {request_id} to reach a terminal state after {}s (last lifecycle_state={state})",
+                timeout.as_secs()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        last_row = fetch_interrupt_request_row(graphql, request_id).await?;
+    }
+}
+
+fn request_row_is_terminal(row: &Value) -> bool {
+    row.get("lifecycle_state")
+        .and_then(Value::as_str)
+        .is_some_and(is_terminal_lifecycle_state)
+}
+
+fn request_row_string(row: &Value, key: &str) -> Option<String> {
+    row.get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn request_interrupt_summary(
+    row: &Value,
+    cause: &str,
+    interrupt_landed_at: &str,
+    already_interrupted: bool,
+) -> Value {
+    let lifecycle_state = request_row_string(row, "lifecycle_state").unwrap_or_default();
+    json!({
+        "request_id": request_row_string(row, "request_id").unwrap_or_default(),
+        "agent_did": request_row_string(row, "agent_did"),
+        "behavior_id": request_row_string(row, "behavior_id"),
+        "session_id": request_row_string(row, "session_id"),
+        "status": request_row_string(row, "status"),
+        "lifecycle_state": lifecycle_state,
+        "failure_reason": request_row_string(row, "failure_reason"),
+        "interrupt_requested_at": request_row_string(row, "interrupt_requested_at"),
+        "interrupt_landed_at": interrupt_landed_at,
+        "cause": cause,
+        "already_interrupted": already_interrupted,
+        "terminal": is_terminal_lifecycle_state(&lifecycle_state),
+        "created_at": request_row_string(row, "created_at"),
+        "claimed_at": request_row_string(row, "claimed_at"),
+        "deadline": request_row_string(row, "deadline"),
+        "valid_until": request_row_string(row, "valid_until"),
+    })
+}
+
+fn print_interrupt_text(summary: &Value) -> Result<()> {
+    let text = |key: &str| {
+        summary
+            .get(key)
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("-")
+            .to_string()
+    };
+    println!("request_id: {}", text("request_id"));
+    println!("state: {}", text("lifecycle_state"));
+    println!("status: {}", text("status"));
+    println!("interrupt_landed_at: {}", text("interrupt_landed_at"));
+    println!("cause: {}", text("cause"));
+    println!(
+        "already_interrupted: {}",
+        summary
+            .get("already_interrupted")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
     );
-    post_graphql(&graphql, &mutation).await?;
-    let summary = json!({
-        "request_id": request_id,
-        "interrupt_requested_at": now,
-        "already_interrupted": false,
-    });
-    print_json(&summary)?;
+    println!(
+        "terminal: {}",
+        summary
+            .get("terminal")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    );
+    if let Some(reason) = summary
+        .get("failure_reason")
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+    {
+        println!("failure_reason: {reason}");
+    }
     Ok(())
 }
 

--- a/crates/defra-agent-cli/src/request_helpers.rs
+++ b/crates/defra-agent-cli/src/request_helpers.rs
@@ -495,7 +495,7 @@ pub(crate) fn print_json(value: &Value) -> Result<()> {
 
 /// Parse a short human duration (e.g. `30s`, `5m`, `2h`, `1d`). Bare numbers
 /// are treated as seconds for convenience.
-fn parse_duration_suffix(raw: &str) -> Result<Duration> {
+pub(crate) fn parse_duration_suffix(raw: &str) -> Result<Duration> {
     let s = raw.trim();
     if s.is_empty() {
         anyhow::bail!("duration must not be empty");

--- a/crates/defra-agent-cli/tests/cli_request.rs
+++ b/crates/defra-agent-cli/tests/cli_request.rs
@@ -318,3 +318,127 @@ async fn request_interrupt_waits_until_running_request_is_terminal() -> Result<(
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_interrupt_does_not_latch_completed_request() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-interrupt-completed-model-{}", Uuid::new_v4().simple());
+    let final_text = format!("completed-before-interrupt-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start(&model_name, &final_text)?;
+    let port = allocate_port()?;
+    let agent_name = format!("cli-interrupt-completed-{}", Uuid::new_v4().simple());
+    let graphql = graphql_url(port);
+    let request_content = format!("CLI completed interrupt request {}", Uuid::new_v4());
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let submitted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "submit",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--content",
+            &request_content,
+            "--timeout-secs",
+            "20",
+            "--poll-secs",
+            "1",
+        ],
+    )?;
+    let request_id = submitted
+        .get("request_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("request submit output missing request_id: {submitted}"))?
+        .to_string();
+    assert_eq!(
+        submitted
+            .pointer("/response/content")
+            .and_then(Value::as_str),
+        Some(final_text.as_str())
+    );
+
+    wait_for_request_lifecycle_state(
+        &graphql,
+        &request_id,
+        &["completed"],
+        Duration::from_secs(30),
+    )
+    .await?;
+
+    let interrupted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "interrupt",
+            "--graphql",
+            &graphql,
+            "--output",
+            "json",
+            &request_id,
+        ],
+    )?;
+    assert_eq!(
+        interrupted.get("request_id").and_then(Value::as_str),
+        Some(request_id.as_str())
+    );
+    assert_eq!(
+        interrupted.get("lifecycle_state").and_then(Value::as_str),
+        Some("completed")
+    );
+    assert_eq!(
+        interrupted.get("already_terminal").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        interrupted
+            .get("already_interrupted")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert!(
+        interrupted
+            .get("interrupt_landed_at")
+            .is_none_or(Value::is_null),
+        "completed request should not report a new interrupt landing time: {interrupted}"
+    );
+    assert!(
+        interrupted
+            .get("interrupt_requested_at")
+            .is_none_or(Value::is_null),
+        "completed request should not latch interrupt_requested_at: {interrupted}"
+    );
+
+    let row = wait_for_request_lifecycle_state(
+        &graphql,
+        &request_id,
+        &["completed"],
+        Duration::from_secs(5),
+    )
+    .await?;
+    assert!(
+        row.get("interrupt_requested_at").is_none_or(Value::is_null),
+        "completed AgentRequest should not be mutated by interrupt: {row}"
+    );
+
+    Ok(())
+}

--- a/crates/defra-agent-cli/tests/cli_request.rs
+++ b/crates/defra-agent-cli/tests/cli_request.rs
@@ -2,7 +2,7 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
@@ -186,6 +186,134 @@ async fn request_submit_supports_content_file_and_output_file() -> Result<()> {
             .pointer("/response/content")
             .and_then(Value::as_str),
         Some(expected_content.as_str())
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_interrupt_waits_until_running_request_is_terminal() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-interrupt-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start_hanging(&model_name)?;
+    let port = allocate_port()?;
+    let agent_name = format!("cli-interrupt-{}", Uuid::new_v4().simple());
+    let graphql = graphql_url(port);
+    let request_content = format!("CLI interrupt request {}", Uuid::new_v4());
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let submitted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "submit",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--content",
+            &request_content,
+            "--no-wait",
+        ],
+    )?;
+    let request_id = submitted
+        .get("request_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("request submit output missing request_id: {submitted}"))?
+        .to_string();
+
+    wait_for_request_lifecycle_state(
+        &graphql,
+        &request_id,
+        &["processing"],
+        Duration::from_secs(30),
+    )
+    .await?;
+    let capture_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if mock_endpoint
+            .captured_chat_requests()
+            .iter()
+            .any(|request| request_contains_role_text(request, "user", &request_content))
+        {
+            break;
+        }
+        if Instant::now() >= capture_deadline {
+            bail!("hanging mock endpoint did not capture the running request");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let interrupted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "interrupt",
+            "--graphql",
+            &graphql,
+            "--cause",
+            "userCancelled",
+            "--wait",
+            "--timeout",
+            "20s",
+            "--output",
+            "json",
+            &request_id,
+        ],
+    )?;
+    assert_eq!(
+        interrupted.get("request_id").and_then(Value::as_str),
+        Some(request_id.as_str())
+    );
+    assert_eq!(
+        interrupted.get("cause").and_then(Value::as_str),
+        Some("userCancelled")
+    );
+    assert_eq!(
+        interrupted.get("lifecycle_state").and_then(Value::as_str),
+        Some("interrupted")
+    );
+    assert_eq!(
+        interrupted.get("terminal").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert!(
+        interrupted
+            .get("interrupt_landed_at")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty()),
+        "interrupt output should include landing time: {interrupted}"
+    );
+
+    let row = wait_for_request_lifecycle_state(
+        &graphql,
+        &request_id,
+        &["interrupted"],
+        Duration::from_secs(5),
+    )
+    .await?;
+    assert!(
+        row.get("interrupt_requested_at")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty()),
+        "AgentRequest should retain interrupt_requested_at: {row}"
     );
 
     Ok(())

--- a/crates/defra-agent-cli/tests/support/mocks/chat.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/chat.rs
@@ -19,15 +19,36 @@ pub struct MockChatEndpoint {
     pub handle: Option<JoinHandle<()>>,
 }
 
+enum MockChatCompletion {
+    Complete(String),
+    Hang,
+}
+
 impl MockChatEndpoint {
     pub fn start(model_name: &str, final_text: &str) -> Result<Self> {
         Self::start_with_required_bearer(model_name, final_text, None)
+    }
+
+    pub fn start_hanging(model_name: &str) -> Result<Self> {
+        Self::start_with_completion(model_name, None, MockChatCompletion::Hang)
     }
 
     pub fn start_with_required_bearer(
         model_name: &str,
         final_text: &str,
         required_bearer: Option<&str>,
+    ) -> Result<Self> {
+        Self::start_with_completion(
+            model_name,
+            required_bearer,
+            MockChatCompletion::Complete(final_text.to_string()),
+        )
+    }
+
+    fn start_with_completion(
+        model_name: &str,
+        required_bearer: Option<&str>,
+        completion: MockChatCompletion,
     ) -> Result<Self> {
         let listener = TcpListener::bind(("127.0.0.1", 0)).context("binding mock chat port")?;
         listener
@@ -40,7 +61,6 @@ impl MockChatEndpoint {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_for_thread = stop.clone();
         let model_name = model_name.to_string();
-        let final_text = final_text.to_string();
         let required_bearer = required_bearer.map(ToOwned::to_owned);
         let captured_chat_requests = Arc::new(Mutex::new(Vec::new()));
         let captured_chat_requests_for_thread = captured_chat_requests.clone();
@@ -111,12 +131,21 @@ impl MockChatEndpoint {
                                     .expect("captured chat request mutex poisoned")
                                     .push(request_json);
 
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    "200 OK",
-                                    "text/event-stream",
-                                    &completion_text_sse(&final_text),
-                                );
+                                match &completion {
+                                    MockChatCompletion::Complete(final_text) => {
+                                        let _ = write_http_response(
+                                            &mut stream,
+                                            "200 OK",
+                                            "text/event-stream",
+                                            &completion_text_sse(final_text),
+                                        );
+                                    }
+                                    MockChatCompletion::Hang => {
+                                        while !stop_for_thread.load(Ordering::Relaxed) {
+                                            thread::sleep(Duration::from_millis(25));
+                                        }
+                                    }
+                                }
                             }
                             _ => {
                                 let _ = write_http_response(

--- a/crates/defra-agent-cli/tests/support/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mod.rs
@@ -27,8 +27,8 @@ pub use process::{
 pub use waits::{
     insert_terminal_response, wait_for_completed_inference_behaviors,
     wait_for_completed_tool_calls, wait_for_connected_peer, wait_for_request,
-    wait_for_runtime_doc_id, wait_for_runtime_quiescence, wait_for_runtime_ready,
-    wait_for_tool_call,
+    wait_for_request_lifecycle_state, wait_for_runtime_doc_id, wait_for_runtime_quiescence,
+    wait_for_runtime_ready, wait_for_tool_call,
 };
 
 pub const DEFAULT_MODEL_ENDPOINT: &str = "http://workstation-1:8000/v1";

--- a/crates/defra-agent-cli/tests/support/waits.rs
+++ b/crates/defra-agent-cli/tests/support/waits.rs
@@ -203,6 +203,55 @@ pub async fn wait_for_request(
     }
 }
 
+pub async fn wait_for_request_lifecycle_state(
+    graphql: &str,
+    request_id: &str,
+    expected_states: &[&str],
+    timeout: Duration,
+) -> Result<Value> {
+    let deadline = Instant::now() + timeout;
+    let mut last_row = None::<Value>;
+    loop {
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{}" }} }},
+                    limit: 1
+                ) {{
+                    request_id
+                    status
+                    lifecycle_state
+                    interrupt_requested_at
+                    failure_reason
+                }}
+            }}"#,
+            escape_graphql_string(request_id),
+        );
+        let response = graphql_query(graphql, &query).await?;
+        if let Ok(row) = first_graphql_row(&response, "AgentRequest") {
+            last_row = Some(row.clone());
+            let lifecycle_state = row
+                .get("lifecycle_state")
+                .and_then(Value::as_str)
+                .unwrap_or_default();
+            if expected_states.contains(&lifecycle_state) {
+                return Ok(row.clone());
+            }
+        }
+
+        if Instant::now() >= deadline {
+            bail!(
+                "timed out waiting for request {request_id} lifecycle_state in {:?}; last row={}",
+                expected_states,
+                last_row
+                    .map(|row| row.to_string())
+                    .unwrap_or_else(|| "null".to_string())
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+}
+
 pub async fn insert_terminal_response(
     graphql: &str,
     request_id: &str,


### PR DESCRIPTION
Summary:
- add `defra-agent request interrupt <request-id>` with cause, wait/timeout, and text/json output
- add integration coverage for interrupting a running request

Verification:
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli`
- `cargo run -p defra-agent-cli --bin defra-agent -- request interrupt --help`

Closes #266