### PR TITLE
CLI: subagent list (#269)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -13,7 +13,7 @@ use crate::{
     CONFIG_EXPORT_AFTER_HELP, CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP,
     INIT_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
     RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP,
-    SUBAGENT_AFTER_HELP, TRACE_AFTER_HELP,
+    SUBAGENT_AFTER_HELP, SUBAGENT_LIST_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -1233,8 +1233,35 @@ pub(crate) enum RequestShowOutputFormat {
 
 #[derive(Subcommand)]
 pub(crate) enum SubagentCommand {
+    #[command(
+        name = "list",
+        about = "List subagent dispatch lineage",
+        after_help = SUBAGENT_LIST_AFTER_HELP
+    )]
+    List(SubagentListArgs),
     #[command(about = "Cancel a subagent request and optionally cascade to linked children")]
     Cancel(SubagentCancelArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct SubagentListArgs {
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) graphql: Option<String>,
+    #[arg(long, value_name = "REQUEST_ID")]
+    pub(crate) root: Option<String>,
+    #[arg(long, value_name = "N")]
+    pub(crate) depth: Option<usize>,
+    #[arg(long, value_enum, default_value_t = SubagentListOutput::Tree)]
+    pub(crate) output: SubagentListOutput,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SubagentListOutput {
+    Tree,
+    Table,
+    Json,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/commands/subagent.rs
+++ b/crates/defra-agent-cli/src/commands/subagent.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashSet, VecDeque};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -6,21 +6,35 @@ use anyhow::{Context, Result};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::tool_call_lifecycle::{CancelCause, CascadeDispatch, ToolCallLifecycle};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::cli::args::{SubagentCancelArgs, SubagentCancelOutput, SubagentCommand};
+use crate::cli::args::{
+    SubagentCancelArgs, SubagentCancelOutput, SubagentCommand, SubagentListArgs,
+    SubagentListOutput,
+};
 use crate::config_writes::ConfigAccess;
 use crate::{
-    parse_duration_suffix, post_graphql, print_json, resolve_agent_did, resolve_config_access,
-    resolve_request_id,
+    graphql_rows, parse_duration_suffix, post_graphql, print_json, resolve_agent_did,
+    resolve_config_access, resolve_request_id,
 };
 
 const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const AGENT_REQUEST_FIELDS: &str = r#"
+    request_id
+    agent_did
+    behavior_id
+    status
+    lifecycle_state
+    created_at
+    claimed_at
+    caused_by_parent_request_id
+"#;
 
 pub(crate) async fn dispatch(command: SubagentCommand) -> Result<()> {
     match command {
+        SubagentCommand::List(args) => subagent_list(args).await,
         SubagentCommand::Cancel(args) => subagent_cancel(args).await,
     }
 }
@@ -653,4 +667,550 @@ struct SubagentCancelRender {
     cause: String,
     wait: bool,
     requests: Vec<RequestCancelSnapshot>,
+}
+
+async fn subagent_list(args: SubagentListArgs) -> Result<()> {
+    let (access, _) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let rows = match args.root.as_deref().and_then(non_empty_str) {
+        Some(root) => load_rooted_lineage(&access, root, args.depth).await?,
+        None => load_lineage_forest(&access, args.depth).await?,
+    };
+
+    match args.output {
+        SubagentListOutput::Tree => print_tree(&rows),
+        SubagentListOutput::Table => print_table(&rows),
+        SubagentListOutput::Json => print_lineage_json(args.root.as_deref(), args.depth, &rows),
+    }
+}
+
+async fn load_rooted_lineage(
+    access: &ConfigAccess,
+    root_request_id: &str,
+    max_depth: Option<usize>,
+) -> Result<Vec<LineageNode>> {
+    let root = load_request_by_id(access, root_request_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("AgentRequest {root_request_id} not found"))?;
+    let max_depth = max_depth.unwrap_or(usize::MAX);
+    let mut rows = Vec::new();
+    let mut seen = BTreeSet::new();
+    let mut stack = vec![(root, 0usize)];
+
+    while let Some((row, depth)) = stack.pop() {
+        let request_id = row.request_id.clone();
+        if !seen.insert(request_id.clone()) {
+            continue;
+        }
+        rows.push(LineageNode { row, depth });
+        if depth >= max_depth {
+            continue;
+        }
+
+        // TODO: replace per-parent child lookups with a batched load if large
+        // rooted trees make this operator command noticeably latent.
+        let children = load_children(access, &request_id).await?;
+        for child in children.into_iter().rev() {
+            stack.push((child, depth + 1));
+        }
+    }
+
+    Ok(rows)
+}
+
+async fn load_lineage_forest(
+    access: &ConfigAccess,
+    max_depth: Option<usize>,
+) -> Result<Vec<LineageNode>> {
+    let all_rows = load_all_requests(access).await?;
+    let mut rows_by_id = BTreeMap::new();
+    let mut children_by_parent = BTreeMap::<String, Vec<String>>::new();
+    let mut included_ids = BTreeSet::<String>::new();
+
+    for row in all_rows {
+        let request_id = row.request_id.clone();
+        if let Some(parent_request_id) = row.parent_request_id() {
+            included_ids.insert(parent_request_id.clone());
+            included_ids.insert(request_id.clone());
+            children_by_parent
+                .entry(parent_request_id)
+                .or_default()
+                .push(request_id.clone());
+        }
+        rows_by_id.insert(request_id, row);
+    }
+
+    let mut roots = included_ids
+        .iter()
+        .filter_map(|request_id| {
+            let row = rows_by_id.get(request_id)?;
+            let has_included_parent = row.parent_request_id().is_some_and(|parent| {
+                included_ids.contains(&parent) && rows_by_id.contains_key(&parent)
+            });
+            (!has_included_parent).then(|| request_id.clone())
+        })
+        .collect::<Vec<_>>();
+    if roots.is_empty() {
+        roots = included_ids
+            .iter()
+            .filter(|request_id| rows_by_id.contains_key(*request_id))
+            .cloned()
+            .collect();
+    }
+    sort_request_ids(&mut roots, &rows_by_id);
+    for children in children_by_parent.values_mut() {
+        sort_request_ids(children, &rows_by_id);
+    }
+
+    let mut output = Vec::new();
+    let mut seen = HashSet::new();
+    let max_depth = max_depth.unwrap_or(usize::MAX);
+    for root in roots {
+        append_forest_node(
+            &root,
+            0,
+            max_depth,
+            &rows_by_id,
+            &children_by_parent,
+            &mut seen,
+            &mut output,
+        );
+    }
+
+    Ok(output)
+}
+
+fn append_forest_node(
+    request_id: &str,
+    depth: usize,
+    max_depth: usize,
+    rows_by_id: &BTreeMap<String, AgentRequestLineageRow>,
+    children_by_parent: &BTreeMap<String, Vec<String>>,
+    seen: &mut HashSet<String>,
+    output: &mut Vec<LineageNode>,
+) {
+    if !seen.insert(request_id.to_string()) {
+        return;
+    }
+    let Some(row) = rows_by_id.get(request_id) else {
+        return;
+    };
+    output.push(LineageNode {
+        row: row.clone(),
+        depth,
+    });
+    if depth >= max_depth {
+        return;
+    }
+    if let Some(children) = children_by_parent.get(request_id) {
+        for child in children {
+            append_forest_node(
+                child,
+                depth + 1,
+                max_depth,
+                rows_by_id,
+                children_by_parent,
+                seen,
+                output,
+            );
+        }
+    }
+}
+
+fn sort_request_ids(
+    request_ids: &mut [String],
+    rows_by_id: &BTreeMap<String, AgentRequestLineageRow>,
+) {
+    request_ids.sort_by(|left, right| {
+        let left_key = rows_by_id
+            .get(left)
+            .map(AgentRequestLineageRow::sort_key)
+            .unwrap_or(("", ""));
+        let right_key = rows_by_id
+            .get(right)
+            .map(AgentRequestLineageRow::sort_key)
+            .unwrap_or(("", ""));
+        left_key.cmp(&right_key)
+    });
+}
+
+async fn load_request_by_id(
+    access: &ConfigAccess,
+    request_id: &str,
+) -> Result<Option<AgentRequestLineageRow>> {
+    let escaped_request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                limit: 1
+            ) {{
+                {AGENT_REQUEST_FIELDS}
+            }}
+        }}"#
+    );
+    let mut rows = load_request_rows(access, &query).await?;
+    Ok(rows.pop())
+}
+
+async fn load_children(
+    access: &ConfigAccess,
+    parent_request_id: &str,
+) -> Result<Vec<AgentRequestLineageRow>> {
+    let escaped_parent_request_id = escape_graphql_string(parent_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ caused_by_parent_request_id: {{ _eq: "{escaped_parent_request_id}" }} }},
+                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
+            ) {{
+                {AGENT_REQUEST_FIELDS}
+            }}
+        }}"#
+    );
+    load_request_rows(access, &query).await
+}
+
+async fn load_all_requests(access: &ConfigAccess) -> Result<Vec<AgentRequestLineageRow>> {
+    let query = format!(
+        r#"{{
+            AgentRequest(order: [{{ created_at: ASC }}, {{ request_id: ASC }}]) {{
+                {AGENT_REQUEST_FIELDS}
+            }}
+        }}"#
+    );
+    load_request_rows(access, &query).await
+}
+
+async fn load_request_rows(
+    access: &ConfigAccess,
+    query: &str,
+) -> Result<Vec<AgentRequestLineageRow>> {
+    graphql_rows(access, "AgentRequest", query)
+        .await?
+        .into_iter()
+        .map(|value| {
+            serde_json::from_value(value).context("decoding AgentRequest lineage row from GraphQL")
+        })
+        .collect()
+}
+
+fn print_tree(rows: &[LineageNode]) -> Result<()> {
+    let output_rows = output_rows(rows, true);
+    if output_rows.is_empty() {
+        println!("No subagent requests found.");
+        return Ok(());
+    }
+    print!("{}", render_table(&output_rows));
+    Ok(())
+}
+
+fn print_table(rows: &[LineageNode]) -> Result<()> {
+    let output_rows = output_rows(rows, false);
+    if output_rows.is_empty() {
+        println!("No subagent requests found.");
+        return Ok(());
+    }
+    print!("{}", render_table(&output_rows));
+    Ok(())
+}
+
+fn print_lineage_json(
+    root: Option<&str>,
+    max_depth: Option<usize>,
+    rows: &[LineageNode],
+) -> Result<()> {
+    let output_rows = output_rows(rows, false);
+    let tree = tree_from_rows(&output_rows);
+    print_json(&serde_json::json!({
+        "root_request_id": root.and_then(non_empty_str),
+        "max_depth": max_depth,
+        "rows": output_rows,
+        "tree": tree,
+    }))
+}
+
+fn output_rows(rows: &[LineageNode], indent: bool) -> Vec<LineageOutputRow> {
+    rows.iter()
+        .map(|node| LineageOutputRow::from_node(node, indent))
+        .collect()
+}
+
+fn render_table(rows: &[LineageOutputRow]) -> String {
+    const HEADERS: [&str; 6] = [
+        "CHILD_REQUEST_ID",
+        "PARENT_REQUEST_ID",
+        "DEPLOYMENT",
+        "BEHAVIOR_ID",
+        "STATE",
+        "STARTED_AT",
+    ];
+    let mut table_rows = Vec::<[String; 6]>::new();
+    for row in rows {
+        table_rows.push([
+            row.display_request_id.clone(),
+            row.parent_request_id
+                .clone()
+                .unwrap_or_else(|| "-".to_string()),
+            row.deployment.clone(),
+            row.behavior_id.clone(),
+            row.state.clone(),
+            row.started_at.clone(),
+        ]);
+    }
+
+    let mut widths = HEADERS.map(|header| header.chars().count());
+    for row in &table_rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(cell.chars().count());
+        }
+    }
+
+    let mut output = String::new();
+    push_cells(&mut output, &HEADERS.map(ToOwned::to_owned), &widths);
+    for row in table_rows {
+        push_cells(&mut output, &row, &widths);
+    }
+    output
+}
+
+fn push_cells(output: &mut String, cells: &[String; 6], widths: &[usize; 6]) {
+    for (idx, cell) in cells.iter().enumerate() {
+        if idx > 0 {
+            output.push_str("  ");
+        }
+        output.push_str(cell);
+        for _ in cell.chars().count()..widths[idx] {
+            output.push(' ');
+        }
+    }
+    output.push('\n');
+}
+
+fn tree_from_rows(rows: &[LineageOutputRow]) -> Vec<LineageTreeNode> {
+    let rows_by_id = rows
+        .iter()
+        .map(|row| (row.request_id.clone(), row.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut children_by_parent = BTreeMap::<String, Vec<String>>::new();
+    let mut root_ids = Vec::new();
+
+    for row in rows {
+        if let Some(parent_request_id) = row.parent_request_id.as_deref() {
+            if rows_by_id.contains_key(parent_request_id) {
+                children_by_parent
+                    .entry(parent_request_id.to_string())
+                    .or_default()
+                    .push(row.request_id.clone());
+                continue;
+            }
+        }
+        root_ids.push(row.request_id.clone());
+    }
+
+    let mut seen = HashSet::new();
+    let mut roots = Vec::new();
+    for root_id in root_ids {
+        append_tree_node(
+            &root_id,
+            &rows_by_id,
+            &children_by_parent,
+            &mut seen,
+            &mut roots,
+        );
+    }
+    roots
+}
+
+fn append_tree_node(
+    request_id: &str,
+    rows_by_id: &BTreeMap<String, LineageOutputRow>,
+    children_by_parent: &BTreeMap<String, Vec<String>>,
+    seen: &mut HashSet<String>,
+    output: &mut Vec<LineageTreeNode>,
+) {
+    if !seen.insert(request_id.to_string()) {
+        return;
+    }
+    let Some(row) = rows_by_id.get(request_id) else {
+        return;
+    };
+    let mut children = Vec::new();
+    if let Some(child_ids) = children_by_parent.get(request_id) {
+        for child_id in child_ids {
+            append_tree_node(
+                child_id,
+                rows_by_id,
+                children_by_parent,
+                seen,
+                &mut children,
+            );
+        }
+    }
+    output.push(LineageTreeNode {
+        row: row.clone(),
+        children,
+    });
+}
+
+#[derive(Debug, Clone)]
+struct LineageNode {
+    row: AgentRequestLineageRow,
+    depth: usize,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AgentRequestLineageRow {
+    request_id: String,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    claimed_at: Option<String>,
+    #[serde(default)]
+    caused_by_parent_request_id: Option<String>,
+}
+
+impl AgentRequestLineageRow {
+    fn parent_request_id(&self) -> Option<String> {
+        self.caused_by_parent_request_id
+            .as_deref()
+            .and_then(non_empty_str)
+            .map(ToOwned::to_owned)
+    }
+
+    fn sort_key(&self) -> (&str, &str) {
+        (
+            self.created_at
+                .as_deref()
+                .and_then(non_empty_str)
+                .unwrap_or_default(),
+            self.request_id.as_str(),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LineageOutputRow {
+    child_request_id: String,
+    request_id: String,
+    parent_request_id: Option<String>,
+    deployment: String,
+    agent_did: Option<String>,
+    behavior_id: String,
+    state: String,
+    started_at: String,
+    depth: usize,
+    #[serde(skip_serializing)]
+    display_request_id: String,
+}
+
+impl LineageOutputRow {
+    fn from_node(node: &LineageNode, indent: bool) -> Self {
+        let request_id = node.row.request_id.clone();
+        let display_request_id = if indent {
+            format!("{}{}", "  ".repeat(node.depth), request_id)
+        } else {
+            request_id.clone()
+        };
+        let agent_did = node
+            .row
+            .agent_did
+            .as_deref()
+            .and_then(non_empty_str)
+            .map(ToOwned::to_owned);
+        let deployment = agent_did.clone().unwrap_or_else(|| "-".to_string());
+        let behavior_id = node
+            .row
+            .behavior_id
+            .as_deref()
+            .and_then(non_empty_str)
+            .unwrap_or("-")
+            .to_string();
+        let state = node
+            .row
+            .lifecycle_state
+            .as_deref()
+            .and_then(non_empty_str)
+            .or_else(|| node.row.status.as_deref().and_then(non_empty_str))
+            .unwrap_or("unknown")
+            .to_string();
+        let started_at = node
+            .row
+            .claimed_at
+            .as_deref()
+            .and_then(non_empty_str)
+            .or_else(|| node.row.created_at.as_deref().and_then(non_empty_str))
+            .unwrap_or("-")
+            .to_string();
+
+        Self {
+            child_request_id: request_id.clone(),
+            request_id,
+            parent_request_id: node.row.parent_request_id(),
+            deployment,
+            agent_did,
+            behavior_id,
+            state,
+            started_at,
+            depth: node.depth,
+            display_request_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LineageTreeNode {
+    #[serde(flatten)]
+    row: LineageOutputRow,
+    children: Vec<LineageTreeNode>,
+}
+
+fn non_empty_str(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(request_id: &str, parent: Option<&str>, created_at: &str) -> AgentRequestLineageRow {
+        AgentRequestLineageRow {
+            request_id: request_id.to_string(),
+            agent_did: Some("did:key:zTest".to_string()),
+            behavior_id: Some(request_id.to_string()),
+            status: Some("pending".to_string()),
+            lifecycle_state: Some("pending".to_string()),
+            created_at: Some(created_at.to_string()),
+            claimed_at: None,
+            caused_by_parent_request_id: parent.map(ToOwned::to_owned),
+        }
+    }
+
+    #[test]
+    fn table_renderer_indents_tree_request_column_only() {
+        let rows = vec![
+            LineageNode {
+                row: row("parent", None, "2026-05-20T00:00:00Z"),
+                depth: 0,
+            },
+            LineageNode {
+                row: row("child", Some("parent"), "2026-05-20T00:00:01Z"),
+                depth: 1,
+            },
+        ];
+        let rendered = render_table(&output_rows(&rows, true));
+        assert!(rendered.contains("CHILD_REQUEST_ID"));
+        assert!(rendered.contains("parent"));
+        assert!(rendered.contains("  child"));
+        assert!(rendered.contains("parent"));
+    }
 }

--- a/crates/defra-agent-cli/src/commands/subagent.rs
+++ b/crates/defra-agent-cli/src/commands/subagent.rs
@@ -10,8 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 use crate::cli::args::{
-    SubagentCancelArgs, SubagentCancelOutput, SubagentCommand, SubagentListArgs,
-    SubagentListOutput,
+    SubagentCancelArgs, SubagentCancelOutput, SubagentCommand, SubagentListArgs, SubagentListOutput,
 };
 use crate::config_writes::ConfigAccess;
 use crate::{

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -205,9 +205,15 @@ of the source. Child inherits principal; behavior can be swapped with \
 --behavior.";
 const SUBAGENT_AFTER_HELP: &str = "\
 Examples:
+  defra-agent subagent list
+  defra-agent subagent list --root REQUEST_ID
+  defra-agent subagent list --root REQUEST_ID --depth 2
+  defra-agent subagent list --root REQUEST_ID --output json
   defra-agent subagent cancel REQUEST_ID
   defra-agent subagent cancel REQUEST_ID --cascade=false
   defra-agent subagent cancel REQUEST_ID --wait --timeout 30s --output json";
+const SUBAGENT_LIST_AFTER_HELP: &str =
+    "Without --root, only requests that participate in subagent lineage are shown.";
 const DIAGNOSE_AFTER_HELP: &str = "\
 Examples:
   defra-agent diagnose

--- a/crates/defra-agent-cli/tests/cli_subagent.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent.rs
@@ -36,7 +36,8 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
 
     let test_agent_did = format!("did:key:zSubagentList{}", Uuid::new_v4().simple());
     let root_request_id = format!("root-{}", Uuid::new_v4().simple());
-    let child_request_id = format!("child-{}", Uuid::new_v4().simple());
+    let first_child_request_id = format!("child-a-{}", Uuid::new_v4().simple());
+    let second_child_request_id = format!("child-b-{}", Uuid::new_v4().simple());
     let grandchild_request_id = format!("grandchild-{}", Uuid::new_v4().simple());
 
     seed_request(
@@ -52,8 +53,8 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
     seed_request(
         &graphql,
         &test_agent_did,
-        &child_request_id,
-        "child-behavior",
+        &first_child_request_id,
+        "first-child-behavior",
         Some(&root_request_id),
         1,
         "2026-05-20T12:00:01Z",
@@ -62,11 +63,21 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
     seed_request(
         &graphql,
         &test_agent_did,
+        &second_child_request_id,
+        "second-child-behavior",
+        Some(&root_request_id),
+        1,
+        "2026-05-20T12:00:02Z",
+    )
+    .await?;
+    seed_request(
+        &graphql,
+        &test_agent_did,
         &grandchild_request_id,
         "grandchild-behavior",
-        Some(&child_request_id),
+        Some(&first_child_request_id),
         2,
-        "2026-05-20T12:00:02Z",
+        "2026-05-20T12:00:03Z",
     )
     .await?;
 
@@ -89,23 +100,37 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         .context("subagent list JSON output missing rows array")?;
     assert_eq!(
         rows.len(),
-        3,
-        "expected root, child, and grandchild: {output}"
+        4,
+        "expected root, two children, and grandchild: {output}"
     );
     assert_lineage_row(rows, &root_request_id, None, 0, "parent-behavior")?;
     assert_lineage_row(
         rows,
-        &child_request_id,
+        &first_child_request_id,
         Some(&root_request_id),
         1,
-        "child-behavior",
+        "first-child-behavior",
+    )?;
+    assert_lineage_row(
+        rows,
+        &second_child_request_id,
+        Some(&root_request_id),
+        1,
+        "second-child-behavior",
     )?;
     assert_lineage_row(
         rows,
         &grandchild_request_id,
-        Some(&child_request_id),
+        Some(&first_child_request_id),
         2,
         "grandchild-behavior",
+    )?;
+    assert_tree_shape(
+        &output,
+        &root_request_id,
+        &first_child_request_id,
+        &second_child_request_id,
+        &grandchild_request_id,
     )?;
 
     let text = run_cli_text(
@@ -124,13 +149,17 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         "missing tree header: {text}"
     );
     assert!(text.contains(&root_request_id), "missing root row: {text}");
+    let lines = text.lines().collect::<Vec<_>>();
+    let root_idx = line_index_starting_with(&lines, &root_request_id)?;
+    let first_child_idx = line_index_starting_with(&lines, &format!("  {first_child_request_id}"))?;
+    let grandchild_idx = line_index_starting_with(&lines, &format!("    {grandchild_request_id}"))?;
+    let second_child_idx =
+        line_index_starting_with(&lines, &format!("  {second_child_request_id}"))?;
     assert!(
-        text.contains(&format!("  {child_request_id}")),
-        "default tree output must indent the child row: {text}"
-    );
-    assert!(
-        text.contains(&format!("    {grandchild_request_id}")),
-        "default tree output must indent the grandchild row: {text}"
+        root_idx < first_child_idx
+            && first_child_idx < grandchild_idx
+            && grandchild_idx < second_child_idx,
+        "default tree output must render descendants before later siblings: {text}"
     );
 
     let table = run_cli_text(
@@ -153,13 +182,19 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
     assert!(
         table
             .lines()
-            .any(|line| line.starts_with(&child_request_id)),
+            .any(|line| line.starts_with(&first_child_request_id)),
         "flat table output must include child row without leading indentation: {table}"
+    );
+    assert!(
+        table
+            .lines()
+            .any(|line| line.starts_with(&second_child_request_id)),
+        "flat table output must include sibling row without leading indentation: {table}"
     );
     assert!(
         !table
             .lines()
-            .any(|line| line.starts_with(&format!("  {child_request_id}"))),
+            .any(|line| line.starts_with(&format!("  {first_child_request_id}"))),
         "flat table output must not indent child rows: {table}"
     );
 
@@ -184,8 +219,8 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         .context("depth-limited output missing rows array")?;
     assert_eq!(
         depth_rows.len(),
-        2,
-        "--depth 1 should include root and direct child only: {depth_limited}"
+        3,
+        "--depth 1 should include root and direct children only: {depth_limited}"
     );
     assert!(
         !depth_rows.iter().any(|row| {
@@ -195,6 +230,66 @@ async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
         "--depth 1 must exclude grandchild: {depth_limited}"
     );
 
+    Ok(())
+}
+
+fn line_index_starting_with(lines: &[&str], prefix: &str) -> Result<usize> {
+    lines
+        .iter()
+        .position(|line| line.starts_with(prefix))
+        .with_context(|| format!("missing line starting with {prefix:?}: {lines:?}"))
+}
+
+fn assert_tree_shape(
+    output: &Value,
+    root_request_id: &str,
+    first_child_request_id: &str,
+    second_child_request_id: &str,
+    grandchild_request_id: &str,
+) -> Result<()> {
+    let roots = output
+        .get("tree")
+        .and_then(Value::as_array)
+        .context("subagent list JSON output missing tree array")?;
+    assert_eq!(roots.len(), 1, "expected one root tree: {output}");
+    assert_tree_node_id(&roots[0], root_request_id)?;
+
+    let root_children = children(&roots[0])?;
+    assert_eq!(
+        root_children.len(),
+        2,
+        "root should have two direct children: {output}"
+    );
+    assert_tree_node_id(&root_children[0], first_child_request_id)?;
+    assert_tree_node_id(&root_children[1], second_child_request_id)?;
+
+    let first_child_children = children(&root_children[0])?;
+    assert_eq!(
+        first_child_children.len(),
+        1,
+        "first child should have one grandchild: {output}"
+    );
+    assert_tree_node_id(&first_child_children[0], grandchild_request_id)?;
+    assert!(
+        children(&root_children[1])?.is_empty(),
+        "second child should not receive first child's grandchild: {output}"
+    );
+    Ok(())
+}
+
+fn children(node: &Value) -> Result<&[Value]> {
+    node.get("children")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .context("tree node missing children array")
+}
+
+fn assert_tree_node_id(node: &Value, request_id: &str) -> Result<()> {
+    assert_eq!(
+        node.get("child_request_id").and_then(Value::as_str),
+        Some(request_id),
+        "unexpected tree node id: {node}"
+    );
     Ok(())
 }
 

--- a/crates/defra-agent-cli/tests/cli_subagent.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent.rs
@@ -1,0 +1,289 @@
+mod support;
+use support::*;
+
+use std::fs;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn subagent_list_shows_two_level_dispatch_lineage() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-subagent-list-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            "cli-subagent-list",
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let runtime_agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &runtime_agent_did, Duration::from_secs(30)).await?;
+
+    let test_agent_did = format!("did:key:zSubagentList{}", Uuid::new_v4().simple());
+    let root_request_id = format!("root-{}", Uuid::new_v4().simple());
+    let child_request_id = format!("child-{}", Uuid::new_v4().simple());
+    let grandchild_request_id = format!("grandchild-{}", Uuid::new_v4().simple());
+
+    seed_request(
+        &graphql,
+        &test_agent_did,
+        &root_request_id,
+        "parent-behavior",
+        None,
+        0,
+        "2026-05-20T12:00:00Z",
+    )
+    .await?;
+    seed_request(
+        &graphql,
+        &test_agent_did,
+        &child_request_id,
+        "child-behavior",
+        Some(&root_request_id),
+        1,
+        "2026-05-20T12:00:01Z",
+    )
+    .await?;
+    seed_request(
+        &graphql,
+        &test_agent_did,
+        &grandchild_request_id,
+        "grandchild-behavior",
+        Some(&child_request_id),
+        2,
+        "2026-05-20T12:00:02Z",
+    )
+    .await?;
+
+    let output = run_cli_json(
+        &home_dir,
+        &[
+            "subagent",
+            "list",
+            "--graphql",
+            &graphql,
+            "--root",
+            &root_request_id,
+            "--output",
+            "json",
+        ],
+    )?;
+    let rows = output
+        .get("rows")
+        .and_then(Value::as_array)
+        .context("subagent list JSON output missing rows array")?;
+    assert_eq!(
+        rows.len(),
+        3,
+        "expected root, child, and grandchild: {output}"
+    );
+    assert_lineage_row(rows, &root_request_id, None, 0, "parent-behavior")?;
+    assert_lineage_row(
+        rows,
+        &child_request_id,
+        Some(&root_request_id),
+        1,
+        "child-behavior",
+    )?;
+    assert_lineage_row(
+        rows,
+        &grandchild_request_id,
+        Some(&child_request_id),
+        2,
+        "grandchild-behavior",
+    )?;
+
+    let text = run_cli_text(
+        &home_dir,
+        &[
+            "subagent",
+            "list",
+            "--graphql",
+            &graphql,
+            "--root",
+            &root_request_id,
+        ],
+    )?;
+    assert!(
+        text.contains("CHILD_REQUEST_ID"),
+        "missing tree header: {text}"
+    );
+    assert!(text.contains(&root_request_id), "missing root row: {text}");
+    assert!(
+        text.contains(&format!("  {child_request_id}")),
+        "default tree output must indent the child row: {text}"
+    );
+    assert!(
+        text.contains(&format!("    {grandchild_request_id}")),
+        "default tree output must indent the grandchild row: {text}"
+    );
+
+    let table = run_cli_text(
+        &home_dir,
+        &[
+            "subagent",
+            "list",
+            "--graphql",
+            &graphql,
+            "--root",
+            &root_request_id,
+            "--output",
+            "table",
+        ],
+    )?;
+    assert!(
+        table.contains("PARENT_REQUEST_ID"),
+        "missing table header: {table}"
+    );
+    assert!(
+        table
+            .lines()
+            .any(|line| line.starts_with(&child_request_id)),
+        "flat table output must include child row without leading indentation: {table}"
+    );
+    assert!(
+        !table
+            .lines()
+            .any(|line| line.starts_with(&format!("  {child_request_id}"))),
+        "flat table output must not indent child rows: {table}"
+    );
+
+    let depth_limited = run_cli_json(
+        &home_dir,
+        &[
+            "subagent",
+            "list",
+            "--graphql",
+            &graphql,
+            "--root",
+            &root_request_id,
+            "--depth",
+            "1",
+            "--output",
+            "json",
+        ],
+    )?;
+    let depth_rows = depth_limited
+        .get("rows")
+        .and_then(Value::as_array)
+        .context("depth-limited output missing rows array")?;
+    assert_eq!(
+        depth_rows.len(),
+        2,
+        "--depth 1 should include root and direct child only: {depth_limited}"
+    );
+    assert!(
+        !depth_rows.iter().any(|row| {
+            row.get("child_request_id").and_then(Value::as_str)
+                == Some(grandchild_request_id.as_str())
+        }),
+        "--depth 1 must exclude grandchild: {depth_limited}"
+    );
+
+    Ok(())
+}
+
+async fn seed_request(
+    graphql: &str,
+    agent_did: &str,
+    request_id: &str,
+    behavior_id: &str,
+    parent_request_id: Option<&str>,
+    subagent_depth: i64,
+    created_at: &str,
+) -> Result<()> {
+    let session_id = format!("session-{request_id}");
+    let parent_fields = parent_request_id
+        .map(|parent| {
+            format!(
+                r#"
+                    ,
+                    caused_by_parent_request_id: "{}",
+                    caused_by_parent_tool_call_id: "spawn-{}",
+                    caused_by_trigger_id: "spawn-{}",
+                    caused_by_trigger_kind: "subagent","#,
+                escape_graphql_string(parent),
+                escape_graphql_string(request_id),
+                escape_graphql_string(request_id),
+            )
+        })
+        .unwrap_or_default();
+    graphql_query(
+        graphql,
+        &format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    session_id: "{session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{request_id}",
+                    superseded_by_request: "",
+                    content: "seeded subagent list row",
+                    status: "pending",
+                    lifecycle_state: "pending",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    failure_reason: "",
+                    created_at: "{created_at}",
+                    retry_count: 0,
+                    max_retries: 3,
+                    subagent_depth: {subagent_depth}{parent_fields}
+                }}) {{ _docID }}
+            }}"#,
+            request_id = escape_graphql_string(request_id),
+            agent_did = escape_graphql_string(agent_did),
+            behavior_id = escape_graphql_string(behavior_id),
+            session_id = escape_graphql_string(&session_id),
+            created_at = escape_graphql_string(created_at),
+        ),
+    )
+    .await?;
+    Ok(())
+}
+
+fn assert_lineage_row(
+    rows: &[Value],
+    request_id: &str,
+    parent_request_id: Option<&str>,
+    depth: i64,
+    behavior_id: &str,
+) -> Result<()> {
+    let row = rows
+        .iter()
+        .find(|row| row.get("child_request_id").and_then(Value::as_str) == Some(request_id))
+        .with_context(|| format!("missing row for {request_id}: {rows:?}"))?;
+    assert_eq!(
+        row.get("parent_request_id").and_then(Value::as_str),
+        parent_request_id
+    );
+    assert_eq!(row.get("depth").and_then(Value::as_i64), Some(depth));
+    assert_eq!(
+        row.get("behavior_id").and_then(Value::as_str),
+        Some(behavior_id)
+    );
+    assert_eq!(row.get("state").and_then(Value::as_str), Some("pending"));
+    assert!(
+        row.get("started_at")
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.is_empty()),
+        "row must expose started_at: {row}"
+    );
+    Ok(())
+}

--- a/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
@@ -398,7 +398,7 @@ existing ledger rows the worked example (§7) tags with this feature.
 | `runtime-reconcile` | `runtimeInternal` | — | 3 |
 | `session-recovery` | `runtimeInternal` | — | 3 |
 | `background-tools` | `agentFacing` | `operatorCli` (#268), `operatorUi` (#276) | 14 |
-| `subagents-cross-deployment` | — | `api` (#272), `agentFacing` (#273), `operatorUi` (#274) | 0 (see §3.1) |
+| `subagents-cross-deployment` | `operatorCli` | `api` (#272), `agentFacing` (#273), `operatorUi` (#274) | 1 (see §3.1) |
 | `interrupt-and-cancel` | `agentFacing` | `operatorCli` (#266), `operatorUi` (#277) | 1 |
 | `mcp-health` | `runtimeInternal` | `operatorUi` (#278), `operatorCli` (#279) | 1 |
 | `identity-permission` | `runtimeInternal` | `api` (#280) | 3 |
@@ -422,16 +422,21 @@ When the matrix schema in this design lands, tag that consumer with
 `feature = "background-tools"` and `surfaces = [operatorCli]`, replacing
 the deferred `operatorCli` slot on the `background-tools` row.
 
-Tag-count totals: 74 row-tags across 74 distinct ledger rows. Under the
-single-tag rule (§3.2 / §6.2), each existing row is tagged exactly once.
-The ledger has 74 rows (18 vocab + 15 state-machine + 37 case + 4
-followUpHook) per `awk` ranges over `CoverageLedger.lean`; every one is
-accounted for in §7.
+Tag-count totals: 75 consumer tags: the 74 existing ledger rows plus the
+new #269 operator CLI lineage consumer. Under the single-tag rule
+(§3.2 / §6.2), each existing ledger row is tagged exactly once. The
+ledger has 74 rows (18 vocab + 15 state-machine + 37 case + 4
+followUpHook) per `awk` ranges over `CoverageLedger.lean`; every
+pre-#269 ledger row is accounted for in §7.
 
-### 3.1 The subagents-cross-deployment feature is all-deferred
+### 3.1 The subagents-cross-deployment feature starts all-deferred
 
-`subagents-cross-deployment` is the one feature with zero existing ledger
-rows. The runtime carries the R5 model in Lean (per the audit's §8
+`subagents-cross-deployment` was initially the one feature with zero
+existing ledger rows. Issue #269 adds the first bound operator surface:
+`defra-agent subagent list`, tagged as `operatorCli`, which lets operators
+inspect request lineage via `AgentRequest.caused_by_parent_request_id`.
+
+The runtime carries the R5 model in Lean (per the audit's §8
 subtree) and the protocol schema carries the R5 fields (exercised by
 `agent_tool_call_has_r5_cross_deployment_fields` and
 `tool_selection_has_cross_deployment_spawn_timeout` at
@@ -439,7 +444,7 @@ subtree) and the protocol schema carries the R5 fields (exercised by
 but those `#[tokio::test]` functions are not Lean-driven case consumers
 and are not in the ledger.
 
-Three follow-ups, all `deferred`:
+Three follow-ups remain `deferred`:
 
 - **`api`.** Promote the existing schema introspection tests to ledger
   consumers by adding a row pointing at them with
@@ -452,10 +457,10 @@ Three follow-ups, all `deferred`:
   shell — a deployment badge or routing diagnostic on the chat shell.
   Tracked as #274.
 
-The matrix v1 lists all three as `deferred` (no `required` slot) so the
-implementation PR ships without immediately failing the new drift test
-on this feature. When any of the three follow-ups land, the surface
-moves to `required` and the relevant ledger row is added.
+The matrix v1 lists the CLI lineage command as the first `required`
+surface for this feature and leaves the three follow-ups above as
+`deferred`. When any of the three follow-ups land, the surface moves to
+`required` and the relevant ledger row is added.
 
 ### 3.2 Multi-tag carve-out: `interrupt-and-cancel`
 
@@ -568,6 +573,9 @@ serialized as:
                          "deferred_note": "" }
   },
   "subagents-cross-deployment": {
+    "operatorCli":     { "coverage_strength": "consumer",
+                         "row_count": 1, "pending_follow_ups": 0,
+                         "deferred_note": "" },
     "api":             { "coverage_strength": "missing",
                          "row_count": 0, "pending_follow_ups": 0,
                          "deferred_note": "" },
@@ -1037,7 +1045,8 @@ Row counts per feature, matching the "Tag count" column in §3:
   `:198`, `:301`, `:305`, `:309`, `:313`, plus the four followUpHook
   rows `:374`, `:378`, `:382`, `:386` (which contribute to count but
   not to any surface cell because their `surfaces := []`).
-- `subagents-cross-deployment` — 0. All surfaces deferred. See §3.1.
+- `subagents-cross-deployment` — 1: operator CLI lineage consumer. The
+  API, agent-facing, and UI surfaces remain deferred. See §3.1.
 - `interrupt-and-cancel` — 1: `:113`. See §3.2.
 - `mcp-health` — 1: `:366`.
 - `identity-permission` — 3: `:321`, `:325`, `:329`. The audit §9
@@ -1132,10 +1141,10 @@ Per `PROMPT.md`'s out-of-scope list:
 - Do not rename rows. The audit at §13 and §3 (cosmetic deltas) flags
   renames; those are separate cleanup PRs.
 - Do not add new ledger rows beyond what the matrix surfaces as
-  required-and-missing. The `subagents-cross-deployment` row
-  promotion is a judgment call at implementation time; if the
-  implementer decides it is out of scope, move the surface to
-  `deferred` and file the follow-up.
+  required-and-missing. The remaining `subagents-cross-deployment`
+  API / agent-facing / UI row promotions are judgment calls at
+  implementation time; if the implementer decides one is out of scope,
+  move the surface to `deferred` and file the follow-up.
 - Do not change the JSON snapshot beyond the two new keys at `:126`.
 
 ### 8.3 If schema extension forces a constructor change


### PR DESCRIPTION
Closes #269.

## Summary
- add `defra-agent subagent list` with tree, table, and JSON output
- traverse AgentRequest lineage via `caused_by_parent_request_id` with optional root/depth limits
- add CLI integration coverage for parent -> child -> grandchild lineage

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli`
- `cargo run -p defra-agent-cli --bin defra-agent -- subagent list --help`