### PR TITLE
CLI: background list (#268)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -356,7 +356,11 @@ pub(crate) enum ShowCommand {
 
 #[derive(Subcommand)]
 pub(crate) enum BackgroundCommand {
-    #[command(name = "list", about = "List backgrounded AgentToolCall rows")]
+    #[command(
+        name = "list",
+        about = "List backgrounded AgentToolCall rows",
+        after_help = BACKGROUND_AFTER_HELP
+    )]
     List(BackgroundListArgs),
 }
 
@@ -375,7 +379,7 @@ pub(crate) struct BackgroundListArgs {
     #[arg(
         long,
         value_name = "STATE",
-        help = "Only show tool calls in this lifecycle state"
+        help = "Only show tool calls whose displayed state matches this value"
     )]
     pub(crate) state: Option<String>,
     #[arg(

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -9,9 +9,9 @@ use defra_agent::BackendProviderKind;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    CHAT_AFTER_HELP, CLI_AFTER_HELP, CONFIG_AFTER_HELP, CONFIG_EXPORT_AFTER_HELP,
-    CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP, INIT_AFTER_HELP,
-    P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
+    BACKGROUND_AFTER_HELP, CHAT_AFTER_HELP, CLI_AFTER_HELP, CONFIG_AFTER_HELP,
+    CONFIG_EXPORT_AFTER_HELP, CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP,
+    INIT_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
     RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP,
     TRACE_AFTER_HELP,
 };
@@ -70,6 +70,14 @@ pub(crate) enum Command {
     },
     #[command(about = "Show the current local runtime status", after_help = STATUS_AFTER_HELP)]
     Status(StatusArgs),
+    #[command(
+        about = "Inspect backgrounded tool calls",
+        after_help = BACKGROUND_AFTER_HELP
+    )]
+    Background {
+        #[command(subcommand)]
+        command: BackgroundCommand,
+    },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
     #[command(about = "Inspect and write runtime configuration documents", after_help = CONFIG_AFTER_HELP)]
@@ -344,6 +352,46 @@ pub(crate) enum ShowCommand {
     Response(ResponseShowArgs),
     #[command(about = "Show the persisted AgentRuntime document")]
     Runtime(RuntimeShowArgs),
+}
+
+#[derive(Subcommand)]
+pub(crate) enum BackgroundCommand {
+    #[command(name = "list", about = "List backgrounded AgentToolCall rows")]
+    List(BackgroundListArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct BackgroundListArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint to read instead of local home state")]
+    pub(crate) graphql: Option<String>,
+    #[arg(
+        long = "request",
+        value_name = "ID",
+        help = "Only show backgrounded tools for this parent request"
+    )]
+    pub(crate) request_id: Option<String>,
+    #[arg(
+        long,
+        value_name = "STATE",
+        help = "Only show tool calls in this lifecycle state"
+    )]
+    pub(crate) state: Option<String>,
+    #[arg(
+        long,
+        value_name = "DURATION",
+        help = "Only show calls older than this duration, e.g. 30s, 5m, 2h"
+    )]
+    pub(crate) age_gt: Option<String>,
+    #[arg(long, value_enum, default_value_t = BackgroundOutputFormat::Table)]
+    pub(crate) output: BackgroundOutputFormat,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum BackgroundOutputFormat {
+    Table,
+    Json,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/commands/background.rs
+++ b/crates/defra-agent-cli/src/commands/background.rs
@@ -1,0 +1,365 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, SecondsFormat, Utc};
+use defra_agent::graphql::escape_graphql_string;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::cli::args::{BackgroundCommand, BackgroundListArgs, BackgroundOutputFormat};
+use crate::config_writes::ConfigAccess;
+use crate::request_helpers::parse_duration_suffix;
+use crate::{
+    graphql_rows_or_empty_if_collection_missing, normalize_optional_string, print_json,
+    resolve_config_access,
+};
+
+pub(crate) async fn dispatch(command: BackgroundCommand) -> Result<()> {
+    match command {
+        BackgroundCommand::List(args) => background_list(args).await,
+    }
+}
+
+async fn background_list(args: BackgroundListArgs) -> Result<()> {
+    let now = Utc::now();
+    let age_cutoff = age_cutoff(args.age_gt.as_deref(), now)?;
+    let (access, _home_dir) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let tool_calls = load_background_tool_calls(&access, &args, age_cutoff).await?;
+    let liveness = match &access {
+        ConfigAccess::Graphql(graphql) => {
+            crate::commands::status::load_liveness_value(graphql).await
+        }
+        ConfigAccess::Local(_) => Value::Null,
+    };
+    let liveness = RuntimeLivenessView::from_value(&liveness);
+    let rows = build_output_rows(now, tool_calls, &liveness);
+    let output = BackgroundListOutput {
+        generated_at: now.to_rfc3339_opts(SecondsFormat::Secs, true),
+        filters: BackgroundListFilters {
+            request_id: normalize_optional_string(args.request_id.as_deref()),
+            state: normalize_optional_string(args.state.as_deref()),
+            age_gt: normalize_optional_string(args.age_gt.as_deref()),
+        },
+        active_native_executors_available: liveness.active_native_executors_available,
+        count: rows.len(),
+        items: rows,
+    };
+
+    match args.output {
+        BackgroundOutputFormat::Json => print_json(&serde_json::to_value(output)?),
+        BackgroundOutputFormat::Table => {
+            print_background_table(&output.items, output.active_native_executors_available);
+            Ok(())
+        }
+    }
+}
+
+async fn load_background_tool_calls(
+    access: &ConfigAccess,
+    args: &BackgroundListArgs,
+    age_cutoff: Option<DateTime<Utc>>,
+) -> Result<Vec<BackgroundToolCallRow>> {
+    let mut filters = vec![r#"{ await_mode: { _eq: "background" } }"#.to_string()];
+    if let Some(request_id) = normalize_optional_string(args.request_id.as_deref()) {
+        filters.push(format!(
+            r#"{{ request_id: {{ _eq: "{}" }} }}"#,
+            escape_graphql_string(&request_id)
+        ));
+    }
+    if let Some(state) = normalize_optional_string(args.state.as_deref()) {
+        filters.push(format!(
+            r#"{{ lifecycle_state: {{ _eq: "{}" }} }}"#,
+            escape_graphql_string(&state)
+        ));
+    }
+    if let Some(cutoff) = age_cutoff {
+        let cutoff = cutoff.to_rfc3339_opts(SecondsFormat::Secs, true);
+        filters.push(format!(
+            r#"{{ started_at: {{ _lt: "{}" }} }}"#,
+            escape_graphql_string(&cutoff)
+        ));
+    }
+
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{ _and: [{}] }},
+                order: {{ started_at: DESC }}
+            ) {{
+                request_id
+                tool_call_id
+                tool_name
+                status
+                lifecycle_state
+                await_mode
+                started_at
+            }}
+        }}"#,
+        filters.join(", ")
+    );
+    load_rows(access, "AgentToolCall", &query).await
+}
+
+fn build_output_rows(
+    now: DateTime<Utc>,
+    tool_calls: Vec<BackgroundToolCallRow>,
+    liveness: &RuntimeLivenessView,
+) -> Vec<BackgroundToolCallOutput> {
+    let active_tool_call_ids = liveness
+        .active_tool_calls
+        .iter()
+        .map(|row| row.tool_call_id.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut native_by_tool_name: BTreeMap<&str, Vec<NativeExecutorView>> = BTreeMap::new();
+    for executor in &liveness.active_native_executors {
+        if let Some(tool_name) = executor.tool_name.as_deref() {
+            native_by_tool_name
+                .entry(tool_name)
+                .or_default()
+                .push(executor.clone());
+        }
+    }
+
+    tool_calls
+        .into_iter()
+        .map(|row| {
+            let started_at = normalize_optional_string(row.started_at.as_deref());
+            let age_ms = started_at
+                .as_deref()
+                .and_then(parse_rfc3339_utc)
+                .map(|started| now.signed_duration_since(started).num_milliseconds().max(0));
+            let tool_name = normalize_optional_string(row.tool_name.as_deref());
+            let native_executors = tool_name
+                .as_deref()
+                .and_then(|name| native_by_tool_name.get(name))
+                .cloned()
+                .unwrap_or_default();
+            let state = normalize_optional_string(row.lifecycle_state.as_deref())
+                .or_else(|| normalize_optional_string(row.status.as_deref()))
+                .unwrap_or_else(|| "-".to_string());
+            let tool_call_id = row.tool_call_id.unwrap_or_default();
+
+            BackgroundToolCallOutput {
+                tool_call_id: tool_call_id.clone(),
+                parent_request_id: row.request_id.unwrap_or_default(),
+                state,
+                await_mode: normalize_optional_string(row.await_mode.as_deref())
+                    .unwrap_or_else(|| "-".to_string()),
+                started_at,
+                age_ms,
+                age: age_ms.map(format_age_ms),
+                tool_name,
+                active_tool_call: active_tool_call_ids.contains(tool_call_id.as_str()),
+                active_native_executor_count: native_executors.len(),
+                active_native_executors: native_executors,
+            }
+        })
+        .collect()
+}
+
+fn age_cutoff(raw: Option<&str>, now: DateTime<Utc>) -> Result<Option<DateTime<Utc>>> {
+    let Some(raw) = normalize_optional_string(raw) else {
+        return Ok(None);
+    };
+    let duration = parse_duration_suffix(&raw)?;
+    let secs = i64::try_from(duration.as_secs()).context("duration too large")?;
+    Ok(Some(now - chrono::Duration::seconds(secs)))
+}
+
+fn parse_rfc3339_utc(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn format_age_ms(age_ms: i64) -> String {
+    if age_ms < 1_000 {
+        return format!("{age_ms}ms");
+    }
+    let total_secs = age_ms / 1_000;
+    let days = total_secs / 86_400;
+    let hours = (total_secs % 86_400) / 3_600;
+    let minutes = (total_secs % 3_600) / 60;
+    let seconds = total_secs % 60;
+    if days > 0 {
+        format!("{days}d{hours}h")
+    } else if hours > 0 {
+        format!("{hours}h{minutes}m")
+    } else if minutes > 0 {
+        format!("{minutes}m{seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn print_background_table(rows: &[BackgroundToolCallOutput], native_liveness_available: bool) {
+    let headers = [
+        "TOOL_CALL_ID",
+        "PARENT_REQUEST",
+        "STATE",
+        "AWAIT_MODE",
+        "STARTED_AT",
+        "AGE",
+        "NATIVE",
+    ];
+    let rendered_rows = rows
+        .iter()
+        .map(|row| {
+            [
+                display_cell(&row.tool_call_id),
+                display_cell(&row.parent_request_id),
+                display_cell(&row.state),
+                display_cell(&row.await_mode),
+                row.started_at.clone().unwrap_or_else(|| "-".to_string()),
+                row.age.clone().unwrap_or_else(|| "-".to_string()),
+                if !native_liveness_available {
+                    "unknown".to_string()
+                } else if row.active_native_executor_count > 0 {
+                    "yes".to_string()
+                } else {
+                    "no".to_string()
+                },
+            ]
+        })
+        .collect::<Vec<_>>();
+    let mut widths = headers.map(str::len);
+    for row in &rendered_rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(cell.len());
+        }
+    }
+
+    print_table_row(&headers.map(|header| header.to_string()), &widths);
+    print_table_row(&widths.map(|width| "-".repeat(width)), &widths);
+    for row in &rendered_rows {
+        print_table_row(row, &widths);
+    }
+}
+
+fn display_cell(value: &str) -> String {
+    if value.trim().is_empty() {
+        "-".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn print_table_row<const N: usize>(cells: &[String; N], widths: &[usize; N]) {
+    let line = cells
+        .iter()
+        .enumerate()
+        .map(|(idx, cell)| format!("{cell:<width$}", width = widths[idx]))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("{line}");
+}
+
+async fn load_rows<T>(access: &ConfigAccess, collection: &str, query: &str) -> Result<Vec<T>>
+where
+    T: DeserializeOwned,
+{
+    graphql_rows_or_empty_if_collection_missing(access, collection, query)
+        .await?
+        .into_iter()
+        .map(serde_json::from_value)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("decoding {collection} rows"))
+}
+
+#[derive(Debug, Deserialize)]
+struct BackgroundToolCallRow {
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    tool_call_id: Option<String>,
+    #[serde(default)]
+    tool_name: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    await_mode: Option<String>,
+    #[serde(default)]
+    started_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct BackgroundListOutput {
+    generated_at: String,
+    filters: BackgroundListFilters,
+    active_native_executors_available: bool,
+    count: usize,
+    items: Vec<BackgroundToolCallOutput>,
+}
+
+#[derive(Debug, Serialize)]
+struct BackgroundListFilters {
+    request_id: Option<String>,
+    state: Option<String>,
+    age_gt: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct BackgroundToolCallOutput {
+    tool_call_id: String,
+    parent_request_id: String,
+    state: String,
+    await_mode: String,
+    started_at: Option<String>,
+    age_ms: Option<i64>,
+    age: Option<String>,
+    tool_name: Option<String>,
+    active_tool_call: bool,
+    active_native_executor_count: usize,
+    active_native_executors: Vec<NativeExecutorView>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct NativeExecutorView {
+    id: u64,
+    pid: i32,
+    argv0: String,
+    tool_name: Option<String>,
+    started_at: String,
+    age_ms: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ActiveToolCallView {
+    tool_call_id: String,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeLivenessView {
+    active_native_executors_available: bool,
+    active_tool_calls: Vec<ActiveToolCallView>,
+    active_native_executors: Vec<NativeExecutorView>,
+}
+
+impl RuntimeLivenessView {
+    fn from_value(value: &Value) -> Self {
+        Self {
+            active_native_executors_available: value
+                .get("active_native_executors_available")
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            active_tool_calls: parse_array(value, "active_tool_calls"),
+            active_native_executors: parse_array(value, "active_native_executors"),
+        }
+    }
+}
+
+fn parse_array<T>(value: &Value, field: &str) -> Vec<T>
+where
+    T: DeserializeOwned,
+{
+    value
+        .get(field)
+        .and_then(Value::as_array)
+        .cloned()
+        .map(Value::Array)
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
+}

--- a/crates/defra-agent-cli/src/commands/background.rs
+++ b/crates/defra-agent-cli/src/commands/background.rs
@@ -67,12 +67,6 @@ async fn load_background_tool_calls(
             escape_graphql_string(&request_id)
         ));
     }
-    if let Some(state) = normalize_optional_string(args.state.as_deref()) {
-        filters.push(format!(
-            r#"{{ lifecycle_state: {{ _eq: "{}" }} }}"#,
-            escape_graphql_string(&state)
-        ));
-    }
     if let Some(cutoff) = age_cutoff {
         let cutoff = cutoff.to_rfc3339_opts(SecondsFormat::Secs, true);
         filters.push(format!(
@@ -98,7 +92,11 @@ async fn load_background_tool_calls(
         }}"#,
         filters.join(", ")
     );
-    load_rows(access, "AgentToolCall", &query).await
+    let mut rows = load_rows::<BackgroundToolCallRow>(access, "AgentToolCall", &query).await?;
+    if let Some(state) = normalize_optional_string(args.state.as_deref()) {
+        rows.retain(|row| row_state(row).as_deref() == Some(state.as_str()));
+    }
+    Ok(rows)
 }
 
 fn build_output_rows(
@@ -112,6 +110,9 @@ fn build_output_rows(
         .map(|row| row.tool_call_id.as_str())
         .collect::<BTreeSet<_>>();
     let mut native_by_tool_name: BTreeMap<&str, Vec<NativeExecutorView>> = BTreeMap::new();
+    // Native executor liveness currently identifies the executable/tool, not
+    // the specific AgentToolCall that spawned it. Treat these as tool-name
+    // matches only.
     for executor in &liveness.active_native_executors {
         if let Some(tool_name) = executor.tool_name.as_deref() {
             native_by_tool_name
@@ -135,9 +136,7 @@ fn build_output_rows(
                 .and_then(|name| native_by_tool_name.get(name))
                 .cloned()
                 .unwrap_or_default();
-            let state = normalize_optional_string(row.lifecycle_state.as_deref())
-                .or_else(|| normalize_optional_string(row.status.as_deref()))
-                .unwrap_or_else(|| "-".to_string());
+            let state = row_state(&row).unwrap_or_else(|| "-".to_string());
             let tool_call_id = row.tool_call_id.unwrap_or_default();
 
             BackgroundToolCallOutput {
@@ -150,12 +149,18 @@ fn build_output_rows(
                 age_ms,
                 age: age_ms.map(format_age_ms),
                 tool_name,
-                active_tool_call: active_tool_call_ids.contains(tool_call_id.as_str()),
-                active_native_executor_count: native_executors.len(),
-                active_native_executors: native_executors,
+                active_tool_call: !tool_call_id.is_empty()
+                    && active_tool_call_ids.contains(tool_call_id.as_str()),
+                native_executor_tool_name_match_count: native_executors.len(),
+                native_executor_tool_name_matches: native_executors,
             }
         })
         .collect()
+}
+
+fn row_state(row: &BackgroundToolCallRow) -> Option<String> {
+    normalize_optional_string(row.lifecycle_state.as_deref())
+        .or_else(|| normalize_optional_string(row.status.as_deref()))
 }
 
 fn age_cutoff(raw: Option<&str>, now: DateTime<Utc>) -> Result<Option<DateTime<Utc>>> {
@@ -201,7 +206,7 @@ fn print_background_table(rows: &[BackgroundToolCallOutput], native_liveness_ava
         "AWAIT_MODE",
         "STARTED_AT",
         "AGE",
-        "NATIVE",
+        "NATIVE_TOOL",
     ];
     let rendered_rows = rows
         .iter()
@@ -215,7 +220,7 @@ fn print_background_table(rows: &[BackgroundToolCallOutput], native_liveness_ava
                 row.age.clone().unwrap_or_else(|| "-".to_string()),
                 if !native_liveness_available {
                     "unknown".to_string()
-                } else if row.active_native_executor_count > 0 {
+                } else if row.native_executor_tool_name_match_count > 0 {
                     "yes".to_string()
                 } else {
                     "no".to_string()
@@ -312,8 +317,8 @@ struct BackgroundToolCallOutput {
     age: Option<String>,
     tool_name: Option<String>,
     active_tool_call: bool,
-    active_native_executor_count: usize,
-    active_native_executors: Vec<NativeExecutorView>,
+    native_executor_tool_name_match_count: usize,
+    native_executor_tool_name_matches: Vec<NativeExecutorView>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -355,11 +360,18 @@ fn parse_array<T>(value: &Value, field: &str) -> Vec<T>
 where
     T: DeserializeOwned,
 {
-    value
-        .get(field)
-        .and_then(Value::as_array)
-        .cloned()
-        .map(Value::Array)
-        .and_then(|value| serde_json::from_value(value).ok())
-        .unwrap_or_default()
+    let Some(array) = value.get(field).and_then(Value::as_array) else {
+        return Vec::new();
+    };
+    match serde_json::from_value(Value::Array(array.clone())) {
+        Ok(rows) => rows,
+        Err(err) => {
+            tracing::warn!(
+                field,
+                error = %err,
+                "failed to decode runtime liveness array"
+            );
+            Vec::new()
+        }
+    }
 }

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 // Subcommand handler implementations. Populated by Phases B4-B7.
+pub(crate) mod background;
 pub(crate) mod chat;
 pub(crate) mod config;
 pub(crate) mod diagnose;

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -154,9 +154,13 @@ Examples:
   defra-agent status --graphql http://127.0.0.1:9191/api/v0/graphql";
 const BACKGROUND_AFTER_HELP: &str = "\
 Lists AgentToolCall rows persisted with await_mode=background and enriches them with live runtime liveness when available.
+Live native-process enrichment requires --graphql pointing at the running runtime; local --home reads print NATIVE_TOOL=unknown.
+Native-process matches are scoped by tool name because runtime liveness does not expose per-call native process IDs.
 
 Examples:
   defra-agent background list
+  defra-agent background list --home /path/to/home
+  defra-agent background list --graphql http://127.0.0.1:9191/api/v0/graphql
   defra-agent background list --request REQUEST_ID
   defra-agent background list --state running --age-gt 5m
   defra-agent background list --output json";

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -65,6 +65,7 @@ Inspect the local runtime:
   defra-agent status
   defra-agent show runtime
   defra-agent show response REQUEST_ID
+  defra-agent background list
   defra-agent reset
 
 Update runtime documents:
@@ -151,6 +152,14 @@ Examples:
   defra-agent status
   defra-agent status --home /path/to/home
   defra-agent status --graphql http://127.0.0.1:9191/api/v0/graphql";
+const BACKGROUND_AFTER_HELP: &str = "\
+Lists AgentToolCall rows persisted with await_mode=background and enriches them with live runtime liveness when available.
+
+Examples:
+  defra-agent background list
+  defra-agent background list --request REQUEST_ID
+  defra-agent background list --state running --age-gt 5m
+  defra-agent background list --output json";
 const SHOW_AFTER_HELP: &str = "\
 Examples:
   defra-agent show runtime
@@ -285,6 +294,7 @@ async fn main() -> Result<()> {
         Command::Show { command } => commands::show::dispatch(command).await,
         Command::Trace { command } => commands::trace::dispatch(command).await,
         Command::Status(args) => commands::status::status(args).await,
+        Command::Background { command } => commands::background::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Config { command } => commands::config::dispatch(command).await,
         Command::Request { command } => commands::request::dispatch(command).await,

--- a/crates/defra-agent-cli/src/request_helpers.rs
+++ b/crates/defra-agent-cli/src/request_helpers.rs
@@ -495,7 +495,7 @@ pub(crate) fn print_json(value: &Value) -> Result<()> {
 
 /// Parse a short human duration (e.g. `30s`, `5m`, `2h`, `1d`). Bare numbers
 /// are treated as seconds for convenience.
-fn parse_duration_suffix(raw: &str) -> Result<Duration> {
+pub(crate) fn parse_duration_suffix(raw: &str) -> Result<Duration> {
     let s = raw.trim();
     if s.is_empty() {
         anyhow::bail!("duration must not be empty");

--- a/crates/defra-agent-cli/tests/cli_background.rs
+++ b/crates/defra-agent-cli/tests/cli_background.rs
@@ -1,0 +1,203 @@
+mod support;
+use support::*;
+
+use anyhow::{Context, Result};
+use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+use defra_agent::ensure_runtime_schemas;
+use serde_json::Value;
+
+// Feature matrix tag: background-tools / operatorCli.
+#[tokio::test]
+async fn background_list_json_filters_and_lists_backgrounded_tool_calls() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+        seed_background_tool_calls(&node).await?;
+    }
+
+    let agent_home = agent_home.to_str().context("agent home utf8")?;
+    let output = run_cli_json(
+        tempdir.path(),
+        &[
+            "background",
+            "list",
+            "--home",
+            agent_home,
+            "--request",
+            "req-background",
+            "--state",
+            "running",
+            "--age-gt",
+            "1d",
+            "--output",
+            "json",
+        ],
+    )?;
+    assert_eq!(output.get("count").and_then(Value::as_u64), Some(1));
+    let items = output
+        .get("items")
+        .and_then(Value::as_array)
+        .context("background list output must include items")?;
+    let row = items.first().context("expected one background row")?;
+    assert_eq!(
+        row.get("tool_call_id").and_then(Value::as_str),
+        Some("call-background-running")
+    );
+    assert_eq!(
+        row.get("parent_request_id").and_then(Value::as_str),
+        Some("req-background")
+    );
+    assert_eq!(row.get("state").and_then(Value::as_str), Some("running"));
+    assert_eq!(
+        row.get("await_mode").and_then(Value::as_str),
+        Some("background")
+    );
+    assert!(
+        row.get("age_ms")
+            .and_then(Value::as_i64)
+            .is_some_and(|age| age > 0),
+        "expected positive age_ms in row: {row}"
+    );
+
+    let table = run_cli_text(
+        tempdir.path(),
+        &[
+            "background",
+            "list",
+            "--home",
+            agent_home,
+            "--request",
+            "req-background",
+        ],
+    )?;
+    assert!(
+        table.contains("TOOL_CALL_ID") && table.contains("PARENT_REQUEST"),
+        "table output should include default columns:\n{table}"
+    );
+    assert!(
+        table.contains("call-background-running")
+            && table.contains("call-background-completed")
+            && !table.contains("call-foreground-running"),
+        "table output should list only backgrounded calls for req-background:\n{table}"
+    );
+
+    Ok(())
+}
+
+async fn seed_background_tool_calls(node: &EmbeddedNode) -> Result<()> {
+    exec(
+        node,
+        r#"mutation {
+            create_AgentRequest(input: {
+                request_id: "req-background",
+                agent_did: "did:defra-agent:test",
+                behavior_id: "default",
+                session_id: "session-background",
+                content: "background list fixture",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "test-backend",
+                created_at: "2024-01-01T11:00:00Z",
+                claimed_at: "2024-01-01T11:00:01Z",
+                deadline: "2024-01-01T11:30:00Z",
+                retry_count: 0
+            }) { _docID }
+            create_AgentRequest(input: {
+                request_id: "req-other",
+                agent_did: "did:defra-agent:test",
+                behavior_id: "default",
+                session_id: "session-other",
+                content: "background list other fixture",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "test-backend",
+                created_at: "2024-01-01T12:00:00Z",
+                claimed_at: "2024-01-01T12:00:01Z",
+                deadline: "2024-01-01T12:30:00Z",
+                retry_count: 0
+            }) { _docID }
+        }"#,
+    )
+    .await?;
+
+    exec(
+        node,
+        r#"mutation {
+            create_AgentToolCall(input: {
+                tool_call_key: "session-background:call-background-running",
+                request_id: "req-background",
+                session_id: "session-background",
+                message_sequence: 1,
+                tool_name: "bash",
+                tool_call_id: "call-background-running",
+                args: "{}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "2024-01-01T11:00:05Z",
+                await_mode: "background"
+            }) { _docID }
+            create_AgentToolCall(input: {
+                tool_call_key: "session-background:call-background-completed",
+                request_id: "req-background",
+                session_id: "session-background",
+                message_sequence: 2,
+                tool_name: "read_file",
+                tool_call_id: "call-background-completed",
+                args: "{}",
+                result: "done",
+                status: "completed",
+                lifecycle_state: "completed",
+                started_at: "2024-01-01T11:00:10Z",
+                completed_at: "2024-01-01T11:00:11Z",
+                await_mode: "background"
+            }) { _docID }
+            create_AgentToolCall(input: {
+                tool_call_key: "session-background:call-foreground-running",
+                request_id: "req-background",
+                session_id: "session-background",
+                message_sequence: 3,
+                tool_name: "bash",
+                tool_call_id: "call-foreground-running",
+                args: "{}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "2024-01-01T11:00:15Z",
+                await_mode: "foreground"
+            }) { _docID }
+            create_AgentToolCall(input: {
+                tool_call_key: "session-other:call-background-other",
+                request_id: "req-other",
+                session_id: "session-other",
+                message_sequence: 1,
+                tool_name: "bash",
+                tool_call_id: "call-background-other",
+                args: "{}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "2024-01-01T12:00:05Z",
+                await_mode: "background"
+            }) { _docID }
+        }"#,
+    )
+    .await
+}
+
+async fn exec(node: &EmbeddedNode, query: &str) -> Result<()> {
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!("GraphQL mutation failed: {:?}", response.errors);
+    }
+    Ok(())
+}

--- a/crates/defra-agent-cli/tests/cli_background.rs
+++ b/crates/defra-agent-cli/tests/cli_background.rs
@@ -68,6 +68,59 @@ async fn background_list_json_filters_and_lists_backgrounded_tool_calls() -> Res
         "expected positive age_ms in row: {row}"
     );
 
+    let unfiltered_state_output = run_cli_json(
+        tempdir.path(),
+        &[
+            "background",
+            "list",
+            "--home",
+            agent_home,
+            "--request",
+            "req-background",
+            "--age-gt",
+            "1d",
+            "--output",
+            "json",
+        ],
+    )?;
+    assert_eq!(
+        unfiltered_state_output.get("count").and_then(Value::as_u64),
+        Some(3),
+        "without --state the fixture should include all three background rows for req-background"
+    );
+
+    let status_fallback_output = run_cli_json(
+        tempdir.path(),
+        &[
+            "background",
+            "list",
+            "--home",
+            agent_home,
+            "--request",
+            "req-background",
+            "--state",
+            "called",
+            "--output",
+            "json",
+        ],
+    )?;
+    assert_eq!(
+        status_fallback_output.get("count").and_then(Value::as_u64),
+        Some(1),
+        "--state should match the displayed status fallback when lifecycle_state is empty"
+    );
+    let fallback_items = status_fallback_output
+        .get("items")
+        .and_then(Value::as_array)
+        .context("status fallback output must include items")?;
+    assert_eq!(
+        fallback_items
+            .first()
+            .and_then(|row| row.get("tool_call_id"))
+            .and_then(Value::as_str),
+        Some("call-background-status-only")
+    );
+
     let table = run_cli_text(
         tempdir.path(),
         &[
@@ -86,6 +139,7 @@ async fn background_list_json_filters_and_lists_backgrounded_tool_calls() -> Res
     assert!(
         table.contains("call-background-running")
             && table.contains("call-background-completed")
+            && table.contains("call-background-status-only")
             && !table.contains("call-foreground-running"),
         "table output should list only backgrounded calls for req-background:\n{table}"
     );
@@ -174,6 +228,19 @@ async fn seed_background_tool_calls(node: &EmbeddedNode) -> Result<()> {
                 lifecycle_state: "running",
                 started_at: "2024-01-01T11:00:15Z",
                 await_mode: "foreground"
+            }) { _docID }
+            create_AgentToolCall(input: {
+                tool_call_key: "session-background:call-background-status-only",
+                request_id: "req-background",
+                session_id: "session-background",
+                message_sequence: 4,
+                tool_name: "bash",
+                tool_call_id: "call-background-status-only",
+                args: "{}",
+                result: "",
+                status: "called",
+                started_at: "2024-01-01T11:00:20Z",
+                await_mode: "background"
             }) { _docID }
             create_AgentToolCall(input: {
                 tool_call_key: "session-other:call-background-other",

--- a/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
+++ b/docs/superpowers/specs/2026-05-20-feature-matrix-design.md
@@ -416,6 +416,12 @@ existing ledger rows the worked example (§7) tags with this feature.
 | `persistence-failure-policy` | `runtimeInternal` | — | 5 |
 | `backend-health` | `runtimeInternal` | `operatorUi` (#TBD-ui-backend-status) | 1 |
 
+Issue #268 adds the operator CLI consumer for `background-tools`:
+`crates/defra-agent-cli/tests/cli_background.rs::background_list_json_filters_and_lists_backgrounded_tool_calls`.
+When the matrix schema in this design lands, tag that consumer with
+`feature = "background-tools"` and `surfaces = [operatorCli]`, replacing
+the deferred `operatorCli` slot on the `background-tools` row.
+
 Tag-count totals: 74 row-tags across 74 distinct ledger rows. Under the
 single-tag rule (§3.2 / §6.2), each existing row is tagged exactly once.
 The ledger has 74 rows (18 vocab + 15 state-machine + 37 case + 4


### PR DESCRIPTION
Closes #268.

## Summary
- add defra-agent background list with request, state, age, and json filters
- query background AgentToolCall rows and enrich with runtime liveness when available
- add CLI integration coverage and feature-matrix consumer note

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent-cli
- cargo test -p defra-agent-cli
- cargo run --bin defra-agent -- background list --help