### PR TITLE
CLI: subagent cancel with cascade (#270)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -4,7 +4,7 @@
 use std::net::IpAddr;
 use std::path::PathBuf;
 
-use clap::{Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, Parser, Subcommand, ValueEnum};
 use defra_agent::BackendProviderKind;
 use serde::{Deserialize, Serialize};
 
@@ -13,7 +13,7 @@ use crate::{
     CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP, INIT_AFTER_HELP,
     P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
     RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP,
-    TRACE_AFTER_HELP,
+    SUBAGENT_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -91,6 +91,14 @@ pub(crate) enum Command {
     Session {
         #[command(subcommand)]
         command: SessionCommand,
+    },
+    #[command(
+        about = "Inspect and control background subagents",
+        after_help = SUBAGENT_AFTER_HELP
+    )]
+    Subagent {
+        #[command(subcommand)]
+        command: SubagentCommand,
     },
 }
 
@@ -1112,6 +1120,61 @@ pub(crate) struct RequestShowArgs {
     pub(crate) request_id_flag: Option<String>,
     #[arg(value_name = "REQUEST_ID")]
     pub(crate) request_id: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub(crate) enum SubagentCommand {
+    #[command(about = "Cancel a subagent request and optionally cascade to linked children")]
+    Cancel(SubagentCancelArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct SubagentCancelArgs {
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long)]
+    pub(crate) graphql: Option<String>,
+    #[arg(long)]
+    pub(crate) agent_did: Option<String>,
+    #[arg(long = "request-id")]
+    pub(crate) request_id_flag: Option<String>,
+    #[arg(value_name = "REQUEST_ID")]
+    pub(crate) request_id: Option<String>,
+    #[arg(
+        long,
+        default_value_t = true,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        action = ArgAction::Set,
+        help = "Cascade through linked child subagents when their cancel policy allows it"
+    )]
+    pub(crate) cascade: bool,
+    #[arg(
+        long,
+        default_value = "userCancelled",
+        help = "CancelCause vocabulary value: interrupted, deadline, or userCancelled"
+    )]
+    pub(crate) cause: String,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Wait until affected requests are terminal"
+    )]
+    pub(crate) wait: bool,
+    #[arg(
+        long,
+        value_name = "DURATION",
+        help = "Wait timeout such as 30s, 5m, or 1h. Only valid with --wait"
+    )]
+    pub(crate) timeout: Option<String>,
+    #[arg(long, value_enum, default_value_t = SubagentCancelOutput::Text)]
+    pub(crate) output: SubagentCancelOutput,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SubagentCancelOutput {
+    Text,
+    Json,
 }
 
 #[derive(Subcommand)]

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1253,7 +1253,7 @@ pub(crate) struct SubagentCancelArgs {
     #[arg(
         long,
         default_value = "userCancelled",
-        help = "CancelCause vocabulary value echoed in output only until cause persistence lands (#249): interrupted, deadline, or userCancelled"
+        help = "CancelCause vocabulary value included in output and persisted for local bridge lifecycle cancellations: interrupted, deadline, or userCancelled"
     )]
     pub(crate) cause: String,
     #[arg(

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1146,13 +1146,13 @@ pub(crate) struct SubagentCancelArgs {
         default_missing_value = "true",
         num_args = 0..=1,
         action = ArgAction::Set,
-        help = "Cascade through linked child subagents when their cancel policy allows it"
+        help = "Cancel linked subagent bridge tool-calls and interrupt linked child requests when their cancel policy allows it"
     )]
     pub(crate) cascade: bool,
     #[arg(
         long,
         default_value = "userCancelled",
-        help = "CancelCause vocabulary value: interrupted, deadline, or userCancelled"
+        help = "CancelCause vocabulary value echoed in output only until cause persistence lands (#249): interrupted, deadline, or userCancelled"
     )]
     pub(crate) cause: String,
     #[arg(

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -12,4 +12,5 @@ pub(crate) mod serve;
 pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod status;
+pub(crate) mod subagent;
 pub(crate) mod trace;

--- a/crates/defra-agent-cli/src/commands/subagent.rs
+++ b/crates/defra-agent-cli/src/commands/subagent.rs
@@ -57,7 +57,8 @@ async fn subagent_cancel(args: SubagentCancelArgs) -> Result<()> {
             let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())
                 .context("resolving local agent_did for cascade ownership checks")?;
             let affected =
-                cancel_subagent_local(node.clone(), &agent_did, &request_id, args.cascade).await?;
+                cancel_subagent_local(node.clone(), &agent_did, &request_id, args.cascade, cause)
+                    .await?;
             if let Some(timeout) = wait_timeout {
                 wait_for_terminal_local(node.as_ref(), &affected, timeout).await?
             } else {
@@ -179,13 +180,14 @@ async fn cancel_subagent_local(
     agent_did: &str,
     request_id: &str,
     cascade: bool,
+    cause: CancelCause,
 ) -> Result<Vec<String>> {
     let target = fetch_request_row_local(node.as_ref(), request_id).await?;
     let mut affected = Vec::new();
     let mut seen_requests = BTreeSet::new();
 
     if cascade {
-        cancel_parent_bridge_local(node.clone(), agent_did, &target).await?;
+        cancel_parent_bridge_local(node.clone(), cause, agent_did, &target).await?;
     }
     interrupt_request_local(node.as_ref(), &mut affected, &mut seen_requests, request_id).await?;
 
@@ -193,6 +195,7 @@ async fn cancel_subagent_local(
         if let Some(session_id) = target.session_id.as_deref() {
             cancel_descendant_bridges_local(
                 node.clone(),
+                cause,
                 agent_did,
                 session_id,
                 &mut affected,
@@ -207,6 +210,7 @@ async fn cancel_subagent_local(
 
 async fn cancel_parent_bridge_local(
     node: Arc<EmbeddedNode>,
+    cause: CancelCause,
     agent_did: &str,
     target: &RequestRow,
 ) -> Result<()> {
@@ -222,6 +226,7 @@ async fn cancel_parent_bridge_local(
     };
     cancel_bridge_local(
         node,
+        cause,
         agent_did,
         parent_session_id,
         parent_tool_call_id,
@@ -233,6 +238,7 @@ async fn cancel_parent_bridge_local(
 
 async fn cancel_descendant_bridges_local(
     node: Arc<EmbeddedNode>,
+    cause: CancelCause,
     agent_did: &str,
     root_session_id: &str,
     affected: &mut Vec<String>,
@@ -247,6 +253,7 @@ async fn cancel_descendant_bridges_local(
         for bridge in running_subagent_bridges_local(node.as_ref(), &session_id).await? {
             let dispatch = cancel_bridge_local(
                 node.clone(),
+                cause,
                 agent_did,
                 &session_id,
                 &bridge.tool_call_id,
@@ -270,6 +277,7 @@ async fn cancel_descendant_bridges_local(
 
 async fn cancel_bridge_local(
     node: Arc<EmbeddedNode>,
+    cause: CancelCause,
     agent_did: &str,
     session_id: &str,
     tool_call_id: &str,
@@ -289,7 +297,7 @@ async fn cancel_bridge_local(
         return Ok(None);
     };
     let dispatch = lifecycle
-        .cancel_during_run_with_cascade_dispatch(agent_did)
+        .cancel_during_run_with_cascade_dispatch(cause, agent_did)
         .await
         .with_context(|| {
             format!(

--- a/crates/defra-agent-cli/src/commands/subagent.rs
+++ b/crates/defra-agent-cli/src/commands/subagent.rs
@@ -40,6 +40,9 @@ async fn subagent_cancel(args: SubagentCancelArgs) -> Result<()> {
 
     let snapshots = match access {
         ConfigAccess::Graphql(graphql) => {
+            // Live GraphQL mode latches request interrupts and lets the daemon
+            // transition any in-flight bridge tool-calls it owns. Local mode
+            // has no daemon process, so it performs bridge transitions itself.
             let affected = cancel_subagent_graphql(&graphql, &request_id, args.cascade).await?;
             if let Some(timeout) = wait_timeout {
                 wait_for_terminal_graphql(&graphql, &affected, timeout).await?
@@ -153,6 +156,9 @@ async fn interrupt_request_graphql(graphql: &str, request_id: &str) -> Result<()
         return Ok(());
     }
 
+    // TODO: Route this through a server-side interrupt endpoint once one
+    // exists, so idempotency and queue-drain behavior stay centralized with
+    // defra_agent::interrupt_request.
     let now = chrono::Utc::now().to_rfc3339();
     let mutation = format!(
         r#"mutation {{
@@ -219,7 +225,7 @@ async fn cancel_parent_bridge_local(
         agent_did,
         parent_session_id,
         parent_tool_call_id,
-        "parent",
+        BridgeKind::Parent,
     )
     .await?;
     Ok(())
@@ -244,7 +250,7 @@ async fn cancel_descendant_bridges_local(
                 agent_did,
                 &session_id,
                 &bridge.tool_call_id,
-                "descendant",
+                BridgeKind::Descendant,
             )
             .await?;
             let Some(child_request_id) = dispatch else {
@@ -267,7 +273,7 @@ async fn cancel_bridge_local(
     agent_did: &str,
     session_id: &str,
     tool_call_id: &str,
-    bridge_kind: &str,
+    bridge_kind: BridgeKind,
 ) -> Result<Option<String>> {
     if tool_lifecycle_state_local(node.as_ref(), session_id, tool_call_id)
         .await?
@@ -286,7 +292,10 @@ async fn cancel_bridge_local(
         .cancel_during_run_with_cascade_dispatch(agent_did)
         .await
         .with_context(|| {
-            format!("cancelling {bridge_kind} subagent bridge {session_id}:{tool_call_id}")
+            format!(
+                "cancelling {} subagent bridge {session_id}:{tool_call_id}",
+                bridge_kind.as_str()
+            )
         })?;
     Ok(match dispatch {
         Some(CascadeDispatch::Local(intent)) => Some(intent.child_request_id),
@@ -602,6 +611,21 @@ impl RequestRow {
 struct BridgeRow {
     tool_call_id: String,
     child_request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BridgeKind {
+    Parent,
+    Descendant,
+}
+
+impl BridgeKind {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Parent => "parent",
+            Self::Descendant => "descendant",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/defra-agent-cli/src/commands/subagent.rs
+++ b/crates/defra-agent-cli/src/commands/subagent.rs
@@ -1,0 +1,624 @@
+use std::collections::{BTreeSet, VecDeque};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::tool_call_lifecycle::{CancelCause, CascadeDispatch, ToolCallLifecycle};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+use crate::cli::args::{SubagentCancelArgs, SubagentCancelOutput, SubagentCommand};
+use crate::config_writes::ConfigAccess;
+use crate::{
+    parse_duration_suffix, post_graphql, print_json, resolve_agent_did, resolve_config_access,
+    resolve_request_id,
+};
+
+const DEFAULT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
+pub(crate) async fn dispatch(command: SubagentCommand) -> Result<()> {
+    match command {
+        SubagentCommand::Cancel(args) => subagent_cancel(args).await,
+    }
+}
+
+async fn subagent_cancel(args: SubagentCancelArgs) -> Result<()> {
+    let request_id =
+        resolve_request_id(args.request_id.as_deref(), args.request_id_flag.as_deref())?;
+    let cause = parse_cancel_cause(&args.cause)?;
+    let wait_timeout = resolve_wait_timeout(args.wait, args.timeout.as_deref())?;
+
+    let (access, _) = resolve_config_access(
+        args.home.as_deref(),
+        args.graphql.as_deref(),
+        /* ensure_local_schemas */ true,
+    )
+    .await?;
+
+    let snapshots = match access {
+        ConfigAccess::Graphql(graphql) => {
+            let affected = cancel_subagent_graphql(&graphql, &request_id, args.cascade).await?;
+            if let Some(timeout) = wait_timeout {
+                wait_for_terminal_graphql(&graphql, &affected, timeout).await?
+            } else {
+                snapshot_requests_graphql(&graphql, &affected).await?
+            }
+        }
+        ConfigAccess::Local(node) => {
+            let node = Arc::new(node);
+            defra_agent::migration::ensure_tool_call_migrations(node.clone()).await?;
+            defra_agent::migration::ensure_subagent_extensions_migrations(node.clone()).await?;
+            let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())
+                .context("resolving local agent_did for cascade ownership checks")?;
+            let affected =
+                cancel_subagent_local(node.clone(), &agent_did, &request_id, args.cascade).await?;
+            if let Some(timeout) = wait_timeout {
+                wait_for_terminal_local(node.as_ref(), &affected, timeout).await?
+            } else {
+                snapshot_requests_local(node.as_ref(), &affected).await?
+            }
+        }
+    };
+
+    render_cancel_output(
+        args.output,
+        SubagentCancelRender {
+            request_id,
+            cascade: args.cascade,
+            cause: cause.as_str().to_string(),
+            wait: args.wait,
+            requests: snapshots,
+        },
+    )
+}
+
+fn parse_cancel_cause(raw: &str) -> Result<CancelCause> {
+    let value = raw.trim();
+    CancelCause::from_persisted(value).ok_or_else(|| {
+        anyhow::anyhow!(
+            "invalid --cause {value:?}; expected one of: interrupted, deadline, userCancelled"
+        )
+    })
+}
+
+fn resolve_wait_timeout(wait: bool, timeout: Option<&str>) -> Result<Option<Duration>> {
+    if timeout.is_some() && !wait {
+        anyhow::bail!("--timeout is only valid with --wait");
+    }
+    if !wait {
+        return Ok(None);
+    }
+    timeout
+        .map(parse_duration_suffix)
+        .transpose()
+        .map(|duration| Some(duration.unwrap_or(DEFAULT_WAIT_TIMEOUT)))
+}
+
+async fn cancel_subagent_graphql(
+    graphql: &str,
+    request_id: &str,
+    cascade: bool,
+) -> Result<Vec<String>> {
+    let mut affected = Vec::new();
+    let mut seen = BTreeSet::new();
+    push_unique(&mut affected, &mut seen, request_id.to_string());
+
+    if cascade {
+        let target = fetch_request_row_graphql(graphql, request_id).await?;
+        if let Some(session_id) = target.session_id.as_deref() {
+            collect_descendant_request_ids_graphql(graphql, session_id, &mut affected, &mut seen)
+                .await?;
+        }
+    }
+
+    for request_id in &affected {
+        interrupt_request_graphql(graphql, request_id).await?;
+    }
+    Ok(affected)
+}
+
+async fn collect_descendant_request_ids_graphql(
+    graphql: &str,
+    root_session_id: &str,
+    affected: &mut Vec<String>,
+    seen_requests: &mut BTreeSet<String>,
+) -> Result<()> {
+    let mut seen_sessions = BTreeSet::new();
+    let mut queue = VecDeque::from([root_session_id.to_string()]);
+    while let Some(session_id) = queue.pop_front() {
+        if !seen_sessions.insert(session_id.clone()) {
+            continue;
+        }
+        for bridge in running_subagent_bridges_graphql(graphql, &session_id).await? {
+            let Some(child_request_id) = bridge.child_request_id else {
+                continue;
+            };
+            push_unique(affected, seen_requests, child_request_id.clone());
+            if let Ok(child) = fetch_request_row_graphql(graphql, &child_request_id).await {
+                if let Some(child_session_id) = child.session_id {
+                    queue.push_back(child_session_id);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn interrupt_request_graphql(graphql: &str, request_id: &str) -> Result<()> {
+    let row = fetch_request_row_graphql(graphql, request_id).await?;
+    if row.interrupt_requested_at.is_some() {
+        return Ok(());
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                input: {{ interrupt_requested_at: "{now}" }}
+            ) {{ _docID }}
+        }}"#,
+        request_id = escape_graphql_string(request_id),
+        now = escape_graphql_string(&now),
+    );
+    post_graphql(graphql, &mutation).await?;
+    Ok(())
+}
+
+async fn cancel_subagent_local(
+    node: Arc<EmbeddedNode>,
+    agent_did: &str,
+    request_id: &str,
+    cascade: bool,
+) -> Result<Vec<String>> {
+    let target = fetch_request_row_local(node.as_ref(), request_id).await?;
+    let mut affected = Vec::new();
+    let mut seen_requests = BTreeSet::new();
+
+    if cascade {
+        cancel_parent_bridge_local(node.clone(), agent_did, &target).await?;
+    }
+    interrupt_request_local(node.as_ref(), &mut affected, &mut seen_requests, request_id).await?;
+
+    if cascade {
+        if let Some(session_id) = target.session_id.as_deref() {
+            cancel_descendant_bridges_local(
+                node.clone(),
+                agent_did,
+                session_id,
+                &mut affected,
+                &mut seen_requests,
+            )
+            .await?;
+        }
+    }
+
+    Ok(affected)
+}
+
+async fn cancel_parent_bridge_local(
+    node: Arc<EmbeddedNode>,
+    agent_did: &str,
+    target: &RequestRow,
+) -> Result<()> {
+    let Some(parent_request_id) = target.parent_request_id.as_deref() else {
+        return Ok(());
+    };
+    let Some(parent_tool_call_id) = target.parent_tool_call_id.as_deref() else {
+        return Ok(());
+    };
+    let parent = fetch_request_row_local(node.as_ref(), parent_request_id).await?;
+    let Some(parent_session_id) = parent.session_id.as_deref() else {
+        return Ok(());
+    };
+    cancel_bridge_local(
+        node,
+        agent_did,
+        parent_session_id,
+        parent_tool_call_id,
+        "parent",
+    )
+    .await?;
+    Ok(())
+}
+
+async fn cancel_descendant_bridges_local(
+    node: Arc<EmbeddedNode>,
+    agent_did: &str,
+    root_session_id: &str,
+    affected: &mut Vec<String>,
+    seen_requests: &mut BTreeSet<String>,
+) -> Result<()> {
+    let mut seen_sessions = BTreeSet::new();
+    let mut queue = VecDeque::from([root_session_id.to_string()]);
+    while let Some(session_id) = queue.pop_front() {
+        if !seen_sessions.insert(session_id.clone()) {
+            continue;
+        }
+        for bridge in running_subagent_bridges_local(node.as_ref(), &session_id).await? {
+            let dispatch = cancel_bridge_local(
+                node.clone(),
+                agent_did,
+                &session_id,
+                &bridge.tool_call_id,
+                "descendant",
+            )
+            .await?;
+            let Some(child_request_id) = dispatch else {
+                continue;
+            };
+            interrupt_request_local(node.as_ref(), affected, seen_requests, &child_request_id)
+                .await?;
+            if let Ok(child) = fetch_request_row_local(node.as_ref(), &child_request_id).await {
+                if let Some(child_session_id) = child.session_id {
+                    queue.push_back(child_session_id);
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn cancel_bridge_local(
+    node: Arc<EmbeddedNode>,
+    agent_did: &str,
+    session_id: &str,
+    tool_call_id: &str,
+    bridge_kind: &str,
+) -> Result<Option<String>> {
+    if tool_lifecycle_state_local(node.as_ref(), session_id, tool_call_id)
+        .await?
+        .as_deref()
+        != Some("running")
+    {
+        return Ok(None);
+    }
+
+    let Some(mut lifecycle) =
+        ToolCallLifecycle::load(node.clone(), session_id, tool_call_id).await?
+    else {
+        return Ok(None);
+    };
+    let dispatch = lifecycle
+        .cancel_during_run_with_cascade_dispatch(agent_did)
+        .await
+        .with_context(|| {
+            format!("cancelling {bridge_kind} subagent bridge {session_id}:{tool_call_id}")
+        })?;
+    Ok(match dispatch {
+        Some(CascadeDispatch::Local(intent)) => Some(intent.child_request_id),
+        Some(CascadeDispatch::RemoteIntentWritten) | None => None,
+    })
+}
+
+async fn interrupt_request_local(
+    node: &EmbeddedNode,
+    affected: &mut Vec<String>,
+    seen_requests: &mut BTreeSet<String>,
+    request_id: &str,
+) -> Result<()> {
+    defra_agent::interrupt_request(node, request_id).await?;
+    push_unique(affected, seen_requests, request_id.to_string());
+    Ok(())
+}
+
+fn push_unique(values: &mut Vec<String>, seen: &mut BTreeSet<String>, value: String) {
+    if seen.insert(value.clone()) {
+        values.push(value);
+    }
+}
+
+async fn wait_for_terminal_graphql(
+    graphql: &str,
+    request_ids: &[String],
+    timeout: Duration,
+) -> Result<Vec<RequestCancelSnapshot>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let snapshots = snapshot_requests_graphql(graphql, request_ids).await?;
+        if snapshots.iter().all(|row| {
+            row.lifecycle_state
+                .as_deref()
+                .is_some_and(is_terminal_state)
+        }) {
+            return Ok(snapshots);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for subagent cancel after {}s; last states: {}",
+                timeout.as_secs(),
+                format_snapshot_states(&snapshots)
+            );
+        }
+        tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+    }
+}
+
+async fn wait_for_terminal_local(
+    node: &EmbeddedNode,
+    request_ids: &[String],
+    timeout: Duration,
+) -> Result<Vec<RequestCancelSnapshot>> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let snapshots = snapshot_requests_local(node, request_ids).await?;
+        if snapshots.iter().all(|row| {
+            row.lifecycle_state
+                .as_deref()
+                .is_some_and(is_terminal_state)
+        }) {
+            return Ok(snapshots);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            anyhow::bail!(
+                "timed out waiting for subagent cancel after {}s; last states: {}",
+                timeout.as_secs(),
+                format_snapshot_states(&snapshots)
+            );
+        }
+        tokio::time::sleep(WAIT_POLL_INTERVAL).await;
+    }
+}
+
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state,
+        "completed" | "failed" | "superseded" | "dead" | "interrupted"
+    )
+}
+
+async fn snapshot_requests_graphql(
+    graphql: &str,
+    request_ids: &[String],
+) -> Result<Vec<RequestCancelSnapshot>> {
+    let mut rows = Vec::with_capacity(request_ids.len());
+    for request_id in request_ids {
+        let row = fetch_request_row_graphql(graphql, request_id).await?;
+        rows.push(row.into_snapshot());
+    }
+    Ok(rows)
+}
+
+async fn snapshot_requests_local(
+    node: &EmbeddedNode,
+    request_ids: &[String],
+) -> Result<Vec<RequestCancelSnapshot>> {
+    let mut rows = Vec::with_capacity(request_ids.len());
+    for request_id in request_ids {
+        let row = fetch_request_row_local(node, request_id).await?;
+        rows.push(row.into_snapshot());
+    }
+    Ok(rows)
+}
+
+fn format_snapshot_states(snapshots: &[RequestCancelSnapshot]) -> String {
+    snapshots
+        .iter()
+        .map(|row| {
+            format!(
+                "{}={}",
+                row.request_id,
+                row.lifecycle_state.as_deref().unwrap_or("missing")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+async fn fetch_request_row_graphql(graphql: &str, request_id: &str) -> Result<RequestRow> {
+    let query = request_row_query(request_id);
+    let response = post_graphql(graphql, &query).await?;
+    request_row_from_response(&response, request_id)
+}
+
+async fn fetch_request_row_local(node: &EmbeddedNode, request_id: &str) -> Result<RequestRow> {
+    let query = request_row_query(request_id);
+    let response = execute_node_json(node, &query).await?;
+    request_row_from_response(&response, request_id)
+}
+
+fn request_row_query(request_id: &str) -> String {
+    format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                limit: 1
+            ) {{
+                request_id
+                agent_did
+                session_id
+                lifecycle_state
+                interrupt_requested_at
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+            }}
+        }}"#,
+        request_id = escape_graphql_string(request_id),
+    )
+}
+
+fn request_row_from_response(response: &Value, request_id: &str) -> Result<RequestRow> {
+    let row = response
+        .pointer("/data/AgentRequest")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .ok_or_else(|| anyhow::anyhow!("request {request_id} not found"))?;
+    Ok(RequestRow {
+        request_id: string_field(row, "request_id").unwrap_or_else(|| request_id.to_string()),
+        agent_did: string_field(row, "agent_did"),
+        session_id: string_field(row, "session_id"),
+        lifecycle_state: string_field(row, "lifecycle_state"),
+        interrupt_requested_at: string_field(row, "interrupt_requested_at"),
+        parent_request_id: string_field(row, "caused_by_parent_request_id"),
+        parent_tool_call_id: string_field(row, "caused_by_parent_tool_call_id"),
+    })
+}
+
+async fn running_subagent_bridges_graphql(
+    graphql: &str,
+    session_id: &str,
+) -> Result<Vec<BridgeRow>> {
+    let response = post_graphql(graphql, &running_subagent_bridges_query(session_id)).await?;
+    bridge_rows_from_response(&response)
+}
+
+async fn running_subagent_bridges_local(
+    node: &EmbeddedNode,
+    session_id: &str,
+) -> Result<Vec<BridgeRow>> {
+    let response = execute_node_json(node, &running_subagent_bridges_query(session_id)).await?;
+    bridge_rows_from_response(&response)
+}
+
+fn running_subagent_bridges_query(session_id: &str) -> String {
+    format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    lifecycle_state: {{ _eq: "running" }},
+                    cancel_policy: {{ _eq: "cascade" }}
+                }},
+                order: [{{ started_at: ASC }}, {{ tool_call_id: ASC }}]
+            ) {{
+                tool_call_id
+                child_request_id
+            }}
+        }}"#,
+        session_id = escape_graphql_string(session_id),
+    )
+}
+
+fn bridge_rows_from_response(response: &Value) -> Result<Vec<BridgeRow>> {
+    let rows = response
+        .pointer("/data/AgentToolCall")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    Ok(rows
+        .iter()
+        .filter_map(|row| {
+            let tool_call_id = string_field(row, "tool_call_id")?;
+            let child_request_id = string_field(row, "child_request_id");
+            Some(BridgeRow {
+                tool_call_id,
+                child_request_id,
+            })
+        })
+        .collect())
+}
+
+async fn tool_lifecycle_state_local(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> Result<Option<String>> {
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_call_id: {{ _eq: "{tool_call_id}" }}
+                }},
+                limit: 1
+            ) {{
+                lifecycle_state
+            }}
+        }}"#,
+        session_id = escape_graphql_string(session_id),
+        tool_call_id = escape_graphql_string(tool_call_id),
+    );
+    let response = execute_node_json(node, &query).await?;
+    Ok(response
+        .pointer("/data/AgentToolCall")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .and_then(|row| string_field(row, "lifecycle_state")))
+}
+
+async fn execute_node_json(node: &EmbeddedNode, query: &str) -> Result<Value> {
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        anyhow::bail!("graphql returned errors: {:?}", response.errors);
+    }
+    Ok(json!({
+        "data": response.data.unwrap_or(Value::Null),
+    }))
+}
+
+fn string_field(row: &Value, field: &str) -> Option<String> {
+    row.get(field)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn render_cancel_output(output: SubagentCancelOutput, render: SubagentCancelRender) -> Result<()> {
+    match output {
+        SubagentCancelOutput::Text => {
+            for request in &render.requests {
+                println!("{}", request.request_id);
+            }
+            Ok(())
+        }
+        SubagentCancelOutput::Json => print_json(&json!({
+            "request_id": render.request_id,
+            "cascade": render.cascade,
+            "cause": render.cause,
+            "wait": render.wait,
+            "interrupted_request_ids": render.requests.iter().map(|row| row.request_id.as_str()).collect::<Vec<_>>(),
+            "requests": render.requests,
+        })),
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RequestRow {
+    request_id: String,
+    agent_did: Option<String>,
+    session_id: Option<String>,
+    lifecycle_state: Option<String>,
+    interrupt_requested_at: Option<String>,
+    parent_request_id: Option<String>,
+    parent_tool_call_id: Option<String>,
+}
+
+impl RequestRow {
+    fn into_snapshot(self) -> RequestCancelSnapshot {
+        RequestCancelSnapshot {
+            request_id: self.request_id,
+            agent_did: self.agent_did,
+            lifecycle_state: self.lifecycle_state,
+            interrupt_requested_at: self.interrupt_requested_at,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct BridgeRow {
+    tool_call_id: String,
+    child_request_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct RequestCancelSnapshot {
+    request_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    agent_did: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lifecycle_state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interrupt_requested_at: Option<String>,
+}
+
+struct SubagentCancelRender {
+    request_id: String,
+    cascade: bool,
+    cause: String,
+    wait: bool,
+    requests: Vec<RequestCancelSnapshot>,
+}

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -190,6 +190,11 @@ const SESSION_AFTER_HELP: &str = "\
 Fork a conversation into a new session seeded from a user-turn prefix \
 of the source. Child inherits principal; behavior can be swapped with \
 --behavior.";
+const SUBAGENT_AFTER_HELP: &str = "\
+Examples:
+  defra-agent subagent cancel REQUEST_ID
+  defra-agent subagent cancel REQUEST_ID --cascade=false
+  defra-agent subagent cancel REQUEST_ID --wait --timeout 30s --output json";
 const DIAGNOSE_AFTER_HELP: &str = "\
 Examples:
   defra-agent diagnose
@@ -290,6 +295,7 @@ async fn main() -> Result<()> {
         Command::Request { command } => commands::request::dispatch(command).await,
         Command::Response { command } => commands::response::dispatch(command).await,
         Command::Session { command } => commands::session::dispatch(command).await,
+        Command::Subagent { command } => commands::subagent::dispatch(command).await,
     };
     telemetry.shutdown();
     result

--- a/crates/defra-agent-cli/src/request_helpers.rs
+++ b/crates/defra-agent-cli/src/request_helpers.rs
@@ -495,7 +495,7 @@ pub(crate) fn print_json(value: &Value) -> Result<()> {
 
 /// Parse a short human duration (e.g. `30s`, `5m`, `2h`, `1d`). Bare numbers
 /// are treated as seconds for convenience.
-fn parse_duration_suffix(raw: &str) -> Result<Duration> {
+pub(crate) fn parse_duration_suffix(raw: &str) -> Result<Duration> {
     let s = raw.trim();
     if s.is_empty() {
         anyhow::bail!("duration must not be empty");

--- a/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
@@ -12,8 +12,9 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
 use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
-use defra_agent::{load_tool_selection, upsert_tool_selection};
-use serde_json::Value;
+use defra_agent::tool_call_lifecycle::{AwaitMode, CancelPolicy, ToolCallLifecycle};
+use defra_agent::{ensure_runtime_schemas, load_tool_selection, upsert_tool_selection};
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -128,6 +129,151 @@ async fn subagent_cancel_cascades_to_linked_child_request() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn subagent_cancel_local_cascades_bridge_lifecycle_dispatch() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-local-subagent-cancel-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &format!("cli-subagent-cancel-local-{}", Uuid::new_v4().simple()),
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let behavior_id = init
+        .get("default_behavior_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("init output missing default_behavior_id: {init}"))?
+        .to_string();
+
+    let parent_request_id = format!("parent-{}", Uuid::new_v4().simple());
+    let child_request_id = format!("child-{}", Uuid::new_v4().simple());
+    let grandchild_request_id = format!("grandchild-{}", Uuid::new_v4().simple());
+    let parent_session_id = format!("parent-session-{}", Uuid::new_v4().simple());
+    let child_session_id = format!("child-session-{}", Uuid::new_v4().simple());
+    let grandchild_session_id = format!("grandchild-session-{}", Uuid::new_v4().simple());
+    let parent_tool_call_id = format!("spawn-child-{}", Uuid::new_v4().simple());
+    let child_tool_call_id = format!("spawn-grandchild-{}", Uuid::new_v4().simple());
+
+    {
+        let node = open_local_node(&home_dir).await?;
+        ensure_runtime_schemas(node.as_ref()).await?;
+        defra_agent::migration::ensure_tool_call_migrations(node.clone()).await?;
+        defra_agent::migration::ensure_subagent_extensions_migrations(node.clone()).await?;
+
+        create_local_processing_request(
+            node.as_ref(),
+            &parent_request_id,
+            &agent_did,
+            &behavior_id,
+            &parent_session_id,
+            0,
+            None,
+        )
+        .await?;
+        create_local_processing_request(
+            node.as_ref(),
+            &child_request_id,
+            &agent_did,
+            &behavior_id,
+            &child_session_id,
+            1,
+            Some((&parent_request_id, &parent_tool_call_id)),
+        )
+        .await?;
+        create_local_processing_request(
+            node.as_ref(),
+            &grandchild_request_id,
+            &agent_did,
+            &behavior_id,
+            &grandchild_session_id,
+            2,
+            Some((&child_request_id, &child_tool_call_id)),
+        )
+        .await?;
+
+        create_running_subagent_bridge(
+            node.clone(),
+            &parent_request_id,
+            &parent_session_id,
+            &parent_tool_call_id,
+            &child_request_id,
+            AwaitMode::Foreground,
+        )
+        .await?;
+        create_running_subagent_bridge(
+            node.clone(),
+            &child_request_id,
+            &child_session_id,
+            &child_tool_call_id,
+            &grandchild_request_id,
+            AwaitMode::Background,
+        )
+        .await?;
+    }
+
+    let cancel = run_cli_json(
+        &home_dir,
+        &["subagent", "cancel", &child_request_id, "--output", "json"],
+    )?;
+    let interrupted_ids = cancel
+        .get("interrupted_request_ids")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("cancel output missing interrupted_request_ids: {cancel}"))?
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    assert!(
+        interrupted_ids.contains(&child_request_id.as_str()),
+        "local cancel output should include target child request {child_request_id}: {cancel}"
+    );
+    assert!(
+        interrupted_ids.contains(&grandchild_request_id.as_str()),
+        "local cancel output should include cascaded grandchild request {grandchild_request_id}: {cancel}"
+    );
+    assert!(
+        !interrupted_ids.contains(&parent_request_id.as_str()),
+        "local cancel should cancel the parent bridge but not interrupt the parent request: {cancel}"
+    );
+
+    let node = open_local_node(&home_dir).await?;
+    assert!(
+        local_request_interrupt_requested_at(node.as_ref(), &child_request_id)
+            .await?
+            .is_some(),
+        "target child request should be interrupted"
+    );
+    assert!(
+        local_request_interrupt_requested_at(node.as_ref(), &grandchild_request_id)
+            .await?
+            .is_some(),
+        "cascaded grandchild request should be interrupted"
+    );
+    assert!(
+        local_request_interrupt_requested_at(node.as_ref(), &parent_request_id)
+            .await?
+            .is_none(),
+        "parent request should not be interrupted when cancelling the child subagent"
+    );
+    assert_eq!(
+        local_tool_lifecycle_state(node.as_ref(), &parent_session_id, &parent_tool_call_id).await?,
+        "cancelled"
+    );
+    assert_eq!(
+        local_tool_lifecycle_state(node.as_ref(), &child_session_id, &child_tool_call_id).await?,
+        "cancelled"
+    );
+    Ok(())
+}
+
 async fn enable_default_subagents_before_server(
     home_dir: &std::path::Path,
     selection_id: &str,
@@ -150,6 +296,169 @@ async fn enable_default_subagents_before_server(
         .await
         .context("enable subagent tool selection")?;
     Ok(())
+}
+
+async fn open_local_node(home_dir: &std::path::Path) -> Result<Arc<EmbeddedNode>> {
+    let data_dir = home_dir.join(".defra-agent").join("data");
+    Ok(Arc::new(
+        EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .with_context(|| format!("opening embedded node at {}", data_dir.display()))?,
+    ))
+}
+
+async fn create_local_processing_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    agent_did: &str,
+    behavior_id: &str,
+    session_id: &str,
+    subagent_depth: u32,
+    parent_link: Option<(&str, &str)>,
+) -> Result<()> {
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let execution_origin = if parent_link.is_some() {
+        "subagent"
+    } else {
+        "interactive"
+    };
+    let parent_fields = parent_link
+        .map(|(parent_request_id, parent_tool_call_id)| {
+            format!(
+                r#",
+                caused_by_parent_request_id: "{}",
+                caused_by_parent_tool_call_id: "{}""#,
+                support::escape_graphql_string(parent_request_id),
+                support::escape_graphql_string(parent_tool_call_id),
+            )
+        })
+        .unwrap_or_default();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "local subagent cancel fixture",
+                metadata: "",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "{execution_origin}",
+                failure_reason: "",
+                created_at: "{created_at}",
+                retry_count: 0,
+                max_retries: 0,
+                subagent_depth: {subagent_depth}{parent_fields}
+            }}) {{ _docID }}
+        }}"#,
+        request_id = support::escape_graphql_string(request_id),
+        agent_did = support::escape_graphql_string(agent_did),
+        behavior_id = support::escape_graphql_string(behavior_id),
+        session_id = support::escape_graphql_string(session_id),
+        created_at = support::escape_graphql_string(&created_at),
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        bail!("create local AgentRequest failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+
+async fn create_running_subagent_bridge(
+    node: Arc<EmbeddedNode>,
+    request_id: &str,
+    session_id: &str,
+    tool_call_id: &str,
+    child_request_id: &str,
+    await_mode: AwaitMode,
+) -> Result<()> {
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        node,
+        request_id.to_string(),
+        session_id.to_string(),
+        tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        await_mode,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+    );
+    lifecycle.start_running().await
+}
+
+async fn local_request_interrupt_requested_at(
+    node: &EmbeddedNode,
+    request_id: &str,
+) -> Result<Option<String>> {
+    let response = local_query(
+        node,
+        &format!(
+            r#"{{
+                AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    interrupt_requested_at
+                }}
+            }}"#,
+            support::escape_graphql_string(request_id),
+        ),
+    )
+    .await?;
+    let row = first_graphql_row(&response, "AgentRequest")?;
+    Ok(row
+        .get("interrupt_requested_at")
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .map(ToOwned::to_owned))
+}
+
+async fn local_tool_lifecycle_state(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> Result<String> {
+    let response = local_query(
+        node,
+        &format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{
+                        session_id: {{ _eq: "{}" }},
+                        tool_call_id: {{ _eq: "{}" }}
+                    }},
+                    limit: 1
+                ) {{
+                    lifecycle_state
+                }}
+            }}"#,
+            support::escape_graphql_string(session_id),
+            support::escape_graphql_string(tool_call_id),
+        ),
+    )
+    .await?;
+    let row = first_graphql_row(&response, "AgentToolCall")?;
+    row.get("lifecycle_state")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("AgentToolCall {session_id}:{tool_call_id} missing state: {row}"))
+}
+
+async fn local_query(node: &EmbeddedNode, query: &str) -> Result<Value> {
+    let response = node.execute(query).await;
+    if response.has_errors() {
+        bail!("local GraphQL query failed: {:?}", response.errors);
+    }
+    Ok(json!({
+        "data": response.data.unwrap_or(Value::Null),
+    }))
 }
 
 async fn wait_for_spawned_child_request(

--- a/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
@@ -222,8 +222,20 @@ async fn subagent_cancel_local_cascades_bridge_lifecycle_dispatch() -> Result<()
 
     let cancel = run_cli_json(
         &home_dir,
-        &["subagent", "cancel", &child_request_id, "--output", "json"],
+        &[
+            "subagent",
+            "cancel",
+            &child_request_id,
+            "--cause",
+            "deadline",
+            "--output",
+            "json",
+        ],
     )?;
+    assert_eq!(
+        cancel.get("cause").and_then(Value::as_str),
+        Some("deadline")
+    );
     let interrupted_ids = cancel
         .get("interrupted_request_ids")
         .and_then(Value::as_array)
@@ -270,6 +282,14 @@ async fn subagent_cancel_local_cascades_bridge_lifecycle_dispatch() -> Result<()
     assert_eq!(
         local_tool_lifecycle_state(node.as_ref(), &child_session_id, &child_tool_call_id).await?,
         "cancelled"
+    );
+    assert_eq!(
+        local_tool_cancel_cause(node.as_ref(), &parent_session_id, &parent_tool_call_id).await?,
+        "deadline"
+    );
+    assert_eq!(
+        local_tool_cancel_cause(node.as_ref(), &child_session_id, &child_tool_call_id).await?,
+        "deadline"
     );
     Ok(())
 }
@@ -449,6 +469,37 @@ async fn local_tool_lifecycle_state(
         .and_then(Value::as_str)
         .map(ToOwned::to_owned)
         .ok_or_else(|| anyhow!("AgentToolCall {session_id}:{tool_call_id} missing state: {row}"))
+}
+
+async fn local_tool_cancel_cause(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> Result<String> {
+    let response = local_query(
+        node,
+        &format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{
+                        session_id: {{ _eq: "{}" }},
+                        tool_call_id: {{ _eq: "{}" }}
+                    }},
+                    limit: 1
+                ) {{
+                    cancel_cause
+                }}
+            }}"#,
+            support::escape_graphql_string(session_id),
+            support::escape_graphql_string(tool_call_id),
+        ),
+    )
+    .await?;
+    let row = first_graphql_row(&response, "AgentToolCall")?;
+    row.get("cancel_cause")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("AgentToolCall {session_id}:{tool_call_id} missing cause: {row}"))
 }
 
 async fn local_query(node: &EmbeddedNode, query: &str) -> Result<Value> {

--- a/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
@@ -1,0 +1,368 @@
+mod support;
+use support::*;
+
+use std::fs;
+use std::io::Write;
+use std::net::{Shutdown, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+use defra_agent::{load_tool_selection, upsert_tool_selection};
+use serde_json::Value;
+use uuid::Uuid;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn subagent_cancel_cascades_to_linked_child_request() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-subagent-cancel-{}", Uuid::new_v4().simple());
+    let target_prompt = format!("target cascade root {}", Uuid::new_v4().simple());
+    let child_prompt = format!("child cascade leaf {}", Uuid::new_v4().simple());
+    let mock_endpoint = BlockingSpawnEndpoint::start(&model_name, &target_prompt, &child_prompt)?;
+
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &format!("cli-subagent-cancel-{}", Uuid::new_v4().simple()),
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let default_behavior_id = init
+        .get("default_behavior_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("init output missing default_behavior_id: {init}"))?
+        .to_string();
+    let tool_selection_id = init
+        .get("tool_selection_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("init output missing tool_selection_id: {init}"))?;
+    mock_endpoint.set_behavior_id(default_behavior_id.clone());
+    enable_default_subagents_before_server(&home_dir, tool_selection_id, &default_behavior_id)
+        .await?;
+
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let submit = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "submit",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--content",
+            &target_prompt,
+            "--no-wait",
+        ],
+    )?;
+    let parent_request_id = submit
+        .get("request_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("submit output missing request_id: {submit}"))?
+        .to_string();
+    let parent_session_id = submit
+        .get("session_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("submit output missing session_id: {submit}"))?
+        .to_string();
+
+    let child_request_id =
+        wait_for_spawned_child_request(&graphql, &parent_session_id, Duration::from_secs(20))
+            .await?;
+
+    let cancel = run_cli_json(
+        &home_dir,
+        &[
+            "subagent",
+            "cancel",
+            &parent_request_id,
+            "--graphql",
+            &graphql,
+            "--wait",
+            "--timeout",
+            "25s",
+            "--output",
+            "json",
+        ],
+    )?;
+    let interrupted_ids = cancel
+        .get("interrupted_request_ids")
+        .and_then(Value::as_array)
+        .ok_or_else(|| anyhow!("cancel output missing interrupted_request_ids: {cancel}"))?
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    assert!(
+        interrupted_ids.contains(&parent_request_id.as_str()),
+        "cancel output should include parent request {parent_request_id}: {cancel}"
+    );
+    assert!(
+        interrupted_ids.contains(&child_request_id.as_str()),
+        "cancel output should include child request {child_request_id}: {cancel}"
+    );
+
+    assert_eq!(
+        request_lifecycle_state(&graphql, &parent_request_id).await?,
+        "interrupted"
+    );
+    assert_eq!(
+        request_lifecycle_state(&graphql, &child_request_id).await?,
+        "interrupted"
+    );
+    Ok(())
+}
+
+async fn enable_default_subagents_before_server(
+    home_dir: &std::path::Path,
+    selection_id: &str,
+    target_behavior_id: &str,
+) -> Result<()> {
+    let data_dir = home_dir.join(".defra-agent").join("data");
+    let node = EmbeddedNode::builder()
+        .data_path(&data_dir)
+        .with_storage_backend(StorageBackend::RocksDb)
+        .build()
+        .await
+        .with_context(|| format!("opening embedded node at {}", data_dir.display()))?;
+    let mut selection = load_tool_selection(&node, selection_id)
+        .await?
+        .ok_or_else(|| anyhow!("ToolSelection {selection_id} not found"))?;
+    selection.subagent_targets = Some(vec![target_behavior_id.to_string()]);
+    selection.subagent_spawn_enabled = Some(true);
+    selection.subagent_background_enabled = Some(true);
+    upsert_tool_selection(&node, &selection)
+        .await
+        .context("enable subagent tool selection")?;
+    Ok(())
+}
+
+async fn wait_for_spawned_child_request(
+    graphql: &str,
+    parent_session_id: &str,
+    timeout: Duration,
+) -> Result<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let response = graphql_query(
+            graphql,
+            &format!(
+                r#"{{
+                    AgentToolCall(
+                        filter: {{
+                            session_id: {{ _eq: "{}" }},
+                            tool_name: {{ _eq: "spawn_subagent" }},
+                            lifecycle_state: {{ _eq: "running" }}
+                        }},
+                        limit: 1
+                    ) {{
+                        child_request_id
+                    }}
+                }}"#,
+                support::escape_graphql_string(parent_session_id),
+            ),
+        )
+        .await?;
+        if let Ok(row) = first_graphql_row(&response, "AgentToolCall") {
+            if let Some(child_request_id) = row
+                .get("child_request_id")
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+            {
+                return Ok(child_request_id.to_string());
+            }
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for spawn_subagent bridge in session {parent_session_id}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn request_lifecycle_state(graphql: &str, request_id: &str) -> Result<String> {
+    let response = graphql_query(
+        graphql,
+        &format!(
+            r#"{{
+                AgentRequest(filter: {{ request_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    lifecycle_state
+                }}
+            }}"#,
+            support::escape_graphql_string(request_id),
+        ),
+    )
+    .await?;
+    let row = first_graphql_row(&response, "AgentRequest")?;
+    row.get("lifecycle_state")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| anyhow!("AgentRequest {request_id} missing lifecycle_state: {row}"))
+}
+
+struct BlockingSpawnEndpoint {
+    endpoint: String,
+    port: u16,
+    behavior_id: Arc<Mutex<String>>,
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl BlockingSpawnEndpoint {
+    fn start(model_name: &str, target_prompt: &str, child_prompt: &str) -> Result<Self> {
+        let listener =
+            TcpListener::bind(("127.0.0.1", 0)).context("binding blocking spawn mock")?;
+        listener
+            .set_nonblocking(true)
+            .context("marking blocking spawn mock nonblocking")?;
+        let port = listener.local_addr()?.port();
+        let behavior_id = Arc::new(Mutex::new("default".to_string()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let behavior_id_for_thread = behavior_id.clone();
+        let stop_for_thread = stop.clone();
+        let model_name = model_name.to_string();
+        let target_prompt = target_prompt.to_string();
+        let child_prompt = child_prompt.to_string();
+
+        let handle = thread::spawn(move || {
+            while !stop_for_thread.load(Ordering::Relaxed) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let request = match support::mocks::read_http_request(&mut stream) {
+                            Ok(request) => request,
+                            Err(_) => {
+                                let _ = stream.shutdown(Shutdown::Both);
+                                continue;
+                            }
+                        };
+                        match (request.method.as_str(), request.path.as_str()) {
+                            ("GET", "/v1/models") => {
+                                let body = format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#);
+                                let _ = support::mocks::write_http_response(
+                                    &mut stream,
+                                    "200 OK",
+                                    "application/json",
+                                    &body,
+                                );
+                            }
+                            ("POST", "/v1/chat/completions") => {
+                                handle_chat_request(
+                                    &mut stream,
+                                    &request.body,
+                                    &target_prompt,
+                                    &child_prompt,
+                                    &behavior_id_for_thread,
+                                    &stop_for_thread,
+                                );
+                            }
+                            _ => {
+                                let _ = support::mocks::write_http_response(
+                                    &mut stream,
+                                    "404 Not Found",
+                                    "application/json",
+                                    r#"{"error":"not found"}"#,
+                                );
+                            }
+                        }
+                        let _ = stream.flush();
+                        let _ = stream.shutdown(Shutdown::Both);
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(25));
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Ok(Self {
+            endpoint: format!("http://127.0.0.1:{port}/v1"),
+            port,
+            behavior_id,
+            stop,
+            handle: Some(handle),
+        })
+    }
+
+    fn set_behavior_id(&self, behavior_id: String) {
+        *self.behavior_id.lock().expect("behavior id lock poisoned") = behavior_id;
+    }
+
+    fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+}
+
+impl Drop for BlockingSpawnEndpoint {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(("127.0.0.1", self.port));
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn handle_chat_request(
+    stream: &mut TcpStream,
+    body: &[u8],
+    target_prompt: &str,
+    child_prompt: &str,
+    behavior_id: &Arc<Mutex<String>>,
+    stop: &AtomicBool,
+) {
+    let request_json: Value = match serde_json::from_slice(body) {
+        Ok(value) => value,
+        Err(_) => {
+            let _ = support::mocks::write_http_response(
+                stream,
+                "400 Bad Request",
+                "application/json",
+                r#"{"error":"invalid json"}"#,
+            );
+            return;
+        }
+    };
+
+    if request_contains_role_text(&request_json, "user", target_prompt)
+        && !request_has_tool_result_message(&request_json)
+    {
+        let behavior_id = behavior_id
+            .lock()
+            .expect("behavior id lock poisoned")
+            .clone();
+        let args = serde_json::json!({
+            "behavior_id": behavior_id,
+            "prompt": child_prompt,
+            "await_mode": "background"
+        })
+        .to_string();
+        let sse = tool_call_sse("spawn_subagent", &args);
+        let _ = support::mocks::write_http_response(stream, "200 OK", "text/event-stream", &sse);
+        return;
+    }
+
+    while !stop.load(Ordering::Relaxed) {
+        thread::sleep(Duration::from_millis(50));
+    }
+    let _ = support::mocks::write_http_response(
+        stream,
+        "503 Service Unavailable",
+        "application/json",
+        r#"{"error":"mock stopped"}"#,
+    );
+}


### PR DESCRIPTION
Closes #270.

Adds the operator CLI subagent cancel command with cascade-aware cancellation, wait/timeout handling, and JSON/text output. Includes an integration test covering parent+child cascade interruption.