### PR TITLE
Upgrade defradb.rs to v0.13.0 (closes #293, #166)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,7 +11,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2973,7 +2973,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -3075,7 +3075,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -3380,7 +3380,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -3395,7 +3395,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "anyhow",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -3466,7 +3466,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "datastore",
@@ -3480,7 +3480,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-lock",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-trait",
@@ -3533,7 +3533,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "anyhow",
  "document",
@@ -3736,7 +3736,7 @@ dependencies = [
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "cid 0.10.1",
@@ -3759,7 +3759,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-stream",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "anyhow",
@@ -3833,7 +3833,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-trait",
@@ -3863,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "serde",
 ]
@@ -4162,7 +4162,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4523,7 +4523,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6161,7 +6161,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -7101,7 +7101,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8802,7 +8802,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9259,7 +9259,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "anyhow",
@@ -10387,7 +10387,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-graphql",
@@ -10423,7 +10423,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10440,7 +10440,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "async-lock",
@@ -10471,7 +10471,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "chrono",
@@ -11625,7 +11625,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "cid 0.10.1",
  "defra-core",
@@ -12466,7 +12466,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -12601,7 +12601,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-trait",
  "bm25",
@@ -16049,7 +16049,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?branch=main#f1ab17173bb53583e121d2951b812cecdc796507"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.13.0#80e1445b5b8ced6ec48e5c67b90290939a469e28"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,22 +36,22 @@ repository = "https://github.com/sourcenetwork/defra-agent"
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["derive", "env"] }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -53,6 +53,6 @@ windows-sys = { version = "0.61.2", features = [
 ] }
 
 [dev-dependencies]
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", branch = "main" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 proptest = "1"
 agent-tool-call-lifecycle-v1-to-v2-lens = { path = "../defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2", default-features = false }

--- a/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
@@ -46,19 +46,6 @@ def deviations : List Deviation :=
     , acceptedFollowUp :=
         some "Track at #187 PR description; deadline-audit followup #5."
     }
-  , { id := "defradb_rs_p2p_subscription_state_not_durable"
-    , domain := "reverse_pairing"
-    , subject := "DefraDB P2P subscription persistence"
-    , statement :=
-        "Reverse-pairing convergence assumes receiver-side P2P gossipsub " ++
-        "subscription state survives process restart. Go DefraDB persists that " ++
-        "state, but defradb.rs currently keeps iroh/libp2p subscription " ++
-        "registration in memory unless a higher-level path re-installs it."
-    , acceptedFailureMode :=
-        some "receiver_restart_drops_subscription_delivery_contract"
-    , acceptedFollowUp :=
-        some "Track upstream at sourcenetwork/defradb.rs#957; downstream at sourcenetwork/defra-agent#166."
-    }
   ]
 
 def Deviation.toJson (deviation : Deviation) : String :=

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -129,7 +129,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/Properties/Decidable.lean` | Finite-state exhaustive checks |
 | `Proofs/Conformance/DefraAgent.lean` | Mapping from Lean state to Rust/DefraDB state |
 | `Proofs/Conformance/Boundaries.lean` | Intentional product policies and external assumptions at the Rust/Lean boundary |
-| `Proofs/Conformance/Deviations.lean` | Active unresolved Rust/spec mismatches; currently empty |
+| `Proofs/Conformance/Deviations.lean` | Active unresolved Rust/spec mismatches |
 | `Proofs/Conformance/SchedulerConformance.lean` | Scheduler-specific conformance notes |
 | `Proofs/Conformance/CoverageLedger.lean` | Checked ledger mapping every emitted conformance domain to a Rust consumer, accepted boundary, or accepted follow-up |
 | `Proofs/Conformance/Contracts.lean` | Test-time JSON extraction surface for Rust vocabularies, finite state counts, transition tables, legal/illegal transition pairs, witness rows, ClientShell cases, and the coverage ledger |
@@ -674,9 +674,8 @@ Current boundaries:
 
 `Proofs/Conformance/Deviations.lean` is reserved only for real unresolved
 Rust/spec mismatches. Active deviations are expected to name an accepted failure
-mode or a follow-up tracker. Current entries cover live event-source rescan gaps
-and the defradb.rs durable P2P subscription-state gap tracked upstream at
-sourcenetwork/defradb.rs#957.
+mode or a follow-up tracker. Current entries cover live event-source rescan
+gaps.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

- Upgrade all defradb.rs workspace git dependencies, plus the defra-agent `acp` dev-dependency, to the v0.13.0 tag (`80e1445b5b8ced6ec48e5c67b90290939a469e28`).
- Remove the resolved Lean deviation `defradb_rs_p2p_subscription_state_not_durable`, added in #240.
- Refresh the proofs README so the resolved durable P2P subscription gap is no longer listed as an active deviation.

Closes #293.
Closes #166.

## Upstream v0.13.0 Release Notes

Release notes: https://github.com/sourcenetwork/defradb.rs/releases/tag/v0.13.0

Pulled in from v0.13.0:

- fix(ffi): restore SE replay options for P2P replicators (#956)
- chore(deps): use beetle bitswap cleanup (#959)
- Persist P2P collection subscriptions in systemstore (#960)
- chore(deps): upgrade Iroh to 1.0.0-rc.0 (#958)
- chore(p2p): audit follow-ups (#962-#968) (#969)
- fix(db): emit Update events on transaction commit (#971)
- fix(query): stabilize downsample rollup test under parallel load (#981)
- feat(cli,db,http): port DeleteCollection CLI + Go upstream survey (Go #4688) (#982)
- feat(query): support multi-cid queries (#975)
- fix(p2p): cross-runtime DAG fetch fairness under saturation (#980)
- Restore Rust FFI integration-test parity (#983)

## Verification

- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent -p defra-agent-cli -p defra-native-fs-runner`
- `cargo test -p defra-agent`
- `cargo test -p defra-agent-cli`
- `cargo test -p defra-agent pairing_reconcile`
- `cargo test -p defra-agent --test pairing_reconcile_conformance`
- `rg "defradb_rs_p2p_subscription_state_not_durable" crates/` returns zero matches
