### PR TITLE
R5: add Lean witness rows + Rust consumer for cross-deployment subagent dispatch (#273)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3605,6 +3605,7 @@ dependencies = [
  "identity",
  "libc",
  "minijinja",
+ "p2p",
  "proptest",
  "rand 0.9.2",
  "reqwest 0.12.28",

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -54,5 +54,6 @@ windows-sys = { version = "0.61.2", features = [
 
 [dev-dependencies]
 acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
+p2p.workspace = true
 proptest = "1"
 agent-tool-call-lifecycle-v1-to-v2-lens = { path = "../defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2", default-features = false }

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases.lean
@@ -6,6 +6,7 @@ import Proofs.Conformance.ContractCases.LifecycleTransitions
 import Proofs.Conformance.ContractCases.LiveOverlay
 import Proofs.Conformance.ContractCases.QueueDeadline
 import Proofs.Conformance.ContractCases.R6Background
+import Proofs.Conformance.ContractCases.R5CrossDeployment
 import Proofs.Conformance.ContractCases.Transcript
 import Proofs.Conformance.ContractCases.ManagedExec
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/R5CrossDeployment.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/R5CrossDeployment.lean
@@ -1,0 +1,68 @@
+import Proofs.Conformance.ContractCases.Types
+
+/-!
+# R5 Cross-Deployment Subagent Conformance Cases
+
+Finite witnesses for the agent-facing R5 dispatch lifecycle. The rows pin the
+production contract around `spawn_subagent`: a parent bridge row is persisted,
+the child request materializes with parent linkage, and routing either crosses
+deployment boundaries or falls back to same-deployment materialization.
+-/
+
+namespace Conformance.ContractCases
+
+def r5CrossDeploymentCase
+    (name route parentDeployment childDeployment parentRequestId parentToolCallId
+      childRequestId targetBehaviorId : String)
+    (crossDeploymentRoutingFired singleDeploymentFallback unclaimedDeadlineSet : Bool) :
+    R5CrossDeploymentCase :=
+  { name := name
+  , route := route
+  , action := "spawn_subagent"
+  , parentDeployment := parentDeployment
+  , childDeployment := childDeployment
+  , parentRequestId := parentRequestId
+  , parentToolCallId := parentToolCallId
+  , childRequestId := childRequestId
+  , targetBehaviorId := targetBehaviorId
+  , awaitMode := "background"
+  , cancelPolicy := "cascade"
+  , parentTriggerPersisted := true
+  , childMaterialized := true
+  , childOwnedByTargetDeployment := true
+  , causedByParentRequestIdMatches := true
+  , causedByParentToolCallIdMatches := true
+  , causedByTriggerKind := "subagent"
+  , crossDeploymentRoutingFired := crossDeploymentRoutingFired
+  , singleDeploymentFallback := singleDeploymentFallback
+  , unclaimedDeadlineSet := unclaimedDeadlineSet
+  }
+
+def r5CrossDeploymentCases : List R5CrossDeploymentCase :=
+  [ r5CrossDeploymentCase
+      "r5_cross_deployment_background_claim_materializes_child"
+      "cross_deployment"
+      "deployment_a"
+      "deployment_b"
+      "r5-lean-cross-parent"
+      "r5-lean-cross-tool"
+      "runtime_generated"
+      "r5-lean-cross-child-behavior"
+      true
+      false
+      true
+  , r5CrossDeploymentCase
+      "r5_single_deployment_background_fallback_materializes_child"
+      "single_deployment"
+      "deployment_a"
+      "deployment_a"
+      "r5-lean-local-parent"
+      "r5-lean-local-tool"
+      "runtime_generated"
+      "r5-lean-local-child-behavior"
+      false
+      true
+      true
+  ]
+
+end Conformance.ContractCases

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -244,6 +244,29 @@ structure R6BackgroundingCase where
   queueKey : Option String
   deriving Repr
 
+structure R5CrossDeploymentCase where
+  name : String
+  route : String
+  action : String
+  parentDeployment : String
+  childDeployment : String
+  parentRequestId : String
+  parentToolCallId : String
+  childRequestId : String
+  targetBehaviorId : String
+  awaitMode : String
+  cancelPolicy : String
+  parentTriggerPersisted : Bool
+  childMaterialized : Bool
+  childOwnedByTargetDeployment : Bool
+  causedByParentRequestIdMatches : Bool
+  causedByParentToolCallIdMatches : Bool
+  causedByTriggerKind : String
+  crossDeploymentRoutingFired : Bool
+  singleDeploymentFallback : Bool
+  unclaimedDeadlineSet : Bool
+  deriving Repr
+
 /-- Runtime witness row for an operationally-driven Background Properties theorem. -/
 structure BackgroundTheoremWitness where
   theoremName : String

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
@@ -182,6 +182,37 @@ def r6BackgroundingCaseJson (witness : R6BackgroundingCase) : String :=
     ++ "\"queue_key\":" ++ jsonOptionalString witness.queueKey
     ++ "}"
 
+def r5CrossDeploymentCaseJson (witness : R5CrossDeploymentCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"route\":" ++ jsonString witness.route ++ ","
+    ++ "\"action\":" ++ jsonString witness.action ++ ","
+    ++ "\"parent_deployment\":" ++ jsonString witness.parentDeployment ++ ","
+    ++ "\"child_deployment\":" ++ jsonString witness.childDeployment ++ ","
+    ++ "\"parent_request_id\":" ++ jsonString witness.parentRequestId ++ ","
+    ++ "\"parent_tool_call_id\":" ++ jsonString witness.parentToolCallId ++ ","
+    ++ "\"child_request_id\":" ++ jsonString witness.childRequestId ++ ","
+    ++ "\"target_behavior_id\":" ++ jsonString witness.targetBehaviorId ++ ","
+    ++ "\"await_mode\":" ++ jsonString witness.awaitMode ++ ","
+    ++ "\"cancel_policy\":" ++ jsonString witness.cancelPolicy ++ ","
+    ++ "\"parent_trigger_persisted\":"
+      ++ boolString witness.parentTriggerPersisted ++ ","
+    ++ "\"child_materialized\":" ++ boolString witness.childMaterialized ++ ","
+    ++ "\"child_owned_by_target_deployment\":"
+      ++ boolString witness.childOwnedByTargetDeployment ++ ","
+    ++ "\"caused_by_parent_request_id_matches\":"
+      ++ boolString witness.causedByParentRequestIdMatches ++ ","
+    ++ "\"caused_by_parent_tool_call_id_matches\":"
+      ++ boolString witness.causedByParentToolCallIdMatches ++ ","
+    ++ "\"caused_by_trigger_kind\":"
+      ++ jsonString witness.causedByTriggerKind ++ ","
+    ++ "\"cross_deployment_routing_fired\":"
+      ++ boolString witness.crossDeploymentRoutingFired ++ ","
+    ++ "\"single_deployment_fallback\":"
+      ++ boolString witness.singleDeploymentFallback ++ ","
+    ++ "\"unclaimed_deadline_set\":" ++ boolString witness.unclaimedDeadlineSet
+    ++ "}"
+
 def backgroundTheoremWitnessJson (witness : BackgroundTheoremWitness) : String :=
   "{"
     ++ "\"theorem_name\":" ++ jsonString witness.theoremName ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -98,6 +98,9 @@ def snapshotJson : String :=
     ++ "\"r6_backgrounding_cases\":"
       ++ jsonArray
         (r6BackgroundingCases.map r6BackgroundingCaseJson) ++ ","
+    ++ "\"r5_cross_deployment_cases\":"
+      ++ jsonArray
+        (r5CrossDeploymentCases.map r5CrossDeploymentCaseJson) ++ ","
     ++ "\"r6_background_theorem_witnesses\":"
       ++ jsonArray
         (r6BackgroundTheoremWitnesses.map backgroundTheoremWitnessJson) ++ ","

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -154,10 +154,9 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
         ]
     }
   , { feature := "subagents-cross-deployment"
-    , required := []
+    , required := [Surface.agentFacing]
     , deferred :=
         [ (Surface.api, "#272")
-        , (Surface.agentFacing, "#273")
         , (Surface.operatorUi, "#274")
         ]
     }
@@ -536,6 +535,11 @@ def caseCoverage : List CoverageEntry :=
       "R6BackgroundingCases"
       "state_machine_conformance::generated_r6_backgrounding_cases_pin_tool_backgrounding_contract")
       "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
+      "r5_cross_deployment_cases"
+      "R5CrossDeploymentCases"
+      "state_machine_conformance::generated_r5_cross_deployment_cases_drive_production_dispatch")
+      "subagents-cross-deployment" [Surface.agentFacing]
   , tagged (consumerCoverage
       "r6_background_theorem_witnesses"
       "BackgroundBudgetBoundedTheoremWitness"

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -62,6 +62,8 @@ pub(crate) struct LeanContractSnapshot {
     #[serde(default)]
     pub(crate) r4c_background_work_cases: Vec<LeanR4cBackgroundWorkCase>,
     pub(crate) r6_backgrounding_cases: Vec<LeanR6BackgroundingCase>,
+    #[serde(default)]
+    pub(crate) r5_cross_deployment_cases: Vec<LeanR5CrossDeploymentCase>,
     pub(crate) r6_background_theorem_witnesses: Vec<LeanBackgroundTheoremWitness>,
     pub(crate) transcript_conformance_cases: Vec<LeanTranscriptCase>,
     pub(crate) streaming_response_cases: Vec<LeanResponseTransitionCase>,
@@ -429,6 +431,10 @@ pub(crate) fn lean_r6_backgrounding_case(name: &str) -> &'static LeanR6Backgroun
         .iter()
         .find(|case| case.name == name)
         .unwrap_or_else(|| panic!("Lean R6 backgrounding case {name:?} was not emitted"))
+}
+
+pub(crate) fn lean_r5_cross_deployment_cases() -> &'static [LeanR5CrossDeploymentCase] {
+    &lean_contract_snapshot().r5_cross_deployment_cases
 }
 
 pub(crate) fn lean_r6_background_theorem_witnesses() -> &'static [LeanBackgroundTheoremWitness] {

--- a/crates/defra-agent/src/lean_vocab_test/background_transcript.rs
+++ b/crates/defra-agent/src/lean_vocab_test/background_transcript.rs
@@ -98,6 +98,30 @@ pub(crate) struct LeanR6BackgroundingCase {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanR5CrossDeploymentCase {
+    pub(crate) name: String,
+    pub(crate) route: String,
+    pub(crate) action: String,
+    pub(crate) parent_deployment: String,
+    pub(crate) child_deployment: String,
+    pub(crate) parent_request_id: String,
+    pub(crate) parent_tool_call_id: String,
+    pub(crate) child_request_id: String,
+    pub(crate) target_behavior_id: String,
+    pub(crate) await_mode: String,
+    pub(crate) cancel_policy: String,
+    pub(crate) parent_trigger_persisted: bool,
+    pub(crate) child_materialized: bool,
+    pub(crate) child_owned_by_target_deployment: bool,
+    pub(crate) caused_by_parent_request_id_matches: bool,
+    pub(crate) caused_by_parent_tool_call_id_matches: bool,
+    pub(crate) caused_by_trigger_kind: String,
+    pub(crate) cross_deployment_routing_fired: bool,
+    pub(crate) single_deployment_fallback: bool,
+    pub(crate) unclaimed_deadline_set: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 pub(crate) struct LeanBackgroundTheoremWitness {
     pub(crate) theorem_name: String,
     pub(crate) witness_kind: String,

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -48,13 +48,13 @@ use lean_vocab_test::{
     lean_event_delivery_transition_cases, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_managed_exec_liveness_cases, lean_mcp_health_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_r4c_background_work_case,
-    lean_r4c_background_work_cases, lean_r6_background_theorem_witness,
-    lean_r6_background_theorem_witnesses, lean_r6_backgrounding_case, lean_r6_backgrounding_cases,
-    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_transition_cases,
-    lean_runtime_reconcile_case, lean_session_recovery_case, lean_state_machine_contract,
-    lean_tool_preflight_case, lean_tool_retry_case, lean_transcript_case, lean_transcript_cases,
-    lean_vocabulary_values, LeanEventDeliveryAction, LeanLifecycleTransitionCase,
-    LeanR4cBackgroundWorkCase,
+    lean_r4c_background_work_cases, lean_r5_cross_deployment_cases,
+    lean_r6_background_theorem_witness, lean_r6_background_theorem_witnesses,
+    lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_sweep_cases,
+    lean_request_transition_cases, lean_response_transition_cases, lean_runtime_reconcile_case,
+    lean_session_recovery_case, lean_state_machine_contract, lean_tool_preflight_case,
+    lean_tool_retry_case, lean_transcript_case, lean_transcript_cases, lean_vocabulary_values,
+    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -80,6 +80,8 @@ mod coverage;
 mod event_delivery;
 #[path = "state_machine_conformance/interrupts_manual.rs"]
 mod interrupts_manual;
+#[path = "state_machine_conformance/r5_cross_deployment.rs"]
+mod r5_cross_deployment;
 #[path = "state_machine_conformance/recovery_sweeps.rs"]
 mod recovery_sweeps;
 #[path = "state_machine_conformance/request_lifecycle.rs"]
@@ -120,6 +122,11 @@ async fn generated_r6_background_theorem_witnesses_drive_admission_budget_invari
 async fn generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace() {
     transcript_background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace()
         .await;
+}
+
+#[tokio::test]
+async fn generated_r5_cross_deployment_cases_drive_production_dispatch() {
+    r5_cross_deployment::generated_r5_cross_deployment_cases_drive_production_dispatch().await;
 }
 
 #[test]

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -695,6 +695,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "R6BackgroundingCases".to_string(),
         ));
     }
+    if !lean_r5_cross_deployment_cases().is_empty() {
+        emitted.insert((
+            "r5_cross_deployment_cases".to_string(),
+            "R5CrossDeploymentCases".to_string(),
+        ));
+    }
     if !lean_r6_background_theorem_witnesses().is_empty() {
         emitted.insert((
             "r6_background_theorem_witnesses".to_string(),
@@ -742,6 +748,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "identity_contracts",
         "r4c_background_work_cases",
         "r6_background_cases",
+        "r5_cross_deployment_cases",
         "r6_background_theorem_witnesses",
         "follow_up_hook",
     ];

--- a/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
@@ -18,7 +18,7 @@ use crate::lean_vocab_test::{lean_r5_cross_deployment_cases, LeanR5CrossDeployme
 use crate::support::fixtures::{bind_default_behavior_backend, test_identity};
 use crate::support::interrupt::{wait_for_runtime_ready, BootedAgent};
 use crate::support::mock_endpoint::MockModelEndpoint;
-use crate::support::{first_optional_row, first_row, test_db, TestDb};
+use crate::support::{first_optional_row, test_db, test_p2p_db, TestDb};
 
 const PARENT_AGENT_DID: &str = "did:defra-agent:r5-lean-parent";
 
@@ -39,18 +39,14 @@ impl CompletionModel for R5DispatchTestModel {
         &self,
         _request: CompletionRequest,
     ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
-        Err(CompletionError::ProviderError(
-            "completion is unused in R5 dispatch conformance".to_string(),
-        ))
+        panic!("R5 dispatch test reached completion path; spawn_subagent should short-circuit")
     }
 
     async fn stream(
         &self,
         _request: CompletionRequest,
     ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
-        Err(CompletionError::ProviderError(
-            "streaming is unused in R5 dispatch conformance".to_string(),
-        ))
+        panic!("R5 dispatch test reached streaming path; spawn_subagent should short-circuit")
     }
 }
 
@@ -63,17 +59,9 @@ struct RunningChildAgent {
 #[derive(Debug, Deserialize)]
 struct ToolCallRow {
     request_id: String,
-    session_id: String,
-    tool_call_key: String,
-    message_sequence: Option<i64>,
     tool_name: String,
     tool_call_id: String,
-    args: String,
-    result: Option<String>,
-    status: Option<String>,
     lifecycle_state: Option<String>,
-    started_at: Option<String>,
-    deadline_at: Option<String>,
     await_mode: Option<String>,
     cancel_policy: Option<String>,
     child_request_id: Option<String>,
@@ -85,13 +73,6 @@ struct AgentRequestRow {
     request_id: String,
     agent_did: String,
     behavior_id: String,
-    session_id: String,
-    status: Option<String>,
-    lifecycle_state: Option<String>,
-    content: Option<String>,
-    created_at: Option<String>,
-    deadline: Option<String>,
-    subagent_depth: Option<i64>,
     caused_by_parent_request_id: Option<String>,
     caused_by_parent_tool_call_id: Option<String>,
     caused_by_trigger_id: Option<String>,
@@ -130,8 +111,23 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
     );
 
     let child_agent = boot_child_agent(case).await;
+    let parent_db = test_p2p_db(&format!("{}-parent", case.name)).await;
+    install_one_way_replicator(
+        parent_db.node.as_ref(),
+        child_agent.db.node.as_ref(),
+        &["AgentRequest", "AgentToolCall"],
+    )
+    .await;
     let (parent_db, hook, parent_session_id, _parent_behavior_id) =
-        setup_parent_hook(case, false).await;
+        setup_parent_hook_on_db(case, false, parent_db).await;
+
+    let replicated_parent =
+        wait_for_request(child_agent.db.node.as_ref(), &case.parent_request_id).await;
+    assert_eq!(
+        replicated_parent.agent_did, PARENT_AGENT_DID,
+        "{}: parent request should replicate to B before the bridge",
+        case.name
+    );
 
     let child_request_id = spawn_from_parent_hook(case, &hook).await;
     assert!(
@@ -150,19 +146,32 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
     .await;
     assert_bridge_matches_case(case, &bridge, &child_request_id);
 
-    replicate_parent_request(parent_db.node.as_ref(), child_agent.db.node.as_ref(), case).await;
-    replicate_tool_call_to_child_node(&bridge, child_agent.db.node.as_ref()).await;
+    let replicated_bridge = wait_for_tool_call(
+        child_agent.db.node.as_ref(),
+        &parent_session_id,
+        &case.parent_tool_call_id,
+    )
+    .await;
+    assert_bridge_matches_case(case, &replicated_bridge, &child_request_id);
 
     let child = wait_for_child_request(child_agent.db.node.as_ref(), &child_request_id).await;
     assert_child_matches_case(case, &child, &child_request_id);
+    let child_agent_did = child_agent.booted.agent_did.clone();
     assert_eq!(
-        child.agent_did, child_agent.booted.agent_did,
+        child.agent_did, child_agent_did,
         "{}: cross-deployment child must be locally owned by B",
         case.name
     );
     assert!(case.child_owned_by_target_deployment, "{}", case.name);
 
-    child_agent.booted.shutdown().await;
+    let RunningChildAgent {
+        db: child_db,
+        booted,
+        _endpoint,
+    } = child_agent;
+    booted.shutdown().await;
+    parent_db.node.shutdown().await;
+    child_db.node.shutdown().await;
 }
 
 async fn drive_single_deployment_case(case: &LeanR5CrossDeploymentCase) {
@@ -196,7 +205,7 @@ async fn drive_single_deployment_case(case: &LeanR5CrossDeploymentCase) {
 }
 
 async fn boot_child_agent(case: &LeanR5CrossDeploymentCase) -> RunningChildAgent {
-    let db = test_db(&format!("{}-child", case.name)).await;
+    let db = test_p2p_db(&format!("{}-child", case.name)).await;
     write_pairing(db.node.as_ref(), "deployment-a", PARENT_AGENT_DID).await;
 
     let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity(&format!("{}-child", case.name)));
@@ -244,6 +253,14 @@ async fn setup_parent_hook(
     target_is_local: bool,
 ) -> (TestDb, DefraSessionHook, String, String) {
     let db = test_db(&format!("{}-parent", case.name)).await;
+    setup_parent_hook_on_db(case, target_is_local, db).await
+}
+
+async fn setup_parent_hook_on_db(
+    case: &LeanR5CrossDeploymentCase,
+    target_is_local: bool,
+    db: TestDb,
+) -> (TestDb, DefraSessionHook, String, String) {
     let parent_behavior_id = format!("{}-parent-behavior", case.name);
     let parent_session_id = format!("{}-session", case.parent_request_id);
     let selection_id = format!("{parent_behavior_id}-tools");
@@ -455,145 +472,101 @@ async fn write_pairing(node: &EmbeddedNode, peer_id: &str, peer_agent_did: &str)
     exec(node, &mutation, "write PeerPairingDesired").await;
 }
 
-async fn replicate_parent_request(
-    from: &EmbeddedNode,
-    to: &EmbeddedNode,
-    case: &LeanR5CrossDeploymentCase,
+async fn install_one_way_replicator(
+    sender: &EmbeddedNode,
+    receiver: &EmbeddedNode,
+    collections: &[&str],
 ) {
-    let parent = fetch_request(from, &case.parent_request_id).await;
-    let request_id = escape_graphql_string(&parent.request_id);
-    let agent_did = escape_graphql_string(&parent.agent_did);
-    let behavior_id = escape_graphql_string(&parent.behavior_id);
-    let session_id = escape_graphql_string(&parent.session_id);
-    let status = escape_graphql_string(parent.status.as_deref().unwrap_or("processing"));
-    let lifecycle_state =
-        escape_graphql_string(parent.lifecycle_state.as_deref().unwrap_or("processing"));
-    let content = escape_graphql_string(parent.content.as_deref().unwrap_or(""));
-    let created_at = escape_graphql_string(
-        parent
-            .created_at
-            .as_deref()
-            .unwrap_or("2026-05-20T00:00:00Z"),
-    );
-    let deadline =
-        escape_graphql_string(parent.deadline.as_deref().unwrap_or("2026-05-20T00:05:00Z"));
-    let subagent_depth = parent.subagent_depth.unwrap_or(0);
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentRequest(
-                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
-                add: {{
-                    request_id: "{request_id}",
-                    agent_did: "{agent_did}",
-                    behavior_id: "{behavior_id}",
-                    session_id: "{session_id}",
-                    retry_parent_request: "",
-                    retry_root_request: "{request_id}",
-                    superseded_by_request: "",
-                    content: "{content}",
-                    status: "{status}",
-                    lifecycle_state: "{lifecycle_state}",
-                    backend_id: "",
-                    execution_origin: "interactive",
-                    metadata: "",
-                    failure_reason: "",
-                    created_at: "{created_at}",
-                    deadline: "{deadline}",
-                    retry_count: 0,
-                    max_retries: 3,
-                    subagent_depth: {subagent_depth}
-                }},
-                update: {{
-                    agent_did: "{agent_did}",
-                    behavior_id: "{behavior_id}",
-                    status: "{status}",
-                    lifecycle_state: "{lifecycle_state}",
-                    subagent_depth: {subagent_depth}
-                }}
-            ) {{ _docID }}
-        }}"#
-    );
-    exec(to, &mutation, "replicate parent AgentRequest").await;
+    let sender_addr = wait_for_listen_addr(sender).await;
+    let receiver_addr = wait_for_listen_addr(receiver).await;
+    let sender_p2p = sender.p2p().expect("sender p2p");
+    let receiver_p2p = receiver.p2p().expect("receiver p2p");
+
+    sender_p2p
+        .connect_peer(&receiver_addr)
+        .await
+        .expect("connect sender to receiver");
+    wait_for_connected_peer(sender).await;
+    wait_for_connected_peer(receiver).await;
+
+    let collection_names = collections
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect::<Vec<_>>();
+    sender_p2p
+        .add_collections(collection_names.clone())
+        .await
+        .expect("add sender p2p collections");
+    receiver_p2p
+        .add_collections(collection_names.clone())
+        .await
+        .expect("add receiver p2p collections");
+    receiver_p2p
+        .add_replicator(
+            collection_names.clone(),
+            Some(&sender_addr),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("authorize sender as receiver-side replicator");
+    sender_p2p
+        .add_replicator(collection_names, Some(&receiver_addr), Vec::new(), None)
+        .await
+        .expect("install sender to receiver replicator");
 }
 
-async fn replicate_tool_call_to_child_node(bridge: &ToolCallRow, to: &EmbeddedNode) {
-    let tool_call_key = escape_graphql_string(&bridge.tool_call_key);
-    let request_id = escape_graphql_string(&bridge.request_id);
-    let session_id = escape_graphql_string(&bridge.session_id);
-    let tool_name = escape_graphql_string(&bridge.tool_name);
-    let tool_call_id = escape_graphql_string(&bridge.tool_call_id);
-    let args = escape_graphql_string(&bridge.args);
-    let result = escape_graphql_string(bridge.result.as_deref().unwrap_or(""));
-    let status = escape_graphql_string(bridge.status.as_deref().unwrap_or("called"));
-    let lifecycle_state =
-        escape_graphql_string(bridge.lifecycle_state.as_deref().unwrap_or("running"));
-    let started_at = escape_graphql_string(
-        bridge
-            .started_at
-            .as_deref()
-            .unwrap_or("2026-05-20T00:00:00Z"),
-    );
-    let deadline_at = escape_graphql_string(
-        bridge
-            .deadline_at
-            .as_deref()
-            .unwrap_or("2026-05-20T00:05:00Z"),
-    );
-    let await_mode = escape_graphql_string(bridge.await_mode.as_deref().unwrap_or("background"));
-    let cancel_policy = escape_graphql_string(bridge.cancel_policy.as_deref().unwrap_or("cascade"));
-    let child_request_id = escape_graphql_string(bridge.child_request_id.as_deref().unwrap_or(""));
-    let message_sequence = bridge.message_sequence.unwrap_or(1);
-    let unclaimed = bridge
-        .unclaimed_deadline_at
-        .as_deref()
-        .map(|value| {
-            format!(
-                r#", unclaimed_deadline_at: "{}""#,
-                escape_graphql_string(value)
-            )
-        })
-        .unwrap_or_default();
+async fn wait_for_listen_addr(node: &EmbeddedNode) -> String {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let addrs = node
+            .p2p()
+            .expect("p2p should be enabled")
+            .listen_addresses()
+            .await
+            .expect("listen addresses");
+        if let Some(addr) = addrs.first() {
+            return addr.clone();
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node never exposed a P2P listen address"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
 
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentToolCall(
-                filter: {{ tool_call_key: {{ _eq: "{tool_call_key}" }} }},
-                add: {{
-                    tool_call_key: "{tool_call_key}",
-                    request_id: "{request_id}",
-                    session_id: "{session_id}",
-                    message_sequence: {message_sequence},
-                    tool_name: "{tool_name}",
-                    tool_call_id: "{tool_call_id}",
-                    args: "{args}",
-                    result: "{result}",
-                    status: "{status}",
-                    lifecycle_state: "{lifecycle_state}",
-                    started_at: "{started_at}",
-                    deadline_at: "{deadline_at}",
-                    await_mode: "{await_mode}",
-                    cancel_policy: "{cancel_policy}",
-                    child_request_id: "{child_request_id}"
-                    {unclaimed}
-                }},
-                update: {{
-                    result: "{result}",
-                    status: "{status}",
-                    lifecycle_state: "{lifecycle_state}",
-                    started_at: "{started_at}",
-                    deadline_at: "{deadline_at}",
-                    await_mode: "{await_mode}",
-                    cancel_policy: "{cancel_policy}",
-                    child_request_id: "{child_request_id}"
-                    {unclaimed}
-                }}
-            ) {{ _docID }}
-        }}"#
-    );
-    exec(to, &mutation, "replicate AgentToolCall").await;
+async fn wait_for_connected_peer(node: &EmbeddedNode) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let peers = node
+            .p2p()
+            .expect("p2p should be enabled")
+            .connected_peers()
+            .await
+            .expect("connected peers");
+        if !peers.is_empty() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "node never reported a connected peer"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &str) -> ToolCallRow {
+    fetch_tool_call_optional(node, session_id, tool_call_id)
+        .await
+        .unwrap_or_else(|| panic!("AgentToolCall {session_id}/{tool_call_id} not found"))
+}
+
+async fn fetch_tool_call_optional(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> Option<ToolCallRow> {
     let session_id = escape_graphql_string(session_id);
     let tool_call_id = escape_graphql_string(tool_call_id);
     let query = format!(
@@ -606,17 +579,9 @@ async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &s
                 limit: 1
             ) {{
                 request_id
-                session_id
-                tool_call_key
-                message_sequence
                 tool_name
                 tool_call_id
-                args
-                result
-                status
                 lifecycle_state
-                started_at
-                deadline_at
                 await_mode
                 cancel_policy
                 child_request_id
@@ -624,32 +589,7 @@ async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &s
             }}
         }}"#
     );
-    first_row(&node.execute(&query).await, "AgentToolCall")
-}
-
-async fn fetch_request(node: &EmbeddedNode, request_id: &str) -> AgentRequestRow {
-    let request_id = escape_graphql_string(request_id);
-    let query = format!(
-        r#"{{
-            AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
-                request_id
-                agent_did
-                behavior_id
-                session_id
-                status
-                lifecycle_state
-                content
-                created_at
-                deadline
-                subagent_depth
-                caused_by_parent_request_id
-                caused_by_parent_tool_call_id
-                caused_by_trigger_id
-                caused_by_trigger_kind
-            }}
-        }}"#
-    );
-    first_row(&node.execute(&query).await, "AgentRequest")
+    first_optional_row(&node.execute(&query).await, "AgentToolCall")
 }
 
 async fn fetch_child_request_optional(
@@ -663,13 +603,6 @@ async fn fetch_child_request_optional(
                 request_id
                 agent_did
                 behavior_id
-                session_id
-                status
-                lifecycle_state
-                content
-                created_at
-                deadline
-                subagent_depth
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
                 caused_by_trigger_id
@@ -678,6 +611,38 @@ async fn fetch_child_request_optional(
         }}"#
     );
     first_optional_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn wait_for_request(node: &EmbeddedNode, request_id: &str) -> AgentRequestRow {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(request) = fetch_child_request_optional(node, request_id).await {
+            return request;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "request {request_id} was not replicated"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_tool_call(
+    node: &EmbeddedNode,
+    session_id: &str,
+    tool_call_id: &str,
+) -> ToolCallRow {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if let Some(tool_call) = fetch_tool_call_optional(node, session_id, tool_call_id).await {
+            return tool_call;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "tool call {tool_call_id} was not replicated"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
 }
 
 async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> AgentRequestRow {

--- a/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
@@ -109,6 +109,7 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
         "{} should cross deployments",
         case.name
     );
+    assert!(case.child_owned_by_target_deployment, "{}", case.name);
 
     let child_agent = boot_child_agent(case).await;
     let parent_db = test_p2p_db(&format!("{}-parent", case.name)).await;
@@ -118,6 +119,9 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
         &["AgentRequest", "AgentToolCall"],
     )
     .await;
+    // The parent deliberately has no pairing row for B. Production R5 routing
+    // treats the missing local target behavior as a remote bridge write; the
+    // installed replicator carries that bridge to B.
     let (parent_db, hook, parent_session_id, _parent_behavior_id) =
         setup_parent_hook_on_db(case, false, parent_db).await;
 
@@ -162,7 +166,6 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
         "{}: cross-deployment child must be locally owned by B",
         case.name
     );
-    assert!(case.child_owned_by_target_deployment, "{}", case.name);
 
     let RunningChildAgent {
         db: child_db,
@@ -170,6 +173,7 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
         _endpoint,
     } = child_agent;
     booted.shutdown().await;
+    // BootedAgent only stops DefraAgent::run; P2P belongs to the embedded node.
     parent_db.node.shutdown().await;
     child_db.node.shutdown().await;
 }
@@ -185,6 +189,9 @@ async fn drive_single_deployment_case(case: &LeanR5CrossDeploymentCase) {
 
     let (parent_db, hook, parent_session_id, _parent_behavior_id) =
         setup_parent_hook(case, true).await;
+    // A local target behavior makes spawn_subagent materialize the child
+    // synchronously in the production hook, so no SubagentSource runtime is
+    // needed for the single-deployment fallback row.
     let child_request_id = spawn_from_parent_hook(case, &hook).await;
 
     let bridge = fetch_tool_call(
@@ -501,6 +508,8 @@ async fn install_one_way_replicator(
         .add_collections(collection_names.clone())
         .await
         .expect("add receiver p2p collections");
+    // DefraDB needs both the sender-side push target and the receiver-side
+    // authorization record. The data-flow under test remains sender -> receiver.
     receiver_p2p
         .add_replicator(
             collection_names.clone(),
@@ -528,10 +537,9 @@ async fn wait_for_listen_addr(node: &EmbeddedNode) -> String {
         if let Some(addr) = addrs.first() {
             return addr.clone();
         }
-        assert!(
-            Instant::now() < deadline,
-            "node never exposed a P2P listen address"
-        );
+        if Instant::now() >= deadline {
+            panic!("node never exposed a P2P listen address; last_addrs={addrs:?}");
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
@@ -548,10 +556,9 @@ async fn wait_for_connected_peer(node: &EmbeddedNode) {
         if !peers.is_empty() {
             return;
         }
-        assert!(
-            Instant::now() < deadline,
-            "node never reported a connected peer"
-        );
+        if Instant::now() >= deadline {
+            panic!("node never reported a connected peer; last_peers={peers:?}");
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
@@ -619,10 +626,10 @@ async fn wait_for_request(node: &EmbeddedNode, request_id: &str) -> AgentRequest
         if let Some(request) = fetch_child_request_optional(node, request_id).await {
             return request;
         }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "request {request_id} was not replicated"
-        );
+        if tokio::time::Instant::now() >= deadline {
+            let diagnostic = agent_request_diagnostic(node).await;
+            panic!("request {request_id} was not replicated; {diagnostic}");
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
@@ -637,10 +644,10 @@ async fn wait_for_tool_call(
         if let Some(tool_call) = fetch_tool_call_optional(node, session_id, tool_call_id).await {
             return tool_call;
         }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "tool call {tool_call_id} was not replicated"
-        );
+        if tokio::time::Instant::now() >= deadline {
+            let diagnostic = agent_tool_call_diagnostic(node).await;
+            panic!("tool call {tool_call_id} was not replicated; {diagnostic}");
+        }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
@@ -651,12 +658,55 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
         if let Some(child) = fetch_child_request_optional(node, child_request_id).await {
             return child;
         }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "child request {child_request_id} was not materialized"
-        );
+        if tokio::time::Instant::now() >= deadline {
+            let diagnostic = agent_request_diagnostic(node).await;
+            panic!("child request {child_request_id} was not materialized; {diagnostic}");
+        }
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+}
+
+async fn agent_request_diagnostic(node: &EmbeddedNode) -> String {
+    let response = node
+        .execute(
+            r#"{
+                AgentRequest {
+                    request_id
+                    agent_did
+                    behavior_id
+                    caused_by_parent_request_id
+                    caused_by_parent_tool_call_id
+                    caused_by_trigger_id
+                    caused_by_trigger_kind
+                }
+            }"#,
+        )
+        .await;
+    format!(
+        "AgentRequest errors={:?} data={:?}",
+        response.errors, response.data
+    )
+}
+
+async fn agent_tool_call_diagnostic(node: &EmbeddedNode) -> String {
+    let response = node
+        .execute(
+            r#"{
+                AgentToolCall {
+                    request_id
+                    session_id
+                    tool_name
+                    tool_call_id
+                    lifecycle_state
+                    child_request_id
+                }
+            }"#,
+        )
+        .await;
+    format!(
+        "AgentToolCall errors={:?} data={:?}",
+        response.errors, response.data
+    )
 }
 
 fn assert_bridge_matches_case(

--- a/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/r5_cross_deployment.rs
@@ -1,0 +1,800 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{
+    default_behavior_id_for_agent, load_agent_behavior, upsert_agent_behavior,
+    upsert_tool_selection, AgentBehaviorDocument, AgentIdentity, DefraAgent, DefraSessionHook,
+    DocumentRuntimeOptions, FailurePolicy, ToolCeiling, ToolSelectionDocument,
+};
+use rig::agent::{PromptHook, ToolCallHookAction};
+use rig::completion::{CompletionError, CompletionModel, CompletionRequest, CompletionResponse};
+use rig::streaming::StreamingCompletionResponse;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::lean_vocab_test::{lean_r5_cross_deployment_cases, LeanR5CrossDeploymentCase};
+use crate::support::fixtures::{bind_default_behavior_backend, test_identity};
+use crate::support::interrupt::{wait_for_runtime_ready, BootedAgent};
+use crate::support::mock_endpoint::MockModelEndpoint;
+use crate::support::{first_optional_row, first_row, test_db, TestDb};
+
+const PARENT_AGENT_DID: &str = "did:defra-agent:r5-lean-parent";
+
+#[derive(Clone, Default)]
+struct R5DispatchTestModel;
+
+#[allow(refining_impl_trait)]
+impl CompletionModel for R5DispatchTestModel {
+    type Response = ();
+    type StreamingResponse = ();
+    type Client = ();
+
+    fn make(_: &Self::Client, _: impl Into<String>) -> Self {
+        Self
+    }
+
+    async fn completion(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<CompletionResponse<Self::Response>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "completion is unused in R5 dispatch conformance".to_string(),
+        ))
+    }
+
+    async fn stream(
+        &self,
+        _request: CompletionRequest,
+    ) -> Result<StreamingCompletionResponse<Self::StreamingResponse>, CompletionError> {
+        Err(CompletionError::ProviderError(
+            "streaming is unused in R5 dispatch conformance".to_string(),
+        ))
+    }
+}
+
+struct RunningChildAgent {
+    db: TestDb,
+    booted: BootedAgent,
+    _endpoint: MockModelEndpoint,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallRow {
+    request_id: String,
+    session_id: String,
+    tool_call_key: String,
+    message_sequence: Option<i64>,
+    tool_name: String,
+    tool_call_id: String,
+    args: String,
+    result: Option<String>,
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    started_at: Option<String>,
+    deadline_at: Option<String>,
+    await_mode: Option<String>,
+    cancel_policy: Option<String>,
+    child_request_id: Option<String>,
+    unclaimed_deadline_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentRequestRow {
+    request_id: String,
+    agent_did: String,
+    behavior_id: String,
+    session_id: String,
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    content: Option<String>,
+    created_at: Option<String>,
+    deadline: Option<String>,
+    subagent_depth: Option<i64>,
+    caused_by_parent_request_id: Option<String>,
+    caused_by_parent_tool_call_id: Option<String>,
+    caused_by_trigger_id: Option<String>,
+    caused_by_trigger_kind: Option<String>,
+}
+
+pub(super) async fn generated_r5_cross_deployment_cases_drive_production_dispatch() {
+    let cases = lean_r5_cross_deployment_cases();
+    assert_eq!(cases.len(), 2, "Lean should emit cross and local R5 rows");
+
+    for case in cases {
+        assert_eq!(case.action.as_str(), "spawn_subagent", "{}", case.name);
+        assert_eq!(case.await_mode.as_str(), "background", "{}", case.name);
+        assert_eq!(case.cancel_policy.as_str(), "cascade", "{}", case.name);
+        assert_eq!(
+            case.child_request_id.as_str(),
+            "runtime_generated",
+            "{}",
+            case.name
+        );
+
+        if case.cross_deployment_routing_fired {
+            drive_cross_deployment_case(case).await;
+        } else {
+            drive_single_deployment_case(case).await;
+        }
+    }
+}
+
+async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
+    assert_eq!(case.route.as_str(), "cross_deployment", "{}", case.name);
+    assert_ne!(
+        case.parent_deployment, case.child_deployment,
+        "{} should cross deployments",
+        case.name
+    );
+
+    let child_agent = boot_child_agent(case).await;
+    let (parent_db, hook, parent_session_id, _parent_behavior_id) =
+        setup_parent_hook(case, false).await;
+
+    let child_request_id = spawn_from_parent_hook(case, &hook).await;
+    assert!(
+        fetch_child_request_optional(parent_db.node.as_ref(), &child_request_id)
+            .await
+            .is_none(),
+        "{}: A must persist the bridge without materializing B's child request",
+        case.name
+    );
+
+    let bridge = fetch_tool_call(
+        parent_db.node.as_ref(),
+        &parent_session_id,
+        &case.parent_tool_call_id,
+    )
+    .await;
+    assert_bridge_matches_case(case, &bridge, &child_request_id);
+
+    replicate_parent_request(parent_db.node.as_ref(), child_agent.db.node.as_ref(), case).await;
+    replicate_tool_call_to_child_node(&bridge, child_agent.db.node.as_ref()).await;
+
+    let child = wait_for_child_request(child_agent.db.node.as_ref(), &child_request_id).await;
+    assert_child_matches_case(case, &child, &child_request_id);
+    assert_eq!(
+        child.agent_did, child_agent.booted.agent_did,
+        "{}: cross-deployment child must be locally owned by B",
+        case.name
+    );
+    assert!(case.child_owned_by_target_deployment, "{}", case.name);
+
+    child_agent.booted.shutdown().await;
+}
+
+async fn drive_single_deployment_case(case: &LeanR5CrossDeploymentCase) {
+    assert_eq!(case.route.as_str(), "single_deployment", "{}", case.name);
+    assert_eq!(
+        case.parent_deployment, case.child_deployment,
+        "{} should stay on one deployment",
+        case.name
+    );
+    assert!(case.single_deployment_fallback, "{}", case.name);
+
+    let (parent_db, hook, parent_session_id, _parent_behavior_id) =
+        setup_parent_hook(case, true).await;
+    let child_request_id = spawn_from_parent_hook(case, &hook).await;
+
+    let bridge = fetch_tool_call(
+        parent_db.node.as_ref(),
+        &parent_session_id,
+        &case.parent_tool_call_id,
+    )
+    .await;
+    assert_bridge_matches_case(case, &bridge, &child_request_id);
+
+    let child = wait_for_child_request(parent_db.node.as_ref(), &child_request_id).await;
+    assert_child_matches_case(case, &child, &child_request_id);
+    assert_eq!(
+        child.agent_did, PARENT_AGENT_DID,
+        "{}: same-deployment fallback should keep child ownership local",
+        case.name
+    );
+}
+
+async fn boot_child_agent(case: &LeanR5CrossDeploymentCase) -> RunningChildAgent {
+    let db = test_db(&format!("{}-child", case.name)).await;
+    write_pairing(db.node.as_ref(), "deployment-a", PARENT_AGENT_DID).await;
+
+    let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity(&format!("{}-child", case.name)));
+    let child_agent_did = identity.did().to_string();
+    let default_behavior_id = default_behavior_id_for_agent(&child_agent_did);
+    let endpoint = MockModelEndpoint::start("default").expect("mock endpoint");
+    bind_default_behavior_backend(
+        db.node.as_ref(),
+        &child_agent_did,
+        &format!("{}-backend", case.name),
+        endpoint.endpoint(),
+    )
+    .await;
+    upsert_active_child_behavior_from_default(
+        db.node.as_ref(),
+        &default_behavior_id,
+        &case.target_behavior_id,
+    )
+    .await;
+
+    let agent = DefraAgent::from_default_behavior_documents(
+        db.node.clone(),
+        identity,
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("child agent");
+    let child_agent_did = agent.agent_did().to_string();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(agent.run(shutdown_rx));
+    wait_for_runtime_ready(db.node.as_ref(), &child_agent_did).await;
+
+    RunningChildAgent {
+        db,
+        booted: BootedAgent::new(shutdown_tx, handle, child_agent_did),
+        _endpoint: endpoint,
+    }
+}
+
+async fn setup_parent_hook(
+    case: &LeanR5CrossDeploymentCase,
+    target_is_local: bool,
+) -> (TestDb, DefraSessionHook, String, String) {
+    let db = test_db(&format!("{}-parent", case.name)).await;
+    let parent_behavior_id = format!("{}-parent-behavior", case.name);
+    let parent_session_id = format!("{}-session", case.parent_request_id);
+    let selection_id = format!("{parent_behavior_id}-tools");
+
+    upsert_tool_selection(
+        db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: selection_id.clone(),
+            agent_did: PARENT_AGENT_DID.to_string(),
+            subagent_targets: Some(vec![case.target_behavior_id.clone()]),
+            subagent_spawn_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            cross_deployment_spawn_timeout_seconds: Some(60),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("parent tool selection");
+    upsert_agent_behavior(
+        db.node.as_ref(),
+        &AgentBehaviorDocument {
+            behavior_id: parent_behavior_id.clone(),
+            agent_did: PARENT_AGENT_DID.to_string(),
+            display_name: Some(parent_behavior_id.clone()),
+            system_prompt: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some(selection_id),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            enabled: true,
+            created_at: Some("2026-05-20T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .expect("parent behavior");
+
+    if target_is_local {
+        upsert_agent_behavior(
+            db.node.as_ref(),
+            &AgentBehaviorDocument {
+                behavior_id: case.target_behavior_id.clone(),
+                agent_did: PARENT_AGENT_DID.to_string(),
+                display_name: Some(case.target_behavior_id.clone()),
+                system_prompt: None,
+                backend_id: None,
+                model_name: None,
+                tool_selection_id: None,
+                inference_profile_id: None,
+                compaction_strategy: None,
+                compaction_threshold: None,
+                enabled: true,
+                created_at: Some("2026-05-20T00:00:01Z".to_string()),
+            },
+        )
+        .await
+        .expect("local child behavior");
+    }
+
+    create_parent_request(
+        db.node.as_ref(),
+        &case.parent_request_id,
+        &parent_session_id,
+        &parent_behavior_id,
+    )
+    .await;
+
+    let hook = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        &parent_session_id,
+        &parent_behavior_id,
+        PARENT_AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .expect("parent hook");
+    hook.set_active_request_id(Some(case.parent_request_id.clone()))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::minutes(5)))
+        .await;
+
+    (db, hook, parent_session_id, parent_behavior_id)
+}
+
+async fn spawn_from_parent_hook(
+    case: &LeanR5CrossDeploymentCase,
+    hook: &DefraSessionHook,
+) -> String {
+    let args = json!({
+        "behavior_id": case.target_behavior_id.as_str(),
+        "prompt": format!("child prompt for {}", case.name),
+        "await_mode": case.await_mode.as_str()
+    })
+    .to_string();
+
+    let action = PromptHook::<R5DispatchTestModel>::on_tool_call(
+        hook,
+        &case.action,
+        Some(format!("model-{}", case.parent_tool_call_id)),
+        &case.parent_tool_call_id,
+        &args,
+    )
+    .await;
+    let receipt = skip_reason_json(action);
+    assert_eq!(receipt["ok"], true, "{}", case.name);
+    assert_eq!(
+        receipt["behavior_id"].as_str(),
+        Some(case.target_behavior_id.as_str()),
+        "{}",
+        case.name
+    );
+    assert_eq!(
+        receipt["await_mode"].as_str(),
+        Some(case.await_mode.as_str()),
+        "{}",
+        case.name
+    );
+    assert_eq!(receipt["status"], "running", "{}", case.name);
+    receipt["child_request_id"]
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| panic!("{}: spawn receipt omitted child_request_id", case.name))
+        .to_string()
+}
+
+async fn upsert_active_child_behavior_from_default(
+    node: &EmbeddedNode,
+    default_behavior_id: &str,
+    target_behavior_id: &str,
+) {
+    let mut behavior = load_agent_behavior(node, default_behavior_id)
+        .await
+        .expect("load default child behavior")
+        .expect("default child behavior");
+    behavior.behavior_id = target_behavior_id.to_string();
+    behavior.display_name = Some(target_behavior_id.to_string());
+    behavior.tool_selection_id = None;
+    upsert_agent_behavior(node, &behavior)
+        .await
+        .expect("upsert target child behavior");
+}
+
+async fn create_parent_request(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    behavior_id: &str,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let session_id = escape_graphql_string(session_id);
+    let behavior_id = escape_graphql_string(behavior_id);
+    let agent_did = escape_graphql_string(PARENT_AGENT_DID);
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let deadline = (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}",
+                session_id: "{session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{request_id}",
+                superseded_by_request: "",
+                content: "R5 parent prompt",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "{created_at}",
+                deadline: "{deadline}",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    exec(node, &mutation, "create parent AgentRequest").await;
+}
+
+async fn write_pairing(node: &EmbeddedNode, peer_id: &str, peer_agent_did: &str) {
+    let peer_id = escape_graphql_string(peer_id);
+    let peer_agent_did = escape_graphql_string(peer_agent_did);
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            upsert_PeerPairingDesired(
+                filter: {{ peer_id: {{ _eq: "{peer_id}" }} }},
+                add: {{
+                    peer_id: "{peer_id}",
+                    agent_did: "{peer_agent_did}",
+                    collections: ["AgentRequest", "AgentToolCall"],
+                    replicator_addresses: [],
+                    created_at: "{now}",
+                    updated_at: "{now}"
+                }},
+                update: {{
+                    agent_did: "{peer_agent_did}",
+                    collections: ["AgentRequest", "AgentToolCall"],
+                    replicator_addresses: [],
+                    updated_at: "{now}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(node, &mutation, "write PeerPairingDesired").await;
+}
+
+async fn replicate_parent_request(
+    from: &EmbeddedNode,
+    to: &EmbeddedNode,
+    case: &LeanR5CrossDeploymentCase,
+) {
+    let parent = fetch_request(from, &case.parent_request_id).await;
+    let request_id = escape_graphql_string(&parent.request_id);
+    let agent_did = escape_graphql_string(&parent.agent_did);
+    let behavior_id = escape_graphql_string(&parent.behavior_id);
+    let session_id = escape_graphql_string(&parent.session_id);
+    let status = escape_graphql_string(parent.status.as_deref().unwrap_or("processing"));
+    let lifecycle_state =
+        escape_graphql_string(parent.lifecycle_state.as_deref().unwrap_or("processing"));
+    let content = escape_graphql_string(parent.content.as_deref().unwrap_or(""));
+    let created_at = escape_graphql_string(
+        parent
+            .created_at
+            .as_deref()
+            .unwrap_or("2026-05-20T00:00:00Z"),
+    );
+    let deadline =
+        escape_graphql_string(parent.deadline.as_deref().unwrap_or("2026-05-20T00:05:00Z"));
+    let subagent_depth = parent.subagent_depth.unwrap_or(0);
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                add: {{
+                    request_id: "{request_id}",
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    session_id: "{session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{request_id}",
+                    superseded_by_request: "",
+                    content: "{content}",
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    metadata: "",
+                    failure_reason: "",
+                    created_at: "{created_at}",
+                    deadline: "{deadline}",
+                    retry_count: 0,
+                    max_retries: 3,
+                    subagent_depth: {subagent_depth}
+                }},
+                update: {{
+                    agent_did: "{agent_did}",
+                    behavior_id: "{behavior_id}",
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}",
+                    subagent_depth: {subagent_depth}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(to, &mutation, "replicate parent AgentRequest").await;
+}
+
+async fn replicate_tool_call_to_child_node(bridge: &ToolCallRow, to: &EmbeddedNode) {
+    let tool_call_key = escape_graphql_string(&bridge.tool_call_key);
+    let request_id = escape_graphql_string(&bridge.request_id);
+    let session_id = escape_graphql_string(&bridge.session_id);
+    let tool_name = escape_graphql_string(&bridge.tool_name);
+    let tool_call_id = escape_graphql_string(&bridge.tool_call_id);
+    let args = escape_graphql_string(&bridge.args);
+    let result = escape_graphql_string(bridge.result.as_deref().unwrap_or(""));
+    let status = escape_graphql_string(bridge.status.as_deref().unwrap_or("called"));
+    let lifecycle_state =
+        escape_graphql_string(bridge.lifecycle_state.as_deref().unwrap_or("running"));
+    let started_at = escape_graphql_string(
+        bridge
+            .started_at
+            .as_deref()
+            .unwrap_or("2026-05-20T00:00:00Z"),
+    );
+    let deadline_at = escape_graphql_string(
+        bridge
+            .deadline_at
+            .as_deref()
+            .unwrap_or("2026-05-20T00:05:00Z"),
+    );
+    let await_mode = escape_graphql_string(bridge.await_mode.as_deref().unwrap_or("background"));
+    let cancel_policy = escape_graphql_string(bridge.cancel_policy.as_deref().unwrap_or("cascade"));
+    let child_request_id = escape_graphql_string(bridge.child_request_id.as_deref().unwrap_or(""));
+    let message_sequence = bridge.message_sequence.unwrap_or(1);
+    let unclaimed = bridge
+        .unclaimed_deadline_at
+        .as_deref()
+        .map(|value| {
+            format!(
+                r#", unclaimed_deadline_at: "{}""#,
+                escape_graphql_string(value)
+            )
+        })
+        .unwrap_or_default();
+
+    let mutation = format!(
+        r#"mutation {{
+            upsert_AgentToolCall(
+                filter: {{ tool_call_key: {{ _eq: "{tool_call_key}" }} }},
+                add: {{
+                    tool_call_key: "{tool_call_key}",
+                    request_id: "{request_id}",
+                    session_id: "{session_id}",
+                    message_sequence: {message_sequence},
+                    tool_name: "{tool_name}",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{args}",
+                    result: "{result}",
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    await_mode: "{await_mode}",
+                    cancel_policy: "{cancel_policy}",
+                    child_request_id: "{child_request_id}"
+                    {unclaimed}
+                }},
+                update: {{
+                    result: "{result}",
+                    status: "{status}",
+                    lifecycle_state: "{lifecycle_state}",
+                    started_at: "{started_at}",
+                    deadline_at: "{deadline_at}",
+                    await_mode: "{await_mode}",
+                    cancel_policy: "{cancel_policy}",
+                    child_request_id: "{child_request_id}"
+                    {unclaimed}
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    exec(to, &mutation, "replicate AgentToolCall").await;
+}
+
+async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &str) -> ToolCallRow {
+    let session_id = escape_graphql_string(session_id);
+    let tool_call_id = escape_graphql_string(tool_call_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    session_id: {{ _eq: "{session_id}" }},
+                    tool_call_id: {{ _eq: "{tool_call_id}" }}
+                }},
+                limit: 1
+            ) {{
+                request_id
+                session_id
+                tool_call_key
+                message_sequence
+                tool_name
+                tool_call_id
+                args
+                result
+                status
+                lifecycle_state
+                started_at
+                deadline_at
+                await_mode
+                cancel_policy
+                child_request_id
+                unclaimed_deadline_at
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentToolCall")
+}
+
+async fn fetch_request(node: &EmbeddedNode, request_id: &str) -> AgentRequestRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                request_id
+                agent_did
+                behavior_id
+                session_id
+                status
+                lifecycle_state
+                content
+                created_at
+                deadline
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+                caused_by_trigger_id
+                caused_by_trigger_kind
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn fetch_child_request_optional(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Option<AgentRequestRow> {
+    let child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(filter: {{ request_id: {{ _eq: "{child_request_id}" }} }}, limit: 1) {{
+                request_id
+                agent_did
+                behavior_id
+                session_id
+                status
+                lifecycle_state
+                content
+                created_at
+                deadline
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+                caused_by_trigger_id
+                caused_by_trigger_kind
+            }}
+        }}"#
+    );
+    first_optional_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> AgentRequestRow {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Some(child) = fetch_child_request_optional(node, child_request_id).await {
+            return child;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "child request {child_request_id} was not materialized"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+fn assert_bridge_matches_case(
+    case: &LeanR5CrossDeploymentCase,
+    bridge: &ToolCallRow,
+    child_request_id: &str,
+) {
+    assert!(case.parent_trigger_persisted, "{}", case.name);
+    assert_eq!(
+        bridge.request_id, case.parent_request_id,
+        "{}: bridge parent request",
+        case.name
+    );
+    assert_eq!(
+        bridge.tool_call_id, case.parent_tool_call_id,
+        "{}: bridge tool id",
+        case.name
+    );
+    assert_eq!(bridge.tool_name, "spawn_subagent", "{}", case.name);
+    assert_eq!(
+        bridge.lifecycle_state.as_deref(),
+        Some("running"),
+        "{}",
+        case.name
+    );
+    assert_eq!(
+        bridge.await_mode.as_deref(),
+        Some(case.await_mode.as_str()),
+        "{}",
+        case.name
+    );
+    assert_eq!(
+        bridge.cancel_policy.as_deref(),
+        Some(case.cancel_policy.as_str()),
+        "{}",
+        case.name
+    );
+    assert_eq!(
+        bridge.child_request_id.as_deref(),
+        Some(child_request_id),
+        "{}: bridge child_request_id",
+        case.name
+    );
+    assert_eq!(
+        bridge.unclaimed_deadline_at.is_some(),
+        case.unclaimed_deadline_set,
+        "{}: unclaimed deadline",
+        case.name
+    );
+}
+
+fn assert_child_matches_case(
+    case: &LeanR5CrossDeploymentCase,
+    child: &AgentRequestRow,
+    child_request_id: &str,
+) {
+    assert!(case.child_materialized, "{}", case.name);
+    assert_eq!(child.request_id, child_request_id, "{}", case.name);
+    assert_eq!(
+        child.behavior_id, case.target_behavior_id,
+        "{}: child target behavior",
+        case.name
+    );
+    assert_eq!(
+        child.caused_by_parent_request_id.as_deref(),
+        case.caused_by_parent_request_id_matches
+            .then_some(case.parent_request_id.as_str()),
+        "{}: parent request linkage",
+        case.name
+    );
+    assert_eq!(
+        child.caused_by_parent_tool_call_id.as_deref(),
+        case.caused_by_parent_tool_call_id_matches
+            .then_some(case.parent_tool_call_id.as_str()),
+        "{}: parent tool linkage",
+        case.name
+    );
+    assert_eq!(
+        child.caused_by_trigger_id.as_deref(),
+        Some(case.parent_tool_call_id.as_str()),
+        "{}: trigger id linkage",
+        case.name
+    );
+    assert_eq!(
+        child.caused_by_trigger_kind.as_deref(),
+        Some(case.caused_by_trigger_kind.as_str()),
+        "{}: trigger kind linkage",
+        case.name
+    );
+}
+
+fn skip_reason_json(action: ToolCallHookAction) -> Value {
+    let ToolCallHookAction::Skip { reason } = action else {
+        panic!("expected Skip action, got {action:?}");
+    };
+    serde_json::from_str(&reason).expect("skip reason should be JSON")
+}
+
+async fn exec(node: &EmbeddedNode, statement: &str, context: &str) {
+    let response = node.execute(statement).await;
+    assert!(
+        !response.has_errors(),
+        "{context} failed: {:?}\n{statement}",
+        response.errors
+    );
+}

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -294,6 +294,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_r6_backgrounding_cases_pin_tool_backgrounding_contract",
         },
         ConformanceConsumer::RustTest {
+            id: "state_machine_conformance::generated_r5_cross_deployment_cases_drive_production_dispatch",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/state_machine_conformance.rs",
+            module_path: "state_machine_conformance",
+            function: "generated_r5_cross_deployment_cases_drive_production_dispatch",
+        },
+        ConformanceConsumer::RustTest {
             id: "state_machine_conformance::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/state_machine_conformance.rs",

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use defra_agent::defra_node::{EmbeddedNode, QueryResponse};
+use defra_agent::defra_node::{EmbeddedNode, P2PConfig, QueryResponse};
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::{ensure_runtime_schemas, watcher::AgentRequest};
 use serde::Deserialize;
@@ -41,6 +41,39 @@ pub async fn test_db(name: &str) -> TestDb {
             .build()
             .await
             .expect("embedded node"),
+    );
+    ensure_runtime_schemas(&node)
+        .await
+        .expect("runtime schemas");
+    TestDb {
+        node,
+        _tempdir: tempdir,
+    }
+}
+
+pub async fn test_p2p_db(name: &str) -> TestDb {
+    let tempdir = tempfile::Builder::new()
+        .prefix(&format!("defra-agent-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let node = Arc::new(
+        EmbeddedNode::builder()
+            .data_path(tempdir.path())
+            .with_p2p(P2PConfig {
+                port: 0,
+                bind_addr: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
+                relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
+                discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+                secret_key_path: None,
+                load_persisted_collections: false,
+                max_concurrent_dag_fetches: p2p::sync::DEFAULT_MAX_CONCURRENT_DAG_FETCHES,
+                max_concurrent_push_tasks: p2p::sync::DEFAULT_MAX_CONCURRENT_PUSH_TASKS,
+                rate_limit_burst: p2p::sync::DEFAULT_RATE_LIMIT_BURST,
+                rate_limit_rate: p2p::sync::DEFAULT_RATE_LIMIT_RATE,
+            })
+            .build()
+            .await
+            .expect("embedded p2p node"),
     );
     ensure_runtime_schemas(&node)
         .await


### PR DESCRIPTION
Closes #273.

Summary:
- Add R5 cross-deployment and single-deployment fallback Lean witness rows.
- Export the rows through the Lean contract snapshot and Rust Lean vocab layer.
- Add a state_machine_conformance consumer that drives spawn_subagent through the production R5 dispatch path.
- Install real embedded P2P replicators for the cross-deployment leg so A's AgentRequest/AgentToolCall writes propagate to B before B's production SubagentSource materializes the child request.
- Promote subagents-cross-deployment.agentFacing from #273 deferred coverage to consumerCoverage.

Verification:
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance