### PR TITLE
CLI: mcp probe (#279)

### DIFF
--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -10,6 +10,10 @@ autobins = false
 name = "defra-agent"
 path = "src/main.rs"
 
+[[bin]]
+name = "defra-agent-cli"
+path = "src/main.rs"
+
 [dependencies]
 anyhow.workspace = true
 axum = "0.8"

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -10,10 +10,6 @@ autobins = false
 name = "defra-agent"
 path = "src/main.rs"
 
-[[bin]]
-name = "defra-agent-cli"
-path = "src/main.rs"
-
 [dependencies]
 anyhow.workspace = true
 axum = "0.8"

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -11,9 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     BACKGROUND_AFTER_HELP, CHAT_AFTER_HELP, CLI_AFTER_HELP, CONFIG_AFTER_HELP,
     CONFIG_EXPORT_AFTER_HELP, CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP,
-    INIT_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP, RESET_AFTER_HELP,
-    RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP,
-    SUBAGENT_AFTER_HELP, SUBAGENT_LIST_AFTER_HELP, TRACE_AFTER_HELP,
+    INIT_AFTER_HELP, MCP_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP,
+    RESET_AFTER_HELP, RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP,
+    STATUS_AFTER_HELP, SUBAGENT_AFTER_HELP, SUBAGENT_LIST_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -77,6 +77,11 @@ pub(crate) enum Command {
     Background {
         #[command(subcommand)]
         command: BackgroundCommand,
+    },
+    #[command(about = "Probe registered MCP service health", after_help = MCP_AFTER_HELP)]
+    Mcp {
+        #[command(subcommand)]
+        command: McpCommand,
     },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
@@ -370,6 +375,41 @@ pub(crate) enum BackgroundCommand {
         after_help = BACKGROUND_AFTER_HELP
     )]
     List(BackgroundListArgs),
+}
+
+#[derive(Subcommand)]
+pub(crate) enum McpCommand {
+    #[command(
+        name = "probe",
+        about = "Run a one-shot health probe for registered MCP services",
+        after_help = MCP_AFTER_HELP
+    )]
+    Probe(McpProbeArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct McpProbeArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "GraphQL endpoint to read registry rows instead of local home state"
+    )]
+    pub(crate) graphql: Option<String>,
+    #[arg(long, action = ArgAction::SetTrue, help = "Probe every online MCP service")]
+    pub(crate) all: bool,
+    #[arg(long, default_value = "5s", value_name = "DURATION")]
+    pub(crate) timeout: String,
+    #[arg(long, value_enum, default_value_t = McpProbeOutput::Text)]
+    pub(crate) output: McpProbeOutput,
+    #[arg(value_name = "SERVICE")]
+    pub(crate) service: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum McpProbeOutput {
+    Text,
+    Json,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/commands/mcp.rs
+++ b/crates/defra-agent-cli/src/commands/mcp.rs
@@ -41,6 +41,9 @@ async fn mcp_probe(args: McpProbeArgs) -> Result<()> {
     let local_hostname = hostname::get()
         .map(|host| host.to_string_lossy().to_string())
         .unwrap_or_else(|_| "unknown".to_string());
+    // The CLI has no persisted local-subnet source today; this matches the
+    // server's default health-check runtime options unless a future subnet
+    // option is added there too.
     let snapshots = probe_services(services, timeout, &local_hostname, None).await;
     let report = McpProbeReport {
         generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
@@ -97,9 +100,38 @@ async fn probe_services(
     local_subnet: Option<&str>,
 ) -> Vec<McpProbeSnapshot> {
     let pool = McpPool::new();
-    let mut snapshots = Vec::with_capacity(services.len());
+    let mut handles = Vec::with_capacity(services.len());
     for service in services {
-        snapshots.push(probe_service(service, &pool, timeout, local_hostname, local_subnet).await);
+        let service_id = service.service_id.clone();
+        let pool = pool.clone();
+        let local_hostname = local_hostname.to_string();
+        let local_subnet = local_subnet.map(ToOwned::to_owned);
+        handles.push((
+            service_id,
+            tokio::spawn(async move {
+                probe_service(
+                    service,
+                    &pool,
+                    timeout,
+                    &local_hostname,
+                    local_subnet.as_deref(),
+                )
+                .await
+            }),
+        ));
+    }
+
+    let mut snapshots = Vec::with_capacity(handles.len());
+    for (service_id, handle) in handles {
+        match handle.await {
+            Ok(snapshot) => snapshots.push(snapshot),
+            Err(error) => snapshots.push(McpProbeSnapshot {
+                service: service_id,
+                health_state: HealthStatus::Unreachable.to_string(),
+                latency_ms: 0,
+                last_error: Some(format!("probe task failed: {error}")),
+            }),
+        }
     }
     snapshots
 }

--- a/crates/defra-agent-cli/src/commands/mcp.rs
+++ b/crates/defra-agent-cli/src/commands/mcp.rs
@@ -1,0 +1,253 @@
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use chrono::{SecondsFormat, Utc};
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{
+    run_health_check_cycle, HealthStatus, McpHealthCheckService, McpPool, ServiceHealthMap,
+};
+use serde::Serialize;
+
+use crate::cli::args::{McpCommand, McpProbeArgs, McpProbeOutput};
+use crate::config_writes::ConfigAccess;
+use crate::{
+    graphql_rows_or_empty_if_collection_missing, normalize_optional_string, parse_duration_suffix,
+    print_json, resolve_config_access,
+};
+
+pub(crate) async fn dispatch(command: McpCommand) -> Result<()> {
+    match command {
+        McpCommand::Probe(args) => mcp_probe(args).await,
+    }
+}
+
+async fn mcp_probe(args: McpProbeArgs) -> Result<()> {
+    let target = ProbeTarget::from_args(&args)?;
+    let timeout = parse_duration_suffix(&args.timeout)?;
+    if timeout.is_zero() {
+        anyhow::bail!("--timeout must be greater than zero");
+    }
+
+    let (access, _) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), false).await?;
+    let services = load_mcp_services(&access, target.service_id()).await?;
+    if matches!(target, ProbeTarget::Single(_)) && services.is_empty() {
+        anyhow::bail!(
+            "no online MCP service matched {}",
+            target.service_id().unwrap_or_default()
+        );
+    }
+
+    let local_hostname = hostname::get()
+        .map(|host| host.to_string_lossy().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    let snapshots = probe_services(services, timeout, &local_hostname, None).await;
+    let report = McpProbeReport {
+        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        timeout_ms: duration_ms(timeout),
+        count: snapshots.len(),
+        items: snapshots,
+    };
+
+    match args.output {
+        McpProbeOutput::Json => print_json(&serde_json::to_value(report)?),
+        McpProbeOutput::Text => {
+            print_probe_table(&report.items);
+            Ok(())
+        }
+    }
+}
+
+async fn load_mcp_services(
+    access: &ConfigAccess,
+    service_id: Option<&str>,
+) -> Result<Vec<McpHealthCheckService>> {
+    let registry_args = match service_id {
+        Some(service_id) => format!(
+            r#"filter: {{ _and: [{{ status: {{ _eq: "online" }} }}, {{ service_id: {{ _eq: "{}" }} }}] }}, limit: 1, order: {{ service_id: ASC }}"#,
+            escape_graphql_string(service_id)
+        ),
+        None => r#"filter: { status: { _eq: "online" } }, order: { service_id: ASC }"#.to_string(),
+    };
+    let query = format!(
+        r#"{{
+            ToolServiceRegistry({registry_args}) {{
+                service_id
+                hostname
+                tailscale_ip
+                lan_ip
+                mcp_port
+                mcp_path
+                updated_at
+            }}
+        }}"#
+    );
+    let rows = graphql_rows_or_empty_if_collection_missing(access, "ToolServiceRegistry", &query)
+        .await
+        .context("loading online MCP service registry rows")?;
+    rows.into_iter()
+        .map(|row| serde_json::from_value(row).context("parsing ToolServiceRegistry row"))
+        .collect()
+}
+
+async fn probe_services(
+    services: Vec<McpHealthCheckService>,
+    timeout: Duration,
+    local_hostname: &str,
+    local_subnet: Option<&str>,
+) -> Vec<McpProbeSnapshot> {
+    let pool = McpPool::new();
+    let mut snapshots = Vec::with_capacity(services.len());
+    for service in services {
+        snapshots.push(probe_service(service, &pool, timeout, local_hostname, local_subnet).await);
+    }
+    snapshots
+}
+
+async fn probe_service(
+    service: McpHealthCheckService,
+    pool: &McpPool,
+    timeout: Duration,
+    local_hostname: &str,
+    local_subnet: Option<&str>,
+) -> McpProbeSnapshot {
+    let service_id = service.service_id.clone();
+    let health_map = ServiceHealthMap::new();
+    let started = Instant::now();
+    let result = tokio::time::timeout(
+        timeout,
+        run_health_check_cycle(
+            vec![service],
+            Utc::now(),
+            pool,
+            &health_map,
+            local_hostname,
+            local_subnet,
+        ),
+    )
+    .await;
+    let latency_ms = elapsed_ms(started);
+
+    match result {
+        Ok(Ok(())) => match health_map.get(&service_id).await {
+            Some(health) => McpProbeSnapshot {
+                service: service_id,
+                health_state: health.status.to_string(),
+                latency_ms,
+                last_error: health.last_error,
+            },
+            None => McpProbeSnapshot {
+                service: service_id,
+                health_state: HealthStatus::Unreachable.to_string(),
+                latency_ms,
+                last_error: Some("probe produced no health snapshot".to_string()),
+            },
+        },
+        Ok(Err(error)) => McpProbeSnapshot {
+            service: service_id,
+            health_state: HealthStatus::Unreachable.to_string(),
+            latency_ms,
+            last_error: Some(error.to_string()),
+        },
+        Err(_) => McpProbeSnapshot {
+            service: service_id,
+            health_state: HealthStatus::Unreachable.to_string(),
+            latency_ms,
+            last_error: Some("probe timed out".to_string()),
+        },
+    }
+}
+
+fn print_probe_table(rows: &[McpProbeSnapshot]) {
+    let headers = ["SERVICE", "HEALTH_STATE", "LATENCY_MS", "LAST_ERROR"];
+    let rendered_rows = rows
+        .iter()
+        .map(|row| {
+            [
+                display_cell(&row.service),
+                display_cell(&row.health_state),
+                row.latency_ms.to_string(),
+                row.last_error.clone().unwrap_or_else(|| "-".to_string()),
+            ]
+        })
+        .collect::<Vec<_>>();
+    let mut widths = headers.map(str::len);
+    for row in &rendered_rows {
+        for (idx, cell) in row.iter().enumerate() {
+            widths[idx] = widths[idx].max(cell.len());
+        }
+    }
+
+    print_table_row(&headers.map(|header| header.to_string()), &widths);
+    print_table_row(&widths.map(|width| "-".repeat(width)), &widths);
+    for row in &rendered_rows {
+        print_table_row(row, &widths);
+    }
+}
+
+fn display_cell(value: &str) -> String {
+    if value.trim().is_empty() {
+        "-".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn print_table_row<const N: usize>(cells: &[String; N], widths: &[usize; N]) {
+    let line = cells
+        .iter()
+        .enumerate()
+        .map(|(idx, cell)| format!("{cell:<width$}", width = widths[idx]))
+        .collect::<Vec<_>>()
+        .join("  ");
+    println!("{line}");
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+enum ProbeTarget {
+    Single(String),
+    All,
+}
+
+impl ProbeTarget {
+    fn from_args(args: &McpProbeArgs) -> Result<Self> {
+        let service = normalize_optional_string(args.service.as_deref());
+        match (args.all, service) {
+            (true, None) => Ok(Self::All),
+            (false, Some(service_id)) => Ok(Self::Single(service_id)),
+            (true, Some(_)) => anyhow::bail!("provide either <service> or --all, not both"),
+            (false, None) => anyhow::bail!("provide a service id or --all"),
+        }
+    }
+
+    fn service_id(&self) -> Option<&str> {
+        match self {
+            Self::Single(service_id) => Some(service_id.as_str()),
+            Self::All => None,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct McpProbeReport {
+    generated_at: String,
+    timeout_ms: u64,
+    count: usize,
+    items: Vec<McpProbeSnapshot>,
+}
+
+#[derive(Serialize)]
+struct McpProbeSnapshot {
+    service: String,
+    health_state: String,
+    latency_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_error: Option<String>,
+}

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod chat;
 pub(crate) mod config;
 pub(crate) mod diagnose;
 pub(crate) mod init;
+pub(crate) mod mcp;
 pub(crate) mod p2p;
 pub(crate) mod provision;
 pub(crate) mod request;

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -66,6 +66,7 @@ Inspect the local runtime:
   defra-agent show runtime
   defra-agent show response REQUEST_ID
   defra-agent background list
+  defra-agent mcp probe --all
   defra-agent reset
 
 Update runtime documents:
@@ -164,6 +165,12 @@ Examples:
   defra-agent background list --request REQUEST_ID
   defra-agent background list --state running --age-gt 5m
   defra-agent background list --output json";
+const MCP_AFTER_HELP: &str = "\
+Examples:
+  defra-agent mcp probe SERVICE_ID
+  defra-agent mcp probe --all
+  defra-agent mcp probe SERVICE_ID --timeout 10s
+  defra-agent mcp probe --all --graphql http://127.0.0.1:9191/api/v0/graphql --output json";
 const SHOW_AFTER_HELP: &str = "\
 Examples:
   defra-agent show runtime
@@ -310,6 +317,7 @@ async fn main() -> Result<()> {
         Command::Trace { command } => commands::trace::dispatch(command).await,
         Command::Status(args) => commands::status::status(args).await,
         Command::Background { command } => commands::background::dispatch(command).await,
+        Command::Mcp { command } => commands::mcp::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Config { command } => commands::config::dispatch(command).await,
         Command::Request { command } => commands::request::dispatch(command).await,

--- a/crates/defra-agent-cli/tests/cli_mcp_probe.rs
+++ b/crates/defra-agent-cli/tests/cli_mcp_probe.rs
@@ -1,0 +1,106 @@
+mod support;
+use support::*;
+
+use anyhow::{Context, Result};
+use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+use defra_agent::ensure_runtime_schemas;
+use serde_json::Value;
+use uuid::Uuid;
+
+// Feature matrix tag: mcp-health / operatorCli.
+#[tokio::test]
+async fn mcp_probe_json_reports_health_snapshot_for_registry_service() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+    let service_id = format!("fixture-mcp-{}", Uuid::new_v4().simple());
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+        seed_unreachable_mcp_service(&node, &service_id).await?;
+    }
+
+    let agent_home = agent_home.to_str().context("agent home utf8")?;
+    let output = run_cli_json(
+        tempdir.path(),
+        &[
+            "mcp",
+            "probe",
+            "--home",
+            agent_home,
+            "--timeout",
+            "1s",
+            "--output",
+            "json",
+            &service_id,
+        ],
+    )?;
+
+    assert_eq!(output.get("count").and_then(Value::as_u64), Some(1));
+    let items = output
+        .get("items")
+        .and_then(Value::as_array)
+        .context("mcp probe output must include items")?;
+    let row = items.first().context("expected one MCP probe row")?;
+    assert_eq!(
+        row.get("service").and_then(Value::as_str),
+        Some(service_id.as_str())
+    );
+    assert_eq!(
+        row.get("health_state").and_then(Value::as_str),
+        Some("unreachable")
+    );
+    assert!(
+        row.get("latency_ms").and_then(Value::as_u64).is_some(),
+        "expected latency_ms in row: {row}"
+    );
+    assert!(
+        row.get("last_error")
+            .and_then(Value::as_str)
+            .is_some_and(|error| error.contains("missing mcp_port")),
+        "expected missing mcp_port error in row: {row}"
+    );
+
+    let table = run_cli_text(
+        tempdir.path(),
+        &["mcp", "probe", "--home", agent_home, &service_id],
+    )?;
+    assert!(
+        table.contains("SERVICE") && table.contains("HEALTH_STATE") && table.contains(&service_id),
+        "text output should include default MCP probe columns:\n{table}"
+    );
+
+    Ok(())
+}
+
+async fn seed_unreachable_mcp_service(node: &EmbeddedNode, service_id: &str) -> Result<()> {
+    let service_id = escape_graphql_string(service_id);
+    let mutation = format!(
+        r#"mutation {{
+            create_ToolServiceRegistry(input: {{
+                service_id: "{service_id}",
+                display_name: "Fixture MCP",
+                description: "MCP probe fixture",
+                hostname: "fixture-host",
+                tailscale_ip: "",
+                lan_ip: "",
+                mcp_port: 0,
+                mcp_path: "/mcp",
+                status: "online",
+                version: "test",
+                updated_at: "2026-05-20T12:00:00Z"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    if response.has_errors() {
+        anyhow::bail!("seed ToolServiceRegistry failed: {:?}", response.errors);
+    }
+    Ok(())
+}

--- a/crates/defra-agent-cli/tests/cli_mcp_probe.rs
+++ b/crates/defra-agent-cli/tests/cli_mcp_probe.rs
@@ -23,7 +23,7 @@ async fn mcp_probe_json_reports_health_snapshot_for_registry_service() -> Result
             .await
             .context("opening embedded node")?;
         ensure_runtime_schemas(&node).await?;
-        seed_unreachable_mcp_service(&node, &service_id).await?;
+        seed_mcp_service(&node, &service_id, "fixture-host", "", "", 0, "online").await?;
     }
 
     let agent_home = agent_home.to_str().context("agent home utf8")?;
@@ -79,20 +79,151 @@ async fn mcp_probe_json_reports_health_snapshot_for_registry_service() -> Result
     Ok(())
 }
 
-async fn seed_unreachable_mcp_service(node: &EmbeddedNode, service_id: &str) -> Result<()> {
+#[tokio::test]
+async fn mcp_probe_all_json_lists_each_online_service() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+    let missing_port_id = format!("a-fixture-mcp-{}", Uuid::new_v4().simple());
+    let missing_address_id = format!("b-fixture-mcp-{}", Uuid::new_v4().simple());
+    let offline_id = format!("z-fixture-mcp-{}", Uuid::new_v4().simple());
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+        seed_mcp_service(&node, &missing_port_id, "fixture-host", "", "", 0, "online").await?;
+        seed_mcp_service(&node, &missing_address_id, "", "", "", 9201, "online").await?;
+        seed_mcp_service(&node, &offline_id, "offline-host", "", "", 0, "offline").await?;
+    }
+
+    let agent_home = agent_home.to_str().context("agent home utf8")?;
+    let output = run_cli_json(
+        tempdir.path(),
+        &[
+            "mcp",
+            "probe",
+            "--home",
+            agent_home,
+            "--all",
+            "--timeout",
+            "1s",
+            "--output",
+            "json",
+        ],
+    )?;
+
+    assert_eq!(output.get("count").and_then(Value::as_u64), Some(2));
+    let items = output
+        .get("items")
+        .and_then(Value::as_array)
+        .context("mcp probe --all output must include items")?;
+    assert_eq!(
+        service_ids(items),
+        vec![missing_port_id.as_str(), missing_address_id.as_str()]
+    );
+    assert!(
+        items
+            .iter()
+            .all(|row| row.get("health_state").and_then(Value::as_str) == Some("unreachable")),
+        "all fixture rows should be unreachable: {items:?}"
+    );
+    assert_last_error_contains(&items[0], "missing mcp_port")?;
+    assert_last_error_contains(&items[1], "missing address fields")?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mcp_probe_single_missing_service_fails() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let agent_home = tempdir.path().join("agent-home");
+    let data_dir = agent_home.join("data");
+
+    {
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .context("opening embedded node")?;
+        ensure_runtime_schemas(&node).await?;
+    }
+
+    let agent_home = agent_home.to_str().context("agent home utf8")?;
+    let stderr = run_cli_failure_stderr(
+        tempdir.path(),
+        &["mcp", "probe", "--home", agent_home, "missing-service"],
+    )?;
+    assert!(
+        stderr.contains("no online MCP service matched missing-service"),
+        "missing service failure should identify the service:\n{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mcp_probe_rejects_zero_timeout() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let stderr =
+        run_cli_failure_stderr(tempdir.path(), &["mcp", "probe", "--all", "--timeout", "0"])?;
+    assert!(
+        stderr.contains("--timeout must be greater than zero"),
+        "zero timeout failure should explain the constraint:\n{stderr}"
+    );
+    Ok(())
+}
+
+fn service_ids(items: &[Value]) -> Vec<&str> {
+    items
+        .iter()
+        .filter_map(|row| row.get("service").and_then(Value::as_str))
+        .collect()
+}
+
+fn assert_last_error_contains(row: &Value, needle: &str) -> Result<()> {
+    let last_error = row
+        .get("last_error")
+        .and_then(Value::as_str)
+        .context("probe row missing last_error")?;
+    assert!(
+        last_error.contains(needle),
+        "expected last_error to contain {needle:?}, got {last_error:?}"
+    );
+    Ok(())
+}
+
+async fn seed_mcp_service(
+    node: &EmbeddedNode,
+    service_id: &str,
+    hostname: &str,
+    tailscale_ip: &str,
+    lan_ip: &str,
+    mcp_port: u16,
+    status: &str,
+) -> Result<()> {
     let service_id = escape_graphql_string(service_id);
+    let hostname = escape_graphql_string(hostname);
+    let tailscale_ip = escape_graphql_string(tailscale_ip);
+    let lan_ip = escape_graphql_string(lan_ip);
+    let status = escape_graphql_string(status);
     let mutation = format!(
         r#"mutation {{
             create_ToolServiceRegistry(input: {{
                 service_id: "{service_id}",
                 display_name: "Fixture MCP",
                 description: "MCP probe fixture",
-                hostname: "fixture-host",
-                tailscale_ip: "",
-                lan_ip: "",
-                mcp_port: 0,
+                hostname: "{hostname}",
+                tailscale_ip: "{tailscale_ip}",
+                lan_ip: "{lan_ip}",
+                mcp_port: {mcp_port},
                 mcp_path: "/mcp",
-                status: "online",
+                status: "{status}",
                 version: "test",
                 updated_at: "2026-05-20T12:00:00Z"
             }}) {{ _docID }}

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -169,11 +169,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
         ]
     }
   , { feature := "mcp-health"
-    , required := [Surface.runtimeInternal]
-    , deferred :=
-        [ (Surface.operatorUi, "#278")
-        , (Surface.operatorCli, "#279")
-        ]
+    , required := [Surface.runtimeInternal, Surface.operatorCli]
+    , deferred := [(Surface.operatorUi, "#278")]
     }
   , { feature := "identity-permission"
     , required := [Surface.runtimeInternal]
@@ -615,6 +612,11 @@ def caseCoverage : List CoverageEntry :=
       "health_checker::tests::generated_mcp_health_k1_cases_match_health_checker_transitions"
       "Issue #253 adds K>=2 MCPHealth backoff behavior in Rust and drops the lean_mcp_health_k1_cases() filter so the full emitted mcp_health_cases domain is consumed.")
       "mcp-health" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "mcp_health_cases"
+      "MCPHealthCases"
+      "cli_mcp_probe::mcp_probe_json_reports_health_snapshot_for_registry_service")
+      "mcp-health" [Surface.operatorCli]
   ]
 
 def followUpHookCoverage : List CoverageEntry :=

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -92,19 +92,21 @@ impl Default for ServiceHealthMap {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-struct RegistryServiceEntry {
-    service_id: String,
+pub struct McpHealthCheckService {
+    pub service_id: String,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
-    hostname: String,
+    pub hostname: String,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
-    tailscale_ip: String,
+    pub tailscale_ip: String,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
-    lan_ip: String,
-    mcp_port: Option<u16>,
+    pub lan_ip: String,
+    pub mcp_port: Option<u16>,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
-    mcp_path: String,
-    updated_at: Option<String>,
+    pub mcp_path: String,
+    pub updated_at: Option<String>,
 }
+
+type RegistryServiceEntry = McpHealthCheckService;
 
 pub fn spawn_health_checker(
     node: Arc<EmbeddedNode>,
@@ -201,8 +203,8 @@ async fn run_health_check(
 }
 
 // Production transition step once the registry query has supplied online rows.
-async fn run_health_check_cycle(
-    services: Vec<RegistryServiceEntry>,
+pub async fn run_health_check_cycle(
+    services: Vec<McpHealthCheckService>,
     now: DateTime<Utc>,
     mcp_pool: &McpPool,
     health_map: &ServiceHealthMap,

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -106,8 +106,6 @@ pub struct McpHealthCheckService {
     pub updated_at: Option<String>,
 }
 
-type RegistryServiceEntry = McpHealthCheckService;
-
 pub fn spawn_health_checker(
     node: Arc<EmbeddedNode>,
     mcp_pool: McpPool,
@@ -188,7 +186,7 @@ async fn run_health_check(
         .cloned()
         .unwrap_or_else(|| serde_json::Value::Array(Vec::new()));
 
-    let services: Vec<RegistryServiceEntry> =
+    let services: Vec<McpHealthCheckService> =
         serde_json::from_value(raw_services).context("parsing ToolServiceRegistry entries")?;
 
     run_health_check_cycle(
@@ -344,7 +342,7 @@ fn parse_updated_at(value: Option<&str>) -> Option<DateTime<Utc>> {
 // Inline test module preserved: single-test smoke check, deliberately not extracted to keep it co-located with the narrow code it tests.
 #[cfg(test)]
 mod registry_parsing_tests {
-    use super::RegistryServiceEntry;
+    use super::McpHealthCheckService;
     use serde_json::json;
 
     #[test]
@@ -359,7 +357,7 @@ mod registry_parsing_tests {
             "updated_at": null,
         });
 
-        let entry: RegistryServiceEntry =
+        let entry: McpHealthCheckService =
             serde_json::from_value(raw).expect("null address fields must parse");
 
         assert_eq!(entry.service_id, "observability-mcp");
@@ -383,7 +381,7 @@ mod registry_parsing_tests {
             }
         ]);
 
-        let entries: Vec<RegistryServiceEntry> =
+        let entries: Vec<McpHealthCheckService> =
             serde_json::from_value(raw).expect("null lan_ip must not fail the batch parse");
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].lan_ip, "");
@@ -397,7 +395,7 @@ mod transitions_tests {
     use rmcp::model::ListToolsResult;
 
     use super::{
-        run_health_check_cycle, HealthStatus, RegistryServiceEntry, ServiceHealth,
+        run_health_check_cycle, HealthStatus, McpHealthCheckService, ServiceHealth,
         ServiceHealthMap, STALENESS_THRESHOLD_SECS,
     };
     use crate::lean_vocab_test::{lean_mcp_health_k1_cases, LeanMcpHealthCase};
@@ -495,8 +493,8 @@ mod transitions_tests {
     fn registry_entry(
         service_id: &str,
         updated_at: chrono::DateTime<chrono::Utc>,
-    ) -> RegistryServiceEntry {
-        RegistryServiceEntry {
+    ) -> McpHealthCheckService {
+        McpHealthCheckService {
             service_id: service_id.to_string(),
             hostname: "remote-host".to_string(),
             tailscale_ip: "100.64.0.1".to_string(),

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -75,7 +75,10 @@ pub use document_config::{
     AgentBehavior as AgentBehaviorDocument, InferenceProfile, PrincipalBootstrap,
     ToolSelectionDocument,
 };
-pub use health_checker::{spawn_health_checker, HealthStatus, ServiceHealth, ServiceHealthMap};
+pub use health_checker::{
+    run_health_check_cycle, spawn_health_checker, HealthStatus, McpHealthCheckService,
+    ServiceHealth, ServiceHealthMap,
+};
 pub use hook::{BackgroundToolRegistry, DefraSessionHook, FailurePolicy, HookStats};
 pub use identity::{
     load_macos_keychain_identity, load_macos_secure_enclave_identity,

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -747,6 +747,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();
     let mut ledger_domains = BTreeSet::new();
+    let mut ledger_domain_surfaces = BTreeSet::new();
     let mut ledger_consumers = BTreeSet::new();
 
     for entry in &snapshot.coverage_ledger {
@@ -793,6 +794,19 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         }
 
         ledger_domains.insert((entry.category.clone(), entry.domain.clone()));
+        for surface in &entry.surfaces {
+            assert!(
+                ledger_domain_surfaces.insert((
+                    entry.category.clone(),
+                    entry.domain.clone(),
+                    *surface
+                )),
+                "duplicate coverage ledger entry for {:?} / {:?} / {:?}",
+                entry.category,
+                entry.domain,
+                surface
+            );
+        }
     }
 
     let missing = emitted

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -746,7 +746,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "follow_up_hook",
     ];
     let registered_consumers = assert_registered_conformance_consumers_resolve();
-    let mut ledger = BTreeSet::new();
+    let mut ledger_domains = BTreeSet::new();
     let mut ledger_consumers = BTreeSet::new();
 
     for entry in &snapshot.coverage_ledger {
@@ -792,23 +792,24 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             ledger_consumers.insert(entry.consumer.as_str());
         }
 
-        assert!(
-            ledger.insert((entry.category.clone(), entry.domain.clone())),
-            "duplicate coverage ledger entry for {:?} / {:?}",
-            entry.category,
-            entry.domain
-        );
+        ledger_domains.insert((entry.category.clone(), entry.domain.clone()));
     }
 
-    let missing = emitted.difference(&ledger).cloned().collect::<Vec<_>>();
-    let extra = ledger.difference(&emitted).cloned().collect::<Vec<_>>();
+    let missing = emitted
+        .difference(&ledger_domains)
+        .cloned()
+        .collect::<Vec<_>>();
+    let extra = ledger_domains
+        .difference(&emitted)
+        .cloned()
+        .collect::<Vec<_>>();
     assert!(
         missing.is_empty() && extra.is_empty(),
         "coverage ledger must exactly match emitted Lean contract domains\n  missing ledger entries: {:?}\n  extra ledger entries: {:?}\n  emitted: {:?}\n  ledger: {:?}",
         missing,
         extra,
         emitted,
-        ledger
+        ledger_domains
     );
     let unreferenced_consumers = registered_consumers
         .difference(&ledger_consumers)

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -119,6 +119,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_apply_reconcile_cases_fence_production_apply_write_boundary",
         },
         ConformanceConsumer::RustTest {
+            id: "cli_mcp_probe::mcp_probe_json_reports_health_snapshot_for_registry_service",
+            package: "defra-agent-cli",
+            source_path: "crates/defra-agent-cli/tests/cli_mcp_probe.rs",
+            module_path: "cli_mcp_probe",
+            function: "mcp_probe_json_reports_health_snapshot_for_registry_service",
+        },
+        ConformanceConsumer::RustTest {
             id: "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/backend_registry/tests.rs",


### PR DESCRIPTION
Closes #279.

## Summary
- Add `defra-agent mcp probe [SERVICE]` / `--all` with text and JSON output.
- Drive the existing K=1 `run_health_check_cycle` path from the CLI and report service health, latency, and last error.
- Add the CLI integration test and tag it in the coverage ledger under `mcp-health` / `operatorCli`.

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli mcp_probe`
- `cargo run --bin defra-agent-cli -- mcp probe --help`
- `cargo test -p defra-agent --test state_machine_conformance lean_feature_matrix_covers_every_declared_required_surface`
- `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain`