### PR TITLE
CLI: drive Lean trigger conformance via config task run (#282)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3593,6 +3593,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "crypto",
+ "defra-agent-lean-contract",
  "defra-agent-protocol",
  "defra-core",
  "defra-native-fs-runner",
@@ -3633,6 +3634,7 @@ dependencies = [
  "chrono",
  "clap",
  "defra-agent",
+ "defra-agent-lean-contract",
  "defra-agent-protocol",
  "defra-node",
  "defra-p2p-adapter",
@@ -3677,6 +3679,7 @@ dependencies = [
  "chrono",
  "crypto",
  "defra-agent",
+ "defra-agent-lean-contract",
  "defra-agent-protocol",
  "defra-node",
  "defra-p2p-adapter",
@@ -3704,6 +3707,7 @@ dependencies = [
  "clap",
  "defra-agent",
  "defra-agent-desktop-core",
+ "defra-agent-lean-contract",
  "defra-agent-protocol",
  "reqwest 0.12.28",
  "rig-core",
@@ -3717,6 +3721,15 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "defra-agent-lean-contract"
+version = "0.1.5"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/defra-agent-cli",
     "crates/defra-agent-desktop",
     "crates/defra-agent-desktop-core",
+    "crates/defra-agent-lean-contract",
     "crates/defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2",
     "crates/defra-agent-lenses/agent_subagent_v2_to_v3",
     "crates/defra-native-fs-runner",
@@ -40,6 +41,7 @@ crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.
 defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
+defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
 defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 dirs = "5"

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -32,4 +32,5 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+defra-agent-lean-contract.workspace = true
 rig-core.workspace = true

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -36,5 +36,6 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+defra-agent-lean-contract.workspace = true
 regex = "1"
 tempfile = "3"

--- a/crates/defra-agent-cli/tests/cli_config_task_run.rs
+++ b/crates/defra-agent-cli/tests/cli_config_task_run.rs
@@ -2,37 +2,14 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
 
-const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
-const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
-
-#[derive(Debug, Deserialize)]
-struct LeanTriggerContractSnapshot {
-    trigger_dispatch_case_count: usize,
-    trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
-}
-
-#[derive(Debug, Deserialize)]
-struct LeanTriggerDispatchCase {
-    name: String,
-    trigger_id: Option<String>,
-    trigger_kind: String,
-    concurrency: String,
-    expected_result: String,
-    expected_materialize_trigger_id: Option<String>,
-    expected_materialize_trigger_kind: Option<String>,
-    expected_execution_origin: Option<String>,
-    request_count_before: usize,
-    request_count_after: usize,
-}
+#[path = "../../defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
 
 /// End-to-end test for `defra-agent config task run --task-id --args`.
 ///
@@ -350,94 +327,15 @@ async fn config_task_run_rejects_disabled_task() -> Result<()> {
     Ok(())
 }
 
-fn lean_manual_dispatch_case() -> Result<LeanTriggerDispatchCase> {
-    let snapshot = load_lean_trigger_contract_snapshot()?;
+fn lean_manual_dispatch_case() -> Result<&'static lean_vocab_test::LeanTriggerDispatchCase> {
+    let cases = lean_vocab_test::lean_trigger_dispatch_cases();
     assert_eq!(
-        snapshot.trigger_dispatch_case_count,
-        snapshot.trigger_dispatch_cases.len(),
+        lean_vocab_test::lean_trigger_dispatch_case_count(),
+        cases.len(),
         "Lean trigger dispatch case-count sentinel drifted"
     );
-    snapshot
-        .trigger_dispatch_cases
-        .into_iter()
+    cases
+        .iter()
         .find(|case| case.name == "manual_unconditional")
         .ok_or_else(|| anyhow!("Lean TriggerDispatch contracts did not emit manual_unconditional"))
-}
-
-fn load_lean_trigger_contract_snapshot() -> Result<LeanTriggerContractSnapshot> {
-    let proofs_dir = proofs_dir()?;
-    let build = Command::new("lake")
-        .args(["build", "Proofs.Conformance.Contracts"])
-        .current_dir(&proofs_dir)
-        .output()
-        .with_context(|| {
-            format!(
-                "building Lean conformance contract target in {}",
-                proofs_dir.display()
-            )
-        })?;
-    if !build.status.success() {
-        anyhow::bail!(
-            "Lean conformance contract build failed\ncwd: {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
-            proofs_dir.display(),
-            build.status,
-            String::from_utf8_lossy(&build.stdout),
-            String::from_utf8_lossy(&build.stderr)
-        );
-    }
-
-    let output = Command::new("lake")
-        .args(["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"])
-        .current_dir(&proofs_dir)
-        .output()
-        .with_context(|| {
-            format!(
-                "running Lean conformance contract generator in {}",
-                proofs_dir.display()
-            )
-        })?;
-    if !output.status.success() {
-        anyhow::bail!(
-            "Lean conformance contract generator failed\ncwd: {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
-            proofs_dir.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let stdout = String::from_utf8(output.stdout).context("Lean stdout was not UTF-8")?;
-    let json = extract_contract_json(&stdout)?;
-    serde_json::from_str(json).context("parsing Lean conformance contract JSON")
-}
-
-fn proofs_dir() -> Result<PathBuf> {
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    for ancestor in manifest_dir.ancestors() {
-        let candidate = ancestor.join("crates/defra-agent/proofs");
-        if candidate.join("lakefile.lean").exists() {
-            return Ok(candidate);
-        }
-    }
-    anyhow::bail!(
-        "could not locate crates/defra-agent/proofs from {}",
-        manifest_dir.display()
-    )
-}
-
-fn extract_contract_json(stdout: &str) -> Result<&str> {
-    let begin = stdout
-        .find(CONTRACT_JSON_BEGIN)
-        .ok_or_else(|| anyhow!("Lean contract JSON begin marker missing"))?;
-    let end = stdout
-        .find(CONTRACT_JSON_END)
-        .ok_or_else(|| anyhow!("Lean contract JSON end marker missing"))?;
-    if begin >= end {
-        anyhow::bail!("Lean contract JSON markers are out of order");
-    }
-    let json = stdout[begin + CONTRACT_JSON_BEGIN.len()..end].trim();
-    if json.is_empty() {
-        anyhow::bail!("Lean contract JSON marker block is empty");
-    }
-    Ok(json)
 }

--- a/crates/defra-agent-cli/tests/cli_config_task_run.rs
+++ b/crates/defra-agent-cli/tests/cli_config_task_run.rs
@@ -2,11 +2,37 @@ mod support;
 use support::*;
 
 use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
 use serde_json::Value;
 use uuid::Uuid;
+
+const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
+const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
+
+#[derive(Debug, Deserialize)]
+struct LeanTriggerContractSnapshot {
+    trigger_dispatch_case_count: usize,
+    trigger_dispatch_cases: Vec<LeanTriggerDispatchCase>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LeanTriggerDispatchCase {
+    name: String,
+    trigger_id: Option<String>,
+    trigger_kind: String,
+    concurrency: String,
+    expected_result: String,
+    expected_materialize_trigger_id: Option<String>,
+    expected_materialize_trigger_kind: Option<String>,
+    expected_execution_origin: Option<String>,
+    request_count_before: usize,
+    request_count_after: usize,
+}
 
 /// End-to-end test for `defra-agent config task run --task-id --args`.
 ///
@@ -19,7 +45,27 @@ use uuid::Uuid;
 ///   * `lifecycle_state` created as `pending`, possibly already advanced by the daemon,
 ///   * the rendered content from `prompt_template` after binding `args.*`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn config_task_run_creates_manual_agent_request() -> Result<()> {
+async fn config_task_run_matches_lean_manual_dispatch_contract() -> Result<()> {
+    let lean_case = lean_manual_dispatch_case()?;
+    assert_eq!(lean_case.name, "manual_unconditional");
+    assert_eq!(lean_case.trigger_id, None);
+    assert_eq!(lean_case.trigger_kind, "manual");
+    assert_eq!(lean_case.concurrency, "parallel");
+    assert_eq!(lean_case.expected_result, "fired");
+    assert_eq!(lean_case.expected_materialize_trigger_id, None);
+    assert_eq!(
+        lean_case.expected_materialize_trigger_kind.as_deref(),
+        Some("manual")
+    );
+    assert_eq!(
+        lean_case.expected_execution_origin.as_deref(),
+        Some("interactive")
+    );
+    assert_eq!(
+        lean_case.request_count_after,
+        lean_case.request_count_before + 1
+    );
+
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     let root = tempdir.path().join("infra").join("agents").join("default");
@@ -179,17 +225,23 @@ async fn config_task_run_creates_manual_agent_request() -> Result<()> {
     );
     assert_eq!(
         row.get("execution_origin").and_then(Value::as_str),
-        Some("interactive")
+        lean_case.expected_execution_origin.as_deref()
     );
     assert_eq!(
         row.get("caused_by_trigger_kind").and_then(Value::as_str),
-        Some("manual")
+        lean_case.expected_materialize_trigger_kind.as_deref()
     );
-    assert!(
-        row.get("caused_by_trigger_id").is_some_and(Value::is_null),
-        "caused_by_trigger_id must be null for manual runs, got {:?}",
-        row.get("caused_by_trigger_id")
-    );
+    match lean_case.expected_materialize_trigger_id.as_deref() {
+        Some(expected_id) => assert_eq!(
+            row.get("caused_by_trigger_id").and_then(Value::as_str),
+            Some(expected_id)
+        ),
+        None => assert!(
+            row.get("caused_by_trigger_id").is_some_and(Value::is_null),
+            "caused_by_trigger_id must be null for manual runs, got {:?}",
+            row.get("caused_by_trigger_id")
+        ),
+    }
 
     Ok(())
 }
@@ -296,4 +348,96 @@ async fn config_task_run_rejects_disabled_task() -> Result<()> {
     );
 
     Ok(())
+}
+
+fn lean_manual_dispatch_case() -> Result<LeanTriggerDispatchCase> {
+    let snapshot = load_lean_trigger_contract_snapshot()?;
+    assert_eq!(
+        snapshot.trigger_dispatch_case_count,
+        snapshot.trigger_dispatch_cases.len(),
+        "Lean trigger dispatch case-count sentinel drifted"
+    );
+    snapshot
+        .trigger_dispatch_cases
+        .into_iter()
+        .find(|case| case.name == "manual_unconditional")
+        .ok_or_else(|| anyhow!("Lean TriggerDispatch contracts did not emit manual_unconditional"))
+}
+
+fn load_lean_trigger_contract_snapshot() -> Result<LeanTriggerContractSnapshot> {
+    let proofs_dir = proofs_dir()?;
+    let build = Command::new("lake")
+        .args(["build", "Proofs.Conformance.Contracts"])
+        .current_dir(&proofs_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "building Lean conformance contract target in {}",
+                proofs_dir.display()
+            )
+        })?;
+    if !build.status.success() {
+        anyhow::bail!(
+            "Lean conformance contract build failed\ncwd: {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            proofs_dir.display(),
+            build.status,
+            String::from_utf8_lossy(&build.stdout),
+            String::from_utf8_lossy(&build.stderr)
+        );
+    }
+
+    let output = Command::new("lake")
+        .args(["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"])
+        .current_dir(&proofs_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "running Lean conformance contract generator in {}",
+                proofs_dir.display()
+            )
+        })?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "Lean conformance contract generator failed\ncwd: {}\nstatus: {}\nstdout:\n{}\nstderr:\n{}",
+            proofs_dir.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let stdout = String::from_utf8(output.stdout).context("Lean stdout was not UTF-8")?;
+    let json = extract_contract_json(&stdout)?;
+    serde_json::from_str(json).context("parsing Lean conformance contract JSON")
+}
+
+fn proofs_dir() -> Result<PathBuf> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    for ancestor in manifest_dir.ancestors() {
+        let candidate = ancestor.join("crates/defra-agent/proofs");
+        if candidate.join("lakefile.lean").exists() {
+            return Ok(candidate);
+        }
+    }
+    anyhow::bail!(
+        "could not locate crates/defra-agent/proofs from {}",
+        manifest_dir.display()
+    )
+}
+
+fn extract_contract_json(stdout: &str) -> Result<&str> {
+    let begin = stdout
+        .find(CONTRACT_JSON_BEGIN)
+        .ok_or_else(|| anyhow!("Lean contract JSON begin marker missing"))?;
+    let end = stdout
+        .find(CONTRACT_JSON_END)
+        .ok_or_else(|| anyhow!("Lean contract JSON end marker missing"))?;
+    if begin >= end {
+        anyhow::bail!("Lean contract JSON markers are out of order");
+    }
+    let json = stdout[begin + CONTRACT_JSON_BEGIN.len()..end].trim();
+    if json.is_empty() {
+        anyhow::bail!("Lean contract JSON marker block is empty");
+    }
+    Ok(json)
 }

--- a/crates/defra-agent-desktop-core/Cargo.toml
+++ b/crates/defra-agent-desktop-core/Cargo.toml
@@ -28,5 +28,6 @@ tracing.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+defra-agent-lean-contract.workspace = true
 tempfile = "3"
 wiremock = "0.6"

--- a/crates/defra-agent-lean-contract/Cargo.toml
+++ b/crates/defra-agent-lean-contract/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "defra-agent-lean-contract"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Test helper for loading defra-agent Lean conformance contracts"
+
+[dependencies]
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/defra-agent-lean-contract/src/lib.rs
+++ b/crates/defra-agent-lean-contract/src/lib.rs
@@ -1,0 +1,174 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use serde::de::DeserializeOwned;
+
+pub const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
+pub const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
+
+const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts";
+const CONTRACT_RUN_FILE: &str = "Proofs/Conformance/Contracts.lean";
+
+pub fn load_contract_snapshot<T>() -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let stdout = load_contract_stdout()?;
+    let json = extract_contract_json(&stdout)?;
+    serde_json::from_str(json).with_context(|| {
+        format!("failed to parse Lean conformance contract JSON\nstdout:\n{stdout}")
+    })
+}
+
+pub fn load_contract_json() -> Result<String> {
+    let stdout = load_contract_stdout()?;
+    extract_contract_json(&stdout).map(ToOwned::to_owned)
+}
+
+pub fn load_contract_stdout() -> Result<String> {
+    let proofs_dir = proofs_dir()?;
+    run_lake_build(&proofs_dir)?;
+    run_contract_generator(&proofs_dir)
+}
+
+pub fn run_lake_build(proofs_dir: &Path) -> Result<()> {
+    let output = Command::new("lake")
+        .args(["build", CONTRACT_TARGET])
+        .current_dir(proofs_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to build Lean conformance contract target in {}",
+                proofs_dir.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Lean conformance contract build failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
+            proofs_dir.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(())
+}
+
+pub fn run_contract_generator(proofs_dir: &Path) -> Result<String> {
+    let output = Command::new("lake")
+        .args(["env", "lean", "--run", CONTRACT_RUN_FILE])
+        .current_dir(proofs_dir)
+        .output()
+        .with_context(|| {
+            format!(
+                "failed to run Lean conformance contract generator in {}",
+                proofs_dir.display()
+            )
+        })?;
+
+    if !output.status.success() {
+        anyhow::bail!(
+            "Lean conformance contract generator failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
+            proofs_dir.display(),
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    String::from_utf8(output.stdout).context("Lean conformance contract stdout was not UTF-8")
+}
+
+pub fn proofs_dir() -> Result<PathBuf> {
+    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let direct = manifest_dir.join("proofs");
+    if direct.join("lakefile.lean").exists() {
+        return Ok(direct);
+    }
+
+    for ancestor in manifest_dir.ancestors() {
+        let candidate = ancestor.join("crates/defra-agent/proofs");
+        if candidate.join("lakefile.lean").exists() {
+            return Ok(candidate);
+        }
+    }
+
+    let sibling = manifest_dir
+        .parent()
+        .map(|parent| parent.join("defra-agent/proofs"));
+    if let Some(candidate) = sibling {
+        if candidate.join("lakefile.lean").exists() {
+            return Ok(candidate);
+        }
+    }
+
+    Err(anyhow!(
+        "could not locate crates/defra-agent/proofs from {}",
+        manifest_dir.display()
+    ))
+}
+
+pub fn extract_contract_json(stdout: &str) -> Result<&str> {
+    let begin = unique_marker_position(stdout, CONTRACT_JSON_BEGIN)?;
+    let end = unique_marker_position(stdout, CONTRACT_JSON_END)?;
+    anyhow::ensure!(
+        begin < end,
+        "Lean contract JSON sentinel order is invalid\n  stdout:\n{}",
+        stdout
+    );
+
+    let json = stdout[begin + CONTRACT_JSON_BEGIN.len()..end].trim();
+    anyhow::ensure!(
+        !json.is_empty(),
+        "Lean contract JSON sentinel block was empty\n  stdout:\n{}",
+        stdout
+    );
+    Ok(json)
+}
+
+fn unique_marker_position(stdout: &str, marker: &str) -> Result<usize> {
+    let positions = stdout
+        .match_indices(marker)
+        .map(|(position, _)| position)
+        .collect::<Vec<_>>();
+    match positions.as_slice() {
+        [position] => Ok(*position),
+        [] => Err(anyhow!(
+            "Lean contract generator stdout did not contain {marker:?}: {stdout}"
+        )),
+        _ => Err(anyhow!(
+            "Lean contract generator stdout contained duplicate {marker:?} sentinels: {stdout}"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_contract_json_between_unique_sentinels() {
+        let stdout = format!(
+            "debug {{noise}}\n{CONTRACT_JSON_BEGIN}\n{{\"ok\":true}}\n{CONTRACT_JSON_END}\nmore {{noise}}\n"
+        );
+
+        assert_eq!(extract_contract_json(&stdout).unwrap(), "{\"ok\":true}");
+    }
+
+    #[test]
+    fn rejects_duplicate_sentinels() {
+        let stdout = format!(
+            "{CONTRACT_JSON_BEGIN}\n{{\"ok\":true}}\n{CONTRACT_JSON_BEGIN}\n{CONTRACT_JSON_END}\n"
+        );
+
+        let err = extract_contract_json(&stdout).unwrap_err().to_string();
+        assert!(
+            err.contains("duplicate"),
+            "expected duplicate sentinel error, got: {err}"
+        );
+    }
+}

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -57,3 +57,4 @@ acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.
 p2p.workspace = true
 proptest = "1"
 agent-tool-call-lifecycle-v1-to-v2-lens = { path = "../defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2", default-features = false }
+defra-agent-lean-contract.workspace = true

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -184,11 +184,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := []
     }
   , { feature := "triggers"
-    , required := [Surface.runtimeInternal]
-    , deferred :=
-        [ (Surface.operatorCli, "#282")
-        , (Surface.operatorUi, "#283")
-        ]
+    , required := [Surface.runtimeInternal, Surface.operatorCli]
+    , deferred := [(Surface.operatorUi, "#283")]
     }
   , { feature := "compaction"
     , required := [Surface.agentFacing]
@@ -423,6 +420,11 @@ def caseCoverage : List CoverageEntry :=
       "TriggerDispatch"
       "trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases")
       "triggers" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "trigger_cases"
+      "TriggerDispatch"
+      "cli_config_task_run::config_task_run_matches_lean_manual_dispatch_contract")
+      "triggers" [Surface.operatorCli]
   , tagged (consumerCoverage
       "runtime_cases"
       "RuntimeReconcileCases"

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::OnceLock;
 
 use serde::Deserialize;
@@ -245,8 +243,6 @@ enum LeanVocabularyParseError<'a> {
 }
 
 static LEAN_CONTRACT_SNAPSHOT: OnceLock<LeanContractSnapshot> = OnceLock::new();
-const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
-const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
 
 pub(crate) fn lean_contract_snapshot() -> &'static LeanContractSnapshot {
     LEAN_CONTRACT_SNAPSHOT.get_or_init(load_lean_contract_snapshot)
@@ -824,111 +820,7 @@ pub(crate) fn assert_lean_to_defradb_vocabulary_matches(spec: LeanVocabulary<'_>
 }
 
 fn load_lean_contract_snapshot() -> LeanContractSnapshot {
-    let proofs_dir = proofs_dir();
-    run_lake_build(&proofs_dir);
-    let output = Command::new("lake")
-        .args(["env", "lean", "--run", "Proofs/Conformance/Contracts.lean"])
-        .current_dir(&proofs_dir)
-        .output()
-        .unwrap_or_else(|error| {
-            panic!(
-                "failed to run Lean conformance contract generator in {}: {error}",
-                proofs_dir.display()
-            )
-        });
-
-    if !output.status.success() {
-        panic!(
-            "Lean conformance contract generator failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
-            proofs_dir.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let json = extract_contract_json(&stdout);
-    serde_json::from_str(json).unwrap_or_else(|error| {
-        panic!(
-            "failed to parse Lean conformance contract JSON: {error}\n  stdout:\n{}",
-            stdout
-        )
-    })
-}
-
-fn run_lake_build(proofs_dir: &Path) {
-    let output = Command::new("lake")
-        .args(["build", "Proofs.Conformance.Contracts"])
-        .current_dir(proofs_dir)
-        .output()
-        .unwrap_or_else(|error| {
-            panic!(
-                "failed to build Lean conformance contract target in {}: {error}",
-                proofs_dir.display()
-            )
-        });
-
-    if !output.status.success() {
-        panic!(
-            "Lean conformance contract build failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
-            proofs_dir.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-}
-
-fn proofs_dir() -> PathBuf {
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let direct = manifest_dir.join("proofs");
-    if direct.exists() {
-        return direct;
-    }
-    for ancestor in manifest_dir.ancestors() {
-        let candidate = ancestor.join("crates/defra-agent/proofs");
-        if candidate.exists() {
-            return candidate;
-        }
-    }
-    manifest_dir
-        .parent()
-        .map(|parent| parent.join("defra-agent/proofs"))
-        .filter(|candidate| candidate.exists())
-        .unwrap_or(direct)
-}
-
-fn extract_contract_json(stdout: &str) -> &str {
-    let begin = unique_marker_position(stdout, CONTRACT_JSON_BEGIN);
-    let end = unique_marker_position(stdout, CONTRACT_JSON_END);
-    assert!(
-        begin < end,
-        "Lean contract JSON sentinel order is invalid\n  stdout:\n{}",
-        stdout
-    );
-
-    let json = stdout[begin + CONTRACT_JSON_BEGIN.len()..end].trim();
-    assert!(
-        !json.is_empty(),
-        "Lean contract JSON sentinel block was empty\n  stdout:\n{}",
-        stdout
-    );
-    json
-}
-
-fn unique_marker_position(stdout: &str, marker: &str) -> usize {
-    let positions = stdout
-        .match_indices(marker)
-        .map(|(position, _)| position)
-        .collect::<Vec<_>>();
-    match positions.as_slice() {
-        [position] => *position,
-        [] => panic!("Lean contract generator stdout did not contain {marker:?}: {stdout}"),
-        _ => panic!(
-            "Lean contract generator stdout contained duplicate {marker:?} sentinels: {stdout}"
-        ),
-    }
+    defra_agent_lean_contract::load_contract_snapshot().unwrap_or_else(|error| panic!("{error:#}"))
 }
 
 pub(crate) fn lean_to_defradb_values<'a>(
@@ -1231,10 +1123,15 @@ end Sample
     #[test]
     fn extracts_contract_json_between_sentinels() {
         let stdout = format!(
-            "debug {{noise}}\n{CONTRACT_JSON_BEGIN}\n{{\"ok\":true}}\n{CONTRACT_JSON_END}\nmore {{noise}}\n"
+            "debug {{noise}}\n{}\n{{\"ok\":true}}\n{}\nmore {{noise}}\n",
+            defra_agent_lean_contract::CONTRACT_JSON_BEGIN,
+            defra_agent_lean_contract::CONTRACT_JSON_END
         );
 
-        assert_eq!(extract_contract_json(&stdout), "{\"ok\":true}");
+        assert_eq!(
+            defra_agent_lean_contract::extract_contract_json(&stdout).unwrap(),
+            "{\"ok\":true}"
+        );
     }
 
     #[test]

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -126,6 +126,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "mcp_probe_json_reports_health_snapshot_for_registry_service",
         },
         ConformanceConsumer::RustTest {
+            id: "cli_config_task_run::config_task_run_matches_lean_manual_dispatch_contract",
+            package: "defra-agent-cli",
+            source_path: "crates/defra-agent-cli/tests/cli_config_task_run.rs",
+            module_path: "cli_config_task_run",
+            function: "config_task_run_matches_lean_manual_dispatch_contract",
+        },
+        ConformanceConsumer::RustTest {
             id: "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/backend_registry/tests.rs",


### PR DESCRIPTION
## Summary
- Drive the existing `config task run` integration path from the Lean `TriggerDispatch` manual case.
- Assert CLI-created manual requests carry the Lean manual materialization tuple and render `args.*`.
- Tag the new `triggers` / `operatorCli` consumer in the coverage ledger.

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli config_task_run`
- `cargo test -p defra-agent --lib trigger_engine::tests::trigger_engine_dispatch_matches_lean_generated_contract_cases`
- `cargo test -p defra-agent --test state_machine_conformance lean_feature_matrix_covers_every_declared_required_surface`
- `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain`