### PR TITLE
Fleet: API endpoint for slot accounting introspection (#287)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -11,8 +11,9 @@ use serde::{Deserialize, Serialize};
 use crate::{
     BACKGROUND_AFTER_HELP, CHAT_AFTER_HELP, CLI_AFTER_HELP, CONFIG_AFTER_HELP,
     CONFIG_EXPORT_AFTER_HELP, CONFIG_IMPORT_AFTER_HELP, DEFAULT_INIT_ENDPOINT, DIAGNOSE_AFTER_HELP,
-    INIT_AFTER_HELP, MCP_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP, REQUEST_AFTER_HELP,
-    RESET_AFTER_HELP, RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP,
+    FLEET_AFTER_HELP, INIT_AFTER_HELP, MCP_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP,
+    REQUEST_AFTER_HELP, RESET_AFTER_HELP, RESPONSE_AFTER_HELP, SERVER_AFTER_HELP, SESSION_AFTER_HELP,
+    SHOW_AFTER_HELP,
     STATUS_AFTER_HELP, SUBAGENT_AFTER_HELP, SUBAGENT_LIST_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
@@ -82,6 +83,11 @@ pub(crate) enum Command {
     Mcp {
         #[command(subcommand)]
         command: McpCommand,
+    },
+    #[command(about = "Inspect fleet admission slot accounting", after_help = FLEET_AFTER_HELP)]
+    Fleet {
+        #[command(subcommand)]
+        command: FleetCommand,
     },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
@@ -412,6 +418,16 @@ pub(crate) enum McpProbeOutput {
     Json,
 }
 
+#[derive(Subcommand)]
+pub(crate) enum FleetCommand {
+    #[command(
+        name = "slots",
+        about = "Show derived fleet slot usage from the live runtime HTTP API",
+        after_help = FLEET_AFTER_HELP
+    )]
+    Slots(FleetSlotsArgs),
+}
+
 #[derive(clap::Args)]
 pub(crate) struct BackgroundListArgs {
     #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
@@ -444,6 +460,14 @@ pub(crate) struct BackgroundListArgs {
 pub(crate) enum BackgroundOutputFormat {
     Table,
     Json,
+}
+
+#[derive(clap::Args)]
+pub(crate) struct FleetSlotsArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint for the live runtime")]
+    pub(crate) graphql: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/commands/fleet.rs
+++ b/crates/defra-agent-cli/src/commands/fleet.rs
@@ -24,6 +24,8 @@ async fn fleet_slots(args: FleetSlotsArgs) -> Result<()> {
 
 fn runtime_fleet_slots_url(graphql: &str) -> Result<String> {
     let mut url = reqwest::Url::parse(graphql).context("parsing GraphQL endpoint URL")?;
+    // Runtime HTTP introspection endpoints are served beside the DefraDB GraphQL endpoint
+    // on the same host and port.
     url.set_path("/fleet/slots");
     url.set_query(None);
     url.set_fragment(None);

--- a/crates/defra-agent-cli/src/commands/fleet.rs
+++ b/crates/defra-agent-cli/src/commands/fleet.rs
@@ -1,0 +1,44 @@
+use anyhow::{Context, Result};
+use serde_json::Value;
+
+use crate::cli::args::{FleetCommand, FleetSlotsArgs};
+use crate::{http_get_json, print_json, resolve_graphql_endpoint};
+
+pub(crate) async fn dispatch(command: FleetCommand) -> Result<()> {
+    match command {
+        FleetCommand::Slots(args) => fleet_slots(args).await,
+    }
+}
+
+async fn fleet_slots(args: FleetSlotsArgs) -> Result<()> {
+    let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
+    let url = runtime_fleet_slots_url(&graphql)?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .context("building HTTP client")?;
+    let snapshot: Value = http_get_json(&client, &url).await?;
+    print_json(&snapshot)?;
+    Ok(())
+}
+
+fn runtime_fleet_slots_url(graphql: &str) -> Result<String> {
+    let mut url = reqwest::Url::parse(graphql).context("parsing GraphQL endpoint URL")?;
+    url.set_path("/fleet/slots");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fleet_slots_url_uses_runtime_http_root() {
+        assert_eq!(
+            runtime_fleet_slots_url("http://127.0.0.1:9191/api/v0/graphql").unwrap(),
+            "http://127.0.0.1:9191/fleet/slots"
+        );
+    }
+}

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod background;
 pub(crate) mod chat;
 pub(crate) mod config;
 pub(crate) mod diagnose;
+pub(crate) mod fleet;
 pub(crate) mod init;
 pub(crate) mod mcp;
 pub(crate) mod p2p;

--- a/crates/defra-agent-cli/src/http/fleet_slots.rs
+++ b/crates/defra-agent-cli/src/http/fleet_slots.rs
@@ -1,0 +1,504 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::post_graphql;
+
+const SNAPSHOT_SOURCE: &str = "graphql.derived_inference_call_rows";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FleetSlotSnapshot {
+    pub(crate) generated_at: String,
+    pub(crate) source: String,
+    pub(crate) totals: FleetSlotTotals,
+    pub(crate) expired: FleetExpiredCounts,
+    pub(crate) behaviors: Vec<FleetBehaviorSlotUsage>,
+    pub(crate) backends: Vec<FleetBackendAdmissionCounters>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FleetSlotTotals {
+    pub(crate) assigned: i64,
+    pub(crate) available: i64,
+    pub(crate) max: i64,
+    pub(crate) queued: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FleetExpiredCounts {
+    pub(crate) processing_requests: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FleetBehaviorSlotUsage {
+    pub(crate) behavior_id: String,
+    pub(crate) agent_did: String,
+    pub(crate) backend_id: String,
+    pub(crate) configured: bool,
+    pub(crate) enabled: bool,
+    pub(crate) backend_available: bool,
+    pub(crate) assigned: i64,
+    pub(crate) available: i64,
+    pub(crate) max: i64,
+    pub(crate) queued: i64,
+    pub(crate) expired_processing: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct FleetBackendAdmissionCounters {
+    pub(crate) backend_id: String,
+    pub(crate) configured: bool,
+    pub(crate) enabled: bool,
+    pub(crate) probe_status: String,
+    pub(crate) accepting_admission: bool,
+    pub(crate) running: i64,
+    pub(crate) queued: i64,
+    pub(crate) available: i64,
+    pub(crate) max_concurrent: i64,
+    pub(crate) max_queue_depth: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct FleetSlotQueryEnvelope {
+    #[serde(rename = "AgentBehavior", default)]
+    behaviors: Vec<BehaviorRow>,
+    #[serde(rename = "InferenceBackend", default)]
+    backends: Vec<BackendRow>,
+    #[serde(rename = "InferenceCall", default)]
+    calls: Vec<InferenceCallRow>,
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BehaviorRow {
+    #[serde(default)]
+    behavior_id: String,
+    #[serde(default)]
+    agent_did: String,
+    #[serde(default)]
+    backend_id: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+impl BehaviorRow {
+    fn normalized_behavior_id(&self) -> String {
+        clean_string(&self.behavior_id)
+    }
+
+    fn normalized_backend_id(&self) -> String {
+        clean_optional_string(self.backend_id.as_deref())
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BackendRow {
+    #[serde(default)]
+    backend_id: String,
+    #[serde(default)]
+    enabled: Option<bool>,
+    #[serde(default)]
+    max_concurrent: Option<i64>,
+    #[serde(default)]
+    max_queue_depth: Option<i64>,
+    #[serde(default)]
+    probe_status: Option<String>,
+}
+
+impl BackendRow {
+    fn normalized_backend_id(&self) -> String {
+        clean_string(&self.backend_id)
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled.unwrap_or(false)
+    }
+
+    fn normalized_probe_status(&self) -> String {
+        clean_optional_string(self.probe_status.as_deref()).if_empty_then(|| "unknown".to_string())
+    }
+
+    fn accepting_admission(&self) -> bool {
+        self.is_enabled() && self.normalized_probe_status() == "healthy"
+    }
+
+    fn max_concurrent(&self) -> i64 {
+        self.max_concurrent.unwrap_or_default().max(0)
+    }
+
+    fn max_queue_depth(&self) -> i64 {
+        self.max_queue_depth.unwrap_or_default().max(0)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct InferenceCallRow {
+    #[serde(default)]
+    backend_id: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    call_state: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    deadline: Option<String>,
+}
+
+#[derive(Clone, Default)]
+struct SlotCounts {
+    assigned: i64,
+    queued: i64,
+    expired_processing: i64,
+}
+
+pub(crate) async fn load_fleet_slot_snapshot(graphql: &str) -> Result<FleetSlotSnapshot> {
+    let generated_at = Utc::now();
+    let response = post_graphql(graphql, fleet_slot_snapshot_query()).await?;
+    let data = response
+        .get("data")
+        .cloned()
+        .unwrap_or_else(|| Value::Object(Default::default()));
+    let envelope: FleetSlotQueryEnvelope =
+        serde_json::from_value(data).context("decoding fleet slot snapshot query response")?;
+    Ok(build_fleet_slot_snapshot(generated_at, envelope))
+}
+
+fn fleet_slot_snapshot_query() -> &'static str {
+    r#"{
+        AgentBehavior(order: { behavior_id: ASC }) {
+            behavior_id
+            agent_did
+            backend_id
+            enabled
+        }
+        InferenceBackend(order: { backend_id: ASC }) {
+            backend_id
+            enabled
+            max_concurrent
+            max_queue_depth
+            probe_status
+        }
+        InferenceCall(filter: { call_state: { _in: ["queued", "running"] } }) {
+            backend_id
+            behavior_id
+            agent_did
+            call_state
+        }
+        AgentRequest(filter: {
+            status: { _eq: "processing" },
+            lifecycle_state: { _eq: "processing" }
+        }) {
+            behavior_id
+            deadline
+        }
+    }"#
+}
+
+fn build_fleet_slot_snapshot(
+    generated_at: DateTime<Utc>,
+    envelope: FleetSlotQueryEnvelope,
+) -> FleetSlotSnapshot {
+    let backends = envelope
+        .backends
+        .into_iter()
+        .filter_map(|backend| {
+            let backend_id = backend.normalized_backend_id();
+            (!backend_id.is_empty()).then_some((backend_id, backend))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let behaviors = envelope
+        .behaviors
+        .into_iter()
+        .filter_map(|behavior| {
+            let behavior_id = behavior.normalized_behavior_id();
+            (!behavior_id.is_empty()).then_some((behavior_id, behavior))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let mut backend_counts = BTreeMap::<String, SlotCounts>::new();
+    let mut behavior_counts = BTreeMap::<String, SlotCounts>::new();
+    let mut active_behavior_metadata = BTreeMap::<String, (String, String)>::new();
+    let mut active_backend_ids = BTreeSet::<String>::new();
+
+    for call in envelope.calls {
+        let backend_id = clean_optional_string(call.backend_id.as_deref());
+        let behavior_id = clean_optional_string(call.behavior_id.as_deref());
+        let agent_did = clean_optional_string(call.agent_did.as_deref());
+
+        if !backend_id.is_empty() {
+            active_backend_ids.insert(backend_id.clone());
+            let counts = backend_counts.entry(backend_id.clone()).or_default();
+            apply_call_state(&call.call_state, counts);
+        }
+        if !behavior_id.is_empty() {
+            let counts = behavior_counts.entry(behavior_id.clone()).or_default();
+            apply_call_state(&call.call_state, counts);
+            active_behavior_metadata
+                .entry(behavior_id)
+                .or_insert((agent_did, backend_id));
+        }
+    }
+
+    let mut expired = FleetExpiredCounts::default();
+    for request in envelope.requests {
+        if deadline_is_expired(generated_at, request.deadline.as_deref()) {
+            expired.processing_requests += 1;
+            let behavior_id = clean_optional_string(request.behavior_id.as_deref());
+            if !behavior_id.is_empty() {
+                behavior_counts
+                    .entry(behavior_id)
+                    .or_default()
+                    .expired_processing += 1;
+            }
+        }
+    }
+
+    let mut backend_ids = backends.keys().cloned().collect::<BTreeSet<_>>();
+    backend_ids.extend(active_backend_ids);
+    let mut backend_snapshots = Vec::new();
+    for backend_id in backend_ids {
+        let configured = backends.get(&backend_id);
+        let counts = backend_counts.get(&backend_id).cloned().unwrap_or_default();
+        let max_concurrent = configured
+            .map(BackendRow::max_concurrent)
+            .unwrap_or_default();
+        let accepting_admission = configured
+            .map(BackendRow::accepting_admission)
+            .unwrap_or(false);
+        backend_snapshots.push(FleetBackendAdmissionCounters {
+            backend_id,
+            configured: configured.is_some(),
+            enabled: configured.map(BackendRow::is_enabled).unwrap_or(false),
+            probe_status: configured
+                .map(BackendRow::normalized_probe_status)
+                .unwrap_or_else(|| "unknown".to_string()),
+            accepting_admission,
+            running: counts.assigned,
+            queued: counts.queued,
+            available: if accepting_admission {
+                max_concurrent.saturating_sub(counts.assigned)
+            } else {
+                0
+            },
+            max_concurrent,
+            max_queue_depth: configured
+                .map(BackendRow::max_queue_depth)
+                .unwrap_or_default(),
+        });
+    }
+
+    let mut behavior_ids = behaviors.keys().cloned().collect::<BTreeSet<_>>();
+    behavior_ids.extend(active_behavior_metadata.keys().cloned());
+    let mut behavior_snapshots = Vec::new();
+    for behavior_id in behavior_ids {
+        let configured = behaviors.get(&behavior_id);
+        let active_metadata = active_behavior_metadata.get(&behavior_id);
+        let backend_id = configured
+            .map(BehaviorRow::normalized_backend_id)
+            .or_else(|| active_metadata.map(|(_, backend_id)| backend_id.clone()))
+            .unwrap_or_default();
+        let counts = behavior_counts
+            .get(&behavior_id)
+            .cloned()
+            .unwrap_or_default();
+        let backend = backends.get(&backend_id);
+        let max = backend.map(BackendRow::max_concurrent).unwrap_or_default();
+        let backend_available = backend
+            .map(BackendRow::accepting_admission)
+            .unwrap_or(false);
+        let enabled = configured.map(BehaviorRow::is_enabled).unwrap_or(false);
+        let backend_running = backend_counts
+            .get(&backend_id)
+            .map(|counts| counts.assigned)
+            .unwrap_or_default();
+        behavior_snapshots.push(FleetBehaviorSlotUsage {
+            behavior_id: behavior_id.clone(),
+            agent_did: configured
+                .map(|behavior| clean_string(&behavior.agent_did))
+                .or_else(|| active_metadata.map(|(agent_did, _)| agent_did.clone()))
+                .unwrap_or_default(),
+            backend_id,
+            configured: configured.is_some(),
+            enabled,
+            backend_available,
+            assigned: counts.assigned,
+            available: if enabled && backend_available {
+                max.saturating_sub(backend_running)
+            } else {
+                0
+            },
+            max,
+            queued: counts.queued,
+            expired_processing: counts.expired_processing,
+        });
+    }
+
+    let totals = FleetSlotTotals {
+        assigned: backend_snapshots
+            .iter()
+            .map(|backend| backend.running)
+            .sum(),
+        available: backend_snapshots
+            .iter()
+            .map(|backend| backend.available)
+            .sum(),
+        max: backend_snapshots
+            .iter()
+            .map(|backend| backend.max_concurrent)
+            .sum(),
+        queued: backend_snapshots.iter().map(|backend| backend.queued).sum(),
+    };
+
+    FleetSlotSnapshot {
+        generated_at: generated_at.to_rfc3339(),
+        source: SNAPSHOT_SOURCE.to_string(),
+        totals,
+        expired,
+        behaviors: behavior_snapshots,
+        backends: backend_snapshots,
+    }
+}
+
+fn apply_call_state(call_state: &str, counts: &mut SlotCounts) {
+    match call_state {
+        "running" => counts.assigned += 1,
+        "queued" => counts.queued += 1,
+        _ => {}
+    }
+}
+
+fn deadline_is_expired(now: DateTime<Utc>, deadline: Option<&str>) -> bool {
+    let Some(deadline) = deadline.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    DateTime::parse_from_rfc3339(deadline)
+        .map(|deadline| deadline.with_timezone(&Utc) < now)
+        .unwrap_or(false)
+}
+
+fn clean_optional_string(value: Option<&str>) -> String {
+    value.map(clean_string).unwrap_or_default()
+}
+
+fn clean_string(value: &str) -> String {
+    value.trim().to_string()
+}
+
+trait IfEmptyThen {
+    fn if_empty_then(self, fallback: impl FnOnce() -> String) -> String;
+}
+
+impl IfEmptyThen for String {
+    fn if_empty_then(self, fallback: impl FnOnce() -> String) -> String {
+        if self.is_empty() {
+            fallback()
+        } else {
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_reconstructs_slots_by_backend_and_behavior() {
+        let now = DateTime::parse_from_rfc3339("2026-05-20T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let snapshot = build_fleet_slot_snapshot(
+            now,
+            FleetSlotQueryEnvelope {
+                behaviors: vec![
+                    BehaviorRow {
+                        behavior_id: "behavior-a".to_string(),
+                        agent_did: "did:defra-agent:test".to_string(),
+                        backend_id: Some("backend-a".to_string()),
+                        enabled: Some(true),
+                    },
+                    BehaviorRow {
+                        behavior_id: "behavior-b".to_string(),
+                        agent_did: "did:defra-agent:test".to_string(),
+                        backend_id: Some("backend-a".to_string()),
+                        enabled: Some(true),
+                    },
+                ],
+                backends: vec![BackendRow {
+                    backend_id: "backend-a".to_string(),
+                    enabled: Some(true),
+                    max_concurrent: Some(2),
+                    max_queue_depth: Some(4),
+                    probe_status: Some("healthy".to_string()),
+                }],
+                calls: vec![
+                    InferenceCallRow {
+                        backend_id: Some("backend-a".to_string()),
+                        behavior_id: Some("behavior-a".to_string()),
+                        agent_did: Some("did:defra-agent:test".to_string()),
+                        call_state: "running".to_string(),
+                    },
+                    InferenceCallRow {
+                        backend_id: Some("backend-a".to_string()),
+                        behavior_id: Some("behavior-b".to_string()),
+                        agent_did: Some("did:defra-agent:test".to_string()),
+                        call_state: "queued".to_string(),
+                    },
+                ],
+                requests: vec![RequestRow {
+                    behavior_id: Some("behavior-a".to_string()),
+                    deadline: Some("2026-05-20T11:59:00Z".to_string()),
+                }],
+            },
+        );
+
+        assert_eq!(
+            snapshot.totals,
+            FleetSlotTotals {
+                assigned: 1,
+                available: 1,
+                max: 2,
+                queued: 1,
+            }
+        );
+        assert_eq!(snapshot.expired.processing_requests, 1);
+        assert_eq!(snapshot.backends[0].running, 1);
+        assert_eq!(snapshot.backends[0].queued, 1);
+        assert_eq!(snapshot.backends[0].available, 1);
+
+        let behavior_a = snapshot
+            .behaviors
+            .iter()
+            .find(|behavior| behavior.behavior_id == "behavior-a")
+            .unwrap();
+        assert_eq!(behavior_a.assigned, 1);
+        assert_eq!(behavior_a.available, 1);
+        assert_eq!(behavior_a.max, 2);
+        assert_eq!(behavior_a.expired_processing, 1);
+
+        let behavior_b = snapshot
+            .behaviors
+            .iter()
+            .find(|behavior| behavior.behavior_id == "behavior-b")
+            .unwrap();
+        assert_eq!(behavior_b.assigned, 0);
+        assert_eq!(behavior_b.queued, 1);
+        assert_eq!(behavior_b.available, 1);
+    }
+}

--- a/crates/defra-agent-cli/src/http/fleet_slots.rs
+++ b/crates/defra-agent-cli/src/http/fleet_slots.rs
@@ -2,12 +2,13 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
+use defra_agent::{HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::post_graphql;
 
-const SNAPSHOT_SOURCE: &str = "graphql.derived_inference_call_rows";
+const SNAPSHOT_SOURCE: &str = "graphql.derived_admission_state";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct FleetSlotSnapshot {
@@ -41,7 +42,9 @@ pub(crate) struct FleetBehaviorSlotUsage {
     pub(crate) enabled: bool,
     pub(crate) backend_available: bool,
     pub(crate) assigned: i64,
+    /// Shared spare capacity on this behavior's backend, not a per-behavior reservation.
     pub(crate) available: i64,
+    /// The backend max_concurrent value visible through this behavior.
     pub(crate) max: i64,
     pub(crate) queued: i64,
     pub(crate) expired_processing: i64,
@@ -95,6 +98,7 @@ impl BehaviorRow {
     }
 
     fn is_enabled(&self) -> bool {
+        // Older generated behavior rows are admission-enabled unless explicitly disabled.
         self.enabled.unwrap_or(true)
     }
 }
@@ -119,15 +123,21 @@ impl BackendRow {
     }
 
     fn is_enabled(&self) -> bool {
+        // A backend row missing the flag should not advertise admission capacity.
         self.enabled.unwrap_or(false)
     }
 
     fn normalized_probe_status(&self) -> String {
-        clean_optional_string(self.probe_status.as_deref()).if_empty_then(|| "unknown".to_string())
+        let probe_status = clean_optional_string(self.probe_status.as_deref());
+        if probe_status.is_empty() {
+            UNKNOWN_PROBE_STATUS.to_string()
+        } else {
+            probe_status
+        }
     }
 
     fn accepting_admission(&self) -> bool {
-        self.is_enabled() && self.normalized_probe_status() == "healthy"
+        self.is_enabled() && self.normalized_probe_status() == HEALTHY_PROBE_STATUS
     }
 
     fn max_concurrent(&self) -> i64 {
@@ -169,13 +179,19 @@ struct SlotCounts {
 pub(crate) async fn load_fleet_slot_snapshot(graphql: &str) -> Result<FleetSlotSnapshot> {
     let generated_at = Utc::now();
     let response = post_graphql(graphql, fleet_slot_snapshot_query()).await?;
+    let envelope = decode_fleet_slot_query_response(response)?;
+    Ok(build_fleet_slot_snapshot(generated_at, envelope))
+}
+
+fn decode_fleet_slot_query_response(response: Value) -> Result<FleetSlotQueryEnvelope> {
     let data = response
         .get("data")
+        .filter(|data| data.is_object())
         .cloned()
-        .unwrap_or_else(|| Value::Object(Default::default()));
-    let envelope: FleetSlotQueryEnvelope =
-        serde_json::from_value(data).context("decoding fleet slot snapshot query response")?;
-    Ok(build_fleet_slot_snapshot(generated_at, envelope))
+        .with_context(|| {
+            format!("fleet slot snapshot query response missing object data: {response}")
+        })?;
+    serde_json::from_value(data).context("decoding fleet slot snapshot query response")
 }
 
 fn fleet_slot_snapshot_query() -> &'static str {
@@ -287,7 +303,7 @@ fn build_fleet_slot_snapshot(
             enabled: configured.map(BackendRow::is_enabled).unwrap_or(false),
             probe_status: configured
                 .map(BackendRow::normalized_probe_status)
-                .unwrap_or_else(|| "unknown".to_string()),
+                .unwrap_or_else(|| UNKNOWN_PROBE_STATUS.to_string()),
             accepting_admission,
             running: counts.assigned,
             queued: counts.queued,
@@ -400,23 +416,32 @@ fn clean_string(value: &str) -> String {
     value.trim().to_string()
 }
 
-trait IfEmptyThen {
-    fn if_empty_then(self, fallback: impl FnOnce() -> String) -> String;
-}
-
-impl IfEmptyThen for String {
-    fn if_empty_then(self, fallback: impl FnOnce() -> String) -> String {
-        if self.is_empty() {
-            fallback()
-        } else {
-            self
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
+
+    fn find_backend<'a>(
+        snapshot: &'a FleetSlotSnapshot,
+        backend_id: &str,
+    ) -> &'a FleetBackendAdmissionCounters {
+        snapshot
+            .backends
+            .iter()
+            .find(|backend| backend.backend_id == backend_id)
+            .unwrap()
+    }
+
+    fn find_behavior<'a>(
+        snapshot: &'a FleetSlotSnapshot,
+        behavior_id: &str,
+    ) -> &'a FleetBehaviorSlotUsage {
+        snapshot
+            .behaviors
+            .iter()
+            .find(|behavior| behavior.behavior_id == behavior_id)
+            .unwrap()
+    }
 
     #[test]
     fn snapshot_reconstructs_slots_by_backend_and_behavior() {
@@ -468,6 +493,7 @@ mod tests {
             },
         );
 
+        assert_eq!(snapshot.source, SNAPSHOT_SOURCE);
         assert_eq!(
             snapshot.totals,
             FleetSlotTotals {
@@ -500,5 +526,130 @@ mod tests {
         assert_eq!(behavior_b.assigned, 0);
         assert_eq!(behavior_b.queued, 1);
         assert_eq!(behavior_b.available, 1);
+    }
+
+    #[test]
+    fn snapshot_preserves_unavailable_and_unconfigured_edges() {
+        let now = DateTime::parse_from_rfc3339("2026-05-20T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let snapshot = build_fleet_slot_snapshot(
+            now,
+            FleetSlotQueryEnvelope {
+                behaviors: vec![BehaviorRow {
+                    behavior_id: "behavior-disabled".to_string(),
+                    agent_did: "did:defra-agent:test".to_string(),
+                    backend_id: Some("backend-unhealthy".to_string()),
+                    enabled: Some(false),
+                }],
+                backends: vec![
+                    BackendRow {
+                        backend_id: "backend-unhealthy".to_string(),
+                        enabled: Some(true),
+                        max_concurrent: Some(3),
+                        max_queue_depth: Some(4),
+                        probe_status: Some("unhealthy".to_string()),
+                    },
+                    BackendRow {
+                        backend_id: "backend-missing-flags".to_string(),
+                        enabled: None,
+                        max_concurrent: Some(2),
+                        max_queue_depth: Some(1),
+                        probe_status: None,
+                    },
+                ],
+                calls: vec![
+                    InferenceCallRow {
+                        backend_id: Some("backend-unhealthy".to_string()),
+                        behavior_id: Some("behavior-disabled".to_string()),
+                        agent_did: Some("did:defra-agent:test".to_string()),
+                        call_state: "running".to_string(),
+                    },
+                    InferenceCallRow {
+                        backend_id: Some("backend-stale".to_string()),
+                        behavior_id: Some("behavior-stale".to_string()),
+                        agent_did: Some("did:defra-agent:stale".to_string()),
+                        call_state: "running".to_string(),
+                    },
+                ],
+                requests: vec![
+                    RequestRow {
+                        behavior_id: Some("behavior-disabled".to_string()),
+                        deadline: Some("2026-05-20T11:59:00Z".to_string()),
+                    },
+                    RequestRow {
+                        behavior_id: Some("behavior-disabled".to_string()),
+                        deadline: Some("not-a-date".to_string()),
+                    },
+                    RequestRow {
+                        behavior_id: Some("behavior-disabled".to_string()),
+                        deadline: None,
+                    },
+                ],
+            },
+        );
+
+        assert_eq!(
+            snapshot.totals,
+            FleetSlotTotals {
+                assigned: 2,
+                available: 0,
+                max: 5,
+                queued: 0,
+            }
+        );
+        assert_eq!(snapshot.expired.processing_requests, 1);
+
+        let unhealthy = find_backend(&snapshot, "backend-unhealthy");
+        assert!(unhealthy.configured);
+        assert!(unhealthy.enabled);
+        assert_eq!(unhealthy.probe_status, "unhealthy");
+        assert!(!unhealthy.accepting_admission);
+        assert_eq!(unhealthy.running, 1);
+        assert_eq!(unhealthy.available, 0);
+        assert_eq!(unhealthy.max_concurrent, 3);
+
+        let missing_flags = find_backend(&snapshot, "backend-missing-flags");
+        assert!(missing_flags.configured);
+        assert!(!missing_flags.enabled);
+        assert_eq!(missing_flags.probe_status, UNKNOWN_PROBE_STATUS);
+        assert!(!missing_flags.accepting_admission);
+        assert_eq!(missing_flags.available, 0);
+
+        let stale_backend = find_backend(&snapshot, "backend-stale");
+        assert!(!stale_backend.configured);
+        assert!(!stale_backend.enabled);
+        assert_eq!(stale_backend.probe_status, UNKNOWN_PROBE_STATUS);
+        assert_eq!(stale_backend.running, 1);
+        assert_eq!(stale_backend.max_concurrent, 0);
+
+        let disabled = find_behavior(&snapshot, "behavior-disabled");
+        assert!(disabled.configured);
+        assert!(!disabled.enabled);
+        assert!(!disabled.backend_available);
+        assert_eq!(disabled.assigned, 1);
+        assert_eq!(disabled.available, 0);
+        assert_eq!(disabled.max, 3);
+        assert_eq!(disabled.expired_processing, 1);
+
+        let stale_behavior = find_behavior(&snapshot, "behavior-stale");
+        assert!(!stale_behavior.configured);
+        assert!(!stale_behavior.enabled);
+        assert_eq!(stale_behavior.agent_did, "did:defra-agent:stale");
+        assert_eq!(stale_behavior.backend_id, "backend-stale");
+        assert_eq!(stale_behavior.assigned, 1);
+        assert_eq!(stale_behavior.available, 0);
+        assert_eq!(stale_behavior.max, 0);
+    }
+
+    #[test]
+    fn decode_rejects_missing_data_object() {
+        let error = decode_fleet_slot_query_response(json!({ "data": null })).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("fleet slot snapshot query response missing object data"),
+            "{error:#}"
+        );
     }
 }

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod fleet_slots;
 pub(crate) mod healthz;
 pub(crate) mod liveness;
 pub(crate) mod prometheus;

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -9,6 +9,7 @@ use axum::{
 };
 use serde_json::{json, Value};
 
+use crate::http::fleet_slots::load_fleet_slot_snapshot;
 use crate::http::healthz::render_healthz_payload;
 use crate::http::prometheus::{
     load_metrics_query_data, render_prometheus_metrics, with_local_native_executors,
@@ -44,6 +45,7 @@ pub(crate) fn runtime_contract_router(
         .route("/version", get(version_handler))
         .route("/healthz", get(healthz_handler))
         .route("/status", get(status_handler))
+        .route("/fleet/slots", get(fleet_slots_handler))
         .with_state(state)
 }
 
@@ -133,4 +135,16 @@ async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
     }
 
     (StatusCode::OK, axum::Json(body)).into_response()
+}
+
+async fn fleet_slots_handler(State(state): State<RuntimeHttpState>) -> Response {
+    match load_fleet_slot_snapshot(&state.graphql).await {
+        Ok(snapshot) => (StatusCode::OK, axum::Json(snapshot)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            format!("fleet slot snapshot failed: {error:#}"),
+        )
+            .into_response(),
+    }
 }

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -171,6 +171,13 @@ Examples:
   defra-agent mcp probe --all
   defra-agent mcp probe SERVICE_ID --timeout 10s
   defra-agent mcp probe --all --graphql http://127.0.0.1:9191/api/v0/graphql --output json";
+const FLEET_AFTER_HELP: &str = "\
+Shows the live fleet slot-accounting snapshot exposed by the local runtime HTTP API.
+
+Examples:
+  defra-agent fleet slots
+  defra-agent fleet slots --home /path/to/home
+  defra-agent fleet slots --graphql http://127.0.0.1:9191/api/v0/graphql";
 const SHOW_AFTER_HELP: &str = "\
 Examples:
   defra-agent show runtime
@@ -318,6 +325,7 @@ async fn main() -> Result<()> {
         Command::Status(args) => commands::status::status(args).await,
         Command::Background { command } => commands::background::dispatch(command).await,
         Command::Mcp { command } => commands::mcp::dispatch(command).await,
+        Command::Fleet { command } => commands::fleet::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Config { command } => commands::config::dispatch(command).await,
         Command::Request { command } => commands::request::dispatch(command).await,

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -3,7 +3,7 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use defra_agent::{default_behavior_id_for_agent, default_tool_selection_id_for_behavior};
@@ -17,6 +17,114 @@ fn generated_backend_id_for_agent(agent_did: &str) -> String {
 fn generated_tool_selection_id_for_agent(agent_did: &str) -> String {
     let default_behavior_id = default_behavior_id_for_agent(agent_did);
     default_tool_selection_id_for_behavior(&default_behavior_id)
+}
+
+fn find_snapshot_row<'a>(
+    snapshot: &'a Value,
+    collection: &str,
+    key: &str,
+    expected: &str,
+) -> Result<&'a Value> {
+    snapshot
+        .get(collection)
+        .and_then(Value::as_array)
+        .and_then(|rows| {
+            rows.iter()
+                .find(|row| row.get(key).and_then(Value::as_str) == Some(expected))
+        })
+        .ok_or_else(|| anyhow!("missing {collection} row with {key}={expected}: {snapshot}"))
+}
+
+async fn wait_for_inference_call_state(
+    graphql: &str,
+    request_id: &str,
+    expected_state: &str,
+) -> Result<Value> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let response = graphql_query(
+            graphql,
+            &format!(
+                r#"{{
+                    InferenceCall(
+                        filter: {{ request_id: {{ _eq: "{}" }} }},
+                        order: {{ call_seq: ASC }}
+                    ) {{
+                        request_id
+                        backend_id
+                        behavior_id
+                        call_state
+                    }}
+                }}"#,
+                escape_graphql_string(request_id),
+            ),
+        )
+        .await?;
+        let rows = response
+            .pointer("/data/InferenceCall")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default();
+        if let Some(row) = rows
+            .iter()
+            .find(|row| row.get("call_state").and_then(Value::as_str) == Some(expected_state))
+        {
+            return Ok(row.clone());
+        }
+
+        if Instant::now() >= deadline {
+            return Err(anyhow!(
+                "timed out waiting for InferenceCall request_id={request_id} call_state={expected_state}; last rows={}",
+                Value::Array(rows)
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn active_inference_calls_for_backend(graphql: &str, backend_id: &str) -> Result<Vec<Value>> {
+    let response = graphql_query(
+        graphql,
+        &format!(
+            r#"{{
+                InferenceCall(
+                    filter: {{ backend_id: {{ _eq: "{}" }} }},
+                    order: {{ call_seq: ASC }}
+                ) {{
+                    request_id
+                    backend_id
+                    behavior_id
+                    call_state
+                }}
+            }}"#,
+            escape_graphql_string(backend_id),
+        ),
+    )
+    .await?;
+    Ok(response
+        .pointer("/data/InferenceCall")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|row| {
+            matches!(
+                row.get("call_state").and_then(Value::as_str),
+                Some("running" | "queued")
+            )
+        })
+        .collect())
+}
+
+fn count_inference_calls(rows: &[Value], behavior_id: Option<&str>, call_state: &str) -> i64 {
+    rows.iter()
+        .filter(|row| {
+            row.get("call_state").and_then(Value::as_str) == Some(call_state)
+                && behavior_id.is_none_or(|expected| {
+                    row.get("behavior_id").and_then(Value::as_str) == Some(expected)
+                })
+        })
+        .count() as i64
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -207,6 +315,189 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
     assert!(
         body.contains("defra_agent_backend_enabled"),
         "expected backend metrics in metrics body:\n{body}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn server_exposes_fleet_slot_snapshot_endpoint() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-fleet-slots-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start_hanging(&model_name)?;
+    let port = allocate_port()?;
+    let agent_name = format!("cli-fleet-slots-{}", Uuid::new_v4().simple());
+    let graphql = graphql_url(port);
+    let request_content = format!("fleet slots live request {}", Uuid::new_v4());
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            "--max-concurrent",
+            "1",
+            "--max-queue-depth",
+            "2",
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let backend_id = init
+        .pointer("/init/backend_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("init output missing backend_id: {init}"))?
+        .to_string();
+    let default_behavior_id = init
+        .pointer("/init/default_behavior_id")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| default_behavior_id_for_agent(&agent_did));
+
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let submitted = run_cli_json(
+        &home_dir,
+        &[
+            "request",
+            "submit",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--content",
+            &request_content,
+            "--no-wait",
+        ],
+    )?;
+    let request_id = submitted
+        .get("request_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("request submit output missing request_id: {submitted}"))?
+        .to_string();
+    wait_for_request_lifecycle_state(
+        &graphql,
+        &request_id,
+        &["processing"],
+        Duration::from_secs(30),
+    )
+    .await?;
+    wait_for_inference_call_state(&graphql, &request_id, "running").await?;
+    let active_calls = active_inference_calls_for_backend(&graphql, &backend_id).await?;
+    let expected_backend_running = count_inference_calls(&active_calls, None, "running");
+    let expected_backend_queued = count_inference_calls(&active_calls, None, "queued");
+    let expected_behavior_running =
+        count_inference_calls(&active_calls, Some(&default_behavior_id), "running");
+    let expected_behavior_queued =
+        count_inference_calls(&active_calls, Some(&default_behavior_id), "queued");
+    let expected_available = 1_i64.saturating_sub(expected_backend_running);
+    assert!(
+        expected_backend_running >= 1,
+        "test setup should hold at least one running call; active calls={}",
+        Value::Array(active_calls.clone())
+    );
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(format!("http://127.0.0.1:{port}/fleet/slots"))
+        .send()
+        .await
+        .context("fetching /fleet/slots")?;
+    assert!(
+        response.status().is_success(),
+        "unexpected /fleet/slots response: {response:?}"
+    );
+    let snapshot: Value = response.json().await.context("reading /fleet/slots body")?;
+
+    assert_eq!(
+        snapshot.pointer("/source").and_then(Value::as_str),
+        Some("graphql.derived_inference_call_rows")
+    );
+    assert_eq!(
+        snapshot.pointer("/totals/assigned").and_then(Value::as_i64),
+        Some(expected_backend_running)
+    );
+    assert_eq!(
+        snapshot
+            .pointer("/totals/available")
+            .and_then(Value::as_i64),
+        Some(expected_available)
+    );
+    assert_eq!(
+        snapshot.pointer("/totals/max").and_then(Value::as_i64),
+        Some(1)
+    );
+    assert_eq!(
+        snapshot.pointer("/totals/queued").and_then(Value::as_i64),
+        Some(expected_backend_queued)
+    );
+    assert_eq!(
+        snapshot
+            .pointer("/expired/processing_requests")
+            .and_then(Value::as_i64),
+        Some(0)
+    );
+
+    let backend = find_snapshot_row(&snapshot, "backends", "backend_id", &backend_id)?;
+    assert_eq!(
+        backend.get("running").and_then(Value::as_i64),
+        Some(expected_backend_running)
+    );
+    assert_eq!(
+        backend.get("queued").and_then(Value::as_i64),
+        Some(expected_backend_queued)
+    );
+    assert_eq!(
+        backend.get("available").and_then(Value::as_i64),
+        Some(expected_available)
+    );
+    assert_eq!(
+        backend.get("max_concurrent").and_then(Value::as_i64),
+        Some(1)
+    );
+    assert_eq!(
+        backend.get("max_queue_depth").and_then(Value::as_i64),
+        Some(2)
+    );
+    assert_eq!(
+        backend.get("accepting_admission").and_then(Value::as_bool),
+        Some(true)
+    );
+
+    let behavior = find_snapshot_row(&snapshot, "behaviors", "behavior_id", &default_behavior_id)?;
+    assert_eq!(
+        behavior.get("backend_id").and_then(Value::as_str),
+        Some(backend_id.as_str())
+    );
+    assert_eq!(
+        behavior.get("assigned").and_then(Value::as_i64),
+        Some(expected_behavior_running)
+    );
+    assert_eq!(
+        behavior.get("available").and_then(Value::as_i64),
+        Some(expected_available)
+    );
+    assert_eq!(behavior.get("max").and_then(Value::as_i64), Some(1));
+    assert_eq!(
+        behavior.get("queued").and_then(Value::as_i64),
+        Some(expected_behavior_queued)
+    );
+
+    let cli_snapshot = run_cli_json(&home_dir, &["fleet", "slots", "--graphql", &graphql])?;
+    assert_eq!(
+        cli_snapshot.pointer("/totals/assigned"),
+        snapshot.pointer("/totals/assigned")
+    );
+    assert_eq!(
+        cli_snapshot.pointer("/backends/0/backend_id"),
+        snapshot.pointer("/backends/0/backend_id")
     );
 
     Ok(())

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -418,7 +418,7 @@ async fn server_exposes_fleet_slot_snapshot_endpoint() -> Result<()> {
 
     assert_eq!(
         snapshot.pointer("/source").and_then(Value::as_str),
-        Some("graphql.derived_inference_call_rows")
+        Some("graphql.derived_admission_state")
     );
     assert_eq!(
         snapshot.pointer("/totals/assigned").and_then(Value::as_i64),

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -212,8 +212,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := []
     }
   , { feature := "fleet-slot-accounting"
-    , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.api, "#287")]
+    , required := [Surface.runtimeInternal, Surface.api]
+    , deferred := []
     }
   , { feature := "storage-observation"
     , required := [Surface.runtimeInternal]
@@ -451,6 +451,11 @@ def caseCoverage : List CoverageEntry :=
       boundaryFleetSlotAccountingDerivedViewId
       "admission::tests::generated_slot_accounting_fleet_cases_match_admission_runtime_boundary")
       "fleet-slot-accounting" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "fleet_cases"
+      "FleetSlotAccounting"
+      "cli_server::server_exposes_fleet_slot_snapshot_endpoint")
+      "fleet-slot-accounting" [Surface.api]
   , tagged (boundaryCoverage
       "persistence_policy_cases"
       "PersistenceFailurePolicyCases"

--- a/crates/defra-agent/src/admission/config.rs
+++ b/crates/defra-agent/src/admission/config.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
-use crate::backend_registry::InferenceBackend;
+use crate::backend_registry::{InferenceBackend, HEALTHY_PROBE_STATUS};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct BackendAdmissionConfig {
@@ -42,7 +42,7 @@ impl BackendAdmissionConfig {
     }
 
     pub(crate) fn is_available(&self) -> bool {
-        self.enabled && self.probe_status == "healthy"
+        self.enabled && self.probe_status == HEALTHY_PROBE_STATUS
     }
 }
 

--- a/crates/defra-agent/src/backend_registry.rs
+++ b/crates/defra-agent/src/backend_registry.rs
@@ -9,6 +9,8 @@ use crate::backend_provider::BackendProviderKind;
 use crate::graphql::escape_graphql_string;
 
 pub const DEFAULT_MAX_QUEUE_DEPTH: i64 = 100;
+pub const HEALTHY_PROBE_STATUS: &str = "healthy";
+pub const UNKNOWN_PROBE_STATUS: &str = "unknown";
 
 #[derive(Debug, Clone)]
 pub struct InferenceBackend {
@@ -84,14 +86,14 @@ impl InferenceBackend {
             probe_status: v
                 .get("probe_status")
                 .and_then(|v| v.as_str())
-                .unwrap_or("unknown")
+                .unwrap_or(UNKNOWN_PROBE_STATUS)
                 .to_string(),
         })
     }
 
     /// Whether this backend is available for scheduling.
     pub fn is_available(&self) -> bool {
-        self.enabled && self.probe_status == "healthy"
+        self.enabled && self.probe_status == HEALTHY_PROBE_STATUS
     }
 }
 

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -57,7 +57,7 @@ pub use agent::{
     ProcessLifecycleObserver, ProcessLifecycleState,
 };
 pub use backend_provider::{discover_models as discover_backend_models, BackendProviderKind};
-pub use backend_registry::InferenceBackend;
+pub use backend_registry::{InferenceBackend, HEALTHY_PROBE_STATUS, UNKNOWN_PROBE_STATUS};
 pub use compaction::CompactionStrategy;
 pub use config::{
     AgentBehavior, SamplingConfig, DEFAULT_COMPACTION_THRESHOLD, DEFAULT_CONTEXT_WINDOW,

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -140,6 +140,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_backend_health_admission_cases_match_registry_and_admission_policy",
         },
         ConformanceConsumer::RustTest {
+            id: "cli_server::server_exposes_fleet_slot_snapshot_endpoint",
+            package: "defra-agent-cli",
+            source_path: "crates/defra-agent-cli/tests/cli_server.rs",
+            module_path: "cli_server",
+            function: "server_exposes_fleet_slot_snapshot_endpoint",
+        },
+        ConformanceConsumer::RustTest {
             id: "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_projection_consumes_generated_client_shell_contract_cases",
             package: "defra-agent-desktop-tauri",
             source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs",


### PR DESCRIPTION
## Summary
- Add `GET /fleet/slots` to the runtime HTTP router, returning a read-only fleet slot snapshot derived from persisted GraphQL rows.
- Add `defra-agent fleet slots` to query the live runtime endpoint.
- Add live server coverage plus Lean/conformance ledger coverage for `fleet-slot-accounting` on the `api` surface.

## Verification
- `cd crates/defra-agent/proofs && lake build`
- `cargo check -p defra-agent -p defra-agent-cli`
- `cargo test -p defra-agent-cli --test cli_server server_exposes_fleet_slot_snapshot_endpoint -- --nocapture`
- `cargo test -p defra-agent --test state_machine_conformance lean_feature_matrix_covers_every_declared_required_surface`
- `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain`
- `cargo test -p defra-agent-cli snapshot_reconstructs_slots_by_backend_and_behavior`
- `cargo run -p defra-agent-cli --bin defra-agent -- fleet slots --help`