### PR TITLE
Identity: API endpoint for ACP decision preview (#280)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8819,7 +8819,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,7 @@ dependencies = [
 name = "defra-agent-cli"
 version = "0.1.5"
 dependencies = [
+ "acp",
  "anyhow",
  "axum",
  "chrono",
@@ -3639,6 +3640,7 @@ dependencies = [
  "defra-node",
  "defra-p2p-adapter",
  "hostname",
+ "identity",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -36,6 +36,8 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
 defra-agent-lean-contract.workspace = true
+identity.workspace = true
 regex = "1"
 tempfile = "3"

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -36,7 +36,7 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.0" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.13.1" }
 defra-agent-lean-contract.workspace = true
 identity.workspace = true
 regex = "1"

--- a/crates/defra-agent-cli/src/http/identity_decide.rs
+++ b/crates/defra-agent-cli/src/http/identity_decide.rs
@@ -1,0 +1,406 @@
+use std::time::Duration;
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::http::router::RuntimeHttpState;
+
+#[cfg(test)]
+#[path = "../../../defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct IdentityDecideRequest {
+    actor: String,
+    permission: String,
+    resource: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DefraDbDecisionResponse {
+    allowed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct IdentityDecideResponse {
+    allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+}
+
+#[derive(Debug)]
+struct ParsedResource {
+    policy_id: String,
+    resource_name: String,
+    doc_id: String,
+}
+
+enum IdentityDecideError {
+    BadRequest(String),
+    Backend(String),
+    Internal(String),
+}
+
+pub(crate) async fn identity_decide_handler(
+    State(state): State<RuntimeHttpState>,
+    Json(body): Json<IdentityDecideRequest>,
+) -> Response {
+    match decide_identity_access(&state, body).await {
+        Ok(allowed) => (
+            StatusCode::OK,
+            Json(IdentityDecideResponse {
+                allowed,
+                reason: None,
+            }),
+        )
+            .into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn decide_identity_access(
+    state: &RuntimeHttpState,
+    body: IdentityDecideRequest,
+) -> Result<bool, IdentityDecideError> {
+    let resource = parse_resource(&body.resource).map_err(IdentityDecideError::BadRequest)?;
+    let permission = parse_permission(&body.permission).map_err(IdentityDecideError::BadRequest)?;
+
+    if body.actor.trim().is_empty() {
+        return Err(IdentityDecideError::BadRequest(
+            "actor must not be empty".to_string(),
+        ));
+    }
+
+    let api_base = crate::graphql_access::graphql_api_base(&state.graphql)
+        .map_err(|error| IdentityDecideError::Internal(error.to_string()))?;
+    let url = format!("{}/acp/document/decide", api_base.trim_end_matches('/'));
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .map_err(|error| IdentityDecideError::Internal(error.to_string()))?;
+    let response = client
+        .post(url)
+        .json(&json!({
+            "actor": body.actor,
+            "permission": permission,
+            "policyID": resource.policy_id,
+            "resourceName": resource.resource_name,
+            "docID": resource.doc_id,
+        }))
+        .send()
+        .await
+        .map_err(|error| IdentityDecideError::Backend(error.to_string()))?;
+
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .map_err(|error| IdentityDecideError::Backend(error.to_string()))?;
+    if !status.is_success() {
+        return Err(IdentityDecideError::Backend(format!(
+            "DefraDB decision endpoint returned {status}: {text}"
+        )));
+    }
+
+    let response: DefraDbDecisionResponse = serde_json::from_str(&text)
+        .map_err(|error| IdentityDecideError::Backend(error.to_string()))?;
+    Ok(response.allowed)
+}
+
+fn parse_resource(resource: &str) -> Result<ParsedResource, String> {
+    let mut parts = resource.split('/');
+    let policy_id = parts.next().unwrap_or_default();
+    let resource_name = parts.next().unwrap_or_default();
+    let doc_id = parts.next().unwrap_or_default();
+
+    if parts.next().is_some()
+        || policy_id.is_empty()
+        || resource_name.is_empty()
+        || doc_id.is_empty()
+    {
+        return Err("resource must have format policy_id/resource_name/doc_id".to_string());
+    }
+
+    Ok(ParsedResource {
+        policy_id: policy_id.to_string(),
+        resource_name: resource_name.to_string(),
+        doc_id: doc_id.to_string(),
+    })
+}
+
+fn parse_permission(permission: &str) -> Result<&'static str, String> {
+    let permission = permission.trim();
+    let suffix = permission.rsplit('.').next().unwrap_or(permission);
+    if suffix.eq_ignore_ascii_case("read") {
+        Ok("read")
+    } else if suffix.eq_ignore_ascii_case("update") {
+        Ok("update")
+    } else if suffix.eq_ignore_ascii_case("delete") {
+        Ok("delete")
+    } else {
+        Err("permission must resolve to read, update, or delete".to_string())
+    }
+}
+
+impl IdentityDecideError {
+    fn into_response(self) -> Response {
+        let (status, reason) = match self {
+            Self::BadRequest(reason) => (StatusCode::BAD_REQUEST, reason),
+            Self::Backend(reason) => (StatusCode::BAD_GATEWAY, reason),
+            Self::Internal(reason) => (StatusCode::INTERNAL_SERVER_ERROR, reason),
+        };
+
+        (
+            status,
+            Json(IdentityDecideResponse {
+                allowed: false,
+                reason: Some(reason),
+            }),
+        )
+            .into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::SocketAddr, sync::Arc};
+
+    use acp::{
+        AcpStore, DocumentACP, DocumentPermission, Identity, LocalDocumentACP, MemoryAcpStore,
+        RelationTuple, READER_RELATION,
+    };
+    use axum::{extract::State, routing::post, Router};
+    use identity::Did;
+    use serde::Deserialize;
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    use super::lean_vocab_test::{lean_identity_permission_cases, LeanIdentityPermissionCase};
+
+    const IDENTITY_PERMISSION_POLICY_ID: &str = "identity-permission-cases";
+    const IDENTITY_PERMISSION_RESOURCE_NAME: &str = "row";
+
+    #[derive(Debug, Deserialize)]
+    struct DefraDbDecisionRequest {
+        actor: String,
+        permission: String,
+        #[serde(rename = "policyID", alias = "policy_id")]
+        policy_id: String,
+        #[serde(rename = "resourceName", alias = "resource_name")]
+        resource_name: String,
+        #[serde(rename = "docID", alias = "doc_id")]
+        doc_id: String,
+    }
+
+    async fn mock_defradb_decide(
+        State(acp): State<Arc<LocalDocumentACP>>,
+        Json(body): Json<DefraDbDecisionRequest>,
+    ) -> Response {
+        let actor = match Did::new(body.actor) {
+            Ok(actor) => actor,
+            Err(error) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({ "error": error.to_string() })),
+                )
+                    .into_response()
+            }
+        };
+        let permission = match parse_acp_permission(&body.permission) {
+            Ok(permission) => permission,
+            Err(error) => {
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": error }))).into_response()
+            }
+        };
+        let allowed = match acp
+            .check_doc_access(
+                &Identity::Authenticated(actor),
+                permission,
+                &body.policy_id,
+                &body.resource_name,
+                &body.doc_id,
+            )
+            .await
+        {
+            Ok(allowed) => allowed,
+            Err(error) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(json!({ "error": error.to_string() })),
+                )
+                    .into_response()
+            }
+        };
+
+        (StatusCode::OK, Json(json!({ "allowed": allowed }))).into_response()
+    }
+
+    fn parse_acp_permission(permission: &str) -> Result<DocumentPermission, String> {
+        match permission {
+            "read" => Ok(DocumentPermission::Read),
+            "update" => Ok(DocumentPermission::Update),
+            "delete" => Ok(DocumentPermission::Delete),
+            _ => Err(format!("invalid permission: {permission}")),
+        }
+    }
+
+    async fn build_local_acp_from_lean_case(
+        case: &LeanIdentityPermissionCase,
+    ) -> anyhow::Result<LocalDocumentACP> {
+        let store = Arc::new(MemoryAcpStore::new());
+        let acp = LocalDocumentACP::new(store.clone());
+        let row_owner = did_from_lean_case(&case.row_owner, case, "row_owner");
+
+        acp.register_doc_object(
+            &row_owner,
+            IDENTITY_PERMISSION_POLICY_ID,
+            IDENTITY_PERMISSION_RESOURCE_NAME,
+            &case.row_owner,
+        )
+        .await?;
+
+        let namespaced_resource =
+            format!("{IDENTITY_PERMISSION_POLICY_ID}:{IDENTITY_PERMISSION_RESOURCE_NAME}");
+        for grant in &case.grants {
+            let principal = did_from_lean_case(&grant.principal, case, "grant.principal");
+            let tuple = RelationTuple::try_new(
+                principal,
+                READER_RELATION,
+                namespaced_resource.as_str(),
+                case.row_owner.as_str(),
+            )?;
+            store.put_tuple(&tuple).await?;
+        }
+
+        Ok(acp)
+    }
+
+    fn did_from_lean_case(value: &str, case: &LeanIdentityPermissionCase, field: &str) -> Did {
+        Did::new(value).unwrap_or_else(|error| {
+            panic!(
+                "case {:?}: {field} {:?} is not a valid Defra identity DID: {error}",
+                case.name, value
+            )
+        })
+    }
+
+    async fn spawn_mock_defradb(acp: LocalDocumentACP) -> anyhow::Result<String> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let router = Router::new()
+            .route("/api/v0/acp/document/decide", post(mock_defradb_decide))
+            .with_state(Arc::new(acp));
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        Ok(format!("http://{addr}"))
+    }
+
+    async fn spawn_runtime_router(graphql: String) -> anyhow::Result<SocketAddr> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let router = crate::http::runtime_contract_router(
+            graphql,
+            "identity-test-agent".to_string(),
+            "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK".to_string(),
+        );
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        Ok(addr)
+    }
+
+    async fn post_identity_decide(
+        runtime_addr: SocketAddr,
+        actor: &str,
+        permission: &str,
+        resource: &str,
+    ) -> anyhow::Result<IdentityDecideResponse> {
+        let response = reqwest::Client::new()
+            .post(format!("http://{runtime_addr}/identity/decide"))
+            .json(&json!({
+                "actor": actor,
+                "permission": permission,
+                "resource": resource,
+            }))
+            .send()
+            .await?;
+        let status = response.status();
+        let body = response.json::<IdentityDecideResponse>().await?;
+        assert!(status.is_success(), "unexpected status {status}: {body:?}");
+        Ok(body)
+    }
+
+    #[test]
+    fn parses_resource_and_lean_style_permissions() {
+        let resource = parse_resource("identity-permission-cases/row/did:key:z6Mkowner").unwrap();
+        assert_eq!(resource.policy_id, "identity-permission-cases");
+        assert_eq!(resource.resource_name, "row");
+        assert_eq!(resource.doc_id, "did:key:z6Mkowner");
+
+        assert_eq!(parse_permission("read").unwrap(), "read");
+        assert_eq!(
+            parse_permission("row:did:key:z6Mkowner:memory.read").unwrap(),
+            "read"
+        );
+        assert!(parse_resource("identity-permission-cases/row").is_err());
+        assert!(parse_permission("row:did:key:z6Mkowner:memory.admin").is_err());
+    }
+
+    #[tokio::test]
+    async fn identity_decide_endpoint_matches_lean_permission_cases() -> anyhow::Result<()> {
+        let cases = lean_identity_permission_cases();
+        assert_eq!(
+            cases.len(),
+            4,
+            "Lean should emit the four executable identity permission rows"
+        );
+
+        for case in cases {
+            let defradb_base =
+                spawn_mock_defradb(build_local_acp_from_lean_case(case).await?).await?;
+            let runtime_addr =
+                spawn_runtime_router(format!("{defradb_base}/api/v0/graphql")).await?;
+            let resource = format!(
+                "{IDENTITY_PERMISSION_POLICY_ID}/{IDENTITY_PERMISSION_RESOURCE_NAME}/{}",
+                case.row_owner
+            );
+
+            let actor = post_identity_decide(
+                runtime_addr,
+                &case.expected_actor_principal,
+                &case.permission,
+                &resource,
+            )
+            .await?;
+            let peer = post_identity_decide(
+                runtime_addr,
+                &case.expected_peer_principal,
+                &case.permission,
+                &resource,
+            )
+            .await?;
+
+            assert_eq!(
+                actor.allowed, case.expected_actor_allowed,
+                "case {:?}: /identity/decide actor decision drifted from Lean witness",
+                case.name
+            );
+            assert_eq!(
+                peer.allowed, case.expected_peer_allowed,
+                "case {:?}: /identity/decide peer decision drifted from Lean witness",
+                case.name
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod fleet_slots;
 pub(crate) mod healthz;
+pub(crate) mod identity_decide;
 pub(crate) mod liveness;
 pub(crate) mod prometheus;
 pub(crate) mod router;

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -4,7 +4,7 @@ use axum::{
     extract::State,
     http::{header, StatusCode},
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
     Router,
 };
 use serde_json::{json, Value};
@@ -46,6 +46,10 @@ pub(crate) fn runtime_contract_router(
         .route("/healthz", get(healthz_handler))
         .route("/status", get(status_handler))
         .route("/fleet/slots", get(fleet_slots_handler))
+        .route(
+            "/identity/decide",
+            post(crate::http::identity_decide::identity_decide_handler),
+        )
         .with_state(state)
 }
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -172,8 +172,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := [(Surface.operatorUi, "#278")]
     }
   , { feature := "identity-permission"
-    , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.api, "#280")]
+    , required := [Surface.runtimeInternal, Surface.api]
+    , deferred := []
     }
   , { feature := "apply-reconcile"
     , required := [Surface.operatorCli]
@@ -574,6 +574,11 @@ def caseCoverage : List CoverageEntry :=
       "IdentityPermissionCases"
       "identity_conformance::identity_permission_cases_pin_runtime_permission_contract_shape")
       "identity-permission" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "identity_permission_cases"
+      "IdentityPermissionCases"
+      "http::identity_decide::tests::identity_decide_endpoint_matches_lean_permission_cases")
+      "identity-permission" [Surface.api]
   , tagged (consumerCoverage
       "identity_contracts"
       "IdentityContracts"

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -182,6 +182,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "identity_permission_cases_pin_runtime_permission_contract_shape",
         },
         ConformanceConsumer::RustTest {
+            id: "http::identity_decide::tests::identity_decide_endpoint_matches_lean_permission_cases",
+            package: "defra-agent-cli",
+            source_path: "crates/defra-agent-cli/src/http/identity_decide.rs",
+            module_path: "http::identity_decide::tests",
+            function: "identity_decide_endpoint_matches_lean_permission_cases",
+        },
+        ConformanceConsumer::RustTest {
             id: "identity_conformance::identity_respects_principal_contract_enforced_by_runtime_routing",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/identity_conformance.rs",


### PR DESCRIPTION
## Summary
- add POST /identity/decide on the runtime HTTP surface
- proxy decisions to DefraDB's document ACP decide endpoint
- tag the API consumer under identity-permission/api in the Lean coverage ledger

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo test -p defra-agent-cli identity_decide -- --nocapture
- cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain -- --nocapture
- cargo test -p defra-agent --test state_machine_conformance lean_feature_matrix_covers_every_declared_required_surface -- --nocapture
- cargo check -p defra-agent -p defra-agent-cli

## Dependency note
This endpoint expects the DefraDB /api/v0/acp/document/decide route from the pending DefraDB PR before live end-to-end use.

Closes #280