### PR TITLE
request-lifecycle: dedicated UI ledger row (#275)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -3,7 +3,9 @@ use super::*;
 #[path = "../../../../../../../crates/defra-agent/src/lean_vocab_test.rs"]
 mod lean_vocab_test;
 
-use lean_vocab_test::{lean_desktop_client_shell_cases, LeanClientShellCase};
+use lean_vocab_test::{
+    lean_desktop_client_shell_cases, lean_request_lifecycle_operator_ui_cases, LeanClientShellCase,
+};
 
 #[test]
 fn session_snapshot_can_be_built_without_conversation_row_when_session_is_observed() {
@@ -304,6 +306,74 @@ fn session_snapshot_projection_consumes_generated_client_shell_contract_cases() 
             );
         }
     }
+}
+
+#[test]
+fn session_snapshot_binds_request_lifecycle_operator_ui_cases() {
+    let cases = lean_request_lifecycle_operator_ui_cases();
+    assert!(
+        !cases.is_empty(),
+        "request-lifecycle operator UI contract cases should be emitted"
+    );
+
+    let mut saw_nonterminal_turn = false;
+    let mut saw_terminal_turn = false;
+
+    for case in cases {
+        let name = case.name.as_str();
+        let observed_turn = case
+            .desktop_observed_turn_state
+            .as_deref()
+            .expect("request-lifecycle UI cases must observe a request turn");
+        let (_request_status, lifecycle_state) = request_state_for_turn(Some(observed_turn));
+        saw_nonterminal_turn |= matches!(observed_turn, "waitingForClaim" | "streaming");
+        saw_terminal_turn |= !matches!(observed_turn, "waitingForClaim" | "streaming");
+
+        let store = client_shell_contract_store(case);
+        let selected_session_id = contract_session_id(
+            case.desktop_selected_session_id
+                .expect("request-lifecycle UI cases should select a session"),
+        );
+        let preferred_request_id = case.desktop_preferred_request_id.map(contract_request_id);
+        let snapshot = build_session_snapshot_from_store(
+            &store,
+            &selected_session_id,
+            preferred_request_id.as_deref(),
+        )
+        .expect("request-lifecycle UI case should build a desktop session snapshot");
+
+        assert_eq!(
+            snapshot.latest_request_id.as_deref(),
+            case.desktop_expected_latest_request_id
+                .map(contract_request_id)
+                .as_deref(),
+            "case {name} should bind the UI snapshot to the observed lifecycle request"
+        );
+        assert_eq!(
+            snapshot.turn_state.as_deref(),
+            Some(observed_turn),
+            "case {name} should expose request lifecycle state as the UI turn state"
+        );
+        if let Some(expect_pending) = case.desktop_expect_pending_turn {
+            assert_eq!(
+                snapshot.pending_turn.is_some(),
+                expect_pending,
+                "case {name} pending-turn visibility drifted from lifecycle state"
+            );
+        }
+        if let Some(pending_turn) = snapshot.pending_turn.as_ref() {
+            assert_eq!(
+                pending_turn.lifecycle_state.as_deref(),
+                Some(lifecycle_state),
+                "case {name} should carry the raw lifecycle state for UI badges"
+            );
+        }
+    }
+
+    assert!(
+        saw_nonterminal_turn && saw_terminal_turn,
+        "request-lifecycle UI cases should cover active and terminal turn bindings"
+    );
 }
 
 #[test]

--- a/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts/Json.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ClientShell/Contracts/Json.lean
@@ -90,4 +90,10 @@ def desktopClientShellCasesJson : String :=
 def desktopClientShellCaseCount : Nat :=
   desktopClientShellCases.length
 
+def requestLifecycleOperatorUiCases : List ClientShellContractCase :=
+  desktopClientShellCases.filter (fun witness => witness.desktopObservedTurnState.isSome)
+
+def requestLifecycleOperatorUiCasesJson : String :=
+  jsonArray (requestLifecycleOperatorUiCases.map ClientShellContractCase.toJson)
+
 end Conformance.ClientShellContracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -46,6 +46,8 @@ def snapshotJson : String :=
       ++ toString Conformance.ClientShellContracts.desktopClientShellCaseCount ++ ","
     ++ "\"desktop_client_shell_cases\":"
       ++ Conformance.ClientShellContracts.desktopClientShellCasesJson ++ ","
+    ++ "\"request_lifecycle_operator_ui_cases\":"
+      ++ Conformance.ClientShellContracts.requestLifecycleOperatorUiCasesJson ++ ","
     ++ "\"runtime_reconcile_cases\":"
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
     ++ "\"apply_reconcile_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -115,8 +115,8 @@ def FeatureSurfaceRequirement.toJson (req : FeatureSurfaceRequirement) : String 
 
 def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
   [ { feature := "request-lifecycle"
-    , required := [Surface.agentFacing, Surface.runtimeInternal]
-    , deferred := [(Surface.operatorUi, "#275")]
+    , required := [Surface.agentFacing, Surface.runtimeInternal, Surface.operatorUi]
+    , deferred := []
     }
   , { feature := "process-lifecycle"
     , required := [Surface.runtimeInternal]
@@ -499,6 +499,11 @@ def caseCoverage : List CoverageEntry :=
       "LiveOverlayCases"
       "live_overlay_conformance::live_overlay_cases_match_lean_table")
       "client-shell" [Surface.operatorUi]
+  , tagged (consumerCoverage
+      "request_lifecycle_operator_ui_cases"
+      "RequestLifecycleOperatorUiCases"
+      "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_binds_request_lifecycle_operator_ui_cases")
+      "request-lifecycle" [Surface.operatorUi]
   , tagged (consumerCoverage
       "tool_cases"
       "ToolExecutionPreflight"

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -36,6 +36,7 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) frontend_client_shell_cases: Vec<LeanClientShellCase>,
     pub(crate) desktop_client_shell_case_count: usize,
     pub(crate) desktop_client_shell_cases: Vec<LeanClientShellCase>,
+    pub(crate) request_lifecycle_operator_ui_cases: Vec<LeanClientShellCase>,
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
     pub(crate) apply_reconcile_cases: Vec<LeanApplyReconcileCase>,
     pub(crate) session_recovery_cases: Vec<LeanSessionRecoveryCase>,
@@ -318,6 +319,10 @@ pub(crate) fn lean_client_shell_case(name: &str) -> &'static LeanClientShellCase
 
 pub(crate) fn lean_desktop_client_shell_cases() -> &'static [LeanClientShellCase] {
     &lean_contract_snapshot().desktop_client_shell_cases
+}
+
+pub(crate) fn lean_request_lifecycle_operator_ui_cases() -> &'static [LeanClientShellCase] {
+    &lean_contract_snapshot().request_lifecycle_operator_ui_cases
 }
 
 pub(crate) fn lean_inference_slot_accounting_cases() -> &'static [LeanInferenceSlotAccountingCase] {

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -576,6 +576,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "DesktopClientShellCases".to_string(),
         ));
     }
+    if !snapshot.request_lifecycle_operator_ui_cases.is_empty() {
+        emitted.insert((
+            "request_lifecycle_operator_ui_cases".to_string(),
+            "RequestLifecycleOperatorUiCases".to_string(),
+        ));
+    }
     if !snapshot.tool_preflight_cases.is_empty() {
         emitted.insert((
             "tool_cases".to_string(),
@@ -733,6 +739,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "managed_exec_cases",
         "frontend_client_shell_cases",
         "desktop_client_shell_cases",
+        "request_lifecycle_operator_ui_cases",
         "tool_cases",
         "command_policy_cases",
         "live_overlay_cases",

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -154,6 +154,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "session_snapshot_projection_consumes_generated_client_shell_contract_cases",
         },
         ConformanceConsumer::RustTest {
+            id: "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_binds_request_lifecycle_operator_ui_cases",
+            package: "defra-agent-desktop-tauri",
+            source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs",
+            module_path: "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state",
+            function: "session_snapshot_binds_request_lifecycle_operator_ui_cases",
+        },
+        ConformanceConsumer::RustTest {
             id: "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/hook/tests.rs",


### PR DESCRIPTION
Closes #275.

## Summary
- add a dedicated RequestLifecycleOperatorUiCases contract slice from desktop ClientShell observations
- add a desktop session snapshot consumer that binds request lifecycle state to operator UI turn state/pending badges
- promote request-lifecycle.operatorUi from deferred to required with a consumerCoverage ledger row

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent-desktop-tauri session_snapshot_binds_request_lifecycle_operator_ui_cases