### PR TITLE
streaming-response: bind operatorUi ledger row (#285)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -4,7 +4,8 @@ use super::*;
 mod lean_vocab_test;
 
 use lean_vocab_test::{
-    lean_desktop_client_shell_cases, lean_request_lifecycle_operator_ui_cases, LeanClientShellCase,
+    lean_desktop_client_shell_cases, lean_request_lifecycle_operator_ui_cases,
+    lean_response_transition_cases, LeanClientShellCase, LeanResponseTransitionCase,
 };
 
 #[test]
@@ -377,6 +378,86 @@ fn session_snapshot_binds_request_lifecycle_operator_ui_cases() {
 }
 
 #[test]
+fn session_snapshot_streaming_response_overlay_consumes_generated_transition_cases() {
+    let cases = lean_response_transition_cases();
+    assert_eq!(
+        cases.len(),
+        12,
+        "desktop streaming renderer should consume every Lean response transition case"
+    );
+
+    for case in cases {
+        let store = streaming_response_contract_store(case);
+        let snapshot = build_session_snapshot_from_store(&store, "session-1", Some("req-1"))
+            .unwrap_or_else(|| panic!("case {} should produce a session snapshot", case.name));
+
+        assert_eq!(
+            snapshot
+                .latest_response
+                .as_ref()
+                .and_then(|response| response.status.as_deref()),
+            Some(case.post_status.as_str()),
+            "case {} should expose the Lean post response status",
+            case.name
+        );
+        assert_eq!(
+            snapshot
+                .latest_response
+                .as_ref()
+                .and_then(|response| response.token_count)
+                .map(|count| count as usize),
+            Some(case.post_token_count),
+            "case {} should expose the Lean post token count",
+            case.name
+        );
+        assert_eq!(
+            snapshot
+                .latest_response
+                .as_ref()
+                .and_then(|response| response.materialized_message_sequence)
+                .map(|sequence| sequence as usize),
+            case.post_materialized_seq,
+            "case {} should expose the Lean materialization sequence",
+            case.name
+        );
+
+        let expected_live_overlay = streaming_case_should_render_live_overlay(case);
+        assert_eq!(
+            snapshot.active_response_overlay.is_some(),
+            expected_live_overlay,
+            "case {} active overlay visibility should follow the Lean streaming post state",
+            case.name
+        );
+
+        let live_items = snapshot
+            .timeline_items
+            .iter()
+            .filter_map(|item| match item {
+                RenderedTimelineItem::LiveAssistant {
+                    content, reasoning, ..
+                } => Some((content.as_deref(), reasoning.as_deref())),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            live_items.len(),
+            usize::from(expected_live_overlay),
+            "case {} should render exactly the Lean-visible live assistant item count",
+            case.name
+        );
+        if expected_live_overlay {
+            let (expected_content, expected_reasoning) = streaming_case_tail(case);
+            assert_eq!(
+                live_items[0],
+                (expected_content.as_deref(), expected_reasoning.as_deref()),
+                "case {} live assistant item should carry the Lean live tail",
+                case.name
+            );
+        }
+    }
+}
+
+#[test]
 fn session_snapshot_stays_renderable_across_single_turn_observation_updates() {
     let submitted = ClientStore::from_rows(ClientStoreRows {
         conversations: vec![AgentConversationRow {
@@ -717,5 +798,118 @@ fn response_status_for_turn(turn_state: Option<&str>) -> Option<&'static str> {
         Some("failed") => Some("error"),
         Some("waitingForClaim") | Some("superseded") | Some("interrupted") | None => None,
         Some(other) => panic!("unsupported Lean ClientShell turn state {other:?}"),
+    }
+}
+
+fn streaming_response_contract_store(case: &LeanResponseTransitionCase) -> ClientStore {
+    let (content, reasoning) = streaming_case_tail(case);
+    let lifecycle_state = request_lifecycle_for_streaming_post_status(case.post_status.as_str());
+
+    ClientStore::from_rows(ClientStoreRows {
+        conversations: vec![AgentConversationRow {
+            session_id: "session-1".to_string(),
+            agent_name: Some("Contract Agent".to_string()),
+            agent_did: Some("did:defra:contract-agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            title: Some("streaming response contract".to_string()),
+            title_source: Some("generated".to_string()),
+            preview_text: Some("contract prompt".to_string()),
+            status: Some("active".to_string()),
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            updated_at: Some("2026-04-21T12:01:00Z".to_string()),
+            latest_request_id: Some("req-1".to_string()),
+        }],
+        requests: vec![AgentRequestRow {
+            request_id: "req-1".to_string(),
+            agent_did: Some("did:defra:contract-agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            session_id: Some("session-1".to_string()),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("contract prompt".to_string()),
+            status: Some(request_status_for_lifecycle(lifecycle_state).to_string()),
+            lifecycle_state: Some(lifecycle_state.to_string()),
+            backend_id: None,
+            execution_origin: Some("interactive".to_string()),
+            failure_reason: None,
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            claimed_at: None,
+            deadline: None,
+            retry_count: Some(0),
+            max_retries: Some(3),
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        }],
+        responses: vec![AgentResponseRow {
+            response_key: "resp-1".to_string(),
+            request_id: Some("req-1".to_string()),
+            agent_did: Some("did:defra:contract-agent".to_string()),
+            behavior_id: Some("contract-behavior".to_string()),
+            session_id: Some("session-1".to_string()),
+            content,
+            reasoning,
+            status: Some(case.post_status.clone()),
+            error_message: case.error_reason.clone(),
+            token_count: Some(case.post_token_count as i64),
+            progress_seq: Some(1),
+            materialized_message_sequence: case
+                .post_materialized_seq
+                .map(|sequence| sequence as i64),
+            materialized_at: case
+                .post_materialized_seq
+                .map(|_| "2026-04-21T12:01:05Z".to_string()),
+            created_at: Some("2026-04-21T12:00:01Z".to_string()),
+            completed_at: matches!(case.post_status.as_str(), "complete" | "error")
+                .then(|| "2026-04-21T12:01:05Z".to_string()),
+            interrupted_at: (case.action == "set_interrupted_at")
+                .then(|| "2026-04-21T12:01:03Z".to_string()),
+        }],
+        ..ClientStoreRows::default()
+    })
+}
+
+fn streaming_case_should_render_live_overlay(case: &LeanResponseTransitionCase) -> bool {
+    case.post_status == "streaming"
+        && case.post_live_tail == "nonEmpty"
+        && case.post_materialized_seq.is_none()
+        && case.action != "set_interrupted_at"
+}
+
+fn streaming_case_tail(case: &LeanResponseTransitionCase) -> (Option<String>, Option<String>) {
+    if case.post_live_tail != "nonEmpty" {
+        return (None, None);
+    }
+    if case.action == "write_reasoning" {
+        return (
+            None,
+            Some(format!(
+                "{} reasoning live tail",
+                case.name.replace('_', " ")
+            )),
+        );
+    }
+    (
+        Some(format!("{} content live tail", case.name.replace('_', " "))),
+        None,
+    )
+}
+
+fn request_lifecycle_for_streaming_post_status(status: &str) -> &'static str {
+    match status {
+        "streaming" => "processing",
+        "complete" => "completed",
+        "error" => "failed",
+        other => panic!("unsupported Lean streaming response post status {other:?}"),
+    }
+}
+
+fn request_status_for_lifecycle(lifecycle_state: &str) -> &str {
+    match lifecycle_state {
+        "completed" => "completed",
+        "failed" => "error",
+        other => other,
     }
 }

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -196,8 +196,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := [(Surface.operatorUi, "#284")]
     }
   , { feature := "streaming-response"
-    , required := [Surface.agentFacing]
-    , deferred := [(Surface.operatorUi, "#285")]
+    , required := [Surface.agentFacing, Surface.operatorUi]
+    , deferred := []
     }
   , { feature := "client-shell"
     , required := [Surface.operatorUi]
@@ -594,6 +594,11 @@ def caseCoverage : List CoverageEntry :=
       "ResponseTransitionCases"
       "state_machine_conformance::generated_streaming_response_cases_pin_lifecycle_contract")
       "streaming-response" [Surface.agentFacing]
+  , tagged (consumerCoverage
+      "streaming_response_cases"
+      "ResponseTransitionCases"
+      "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_streaming_response_overlay_consumes_generated_transition_cases")
+      "streaming-response" [Surface.operatorUi]
   , tagged (consumerCoverage
       "compaction_reducer_cases"
       "CompactionReducerCases"

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -161,6 +161,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "session_snapshot_binds_request_lifecycle_operator_ui_cases",
         },
         ConformanceConsumer::RustTest {
+            id: "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state::session_snapshot_streaming_response_overlay_consumes_generated_transition_cases",
+            package: "defra-agent-desktop-tauri",
+            source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs",
+            module_path: "defra_agent_desktop_tauri::bridge::snapshot::tests::session_state",
+            function: "session_snapshot_streaming_response_overlay_consumes_generated_transition_cases",
+        },
+        ConformanceConsumer::RustTest {
             id: "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/hook/tests.rs",


### PR DESCRIPTION
Closes #285.

## Summary
- Add a desktop snapshot consumer that runs generated Lean StreamingResponse transition cases through the active response overlay/timeline projection.
- Register the desktop consumer in the conformance consumer registry.
- Promote the streaming-response operatorUi feature matrix surface from deferred to required consumer coverage.

## Verification
- cd crates/defra-agent/proofs && lake build
- cargo check -p defra-agent
- cargo test -p defra-agent --test state_machine_conformance
- cargo test -p defra-agent-desktop-tauri
- npm ci && npm test (apps/desktop-tauri)