### PR TITLE
EventDelivery: drive transition + convergence cases through production sources (#252)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -594,30 +594,20 @@ def caseCoverage : List CoverageEntry :=
       "CompactionReducerCases"
       "state_machine_conformance::generated_compaction_reducer_cases_pin_contract")
       "compaction" [Surface.agentFacing]
-  -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
-  -- and follow-up issue #252: this consumer still drives the Lean rows
-  -- through InMemoryEventDeliverySource rather than the production
-  -- DefraWatcher/EventSource/SubagentSource loops.
-  , tagged (consumerWithFollowUpCoverage
+  , tagged (consumerCoverage
       "event_delivery_cases"
       "EventDeliveryTransitionCases"
-      "state_machine_conformance::event_delivery_transition_cases_match_contract"
-      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops.")
+      "state_machine_conformance::event_delivery_transition_cases_match_contract")
       "event-delivery" [Surface.runtimeInternal]
   , tagged (consumerCoverage
       "event_delivery_cases"
       "EventDeliverySourceInstances"
       "state_machine_conformance::event_delivery_source_instances_match_runtime")
       "event-delivery" [Surface.runtimeInternal]
-  -- See docs/superpowers/audits/2026-05-19-conformance-audit.md#15-eventdelivery
-  -- and follow-up issue #252: this consumer still drives the Lean traces
-  -- through InMemoryEventDeliverySource rather than the production
-  -- DefraWatcher/EventSource/SubagentSource loops.
-  , tagged (consumerWithFollowUpCoverage
+  , tagged (consumerCoverage
       "event_delivery_cases"
       "EventDeliveryConvergenceTraces"
-      "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation"
-      "Issue #252 replaces the InMemoryEventDeliverySource replay with a thin driver over the production DefraWatcher/EventSource/SubagentSource event-delivery loops.")
+      "state_machine_conformance::event_delivery_convergence_traces_match_runtime_or_deviation")
       "event-delivery" [Surface.runtimeInternal]
   -- 2026-05-19 conformance audit section 10 / section 6 item #2:
   -- Stage 1 drives the K=1 runtime health-check path; Stage 2 issue #253

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -126,6 +126,7 @@ pub use toolset::{
 pub use trigger_engine::event_source::EventSource;
 pub use trigger_engine::subagent_source::SubagentSource;
 pub use trigger_engine::subscription_source::UpdateSubscriptionSource;
+pub use trigger_engine::{FireIntent, FireResult, TriggerKind, TriggerSource};
 pub use truncation::{DefraSpillTruncator, TruncationLimits, TruncationMode, Truncator};
 pub use watcher::{AgentRequest, DefraWatcher, Watcher};
 

--- a/crates/defra-agent/src/trigger_engine/mod.rs
+++ b/crates/defra-agent/src/trigger_engine/mod.rs
@@ -34,7 +34,7 @@ type TriggerLockMap = HashMap<TriggerLockKey, TriggerLock>;
 /// documents. Manual is reserved for direct fire requests (e.g. CLI / API
 /// invocations) that do not have a persisted trigger document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum TriggerKind {
+pub enum TriggerKind {
     Schedule,
     #[allow(dead_code)]
     Event,
@@ -60,16 +60,16 @@ impl TriggerKind {
 /// request: the resolved task, the concurrency policy, the template variable
 /// bags, and a one-shot `on_result` callback so the source can react (e.g.
 /// write back `last_status` bookkeeping on the trigger document).
-pub(crate) struct FireIntent {
-    pub(crate) trigger_id: Option<String>,
-    pub(crate) trigger_kind: TriggerKind,
-    pub(crate) task: crate::runtime_snapshot::ResolvedTask,
-    pub(crate) concurrency: crate::runtime_snapshot::ConcurrencyMode,
-    pub(crate) event_vars: serde_json::Value,
-    pub(crate) doc_vars: Option<serde_json::Value>,
-    pub(crate) args_vars: Option<serde_json::Value>,
-    pub(crate) pre_materialized_request_id: Option<String>,
-    pub(crate) on_result: Box<dyn FnOnce(FireResult) + Send>,
+pub struct FireIntent {
+    pub trigger_id: Option<String>,
+    pub trigger_kind: TriggerKind,
+    pub task: crate::runtime_snapshot::ResolvedTask,
+    pub concurrency: crate::runtime_snapshot::ConcurrencyMode,
+    pub event_vars: serde_json::Value,
+    pub doc_vars: Option<serde_json::Value>,
+    pub args_vars: Option<serde_json::Value>,
+    pub pre_materialized_request_id: Option<String>,
+    pub on_result: Box<dyn FnOnce(FireResult) + Send>,
 }
 
 impl FireIntent {
@@ -91,7 +91,7 @@ impl FireIntent {
 /// unexpected failure that the source should record and, in most cases, retry
 /// on a later tick.
 #[derive(Debug, Clone)]
-pub(crate) enum FireResult {
+pub enum FireResult {
     #[allow(dead_code)]
     Fired {
         request_id: String,
@@ -110,7 +110,7 @@ pub(crate) enum FireResult {
 ///
 /// Sources are polled by the engine's main loop; returning `None` indicates
 /// the source is exhausted and should be dropped.
-pub(crate) trait TriggerSource: Send + Sync {
+pub trait TriggerSource: Send + Sync {
     fn next_fire(
         &mut self,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Option<FireIntent>> + Send + '_>>;

--- a/crates/defra-agent/tests/state_machine_conformance.rs
+++ b/crates/defra-agent/tests/state_machine_conformance.rs
@@ -257,9 +257,9 @@ async fn generated_request_transition_cases_cover_lifecycle_policy() {
     request_lifecycle::generated_request_transition_cases_cover_lifecycle_policy().await;
 }
 
-#[test]
-fn event_delivery_transition_cases_match_contract() {
-    event_delivery::event_delivery_transition_cases_match_contract();
+#[tokio::test]
+async fn event_delivery_transition_cases_match_contract() {
+    event_delivery::event_delivery_transition_cases_match_contract().await;
 }
 
 #[test]
@@ -267,7 +267,7 @@ fn event_delivery_source_instances_match_runtime() {
     event_delivery::event_delivery_source_instances_match_runtime();
 }
 
-#[test]
-fn event_delivery_convergence_traces_match_runtime_or_deviation() {
-    event_delivery::event_delivery_convergence_traces_match_runtime_or_deviation();
+#[tokio::test]
+async fn event_delivery_convergence_traces_match_runtime_or_deviation() {
+    event_delivery::event_delivery_convergence_traces_match_runtime_or_deviation().await;
 }

--- a/crates/defra-agent/tests/state_machine_conformance/event_delivery.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/event_delivery.rs
@@ -1,6 +1,23 @@
 use super::*;
+use std::sync::Arc;
+use std::time::Duration;
 
-pub(super) fn event_delivery_transition_cases_match_contract() {
+use defra_agent::defra_node::{EmbeddedNode, QueryResponse};
+use defra_agent::{
+    ActiveRuntimeSnapshot, AgentRequest, ConcurrencyMode, DefraWatcher, EventSource,
+    ResolvedEventTrigger, ResolvedTask, SubagentSource, TriggerSource, Watcher,
+};
+use tokio::sync::{mpsc, watch};
+use tokio_util::sync::CancellationToken;
+
+use super::support::mock_subscription::MockUpdateSubscriptionSource;
+
+const EVENT_SOURCE_COLLECTION: &str = "EventDeliveryDoc";
+const EVENT_SOURCE_TRIGGER_ID: &str = "event-delivery-trigger";
+const EVENT_SOURCE_TASK_ID: &str = "event-delivery-task";
+const DELIVERY_TIMEOUT: Duration = Duration::from_secs(2);
+
+pub(super) async fn event_delivery_transition_cases_match_contract() {
     let cases = lean_event_delivery_transition_cases();
     let watcher = runtime_event_delivery_source_contract("Watcher");
     assert!(
@@ -9,13 +26,14 @@ pub(super) fn event_delivery_transition_cases_match_contract() {
         cases.len()
     );
     for case in cases {
-        let mut runtime = InMemoryEventDeliverySource::new(watcher, &case.pre);
+        let mut runtime = ProductionEventDeliveryDriver::new(watcher, &case.pre).await;
         runtime
             .apply(&case.action)
+            .await
             .unwrap_or_else(|err| panic!("case `{}` rejected runtime action: {err}", case.name));
         assert_eq!(
             runtime.world, case.post,
-            "case `{}` drifted from in-memory runtime replay",
+            "case `{}` drifted from production runtime replay",
             case.name
         );
     }
@@ -42,7 +60,7 @@ pub(super) fn event_delivery_source_instances_match_runtime() {
     );
 }
 
-pub(super) fn event_delivery_convergence_traces_match_runtime_or_deviation() {
+pub(super) async fn event_delivery_convergence_traces_match_runtime_or_deviation() {
     let traces = lean_event_delivery_convergence_traces();
     assert!(
         traces.len() >= 3,
@@ -51,25 +69,25 @@ pub(super) fn event_delivery_convergence_traces_match_runtime_or_deviation() {
 
     for trace in traces {
         let source = runtime_event_delivery_source_contract(&trace.instance_name);
-        let mut runtime = InMemoryEventDeliverySource::new(source, &trace.initial_world);
+        let mut runtime = ProductionEventDeliveryDriver::new(source, &trace.initial_world).await;
         for action in &trace.actions {
-            runtime.apply(action).unwrap_or_else(|err| {
+            runtime.apply(action).await.unwrap_or_else(|err| {
                 panic!("trace `{}` rejected runtime action: {err}", trace.name)
             });
         }
         assert_eq!(
             runtime.world, trace.final_world,
-            "trace `{}` drifted from in-memory runtime replay",
+            "trace `{}` drifted from production runtime replay",
             trace.name
         );
 
         match trace.status.as_str() {
             "substantive" => {
                 assert!(
-                    runtime.unhandled_persistent_docs().is_empty(),
+                    runtime.unhandled_persistent_docs().await.is_empty(),
                     "substantive trace `{}` left persistent docs unhandled: {:?}",
                     trace.name,
-                    runtime.unhandled_persistent_docs()
+                    runtime.unhandled_persistent_docs().await
                 );
                 assert!(
                     source.deviation.is_none(),
@@ -89,7 +107,7 @@ pub(super) fn event_delivery_convergence_traces_match_runtime_or_deviation() {
                     trace.name
                 );
                 assert!(
-                    !runtime.unhandled_persistent_docs().is_empty(),
+                    !runtime.unhandled_persistent_docs().await.is_empty(),
                     "deviation trace `{}` did not witness the documented \
                      deviation state (no orphan persistent doc remaining)",
                     trace.name,
@@ -113,45 +131,160 @@ pub(super) fn event_delivery_convergence_traces_match_runtime_or_deviation() {
     }
 }
 
-#[derive(Debug)]
-struct InMemoryEventDeliverySource {
+struct ProductionEventDeliveryDriver {
     source: EventDeliverySourceContract,
+    db: super::support::TestDb,
+    mock_subs: MockUpdateSubscriptionSource,
+    runtime: ProductionRuntime,
+    cancel: CancellationToken,
+    _snapshot_tx: Option<watch::Sender<Arc<ActiveRuntimeSnapshot>>>,
+    runner: Option<tokio::task::JoinHandle<()>>,
+    emitted_rx: Option<mpsc::Receiver<String>>,
+    emitted_buffer: Vec<String>,
+    doc_ids: HashMap<String, String>,
     world: lean_vocab_test::LeanEventDeliveryWorld,
 }
 
-impl InMemoryEventDeliverySource {
-    fn new(
+enum ProductionRuntime {
+    Watcher { watcher: DefraWatcher },
+    EventSource,
+    SubagentSource,
+}
+
+impl ProductionEventDeliveryDriver {
+    async fn new(
         source: EventDeliverySourceContract,
         world: &lean_vocab_test::LeanEventDeliveryWorld,
     ) -> Self {
-        Self {
-            source,
-            world: world.clone(),
-        }
+        let db = test_db(&format!("event-delivery-{}", source.name)).await;
+        let mock_subs = MockUpdateSubscriptionSource::new();
+        let cancel = CancellationToken::new();
+        let mut driver = match source.name {
+            "Watcher" => {
+                let watcher = DefraWatcher::with_subscription_source(
+                    Arc::new(mock_subs.clone()),
+                    db.node.clone(),
+                    AGENT_DID,
+                );
+                Self {
+                    source,
+                    db,
+                    mock_subs,
+                    runtime: ProductionRuntime::Watcher { watcher },
+                    cancel,
+                    _snapshot_tx: None,
+                    runner: None,
+                    emitted_rx: None,
+                    emitted_buffer: Vec::new(),
+                    doc_ids: HashMap::new(),
+                    world: empty_event_delivery_world(),
+                }
+            }
+            "EventSource" => {
+                install_event_delivery_source_schema(db.node.as_ref()).await;
+                let (runner, emitted_rx, snapshot_tx) =
+                    spawn_event_source_runner(db.node.clone(), mock_subs.clone(), cancel.clone());
+                assert!(
+                    mock_subs
+                        .wait_for_subscribers(1, Duration::from_secs(2))
+                        .await,
+                    "EventSource runner did not open its mock subscription"
+                );
+                Self {
+                    source,
+                    db,
+                    mock_subs,
+                    runtime: ProductionRuntime::EventSource,
+                    cancel,
+                    _snapshot_tx: Some(snapshot_tx),
+                    runner: Some(runner),
+                    emitted_rx: Some(emitted_rx),
+                    emitted_buffer: Vec::new(),
+                    doc_ids: HashMap::new(),
+                    world: empty_event_delivery_world(),
+                }
+            }
+            "SubagentSource" => {
+                let (runner, emitted_rx, snapshot_tx) = spawn_subagent_source_runner(
+                    db.node.clone(),
+                    mock_subs.clone(),
+                    cancel.clone(),
+                );
+                assert!(
+                    mock_subs
+                        .wait_for_subscribers(1, Duration::from_secs(2))
+                        .await,
+                    "SubagentSource runner did not open its mock subscription"
+                );
+                Self {
+                    source,
+                    db,
+                    mock_subs,
+                    runtime: ProductionRuntime::SubagentSource,
+                    cancel,
+                    _snapshot_tx: Some(snapshot_tx),
+                    runner: Some(runner),
+                    emitted_rx: Some(emitted_rx),
+                    emitted_buffer: Vec::new(),
+                    doc_ids: HashMap::new(),
+                    world: empty_event_delivery_world(),
+                }
+            }
+            other => panic!("unhandled event-delivery source {other:?}"),
+        };
+        driver.seed_world(world).await.unwrap_or_else(|err| {
+            panic!(
+                "failed to seed production event-delivery world for {}: {err}",
+                driver.source.name
+            )
+        });
+        driver
     }
 
-    fn apply(&mut self, action: &LeanEventDeliveryAction) -> Result<(), String> {
+    async fn seed_world(
+        &mut self,
+        world: &lean_vocab_test::LeanEventDeliveryWorld,
+    ) -> Result<(), String> {
+        for (index, doc) in world.persistent_set.iter().enumerate() {
+            self.persist_runtime_doc(doc, index).await?;
+            if world.processed_set.contains(doc) {
+                self.mark_runtime_doc_processed(doc).await?;
+            }
+        }
+        for doc in &world.subscription_queue {
+            self.publish_update(doc)?;
+        }
+        self.world = world.clone();
+        Ok(())
+    }
+
+    async fn apply(&mut self, action: &LeanEventDeliveryAction) -> Result<(), String> {
         match action {
             LeanEventDeliveryAction::Persist { doc } => {
                 if self.world.persistent_set.contains(doc) {
                     return Err(format!("doc {doc:?} already persisted"));
                 }
+                let sequence = self.world.persistent_set.len();
+                self.persist_runtime_doc(doc, sequence).await?;
                 self.world.persistent_set.insert(0, doc.clone());
             }
             LeanEventDeliveryAction::Depersist { doc } => {
                 erase_first(&mut self.world.persistent_set, doc)
                     .ok_or_else(|| format!("doc {doc:?} is not persistent"))?;
+                self.depersist_runtime_doc(doc).await?;
             }
             LeanEventDeliveryAction::Enqueue { doc } => {
                 if !self.world.persistent_set.contains(doc) {
                     return Err(format!("doc {doc:?} is not persistent"));
                 }
+                self.publish_update(doc)?;
                 self.world.subscription_queue.insert(0, doc.clone());
             }
             LeanEventDeliveryAction::Drop { doc }
             | LeanEventDeliveryAction::DeliverFromQueue { doc } => {
                 erase_first(&mut self.world.subscription_queue, doc)
                     .ok_or_else(|| format!("doc {doc:?} is not queued"))?;
+                self.drop_production_delivery(doc).await?;
             }
             LeanEventDeliveryAction::RescanTick => {
                 if self.source.rescan_bounded_by == 0 {
@@ -167,6 +300,7 @@ impl InMemoryEventDeliverySource {
                     .filter(|doc| !self.world.processed_set.contains(*doc))
                     .cloned()
                     .collect::<Vec<_>>();
+                self.drive_rescan(&rescanned).await?;
                 rescanned.extend(self.world.subscription_queue.clone());
                 self.world.subscription_queue = rescanned;
             }
@@ -176,6 +310,8 @@ impl InMemoryEventDeliverySource {
                 }
                 erase_first(&mut self.world.subscription_queue, doc)
                     .ok_or_else(|| format!("doc {doc:?} is not queued"))?;
+                self.drive_handle(doc).await?;
+                self.mark_runtime_doc_processed(doc).await?;
                 self.world.processed_set.insert(0, doc.clone());
                 self.world.handled.insert(0, doc.clone());
             }
@@ -183,7 +319,7 @@ impl InMemoryEventDeliverySource {
         Ok(())
     }
 
-    fn unhandled_persistent_docs(&self) -> Vec<String> {
+    async fn unhandled_persistent_docs(&self) -> Vec<String> {
         self.world
             .persistent_set
             .iter()
@@ -191,6 +327,480 @@ impl InMemoryEventDeliverySource {
             .cloned()
             .collect()
     }
+
+    async fn persist_runtime_doc(&mut self, doc: &str, sequence: usize) -> Result<(), String> {
+        if self.doc_ids.contains_key(doc) {
+            return Ok(());
+        }
+        let doc_id = match self.source.name {
+            "Watcher" => {
+                create_request(
+                    self.db.node.as_ref(),
+                    doc,
+                    &format!("event-delivery-session-{}", sanitize_graphql_id(doc)),
+                    "pending",
+                    &format!("2026-05-20T00:00:{:02}Z", sequence % 60),
+                )
+                .await
+            }
+            "EventSource" => self.create_event_delivery_doc(doc).await?,
+            "SubagentSource" => self.create_subagent_tool_call_doc(doc).await?,
+            other => return Err(format!("unsupported source {other:?}")),
+        };
+        self.doc_ids.insert(doc.to_string(), doc_id);
+        Ok(())
+    }
+
+    async fn depersist_runtime_doc(&mut self, doc: &str) -> Result<(), String> {
+        match self.source.name {
+            "Watcher" => {
+                self.update_agent_request_state(doc, "completed", "completed")
+                    .await
+            }
+            "EventSource" | "SubagentSource" => Ok(()),
+            other => Err(format!("unsupported source {other:?}")),
+        }
+    }
+
+    async fn mark_runtime_doc_processed(&self, doc: &str) -> Result<(), String> {
+        match self.source.name {
+            "Watcher" => {
+                self.update_agent_request_state(doc, "completed", "completed")
+                    .await
+            }
+            "EventSource" | "SubagentSource" => Ok(()),
+            other => Err(format!("unsupported source {other:?}")),
+        }
+    }
+
+    async fn update_agent_request_state(
+        &self,
+        doc: &str,
+        status: &str,
+        lifecycle_state: &str,
+    ) -> Result<(), String> {
+        let doc_id = self
+            .doc_ids
+            .get(doc)
+            .ok_or_else(|| format!("doc {doc:?} has no AgentRequest row"))?;
+        let doc_id = escape_graphql_string(doc_id);
+        let status = escape_graphql_string(status);
+        let lifecycle_state = escape_graphql_string(lifecycle_state);
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentRequest(
+                    filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                    input: {{
+                        status: "{status}",
+                        lifecycle_state: "{lifecycle_state}"
+                    }}
+                ) {{ _docID }}
+            }}"#
+        );
+        let resp = self.db.node.execute(&mutation).await;
+        if resp.has_errors() {
+            return Err(format!("update_AgentRequest failed: {:?}", resp.errors));
+        }
+        Ok(())
+    }
+
+    async fn create_event_delivery_doc(&self, doc: &str) -> Result<String, String> {
+        let external_id = escape_graphql_string(doc);
+        let mutation = format!(
+            r#"mutation {{
+                add_{EVENT_SOURCE_COLLECTION}(input: {{
+                    external_id: "{external_id}",
+                    payload: "{{}}"
+                }}) {{ _docID }}
+            }}"#
+        );
+        let resp = self.db.node.execute(&mutation).await;
+        if resp.has_errors() {
+            return Err(format!(
+                "add_{EVENT_SOURCE_COLLECTION} failed: {:?}",
+                resp.errors
+            ));
+        }
+        mutation_doc_id(&resp, &format!("add_{EVENT_SOURCE_COLLECTION}"))
+            .ok_or_else(|| format!("add_{EVENT_SOURCE_COLLECTION} returned no _docID"))
+    }
+
+    async fn create_subagent_tool_call_doc(&self, doc: &str) -> Result<String, String> {
+        let tool_call_id = escape_graphql_string(doc);
+        let tool_call_key = escape_graphql_string(&format!("event-delivery-session:{doc}"));
+        let mutation = format!(
+            r#"mutation {{
+                create_AgentToolCall(input: {{
+                    tool_call_key: "{tool_call_key}",
+                    request_id: "",
+                    session_id: "event-delivery-session",
+                    message_sequence: 1,
+                    tool_name: "spawn_subagent",
+                    tool_call_id: "{tool_call_id}",
+                    args: "{{}}",
+                    result: "",
+                    status: "called",
+                    lifecycle_state: "running",
+                    started_at: "2026-05-20T00:00:00Z",
+                    await_mode: "foreground",
+                    cancel_policy: "cascade",
+                    child_request_id: "",
+                    selected_service_id: null,
+                    selected_tool_name: null,
+                    tool_failure_class: null,
+                    latency_ms: null
+                }}) {{ _docID }}
+            }}"#
+        );
+        let resp = self.db.node.execute(&mutation).await;
+        if resp.has_errors() {
+            return Err(format!("create_AgentToolCall failed: {:?}", resp.errors));
+        }
+        if let Some(doc_id) = mutation_doc_id(&resp, "create_AgentToolCall") {
+            return Ok(doc_id);
+        }
+        let query = format!(
+            r#"{{
+                AgentToolCall(
+                    filter: {{ tool_call_id: {{ _eq: "{tool_call_id}" }} }},
+                    limit: 1
+                ) {{ _docID }}
+            }}"#
+        );
+        let resp = self.db.node.execute(&query).await;
+        if resp.has_errors() {
+            return Err(format!(
+                "query AgentToolCall after create failed: {:?}",
+                resp.errors
+            ));
+        }
+        first_optional_row::<super::support::DocIdRow>(&resp, "AgentToolCall")
+            .map(|row| row.doc_id)
+            .ok_or_else(|| "created AgentToolCall row was not found".to_string())
+    }
+
+    fn publish_update(&self, doc: &str) -> Result<(), String> {
+        let collection = match self.source.name {
+            "Watcher" => "AgentRequest",
+            "EventSource" => EVENT_SOURCE_COLLECTION,
+            "SubagentSource" => "AgentToolCall",
+            other => return Err(format!("unsupported source {other:?}")),
+        };
+        let collection_id = self.collection_id(collection)?;
+        let doc_id = self
+            .doc_ids
+            .get(doc)
+            .cloned()
+            .unwrap_or_else(|| doc.to_string());
+        self.mock_subs.publish_update(collection_id, doc_id);
+        Ok(())
+    }
+
+    fn collection_id(&self, collection: &str) -> Result<String, String> {
+        self.db
+            .node
+            .get_collection(collection)
+            .map_err(|err| format!("get_collection({collection}) failed: {err}"))?
+            .map(|definition| definition.collection_id)
+            .ok_or_else(|| format!("collection {collection:?} not found"))
+    }
+
+    async fn drive_rescan(&mut self, expected_docs: &[String]) -> Result<(), String> {
+        match &mut self.runtime {
+            ProductionRuntime::Watcher { watcher } => {
+                for expected in expected_docs {
+                    let request = poll_watcher(watcher).await?;
+                    if request.request_id != *expected {
+                        return Err(format!(
+                            "watcher rescan emitted {:?}, expected {:?}",
+                            request.request_id, expected
+                        ));
+                    }
+                    self.emitted_buffer.push(request.request_id);
+                }
+                Ok(())
+            }
+            ProductionRuntime::EventSource | ProductionRuntime::SubagentSource => {
+                if expected_docs.is_empty() {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "source {} has no bounded live rescan",
+                        self.source.name
+                    ))
+                }
+            }
+        }
+    }
+
+    async fn drive_handle(&mut self, doc: &str) -> Result<(), String> {
+        match &mut self.runtime {
+            ProductionRuntime::Watcher { watcher } => {
+                if erase_first(&mut self.emitted_buffer, doc).is_some() {
+                    return Ok(());
+                }
+                let request = poll_watcher(watcher).await?;
+                if request.request_id != doc {
+                    return Err(format!(
+                        "watcher handle emitted {:?}, expected {:?}",
+                        request.request_id, doc
+                    ));
+                }
+                Ok(())
+            }
+            ProductionRuntime::EventSource | ProductionRuntime::SubagentSource => {
+                let expected = self.production_doc_id(doc)?;
+                self.wait_for_emitted_doc(&expected, DELIVERY_TIMEOUT).await
+            }
+        }
+    }
+
+    async fn drop_production_delivery(&mut self, doc: &str) -> Result<(), String> {
+        if matches!(self.runtime, ProductionRuntime::Watcher { .. }) {
+            return Ok(());
+        }
+        let expected = self.production_doc_id(doc)?;
+        match self
+            .wait_for_any_emitted_doc(Duration::from_millis(250))
+            .await?
+        {
+            Some(emitted) if emitted == expected => Ok(()),
+            Some(emitted) => {
+                self.emitted_buffer.push(emitted);
+                Ok(())
+            }
+            None => Ok(()),
+        }
+    }
+
+    fn production_doc_id(&self, doc: &str) -> Result<String, String> {
+        match self.source.name {
+            "Watcher" => Ok(doc.to_string()),
+            "EventSource" | "SubagentSource" => self
+                .doc_ids
+                .get(doc)
+                .cloned()
+                .ok_or_else(|| format!("doc {doc:?} has no runtime row")),
+            other => Err(format!("unsupported source {other:?}")),
+        }
+    }
+
+    async fn wait_for_emitted_doc(
+        &mut self,
+        expected: &str,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        if erase_first(&mut self.emitted_buffer, expected).is_some() {
+            return Ok(());
+        }
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match self.wait_for_any_emitted_doc_until(deadline).await? {
+                Some(emitted) if emitted == expected => return Ok(()),
+                Some(emitted) => self.emitted_buffer.push(emitted),
+                None => {
+                    return Err(format!(
+                        "{} did not emit expected runtime doc {:?}",
+                        self.source.name, expected
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn wait_for_any_emitted_doc(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<Option<String>, String> {
+        self.wait_for_any_emitted_doc_until(tokio::time::Instant::now() + timeout)
+            .await
+    }
+
+    async fn wait_for_any_emitted_doc_until(
+        &mut self,
+        deadline: tokio::time::Instant,
+    ) -> Result<Option<String>, String> {
+        let Some(rx) = &mut self.emitted_rx else {
+            return Ok(None);
+        };
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Some(doc)) => Ok(Some(doc)),
+            Ok(None) => Err(format!("{} runner exited", self.source.name)),
+            Err(_) => Ok(None),
+        }
+    }
+}
+
+impl Drop for ProductionEventDeliveryDriver {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(runner) = &self.runner {
+            runner.abort();
+        }
+    }
+}
+
+fn spawn_event_source_runner(
+    node: Arc<EmbeddedNode>,
+    mock_subs: MockUpdateSubscriptionSource,
+    cancel: CancellationToken,
+) -> (
+    tokio::task::JoinHandle<()>,
+    mpsc::Receiver<String>,
+    watch::Sender<Arc<ActiveRuntimeSnapshot>>,
+) {
+    let snapshot = active_snapshot_with_event_trigger();
+    let (snapshot_tx, snapshot_rx) = watch::channel(snapshot);
+    let mut source =
+        EventSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel);
+    let (tx, rx) = mpsc::channel(16);
+    let runner = tokio::spawn(async move {
+        while let Some(intent) = source.next_fire().await {
+            if let Some(doc_id) = intent
+                .event_vars
+                .get("source_doc_id")
+                .and_then(serde_json::Value::as_str)
+            {
+                if tx.send(doc_id.to_string()).await.is_err() {
+                    break;
+                }
+            }
+        }
+    });
+    (runner, rx, snapshot_tx)
+}
+
+fn spawn_subagent_source_runner(
+    node: Arc<EmbeddedNode>,
+    mock_subs: MockUpdateSubscriptionSource,
+    cancel: CancellationToken,
+) -> (
+    tokio::task::JoinHandle<()>,
+    mpsc::Receiver<String>,
+    watch::Sender<Arc<ActiveRuntimeSnapshot>>,
+) {
+    let snapshot = active_snapshot_without_event_triggers();
+    let (snapshot_tx, snapshot_rx) = watch::channel(snapshot);
+    let mut source =
+        SubagentSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel);
+    let (tx, rx) = mpsc::channel(16);
+    let runner = tokio::spawn(async move {
+        while let Some(intent) = source.next_fire().await {
+            if let Some(doc_id) = intent
+                .event_vars
+                .get("trigger_id")
+                .and_then(serde_json::Value::as_str)
+            {
+                if tx.send(doc_id.to_string()).await.is_err() {
+                    break;
+                }
+            }
+        }
+    });
+    (runner, rx, snapshot_tx)
+}
+
+async fn poll_watcher(watcher: &mut DefraWatcher) -> Result<AgentRequest, String> {
+    tokio::time::timeout(DELIVERY_TIMEOUT, watcher.next_request())
+        .await
+        .map_err(|_| "watcher timed out waiting for AgentRequest".to_string())?
+        .ok_or_else(|| "watcher exhausted before emitting AgentRequest".to_string())?
+        .map_err(|err| format!("watcher returned error: {err}"))
+}
+
+async fn install_event_delivery_source_schema(node: &EmbeddedNode) {
+    let schema = r#"
+        type EventDeliveryDoc {
+            external_id: String @index
+            payload: String
+        }
+    "#;
+    node.add_schema(schema)
+        .await
+        .expect("add_schema for EventDeliveryDoc");
+}
+
+fn active_snapshot_with_event_trigger() -> Arc<ActiveRuntimeSnapshot> {
+    let task = ResolvedTask {
+        task_id: EVENT_SOURCE_TASK_ID.to_string(),
+        name: Some(EVENT_SOURCE_TASK_ID.to_string()),
+        behavior_id: AGENT_NAME.to_string(),
+        prompt_template: "handle event delivery doc".to_string(),
+        output_schema_ref: None,
+    };
+    let trigger = ResolvedEventTrigger {
+        trigger_id: EVENT_SOURCE_TRIGGER_ID.to_string(),
+        task_id: task.task_id.clone(),
+        task: task.clone(),
+        source_collection: EVENT_SOURCE_COLLECTION.to_string(),
+        event_kind: "created".to_string(),
+        filter: None,
+        enabled: true,
+        concurrency: ConcurrencyMode::Serial,
+    };
+    active_snapshot(
+        HashMap::from([(trigger.trigger_id.clone(), trigger)]),
+        HashMap::from([(task.task_id.clone(), task)]),
+    )
+}
+
+fn active_snapshot_without_event_triggers() -> Arc<ActiveRuntimeSnapshot> {
+    active_snapshot(HashMap::new(), HashMap::new())
+}
+
+fn active_snapshot(
+    active_event_triggers: HashMap<String, ResolvedEventTrigger>,
+    active_tasks: HashMap<String, ResolvedTask>,
+) -> Arc<ActiveRuntimeSnapshot> {
+    Arc::new(ActiveRuntimeSnapshot {
+        generation: 1,
+        principal: None,
+        local_did: AGENT_DID.to_string(),
+        paired_peer_dids: HashSet::new(),
+        default_behavior_id: AGENT_NAME.to_string(),
+        behaviors: HashMap::new(),
+        tool_surfaces: HashMap::new(),
+        backend_admission_configs: HashMap::new(),
+        unavailable_behaviors: HashMap::new(),
+        active_schedules: HashMap::new(),
+        unavailable_schedules: HashSet::new(),
+        active_event_triggers,
+        unavailable_event_triggers: HashSet::new(),
+        active_tasks,
+        dispatchers: HashMap::new(),
+    })
+}
+
+fn empty_event_delivery_world() -> lean_vocab_test::LeanEventDeliveryWorld {
+    lean_vocab_test::LeanEventDeliveryWorld {
+        persistent_set: Vec::new(),
+        subscription_queue: Vec::new(),
+        processed_set: Vec::new(),
+        handled: Vec::new(),
+    }
+}
+
+fn sanitize_graphql_id(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '-' })
+        .collect()
+}
+
+fn mutation_doc_id(resp: &QueryResponse, field: &str) -> Option<String> {
+    let value = resp.data.as_ref()?.get(field)?;
+    value
+        .get("_docID")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_string)
+        .or_else(|| {
+            value
+                .as_array()
+                .and_then(|rows| rows.first())
+                .and_then(|row| row.get("_docID"))
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
 }
 
 fn erase_first(values: &mut Vec<String>, target: &str) -> Option<String> {

--- a/crates/defra-agent/tests/support/mock_subscription.rs
+++ b/crates/defra-agent/tests/support/mock_subscription.rs
@@ -4,20 +4,27 @@
 //! `publish_update(collection_id, doc_id)`; the source receives them through
 //! the real `events::Subscription` returned by `subscribe_updates()`.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 
 use defra_agent::UpdateSubscriptionSource;
 use events::{Bus, ChannelBus, EventName, Message, Subscription, Update};
+use tokio::sync::Notify;
 
 #[derive(Clone)]
 pub struct MockUpdateSubscriptionSource {
     bus: Arc<ChannelBus>,
+    subscriber_count: Arc<AtomicUsize>,
+    subscriber_notify: Arc<Notify>,
 }
 
 impl MockUpdateSubscriptionSource {
     pub fn new() -> Self {
         Self {
             bus: Arc::new(ChannelBus::new()),
+            subscriber_count: Arc::new(AtomicUsize::new(0)),
+            subscriber_notify: Arc::new(Notify::new()),
         }
     }
 
@@ -36,6 +43,25 @@ impl MockUpdateSubscriptionSource {
         let update = Update::new(doc_id, cid, collection_id, block, false, true);
         self.bus.publish(Message::update(update));
     }
+
+    pub async fn wait_for_subscribers(&self, expected: usize, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.subscriber_count.load(Ordering::SeqCst) >= expected {
+                return true;
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            if tokio::time::timeout_at(deadline, self.subscriber_notify.notified())
+                .await
+                .is_err()
+            {
+                return false;
+            }
+        }
+    }
 }
 
 impl Default for MockUpdateSubscriptionSource {
@@ -46,6 +72,9 @@ impl Default for MockUpdateSubscriptionSource {
 
 impl UpdateSubscriptionSource for MockUpdateSubscriptionSource {
     fn subscribe_updates(&self) -> Subscription {
-        self.bus.subscribe(&[EventName::Update])
+        let subscription = self.bus.subscribe(&[EventName::Update]);
+        self.subscriber_count.fetch_add(1, Ordering::SeqCst);
+        self.subscriber_notify.notify_waiters();
+        subscription
     }
 }

--- a/docs/superpowers/specs/2026-05-20-event-source-subscription-factory-design.md
+++ b/docs/superpowers/specs/2026-05-20-event-source-subscription-factory-design.md
@@ -363,6 +363,7 @@ three test-relevant symbols at the crate root. After this change, the
 pub use trigger_engine::event_source::EventSource;
 pub use trigger_engine::subagent_source::SubagentSource;
 pub use trigger_engine::subscription_source::UpdateSubscriptionSource;
+pub use trigger_engine::{FireIntent, FireResult, TriggerKind, TriggerSource};
 ```
 
 Inside `trigger_engine`, the relevant items become `pub` (not `pub(crate)`):
@@ -380,9 +381,8 @@ Inside `trigger_engine`, the relevant items become `pub` (not `pub(crate)`):
   trait + impls all `pub`.
 
 Everything else inside `trigger_engine` stays `pub(crate)`. The
-`TriggerSource` trait, `FireIntent`, `FireResult`, `TriggerKind`, the
-materializer, manual handle, etc. are unchanged. The blast radius is the
-two structs and the new trait, period.
+materializer, manual handle, `TriggerEngine`, and schedule source internals
+are unchanged.
 
 `DefraWatcher` is already `pub` at `lib.rs:119`; no change there.
 
@@ -395,6 +395,16 @@ receiver over the snapshot type; if the type is not public, the constructor
 cannot be called from outside the crate. A test-helper constructor was
 considered but rejected as additional indirection without proportional API
 hygiene benefit — the snapshot type is already documented and stable.
+
+Post-#252 amendment: the visibility lift also extends to `TriggerSource`,
+`FireIntent`, and the transitive payload types forced by the
+`private_interfaces` lint (`FireResult` and `TriggerKind`). Constructors and
+trait methods take types that must be public to be callable from integration
+tests; lifting the test-helper alternative was considered but rejected as
+indirection without proportional API hygiene benefit. This is the same
+pragmatic rationale as the `ActiveRuntimeSnapshot` lift: the integration
+consumer polls `EventSource::next_fire` and `SubagentSource::next_fire`
+through the real production trait and matches the emitted intent shape.
 
 ### Why not `pub mod trigger_engine`
 


### PR DESCRIPTION
## Summary

- Lifts \`TriggerSource\`, \`FireIntent\`, \`FireResult\`, and \`TriggerKind\` to \`pub\` so integration tests can poll the production event-source loops. Same pragmatic visibility-lift pattern as #259's \`ActiveRuntimeSnapshot\` lift, documented in the subscription-factory spec at \`docs/superpowers/specs/2026-05-20-event-source-subscription-factory-design.md\`.
- Replaces \`InMemoryEventDeliverySource\` with a production-backed conformance driver against \`MockUpdateSubscriptionSource\` + real \`DefraWatcher\` / \`EventSource\` / \`SubagentSource\` polling.
- Promotes the two \`event_delivery_cases\` ledger rows from \`consumerWithFollowUpCoverage\` back to \`consumerCoverage\`.
- Closes the audit's §15 EventDelivery item #1.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`git diff --check\`
- [x] \`cargo check -p defra-agent\` — zero \`private_interfaces\` warnings
- [x] \`cargo test -p defra-agent --test state_machine_conformance\` — 84 passed
- [x] \`cd crates/defra-agent/proofs && lake build\`

Closes #252.

🤖 Generated with [Claude Code](https://claude.com/claude-code)