### PR TITLE
R5 subagent lineage view: prototype + impl (#274)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests.rs
@@ -94,3 +94,5 @@ mod session_stale_rows;
 mod session_state;
 #[path = "tests/session_timeline.rs"]
 mod session_timeline;
+#[path = "tests/subagent_lineage.rs"]
+mod subagent_lineage;

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/subagent_lineage.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/subagent_lineage.rs
@@ -1,0 +1,164 @@
+use super::*;
+
+#[path = "../../../../../../../crates/defra-agent/src/lean_vocab_test.rs"]
+mod lean_vocab_test;
+
+use crate::bridge::types::{SubagentEdgeView, SubagentNodeView, SubagentTreeView};
+use lean_vocab_test::{lean_r5_cross_deployment_cases, LeanR5CrossDeploymentCase};
+
+/// Build a UI-shaped `SubagentTreeView` from a Lean R5 cross-deployment case.
+///
+/// The desktop panel renders this exact shape — the runtime `/subagents/tree`
+/// handler emits it, and `SubagentLineageView` consumes it. Synthesizing it
+/// here from the Lean witness lets us assert that every UI-renderable
+/// invariant the contract describes (deployment split, bridge metadata,
+/// caused-by lineage) survives the trip into the operator surface.
+fn subagent_tree_view_from_lean_case(case: &LeanR5CrossDeploymentCase) -> SubagentTreeView {
+    SubagentTreeView {
+        root_request_id: case.parent_request_id.clone(),
+        nodes: vec![
+            SubagentNodeView {
+                request_id: case.parent_request_id.clone(),
+                session_id: None,
+                agent_did: Some(case.parent_deployment.clone()),
+                behavior_id: None,
+                lifecycle_state: Some("Processing".to_string()),
+                status: Some("processing".to_string()),
+                subagent_depth: Some(0),
+                caused_by_parent_request_id: None,
+                caused_by_parent_tool_call_id: None,
+            },
+            SubagentNodeView {
+                request_id: case.child_request_id.clone(),
+                session_id: None,
+                agent_did: Some(case.child_deployment.clone()),
+                behavior_id: Some(case.target_behavior_id.clone()),
+                lifecycle_state: Some("Processing".to_string()),
+                status: Some("processing".to_string()),
+                subagent_depth: Some(1),
+                caused_by_parent_request_id: case
+                    .caused_by_parent_request_id_matches
+                    .then(|| case.parent_request_id.clone()),
+                caused_by_parent_tool_call_id: case
+                    .caused_by_parent_tool_call_id_matches
+                    .then(|| case.parent_tool_call_id.clone()),
+            },
+        ],
+        edges: vec![SubagentEdgeView {
+            parent_request_id: case.parent_request_id.clone(),
+            child_request_id: case.child_request_id.clone(),
+            parent_tool_call_id: Some(case.parent_tool_call_id.clone()),
+            tool_name: Some(case.action.clone()),
+            await_mode: Some(case.await_mode.clone()),
+            cancel_policy: Some(case.cancel_policy.clone()),
+            lifecycle_state: Some("running".to_string()),
+        }],
+        truncated: false,
+    }
+}
+
+#[test]
+fn subagent_tree_view_consumes_generated_r5_cross_deployment_contract_cases() {
+    let cases = lean_r5_cross_deployment_cases();
+    assert!(
+        !cases.is_empty(),
+        "Lean R5 contract should emit cross-deployment cases"
+    );
+
+    let mut cross_seen = false;
+    let mut local_seen = false;
+
+    for case in cases {
+        assert_eq!(case.action, "spawn_subagent", "{}", case.name);
+        assert_eq!(case.await_mode, "background", "{}", case.name);
+        assert_eq!(case.cancel_policy, "cascade", "{}", case.name);
+
+        let view = subagent_tree_view_from_lean_case(case);
+        assert_eq!(view.root_request_id, case.parent_request_id, "{}", case.name);
+        assert_eq!(view.nodes.len(), 2, "{}", case.name);
+        assert_eq!(view.edges.len(), 1, "{}", case.name);
+        assert!(!view.truncated, "{} should not be truncated", case.name);
+
+        let parent = view
+            .nodes
+            .iter()
+            .find(|node| node.request_id == case.parent_request_id)
+            .expect("parent node present");
+        let child = view
+            .nodes
+            .iter()
+            .find(|node| node.request_id == case.child_request_id)
+            .expect("child node present");
+        let edge = view.edges.first().expect("bridge edge present");
+
+        assert_eq!(parent.agent_did.as_deref(), Some(case.parent_deployment.as_str()));
+        assert_eq!(child.agent_did.as_deref(), Some(case.child_deployment.as_str()));
+        assert_eq!(edge.tool_name.as_deref(), Some("spawn_subagent"));
+        assert_eq!(edge.await_mode.as_deref(), Some("background"));
+        assert_eq!(edge.cancel_policy.as_deref(), Some("cascade"));
+        assert_eq!(edge.parent_tool_call_id.as_deref(), Some(case.parent_tool_call_id.as_str()));
+
+        if case.cross_deployment_routing_fired {
+            cross_seen = true;
+            assert_ne!(
+                parent.agent_did, child.agent_did,
+                "{}: cross_deployment_routing_fired requires parent.agentDid != child.agentDid",
+                case.name
+            );
+            assert!(
+                case.child_owned_by_target_deployment,
+                "{}: cross-deployment routing implies child owned by target",
+                case.name
+            );
+        }
+        if case.single_deployment_fallback {
+            local_seen = true;
+            assert_eq!(
+                parent.agent_did, child.agent_did,
+                "{}: single_deployment_fallback requires parent and child on same deployment",
+                case.name
+            );
+        }
+
+        if case.caused_by_parent_request_id_matches {
+            assert_eq!(
+                child.caused_by_parent_request_id.as_deref(),
+                Some(case.parent_request_id.as_str()),
+                "{}: caused_by_parent_request_id should carry through to UI",
+                case.name
+            );
+        }
+        if case.caused_by_parent_tool_call_id_matches {
+            assert_eq!(
+                child.caused_by_parent_tool_call_id.as_deref(),
+                Some(case.parent_tool_call_id.as_str()),
+                "{}: caused_by_parent_tool_call_id should carry through to UI",
+                case.name
+            );
+        }
+
+        // Round-trip through serde camelCase to confirm the panel receives the
+        // same shape the bridge serializes. The runtime handler emits this
+        // shape; the bridge re-serializes it for the React panel; the React
+        // panel reads camelCase. A field rename here would break the whole
+        // chain at once.
+        let payload = serde_json::to_string(&view).expect("serialize subagent tree");
+        assert!(payload.contains("\"rootRequestId\""), "{}", case.name);
+        assert!(payload.contains("\"causedByParentRequestId\""), "{}", case.name);
+        assert!(payload.contains("\"awaitMode\""), "{}", case.name);
+        let round_tripped: SubagentTreeView =
+            serde_json::from_str(&payload).expect("deserialize subagent tree");
+        assert_eq!(round_tripped.root_request_id, view.root_request_id);
+        assert_eq!(round_tripped.nodes.len(), view.nodes.len());
+        assert_eq!(round_tripped.edges.len(), view.edges.len());
+    }
+
+    assert!(
+        cross_seen,
+        "Lean R5 contract should include a cross-deployment case"
+    );
+    assert!(
+        local_seen,
+        "Lean R5 contract should include a single-deployment fallback case"
+    );
+}

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
@@ -4,14 +4,19 @@
 //! panicking if these are accidentally invoked before the real bodies
 //! land. Panel PRs replace the body with the real implementation.
 
+use std::time::Duration;
+
+use reqwest::Url;
 use tauri::State;
 
-use super::super::state::DesktopAppState;
+use super::super::state::{current_core, DesktopAppState};
 use super::super::types::{
     CascadeCancelPreview, DesktopInterruptRequest, DesktopListSubagentTreeRequest,
     DesktopOperationsSnapshot, DesktopOperationsSnapshotRequest,
     DesktopPreviewInterruptCascadeRequest, InterruptRequestResult, SubagentTreeView,
 };
+
+const SUBAGENT_TREE_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[tauri::command]
 pub(crate) async fn desktop_operations_snapshot(
@@ -27,14 +32,151 @@ pub(crate) async fn desktop_operations_snapshot(
 
 #[tauri::command]
 pub(crate) async fn desktop_list_subagent_tree(
-    _state: State<'_, DesktopAppState>,
-    _request: DesktopListSubagentTreeRequest,
+    state: State<'_, DesktopAppState>,
+    request: DesktopListSubagentTreeRequest,
 ) -> Result<SubagentTreeView, String> {
-    Err(
-        "desktop_list_subagent_tree not implemented yet; landing via panel #285 \
-         (subagent lineage view)"
-            .to_string(),
-    )
+    let root_request_id = request.root_request_id.trim();
+    if root_request_id.is_empty() {
+        return Err("rootRequestId is required".to_string());
+    }
+    let core = current_core(&state)
+        .ok_or_else(|| "desktop bridge has not finished bootstrapping".to_string())?;
+
+    let agent_did = match request.agent_did.as_deref().map(str::trim) {
+        Some(value) if !value.is_empty() => value.to_string(),
+        _ => core
+            .selected_agent_did()
+            .ok_or_else(|| "no agent selected; pass agentDid explicitly".to_string())?,
+    };
+
+    let graphql = core
+        .graphql_for_agent(&agent_did)
+        .await
+        .ok_or_else(|| format!("no graphql URL configured for agent {agent_did}"))?;
+    let url = subagent_tree_url(&graphql, root_request_id, &request)?;
+
+    let client = reqwest::Client::builder()
+        .timeout(SUBAGENT_TREE_TIMEOUT)
+        .build()
+        .map_err(|error| format!("build subagent tree http client: {error}"))?;
+
+    let response = client
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(|error| format!("subagent tree fetch failed: {error}"))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!(
+            "subagent tree fetch returned {status}: {}",
+            body.trim()
+        ));
+    }
+
+    response
+        .json::<SubagentTreeView>()
+        .await
+        .map_err(|error| format!("decode subagent tree response: {error}"))
+}
+
+/// Translate the agent's GraphQL URL into the runtime's `/subagents/tree`
+/// endpoint URL. Mirrors the path-stripping logic in
+/// `defra_agent_desktop_core::local_runtime::runtime_status_url` but targets
+/// the R5 subagent-lineage handler.
+fn subagent_tree_url(
+    graphql: &str,
+    root_request_id: &str,
+    request: &DesktopListSubagentTreeRequest,
+) -> Result<Url, String> {
+    let trimmed = graphql.trim();
+    if trimmed.is_empty() {
+        return Err("agent graphql URL is empty".to_string());
+    }
+    let with_scheme = if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        trimmed.to_string()
+    } else {
+        format!("http://{trimmed}")
+    };
+    let mut url = Url::parse(&with_scheme)
+        .map_err(|error| format!("agent graphql URL is not a valid URL: {error}"))?;
+    let path = url.path().trim_end_matches('/').to_string();
+    if path.is_empty() || path == "/api/v0" || path == "/api/v0/graphql" {
+        url.set_path("/subagents/tree");
+    } else if !path.ends_with("/subagents/tree") {
+        url.set_path(&format!("{path}/subagents/tree"));
+    }
+    url.set_query(None);
+    url.set_fragment(None);
+
+    let mut pairs = url.query_pairs_mut();
+    pairs.append_pair("root_request_id", root_request_id);
+    if let Some(include_terminal) = request.include_terminal {
+        pairs.append_pair("include_terminal", &include_terminal.to_string());
+    }
+    if let Some(max_depth) = request.max_depth {
+        pairs.append_pair("max_depth", &max_depth.to_string());
+    }
+    drop(pairs);
+    Ok(url)
+}
+
+#[cfg(test)]
+mod subagent_tree_url_tests {
+    use super::*;
+
+    fn request(include_terminal: Option<bool>, max_depth: Option<u32>) -> DesktopListSubagentTreeRequest {
+        DesktopListSubagentTreeRequest {
+            root_request_id: "req-root".to_string(),
+            agent_did: None,
+            include_terminal,
+            max_depth,
+        }
+    }
+
+    #[test]
+    fn strips_graphql_path_and_appends_subagents_tree() {
+        let url = subagent_tree_url(
+            "http://127.0.0.1:9181/api/v0/graphql",
+            "req-root",
+            &request(None, None),
+        )
+        .unwrap();
+        assert_eq!(url.path(), "/subagents/tree");
+        assert!(url.query().unwrap().contains("root_request_id=req-root"));
+    }
+
+    #[test]
+    fn accepts_bare_host_and_defaults_scheme() {
+        let url = subagent_tree_url("127.0.0.1:9181", "req-root", &request(Some(true), Some(4)))
+            .unwrap();
+        assert_eq!(url.scheme(), "http");
+        assert_eq!(url.path(), "/subagents/tree");
+        let query = url.query().unwrap();
+        assert!(query.contains("include_terminal=true"));
+        assert!(query.contains("max_depth=4"));
+    }
+
+    #[test]
+    fn preserves_remote_host_and_port() {
+        let url = subagent_tree_url(
+            "https://runtime.example.com:8443/api/v0/graphql",
+            "req-root",
+            &request(None, None),
+        )
+        .unwrap();
+        assert_eq!(url.scheme(), "https");
+        assert_eq!(url.host_str(), Some("runtime.example.com"));
+        assert_eq!(url.port(), Some(8443));
+        assert_eq!(url.path(), "/subagents/tree");
+    }
+
+    #[test]
+    fn rejects_empty_graphql_url() {
+        let err = subagent_tree_url("   ", "req-root", &request(None, None)).unwrap_err();
+        assert!(err.contains("empty"));
+    }
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -4,7 +4,7 @@
 //! own PRs (#276/#277/#278/#281/#283/#284/#285/#286/#288) build and populate
 //! these structs.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -98,7 +98,7 @@ pub(crate) struct StuckWorkDiagnosticView {
     pub stuck_since: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SubagentTreeView {
     pub root_request_id: String,
@@ -107,29 +107,42 @@ pub(crate) struct SubagentTreeView {
     pub truncated: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SubagentNodeView {
     pub request_id: String,
+    #[serde(default)]
     pub session_id: Option<String>,
+    #[serde(default)]
     pub agent_did: Option<String>,
+    #[serde(default)]
     pub behavior_id: Option<String>,
+    #[serde(default)]
     pub lifecycle_state: Option<String>,
+    #[serde(default)]
     pub status: Option<String>,
+    #[serde(default)]
     pub subagent_depth: Option<i64>,
+    #[serde(default)]
     pub caused_by_parent_request_id: Option<String>,
+    #[serde(default)]
     pub caused_by_parent_tool_call_id: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SubagentEdgeView {
     pub parent_request_id: String,
     pub child_request_id: String,
+    #[serde(default)]
     pub parent_tool_call_id: Option<String>,
+    #[serde(default)]
     pub tool_name: Option<String>,
+    #[serde(default)]
     pub await_mode: Option<String>,
+    #[serde(default)]
     pub cancel_policy: Option<String>,
+    #[serde(default)]
     pub lifecycle_state: Option<String>,
 }
 

--- a/apps/desktop-tauri/src/App.css
+++ b/apps/desktop-tauri/src/App.css
@@ -1,4 +1,4 @@
-@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, utilities;
+@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, components, utilities;
 
 @import "./styles/tokens.css";
 @import "./styles/base.css";
@@ -23,4 +23,5 @@
 @import "./styles/config/forms.css";
 @import "./styles/transcript/messages.css";
 @import "./styles/transcript/tools.css";
+@import "./styles/subagent-lineage.css";
 @import "./styles/utilities.css";

--- a/apps/desktop-tauri/src/components/ChatWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ChatWorkspace.tsx
@@ -1,4 +1,4 @@
-import type { FormEvent } from "react";
+import { useMemo, type FormEvent } from "react";
 
 import type {
   DeploymentView,
@@ -8,6 +8,8 @@ import type {
 import { displayBehaviorLabel } from "../lib/types";
 import { ChatComposer, ChatHeader, ChatTranscriptPanel } from "./chat";
 import { OperationsRail, OperationsRailProvider } from "./operations";
+import type { OperationsRailTabDescriptor } from "./operations";
+import { SubagentLineageView } from "./subagentLineage";
 
 export type ChatWorkspaceProps = {
   selectedDeployment: DeploymentView | null;
@@ -80,8 +82,25 @@ export function ActiveChatWorkspace({
       (behavior) => behavior.behaviorId === activeBehaviorId,
     )?.displayName ?? displayBehaviorLabel(activeBehaviorId);
 
+  const operationsRailTabs = useMemo<OperationsRailTabDescriptor[]>(() => {
+    const rootRequestId = session?.latestRequestId ?? null;
+    const lineageAgentDid = selectedDeployment.agentDid;
+    return [
+      {
+        id: "lineage",
+        label: "Lineage",
+        render: () => (
+          <SubagentLineageView
+            rootRequestId={rootRequestId}
+            agentDid={lineageAgentDid}
+          />
+        ),
+      },
+    ];
+  }, [session?.latestRequestId, selectedDeployment.agentDid]);
+
   return (
-    <OperationsRailProvider tabs={[]}>
+    <OperationsRailProvider tabs={operationsRailTabs}>
       <ChatHeader
         behaviorLabel={behaviorLabel}
         runtimeHealth={runtimeHealth}

--- a/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
+++ b/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
@@ -1,0 +1,709 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react";
+
+import { listSubagentTree } from "../../lib/desktop-api";
+import type {
+  SubagentEdgeView,
+  SubagentNodeView,
+  SubagentTreeView,
+} from "../../lib/types";
+
+export type SubagentLineageViewProps = {
+  rootRequestId: string | null;
+  agentDid: string | null;
+};
+
+type RequestNode = {
+  kind: "req";
+  id: string;
+  node: SubagentNodeView;
+  children: ToolNode[];
+};
+
+type ToolNode = {
+  kind: "tool";
+  id: string;
+  edge: SubagentEdgeView;
+  child: RequestNode | null;
+};
+
+type AnyNode = RequestNode | ToolNode;
+
+type Selected =
+  | { kind: "req"; node: SubagentNodeView }
+  | { kind: "tool"; edge: SubagentEdgeView }
+  | null;
+
+const TERMINAL_STATES = new Set([
+  "completed",
+  "failed",
+  "cancelled",
+  "interrupted",
+  "superseded",
+  "dead",
+]);
+
+function lifecycleIsLive(state?: string | null) {
+  if (!state) return true;
+  return !TERMINAL_STATES.has(state.toLowerCase());
+}
+
+function nodeId(node: AnyNode): string {
+  return `${node.kind}:${node.id}`;
+}
+
+function shortenDid(did?: string | null): string {
+  if (!did) return "—";
+  if (did.length <= 24) return did;
+  return `${did.slice(0, 20)}…${did.slice(-4)}`;
+}
+
+function buildTree(
+  view: SubagentTreeView,
+): { root: RequestNode | null; deployments: string[] } {
+  const nodeMap = new Map<string, SubagentNodeView>();
+  for (const node of view.nodes) {
+    nodeMap.set(node.requestId, node);
+  }
+  const edgesByParent = new Map<string, SubagentEdgeView[]>();
+  for (const edge of view.edges) {
+    const list = edgesByParent.get(edge.parentRequestId) ?? [];
+    list.push(edge);
+    edgesByParent.set(edge.parentRequestId, list);
+  }
+  const visited = new Set<string>();
+  const deployments = new Set<string>();
+
+  function buildRequest(requestId: string): RequestNode | null {
+    if (visited.has(requestId)) return null;
+    visited.add(requestId);
+    const view = nodeMap.get(requestId);
+    if (!view) return null;
+    if (view.agentDid) deployments.add(view.agentDid);
+    const children = (edgesByParent.get(requestId) ?? []).map<ToolNode>((edge) => ({
+      kind: "tool",
+      id: edge.parentToolCallId ?? `${edge.parentRequestId}->${edge.childRequestId}`,
+      edge,
+      child: buildRequest(edge.childRequestId),
+    }));
+    return { kind: "req", id: requestId, node: view, children };
+  }
+
+  const root = buildRequest(view.rootRequestId);
+  return { root, deployments: [...deployments].sort() };
+}
+
+function depthOfRequest(node: SubagentNodeView, fallback: number): number {
+  return node.subagentDepth ?? fallback;
+}
+
+function subtreeHasSurvivor(
+  node: RequestNode,
+  depth: number,
+  state: FilterState,
+): boolean {
+  const passes = nodePasses(node, depth, state);
+  if (passes && (state.deployments.size === 0 || (node.node.agentDid && state.deployments.has(node.node.agentDid)))) {
+    return true;
+  }
+  for (const tool of node.children) {
+    if (tool.child && subtreeHasSurvivor(tool.child, depth + 1, state)) {
+      return true;
+    }
+  }
+  return passes;
+}
+
+type FilterState = {
+  depth: "all" | 0 | 1 | 2 | 3;
+  deployments: Set<string>;
+  liveOnly: boolean;
+};
+
+function nodePasses(node: RequestNode, depth: number, state: FilterState): boolean {
+  if (state.depth !== "all") {
+    const max = state.depth;
+    if (depthOfRequest(node.node, depth) > max) return false;
+  }
+  if (state.liveOnly && !lifecycleIsLive(node.node.lifecycleState)) {
+    // Only keep if any descendant survives; that check happens at render time.
+    return false;
+  }
+  if (state.deployments.size > 0) {
+    if (!node.node.agentDid || !state.deployments.has(node.node.agentDid)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function flattenTreeOrder(root: RequestNode | null, expanded: Set<string>): AnyNode[] {
+  const out: AnyNode[] = [];
+  function walk(node: AnyNode) {
+    out.push(node);
+    if (!expanded.has(nodeId(node))) return;
+    if (node.kind === "req") {
+      for (const child of node.children) walk(child);
+    } else if (node.child) {
+      walk(node.child);
+    }
+  }
+  if (root) walk(root);
+  return out;
+}
+
+export function SubagentLineageView({ rootRequestId, agentDid }: SubagentLineageViewProps) {
+  const [tree, setTree] = useState<SubagentTreeView | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [depthFilter, setDepthFilter] =
+    useState<FilterState["depth"]>("all");
+  const [liveOnly, setLiveOnly] = useState(false);
+  const [deploymentFilter, setDeploymentFilter] = useState<Set<string>>(new Set());
+
+  const treeContainerRef = useRef<HTMLUListElement | null>(null);
+
+  // Fetch when root or agent changes.
+  useEffect(() => {
+    let cancelled = false;
+    if (!rootRequestId) {
+      setTree(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    listSubagentTree({ rootRequestId, agentDid: agentDid ?? null })
+      .then((value) => {
+        if (cancelled) return;
+        setTree(value);
+        // Expand everything by default so the panel shows useful data on load.
+        const next = new Set<string>();
+        for (const node of value.nodes) next.add(`req:${node.requestId}`);
+        for (const edge of value.edges) {
+          next.add(`tool:${edge.parentToolCallId ?? `${edge.parentRequestId}->${edge.childRequestId}`}`);
+        }
+        setExpanded(next);
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setTree(null);
+        setError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [rootRequestId, agentDid]);
+
+  const { rootBuilt, deployments } = useMemo(() => {
+    if (!tree) return { rootBuilt: null, deployments: [] };
+    const { root, deployments } = buildTree(tree);
+    return { rootBuilt: root, deployments };
+  }, [tree]);
+
+  // Prune the deployment filter set when scenario changes underneath us so
+  // stale ids don't silently hide everything.
+  useEffect(() => {
+    setDeploymentFilter((current) => {
+      const available = new Set(deployments);
+      const next = new Set<string>();
+      for (const value of current) if (available.has(value)) next.add(value);
+      return next.size === current.size ? current : next;
+    });
+  }, [deployments]);
+
+  const filterState: FilterState = useMemo(
+    () => ({
+      depth: depthFilter,
+      deployments: deploymentFilter,
+      liveOnly,
+    }),
+    [depthFilter, deploymentFilter, liveOnly],
+  );
+
+  const visibleOrder = useMemo(
+    () => flattenTreeOrder(rootBuilt, expanded),
+    [rootBuilt, expanded],
+  );
+
+  const toggleExpanded = useCallback((id: string) => {
+    setExpanded((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const focusNode = useCallback((id: string) => {
+    const container = treeContainerRef.current;
+    if (!container) return;
+    const target = container.querySelector<HTMLDivElement>(
+      `[data-node-id="${cssEscape(id)}"]`,
+    );
+    if (target) target.focus({ preventScroll: false });
+  }, []);
+
+  const selectNode = useCallback(
+    (node: AnyNode, focus: boolean) => {
+      const id = nodeId(node);
+      setSelectedId(id);
+      if (focus) focusNode(id);
+    },
+    [focusNode],
+  );
+
+  const move = useCallback(
+    (delta: number) => {
+      if (visibleOrder.length === 0) return;
+      const ids = visibleOrder.map(nodeId);
+      let idx = selectedId ? ids.indexOf(selectedId) : -1;
+      idx = idx < 0 ? 0 : Math.max(0, Math.min(ids.length - 1, idx + delta));
+      const target = visibleOrder[idx];
+      if (target) selectNode(target, true);
+    },
+    [visibleOrder, selectedId, selectNode],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLUListElement>) => {
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault();
+          move(1);
+          break;
+        case "ArrowUp":
+          event.preventDefault();
+          move(-1);
+          break;
+        case "ArrowRight": {
+          event.preventDefault();
+          if (!selectedId) return;
+          if (!expanded.has(selectedId)) toggleExpanded(selectedId);
+          else move(1);
+          break;
+        }
+        case "ArrowLeft": {
+          event.preventDefault();
+          if (!selectedId) return;
+          if (expanded.has(selectedId)) toggleExpanded(selectedId);
+          break;
+        }
+        case "Home":
+          event.preventDefault();
+          if (visibleOrder[0]) selectNode(visibleOrder[0], true);
+          break;
+        case "End":
+          event.preventDefault();
+          {
+            const last = visibleOrder[visibleOrder.length - 1];
+            if (last) selectNode(last, true);
+          }
+          break;
+        case "Enter":
+        case " ":
+          event.preventDefault();
+          if (selectedId) toggleExpanded(selectedId);
+          break;
+        default:
+          break;
+      }
+    },
+    [move, expanded, selectedId, toggleExpanded, selectNode, visibleOrder],
+  );
+
+  const selected: Selected = useMemo(() => {
+    if (!selectedId || !tree) return null;
+    const [kind, id] = splitNodeId(selectedId);
+    if (kind === "req") {
+      const node = tree.nodes.find((n) => n.requestId === id);
+      return node ? { kind: "req", node } : null;
+    }
+    const edge = tree.edges.find(
+      (e) => (e.parentToolCallId ?? `${e.parentRequestId}->${e.childRequestId}`) === id,
+    );
+    return edge ? { kind: "tool", edge } : null;
+  }, [selectedId, tree]);
+
+  return (
+    <div className="subagent-lineage" aria-label="Subagent lineage">
+      <header className="subagent-lineage-header">
+        <h2>Lineage</h2>
+        <div className="subagent-lineage-meta">
+          {tree
+            ? `root ${tree.rootRequestId} · ${tree.nodes.length} req · ${tree.edges.length} bridge${tree.truncated ? " · truncated" : ""}`
+            : rootRequestId
+              ? loading
+                ? "loading…"
+                : "—"
+              : "no active turn"}
+        </div>
+      </header>
+
+      <div className="subagent-lineage-filters" role="toolbar" aria-label="Lineage filters">
+        <span className="subagent-lineage-filter-label">Depth</span>
+        {(["all", 0, 1, 2, 3] as const).map((value) => (
+          <button
+            key={String(value)}
+            type="button"
+            className="subagent-lineage-chip"
+            aria-pressed={depthFilter === value}
+            onClick={() => setDepthFilter(value)}
+          >
+            {value === "all" ? "All" : value === 0 ? "0" : `≤${value}`}
+          </button>
+        ))}
+        {deployments.length > 0 ? (
+          <>
+            <span className="subagent-lineage-filter-label">Deployment</span>
+            {deployments.map((did) => {
+              const active = deploymentFilter.has(did);
+              return (
+                <button
+                  key={did}
+                  type="button"
+                  className="subagent-lineage-chip"
+                  aria-pressed={active}
+                  title={did}
+                  onClick={() =>
+                    setDeploymentFilter((current) => {
+                      const next = new Set(current);
+                      if (next.has(did)) next.delete(did);
+                      else next.add(did);
+                      return next;
+                    })
+                  }
+                >
+                  {shortenDid(did)}
+                </button>
+              );
+            })}
+          </>
+        ) : null}
+        <label className="subagent-lineage-live-toggle">
+          <input
+            type="checkbox"
+            checked={liveOnly}
+            onChange={(event) => setLiveOnly(event.target.checked)}
+          />
+          Live only
+        </label>
+      </div>
+
+      <div className="subagent-lineage-body">
+        <section className="subagent-lineage-tree-pane" aria-label="Lineage tree">
+          {loading ? (
+            <p className="subagent-lineage-empty">Loading lineage…</p>
+          ) : error ? (
+            <p className="subagent-lineage-empty subagent-lineage-error" role="alert">
+              {error}
+            </p>
+          ) : !rootRequestId ? (
+            <p className="subagent-lineage-empty">
+              Open a session with a recent turn to see its subagent lineage.
+            </p>
+          ) : !rootBuilt ? (
+            <p className="subagent-lineage-empty">No active subagent dispatches.</p>
+          ) : (
+            <ul
+              role="tree"
+              aria-label="Subagent lineage"
+              tabIndex={0}
+              className="subagent-lineage-tree"
+              ref={treeContainerRef}
+              onKeyDown={handleKeyDown}
+            >
+              <SubagentTreeRow
+                node={rootBuilt}
+                depth={0}
+                expanded={expanded}
+                selectedId={selectedId}
+                filter={filterState}
+                onToggle={toggleExpanded}
+                onSelect={selectNode}
+              />
+            </ul>
+          )}
+        </section>
+
+        <aside className="subagent-lineage-detail" aria-label="Selected node detail">
+          <SubagentDetailPanel selected={selected} />
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+type SubagentTreeRowProps = {
+  node: AnyNode;
+  depth: number;
+  expanded: Set<string>;
+  selectedId: string | null;
+  filter: FilterState;
+  onToggle: (id: string) => void;
+  onSelect: (node: AnyNode, focus: boolean) => void;
+};
+
+function SubagentTreeRow({
+  node,
+  depth,
+  expanded,
+  selectedId,
+  filter,
+  onToggle,
+  onSelect,
+}: SubagentTreeRowProps) {
+  if (node.kind === "req") {
+    if (!subtreeHasSurvivor(node, depth, filter)) return null;
+  }
+  const id = nodeId(node);
+  const isExpanded = expanded.has(id);
+  const isSelected = selectedId === id;
+  const hasChildren =
+    node.kind === "req" ? node.children.length > 0 : Boolean(node.child);
+  const childDepth = node.kind === "req" ? depth + 1 : depth;
+
+  return (
+    <li
+      role="treeitem"
+      aria-expanded={hasChildren ? isExpanded : undefined}
+      aria-selected={isSelected || undefined}
+      className="subagent-lineage-tree-item"
+    >
+      <div
+        className={
+          "subagent-lineage-row" + (isSelected ? " is-selected" : "")
+        }
+        data-node-id={id}
+        tabIndex={isSelected ? 0 : -1}
+        onClick={() => onSelect(node, false)}
+        onFocus={() => onSelect(node, false)}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            className="subagent-lineage-twisty"
+            aria-expanded={isExpanded}
+            aria-label={isExpanded ? "Collapse" : "Expand"}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggle(id);
+            }}
+          >
+            <svg
+              viewBox="0 0 8 8"
+              width="8"
+              height="8"
+              aria-hidden="true"
+              style={{
+                transform: isExpanded ? "rotate(0deg)" : "rotate(-90deg)",
+                transition: "transform 120ms ease",
+              }}
+            >
+              <path
+                d="M0.5 2 L4 6 L7.5 2"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </button>
+        ) : (
+          <span className="subagent-lineage-twisty subagent-lineage-twisty-placeholder" />
+        )}
+        <span className="subagent-lineage-label">
+          <span
+            className={
+              "subagent-lineage-kind " +
+              (node.kind === "req"
+                ? "subagent-lineage-kind-req"
+                : "subagent-lineage-kind-tool")
+            }
+          >
+            {node.kind === "req" ? "req" : "tool"}
+          </span>
+          <span className="subagent-lineage-id">
+            {node.kind === "req" ? node.node.requestId : node.edge.parentToolCallId ?? "—"}
+          </span>
+          <span className="subagent-lineage-secondary">
+            {nodeSecondary(node)}
+          </span>
+        </span>
+        {nodeBadge(node)}
+      </div>
+      {hasChildren && isExpanded ? (
+        <ul role="group" className="subagent-lineage-children">
+          {node.kind === "req"
+            ? node.children.map((child) => (
+                <SubagentTreeRow
+                  key={nodeId(child)}
+                  node={child}
+                  depth={childDepth}
+                  expanded={expanded}
+                  selectedId={selectedId}
+                  filter={filter}
+                  onToggle={onToggle}
+                  onSelect={onSelect}
+                />
+              ))
+            : node.child
+              ? (
+                  <SubagentTreeRow
+                    key={nodeId(node.child)}
+                    node={node.child}
+                    depth={childDepth}
+                    expanded={expanded}
+                    selectedId={selectedId}
+                    filter={filter}
+                    onToggle={onToggle}
+                    onSelect={onSelect}
+                  />
+                )
+              : null}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function nodeSecondary(node: AnyNode): string {
+  if (node.kind === "req") {
+    const bits = [
+      node.node.behaviorId,
+      node.node.agentDid ? shortenDid(node.node.agentDid) : null,
+    ].filter(Boolean);
+    return bits.join("  ·  ");
+  }
+  const bits = [
+    node.edge.toolName ?? "spawn_subagent",
+    [node.edge.awaitMode, node.edge.cancelPolicy].filter(Boolean).join("/") || null,
+  ].filter(Boolean);
+  return bits.join("  ·  ");
+}
+
+function nodeBadge(node: AnyNode) {
+  const value =
+    node.kind === "req"
+      ? node.node.lifecycleState ?? node.node.status ?? null
+      : node.edge.lifecycleState ?? null;
+  if (!value) return null;
+  const safe = value.toLowerCase();
+  return (
+    <span
+      className={`subagent-lineage-state subagent-lineage-state-${safe}`}
+      aria-label={`state ${value}`}
+    >
+      {value}
+    </span>
+  );
+}
+
+function SubagentDetailPanel({ selected }: { selected: Selected }) {
+  if (!selected) {
+    return (
+      <p className="subagent-lineage-empty">
+        Select a node in the lineage tree to see request or bridge metadata.
+      </p>
+    );
+  }
+  if (selected.kind === "req") {
+    const node = selected.node;
+    return (
+      <dl className="subagent-lineage-detail-grid">
+        <DetailRow label="request id" value={node.requestId} />
+        <DetailRow label="session" value={node.sessionId} />
+        <DetailRow label="deployment" value={node.agentDid} mono />
+        <DetailRow label="behavior" value={node.behaviorId} />
+        <DetailRow label="lifecycle" value={node.lifecycleState} badge />
+        <DetailRow label="status" value={node.status} />
+        <DetailRow
+          label="depth"
+          value={node.subagentDepth != null ? String(node.subagentDepth) : null}
+        />
+        <DetailRow
+          label="parent req"
+          value={node.causedByParentRequestId}
+        />
+        <DetailRow
+          label="parent tool"
+          value={node.causedByParentToolCallId}
+        />
+      </dl>
+    );
+  }
+  const edge = selected.edge;
+  return (
+    <dl className="subagent-lineage-detail-grid">
+      <DetailRow label="tool call id" value={edge.parentToolCallId} />
+      <DetailRow label="parent req" value={edge.parentRequestId} />
+      <DetailRow label="child req" value={edge.childRequestId} />
+      <DetailRow label="tool" value={edge.toolName} />
+      <DetailRow label="await mode" value={edge.awaitMode} />
+      <DetailRow label="cancel policy" value={edge.cancelPolicy} />
+      <DetailRow label="lifecycle" value={edge.lifecycleState} badge />
+    </dl>
+  );
+}
+
+function DetailRow({
+  label,
+  value,
+  badge,
+  mono,
+}: {
+  label: string;
+  value: string | null | undefined;
+  badge?: boolean;
+  mono?: boolean;
+}) {
+  const hasValue = Boolean(value && value.length > 0);
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd className={hasValue ? (mono ? "is-mono" : "") : "is-muted"}>
+        {hasValue ? (
+          badge ? (
+            <span
+              className={`subagent-lineage-state subagent-lineage-state-${(value ?? "").toLowerCase()}`}
+            >
+              {value}
+            </span>
+          ) : (
+            value
+          )
+        ) : (
+          "—"
+        )}
+      </dd>
+    </>
+  );
+}
+
+function cssEscape(value: string): string {
+  if (typeof window !== "undefined" && window.CSS && CSS.escape) {
+    return CSS.escape(value);
+  }
+  return value.replace(/([^\w-])/g, "\\$1");
+}
+
+function splitNodeId(id: string): ["req" | "tool", string] {
+  const idx = id.indexOf(":");
+  if (idx < 0) return ["req", id];
+  const kind = id.slice(0, idx);
+  const rest = id.slice(idx + 1);
+  return [kind === "tool" ? "tool" : "req", rest];
+}

--- a/apps/desktop-tauri/src/components/subagentLineage/index.ts
+++ b/apps/desktop-tauri/src/components/subagentLineage/index.ts
@@ -1,0 +1,2 @@
+export { SubagentLineageView } from "./SubagentLineageView";
+export type { SubagentLineageViewProps } from "./SubagentLineageView";

--- a/apps/desktop-tauri/src/lib/desktop-api.ts
+++ b/apps/desktop-tauri/src/lib/desktop-api.ts
@@ -6,6 +6,7 @@ import type {
   BehaviorSaveRequest,
   ChatSendResult,
   DesktopClientSnapshot,
+  DesktopListSubagentTreeRequest,
   DesktopSessionSnapshot,
   EventTriggerSaveRequest,
   InferenceProfileSaveRequest,
@@ -13,6 +14,7 @@ import type {
   PeerAddRequest,
   ScheduleRunRequest,
   ScheduleSaveRequest,
+  SubagentTreeView,
   TaskRunRequest,
   TaskRunResult,
   TaskSaveRequest,
@@ -109,6 +111,9 @@ export type DesktopApiAdapter = {
     request: EventTriggerSaveRequest,
   ) => Promise<DesktopClientSnapshot>;
   runTask: (request: TaskRunRequest) => Promise<TaskRunResult>;
+  listSubagentTree: (
+    request: DesktopListSubagentTreeRequest,
+  ) => Promise<SubagentTreeView>;
 };
 
 const defaultDesktopApiAdapter: DesktopApiAdapter = {
@@ -200,6 +205,11 @@ const defaultDesktopApiAdapter: DesktopApiAdapter = {
   },
   runTask(request) {
     return invokeDesktop<TaskRunResult>("desktop_task_run", { request });
+  },
+  listSubagentTree(request) {
+    return invokeDesktop<SubagentTreeView>("desktop_list_subagent_tree", {
+      request,
+    });
   },
 };
 
@@ -325,4 +335,8 @@ export async function saveEventTriggerConfig(
 
 export async function runTask(request: TaskRunRequest) {
   return desktopApiAdapter().runTask(request);
+}
+
+export async function listSubagentTree(request: DesktopListSubagentTreeRequest) {
+  return desktopApiAdapter().listSubagentTree(request);
 }

--- a/apps/desktop-tauri/src/styles/subagent-lineage.css
+++ b/apps/desktop-tauri/src/styles/subagent-lineage.css
@@ -1,0 +1,311 @@
+@layer components {
+  .subagent-lineage {
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr);
+    gap: var(--space-3);
+    height: 100%;
+    min-height: 0;
+    overflow: hidden;
+    font-size: 13px;
+  }
+
+  .subagent-lineage-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: var(--space-3) var(--space-5);
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .subagent-lineage-header h2 {
+    font-family: var(--font-heading);
+    font-size: 15px;
+    margin: 0;
+    color: var(--color-text-soft);
+  }
+  .subagent-lineage-meta {
+    color: var(--color-text-muted);
+    font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+    font-size: 11px;
+  }
+
+  .subagent-lineage-filters {
+    display: flex;
+    gap: var(--space-2);
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 0 var(--space-5);
+  }
+  .subagent-lineage-filter-label {
+    color: var(--color-text-muted);
+    font-size: 10.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-right: 2px;
+  }
+  .subagent-lineage-filter-label + .subagent-lineage-filter-label {
+    margin-left: var(--space-3);
+  }
+  .subagent-lineage-chip {
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-default);
+    color: var(--color-text-soft);
+    border-radius: var(--radius-pill);
+    padding: 2px 10px;
+    font: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+    transition: 120ms ease;
+  }
+  .subagent-lineage-chip:hover {
+    border-color: var(--border-strong);
+  }
+  .subagent-lineage-chip[aria-pressed="true"] {
+    background: rgb(var(--source-green-rgb) / 0.16);
+    border-color: var(--border-selected);
+    color: var(--color-text);
+  }
+  .subagent-lineage-chip:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+  .subagent-lineage-live-toggle {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--color-text-muted);
+    font-size: 11.5px;
+  }
+  .subagent-lineage-live-toggle input {
+    accent-color: var(--color-accent);
+  }
+
+  .subagent-lineage-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 260px;
+    gap: var(--space-3);
+    min-height: 0;
+    padding: 0 var(--space-5) var(--space-3) var(--space-5);
+  }
+  @media (max-width: 1200px) {
+    .subagent-lineage-body {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .subagent-lineage-tree-pane {
+    min-height: 0;
+    overflow: auto;
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    padding: var(--space-2);
+  }
+  .subagent-lineage-detail {
+    background: var(--color-surface-muted);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3) var(--space-4);
+    overflow: auto;
+    min-height: 0;
+  }
+
+  .subagent-lineage-empty {
+    color: var(--color-text-muted);
+    font-size: 12px;
+    padding: var(--space-4);
+    margin: 0;
+  }
+  .subagent-lineage-error {
+    color: var(--color-error);
+  }
+
+  .subagent-lineage-tree {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  }
+  .subagent-lineage-children {
+    list-style: none;
+    padding-left: 18px;
+    margin: 0;
+    position: relative;
+  }
+  .subagent-lineage-children::before {
+    content: "";
+    position: absolute;
+    left: 8px;
+    top: 0;
+    bottom: 8px;
+    border-left: 1px dashed rgb(var(--source-green-rgb) / 0.22);
+  }
+  .subagent-lineage-tree-item {
+    position: relative;
+  }
+  .subagent-lineage-children > .subagent-lineage-tree-item::before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 14px;
+    width: 10px;
+    border-top: 1px dashed rgb(var(--source-green-rgb) / 0.22);
+  }
+
+  .subagent-lineage-row {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    gap: var(--space-2);
+    align-items: center;
+    padding: 3px var(--space-2);
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    cursor: pointer;
+    margin: 2px 0;
+    font-size: 12.5px;
+  }
+  .subagent-lineage-row:hover {
+    background: rgb(var(--source-green-rgb) / 0.06);
+  }
+  .subagent-lineage-row.is-selected {
+    background: rgb(var(--source-green-rgb) / 0.14);
+    border-color: var(--border-selected);
+  }
+  .subagent-lineage-row:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+
+  .subagent-lineage-twisty {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 0;
+  }
+  .subagent-lineage-twisty-placeholder {
+    visibility: hidden;
+    cursor: default;
+  }
+  .subagent-lineage-twisty:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+    border-radius: 4px;
+  }
+
+  .subagent-lineage-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-width: 0;
+  }
+  .subagent-lineage-kind {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: var(--font-heading);
+    border: 1px solid var(--border-default);
+    color: var(--color-text-soft);
+    background: var(--color-surface-strong);
+  }
+  .subagent-lineage-kind-req {
+    color: var(--color-accent-strong);
+    border-color: rgb(var(--source-green-rgb) / 0.38);
+  }
+  .subagent-lineage-kind-tool {
+    color: var(--color-info);
+    border-color: rgb(16 203 255 / 0.35);
+  }
+  .subagent-lineage-id {
+    color: var(--color-text);
+  }
+  .subagent-lineage-secondary {
+    color: var(--color-text-muted);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 11.5px;
+  }
+
+  .subagent-lineage-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 10.5px;
+    font-family: var(--font-heading);
+    font-weight: 600;
+    border: 1px solid currentColor;
+    text-transform: lowercase;
+  }
+  .subagent-lineage-state::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+  .subagent-lineage-state-running,
+  .subagent-lineage-state-processing,
+  .subagent-lineage-state-claimed {
+    color: var(--color-info);
+  }
+  .subagent-lineage-state-completed {
+    color: var(--color-success);
+  }
+  .subagent-lineage-state-failed,
+  .subagent-lineage-state-dead {
+    color: var(--color-error);
+  }
+  .subagent-lineage-state-cancelled,
+  .subagent-lineage-state-interrupted,
+  .subagent-lineage-state-superseded {
+    color: var(--color-warning);
+  }
+  .subagent-lineage-state-pending,
+  .subagent-lineage-state-uninitialized {
+    color: var(--color-text-muted);
+  }
+  .subagent-lineage-state-input_required {
+    color: var(--color-warning);
+  }
+
+  .subagent-lineage-detail-grid {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    gap: var(--space-2) var(--space-4);
+    margin: 0;
+    font-size: 12px;
+  }
+  .subagent-lineage-detail-grid dt {
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 10px;
+    align-self: center;
+  }
+  .subagent-lineage-detail-grid dd {
+    margin: 0;
+    color: var(--color-text);
+    font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+    word-break: break-all;
+  }
+  .subagent-lineage-detail-grid dd.is-muted {
+    color: var(--color-text-muted);
+    font-style: italic;
+  }
+  .subagent-lineage-detail-grid dd.is-mono {
+    font-family: "JetBrains Mono", "SF Mono", ui-monospace, monospace;
+  }
+}

--- a/crates/defra-agent-cli/src/commands/mcp.rs
+++ b/crates/defra-agent-cli/src/commands/mcp.rs
@@ -4,7 +4,8 @@ use anyhow::{Context, Result};
 use chrono::{SecondsFormat, Utc};
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::{
-    run_health_check_cycle, HealthStatus, McpHealthCheckService, McpPool, ServiceHealthMap,
+    health_checker::HealthCheckerOptions, run_health_check_cycle, HealthStatus,
+    McpHealthCheckService, McpPool, ServiceHealthMap,
 };
 use serde::Serialize;
 
@@ -155,6 +156,7 @@ async fn probe_service(
             &health_map,
             local_hostname,
             local_subnet,
+            &HealthCheckerOptions::default(),
         ),
     )
     .await;

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod liveness;
 pub(crate) mod prometheus;
 pub(crate) mod r5_dispatch;
 pub(crate) mod router;
+pub(crate) mod subagent_tree;
 pub(crate) mod version;
 
 pub(crate) use router::runtime_contract_router;

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -51,6 +51,10 @@ pub(crate) fn runtime_contract_router(
             get(crate::http::r5_dispatch::subagent_dispatches_handler),
         )
         .route(
+            "/subagents/tree",
+            get(crate::http::subagent_tree::subagent_tree_handler),
+        )
+        .route(
             "/identity/decide",
             post(crate::http::identity_decide::identity_decide_handler),
         )

--- a/crates/defra-agent-cli/src/http/subagent_tree.rs
+++ b/crates/defra-agent-cli/src/http/subagent_tree.rs
@@ -1,0 +1,837 @@
+//! `GET /subagents/tree` — walks the parent → child request graph rooted at a
+//! single `root_request_id`, returning a tree shape the desktop bridge can
+//! render directly. Edges carry the `spawn_subagent` bridge metadata
+//! (`await_mode`, `cancel_policy`, `tool_name`) so the panel can label the
+//! routing between request nodes without a second query.
+//!
+//! Companion to `/subagents/dispatches` (see [`crate::http::r5_dispatch`]):
+//! that endpoint returns immediate children of one parent and is the canonical
+//! source for the `subagents-cross-deployment` Rust consumer. This handler
+//! exists to spare the desktop bridge from issuing N+1 round trips against the
+//! one-level endpoint when it just wants the closure rooted at a turn.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use anyhow::{Context, Result};
+use axum::{
+    extract::{Query, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use chrono::Utc;
+use defra_agent::graphql::escape_graphql_string;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{http::router::RuntimeHttpState, post_graphql};
+
+const SNAPSHOT_SOURCE: &str = "graphql.subagent_tree";
+const DEFAULT_MAX_DEPTH: usize = 8;
+const HARD_MAX_DEPTH: usize = 32;
+const TERMINAL_STATES: &[&str] = &[
+    "completed",
+    "failed",
+    "cancelled",
+    "interrupted",
+    "superseded",
+    "dead",
+];
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SubagentTreeSnapshot {
+    pub(crate) generated_at: String,
+    pub(crate) source: String,
+    pub(crate) root_request_id: String,
+    pub(crate) nodes: Vec<SubagentTreeNode>,
+    pub(crate) edges: Vec<SubagentTreeEdge>,
+    pub(crate) truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SubagentTreeNode {
+    pub(crate) request_id: String,
+    pub(crate) session_id: Option<String>,
+    pub(crate) agent_did: Option<String>,
+    pub(crate) behavior_id: Option<String>,
+    pub(crate) lifecycle_state: Option<String>,
+    pub(crate) status: Option<String>,
+    pub(crate) subagent_depth: Option<i64>,
+    pub(crate) caused_by_parent_request_id: Option<String>,
+    pub(crate) caused_by_parent_tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct SubagentTreeEdge {
+    pub(crate) parent_request_id: String,
+    pub(crate) child_request_id: String,
+    pub(crate) parent_tool_call_id: Option<String>,
+    pub(crate) tool_name: Option<String>,
+    pub(crate) await_mode: Option<String>,
+    pub(crate) cancel_policy: Option<String>,
+    pub(crate) lifecycle_state: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub(crate) struct SubagentTreeQuery {
+    root_request_id: Option<String>,
+    #[serde(default)]
+    include_terminal: Option<bool>,
+    #[serde(default)]
+    max_depth: Option<usize>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LevelQueryEnvelope {
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+    #[serde(rename = "AgentToolCall", default)]
+    bridges: Vec<BridgeRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RootRequestEnvelope {
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    agent_did: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    subagent_depth: Option<i64>,
+    #[serde(default)]
+    caused_by_parent_request_id: Option<String>,
+    #[serde(default)]
+    caused_by_parent_tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BridgeRow {
+    #[serde(default)]
+    request_id: String,
+    #[serde(default)]
+    tool_call_id: Option<String>,
+    #[serde(default)]
+    tool_name: Option<String>,
+    #[serde(default)]
+    args: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    child_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpawnSubagentArgs {
+    #[serde(default)]
+    await_mode: Option<String>,
+    #[serde(default)]
+    cancel_policy: Option<String>,
+}
+
+pub(crate) async fn subagent_tree_handler(
+    State(state): State<RuntimeHttpState>,
+    Query(query): Query<SubagentTreeQuery>,
+) -> Response {
+    let root_request_id = match clean_optional_string(query.root_request_id.as_deref()) {
+        Some(value) => value,
+        None => {
+            return (
+                StatusCode::BAD_REQUEST,
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                "subagent tree request missing root_request_id".to_string(),
+            )
+                .into_response()
+        }
+    };
+    let include_terminal = query.include_terminal.unwrap_or(false);
+    let max_depth = query
+        .max_depth
+        .map(|value| value.min(HARD_MAX_DEPTH))
+        .unwrap_or(DEFAULT_MAX_DEPTH);
+
+    match load_subagent_tree_snapshot(
+        &state.graphql,
+        &root_request_id,
+        include_terminal,
+        max_depth,
+    )
+    .await
+    {
+        Ok(snapshot) => (StatusCode::OK, Json(snapshot)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            format!("subagent tree snapshot failed: {error:#}"),
+        )
+            .into_response(),
+    }
+}
+
+pub(crate) async fn load_subagent_tree_snapshot(
+    graphql: &str,
+    root_request_id: &str,
+    include_terminal: bool,
+    max_depth: usize,
+) -> Result<SubagentTreeSnapshot> {
+    let generated_at = Utc::now();
+
+    let mut nodes: BTreeMap<String, SubagentTreeNode> = BTreeMap::new();
+    let mut edges: Vec<SubagentTreeEdge> = Vec::new();
+    let mut seen_edges: BTreeSet<(String, String)> = BTreeSet::new();
+
+    if let Some(root) = fetch_root_request(graphql, root_request_id).await? {
+        nodes.insert(root.request_id.clone(), request_row_into_node(root));
+    }
+
+    let mut frontier: VecDeque<String> = VecDeque::new();
+    frontier.push_back(root_request_id.to_string());
+
+    let mut depth: usize = 0;
+    let mut truncated = false;
+
+    while !frontier.is_empty() && depth < max_depth {
+        let level: Vec<String> = frontier.drain(..).collect();
+        let envelope = fetch_level(graphql, &level).await?;
+
+        for request in envelope.requests {
+            if request.request_id.is_empty() {
+                continue;
+            }
+            let node = request_row_into_node(request);
+            // Prefer keeping the first node we resolved for a request id; the
+            // root fetch already populated the root before the loop started.
+            nodes.entry(node.request_id.clone()).or_insert(node);
+        }
+
+        let mut next_frontier: BTreeSet<String> = BTreeSet::new();
+        for bridge in envelope.bridges {
+            let parent_request_id = clean_string(&bridge.request_id);
+            let child_request_id = match clean_optional_string(bridge.child_request_id.as_deref()) {
+                Some(value) => value,
+                None => continue,
+            };
+            if parent_request_id.is_empty() {
+                continue;
+            }
+            if !seen_edges.insert((parent_request_id.clone(), child_request_id.clone())) {
+                continue;
+            }
+            let (await_mode, cancel_policy) = parse_spawn_args(bridge.args.as_deref());
+            let bridge_state = clean_optional_string(bridge.lifecycle_state.as_deref())
+                .or_else(|| clean_optional_string(bridge.status.as_deref()));
+            edges.push(SubagentTreeEdge {
+                parent_request_id,
+                child_request_id: child_request_id.clone(),
+                parent_tool_call_id: clean_optional_string(bridge.tool_call_id.as_deref()),
+                tool_name: clean_optional_string(bridge.tool_name.as_deref()),
+                await_mode,
+                cancel_policy,
+                lifecycle_state: bridge_state,
+            });
+            if !nodes.contains_key(&child_request_id) {
+                next_frontier.insert(child_request_id);
+            } else {
+                // We already have the request row; still walk descendants in
+                // case the local cache was populated by an earlier sibling
+                // bridge but its subtree has not been explored yet.
+                next_frontier.insert(child_request_id);
+            }
+        }
+
+        for child in next_frontier {
+            frontier.push_back(child);
+        }
+        depth += 1;
+    }
+
+    if !frontier.is_empty() {
+        truncated = true;
+    }
+
+    if !include_terminal {
+        prune_terminal_subtrees(&mut nodes, &mut edges, root_request_id);
+    }
+
+    edges.sort_by(|left, right| {
+        (
+            left.parent_request_id.as_str(),
+            left.child_request_id.as_str(),
+        )
+            .cmp(&(
+                right.parent_request_id.as_str(),
+                right.child_request_id.as_str(),
+            ))
+    });
+
+    let nodes = nodes.into_values().collect::<Vec<_>>();
+
+    Ok(SubagentTreeSnapshot {
+        generated_at: generated_at.to_rfc3339(),
+        source: SNAPSHOT_SOURCE.to_string(),
+        root_request_id: root_request_id.to_string(),
+        nodes,
+        edges,
+        truncated,
+    })
+}
+
+fn request_row_into_node(row: RequestRow) -> SubagentTreeNode {
+    SubagentTreeNode {
+        request_id: clean_string(&row.request_id),
+        session_id: clean_optional_string(row.session_id.as_deref()),
+        agent_did: clean_optional_string(row.agent_did.as_deref()),
+        behavior_id: clean_optional_string(row.behavior_id.as_deref()),
+        lifecycle_state: clean_optional_string(row.lifecycle_state.as_deref()),
+        status: clean_optional_string(row.status.as_deref()),
+        subagent_depth: row.subagent_depth,
+        caused_by_parent_request_id: clean_optional_string(
+            row.caused_by_parent_request_id.as_deref(),
+        ),
+        caused_by_parent_tool_call_id: clean_optional_string(
+            row.caused_by_parent_tool_call_id.as_deref(),
+        ),
+    }
+}
+
+async fn fetch_root_request(graphql: &str, root_request_id: &str) -> Result<Option<RequestRow>> {
+    let escaped = escape_graphql_string(root_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{
+                request_id
+                session_id
+                agent_did
+                behavior_id
+                lifecycle_state
+                status
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+            }}
+        }}"#
+    );
+    let response = post_graphql(graphql, &query).await?;
+    let envelope: RootRequestEnvelope = decode_data_object(response, "root request lookup")?;
+    Ok(envelope.requests.into_iter().next())
+}
+
+async fn fetch_level(graphql: &str, parent_request_ids: &[String]) -> Result<LevelQueryEnvelope> {
+    let list = parent_request_ids
+        .iter()
+        .map(|value| format!("\"{}\"", escape_graphql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ caused_by_parent_request_id: {{ _in: [{list}] }} }},
+                order: [{{ created_at: ASC }}, {{ request_id: ASC }}]
+            ) {{
+                request_id
+                session_id
+                agent_did
+                behavior_id
+                lifecycle_state
+                status
+                subagent_depth
+                caused_by_parent_request_id
+                caused_by_parent_tool_call_id
+            }}
+            AgentToolCall(
+                filter: {{
+                    _and: [
+                        {{ request_id: {{ _in: [{list}] }} }},
+                        {{ tool_name: {{ _eq: "spawn_subagent" }} }},
+                        {{ child_request_id: {{ _ne: "" }} }}
+                    ]
+                }},
+                order: [{{ started_at: ASC }}, {{ child_request_id: ASC }}]
+            ) {{
+                request_id
+                tool_call_id
+                tool_name
+                args
+                status
+                lifecycle_state
+                child_request_id
+            }}
+        }}"#
+    );
+    let response = post_graphql(graphql, &query).await?;
+    decode_data_object(response, "subagent tree level fetch")
+}
+
+fn decode_data_object<T: serde::de::DeserializeOwned>(response: Value, context: &str) -> Result<T> {
+    let data = response
+        .get("data")
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("{context} response missing object data: {response}"))?;
+    serde_json::from_value(data).with_context(|| format!("decoding {context}"))
+}
+
+fn parse_spawn_args(args: Option<&str>) -> (Option<String>, Option<String>) {
+    let args = match args {
+        Some(value) => value.trim(),
+        None => return (None, None),
+    };
+    if args.is_empty() {
+        return (None, None);
+    }
+    let parsed = match serde_json::from_str::<SpawnSubagentArgs>(args) {
+        Ok(parsed) => parsed,
+        Err(_) => return (None, None),
+    };
+    (
+        clean_optional_string(parsed.await_mode.as_deref()),
+        clean_optional_string(parsed.cancel_policy.as_deref()),
+    )
+}
+
+fn prune_terminal_subtrees(
+    nodes: &mut BTreeMap<String, SubagentTreeNode>,
+    edges: &mut Vec<SubagentTreeEdge>,
+    root_request_id: &str,
+) {
+    // Drop request nodes whose entire subtree (including themselves) is
+    // terminal. The root is always retained so the panel can render an empty
+    // tree placeholder rooted at the caller's turn.
+    let mut children: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for edge in edges.iter() {
+        children
+            .entry(edge.parent_request_id.clone())
+            .or_default()
+            .push(edge.child_request_id.clone());
+    }
+
+    let mut keep: BTreeSet<String> = BTreeSet::new();
+    fn mark(
+        request_id: &str,
+        nodes: &BTreeMap<String, SubagentTreeNode>,
+        children: &BTreeMap<String, Vec<String>>,
+        keep: &mut BTreeSet<String>,
+    ) -> bool {
+        let live_self = nodes
+            .get(request_id)
+            .map(|node| !lifecycle_is_terminal(node.lifecycle_state.as_deref()))
+            .unwrap_or(false);
+        let mut keep_self = live_self;
+        if let Some(child_ids) = children.get(request_id) {
+            for child_id in child_ids {
+                if mark(child_id, nodes, children, keep) {
+                    keep_self = true;
+                }
+            }
+        }
+        if keep_self {
+            keep.insert(request_id.to_string());
+        }
+        keep_self
+    }
+    mark(root_request_id, nodes, &children, &mut keep);
+    keep.insert(root_request_id.to_string());
+
+    nodes.retain(|request_id, _| keep.contains(request_id));
+    edges.retain(|edge| {
+        keep.contains(&edge.parent_request_id) && keep.contains(&edge.child_request_id)
+    });
+}
+
+fn lifecycle_is_terminal(value: Option<&str>) -> bool {
+    let Some(value) = value else {
+        return false;
+    };
+    let value = value.trim().to_ascii_lowercase();
+    TERMINAL_STATES.iter().any(|terminal| value == *terminal)
+}
+
+fn clean_optional_string(value: Option<&str>) -> Option<String> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn clean_string(value: &str) -> String {
+    value.trim().to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::SocketAddr,
+        sync::{Arc, Mutex},
+    };
+
+    use axum::{extract::State, routing::post, Router};
+    use serde_json::{json, Value};
+    use tokio::net::TcpListener;
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct MockGraphqlState {
+        responses: Arc<Mutex<Vec<Value>>>,
+        queries: Arc<Mutex<Vec<String>>>,
+    }
+
+    async fn mock_graphql(
+        State(state): State<MockGraphqlState>,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        let query = body
+            .get("query")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        state.queries.lock().unwrap().push(query);
+        let mut responses = state.responses.lock().unwrap();
+        let response = if responses.len() == 1 {
+            responses[0].clone()
+        } else {
+            responses.remove(0)
+        };
+        Json(response)
+    }
+
+    async fn spawn_mock_graphql(
+        responses: Vec<Value>,
+    ) -> anyhow::Result<(String, Arc<Mutex<Vec<String>>>)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let queries = Arc::new(Mutex::new(Vec::new()));
+        let responses = Arc::new(Mutex::new(responses));
+        let router = Router::new()
+            .route("/api/v0/graphql", post(mock_graphql))
+            .with_state(MockGraphqlState {
+                responses,
+                queries: queries.clone(),
+            });
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        Ok((format!("http://{addr}/api/v0/graphql"), queries))
+    }
+
+    async fn spawn_runtime_router(graphql: String) -> anyhow::Result<SocketAddr> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let router = crate::http::runtime_contract_router(
+            graphql,
+            "subagent-tree-test-agent".to_string(),
+            "did:key:z6Mksubagenttree".to_string(),
+        );
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, router).await;
+        });
+        Ok(addr)
+    }
+
+    fn root_response() -> Value {
+        json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-root",
+                        "session_id": "sess-root",
+                        "agent_did": "deployment-a",
+                        "behavior_id": "amy-general",
+                        "lifecycle_state": "Processing",
+                        "status": "processing",
+                        "subagent_depth": 0,
+                        "caused_by_parent_request_id": null,
+                        "caused_by_parent_tool_call_id": null
+                    }
+                ]
+            }
+        })
+    }
+
+    fn level_one_response() -> Value {
+        json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-child",
+                        "session_id": "sess-child",
+                        "agent_did": "deployment-b",
+                        "behavior_id": "amy-code",
+                        "lifecycle_state": "Processing",
+                        "status": "processing",
+                        "subagent_depth": 1,
+                        "caused_by_parent_request_id": "req-root",
+                        "caused_by_parent_tool_call_id": "tc-bridge"
+                    }
+                ],
+                "AgentToolCall": [
+                    {
+                        "request_id": "req-root",
+                        "tool_call_id": "tc-bridge",
+                        "tool_name": "spawn_subagent",
+                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
+                        "status": "running",
+                        "lifecycle_state": "running",
+                        "child_request_id": "req-child"
+                    }
+                ]
+            }
+        })
+    }
+
+    fn level_two_empty() -> Value {
+        json!({
+            "data": {
+                "AgentRequest": [],
+                "AgentToolCall": []
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn tree_walks_cross_deployment_bridge_and_carries_await_mode_metadata(
+    ) -> anyhow::Result<()> {
+        let (graphql, _queries) = spawn_mock_graphql(vec![
+            root_response(),
+            level_one_response(),
+            level_two_empty(),
+        ])
+        .await?;
+        let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", false, 4).await?;
+
+        assert_eq!(snapshot.root_request_id, "req-root");
+        assert!(!snapshot.truncated, "shallow tree should not be truncated");
+        assert_eq!(snapshot.nodes.len(), 2);
+        assert_eq!(snapshot.edges.len(), 1);
+
+        let root = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.request_id == "req-root")
+            .expect("root node");
+        assert_eq!(root.agent_did.as_deref(), Some("deployment-a"));
+        assert_eq!(root.subagent_depth, Some(0));
+
+        let child = snapshot
+            .nodes
+            .iter()
+            .find(|node| node.request_id == "req-child")
+            .expect("child node");
+        assert_eq!(child.agent_did.as_deref(), Some("deployment-b"));
+        assert_eq!(
+            child.caused_by_parent_request_id.as_deref(),
+            Some("req-root")
+        );
+        assert_eq!(
+            child.caused_by_parent_tool_call_id.as_deref(),
+            Some("tc-bridge")
+        );
+
+        let edge = &snapshot.edges[0];
+        assert_eq!(edge.parent_request_id, "req-root");
+        assert_eq!(edge.child_request_id, "req-child");
+        assert_eq!(edge.tool_name.as_deref(), Some("spawn_subagent"));
+        assert_eq!(edge.await_mode.as_deref(), Some("background"));
+        assert_eq!(edge.cancel_policy.as_deref(), Some("cascade"));
+        assert_eq!(edge.lifecycle_state.as_deref(), Some("running"));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tree_respects_max_depth_and_sets_truncated_flag() -> anyhow::Result<()> {
+        // Build a 3-level chain: root -> a -> b -> c. We cap max_depth at 1 so
+        // only root -> a should land in the tree, with truncated = true.
+        let root = json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-root",
+                        "agent_did": "deployment-a",
+                        "lifecycle_state": "Processing",
+                        "status": "processing",
+                        "subagent_depth": 0
+                    }
+                ]
+            }
+        });
+        let level_one = json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-a",
+                        "agent_did": "deployment-a",
+                        "lifecycle_state": "Processing",
+                        "status": "processing",
+                        "subagent_depth": 1,
+                        "caused_by_parent_request_id": "req-root",
+                        "caused_by_parent_tool_call_id": "tc-a"
+                    }
+                ],
+                "AgentToolCall": [
+                    {
+                        "request_id": "req-root",
+                        "tool_call_id": "tc-a",
+                        "tool_name": "spawn_subagent",
+                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
+                        "lifecycle_state": "running",
+                        "child_request_id": "req-a"
+                    }
+                ]
+            }
+        });
+        let (graphql, _queries) = spawn_mock_graphql(vec![root, level_one]).await?;
+        let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", true, 1).await?;
+        assert!(snapshot.truncated, "max_depth=1 should set truncated");
+        assert_eq!(snapshot.nodes.len(), 2);
+        assert_eq!(snapshot.edges.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tree_endpoint_routes_under_runtime_router() -> anyhow::Result<()> {
+        let (graphql, _queries) = spawn_mock_graphql(vec![
+            root_response(),
+            level_one_response(),
+            level_two_empty(),
+        ])
+        .await?;
+        let runtime_addr = spawn_runtime_router(graphql).await?;
+        let response = reqwest::Client::new()
+            .get(format!(
+                "http://{runtime_addr}/subagents/tree?root_request_id=req-root&include_terminal=true"
+            ))
+            .send()
+            .await?;
+        let status = response.status();
+        let snapshot = response.json::<SubagentTreeSnapshot>().await?;
+        assert!(status.is_success(), "unexpected status {status}");
+        assert_eq!(snapshot.root_request_id, "req-root");
+        assert_eq!(snapshot.nodes.len(), 2);
+        assert_eq!(snapshot.edges.len(), 1);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tree_endpoint_rejects_missing_root_request_id() -> anyhow::Result<()> {
+        let (graphql, _queries) = spawn_mock_graphql(vec![]).await?;
+        let runtime_addr = spawn_runtime_router(graphql).await?;
+        let response = reqwest::Client::new()
+            .get(format!("http://{runtime_addr}/subagents/tree"))
+            .send()
+            .await?;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response.text().await?;
+        assert!(
+            body.contains("root_request_id"),
+            "error body should call out missing param: {body}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tree_prunes_fully_terminal_subtrees_when_include_terminal_is_false(
+    ) -> anyhow::Result<()> {
+        let root = json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-root",
+                        "agent_did": "deployment-a",
+                        "lifecycle_state": "Processing",
+                        "status": "processing",
+                        "subagent_depth": 0
+                    }
+                ]
+            }
+        });
+        let level_one = json!({
+            "data": {
+                "AgentRequest": [
+                    {
+                        "request_id": "req-live",
+                        "agent_did": "deployment-a",
+                        "lifecycle_state": "Processing",
+                        "subagent_depth": 1,
+                        "caused_by_parent_request_id": "req-root",
+                        "caused_by_parent_tool_call_id": "tc-live"
+                    },
+                    {
+                        "request_id": "req-dead",
+                        "agent_did": "deployment-a",
+                        "lifecycle_state": "Completed",
+                        "subagent_depth": 1,
+                        "caused_by_parent_request_id": "req-root",
+                        "caused_by_parent_tool_call_id": "tc-dead"
+                    }
+                ],
+                "AgentToolCall": [
+                    {
+                        "request_id": "req-root",
+                        "tool_call_id": "tc-live",
+                        "tool_name": "spawn_subagent",
+                        "args": "{\"await_mode\":\"background\",\"cancel_policy\":\"cascade\"}",
+                        "lifecycle_state": "running",
+                        "child_request_id": "req-live"
+                    },
+                    {
+                        "request_id": "req-root",
+                        "tool_call_id": "tc-dead",
+                        "tool_name": "spawn_subagent",
+                        "args": "{\"await_mode\":\"foreground\",\"cancel_policy\":\"cascade\"}",
+                        "lifecycle_state": "completed",
+                        "child_request_id": "req-dead"
+                    }
+                ]
+            }
+        });
+        let level_two_empty = json!({
+            "data": {
+                "AgentRequest": [],
+                "AgentToolCall": []
+            }
+        });
+        let (graphql, _queries) =
+            spawn_mock_graphql(vec![root, level_one, level_two_empty]).await?;
+        let snapshot = load_subagent_tree_snapshot(&graphql, "req-root", false, 4).await?;
+        let request_ids = snapshot
+            .nodes
+            .iter()
+            .map(|node| node.request_id.as_str())
+            .collect::<Vec<_>>();
+        assert!(request_ids.contains(&"req-root"));
+        assert!(request_ids.contains(&"req-live"));
+        assert!(
+            !request_ids.contains(&"req-dead"),
+            "terminal request without live descendants should be pruned"
+        );
+        assert!(
+            snapshot
+                .edges
+                .iter()
+                .all(|edge| edge.child_request_id != "req-dead"),
+            "edges into a pruned node should also be dropped"
+        );
+        Ok(())
+    }
+}

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -154,9 +154,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
         ]
     }
   , { feature := "subagents-cross-deployment"
-    , required := [Surface.agentFacing, Surface.api]
-    , deferred :=
-        [ (Surface.operatorUi, "#274") ]
+    , required := [Surface.agentFacing, Surface.api, Surface.operatorUi]
+    , deferred := []
     }
   , { feature := "interrupt-and-cancel"
     , required := [Surface.agentFacing]
@@ -557,6 +556,11 @@ def caseCoverage : List CoverageEntry :=
       "R5CrossDeploymentCases"
       "http::r5_dispatch::tests::subagent_dispatch_endpoint_matches_agent_request_parent_walk")
       "subagents-cross-deployment" [Surface.api]
+  , tagged (consumerCoverage
+      "r5_cross_deployment_cases"
+      "R5CrossDeploymentCases"
+      "defra_agent_desktop_tauri::bridge::snapshot::tests::subagent_lineage::subagent_tree_view_consumes_generated_r5_cross_deployment_contract_cases")
+      "subagents-cross-deployment" [Surface.operatorUi]
   , tagged (consumerCoverage
       "r6_background_theorem_witnesses"
       "BackgroundBudgetBoundedTheoremWitness"

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -175,6 +175,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "task_recent_runs_view_consumes_generated_trigger_dispatch_lineage_contract_cases",
         },
         ConformanceConsumer::RustTest {
+            id: "defra_agent_desktop_tauri::bridge::snapshot::tests::subagent_lineage::subagent_tree_view_consumes_generated_r5_cross_deployment_contract_cases",
+            package: "defra-agent-desktop-tauri",
+            source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/subagent_lineage.rs",
+            module_path: "defra_agent_desktop_tauri::bridge::snapshot::tests::subagent_lineage",
+            function: "subagent_tree_view_consumes_generated_r5_cross_deployment_contract_cases",
+        },
+        ConformanceConsumer::RustTest {
             id: "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/hook/tests.rs",

--- a/docs/ui-prototypes/panel-274-subagent-lineage.html
+++ b/docs/ui-prototypes/panel-274-subagent-lineage.html
@@ -1,0 +1,1528 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Subagent Lineage View — Prototype (#274)</title>
+<style>
+  :root {
+    color-scheme: dark;
+    --font-sans: "Inter", "SF Pro Text", system-ui, sans-serif;
+    --font-heading: "Funnel Display", "Inter", "SF Pro Display", system-ui, sans-serif;
+    --font-mono: "JetBrains Mono", "SF Mono", ui-monospace, "Menlo", monospace;
+
+    --source-black: #000000;
+    --source-green: #06b250;
+    --source-dark-green-rgb: 28 39 36;
+    --source-green-rgb: 6 178 80;
+    --source-blue: #10cbff;
+    --source-orange: #ffa011;
+
+    --color-bg: var(--source-black);
+    --color-surface: rgb(var(--source-dark-green-rgb) / 0.86);
+    --color-surface-strong: #07110e;
+    --color-surface-deep: #020504;
+    --color-surface-muted: rgb(var(--source-dark-green-rgb) / 0.58);
+    --color-surface-row: rgb(9 17 14 / 0.86);
+    --color-text: #ffffff;
+    --color-text-muted: #95a49d;
+    --color-text-soft: #d6ddda;
+    --color-accent: var(--source-green);
+    --color-accent-strong: #39e27a;
+    --color-success: #8df2b4;
+    --color-warning: var(--source-orange);
+    --color-info: var(--source-blue);
+    --color-error: #ff6f5f;
+
+    --border-subtle: rgb(var(--source-green-rgb) / 0.12);
+    --border-default: rgb(var(--source-green-rgb) / 0.18);
+    --border-strong: rgb(var(--source-green-rgb) / 0.28);
+    --border-selected: rgb(var(--source-green-rgb) / 0.48);
+
+    --radius-sm: 8px;
+    --radius-md: 8px;
+    --radius-lg: 8px;
+    --radius-pill: 999px;
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body {
+    margin: 0;
+    background: var(--color-bg);
+    color: var(--color-text);
+    font-family: var(--font-sans);
+    font-size: 14px;
+    line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  body {
+    min-height: 100vh;
+    background:
+      linear-gradient(180deg, rgb(0 0 0 / 0.96) 0%, rgb(2 8 6 / 0.98) 100%),
+      var(--color-bg);
+    padding: 18px;
+  }
+
+  .prototype-banner {
+    border: 1px dashed var(--border-strong);
+    background: rgb(var(--source-green-rgb) / 0.06);
+    color: var(--color-text-soft);
+    padding: 8px 12px;
+    font-size: 12px;
+    margin-bottom: 14px;
+    border-radius: var(--radius-sm);
+  }
+  .prototype-banner b { color: var(--color-accent-strong); }
+
+  h1, h2, h3 {
+    font-family: var(--font-heading);
+    margin: 0;
+    line-height: 1.15;
+    font-weight: 600;
+  }
+  h1 { font-size: 22px; }
+  h2 { font-size: 16px; color: var(--color-text-soft); }
+
+  /* --- Top bar --------------------------------------------- */
+  .panel {
+    border: 1px solid var(--border-default);
+    background: var(--color-surface);
+    border-radius: var(--radius-md);
+    backdrop-filter: blur(6px);
+  }
+
+  .top-bar {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 14px;
+    align-items: center;
+    padding: 14px 18px;
+    margin-bottom: 14px;
+  }
+
+  .top-bar .titles {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
+  .top-bar .titles .subtitle {
+    color: var(--color-text-muted);
+    font-size: 12px;
+  }
+
+  .scenario-select {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    padding: 4px 6px 4px 10px;
+    color: var(--color-text-soft);
+    font-size: 12px;
+  }
+  .scenario-select select {
+    background: transparent;
+    color: var(--color-text);
+    border: 0;
+    font-family: inherit;
+    font-size: 13px;
+    outline: none;
+    padding: 4px 4px;
+  }
+  .scenario-select select:focus-visible {
+    outline: 2px solid var(--color-accent);
+    border-radius: 4px;
+  }
+
+  /* --- Filter row ----------------------------------------- */
+  .filter-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    padding: 10px 18px;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .filter-row .filter-label {
+    color: var(--color-text-muted);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-right: 4px;
+  }
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-default);
+    color: var(--color-text-soft);
+    font-size: 12px;
+    cursor: pointer;
+    user-select: none;
+  }
+  .chip:hover { border-color: var(--border-strong); }
+  .chip[aria-pressed="true"] {
+    background: rgb(var(--source-green-rgb) / 0.16);
+    border-color: var(--border-selected);
+    color: var(--color-text);
+  }
+  .chip-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+    color: var(--color-text-muted);
+    font-size: 12px;
+  }
+  .chip-toggle input { accent-color: var(--color-accent); }
+
+  /* --- Layout grid ---------------------------------------- */
+  .workspace {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 340px;
+    gap: 14px;
+    align-items: stretch;
+  }
+
+  @media (max-width: 900px) {
+    .workspace { grid-template-columns: 1fr; }
+  }
+
+  .tree-panel, .detail-panel {
+    min-height: 360px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tree-panel header, .detail-panel header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    padding: 12px 16px;
+    border-bottom: 1px solid var(--border-subtle);
+  }
+  .tree-panel header .meta {
+    color: var(--color-text-muted);
+    font-size: 11px;
+    font-family: var(--font-mono);
+  }
+
+  .tree-panel .body {
+    padding: 10px 8px 14px 8px;
+    overflow: auto;
+    flex: 1;
+  }
+
+  /* --- Tree --------------------------------------------- */
+  .tree {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 13px;
+  }
+  .tree ul {
+    list-style: none;
+    padding-left: 18px;
+    margin: 0;
+    position: relative;
+  }
+  .tree ul::before {
+    content: "";
+    position: absolute;
+    left: 8px;
+    top: 0;
+    bottom: 8px;
+    border-left: 1px dashed rgb(var(--source-green-rgb) / 0.22);
+  }
+  .tree li { position: relative; }
+  .tree li::before {
+    content: "";
+    position: absolute;
+    left: -10px;
+    top: 14px;
+    width: 10px;
+    border-top: 1px dashed rgb(var(--source-green-rgb) / 0.22);
+  }
+  .tree > li::before, .tree > li::after { display: none; }
+
+  .node {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    gap: 8px;
+    align-items: center;
+    padding: 4px 8px;
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    cursor: pointer;
+    margin: 2px 0;
+  }
+  .node:hover {
+    background: rgb(var(--source-green-rgb) / 0.06);
+  }
+  .node.selected {
+    background: rgb(var(--source-green-rgb) / 0.14);
+    border-color: var(--border-selected);
+  }
+  .node:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+  }
+
+  .twisty {
+    width: 18px;
+    height: 18px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--color-text-muted);
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    font-size: 10px;
+    padding: 0;
+  }
+  .twisty.placeholder { visibility: hidden; }
+  .twisty[aria-expanded="false"] svg { transform: rotate(-90deg); }
+  .twisty svg { transition: transform 120ms ease; }
+  .twisty:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 1px;
+    border-radius: 4px;
+  }
+
+  .node-label {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  .kind-pill {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    font-weight: 600;
+    font-family: var(--font-sans);
+    border: 1px solid var(--border-default);
+    color: var(--color-text-soft);
+    background: var(--color-surface-strong);
+  }
+  .kind-pill.req {
+    color: var(--color-accent-strong);
+    border-color: rgb(var(--source-green-rgb) / 0.38);
+  }
+  .kind-pill.tool {
+    color: var(--color-info);
+    border-color: rgb(16 203 255 / 0.35);
+  }
+
+  .node-id {
+    font-family: var(--font-mono);
+    color: var(--color-text);
+  }
+  .node-secondary {
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: 12px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .state-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 1px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 11px;
+    font-family: var(--font-sans);
+    font-weight: 600;
+    border: 1px solid currentColor;
+  }
+  .state-badge::before {
+    content: "";
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+  }
+  .state-running, .state-processing, .state-claimed { color: var(--color-info); }
+  .state-completed { color: var(--color-success); }
+  .state-failed, .state-dead { color: var(--color-error); }
+  .state-cancelled, .state-interrupted, .state-superseded { color: var(--color-warning); }
+  .state-pending, .state-uninitialized { color: var(--color-text-muted); }
+  .state-input_required { color: var(--color-warning); }
+
+  /* --- Detail panel ----------------------------------- */
+  .detail-panel { background: var(--color-surface-muted); }
+  .detail-panel .body {
+    padding: 14px 16px;
+    flex: 1;
+    overflow: auto;
+  }
+  .detail-empty {
+    color: var(--color-text-muted);
+    font-size: 13px;
+    padding: 18px 4px;
+    text-align: center;
+  }
+  .detail-grid {
+    display: grid;
+    grid-template-columns: 110px 1fr;
+    gap: 6px 12px;
+    font-size: 12.5px;
+  }
+  .detail-grid dt {
+    color: var(--color-text-muted);
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    font-size: 10.5px;
+    letter-spacing: 0.06em;
+    align-self: center;
+  }
+  .detail-grid dd {
+    margin: 0;
+    color: var(--color-text);
+    font-family: var(--font-mono);
+    word-break: break-all;
+  }
+  .detail-grid dd.muted { color: var(--color-text-muted); font-style: italic; }
+
+  .detail-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 12px 16px;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    border: 1px solid var(--border-default);
+    background: var(--color-surface-strong);
+    color: var(--color-text-soft);
+    font: inherit;
+    font-size: 12px;
+    padding: 6px 12px;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+  .btn:hover { border-color: var(--border-strong); color: var(--color-text); }
+  .btn:focus-visible { outline: 2px solid var(--color-accent); outline-offset: 1px; }
+  .btn.danger { color: var(--color-error); border-color: rgb(255 111 95 / 0.35); }
+  .btn.danger:hover { background: rgb(255 111 95 / 0.08); }
+
+  .detail-section + .detail-section { margin-top: 14px; }
+  .detail-section h3 {
+    font-family: var(--font-sans);
+    font-size: 11px;
+    letter-spacing: 0.08em;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    margin-bottom: 8px;
+  }
+
+  .empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 40px 12px;
+    color: var(--color-text-muted);
+    text-align: center;
+    gap: 6px;
+  }
+  .empty-state code {
+    color: var(--color-text-soft);
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-subtle);
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11.5px;
+  }
+
+  /* --- Toast --------------------------------------------- */
+  .toast {
+    position: fixed;
+    bottom: 18px;
+    right: 18px;
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-strong);
+    color: var(--color-text-soft);
+    padding: 8px 12px;
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    opacity: 0;
+    transform: translateY(4px);
+    transition: opacity 140ms ease, transform 140ms ease;
+    pointer-events: none;
+    z-index: 999;
+    max-width: 320px;
+  }
+  .toast.show { opacity: 1; transform: translateY(0); }
+
+  /* --- Design notes -------------------------------------- */
+  details.notes {
+    margin-top: 14px;
+    padding: 0;
+  }
+  details.notes summary {
+    cursor: pointer;
+    padding: 12px 16px;
+    list-style: none;
+    color: var(--color-text-soft);
+    font-family: var(--font-heading);
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  details.notes summary::before {
+    content: "▸";
+    color: var(--color-text-muted);
+    font-size: 11px;
+    transition: transform 120ms ease;
+  }
+  details.notes[open] summary::before { transform: rotate(90deg); }
+  details.notes summary::-webkit-details-marker { display: none; }
+  details.notes .notes-body {
+    padding: 0 18px 18px 18px;
+    border-top: 1px solid var(--border-subtle);
+    color: var(--color-text-soft);
+    font-size: 13px;
+  }
+  details.notes .notes-body h3 {
+    font-family: var(--font-heading);
+    font-size: 13px;
+    margin-top: 14px;
+    color: var(--color-text);
+  }
+  details.notes .notes-body code,
+  details.notes .notes-body pre {
+    font-family: var(--font-mono);
+    background: var(--color-surface-strong);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 1px 6px;
+    font-size: 12px;
+    color: var(--color-text);
+  }
+  details.notes .notes-body pre {
+    padding: 10px 12px;
+    overflow-x: auto;
+    line-height: 1.5;
+    white-space: pre;
+  }
+  details.notes .notes-body ul { padding-left: 18px; }
+  details.notes .notes-body li { margin: 4px 0; }
+  details.notes .notes-body p { margin: 6px 0; }
+</style>
+</head>
+<body>
+
+<div class="prototype-banner">
+  <b>Prototype</b> — Panel 3: Subagent Lineage View (issue
+  <a href="https://github.com/sourcenetwork/defra-agent/issues/274" style="color:var(--color-accent-strong)">#274</a>).
+  Standalone HTML; not wired to a real Tauri bridge. Mock data is baked into the file — toggle the scenario in the top right.
+</div>
+
+<section class="panel top-bar">
+  <div class="titles">
+    <h1>Subagent Lineage</h1>
+    <div class="subtitle">Operator view of parent → child request dispatch across deployments.</div>
+  </div>
+  <label class="scenario-select" aria-label="Choose mock scenario">
+    <span style="color:var(--color-text-muted);font-size:11px;text-transform:uppercase;letter-spacing:0.06em">Mock</span>
+    <select id="scenario">
+      <option value="empty">empty — no active subagents</option>
+      <option value="single" selected>single — parent → one child</option>
+      <option value="fanout">fanout — parent → multi children, mixed states</option>
+      <option value="deep">deep — 3+ level tree</option>
+      <option value="cross">cross-deployment — local ↔ remote fan-out</option>
+    </select>
+  </label>
+</section>
+
+<section class="panel" style="margin-bottom:14px">
+  <div class="filter-row">
+    <span class="filter-label">Depth</span>
+    <button class="chip" data-depth="all" aria-pressed="true">All</button>
+    <button class="chip" data-depth="0" aria-pressed="false">0</button>
+    <button class="chip" data-depth="1" aria-pressed="false">≤1</button>
+    <button class="chip" data-depth="2" aria-pressed="false">≤2</button>
+    <button class="chip" data-depth="3" aria-pressed="false">≤3</button>
+
+    <span class="filter-label" style="margin-left:14px">Deployment</span>
+    <div id="deployment-chips" style="display:inline-flex;gap:8px;flex-wrap:wrap"></div>
+
+    <label class="chip-toggle">
+      <input type="checkbox" id="live-only" />
+      Show live only
+    </label>
+  </div>
+</section>
+
+<div class="workspace">
+  <section class="panel tree-panel" aria-labelledby="lineage-heading">
+    <header>
+      <h2 id="lineage-heading">Lineage</h2>
+      <span class="meta" id="root-meta">—</span>
+    </header>
+    <div class="body">
+      <ul id="tree" class="tree" role="tree" aria-label="Subagent lineage tree" tabindex="0"></ul>
+      <div id="empty-state" class="empty-state" hidden>
+        <span style="font-size:22px">⌀</span>
+        <div>No active subagent dispatches.</div>
+        <div style="font-size:12px">Bridges and child requests appear here as <code>spawn_subagent</code> tools dispatch.</div>
+      </div>
+    </div>
+  </section>
+
+  <aside class="panel detail-panel" aria-label="Selected node details">
+    <header>
+      <h2>Details</h2>
+      <span class="meta" id="detail-meta" style="color:var(--color-text-muted);font-size:11px;font-family:var(--font-mono)"></span>
+    </header>
+    <div class="body" id="detail-body">
+      <div class="detail-empty">Select a node in the lineage tree to see request, behavior, and bridge edge metadata.</div>
+    </div>
+    <div class="detail-actions">
+      <button class="btn danger" id="btn-interrupt" disabled>Interrupt selected</button>
+      <button class="btn" id="btn-copy">Copy graph JSON</button>
+    </div>
+  </aside>
+</div>
+
+<details class="panel notes">
+  <summary>Design notes for impl</summary>
+  <div class="notes-body">
+    <h3>Tauri command surface</h3>
+    <p>This panel is the consumer of the design spec's <code>desktop_list_subagent_tree</code> command
+      (see <code>docs/superpowers/specs/2026-05-20-desktop-operator-surfaces-design.md</code> §"Panel 3"):</p>
+    <pre>desktop_list_subagent_tree({
+  rootRequestId: string,
+  agentDid?: string | null,
+  includeTerminal?: boolean,
+  maxDepth?: number,
+}) -> SubagentTreeView</pre>
+    <p>An R5 cross-deployment snapshot is already exposed by the runtime HTTP layer at
+      <code>GET /subagents/dispatches?parent_request_id=&lt;id&gt;</code>
+      (see <code>crates/defra-agent-cli/src/http/r5_dispatch.rs</code>). The Tauri command can be a thin
+      wrapper around that endpoint plus a local-DB walk for in-process descendants — keeping a single
+      authoritative shape on the UI side.</p>
+
+    <h3>Data shape</h3>
+    <p>The tree alternates request nodes and tool-call nodes; edges carry the bridge metadata
+      (<code>await_mode</code>, <code>cancel_policy</code>, <code>tool_name</code>). The minimum the panel
+      needs per node:</p>
+    <pre>SubagentNodeView {
+  requestId, sessionId?, agentDid?, behaviorId?,
+  lifecycleState?, status?, subagentDepth?,
+  causedByParentRequestId?, causedByParentToolCallId?
+}
+SubagentEdgeView {
+  parentRequestId, childRequestId,
+  parentToolCallId?, toolName?,
+  awaitMode?, cancelPolicy?, lifecycleState?
+}</pre>
+    <p>The runtime walks <code>AgentRequest.caused_by_parent_request_id</code> and cross-checks against
+      <code>AgentToolCall.child_request_id</code>; the panel renders both edge sources so a missing
+      bridge (e.g. unclaimed) is visible rather than silently dropped.</p>
+
+    <h3>Cross-deployment notes (this issue, #274)</h3>
+    <p>R5 splits a single lineage across deployments — a parent on the local deployment may dispatch a
+      child onto a remote deployment via a <code>spawn_subagent</code> tool. The panel labels each request
+      with its <code>agent_did</code> (deployment) so the operator can see the routing at a glance. The
+      <em>deployment</em> chips at the top let the operator slice to one side of the boundary at a time.
+      This is the surface the matrix row <code>subagents-cross-deployment / operatorUi</code> tracks.</p>
+
+    <h3>Accessibility</h3>
+    <ul>
+      <li>The lineage is a WAI-ARIA tree: <code>role="tree"</code> on the root, <code>role="treeitem"</code>
+        and <code>role="group"</code> on children, <code>aria-expanded</code> on each node that has children.</li>
+      <li>Single tab-stop. Arrow keys move within the tree:
+        <code>↑/↓</code> previous/next visible node, <code>→</code> expand or descend, <code>←</code> collapse or
+        ascend, <code>Enter / Space</code> selects, <code>Home / End</code> jump to first/last.</li>
+      <li>Selection is independent of expansion; <code>aria-selected</code> reflects the active node and
+        the detail panel is the live region for that selection.</li>
+      <li>Focus restored to the previously-selected node when scenarios change so the operator does not
+        lose their place.</li>
+    </ul>
+
+    <h3>Open questions</h3>
+    <ul>
+      <li>Should the panel poll <code>desktop_list_subagent_tree</code> or subscribe via the existing
+        snapshot-feed channel that the rail's other panels use? Polling is simpler; subscription matches
+        background-tools and cascade-preview behavior.</li>
+      <li>When a parent and a child sit on different deployments, do we want to surface latency between
+        the bridge's <code>started_at</code> and the child's <code>claimed_at</code>? Useful signal, but
+        adds another column to a tree that's already dense.</li>
+      <li>"Interrupt selected" rooted at a child request shares plumbing with the composer interrupt
+        flow (Panel 1). The cascade-preview confirmation belongs to that path — out of scope for this
+        prototype but the button is shown for placement.</li>
+      <li>Truncation: should we cap depth client-side (e.g., collapse subtrees past
+        <code>maxDepth</code>) or let the bridge enforce it? Today the prototype renders everything.</li>
+    </ul>
+  </div>
+</details>
+
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+<script>
+// ---------- Mock scenarios ----------
+// Each node is { kind: 'req' | 'tool', ...fields, children: [...] }.
+// Edges live on the tool nodes (since each tool fans out to exactly one child request).
+const SCENARIOS = {
+  empty: {
+    rootRequestId: null,
+    truncated: false,
+    tree: null,
+  },
+
+  single: {
+    rootRequestId: "req_a17",
+    truncated: false,
+    tree: {
+      kind: "req",
+      requestId: "req_a17",
+      sessionId: "sess_91f0",
+      agentDid: "did:key:z6Mk…local-A",
+      behaviorId: "amy-general",
+      lifecycleState: "Processing",
+      status: "processing",
+      subagentDepth: 0,
+      children: [
+        {
+          kind: "tool",
+          toolCallId: "tc_bg-91",
+          parentRequestId: "req_a17",
+          toolName: "spawn_subagent",
+          awaitMode: "background",
+          cancelPolicy: "cascade",
+          lifecycleState: "running",
+          startedAt: "2026-05-20T17:02:14Z",
+          children: [
+            {
+              kind: "req",
+              requestId: "req_b91",
+              sessionId: "sess_b91",
+              agentDid: "did:key:z6Mk…local-A",
+              behaviorId: "amy-code",
+              lifecycleState: "Processing",
+              status: "processing",
+              subagentDepth: 1,
+              causedByParentRequestId: "req_a17",
+              causedByParentToolCallId: "tc_bg-91",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  fanout: {
+    rootRequestId: "req_a17",
+    truncated: false,
+    tree: {
+      kind: "req",
+      requestId: "req_a17",
+      sessionId: "sess_91f0",
+      agentDid: "did:key:z6Mk…local-A",
+      behaviorId: "amy-general",
+      lifecycleState: "Processing",
+      status: "processing",
+      subagentDepth: 0,
+      children: [
+        {
+          kind: "tool",
+          toolCallId: "tc_bg-91",
+          parentRequestId: "req_a17",
+          toolName: "spawn_subagent",
+          awaitMode: "background",
+          cancelPolicy: "cascade",
+          lifecycleState: "running",
+          startedAt: "2026-05-20T17:02:14Z",
+          children: [
+            {
+              kind: "req",
+              requestId: "req_b91",
+              sessionId: "sess_b91",
+              agentDid: "did:key:z6Mk…local-A",
+              behaviorId: "amy-code",
+              lifecycleState: "Processing",
+              status: "processing",
+              subagentDepth: 1,
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: "tool",
+          toolCallId: "tc_fg-10",
+          parentRequestId: "req_a17",
+          toolName: "spawn_subagent",
+          awaitMode: "foreground",
+          cancelPolicy: "cascade",
+          lifecycleState: "completed",
+          startedAt: "2026-05-20T17:01:50Z",
+          children: [
+            {
+              kind: "req",
+              requestId: "req_c10",
+              sessionId: "sess_c10",
+              agentDid: "did:key:z6Mk…local-A",
+              behaviorId: "amy-review",
+              lifecycleState: "Completed",
+              status: "completed",
+              subagentDepth: 1,
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: "tool",
+          toolCallId: "tc_bg-03",
+          parentRequestId: "req_a17",
+          toolName: "spawn_subagent",
+          awaitMode: "background",
+          cancelPolicy: "cascade",
+          lifecycleState: "cancelled",
+          startedAt: "2026-05-20T17:01:32Z",
+          children: [
+            {
+              kind: "req",
+              requestId: "req_d03",
+              sessionId: "sess_d03",
+              agentDid: "did:key:z6Mk…local-A",
+              behaviorId: "amy-rumination",
+              lifecycleState: "Interrupted",
+              status: "interrupted",
+              subagentDepth: 1,
+              children: [],
+            },
+          ],
+        },
+        {
+          kind: "tool",
+          toolCallId: "tc_bg-77",
+          parentRequestId: "req_a17",
+          toolName: "spawn_subagent",
+          awaitMode: "background",
+          cancelPolicy: "detach",
+          lifecycleState: "failed",
+          startedAt: "2026-05-20T17:01:11Z",
+          children: [
+            {
+              kind: "req",
+              requestId: "req_e77",
+              sessionId: "sess_e77",
+              agentDid: "did:key:z6Mk…local-A",
+              behaviorId: "amy-code",
+              lifecycleState: "Failed",
+              status: "failed",
+              subagentDepth: 1,
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  },
+
+  deep: {
+    rootRequestId: "req_root",
+    truncated: false,
+    tree: {
+      kind: "req",
+      requestId: "req_root",
+      sessionId: "sess_root",
+      agentDid: "did:key:z6Mk…local-A",
+      behaviorId: "amy-general",
+      lifecycleState: "Processing",
+      status: "processing",
+      subagentDepth: 0,
+      children: [
+        {
+          kind: "tool", toolCallId: "tc_l1", parentRequestId: "req_root",
+          toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "cascade",
+          lifecycleState: "running", startedAt: "2026-05-20T17:00:01Z",
+          children: [{
+            kind: "req", requestId: "req_l1", sessionId: "sess_l1",
+            agentDid: "did:key:z6Mk…local-A", behaviorId: "amy-code",
+            lifecycleState: "Processing", status: "processing", subagentDepth: 1,
+            children: [{
+              kind: "tool", toolCallId: "tc_l2", parentRequestId: "req_l1",
+              toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "detach",
+              lifecycleState: "running", startedAt: "2026-05-20T17:00:08Z",
+              children: [{
+                kind: "req", requestId: "req_l2", sessionId: "sess_l2",
+                agentDid: "did:key:z6Mk…local-A", behaviorId: "amy-review",
+                lifecycleState: "Processing", status: "processing", subagentDepth: 2,
+                children: [{
+                  kind: "tool", toolCallId: "tc_l3", parentRequestId: "req_l2",
+                  toolName: "spawn_subagent", awaitMode: "foreground", cancelPolicy: "cascade",
+                  lifecycleState: "running", startedAt: "2026-05-20T17:00:21Z",
+                  children: [{
+                    kind: "req", requestId: "req_l3", sessionId: "sess_l3",
+                    agentDid: "did:key:z6Mk…local-A", behaviorId: "amy-rumination",
+                    lifecycleState: "Claimed", status: "claimed", subagentDepth: 3,
+                    children: [{
+                      kind: "tool", toolCallId: "tc_l4", parentRequestId: "req_l3",
+                      toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "detach",
+                      lifecycleState: "running", startedAt: "2026-05-20T17:00:34Z",
+                      children: [{
+                        kind: "req", requestId: "req_l4", sessionId: "sess_l4",
+                        agentDid: "did:key:z6Mk…local-A", behaviorId: "amy-code",
+                        lifecycleState: "Pending", status: "pending", subagentDepth: 4,
+                        children: [],
+                      }],
+                    }],
+                  }],
+                }],
+              }],
+            }],
+          }],
+        },
+      ],
+    },
+  },
+
+  cross: {
+    rootRequestId: "req_a17",
+    truncated: false,
+    tree: {
+      kind: "req",
+      requestId: "req_a17",
+      sessionId: "sess_91f0",
+      agentDid: "did:key:z6Mk…local-A",
+      behaviorId: "amy-general",
+      lifecycleState: "Processing",
+      status: "processing",
+      subagentDepth: 0,
+      children: [
+        {
+          kind: "tool", toolCallId: "tc_bg-91", parentRequestId: "req_a17",
+          toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "cascade",
+          lifecycleState: "running", startedAt: "2026-05-20T17:02:14Z",
+          children: [{
+            kind: "req", requestId: "req_b91", sessionId: "sess_b91",
+            agentDid: "did:key:z6Mk…remote-B", behaviorId: "amy-code",
+            lifecycleState: "Processing", status: "processing", subagentDepth: 1,
+            children: [{
+              kind: "tool", toolCallId: "tc_bg-44", parentRequestId: "req_b91",
+              toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "cascade",
+              lifecycleState: "running", startedAt: "2026-05-20T17:02:39Z",
+              children: [{
+                kind: "req", requestId: "req_c44", sessionId: "sess_c44",
+                agentDid: "did:key:z6Mk…remote-B", behaviorId: "amy-review",
+                lifecycleState: "Processing", status: "processing", subagentDepth: 2,
+                children: [],
+              }],
+            }],
+          }],
+        },
+        {
+          kind: "tool", toolCallId: "tc_bg-22", parentRequestId: "req_a17",
+          toolName: "spawn_subagent", awaitMode: "background", cancelPolicy: "detach",
+          lifecycleState: "running", startedAt: "2026-05-20T17:02:18Z",
+          children: [{
+            kind: "req", requestId: "req_x22", sessionId: "sess_x22",
+            agentDid: "did:key:z6Mk…remote-C", behaviorId: "amy-rumination",
+            lifecycleState: "Processing", status: "processing", subagentDepth: 1,
+            children: [],
+          }],
+        },
+        {
+          kind: "tool", toolCallId: "tc_fg-09", parentRequestId: "req_a17",
+          toolName: "spawn_subagent", awaitMode: "foreground", cancelPolicy: "cascade",
+          lifecycleState: "completed", startedAt: "2026-05-20T17:01:48Z",
+          children: [{
+            kind: "req", requestId: "req_y09", sessionId: "sess_y09",
+            agentDid: "did:key:z6Mk…local-A", behaviorId: "amy-code",
+            lifecycleState: "Completed", status: "completed", subagentDepth: 1,
+            children: [],
+          }],
+        },
+      ],
+    },
+  },
+};
+
+// ---------- App state ----------
+const state = {
+  scenario: "single",
+  selectedNodeId: null,    // composite id: kind:id
+  expanded: new Set(),
+  depthFilter: "all",      // "all" | "0" | "1" | "2" | "3"
+  deployments: new Set(),  // active deployment filter set; empty = all
+  allDeployments: [],
+  liveOnly: false,
+  flatNodes: [],           // tree-order list of node refs for keyboard nav
+};
+
+const TERMINAL_STATES = new Set([
+  "completed", "failed", "cancelled", "interrupted", "superseded", "dead",
+]);
+
+const nodeId = (n) => n.kind === "req" ? `req:${n.requestId}` : `tool:${n.toolCallId}`;
+
+function isLive(node) {
+  const lf = (node.lifecycleState || "").toLowerCase();
+  return !TERMINAL_STATES.has(lf);
+}
+
+function collectDeployments(node, out) {
+  if (!node) return;
+  if (node.kind === "req" && node.agentDid) out.add(node.agentDid);
+  for (const c of node.children || []) collectDeployments(c, out);
+}
+
+function descendantHasMatchingReq(node) {
+  // Returns true if any descendant request node passes deployment+live filters.
+  if (!node) return false;
+  if (node.kind === "req") {
+    const okDeploy = state.deployments.size === 0 || (node.agentDid && state.deployments.has(node.agentDid));
+    const okLive = !state.liveOnly || isLive(node);
+    if (okDeploy && okLive) return true;
+  }
+  for (const c of node.children || []) if (descendantHasMatchingReq(c)) return true;
+  return false;
+}
+
+function nodePassesFilter(node, depth) {
+  // Depth filter (0-based on request nodes)
+  if (state.depthFilter !== "all") {
+    const max = Number(state.depthFilter);
+    if (node.kind === "req" && (node.subagentDepth ?? depth) > max) return false;
+  }
+  // Live-only on terminal request nodes — but keep the node if any descendant survives.
+  if (state.liveOnly && node.kind === "req" && !isLive(node) && !descendantHasMatchingReq(node)) {
+    return false;
+  }
+  // Deployment filter applies to request nodes; tool nodes inherit parent's deployment.
+  if (state.deployments.size > 0 && node.kind === "req") {
+    if (!node.agentDid || !state.deployments.has(node.agentDid)) {
+      // Keep if any descendant matches, so we don't orphan the tree.
+      if (!descendantHasMatchingReq(node)) return false;
+    }
+  }
+  return true;
+}
+
+// ---------- Rendering ----------
+function clear(el) { while (el.firstChild) el.removeChild(el.firstChild); }
+
+function escapeText(s) { return String(s == null ? "" : s); }
+
+function renderStateBadge(stateStr) {
+  if (!stateStr) return null;
+  const safe = stateStr.toLowerCase();
+  const span = document.createElement("span");
+  span.className = `state-badge state-${safe}`;
+  span.textContent = stateStr;
+  return span;
+}
+
+function chevronSvg() {
+  // 8x8 chevron pointing down
+  return '<svg viewBox="0 0 8 8" width="8" height="8" aria-hidden="true"><path d="M0.5 2 L4 6 L7.5 2" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+}
+
+function renderNode(node, depth, parentUl) {
+  if (!nodePassesFilter(node, depth)) return;
+
+  const li = document.createElement("li");
+  li.setAttribute("role", "treeitem");
+  const id = nodeId(node);
+  li.dataset.nodeId = id;
+
+  const hasChildren = (node.children || []).some(c => nodePassesFilter(c, depth + (node.kind === "req" ? 1 : 0)));
+  if (hasChildren) {
+    const expanded = state.expanded.has(id);
+    li.setAttribute("aria-expanded", expanded ? "true" : "false");
+  }
+  if (state.selectedNodeId === id) li.setAttribute("aria-selected", "true");
+
+  // Node row
+  const row = document.createElement("div");
+  row.className = "node" + (state.selectedNodeId === id ? " selected" : "");
+  row.tabIndex = -1;
+  row.dataset.nodeId = id;
+
+  // Twisty
+  const twisty = document.createElement("button");
+  twisty.className = "twisty" + (hasChildren ? "" : " placeholder");
+  twisty.type = "button";
+  if (hasChildren) {
+    const expanded = state.expanded.has(id);
+    twisty.setAttribute("aria-expanded", expanded ? "true" : "false");
+    twisty.setAttribute("aria-label", expanded ? "Collapse" : "Expand");
+    twisty.innerHTML = chevronSvg();
+    twisty.addEventListener("click", (ev) => {
+      ev.stopPropagation();
+      toggleExpanded(id);
+    });
+  }
+  row.appendChild(twisty);
+
+  // Label
+  const label = document.createElement("div");
+  label.className = "node-label";
+
+  const kindPill = document.createElement("span");
+  kindPill.className = "kind-pill " + (node.kind === "req" ? "req" : "tool");
+  kindPill.textContent = node.kind === "req" ? "req" : "tool";
+  label.appendChild(kindPill);
+
+  const idSpan = document.createElement("span");
+  idSpan.className = "node-id";
+  idSpan.textContent = node.kind === "req" ? node.requestId : node.toolCallId;
+  label.appendChild(idSpan);
+
+  const secondary = document.createElement("span");
+  secondary.className = "node-secondary";
+  if (node.kind === "req") {
+    const bits = [];
+    if (node.behaviorId) bits.push(node.behaviorId);
+    if (node.agentDid) bits.push(node.agentDid);
+    secondary.textContent = bits.join("  ·  ");
+  } else {
+    const bits = [];
+    if (node.toolName) bits.push(node.toolName);
+    if (node.awaitMode || node.cancelPolicy) {
+      bits.push([node.awaitMode, node.cancelPolicy].filter(Boolean).join("/"));
+    }
+    secondary.textContent = bits.join("  ·  ");
+  }
+  label.appendChild(secondary);
+
+  row.appendChild(label);
+
+  // State badge
+  const badge = renderStateBadge(node.lifecycleState);
+  if (badge) row.appendChild(badge);
+  else {
+    const filler = document.createElement("span");
+    row.appendChild(filler);
+  }
+
+  row.addEventListener("click", (ev) => {
+    ev.stopPropagation();
+    selectNode(id, true);
+  });
+  row.addEventListener("focus", () => selectNode(id, false));
+
+  li.appendChild(row);
+
+  // Children
+  if (hasChildren && state.expanded.has(id)) {
+    const ul = document.createElement("ul");
+    ul.setAttribute("role", "group");
+    for (const child of node.children) {
+      renderNode(child, depth + (node.kind === "req" ? 1 : 0), ul);
+    }
+    li.appendChild(ul);
+  }
+
+  parentUl.appendChild(li);
+}
+
+function rebuildFlatList() {
+  state.flatNodes = [];
+  const visit = (li) => {
+    const id = li.dataset.nodeId;
+    state.flatNodes.push(id);
+    if (li.getAttribute("aria-expanded") === "true") {
+      const childUl = li.querySelector(":scope > ul");
+      if (childUl) {
+        for (const c of childUl.children) visit(c);
+      }
+    }
+  };
+  const root = document.getElementById("tree");
+  for (const li of root.children) visit(li);
+}
+
+function render() {
+  const scenario = SCENARIOS[state.scenario];
+  const treeEl = document.getElementById("tree");
+  const emptyEl = document.getElementById("empty-state");
+  const meta = document.getElementById("root-meta");
+
+  clear(treeEl);
+
+  if (!scenario.tree) {
+    treeEl.hidden = true;
+    emptyEl.hidden = false;
+    meta.textContent = "0 nodes";
+    state.flatNodes = [];
+    renderDetail();
+    return;
+  }
+
+  treeEl.hidden = false;
+  emptyEl.hidden = true;
+  renderNode(scenario.tree, 0, treeEl);
+  rebuildFlatList();
+
+  // Make tabbable node the selected one (or first).
+  setTabStop();
+
+  // Meta
+  let reqCount = 0, toolCount = 0;
+  const tally = (n) => {
+    if (!n) return;
+    if (n.kind === "req") reqCount++; else toolCount++;
+    (n.children || []).forEach(tally);
+  };
+  tally(scenario.tree);
+  meta.textContent = `root ${scenario.rootRequestId} · ${reqCount} req · ${toolCount} tool`;
+
+  renderDetail();
+}
+
+function setTabStop() {
+  const rows = document.querySelectorAll("#tree .node");
+  rows.forEach(r => r.tabIndex = -1);
+  let target = null;
+  if (state.selectedNodeId) {
+    target = document.querySelector(`#tree .node[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+  }
+  if (!target && rows.length) target = rows[0];
+  if (target) target.tabIndex = 0;
+}
+
+function cssEscape(s) {
+  if (window.CSS && CSS.escape) return CSS.escape(s);
+  return s.replace(/([^\w-])/g, "\\$1");
+}
+
+// ---------- Detail panel ----------
+function findNodeById(root, id) {
+  if (!root) return null;
+  if (nodeId(root) === id) return root;
+  for (const c of root.children || []) {
+    const f = findNodeById(c, id);
+    if (f) return f;
+  }
+  return null;
+}
+
+function renderDetail() {
+  const body = document.getElementById("detail-body");
+  const meta = document.getElementById("detail-meta");
+  const interruptBtn = document.getElementById("btn-interrupt");
+
+  const scenario = SCENARIOS[state.scenario];
+  const node = state.selectedNodeId ? findNodeById(scenario.tree, state.selectedNodeId) : null;
+
+  clear(body);
+  if (!node) {
+    meta.textContent = "";
+    interruptBtn.disabled = true;
+    const e = document.createElement("div");
+    e.className = "detail-empty";
+    e.textContent = "Select a node in the lineage tree to see request, behavior, and bridge edge metadata.";
+    body.appendChild(e);
+    return;
+  }
+
+  meta.textContent = node.kind === "req" ? "AgentRequest" : "AgentToolCall (bridge)";
+
+  const section = document.createElement("div");
+  section.className = "detail-section";
+  const dl = document.createElement("dl");
+  dl.className = "detail-grid";
+
+  const row = (label, value, opts = {}) => {
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    if (value == null || value === "") {
+      dd.classList.add("muted");
+      dd.textContent = "—";
+    } else if (opts.badge) {
+      const badge = renderStateBadge(String(value));
+      dd.appendChild(badge);
+    } else {
+      dd.textContent = String(value);
+    }
+    dl.appendChild(dt);
+    dl.appendChild(dd);
+  };
+
+  if (node.kind === "req") {
+    row("request id", node.requestId);
+    row("session", node.sessionId);
+    row("deployment", node.agentDid);
+    row("behavior", node.behaviorId);
+    row("lifecycle", node.lifecycleState, { badge: true });
+    row("status", node.status);
+    row("depth", node.subagentDepth);
+    if (node.causedByParentRequestId) {
+      const sub = document.createElement("div");
+      sub.className = "detail-section";
+      const h = document.createElement("h3");
+      h.textContent = "Caused by";
+      sub.appendChild(h);
+      const dl2 = document.createElement("dl");
+      dl2.className = "detail-grid";
+      const r2 = (l, v) => {
+        const dt = document.createElement("dt"); dt.textContent = l;
+        const dd = document.createElement("dd"); dd.textContent = v ?? "—";
+        if (!v) dd.classList.add("muted");
+        dl2.appendChild(dt); dl2.appendChild(dd);
+      };
+      r2("parent request", node.causedByParentRequestId);
+      r2("parent tool call", node.causedByParentToolCallId);
+      sub.appendChild(dl2);
+      section.appendChild(dl);
+      body.appendChild(section);
+      body.appendChild(sub);
+      interruptBtn.disabled = !isLive(node);
+      return;
+    }
+  } else {
+    row("tool call id", node.toolCallId);
+    row("parent request", node.parentRequestId);
+    row("tool", node.toolName);
+    row("await mode", node.awaitMode);
+    row("cancel policy", node.cancelPolicy);
+    row("lifecycle", node.lifecycleState, { badge: true });
+    row("started at", node.startedAt);
+  }
+  section.appendChild(dl);
+  body.appendChild(section);
+
+  interruptBtn.disabled = node.kind !== "req" || !isLive(node);
+}
+
+// ---------- Interactions ----------
+function selectNode(id, focusRow) {
+  state.selectedNodeId = id;
+  document.querySelectorAll("#tree .node").forEach(n => {
+    n.classList.toggle("selected", n.dataset.nodeId === id);
+  });
+  document.querySelectorAll("#tree li").forEach(li => {
+    if (li.dataset.nodeId === id) li.setAttribute("aria-selected", "true");
+    else li.removeAttribute("aria-selected");
+  });
+  setTabStop();
+  if (focusRow) {
+    const row = document.querySelector(`#tree .node[data-node-id="${cssEscape(id)}"]`);
+    if (row) row.focus({ preventScroll: false });
+  }
+  renderDetail();
+}
+
+function toggleExpanded(id) {
+  if (state.expanded.has(id)) state.expanded.delete(id);
+  else state.expanded.add(id);
+  render();
+  const row = document.querySelector(`#tree .node[data-node-id="${cssEscape(id)}"]`);
+  if (row) row.focus({ preventScroll: true });
+}
+
+function expandAllInScenario() {
+  const scenario = SCENARIOS[state.scenario];
+  state.expanded.clear();
+  const visit = (n) => {
+    if (!n) return;
+    if ((n.children || []).length) state.expanded.add(nodeId(n));
+    (n.children || []).forEach(visit);
+  };
+  visit(scenario.tree);
+}
+
+// Keyboard navigation
+function moveSelection(delta) {
+  if (!state.flatNodes.length) return;
+  let idx = state.flatNodes.indexOf(state.selectedNodeId);
+  if (idx < 0) idx = 0;
+  else idx = Math.max(0, Math.min(state.flatNodes.length - 1, idx + delta));
+  selectNode(state.flatNodes[idx], true);
+}
+
+function moveToParent() {
+  if (!state.selectedNodeId) return;
+  const li = document.querySelector(`#tree li[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+  if (!li) return;
+  if (li.getAttribute("aria-expanded") === "true") {
+    state.expanded.delete(state.selectedNodeId);
+    render();
+    const r = document.querySelector(`#tree .node[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+    if (r) r.focus({ preventScroll: true });
+    return;
+  }
+  const parentLi = li.parentElement && li.parentElement.closest("li[role='treeitem']");
+  if (parentLi) selectNode(parentLi.dataset.nodeId, true);
+}
+
+function moveToChildOrExpand() {
+  if (!state.selectedNodeId) return;
+  const li = document.querySelector(`#tree li[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+  if (!li) return;
+  const ariaExp = li.getAttribute("aria-expanded");
+  if (ariaExp === "false") {
+    state.expanded.add(state.selectedNodeId);
+    render();
+    const r = document.querySelector(`#tree .node[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+    if (r) r.focus({ preventScroll: true });
+    return;
+  }
+  if (ariaExp === "true") {
+    const childUl = li.querySelector(":scope > ul");
+    const firstChild = childUl && childUl.querySelector(":scope > li");
+    if (firstChild) selectNode(firstChild.dataset.nodeId, true);
+  }
+}
+
+function moveToFirst() {
+  if (!state.flatNodes.length) return;
+  selectNode(state.flatNodes[0], true);
+}
+
+function moveToLast() {
+  if (!state.flatNodes.length) return;
+  selectNode(state.flatNodes[state.flatNodes.length - 1], true);
+}
+
+document.getElementById("tree").addEventListener("keydown", (ev) => {
+  switch (ev.key) {
+    case "ArrowDown": ev.preventDefault(); moveSelection(1); break;
+    case "ArrowUp":   ev.preventDefault(); moveSelection(-1); break;
+    case "ArrowRight":ev.preventDefault(); moveToChildOrExpand(); break;
+    case "ArrowLeft": ev.preventDefault(); moveToParent(); break;
+    case "Home":      ev.preventDefault(); moveToFirst(); break;
+    case "End":       ev.preventDefault(); moveToLast(); break;
+    case "Enter":
+    case " ":
+      ev.preventDefault();
+      if (state.selectedNodeId) {
+        const li = document.querySelector(`#tree li[data-node-id="${cssEscape(state.selectedNodeId)}"]`);
+        if (li && li.hasAttribute("aria-expanded")) toggleExpanded(state.selectedNodeId);
+      }
+      break;
+  }
+});
+
+// ---------- Scenario change ----------
+document.getElementById("scenario").addEventListener("change", (ev) => {
+  state.scenario = ev.target.value;
+  state.selectedNodeId = null;
+  expandAllInScenario();
+  refreshDeploymentChips();
+  render();
+});
+
+// ---------- Filter chips ----------
+document.querySelectorAll(".chip[data-depth]").forEach(chip => {
+  chip.addEventListener("click", () => {
+    document.querySelectorAll(".chip[data-depth]").forEach(c => c.setAttribute("aria-pressed", "false"));
+    chip.setAttribute("aria-pressed", "true");
+    state.depthFilter = chip.dataset.depth;
+    render();
+  });
+});
+
+document.getElementById("live-only").addEventListener("change", (ev) => {
+  state.liveOnly = ev.target.checked;
+  render();
+});
+
+function refreshDeploymentChips() {
+  const container = document.getElementById("deployment-chips");
+  clear(container);
+  const set = new Set();
+  collectDeployments(SCENARIOS[state.scenario].tree, set);
+  state.allDeployments = [...set].sort();
+  // Keep only deployments still present.
+  const filtered = new Set();
+  for (const d of state.deployments) if (set.has(d)) filtered.add(d);
+  state.deployments = filtered;
+
+  if (!state.allDeployments.length) {
+    const muted = document.createElement("span");
+    muted.style.color = "var(--color-text-muted)";
+    muted.style.fontSize = "11px";
+    muted.textContent = "none in this scenario";
+    container.appendChild(muted);
+    return;
+  }
+
+  for (const dep of state.allDeployments) {
+    const chip = document.createElement("button");
+    chip.className = "chip";
+    chip.type = "button";
+    chip.textContent = dep;
+    chip.setAttribute("aria-pressed", state.deployments.has(dep) ? "true" : "false");
+    chip.addEventListener("click", () => {
+      if (state.deployments.has(dep)) state.deployments.delete(dep);
+      else state.deployments.add(dep);
+      chip.setAttribute("aria-pressed", state.deployments.has(dep) ? "true" : "false");
+      render();
+    });
+    container.appendChild(chip);
+  }
+}
+
+// ---------- Action buttons ----------
+function showToast(msg) {
+  const t = document.getElementById("toast");
+  t.textContent = msg;
+  t.classList.add("show");
+  clearTimeout(t._timer);
+  t._timer = setTimeout(() => t.classList.remove("show"), 2400);
+}
+
+document.getElementById("btn-copy").addEventListener("click", async () => {
+  const scenario = SCENARIOS[state.scenario];
+  const payload = {
+    rootRequestId: scenario.rootRequestId,
+    truncated: scenario.truncated,
+    tree: scenario.tree,
+  };
+  const json = JSON.stringify(payload, null, 2);
+  try {
+    await navigator.clipboard.writeText(json);
+    showToast("Graph JSON copied to clipboard.");
+  } catch {
+    // Fallback (e.g., file:// without clipboard perms): open a textarea so the user can copy.
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    window.open(url, "_blank");
+    showToast("Clipboard unavailable; opened JSON in a new tab.");
+  }
+});
+
+document.getElementById("btn-interrupt").addEventListener("click", () => {
+  const node = state.selectedNodeId
+    ? findNodeById(SCENARIOS[state.scenario].tree, state.selectedNodeId)
+    : null;
+  if (!node || node.kind !== "req") return;
+  showToast(`Mock: would call desktop_interrupt_request({ requestId: "${node.requestId}", cause: "userCancelled", cascade: true })`);
+});
+
+// ---------- Boot ----------
+expandAllInScenario();
+refreshDeploymentChips();
+render();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Closes the R5 cross-deployment subagent lineage UI surface for the desktop app:

- **Prototype** — `docs/ui-prototypes/panel-274-subagent-lineage.html` (already approved by the operator) is the design source of truth.
- **Runtime endpoint** — new `GET /subagents/tree?root_request_id=…&include_terminal=…&max_depth=…` companion to `/subagents/dispatches` from #320, BFS-walking the parent → child request graph with `spawn_subagent` bridge edges.
- **Tauri command** — `desktop_list_subagent_tree` is no longer a stub; it resolves the agent's graphql URL via `ClientCore::graphql_for_agent`, strips it to the runtime base, and GETs the new endpoint.
- **React panel** — `apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx` plus styles, mounted as the `Lineage` tab on `OperationsRail` with `session.latestRequestId` seeded as the initial root.
- **Lean ledger promotion** — `subagents-cross-deployment / operatorUi` moves from deferred (#274) to `required` + `consumerCoverage`, pinned to a new desktop snapshot consumer test that drives `lean_r5_cross_deployment_cases()` through the UI shape and asserts cross-deployment routing, caused-by lineage, and camelCase round-trip invariants.

Commits on top of the prototype commit:

| Commit | Scope |
|---|---|
| `cli: pass HealthCheckerOptions::default() to mcp probe call site` | Incidental fix — `commands/mcp.rs:151` was missed by #316's 7th-arg signature change, blocking the `defra-agent-cli` bin build on `main`. |
| `tauri_commands: replace desktop_list_subagent_tree stub with real impl` | Runtime endpoint + Tauri command + `Deserialize` on the bridge view types. |
| `desktop: implement subagent lineage view per prototype` | React panel, styles, OperationsRail tab mount, `listSubagentTree` adapter. |
| `proofs: promote subagents-cross-deployment operatorUi to consumerCoverage` | Lean ledger row promotion + conformance test + registration. |

## Verification

- ✅ `lake build` in `crates/defra-agent/proofs` (Lean conformance ledger passes)
- ✅ `cargo check -p defra-agent`
- ✅ `cargo test -p defra-agent --lib` (478 passed)
- ✅ `cargo test -p defra-agent --test state_machine_conformance coverage` (ledger structural tests pass)
- ✅ `cargo test -p defra-agent-desktop-tauri` (57 passed including the new subagent_lineage consumer)
- ✅ `cargo test -p defra-agent-cli http::subagent_tree` (5 new endpoint tests)
- ✅ `npx tsc --noEmit` + `npm test` in `apps/desktop-tauri` (57 passed)

## Expected conflict surface

Sibling panel PRs (#276, #277, #286, #288) also replace stubs in `operations.rs` and register `OperationsRail` tab descriptors. Expect a mechanical rebase if one of those merges first.

## Test plan

- [ ] `cd crates/defra-agent/proofs && lake build`
- [ ] `cargo check -p defra-agent && cargo test -p defra-agent && cargo test -p defra-agent-desktop-tauri`
- [ ] `cd apps/desktop-tauri && npx tsc --noEmit && npm test`
- [ ] Build the desktop app, open a session that's spawned at least one subagent, click the **Lineage** tab — confirm the tree renders with the same interactions the prototype demonstrates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)