### PR TITLE
Backend health status panel: prototype + impl (#288)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/mod.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/mod.rs
@@ -60,7 +60,8 @@ pub fn run() {
             tauri_commands::operations::desktop_operations_snapshot,
             tauri_commands::operations::desktop_list_subagent_tree,
             tauri_commands::operations::desktop_preview_interrupt_cascade,
-            tauri_commands::operations::desktop_interrupt_request
+            tauri_commands::operations::desktop_interrupt_request,
+            tauri_commands::operations::desktop_list_backends_with_health
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
@@ -6,17 +6,27 @@
 
 use std::time::Duration;
 
+use defra_agent::backend_registry::{derive_display_state, list_all_backends};
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
 use reqwest::Url;
 use tauri::State;
 
 use super::super::state::{current_core, DesktopAppState};
 use super::super::types::{
-    CascadeCancelPreview, DesktopInterruptRequest, DesktopListSubagentTreeRequest,
-    DesktopOperationsSnapshot, DesktopOperationsSnapshotRequest,
-    DesktopPreviewInterruptCascadeRequest, InterruptRequestResult, SubagentTreeView,
+    BackendHealthView, CascadeCancelPreview, DesktopInterruptRequest,
+    DesktopListSubagentTreeRequest, DesktopOperationsSnapshot, DesktopOperationsSnapshotRequest,
+    DesktopPreviewInterruptCascadeRequest, InferenceCallSummaryView, InterruptRequestResult,
+    SubagentTreeView,
 };
 
 const SUBAGENT_TREE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Number of most-recent `InferenceCall` rows surfaced per backend in the
+/// health panel. Picked to give the operator enough history to see a
+/// pattern (e.g. consecutive `QueueFull` rejections) without overwhelming
+/// the row's expanded detail.
+const RECENT_CALLS_PER_BACKEND: usize = 10;
 
 #[tauri::command]
 pub(crate) async fn desktop_operations_snapshot(
@@ -201,4 +211,128 @@ pub(crate) async fn desktop_interrupt_request(
          (interrupt button)"
             .to_string(),
     )
+}
+
+#[tauri::command]
+pub(crate) async fn desktop_list_backends_with_health(
+    state: State<'_, DesktopAppState>,
+) -> Result<Vec<BackendHealthView>, String> {
+    let Some(core) = current_core(&state) else {
+        return Err("desktop client is not running".to_string());
+    };
+
+    let node = core.node();
+    let backends = list_all_backends(node).await.map_err(|err| err.to_string())?;
+
+    let mut views = Vec::with_capacity(backends.len());
+    for backend in backends {
+        let recent_calls = fetch_recent_calls(node, &backend.backend_id)
+            .await
+            .map_err(|err| err.to_string())?;
+        let display_state = derive_display_state(backend.enabled, &backend.probe_status).to_string();
+        views.push(BackendHealthView {
+            backend_id: backend.backend_id,
+            name: backend.name,
+            provider_kind: backend.provider_kind.as_str().to_string(),
+            endpoint: backend.endpoint,
+            enabled: backend.enabled,
+            probe_status: backend.probe_status,
+            display_state,
+            // `last_probe` is a DateTime on the schema but not currently
+            // surfaced via `InferenceBackend::from_value`. Returning None
+            // keeps the wire shape stable for a follow-up that exposes
+            // probe metadata; the panel renders "never" when absent.
+            last_probe: None,
+            max_concurrent: backend.max_concurrent,
+            max_queue_depth: backend.max_queue_depth,
+            models: backend.models,
+            recent_calls,
+        });
+    }
+    Ok(views)
+}
+
+async fn fetch_recent_calls(
+    node: &EmbeddedNode,
+    backend_id: &str,
+) -> Result<Vec<InferenceCallSummaryView>, anyhow::Error> {
+    let escaped_id = escape_graphql_string(backend_id);
+    let query = format!(
+        r#"query {{
+            InferenceCall(
+                filter: {{ backend_id: {{ _eq: "{escaped_id}" }} }},
+                order: {{ queued_at: DESC }},
+                limit: {limit}
+            ) {{
+                call_id
+                call_seq
+                call_kind
+                call_state
+                failure_reason
+                queued_at
+                started_at
+                ended_at
+                queue_depth_at_enqueue
+                prompt_tokens
+                completion_tokens
+            }}
+        }}"#,
+        limit = RECENT_CALLS_PER_BACKEND,
+    );
+
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "list InferenceCall for backend {backend_id} failed: {:?}",
+            resp.errors
+        );
+    }
+
+    Ok(resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceCall"))
+        .and_then(|value| value.as_array())
+        .map(|rows| rows.iter().map(parse_call_row).collect::<Vec<_>>())
+        .unwrap_or_default())
+}
+
+fn parse_call_row(row: &serde_json::Value) -> InferenceCallSummaryView {
+    InferenceCallSummaryView {
+        call_id: row
+            .get("call_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        call_seq: row.get("call_seq").and_then(|v| v.as_i64()).unwrap_or(0),
+        call_kind: row
+            .get("call_kind")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        call_state: row
+            .get("call_state")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        failure_reason: row
+            .get("failure_reason")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned),
+        queued_at: row
+            .get("queued_at")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned),
+        started_at: row
+            .get("started_at")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned),
+        ended_at: row
+            .get("ended_at")
+            .and_then(|v| v.as_str())
+            .map(ToOwned::to_owned),
+        queue_depth_at_enqueue: row.get("queue_depth_at_enqueue").and_then(|v| v.as_i64()),
+        prompt_tokens: row.get("prompt_tokens").and_then(|v| v.as_i64()),
+        completion_tokens: row.get("completion_tokens").and_then(|v| v.as_i64()),
+    }
 }

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -194,3 +194,42 @@ pub(crate) struct InterruptRequestResult {
     pub stale_preview: bool,
     pub preview: Option<CascadeCancelPreview>,
 }
+
+/// One backend's persisted health + recent admission outcomes. Read-only
+/// projection of `InferenceBackend` joined with the last N `InferenceCall`
+/// rows for that backend. `display_state` is derived from
+/// `(enabled, probe_status)` per the prototype's mapping (matches
+/// `InferenceBackend::is_available` and the Lean `backendAvailable`
+/// witness in `BoundaryRuntime.lean`).
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BackendHealthView {
+    pub backend_id: String,
+    pub name: String,
+    pub provider_kind: String,
+    pub endpoint: String,
+    pub enabled: bool,
+    pub probe_status: String,
+    pub display_state: String,
+    pub last_probe: Option<String>,
+    pub max_concurrent: i64,
+    pub max_queue_depth: i64,
+    pub models: Vec<String>,
+    pub recent_calls: Vec<InferenceCallSummaryView>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct InferenceCallSummaryView {
+    pub call_id: String,
+    pub call_seq: i64,
+    pub call_kind: String,
+    pub call_state: String,
+    pub failure_reason: Option<String>,
+    pub queued_at: Option<String>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub queue_depth_at_enqueue: Option<i64>,
+    pub prompt_tokens: Option<i64>,
+    pub completion_tokens: Option<i64>,
+}

--- a/apps/desktop-tauri/src/App.css
+++ b/apps/desktop-tauri/src/App.css
@@ -1,4 +1,4 @@
-@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, components, utilities;
+@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, components, backend-health, utilities;
 
 @import "./styles/tokens.css";
 @import "./styles/base.css";
@@ -24,4 +24,5 @@
 @import "./styles/transcript/messages.css";
 @import "./styles/transcript/tools.css";
 @import "./styles/subagent-lineage.css";
+@import "./styles/backend-health/backend-health.css";
 @import "./styles/utilities.css";

--- a/apps/desktop-tauri/src/components/ChatWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ChatWorkspace.tsx
@@ -6,6 +6,7 @@ import type {
   P2PHealth,
 } from "../lib/types";
 import { displayBehaviorLabel } from "../lib/types";
+import { BackendHealthPanel } from "./backendHealth";
 import { ChatComposer, ChatHeader, ChatTranscriptPanel } from "./chat";
 import { OperationsRail, OperationsRailProvider } from "./operations";
 import type { OperationsRailTabDescriptor } from "./operations";
@@ -96,11 +97,17 @@ export function ActiveChatWorkspace({
           />
         ),
       },
+      {
+        id: "backend-health",
+        label: "Backends",
+        render: () => <BackendHealthPanel />,
+      },
     ];
   }, [session?.latestRequestId, selectedDeployment.agentDid]);
 
   return (
     <OperationsRailProvider tabs={operationsRailTabs}>
+
       <ChatHeader
         behaviorLabel={behaviorLabel}
         runtimeHealth={runtimeHealth}

--- a/apps/desktop-tauri/src/components/backendHealth/BackendHealthPanel.tsx
+++ b/apps/desktop-tauri/src/components/backendHealth/BackendHealthPanel.tsx
@@ -1,0 +1,144 @@
+import { useMemo } from "react";
+
+import { BackendHealthRow } from "./BackendHealthRow";
+import type { BackendDisplayState, BackendHealth } from "./types";
+import { useBackendHealth } from "./useBackendHealth";
+
+type ChipTone = "success" | "warning" | "error" | "neutral";
+
+function FleetSummary({ backends }: { backends: BackendHealth[] }) {
+  const counts: Record<BackendDisplayState, number> = {
+    available: 0,
+    unhealthy: 0,
+    stale: 0,
+    "rate-limited": 0,
+    "circuit-open": 0,
+    unknown: 0,
+    disabled: 0,
+  };
+  for (const b of backends) counts[b.displayState]++;
+  const total = backends.length;
+
+  const chips: { tone: ChipTone; count: number; label: string }[] = [];
+  if (total === 0) {
+    chips.push({ tone: "neutral", count: 0, label: "backends" });
+  } else {
+    chips.push({ tone: "neutral", count: total, label: "registered" });
+    if (counts.available)
+      chips.push({ tone: "success", count: counts.available, label: "available" });
+    if (counts.unhealthy)
+      chips.push({ tone: "error", count: counts.unhealthy, label: "unhealthy" });
+    if (counts.stale)
+      chips.push({ tone: "warning", count: counts.stale, label: "stale" });
+    if (counts["rate-limited"])
+      chips.push({
+        tone: "warning",
+        count: counts["rate-limited"],
+        label: "rate-limited",
+      });
+    if (counts["circuit-open"])
+      chips.push({
+        tone: "warning",
+        count: counts["circuit-open"],
+        label: "circuit-open",
+      });
+    if (counts.unknown)
+      chips.push({ tone: "neutral", count: counts.unknown, label: "unknown" });
+    if (counts.disabled)
+      chips.push({ tone: "neutral", count: counts.disabled, label: "disabled" });
+  }
+
+  return (
+    <div className="backend-health__fleet-summary" aria-live="polite">
+      {chips.map((c) => (
+        <span
+          key={`${c.label}-${c.count}`}
+          className="backend-health__summary-chip"
+          data-tone={c.tone}
+        >
+          <span className="backend-health__summary-count">{c.count}</span>{" "}
+          {c.label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function EmptyFleet() {
+  return (
+    <div className="backend-health__empty-fleet">
+      <div className="backend-health__empty-icon" aria-hidden="true">
+        ∅
+      </div>
+      <h2 className="backend-health__empty-heading">No backends registered</h2>
+      <p className="backend-health__empty-body">
+        Add an <code>InferenceBackend</code> document to the control plane to
+        register a provider. The runtime reads from the
+        <code> InferenceBackend</code> collection at start-up and on every
+        control-doc update.
+      </p>
+    </div>
+  );
+}
+
+export function BackendHealthPanel({
+  initialBackends,
+  now: providedNow,
+}: {
+  /**
+   * When provided, the panel renders these rows without calling the
+   * Tauri bridge. Used by the component test harness to drive each
+   * Lean witness state without a real backend.
+   */
+  initialBackends?: BackendHealth[];
+  now?: Date;
+} = {}) {
+  const live = useBackendHealth();
+  const backends = initialBackends ?? live.backends;
+  const error = initialBackends ? null : live.error;
+  const loading = initialBackends ? false : live.loading;
+
+  // Stable "now" for age display so the panel doesn't re-render every tick.
+  // Components that need wall-clock currency should re-mount or call refresh.
+  const now = useMemo(() => providedNow ?? new Date(), [providedNow]);
+
+  return (
+    <section
+      className="backend-health"
+      aria-labelledby="backend-health-title"
+    >
+      <header className="backend-health__header">
+        <div>
+          <h2 id="backend-health-title" className="backend-health__title">
+            Backend health
+          </h2>
+          <p className="backend-health__subtitle">
+            Inference backends registered to this deployment, with admission
+            policy and recent call outcomes.
+          </p>
+        </div>
+        {backends ? <FleetSummary backends={backends} /> : null}
+      </header>
+
+      {loading && !backends ? (
+        <div className="backend-health__loading">Loading…</div>
+      ) : null}
+
+      {error ? (
+        <div className="backend-health__error" role="alert">
+          Failed to load backend health: {error}
+        </div>
+      ) : null}
+
+      {backends && backends.length === 0 ? <EmptyFleet /> : null}
+
+      {backends && backends.length > 0 ? (
+        <ul className="backend-health__list">
+          {backends.map((b) => (
+            <BackendHealthRow key={b.backendId} backend={b} now={now} />
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/desktop-tauri/src/components/backendHealth/BackendHealthRow.tsx
+++ b/apps/desktop-tauri/src/components/backendHealth/BackendHealthRow.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+
+import { STATE_GLYPH, STATE_LABEL } from "./displayState";
+import type { BackendHealth, InferenceCallSummary } from "./types";
+
+function ageString(iso: string | null, now: Date): string {
+  if (!iso) return "—";
+  const ms = now.getTime() - new Date(iso).getTime();
+  if (Number.isNaN(ms)) return "—";
+  if (ms < 0) return "in the future";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+function probeTone(status: string): "success" | "warning" | "error" | null {
+  switch (status) {
+    case "healthy":
+      return "success";
+    case "unhealthy":
+      return "error";
+    case "stale":
+    case "rate_limited":
+    case "circuit_open":
+      return "warning";
+    default:
+      return null;
+  }
+}
+
+function lastCallEndedAt(c: InferenceCallSummary): string | null {
+  return c.endedAt ?? c.startedAt ?? c.queuedAt;
+}
+
+function LastCallHint({
+  backend,
+  now,
+}: {
+  backend: BackendHealth;
+  now: Date;
+}) {
+  const last = backend.recentCalls[0];
+  if (!last) {
+    return (
+      <div className="backend-health__last-call-hint">no calls observed</div>
+    );
+  }
+  if (last.failureReason) {
+    return (
+      <div className="backend-health__last-call-hint">
+        last call failed:{" "}
+        <span className="backend-health__last-call-reason">
+          {last.failureReason}
+        </span>{" "}
+        · {ageString(lastCallEndedAt(last), now)}
+      </div>
+    );
+  }
+  return (
+    <div className="backend-health__last-call-hint">
+      last call{" "}
+      <span
+        className="backend-health__last-call-reason"
+        data-tone="ok"
+      >
+        {last.callState}
+      </span>{" "}
+      · {ageString(lastCallEndedAt(last), now)}
+    </div>
+  );
+}
+
+function ConfigCell({
+  label,
+  value,
+  tone,
+  muted,
+}: {
+  label: string;
+  value: string;
+  tone?: "success" | "warning" | "error";
+  muted?: boolean;
+}) {
+  return (
+    <div className="backend-health__config-cell">
+      <span className="backend-health__config-label">{label}</span>
+      <span
+        className={
+          "backend-health__config-value" +
+          (muted ? " backend-health__config-value--muted" : "")
+        }
+        data-tone={tone}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function CallsTable({
+  calls,
+  now,
+}: {
+  calls: InferenceCallSummary[];
+  now: Date;
+}) {
+  if (calls.length === 0) {
+    return (
+      <div className="backend-health__empty-calls">
+        No InferenceCall records for this backend. Either no work has been
+        routed here yet, or all records have aged out of the query window.
+      </div>
+    );
+  }
+  return (
+    <table className="backend-health__calls-table">
+      <thead>
+        <tr>
+          <th scope="col">seq</th>
+          <th scope="col">kind</th>
+          <th scope="col">state</th>
+          <th scope="col">queue_depth</th>
+          <th scope="col">failure_reason</th>
+          <th scope="col">tokens (p / c)</th>
+          <th scope="col">age</th>
+        </tr>
+      </thead>
+      <tbody>
+        {calls.map((c) => (
+          <tr key={c.callId || `${c.callSeq}`}>
+            <td>{c.callSeq}</td>
+            <td>{c.callKind}</td>
+            <td>
+              <span
+                className="backend-health__call-state"
+                data-state={c.callState}
+              >
+                {c.callState}
+              </span>
+            </td>
+            <td>{c.queueDepthAtEnqueue ?? "—"}</td>
+            <td className="backend-health__call-reason">
+              {c.failureReason ?? "—"}
+            </td>
+            <td>
+              {c.promptTokens != null
+                ? `${c.promptTokens} / ${c.completionTokens ?? "—"}`
+                : "—"}
+            </td>
+            <td>{ageString(lastCallEndedAt(c), now)}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export type BackendHealthRowProps = {
+  backend: BackendHealth;
+  now: Date;
+};
+
+export function BackendHealthRow({ backend, now }: BackendHealthRowProps) {
+  const [expanded, setExpanded] = useState(false);
+  const state = backend.displayState;
+  const detailId = `backend-health-detail-${backend.backendId}`;
+
+  return (
+    <li
+      className="backend-health__row"
+      data-state={state}
+      data-expanded={expanded ? "true" : "false"}
+      data-backend-id={backend.backendId}
+    >
+      <button
+        type="button"
+        className="backend-health__summary"
+        aria-expanded={expanded}
+        aria-controls={detailId}
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <span
+          className="backend-health__status-glyph"
+          data-state={state}
+          aria-hidden="true"
+        >
+          {STATE_GLYPH[state]}
+        </span>
+        <div className="backend-health__identity">
+          <div className="backend-health__name">
+            <span>{backend.name}</span>
+            <span className="backend-health__kind-badge">
+              {backend.providerKind}
+            </span>
+          </div>
+          <div className="backend-health__endpoint">{backend.endpoint}</div>
+          <LastCallHint backend={backend} now={now} />
+        </div>
+        <span className="backend-health__state-label" data-state={state}>
+          {STATE_LABEL[state]}
+        </span>
+        <span className="backend-health__chevron" aria-hidden="true">
+          ›
+        </span>
+      </button>
+      {expanded ? (
+        <div className="backend-health__detail" id={detailId}>
+          <section className="backend-health__detail-section">
+            <h3 className="backend-health__detail-heading">
+              Admission policy &amp; probe
+            </h3>
+            <div className="backend-health__config-grid">
+              <ConfigCell
+                label="enabled"
+                value={String(backend.enabled)}
+                tone={backend.enabled ? "success" : "warning"}
+              />
+              <ConfigCell
+                label="probe_status"
+                value={backend.probeStatus}
+                tone={probeTone(backend.probeStatus) ?? undefined}
+              />
+              <ConfigCell
+                label="last_probe"
+                value={backend.lastProbe ? ageString(backend.lastProbe, now) : "never"}
+                muted={!backend.lastProbe}
+              />
+              <ConfigCell
+                label="max_concurrent"
+                value={String(backend.maxConcurrent)}
+              />
+              <ConfigCell
+                label="max_queue_depth"
+                value={String(backend.maxQueueDepth)}
+              />
+            </div>
+          </section>
+          <section className="backend-health__detail-section">
+            <h3 className="backend-health__detail-heading">Models</h3>
+            {backend.models.length === 0 ? (
+              <span className="backend-health__config-value backend-health__config-value--muted">
+                (no models declared)
+              </span>
+            ) : (
+              <div className="backend-health__model-chips">
+                {backend.models.map((m) => (
+                  <span key={m} className="backend-health__model-chip">
+                    {m}
+                  </span>
+                ))}
+              </div>
+            )}
+          </section>
+          <section className="backend-health__detail-section">
+            <h3 className="backend-health__detail-heading">
+              Recent calls (InferenceCall, last 10)
+            </h3>
+            <CallsTable calls={backend.recentCalls} now={now} />
+          </section>
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/desktop-tauri/src/components/backendHealth/displayState.ts
+++ b/apps/desktop-tauri/src/components/backendHealth/displayState.ts
@@ -1,0 +1,56 @@
+import type { BackendDisplayState } from "./types";
+
+/**
+ * JS mirror of `defra_agent::backend_registry::derive_display_state`.
+ * Kept in sync by the bridge-snapshot consumer test in defra-agent
+ * (`backend_registry::tests::display_state_matches_every_lean_backend_health_admission_case`)
+ * and by the component test in `tests/backend-health-panel.test.tsx`,
+ * which enumerates the same Lean witness inputs and asserts this JS
+ * function produces the same bucket the Rust function does.
+ *
+ * The bridge already attaches `displayState` to every
+ * `BackendHealthView` it returns, so most consumers should read
+ * `backend.displayState` directly. This helper exists so the test
+ * harness can drive the mapping in isolation.
+ */
+export function deriveDisplayState(
+  enabled: boolean,
+  probeStatus: string,
+): BackendDisplayState {
+  if (!enabled) return "disabled";
+  switch (probeStatus) {
+    case "healthy":
+      return "available";
+    case "unhealthy":
+      return "unhealthy";
+    case "stale":
+      return "stale";
+    case "rate_limited":
+      return "rate-limited";
+    case "circuit_open":
+      return "circuit-open";
+    case "unknown":
+    default:
+      return "unknown";
+  }
+}
+
+export const STATE_LABEL: Record<BackendDisplayState, string> = {
+  available: "Available",
+  unhealthy: "Unhealthy",
+  stale: "Stale",
+  "rate-limited": "Rate-limited",
+  "circuit-open": "Circuit-open",
+  unknown: "Unknown",
+  disabled: "Disabled",
+};
+
+export const STATE_GLYPH: Record<BackendDisplayState, string> = {
+  available: "●",
+  unhealthy: "×",
+  stale: "!",
+  "rate-limited": "⏱",
+  "circuit-open": "⊘",
+  unknown: "?",
+  disabled: "—",
+};

--- a/apps/desktop-tauri/src/components/backendHealth/index.ts
+++ b/apps/desktop-tauri/src/components/backendHealth/index.ts
@@ -1,0 +1,13 @@
+export { BackendHealthPanel } from "./BackendHealthPanel";
+export { BackendHealthRow } from "./BackendHealthRow";
+export {
+  STATE_GLYPH,
+  STATE_LABEL,
+  deriveDisplayState,
+} from "./displayState";
+export type {
+  BackendDisplayState,
+  BackendHealth,
+  InferenceCallSummary,
+} from "./types";
+export { useBackendHealth } from "./useBackendHealth";

--- a/apps/desktop-tauri/src/components/backendHealth/types.ts
+++ b/apps/desktop-tauri/src/components/backendHealth/types.ts
@@ -1,0 +1,44 @@
+/**
+ * Mirrors `BackendHealthView` / `InferenceCallSummaryView` from
+ * `apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs`.
+ * The Tauri layer serializes with `#[serde(rename_all = "camelCase")]`,
+ * so field names here are camelCase even though the underlying
+ * `InferenceBackend` / `InferenceCall` columns are snake_case.
+ */
+export type BackendDisplayState =
+  | "available"
+  | "unhealthy"
+  | "stale"
+  | "rate-limited"
+  | "circuit-open"
+  | "unknown"
+  | "disabled";
+
+export type InferenceCallSummary = {
+  callId: string;
+  callSeq: number;
+  callKind: string;
+  callState: string;
+  failureReason: string | null;
+  queuedAt: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  queueDepthAtEnqueue: number | null;
+  promptTokens: number | null;
+  completionTokens: number | null;
+};
+
+export type BackendHealth = {
+  backendId: string;
+  name: string;
+  providerKind: string;
+  endpoint: string;
+  enabled: boolean;
+  probeStatus: string;
+  displayState: BackendDisplayState;
+  lastProbe: string | null;
+  maxConcurrent: number;
+  maxQueueDepth: number;
+  models: string[];
+  recentCalls: InferenceCallSummary[];
+};

--- a/apps/desktop-tauri/src/components/backendHealth/useBackendHealth.ts
+++ b/apps/desktop-tauri/src/components/backendHealth/useBackendHealth.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { listBackendsWithHealth } from "../../lib/desktop-api";
+import type { BackendHealth } from "./types";
+
+export type BackendHealthState = {
+  backends: BackendHealth[] | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+};
+
+export function useBackendHealth(): BackendHealthState {
+  const [backends, setBackends] = useState<BackendHealth[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows = await listBackendsWithHealth();
+      setBackends(rows);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { backends, loading, error, refresh };
+}

--- a/apps/desktop-tauri/src/lib/desktop-api.ts
+++ b/apps/desktop-tauri/src/lib/desktop-api.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 
+import type { BackendHealth } from "../components/backendHealth/types";
 import type {
   AgentConfigSaveRequest,
   BackendSaveRequest,
@@ -114,6 +115,7 @@ export type DesktopApiAdapter = {
   listSubagentTree: (
     request: DesktopListSubagentTreeRequest,
   ) => Promise<SubagentTreeView>;
+  listBackendsWithHealth: () => Promise<BackendHealth[]>;
 };
 
 const defaultDesktopApiAdapter: DesktopApiAdapter = {
@@ -210,6 +212,9 @@ const defaultDesktopApiAdapter: DesktopApiAdapter = {
     return invokeDesktop<SubagentTreeView>("desktop_list_subagent_tree", {
       request,
     });
+  },
+  listBackendsWithHealth() {
+    return invokeDesktop<BackendHealth[]>("desktop_list_backends_with_health");
   },
 };
 
@@ -339,4 +344,8 @@ export async function runTask(request: TaskRunRequest) {
 
 export async function listSubagentTree(request: DesktopListSubagentTreeRequest) {
   return desktopApiAdapter().listSubagentTree(request);
+}
+
+export async function listBackendsWithHealth() {
+  return desktopApiAdapter().listBackendsWithHealth();
 }

--- a/apps/desktop-tauri/src/styles/backend-health/backend-health.css
+++ b/apps/desktop-tauri/src/styles/backend-health/backend-health.css
@@ -1,0 +1,453 @@
+/* Backend health panel — lifted from
+   docs/ui-prototypes/panel-288-backend-health.html. Uses the existing
+   design tokens from styles/tokens.css so this picks up theme drift
+   automatically. */
+
+.backend-health {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-9);
+  padding: var(--space-7);
+}
+
+.backend-health__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-7);
+  padding-bottom: var(--space-7);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.backend-health__title {
+  margin: 0 0 var(--space-2) 0;
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: 22px;
+  letter-spacing: -0.01em;
+}
+
+.backend-health__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.backend-health__fleet-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.backend-health__summary-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--border-subtle);
+  font-size: 12px;
+  color: var(--color-text-soft);
+}
+
+.backend-health__summary-chip[data-tone="success"] {
+  border-color: rgb(var(--source-green-rgb) / 0.36);
+}
+.backend-health__summary-chip[data-tone="warning"] {
+  border-color: rgb(var(--source-orange-rgb) / 0.36);
+}
+.backend-health__summary-chip[data-tone="error"] {
+  border-color: rgb(255 111 95 / 0.36);
+}
+
+.backend-health__summary-count {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.backend-health__loading,
+.backend-health__error {
+  padding: var(--space-7);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--border-subtle);
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.backend-health__error {
+  color: var(--color-error);
+  border-color: rgb(255 111 95 / 0.36);
+}
+
+/* ── list ──────────────────────────────────────────────── */
+
+.backend-health__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.backend-health__row {
+  background: var(--color-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  transition: border-color 120ms ease;
+}
+
+.backend-health__row[data-state="available"]    { border-left: 3px solid var(--color-success-strong); }
+.backend-health__row[data-state="unhealthy"]    { border-left: 3px solid var(--color-error-strong); }
+.backend-health__row[data-state="stale"]        { border-left: 3px solid var(--color-warning); }
+.backend-health__row[data-state="rate-limited"] { border-left: 3px solid var(--color-warning); }
+.backend-health__row[data-state="circuit-open"] { border-left: 3px solid var(--color-warning); }
+.backend-health__row[data-state="unknown"]      { border-left: 3px solid var(--color-text-muted); }
+.backend-health__row[data-state="disabled"]     {
+  border-left: 3px solid var(--color-text-muted);
+  opacity: 0.78;
+}
+
+.backend-health__row[data-expanded="true"] {
+  border-color: var(--border-strong);
+}
+
+.backend-health__summary {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: var(--space-7);
+  padding: var(--space-7);
+  background: transparent;
+  border: 0;
+  color: inherit;
+  width: 100%;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.backend-health__summary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-lg);
+}
+
+.backend-health__status-glyph {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--color-surface-strong);
+  border: 1px solid var(--border-subtle);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.backend-health__status-glyph[data-state="available"] {
+  color: var(--color-success);
+  border-color: rgb(var(--source-green-rgb) / 0.4);
+}
+.backend-health__status-glyph[data-state="unhealthy"] {
+  color: var(--color-error);
+  border-color: rgb(255 111 95 / 0.4);
+}
+.backend-health__status-glyph[data-state="stale"],
+.backend-health__status-glyph[data-state="rate-limited"],
+.backend-health__status-glyph[data-state="circuit-open"] {
+  color: var(--color-warning);
+  border-color: rgb(var(--source-orange-rgb) / 0.4);
+}
+.backend-health__status-glyph[data-state="unknown"],
+.backend-health__status-glyph[data-state="disabled"] {
+  color: var(--color-text-muted);
+}
+
+.backend-health__identity {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.backend-health__name {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--color-text);
+}
+
+.backend-health__endpoint {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.backend-health__kind-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-soft);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--border-subtle);
+  letter-spacing: 0.02em;
+}
+
+.backend-health__state-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.backend-health__state-label[data-state="available"]    { color: var(--color-success); }
+.backend-health__state-label[data-state="unhealthy"]    { color: var(--color-error); }
+.backend-health__state-label[data-state="stale"],
+.backend-health__state-label[data-state="rate-limited"],
+.backend-health__state-label[data-state="circuit-open"] { color: var(--color-warning); }
+.backend-health__state-label[data-state="unknown"],
+.backend-health__state-label[data-state="disabled"]     { color: var(--color-text-muted); }
+
+.backend-health__last-call-hint {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-top: var(--space-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.backend-health__last-call-reason {
+  color: var(--color-error);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+.backend-health__last-call-reason[data-tone="ok"] {
+  color: var(--color-success);
+}
+
+.backend-health__chevron {
+  color: var(--color-text-muted);
+  transition: transform 150ms ease;
+  font-size: 14px;
+}
+
+.backend-health__row[data-expanded="true"] .backend-health__chevron {
+  transform: rotate(90deg);
+}
+
+/* ── detail ───────────────────────────────────────────── */
+
+.backend-health__detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-9);
+  padding: var(--space-7) var(--space-7) var(--space-9);
+  border-top: 1px solid var(--border-subtle);
+  background: rgb(0 0 0 / 0.2);
+}
+
+.backend-health__detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.backend-health__detail-heading {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-text-muted);
+}
+
+.backend-health__config-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--space-5);
+}
+
+.backend-health__config-cell {
+  padding: var(--space-5);
+  background: var(--color-surface-strong);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.backend-health__config-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--color-text-muted);
+}
+
+.backend-health__config-value {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  color: var(--color-text);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
+.backend-health__config-value--muted {
+  color: var(--color-text-muted);
+}
+
+.backend-health__config-value[data-tone="success"] { color: var(--color-success); }
+.backend-health__config-value[data-tone="warning"] { color: var(--color-warning); }
+.backend-health__config-value[data-tone="error"]   { color: var(--color-error); }
+
+.backend-health__model-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.backend-health__model-chip {
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-pill);
+  background: var(--color-surface-muted);
+  border: 1px solid var(--border-subtle);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  color: var(--color-text-soft);
+}
+
+.backend-health__calls-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.backend-health__calls-table th,
+.backend-health__calls-table td {
+  padding: var(--space-3) var(--space-4);
+  text-align: left;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.backend-health__calls-table th {
+  font-weight: 500;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-size: 10px;
+}
+
+.backend-health__calls-table td {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text-soft);
+}
+
+.backend-health__calls-table tr:last-child td {
+  border-bottom: 0;
+}
+
+.backend-health__call-state {
+  display: inline-block;
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.backend-health__call-state[data-state="completed"] {
+  color: var(--color-success);
+  background: rgb(var(--source-green-rgb) / 0.1);
+}
+.backend-health__call-state[data-state="running"] {
+  color: var(--color-info);
+  background: rgb(var(--source-blue-rgb) / 0.1);
+}
+.backend-health__call-state[data-state="queued"] {
+  color: var(--color-text-muted);
+  background: var(--color-surface-muted);
+}
+.backend-health__call-state[data-state="failed"] {
+  color: var(--color-error);
+  background: rgb(255 111 95 / 0.1);
+}
+.backend-health__call-state[data-state="cancelled"] {
+  color: var(--color-warning);
+  background: rgb(var(--source-orange-rgb) / 0.1);
+}
+
+.backend-health__call-reason {
+  color: var(--color-error);
+}
+
+.backend-health__empty-calls {
+  padding: var(--space-7);
+  background: var(--color-surface-strong);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+/* ── empty fleet ──────────────────────────────────────── */
+
+.backend-health__empty-fleet {
+  padding: var(--space-10);
+  border: 1px dashed var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  text-align: center;
+  color: var(--color-text-muted);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  align-items: center;
+}
+
+.backend-health__empty-icon {
+  font-size: 28px;
+  color: var(--color-text-soft);
+}
+
+.backend-health__empty-heading {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-weight: 500;
+  font-size: 18px;
+  color: var(--color-text);
+}
+
+.backend-health__empty-body {
+  margin: 0;
+  max-width: 420px;
+  font-size: 13px;
+}
+
+.backend-health__empty-body code {
+  padding: 1px 6px;
+  background: var(--color-surface-strong);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-subtle);
+  font-size: 12px;
+  color: var(--color-text-soft);
+}

--- a/apps/desktop-tauri/tests/backend-health-panel.test.tsx
+++ b/apps/desktop-tauri/tests/backend-health-panel.test.tsx
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+
+import { BackendHealthPanel } from "../src/components/backendHealth";
+import {
+  deriveDisplayState,
+  STATE_LABEL,
+} from "../src/components/backendHealth/displayState";
+import type {
+  BackendDisplayState,
+  BackendHealth,
+} from "../src/components/backendHealth/types";
+
+/**
+ * One row per Lean BackendHealthAdmissionCase
+ * (`crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean:214`).
+ * The Rust-side consumer test
+ * (`backend_registry::tests::display_state_matches_every_lean_backend_health_admission_case`)
+ * drives the same inputs through `derive_display_state`; this enumeration
+ * checks the JS `deriveDisplayState` agrees and that each bucket renders a
+ * distinct label / data-state attribute in the panel.
+ */
+type WitnessCase = {
+  name: string;
+  enabled: boolean;
+  probeStatus: string;
+  expectedDisplayState: BackendDisplayState;
+  expectedAvailable: boolean;
+};
+
+const LEAN_WITNESSES: WitnessCase[] = [
+  {
+    name: "enabled_healthy_backend_is_available_from_observed_document",
+    enabled: true,
+    probeStatus: "healthy",
+    expectedDisplayState: "available",
+    expectedAvailable: true,
+  },
+  {
+    name: "disabled_healthy_backend_is_unavailable_from_observed_document",
+    enabled: false,
+    probeStatus: "healthy",
+    expectedDisplayState: "disabled",
+    expectedAvailable: false,
+  },
+  {
+    name: "enabled_unhealthy_backend_is_unavailable_from_observed_document",
+    enabled: true,
+    probeStatus: "unhealthy",
+    expectedDisplayState: "unhealthy",
+    expectedAvailable: false,
+  },
+  {
+    name: "enabled_unknown_backend_is_unavailable_from_observed_document",
+    enabled: true,
+    probeStatus: "unknown",
+    expectedDisplayState: "unknown",
+    expectedAvailable: false,
+  },
+  {
+    name: "enabled_stale_backend_is_unavailable_from_observed_document",
+    enabled: true,
+    probeStatus: "stale",
+    expectedDisplayState: "stale",
+    expectedAvailable: false,
+  },
+  {
+    name: "enabled_rate_limited_backend_is_unavailable_from_observed_document",
+    enabled: true,
+    probeStatus: "rate_limited",
+    expectedDisplayState: "rate-limited",
+    expectedAvailable: false,
+  },
+  {
+    name: "enabled_circuit_open_backend_is_unavailable_from_observed_document",
+    enabled: true,
+    probeStatus: "circuit_open",
+    expectedDisplayState: "circuit-open",
+    expectedAvailable: false,
+  },
+];
+
+function makeBackend(witness: WitnessCase): BackendHealth {
+  return {
+    backendId: `id-${witness.expectedDisplayState}`,
+    name: `${witness.expectedDisplayState} fixture`,
+    providerKind: "OpenAiCompatible",
+    endpoint: `https://example.test/${witness.expectedDisplayState}/v1`,
+    enabled: witness.enabled,
+    probeStatus: witness.probeStatus,
+    displayState: deriveDisplayState(witness.enabled, witness.probeStatus),
+    lastProbe: "2026-05-20T17:30:00Z",
+    maxConcurrent: 4,
+    maxQueueDepth: 50,
+    models: ["fixture-model"],
+    recentCalls: [],
+  };
+}
+
+const NOW = new Date("2026-05-20T17:32:18Z");
+
+describe("BackendHealthPanel — Lean witness coverage", () => {
+  it("deriveDisplayState lands every Lean witness in the expected bucket", () => {
+    for (const w of LEAN_WITNESSES) {
+      const got = deriveDisplayState(w.enabled, w.probeStatus);
+      expect(got, `case ${w.name}`).toBe(w.expectedDisplayState);
+      const isAvailable = got === "available";
+      expect(isAvailable, `case ${w.name} availability`).toBe(
+        w.expectedAvailable,
+      );
+    }
+  });
+
+  it("renders all seven Lean witnesses with visually distinct state badges", () => {
+    const backends = LEAN_WITNESSES.map(makeBackend);
+    render(<BackendHealthPanel initialBackends={backends} now={NOW} />);
+
+    // Fleet summary chip count matches the variety of buckets present.
+    // `disabled` is the only non-`available` case where `enabled=false`,
+    // so the summary surfaces every distinct state plus one neutral
+    // "N registered" chip.
+    const distinctStates = new Set(backends.map((b) => b.displayState));
+    const expectedChipCount = distinctStates.size + 1; // +1 for "N registered"
+    const chips = screen
+      .getAllByText(/registered|available|unhealthy|stale|rate-limited|circuit-open|unknown|disabled/)
+      .filter((el) => el.className.includes("backend-health__summary-chip"));
+    expect(chips.length).toBe(expectedChipCount);
+
+    // Every backend renders a row with the right data-state and label.
+    for (const w of LEAN_WITNESSES) {
+      const row = screen.getByText(`${w.expectedDisplayState} fixture`)
+        .closest("li.backend-health__row");
+      expect(row, `row for ${w.name}`).not.toBeNull();
+      expect(row?.getAttribute("data-state"), `data-state for ${w.name}`).toBe(
+        w.expectedDisplayState,
+      );
+      const stateLabel = within(row as HTMLElement).getByText(
+        STATE_LABEL[w.expectedDisplayState],
+      );
+      expect(stateLabel.getAttribute("data-state")).toBe(
+        w.expectedDisplayState,
+      );
+    }
+
+    // The seven buckets must be pairwise distinct in the DOM. If any two
+    // collapse to the same data-state we'd lose operator-visible
+    // information that the Lean witnesses model.
+    const renderedStates = LEAN_WITNESSES.map((w) => w.expectedDisplayState);
+    expect(new Set(renderedStates).size).toBe(renderedStates.length);
+  });
+
+  it("expanding a row reveals admission policy + models + recent calls sections", () => {
+    const withCalls: BackendHealth = {
+      ...makeBackend(LEAN_WITNESSES[0]),
+      recentCalls: [
+        {
+          callId: "c-1",
+          callSeq: 42,
+          callKind: "completion",
+          callState: "completed",
+          failureReason: null,
+          queuedAt: "2026-05-20T17:30:00Z",
+          startedAt: "2026-05-20T17:30:01Z",
+          endedAt: "2026-05-20T17:30:05Z",
+          queueDepthAtEnqueue: 0,
+          promptTokens: 100,
+          completionTokens: 25,
+        },
+      ],
+    };
+    render(<BackendHealthPanel initialBackends={[withCalls]} now={NOW} />);
+
+    const summaryButton = screen.getByRole("button", {
+      name: /available fixture/i,
+    });
+    expect(summaryButton.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(summaryButton);
+
+    expect(summaryButton.getAttribute("aria-expanded")).toBe("true");
+    expect(
+      screen.getByRole("heading", { name: /Admission policy & probe/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /^Models$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", {
+        name: /Recent calls \(InferenceCall, last 10\)/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty-fleet card when zero backends are returned", () => {
+    render(<BackendHealthPanel initialBackends={[]} now={NOW} />);
+    expect(screen.getByText(/No backends registered/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/available fixture/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("rate-limited and circuit-open rows surface their failure_reason hint", () => {
+    const rateLimited: BackendHealth = {
+      ...makeBackend(LEAN_WITNESSES[5]),
+      recentCalls: [
+        {
+          callId: "rl-1",
+          callSeq: 1224,
+          callKind: "completion",
+          callState: "failed",
+          failureReason: "upstream 429",
+          queuedAt: "2026-05-20T17:32:00Z",
+          startedAt: null,
+          endedAt: "2026-05-20T17:32:01Z",
+          queueDepthAtEnqueue: 12,
+          promptTokens: null,
+          completionTokens: null,
+        },
+      ],
+    };
+    const circuitOpen: BackendHealth = {
+      ...makeBackend(LEAN_WITNESSES[6]),
+      recentCalls: [
+        {
+          callId: "co-1",
+          callSeq: 318,
+          callKind: "completion",
+          callState: "failed",
+          failureReason: "BackendGone",
+          queuedAt: "2026-05-20T17:32:00Z",
+          startedAt: null,
+          endedAt: "2026-05-20T17:32:01Z",
+          queueDepthAtEnqueue: 0,
+          promptTokens: null,
+          completionTokens: null,
+        },
+      ],
+    };
+    render(
+      <BackendHealthPanel
+        initialBackends={[rateLimited, circuitOpen]}
+        now={NOW}
+      />,
+    );
+    expect(screen.getByText("upstream 429")).toBeInTheDocument();
+    expect(screen.getByText("BackendGone")).toBeInTheDocument();
+  });
+});

--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean
@@ -31,6 +31,8 @@ inductive BackendProbeStatus where
   | unhealthy
   | unknown
   | stale
+  | rateLimited
+  | circuitOpen
   deriving DecidableEq, Repr
 
 namespace BackendProbeStatus
@@ -40,6 +42,8 @@ def toDefraDB : BackendProbeStatus -> String
   | .unhealthy => "unhealthy"
   | .unknown => "unknown"
   | .stale => "stale"
+  | .rateLimited => "rate_limited"
+  | .circuitOpen => "circuit_open"
 
 end BackendProbeStatus
 
@@ -232,6 +236,14 @@ def backendHealthAdmissionCases : List BackendHealthAdmissionCase :=
       "enabled_stale_backend_is_unavailable_from_observed_document"
       true
       .stale
+  , backendHealthAdmissionCase
+      "enabled_rate_limited_backend_is_unavailable_from_observed_document"
+      true
+      .rateLimited
+  , backendHealthAdmissionCase
+      "enabled_circuit_open_backend_is_unavailable_from_observed_document"
+      true
+      .circuitOpen
   ]
 
 def nativeFilesystemBoundaryCase (toolName : String) : NativeFilesystemBoundaryCase :=

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -231,8 +231,8 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := []
     }
   , { feature := "backend-health"
-    , required := [Surface.runtimeInternal]
-    , deferred := [(Surface.operatorUi, "#288")]
+    , required := [Surface.runtimeInternal, Surface.operatorUi]
+    , deferred := []
     }
   ]
 
@@ -486,6 +486,11 @@ def caseCoverage : List CoverageEntry :=
       boundaryBackendHealthAdmissionFreshnessId
       "backend_registry::tests::generated_backend_health_admission_cases_match_registry_and_admission_policy")
       "backend-health" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
+      "backend_health_cases"
+      "BackendHealthAdmissionCases"
+      "backend_registry::tests::display_state_matches_every_lean_backend_health_admission_case")
+      "backend-health" [Surface.operatorUi]
   , tagged (consumerCoverage
       "native_filesystem_boundary_cases"
       "NativeFilesystemBoundaryCases"

--- a/crates/defra-agent/src/backend_registry.rs
+++ b/crates/defra-agent/src/backend_registry.rs
@@ -95,6 +95,33 @@ impl InferenceBackend {
     pub fn is_available(&self) -> bool {
         self.enabled && self.probe_status == HEALTHY_PROBE_STATUS
     }
+
+    /// Operator-UI rollup of `(enabled, probe_status)` into a single label.
+    /// `available` is the only state in which `is_available()` is true; the
+    /// other states split the unavailable cases for operator visibility.
+    /// Mirrors the panel-288 prototype's JS mapping.
+    pub fn display_state(&self) -> &'static str {
+        derive_display_state(self.enabled, &self.probe_status)
+    }
+}
+
+/// Pure function backing [`InferenceBackend::display_state`]. Lives outside
+/// the impl so the Tauri bridge can call it on raw `(enabled, probe_status)`
+/// pairs from the Lean witness fixtures without constructing a full
+/// `InferenceBackend`.
+pub fn derive_display_state(enabled: bool, probe_status: &str) -> &'static str {
+    if !enabled {
+        return "disabled";
+    }
+    match probe_status {
+        "healthy" => "available",
+        "unhealthy" => "unhealthy",
+        "stale" => "stale",
+        "rate_limited" => "rate-limited",
+        "circuit_open" => "circuit-open",
+        "unknown" => "unknown",
+        _ => "unknown",
+    }
 }
 
 pub async fn lookup_backend(
@@ -225,6 +252,17 @@ pub(crate) async fn list_backend_records(
         .unwrap_or_default();
 
     Ok(backends)
+}
+
+/// Lists every registered backend, including disabled ones — the operator
+/// UI needs to surface disabled rows so the operator can see why a backend
+/// isn't accepting work.
+pub async fn list_all_backends(node: &EmbeddedNode) -> Result<Vec<InferenceBackend>> {
+    Ok(list_backend_records(node)
+        .await?
+        .into_iter()
+        .map(|(_, backend)| backend)
+        .collect())
 }
 
 pub async fn list_enabled_backends(node: &EmbeddedNode) -> Result<Vec<InferenceBackend>> {

--- a/crates/defra-agent/src/backend_registry/tests.rs
+++ b/crates/defra-agent/src/backend_registry/tests.rs
@@ -90,7 +90,7 @@ fn is_available_requires_enabled_and_healthy() {
 #[test]
 fn generated_backend_health_admission_cases_match_registry_and_admission_policy() {
     let cases = lean_backend_health_admission_cases();
-    assert_eq!(cases.len(), 5);
+    assert_eq!(cases.len(), 7);
 
     for case in cases {
         let backend = InferenceBackend {
@@ -141,5 +141,56 @@ fn generated_backend_health_admission_cases_match_registry_and_admission_policy(
             "{} must not claim endpoint/provider freshness",
             case.name
         );
+    }
+}
+
+/// Operator-UI projection of `(enabled, probe_status)`. Drives every Lean
+/// witness through `derive_display_state` and asserts:
+///   * the derivation is total (every witness maps to a known bucket);
+///   * the `available` bucket coincides exactly with the Lean
+///     `expected_available` verdict.
+///
+/// This is the bridge-snapshot consumer test for the
+/// `backend-health.operatorUi` row of the feature matrix — registered in
+/// `CoverageLedger.lean` and `conformance_consumers.rs`.
+#[test]
+fn display_state_matches_every_lean_backend_health_admission_case() {
+    let cases = lean_backend_health_admission_cases();
+    assert_eq!(
+        cases.len(),
+        7,
+        "Lean witness count drifted from operator UI expectations"
+    );
+
+    for case in cases {
+        let actual = derive_display_state(case.enabled, &case.probe_status);
+        let expected = expected_display_state(case.enabled, &case.probe_status);
+        assert_eq!(
+            actual, expected,
+            "case {} mapped probe_status {} to {} but expected {}",
+            case.name, case.probe_status, actual, expected
+        );
+
+        let panel_says_available = actual == "available";
+        assert_eq!(
+            panel_says_available, case.expected_available,
+            "case {} drifted from Lean availability witness",
+            case.name
+        );
+    }
+
+    fn expected_display_state(enabled: bool, probe_status: &str) -> &'static str {
+        if !enabled {
+            return "disabled";
+        }
+        match probe_status {
+            "healthy" => "available",
+            "unhealthy" => "unhealthy",
+            "stale" => "stale",
+            "rate_limited" => "rate-limited",
+            "circuit_open" => "circuit-open",
+            "unknown" => "unknown",
+            _ => "unknown",
+        }
     }
 }

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -140,6 +140,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_backend_health_admission_cases_match_registry_and_admission_policy",
         },
         ConformanceConsumer::RustTest {
+            id: "backend_registry::tests::display_state_matches_every_lean_backend_health_admission_case",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/src/backend_registry/tests.rs",
+            module_path: "backend_registry::tests",
+            function: "display_state_matches_every_lean_backend_health_admission_case",
+        },
+        ConformanceConsumer::RustTest {
             id: "cli_server::server_exposes_fleet_slot_snapshot_endpoint",
             package: "defra-agent-cli",
             source_path: "crates/defra-agent-cli/tests/cli_server.rs",

--- a/docs/ui-prototypes/panel-288-backend-health.html
+++ b/docs/ui-prototypes/panel-288-backend-health.html
@@ -1,0 +1,1421 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Backend Health · panel-288 prototype</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --source-black: #000000;
+      --source-green: #06b250;
+      --source-dark-green: #1c2724;
+      --source-white: #ffffff;
+      --source-blue: #10cbff;
+      --source-orange: #ffa011;
+      --source-green-rgb: 6 178 80;
+      --source-dark-green-rgb: 28 39 36;
+
+      --color-bg: var(--source-black);
+      --color-surface: rgb(var(--source-dark-green-rgb) / 0.86);
+      --color-surface-strong: #07110e;
+      --color-surface-row: rgb(9 17 14 / 0.86);
+      --color-surface-muted: rgb(var(--source-dark-green-rgb) / 0.58);
+      --color-text: var(--source-white);
+      --color-text-muted: #95a49d;
+      --color-text-soft: #d6ddda;
+      --color-text-warm: #dff8e8;
+      --color-accent: var(--source-green);
+      --color-success: #8df2b4;
+      --color-success-strong: var(--source-green);
+      --color-warning: var(--source-orange);
+      --color-info: var(--source-blue);
+      --color-error: #ffad9d;
+      --color-error-strong: #ff6f5f;
+      --color-neutral: #6c7a74;
+
+      --border-subtle: rgb(var(--source-green-rgb) / 0.12);
+      --border-default: rgb(var(--source-green-rgb) / 0.18);
+      --border-strong: rgb(var(--source-green-rgb) / 0.28);
+
+      --radius-sm: 8px;
+      --radius-md: 8px;
+      --radius-lg: 12px;
+      --radius-pill: 999px;
+
+      --space-1: 4px;
+      --space-2: 6px;
+      --space-3: 8px;
+      --space-4: 10px;
+      --space-5: 12px;
+      --space-6: 14px;
+      --space-7: 16px;
+      --space-8: 18px;
+      --space-9: 24px;
+      --space-10: 32px;
+
+      font-family: "Inter", "SF Pro Text", system-ui, sans-serif;
+      --font-heading: "Funnel Display", "Inter", "SF Pro Display", system-ui, sans-serif;
+      line-height: 1.45;
+      font-synthesis: none;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      background: var(--color-bg);
+      color: var(--color-text);
+      min-height: 100vh;
+    }
+
+    .app {
+      max-width: 960px;
+      margin: 0 auto;
+      padding: var(--space-10) var(--space-9);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-9);
+    }
+
+    /* ── header ───────────────────────────────────────────── */
+
+    .panel-header {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: flex-end;
+      justify-content: space-between;
+      gap: var(--space-7);
+      padding-bottom: var(--space-7);
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .panel-title {
+      margin: 0 0 var(--space-2) 0;
+      font-family: var(--font-heading);
+      font-weight: 500;
+      font-size: 28px;
+      letter-spacing: -0.01em;
+    }
+
+    .panel-subtitle {
+      margin: 0;
+      color: var(--color-text-muted);
+      font-size: 13px;
+    }
+
+    .fleet-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-3);
+    }
+
+    .summary-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      padding: var(--space-2) var(--space-5);
+      border-radius: var(--radius-pill);
+      background: var(--color-surface-strong);
+      border: 1px solid var(--border-subtle);
+      font-size: 12px;
+      color: var(--color-text-soft);
+    }
+
+    .summary-chip[data-tone="success"] { border-color: rgb(var(--source-green-rgb) / 0.36); }
+    .summary-chip[data-tone="warning"] { border-color: rgb(255 160 17 / 0.36); }
+    .summary-chip[data-tone="error"]   { border-color: rgb(255 111 95 / 0.36); }
+    .summary-chip[data-tone="neutral"] { border-color: var(--border-subtle); }
+
+    .summary-chip .count {
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+
+    /* ── toolbar ──────────────────────────────────────────── */
+
+    .toolbar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-5);
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .toolbar-label {
+      font-size: 12px;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .variation-picker {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+    }
+
+    .variation-picker select {
+      background: var(--color-surface);
+      color: var(--color-text);
+      border: 1px solid var(--border-default);
+      border-radius: var(--radius-md);
+      padding: var(--space-3) var(--space-5);
+      font: inherit;
+      font-size: 13px;
+      min-width: 220px;
+    }
+
+    .variation-picker select:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: 2px;
+    }
+
+    .last-refreshed {
+      font-size: 12px;
+      color: var(--color-text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    /* ── list ─────────────────────────────────────────────── */
+
+    .backend-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+    }
+
+    .backend-row {
+      background: var(--color-surface);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      transition: border-color 120ms ease;
+    }
+
+    .backend-row[data-state="available"] { border-left: 3px solid var(--color-success-strong); }
+    .backend-row[data-state="unhealthy"] { border-left: 3px solid var(--color-error-strong); }
+    .backend-row[data-state="stale"]     { border-left: 3px solid var(--color-warning); }
+    .backend-row[data-state="unknown"]   { border-left: 3px solid var(--color-neutral); }
+    .backend-row[data-state="disabled"]  { border-left: 3px solid var(--color-text-muted); opacity: 0.78; }
+
+    .backend-row[data-expanded="true"] { border-color: var(--border-strong); }
+
+    .backend-summary {
+      display: grid;
+      grid-template-columns: auto 1fr auto auto;
+      align-items: center;
+      gap: var(--space-7);
+      padding: var(--space-7) var(--space-7);
+      background: transparent;
+      border: 0;
+      color: inherit;
+      width: 100%;
+      cursor: pointer;
+      font: inherit;
+      text-align: left;
+    }
+
+    .backend-summary:focus-visible {
+      outline: 2px solid var(--color-accent);
+      outline-offset: -2px;
+      border-radius: var(--radius-lg);
+    }
+
+    .status-glyph {
+      display: inline-grid;
+      place-items: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--color-surface-strong);
+      border: 1px solid var(--border-subtle);
+      font-size: 14px;
+      line-height: 1;
+    }
+
+    .status-glyph[data-state="available"] { color: var(--color-success); border-color: rgb(var(--source-green-rgb) / 0.4); }
+    .status-glyph[data-state="unhealthy"] { color: var(--color-error); border-color: rgb(255 111 95 / 0.4); }
+    .status-glyph[data-state="stale"]     { color: var(--color-warning); border-color: rgb(255 160 17 / 0.4); }
+    .status-glyph[data-state="unknown"]   { color: var(--color-text-muted); }
+    .status-glyph[data-state="disabled"]  { color: var(--color-text-muted); }
+
+    .backend-identity {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+      min-width: 0;
+    }
+
+    .backend-name {
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      font-weight: 600;
+      font-size: 15px;
+      color: var(--color-text);
+    }
+
+    .backend-endpoint {
+      font-size: 12px;
+      color: var(--color-text-muted);
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .kind-badge {
+      display: inline-flex;
+      align-items: center;
+      padding: 1px var(--space-3);
+      border-radius: var(--radius-pill);
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--color-text-soft);
+      background: var(--color-surface-muted);
+      border: 1px solid var(--border-subtle);
+      letter-spacing: 0.02em;
+    }
+
+    .state-label {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--space-2);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .state-label[data-state="available"] { color: var(--color-success); }
+    .state-label[data-state="unhealthy"] { color: var(--color-error); }
+    .state-label[data-state="stale"]     { color: var(--color-warning); }
+    .state-label[data-state="unknown"]   { color: var(--color-text-muted); }
+    .state-label[data-state="disabled"]  { color: var(--color-text-muted); }
+
+    .last-call-hint {
+      font-size: 12px;
+      color: var(--color-text-muted);
+      margin-top: var(--space-1);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .last-call-hint .reason {
+      color: var(--color-error);
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    }
+
+    .last-call-hint .reason[data-tone="ok"] { color: var(--color-success); }
+
+    .chevron {
+      color: var(--color-text-muted);
+      transition: transform 150ms ease;
+      font-size: 14px;
+    }
+
+    .backend-row[data-expanded="true"] .chevron { transform: rotate(90deg); }
+
+    /* ── detail ───────────────────────────────────────────── */
+
+    .backend-detail {
+      display: none;
+      padding: var(--space-7) var(--space-7) var(--space-9);
+      border-top: 1px solid var(--border-subtle);
+      background: rgb(0 0 0 / 0.2);
+      flex-direction: column;
+      gap: var(--space-9);
+    }
+
+    .backend-row[data-expanded="true"] .backend-detail { display: flex; }
+
+    .detail-section {
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+    }
+
+    .detail-section h3 {
+      margin: 0;
+      font-family: var(--font-heading);
+      font-size: 13px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+    }
+
+    .config-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: var(--space-5);
+    }
+
+    .config-cell {
+      padding: var(--space-5);
+      background: var(--color-surface-strong);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-2);
+    }
+
+    .config-cell .label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+    }
+
+    .config-cell .value {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 14px;
+      color: var(--color-text);
+      font-variant-numeric: tabular-nums;
+      word-break: break-word;
+    }
+
+    .config-cell .value.muted { color: var(--color-text-muted); }
+
+    .config-cell .value[data-tone="success"] { color: var(--color-success); }
+    .config-cell .value[data-tone="warning"] { color: var(--color-warning); }
+    .config-cell .value[data-tone="error"]   { color: var(--color-error); }
+
+    .model-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: var(--space-2);
+    }
+
+    .model-chip {
+      padding: var(--space-2) var(--space-4);
+      border-radius: var(--radius-pill);
+      background: var(--color-surface-muted);
+      border: 1px solid var(--border-subtle);
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 12px;
+      color: var(--color-text-soft);
+    }
+
+    .calls-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+
+    .calls-table th,
+    .calls-table td {
+      padding: var(--space-3) var(--space-4);
+      text-align: left;
+      border-bottom: 1px solid var(--border-subtle);
+    }
+
+    .calls-table th {
+      font-weight: 500;
+      color: var(--color-text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 10px;
+    }
+
+    .calls-table td {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-variant-numeric: tabular-nums;
+      color: var(--color-text-soft);
+    }
+
+    .calls-table tr:last-child td { border-bottom: 0; }
+
+    .calls-table .state {
+      display: inline-block;
+      padding: 1px var(--space-3);
+      border-radius: var(--radius-pill);
+      font-size: 10px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      font-weight: 600;
+    }
+
+    .calls-table .state[data-state="completed"] { color: var(--color-success); background: rgb(var(--source-green-rgb) / 0.1); }
+    .calls-table .state[data-state="running"]   { color: var(--color-info); background: rgb(16 203 255 / 0.1); }
+    .calls-table .state[data-state="queued"]    { color: var(--color-text-muted); background: var(--color-surface-muted); }
+    .calls-table .state[data-state="failed"]    { color: var(--color-error); background: rgb(255 111 95 / 0.1); }
+    .calls-table .state[data-state="cancelled"] { color: var(--color-warning); background: rgb(255 160 17 / 0.1); }
+
+    .calls-table .reason-cell {
+      color: var(--color-error);
+    }
+
+    .empty-calls {
+      padding: var(--space-7);
+      background: var(--color-surface-strong);
+      border: 1px dashed var(--border-subtle);
+      border-radius: var(--radius-md);
+      text-align: center;
+      color: var(--color-text-muted);
+      font-size: 13px;
+    }
+
+    /* ── empty state ──────────────────────────────────────── */
+
+    .empty-fleet {
+      padding: var(--space-10);
+      border: 1px dashed var(--border-default);
+      border-radius: var(--radius-lg);
+      background: var(--color-surface);
+      text-align: center;
+      color: var(--color-text-muted);
+      display: flex;
+      flex-direction: column;
+      gap: var(--space-4);
+      align-items: center;
+    }
+
+    .empty-fleet[hidden] { display: none; }
+
+    .empty-fleet .icon {
+      font-size: 28px;
+      color: var(--color-text-soft);
+    }
+
+    .empty-fleet h2 {
+      margin: 0;
+      font-family: var(--font-heading);
+      font-weight: 500;
+      font-size: 18px;
+      color: var(--color-text);
+    }
+
+    .empty-fleet p {
+      margin: 0;
+      max-width: 420px;
+      font-size: 13px;
+    }
+
+    .empty-fleet code {
+      padding: 1px 6px;
+      background: var(--color-surface-strong);
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border-subtle);
+      font-size: 12px;
+      color: var(--color-text-soft);
+    }
+
+    /* ── design notes ─────────────────────────────────────── */
+
+    .design-notes {
+      margin-top: var(--space-9);
+      padding: var(--space-7);
+      background: var(--color-surface-muted);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-lg);
+      font-size: 13px;
+      color: var(--color-text-soft);
+    }
+
+    .design-notes > summary {
+      cursor: pointer;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: var(--space-3);
+      font-family: var(--font-heading);
+      font-weight: 500;
+      font-size: 14px;
+      color: var(--color-text);
+    }
+
+    .design-notes > summary::-webkit-details-marker { display: none; }
+
+    .design-notes > summary::before {
+      content: "▸";
+      color: var(--color-text-muted);
+      transition: transform 150ms ease;
+    }
+
+    .design-notes[open] > summary::before { transform: rotate(90deg); }
+
+    .design-notes h3 {
+      margin: var(--space-8) 0 var(--space-3) 0;
+      font-family: var(--font-heading);
+      font-size: 13px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--color-text-muted);
+    }
+
+    .design-notes p { margin: 0 0 var(--space-4) 0; }
+    .design-notes ul { margin: 0 0 var(--space-5) 0; padding-left: var(--space-8); }
+    .design-notes li { margin-bottom: var(--space-3); }
+
+    .design-notes code {
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 12px;
+      padding: 1px 5px;
+      background: var(--color-surface-strong);
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border-subtle);
+      color: var(--color-text-warm);
+    }
+
+    .design-notes pre {
+      background: var(--color-surface-strong);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-md);
+      padding: var(--space-5);
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 12px;
+      overflow-x: auto;
+      color: var(--color-text-warm);
+      margin: 0 0 var(--space-5) 0;
+    }
+
+    .gap-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 0 0 var(--space-5) 0;
+      font-size: 12px;
+    }
+
+    .gap-table th,
+    .gap-table td {
+      padding: var(--space-3) var(--space-4);
+      border-bottom: 1px solid var(--border-subtle);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .gap-table th {
+      color: var(--color-text-muted);
+      font-weight: 500;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      font-size: 10px;
+    }
+
+    .gap-table td.gap { color: var(--color-warning); }
+    .gap-table td.gap-bad { color: var(--color-error); }
+    .gap-table td.gap-ok { color: var(--color-success); }
+
+    .sr-only {
+      position: absolute; width: 1px; height: 1px;
+      padding: 0; margin: -1px; overflow: hidden;
+      clip: rect(0 0 0 0); white-space: nowrap; border: 0;
+    }
+  </style>
+</head>
+<body>
+  <main class="app" aria-labelledby="panel-title">
+    <header class="panel-header">
+      <div>
+        <h1 id="panel-title" class="panel-title">Backend health</h1>
+        <p class="panel-subtitle">
+          Inference backends registered to this deployment, with admission
+          policy and recent call outcomes.
+        </p>
+      </div>
+      <div class="fleet-summary" id="fleet-summary" aria-live="polite">
+        <!-- populated by JS -->
+      </div>
+    </header>
+
+    <section class="toolbar" aria-label="Prototype controls">
+      <div class="variation-picker">
+        <label class="toolbar-label" for="variation">Mock scenario</label>
+        <select id="variation">
+          <option value="mixed">Mixed fleet</option>
+          <option value="empty">Empty (no backends registered)</option>
+          <option value="all-healthy">All healthy</option>
+          <option value="one-stale">One stale</option>
+          <option value="one-unhealthy">One unhealthy (recent QueueFull)</option>
+          <option value="one-disabled">One disabled by operator</option>
+        </select>
+      </div>
+      <div class="last-refreshed" id="last-refreshed">
+        observed at <span id="observed-at">—</span>
+      </div>
+    </section>
+
+    <section aria-label="Backend list">
+      <ul class="backend-list" id="backend-list"></ul>
+      <div id="empty-fleet" class="empty-fleet" hidden>
+        <div class="icon" aria-hidden="true">∅</div>
+        <h2>No backends registered</h2>
+        <p>
+          Add an <code>InferenceBackend</code> document to the control plane
+          to register a provider. The runtime reads from the
+          <code>InferenceBackend</code> collection at start-up and on every
+          control-doc update.
+        </p>
+      </div>
+    </section>
+
+    <details class="design-notes">
+      <summary>Design notes</summary>
+
+      <h3>Data shape (faithful to runtime)</h3>
+      <p>
+        This panel reads two persisted collections — no new persistence is
+        required. The runtime owns the live state; the operator UI is a
+        read-only projection.
+      </p>
+      <pre><code>// crates/defra-agent-protocol/schemas/inference/inference_backend.graphql
+type InferenceBackend {
+  backend_id: String          // unique per deployment
+  name: String
+  provider_kind: String       // "OpenAiCompatible" | "OpenRouter"
+  endpoint: String            // OpenAI-compatible base URL (incl. /v1)
+  max_concurrent: Int
+  max_queue_depth: Int
+  enabled: Boolean
+  models: [String]
+  last_probe: DateTime        // populated on probe; may be absent
+  probe_status: String        // "healthy" | "unhealthy" | "unknown" | "stale"
+}
+
+// crates/defra-agent-protocol/schemas/inference/inference_call.graphql
+type InferenceCall {
+  call_id, runtime_instance_id, request_id, call_seq,
+  backend_id, behavior_id, agent_did, call_kind, attempt,
+  call_state: String          // "queued" | "running" | "completed"
+                              // | "failed" | "cancelled"
+  failure_reason: String      // e.g. "QueueFull", "BackendGone", provider err
+  queued_at, started_at, ended_at,
+  queue_depth_at_enqueue: Int,
+  prompt_tokens, completion_tokens
+}</code></pre>
+
+      <h3>Tauri command surface</h3>
+      <pre><code>// minimal, read-only — sufficient for this panel
+list_backends_with_health() -> Vec&lt;BackendHealthView&gt;
+
+struct BackendHealthView {
+  // mirrors InferenceBackend
+  backend_id, name, provider_kind, endpoint, models,
+  enabled, max_concurrent, max_queue_depth,
+  probe_status, last_probe,
+
+  // last 10 InferenceCall rows where backend_id matches,
+  // ordered by queued_at DESC
+  recent_calls: Vec&lt;InferenceCallSummary&gt;,
+}</code></pre>
+      <p>
+        Implementation: one GraphQL query against
+        <code>InferenceBackend(order: { backend_id: ASC })</code> (mirrors
+        <code>backend_registry.rs:179–228 list_backend_records</code>),
+        plus a second query per backend against <code>InferenceCall</code>
+        filtered by <code>backend_id</code> with <code>limit: 10</code> and
+        <code>order: { queued_at: DESC }</code>.
+      </p>
+
+      <h3>Visual treatment</h3>
+      <p>
+        The derived display state is a pure UI rollup of
+        <code>enabled × probe_status</code> — it does not introduce any new
+        runtime concept. The mapping mirrors
+        <code>InferenceBackend::is_available</code>
+        (<code>backend_registry.rs:95</code>) and the Lean witness
+        <code>backendAvailable</code>
+        (<code>proofs/Proofs/Conformance/ContractCases/BoundaryRuntime.lean:197</code>):
+      </p>
+      <ul>
+        <li>
+          <strong style="color: var(--color-success)">available</strong> —
+          <code>enabled && probe_status == "healthy"</code>; the only case
+          where the admission gate will admit work.
+        </li>
+        <li>
+          <strong style="color: var(--color-error)">unhealthy</strong> —
+          <code>enabled && probe_status == "unhealthy"</code>; the probe
+          rejected the backend.
+        </li>
+        <li>
+          <strong style="color: var(--color-warning)">stale</strong> —
+          <code>enabled && probe_status == "stale"</code>; the probe data
+          itself is too old to be trusted. Treated as a warning because
+          remediation is usually rerunning the prober, not replacing the
+          backend.
+        </li>
+        <li>
+          <strong style="color: var(--color-text-muted)">unknown</strong> —
+          <code>enabled && probe_status == "unknown"</code>; default for a
+          newly-registered backend that has not yet been probed.
+        </li>
+        <li>
+          <strong style="color: var(--color-text-muted)">disabled</strong>
+          — <code>!enabled</code>; operator-controlled; the row is dimmed
+          and the gate is closed regardless of probe state.
+        </li>
+      </ul>
+
+      <h3>What this panel deliberately does <em>not</em> show</h3>
+      <p>
+        Several states named in the original prompt (rate-limited,
+        circuit-open) and several controls (probe button, reset-circuit
+        button) are absent because the runtime does not implement them
+        today. Surfacing them would create UI fiction that diverges from
+        the Lean witnesses. Each gap is a separate workstream:
+      </p>
+      <table class="gap-table">
+        <thead>
+          <tr>
+            <th>Surface (named in original prompt)</th>
+            <th>Status</th>
+            <th>What would need to change</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>rate-limited</code> state</td>
+            <td class="gap-bad">absent</td>
+            <td>
+              No rate-limit detection in
+              <code>BackendAdmissionController</code>. Would need a sliding
+              window over <code>failure_reason</code> on
+              <code>InferenceCall</code>, plus a new
+              <code>probe_status</code> enum variant (and Lean case).
+            </td>
+          </tr>
+          <tr>
+            <td><code>circuit-open</code> state</td>
+            <td class="gap-bad">absent</td>
+            <td>
+              No circuit breaker in <code>admission/</code>. Would need a
+              new controller state + persistent transition log + reset
+              command + Lean spec for trip / half-open / reset transitions.
+            </td>
+          </tr>
+          <tr>
+            <td>Live active / queued counters</td>
+            <td class="gap">in-memory only</td>
+            <td>
+              <code>BackendAdmissionController.{running, waiters}</code>
+              are atomics held in RAM and lost on restart
+              (<code>admission/controller.rs:23–25</code>). To surface in
+              the UI: either ship as a one-shot snapshot from the running
+              process (Tauri command reads atomics) or persist a periodic
+              checkpoint.
+            </td>
+          </tr>
+          <tr>
+            <td>"Probe" button (re-run probe)</td>
+            <td class="gap-bad">no mechanism</td>
+            <td>
+              <code>probe_status</code> is populated at config load (no
+              background prober loop). A probe action needs a runtime
+              subsystem to schedule, execute, and record the probe — and a
+              decision about whether the probe runs against the operator's
+              process or via the inference backend itself.
+            </td>
+          </tr>
+          <tr>
+            <td>"Reset circuit" button</td>
+            <td class="gap-bad">no circuit</td>
+            <td>Depends on circuit breaker landing first.</td>
+          </tr>
+          <tr>
+            <td>Last probe latency</td>
+            <td class="gap-ok">partial</td>
+            <td>
+              <code>last_probe: DateTime</code> exists on the schema
+              (<code>inference_backend.graphql:16</code>); a latency field
+              would extend the same row.
+            </td>
+          </tr>
+          <tr>
+            <td>Recent call history per backend</td>
+            <td class="gap-ok">queryable</td>
+            <td>
+              Filter <code>InferenceCall</code> by <code>backend_id</code>;
+              terminal reasons (<code>QueueFull</code>,
+              <code>BackendGone</code>, provider errors) are already
+              persisted (<code>admission/persistence.rs:84–109</code>).
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3>Lean conformance</h3>
+      <p>
+        Witnesses for the panel's status derivation live in
+        <code>backendHealthAdmissionCases</code>
+        (<code>BoundaryRuntime.lean:214</code>). Five cases cover
+        <code>enabled × probe_status ∈ {healthy, unhealthy, unknown, stale}
+        → admissionDecision</code>. The panel does not extend this surface;
+        any new state (rate-limited, circuit-open) requires a new Lean
+        case before the UI ships it.
+      </p>
+
+      <h3>Accessibility</h3>
+      <ul>
+        <li>
+          Status is conveyed by three redundant channels: a coloured dot
+          glyph (◉ / × / ! / ? / —), an uppercase text label
+          (<code>AVAILABLE</code>, <code>UNHEALTHY</code>, …), and the
+          row's left border colour. No information is colour-only.
+        </li>
+        <li>
+          Each row is a native <code>&lt;button&gt;</code> with
+          <code>aria-expanded</code>; expand/collapse responds to Enter,
+          Space, and click. Tab order is row-by-row.
+        </li>
+        <li>
+          The fleet summary chips are inside an
+          <code>aria-live="polite"</code> region so the variation switcher
+          announces fleet rollup changes to assistive tech.
+        </li>
+        <li>
+          Tabular numerics (<code>font-variant-numeric: tabular-nums</code>)
+          on counts, queue depths, and timestamps so they do not shift as
+          mock data cycles.
+        </li>
+      </ul>
+
+      <h3>Out of scope (per PROMPT.md)</h3>
+      <p>
+        Tauri integration, real fetching, build tooling, multiple HTML
+        files, ledger promotion, modifications to the backend registry or
+        admission policy, adding new backend kinds.
+      </p>
+    </details>
+  </main>
+
+  <script>
+    // ── mock fixtures ────────────────────────────────────────
+    //
+    // Field names mirror the persisted schemas verbatim; the only fields
+    // present here are fields the runtime actually persists today. See
+    // the design-notes section for which prompt-spec fields are
+    // deliberately absent and why.
+
+    const NOW = new Date("2026-05-20T17:32:18Z");
+
+    function isoMinusMinutes(mins) {
+      return new Date(NOW.getTime() - mins * 60_000).toISOString();
+    }
+
+    function isoMinusHours(hours) {
+      return new Date(NOW.getTime() - hours * 3_600_000).toISOString();
+    }
+
+    function ageString(iso) {
+      if (!iso) return "—";
+      const ms = NOW.getTime() - new Date(iso).getTime();
+      if (ms < 0) return "in the future";
+      const s = Math.floor(ms / 1000);
+      if (s < 60) return s + "s ago";
+      const m = Math.floor(s / 60);
+      if (m < 60) return m + "m ago";
+      const h = Math.floor(m / 60);
+      if (h < 24) return h + "h ago";
+      const d = Math.floor(h / 24);
+      return d + "d ago";
+    }
+
+    // Reusable backend fixtures keyed by name; variations select from these.
+    const BACKENDS = {
+      openaiHealthy: {
+        backend_id: "openai-prod",
+        name: "OpenAI · production key",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "https://api.openai.com/v1",
+        enabled: true,
+        probe_status: "healthy",
+        last_probe: isoMinusMinutes(2),
+        max_concurrent: 8,
+        max_queue_depth: 100,
+        models: ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
+        recent_calls: [
+          { call_seq: 4821, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(1), ended_at: isoMinusMinutes(1),
+            queue_depth_at_enqueue: 0, prompt_tokens: 1284, completion_tokens: 312 },
+          { call_seq: 4820, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(3), ended_at: isoMinusMinutes(3),
+            queue_depth_at_enqueue: 1, prompt_tokens: 904, completion_tokens: 188 },
+          { call_seq: 4819, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(6), ended_at: isoMinusMinutes(6),
+            queue_depth_at_enqueue: 0, prompt_tokens: 612, completion_tokens: 244 },
+        ],
+      },
+
+      openrouterHealthy: {
+        backend_id: "openrouter-shared",
+        name: "OpenRouter · shared",
+        provider_kind: "OpenRouter",
+        endpoint: "https://openrouter.ai/api/v1",
+        enabled: true,
+        probe_status: "healthy",
+        last_probe: isoMinusMinutes(1),
+        max_concurrent: 4,
+        max_queue_depth: 50,
+        models: [
+          "anthropic/claude-opus-4-7",
+          "anthropic/claude-sonnet-4-6",
+          "meta-llama/llama-3.1-70b-instruct",
+        ],
+        recent_calls: [
+          { call_seq: 1207, call_kind: "completion", call_state: "running",
+            queued_at: isoMinusMinutes(0.5), started_at: isoMinusMinutes(0.4),
+            queue_depth_at_enqueue: 2 },
+          { call_seq: 1206, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(4), ended_at: isoMinusMinutes(4),
+            queue_depth_at_enqueue: 1, prompt_tokens: 2210, completion_tokens: 901 },
+          { call_seq: 1205, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(8), ended_at: isoMinusMinutes(7),
+            queue_depth_at_enqueue: 0, prompt_tokens: 1480, completion_tokens: 405 },
+        ],
+      },
+
+      localHealthy: {
+        backend_id: "local-llama",
+        name: "Local · llama.cpp on-host",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "http://127.0.0.1:8080/v1",
+        enabled: true,
+        probe_status: "healthy",
+        last_probe: isoMinusMinutes(0.5),
+        max_concurrent: 1,
+        max_queue_depth: 8,
+        models: ["llama-3.1-8b-instruct-q4"],
+        recent_calls: [
+          { call_seq: 312, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(2), ended_at: isoMinusMinutes(2),
+            queue_depth_at_enqueue: 0, prompt_tokens: 488, completion_tokens: 124 },
+        ],
+      },
+
+      openaiStale: {
+        backend_id: "openai-prod",
+        name: "OpenAI · production key",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "https://api.openai.com/v1",
+        enabled: true,
+        probe_status: "stale",
+        last_probe: isoMinusHours(6.5),
+        max_concurrent: 8,
+        max_queue_depth: 100,
+        models: ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
+        recent_calls: [
+          { call_seq: 4820, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusHours(6.2), ended_at: isoMinusHours(6.2),
+            queue_depth_at_enqueue: 0, prompt_tokens: 904, completion_tokens: 188 },
+        ],
+      },
+
+      openrouterUnhealthy: {
+        backend_id: "openrouter-shared",
+        name: "OpenRouter · shared",
+        provider_kind: "OpenRouter",
+        endpoint: "https://openrouter.ai/api/v1",
+        enabled: true,
+        probe_status: "unhealthy",
+        last_probe: isoMinusMinutes(1),
+        max_concurrent: 4,
+        max_queue_depth: 50,
+        models: [
+          "anthropic/claude-opus-4-7",
+          "anthropic/claude-sonnet-4-6",
+        ],
+        recent_calls: [
+          { call_seq: 1212, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(0.5), ended_at: isoMinusMinutes(0.5),
+            queue_depth_at_enqueue: 50, failure_reason: "QueueFull" },
+          { call_seq: 1211, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(1.1), ended_at: isoMinusMinutes(1.1),
+            queue_depth_at_enqueue: 50, failure_reason: "QueueFull" },
+          { call_seq: 1210, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(2.4), ended_at: isoMinusMinutes(2.4),
+            queue_depth_at_enqueue: 49, failure_reason: "QueueFull" },
+          { call_seq: 1209, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(3.8), ended_at: isoMinusMinutes(3.8),
+            queue_depth_at_enqueue: 48, failure_reason: "upstream 503" },
+          { call_seq: 1208, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(7), ended_at: isoMinusMinutes(7),
+            queue_depth_at_enqueue: 12, prompt_tokens: 800, completion_tokens: 200 },
+        ],
+      },
+
+      openaiDisabled: {
+        backend_id: "openai-legacy",
+        name: "OpenAI · legacy org key",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "https://api.openai.com/v1",
+        enabled: false,
+        probe_status: "healthy",
+        last_probe: isoMinusHours(11),
+        max_concurrent: 4,
+        max_queue_depth: 50,
+        models: ["gpt-4-turbo"],
+        recent_calls: [
+          { call_seq: 3104, call_kind: "completion", call_state: "cancelled",
+            queued_at: isoMinusHours(11), ended_at: isoMinusHours(11),
+            queue_depth_at_enqueue: 0, failure_reason: "BackendGone" },
+        ],
+      },
+
+      newUnknown: {
+        backend_id: "groq-evaluation",
+        name: "Groq · evaluation",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "https://api.groq.com/openai/v1",
+        enabled: true,
+        probe_status: "unknown",
+        last_probe: null,
+        max_concurrent: 2,
+        max_queue_depth: 20,
+        models: ["llama-3.1-70b-versatile"],
+        recent_calls: [],
+      },
+    };
+
+    const VARIATIONS = {
+      "empty": [],
+      "all-healthy": ["openaiHealthy", "openrouterHealthy", "localHealthy"],
+      "one-stale": ["openaiStale", "openrouterHealthy", "localHealthy"],
+      "one-unhealthy": ["openaiHealthy", "openrouterUnhealthy", "localHealthy"],
+      "one-disabled": ["openaiHealthy", "openrouterHealthy", "localHealthy", "openaiDisabled"],
+      "mixed": ["openaiHealthy", "openrouterUnhealthy", "localHealthy", "openaiDisabled", "newUnknown"],
+    };
+
+    // ── derived display state ────────────────────────────────
+
+    function displayState(backend) {
+      if (!backend.enabled) return "disabled";
+      switch (backend.probe_status) {
+        case "healthy":   return "available";
+        case "unhealthy": return "unhealthy";
+        case "stale":     return "stale";
+        case "unknown":
+        default:          return "unknown";
+      }
+    }
+
+    const STATE_LABEL = {
+      available: "Available",
+      unhealthy: "Unhealthy",
+      stale: "Stale",
+      unknown: "Unknown",
+      disabled: "Disabled",
+    };
+
+    const STATE_GLYPH = {
+      available: "●",
+      unhealthy: "×",
+      stale: "!",
+      unknown: "?",
+      disabled: "—",
+    };
+
+    // ── render ───────────────────────────────────────────────
+
+    const list = document.getElementById("backend-list");
+    const empty = document.getElementById("empty-fleet");
+    const summaryRoot = document.getElementById("fleet-summary");
+    const observedAt = document.getElementById("observed-at");
+
+    function renderFleetSummary(backends) {
+      const counts = { available: 0, unhealthy: 0, stale: 0, unknown: 0, disabled: 0 };
+      for (const b of backends) counts[displayState(b)]++;
+      const total = backends.length;
+
+      const chips = [];
+      if (total === 0) {
+        chips.push(chip("neutral", "0 backends"));
+      } else {
+        chips.push(chip("neutral", `${total} registered`));
+        if (counts.available) chips.push(chip("success", `${counts.available} available`));
+        if (counts.unhealthy) chips.push(chip("error",   `${counts.unhealthy} unhealthy`));
+        if (counts.stale)     chips.push(chip("warning", `${counts.stale} stale`));
+        if (counts.unknown)   chips.push(chip("neutral", `${counts.unknown} unknown`));
+        if (counts.disabled)  chips.push(chip("neutral", `${counts.disabled} disabled`));
+      }
+
+      summaryRoot.replaceChildren(...chips);
+    }
+
+    function chip(tone, label) {
+      const el = document.createElement("span");
+      el.className = "summary-chip";
+      el.dataset.tone = tone;
+      const m = label.match(/^(\d+)\s+(.*)$/);
+      if (m) {
+        const n = document.createElement("span");
+        n.className = "count";
+        n.textContent = m[1];
+        el.append(n, document.createTextNode(" " + m[2]));
+      } else {
+        el.textContent = label;
+      }
+      return el;
+    }
+
+    function renderRow(backend) {
+      const state = displayState(backend);
+
+      const row = document.createElement("li");
+      row.className = "backend-row";
+      row.dataset.state = state;
+      row.dataset.expanded = "false";
+      row.dataset.backendId = backend.backend_id;
+
+      // summary (clickable)
+      const summary = document.createElement("button");
+      summary.type = "button";
+      summary.className = "backend-summary";
+      summary.setAttribute("aria-expanded", "false");
+      summary.setAttribute("aria-controls", `detail-${backend.backend_id}`);
+
+      const glyph = document.createElement("span");
+      glyph.className = "status-glyph";
+      glyph.dataset.state = state;
+      glyph.setAttribute("aria-hidden", "true");
+      glyph.textContent = STATE_GLYPH[state];
+
+      const identity = document.createElement("div");
+      identity.className = "backend-identity";
+
+      const nameLine = document.createElement("div");
+      nameLine.className = "backend-name";
+      nameLine.append(
+        document.createTextNode(backend.name),
+        kindBadge(backend.provider_kind),
+      );
+
+      const endpoint = document.createElement("div");
+      endpoint.className = "backend-endpoint";
+      endpoint.textContent = backend.endpoint;
+
+      const lastHint = document.createElement("div");
+      lastHint.className = "last-call-hint";
+      const lastCall = (backend.recent_calls || [])[0];
+      if (lastCall) {
+        if (lastCall.failure_reason) {
+          const reason = document.createElement("span");
+          reason.className = "reason";
+          reason.textContent = lastCall.failure_reason;
+          lastHint.append(
+            document.createTextNode("last call failed: "),
+            reason,
+            document.createTextNode(` · ${ageString(lastCall.ended_at || lastCall.queued_at)}`),
+          );
+        } else {
+          const reason = document.createElement("span");
+          reason.className = "reason";
+          reason.dataset.tone = "ok";
+          reason.textContent = lastCall.call_state;
+          lastHint.append(
+            document.createTextNode("last call "),
+            reason,
+            document.createTextNode(` · ${ageString(lastCall.ended_at || lastCall.started_at || lastCall.queued_at)}`),
+          );
+        }
+      } else {
+        lastHint.append(document.createTextNode("no calls observed"));
+      }
+
+      identity.append(nameLine, endpoint, lastHint);
+
+      const stateLabel = document.createElement("span");
+      stateLabel.className = "state-label";
+      stateLabel.dataset.state = state;
+      stateLabel.textContent = STATE_LABEL[state];
+
+      const chevron = document.createElement("span");
+      chevron.className = "chevron";
+      chevron.setAttribute("aria-hidden", "true");
+      chevron.textContent = "›";
+
+      summary.append(glyph, identity, stateLabel, chevron);
+
+      // detail
+      const detail = document.createElement("div");
+      detail.className = "backend-detail";
+      detail.id = `detail-${backend.backend_id}`;
+
+      detail.append(renderConfigSection(backend), renderModelsSection(backend), renderCallsSection(backend));
+
+      row.append(summary, detail);
+
+      summary.addEventListener("click", () => {
+        const expanded = row.dataset.expanded === "true";
+        row.dataset.expanded = expanded ? "false" : "true";
+        summary.setAttribute("aria-expanded", expanded ? "false" : "true");
+      });
+
+      return row;
+    }
+
+    function kindBadge(kind) {
+      const el = document.createElement("span");
+      el.className = "kind-badge";
+      el.textContent = kind;
+      return el;
+    }
+
+    function renderConfigSection(backend) {
+      const section = document.createElement("section");
+      section.className = "detail-section";
+
+      const heading = document.createElement("h3");
+      heading.textContent = "Admission policy & probe";
+      section.appendChild(heading);
+
+      const grid = document.createElement("div");
+      grid.className = "config-grid";
+
+      grid.append(
+        configCell("enabled", String(backend.enabled), backend.enabled ? "success" : "warning"),
+        configCell("probe_status", backend.probe_status, probeTone(backend.probe_status)),
+        configCell("last_probe", backend.last_probe ? ageString(backend.last_probe) : "never"),
+        configCell("max_concurrent", String(backend.max_concurrent)),
+        configCell("max_queue_depth", String(backend.max_queue_depth)),
+      );
+
+      section.appendChild(grid);
+      return section;
+    }
+
+    function probeTone(status) {
+      switch (status) {
+        case "healthy":   return "success";
+        case "unhealthy": return "error";
+        case "stale":     return "warning";
+        default:          return null;
+      }
+    }
+
+    function configCell(label, value, tone) {
+      const cell = document.createElement("div");
+      cell.className = "config-cell";
+
+      const labelEl = document.createElement("span");
+      labelEl.className = "label";
+      labelEl.textContent = label;
+
+      const valueEl = document.createElement("span");
+      valueEl.className = "value";
+      valueEl.textContent = value;
+      if (tone) valueEl.dataset.tone = tone;
+      if (value === "never" || value === "—") valueEl.classList.add("muted");
+
+      cell.append(labelEl, valueEl);
+      return cell;
+    }
+
+    function renderModelsSection(backend) {
+      const section = document.createElement("section");
+      section.className = "detail-section";
+
+      const heading = document.createElement("h3");
+      heading.textContent = "Models";
+      section.appendChild(heading);
+
+      const chips = document.createElement("div");
+      chips.className = "model-chips";
+
+      if (backend.models.length === 0) {
+        const muted = document.createElement("span");
+        muted.className = "config-cell value muted";
+        muted.textContent = "(no models declared)";
+        section.appendChild(muted);
+      } else {
+        for (const m of backend.models) {
+          const chip = document.createElement("span");
+          chip.className = "model-chip";
+          chip.textContent = m;
+          chips.appendChild(chip);
+        }
+        section.appendChild(chips);
+      }
+
+      return section;
+    }
+
+    function renderCallsSection(backend) {
+      const section = document.createElement("section");
+      section.className = "detail-section";
+
+      const heading = document.createElement("h3");
+      heading.textContent = "Recent calls (InferenceCall, last 10)";
+      section.appendChild(heading);
+
+      const calls = backend.recent_calls || [];
+      if (calls.length === 0) {
+        const empty = document.createElement("div");
+        empty.className = "empty-calls";
+        empty.textContent =
+          "No InferenceCall records for this backend. " +
+          "Either no work has been routed here yet, or all records have aged out of the query window.";
+        section.appendChild(empty);
+        return section;
+      }
+
+      const table = document.createElement("table");
+      table.className = "calls-table";
+
+      const thead = document.createElement("thead");
+      thead.innerHTML = `
+        <tr>
+          <th scope="col">seq</th>
+          <th scope="col">kind</th>
+          <th scope="col">state</th>
+          <th scope="col">queue_depth</th>
+          <th scope="col">failure_reason</th>
+          <th scope="col">tokens (p / c)</th>
+          <th scope="col">age</th>
+        </tr>
+      `;
+
+      const tbody = document.createElement("tbody");
+      for (const c of calls) {
+        const tr = document.createElement("tr");
+        tr.innerHTML = `
+          <td>${c.call_seq}</td>
+          <td>${c.call_kind}</td>
+          <td><span class="state" data-state="${c.call_state}">${c.call_state}</span></td>
+          <td>${c.queue_depth_at_enqueue ?? "—"}</td>
+          <td class="reason-cell">${c.failure_reason || "—"}</td>
+          <td>${c.prompt_tokens != null ? `${c.prompt_tokens} / ${c.completion_tokens}` : "—"}</td>
+          <td>${ageString(c.ended_at || c.started_at || c.queued_at)}</td>
+        `;
+        tbody.appendChild(tr);
+      }
+
+      table.append(thead, tbody);
+      section.appendChild(table);
+      return section;
+    }
+
+    // ── apply variation ──────────────────────────────────────
+
+    function applyVariation(name) {
+      const keys = VARIATIONS[name] || [];
+      const backends = keys.map((k) => BACKENDS[k]);
+
+      observedAt.textContent = NOW.toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+
+      renderFleetSummary(backends);
+
+      list.replaceChildren();
+      if (backends.length === 0) {
+        empty.hidden = false;
+      } else {
+        empty.hidden = true;
+        for (const b of backends) list.appendChild(renderRow(b));
+      }
+    }
+
+    const variationSelect = document.getElementById("variation");
+    variationSelect.addEventListener("change", (e) => applyVariation(e.target.value));
+    applyVariation(variationSelect.value);
+  </script>
+</body>
+</html>

--- a/docs/ui-prototypes/panel-288-backend-health.html
+++ b/docs/ui-prototypes/panel-288-backend-health.html
@@ -200,11 +200,13 @@
       transition: border-color 120ms ease;
     }
 
-    .backend-row[data-state="available"] { border-left: 3px solid var(--color-success-strong); }
-    .backend-row[data-state="unhealthy"] { border-left: 3px solid var(--color-error-strong); }
-    .backend-row[data-state="stale"]     { border-left: 3px solid var(--color-warning); }
-    .backend-row[data-state="unknown"]   { border-left: 3px solid var(--color-neutral); }
-    .backend-row[data-state="disabled"]  { border-left: 3px solid var(--color-text-muted); opacity: 0.78; }
+    .backend-row[data-state="available"]     { border-left: 3px solid var(--color-success-strong); }
+    .backend-row[data-state="unhealthy"]     { border-left: 3px solid var(--color-error-strong); }
+    .backend-row[data-state="stale"]         { border-left: 3px solid var(--color-warning); }
+    .backend-row[data-state="rate-limited"]  { border-left: 3px solid var(--color-warning); }
+    .backend-row[data-state="circuit-open"]  { border-left: 3px solid var(--color-warning); }
+    .backend-row[data-state="unknown"]       { border-left: 3px solid var(--color-neutral); }
+    .backend-row[data-state="disabled"]      { border-left: 3px solid var(--color-text-muted); opacity: 0.78; }
 
     .backend-row[data-expanded="true"] { border-color: var(--border-strong); }
 
@@ -241,11 +243,13 @@
       line-height: 1;
     }
 
-    .status-glyph[data-state="available"] { color: var(--color-success); border-color: rgb(var(--source-green-rgb) / 0.4); }
-    .status-glyph[data-state="unhealthy"] { color: var(--color-error); border-color: rgb(255 111 95 / 0.4); }
-    .status-glyph[data-state="stale"]     { color: var(--color-warning); border-color: rgb(255 160 17 / 0.4); }
-    .status-glyph[data-state="unknown"]   { color: var(--color-text-muted); }
-    .status-glyph[data-state="disabled"]  { color: var(--color-text-muted); }
+    .status-glyph[data-state="available"]    { color: var(--color-success); border-color: rgb(var(--source-green-rgb) / 0.4); }
+    .status-glyph[data-state="unhealthy"]    { color: var(--color-error); border-color: rgb(255 111 95 / 0.4); }
+    .status-glyph[data-state="stale"]        { color: var(--color-warning); border-color: rgb(255 160 17 / 0.4); }
+    .status-glyph[data-state="rate-limited"] { color: var(--color-warning); border-color: rgb(255 160 17 / 0.4); }
+    .status-glyph[data-state="circuit-open"] { color: var(--color-warning); border-color: rgb(255 160 17 / 0.4); }
+    .status-glyph[data-state="unknown"]      { color: var(--color-text-muted); }
+    .status-glyph[data-state="disabled"]     { color: var(--color-text-muted); }
 
     .backend-identity {
       display: flex;
@@ -295,11 +299,13 @@
       letter-spacing: 0.06em;
     }
 
-    .state-label[data-state="available"] { color: var(--color-success); }
-    .state-label[data-state="unhealthy"] { color: var(--color-error); }
-    .state-label[data-state="stale"]     { color: var(--color-warning); }
-    .state-label[data-state="unknown"]   { color: var(--color-text-muted); }
-    .state-label[data-state="disabled"]  { color: var(--color-text-muted); }
+    .state-label[data-state="available"]    { color: var(--color-success); }
+    .state-label[data-state="unhealthy"]    { color: var(--color-error); }
+    .state-label[data-state="stale"]        { color: var(--color-warning); }
+    .state-label[data-state="rate-limited"] { color: var(--color-warning); }
+    .state-label[data-state="circuit-open"] { color: var(--color-warning); }
+    .state-label[data-state="unknown"]      { color: var(--color-text-muted); }
+    .state-label[data-state="disabled"]     { color: var(--color-text-muted); }
 
     .last-call-hint {
       font-size: 12px;
@@ -635,7 +641,9 @@
           <option value="empty">Empty (no backends registered)</option>
           <option value="all-healthy">All healthy</option>
           <option value="one-stale">One stale</option>
-          <option value="one-unhealthy">One unhealthy (recent QueueFull)</option>
+          <option value="one-unhealthy">One unhealthy (probe failed)</option>
+          <option value="one-rate-limited">One rate-limited</option>
+          <option value="one-circuit-open">One circuit-open</option>
           <option value="one-disabled">One disabled by operator</option>
         </select>
       </div>
@@ -678,7 +686,8 @@ type InferenceBackend {
   enabled: Boolean
   models: [String]
   last_probe: DateTime        // populated on probe; may be absent
-  probe_status: String        // "healthy" | "unhealthy" | "unknown" | "stale"
+  probe_status: String        // "healthy" | "unhealthy" | "unknown"
+                              // | "stale" | "rate_limited" | "circuit_open"
 }
 
 // crates/defra-agent-protocol/schemas/inference/inference_call.graphql
@@ -745,6 +754,22 @@ struct BackendHealthView {
           backend.
         </li>
         <li>
+          <strong style="color: var(--color-warning)">rate-limited</strong>
+          — <code>enabled && probe_status == "rate_limited"</code>; the
+          backend is reachable but the provider is throttling us.
+          Warning, not error: the condition typically resolves itself; the
+          admission gate just shouldn't route new work to this backend
+          right now.
+        </li>
+        <li>
+          <strong style="color: var(--color-warning)">circuit-open</strong>
+          — <code>enabled && probe_status == "circuit_open"</code>; recent
+          failures tripped a circuit breaker. The backend may be reachable
+          but we've decided not to call it until the circuit half-opens.
+          Warning rather than error because the state is a local decision,
+          not a verdict on the backend itself.
+        </li>
+        <li>
           <strong style="color: var(--color-text-muted)">unknown</strong> —
           <code>enabled && probe_status == "unknown"</code>; default for a
           newly-registered backend that has not yet been probed.
@@ -756,41 +781,49 @@ struct BackendHealthView {
         </li>
       </ul>
 
-      <h3>What this panel deliberately does <em>not</em> show</h3>
+      <h3>Gap status</h3>
       <p>
-        Several states named in the original prompt (rate-limited,
-        circuit-open) and several controls (probe button, reset-circuit
-        button) are absent because the runtime does not implement them
-        today. Surfacing them would create UI fiction that diverges from
-        the Lean witnesses. Each gap is a separate workstream:
+        <code>rate_limited</code> and <code>circuit_open</code> are now
+        first-class spec states (Lean witnesses + Rust availability check
+        + UI). The runtime accepts the strings via the existing
+        <code>probe_status: String</code> field, and
+        <code>is_available()</code> stays false for anything other than
+        <code>"healthy"</code>. What is <em>not</em> yet in place is the
+        runtime logic that <em>produces</em> these states; the panel
+        renders them when the document carries them. Each gap below is a
+        separate workstream:
       </p>
       <table class="gap-table">
         <thead>
           <tr>
-            <th>Surface (named in original prompt)</th>
+            <th>Capability</th>
             <th>Status</th>
-            <th>What would need to change</th>
+            <th>What still needs to land</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td><code>rate-limited</code> state</td>
-            <td class="gap-bad">absent</td>
+            <td>Rate-limit detector</td>
+            <td class="gap">spec only</td>
             <td>
-              No rate-limit detection in
-              <code>BackendAdmissionController</code>. Would need a sliding
-              window over <code>failure_reason</code> on
-              <code>InferenceCall</code>, plus a new
-              <code>probe_status</code> enum variant (and Lean case).
+              The Lean enum has <code>.rateLimited</code> and the UI
+              renders <code>probe_status == "rate_limited"</code>. Missing:
+              a runtime that watches <code>InferenceCall.failure_reason</code>
+              over a sliding window (e.g. consecutive HTTP 429s) and
+              writes the state back into <code>InferenceBackend</code>.
             </td>
           </tr>
           <tr>
-            <td><code>circuit-open</code> state</td>
-            <td class="gap-bad">absent</td>
+            <td>Circuit breaker</td>
+            <td class="gap">spec only</td>
             <td>
-              No circuit breaker in <code>admission/</code>. Would need a
-              new controller state + persistent transition log + reset
-              command + Lean spec for trip / half-open / reset transitions.
+              The Lean enum has <code>.circuitOpen</code> and the UI
+              renders <code>probe_status == "circuit_open"</code>. Missing:
+              a controller state machine in <code>admission/</code> for
+              trip / half-open / reset transitions, plus the persistent
+              transition log and the reset command. The reset command is
+              deliberately out of this PR (no <code>probe_backend</code> /
+              <code>reset_backend_circuit</code> on the Tauri surface).
             </td>
           </tr>
           <tr>
@@ -806,20 +839,15 @@ struct BackendHealthView {
             </td>
           </tr>
           <tr>
-            <td>"Probe" button (re-run probe)</td>
+            <td>Live probe action</td>
             <td class="gap-bad">no mechanism</td>
             <td>
               <code>probe_status</code> is populated at config load (no
               background prober loop). A probe action needs a runtime
-              subsystem to schedule, execute, and record the probe — and a
-              decision about whether the probe runs against the operator's
-              process or via the inference backend itself.
+              subsystem to schedule, execute, and record the probe. This
+              panel is read-only — there is no "Probe" or "Reset circuit"
+              button.
             </td>
-          </tr>
-          <tr>
-            <td>"Reset circuit" button</td>
-            <td class="gap-bad">no circuit</td>
-            <td>Depends on circuit breaker landing first.</td>
           </tr>
           <tr>
             <td>Last probe latency</td>
@@ -847,11 +875,11 @@ struct BackendHealthView {
       <p>
         Witnesses for the panel's status derivation live in
         <code>backendHealthAdmissionCases</code>
-        (<code>BoundaryRuntime.lean:214</code>). Five cases cover
-        <code>enabled × probe_status ∈ {healthy, unhealthy, unknown, stale}
-        → admissionDecision</code>. The panel does not extend this surface;
-        any new state (rate-limited, circuit-open) requires a new Lean
-        case before the UI ships it.
+        (<code>BoundaryRuntime.lean:214</code>). Seven cases cover
+        <code>enabled × probe_status ∈ {healthy, unhealthy, unknown, stale,
+        rate_limited, circuit_open} → admissionDecision</code>. The
+        bridge-snapshot consumer test drives the Tauri command with a
+        fixture per witness and asserts the derived display state.
       </p>
 
       <h3>Accessibility</h3>
@@ -1043,6 +1071,63 @@ struct BackendHealthView {
         ],
       },
 
+      openrouterRateLimited: {
+        backend_id: "openrouter-shared",
+        name: "OpenRouter · shared",
+        provider_kind: "OpenRouter",
+        endpoint: "https://openrouter.ai/api/v1",
+        enabled: true,
+        probe_status: "rate_limited",
+        last_probe: isoMinusMinutes(0.5),
+        max_concurrent: 4,
+        max_queue_depth: 50,
+        models: [
+          "anthropic/claude-opus-4-7",
+          "anthropic/claude-sonnet-4-6",
+        ],
+        recent_calls: [
+          { call_seq: 1224, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(0.3), ended_at: isoMinusMinutes(0.3),
+            queue_depth_at_enqueue: 12, failure_reason: "upstream 429" },
+          { call_seq: 1223, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(0.6), ended_at: isoMinusMinutes(0.6),
+            queue_depth_at_enqueue: 11, failure_reason: "upstream 429" },
+          { call_seq: 1222, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(2), ended_at: isoMinusMinutes(2),
+            queue_depth_at_enqueue: 8, prompt_tokens: 1100, completion_tokens: 320 },
+        ],
+      },
+
+      localCircuitOpen: {
+        backend_id: "local-llama",
+        name: "Local · llama.cpp on-host",
+        provider_kind: "OpenAiCompatible",
+        endpoint: "http://127.0.0.1:8080/v1",
+        enabled: true,
+        probe_status: "circuit_open",
+        last_probe: isoMinusMinutes(1),
+        max_concurrent: 1,
+        max_queue_depth: 8,
+        models: ["llama-3.1-8b-instruct-q4"],
+        recent_calls: [
+          { call_seq: 318, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(0.4), ended_at: isoMinusMinutes(0.4),
+            queue_depth_at_enqueue: 0, failure_reason: "BackendGone" },
+          { call_seq: 317, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(0.9), ended_at: isoMinusMinutes(0.9),
+            queue_depth_at_enqueue: 0, failure_reason: "connection refused" },
+          { call_seq: 316, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(1.4), ended_at: isoMinusMinutes(1.4),
+            queue_depth_at_enqueue: 0, failure_reason: "connection refused" },
+          { call_seq: 315, call_kind: "completion", call_state: "failed",
+            queued_at: isoMinusMinutes(2.1), ended_at: isoMinusMinutes(2.1),
+            queue_depth_at_enqueue: 0, failure_reason: "connection refused" },
+          { call_seq: 314, call_kind: "completion", call_state: "completed",
+            queued_at: isoMinusMinutes(6), ended_at: isoMinusMinutes(6),
+            queue_depth_at_enqueue: 0, prompt_tokens: 488, completion_tokens: 124 },
+        ],
+      },
+
       openaiDisabled: {
         backend_id: "openai-legacy",
         name: "OpenAI · legacy org key",
@@ -1081,8 +1166,13 @@ struct BackendHealthView {
       "all-healthy": ["openaiHealthy", "openrouterHealthy", "localHealthy"],
       "one-stale": ["openaiStale", "openrouterHealthy", "localHealthy"],
       "one-unhealthy": ["openaiHealthy", "openrouterUnhealthy", "localHealthy"],
+      "one-rate-limited": ["openaiHealthy", "openrouterRateLimited", "localHealthy"],
+      "one-circuit-open": ["openaiHealthy", "openrouterHealthy", "localCircuitOpen"],
       "one-disabled": ["openaiHealthy", "openrouterHealthy", "localHealthy", "openaiDisabled"],
-      "mixed": ["openaiHealthy", "openrouterUnhealthy", "localHealthy", "openaiDisabled", "newUnknown"],
+      "mixed": [
+        "openaiHealthy", "openrouterRateLimited", "localCircuitOpen",
+        "openaiDisabled", "newUnknown",
+      ],
     };
 
     // ── derived display state ────────────────────────────────
@@ -1090,11 +1180,13 @@ struct BackendHealthView {
     function displayState(backend) {
       if (!backend.enabled) return "disabled";
       switch (backend.probe_status) {
-        case "healthy":   return "available";
-        case "unhealthy": return "unhealthy";
-        case "stale":     return "stale";
+        case "healthy":      return "available";
+        case "unhealthy":    return "unhealthy";
+        case "stale":        return "stale";
+        case "rate_limited": return "rate-limited";
+        case "circuit_open": return "circuit-open";
         case "unknown":
-        default:          return "unknown";
+        default:             return "unknown";
       }
     }
 
@@ -1102,6 +1194,8 @@ struct BackendHealthView {
       available: "Available",
       unhealthy: "Unhealthy",
       stale: "Stale",
+      "rate-limited": "Rate-limited",
+      "circuit-open": "Circuit-open",
       unknown: "Unknown",
       disabled: "Disabled",
     };
@@ -1110,6 +1204,8 @@ struct BackendHealthView {
       available: "●",
       unhealthy: "×",
       stale: "!",
+      "rate-limited": "⏱",
+      "circuit-open": "⊘",
       unknown: "?",
       disabled: "—",
     };
@@ -1122,7 +1218,11 @@ struct BackendHealthView {
     const observedAt = document.getElementById("observed-at");
 
     function renderFleetSummary(backends) {
-      const counts = { available: 0, unhealthy: 0, stale: 0, unknown: 0, disabled: 0 };
+      const counts = {
+        available: 0, unhealthy: 0, stale: 0,
+        "rate-limited": 0, "circuit-open": 0,
+        unknown: 0, disabled: 0,
+      };
       for (const b of backends) counts[displayState(b)]++;
       const total = backends.length;
 
@@ -1131,11 +1231,13 @@ struct BackendHealthView {
         chips.push(chip("neutral", "0 backends"));
       } else {
         chips.push(chip("neutral", `${total} registered`));
-        if (counts.available) chips.push(chip("success", `${counts.available} available`));
-        if (counts.unhealthy) chips.push(chip("error",   `${counts.unhealthy} unhealthy`));
-        if (counts.stale)     chips.push(chip("warning", `${counts.stale} stale`));
-        if (counts.unknown)   chips.push(chip("neutral", `${counts.unknown} unknown`));
-        if (counts.disabled)  chips.push(chip("neutral", `${counts.disabled} disabled`));
+        if (counts.available)            chips.push(chip("success", `${counts.available} available`));
+        if (counts.unhealthy)            chips.push(chip("error",   `${counts.unhealthy} unhealthy`));
+        if (counts.stale)                chips.push(chip("warning", `${counts.stale} stale`));
+        if (counts["rate-limited"])      chips.push(chip("warning", `${counts["rate-limited"]} rate-limited`));
+        if (counts["circuit-open"])      chips.push(chip("warning", `${counts["circuit-open"]} circuit-open`));
+        if (counts.unknown)              chips.push(chip("neutral", `${counts.unknown} unknown`));
+        if (counts.disabled)             chips.push(chip("neutral", `${counts.disabled} disabled`));
       }
 
       summaryRoot.replaceChildren(...chips);
@@ -1285,10 +1387,12 @@ struct BackendHealthView {
 
     function probeTone(status) {
       switch (status) {
-        case "healthy":   return "success";
-        case "unhealthy": return "error";
-        case "stale":     return "warning";
-        default:          return null;
+        case "healthy":      return "success";
+        case "unhealthy":    return "error";
+        case "stale":        return "warning";
+        case "rate_limited": return "warning";
+        case "circuit_open": return "warning";
+        default:             return null;
       }
     }
 


### PR DESCRIPTION
## Summary

Operator-UI projection of inference backend health, end-to-end:

- **Phase 1**: HTML+CSS+JS prototype at `docs/ui-prototypes/panel-288-backend-health.html`. Established as the design source of truth before any impl.
- **Phase 2**: Real Tauri-backed React panel mounted into `OperationsRail`, with the Lean spec extended so the operator UI states are first-class witnesses (not UI fiction).

## Spec

The original `BackendProbeStatus` enum modeled four states (`healthy | unhealthy | unknown | stale`); the operator UI also needs `rate-limited` and `circuit-open` to be visually distinct. We extended the Lean enum + `backendHealthAdmissionCases` (now 7 witnesses, was 5) rather than letting the UI invent states the runtime can never produce. `is_available()` and the admission policy stay unchanged — only `"healthy"` admits work. The new states extend what the panel can render when the runtime later writes them.

`backend-health.operatorUi` promoted out of `deferred` in `CoverageLedger.lean`. A new `consumerCoverage` entry tags the bridge consumer test against `BackendHealthAdmissionCases`.

## Runtime + bridge

- `defra_agent::backend_registry`:
  - `list_all_backends(node)` (new public) — includes disabled rows so operators see why backends aren't accepting work
  - `derive_display_state(enabled, probe_status)` (new public) — pure mapping into the panel's bucket; tested against every Lean witness
  - `InferenceBackend::display_state()` method
- `apps/desktop-tauri/src-tauri/.../bridge/tauri_commands/operations.rs`:
  - `desktop_list_backends_with_health() -> Vec<BackendHealthView>` — joins `InferenceBackend` with the last 10 `InferenceCall` rows per backend
  - **No `probe_backend` / `reset_backend_circuit`** — the runtime has no live prober and no circuit breaker. Surfacing buttons for those actions would be UI fiction. The Design notes section of the prototype documents the gap; each row names the runtime change still needed.

## React panel

- `apps/desktop-tauri/src/components/backendHealth/` — panel, row (with expand), `useBackendHealth` hook, types matching the wire shape, JS mirror of `derive_display_state` (the consumer test harness)
- Mounted into `OperationsRail`'s tabs as the first registered tab (replacing the empty foundation from #310)
- Styles use existing tokens (`styles/tokens.css`) so theme drift propagates

## Tests

- **Rust consumer** (`backend_registry::tests::display_state_matches_every_lean_backend_health_admission_case`) — drives all 7 Lean witnesses through `derive_display_state` and asserts both bucket alignment and Lean availability verdict agreement. Registered in `conformance_consumers.rs`.
- **React component** (`apps/desktop-tauri/tests/backend-health-panel.test.tsx`) — enumerates the same 7 witnesses, asserts the JS mirror agrees with the Rust mapping, and confirms the rendered DOM is visually distinct across all seven states (pairwise-distinct `data-state` attributes). Also covers expand, empty fleet, and `failure_reason` surfacing on rate-limited / circuit-open rows.
- **Existing runtime test** (`generated_backend_health_admission_cases_match_registry_and_admission_policy`) updated to expect 7 cases.

## Verification

- ✅ `lake build` (proofs)
- ✅ `cargo test -p defra-agent backend_registry::tests` (5 passed)
- ✅ `cargo test -p defra-agent --test state_machine_conformance lean_contract_coverage_ledger_accounts_for_every_emitted_domain` (1 passed — ledger validator)
- ✅ `cargo check -p defra-agent-desktop-tauri`
- ✅ `npx vitest run` in `apps/desktop-tauri/` — 62 passed (3 live drivers skipped)
- ✅ Prototype re-verified in headless Chrome with all 8 mock variations rendering, expand interactions firing, zero console errors

## Commits

1. `proofs: extend BackendProbeStatus + promote backend-health operatorUi` — Lean enum + cases + ledger promotion + runtime helpers + Rust consumer test + conformance_consumers registration
2. `docs/ui-prototypes: extend panel-288 with rate-limited + circuit-open` — prototype catches up to extended spec
3. `desktop: implement backend health status panel per prototype (#288)` — Tauri command + view types + React panel + mount + vitest component test

(Phase 1 prototype commit `docs/ui-prototypes: add panel-288 backend health status prototype` retained on the branch for review continuity.)

## Expected conflict surface

Per the Phase 2 amendment, other panels (#274, #276, #277, #286) touch `operations.rs`, `OperationsRail`, `CoverageLedger.lean`, and `conformance_consumers.rs`. Expect a rebase.

## Test plan

- [ ] Open the prototype in a browser; cycle Mock scenario through all 8 variations; expand rows; open Design notes
- [ ] `lake build` in `crates/defra-agent/proofs`
- [ ] `cargo test -p defra-agent`
- [ ] `cd apps/desktop-tauri && npx vitest run`
- [ ] Launch desktop app; confirm "Backends" tab appears in `OperationsRail` and renders the local fleet

🤖 Generated with [Claude Code](https://claude.com/claude-code)