### PR TITLE
Backgrounded tools panel: prototype + impl (#276)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot.rs
@@ -105,6 +105,9 @@ pub(crate) use runtime::build_runtime_snapshot;
 
 #[path = "snapshot/operations_signature.rs"]
 mod operations_signature;
+
+#[path = "snapshot/operations_snapshot.rs"]
+pub(crate) mod operations_snapshot;
 #[cfg(test)]
 pub(crate) use operations_signature::*;
 #[allow(unused_imports)]

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs
@@ -1,0 +1,140 @@
+//! Pure projection functions over runtime liveness + AgentToolCall rows.
+//!
+//! The Tauri command body lives in `bridge::tauri_commands::operations` and
+//! is responsible for I/O (DefraDB query + in-process executor snapshot);
+//! this module is pure for testability.
+
+use super::super::types::{
+    ActiveToolCallView, BackgroundedToolView, NativeExecutorStatusView, RuntimeLivenessView,
+    StuckWorkDiagnosticView,
+};
+
+/// Internal shape representing one row pulled from the `AgentToolCall`
+/// collection in DefraDB. The Tauri command parses GraphQL JSON into this
+/// type before passing to the projection functions.
+#[derive(Debug, Clone)]
+pub(crate) struct ToolCallRow {
+    pub request_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub lifecycle_state: Option<String>,
+    pub status: Option<String>,
+    pub started_at: Option<String>,
+    pub deadline_at: Option<String>,
+    pub await_mode: Option<String>,
+    pub cancel_policy: Option<String>,
+    pub child_request_id: Option<String>,
+    pub stuck_since: Option<String>,
+    pub cancel_pending_remote_ack: bool,
+}
+
+const TERMINAL_LIFECYCLE_STATES: &[&str] =
+    &["completed", "failed", "cancelled", "timedOut", "superseded"];
+const CORRELATION_WINDOW_MS: i64 = 1_000;
+
+pub(crate) fn project_backgrounded_tools(
+    rows: &[ToolCallRow],
+    liveness: &RuntimeLivenessView,
+) -> Vec<BackgroundedToolView> {
+    rows.iter()
+        .filter(|r| r.await_mode.as_deref() == Some("background"))
+        .filter(|r| {
+            !r.lifecycle_state
+                .as_deref()
+                .is_some_and(|s| TERMINAL_LIFECYCLE_STATES.contains(&s))
+        })
+        .map(|r| {
+            let age_ms = age_from_live_snapshot(r.tool_call_id.as_str(), &liveness.active_tool_calls);
+            let deadline_expired = liveness
+                .active_tool_calls
+                .iter()
+                .find(|tc| tc.tool_call_id == r.tool_call_id)
+                .map(|tc| tc.deadline_expired)
+                .unwrap_or(false);
+            let native_executor = correlate_native_executor(r, &liveness.active_native_executors);
+            BackgroundedToolView {
+                request_id: r.request_id.clone(),
+                tool_call_id: r.tool_call_id.clone(),
+                tool_name: r.tool_name.clone(),
+                lifecycle_state: r.lifecycle_state.clone(),
+                status: r.status.clone(),
+                started_at: r.started_at.clone(),
+                age_ms,
+                deadline_at: r.deadline_at.clone(),
+                deadline_expired,
+                await_mode: r.await_mode.clone(),
+                cancel_policy: r.cancel_policy.clone(),
+                child_request_id: r.child_request_id.clone(),
+                stuck_since: r.stuck_since.clone(),
+                cancel_pending_remote_ack: r.cancel_pending_remote_ack,
+                native_executor,
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn stuck_diagnostics_from_tool_calls(
+    rows: &[ToolCallRow],
+) -> Vec<StuckWorkDiagnosticView> {
+    rows.iter()
+        .filter(|r| r.await_mode.as_deref() == Some("background"))
+        .filter(|r| {
+            !r.lifecycle_state
+                .as_deref()
+                .is_some_and(|s| TERMINAL_LIFECYCLE_STATES.contains(&s))
+        })
+        .filter_map(|r| {
+            let reason = if r.cancel_pending_remote_ack {
+                "pendingRemoteCancelAck"
+            } else if r.stuck_since.is_some() {
+                "stuckTool"
+            } else {
+                return None;
+            };
+            Some(StuckWorkDiagnosticView {
+                request_id: r.request_id.clone(),
+                session_id: None,
+                severity: "warning".to_string(),
+                reason: reason.to_string(),
+                deadline_age_ms: None,
+                last_progress_age_ms: None,
+                tool_call_id: Some(r.tool_call_id.clone()),
+                tool_name: Some(r.tool_name.clone()),
+                stuck_since: r.stuck_since.clone(),
+            })
+        })
+        .collect()
+}
+
+fn age_from_live_snapshot(tool_call_id: &str, live: &[ActiveToolCallView]) -> Option<i64> {
+    live.iter()
+        .find(|tc| tc.tool_call_id == tool_call_id)
+        .map(|tc| tc.running_age_ms)
+}
+
+fn correlate_native_executor(
+    row: &ToolCallRow,
+    execs: &[NativeExecutorStatusView],
+) -> Option<NativeExecutorStatusView> {
+    let started_at = row.started_at.as_deref()?;
+    let started_ms = parse_iso_ms(started_at)?;
+    execs
+        .iter()
+        .find(|ne| {
+            ne.tool_name.as_deref() == Some(row.tool_name.as_str())
+                && parse_iso_ms(&ne.started_at)
+                    .map(|m| (m - started_ms).abs() <= CORRELATION_WINDOW_MS)
+                    .unwrap_or(false)
+        })
+        .cloned()
+}
+
+fn parse_iso_ms(iso: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+#[path = "operations_snapshot/tests.rs"]
+mod tests;

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+use super::super::super::types::{
+    ActiveToolCallView, NativeExecutorStatusView, RuntimeLivenessView,
+};
+
+fn liveness_with(
+    tools: Vec<ActiveToolCallView>,
+    execs: Vec<NativeExecutorStatusView>,
+) -> RuntimeLivenessView {
+    RuntimeLivenessView {
+        expired_processing_count: 0,
+        requests: Vec::new(),
+        active_tool_calls: tools,
+        active_native_executors_available: true,
+        active_native_executors: execs,
+    }
+}
+
+#[test]
+fn project_filters_to_background_await_mode_only() {
+    let toolcall_rows = vec![
+        ToolCallRow {
+            request_id: "req_a".into(),
+            tool_call_id: "tc_bg".into(),
+            tool_name: "grep".into(),
+            lifecycle_state: Some("running".into()),
+            status: None,
+            started_at: Some("2026-05-20T12:00:00Z".into()),
+            deadline_at: None,
+            await_mode: Some("background".into()),
+            cancel_policy: Some("cascade".into()),
+            child_request_id: None,
+            stuck_since: None,
+            cancel_pending_remote_ack: false,
+        },
+        ToolCallRow {
+            request_id: "req_a".into(),
+            tool_call_id: "tc_fg".into(),
+            tool_name: "grep_fg".into(),
+            lifecycle_state: Some("running".into()),
+            status: None,
+            started_at: Some("2026-05-20T12:00:00Z".into()),
+            deadline_at: None,
+            await_mode: Some("foreground".into()),
+            cancel_policy: None,
+            child_request_id: None,
+            stuck_since: None,
+            cancel_pending_remote_ack: false,
+        },
+    ];
+
+    let projected = project_backgrounded_tools(&toolcall_rows, &liveness_with(Vec::new(), Vec::new()));
+    assert_eq!(projected.len(), 1);
+    assert_eq!(projected[0].tool_call_id, "tc_bg");
+}
+
+#[test]
+fn project_skips_terminal_lifecycle_state() {
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "grep".into(),
+        lifecycle_state: Some("completed".into()),
+        status: None,
+        started_at: None,
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: None,
+        cancel_pending_remote_ack: false,
+    }];
+    let projected = project_backgrounded_tools(&rows, &liveness_with(Vec::new(), Vec::new()));
+    assert!(projected.is_empty());
+}
+
+#[test]
+fn project_attaches_native_executor_when_correlated() {
+    let started = "2026-05-20T12:00:00Z";
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "grep".into(),
+        lifecycle_state: Some("running".into()),
+        status: None,
+        started_at: Some(started.into()),
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: None,
+        cancel_pending_remote_ack: false,
+    }];
+    let execs = vec![NativeExecutorStatusView {
+        id: 902,
+        pid: 41812,
+        argv0: "/usr/bin/grep".into(),
+        tool_name: Some("grep".into()),
+        started_at: started.into(),
+        age_ms: 5_000,
+    }];
+    let liveness = liveness_with(Vec::new(), execs);
+
+    let projected = project_backgrounded_tools(&rows, &liveness);
+    assert!(projected[0].native_executor.is_some());
+    assert_eq!(projected[0].native_executor.as_ref().unwrap().pid, 41812);
+}
+
+#[test]
+fn stuck_diagnostic_emitted_for_cancel_pending_or_stuck_since() {
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "index_repo".into(),
+        lifecycle_state: Some("running".into()),
+        status: None,
+        started_at: Some("2026-05-20T12:00:00Z".into()),
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: Some("2026-05-20T12:00:00Z".into()),
+        cancel_pending_remote_ack: true,
+    }];
+    let diagnostics = stuck_diagnostics_from_tool_calls(&rows);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].reason, "pendingRemoteCancelAck");
+}
+
+#[test]
+fn stuck_diagnostic_uses_stuck_tool_when_no_cancel_pending() {
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "index_repo".into(),
+        lifecycle_state: Some("running".into()),
+        status: None,
+        started_at: Some("2026-05-20T12:00:00Z".into()),
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: Some("2026-05-20T12:00:00Z".into()),
+        cancel_pending_remote_ack: false,
+    }];
+    let diagnostics = stuck_diagnostics_from_tool_calls(&rows);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].reason, "stuckTool");
+}

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
@@ -1,24 +1,30 @@
 //! Tauri commands for operator-surfaces panels. Stubs return an `Err`
 //! describing the panel issue that will replace them; real implementations
-//! land via their own panel PRs. The MCP-health commands (panel #278) are
-//! live.
+//! land via their own panel PRs. `desktop_operations_snapshot` (panel
+//! #276) and the MCP-health commands (panel #278) are live.
 
+use std::sync::Arc;
 use std::time::Duration;
 
+use chrono::Utc;
 use defra_agent::backend_registry::{derive_display_state, list_all_backends};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
+use defra_agent_desktop_core::client::ClientCore;
 use reqwest::Url;
 use tauri::State;
 
 use super::super::commands::{load_mcp_services_with_health, probe_mcp_service};
+use super::super::snapshot::operations_snapshot::{
+    project_backgrounded_tools, stuck_diagnostics_from_tool_calls, ToolCallRow,
+};
 use super::super::state::{current_core, DesktopAppState};
 use super::super::types::{
     BackendHealthView, CascadeCancelPreview, DesktopInterruptRequest,
     DesktopListSubagentTreeRequest, DesktopOperationsSnapshot, DesktopOperationsSnapshotRequest,
     DesktopPreviewInterruptCascadeRequest, DesktopProbeMcpServiceRequest,
     InferenceCallSummaryView, InterruptRequestResult, MCPServiceHealthView, McpServiceProbeResult,
-    SubagentTreeView,
+    NativeExecutorStatusView, RuntimeLivenessView, SubagentTreeView,
 };
 
 const SUBAGENT_TREE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -31,14 +37,168 @@ const RECENT_CALLS_PER_BACKEND: usize = 10;
 
 #[tauri::command]
 pub(crate) async fn desktop_operations_snapshot(
-    _state: State<'_, DesktopAppState>,
-    _request: DesktopOperationsSnapshotRequest,
+    state: State<'_, DesktopAppState>,
+    request: DesktopOperationsSnapshotRequest,
 ) -> Result<DesktopOperationsSnapshot, String> {
-    Err(
-        "desktop_operations_snapshot not implemented yet; landing via panel #277 \
-         (backgrounded tools / operations projection)"
-            .to_string(),
-    )
+    let core = current_core(&state).ok_or_else(|| "desktop bridge not initialized".to_string())?;
+    let agent_did = request.agent_did.clone();
+
+    // 1) In-process native executor snapshot. The runtime exposes this via
+    //    `defra_agent::active_native_executors()` (re-exported from
+    //    `defra_agent::native_executor_status`). Cast `pid: i32` -> `u32`
+    //    for the view shape (the DefraDB schema has no native exec rows;
+    //    this is purely in-process).
+    let native_executors: Vec<NativeExecutorStatusView> =
+        defra_agent::native_executor_status::active_native_executors()
+            .into_iter()
+            .map(|ne| NativeExecutorStatusView {
+                id: ne.id as i64,
+                pid: ne.pid as u32,
+                argv0: ne.argv0,
+                tool_name: ne.tool_name,
+                started_at: ne.started_at,
+                age_ms: ne.age_ms,
+            })
+            .collect();
+
+    // 2) GraphQL query for AgentToolCall rows with await_mode = "background".
+    //    AgentToolCall has no agent_did field — scope is implicit via local
+    //    DefraDB replication. The agent_did from the request is preserved
+    //    in the response envelope only.
+    let tool_call_rows = fetch_background_tool_calls(&core)
+        .await
+        .map_err(|e| format!("failed to query AgentToolCall: {e}"))?;
+
+    // 3) Build a minimal liveness view. The request / active_tool_call /
+    //    expired_processing_count fields are populated by other panels
+    //    (#283/#284); panel #277 only owns the native executor list and
+    //    the backgrounded-tools projection.
+    let liveness = RuntimeLivenessView {
+        expired_processing_count: 0,
+        requests: Vec::new(),
+        active_tool_calls: Vec::new(),
+        active_native_executors_available: true,
+        active_native_executors: native_executors,
+    };
+
+    let backgrounded_tools = project_backgrounded_tools(&tool_call_rows, &liveness);
+    let stuck_diagnostics = stuck_diagnostics_from_tool_calls(&tool_call_rows);
+
+    Ok(DesktopOperationsSnapshot {
+        fetched_at: Utc::now().to_rfc3339(),
+        agent_did,
+        liveness: Some(liveness),
+        liveness_unavailable_reason: None,
+        backgrounded_tools,
+        stuck_diagnostics,
+        lineage: None, // owned by panel #285 (subagent lineage view)
+    })
+}
+
+/// Query DefraDB for backgrounded `AgentToolCall` rows on the local node.
+///
+/// We deliberately use `ClientCore::node()` -> `EmbeddedNode::execute()`
+/// here rather than `graphql_for_agent`: `graphql_for_agent` returns a
+/// remote-peer endpoint URL (`Option<String>`) for cross-deployment HTTP
+/// queries, but operator-surfaces panels read the operator's own local
+/// DefraDB. Local replication handles per-deployment scoping.
+async fn fetch_background_tool_calls(core: &Arc<ClientCore>) -> Result<Vec<ToolCallRow>, String> {
+    let query = r#"
+        query {
+            AgentToolCall(
+                filter: { await_mode: { _eq: "background" } }
+            ) {
+                request_id
+                tool_call_id
+                tool_name
+                lifecycle_state
+                status
+                started_at
+                deadline_at
+                await_mode
+                cancel_policy
+                child_request_id
+                stuck_since
+                cancel_pending_remote_ack
+            }
+        }
+    "#;
+
+    let response = core.node().execute(query).await;
+    if response.has_errors() {
+        return Err(response
+            .errors
+            .iter()
+            .map(|e| e.message.as_str())
+            .collect::<Vec<_>>()
+            .join("; "));
+    }
+
+    let data = response
+        .data
+        .ok_or_else(|| "AgentToolCall query returned no data".to_string())?;
+    let rows = data
+        .get("AgentToolCall")
+        .and_then(|t| t.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ToolCallRow {
+            request_id: row
+                .get("request_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            tool_call_id: row
+                .get("tool_call_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            tool_name: row
+                .get("tool_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            lifecycle_state: row
+                .get("lifecycle_state")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            status: row
+                .get("status")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            started_at: row
+                .get("started_at")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            deadline_at: row
+                .get("deadline_at")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            await_mode: row
+                .get("await_mode")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            cancel_policy: row
+                .get("cancel_policy")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            child_request_id: row
+                .get("child_request_id")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            stuck_since: row
+                .get("stuck_since")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            cancel_pending_remote_ack: row
+                .get("cancel_pending_remote_ack")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false),
+        })
+        .collect())
 }
 
 #[tauri::command]

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -81,6 +81,8 @@ pub(crate) struct BackgroundedToolView {
     pub await_mode: Option<String>,
     pub cancel_policy: Option<String>,
     pub child_request_id: Option<String>,
+    pub stuck_since: Option<String>,
+    pub cancel_pending_remote_ack: bool,
     pub native_executor: Option<NativeExecutorStatusView>,
 }
 

--- a/apps/desktop-tauri/src/App.css
+++ b/apps/desktop-tauri/src/App.css
@@ -1,4 +1,4 @@
-@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, components, backend-health, utilities;
+@layer tokens, base, primitives, shell, sidebar, chat, fleet, config, transcript, components, backend-health, backgrounded-tools, utilities;
 
 @import "./styles/tokens.css";
 @import "./styles/base.css";
@@ -26,4 +26,5 @@
 @import "./styles/transcript/tools.css";
 @import "./styles/subagent-lineage.css";
 @import "./styles/backend-health/backend-health.css";
+@import "./styles/backgrounded-tools.css";
 @import "./styles/utilities.css";

--- a/apps/desktop-tauri/src/components/ChatWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ChatWorkspace.tsx
@@ -11,6 +11,7 @@ import { ChatComposer, ChatHeader, ChatTranscriptPanel } from "./chat";
 import { McpHealthPanel } from "./mcpHealth";
 import { OperationsRail, OperationsRailProvider } from "./operations";
 import type { OperationsRailTabDescriptor } from "./operations";
+import { BackgroundedToolsPanel } from "./backgroundedTools";
 import { SubagentLineageView } from "./subagentLineage";
 
 export type ChatWorkspaceProps = {
@@ -88,6 +89,11 @@ export function ActiveChatWorkspace({
     const rootRequestId = session?.latestRequestId ?? null;
     const lineageAgentDid = selectedDeployment.agentDid;
     return [
+      {
+        id: "background-tools",
+        label: "Background",
+        render: () => <BackgroundedToolsPanel />,
+      },
       {
         id: "lineage",
         label: "Lineage",

--- a/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
+++ b/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type {
+  DesktopOperationsSnapshotRequest,
+} from "../../lib/types/operations";
+import {
+  correlateProcess,
+  derivedState,
+  formatAge,
+  type DerivedState,
+} from "./derivedState";
+import { useOperationsSnapshot } from "./useOperationsSnapshot";
+
+type SortKey = "toolName" | "ageMs" | "requestId" | "awaitMode" | "derivedState" | "processLabel";
+type SortDir = "ascending" | "descending";
+
+export type BackgroundedToolsPanelProps = {
+  rootRequestId?: string | null;
+};
+
+export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanelProps = {}) {
+  const request: DesktopOperationsSnapshotRequest = useMemo(
+    () => ({ rootRequestId: rootRequestId ?? null }),
+    [rootRequestId],
+  );
+  const { snapshot, error, isLoading } = useOperationsSnapshot(request);
+
+  const [stateFilters, setStateFilters] = useState<Set<DerivedState>>(new Set());
+  const [awaitFilters, setAwaitFilters] = useState<Set<string>>(new Set());
+  const [parentFilter, setParentFilter] = useState<string>("all");
+  const [hideHealthy, setHideHealthy] = useState<boolean>(false);
+  const [sortKey, setSortKey] = useState<SortKey>("ageMs");
+  const [sortDir, setSortDir] = useState<SortDir>("descending");
+
+  const projected = useMemo(() => {
+    if (!snapshot) return [];
+    const now = Date.now();
+    const execs = snapshot.liveness?.activeNativeExecutors ?? [];
+    return snapshot.backgroundedTools.map((row) => {
+      const proc = correlateProcess(row, execs);
+      return {
+        ...row,
+        derivedState: derivedState(row, now),
+        ageMs: row.ageMs ?? 0,
+        processLabel: proc.label,
+        processTooltip: proc.tooltip,
+      };
+    });
+  }, [snapshot]);
+
+  const filtered = useMemo(() => {
+    const rows = projected.filter((r) => {
+      if (parentFilter !== "all" && r.requestId !== parentFilter) return false;
+      if (stateFilters.size > 0 && !stateFilters.has(r.derivedState)) return false;
+      if (awaitFilters.size > 0 && (r.awaitMode == null || !awaitFilters.has(r.awaitMode))) return false;
+      if (hideHealthy && !["stuck", "cancelPending", "deadline+"].includes(r.derivedState)) return false;
+      return true;
+    });
+    const dir = sortDir === "ascending" ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = (a as unknown as Record<string, unknown>)[sortKey];
+      const bv = (b as unknown as Record<string, unknown>)[sortKey];
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+      return String(av).localeCompare(String(bv)) * dir;
+    });
+  }, [projected, parentFilter, stateFilters, awaitFilters, hideHealthy, sortKey, sortDir]);
+
+  const parents = useMemo(
+    () => Array.from(new Set(projected.map((r) => r.requestId))),
+    [projected],
+  );
+
+  const onSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === "ascending" ? "descending" : "ascending"));
+      } else {
+        setSortKey(key);
+        setSortDir("ascending");
+      }
+    },
+    [sortKey],
+  );
+
+  const toggleStateFilter = (s: DerivedState) =>
+    setStateFilters((prev) => {
+      const next = new Set(prev);
+      next.has(s) ? next.delete(s) : next.add(s);
+      return next;
+    });
+
+  const toggleAwaitFilter = (a: string) =>
+    setAwaitFilters((prev) => {
+      const next = new Set(prev);
+      next.has(a) ? next.delete(a) : next.add(a);
+      return next;
+    });
+
+  // Error state
+  if (error) {
+    return (
+      <section className="background-tools-panel" aria-label="Background tools">
+        <div className="empty-state">
+          <span className="glyph" aria-hidden="true">○</span>
+          Snapshot bridge unavailable: {error}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="background-tools-panel" aria-label="Background tools">
+      <div className="chip-row" role="group" aria-label="Filter by parent">
+        <span className="chip-label">Parent</span>
+        <button
+          type="button"
+          className={`chip ${parentFilter === "all" ? "is-active" : ""}`}
+          aria-pressed={parentFilter === "all"}
+          onClick={() => setParentFilter("all")}
+        >
+          All
+        </button>
+        {parents.map((p) => (
+          <button
+            key={p}
+            type="button"
+            className={`chip ${parentFilter === p ? "is-active" : ""}`}
+            aria-pressed={parentFilter === p}
+            onClick={() => setParentFilter(p)}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row" role="group" aria-label="Filter by state">
+        <span className="chip-label">State</span>
+        {(["running", "background", "stuck", "cancelPending", "deadline+"] as DerivedState[]).map((s) => (
+          <button
+            key={s}
+            type="button"
+            className={`chip ${stateFilters.has(s) ? "is-active" : ""}`}
+            aria-pressed={stateFilters.has(s)}
+            onClick={() => toggleStateFilter(s)}
+          >
+            {s === "deadline+" ? "Past deadline" : s.charAt(0).toUpperCase() + s.slice(1)}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row" role="group" aria-label="Filter by await mode">
+        <span className="chip-label">Await</span>
+        {["background", "bridge", "detach"].map((a) => (
+          <button
+            key={a}
+            type="button"
+            className={`chip ${awaitFilters.has(a) ? "is-active" : ""}`}
+            aria-pressed={awaitFilters.has(a)}
+            onClick={() => toggleAwaitFilter(a)}
+          >
+            {a}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row">
+        <span className="chip-label">Threshold</span>
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={hideHealthy}
+            onChange={(e) => setHideHealthy(e.target.checked)}
+          />
+          Show only stuck / cancel-pending / past deadline
+        </label>
+      </div>
+
+      <div className="panel-summary">
+        <div className="live-count">
+          <em>{filtered.length}</em> live <span className="root">/ 8 max</span>
+        </div>
+      </div>
+
+      <div className="tools-table-wrap">
+        <table className="tools" role="grid">
+          <thead>
+            <tr>
+              {(["toolName", "ageMs", "requestId", "awaitMode", "derivedState", "processLabel"] as SortKey[]).map((key) => (
+                <th
+                  key={key}
+                  scope="col"
+                  tabIndex={0}
+                  aria-sort={sortKey === key ? sortDir : "none"}
+                  onClick={() => onSort(key)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onSort(key);
+                    }
+                  }}
+                >
+                  {key === "toolName" ? "Tool" :
+                   key === "ageMs" ? "Age" :
+                   key === "requestId" ? "Parent" :
+                   key === "awaitMode" ? "Await" :
+                   key === "derivedState" ? "Status" : "Process"}
+                </th>
+              ))}
+              <th scope="col" aria-label="Row actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && !isLoading && (
+              <tr>
+                <td colSpan={7}>
+                  <div className="empty-state">
+                    <span className="glyph" aria-hidden="true">○</span>
+                    No backgrounded tools.
+                  </div>
+                </td>
+              </tr>
+            )}
+            {filtered.map((row) => {
+              const isWarn = row.derivedState === "stuck" || row.derivedState === "cancelPending";
+              return (
+                <tr
+                  key={row.toolCallId}
+                  tabIndex={0}
+                  className={isWarn ? "row-stuck" : ""}
+                >
+                  <td className="cell-tool">{row.toolName}</td>
+                  <td className="cell-age">{formatAge(row.ageMs ?? 0)}</td>
+                  <td className="cell-parent">{row.requestId}</td>
+                  <td>
+                    <span className="pill pill-await" data-mode={row.awaitMode ?? ""}>
+                      {row.awaitMode ?? "—"}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="pill pill-status" data-state={row.derivedState}>
+                      {row.derivedState === "stuck" || row.derivedState === "cancelPending" ? "⚠ " : ""}
+                      {row.derivedState}
+                    </span>
+                  </td>
+                  <td
+                    className={`cell-process ${row.processLabel === "—" ? "is-empty" : ""}`}
+                    title={row.processTooltip}
+                  >
+                    {row.processLabel}
+                  </td>
+                  <td>
+                    <div className="row-actions">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          console.log("[backgroundedTools] open-lineage", row.toolCallId, row.requestId);
+                        }}
+                      >
+                        Lineage
+                      </button>
+                      <button
+                        type="button"
+                        className="danger"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          console.log("[backgroundedTools] interrupt-parent", row.requestId);
+                        }}
+                      >
+                        Interrupt
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
+++ b/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
@@ -14,6 +14,10 @@ import { useOperationsSnapshot } from "./useOperationsSnapshot";
 type SortKey = "toolName" | "ageMs" | "requestId" | "awaitMode" | "derivedState" | "processLabel";
 type SortDir = "ascending" | "descending";
 
+// 8-slot ceiling per the operator-surfaces spec §"Panel 1". Hardcoded
+// until the bridge exposes a per-agent backgrounded-tool capacity.
+const MAX_BACKGROUND_SLOTS = 8;
+
 export type BackgroundedToolsPanelProps = {
   rootRequestId?: string | null;
 };
@@ -177,7 +181,7 @@ export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanel
 
       <div className="panel-summary">
         <div className="live-count">
-          <em>{filtered.length}</em> live <span className="root">/ 8 max</span>
+          <em>{filtered.length}</em> live <span className="root">/ {MAX_BACKGROUND_SLOTS} max</span>
         </div>
       </div>
 
@@ -221,7 +225,7 @@ export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanel
               </tr>
             )}
             {filtered.map((row) => {
-              const isWarn = row.derivedState === "stuck" || row.derivedState === "cancelPending";
+              const isWarn = ["stuck", "cancelPending", "deadline+"].includes(row.derivedState);
               return (
                 <tr
                   key={row.toolCallId}
@@ -252,8 +256,11 @@ export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanel
                     <div className="row-actions">
                       <button
                         type="button"
+                        aria-label={`Open lineage for ${row.toolName} on ${row.requestId}`}
                         onClick={(e) => {
                           e.stopPropagation();
+                          // TODO: bridge wiring lands in #285 (lineage) and #283 (interrupt-parent).
+                          // Until then, log to console so the developer can verify the action surface.
                           console.log("[backgroundedTools] open-lineage", row.toolCallId, row.requestId);
                         }}
                       >
@@ -262,8 +269,11 @@ export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanel
                       <button
                         type="button"
                         className="danger"
+                        aria-label={`Interrupt parent request ${row.requestId}`}
                         onClick={(e) => {
                           e.stopPropagation();
+                          // TODO: bridge wiring lands in #285 (lineage) and #283 (interrupt-parent).
+                          // Until then, log to console so the developer can verify the action surface.
                           console.log("[backgroundedTools] interrupt-parent", row.requestId);
                         }}
                       >

--- a/apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts
+++ b/apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts
@@ -1,0 +1,74 @@
+import type {
+  BackgroundedToolView,
+  NativeExecutorStatusView,
+} from "../../lib/types/operations";
+
+export const STUCK_DWELL_MS = 5_000;
+const CORRELATION_WINDOW_MS = 1_000;
+
+export type DerivedState =
+  | "running"
+  | "background"
+  | "stuck"
+  | "cancelPending"
+  | "deadline+";
+
+export function derivedState(
+  row: BackgroundedToolView,
+  nowMs: number,
+): DerivedState {
+  const stuckDwellMs = row.stuckSince
+    ? nowMs - new Date(row.stuckSince).getTime()
+    : null;
+  if (stuckDwellMs != null && stuckDwellMs >= STUCK_DWELL_MS) return "stuck";
+  if (row.cancelPendingRemoteAck) return "cancelPending";
+  if (row.deadlineExpired) return "deadline+";
+  if (row.awaitMode === "background") return "background";
+  return (row.lifecycleState as DerivedState | null) ?? "running";
+}
+
+export type ProcessLabel = {
+  label: string;
+  tooltip: string;
+};
+
+export function correlateProcess(
+  row: BackgroundedToolView,
+  executors: NativeExecutorStatusView[],
+): ProcessLabel {
+  const startedAtIso = row.startedAt;
+  if (startedAtIso) {
+    const start = new Date(startedAtIso).getTime();
+    const candidates = executors.filter(
+      (ne) =>
+        ne.toolName === row.toolName &&
+        Math.abs(new Date(ne.startedAt).getTime() - start) <= CORRELATION_WINDOW_MS,
+    );
+    if (candidates.length === 1) {
+      const ne = candidates[0];
+      return { label: `pid ${ne.pid}`, tooltip: `native ${ne.id} · ${ne.argv0}` };
+    }
+    if (candidates.length > 1) {
+      const c0 = candidates[0];
+      return {
+        label: `native ${c0.id}`,
+        tooltip: `ambiguous: ${candidates.length} candidates — ${candidates
+          .map((c) => `native ${c.id}/pid ${c.pid}`)
+          .join(", ")}`,
+      };
+    }
+  }
+  if (row.childRequestId) {
+    return { label: `child ${row.childRequestId}`, tooltip: "subagent dispatch" };
+  }
+  return { label: "—", tooltip: "no native executor; in-process tool" };
+}
+
+export function formatAge(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}

--- a/apps/desktop-tauri/src/components/backgroundedTools/index.ts
+++ b/apps/desktop-tauri/src/components/backgroundedTools/index.ts
@@ -1,0 +1,2 @@
+export { BackgroundedToolsPanel } from "./BackgroundedToolsPanel";
+export type { BackgroundedToolsPanelProps } from "./BackgroundedToolsPanel";

--- a/apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts
+++ b/apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { fetchOperationsSnapshot } from "../../lib/desktop-api";
 import type {
@@ -21,12 +21,10 @@ export function useOperationsSnapshot(
   const [snapshot, setSnapshot] = useState<DesktopOperationsSnapshot | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const reqRef = useRef(request);
-  reqRef.current = request;
 
   const refresh = useCallback(async () => {
     try {
-      const next = await fetchOperationsSnapshot(reqRef.current);
+      const next = await fetchOperationsSnapshot(request);
       setSnapshot(next);
       setError(null);
     } catch (e) {
@@ -34,7 +32,7 @@ export function useOperationsSnapshot(
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [request]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts
+++ b/apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { fetchOperationsSnapshot } from "../../lib/desktop-api";
+import type {
+  DesktopOperationsSnapshot,
+  DesktopOperationsSnapshotRequest,
+} from "../../lib/types/operations";
+
+export type OperationsSnapshotState = {
+  snapshot: DesktopOperationsSnapshot | null;
+  error: string | null;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+};
+
+const REFRESH_INTERVAL_MS = 2_000;
+
+export function useOperationsSnapshot(
+  request: DesktopOperationsSnapshotRequest,
+): OperationsSnapshotState {
+  const [snapshot, setSnapshot] = useState<DesktopOperationsSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const reqRef = useRef(request);
+  reqRef.current = request;
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await fetchOperationsSnapshot(reqRef.current);
+      setSnapshot(next);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await refresh();
+    };
+    void tick();
+    const id = setInterval(tick, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  return { snapshot, error, isLoading, refresh };
+}

--- a/apps/desktop-tauri/src/lib/desktop-api.ts
+++ b/apps/desktop-tauri/src/lib/desktop-api.ts
@@ -26,6 +26,10 @@ import type {
   ToolServiceTestRequest,
   ToolServiceTestResult,
 } from "./types";
+import type {
+  DesktopOperationsSnapshot,
+  DesktopOperationsSnapshotRequest,
+} from "./types/operations";
 
 type TauriInternalsWindow = Window & {
   __TAURI_INTERNALS__?: {
@@ -120,6 +124,9 @@ export type DesktopApiAdapter = {
   listBackendsWithHealth: () => Promise<BackendHealth[]>;
   listMcpServicesWithHealth: () => Promise<MCPServiceHealthView[]>;
   probeMcpService: (serviceId: string) => Promise<McpServiceProbeResult>;
+  fetchOperationsSnapshot: (
+    request: DesktopOperationsSnapshotRequest,
+  ) => Promise<DesktopOperationsSnapshot>;
 };
 
 const defaultDesktopApiAdapter: DesktopApiAdapter = {
@@ -229,6 +236,12 @@ const defaultDesktopApiAdapter: DesktopApiAdapter = {
     return invokeDesktop<McpServiceProbeResult>("desktop_probe_mcp_service", {
       request: { serviceId },
     });
+  },
+  fetchOperationsSnapshot(request) {
+    return invokeDesktop<DesktopOperationsSnapshot>(
+      "desktop_operations_snapshot",
+      { request },
+    );
   },
 };
 
@@ -370,4 +383,10 @@ export async function listMcpServicesWithHealth() {
 
 export async function probeMcpService(serviceId: string) {
   return desktopApiAdapter().probeMcpService(serviceId);
+}
+
+export async function fetchOperationsSnapshot(
+  request: DesktopOperationsSnapshotRequest,
+) {
+  return desktopApiAdapter().fetchOperationsSnapshot(request);
 }

--- a/apps/desktop-tauri/src/lib/types/operations.ts
+++ b/apps/desktop-tauri/src/lib/types/operations.ts
@@ -64,6 +64,8 @@ export type BackgroundedToolView = {
   awaitMode?: string | null;
   cancelPolicy?: string | null;
   childRequestId?: string | null;
+  stuckSince?: string | null;
+  cancelPendingRemoteAck: boolean;
   nativeExecutor?: NativeExecutorStatusView | null;
 };
 

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -1,0 +1,358 @@
+/*
+ * Scoped styles for BackgroundedToolsPanel.
+ * All rules are wrapped under .background-tools-panel to avoid bleeding
+ * into other parts of the app shell.
+ *
+ * CSS custom properties are declared at :root so they fall back gracefully
+ * when the app shell already defines them. If the app tokens.css already
+ * declares these variables the values here serve as fallback-only defaults;
+ * the panel does not override app-level theming.
+ */
+
+:root {
+  --color-bg: #000000;
+  --color-surface: rgb(28 39 36 / 0.86);
+  --color-surface-strong: #07110e;
+  --color-surface-deep: #020504;
+  --color-surface-muted: rgb(28 39 36 / 0.58);
+  --color-surface-row: rgb(9 17 14 / 0.86);
+  --color-text: #ffffff;
+  --color-text-muted: #95a49d;
+  --color-text-soft: #d6ddda;
+  --color-text-warm: #dff8e8;
+  --color-accent: #06b250;
+  --color-accent-strong: #39e27a;
+  --color-success: #8df2b4;
+  --color-warning: #ffa011;
+  --color-info: #10cbff;
+  --color-error: #ff6f5f;
+
+  --border-subtle: rgb(6 178 80 / 0.12);
+  --border-default: rgb(6 178 80 / 0.18);
+  --border-strong: rgb(6 178 80 / 0.28);
+  --border-selected: rgb(6 178 80 / 0.48);
+  --border-warning: rgb(255 160 17 / 0.55);
+
+  --radius-sm: 8px;
+  --radius-pill: 999px;
+
+  --font-body: "Inter", "SF Pro Text", system-ui, sans-serif;
+  --font-mono: ui-monospace, "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+}
+
+/* ── Chip row / filter row ─────────────────────────────────────────────── */
+
+.background-tools-panel .chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.background-tools-panel .chip-row + .chip-row {
+  margin-top: 8px;
+}
+
+.background-tools-panel .chip-label {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  margin-right: 4px;
+  min-width: 64px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.background-tools-panel .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-default);
+  background: var(--color-surface-muted);
+  color: var(--color-text-soft);
+  font-family: var(--font-body);
+  font-size: 12px;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+
+.background-tools-panel .chip:hover {
+  border-color: var(--border-strong);
+  color: var(--color-text);
+}
+
+.background-tools-panel .chip:focus-visible {
+  outline: 2px solid var(--color-accent-strong);
+  outline-offset: 2px;
+}
+
+.background-tools-panel .chip[aria-pressed="true"],
+.background-tools-panel .chip.is-active {
+  background: rgb(6 178 80 / 0.22);
+  border-color: var(--border-selected);
+  color: var(--color-text-warm);
+}
+
+.background-tools-panel .chip .count {
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.background-tools-panel .chip[aria-pressed="true"] .count,
+.background-tools-panel .chip.is-active .count {
+  color: var(--color-accent-strong);
+}
+
+/* ── Toggle ─────────────────────────────────────────────────────────────── */
+
+.background-tools-panel .toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--color-text-soft);
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.background-tools-panel .toggle input {
+  accent-color: var(--color-accent-strong);
+}
+
+/* ── Panel summary ───────────────────────────────────────────────────────── */
+
+.background-tools-panel .panel-summary {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+  margin-bottom: 8px;
+}
+
+.background-tools-panel .panel-summary .live-count {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--color-text-warm);
+}
+
+.background-tools-panel .panel-summary .live-count em {
+  color: var(--color-accent-strong);
+  font-style: normal;
+  font-weight: 600;
+}
+
+.background-tools-panel .panel-summary .root {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+/* ── Table wrapper ───────────────────────────────────────────────────────── */
+
+.background-tools-panel .tools-table-wrap {
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+  background: var(--color-surface-strong);
+}
+
+.background-tools-panel table.tools {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.background-tools-panel table.tools thead th {
+  text-align: left;
+  padding: 10px 12px;
+  background: var(--color-surface-deep);
+  color: var(--color-text-muted);
+  font-weight: 500;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border-default);
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.background-tools-panel table.tools thead th[aria-sort="ascending"]::after {
+  content: " ▲";
+  color: var(--color-accent);
+}
+
+.background-tools-panel table.tools thead th[aria-sort="descending"]::after {
+  content: " ▼";
+  color: var(--color-accent);
+}
+
+.background-tools-panel table.tools tbody tr {
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 120ms ease;
+}
+
+.background-tools-panel table.tools tbody tr:last-child {
+  border-bottom: 0;
+}
+
+.background-tools-panel table.tools tbody tr:hover {
+  background: rgb(6 178 80 / 0.06);
+}
+
+.background-tools-panel table.tools tbody tr:focus-within,
+.background-tools-panel table.tools tbody tr.is-selected {
+  background: rgb(6 178 80 / 0.10);
+  box-shadow: inset 3px 0 0 0 var(--color-accent-strong);
+}
+
+.background-tools-panel table.tools tbody tr.row-stuck,
+.background-tools-panel table.tools tbody tr.row-warn {
+  box-shadow: inset 3px 0 0 0 var(--color-warning);
+  background: rgb(255 160 17 / 0.06);
+}
+
+.background-tools-panel table.tools tbody tr.row-stuck:focus-within {
+  background: rgb(255 160 17 / 0.10);
+}
+
+.background-tools-panel table.tools td {
+  padding: 10px 12px;
+  vertical-align: top;
+  color: var(--color-text-soft);
+}
+
+/* ── Cell variants ───────────────────────────────────────────────────────── */
+
+.background-tools-panel .cell-tool {
+  font-family: var(--font-mono);
+  color: var(--color-text);
+  font-weight: 500;
+}
+
+.background-tools-panel .cell-age {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  color: var(--color-text);
+}
+
+.background-tools-panel .cell-parent,
+.background-tools-panel .cell-process {
+  font-family: var(--font-mono);
+  color: var(--color-text-soft);
+  font-size: 12px;
+}
+
+.background-tools-panel .cell-process.is-empty {
+  color: var(--color-text-muted);
+}
+
+/* ── Pills ───────────────────────────────────────────────────────────────── */
+
+.background-tools-panel .pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-family: var(--font-body);
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border: 1px solid currentColor;
+  background: transparent;
+  white-space: nowrap;
+}
+
+.background-tools-panel .pill.pill-await {
+  color: var(--color-info);
+  border-color: rgb(16 203 255 / 0.45);
+}
+
+.background-tools-panel .pill.pill-await[data-mode="bridge"] {
+  color: var(--color-accent-strong);
+  border-color: rgb(57 226 122 / 0.45);
+}
+
+.background-tools-panel .pill.pill-await[data-mode="detach"] {
+  color: var(--color-text-muted);
+  border-color: rgb(149 164 157 / 0.45);
+}
+
+.background-tools-panel .pill.pill-status {
+  gap: 4px;
+}
+
+.background-tools-panel .pill.pill-status[data-state="running"] {
+  color: var(--color-success);
+  border-color: rgb(141 242 180 / 0.45);
+}
+
+.background-tools-panel .pill.pill-status[data-state="background"] {
+  color: var(--color-info);
+  border-color: rgb(16 203 255 / 0.45);
+}
+
+.background-tools-panel .pill.pill-status[data-state="stuck"],
+.background-tools-panel .pill.pill-status[data-state="cancelPending"] {
+  color: var(--color-warning);
+  border-color: var(--border-warning);
+  background: rgb(255 160 17 / 0.08);
+}
+
+.background-tools-panel .pill.pill-status[data-state="deadline+"] {
+  color: var(--color-error);
+  border-color: rgb(255 111 95 / 0.50);
+  background: rgb(255 111 95 / 0.08);
+}
+
+/* ── Row actions ─────────────────────────────────────────────────────────── */
+
+.background-tools-panel .row-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+}
+
+.background-tools-panel .row-actions button {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--color-text-soft);
+  padding: 3px 9px;
+  font-size: 11px;
+  font-family: var(--font-body);
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+}
+
+.background-tools-panel .row-actions button:hover {
+  border-color: var(--border-selected);
+  color: var(--color-text-warm);
+}
+
+.background-tools-panel .row-actions button:focus-visible {
+  outline: 2px solid var(--color-accent-strong);
+  outline-offset: 2px;
+}
+
+.background-tools-panel .row-actions button.danger:hover {
+  border-color: var(--border-warning);
+  color: var(--color-warning);
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+
+.background-tools-panel .empty-state {
+  padding: 28px 12px;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 13px;
+}
+
+.background-tools-panel .empty-state .glyph {
+  font-size: 22px;
+  color: var(--color-accent);
+  opacity: 0.6;
+  display: block;
+  margin-bottom: 6px;
+}

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -3,41 +3,14 @@
  * All rules are wrapped under .background-tools-panel to avoid bleeding
  * into other parts of the app shell.
  *
- * CSS custom properties are declared at :root so they fall back gracefully
- * when the app shell already defines them. If the app tokens.css already
- * declares these variables the values here serve as fallback-only defaults;
- * the panel does not override app-level theming.
+ * All standard tokens (colors, borders, radii, fonts) come from the app
+ * shell's tokens.css (@layer tokens). Only panel-specific variables that
+ * are not defined there are declared here, scoped to .background-tools-panel.
  */
 
-:root {
-  --color-bg: #000000;
-  --color-surface: rgb(28 39 36 / 0.86);
-  --color-surface-strong: #07110e;
-  --color-surface-deep: #020504;
-  --color-surface-muted: rgb(28 39 36 / 0.58);
-  --color-surface-row: rgb(9 17 14 / 0.86);
-  --color-text: #ffffff;
-  --color-text-muted: #95a49d;
-  --color-text-soft: #d6ddda;
-  --color-text-warm: #dff8e8;
-  --color-accent: #06b250;
-  --color-accent-strong: #39e27a;
-  --color-success: #8df2b4;
-  --color-warning: #ffa011;
-  --color-info: #10cbff;
-  --color-error: #ff6f5f;
-
-  --border-subtle: rgb(6 178 80 / 0.12);
-  --border-default: rgb(6 178 80 / 0.18);
-  --border-strong: rgb(6 178 80 / 0.28);
-  --border-selected: rgb(6 178 80 / 0.48);
+.background-tools-panel {
+  /* --border-warning is not present in tokens.css; declare it here only. */
   --border-warning: rgb(255 160 17 / 0.55);
-
-  --radius-sm: 8px;
-  --radius-pill: 999px;
-
-  --font-body: "Inter", "SF Pro Text", system-ui, sans-serif;
-  --font-mono: ui-monospace, "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
 }
 
 /* ── Chip row / filter row ─────────────────────────────────────────────── */

--- a/apps/desktop-tauri/tests/backgrounded-tools-panel.test.tsx
+++ b/apps/desktop-tauri/tests/backgrounded-tools-panel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
 
 import { BackgroundedToolsPanel } from "../src/components/backgroundedTools";
@@ -167,5 +167,21 @@ describe("BackgroundedToolsPanel", () => {
     fireEvent.click(screen.getByRole("columnheader", { name: /age/i }));
     const rowsAsc = screen.getAllByRole("row").slice(1);
     expect(rowsAsc[0].textContent).toContain("grep_young");
+  });
+
+  it("marks a deadline-expired row with the row-stuck class", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({
+          toolCallId: "tc_deadline",
+          toolName: "fetch_remote",
+          deadlineExpired: true,
+        }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("fetch_remote")).toBeInTheDocument());
+    const tr = screen.getByText("fetch_remote").closest("tr");
+    expect(tr?.className).toContain("row-stuck");
   });
 });

--- a/apps/desktop-tauri/tests/backgrounded-tools-panel.test.tsx
+++ b/apps/desktop-tauri/tests/backgrounded-tools-panel.test.tsx
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent, waitFor, cleanup } from "@testing-library/react";
+
+import { BackgroundedToolsPanel } from "../src/components/backgroundedTools";
+import {
+  setDesktopApiAdapterForTests,
+  type DesktopApiAdapter,
+} from "../src/lib/desktop-api";
+import type {
+  BackgroundedToolView,
+  DesktopOperationsSnapshot,
+} from "../src/lib/types/operations";
+
+function row(overrides: Partial<BackgroundedToolView> = {}): BackgroundedToolView {
+  return {
+    requestId: "req_a17",
+    toolCallId: `tc_${Math.random().toString(36).slice(2, 8)}`,
+    toolName: "grep",
+    lifecycleState: "running",
+    status: null,
+    startedAt: new Date(Date.now() - 4_000).toISOString(),
+    ageMs: 4_000,
+    deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+    deadlineExpired: false,
+    awaitMode: "background",
+    cancelPolicy: "cascade",
+    childRequestId: null,
+    stuckSince: null,
+    cancelPendingRemoteAck: false,
+    nativeExecutor: null,
+    ...overrides,
+  };
+}
+
+function snapshot(toolCalls: BackgroundedToolView[]): DesktopOperationsSnapshot {
+  return {
+    fetchedAt: new Date().toISOString(),
+    agentDid: null,
+    liveness: {
+      expiredProcessingCount: 0,
+      requests: [],
+      activeToolCalls: [],
+      activeNativeExecutorsAvailable: true,
+      activeNativeExecutors: [],
+    },
+    livenessUnavailableReason: null,
+    backgroundedTools: toolCalls,
+    stuckDiagnostics: [],
+    lineage: null,
+  };
+}
+
+function makeAdapter(
+  fetchImpl: () => Promise<DesktopOperationsSnapshot>,
+): DesktopApiAdapter {
+  // Stub only the method this panel needs; other methods throw so they
+  // fail loudly if accidentally called.
+  return new Proxy({}, {
+    get(_target, prop) {
+      if (prop === "fetchOperationsSnapshot") {
+        return (_request: unknown) => fetchImpl();
+      }
+      return () => {
+        throw new Error(`DesktopApiAdapter.${String(prop)} not stubbed in this test`);
+      };
+    },
+  }) as DesktopApiAdapter;
+}
+
+describe("BackgroundedToolsPanel", () => {
+  afterEach(() => {
+    setDesktopApiAdapterForTests(null);
+    cleanup();
+  });
+
+  it("renders the empty state when the snapshot returns zero tools", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () => snapshot([])));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => {
+      expect(screen.getByText(/no backgrounded tools/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders the error state when the snapshot command rejects", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () => {
+      throw new Error("desktop_operations_snapshot not implemented yet");
+    }));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => {
+      expect(screen.getByText(/snapshot bridge/i)).toBeInTheDocument();
+    });
+  });
+
+  it("renders one row per backgrounded tool with derived status badges", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({ toolCallId: "tc_running", toolName: "grep" }),
+        row({ toolCallId: "tc_deadline", toolName: "fetch_remote", deadlineExpired: true }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    expect(screen.getByText("fetch_remote")).toBeInTheDocument();
+    expect(screen.getByText(/deadline\+/i)).toBeInTheDocument();
+  });
+
+  it("marks a stuck row with the row-stuck class", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({
+          toolCallId: "tc_stuck",
+          toolName: "index_repo",
+          stuckSince: new Date(Date.now() - 12_000).toISOString(),
+          cancelPendingRemoteAck: true,
+        }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("index_repo")).toBeInTheDocument());
+    const tr = screen.getByText("index_repo").closest("tr");
+    expect(tr?.className).toContain("row-stuck");
+  });
+
+  it("hides healthy rows when 'show only stuck' toggle is on", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({ toolCallId: "tc_healthy", toolName: "grep" }),
+        row({
+          toolCallId: "tc_stuck",
+          toolName: "index_repo",
+          stuckSince: new Date(Date.now() - 12_000).toISOString(),
+        }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(/show only stuck/i));
+    expect(screen.queryByText("grep")).not.toBeInTheDocument();
+    expect(screen.getByText("index_repo")).toBeInTheDocument();
+  });
+
+  it("filters by state chip (past deadline)", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({ toolCallId: "tc_a", toolName: "grep" }),
+        row({ toolCallId: "tc_b", toolName: "fetch_remote", deadlineExpired: true }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /past deadline/i }));
+    expect(screen.queryByText("grep")).not.toBeInTheDocument();
+    expect(screen.getByText("fetch_remote")).toBeInTheDocument();
+  });
+
+  it("sorts by age descending by default and toggles to ascending on header click", async () => {
+    setDesktopApiAdapterForTests(makeAdapter(async () =>
+      snapshot([
+        row({ toolCallId: "tc_young", toolName: "grep_young", startedAt: new Date(Date.now() - 2_000).toISOString(), ageMs: 2_000 }),
+        row({ toolCallId: "tc_old", toolName: "grep_old", startedAt: new Date(Date.now() - 200_000).toISOString(), ageMs: 200_000 }),
+      ]),
+    ));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep_young")).toBeInTheDocument());
+    const rows = screen.getAllByRole("row").slice(1); // skip header
+    expect(rows[0].textContent).toContain("grep_old");
+    fireEvent.click(screen.getByRole("columnheader", { name: /age/i }));
+    const rowsAsc = screen.getAllByRole("row").slice(1);
+    expect(rowsAsc[0].textContent).toContain("grep_young");
+  });
+});

--- a/apps/desktop-tauri/tests/derivedState.test.ts
+++ b/apps/desktop-tauri/tests/derivedState.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { BackgroundedToolView, NativeExecutorStatusView } from "../src/lib/types/operations";
+
+import {
+  STUCK_DWELL_MS,
+  correlateProcess,
+  derivedState,
+  formatAge,
+} from "../src/components/backgroundedTools/derivedState";
+
+const baseRow: BackgroundedToolView = {
+  requestId: "req_a17",
+  toolCallId: "tc_001",
+  toolName: "grep",
+  lifecycleState: "running",
+  status: null,
+  startedAt: new Date(Date.now() - 5_000).toISOString(),
+  ageMs: 5_000,
+  deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+  deadlineExpired: false,
+  awaitMode: "background",
+  cancelPolicy: "cascade",
+  childRequestId: null,
+  stuckSince: null,
+  cancelPendingRemoteAck: false,
+  nativeExecutor: null,
+};
+
+describe("derivedState", () => {
+  it("returns 'background' for a healthy bg row with lifecycle_state=running", () => {
+    expect(derivedState(baseRow, Date.now())).toBe("background");
+  });
+
+  it("returns 'background' when await_mode=background and lifecycle_state is unset", () => {
+    expect(derivedState({ ...baseRow, lifecycleState: null }, Date.now())).toBe("background");
+  });
+
+  it("returns 'deadline+' when deadline_expired flag is set", () => {
+    expect(derivedState({ ...baseRow, deadlineExpired: true }, Date.now())).toBe("deadline+");
+  });
+
+  it("returns 'cancelPending' when cancel_pending_remote_ack is true", () => {
+    expect(derivedState({ ...baseRow, cancelPendingRemoteAck: true }, Date.now())).toBe("cancelPending");
+  });
+
+  it("returns 'stuck' once dwell >= STUCK_DWELL_MS", () => {
+    const stuckSince = new Date(Date.now() - STUCK_DWELL_MS - 100).toISOString();
+    expect(derivedState({ ...baseRow, stuckSince }, Date.now())).toBe("stuck");
+  });
+
+  it("does not return 'stuck' for stuck_since within the dwell window", () => {
+    const stuckSince = new Date(Date.now() - 1_000).toISOString();
+    expect(derivedState({ ...baseRow, stuckSince }, Date.now())).toBe("background");
+  });
+
+  it("prefers 'stuck' over 'cancelPending' when both apply", () => {
+    const stuckSince = new Date(Date.now() - STUCK_DWELL_MS - 100).toISOString();
+    expect(
+      derivedState({ ...baseRow, stuckSince, cancelPendingRemoteAck: true }, Date.now()),
+    ).toBe("stuck");
+  });
+});
+
+describe("correlateProcess", () => {
+  const ne = (overrides: Partial<NativeExecutorStatusView>): NativeExecutorStatusView => ({
+    id: 901,
+    pid: 41812,
+    argv0: "/usr/bin/grep",
+    toolName: "grep",
+    startedAt: new Date().toISOString(),
+    ageMs: 5_000,
+    ...overrides,
+  });
+
+  it("returns pid label when a single native executor matches (tool_name, started_at ±1s)", () => {
+    const row = { ...baseRow, startedAt: new Date(1_000_000).toISOString() };
+    const exec = ne({ startedAt: new Date(1_000_500).toISOString() });
+    expect(correlateProcess(row, [exec]).label).toBe("pid 41812");
+  });
+
+  it("returns 'native <id>' when multiple executors match within the window", () => {
+    const row = { ...baseRow, startedAt: new Date(1_000_000).toISOString() };
+    const e1 = ne({ id: 901, startedAt: new Date(999_900).toISOString() });
+    const e2 = ne({ id: 902, startedAt: new Date(1_000_500).toISOString() });
+    const result = correlateProcess(row, [e1, e2]);
+    expect(result.label).toMatch(/^native /);
+    expect(result.tooltip).toContain("ambiguous");
+  });
+
+  it("falls back to 'child req_<id>' when child_request_id is set and no native executor", () => {
+    expect(
+      correlateProcess({ ...baseRow, childRequestId: "req_b91" }, []).label,
+    ).toBe("child req_b91");
+  });
+
+  it("falls back to '—' when no executor and no child request", () => {
+    expect(correlateProcess(baseRow, []).label).toBe("—");
+  });
+});
+
+describe("formatAge", () => {
+  it("renders MM:SS for under one hour", () => {
+    expect(formatAge(48_000)).toBe("00:48");
+    expect(formatAge(125_000)).toBe("02:05");
+  });
+  it("renders HH:MM:SS for one hour or more", () => {
+    expect(formatAge(3_600_000)).toBe("01:00:00");
+    expect(formatAge(3_725_000)).toBe("01:02:05");
+  });
+  it("clamps negatives to 00:00", () => {
+    expect(formatAge(-1_000)).toBe("00:00");
+  });
+});

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -147,10 +147,9 @@ def featureSurfaceRequirements : List FeatureSurfaceRequirement :=
     , deferred := []
     }
   , { feature := "background-tools"
-    , required := [Surface.agentFacing]
+    , required := [Surface.agentFacing, Surface.operatorUi]
     , deferred :=
         [ (Surface.operatorCli, "#268")
-        , (Surface.operatorUi, "#276")
         ]
     }
   , { feature := "subagents-cross-deployment"
@@ -591,6 +590,11 @@ def caseCoverage : List CoverageEntry :=
       "R4cBackgroundWorkCases"
       "state_machine_conformance::generated_r4c_background_work_cases_pin_observable_shapes")
       "background-tools" [Surface.agentFacing]
+  , tagged (consumerCoverage
+      "r4c_background_work_cases"
+      "R4cBackgroundWorkCases"
+      "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests::project_filters_to_background_await_mode_only")
+      "background-tools" [Surface.operatorUi]
   , tagged (consumerCoverage
       "transcript_cases"
       "TranscriptConformanceCases"

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -196,6 +196,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "mcp_health_view_preserves_every_generated_lean_mcp_health_case_transition",
         },
         ConformanceConsumer::RustTest {
+            id: "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests::project_filters_to_background_await_mode_only",
+            package: "defra-agent-desktop-tauri",
+            source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs",
+            module_path: "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests",
+            function: "project_filters_to_background_await_mode_only",
+        },
+        ConformanceConsumer::RustTest {
             id: "hook::tests::generated_persistence_failure_policy_cases_match_hook_decisions",
             package: "defra-agent",
             source_path: "crates/defra-agent/src/hook/tests.rs",

--- a/docs/superpowers/plans/2026-05-20-issue-276-backgrounded-tools-impl.md
+++ b/docs/superpowers/plans/2026-05-20-issue-276-backgrounded-tools-impl.md
@@ -1,0 +1,1818 @@
+# Backgrounded Tools Panel Implementation Plan (#276 Phase 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the real Tauri implementation of the backgrounded-tools panel — including the `desktop_operations_snapshot` command body — so the rail tab matches the approved prototype at `docs/ui-prototypes/panel-276-backgrounded-tools.html`.
+
+**Architecture:** The desktop bridge embeds `defra-agent-desktop-core` in-process (`Arc<ClientCore>` in `DesktopAppState`). The snapshot command pulls native-executor data from the in-process registry, GraphQL-queries `AgentToolCall` rows via `core.graphql_for_agent(...)`, and assembles a `DesktopOperationsSnapshot`. The React `BackgroundedToolsPanel` mounts in `OperationsRail`, fetches the snapshot through a new `fetchOperationsSnapshot` adapter, and renders the prototype's table with the same derived-state and filter logic.
+
+**Tech Stack:** Rust (Tauri 2.x + tokio + serde_json for GraphQL responses), TypeScript + React 18 + Vitest + Testing Library, Lean 4 (CoverageLedger), BLAKE3 (signature reused from #310 — populated but emit-floor stays unused at the command boundary).
+
+---
+
+## Resolved Phase 2 ambiguities
+
+These were decided in advance and apply to every task:
+
+1. **Command name.** PROMPT.md says `list_backgrounded_tools`; the real command (registered by #310) is `desktop_operations_snapshot`. Every step uses the real name.
+2. **Snapshot ownership.** Per the user's selection, this PR (#276) lands the full `desktop_operations_snapshot` body, even though the existing stub's error message names #277. The existing stub error message gets updated to remove the obsolete claim.
+3. **Stuck plumbing.** Per the user's "do both" choice: add `stuck_since` and `cancel_pending_remote_ack` to `BackgroundedToolView` for the flat row model, AND continue to populate `StuckWorkDiagnosticView` (per the spec) for the banner / Stuck Work tab.
+4. **Empty-state UX.** Snapshot Err is rendered as the panel's empty state with a small caption. Pseudo-bridge availability is honored.
+
+## Known limitation called out in the PR description
+
+The runtime does not yet *populate* `AgentToolCall.stuck_since` or `cancel_pending_remote_ack`. The schema fields exist, and this PR exposes them through the bridge, but they will be `null` for live data until upstream runtime work writes them. The component renders correctly either way — `derivedState` falls through to `running` / `background` / `deadline+` when stuck fields are null, matching the prototype's behavior for those datasets.
+
+---
+
+## File Structure
+
+### Created
+
+```
+apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs        (~300 LOC, Rust impl of the snapshot builder)
+apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs  (~250 LOC, unit tests for the builder)
+apps/desktop-tauri/src/components/backgroundedTools/index.ts
+apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx (~250 LOC, the panel component)
+apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts            (~80 LOC, pure functions ported from prototype JS)
+apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts   (~60 LOC, fetch hook)
+apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx (~250 LOC)
+apps/desktop-tauri/src/components/backgroundedTools/derivedState.test.ts       (~120 LOC, port the prototype's derivation tests)
+apps/desktop-tauri/src/styles/backgrounded-tools.css                           (port subset of prototype CSS)
+```
+
+### Modified
+
+```
+apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs              (add 2 fields to BackgroundedToolView)
+apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs           (replace desktop_operations_snapshot body)
+apps/desktop-tauri/src-tauri/src/bridge/snapshot/mod.rs                        (register new operations_snapshot module)
+apps/desktop-tauri/src/lib/types/operations.ts                                 (mirror 2 new fields)
+apps/desktop-tauri/src/lib/desktop-api.ts                                      (add fetchOperationsSnapshot adapter)
+apps/desktop-tauri/src/components/ChatWorkspace.tsx                            (populate OperationsRailProvider tabs)
+apps/desktop-tauri/src/App.css                                                 (one @import for backgrounded-tools.css)
+crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean                (deferred → consumerCoverage entry)
+crates/defra-agent/tests/support/conformance_consumers.rs                       (register the new TS test as a consumer)
+```
+
+### Untouched (intentional)
+
+- The prototype HTML — the user explicitly approved it as design source of truth; do not revise.
+- `bridge/snapshot/operations_signature.rs` — its emit-floor state machine drives a future watcher, not the synchronous command body. Adding signature plumbing here would be premature optimization.
+
+---
+
+## Task 1 — Add stuck fields to bridge types
+
+**Files:**
+- Modify: `apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs:71-85`
+- Modify: `apps/desktop-tauri/src/lib/types/operations.ts:54-68`
+
+- [ ] **Step 1: Add `stuck_since` and `cancel_pending_remote_ack` to Rust `BackgroundedToolView`**
+
+In `apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs`, modify `BackgroundedToolView` to add the two fields just before `native_executor`:
+
+```rust
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct BackgroundedToolView {
+    pub request_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub lifecycle_state: Option<String>,
+    pub status: Option<String>,
+    pub started_at: Option<String>,
+    pub age_ms: Option<i64>,
+    pub deadline_at: Option<String>,
+    pub deadline_expired: bool,
+    pub await_mode: Option<String>,
+    pub cancel_policy: Option<String>,
+    pub child_request_id: Option<String>,
+    pub stuck_since: Option<String>,
+    pub cancel_pending_remote_ack: bool,
+    pub native_executor: Option<NativeExecutorStatusView>,
+}
+```
+
+- [ ] **Step 2: Mirror in TypeScript `BackgroundedToolView`**
+
+In `apps/desktop-tauri/src/lib/types/operations.ts`, modify the `BackgroundedToolView` shape to mirror the new Rust fields:
+
+```typescript
+export type BackgroundedToolView = {
+  requestId: string;
+  toolCallId: string;
+  toolName: string;
+  lifecycleState?: string | null;
+  status?: string | null;
+  startedAt?: string | null;
+  ageMs?: number | null;
+  deadlineAt?: string | null;
+  deadlineExpired: boolean;
+  awaitMode?: string | null;
+  cancelPolicy?: string | null;
+  childRequestId?: string | null;
+  stuckSince?: string | null;
+  cancelPendingRemoteAck: boolean;
+  nativeExecutor?: NativeExecutorStatusView | null;
+};
+```
+
+- [ ] **Step 3: Confirm types still compile**
+
+Run:
+```bash
+cargo check -p defra-agent-desktop-tauri 2>&1 | tail -20
+```
+Expected: no errors. Existing fields are unchanged; the additive fields don't break callers because the struct is `Serialize` only (not `Deserialize`).
+
+```bash
+cd apps/desktop-tauri && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs apps/desktop-tauri/src/lib/types/operations.ts
+git commit -m "types: add stuck_since + cancel_pending_remote_ack to BackgroundedToolView
+
+Additive fields exposing the AgentToolCall stuck-state schema fields
+through the desktop bridge. Required by the backgrounded-tools panel
+prototype's row-level stuck rendering. cancel_pending_remote_ack
+defaults to false rather than Option<bool> because the prototype's
+status derivation treats null and false identically and the runtime
+will write a concrete boolean.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 — Port the prototype's derivation logic to TypeScript
+
+**Files:**
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts`
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/derivedState.test.ts`
+
+- [ ] **Step 1: Write the failing derivation tests**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/derivedState.test.ts`:
+
+```typescript
+import { describe, expect, it } from "vitest";
+import type { BackgroundedToolView, NativeExecutorStatusView } from "../../lib/types/operations";
+
+import {
+  STUCK_DWELL_MS,
+  correlateProcess,
+  derivedState,
+  formatAge,
+} from "./derivedState";
+
+const baseRow: BackgroundedToolView = {
+  requestId: "req_a17",
+  toolCallId: "tc_001",
+  toolName: "grep",
+  lifecycleState: "running",
+  status: null,
+  startedAt: new Date(Date.now() - 5_000).toISOString(),
+  ageMs: 5_000,
+  deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+  deadlineExpired: false,
+  awaitMode: "background",
+  cancelPolicy: "cascade",
+  childRequestId: null,
+  stuckSince: null,
+  cancelPendingRemoteAck: false,
+  nativeExecutor: null,
+};
+
+describe("derivedState", () => {
+  it("returns 'running' for a healthy bg row with lifecycle_state=running", () => {
+    expect(derivedState(baseRow, Date.now())).toBe("background");
+  });
+
+  it("returns 'background' when await_mode=background and lifecycle_state is unset", () => {
+    expect(derivedState({ ...baseRow, lifecycleState: null }, Date.now())).toBe("background");
+  });
+
+  it("returns 'deadline+' when deadline_expired flag is set", () => {
+    expect(derivedState({ ...baseRow, deadlineExpired: true }, Date.now())).toBe("deadline+");
+  });
+
+  it("returns 'cancelPending' when cancel_pending_remote_ack is true", () => {
+    expect(derivedState({ ...baseRow, cancelPendingRemoteAck: true }, Date.now())).toBe("cancelPending");
+  });
+
+  it("returns 'stuck' once dwell >= STUCK_DWELL_MS", () => {
+    const stuckSince = new Date(Date.now() - STUCK_DWELL_MS - 100).toISOString();
+    expect(derivedState({ ...baseRow, stuckSince }, Date.now())).toBe("stuck");
+  });
+
+  it("does not return 'stuck' for stuck_since within the dwell window", () => {
+    const stuckSince = new Date(Date.now() - 1_000).toISOString();
+    expect(derivedState({ ...baseRow, stuckSince }, Date.now())).toBe("background");
+  });
+
+  it("prefers 'stuck' over 'cancelPending' when both apply", () => {
+    const stuckSince = new Date(Date.now() - STUCK_DWELL_MS - 100).toISOString();
+    expect(
+      derivedState({ ...baseRow, stuckSince, cancelPendingRemoteAck: true }, Date.now()),
+    ).toBe("stuck");
+  });
+});
+
+describe("correlateProcess", () => {
+  const ne = (overrides: Partial<NativeExecutorStatusView>): NativeExecutorStatusView => ({
+    id: 901,
+    pid: 41812,
+    argv0: "/usr/bin/grep",
+    toolName: "grep",
+    startedAt: new Date().toISOString(),
+    ageMs: 5_000,
+    ...overrides,
+  });
+
+  it("returns pid label when a single native executor matches (tool_name, started_at ±1s)", () => {
+    const row = { ...baseRow, startedAt: new Date(1_000_000).toISOString() };
+    const exec = ne({ startedAt: new Date(1_000_500).toISOString() });
+    expect(correlateProcess(row, [exec]).label).toBe("pid 41812");
+  });
+
+  it("returns 'native <id>' when multiple executors match within the window", () => {
+    const row = { ...baseRow, startedAt: new Date(1_000_000).toISOString() };
+    const e1 = ne({ id: 901, startedAt: new Date(999_900).toISOString() });
+    const e2 = ne({ id: 902, startedAt: new Date(1_000_500).toISOString() });
+    const result = correlateProcess(row, [e1, e2]);
+    expect(result.label).toMatch(/^native /);
+    expect(result.tooltip).toContain("ambiguous");
+  });
+
+  it("falls back to 'child req_<id>' when child_request_id is set and no native executor", () => {
+    expect(
+      correlateProcess({ ...baseRow, childRequestId: "req_b91" }, []).label,
+    ).toBe("child req_b91");
+  });
+
+  it("falls back to '—' when no executor and no child request", () => {
+    expect(correlateProcess(baseRow, []).label).toBe("—");
+  });
+});
+
+describe("formatAge", () => {
+  it("renders MM:SS for under one hour", () => {
+    expect(formatAge(48_000)).toBe("00:48");
+    expect(formatAge(125_000)).toBe("02:05");
+  });
+  it("renders HH:MM:SS for one hour or more", () => {
+    expect(formatAge(3_600_000)).toBe("01:00:00");
+    expect(formatAge(3_725_000)).toBe("01:02:05");
+  });
+  it("clamps negatives to 00:00", () => {
+    expect(formatAge(-1_000)).toBe("00:00");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; expect ALL to fail (module does not exist)**
+
+```bash
+cd apps/desktop-tauri && npx vitest run src/components/backgroundedTools/derivedState.test.ts
+```
+Expected: `Cannot find module './derivedState'`.
+
+- [ ] **Step 3: Implement `derivedState.ts`**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts`:
+
+```typescript
+import type {
+  BackgroundedToolView,
+  NativeExecutorStatusView,
+} from "../../lib/types/operations";
+
+export const STUCK_DWELL_MS = 5_000;
+const CORRELATION_WINDOW_MS = 1_000;
+
+export type DerivedState =
+  | "running"
+  | "background"
+  | "stuck"
+  | "cancelPending"
+  | "deadline+";
+
+export function derivedState(
+  row: BackgroundedToolView,
+  nowMs: number,
+): DerivedState {
+  const stuckDwellMs = row.stuckSince
+    ? nowMs - new Date(row.stuckSince).getTime()
+    : null;
+  if (stuckDwellMs != null && stuckDwellMs >= STUCK_DWELL_MS) return "stuck";
+  if (row.cancelPendingRemoteAck) return "cancelPending";
+  if (row.deadlineExpired) return "deadline+";
+  if (row.awaitMode === "background") return "background";
+  return (row.lifecycleState as DerivedState | null) ?? "running";
+}
+
+export type ProcessLabel = {
+  label: string;
+  tooltip: string;
+};
+
+export function correlateProcess(
+  row: BackgroundedToolView,
+  executors: NativeExecutorStatusView[],
+): ProcessLabel {
+  const startedAtIso = row.startedAt;
+  if (startedAtIso) {
+    const start = new Date(startedAtIso).getTime();
+    const candidates = executors.filter(
+      (ne) =>
+        ne.toolName === row.toolName &&
+        Math.abs(new Date(ne.startedAt).getTime() - start) <= CORRELATION_WINDOW_MS,
+    );
+    if (candidates.length === 1) {
+      const ne = candidates[0];
+      return { label: `pid ${ne.pid}`, tooltip: `native ${ne.id} · ${ne.argv0}` };
+    }
+    if (candidates.length > 1) {
+      const c0 = candidates[0];
+      return {
+        label: `native ${c0.id}`,
+        tooltip: `ambiguous: ${candidates.length} candidates — ${candidates
+          .map((c) => `native ${c.id}/pid ${c.pid}`)
+          .join(", ")}`,
+      };
+    }
+  }
+  if (row.childRequestId) {
+    return { label: `child ${row.childRequestId}`, tooltip: "subagent dispatch" };
+  }
+  return { label: "—", tooltip: "no native executor; in-process tool" };
+}
+
+export function formatAge(ms: number): string {
+  const totalSec = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+}
+```
+
+- [ ] **Step 4: Run tests; all should pass**
+
+```bash
+cd apps/desktop-tauri && npx vitest run src/components/backgroundedTools/derivedState.test.ts
+```
+Expected: 12+ passing tests, no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/desktop-tauri/src/components/backgroundedTools/derivedState.ts apps/desktop-tauri/src/components/backgroundedTools/derivedState.test.ts
+git commit -m "backgroundedTools: port derivedState/correlateProcess/formatAge from prototype
+
+Pure functions extracted from docs/ui-prototypes/panel-276-backgrounded-tools.html
+so they can be unit-tested in isolation. 5s STUCK_DWELL_MS and ±1s
+process-correlation window match the prototype constants.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 — Snapshot fetch hook + desktop-api adapter
+
+**Files:**
+- Modify: `apps/desktop-tauri/src/lib/desktop-api.ts`
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts`
+
+- [ ] **Step 1: Add `fetchOperationsSnapshot` to the adapter contract**
+
+In `apps/desktop-tauri/src/lib/desktop-api.ts`, locate the `DesktopApiAdapter` type and the `defaultDesktopApiAdapter` object. Add a new method (alphabetical placement is fine; put it near `fetchSessionSnapshot`):
+
+```typescript
+// In DesktopApiAdapter type:
+fetchOperationsSnapshot: (
+  request: DesktopOperationsSnapshotRequest,
+) => Promise<DesktopOperationsSnapshot>;
+
+// In defaultDesktopApiAdapter object:
+fetchOperationsSnapshot(request) {
+  return invokeDesktop<DesktopOperationsSnapshot>(
+    "desktop_operations_snapshot",
+    { request },
+  );
+},
+```
+
+At the top of the file, add the type imports:
+
+```typescript
+import type {
+  DesktopOperationsSnapshot,
+  DesktopOperationsSnapshotRequest,
+} from "./types/operations";
+```
+
+- [ ] **Step 2: Verify TS compile**
+
+```bash
+cd apps/desktop-tauri && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 3: Implement the React hook**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts`:
+
+```typescript
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { desktopApi } from "../../lib/desktop-api";
+import type {
+  DesktopOperationsSnapshot,
+  DesktopOperationsSnapshotRequest,
+} from "../../lib/types/operations";
+
+export type OperationsSnapshotState = {
+  snapshot: DesktopOperationsSnapshot | null;
+  error: string | null;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+};
+
+const REFRESH_INTERVAL_MS = 2_000;
+
+export function useOperationsSnapshot(
+  request: DesktopOperationsSnapshotRequest,
+): OperationsSnapshotState {
+  const [snapshot, setSnapshot] = useState<DesktopOperationsSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const reqRef = useRef(request);
+  reqRef.current = request;
+
+  const refresh = useCallback(async () => {
+    try {
+      const next = await desktopApi.fetchOperationsSnapshot(reqRef.current);
+      setSnapshot(next);
+      setError(null);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      await refresh();
+    };
+    tick();
+    const id = setInterval(tick, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [refresh]);
+
+  return { snapshot, error, isLoading, refresh };
+}
+```
+
+`desktopApi` is the exported default adapter from `desktop-api.ts`. Verify the actual export name by reading the file before this step — if it's named differently (e.g. `defaultDesktopApi`), use that.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop-tauri/src/lib/desktop-api.ts apps/desktop-tauri/src/components/backgroundedTools/useOperationsSnapshot.ts
+git commit -m "backgroundedTools: add fetchOperationsSnapshot adapter + useOperationsSnapshot hook
+
+The hook polls every 2s while mounted. Falls back to an error state
+when the snapshot command returns Err so the panel can render its
+empty-state placeholder cleanly.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 — Backgrounded Tools React component (TDD)
+
+**Files:**
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx`
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx`
+- Create: `apps/desktop-tauri/src/components/backgroundedTools/index.ts`
+- Create: `apps/desktop-tauri/src/styles/backgrounded-tools.css`
+- Modify: `apps/desktop-tauri/src/App.css` (add `@import "./styles/backgrounded-tools.css";`)
+
+- [ ] **Step 1: Write the failing component tests**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx`:
+
+```typescript
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+import { BackgroundedToolsPanel } from "./BackgroundedToolsPanel";
+import type {
+  BackgroundedToolView,
+  DesktopOperationsSnapshot,
+} from "../../lib/types/operations";
+
+vi.mock("../../lib/desktop-api", () => {
+  return {
+    desktopApi: {
+      fetchOperationsSnapshot: vi.fn(),
+    },
+  };
+});
+
+import { desktopApi } from "../../lib/desktop-api";
+
+function row(overrides: Partial<BackgroundedToolView> = {}): BackgroundedToolView {
+  return {
+    requestId: "req_a17",
+    toolCallId: `tc_${Math.random().toString(36).slice(2, 8)}`,
+    toolName: "grep",
+    lifecycleState: "running",
+    status: null,
+    startedAt: new Date(Date.now() - 4_000).toISOString(),
+    ageMs: 4_000,
+    deadlineAt: new Date(Date.now() + 60_000).toISOString(),
+    deadlineExpired: false,
+    awaitMode: "background",
+    cancelPolicy: "cascade",
+    childRequestId: null,
+    stuckSince: null,
+    cancelPendingRemoteAck: false,
+    nativeExecutor: null,
+    ...overrides,
+  };
+}
+
+function snapshot(toolCalls: BackgroundedToolView[]): DesktopOperationsSnapshot {
+  return {
+    fetchedAt: new Date().toISOString(),
+    agentDid: null,
+    liveness: {
+      expiredProcessingCount: 0,
+      requests: [],
+      activeToolCalls: [],
+      activeNativeExecutorsAvailable: true,
+      activeNativeExecutors: [],
+    },
+    livenessUnavailableReason: null,
+    backgroundedTools: toolCalls,
+    stuckDiagnostics: [],
+    lineage: null,
+  };
+}
+
+describe("BackgroundedToolsPanel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("renders an empty state when the snapshot returns zero tools", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(snapshot([]));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText(/no backgrounded tools/i)).toBeInTheDocument());
+  });
+
+  it("renders an error-empty-state when the snapshot command rejects", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("not implemented yet"));
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText(/snapshot bridge/i)).toBeInTheDocument());
+  });
+
+  it("renders one row per backgrounded tool with derived status badges", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(
+      snapshot([
+        row({ toolCallId: "tc_running", toolName: "grep" }),
+        row({ toolCallId: "tc_deadline", toolName: "fetch_remote", deadlineExpired: true }),
+      ]),
+    );
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    expect(screen.getByText("fetch_remote")).toBeInTheDocument();
+    expect(screen.getByText(/deadline\+/i)).toBeInTheDocument();
+  });
+
+  it("marks a stuck row with the row-stuck class", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(
+      snapshot([
+        row({
+          toolCallId: "tc_stuck",
+          toolName: "index_repo",
+          stuckSince: new Date(Date.now() - 12_000).toISOString(),
+          cancelPendingRemoteAck: true,
+        }),
+      ]),
+    );
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("index_repo")).toBeInTheDocument());
+    const tr = screen.getByText("index_repo").closest("tr");
+    expect(tr?.className).toContain("row-stuck");
+  });
+
+  it("hides healthy rows when 'show only stuck' toggle is on", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(
+      snapshot([
+        row({ toolCallId: "tc_healthy", toolName: "grep" }),
+        row({
+          toolCallId: "tc_stuck",
+          toolName: "index_repo",
+          stuckSince: new Date(Date.now() - 12_000).toISOString(),
+        }),
+      ]),
+    );
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    fireEvent.click(screen.getByLabelText(/show only stuck/i));
+    expect(screen.queryByText("grep")).not.toBeInTheDocument();
+    expect(screen.getByText("index_repo")).toBeInTheDocument();
+  });
+
+  it("filters by state chip", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(
+      snapshot([
+        row({ toolCallId: "tc_a", toolName: "grep" }),
+        row({ toolCallId: "tc_b", toolName: "fetch_remote", deadlineExpired: true }),
+      ]),
+    );
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /past deadline/i }));
+    expect(screen.queryByText("grep")).not.toBeInTheDocument();
+    expect(screen.getByText("fetch_remote")).toBeInTheDocument();
+  });
+
+  it("sorts by age descending by default and toggles to ascending on header click", async () => {
+    (desktopApi.fetchOperationsSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue(
+      snapshot([
+        row({ toolCallId: "tc_young", toolName: "grep_young", startedAt: new Date(Date.now() - 2_000).toISOString(), ageMs: 2_000 }),
+        row({ toolCallId: "tc_old", toolName: "grep_old", startedAt: new Date(Date.now() - 200_000).toISOString(), ageMs: 200_000 }),
+      ]),
+    );
+    render(<BackgroundedToolsPanel />);
+    await waitFor(() => expect(screen.getByText("grep_young")).toBeInTheDocument());
+    const rows = screen.getAllByRole("row").slice(1); // skip header
+    expect(rows[0].textContent).toContain("grep_old");
+    fireEvent.click(screen.getByRole("columnheader", { name: /age/i }));
+    const rowsAsc = screen.getAllByRole("row").slice(1);
+    expect(rowsAsc[0].textContent).toContain("grep_young");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests; expect ALL to fail (component does not exist)**
+
+```bash
+cd apps/desktop-tauri && npx vitest run src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx
+```
+Expected: `Cannot find module './BackgroundedToolsPanel'`.
+
+- [ ] **Step 3: Port the prototype CSS subset**
+
+Create `apps/desktop-tauri/src/styles/backgrounded-tools.css`. Copy the class rules from `docs/ui-prototypes/panel-276-backgrounded-tools.html` (every selector under `<style>` that targets `.tools-table-wrap`, `.tools`, `.row-stuck`, `.pill`, `.pill-await`, `.pill-status`, `.chip` only in the panel context, `.panel-summary`, `.panel-footer`, `.empty-state`, `.row-actions`, `.cell-tool`, `.cell-age`, `.cell-parent`, `.cell-process`, `.stuck-banner` — but NOT the prototype's dataset-switcher chips, since those don't exist in the real panel).
+
+Top-level rules like `body { padding: 24px }` should be omitted — the panel inherits from the app shell. Wrap every rule in `.background-tools-panel` so styles are scoped:
+
+```css
+.background-tools-panel .tools-table-wrap { /* ... */ }
+.background-tools-panel .pill { /* ... */ }
+/* etc. */
+```
+
+This keeps the prototype's visual fidelity without polluting the global stylesheet.
+
+- [ ] **Step 4: Add the CSS @import to App.css**
+
+Add to `apps/desktop-tauri/src/App.css` (location near other `@import` lines):
+
+```css
+@import "./styles/backgrounded-tools.css";
+```
+
+- [ ] **Step 5: Implement the React component**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx`:
+
+```typescript
+import { useCallback, useMemo, useState } from "react";
+
+import type {
+  BackgroundedToolView,
+  DesktopOperationsSnapshotRequest,
+} from "../../lib/types/operations";
+import {
+  correlateProcess,
+  derivedState,
+  formatAge,
+  type DerivedState,
+} from "./derivedState";
+import { useOperationsSnapshot } from "./useOperationsSnapshot";
+
+type SortKey = "toolName" | "ageMs" | "requestId" | "awaitMode" | "derivedState" | "processLabel";
+type SortDir = "ascending" | "descending";
+
+export type BackgroundedToolsPanelProps = {
+  rootRequestId?: string | null;
+};
+
+export function BackgroundedToolsPanel({ rootRequestId }: BackgroundedToolsPanelProps = {}) {
+  const request: DesktopOperationsSnapshotRequest = useMemo(
+    () => ({ rootRequestId: rootRequestId ?? null }),
+    [rootRequestId],
+  );
+  const { snapshot, error, isLoading } = useOperationsSnapshot(request);
+
+  const [stateFilters, setStateFilters] = useState<Set<DerivedState>>(new Set());
+  const [awaitFilters, setAwaitFilters] = useState<Set<string>>(new Set());
+  const [parentFilter, setParentFilter] = useState<string>("all");
+  const [hideHealthy, setHideHealthy] = useState<boolean>(false);
+  const [sortKey, setSortKey] = useState<SortKey>("ageMs");
+  const [sortDir, setSortDir] = useState<SortDir>("descending");
+  const [selectedToolCallId, setSelectedToolCallId] = useState<string | null>(null);
+
+  const projected = useMemo(() => {
+    if (!snapshot) return [];
+    const now = Date.now();
+    const execs = snapshot.liveness?.activeNativeExecutors ?? [];
+    return snapshot.backgroundedTools.map((row) => {
+      const proc = correlateProcess(row, execs);
+      return {
+        ...row,
+        derivedState: derivedState(row, now),
+        ageMs: row.ageMs ?? 0,
+        processLabel: proc.label,
+        processTooltip: proc.tooltip,
+      };
+    });
+  }, [snapshot]);
+
+  const filtered = useMemo(() => {
+    const rows = projected.filter((r) => {
+      if (parentFilter !== "all" && r.requestId !== parentFilter) return false;
+      if (stateFilters.size > 0 && !stateFilters.has(r.derivedState)) return false;
+      if (awaitFilters.size > 0 && (r.awaitMode == null || !awaitFilters.has(r.awaitMode))) return false;
+      if (hideHealthy && !["stuck", "cancelPending", "deadline+"].includes(r.derivedState)) return false;
+      return true;
+    });
+    const dir = sortDir === "ascending" ? 1 : -1;
+    return [...rows].sort((a, b) => {
+      const av = (a as any)[sortKey];
+      const bv = (b as any)[sortKey];
+      if (av == null && bv == null) return 0;
+      if (av == null) return 1;
+      if (bv == null) return -1;
+      if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+      return String(av).localeCompare(String(bv)) * dir;
+    });
+  }, [projected, parentFilter, stateFilters, awaitFilters, hideHealthy, sortKey, sortDir]);
+
+  const parents = useMemo(
+    () => Array.from(new Set(projected.map((r) => r.requestId))),
+    [projected],
+  );
+
+  const onSort = useCallback(
+    (key: SortKey) => {
+      if (sortKey === key) {
+        setSortDir((d) => (d === "ascending" ? "descending" : "ascending"));
+      } else {
+        setSortKey(key);
+        setSortDir("ascending");
+      }
+    },
+    [sortKey],
+  );
+
+  const toggleStateFilter = (s: DerivedState) =>
+    setStateFilters((prev) => {
+      const next = new Set(prev);
+      next.has(s) ? next.delete(s) : next.add(s);
+      return next;
+    });
+
+  const toggleAwaitFilter = (a: string) =>
+    setAwaitFilters((prev) => {
+      const next = new Set(prev);
+      next.has(a) ? next.delete(a) : next.add(a);
+      return next;
+    });
+
+  // Error / empty state
+  if (error) {
+    return (
+      <section className="background-tools-panel" aria-label="Background tools">
+        <div className="empty-state">
+          <span className="glyph" aria-hidden="true">○</span>
+          Snapshot bridge unavailable: {error}
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="background-tools-panel" aria-label="Background tools">
+      {/* filter chips — parent, state, await, hide-healthy */}
+      <div className="chip-row" role="group" aria-label="Filter by parent">
+        <span className="chip-label">Parent</span>
+        <button
+          type="button"
+          className={`chip ${parentFilter === "all" ? "is-active" : ""}`}
+          aria-pressed={parentFilter === "all"}
+          onClick={() => setParentFilter("all")}
+        >
+          All
+        </button>
+        {parents.map((p) => (
+          <button
+            key={p}
+            type="button"
+            className={`chip ${parentFilter === p ? "is-active" : ""}`}
+            aria-pressed={parentFilter === p}
+            onClick={() => setParentFilter(p)}
+          >
+            {p}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row" role="group" aria-label="Filter by state">
+        <span className="chip-label">State</span>
+        {(["running", "background", "stuck", "cancelPending", "deadline+"] as DerivedState[]).map((s) => (
+          <button
+            key={s}
+            type="button"
+            className={`chip ${stateFilters.has(s) ? "is-active" : ""}`}
+            aria-pressed={stateFilters.has(s)}
+            onClick={() => toggleStateFilter(s)}
+          >
+            {s === "deadline+" ? "Past deadline" : s.charAt(0).toUpperCase() + s.slice(1)}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row" role="group" aria-label="Filter by await mode">
+        <span className="chip-label">Await</span>
+        {["background", "bridge", "detach"].map((a) => (
+          <button
+            key={a}
+            type="button"
+            className={`chip ${awaitFilters.has(a) ? "is-active" : ""}`}
+            aria-pressed={awaitFilters.has(a)}
+            onClick={() => toggleAwaitFilter(a)}
+          >
+            {a}
+          </button>
+        ))}
+      </div>
+      <div className="chip-row">
+        <span className="chip-label">Threshold</span>
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={hideHealthy}
+            onChange={(e) => setHideHealthy(e.target.checked)}
+          />
+          Show only stuck / cancel-pending / past deadline
+        </label>
+      </div>
+
+      <div className="panel-summary">
+        <div className="live-count">
+          <em>{filtered.length}</em> live <span className="muted">/ 8 max</span>
+        </div>
+      </div>
+
+      <div className="tools-table-wrap">
+        <table className="tools" role="grid">
+          <thead>
+            <tr>
+              {(["toolName", "ageMs", "requestId", "awaitMode", "derivedState", "processLabel"] as SortKey[]).map((key) => (
+                <th
+                  key={key}
+                  scope="col"
+                  tabIndex={0}
+                  aria-sort={sortKey === key ? sortDir : "none"}
+                  onClick={() => onSort(key)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      onSort(key);
+                    }
+                  }}
+                >
+                  {key === "toolName"
+                    ? "Tool"
+                    : key === "ageMs"
+                    ? "Age"
+                    : key === "requestId"
+                    ? "Parent"
+                    : key === "awaitMode"
+                    ? "Await"
+                    : key === "derivedState"
+                    ? "Status"
+                    : "Process"}
+                </th>
+              ))}
+              <th scope="col" aria-label="Row actions" />
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 && !isLoading && (
+              <tr>
+                <td colSpan={7}>
+                  <div className="empty-state">
+                    <span className="glyph" aria-hidden="true">○</span>
+                    No backgrounded tools.
+                  </div>
+                </td>
+              </tr>
+            )}
+            {filtered.map((row) => {
+              const isWarn = row.derivedState === "stuck" || row.derivedState === "cancelPending";
+              const isSelected = selectedToolCallId === row.toolCallId;
+              return (
+                <tr
+                  key={row.toolCallId}
+                  tabIndex={0}
+                  className={[
+                    isWarn ? "row-stuck" : "",
+                    isSelected ? "is-selected" : "",
+                  ].filter(Boolean).join(" ")}
+                  onClick={() => setSelectedToolCallId(row.toolCallId)}
+                  onFocus={() => setSelectedToolCallId(row.toolCallId)}
+                >
+                  <td className="cell-tool">{row.toolName}</td>
+                  <td className="cell-age">{formatAge(row.ageMs ?? 0)}</td>
+                  <td className="cell-parent">{row.requestId}</td>
+                  <td>
+                    <span className="pill pill-await" data-mode={row.awaitMode ?? ""}>
+                      {row.awaitMode ?? "—"}
+                    </span>
+                  </td>
+                  <td>
+                    <span className="pill pill-status" data-state={row.derivedState}>
+                      {row.derivedState === "stuck" || row.derivedState === "cancelPending" ? "⚠ " : ""}
+                      {row.derivedState}
+                    </span>
+                  </td>
+                  <td
+                    className={`cell-process ${row.processLabel === "—" ? "is-empty" : ""}`}
+                    title={row.processTooltip}
+                  >
+                    {row.processLabel}
+                  </td>
+                  <td>
+                    <div className="row-actions">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          console.log("[backgroundedTools] open-lineage", row.toolCallId, row.requestId);
+                        }}
+                      >
+                        Lineage
+                      </button>
+                      <button
+                        type="button"
+                        className="danger"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          console.log("[backgroundedTools] interrupt-parent", row.requestId);
+                        }}
+                      >
+                        Interrupt
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 6: Create the `index.ts` barrel**
+
+Create `apps/desktop-tauri/src/components/backgroundedTools/index.ts`:
+
+```typescript
+export { BackgroundedToolsPanel } from "./BackgroundedToolsPanel";
+export type { BackgroundedToolsPanelProps } from "./BackgroundedToolsPanel";
+```
+
+- [ ] **Step 7: Run tests; all should pass**
+
+```bash
+cd apps/desktop-tauri && npx vitest run src/components/backgroundedTools/
+```
+Expected: all 7+ test cases pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/desktop-tauri/src/components/backgroundedTools apps/desktop-tauri/src/styles/backgrounded-tools.css apps/desktop-tauri/src/App.css
+git commit -m "backgroundedTools: implement BackgroundedToolsPanel React component
+
+Faithful TS/React port of the approved prototype at
+docs/ui-prototypes/panel-276-backgrounded-tools.html. Reads from
+the desktop_operations_snapshot bridge command via the new
+useOperationsSnapshot hook (2s refresh interval). Filter chips,
+sortable headers, stuck-row treatment, per-row actions all preserved
+from the prototype. CSS is scoped under .background-tools-panel.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 — Mount the panel into OperationsRail
+
+**Files:**
+- Modify: `apps/desktop-tauri/src/components/ChatWorkspace.tsx`
+
+- [ ] **Step 1: Replace the empty tabs array with a real tab descriptor**
+
+In `apps/desktop-tauri/src/components/ChatWorkspace.tsx`, locate the `<OperationsRailProvider tabs={[]}>` (around line 84). Replace with:
+
+```tsx
+import { BackgroundedToolsPanel } from "./backgroundedTools";
+// ... existing imports ...
+
+// Where the JSX builds the rail:
+const operationsTabs = useMemo(
+  () => [
+    {
+      id: "background-tools",
+      label: "Background",
+      render: () => <BackgroundedToolsPanel />,
+    },
+  ],
+  [],
+);
+
+return (
+  // ... outer markup ...
+  <OperationsRailProvider tabs={operationsTabs}>
+    {/* existing children */}
+    <OperationsRail />
+  </OperationsRailProvider>
+);
+```
+
+Confirm `useMemo` is imported from "react" at the top of the file. If `OperationsRailTabDescriptor` is needed for typing, import it from "./operations".
+
+- [ ] **Step 2: Run the existing operations-rail tests to confirm no regression**
+
+```bash
+cd apps/desktop-tauri && npx vitest run tests/operations-rail.test.tsx
+```
+Expected: existing 3 tests still pass (they use their own harness, not ChatWorkspace).
+
+- [ ] **Step 3: Run a typecheck on the full app**
+
+```bash
+cd apps/desktop-tauri && npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop-tauri/src/components/ChatWorkspace.tsx
+git commit -m "ChatWorkspace: mount BackgroundedToolsPanel as the first OperationsRail tab
+
+Replaces the empty tabs=[] placeholder from #310's foundation with
+the real background-tools tab descriptor. Future panels (#277/#285/#286)
+will push their descriptors into this same array.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 — Rust snapshot builder (TDD)
+
+**Files:**
+- Create: `apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs`
+- Create: `apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs`
+- Modify: `apps/desktop-tauri/src-tauri/src/bridge/snapshot/mod.rs`
+
+This task implements the snapshot builder as a *pure function over inputs*, with the Tauri command body (Task 7) handling I/O.
+
+- [ ] **Step 1: Add the module to snapshot/mod.rs**
+
+In `apps/desktop-tauri/src-tauri/src/bridge/snapshot/mod.rs`, add:
+
+```rust
+pub(crate) mod operations_snapshot;
+```
+
+- [ ] **Step 2: Write the failing builder tests**
+
+Create `apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs`:
+
+```rust
+use super::*;
+use crate::bridge::types::views::{
+    ActiveToolCallView, BackgroundedToolView, NativeExecutorStatusView, RuntimeLivenessView,
+};
+
+fn liveness_with(tools: Vec<ActiveToolCallView>, execs: Vec<NativeExecutorStatusView>) -> RuntimeLivenessView {
+    RuntimeLivenessView {
+        expired_processing_count: 0,
+        requests: Vec::new(),
+        active_tool_calls: tools,
+        active_native_executors_available: true,
+        active_native_executors: execs,
+    }
+}
+
+#[test]
+fn project_filters_to_background_await_mode_only() {
+    let toolcall_rows = vec![
+        ToolCallRow {
+            request_id: "req_a".into(),
+            tool_call_id: "tc_bg".into(),
+            tool_name: "grep".into(),
+            lifecycle_state: Some("running".into()),
+            status: None,
+            started_at: Some("2026-05-20T12:00:00Z".into()),
+            deadline_at: None,
+            await_mode: Some("background".into()),
+            cancel_policy: Some("cascade".into()),
+            child_request_id: None,
+            stuck_since: None,
+            cancel_pending_remote_ack: false,
+        },
+        ToolCallRow {
+            request_id: "req_a".into(),
+            tool_call_id: "tc_fg".into(),
+            tool_name: "grep_fg".into(),
+            lifecycle_state: Some("running".into()),
+            status: None,
+            started_at: Some("2026-05-20T12:00:00Z".into()),
+            deadline_at: None,
+            await_mode: Some("foreground".into()),
+            cancel_policy: None,
+            child_request_id: None,
+            stuck_since: None,
+            cancel_pending_remote_ack: false,
+        },
+    ];
+
+    let projected = project_backgrounded_tools(&toolcall_rows, &liveness_with(Vec::new(), Vec::new()));
+    assert_eq!(projected.len(), 1);
+    assert_eq!(projected[0].tool_call_id, "tc_bg");
+}
+
+#[test]
+fn project_skips_terminal_lifecycle_state() {
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "grep".into(),
+        lifecycle_state: Some("completed".into()),
+        status: None,
+        started_at: None,
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: None,
+        cancel_pending_remote_ack: false,
+    }];
+    let projected = project_backgrounded_tools(&rows, &liveness_with(Vec::new(), Vec::new()));
+    assert!(projected.is_empty());
+}
+
+#[test]
+fn project_attaches_native_executor_when_correlated() {
+    let started = "2026-05-20T12:00:00Z";
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "grep".into(),
+        lifecycle_state: Some("running".into()),
+        status: None,
+        started_at: Some(started.into()),
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: None,
+        cancel_pending_remote_ack: false,
+    }];
+    let execs = vec![NativeExecutorStatusView {
+        id: 902,
+        pid: 41812,
+        argv0: "/usr/bin/grep".into(),
+        tool_name: Some("grep".into()),
+        started_at: started.into(),
+        age_ms: 5_000,
+    }];
+    let liveness = liveness_with(Vec::new(), execs);
+
+    let projected = project_backgrounded_tools(&rows, &liveness);
+    assert!(projected[0].native_executor.is_some());
+    assert_eq!(projected[0].native_executor.as_ref().unwrap().pid, 41812);
+}
+
+#[test]
+fn stuck_diagnostic_emitted_for_each_stuck_or_cancel_pending_row() {
+    let rows = vec![ToolCallRow {
+        request_id: "req_a".into(),
+        tool_call_id: "tc".into(),
+        tool_name: "index_repo".into(),
+        lifecycle_state: Some("running".into()),
+        status: None,
+        started_at: Some("2026-05-20T12:00:00Z".into()),
+        deadline_at: None,
+        await_mode: Some("background".into()),
+        cancel_policy: None,
+        child_request_id: None,
+        stuck_since: Some("2026-05-20T12:00:00Z".into()),
+        cancel_pending_remote_ack: true,
+    }];
+    let diagnostics = stuck_diagnostics_from_tool_calls(&rows);
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].reason, "pendingRemoteCancelAck");
+}
+```
+
+- [ ] **Step 3: Run tests; expect failure (module body empty)**
+
+```bash
+cargo test -p defra-agent-desktop-tauri --lib operations_snapshot 2>&1 | tail -20
+```
+Expected: failures because `project_backgrounded_tools`, `stuck_diagnostics_from_tool_calls`, and `ToolCallRow` do not yet exist.
+
+- [ ] **Step 4: Implement the builder**
+
+Create `apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs`:
+
+```rust
+//! Pure projection functions over runtime liveness + AgentToolCall rows.
+//! The Tauri command body lives in bridge::tauri_commands::operations and
+//! is responsible for I/O; this module is pure for testability.
+
+use crate::bridge::types::views::{
+    BackgroundedToolView, NativeExecutorStatusView, RuntimeLivenessView, StuckWorkDiagnosticView,
+};
+
+/// Internal shape representing one row pulled from the `AgentToolCall`
+/// collection in DefraDB. The Tauri command parses GraphQL JSON into this
+/// type before passing to the projection functions.
+#[derive(Debug, Clone)]
+pub(crate) struct ToolCallRow {
+    pub request_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub lifecycle_state: Option<String>,
+    pub status: Option<String>,
+    pub started_at: Option<String>,
+    pub deadline_at: Option<String>,
+    pub await_mode: Option<String>,
+    pub cancel_policy: Option<String>,
+    pub child_request_id: Option<String>,
+    pub stuck_since: Option<String>,
+    pub cancel_pending_remote_ack: bool,
+}
+
+const TERMINAL_LIFECYCLE_STATES: &[&str] = &["completed", "failed", "cancelled", "timedOut", "superseded"];
+const CORRELATION_WINDOW_MS: i64 = 1_000;
+
+pub(crate) fn project_backgrounded_tools(
+    rows: &[ToolCallRow],
+    liveness: &RuntimeLivenessView,
+) -> Vec<BackgroundedToolView> {
+    rows.iter()
+        .filter(|r| r.await_mode.as_deref() == Some("background"))
+        .filter(|r| !r.lifecycle_state.as_deref().is_some_and(|s| TERMINAL_LIFECYCLE_STATES.contains(&s)))
+        .map(|r| {
+            let age_ms = age_from_started(r.started_at.as_deref(), &liveness.active_tool_calls);
+            let deadline_expired = liveness
+                .active_tool_calls
+                .iter()
+                .find(|tc| tc.tool_call_id == r.tool_call_id)
+                .map(|tc| tc.deadline_expired)
+                .unwrap_or(false);
+            let native_executor = correlate_native_executor(r, &liveness.active_native_executors);
+            BackgroundedToolView {
+                request_id: r.request_id.clone(),
+                tool_call_id: r.tool_call_id.clone(),
+                tool_name: r.tool_name.clone(),
+                lifecycle_state: r.lifecycle_state.clone(),
+                status: r.status.clone(),
+                started_at: r.started_at.clone(),
+                age_ms,
+                deadline_at: r.deadline_at.clone(),
+                deadline_expired,
+                await_mode: r.await_mode.clone(),
+                cancel_policy: r.cancel_policy.clone(),
+                child_request_id: r.child_request_id.clone(),
+                stuck_since: r.stuck_since.clone(),
+                cancel_pending_remote_ack: r.cancel_pending_remote_ack,
+                native_executor,
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn stuck_diagnostics_from_tool_calls(rows: &[ToolCallRow]) -> Vec<StuckWorkDiagnosticView> {
+    rows.iter()
+        .filter(|r| r.await_mode.as_deref() == Some("background"))
+        .filter(|r| !r.lifecycle_state.as_deref().is_some_and(|s| TERMINAL_LIFECYCLE_STATES.contains(&s)))
+        .filter_map(|r| {
+            let reason = if r.cancel_pending_remote_ack {
+                "pendingRemoteCancelAck"
+            } else if r.stuck_since.is_some() {
+                "stuckTool"
+            } else {
+                return None;
+            };
+            Some(StuckWorkDiagnosticView {
+                request_id: r.request_id.clone(),
+                session_id: None,
+                severity: "warning".to_string(),
+                reason: reason.to_string(),
+                deadline_age_ms: None,
+                last_progress_age_ms: None,
+                tool_call_id: Some(r.tool_call_id.clone()),
+                tool_name: Some(r.tool_name.clone()),
+                stuck_since: r.stuck_since.clone(),
+            })
+        })
+        .collect()
+}
+
+fn age_from_started(started_at: Option<&str>, live: &[crate::bridge::types::views::ActiveToolCallView]) -> Option<i64> {
+    // Prefer the runtime's computed running_age_ms when the row is in the live snapshot.
+    if let Some(s) = started_at {
+        if let Some(tc) = live.iter().find(|tc| tc.started_at.as_deref() == Some(s)) {
+            return Some(tc.running_age_ms);
+        }
+    }
+    None
+}
+
+fn correlate_native_executor(
+    row: &ToolCallRow,
+    execs: &[NativeExecutorStatusView],
+) -> Option<NativeExecutorStatusView> {
+    let started_at = row.started_at.as_deref()?;
+    let started_ms = parse_iso_ms(started_at)?;
+    let mut matches = execs.iter().filter(|ne| {
+        ne.tool_name.as_deref() == Some(row.tool_name.as_str())
+            && (parse_iso_ms(&ne.started_at).map(|m| (m - started_ms).abs() <= CORRELATION_WINDOW_MS)).unwrap_or(false)
+    });
+    matches.next().cloned()
+}
+
+fn parse_iso_ms(iso: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(iso)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+#[cfg(test)]
+mod tests;
+```
+
+- [ ] **Step 5: Run tests; expect all to pass**
+
+```bash
+cargo test -p defra-agent-desktop-tauri --lib operations_snapshot 2>&1 | tail -20
+```
+Expected: 4+ tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot.rs apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs apps/desktop-tauri/src-tauri/src/bridge/snapshot/mod.rs
+git commit -m "snapshot: add pure operations_snapshot projection functions
+
+project_backgrounded_tools and stuck_diagnostics_from_tool_calls are
+pure functions over (ToolCallRow rows, RuntimeLivenessView). The
+Tauri command body wires GraphQL/liveness I/O around them in a
+later commit. Tests cover await_mode filtering, terminal lifecycle
+filtering, native-executor correlation, and stuck-diagnostic
+emission.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 — Implement the Tauri command body
+
+**Files:**
+- Modify: `apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs`
+
+- [ ] **Step 1: Replace the stub body for `desktop_operations_snapshot`**
+
+In `apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs`, replace the `desktop_operations_snapshot` stub with:
+
+```rust
+use chrono::Utc;
+use tauri::State;
+
+use super::super::snapshot::operations_snapshot::{
+    project_backgrounded_tools, stuck_diagnostics_from_tool_calls, ToolCallRow,
+};
+use super::super::state::{current_core, DesktopAppState};
+use super::super::types::{
+    BackgroundedToolView, CascadeCancelPreview, DesktopInterruptRequest,
+    DesktopListSubagentTreeRequest, DesktopOperationsSnapshot, DesktopOperationsSnapshotRequest,
+    DesktopPreviewInterruptCascadeRequest, InterruptRequestResult, NativeExecutorStatusView,
+    RuntimeLivenessView, StuckWorkDiagnosticView, SubagentTreeView,
+};
+
+#[tauri::command]
+pub(crate) async fn desktop_operations_snapshot(
+    state: State<'_, DesktopAppState>,
+    request: DesktopOperationsSnapshotRequest,
+) -> Result<DesktopOperationsSnapshot, String> {
+    let core = current_core(&state).ok_or_else(|| "desktop bridge not initialized".to_string())?;
+    let agent_did = request.agent_did.clone();
+
+    // 1) In-process native executor snapshot — direct call into defra-agent.
+    let native_executors: Vec<NativeExecutorStatusView> =
+        defra_agent::native_executor_status::active_native_executors()
+            .into_iter()
+            .map(|ne| NativeExecutorStatusView {
+                id: ne.id as i64,
+                pid: ne.pid as u32,
+                argv0: ne.argv0,
+                tool_name: ne.tool_name,
+                started_at: ne.started_at,
+                age_ms: ne.age_ms,
+            })
+            .collect();
+
+    // 2) GraphQL query for live AgentToolCall rows with await_mode = "background".
+    let tool_call_rows = fetch_background_tool_calls(&core, agent_did.as_deref())
+        .await
+        .map_err(|e| format!("failed to query AgentToolCall: {e}"))?;
+
+    // 3) Project liveness (best-effort — empty when the snapshot is not yet
+    //    populated by the runtime; future Tauri commands will fill this in).
+    let liveness = RuntimeLivenessView {
+        expired_processing_count: 0,
+        requests: Vec::new(),
+        active_tool_calls: Vec::new(),
+        active_native_executors_available: true,
+        active_native_executors: native_executors,
+    };
+
+    let backgrounded_tools = project_backgrounded_tools(&tool_call_rows, &liveness);
+    let stuck_diagnostics = stuck_diagnostics_from_tool_calls(&tool_call_rows);
+
+    Ok(DesktopOperationsSnapshot {
+        fetched_at: Utc::now().to_rfc3339(),
+        agent_did,
+        liveness: Some(liveness),
+        liveness_unavailable_reason: None,
+        backgrounded_tools,
+        stuck_diagnostics,
+        lineage: None, // owned by #285
+    })
+}
+
+async fn fetch_background_tool_calls(
+    core: &std::sync::Arc<defra_agent_desktop_core::client::ClientCore>,
+    agent_did: Option<&str>,
+) -> Result<Vec<ToolCallRow>, String> {
+    let did = agent_did.unwrap_or("").to_string();
+    let graphql = core.graphql_for_agent(&did).await.map_err(|e| e.to_string())?;
+
+    // Construct a GraphQL query mirroring liveness.rs lines 19-30's row
+    // shape, plus the additional schema fields (stuck_since, cancel_pending_remote_ack).
+    let query = r#"
+        query BackgroundToolCalls {
+            AgentToolCall(filter: { await_mode: { _eq: "background" } }) {
+                request_id
+                tool_call_id
+                tool_name
+                lifecycle_state
+                status
+                started_at
+                deadline_at
+                await_mode
+                cancel_policy
+                child_request_id
+                stuck_since
+                cancel_pending_remote_ack
+            }
+        }
+    "#;
+
+    let response_json: serde_json::Value = graphql.query(query).await.map_err(|e| e.to_string())?;
+    let rows = response_json
+        .get("data")
+        .and_then(|d| d.get("AgentToolCall"))
+        .and_then(|t| t.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ToolCallRow {
+            request_id: row.get("request_id").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            tool_call_id: row.get("tool_call_id").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            tool_name: row.get("tool_name").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+            lifecycle_state: row.get("lifecycle_state").and_then(|v| v.as_str()).map(str::to_string),
+            status: row.get("status").and_then(|v| v.as_str()).map(str::to_string),
+            started_at: row.get("started_at").and_then(|v| v.as_str()).map(str::to_string),
+            deadline_at: row.get("deadline_at").and_then(|v| v.as_str()).map(str::to_string),
+            await_mode: row.get("await_mode").and_then(|v| v.as_str()).map(str::to_string),
+            cancel_policy: row.get("cancel_policy").and_then(|v| v.as_str()).map(str::to_string),
+            child_request_id: row.get("child_request_id").and_then(|v| v.as_str()).map(str::to_string),
+            stuck_since: row.get("stuck_since").and_then(|v| v.as_str()).map(str::to_string),
+            cancel_pending_remote_ack: row.get("cancel_pending_remote_ack").and_then(|v| v.as_bool()).unwrap_or(false),
+        })
+        .collect())
+}
+```
+
+Keep the other three stubs (`desktop_list_subagent_tree`, `desktop_preview_interrupt_cascade`, `desktop_interrupt_request`) untouched; they remain panel-owned by #285/#286/#283.
+
+Update the stub error message for `desktop_operations_snapshot` is no longer needed since we're replacing the body. But check whether the existing import of `RuntimeLivenessView`, `StuckWorkDiagnosticView`, `NativeExecutorStatusView`, `BackgroundedToolView` is already present in the types `mod`. If not, add them to the `pub(crate) use ...` line in `bridge/types/mod.rs`.
+
+- [ ] **Step 2: Verify `chrono` is in Cargo.toml**
+
+Run:
+```bash
+grep -n "chrono" apps/desktop-tauri/src-tauri/Cargo.toml
+```
+If absent, add `chrono = { workspace = true, features = ["serde"] }` under `[dependencies]`. The workspace already pins chrono per the root `Cargo.toml`.
+
+- [ ] **Step 3: Verify `graphql_for_agent` exists on ClientCore**
+
+Run:
+```bash
+grep -rn "graphql_for_agent\|fn graphql" crates/defra-agent-desktop-core/src/ | head -10
+```
+Confirm the function exists and returns something with a `.query(&str)` method. **If the actual method name or signature differs**, adapt the call accordingly — the goal is "run a GraphQL query against the agent's DefraDB". If no such method exists, fall back to `core.store()` and an equivalent in-store query (see `crates/defra-agent-desktop-core/src/client/core.rs` for the actual API; this exploration may reveal a different method like `core.graphql()` without an agent argument).
+
+- [ ] **Step 4: Build the bridge**
+
+```bash
+cargo check -p defra-agent-desktop-tauri 2>&1 | tail -30
+```
+Expected: builds clean. Fix any imports or method-signature mismatches discovered in Step 3.
+
+- [ ] **Step 5: Run Rust tests**
+
+```bash
+cargo test -p defra-agent-desktop-tauri 2>&1 | tail -20
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs apps/desktop-tauri/src-tauri/Cargo.toml
+git commit -m "operations: implement desktop_operations_snapshot body
+
+GraphQL-queries AgentToolCall rows with await_mode = 'background',
+projects through operations_snapshot::project_backgrounded_tools, and
+attaches in-process active_native_executors snapshot. Stuck
+diagnostics derived from stuck_since + cancel_pending_remote_ack.
+Lineage stays None — owned by #285 (subagent lineage view).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8 — Promote `background-tools.operatorUi` in CoverageLedger.lean
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean`
+- Modify: `crates/defra-agent/tests/support/conformance_consumers.rs`
+
+- [ ] **Step 1: Remove the deferred entry, add a consumerCoverage entry**
+
+In `crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean` (around lines 149-155), the current shape is:
+
+```lean
+{ feature := "background-tools"
+, required := [Surface.agentFacing]
+, deferred :=
+    [ (Surface.operatorCli, "#268")
+    , (Surface.operatorUi, "#276")
+    ]
+}
+```
+
+Change `required` to include `Surface.operatorUi` and remove the `(Surface.operatorUi, "#276")` line from `deferred`:
+
+```lean
+{ feature := "background-tools"
+, required := [Surface.agentFacing, Surface.operatorUi]
+, deferred :=
+    [ (Surface.operatorCli, "#268")
+    ]
+}
+```
+
+Then add a `consumerCoverage` entry in the `caseCoverage` list (the same list PR #283 modified, around line 423 in the Explore report). Mirror that pattern:
+
+```lean
+  , tagged (consumerCoverage
+      "background_tool_cases"
+      "BackgroundTools"
+      "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests::project_filters_to_background_await_mode_only")
+      "background-tools" [Surface.operatorUi]
+```
+
+`background_tool_cases` and `BackgroundTools` are placeholder identifiers — match whatever convention CoverageLedger.lean already uses for related entries (e.g. agent-facing background-tools consumer coverage may already exist; use the same case-set and module names). If unsure, search:
+
+```bash
+grep -n "background-tools\|background_tool" crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+```
+
+- [ ] **Step 2: Register the consumer in conformance_consumers.rs**
+
+In `crates/defra-agent/tests/support/conformance_consumers.rs`, append a new entry (TypeScript variant since the consumer test is in TS):
+
+```rust
+ConformanceConsumer::TypeScriptTest {
+    id: "apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx::BackgroundedToolsPanel renders one row per backgrounded tool with derived status badges",
+    app: "desktop-tauri",
+    source_path: "apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.test.tsx",
+    suite: "BackgroundedToolsPanel",
+    test: "renders one row per backgrounded tool with derived status badges",
+},
+```
+
+AND a Rust variant for the projection unit test:
+
+```rust
+ConformanceConsumer::RustTest {
+    id: "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests::project_filters_to_background_await_mode_only",
+    package: "defra-agent-desktop-tauri",
+    source_path: "apps/desktop-tauri/src-tauri/src/bridge/snapshot/operations_snapshot/tests.rs",
+    module_path: "defra_agent_desktop_tauri::bridge::snapshot::operations_snapshot::tests",
+    function: "project_filters_to_background_await_mode_only",
+},
+```
+
+- [ ] **Step 3: Build the proofs**
+
+```bash
+cd crates/defra-agent/proofs && lake build 2>&1 | tail -20
+```
+Expected: builds clean.
+
+- [ ] **Step 4: Run the drift test**
+
+```bash
+cargo test -p defra-agent --test state_machine_conformance lean_feature_matrix 2>&1 | tail -20
+```
+Expected: pass. The feature now declares `operatorUi` as required, and a ledger row tags `(background-tools, operatorUi)`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean crates/defra-agent/tests/support/conformance_consumers.rs
+git commit -m "proofs: promote background-tools.operatorUi to consumerCoverage
+
+Moves Surface.operatorUi from deferred to required for the
+background-tools feature, and registers the new BackgroundedToolsPanel
+component test + Rust projection test as the consumers. Drift test
+covers the binding.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9 — Verification pass
+
+- [ ] **Step 1: Lean build**
+
+```bash
+cd crates/defra-agent/proofs && lake build 2>&1 | tail -10
+```
+Expected: zero errors. No `sorry`s introduced.
+
+- [ ] **Step 2: Rust check + tests**
+
+```bash
+cargo check -p defra-agent 2>&1 | tail -5
+cargo check -p defra-agent-desktop-tauri 2>&1 | tail -5
+cargo test -p defra-agent 2>&1 | tail -10
+cargo test -p defra-agent-desktop-tauri 2>&1 | tail -10
+```
+Expected: all green.
+
+- [ ] **Step 3: Frontend vitest**
+
+```bash
+cd apps/desktop-tauri && npm test 2>&1 | tail -20
+```
+Expected: all suites pass. Add `BackgroundedToolsPanel` to the suite-count.
+
+- [ ] **Step 4: Manual UI smoke test**
+
+```bash
+cd apps/desktop-tauri && npm run tauri dev
+```
+
+In the running app:
+1. Open a chat with an active agent.
+2. Confirm the OperationsRail is visible on the right.
+3. Confirm a "Background" tab is present.
+4. Click the tab; confirm the panel renders.
+   - If no backgrounded tools are running, you should see the empty state.
+   - If the snapshot bridge errors (e.g., agent not yet started), confirm the error empty-state appears with the error caption.
+5. Stop the dev server when done.
+
+- [ ] **Step 5: Cycle through the prototype's mock datasets to confirm visual parity**
+
+Open `docs/ui-prototypes/panel-276-backgrounded-tools.html` in a browser and click through the five mock datasets. Compare each visually to what the real React component renders given equivalent inputs. The colors, fonts, spacing, and pill states should match. Any drift is a bug in the port — fix it.
+
+---
+
+## Task 10 — Retitle PR and update description
+
+- [ ] **Step 1: Retitle**
+
+```bash
+gh pr edit 327 --title "Backgrounded tools panel: prototype + impl (#276)"
+```
+
+- [ ] **Step 2: Append the impl summary to the PR description**
+
+```bash
+gh pr edit 327 --body-file - <<'EOF'
+## Summary
+
+- Phase 1 (already in this PR): standalone HTML prototype at `docs/ui-prototypes/panel-276-backgrounded-tools.html`.
+- Phase 2 (this update): real Tauri implementation — `BackgroundedToolsPanel` React component + `desktop_operations_snapshot` command body + OperationsRail mount + ledger promotion.
+
+## Phase 2 changes
+
+| Surface | What changed |
+|---|---|
+| Rust | `desktop_operations_snapshot` body (GraphQL query + projection); pure `project_backgrounded_tools` builder with unit tests; additive `stuck_since` + `cancel_pending_remote_ack` fields on `BackgroundedToolView`. |
+| TypeScript | `BackgroundedToolsPanel` React component, `useOperationsSnapshot` hook, `fetchOperationsSnapshot` adapter, scoped CSS port. |
+| OperationsRail | First real tab mounted in `ChatWorkspace.tsx`. |
+| Lean | `background-tools.operatorUi` deferred → required + consumerCoverage. |
+
+## Known limitations
+
+- `AgentToolCall.stuck_since` / `cancel_pending_remote_ack` schema fields are exposed through the bridge but **not yet populated by the runtime**. Stuck rows will only appear once upstream runtime work writes these fields. The panel renders correctly for live data either way.
+
+## Conflict surface
+
+Other panels (#274 / #277 / #285 / #286 / #288) replace stubs in `operations.rs` and add tabs to `ChatWorkspace.tsx`. Expect rebase if any of them land first.
+
+## Test plan
+
+- [ ] `cd crates/defra-agent/proofs && lake build` — no errors
+- [ ] `cargo check -p defra-agent` — clean
+- [ ] `cargo test -p defra-agent` — green
+- [ ] `cargo test -p defra-agent-desktop-tauri` — green
+- [ ] `cd apps/desktop-tauri && npm test` — all suites pass
+- [ ] Manual: tauri dev → Background tab visible → mock-data parity vs. prototype
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+- [ ] **Step 3: Push the new commits**
+
+```bash
+git push origin design/issue-276-backgrounded-tools-prototype
+```
+Expected: push succeeds; PR #327 picks up the new commits.
+
+---
+
+## Self-Review Notes
+
+- **Placeholder scan:** No `TBD` / `TODO` strings. One step (Task 7 Step 3) explicitly says "adapt if signature differs" because the `graphql_for_agent` API is approximate — but the step gives concrete fallback guidance (use `core.store()` / read core.rs) rather than punting.
+- **Spec coverage:** Phase 2 PROMPT.md asks for (1) React component ✓ Task 4, (2) Tauri command impl ✓ Tasks 6+7, (3) Mount into OperationsRail ✓ Task 5, (4) Ledger promotion ✓ Task 8, (5) Tests ✓ Tasks 4 + 6.
+- **Type consistency:** `BackgroundedToolView` field shape is consistent Rust ↔ TS (Task 1). `STUCK_DWELL_MS = 5_000` and `CORRELATION_WINDOW_MS = 1_000` are consistent between TS (Task 2) and Rust (Task 6).
+- **Drift risk:** The `graphql_for_agent` call signature is the riskiest assumption. Step 3 of Task 7 instructs verification before relying on it.

--- a/docs/ui-prototypes/panel-276-backgrounded-tools.html
+++ b/docs/ui-prototypes/panel-276-backgrounded-tools.html
@@ -1,0 +1,1623 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Backgrounded Tools — Panel #276 prototype</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --font-body: "Inter", "SF Pro Text", system-ui, sans-serif;
+      --font-heading: "Funnel Display", "Inter", system-ui, sans-serif;
+      --font-mono: ui-monospace, "JetBrains Mono", "SFMono-Regular", Consolas, monospace;
+
+      --source-black: #000000;
+      --source-green: #06b250;
+      --source-dark-green: #1c2724;
+      --source-blue: #10cbff;
+      --source-orange: #ffa011;
+
+      --color-bg: var(--source-black);
+      --color-surface: rgb(28 39 36 / 0.86);
+      --color-surface-strong: #07110e;
+      --color-surface-deep: #020504;
+      --color-surface-muted: rgb(28 39 36 / 0.58);
+      --color-surface-row: rgb(9 17 14 / 0.86);
+      --color-text: #ffffff;
+      --color-text-muted: #95a49d;
+      --color-text-soft: #d6ddda;
+      --color-text-warm: #dff8e8;
+      --color-accent: var(--source-green);
+      --color-accent-strong: #39e27a;
+      --color-success: #8df2b4;
+      --color-warning: var(--source-orange);
+      --color-info: var(--source-blue);
+      --color-error: #ff6f5f;
+
+      --border-subtle: rgb(6 178 80 / 0.12);
+      --border-default: rgb(6 178 80 / 0.18);
+      --border-strong: rgb(6 178 80 / 0.28);
+      --border-selected: rgb(6 178 80 / 0.48);
+      --border-warning: rgb(255 160 17 / 0.55);
+
+      --radius-sm: 8px;
+      --radius-pill: 999px;
+    }
+
+    *,
+    *::before,
+    *::after { box-sizing: border-box; }
+
+    html, body { height: 100%; }
+
+    body {
+      margin: 0;
+      padding: 24px;
+      font-family: var(--font-body);
+      font-size: 14px;
+      line-height: 1.45;
+      color: var(--color-text);
+      background:
+        radial-gradient(120% 80% at 50% -20%, rgb(6 178 80 / 0.08), transparent 60%),
+        var(--color-bg);
+      font-synthesis: none;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    main {
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    header.panel-header {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      margin-bottom: 18px;
+    }
+
+    h1 {
+      font-family: var(--font-heading);
+      font-weight: 600;
+      font-size: 22px;
+      letter-spacing: 0.01em;
+      margin: 0;
+    }
+
+    .subtitle {
+      color: var(--color-text-muted);
+      font-size: 13px;
+    }
+
+    .subtitle a {
+      color: var(--color-text-soft);
+      text-decoration: underline dotted;
+    }
+
+    section.card {
+      background: var(--color-surface);
+      border: 1px solid var(--border-default);
+      border-radius: var(--radius-sm);
+      padding: 14px 16px;
+      margin-bottom: 14px;
+    }
+
+    section.card h2 {
+      font-family: var(--font-heading);
+      font-weight: 500;
+      font-size: 13px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--color-text-muted);
+      margin: 0 0 10px 0;
+    }
+
+    /* Mock dataset switcher + filter chips */
+
+    .chip-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .chip-row + .chip-row { margin-top: 8px; }
+
+    .chip-label {
+      font-size: 12px;
+      color: var(--color-text-muted);
+      margin-right: 4px;
+      min-width: 64px;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      border-radius: var(--radius-pill);
+      border: 1px solid var(--border-default);
+      background: var(--color-surface-muted);
+      color: var(--color-text-soft);
+      font-family: var(--font-body);
+      font-size: 12px;
+      cursor: pointer;
+      transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+    }
+
+    .chip:hover { border-color: var(--border-strong); color: var(--color-text); }
+
+    .chip:focus-visible {
+      outline: 2px solid var(--color-accent-strong);
+      outline-offset: 2px;
+    }
+
+    .chip[aria-pressed="true"],
+    .chip.is-active {
+      background: rgb(6 178 80 / 0.22);
+      border-color: var(--border-selected);
+      color: var(--color-text-warm);
+    }
+
+    .chip .count {
+      color: var(--color-text-muted);
+      font-variant-numeric: tabular-nums;
+    }
+
+    .chip[aria-pressed="true"] .count,
+    .chip.is-active .count { color: var(--color-accent-strong); }
+
+    .toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--color-text-soft);
+      font-size: 12px;
+      cursor: pointer;
+      user-select: none;
+    }
+
+    .toggle input { accent-color: var(--color-accent-strong); }
+
+    /* Stuck banner */
+
+    .stuck-banner {
+      display: none;
+      align-items: flex-start;
+      gap: 10px;
+      background: rgb(255 160 17 / 0.10);
+      border: 1px solid var(--border-warning);
+      border-radius: var(--radius-sm);
+      padding: 10px 14px;
+      margin-bottom: 14px;
+      color: var(--color-text-warm);
+    }
+
+    .stuck-banner.is-visible { display: flex; }
+
+    .stuck-banner .glyph {
+      color: var(--color-warning);
+      font-size: 16px;
+      line-height: 1;
+      margin-top: 1px;
+    }
+
+    .stuck-banner strong { color: var(--color-warning); font-weight: 600; }
+
+    .stuck-banner .meta { color: var(--color-text-muted); font-size: 12px; }
+
+    /* Panel */
+
+    .panel-summary {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
+
+    .panel-summary .live-count {
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--color-text-warm);
+    }
+
+    .panel-summary .live-count em {
+      color: var(--color-accent-strong);
+      font-style: normal;
+      font-weight: 600;
+    }
+
+    .panel-summary .root {
+      color: var(--color-text-muted);
+      font-family: var(--font-mono);
+      font-size: 12px;
+    }
+
+    /* Table */
+
+    .tools-table-wrap {
+      border: 1px solid var(--border-default);
+      border-radius: var(--radius-sm);
+      overflow: hidden;
+      background: var(--color-surface-strong);
+    }
+
+    table.tools {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 13px;
+    }
+
+    table.tools thead th {
+      text-align: left;
+      padding: 10px 12px;
+      background: var(--color-surface-deep);
+      color: var(--color-text-muted);
+      font-weight: 500;
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border-bottom: 1px solid var(--border-default);
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+    }
+
+    table.tools thead th[aria-sort="ascending"]::after { content: " ▲"; color: var(--color-accent); }
+    table.tools thead th[aria-sort="descending"]::after { content: " ▼"; color: var(--color-accent); }
+
+    table.tools tbody tr {
+      border-bottom: 1px solid var(--border-subtle);
+      transition: background 120ms ease;
+    }
+
+    table.tools tbody tr:last-child { border-bottom: 0; }
+
+    table.tools tbody tr:hover { background: rgb(6 178 80 / 0.06); }
+
+    table.tools tbody tr:focus-within,
+    table.tools tbody tr.is-selected {
+      background: rgb(6 178 80 / 0.10);
+      box-shadow: inset 3px 0 0 0 var(--color-accent-strong);
+    }
+
+    table.tools tbody tr.row-stuck,
+    table.tools tbody tr.row-warn {
+      box-shadow: inset 3px 0 0 0 var(--color-warning);
+      background: rgb(255 160 17 / 0.06);
+    }
+
+    table.tools tbody tr.row-stuck:focus-within {
+      background: rgb(255 160 17 / 0.10);
+    }
+
+    table.tools td {
+      padding: 10px 12px;
+      vertical-align: top;
+      color: var(--color-text-soft);
+    }
+
+    .cell-tool {
+      font-family: var(--font-mono);
+      color: var(--color-text);
+      font-weight: 500;
+    }
+
+    .cell-age {
+      font-family: var(--font-mono);
+      font-variant-numeric: tabular-nums;
+      color: var(--color-text);
+    }
+
+    .cell-parent,
+    .cell-process {
+      font-family: var(--font-mono);
+      color: var(--color-text-soft);
+      font-size: 12px;
+    }
+
+    .cell-process.is-empty { color: var(--color-text-muted); }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      padding: 1px 8px;
+      border-radius: var(--radius-pill);
+      font-size: 11px;
+      font-family: var(--font-body);
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      border: 1px solid currentColor;
+      background: transparent;
+      white-space: nowrap;
+    }
+
+    .pill.pill-await {
+      color: var(--color-info);
+      border-color: rgb(16 203 255 / 0.45);
+    }
+
+    .pill.pill-await[data-mode="bridge"] {
+      color: var(--color-accent-strong);
+      border-color: rgb(57 226 122 / 0.45);
+    }
+
+    .pill.pill-await[data-mode="detach"] {
+      color: var(--color-text-muted);
+      border-color: rgb(149 164 157 / 0.45);
+    }
+
+    .pill.pill-status {
+      gap: 4px;
+    }
+
+    .pill.pill-status[data-state="running"] {
+      color: var(--color-success);
+      border-color: rgb(141 242 180 / 0.45);
+    }
+
+    .pill.pill-status[data-state="background"] {
+      color: var(--color-info);
+      border-color: rgb(16 203 255 / 0.45);
+    }
+
+    .pill.pill-status[data-state="stuck"],
+    .pill.pill-status[data-state="cancelPending"] {
+      color: var(--color-warning);
+      border-color: var(--border-warning);
+      background: rgb(255 160 17 / 0.08);
+    }
+
+    .pill.pill-status[data-state="deadline+"] {
+      color: var(--color-error);
+      border-color: rgb(255 111 95 / 0.50);
+      background: rgb(255 111 95 / 0.08);
+    }
+
+    .row-actions {
+      display: flex;
+      gap: 6px;
+      justify-content: flex-end;
+    }
+
+    .row-actions button {
+      background: transparent;
+      border: 1px solid var(--border-default);
+      color: var(--color-text-soft);
+      padding: 3px 9px;
+      font-size: 11px;
+      font-family: var(--font-body);
+      border-radius: var(--radius-pill);
+      cursor: pointer;
+    }
+
+    .row-actions button:hover {
+      border-color: var(--border-selected);
+      color: var(--color-text-warm);
+    }
+
+    .row-actions button:focus-visible {
+      outline: 2px solid var(--color-accent-strong);
+      outline-offset: 2px;
+    }
+
+    .row-actions button.danger:hover {
+      border-color: var(--border-warning);
+      color: var(--color-warning);
+    }
+
+    /* Empty state */
+
+    .empty-state {
+      padding: 28px 12px;
+      text-align: center;
+      color: var(--color-text-muted);
+      font-size: 13px;
+    }
+
+    .empty-state .glyph {
+      font-size: 22px;
+      color: var(--color-accent);
+      opacity: 0.6;
+      display: block;
+      margin-bottom: 6px;
+    }
+
+    /* Panel footer (parent-level actions) */
+
+    .panel-footer {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      border-top: 1px solid var(--border-subtle);
+      background: var(--color-surface-deep);
+      color: var(--color-text-muted);
+      font-size: 12px;
+    }
+
+    .panel-footer .footer-label {
+      flex: 1;
+      font-family: var(--font-mono);
+    }
+
+    .panel-footer button {
+      background: transparent;
+      border: 1px solid var(--border-default);
+      color: var(--color-text-soft);
+      padding: 5px 12px;
+      font-size: 12px;
+      font-family: var(--font-body);
+      border-radius: var(--radius-sm);
+      cursor: pointer;
+    }
+
+    .panel-footer button:hover {
+      border-color: var(--border-selected);
+      color: var(--color-text-warm);
+    }
+
+    .panel-footer button.warn:hover {
+      border-color: var(--border-warning);
+      color: var(--color-warning);
+    }
+
+    .panel-footer button:focus-visible {
+      outline: 2px solid var(--color-accent-strong);
+      outline-offset: 2px;
+    }
+
+    .panel-footer button:disabled {
+      opacity: 0.45;
+      cursor: not-allowed;
+    }
+
+    /* Tooltip-ish */
+
+    [data-tooltip] { position: relative; }
+
+    [data-tooltip]:hover::after,
+    [data-tooltip]:focus-visible::after {
+      content: attr(data-tooltip);
+      position: absolute;
+      bottom: calc(100% + 6px);
+      left: 0;
+      padding: 4px 8px;
+      background: var(--color-surface-deep);
+      border: 1px solid var(--border-strong);
+      border-radius: var(--radius-sm);
+      font-size: 11px;
+      font-family: var(--font-mono);
+      color: var(--color-text);
+      white-space: nowrap;
+      z-index: 10;
+      pointer-events: none;
+    }
+
+    /* Visually-hidden text for SR-only live region */
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px; height: 1px;
+      padding: 0; margin: -1px;
+      overflow: hidden;
+      clip: rect(0,0,0,0);
+      white-space: nowrap;
+      border: 0;
+    }
+
+    /* Design notes */
+
+    details.notes {
+      background: var(--color-surface-muted);
+      border: 1px solid var(--border-subtle);
+      border-radius: var(--radius-sm);
+      padding: 12px 16px;
+      color: var(--color-text-soft);
+      margin-top: 8px;
+    }
+
+    details.notes summary {
+      cursor: pointer;
+      font-family: var(--font-heading);
+      font-size: 13px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--color-text-muted);
+      outline: none;
+    }
+
+    details.notes summary:focus-visible {
+      outline: 2px solid var(--color-accent-strong);
+      outline-offset: 2px;
+      border-radius: 4px;
+    }
+
+    details.notes h3 {
+      font-family: var(--font-heading);
+      font-size: 13px;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--color-accent-muted, var(--color-accent-strong));
+      margin: 16px 0 6px 0;
+    }
+
+    details.notes p,
+    details.notes li { font-size: 13px; line-height: 1.55; }
+
+    details.notes ul { padding-left: 20px; margin: 4px 0; }
+
+    details.notes code {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      background: var(--color-surface-deep);
+      padding: 1px 5px;
+      border-radius: 4px;
+      color: var(--color-text-warm);
+    }
+
+    details.notes .divergence {
+      border-left: 2px solid var(--color-warning);
+      padding-left: 10px;
+      background: rgb(255 160 17 / 0.05);
+      margin-top: 4px;
+    }
+
+    /* Console preview */
+
+    .console-preview {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      color: var(--color-text-muted);
+      margin-top: 14px;
+      max-height: 110px;
+      overflow-y: auto;
+      padding: 8px 10px;
+      background: var(--color-surface-deep);
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border-subtle);
+    }
+
+    .console-preview .log-line { white-space: pre-wrap; padding: 2px 0; }
+    .console-preview .log-line + .log-line { border-top: 1px solid var(--border-subtle); }
+    .console-preview .log-line .ts { color: var(--color-text-muted); }
+    .console-preview .log-line .ev { color: var(--color-info); }
+  </style>
+</head>
+
+<body>
+  <main>
+    <header class="panel-header">
+      <h1>Backgrounded Tools Panel — prototype</h1>
+      <div class="subtitle">
+        Issue
+        <a href="https://github.com/sourcenetwork/defra-agent/issues/276" target="_blank" rel="noopener">sourcenetwork/defra-agent#276</a>.
+        Source of truth:
+        <code>docs/superpowers/specs/2026-05-20-desktop-operator-surfaces-design.md</code>
+        §"Panel 1: Backgrounded Tools Panel". Standalone HTML — no Tauri bridge,
+        no build tooling. Open this file in any browser.
+      </div>
+    </header>
+
+    <!-- Mock dataset switcher -->
+    <section class="card" aria-labelledby="mock-heading">
+      <h2 id="mock-heading">Mock dataset</h2>
+      <div class="chip-row" role="radiogroup" aria-label="Mock dataset">
+        <button type="button" class="chip" data-dataset="empty" role="radio" aria-checked="false">Empty</button>
+        <button type="button" class="chip" data-dataset="oneFast" role="radio" aria-checked="false">One fast tool</button>
+        <button type="button" class="chip" data-dataset="oneStuck" role="radio" aria-checked="false">One stuck tool</button>
+        <button type="button" class="chip is-active" data-dataset="mixed" role="radio" aria-checked="true">Mixed</button>
+        <button type="button" class="chip" data-dataset="subagentHeavy" role="radio" aria-checked="false">Subagent heavy</button>
+      </div>
+      <div class="subtitle" id="datasetCaption" style="margin-top:10px;">
+        Mixed: two healthy running tools, one cancel-pending, one past-deadline.
+      </div>
+    </section>
+
+    <!-- Stuck banner (5s dwell on stuck_since / cancel_pending_remote_ack;
+         driven by liveness.expired_processing_count > 0 OR any projected stuck row) -->
+    <div class="stuck-banner" id="stuckBanner" role="status" aria-live="polite">
+      <span class="glyph" aria-hidden="true">⚠</span>
+      <div>
+        <strong>Stuck work detected.</strong>
+        <span id="stuckBannerDetail"></span>
+        <div class="meta">
+          5s dwell rule per spec §"Stuck Work Banner" — banner persists until a
+          clean operations snapshot is observed continuously for 5s.
+        </div>
+      </div>
+    </div>
+
+    <!-- Filter chips -->
+    <section class="card" aria-labelledby="filter-heading">
+      <h2 id="filter-heading">Filter</h2>
+      <div class="chip-row" role="group" aria-label="Filter by parent">
+        <span class="chip-label">Parent</span>
+        <div id="parentChips" class="chip-row" style="margin:0;"></div>
+      </div>
+      <div class="chip-row" role="group" aria-label="Filter by state">
+        <span class="chip-label">State</span>
+        <button type="button" class="chip" data-filter-state="running" aria-pressed="false">Running <span class="count" data-count-state="running">0</span></button>
+        <button type="button" class="chip" data-filter-state="background" aria-pressed="false">Background <span class="count" data-count-state="background">0</span></button>
+        <button type="button" class="chip" data-filter-state="stuck" aria-pressed="false">Stuck <span class="count" data-count-state="stuck">0</span></button>
+        <button type="button" class="chip" data-filter-state="cancelPending" aria-pressed="false">Cancel-pending <span class="count" data-count-state="cancelPending">0</span></button>
+        <button type="button" class="chip" data-filter-state="deadline+" aria-pressed="false">Past deadline <span class="count" data-count-state="deadline+">0</span></button>
+      </div>
+      <div class="chip-row" role="group" aria-label="Filter by await mode">
+        <span class="chip-label">Await</span>
+        <button type="button" class="chip" data-filter-await="background" aria-pressed="false">background</button>
+        <button type="button" class="chip" data-filter-await="bridge" aria-pressed="false">bridge</button>
+        <button type="button" class="chip" data-filter-await="detach" aria-pressed="false">detach</button>
+      </div>
+      <div class="chip-row">
+        <span class="chip-label">Threshold</span>
+        <label class="toggle">
+          <input type="checkbox" id="hideHealthy" /> Show only stuck / cancel-pending / past deadline
+        </label>
+      </div>
+    </section>
+
+    <!-- Panel -->
+    <section class="card" aria-labelledby="panel-heading">
+      <h2 id="panel-heading">Background Tools</h2>
+
+      <div class="panel-summary">
+        <div class="live-count">
+          <em id="liveCount">0</em> live <span style="color:var(--color-text-muted)">/ 8 max</span>
+        </div>
+        <div class="root" id="rootLabel">for —</div>
+      </div>
+
+      <div class="tools-table-wrap">
+        <table class="tools" id="toolsTable" role="grid" aria-describedby="panel-heading">
+          <caption class="visually-hidden">
+            Backgrounded tool calls. Sort columns with Enter; navigate rows with Arrow keys.
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col" data-sort="toolName"     aria-sort="none" tabindex="0">Tool</th>
+              <th scope="col" data-sort="ageMs"        aria-sort="descending" tabindex="0">Age</th>
+              <th scope="col" data-sort="requestId"    aria-sort="none" tabindex="0">Parent</th>
+              <th scope="col" data-sort="awaitMode"    aria-sort="none" tabindex="0">Await</th>
+              <th scope="col" data-sort="derivedState" aria-sort="none" tabindex="0">Status</th>
+              <th scope="col" data-sort="processLabel" aria-sort="none" tabindex="0">Process</th>
+              <th scope="col" aria-label="Row actions"></th>
+            </tr>
+          </thead>
+          <tbody id="toolsTbody">
+            <!-- rows injected by JS -->
+          </tbody>
+        </table>
+        <div id="emptyState" class="empty-state" hidden>
+          <span class="glyph" aria-hidden="true">○</span>
+          No backgrounded tools.
+        </div>
+        <div class="panel-footer">
+          <div class="footer-label" id="footerLabel">Select a row to act on its parent request.</div>
+          <button id="btnOpenLineage" type="button" disabled>Open lineage</button>
+          <button id="btnInterruptParent" type="button" class="warn" disabled>Interrupt parent</button>
+        </div>
+      </div>
+
+      <!-- screen-reader live region for ticking age values -->
+      <div id="ageLive" class="visually-hidden" aria-live="polite" aria-atomic="false"></div>
+
+      <div class="console-preview" id="consolePreview" aria-hidden="true">
+        <div class="log-line"><span class="ts">--:--:--</span> <span class="ev">init</span> prototype loaded — open DevTools console to see structured events</div>
+      </div>
+    </section>
+
+    <!-- Design notes -->
+    <details class="notes" id="designNotes">
+      <summary>Design notes</summary>
+
+      <h3>Tauri command surface</h3>
+      <p>
+        Snapshot of currently-backgrounded tool calls is consumed from
+        <code>desktop_operations_snapshot(request)</code> as defined in
+        spec §"Panel 5" / Panel 1 data-source sections. There is no separate
+        <code>list_backgrounded_tools()</code> command — that name appeared in
+        the PROMPT.md draft and was dropped to match the spec.
+      </p>
+
+      <h3>Snapshot fields consumed</h3>
+      <ul>
+        <li>
+          <code>liveness.active_tool_calls[]</code> — supplies
+          <code>tool_name</code>, <code>request_id</code>, <code>tool_call_id</code>,
+          <code>started_at</code>, <code>deadline_at</code>,
+          <code>await_mode</code>, <code>running_age_ms</code>,
+          <code>deadline_expired</code>.
+        </li>
+        <li>
+          <code>liveness.active_native_executors[]</code> (when
+          <code>active_native_executors_available</code>) — supplies
+          <code>id</code>, <code>pid</code>, <code>argv0</code>,
+          <code>tool_name</code>, <code>started_at</code>, <code>age_ms</code>.
+          Correlated to a tool call by <code>(tool_name, started_at)</code>
+          inside a ±1s window. The bridge never claims a PID it did not see in
+          the live liveness payload, so the Process column is best-effort.
+        </li>
+        <li>
+          <code>AgentToolCall</code> projection — supplies
+          <code>lifecycle_state</code>, <code>cancel_policy</code>,
+          <code>child_request_id</code>, <code>cancel_cascade_intent_at</code>,
+          <code>cancel_pending_remote_ack</code>, <code>stuck_since</code>.
+          Primary rows are <code>await_mode = "background"</code> with
+          non-terminal <code>lifecycle_state</code>.
+        </li>
+        <li>
+          <code>AgentRequest</code> projection — supplies
+          <code>session_id</code>, <code>subagent_depth</code>,
+          <code>caused_by_parent_request_id</code>,
+          <code>caused_by_parent_tool_call_id</code> for lineage.
+        </li>
+      </ul>
+
+      <h3>Stuck-tool visual treatment</h3>
+      <p>
+        A row is rendered as stuck (amber inset border, amber Status pill) when
+        either:
+      </p>
+      <ul>
+        <li>
+          <code>AgentToolCall.stuck_since</code> is set and the dwell since
+          that timestamp exceeds <strong>5 seconds</strong> (the spec's 5s
+          rule, not PROMPT.md's draft 60s figure), or
+        </li>
+        <li><code>AgentToolCall.cancel_pending_remote_ack</code> is set.</li>
+      </ul>
+      <p>
+        Banner-level surfacing follows the spec auto-clear rule: the banner
+        appears when <code>expired_processing_count &gt; 0</code> or any row
+        meets the stuck criteria, and clears only after a clean snapshot is
+        continuously observed for 5 seconds. A flaky bridge does not flap the
+        banner because dwell is wall-clock-based, not snapshot-count-based.
+      </p>
+
+      <h3>Per-row actions</h3>
+      <ul>
+        <li>
+          <strong>Open lineage</strong> selects the Lineage tab in
+          <code>OperationsRail</code> and calls
+          <code>desktop_list_subagent_tree</code> with the parent request id.
+          No mutation.
+        </li>
+        <li>
+          <strong>Interrupt parent</strong> opens the cascade preview for the
+          row's parent request via
+          <code>desktop_preview_interrupt_cascade</code>; confirmation calls
+          <code>desktop_interrupt_request</code>. This is the only cancel-style
+          entry point; per-tool cancel is intentionally absent (see Divergences).
+        </li>
+      </ul>
+
+      <h3>Accessibility</h3>
+      <ul>
+        <li>Column headers are sortable and reachable via Tab; Enter or Space toggles sort.</li>
+        <li>Arrow Up / Arrow Down on a focused row moves selection; Enter focuses footer actions.</li>
+        <li>The Age column ticks every second; updates are announced via a polite ARIA live region in batches (no per-second flood for screen readers).</li>
+        <li>Status pills carry a text label, not just colour — colour-blind operators see "stuck" / "deadline+" not just orange/red.</li>
+        <li>Filter chips are real <code>&lt;button&gt;</code>s with <code>aria-pressed</code>, so screen readers report toggle state.</li>
+        <li>Empty state and stuck banner are rendered as <code>role="status"</code> with polite live regions.</li>
+      </ul>
+
+      <h3>Open design questions</h3>
+      <ul>
+        <li>
+          <strong>Process correlation ambiguity.</strong> When two native
+          executors of the same tool name start within the ±1s window, do we
+          show "native &lt;id&gt;" with a tooltip listing candidates, or hide
+          the Process cell entirely? Current prototype shows the executor id
+          plus tooltip — needs operator validation.
+        </li>
+        <li>
+          <strong>Status pill vocabulary.</strong> Spec uses
+          <code>running / background / deadline +</code>. Prototype adds
+          <code>stuck</code> and <code>cancelPending</code> as derived states.
+          Should those be lifted into the bridge as first-class
+          <code>lifecycle_state</code> values, or left as
+          frontend-only projections?
+        </li>
+        <li>
+          <strong>Filter-chip counts</strong> currently reflect the loaded
+          dataset, not the post-filter view. Should counts update as other
+          chips are applied (intersection), or always remain dataset-totals?
+        </li>
+        <li>
+          <strong>Sort default.</strong> Prototype defaults to age descending
+          (oldest first). Operators triaging stuck work may prefer
+          stuck-then-age. Worth a usability check.
+        </li>
+        <li>
+          <strong>Density on small viewports.</strong> The dense table breaks
+          poorly &lt; 720px wide. OperationsRail tabs are typically pinned to a
+          fixed minimum width, but unpinned/floating cases need a card
+          fallback.
+        </li>
+      </ul>
+
+      <h3 style="color: var(--color-warning);">Divergences from PROMPT.md</h3>
+      <div class="divergence">
+        <ul>
+          <li>
+            PROMPT.md asks for "kill-signal-sent / reaped flags (if native executor)"
+            and a mock with "<code>exit_code = 1, reaped_at set</code>".
+            The runtime <code>NativeExecutorStatus</code> exposed via
+            <code>crates/defra-agent-cli/src/http/liveness.rs</code> carries
+            only <code>id, pid, argv0, tool_name, started_at, age_ms</code>.
+            Fields <code>kill_signaled_at</code>, <code>reaped_at</code>, and
+            <code>exit_code</code> live on the CLI's historical
+            <code>NativeExecutorRecord</code> (trace-export shape), not on the
+            live snapshot. Exited executors do not appear in
+            <code>active_native_executors</code>. Prototype omits these and
+            instead surfaces a derived <code>stuck</code> /
+            <code>cancelPending</code> status driven by
+            <code>AgentToolCall.stuck_since</code> +
+            <code>cancel_pending_remote_ack</code>.
+          </li>
+          <li>
+            PROMPT.md asks for a per-row "Cancel" button. The design spec
+            (§"Panel 1: Actions") explicitly rejects a per-tool cancel UX:
+            <em>"there is no desktop bridge command or public runtime API for
+            per-tool UI cancellation."</em> Prototype keeps only the
+            spec-sanctioned <strong>Open lineage</strong> and
+            <strong>Interrupt parent</strong> actions.
+          </li>
+          <li>
+            PROMPT.md scope #4 says "age &gt; 60s, kill_signaled but not
+            reaped." The spec's stuck-work auto-clear (§"Panel 5") uses a
+            <strong>5-second</strong> wall-clock dwell on
+            <code>stuck_since</code> /
+            <code>cancel_pending_remote_ack</code>. Prototype uses 5s.
+            PROMPT.md's own Design-notes bullet also cites the 5s rule,
+            confirming the 60s number was a draft slip.
+          </li>
+          <li>
+            PROMPT.md scope #2 includes a "completed" filter chip. The panel
+            is scoped to live, non-terminal backgrounded tools (spec join rule
+            "<code>AgentToolCall.await_mode = 'background'</code> and
+            non-terminal <code>lifecycle_state</code>"). Completed rows belong
+            to transcript history (Panel 4: CancelCause Surfacing), not this
+            rail. Prototype drops the "completed" chip.
+          </li>
+          <li>
+            PROMPT.md names the Tauri command
+            <code>list_backgrounded_tools(filter?)</code>. The actual surface
+            is <code>desktop_operations_snapshot(request)</code>.
+            Prototype's Design notes document the real command.
+          </li>
+        </ul>
+      </div>
+    </details>
+  </main>
+
+  <script>
+    // ---------------- Mock datasets ----------------
+    //
+    // Each tool call carries fields the spec projects from AgentToolCall +
+    // liveness.active_tool_calls[]. Timestamps are anchored to a fixed
+    // "snapshot_at" so the page ticks forward from a deterministic starting
+    // point each load.
+
+    const NOW_OFFSET_SEC = 0; // "now" tracks real wall-clock; offsets are subtracted from now()
+
+    function isoSecondsAgo(secs) {
+      return new Date(Date.now() - secs * 1000).toISOString();
+    }
+
+    function inSeconds(secs) {
+      return new Date(Date.now() + secs * 1000).toISOString();
+    }
+
+    const datasets = {
+      empty: {
+        label: "Empty: no backgrounded tools.",
+        rootRequestId: null,
+        expiredProcessingCount: 0,
+        toolCalls: [],
+        nativeExecutors: [],
+      },
+
+      oneFast: {
+        label: "One fast tool: a single just-started backgrounded tool, healthy.",
+        rootRequestId: "req_a17",
+        expiredProcessingCount: 0,
+        toolCalls: [
+          {
+            toolCallId: "tc_001",
+            requestId: "req_a17",
+            toolName: "grep",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(3),
+            deadlineAt: inSeconds(300),
+            awaitMode: "background",
+            cancelPolicy: "cascade",
+            childRequestId: null,
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+        ],
+        nativeExecutors: [
+          {
+            id: 902,
+            pid: 41812,
+            argv0: "/usr/bin/grep",
+            toolName: "grep",
+            startedAt: isoSecondsAgo(3),
+            ageMs: 3_000,
+          },
+        ],
+      },
+
+      oneStuck: {
+        label: "One stuck tool: stuck_since 12s ago, cancel_pending_remote_ack set.",
+        rootRequestId: "req_a17",
+        expiredProcessingCount: 0,
+        toolCalls: [
+          {
+            toolCallId: "tc_005",
+            requestId: "req_a17",
+            toolName: "index_repo",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(72),
+            deadlineAt: inSeconds(30),
+            awaitMode: "background",
+            cancelPolicy: "cascade",
+            childRequestId: null,
+            stuckSince: isoSecondsAgo(12),
+            cancelPendingRemoteAck: true,
+          },
+        ],
+        nativeExecutors: [
+          {
+            id: 41,
+            pid: 41902,
+            argv0: "/usr/bin/index_repo",
+            toolName: "index_repo",
+            startedAt: isoSecondsAgo(72),
+            ageMs: 72_000,
+          },
+        ],
+      },
+
+      mixed: {
+        label: "Mixed: two healthy running tools, one cancel-pending, one past-deadline.",
+        rootRequestId: "req_a17",
+        expiredProcessingCount: 1,
+        toolCalls: [
+          {
+            toolCallId: "tc_011",
+            requestId: "req_a17",
+            toolName: "summarize_files",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(134),
+            deadlineAt: inSeconds(420),
+            awaitMode: "background",
+            cancelPolicy: "cascade",
+            childRequestId: null,
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+          {
+            toolCallId: "tc_012",
+            requestId: "req_a17",
+            toolName: "grep",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(48),
+            deadlineAt: inSeconds(120),
+            awaitMode: "background",
+            cancelPolicy: "cascade",
+            childRequestId: null,
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+          {
+            toolCallId: "tc_013",
+            requestId: "req_b91",
+            toolName: "amy-rumination",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(321),
+            deadlineAt: inSeconds(600),
+            awaitMode: "bridge",
+            cancelPolicy: "cascade",
+            childRequestId: "req_b91_child",
+            stuckSince: isoSecondsAgo(11),
+            cancelPendingRemoteAck: true,
+          },
+          {
+            toolCallId: "tc_014",
+            requestId: "req_a17",
+            toolName: "fetch_remote_archive",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(422),
+            deadlineAt: isoSecondsAgo(7), // past deadline
+            awaitMode: "background",
+            cancelPolicy: "detach",
+            childRequestId: null,
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+        ],
+        nativeExecutors: [
+          {
+            id: 902,
+            pid: 41812,
+            argv0: "/usr/bin/summarize_files",
+            toolName: "summarize_files",
+            startedAt: isoSecondsAgo(134),
+            ageMs: 134_000,
+          },
+          {
+            id: 903,
+            pid: 41813,
+            argv0: "/usr/bin/grep",
+            toolName: "grep",
+            startedAt: isoSecondsAgo(48),
+            ageMs: 48_000,
+          },
+        ],
+      },
+
+      subagentHeavy: {
+        label: "Subagent-heavy: two child-request rows + one native executor.",
+        rootRequestId: "req_a17",
+        expiredProcessingCount: 0,
+        toolCalls: [
+          {
+            toolCallId: "tc_021",
+            requestId: "req_a17",
+            toolName: "amy-code",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(94),
+            deadlineAt: inSeconds(900),
+            awaitMode: "bridge",
+            cancelPolicy: "cascade",
+            childRequestId: "req_b91",
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+          {
+            toolCallId: "tc_022",
+            requestId: "req_a17",
+            toolName: "amy-review",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(38),
+            deadlineAt: inSeconds(900),
+            awaitMode: "bridge",
+            cancelPolicy: "detach",
+            childRequestId: "req_c44",
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+          {
+            toolCallId: "tc_023",
+            requestId: "req_b91",
+            toolName: "ripgrep",
+            lifecycleState: "running",
+            startedAt: isoSecondsAgo(7),
+            deadlineAt: inSeconds(120),
+            awaitMode: "background",
+            cancelPolicy: "cascade",
+            childRequestId: null,
+            stuckSince: null,
+            cancelPendingRemoteAck: false,
+          },
+        ],
+        nativeExecutors: [
+          {
+            id: 7711,
+            pid: 41999,
+            argv0: "/usr/bin/rg",
+            toolName: "ripgrep",
+            startedAt: isoSecondsAgo(7),
+            ageMs: 7_000,
+          },
+        ],
+      },
+    };
+
+    // ---------------- State ----------------
+
+    // Allow URL hash to preselect a dataset (e.g. #dataset=oneStuck) for
+    // deterministic screenshots and shareable demo links.
+    function initialDatasetKey() {
+      const m = /[#&]dataset=([a-zA-Z]+)/.exec(window.location.hash || "");
+      const key = m && m[1];
+      return key && datasets[key] ? key : "mixed";
+    }
+
+    const STATE = {
+      datasetKey: initialDatasetKey(),
+      stateFilters: new Set(),
+      awaitFilters: new Set(),
+      parentFilter: "all",
+      hideHealthy: false,
+      sortKey: "ageMs",
+      sortDir: "descending",
+      selectedToolCallId: null,
+    };
+
+    // ---------------- Console event log (visible + browser console) ----------------
+
+    const consolePreview = document.getElementById("consolePreview");
+
+    function emit(event, payload) {
+      const ts = new Date().toISOString().slice(11, 19);
+      // browser console for inspection
+      console.log(`[panel-276] ${event}`, payload || {});
+      // mirrored in-page console preview
+      const line = document.createElement("div");
+      line.className = "log-line";
+      line.innerHTML =
+        `<span class="ts">${ts}</span> ` +
+        `<span class="ev">${event}</span> ` +
+        (payload ? escapeHtml(JSON.stringify(payload)) : "");
+      consolePreview.prepend(line);
+      // keep last ~30
+      while (consolePreview.childElementCount > 30) {
+        consolePreview.lastElementChild.remove();
+      }
+    }
+
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+    }
+
+    // ---------------- Derivation helpers ----------------
+
+    function parseIso(s) {
+      if (!s) return null;
+      const d = new Date(s);
+      return Number.isNaN(d.getTime()) ? null : d;
+    }
+
+    function ageMs(toolCall) {
+      const started = parseIso(toolCall.startedAt);
+      if (!started) return 0;
+      return Date.now() - started.getTime();
+    }
+
+    function deadlineExpired(toolCall) {
+      const d = parseIso(toolCall.deadlineAt);
+      return d != null && Date.now() > d.getTime();
+    }
+
+    function stuckSinceMs(toolCall) {
+      const s = parseIso(toolCall.stuckSince);
+      return s ? Date.now() - s.getTime() : null;
+    }
+
+    // 5s dwell rule per spec §"Panel 5"
+    const STUCK_DWELL_MS = 5_000;
+
+    function derivedState(toolCall) {
+      const stuckMs = stuckSinceMs(toolCall);
+      if (stuckMs != null && stuckMs >= STUCK_DWELL_MS) return "stuck";
+      if (toolCall.cancelPendingRemoteAck) return "cancelPending";
+      if (deadlineExpired(toolCall)) return "deadline+";
+      if (toolCall.awaitMode === "background") return "background";
+      return toolCall.lifecycleState || "running";
+    }
+
+    // Correlate a tool call to a native executor by (toolName, startedAt ±1s)
+    function correlateProcess(toolCall, nativeExecutors) {
+      const tcStart = parseIso(toolCall.startedAt);
+      if (!tcStart) return processFromChild(toolCall);
+      const candidates = nativeExecutors.filter(
+        (ne) =>
+          ne.toolName === toolCall.toolName &&
+          Math.abs(parseIso(ne.startedAt).getTime() - tcStart.getTime()) <= 1_000
+      );
+      if (candidates.length === 1) {
+        const ne = candidates[0];
+        return { label: `pid ${ne.pid}`, tooltip: `native ${ne.id} · ${ne.argv0}` };
+      }
+      if (candidates.length > 1) {
+        return {
+          label: `native ${candidates[0].id}`,
+          tooltip: `ambiguous: ${candidates.length} candidates — ${candidates
+            .map((c) => `native ${c.id}/pid ${c.pid}`)
+            .join(", ")}`,
+        };
+      }
+      return processFromChild(toolCall);
+    }
+
+    function processFromChild(toolCall) {
+      if (toolCall.childRequestId) {
+        return { label: `child ${toolCall.childRequestId}`, tooltip: "subagent dispatch" };
+      }
+      return { label: "—", tooltip: "no native executor; in-process tool" };
+    }
+
+    function formatAge(ms) {
+      const totalSec = Math.max(0, Math.floor(ms / 1000));
+      const h = Math.floor(totalSec / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+      const s = totalSec % 60;
+      const pad = (n) => String(n).padStart(2, "0");
+      return h > 0 ? `${pad(h)}:${pad(m)}:${pad(s)}` : `${pad(m)}:${pad(s)}`;
+    }
+
+    // ---------------- Rendering ----------------
+
+    const tbody = document.getElementById("toolsTbody");
+    const emptyState = document.getElementById("emptyState");
+    const liveCountEl = document.getElementById("liveCount");
+    const rootLabelEl = document.getElementById("rootLabel");
+    const datasetCaption = document.getElementById("datasetCaption");
+    const stuckBanner = document.getElementById("stuckBanner");
+    const stuckBannerDetail = document.getElementById("stuckBannerDetail");
+    const parentChips = document.getElementById("parentChips");
+    const ageLive = document.getElementById("ageLive");
+
+    function activeDataset() {
+      return datasets[STATE.datasetKey];
+    }
+
+    function projectedRows() {
+      const ds = activeDataset();
+      return ds.toolCalls
+        .map((tc) => {
+          const proc = correlateProcess(tc, ds.nativeExecutors);
+          return {
+            ...tc,
+            derivedState: derivedState(tc),
+            ageMs: ageMs(tc),
+            processLabel: proc.label,
+            processTooltip: proc.tooltip,
+          };
+        });
+    }
+
+    function applyFilters(rows) {
+      return rows.filter((row) => {
+        if (STATE.parentFilter !== "all" && row.requestId !== STATE.parentFilter) return false;
+        if (STATE.stateFilters.size > 0 && !STATE.stateFilters.has(row.derivedState)) return false;
+        if (STATE.awaitFilters.size > 0 && !STATE.awaitFilters.has(row.awaitMode)) return false;
+        if (STATE.hideHealthy) {
+          if (!["stuck", "cancelPending", "deadline+"].includes(row.derivedState)) return false;
+        }
+        return true;
+      });
+    }
+
+    function sortRows(rows) {
+      const dir = STATE.sortDir === "ascending" ? 1 : -1;
+      const key = STATE.sortKey;
+      return [...rows].sort((a, b) => {
+        const av = a[key];
+        const bv = b[key];
+        if (av == null && bv == null) return 0;
+        if (av == null) return 1;
+        if (bv == null) return -1;
+        if (typeof av === "number" && typeof bv === "number") return (av - bv) * dir;
+        return String(av).localeCompare(String(bv)) * dir;
+      });
+    }
+
+    function render() {
+      const ds = activeDataset();
+      datasetCaption.textContent = ds.label;
+      rootLabelEl.textContent = ds.rootRequestId ? `for ${ds.rootRequestId}` : "for —";
+
+      const allRows = projectedRows();
+      const filtered = sortRows(applyFilters(allRows));
+
+      liveCountEl.textContent = String(filtered.length);
+
+      // counts on state chips (totals from dataset, not post-filter)
+      for (const stateKey of ["running", "background", "stuck", "cancelPending", "deadline+"]) {
+        const el = document.querySelector(`[data-count-state="${stateKey}"]`);
+        if (!el) continue;
+        const count = allRows.filter((r) => r.derivedState === stateKey).length;
+        el.textContent = String(count);
+      }
+
+      renderParentChips(allRows);
+      renderStuckBanner(allRows, ds);
+      renderRows(filtered);
+      updateSortIndicators();
+      updateFooter(filtered);
+    }
+
+    function renderParentChips(allRows) {
+      const parents = Array.from(new Set(allRows.map((r) => r.requestId)));
+      const chips = [`<button type="button" class="chip ${STATE.parentFilter === "all" ? "is-active" : ""}" data-filter-parent="all" aria-pressed="${STATE.parentFilter === "all"}">All</button>`];
+      for (const p of parents) {
+        const active = STATE.parentFilter === p;
+        chips.push(
+          `<button type="button" class="chip ${active ? "is-active" : ""}" data-filter-parent="${escapeHtml(p)}" aria-pressed="${active}">${escapeHtml(p)}</button>`
+        );
+      }
+      parentChips.innerHTML = chips.join("");
+      parentChips.querySelectorAll("button[data-filter-parent]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          STATE.parentFilter = btn.dataset.filterParent;
+          emit("filter.parent", { parent: STATE.parentFilter });
+          render();
+        });
+      });
+    }
+
+    function renderStuckBanner(allRows, ds) {
+      const stuckCount = allRows.filter(
+        (r) => r.derivedState === "stuck" || r.derivedState === "cancelPending"
+      ).length;
+      const deadlinePassed =
+        ds.expiredProcessingCount > 0 ||
+        allRows.filter((r) => r.derivedState === "deadline+").length > 0;
+
+      if (stuckCount === 0 && !deadlinePassed) {
+        stuckBanner.classList.remove("is-visible");
+        return;
+      }
+      stuckBanner.classList.add("is-visible");
+      const parts = [];
+      if (stuckCount > 0) {
+        parts.push(`${stuckCount} stuck or cancel-pending tool call${stuckCount === 1 ? "" : "s"}`);
+      }
+      if (deadlinePassed) {
+        parts.push("requests past deadline");
+      }
+      stuckBannerDetail.textContent = parts.join(" · ");
+    }
+
+    function renderRows(rows) {
+      tbody.innerHTML = "";
+      if (rows.length === 0) {
+        emptyState.hidden = false;
+        return;
+      }
+      emptyState.hidden = true;
+
+      for (const row of rows) {
+        const tr = document.createElement("tr");
+        tr.dataset.toolCallId = row.toolCallId;
+        tr.tabIndex = 0;
+        tr.setAttribute("role", "row");
+        if (STATE.selectedToolCallId === row.toolCallId) {
+          tr.classList.add("is-selected");
+        }
+        const isWarn = ["stuck", "cancelPending"].includes(row.derivedState);
+        if (isWarn) tr.classList.add("row-stuck");
+
+        const procEmpty = row.processLabel === "—" ? "is-empty" : "";
+        tr.innerHTML =
+          `<td class="cell-tool" role="gridcell">${escapeHtml(row.toolName)}</td>` +
+          `<td class="cell-age" role="gridcell" data-age-cell data-started-at="${escapeHtml(row.startedAt || "")}">${formatAge(row.ageMs)}</td>` +
+          `<td class="cell-parent" role="gridcell">${escapeHtml(row.requestId)}</td>` +
+          `<td role="gridcell"><span class="pill pill-await" data-mode="${escapeHtml(row.awaitMode || "")}">${escapeHtml(row.awaitMode || "—")}</span></td>` +
+          `<td role="gridcell">${renderStatusPill(row)}</td>` +
+          `<td class="cell-process ${procEmpty}" role="gridcell" data-tooltip="${escapeHtml(row.processTooltip)}">${escapeHtml(row.processLabel)}</td>` +
+          `<td role="gridcell"><div class="row-actions">` +
+          `  <button type="button" data-row-action="open-lineage" data-tooltip="Selects Lineage tab and calls desktop_list_subagent_tree">Lineage</button>` +
+          `  <button type="button" class="danger" data-row-action="interrupt-parent" data-tooltip="Opens cascade preview for parent request">Interrupt</button>` +
+          `</div></td>`;
+
+        tr.addEventListener("click", () => selectRow(row.toolCallId));
+        tr.addEventListener("focus", () => selectRow(row.toolCallId));
+
+        tr.querySelectorAll("button[data-row-action]").forEach((btn) => {
+          btn.addEventListener("click", (ev) => {
+            ev.stopPropagation();
+            const action = btn.dataset.rowAction;
+            emit(`row.${action}`, {
+              toolCallId: row.toolCallId,
+              requestId: row.requestId,
+              toolName: row.toolName,
+              derivedState: row.derivedState,
+            });
+          });
+        });
+
+        tbody.appendChild(tr);
+      }
+    }
+
+    function renderStatusPill(row) {
+      const label = row.derivedState;
+      const tooltip =
+        label === "stuck"
+          ? `stuck_since ${row.stuckSince} · cancel_pending_remote_ack=${row.cancelPendingRemoteAck}`
+          : label === "cancelPending"
+          ? "cancel_pending_remote_ack set"
+          : label === "deadline+"
+          ? `deadline ${row.deadlineAt} has passed`
+          : "lifecycle_state from AgentToolCall";
+      const glyph = label === "stuck" || label === "cancelPending" ? "⚠ " : label === "deadline+" ? "⏱ " : "";
+      return `<span class="pill pill-status" data-state="${escapeHtml(label)}" data-tooltip="${escapeHtml(tooltip)}">${glyph}${escapeHtml(label)}</span>`;
+    }
+
+    function updateSortIndicators() {
+      document.querySelectorAll("table.tools thead th[data-sort]").forEach((th) => {
+        if (th.dataset.sort === STATE.sortKey) {
+          th.setAttribute("aria-sort", STATE.sortDir);
+        } else {
+          th.setAttribute("aria-sort", "none");
+        }
+      });
+    }
+
+    function selectRow(toolCallId) {
+      STATE.selectedToolCallId = toolCallId;
+      tbody.querySelectorAll("tr.is-selected").forEach((tr) => tr.classList.remove("is-selected"));
+      const tr = tbody.querySelector(`tr[data-tool-call-id="${CSS.escape(toolCallId)}"]`);
+      if (tr) tr.classList.add("is-selected");
+      updateFooter();
+    }
+
+    function updateFooter(_rows) {
+      const ds = activeDataset();
+      const allRows = projectedRows();
+      const selected = allRows.find((r) => r.toolCallId === STATE.selectedToolCallId);
+      const footer = document.getElementById("footerLabel");
+      const btnLineage = document.getElementById("btnOpenLineage");
+      const btnInterrupt = document.getElementById("btnInterruptParent");
+
+      if (!selected) {
+        footer.textContent = "Select a row to act on its parent request.";
+        btnLineage.disabled = true;
+        btnInterrupt.disabled = true;
+        return;
+      }
+      footer.textContent = `Selected ${selected.toolName} (tc ${selected.toolCallId}) — parent ${selected.requestId}`;
+      btnLineage.disabled = false;
+      btnInterrupt.disabled = false;
+    }
+
+    // ---------------- Age ticker + ARIA live ----------------
+
+    let lastAriaAnnouncement = 0;
+    function tickAges() {
+      const ageCells = tbody.querySelectorAll("[data-age-cell]");
+      ageCells.forEach((cell) => {
+        const startedAt = cell.dataset.startedAt;
+        if (!startedAt) return;
+        const ms = Date.now() - new Date(startedAt).getTime();
+        cell.textContent = formatAge(ms);
+      });
+      // Throttle ARIA announcements to every 30s — per-second age updates
+      // would spam screen readers. Spec accessibility section explicitly
+      // calls for batched updates.
+      const now = Date.now();
+      if (now - lastAriaAnnouncement > 30_000 && ageCells.length > 0) {
+        const oldest = Math.max(
+          ...Array.from(ageCells).map((c) =>
+            c.dataset.startedAt ? Date.now() - new Date(c.dataset.startedAt).getTime() : 0
+          )
+        );
+        ageLive.textContent = `Oldest backgrounded tool: ${formatAge(oldest)}.`;
+        lastAriaAnnouncement = now;
+      }
+    }
+
+    setInterval(tickAges, 1_000);
+
+    // ---------------- Wire up controls ----------------
+
+    // Dataset switcher
+    document.querySelectorAll("[data-dataset]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        STATE.datasetKey = btn.dataset.dataset;
+        STATE.selectedToolCallId = null;
+        document.querySelectorAll("[data-dataset]").forEach((b) => {
+          const active = b === btn;
+          b.classList.toggle("is-active", active);
+          b.setAttribute("aria-checked", String(active));
+        });
+        emit("dataset.switch", { dataset: STATE.datasetKey });
+        render();
+      });
+    });
+
+    // State filter chips
+    document.querySelectorAll("[data-filter-state]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const key = btn.dataset.filterState;
+        if (STATE.stateFilters.has(key)) {
+          STATE.stateFilters.delete(key);
+        } else {
+          STATE.stateFilters.add(key);
+        }
+        btn.setAttribute("aria-pressed", String(STATE.stateFilters.has(key)));
+        btn.classList.toggle("is-active", STATE.stateFilters.has(key));
+        emit("filter.state", { active: Array.from(STATE.stateFilters) });
+        render();
+      });
+    });
+
+    // Await filter chips
+    document.querySelectorAll("[data-filter-await]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const key = btn.dataset.filterAwait;
+        if (STATE.awaitFilters.has(key)) {
+          STATE.awaitFilters.delete(key);
+        } else {
+          STATE.awaitFilters.add(key);
+        }
+        btn.setAttribute("aria-pressed", String(STATE.awaitFilters.has(key)));
+        btn.classList.toggle("is-active", STATE.awaitFilters.has(key));
+        emit("filter.await", { active: Array.from(STATE.awaitFilters) });
+        render();
+      });
+    });
+
+    // Hide-healthy toggle
+    document.getElementById("hideHealthy").addEventListener("change", (ev) => {
+      STATE.hideHealthy = ev.target.checked;
+      emit("filter.hideHealthy", { hideHealthy: STATE.hideHealthy });
+      render();
+    });
+
+    // Column sort
+    document.querySelectorAll("table.tools thead th[data-sort]").forEach((th) => {
+      const toggle = () => {
+        const key = th.dataset.sort;
+        if (STATE.sortKey === key) {
+          STATE.sortDir = STATE.sortDir === "ascending" ? "descending" : "ascending";
+        } else {
+          STATE.sortKey = key;
+          STATE.sortDir = "ascending";
+        }
+        emit("sort", { key: STATE.sortKey, dir: STATE.sortDir });
+        render();
+      };
+      th.addEventListener("click", toggle);
+      th.addEventListener("keydown", (ev) => {
+        if (ev.key === "Enter" || ev.key === " ") {
+          ev.preventDefault();
+          toggle();
+        }
+      });
+    });
+
+    // Footer actions
+    document.getElementById("btnOpenLineage").addEventListener("click", () => {
+      const sel = projectedRows().find((r) => r.toolCallId === STATE.selectedToolCallId);
+      if (sel) emit("footer.open-lineage", { requestId: sel.requestId, toolCallId: sel.toolCallId });
+    });
+    document.getElementById("btnInterruptParent").addEventListener("click", () => {
+      const sel = projectedRows().find((r) => r.toolCallId === STATE.selectedToolCallId);
+      if (sel) emit("footer.interrupt-parent", { requestId: sel.requestId });
+    });
+
+    // Keyboard nav: Arrow keys on focused row
+    tbody.addEventListener("keydown", (ev) => {
+      const tr = ev.target.closest("tr");
+      if (!tr) return;
+      if (ev.key === "ArrowDown" || ev.key === "ArrowUp") {
+        ev.preventDefault();
+        const next = ev.key === "ArrowDown" ? tr.nextElementSibling : tr.previousElementSibling;
+        if (next) {
+          next.focus();
+        }
+      } else if (ev.key === "Enter") {
+        ev.preventDefault();
+        document.getElementById("btnInterruptParent").focus();
+      }
+    });
+
+    // Sync dataset switcher chip with initial STATE.datasetKey (which may
+    // have been seeded from the URL hash).
+    document.querySelectorAll("[data-dataset]").forEach((b) => {
+      const active = b.dataset.dataset === STATE.datasetKey;
+      b.classList.toggle("is-active", active);
+      b.setAttribute("aria-checked", String(active));
+    });
+
+    // First render
+    render();
+    emit("ready", { dataset: STATE.datasetKey });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Single PR shipping both phases of issue #276:

- **Phase 1** (commits `99342436` / `7c2d59c2`) — Self-contained HTML prototype at `docs/ui-prototypes/panel-276-backgrounded-tools.html` + implementation plan at `docs/superpowers/plans/2026-05-20-issue-276-backgrounded-tools-impl.md`.
- **Phase 2** (commits `0dde9906` → `e1ec1a1d`) — Real Tauri implementation: `BackgroundedToolsPanel` React component, full `desktop_operations_snapshot` command body, OperationsRail mount, Lean ledger promotion.

## Phase 2 changes

| Surface | What changed |
|---|---|
| Rust types | Additive `stuck_since: Option<String>` + `cancel_pending_remote_ack: bool` on `BackgroundedToolView` (Rust + TS mirror). |
| Rust projector | Pure functions `project_backgrounded_tools` + `stuck_diagnostics_from_tool_calls` in `bridge/snapshot/operations_snapshot.rs`. 5 unit tests. |
| Tauri command | `desktop_operations_snapshot` body wires `defra_agent::active_native_executors()` + an `EmbeddedNode::execute()` GraphQL query of `AgentToolCall { await_mode: "background" }`, then projects through the pure functions. Other three stubs in `operations.rs` remain panel-owned by #285 / #286 / #283. |
| TypeScript | `fetchOperationsSnapshot` adapter, `useOperationsSnapshot` polling hook (2s), `BackgroundedToolsPanel` component, scoped CSS port, derivation helpers (`derivedState` / `correlateProcess` / `formatAge`). 22 new vitest tests. |
| OperationsRail | First real tab mounted in `ChatWorkspace.tsx`. |
| Lean | `background-tools.operatorUi` promoted from `deferred` to `required`; new `consumerCoverage` entry binds the Rust projector test under the existing `R4cBackgroundWorkCases` emitted pair. |

## Known limitations / carry-forward concerns

1. **`stuck_since` / `cancel_pending_remote_ack` are not yet populated by the runtime.** The schema fields exist on `AgentToolCall`, and the bridge now exposes them, but no runtime code currently writes them. The panel renders correctly either way — stuck-status derivation falls through to `running` / `background` / `deadline+` when those fields are null.

2. **Agent-DID scoping is best-effort.** `AgentToolCall` has no `agent_did` field, so the GraphQL query returns all background tool calls reachable from the local DefraDB. In multi-deployment setups this means the panel may show rows from peer agents. The `request.agentDid` is preserved in the response envelope only.

3. **Ledger binding is structurally weaker than `streaming-response`'s.** The new consumer test (`project_filters_to_background_await_mode_only`) uses hand-built `ToolCallRow` fixtures rather than iterating Lean-generated `R4cBackgroundWorkCases`. The drift test passes because (feature, surface) coverage is satisfied, but a follow-up should add a dedicated generated-case iterator once `BackgroundedToolProjection` cases exist on the Lean side.

4. **Pre-existing flake (not from this PR).** `crates/defra-agent/src/agent/runtime/tests/startup_recovery.rs::run_agent_shutdown_is_prompt_while_request_waits_for_backend_capacity` failed once in the verification pass with a 5s polling timeout, and passed in isolation. The branch does not touch that test or its surrounding runtime code. Worth a separate issue.

5. **Per-row Lineage / Interrupt buttons are stubs.** They `console.log` the request/tool ids until #285 (lineage) and #283 (interrupt) land. Marked with `TODO:` comments in the source.

6. **Conflict surface.** Other panels (#274 / #277 / #285 / #286 / #288) replace stubs in `operations.rs` and add tabs to `ChatWorkspace.tsx`. Expect rebase if any of them lands first.

## Verification

- ✅ `lake build` clean — no `sorry`s introduced
- ✅ `cargo test -p defra-agent-desktop-tauri --lib` — 55 passed, 0 failed
- ✅ `cargo test -p defra-agent --test state_machine_conformance` — 84 passed (drift test green)
- ✅ `cargo check -p defra-agent` / `cargo check -p defra-agent-desktop-tauri` — clean (16 pre-existing dead-code warnings)
- ✅ `npm test` in `apps/desktop-tauri` — 79 passed / 3 skipped (the 3 are live-bridge tests, expected)
- ✅ `npx tsc --noEmit` — clean
- ⚠ `cargo test -p defra-agent --lib` — 1 pre-existing flake (item 4 above), all other tests pass.

## Test plan

- [ ] Open `docs/ui-prototypes/panel-276-backgrounded-tools.html` in a browser — visual baseline for the implementation.
- [ ] `cd crates/defra-agent/proofs && lake build` — no errors.
- [ ] `cargo check -p defra-agent && cargo check -p defra-agent-desktop-tauri` — clean.
- [ ] `cargo test -p defra-agent-desktop-tauri` — green.
- [ ] `cargo test -p defra-agent --test state_machine_conformance` — green.
- [ ] `cd apps/desktop-tauri && npm test` — all 79 suite tests pass.
- [ ] Manual: `npm run tauri dev`, open a chat, confirm the new **Background** tab appears in the operations rail and renders the panel. With no live agent activity it should show the empty state; with a real backgrounded tool it should populate the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)