### PR TITLE
Implement B3 cascade interrupt

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/cascade.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/cascade.rs
@@ -76,9 +76,10 @@ pub(crate) struct CascadeWalkResult {
 /// Filters terminal rows when `include_terminal == false`, except as
 /// AlreadyTerminal evidence.
 ///
-/// When `req.agent_did` is `Some(did)`, both the root AgentRequest query and
-/// every AgentToolCall / child AgentRequest query include an `agent_did` filter
-/// so the walk is scoped to that operator's documents only.
+/// When `req.agent_did` is `Some(did)`, the root AgentRequest query is scoped
+/// to that operator's documents. Descendants are then authorized by persisted
+/// AgentToolCall.child_request_id edges, because linked subagents may be owned
+/// by a different deployment DID than the root request.
 pub(crate) async fn walk(
     core: &Arc<ClientCore>,
     req: &CascadeWalkRequest,
@@ -105,7 +106,6 @@ pub(crate) async fn walk(
 
     bfs(
         node,
-        agent_did,
         &req.root_request_id,
         req.include_terminal,
         0,
@@ -119,11 +119,8 @@ pub(crate) async fn walk(
 
 /// BFS descent over AgentToolCall edges. `parent_request_id` is the node whose
 /// children we're expanding at this call level. `depth` starts at 0.
-///
-/// When `agent_did` is `Some(did)`, queries filter to rows owned by that DID.
 async fn bfs(
     node: &EmbeddedNode,
-    agent_did: Option<&str>,
     parent_request_id: &str,
     include_terminal: bool,
     depth: usize,
@@ -135,8 +132,9 @@ async fn bfs(
     }
 
     // Query all AgentToolCall rows where request_id == parent AND child_request_id is set.
-    // AgentToolCall does not carry agent_did; operator scoping is enforced via
-    // fetch_request (which does filter by agent_did) for the root and each child.
+    // AgentToolCall does not carry agent_did. Operator scoping is enforced on
+    // the root request before the walk starts; child reachability is the bridge
+    // edge itself, which supports cross-deployment subagents.
     let escaped_parent = escape_graphql_string(parent_request_id);
     let query = format!(
         r#"{{
@@ -187,14 +185,11 @@ async fn bfs(
         let await_mode = string_field(tc, "await_mode");
         let cancel_policy = string_field(tc, "cancel_policy");
 
-        // Fetch child request to determine lifecycle state. Scope by agent_did if provided.
-        // If the child is owned by a different agent (not found under the filter), skip it.
-        let child_row = match fetch_request(node, &child_id, agent_did).await {
+        // Fetch child request to determine lifecycle state. Do not apply the
+        // root agent_did filter here: a valid subagent edge can point at a child
+        // request owned by a different deployment DID.
+        let child_row = match fetch_request(node, &child_id, None).await {
             Ok(row) => row,
-            Err(_) if agent_did.is_some() => {
-                // Child is not visible under the agent_did scope — skip it.
-                continue;
-            }
             Err(e) => {
                 return Err(format!(
                     "cascade::walk: child request {child_id} not found: {e}"
@@ -246,7 +241,6 @@ async fn bfs(
         if should_recurse {
             Box::pin(bfs(
                 node,
-                agent_did,
                 &child_id,
                 include_terminal,
                 depth + 1,
@@ -454,7 +448,6 @@ pub(crate) async fn latch_root_interrupt(
 /// `InterruptRequestResult` reflecting whether this call was the first to set
 /// the field (`accepted`) or the field was already set (`already_interrupted`).
 ///
-/// The cascade path is not yet implemented (Task 6).
 pub(crate) async fn interrupt_request(
     core: &Arc<ClientCore>,
     req: &DesktopInterruptRequest,
@@ -505,10 +498,13 @@ pub(crate) async fn interrupt_request(
         });
     }
 
-    // Signature matches — latch the root. Cascade observers / runtime will
-    // complete child requests; the bridge does not eagerly cancel children
-    // (that's the runtime's contract).
+    // Signature matches — latch the root and every descendant that the
+    // preview classified as cascade-interruptible. This is the Rust bridge
+    // counterpart to Lean's bridge_cancel_cascade step: set
+    // interrupt_requested_at on the child so the child daemon can lift
+    // interrupt_processing to the interrupted terminal state.
     let latched = latch_root_interrupt(core, &req.request_id).await?;
+    latch_cascade_descendants(core, &preview).await?;
     Ok(InterruptRequestResult {
         request_id: req.request_id.clone(),
         accepted: true, // idempotent success — always accepted when latched or already latched
@@ -517,6 +513,28 @@ pub(crate) async fn interrupt_request(
         stale_preview: false,
         preview: None,
     })
+}
+
+async fn latch_cascade_descendants(
+    core: &Arc<ClientCore>,
+    preview: &CascadeCancelPreview,
+) -> Result<(), String> {
+    for child in &preview.will_interrupt {
+        defra_agent::interrupt_request(core.node(), &child.request_id)
+            .await
+            .map_err(|error| {
+                format!(
+                    "cascade interrupt failed to latch child request {}: {error}",
+                    child.request_id
+                )
+            })?;
+        tracing::info!(
+            root_request_id = %preview.root_request_id,
+            child_request_id = %child.request_id,
+            "cascade interrupt latched descendant request"
+        );
+    }
+    Ok(())
 }
 
 /// Extract a non-empty string field from a JSON object.

--- a/apps/desktop-tauri/src-tauri/src/bridge/tests/operations_cascade.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tests/operations_cascade.rs
@@ -136,10 +136,10 @@ async fn walk_returns_no_rows_for_standalone_root() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn walk_excludes_rows_owned_by_different_agent_did() {
-    // Seed the cascade fixture (owned by did:test:operator) plus one
-    // AgentRequest owned by did:test:other. Walk with agent_did filter.
-    // Assert: the other-agent request is NOT in the result.
+async fn walk_excludes_unlinked_rows_owned_by_different_agent_did() {
+    // The root is scoped by agent_did, but the walk only follows AgentToolCall
+    // bridge edges. A foreign row that is not linked by a tool edge must not
+    // appear just because it points at the root in lineage fields.
     let (core, _tmp) = super::support::seed_cascade_fixture_with_foreign_request().await;
     let req = CascadeWalkRequest {
         root_request_id: "req_root".into(),
@@ -150,11 +150,10 @@ async fn walk_excludes_rows_owned_by_different_agent_did() {
         .await
         .expect("walk ok");
 
-    // The foreign request must not appear in any walked row.
     let has_foreign = result.rows.iter().any(|r| r.request_id == "req_foreign");
     assert!(
         !has_foreign,
-        "walk with agent_did=did:test:operator should NOT include req_foreign (owned by did:test:other)"
+        "walk should not include unlinked foreign request rows"
     );
 
     // The operator's own rows must still be present.
@@ -166,5 +165,29 @@ async fn walk_excludes_rows_owned_by_different_agent_did() {
     assert!(
         operator_count > 0,
         "expected operator-owned rows to be present"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn walk_includes_bridge_linked_child_owned_by_different_agent_did() {
+    let (core, _tmp) = super::support::seed_cascade_fixture_with_foreign_linked_child().await;
+    let preview = build_cascade_preview(
+        &core,
+        &DesktopPreviewInterruptCascadeRequest {
+            request_id: "req_root".into(),
+            agent_did: Some("did:test:operator".into()),
+            include_terminal: Some(true),
+        },
+    )
+    .await
+    .expect("preview ok");
+
+    let linked = preview
+        .will_interrupt
+        .iter()
+        .find(|row| row.request_id == "req_foreign_linked");
+    assert!(
+        linked.is_some(),
+        "cascade preview should include cross-DID children reached by bridge edge"
     );
 }

--- a/apps/desktop-tauri/src-tauri/src/bridge/tests/operations_interrupt.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tests/operations_interrupt.rs
@@ -134,6 +134,49 @@ async fn interrupt_request_cascade_returns_accepted_when_signature_matches() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn interrupt_request_cascade_latches_only_cascade_descendants() {
+    let (core, _tmp) = seed_cascade_fixture().await;
+    let preview = build_cascade_preview(
+        &core,
+        &DesktopPreviewInterruptCascadeRequest {
+            request_id: "req_root".into(),
+            agent_did: Some("did:test:operator".into()),
+            include_terminal: Some(true),
+        },
+    )
+    .await
+    .unwrap();
+
+    let result = interrupt_request(
+        &core,
+        &DesktopInterruptRequest {
+            request_id: "req_root".into(),
+            cause: "userCancelled".into(),
+            cascade: true,
+            expected_preview_signature: Some(preview.preview_signature.clone()),
+        },
+    )
+    .await
+    .expect("cascade interrupt ok");
+
+    assert!(result.accepted);
+    for request_id in ["req_root", "req_b91", "req_b92", "req_c01"] {
+        let row = fetch_request_row(&core, request_id).await;
+        assert!(
+            row.interrupt_requested_at.is_some(),
+            "{request_id} should be latched by cascade interrupt"
+        );
+    }
+    for request_id in ["req_b93", "req_c02", "req_a17_old"] {
+        let row = fetch_request_row(&core, request_id).await;
+        assert!(
+            row.interrupt_requested_at.is_none(),
+            "{request_id} should not be latched by cascade interrupt"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn interrupt_request_cascade_returns_stale_preview_when_signature_drifts() {
     let (core, _tmp) = seed_cascade_fixture().await;
     let result = interrupt_request(

--- a/apps/desktop-tauri/src-tauri/src/bridge/tests/support.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tests/support.rs
@@ -285,14 +285,14 @@ pub(crate) async fn seed_cascade_fixture() -> (Arc<ClientCore>, TempDir) {
     (core, tmp)
 }
 
-/// Seeds the cascade fixture PLUS one `AgentRequest` owned by `did:test:other`
-/// to verify that agent_did-scoped walks exclude foreign-agent rows.
+/// Seeds the cascade fixture PLUS one unlinked `AgentRequest` owned by
+/// `did:test:other` to verify that walks only follow bridge edges.
 pub(crate) async fn seed_cascade_fixture_with_foreign_request() -> (Arc<ClientCore>, TempDir) {
     let (core, tmp) = seed_cascade_fixture().await;
 
-    // Seed one extra request owned by a different agent DID.
-    // It references req_root's session just to be realistic, but its agent_did
-    // is different so a did:test:operator-scoped walk must not see it.
+    // Seed one extra request owned by a different agent DID. It references the
+    // root lineage fields, but no AgentToolCall points at it, so the walk must
+    // not include it.
     let mutation = r#"mutation {
         create_AgentRequest(input: {
             request_id: "req_foreign",
@@ -313,6 +313,54 @@ pub(crate) async fn seed_cascade_fixture_with_foreign_request() -> (Arc<ClientCo
     assert!(
         !response.has_errors(),
         "seed foreign AgentRequest failed: {:?}",
+        response.errors
+    );
+
+    (core, tmp)
+}
+
+/// Seeds the cascade fixture PLUS one cascade-linked `AgentRequest` owned by
+/// `did:test:other`, matching live cross-deployment subagent edges.
+pub(crate) async fn seed_cascade_fixture_with_foreign_linked_child() -> (Arc<ClientCore>, TempDir) {
+    let (core, tmp) = seed_cascade_fixture().await;
+
+    let mutation = r#"mutation {
+        create_AgentRequest(input: {
+            request_id: "req_foreign_linked",
+            agent_did: "did:test:other",
+            behavior_id: "other-behavior",
+            session_id: "sess_foreign_linked",
+            content: "foreign linked child request",
+            status: "processing",
+            lifecycle_state: "processing",
+            backend_id: "",
+            created_at: "2026-05-20T00:07:00Z",
+            retry_count: 0,
+            caused_by_parent_request_id: "req_root",
+            caused_by_parent_tool_call_id: "tc_foreign"
+        }) { _docID }
+
+        create_AgentToolCall(input: {
+            tool_call_key: "sess_root:tc_foreign",
+            request_id: "req_root",
+            session_id: "sess_root",
+            message_sequence: 7,
+            tool_name: "remote_subagent",
+            tool_call_id: "tc_foreign",
+            args: "{}",
+            result: "",
+            status: "called",
+            lifecycle_state: "running",
+            started_at: "2026-05-20T00:07:00Z",
+            await_mode: "background",
+            cancel_policy: "cascade",
+            child_request_id: "req_foreign_linked"
+        }) { _docID }
+    }"#;
+    let response = core.node().execute(mutation).await;
+    assert!(
+        !response.has_errors(),
+        "seed foreign linked child failed: {:?}",
         response.errors
     );
 

--- a/apps/desktop-tauri/tests/run-live-test.mjs
+++ b/apps/desktop-tauri/tests/run-live-test.mjs
@@ -83,9 +83,8 @@ const liveTestSuites = {
   subagent: "tests/tauri-driver.live.subagent.test.tsx",
   replication: "tests/tauri-driver.live.replication.test.tsx",
   "sad-path": "tests/tauri-driver.live.sad-path.test.tsx",
-  // cascade is intentionally excluded from the default sweep — it is
-  // an it.fails suite (B3+C2 pending Rust implementation) that takes
-  // 5-10 minutes with no CI signal.  Run it explicitly:
+  // cascade is intentionally excluded from the default sweep because it
+  // requires live inference and can take several minutes. Run it explicitly:
   //   bun run test:live:cascade -- --inference-url <url> --model-name <model>
   cascade: "tests/tauri-driver.live.cascade.test.tsx",
 };

--- a/apps/desktop-tauri/tests/tauri-driver.live.cascade.test.tsx
+++ b/apps/desktop-tauri/tests/tauri-driver.live.cascade.test.tsx
@@ -16,9 +16,8 @@ import { describeLive, logTurn } from "./tauri-driver-live/helpers";
  * If a theorem's statement changes, this file MUST be updated to match —
  * see CLAUDE.md "Development Flow": spec changes are authoritative.
  *
- * This suite is intentionally excluded from the default live sweep because
- * the B3+C2 test is currently `it.fails` (pending Rust implementation) and
- * takes 5-10 minutes per run with no useful CI signal.  Run it explicitly:
+ * This suite is intentionally excluded from the default live sweep because it
+ * requires live inference and can take several minutes per run. Run it explicitly:
  *
  *   bun run test:live:cascade -- --inference-url <url> --model-name <model>
  */
@@ -33,41 +32,7 @@ describeLive("Tauri app live cascade interrupt (B3 + C2 witnesses)", () => {
   // lifecycleState transitions to "interrupted" and the bridge tool call
   // carries cancelCause.cause === "interrupted".
   //
-  // ⚠️ KNOWN-FAILING — pending Rust implementation. B3 came out of recent
-  // Lean cascade refactoring; the corresponding Rust work was not fully
-  // brought through. Observed gaps (deterministic across 7+ runs):
-  //
-  //   1. apps/desktop-tauri/src-tauri/src/bridge/cascade.rs::interrupt_request
-  //      only latches `interrupt_requested_at` on the parent. The CLI's
-  //      `cancel_descendant_bridges_local`
-  //      (crates/defra-agent-cli/src/commands/subagent.rs:252) walks
-  //      descendants and calls `defra_agent::interrupt_request` on each
-  //      child — the bridge has no equivalent walk. Adding it is necessary
-  //      but not sufficient (verified empirically: even with the descendant
-  //      write, the child still terminates as `failed`).
-  //
-  //   2. When the parent is blocked in a background `wait_subagent` (which
-  //      returns immediately via `backgrounded_receipt_payload` at
-  //      subagent_bridge.rs:161-172), the parent's interrupt observer
-  //      firing doesn't produce a clean `.interrupted` transition — the
-  //      parent ends as `failed` with `cancelCause=undefined`, breaking
-  //      C2's "every live linked tool tagged CancelCause.interrupted"
-  //      conclusion.
-  //
-  //   3. The child runtime's pickup of `interrupt_requested_at` either
-  //      doesn't fire for subagent-spawned requests, or fires but
-  //      transitions through a path that classifies the terminal as
-  //      `failed`, not `interrupted`. Needs trace instrumentation in
-  //      `interrupt.rs::spawn_request_interrupt_observer` + the child
-  //      daemon's inference loop to determine which.
-  //
-  // Marked `it.fails` so the test stays in the suite as a forcing
-  // function: when the Rust catches up and the test starts passing,
-  // vitest reports an unexpected pass and demands removal of the marker.
-  // DO NOT silently delete this test if it flips green — that's the
-  // signal the spec is satisfied. Tracking issue: B3 cascade Rust
-  // implementation stream (file separately).
-  it.fails("B3+C2: cascade-mode interrupt drives a running child subagent to interrupted", async () => {
+  it("B3+C2: cascade-mode interrupt drives a running child subagent to interrupted", async () => {
     await withLiveDesktop(async ({ runner, driver, deployment }) => {
       const defaultBehavior = deployment.behaviors.find((b) => b.isDefault);
       const defaultTools = deployment.toolSelections.find(
@@ -131,10 +96,42 @@ describeLive("Tauri app live cascade interrupt (B3 + C2 witnesses)", () => {
         .catch(() => null);
       if (dialog) {
         logTurn("cascade dialog opened; confirming cascade (B3 cascade path)");
-        // Confirm cascade (not detach) so we witness B3 rather than B3'.
-        await driver.user.click(
-          within(dialog).getByRole("button", { name: /interrupt parent and cascade/i }),
-        );
+        // Confirm cascade (not detach) so we witness B3 rather than B3'. The
+        // dialog may return a stale preview if the child moves claimed→processing
+        // between preview and submit; in that case it refreshes and requires
+        // another confirmation.
+        for (let attempt = 1; attempt <= 4; attempt += 1) {
+          const activeDialog = screen.queryByRole("dialog", {
+            name: /interrupt parent request/i,
+          });
+          if (!activeDialog) break;
+          if (within(activeDialog).queryByText(/preview updated/i)) {
+            logTurn(`cascade preview refreshed; re-confirming attempt ${attempt}`);
+          }
+          await driver.user.click(
+            within(activeDialog).getByRole("button", {
+              name: /interrupt parent and cascade/i,
+            }),
+          );
+          await waitFor(
+            () => {
+              const currentDialog = screen.queryByRole("dialog", {
+                name: /interrupt parent request/i,
+              });
+              if (!currentDialog) return;
+              expect(
+                within(currentDialog).getByRole("button", {
+                  name: /interrupt parent and cascade/i,
+                }),
+              ).toBeEnabled();
+            },
+            { timeout: 15_000, interval: 250 },
+          );
+        }
+        expect(
+          screen.queryByRole("dialog", { name: /interrupt parent request/i }),
+          "cascade dialog should close after an accepted confirmation",
+        ).toBeNull();
       } else {
         // Child completed before the preview call — direct interrupt was taken.
         // B3's cascade precondition requires a live child; if the child finished

--- a/crates/defra-agent/src/agent/daemon/request.rs
+++ b/crates/defra-agent/src/agent/daemon/request.rs
@@ -148,25 +148,61 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 ))
                 .await;
 
-            if request_token.is_cancelled() {
-                // Interrupt detected inside run_inference — execute the 6-step flow.
-                // Graceful fallback: if the token was cancelled by a path that did not
-                // also publish an InterruptIntent on the watch channel (e.g. a future
-                // tool-child cancellation from Task 8), treat it as a failure rather
-                // than panicking. This preserves safety as the cancellation hierarchy
-                // expands.
-                let Some(intent) = interrupt_rx.borrow().clone() else {
+            let token_was_cancelled = request_token.is_cancelled();
+            let watched_interrupt = { interrupt_rx.borrow().clone() };
+            let interrupt_at = if token_was_cancelled {
+                // Interrupt detected inside run_inference. Prefer the watch
+                // intent, but fall back to the persisted latch: a foreground
+                // tool path can observe interrupt_requested_at before the
+                // polling observer publishes on the channel.
+                if let Some(intent) = watched_interrupt {
+                    Some(intent.at.to_rfc3339())
+                } else {
+                    crate::interrupt::fetch_interrupt_requested_at(&self.node, &request.request_id)
+                        .await?
+                }
+            } else if let Some(intent) = watched_interrupt {
+                request_token.cancel();
+                Some(intent.at.to_rfc3339())
+            } else {
+                let persisted =
+                    crate::interrupt::fetch_interrupt_requested_at(&self.node, &request.request_id)
+                        .await?;
+                if persisted.is_some() {
+                    request_token.cancel();
+                }
+                persisted
+            };
+
+            if token_was_cancelled && interrupt_at.is_none() {
+                tracing::warn!(
+                    request_id = %lifecycle.request().request_id,
+                    "request_token was cancelled without an interrupt latch; \
+                     treating as failure rather than interrupt"
+                );
+                return Ok(HandleRequestOutcome::FailedAfterResponse(anyhow::anyhow!(
+                    "request_token cancelled without interrupt latch"
+                )));
+            }
+
+            if let Some(interrupt_at) = interrupt_at {
+                // Interrupt detected inside run_inference, by the observer just
+                // after it returned, or by a synchronous tool path that read
+                // interrupt_requested_at before the observer's next poll.
+                if !request_token.is_cancelled() {
+                    request_token.cancel();
+                }
+                if interrupt_at.trim().is_empty() {
                     tracing::warn!(
                         request_id = %lifecycle.request().request_id,
-                        "request_token was cancelled without an interrupt intent on the channel; \
+                        "request_token was cancelled without an interrupt latch; \
                          treating as failure rather than interrupt"
                     );
                     return Ok(HandleRequestOutcome::FailedAfterResponse(anyhow::anyhow!(
-                        "request_token cancelled without interrupt intent"
+                        "request_token cancelled without interrupt latch"
                     )));
-                };
+                }
 
-                let interrupt_at = intent.at.to_rfc3339();
                 let flow_span = tracing::info_span!(
                     "interrupt.flow",
                     request_id = %lifecycle.request().request_id,

--- a/crates/defra-agent/src/lifecycle/transition.rs
+++ b/crates/defra-agent/src/lifecycle/transition.rs
@@ -257,6 +257,17 @@ impl RequestLifecycle {
             );
             return Ok(());
         }
+        if crate::interrupt::fetch_interrupt_requested_at(&self.node, &self.request.request_id)
+            .await?
+            .is_some()
+        {
+            tracing::info!(
+                request_id = %self.request.request_id,
+                "request failure observed after interrupt_requested_at was latched; transitioning to interrupted"
+            );
+            self.transition_to_interrupted().await?;
+            return Ok(());
+        }
         self.ensure_state(
             &[LocalLifecycleState::Claimed, LocalLifecycleState::Streaming],
             "fail",

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -147,7 +147,7 @@ pub(super) fn lean_executable_contracts_cover_initial_domains() {
         lean_contract_snapshot()
             .backend_health_admission_cases
             .len(),
-        5
+        7
     );
     assert_eq!(
         lean_contract_snapshot().frontend_client_shell_case_count,

--- a/crates/defra-agent/tests/state_machine_conformance/interrupts_manual.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/interrupts_manual.rs
@@ -444,6 +444,49 @@ async fn transition_to_interrupted_from_processing() {
 }
 
 #[tokio::test]
+async fn fail_after_interrupt_latch_prefers_interrupted() {
+    // B3's second step is interrupt_processing: once interruptRequestedAt is
+    // latched on a processing request, a later failure path must not classify
+    // the terminal state as failed.
+    let db = test_db("fail-after-interrupt-latch").await;
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let created_at = chrono::Utc::now().to_rfc3339();
+    let doc_id = create_request(&db.node, &request_id, &session_id, "pending", &created_at).await;
+
+    let request = build_request(
+        doc_id.clone(),
+        request_id.clone(),
+        session_id.clone(),
+        created_at,
+    );
+    let mut lifecycle = RequestLifecycle::new_with_execution_binding(
+        db.node.clone(),
+        AGENT_NAME,
+        AGENT_DID,
+        request,
+        DEADLINE_SECS,
+        ExecutionOrigin::Interactive,
+        BACKEND_ID,
+    );
+
+    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+    lifecycle.prepare_session_with_identity().await.unwrap();
+    lifecycle.begin_execution().await.unwrap();
+
+    let interrupt_at = chrono::Utc::now().to_rfc3339();
+    set_interrupt_requested_at(&db.node, &doc_id, &interrupt_at).await;
+
+    lifecycle.fail().await.unwrap();
+
+    let snap = fetch_request_snapshot(&db.node, &doc_id).await;
+    assert_eq!(snap.status, "interrupted");
+    assert_eq!(snap.lifecycle_state, "interrupted");
+    assert_lean_transition_is_legal("Request", "processing", "interrupted");
+    assert_lean_transition_is_illegal("Request", "interrupted", "failed");
+}
+
+#[tokio::test]
 async fn interrupt_request_is_idempotent() {
     // Two calls to `interrupt_request` on the same doc must latch exactly
     // once: the daemon observer relies on the first submitter's timestamp


### PR DESCRIPTION
## Summary
- latch desktop cascade descendants from the accepted preview, including cross-DID subagents reached by persisted bridge edges
- preserve persisted interrupt latches through daemon and failure paths so cascade children terminalize as interrupted
- promote the B3/C2 live cascade witness from expected-failure to passing and handle stale preview re-confirmation
- sync the stale backend-health Lean contract coverage count with the generated cases

## Lean alignment
- Implements the Rust side of `cascade_cancels_child` by writing `interrupt_requested_at` on cascade children before the child runtime lifts to `interrupted`.
- Preserves the `interrupted_request_cancels_live_linked_tools` witness by keeping linked cascade tool calls observable as `CancelCause.interrupted`.

## Verification
- `cargo test -p defra-agent`
- `cargo test -p defra-agent-desktop-tauri`
- `cd crates/defra-agent/proofs && lake build`
- `cd apps/desktop-tauri && bun run test:live:cascade -- --inference-url http://100.69.4.79:8000/v1 --model-name baa-ai/GLM-5.1-RAM-420GB-MLX`

Targets #332.
