### PR TITLE
Production deployment affordances (v0.2.1): launchable binary, store migration, fresh-store bootstrap, codex shim, backend auto-probe

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -239,6 +239,7 @@ jobs:
           MACOS_CODESIGN_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CODESIGN_KEYCHAIN_PASSWORD }}
           TIMESTAMP_MODE_INPUT: ${{ inputs.codesign_timestamp }}
           TIMESTAMP_MODE_VAR: ${{ vars.MACOS_CODESIGN_TIMESTAMP_MODE }}
+          MACOS_APPLY_SE_ENTITLEMENTS: ${{ vars.MACOS_APPLY_SE_ENTITLEMENTS }}
         run: |
           set -euo pipefail
 
@@ -262,22 +263,52 @@ jobs:
             echo "::error::Could not extract Apple Team ID from SIGNING_IDENTITY_NAME '${signing_identity}'."
             exit 1
           fi
-          sed "s/__APPLE_TEAM_ID__/${apple_team_id}/g" release/entitlements.plist > "${entitlements_path}"
-          plutil -lint "${entitlements_path}"
+
+          # The release/entitlements.plist requests `keychain-access-groups`, a
+          # RESTRICTED entitlement. On a Developer-ID, hardened-runtime binary
+          # distributed outside the App Store, a restricted entitlement with no
+          # embedded provisioning profile makes AMFI SIGKILL the process at launch
+          # (exit 137, no output) — which made every released binary un-launchable
+          # on macOS. Until a provisioning-profile path exists for Secure Enclave
+          # identities, sign the standard release WITHOUT the entitlement so the
+          # binary launches; it notarizes fine with hardened runtime alone. Opt in
+          # only when the repo var MACOS_APPLY_SE_ENTITLEMENTS is "true" (and a
+          # provisioning profile is in place).
+          apply_entitlements="${MACOS_APPLY_SE_ENTITLEMENTS:-false}"
+          if [[ "${apply_entitlements}" == "true" ]]; then
+            sed "s/__APPLE_TEAM_ID__/${apple_team_id}/g" release/entitlements.plist > "${entitlements_path}"
+            plutil -lint "${entitlements_path}"
+            echo "Signing WITH keychain-access-groups entitlement (MACOS_APPLY_SE_ENTITLEMENTS=true)."
+          else
+            entitlements_path=""
+            echo "Signing without the keychain-access-groups entitlement (default); see release-macos.yml for the Secure Enclave caveat."
+          fi
 
           security unlock-keychain -p "${MACOS_CODESIGN_KEYCHAIN_PASSWORD}" "${keychain_path}"
           echo "Signing with native macOS identity from ${keychain_path}."
 
           sign_with_timestamp_arg() {
             local timestamp_arg="$1"
-            codesign \
-              --force \
-              --sign "${signing_identity}" \
-              --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
-              --options runtime \
-              --entitlements "${entitlements_path}" \
-              "${timestamp_arg}" \
-              "${binary_path}"
+            # Avoid empty-array expansion under `set -u` (unsafe on bash 3.2);
+            # branch on whether an entitlements file was rendered instead.
+            if [[ -n "${entitlements_path}" ]]; then
+              codesign \
+                --force \
+                --sign "${signing_identity}" \
+                --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
+                --options runtime \
+                --entitlements "${entitlements_path}" \
+                "${timestamp_arg}" \
+                "${binary_path}"
+            else
+              codesign \
+                --force \
+                --sign "${signing_identity}" \
+                --identifier "${MACOS_CODESIGN_IDENTIFIER}" \
+                --options runtime \
+                "${timestamp_arg}" \
+                "${binary_path}"
+            fi
           }
 
           codesign --remove-signature "${binary_path}" 2>/dev/null || true

--- a/crates/defra-agent-cli/src/commands/codex_shim.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim.rs
@@ -132,8 +132,12 @@ pub(crate) async fn bind_codex_shim(args: CodexShimBindArgs) -> Result<BoundCode
         .with_context(|| format!("creating Codex UI log dir {}", codex_log_dir.display()))?;
     let trace_path = codex_log_dir.join("codex-shim-events.jsonl");
 
-    let bound_behavior_id =
-        bound_behavior::resolve_bound_behavior_id(args.behavior_id.as_deref(), &args.agent_did);
+    let bound_behavior_id = bound_behavior::resolve_bound_behavior_id(
+        args.node.as_ref(),
+        args.behavior_id.as_deref(),
+        &args.agent_did,
+    )
+    .await;
     bound_behavior::load_bound_inference_profile_id(args.node.as_ref(), &bound_behavior_id)
         .await
         .with_context(|| format!("validating Codex shim bound behavior {bound_behavior_id:?}"))?;

--- a/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
@@ -2,18 +2,45 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use defra_agent::defra_node::EmbeddedNode;
-use defra_agent::{default_behavior_id_for_agent, load_agent_behavior, load_inference_profile};
+use defra_agent::{
+    default_behavior_id_for_agent, load_agent_behavior, load_agent_principal,
+    load_inference_profile,
+};
 
-pub(super) fn resolve_bound_behavior_id(
+/// Normalize an explicit `--codex-shim-behavior-id` override: trim whitespace and
+/// treat empty as unset.
+fn explicit_override(override_behavior_id: Option<&str>) -> Option<String> {
+    override_behavior_id
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string)
+}
+
+/// Resolve the behavior the Codex shim binds to.
+///
+/// An explicit override always wins. Otherwise we use the agent principal's
+/// configured `default_behavior_id` — that is the id behaviors are actually
+/// stored under (e.g. `default` from an applied manifest). We only fall back to
+/// the synthesized `<did>:default` form when the principal is missing or has no
+/// default set, which preserves the historical behavior for legacy homes.
+///
+/// Previously this always synthesized `<did>:default`, which never matched a
+/// manifest-applied behavior keyed `default`, so the shim failed to start with
+/// "no AgentBehavior document with that behavior_id exists".
+pub(super) async fn resolve_bound_behavior_id(
+    node: &EmbeddedNode,
     override_behavior_id: Option<&str>,
     agent_did: &str,
 ) -> String {
-    match override_behavior_id
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-    {
-        Some(value) => value.to_string(),
-        None => default_behavior_id_for_agent(agent_did),
+    if let Some(value) = explicit_override(override_behavior_id) {
+        return value;
+    }
+    match load_agent_principal(node, agent_did).await {
+        Ok(Some(principal)) => principal
+            .default_behavior_id
+            .filter(|id| !id.trim().is_empty())
+            .unwrap_or_else(|| default_behavior_id_for_agent(agent_did)),
+        _ => default_behavior_id_for_agent(agent_did),
     }
 }
 
@@ -59,26 +86,34 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_bound_behavior_id_uses_explicit_override() {
-        let resolved = resolve_bound_behavior_id(Some("custom-behavior"), "did:key:zABC");
-        assert_eq!(resolved, "custom-behavior");
+    fn explicit_override_uses_value() {
+        assert_eq!(
+            explicit_override(Some("custom-behavior")),
+            Some("custom-behavior".to_string())
+        );
     }
 
     #[test]
-    fn resolve_bound_behavior_id_falls_back_to_default_for_did() {
-        let resolved = resolve_bound_behavior_id(None, "did:key:zABC");
-        assert_eq!(resolved, "did:key:zABC:default");
+    fn explicit_override_trims_whitespace() {
+        assert_eq!(
+            explicit_override(Some("  spaced  ")),
+            Some("spaced".to_string())
+        );
     }
 
     #[test]
-    fn resolve_bound_behavior_id_trims_whitespace() {
-        let resolved = resolve_bound_behavior_id(Some("  spaced  "), "did:key:zABC");
-        assert_eq!(resolved, "spaced");
+    fn explicit_override_treats_empty_as_unset() {
+        // Empty / whitespace-only override is unset, so resolution falls through
+        // to the principal's default_behavior_id (or the synthesized fallback).
+        assert_eq!(explicit_override(Some("")), None);
+        assert_eq!(explicit_override(Some("   ")), None);
+        assert_eq!(explicit_override(None), None);
     }
 
     #[test]
-    fn resolve_bound_behavior_id_treats_empty_override_as_unset() {
-        let resolved = resolve_bound_behavior_id(Some(""), "did:key:zABC");
-        assert_eq!(resolved, "did:key:zABC:default");
+    fn synthesized_fallback_matches_did_default() {
+        // When no override and no loadable principal default, resolution falls
+        // back to this synthesized form.
+        assert_eq!(default_behavior_id_for_agent("did:key:zABC"), "did:key:zABC:default");
     }
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
@@ -114,6 +114,9 @@ mod tests {
     fn synthesized_fallback_matches_did_default() {
         // When no override and no loadable principal default, resolution falls
         // back to this synthesized form.
-        assert_eq!(default_behavior_id_for_agent("did:key:zABC"), "did:key:zABC:default");
+        assert_eq!(
+            default_behavior_id_for_agent("did:key:zABC"),
+            "did:key:zABC:default"
+        );
     }
 }

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -467,6 +467,14 @@ fn is_degraded_startup_unavailable_reason(reason: &str) -> bool {
             && reason.contains(" probe_status="))
         || reason.contains("did not advertise model")
         || reason.contains("startup readiness probe")
+        // A behavior with no backend binding is unconfigured, not structurally
+        // invalid. Starting degraded (with /healthz reporting the reason and a
+        // zero runnable count) lets an operator inspect and finish configuration
+        // — applying a manifest, attaching a backend — over a live endpoint.
+        // Treating it as fatal instead crash-loops the runtime, which is how a
+        // fresh-store bootstrap (where ensure_agent_principal seeds a backendless
+        // default behavior) became unstartable.
+        || reason.contains("has no backend binding")
 }
 
 async fn validate_startup_snapshot(
@@ -640,4 +648,37 @@ async fn resolve_document_snapshot_with_tools(
     resolve_context: &DocumentResolveContext,
 ) -> Result<ResolvedRuntimeSnapshot> {
     crate::agent::resolve_document_runtime_snapshot(node, resolve_context).await
+}
+
+#[cfg(test)]
+mod degraded_reason_tests {
+    use super::is_degraded_startup_unavailable_reason;
+
+    #[test]
+    fn unprobed_backend_is_degraded() {
+        assert!(is_degraded_startup_unavailable_reason(
+            "behavior 'default' backend workstation-1 is unavailable (enabled=true probe_status=unknown)"
+        ));
+    }
+
+    #[test]
+    fn disabled_behavior_is_degraded() {
+        assert!(is_degraded_startup_unavailable_reason("behavior 'x' is disabled"));
+    }
+
+    #[test]
+    fn no_backend_binding_is_degraded() {
+        // A backendless behavior (e.g. the seeded bootstrap default before a
+        // backend is configured) must not be fatal at startup.
+        assert!(is_degraded_startup_unavailable_reason(
+            "behavior did:key:zABC:default has no backend binding"
+        ));
+    }
+
+    #[test]
+    fn unknown_structural_reason_is_blocking() {
+        assert!(!is_degraded_startup_unavailable_reason(
+            "behavior 'default' references missing tool selection 'gone'"
+        ));
+    }
 }

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -63,6 +63,13 @@ pub(in crate::agent) async fn run_agent(
         agent.local_hostname.clone(),
         agent.local_subnet.clone(),
     );
+    // Promote reachable enabled backends to healthy before resolving which
+    // behaviors are runnable. A fresh store's backends start `probe_status=
+    // unknown`, and nothing else promotes them, so without this the runtime
+    // comes up with zero runnable behaviors until an operator manually runs
+    // `config backend set --probe-status healthy`.
+    backend_registry::probe_and_promote_enabled_backends(agent.node.as_ref()).await;
+
     let resolved_snapshot = match resolve_startup_snapshot(&agent).await {
         Ok(snapshot) => snapshot,
         Err(error) => {

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -670,7 +670,9 @@ mod degraded_reason_tests {
 
     #[test]
     fn disabled_behavior_is_degraded() {
-        assert!(is_degraded_startup_unavailable_reason("behavior 'x' is disabled"));
+        assert!(is_degraded_startup_unavailable_reason(
+            "behavior 'x' is disabled"
+        ));
     }
 
     #[test]

--- a/crates/defra-agent/src/backend_registry.rs
+++ b/crates/defra-agent/src/backend_registry.rs
@@ -375,20 +375,22 @@ pub async fn probe_and_promote_enabled_backends(node: &EmbeddedNode) {
         )
         .await
         {
-            Ok(_) => match set_backend_probe_status(node, &backend.backend_id, HEALTHY_PROBE_STATUS)
-                .await
-            {
-                Ok(()) => tracing::info!(
-                    backend_id = %backend.backend_id,
-                    endpoint = %backend.endpoint,
-                    "startup backend probe: promoted to healthy"
-                ),
-                Err(error) => tracing::warn!(
-                    backend_id = %backend.backend_id,
-                    error = %error,
-                    "startup backend probe: reachable but failed to persist healthy status"
-                ),
-            },
+            Ok(_) => {
+                match set_backend_probe_status(node, &backend.backend_id, HEALTHY_PROBE_STATUS)
+                    .await
+                {
+                    Ok(()) => tracing::info!(
+                        backend_id = %backend.backend_id,
+                        endpoint = %backend.endpoint,
+                        "startup backend probe: promoted to healthy"
+                    ),
+                    Err(error) => tracing::warn!(
+                        backend_id = %backend.backend_id,
+                        error = %error,
+                        "startup backend probe: reachable but failed to persist healthy status"
+                    ),
+                }
+            }
             Err(error) => tracing::warn!(
                 backend_id = %backend.backend_id,
                 endpoint = %backend.endpoint,

--- a/crates/defra-agent/src/backend_registry.rs
+++ b/crates/defra-agent/src/backend_registry.rs
@@ -96,6 +96,19 @@ impl InferenceBackend {
         self.enabled && self.probe_status == HEALTHY_PROBE_STATUS
     }
 
+    /// Effective API key for an outbound call: the raw `api_key` if set,
+    /// otherwise the value of `api_key_env_var` from the environment.
+    pub fn resolved_api_key(&self) -> Option<String> {
+        if let Some(key) = self.api_key.as_ref() {
+            return Some(key.clone());
+        }
+        self.api_key_env_var
+            .as_ref()
+            .and_then(|var| std::env::var(var).ok())
+            .map(|v| v.trim().to_string())
+            .filter(|v| !v.is_empty())
+    }
+
     /// Operator-UI rollup of `(enabled, probe_status)` into a single label.
     /// `available` is the only state in which `is_available()` is true; the
     /// other states split the unavailable cases for operator visibility.
@@ -287,6 +300,103 @@ pub async fn list_enabled_backends(node: &EmbeddedNode) -> Result<Vec<InferenceB
         .unwrap_or_default();
 
     Ok(backends)
+}
+
+/// Persist a backend's `probe_status` by `backend_id`.
+pub async fn set_backend_probe_status(
+    node: &EmbeddedNode,
+    backend_id: &str,
+    probe_status: &str,
+) -> Result<()> {
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{}" }} }},
+                input: {{ probe_status: "{}" }}
+            ) {{ _docID }}
+        }}"#,
+        escape_graphql_string(backend_id),
+        escape_graphql_string(probe_status),
+    );
+    let resp = node.execute(&mutation).await;
+    if resp.has_errors() {
+        anyhow::bail!(
+            "update InferenceBackend probe_status for {backend_id} failed: {:?}",
+            resp.errors
+        );
+    }
+    Ok(())
+}
+
+/// Probe each enabled backend that is not already healthy and promote the
+/// reachable ones to `healthy`.
+///
+/// A fresh store's backends start at `probe_status=unknown`, and nothing else
+/// promotes them — so without this a brand-new deploy has zero runnable
+/// behaviors until an operator runs `config backend set --probe-status healthy`
+/// by hand. Run this once at startup, before the runtime resolves which
+/// behaviors are runnable.
+///
+/// Probe failures are intentionally non-destructive: the backend is left at its
+/// current status (typically `unknown`) and logged, so a transiently-unreachable
+/// backend degrades rather than being marked `unhealthy` and flapping. Recurring
+/// re-probing and unhealthy demotion are a separate concern (the admission path
+/// handles live request failures).
+pub async fn probe_and_promote_enabled_backends(node: &EmbeddedNode) {
+    let backends = match list_enabled_backends(node).await {
+        Ok(backends) => backends,
+        Err(error) => {
+            tracing::warn!(error = %error, "startup backend probe: could not list backends");
+            return;
+        }
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            tracing::warn!(error = %error, "startup backend probe: could not build HTTP client");
+            return;
+        }
+    };
+
+    for backend in backends {
+        if backend.probe_status == HEALTHY_PROBE_STATUS {
+            continue;
+        }
+        let api_key = backend.resolved_api_key();
+        match crate::backend_provider::discover_models(
+            &client,
+            backend.provider_kind,
+            &backend.endpoint,
+            api_key.as_deref(),
+        )
+        .await
+        {
+            Ok(_) => match set_backend_probe_status(node, &backend.backend_id, HEALTHY_PROBE_STATUS)
+                .await
+            {
+                Ok(()) => tracing::info!(
+                    backend_id = %backend.backend_id,
+                    endpoint = %backend.endpoint,
+                    "startup backend probe: promoted to healthy"
+                ),
+                Err(error) => tracing::warn!(
+                    backend_id = %backend.backend_id,
+                    error = %error,
+                    "startup backend probe: reachable but failed to persist healthy status"
+                ),
+            },
+            Err(error) => tracing::warn!(
+                backend_id = %backend.backend_id,
+                endpoint = %backend.endpoint,
+                error = %error,
+                "startup backend probe: unreachable, leaving probe_status unchanged"
+            ),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/backend_registry/tests.rs
+++ b/crates/defra-agent/src/backend_registry/tests.rs
@@ -194,3 +194,43 @@ fn display_state_matches_every_lean_backend_health_admission_case() {
         }
     }
 }
+
+fn backend_with_keys(api_key: Option<&str>, env_var: Option<&str>) -> InferenceBackend {
+    InferenceBackend {
+        backend_id: "test".into(),
+        name: "Test".into(),
+        provider_kind: BackendProviderKind::OpenAiCompatible,
+        endpoint: "http://localhost:8000/v1".into(),
+        api_key: api_key.map(ToOwned::to_owned),
+        api_key_env_var: env_var.map(ToOwned::to_owned),
+        max_concurrent: 1,
+        max_queue_depth: DEFAULT_MAX_QUEUE_DEPTH,
+        enabled: true,
+        models: Vec::new(),
+        probe_status: "unknown".into(),
+    }
+}
+
+#[test]
+fn resolved_api_key_prefers_raw_key() {
+    let backend = backend_with_keys(Some("raw-key"), Some("BACKEND_REGISTRY_TEST_KEY_UNUSED"));
+    assert_eq!(backend.resolved_api_key().as_deref(), Some("raw-key"));
+}
+
+#[test]
+fn resolved_api_key_falls_back_to_env() {
+    let var = "BACKEND_REGISTRY_TEST_KEY_FALLBACK";
+    std::env::set_var(var, "env-key");
+    let backend = backend_with_keys(None, Some(var));
+    assert_eq!(backend.resolved_api_key().as_deref(), Some("env-key"));
+    std::env::remove_var(var);
+}
+
+#[test]
+fn resolved_api_key_none_when_unset() {
+    let backend = backend_with_keys(None, None);
+    assert_eq!(backend.resolved_api_key(), None);
+    // Env var named but unset in the environment.
+    let backend = backend_with_keys(None, Some("BACKEND_REGISTRY_TEST_KEY_MISSING"));
+    assert_eq!(backend.resolved_api_key(), None);
+}

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -38,9 +38,15 @@ const ADD_AGENT_REQUEST_SUBAGENT_PATCH: &str = r#"[
     {"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"caused_by_parent_tool_call_id","Kind":11}}
 ]"#;
 
+// Kind 21 == ScalarArrayKind::NillableStringArray in defradb.rs. The SDL
+// `[String]` (nullable elements) for these fields compiles to that kind, so the
+// migration patch must use it. The previous value of 17 was a stale Go-DefraDB
+// field-kind number that is unassigned in defradb.rs's enum, so the SDL builder
+// treated the patch as a named-type reference and failed with
+// "no type found for given name. Kind: 17" — crash-looping every store upgrade.
 #[allow(dead_code)]
 const ADD_TOOL_SELECTION_SUBAGENT_PATCH: &str = r#"[
-    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_targets","Kind":17}},
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_targets","Kind":21}},
     {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_spawn_enabled","Kind":2}},
     {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_steering_enabled","Kind":2}},
     {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"subagent_background_enabled","Kind":2}}
@@ -48,7 +54,7 @@ const ADD_TOOL_SELECTION_SUBAGENT_PATCH: &str = r#"[
 
 #[allow(dead_code)]
 const ADD_TOOL_SELECTION_BACKGROUND_TOOLS_PATCH: &str = r#"[
-    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"backgroundable_tool_names","Kind":17}}
+    {"op":"add","path":"/ToolSelection/Fields/-","value":{"Name":"backgroundable_tool_names","Kind":21}}
 ]"#;
 
 #[allow(dead_code)]
@@ -462,4 +468,68 @@ pub async fn ensure_peer_pairing_desired_migrations(node: Arc<EmbeddedNode>) -> 
         "PeerPairingDesired patched with agent_did field"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod patch_kind_tests {
+    use super::*;
+
+    // defradb.rs ScalarArrayKind::NillableStringArray. SDL `[String]` (nullable
+    // elements) compiles to this; migration patches adding such fields must match.
+    const NILLABLE_STRING_ARRAY_KIND: i64 = 21;
+
+    fn field_kinds(patch_json: &str) -> Vec<(String, i64)> {
+        let ops: serde_json::Value = serde_json::from_str(patch_json).expect("patch is valid JSON");
+        ops.as_array()
+            .expect("patch is an array")
+            .iter()
+            .filter_map(|op| {
+                let value = op.get("value")?;
+                let name = value.get("Name")?.as_str()?.to_string();
+                let kind = value.get("Kind")?.as_i64()?;
+                Some((name, kind))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn tool_selection_string_array_fields_use_nillable_string_array_kind() {
+        for (name, kind) in field_kinds(ADD_TOOL_SELECTION_SUBAGENT_PATCH) {
+            if name == "subagent_targets" {
+                assert_eq!(
+                    kind, NILLABLE_STRING_ARRAY_KIND,
+                    "subagent_targets must be NillableStringArray (21), got {kind}"
+                );
+            }
+        }
+        for (name, kind) in field_kinds(ADD_TOOL_SELECTION_BACKGROUND_TOOLS_PATCH) {
+            assert_eq!(
+                name, "backgroundable_tool_names",
+                "unexpected field in background-tools patch"
+            );
+            assert_eq!(
+                kind, NILLABLE_STRING_ARRAY_KIND,
+                "backgroundable_tool_names must be NillableStringArray (21), got {kind}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_patch_uses_the_unassigned_kind_17() {
+        // 17 is unassigned in defradb.rs's FieldKind enum; the SDL builder treats
+        // it as a named-type reference and fails with "no type found. Kind: 17".
+        for patch in [
+            ADD_LIFECYCLE_STATE_PATCH,
+            ADD_AGENT_TOOL_CALL_SUBAGENT_PATCH,
+            ADD_AGENT_REQUEST_SUBAGENT_PATCH,
+            ADD_TOOL_SELECTION_SUBAGENT_PATCH,
+            ADD_TOOL_SELECTION_BACKGROUND_TOOLS_PATCH,
+            ADD_AGENT_TOOL_CALL_R5_PATCH,
+            ADD_TOOL_SELECTION_R5_PATCH,
+        ] {
+            for (name, kind) in field_kinds(patch) {
+                assert_ne!(kind, 17, "field {name} uses unassigned Kind 17");
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes the cluster of first-prod-deployment bugs found while deploying a fresh agent (Amy) on v0.2.0. Each is independently a deploy-blocker; together they make a fresh `defra-agent` deploy work without manual hand-holding.

Context: the build-deadlock (#335) is already fixed on main; this PR is the runtime/CLI/CI affordances on top.

## Fixes (all landed)

- [x] **#4 — Codex shim binds to the real `default_behavior_id`** (`8332016c`). The shim synthesized `<agent_did>:default`, which never matched a manifest-applied behavior keyed `default`, so it aborted startup with "no AgentBehavior document with that behavior_id exists." Now resolves from the agent principal's configured `default_behavior_id`.
- [x] **#3 — "no backend binding" is a degraded, non-fatal startup reason** (`1de5f4b0`). A fresh store's seeded backendless default (and any under-configured behavior) crash-looped the runtime via the strict startup check. Now starts degraded-but-inspectable (`/healthz` reports the reason, `runnable=0`). Genuinely-structural problems stay fatal.
- [x] **#5 — Runtime auto-probes enabled backends** (`c80c7988`). `probe_status` started `unknown` and never auto-promoted (health_checker is MCP-only), so fresh deploys had `runnable=0` until a manual `config backend set --probe-status healthy`. Adds a startup probe that promotes reachable backends to healthy; probe failures are non-destructive.
- [x] **#2 — ToolSelection v2→v3 migration kind fix** (`50896ff4`). `subagent_targets` / `backgroundable_tool_names` used `Kind:17` (a stale Go-DefraDB number, unassigned in defradb.rs) → "no type found for given name. Kind: 17", crash-looping every store upgrade. Now uses `Kind:21` (NillableStringArray) to match the SDL `[String]`.
- [x] **#1 — Launchable release binary** (`35471d32`). The release signed in the restricted `keychain-access-groups` entitlement + hardened runtime with no provisioning profile → AMFI SIGKILL on every Mac. Gated behind `MACOS_APPLY_SE_ENTITLEMENTS` (default off); the standard release now launches and still notarizes. SE-identity builds re-enable it once a provisioning-profile path exists (follow-up).

## Verification
- Unit tests added for #2, #3, #4, #5; `cargo check -p defra-agent -p defra-agent-cli` green.
- Live: Amy deployed on a v0.2.0 build with #3/#4 + manual workarounds for #1/#2/#5; this PR removes the need for those workarounds. The fresh-store + auto-probe path should be exercised on the next deploy.

## Follow-ups (not in this PR)
- Recurring backend re-probe / unhealthy demotion (this PR probes once at startup).
- Secure-Enclave identity signing: provisioning-profile path so `MACOS_APPLY_SE_ENTITLEMENTS=true` produces a launchable binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)