### PR TITLE
Fix macOS unrestricted bash policy mapping and desktop controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ $AGENT init --write-tools
 
 With `--write-tools`, the same tool root also caps write/edit and write-capable
 bash access. On macOS, the default write-capable bash policy uses
-`sandbox-exec` to contain writes to that root. An explicit `unrestricted`
-command execution policy is unsandboxed.
+`sandbox-exec` to contain writes to that root. Custom tool selections with
+`bash_mode: Unrestricted` default to the unsandboxed command policy unless they
+explicitly request `workspace_write`. See [macOS Bash Sandbox Policies](docs/macos-bash-sandbox.md)
+for the policy tiers and the host-diagnostics configuration path.
 
 If you want to wipe and recreate the configured agent home from scratch:
 

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -15,6 +15,19 @@ import {
   parseOptionalInt,
 } from "./formUtils";
 
+const COMMAND_POLICY_OPTIONS = [
+  { value: "", label: "Default for bash mode" },
+  { value: "read_only", label: "Read only" },
+  { value: "workspace_write", label: "Workspace write" },
+  { value: "unrestricted", label: "Unrestricted" },
+] as const;
+
+const COMMAND_NETWORK_OPTIONS = [
+  { value: "", label: "Inherit" },
+  { value: "disabled", label: "Disabled" },
+  { value: "enabled", label: "Enabled" },
+] as const;
+
 export type ToolSelectionConfigPanelProps = {
   deployment: DeploymentView;
   selectedToolSelectionId: string | null;
@@ -163,14 +176,16 @@ export function ToolSelectionConfigEditor({
         ? "Unrestricted"
         : (toolSelection?.bashMode ?? "ReadOnly"),
     );
-    setCommandExecutionPolicy(toolSelection?.commandExecutionPolicy ?? "");
+    setCommandExecutionPolicy(
+      normalizeCommandExecutionPolicy(toolSelection?.commandExecutionPolicy),
+    );
     setCommandAllowedArgvPrefixes(
       (toolSelection?.commandAllowedArgvPrefixes ?? []).join("\n"),
     );
     setCommandForbiddenArgvPrefixes(
       (toolSelection?.commandForbiddenArgvPrefixes ?? []).join("\n"),
     );
-    setCommandNetworkMode(toolSelection?.commandNetworkMode ?? "");
+    setCommandNetworkMode(normalizeCommandNetworkMode(toolSelection?.commandNetworkMode));
     setCliToolNames((toolSelection?.cliToolNames ?? []).join("\n"));
     setEnableMetaTools(toolSelection?.enableMetaTools ?? false);
     const knownServiceIds = new Set(toolServiceIdKey.split("\n").filter(Boolean));
@@ -372,19 +387,31 @@ export function ToolSelectionConfigEditor({
       <div className="grid-2">
         <label className="field">
           <span>Command policy</span>
-          <input
+          <select
             data-testid="tool-command-execution-policy"
             onChange={(event) => setCommandExecutionPolicy(event.currentTarget.value)}
             value={commandExecutionPolicy}
-          />
+          >
+            {COMMAND_POLICY_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </label>
         <label className="field">
           <span>Command network mode</span>
-          <input
+          <select
             data-testid="tool-command-network-mode"
             onChange={(event) => setCommandNetworkMode(event.currentTarget.value)}
             value={commandNetworkMode}
-          />
+          >
+            {COMMAND_NETWORK_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </label>
       </div>
       <div className="grid-2">
@@ -563,6 +590,41 @@ function normalizeToolCeiling(value?: string | null) {
       return "Readonly";
     default:
       return "Unknown";
+  }
+}
+
+function normalizeCommandExecutionPolicy(value?: string | null) {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "":
+      return "";
+    case "readonly":
+    case "read_only":
+      return "read_only";
+    case "managedwrite":
+    case "managed_write":
+    case "workspacewrite":
+    case "workspace_write":
+      return "workspace_write";
+    case "unrestricted":
+      return "unrestricted";
+    default:
+      return "";
+  }
+}
+
+function normalizeCommandNetworkMode(value?: string | null) {
+  switch ((value ?? "").trim().toLowerCase()) {
+    case "":
+    case "inherit":
+      return "";
+    case "off":
+    case "disabled":
+      return "disabled";
+    case "on":
+    case "enabled":
+      return "enabled";
+    default:
+      return "";
   }
 }
 

--- a/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
@@ -256,6 +256,51 @@ describe("config panel action buttons", () => {
     );
   });
 
+  it("normalizes command policy choices when saving tool selections", async () => {
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={{
+          ...toolSelection,
+          commandExecutionPolicy: "ReadOnly",
+          commandNetworkMode: "Disabled",
+        }}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("tool-command-execution-policy")).toHaveValue(
+      "read_only",
+    );
+    expect(screen.getByTestId("tool-command-network-mode")).toHaveValue("disabled");
+    fireEvent.change(screen.getByTestId("tool-command-execution-policy"), {
+      target: { value: "unrestricted" },
+    });
+    fireEvent.change(screen.getByTestId("tool-command-network-mode"), {
+      target: { value: "enabled" },
+    });
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commandExecutionPolicy: "unrestricted",
+          commandNetworkMode: "enabled",
+        }),
+      ),
+    );
+  });
+
   it("applies the server tool ceiling when saving tool selections", async () => {
     const onSaveToolSelectionConfig = vi.fn<
       [(request: ToolSelectionSaveRequest) => Promise<unknown>]

--- a/apps/desktop-tauri/tests/tauri-driver-live/config-flow.ts
+++ b/apps/desktop-tauri/tests/tauri-driver-live/config-flow.ts
@@ -138,8 +138,8 @@ export async function createToolSelection({
   await driver.setChecked("tool-enable-meta-tools", true);
   await driver.setChecked(`tool-allowed-mcp-service-${ids.toolServiceId}`, true);
   await driver.replaceInput("tool-file-tool-root", fileToolRoot);
-  await driver.replaceInput("tool-command-execution-policy", "ReadOnly");
-  await driver.replaceInput("tool-command-network-mode", "Disabled");
+  await driver.selectOption("tool-command-execution-policy", "read_only");
+  await driver.selectOption("tool-command-network-mode", "disabled");
   await driver.replaceTextarea("tool-command-allowed-argv-prefixes", "rg");
   await driver.replaceTextarea("tool-command-forbidden-argv-prefixes", "rm -rf");
   await driver.replaceTextarea("tool-cli-tool-names", "rg");
@@ -156,10 +156,10 @@ export async function createToolSelection({
     );
     expect(selection?.allowedMcpServiceIds).toContain(ids.toolServiceId);
     expect(selection?.fileToolRoot).toBe(fileToolRoot);
-    expect(selection?.commandExecutionPolicy).toBe("ReadOnly");
+    expect(selection?.commandExecutionPolicy).toBe("read_only");
     expect(selection?.commandAllowedArgvPrefixes).toContain("rg");
     expect(selection?.commandForbiddenArgvPrefixes).toContain("rm -rf");
-    expect(selection?.commandNetworkMode).toBe("Disabled");
+    expect(selection?.commandNetworkMode).toBe("disabled");
     expect(selection?.backgroundableToolNames).toContain("bash");
     expect(selection?.subagentTargets).toContain(ids.behaviorId);
     expect(selection?.subagentSpawnEnabled).toBe(true);

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -803,6 +803,20 @@ pub(crate) struct ToolSelectionUpsertArgs {
     pub(crate) enable_bash: bool,
     #[arg(long)]
     pub(crate) bash_mode: Option<String>,
+    #[arg(
+        long,
+        help = "Command policy for bash: read_only, workspace_write, managed_write, or unrestricted"
+    )]
+    pub(crate) command_execution_policy: Option<String>,
+    #[arg(
+        long,
+        help = "Network policy hint for bash commands: inherit, disabled, or enabled"
+    )]
+    pub(crate) command_network_mode: Option<String>,
+    #[arg(long = "command-allowed-argv-prefix")]
+    pub(crate) command_allowed_argv_prefixes: Vec<String>,
+    #[arg(long = "command-forbidden-argv-prefix")]
+    pub(crate) command_forbidden_argv_prefixes: Vec<String>,
     #[arg(long = "cli-tool-name")]
     pub(crate) cli_tool_names: Vec<String>,
     #[arg(long, default_value_t = true)]

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -1,16 +1,25 @@
 use anyhow::Result;
-use defra_agent::ToolSelectionDocument;
+use defra_agent::{CommandExecutionMode, CommandNetworkMode, ToolSelectionDocument};
 use serde_json::json;
 
 use crate::cli::*;
 use crate::config_writes::{write_tool_selection_document, ConfigAccess};
 use crate::print_json;
-use crate::{normalize_bash_mode, normalize_file_tools_mode};
+use crate::{normalize_bash_mode, normalize_file_tools_mode, normalize_optional_string};
 
 pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<()> {
     let file_tools_mode =
         normalize_file_tools_mode(args.enable_file_tools, args.file_tools_mode.as_deref())?;
     let bash_mode = normalize_bash_mode(args.enable_bash, args.bash_mode.as_deref())?;
+    let command_execution_policy =
+        normalize_optional_string(args.command_execution_policy.as_deref());
+    if let Some(mode) = command_execution_policy.as_deref() {
+        CommandExecutionMode::parse(mode)?;
+    }
+    let command_network_mode = normalize_optional_string(args.command_network_mode.as_deref());
+    if let Some(mode) = command_network_mode.as_deref() {
+        CommandNetworkMode::parse(mode)?;
+    }
     let file_tool_root = args
         .file_tool_root
         .as_ref()
@@ -25,10 +34,10 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         file_tool_root: file_tool_root.clone(),
         enable_bash: Some(args.enable_bash),
         bash_mode: Some(bash_mode.clone()),
-        command_execution_policy: None,
-        command_allowed_argv_prefixes: Some(Vec::new()),
-        command_forbidden_argv_prefixes: Some(Vec::new()),
-        command_network_mode: None,
+        command_execution_policy: command_execution_policy.clone(),
+        command_allowed_argv_prefixes: Some(args.command_allowed_argv_prefixes.clone()),
+        command_forbidden_argv_prefixes: Some(args.command_forbidden_argv_prefixes.clone()),
+        command_network_mode: command_network_mode.clone(),
         cli_tool_names: Some(args.cli_tool_names.clone()),
         enable_meta_tools: Some(args.enable_meta_tools),
         allowed_mcp_service_ids: Some(args.allowed_mcp_service_ids.clone()),
@@ -50,6 +59,10 @@ pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<
         "file_tool_root": file_tool_root,
         "enable_bash": args.enable_bash,
         "bash_mode": bash_mode,
+        "command_execution_policy": command_execution_policy,
+        "command_allowed_argv_prefixes": args.command_allowed_argv_prefixes,
+        "command_forbidden_argv_prefixes": args.command_forbidden_argv_prefixes,
+        "command_network_mode": command_network_mode,
         "cli_tool_names": args.cli_tool_names,
         "enable_meta_tools": args.enable_meta_tools,
         "allowed_mcp_service_ids": args.allowed_mcp_service_ids,

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -536,7 +536,7 @@ fn standard_tool_selection(
         file_tool_root: None,
         enable_bash: Some(true),
         bash_mode: Some(bash_mode.to_string()),
-        command_execution_policy: None,
+        command_execution_policy: default_command_execution_policy_for_init(tool_ceiling),
         command_allowed_argv_prefixes: Some(Vec::new()),
         command_forbidden_argv_prefixes: Some(Vec::new()),
         command_network_mode: None,
@@ -550,6 +550,16 @@ fn standard_tool_selection(
         subagent_steering_enabled: Some(false),
         subagent_background_enabled: Some(false),
         cross_deployment_spawn_timeout_seconds: None,
+    }
+}
+
+fn default_command_execution_policy_for_init(tool_ceiling: ToolCeilingArg) -> Option<String> {
+    match tool_ceiling {
+        ToolCeilingArg::Readwrite if cfg!(target_os = "macos") => {
+            Some("workspace_write".to_string())
+        }
+        ToolCeilingArg::Readwrite => Some("unrestricted".to_string()),
+        ToolCeilingArg::MetaOnly | ToolCeilingArg::Readonly => None,
     }
 }
 

--- a/crates/defra-agent-cli/tests/cli_config_tools.rs
+++ b/crates/defra-agent-cli/tests/cli_config_tools.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use uuid::Uuid;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()> {
+async fn tool_selection_upsert_defaults_enabled_modes_and_persists_command_policy() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
@@ -111,6 +111,79 @@ async fn tool_selection_upsert_defaults_enabled_modes_to_readonly() -> Result<()
         row.pointer("/allowed_mcp_service_ids/0")
             .and_then(Value::as_str),
         Some("x-data")
+    );
+
+    let output = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "tools",
+            "set",
+            "--graphql",
+            &graphql,
+            "--agent-did",
+            &agent_did,
+            "--selection-id",
+            &selection_id,
+            "--enable-bash",
+            "--bash-mode",
+            "Unrestricted",
+            "--command-execution-policy",
+            "unrestricted",
+            "--command-network-mode",
+            "enabled",
+            "--command-allowed-argv-prefix",
+            "ps",
+            "--command-forbidden-argv-prefix",
+            "rm -rf",
+        ],
+    )?;
+    assert_eq!(
+        output
+            .get("command_execution_policy")
+            .and_then(Value::as_str),
+        Some("unrestricted")
+    );
+    assert_eq!(
+        output.get("command_network_mode").and_then(Value::as_str),
+        Some("enabled")
+    );
+
+    let query = format!(
+        r#"{{
+            ToolSelection(filter: {{ selection_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                bash_mode
+                command_execution_policy
+                command_network_mode
+                command_allowed_argv_prefixes
+                command_forbidden_argv_prefixes
+            }}
+        }}"#,
+        escape_graphql_string(&selection_id),
+    );
+    let response = graphql_query(&graphql, &query).await?;
+    let row = first_graphql_row(&response, "ToolSelection")?;
+    assert_eq!(
+        row.get("bash_mode").and_then(Value::as_str),
+        Some("Unrestricted")
+    );
+    assert_eq!(
+        row.get("command_execution_policy").and_then(Value::as_str),
+        Some("unrestricted")
+    );
+    assert_eq!(
+        row.get("command_network_mode").and_then(Value::as_str),
+        Some("enabled")
+    );
+    assert_eq!(
+        row.pointer("/command_allowed_argv_prefixes/0")
+            .and_then(Value::as_str),
+        Some("ps")
+    );
+    assert_eq!(
+        row.pointer("/command_forbidden_argv_prefixes/0")
+            .and_then(Value::as_str),
+        Some("rm -rf")
     );
 
     Ok(())

--- a/crates/defra-agent-cli/tests/cli_init.rs
+++ b/crates/defra-agent-cli/tests/cli_init.rs
@@ -569,6 +569,7 @@ async fn init_with_write_tools_bootstraps_write_defaults() -> Result<()> {
         &format!(
             r#"{{
                 ToolSelection(filter: {{ selection_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    command_execution_policy
                     backgroundable_tool_names
                 }}
             }}"#,
@@ -577,6 +578,17 @@ async fn init_with_write_tools_bootstraps_write_defaults() -> Result<()> {
     )
     .await?;
     let tool_selection = first_graphql_row(&response, "ToolSelection")?;
+    let expected_command_policy = if cfg!(target_os = "macos") {
+        Some("workspace_write")
+    } else {
+        Some("unrestricted")
+    };
+    assert_eq!(
+        tool_selection
+            .get("command_execution_policy")
+            .and_then(Value::as_str),
+        expected_command_policy
+    );
     assert_eq!(
         tool_selection
             .get("backgroundable_tool_names")

--- a/crates/defra-agent-protocol/schemas/README.md
+++ b/crates/defra-agent-protocol/schemas/README.md
@@ -197,7 +197,10 @@ Some boundaries are deliberate:
   `command_allowed_argv_prefixes` and `command_forbidden_argv_prefixes` refine
   argv-level allow/deny behavior; `command_network_mode` is an optional network
   policy hint. Runtime enforcement still depends on the selected bash mode and
-  host platform.
+  host platform. On macOS, `workspace_write` uses the seatbelt sandbox and only
+  permits same-sandbox process introspection; `unrestricted` is unsandboxed and
+  is the policy to use for host-diagnostics stewards that need `ps` or broad
+  `lsof`.
 - backend credentials may currently be stored either directly in
   `InferenceBackend.api_key` or indirectly via `InferenceBackend.api_key_env_var`.
 - backend capability metadata is not stored in `InferenceBackend`; provider

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -401,7 +401,14 @@ fn command_policy_from_document(
             .as_ref()
             .is_some_and(|prefixes| !prefixes.is_empty());
     if !has_policy {
-        return Ok(None);
+        return if matches!(bash, BashMode::Unrestricted) {
+            Ok(Some(
+                CommandExecutionPolicy::write_capable()
+                    .with_mode(CommandExecutionMode::Unrestricted),
+            ))
+        } else {
+            Ok(None)
+        };
     }
 
     let requested_mode = selection
@@ -413,13 +420,7 @@ fn command_policy_from_document(
     let mode = match bash {
         BashMode::Off => CommandExecutionMode::ReadOnly,
         BashMode::ReadOnly => CommandExecutionMode::ReadOnly,
-        BashMode::Unrestricted => requested_mode.unwrap_or_else(|| {
-            if cfg!(target_os = "macos") {
-                CommandExecutionMode::WorkspaceWrite
-            } else {
-                CommandExecutionMode::Unrestricted
-            }
-        }),
+        BashMode::Unrestricted => requested_mode.unwrap_or(CommandExecutionMode::Unrestricted),
     };
 
     let allowed = parse_argv_prefixes(

--- a/crates/defra-agent/src/agent/tests/command_policy.rs
+++ b/crates/defra-agent/src/agent/tests/command_policy.rs
@@ -1,0 +1,60 @@
+use crate::agent::tool_selection_from_document;
+use crate::document_config::ToolSelectionDocument;
+use crate::toolset::CommandExecutionMode;
+
+fn tool_selection_doc(bash_mode: &str) -> ToolSelectionDocument {
+    ToolSelectionDocument {
+        selection_id: "tools".to_string(),
+        agent_did: "did:key:zAgent".to_string(),
+        display_name: Some("Tools".to_string()),
+        enable_file_tools: Some(false),
+        file_tools_mode: Some("Off".to_string()),
+        file_tool_root: None,
+        enable_bash: Some(true),
+        bash_mode: Some(bash_mode.to_string()),
+        command_execution_policy: None,
+        command_allowed_argv_prefixes: Some(Vec::new()),
+        command_forbidden_argv_prefixes: Some(Vec::new()),
+        command_network_mode: None,
+        cli_tool_names: Some(Vec::new()),
+        enable_meta_tools: Some(false),
+        allowed_mcp_service_ids: Some(Vec::new()),
+        delegate_to: Some(Vec::new()),
+        backgroundable_tool_names: Some(Vec::new()),
+        subagent_targets: Some(Vec::new()),
+        subagent_spawn_enabled: Some(false),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(false),
+        cross_deployment_spawn_timeout_seconds: None,
+    }
+}
+
+#[test]
+fn unrestricted_bash_mode_defaults_to_unrestricted_command_policy() {
+    let selection = tool_selection_from_document(&tool_selection_doc("Unrestricted")).unwrap();
+
+    assert_eq!(
+        selection.command_policy.unwrap().mode,
+        CommandExecutionMode::Unrestricted
+    );
+}
+
+#[test]
+fn unrestricted_bash_mode_can_request_workspace_write_command_policy() {
+    let mut doc = tool_selection_doc("Unrestricted");
+    doc.command_execution_policy = Some("workspace_write".to_string());
+
+    let selection = tool_selection_from_document(&doc).unwrap();
+
+    assert_eq!(
+        selection.command_policy.unwrap().mode,
+        CommandExecutionMode::WorkspaceWrite
+    );
+}
+
+#[test]
+fn readonly_bash_mode_uses_builder_default_policy() {
+    let selection = tool_selection_from_document(&tool_selection_doc("ReadOnly")).unwrap();
+
+    assert!(selection.command_policy.is_none());
+}

--- a/crates/defra-agent/src/agent/tests/mod.rs
+++ b/crates/defra-agent/src/agent/tests/mod.rs
@@ -1,4 +1,5 @@
 mod builder;
+mod command_policy;
 mod document_loading;
 mod supervision;
 mod support;

--- a/crates/defra-agent/src/toolset/bash_tools.rs
+++ b/crates/defra-agent/src/toolset/bash_tools.rs
@@ -6,7 +6,8 @@ use rig::tool::Tool;
 
 use super::args::BashArgs;
 use super::shared::{
-    run_command, validate_command_policy, CommandExecutionPolicy, ToolContext, ToolError,
+    run_command, validate_command_policy, CommandExecutionMode, CommandExecutionPolicy,
+    ToolContext, ToolError,
 };
 
 #[derive(Clone)]
@@ -145,10 +146,20 @@ impl Tool for UnrestrictedBashTool {
     type Output = String;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
+        let policy_description = match self.policy.mode {
+            CommandExecutionMode::ReadOnly => "read-only policy",
+            CommandExecutionMode::WorkspaceWrite => {
+                "workspace_write policy; macOS uses sandbox-exec to contain writes to the tool root"
+            }
+            CommandExecutionMode::Unrestricted => {
+                "unrestricted policy; commands run without the macOS seatbelt sandbox"
+            }
+        };
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Run a write-capable command under the configured writable root. Relative cwd values resolve from the active request workspace when one is provided, otherwise from the root. On macOS the default policy uses sandbox-exec to contain writes to that root; an explicit unrestricted command policy is unsandboxed. If args is empty, command may be a shell command string; if args is present, command is treated as an executable name or path. Returns compact text with first-line defra_exec metadata. Set raw_json=true for structured JSON."
-                .to_string(),
+            description: format!(
+                "Run a write-capable command under the configured writable root. Relative cwd values resolve from the active request workspace when one is provided, otherwise from the root. Current command policy: {policy_description}. If args is empty, command may be a shell command string; if args is present, command is treated as an executable name or path. Returns compact text with first-line defra_exec metadata. Set raw_json=true for structured JSON."
+            ),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {

--- a/docs/macos-bash-sandbox.md
+++ b/docs/macos-bash-sandbox.md
@@ -1,0 +1,75 @@
+# macOS Bash Sandbox Policies
+
+`ToolSelection.bash_mode` chooses the bash tool surface:
+
+- `Off`: no bash tool.
+- `ReadOnly`: exposes the read-only `bash` tool with the read-only command allowlist.
+- `Unrestricted`: exposes `bash_unrestricted`, which can run arbitrary command strings subject to the selected command policy.
+
+`ToolSelection.command_execution_policy` chooses the runtime command policy:
+
+| Policy | macOS runtime | Process introspection | Writes | Network mode |
+| --- | --- | --- | --- | --- |
+| `read_only` | no seatbelt; Rust allowlist validation | allowed when the command itself is allowlisted | denied by read-only validation | `disabled` is enforced for known network probes |
+| `workspace_write` / `managed_write` | `/usr/bin/sandbox-exec` seatbelt | only same-sandbox process info | allowed under `WRITABLE_ROOT` | `disabled` removes network allow rules |
+| `unrestricted` | no seatbelt | allowed by host user permissions, so `ps` and cross-process `lsof` can work | allowed by host user permissions | `disabled` is rejected because it cannot be enforced |
+
+For custom tool selections, `bash_mode: Unrestricted` with no explicit
+`command_execution_policy` defaults to `unrestricted`.
+
+The generated `defra-agent init --write-tools` selection pins
+`command_execution_policy: workspace_write` on macOS so the default demo path
+keeps write-capable bash contained to the configured tool root. Change that
+policy to `unrestricted` for host-diagnostics stewards that need `ps`, broad
+`lsof`, or other cross-process inspection.
+
+## Configure It
+
+Desktop app:
+
+1. Open Config, then Tool Selections.
+2. Enable Bash.
+3. Set Bash mode to `Unrestricted`.
+4. Set Command policy to `Unrestricted` for host diagnostics, or `Workspace write` for root-contained writes.
+
+CLI:
+
+```bash
+defra-agent config tools set \
+  --graphql "$GRAPHQL" \
+  --agent-did "$AGENT_DID" \
+  --selection-id "$TOOL_SELECTION_ID" \
+  --enable-bash \
+  --bash-mode Unrestricted \
+  --command-execution-policy unrestricted
+```
+
+Manifest or direct DefraDB document:
+
+```json
+{
+  "enable_bash": true,
+  "bash_mode": "Unrestricted",
+  "command_execution_policy": "unrestricted"
+}
+```
+
+## macOS Seatbelt Profile
+
+The `workspace_write` policy uses a deny-by-default seatbelt profile with:
+
+```scheme
+(allow process-exec)
+(allow process-fork)
+(allow signal (target same-sandbox))
+(allow process-info* (target same-sandbox))
+(allow sysctl-read)
+(allow file-read*)
+(allow file-write-data (literal "/dev/null"))
+(allow file-write* (subpath (param "WRITABLE_ROOT")))
+```
+
+When network mode is not `disabled`, the profile also allows inbound and
+outbound network access. Because `process-info*` is scoped to `same-sandbox`,
+general `ps` output and broad cross-process `lsof` inspection are expected to
+fail under `workspace_write`.


### PR DESCRIPTION
## Summary

Fixes #348.

This clarifies and wires the distinction between `bash_mode` and `command_execution_policy` for macOS host diagnostics:

- make custom `bash_mode: Unrestricted` tool selections default to the actual `unrestricted` command policy
- keep `defra-agent init --write-tools` pinned to `workspace_write` on macOS so the generated default remains root-contained
- add explicit desktop dropdowns for command policy and command network mode
- add CLI `config tools set` support for command policy, network mode, and argv prefix fields
- document the macOS seatbelt tiers and the host-diagnostics setup path

## Why

Before this, operators could set `bash_mode: Unrestricted` and still get the macOS `sandbox-exec` workspace-write policy, which blocks cross-process diagnostics like broad `ps` / `lsof`. The UI also made the policy tier hard to discover.

## Testing

- `cargo test -p defra-agent --lib bash_mode --no-default-features`
- `cargo test -p defra-agent --lib command_policy_explicit_unrestricted_reports_unsandboxed_metadata --no-default-features`
- `cargo test -p defra-agent-cli --test cli_config_tools tool_selection_upsert_defaults_enabled_modes_and_persists_command_policy --no-default-features`
- `cargo test -p defra-agent-cli --test cli_init init_with_write_tools_bootstraps_write_defaults --no-default-features`
- `./node_modules/.bin/tsc --noEmit`
- `npm run test -- config-panel-buttons.test.tsx`
- `git diff --check`