### PR TITLE
Add Linux release artifacts

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -5,3 +5,7 @@ self-hosted-runner:
     - studio
     - studio-1
     - studio-2
+    - Linux
+    - X64
+    - spark
+    - workstation-1

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -40,6 +40,7 @@ jobs:
       - ${{ matrix.runner_label }}
 
     env:
+      GIT_CONFIG_GLOBAL: /tmp/defra-agent-release-${{ github.run_id }}-${{ matrix.target }}.gitconfig
       TARGET_TRIPLE: ${{ matrix.target }}
 
     steps:
@@ -159,3 +160,4 @@ jobs:
         run: |
           git config --global --remove-section "url.https://x-access-token:${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
           git config --global --remove-section "url.https://${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
+          rm -f "${GIT_CONFIG_GLOBAL}"

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -28,10 +28,16 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            runner: ubuntu-24.04
+            runner_arch: X64
+            runner_label: workstation-1
           - target: aarch64-unknown-linux-gnu
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
+            runner_arch: ARM64
+            runner_label: spark
+    runs-on:
+      - self-hosted
+      - Linux
+      - ${{ matrix.runner_arch }}
+      - ${{ matrix.runner_label }}
 
     env:
       TARGET_TRIPLE: ${{ matrix.target }}

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -62,6 +62,8 @@ jobs:
           git config --global --add url."${auth_url}".insteadOf "ssh://git@github.com/sourcenetwork/"
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
 
       - name: Install native build dependencies
         run: |

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,155 @@
+name: Release Linux defra-agent
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+concurrency:
+  group: release-linux-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '4' }}
+  CARGO_INCREMENTAL: "0"
+  CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  RUST_BACKTRACE: "1"
+
+jobs:
+  build-package:
+    name: Build and package ${{ matrix.target }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-24.04
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+
+    env:
+      TARGET_TRIPLE: ${{ matrix.target }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Rewrite Git SSH dependencies to HTTPS
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PRIVATE_REPO_PAT}" ]]; then
+            echo "::error::Missing PRIVATE_REPO_PAT; required to fetch private Source Network git dependencies."
+            exit 1
+          fi
+          auth_url="https://x-access-token:${PRIVATE_REPO_PAT}@github.com/sourcenetwork/"
+          git config --global --add url."${auth_url}".insteadOf "https://github.com/sourcenetwork/"
+          git config --global --add url."${auth_url}".insteadOf "ssh://git@github.com/sourcenetwork/"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install native build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            libssl-dev \
+            pkg-config \
+            protobuf-compiler
+          protoc --version
+
+      - name: Build release binary
+        run: |
+          set -euo pipefail
+          rustc -Vv
+          host_triple="$(rustc -Vv | awk '/^host:/ { print $2 }')"
+          if [[ "${host_triple}" != "${TARGET_TRIPLE}" ]]; then
+            echo "::error::Expected native ${TARGET_TRIPLE} runner, got ${host_triple}."
+            exit 1
+          fi
+          cargo build -p defra-agent-cli --release
+          file target/release/defra-agent
+
+      - name: Verify binary
+        run: |
+          set -euo pipefail
+          binary_path="target/release/defra-agent"
+          version_output="$("${binary_path}" version)"
+          printf '%s\n' "${version_output}"
+          if [[ -z "${version_output}" ]]; then
+            echo "::error::defra-agent version produced no output."
+            exit 1
+          fi
+
+      - name: Package artifact
+        id: package
+        run: |
+          set -euo pipefail
+
+          artifact_basename="defra-agent-${TARGET_TRIPLE}"
+          package_parent="${RUNNER_TEMP}/package"
+          package_root="${package_parent}/${artifact_basename}"
+          dist_dir="${RUNNER_TEMP}/dist"
+          tarball="${dist_dir}/${artifact_basename}.tar.gz"
+          checksum_file="${tarball}.sha256"
+
+          rm -rf "${package_parent}" "${dist_dir}"
+          mkdir -p "${package_root}" "${dist_dir}"
+          cp target/release/defra-agent "${package_root}/defra-agent"
+          chmod 0755 "${package_root}/defra-agent"
+
+          tar -C "${package_parent}" -czf "${tarball}" "${artifact_basename}"
+          (
+            cd "${dist_dir}"
+            sha256sum "${artifact_basename}.tar.gz" > "${artifact_basename}.tar.gz.sha256"
+          )
+
+          echo "tarball=${tarball}" >> "${GITHUB_OUTPUT}"
+          echo "checksum_file=${checksum_file}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_basename=${artifact_basename}" >> "${GITHUB_OUTPUT}"
+          ls -lh "${dist_dir}"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.artifact_basename }}
+          path: |
+            ${{ steps.package.outputs.tarball }}
+            ${{ steps.package.outputs.checksum_file }}
+          if-no-files-found: error
+
+      - name: Attach artifacts to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARBALL: ${{ steps.package.outputs.tarball }}
+          CHECKSUM_FILE: ${{ steps.package.outputs.checksum_file }}
+        run: |
+          set -euo pipefail
+
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "defra-agent release artifacts." \
+              || gh release view "${GITHUB_REF_NAME}" >/dev/null
+          fi
+          gh release upload "${GITHUB_REF_NAME}" "${TARBALL}" "${CHECKSUM_FILE}" --clobber
+
+      - name: Cleanup git auth
+        if: always()
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add a Linux release workflow for `x86_64-unknown-linux-gnu` on the self-hosted `Linux/X64/workstation-1` Ubuntu 24.04 runner and `aarch64-unknown-linux-gnu` on the self-hosted `Linux/ARM64/spark` Ubuntu 24.04 runner
- build natively after asserting the runner host triple matches the artifact target; no downstream cross-compilation
- package `defra-agent-${target}.tar.gz` plus `.sha256`, upload workflow artifacts, and attach them to tagged GitHub releases
- isolate workflow git config on self-hosted runners and install the `wasm32-unknown-unknown` Rust target required by the release build

Closes #353

## Validation
- `actionlint .github/workflows/release-linux.yml` using actionlint v1.7.12 installed to a temp directory
- YAML inspection for target/runner matrix, packaging, wasm target install, and tagged release attach step
- `bash -n` for all `run:` blocks in `.github/workflows/release-linux.yml`
- `git diff --check`
- `git diff --cached --check`
- native test workflow passed on both runners: https://github.com/sourcenetwork/defra-agent/actions/runs/26769644787
- test workflow uploaded `defra-agent-aarch64-unknown-linux-gnu` and `defra-agent-x86_64-unknown-linux-gnu` artifacts
- PR CI is green for `rust-and-cli`, `lean-proofs`, and CodeRabbit
