### PR TITLE
Fix startup recovery flaky tests

### DIFF
--- a/crates/defra-agent/src/agent/runtime/tests/startup_recovery.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/startup_recovery.rs
@@ -111,6 +111,23 @@ async fn run_agent_fails_when_all_behaviors_are_unavailable_due_to_invalid_confi
     let node = test_node().await;
     ensure_runtime_schemas(node.as_ref()).await.unwrap();
     let identity = Arc::new(test_identity("startup-invalid-config"));
+    bind_default_behavior_backend(
+        node.as_ref(),
+        identity.did(),
+        "backend-invalid-config",
+        "http://127.0.0.1:9/v1",
+    )
+    .await;
+    let default_behavior_id = crate::default_behavior_id_for_agent(identity.did());
+    let mut default_behavior = crate::load_agent_behavior(node.as_ref(), &default_behavior_id)
+        .await
+        .unwrap()
+        .expect("default behavior document");
+    default_behavior.tool_selection_id = Some("missing-tool-selection".to_string());
+    crate::upsert_agent_behavior(node.as_ref(), &default_behavior)
+        .await
+        .unwrap();
+
     let agent = crate::DefraAgent::from_default_behavior_documents(
         node.clone(),
         identity.clone(),
@@ -123,6 +140,14 @@ async fn run_agent_fails_when_all_behaviors_are_unavailable_due_to_invalid_confi
     .unwrap();
     assert!(agent.behaviors().is_empty());
     assert_eq!(agent.unavailable_behaviors().len(), 1);
+    let unavailable_reason = agent
+        .unavailable_behaviors()
+        .get(&default_behavior_id)
+        .expect("default behavior should be unavailable");
+    assert!(
+        unavailable_reason.contains("references missing tool selection missing-tool-selection"),
+        "unexpected unavailable reason: {unavailable_reason}"
+    );
 
     let (_shutdown_tx, shutdown_rx) = watch::channel(false);
     let error = agent
@@ -135,7 +160,7 @@ async fn run_agent_fails_when_all_behaviors_are_unavailable_due_to_invalid_confi
         "unexpected startup error: {error_text}"
     );
     assert!(
-        error_text.contains("has no backend binding"),
+        error_text.contains("references missing tool selection missing-tool-selection"),
         "unexpected startup error: {error_text}"
     );
 
@@ -148,7 +173,7 @@ async fn run_agent_fails_when_all_behaviors_are_unavailable_due_to_invalid_confi
     assert_eq!(status.last_reconcile_result, "error");
     assert!(status
         .last_reconcile_error
-        .contains("has no backend binding"));
+        .contains("references missing tool selection missing-tool-selection"));
 }
 
 #[tokio::test]
@@ -242,12 +267,11 @@ async fn run_agent_recovers_backend_availability_without_restart() {
     let node = test_node().await;
     ensure_runtime_schemas(node.as_ref()).await.unwrap();
     let identity = Arc::new(test_identity("startup-backend-recovers"));
-    let mock_endpoint = MockModelEndpoint::start("default").unwrap();
     bind_default_behavior_backend_with_capacity_and_probe_status(
         node.as_ref(),
         identity.did(),
         "backend-recovers",
-        mock_endpoint.endpoint(),
+        "http://127.0.0.1:9/v1",
         1,
         "unknown",
     )

--- a/crates/defra-agent/src/agent/runtime/tests/support.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/support.rs
@@ -141,6 +141,7 @@ pub(super) struct MockModelEndpoint {
     pub(super) port: u16,
     pub(super) stop: Arc<AtomicBool>,
     pub(super) chat_requests: Arc<AtomicUsize>,
+    pub(super) chat_requests_changed: Arc<tokio::sync::Notify>,
     pub(super) handle: Option<JoinHandle<()>>,
 }
 
@@ -161,6 +162,8 @@ impl MockModelEndpoint {
         let stop_for_thread = stop.clone();
         let chat_requests = Arc::new(AtomicUsize::new(0));
         let chat_requests_for_thread = chat_requests.clone();
+        let chat_requests_changed = Arc::new(tokio::sync::Notify::new());
+        let chat_requests_changed_for_thread = chat_requests_changed.clone();
         let model_name = model_name.to_string();
         let handle = thread::spawn(move || {
             while !stop_for_thread.load(Ordering::Relaxed) {
@@ -175,6 +178,7 @@ impl MockModelEndpoint {
                         };
                         if request.method == "POST" && request.path == "/v1/chat/completions" {
                             chat_requests_for_thread.fetch_add(1, Ordering::SeqCst);
+                            chat_requests_changed_for_thread.notify_waiters();
                             if blocking_chat {
                                 while !stop_for_thread.load(Ordering::Relaxed) {
                                     thread::sleep(Duration::from_millis(25));
@@ -207,6 +211,7 @@ impl MockModelEndpoint {
             port,
             stop,
             chat_requests,
+            chat_requests_changed,
             handle: Some(handle),
         })
     }
@@ -466,15 +471,19 @@ pub(super) async fn create_agent_request_for_behavior(
 pub(super) async fn wait_for_chat_request_count(endpoint: &MockModelEndpoint, expected: usize) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     loop {
+        let notified = endpoint.chat_requests_changed.notified();
         let actual = endpoint.chat_request_count();
         if actual >= expected {
             return;
         }
+        let now = tokio::time::Instant::now();
         assert!(
-            tokio::time::Instant::now() < deadline,
+            now < deadline,
             "timed out waiting for {expected} chat request(s), observed {actual}"
         );
-        tokio::time::sleep(Duration::from_millis(50)).await;
+        tokio::time::timeout_at(deadline, notified)
+            .await
+            .unwrap_or(());
     }
 }
 

--- a/crates/defra-agent/src/tool_surface/build.rs
+++ b/crates/defra-agent/src/tool_surface/build.rs
@@ -4,7 +4,10 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use defra_node::EmbeddedNode;
 
-use crate::toolset::{CommandExecutionPolicy, ToolSet, ToolSetBuilder};
+use crate::toolset::{
+    default_read_only_command_policy, CommandExecutionMode, CommandExecutionPolicy, ToolSet,
+    ToolSetBuilder,
+};
 
 use super::modes::{BashMode, FileToolMode, ToolCeiling};
 
@@ -76,6 +79,7 @@ pub(super) fn build_host_tools(
         builder = builder.write_file(root.clone()).edit_file(root);
     }
 
+    let command_policy = constrain_command_policy_to_effective_bash(command_policy, bash);
     match bash {
         BashMode::Off => {}
         BashMode::ReadOnly => {
@@ -112,6 +116,27 @@ pub(super) fn build_host_tools(
     }
 
     Ok(builder.build())
+}
+
+fn constrain_command_policy_to_effective_bash(
+    command_policy: Option<CommandExecutionPolicy>,
+    bash: BashMode,
+) -> Option<CommandExecutionPolicy> {
+    match (command_policy, bash) {
+        (_, BashMode::Off) | (None, _) => None,
+        (Some(policy), BashMode::Unrestricted) => Some(policy),
+        (Some(policy), BashMode::ReadOnly)
+            if matches!(policy.mode, CommandExecutionMode::ReadOnly) =>
+        {
+            Some(policy)
+        }
+        (Some(policy), BashMode::ReadOnly) => Some(
+            default_read_only_command_policy()
+                .with_allowed_argv_prefixes(policy.allowed_argv_prefixes)
+                .with_forbidden_argv_prefixes(policy.forbidden_argv_prefixes)
+                .with_network_mode(policy.network_mode),
+        ),
+    }
 }
 
 pub(super) fn resolve_effective_tool_root(

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -148,6 +148,32 @@ fn downgraded_off_selection_ignores_stale_file_tool_root() {
 }
 
 #[test]
+fn readonly_ceiling_clamps_unrestricted_bash_policy() {
+    let config = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection {
+            file_tools: FileToolMode::ReadWrite,
+            file_tool_root: None,
+            bash: BashMode::Unrestricted,
+            command_policy: Some(
+                crate::toolset::CommandExecutionPolicy::write_capable()
+                    .with_mode(crate::toolset::CommandExecutionMode::Unrestricted),
+            ),
+            cli_tool_names: Vec::new(),
+            enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
+            delegate_to: Vec::new(),
+            backgroundable_tool_names: Vec::new(),
+        },
+        &ToolCeiling::readonly(),
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert_eq!(config.host_tools(), &crate::toolset::ToolSet::readonly());
+}
+
+#[test]
 fn selection_without_root_inherits_operator_root() {
     let operator_root = temp_root("defra-agent-operator-root");
 


### PR DESCRIPTION
## Summary
- replace mock chat request polling with a `Notify` signal for the shutdown-while-queued test
- keep the backend recovery test unavailable at startup so startup probing cannot auto-promote it
- update the invalid-config startup test to use a genuinely blocking missing tool selection
- clamp command policy when a read-only tool ceiling downgrades unrestricted bash

## Verification
- `cargo test -p defra-agent --lib agent::runtime::tests::startup_recovery -- --nocapture`
- `cargo test -p defra-agent --lib agent::runtime::tests::startup_recovery::run_agent_shutdown_is_prompt_while_request_waits_for_backend_capacity -- --exact` repeated 50x
- `cargo test -p defra-agent --lib`

Fixes #330