### PR TITLE
Add opt-in agent DID forwarding for MCP services

### DIFF
--- a/crates/defra-agent-cli/src/commands/mcp.rs
+++ b/crates/defra-agent-cli/src/commands/mcp.rs
@@ -82,6 +82,7 @@ async fn load_mcp_services(
                 lan_ip
                 mcp_port
                 mcp_path
+                send_agent_did
                 updated_at
             }}
         }}"#

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1641,6 +1641,7 @@ mod lean_apply_write_boundary_tests {
             lan_ip: None,
             mcp_port: None,
             mcp_path: None,
+            send_agent_did: false,
         }
     }
 

--- a/crates/defra-agent-cli/src/desired_state/convert.rs
+++ b/crates/defra-agent-cli/src/desired_state/convert.rs
@@ -30,6 +30,10 @@ pub(crate) fn tool_service_registry_from_live_value(
         lan_ip: optional_string_from_value("lan_ip", object.get("lan_ip"))?,
         mcp_port: optional_i64_from_value("mcp_port", object.get("mcp_port"))?,
         mcp_path: optional_string_from_value("mcp_path", object.get("mcp_path"))?,
+        send_agent_did: object
+            .get("send_agent_did")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
     })
 }
 

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -205,6 +205,7 @@ pub(crate) struct DesiredToolServiceRegistry {
     pub(crate) lan_ip: Option<String>,
     pub(crate) mcp_port: Option<i64>,
     pub(crate) mcp_path: Option<String>,
+    pub(crate) send_agent_did: bool,
 }
 
 impl<'de> Deserialize<'de> for DesiredToolServiceRegistry {
@@ -223,6 +224,8 @@ impl<'de> Deserialize<'de> for DesiredToolServiceRegistry {
             lan_ip: Option<String>,
             mcp_port: Option<i64>,
             mcp_path: Option<String>,
+            #[serde(default)]
+            send_agent_did: bool,
         }
 
         let wire = Wire::deserialize(deserializer)?;
@@ -235,6 +238,7 @@ impl<'de> Deserialize<'de> for DesiredToolServiceRegistry {
             lan_ip: Some(validate::normalize_tool_service_string(wire.lan_ip)),
             mcp_port: wire.mcp_port,
             mcp_path: Some(validate::normalize_tool_service_mcp_path(wire.mcp_path)),
+            send_agent_did: wire.send_agent_did,
         })
     }
 }

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -128,6 +128,7 @@ fn desired_tool_service_registry_normalizes_address_storage_fields() {
     assert_eq!(service.tailscale_ip.as_deref(), Some("100.64.0.10"));
     assert_eq!(service.lan_ip.as_deref(), Some(""));
     assert_eq!(service.mcp_path.as_deref(), Some("/mcp"));
+    assert!(!service.send_agent_did);
 }
 
 #[test]
@@ -146,6 +147,36 @@ fn live_tool_service_registry_preserves_null_storage_for_diff() {
     assert_eq!(service.tailscale_ip, None);
     assert_eq!(service.lan_ip, None);
     assert_eq!(service.mcp_path, None);
+    assert!(!service.send_agent_did);
+}
+
+#[test]
+fn tool_service_registry_round_trip_preserves_send_agent_did() {
+    let mut manifest = empty_manifest("did:defra-agent:test");
+    manifest
+        .tool_service_registries
+        .push(DesiredToolServiceRegistry {
+            service_id: "identity-aware-mcp".to_string(),
+            display_name: Some("Identity-aware MCP".to_string()),
+            description: None,
+            hostname: Some("studio-1".to_string()),
+            tailscale_ip: Some(String::new()),
+            lan_ip: Some(String::new()),
+            mcp_port: Some(9201),
+            mcp_path: Some("/mcp".to_string()),
+            send_agent_did: true,
+        });
+
+    let bundle =
+        export_bundle_from_manifest(&manifest, "local").expect("export bundle should be produced");
+    assert_eq!(
+        bundle.as_bundle().tool_service_registries[0]["send_agent_did"],
+        json!(true)
+    );
+
+    let round_tripped = manifest_from_export_bundle(bundle.as_bundle())
+        .expect("manifest should parse back from bundle");
+    assert!(round_tripped.tool_service_registries[0].send_agent_did);
 }
 
 #[test]

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -311,7 +311,7 @@ pub(crate) const EXPORT_INFERENCE_BACKEND_FIELDS: &str =
 pub(crate) const EXPORT_INFERENCE_PROFILE_FIELDS: &str =
     "profile_id display_name context_window max_output_tokens max_turns temperature stream_batch_ms deadline_duration_secs";
 pub(crate) const EXPORT_TOOL_SERVICE_REGISTRY_FIELDS: &str =
-    "service_id display_name description hostname tailscale_ip lan_ip mcp_port mcp_path";
+    "service_id display_name description hostname tailscale_ip lan_ip mcp_port mcp_path send_agent_did";
 pub(crate) const EXPORT_TASK_FIELDS: &str =
     "task_id name description behavior_id prompt_template enabled output_schema_ref created_at updated_at";
 pub(crate) const EXPORT_SCHEDULE_FIELDS: &str =

--- a/crates/defra-agent-cli/tests/support/fs.rs
+++ b/crates/defra-agent-cli/tests/support/fs.rs
@@ -229,6 +229,7 @@ pub fn write_manifest_root_from_export(root: &Path, exported: &Value) -> Result<
                 "lan_ip",
                 "mcp_port",
                 "mcp_path",
+                "send_agent_did",
             ],
         )?;
     }

--- a/crates/defra-agent-protocol/schemas/services/tool_service_registry.graphql
+++ b/crates/defra-agent-protocol/schemas/services/tool_service_registry.graphql
@@ -7,6 +7,7 @@ type ToolServiceRegistry {
     lan_ip: String
     mcp_port: Int
     mcp_path: String
+    send_agent_did: Boolean
     status: String @index
     version: String
     updated_at: DateTime @index(direction: DESC)

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -610,6 +610,8 @@ pub struct ToolServiceRegistryRow {
     #[serde(default)]
     pub mcp_path: Option<String>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
+    pub send_agent_did: bool,
+    #[serde(default, deserialize_with = "deserialize_null_default")]
     pub tools: Vec<ToolServiceEntry>,
     #[serde(default)]
     pub status: Option<String>,
@@ -765,5 +767,30 @@ mod tests {
         let re: String = serde_json::to_string(&row).expect("serialize");
         let round: ToolSelectionRow = serde_json::from_str(&re).expect("reparse");
         assert_eq!(row, round);
+    }
+
+    #[test]
+    fn tool_service_registry_defaults_send_agent_did_to_false() {
+        let json = r#"{
+            "service_id": "observability-mcp",
+            "hostname": "studio-1",
+            "mcp_port": 9201,
+            "mcp_path": "/mcp"
+        }"#;
+        let row: ToolServiceRegistryRow = serde_json::from_str(json).expect("parse");
+        assert!(!row.send_agent_did);
+    }
+
+    #[test]
+    fn tool_service_registry_treats_null_send_agent_did_as_false() {
+        let json = r#"{
+            "service_id": "observability-mcp",
+            "hostname": "studio-1",
+            "mcp_port": 9201,
+            "mcp_path": "/mcp",
+            "send_agent_did": null
+        }"#;
+        let row: ToolServiceRegistryRow = serde_json::from_str(json).expect("parse");
+        assert!(!row.send_agent_did);
     }
 }

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -55,13 +55,22 @@ pub(in crate::agent) async fn run_agent(
         runtime_status.publish_error(&format!("{error:#}")).await;
         return Err(error);
     }
+    if let Err(error) =
+        crate::migration::ensure_tool_service_registry_migrations(agent.node.clone())
+            .await
+            .context("ensure ToolServiceRegistry migrations")
+    {
+        runtime_status.publish_error(&format!("{error:#}")).await;
+        return Err(error);
+    }
     let health_map = ServiceHealthMap::new();
-    let tool_runtime = ToolRuntimeContext::new(
+    let tool_runtime = ToolRuntimeContext::new_with_agent_did(
         agent.node.clone(),
         agent.mcp_pool.clone(),
         health_map.clone(),
         agent.local_hostname.clone(),
         agent.local_subnet.clone(),
+        agent.agent_did().to_string(),
     );
     // Promote reachable enabled backends to healthy before resolving which
     // behaviors are runnable. A fresh store's backends start `probe_status=

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -319,6 +319,8 @@ pub struct McpHealthCheckService {
     pub mcp_port: Option<u16>,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
     pub mcp_path: String,
+    #[serde(default, deserialize_with = "crate::registry::null_as_default")]
+    pub send_agent_did: bool,
     pub updated_at: Option<String>,
 }
 
@@ -402,6 +404,7 @@ async fn run_health_check(
     lan_ip
     mcp_port
     mcp_path
+    send_agent_did
     updated_at
   }
 }"#;
@@ -529,7 +532,14 @@ pub async fn run_health_check_cycle(
 
         match tokio::time::timeout(
             options.probe_timeout,
-            mcp_pool.list_tools(&service_id, &endpoint),
+            mcp_pool.list_tools_with_agent_did(
+                &service_id,
+                &endpoint,
+                persistence
+                    .as_ref()
+                    .filter(|_| service.send_agent_did)
+                    .map(|p| p.agent_did),
+            ),
         )
         .await
         {
@@ -939,6 +949,7 @@ mod registry_parsing_tests {
             "lan_ip": null,
             "mcp_port": 9201,
             "mcp_path": null,
+            "send_agent_did": null,
             "updated_at": null,
         });
 
@@ -950,6 +961,7 @@ mod registry_parsing_tests {
         assert_eq!(entry.tailscale_ip, "");
         assert_eq!(entry.lan_ip, "");
         assert_eq!(entry.mcp_port, Some(9201));
+        assert!(!entry.send_agent_did);
     }
 
     #[test]
@@ -1036,6 +1048,7 @@ mod tests {
             lan_ip: String::new(),
             mcp_port: Some(9201),
             mcp_path: "/mcp".to_string(),
+            send_agent_did: false,
             updated_at: Some(updated_at.to_rfc3339()),
         }
     }

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -11,11 +11,15 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use reqwest::header::{HeaderName, HeaderValue};
 use rmcp::{
     model::{CallToolRequestParams, CallToolResult, ListToolsResult},
+    transport::streamable_http_client::StreamableHttpClientTransportConfig,
     RoleClient, ServiceExt,
 };
 use tokio::sync::RwLock;
+
+pub const AGENT_DID_HEADER: &str = "x-agent-did";
 
 /// Wrapper that stores list_tools / call_tool closures over a concrete
 /// `RunningService` so that the pool doesn't need to name the transport
@@ -25,10 +29,11 @@ type CallToolFuture = Pin<Box<dyn Future<Output = Result<CallToolResult>> + Send
 type ConnectFuture = Pin<Box<dyn Future<Output = Result<McpConnection>> + Send + 'static>>;
 type ListToolsFn = dyn Fn() -> ListToolsFuture + Send + Sync;
 type CallToolFn = dyn Fn(CallToolRequestParams) -> CallToolFuture + Send + Sync;
-type ConnectFn = dyn Fn(String, String) -> ConnectFuture + Send + Sync;
+type ConnectFn = dyn Fn(String, String, Option<String>) -> ConnectFuture + Send + Sync;
 
 struct McpConnection {
     endpoint: String,
+    agent_did_header: Option<String>,
     list_tools_fn: Box<ListToolsFn>,
     call_tool_fn: Box<CallToolFn>,
 }
@@ -46,6 +51,7 @@ where
 
     McpConnection {
         endpoint,
+        agent_did_header: None,
         list_tools_fn: Box::new(move || {
             let c = Arc::clone(&c1);
             Box::pin(async move {
@@ -67,19 +73,46 @@ where
     }
 }
 
-async fn connect_mcp_service(service_id: &str, endpoint: &str) -> Result<McpConnection> {
-    let transport = rmcp::transport::StreamableHttpClientTransport::from_uri(endpoint);
+fn streamable_http_transport_config(
+    endpoint: &str,
+    agent_did_header: Option<&str>,
+) -> Result<StreamableHttpClientTransportConfig> {
+    let mut config = StreamableHttpClientTransportConfig::with_uri(endpoint.to_string());
+    if let Some(agent_did) = agent_did_header {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert(
+            HeaderName::from_static(AGENT_DID_HEADER),
+            HeaderValue::from_str(agent_did).context("invalid agent DID header value")?,
+        );
+        config = config.custom_headers(headers);
+    }
+    Ok(config)
+}
+
+async fn connect_mcp_service(
+    service_id: &str,
+    endpoint: &str,
+    agent_did_header: Option<&str>,
+) -> Result<McpConnection> {
+    let config = streamable_http_transport_config(endpoint, agent_did_header)?;
+    let transport = rmcp::transport::StreamableHttpClientTransport::from_config(config);
     let client = ()
         .serve(transport)
         .await
         .map_err(|e| anyhow::anyhow!("MCP handshake failed for {service_id} ({endpoint}): {e}"))?;
-    Ok(wrap_connection(endpoint.to_string(), client))
+    let mut connection = wrap_connection(endpoint.to_string(), client);
+    connection.agent_did_header = agent_did_header.map(ToOwned::to_owned);
+    Ok(connection)
 }
 
 fn default_connect_fn() -> Arc<ConnectFn> {
-    Arc::new(|service_id: String, endpoint: String| {
-        Box::pin(async move { connect_mcp_service(&service_id, &endpoint).await })
-    })
+    Arc::new(
+        |service_id: String, endpoint: String, agent_did_header: Option<String>| {
+            Box::pin(async move {
+                connect_mcp_service(&service_id, &endpoint, agent_did_header.as_deref()).await
+            })
+        },
+    )
 }
 
 #[cfg(test)]
@@ -166,13 +199,13 @@ impl McpPool {
     #[cfg(test)]
     fn new_with_connector<F, Fut>(connector: F) -> Self
     where
-        F: Fn(String, String) -> Fut + Send + Sync + 'static,
+        F: Fn(String, String, Option<String>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<McpConnection>> + Send + 'static,
     {
         Self {
             inner: Arc::new(RwLock::new(HashMap::new())),
-            connect_fn: Arc::new(move |service_id, endpoint| {
-                Box::pin(connector(service_id, endpoint))
+            connect_fn: Arc::new(move |service_id, endpoint, agent_did_header| {
+                Box::pin(connector(service_id, endpoint, agent_did_header))
             }),
         }
     }
@@ -184,13 +217,14 @@ impl McpPool {
         Fut: Future<Output = Result<ListToolsResult>> + Send + 'static,
     {
         let handler = Arc::new(handler);
-        Self::new_with_connector(move |service_id, endpoint| {
+        Self::new_with_connector(move |service_id, endpoint, agent_did_header| {
             let handler = Arc::clone(&handler);
             async move {
                 let service_id_for_list = service_id.clone();
                 let endpoint_for_list = endpoint.clone();
                 Ok(McpConnection {
                     endpoint,
+                    agent_did_header,
                     list_tools_fn: Box::new(move || {
                         let handler = Arc::clone(&handler);
                         let service_id = service_id_for_list.clone();
@@ -211,7 +245,17 @@ impl McpPool {
     /// created.  If the cached connection points at a *different* endpoint the
     /// old connection is dropped and a fresh one is opened.
     pub async fn list_tools(&self, service_id: &str, endpoint: &str) -> Result<ListToolsResult> {
-        self.get_or_connect(service_id, endpoint).await?;
+        self.list_tools_with_agent_did(service_id, endpoint, None)
+            .await
+    }
+
+    pub async fn list_tools_with_agent_did(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        agent_did: Option<&str>,
+    ) -> Result<ListToolsResult> {
+        self.get_or_connect(service_id, endpoint, agent_did).await?;
         match self.list_tools_once(service_id).await {
             Ok(result) => Ok(result),
             Err(error) => {
@@ -221,7 +265,7 @@ impl McpPool {
                     "MCP list_tools failed, evicting connection and retrying"
                 );
                 self.remove(service_id).await;
-                self.get_or_connect(service_id, endpoint).await?;
+                self.get_or_connect(service_id, endpoint, agent_did).await?;
                 self.list_tools_once(service_id).await
             }
         }
@@ -243,7 +287,19 @@ impl McpPool {
         tool_name: &str,
         arguments: serde_json::Value,
     ) -> Result<CallToolResult> {
-        self.get_or_connect(service_id, endpoint).await?;
+        self.call_tool_with_agent_did(service_id, endpoint, tool_name, arguments, None)
+            .await
+    }
+
+    pub async fn call_tool_with_agent_did(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        tool_name: &str,
+        arguments: serde_json::Value,
+        agent_did: Option<&str>,
+    ) -> Result<CallToolResult> {
+        self.get_or_connect(service_id, endpoint, agent_did).await?;
         self.call_tool_once(service_id, build_call_tool_params(tool_name, arguments))
             .await
     }
@@ -282,12 +338,18 @@ impl McpPool {
     /// Uses a double-checked locking pattern:
     /// 1. Read-lock: check if a connection exists and the endpoint matches.
     /// 2. If not, take write-lock and re-check before actually connecting.
-    async fn get_or_connect(&self, service_id: &str, endpoint: &str) -> Result<()> {
+    async fn get_or_connect(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        agent_did: Option<&str>,
+    ) -> Result<()> {
+        let agent_did_header = agent_did.map(ToOwned::to_owned);
         // Fast path — read lock
         {
             let guard = self.inner.read().await;
             if let Some(conn) = guard.get(service_id) {
-                if conn.endpoint == endpoint {
+                if conn.endpoint == endpoint && conn.agent_did_header == agent_did_header {
                     return Ok(());
                 }
             }
@@ -296,19 +358,24 @@ impl McpPool {
         // Slow path — write lock, re-check
         let mut guard = self.inner.write().await;
         if let Some(conn) = guard.get(service_id) {
-            if conn.endpoint == endpoint {
+            if conn.endpoint == endpoint && conn.agent_did_header == agent_did_header {
                 return Ok(());
             }
             tracing::info!(
                 service_id,
                 old = %conn.endpoint,
                 new = %endpoint,
-                "endpoint changed, reconnecting"
+                "MCP connection context changed, reconnecting"
             );
         }
 
         tracing::info!(service_id, endpoint, "connecting MCP client");
-        let connection = (self.connect_fn)(service_id.to_string(), endpoint.to_string()).await?;
+        let connection = (self.connect_fn)(
+            service_id.to_string(),
+            endpoint.to_string(),
+            agent_did_header,
+        )
+        .await?;
         guard.insert(service_id.to_string(), connection);
         Ok(())
     }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -1,6 +1,9 @@
 use super::*;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
 
 use crate::lean_vocab_test::{
     assert_lean_contract_vocabulary_matches, lean_tool_retry_case, lean_tool_retry_cases,
@@ -155,13 +158,14 @@ async fn list_tools_transport_failure_retries_generated_safe_read_case() {
     let connect_attempts_for_fn = Arc::clone(&connect_attempts);
     let list_calls_for_fn = Arc::clone(&list_calls);
 
-    let pool = McpPool::new_with_connector(move |_service_id, endpoint| {
+    let pool = McpPool::new_with_connector(move |_service_id, endpoint, agent_did_header| {
         let connect_attempts = Arc::clone(&connect_attempts_for_fn);
         let list_calls = Arc::clone(&list_calls_for_fn);
         async move {
             let attempt = connect_attempts.fetch_add(1, Ordering::SeqCst) + 1;
             Ok(McpConnection {
                 endpoint,
+                agent_did_header,
                 list_tools_fn: Box::new(move || {
                     let list_calls = Arc::clone(&list_calls);
                     Box::pin(async move {
@@ -214,6 +218,7 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
             service_id.clone(),
             McpConnection {
                 endpoint: endpoint.to_string(),
+                agent_did_header: None,
                 list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
                 call_tool_fn: Box::new(move |_params| {
                     let calls = Arc::clone(&calls_for_fn);
@@ -247,4 +252,189 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
         pool.inner.read().await.contains_key(&service_id),
         "a failed call_tool must not evict and reconnect without idempotency evidence"
     );
+}
+
+#[tokio::test]
+async fn streamable_http_default_does_not_send_agent_did_header() {
+    let (endpoint, requests) = spawn_header_capture_mcp_server().await;
+    let pool = McpPool::new();
+
+    pool.list_tools("default-service", &endpoint)
+        .await
+        .expect("mock MCP server should list tools");
+
+    let requests = requests.lock().expect("captures lock");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.method == "tools/list"),
+        "expected a tools/list request, got {requests:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.agent_did_header.is_none()),
+        "default MCP calls must not send {AGENT_DID_HEADER}: {requests:?}"
+    );
+}
+
+#[tokio::test]
+async fn streamable_http_opt_in_sends_agent_did_header() {
+    let (endpoint, requests) = spawn_header_capture_mcp_server().await;
+    let pool = McpPool::new();
+    let agent_did = "did:key:zIdentityAwareAgent";
+
+    pool.list_tools_with_agent_did("identity-service", &endpoint, Some(agent_did))
+        .await
+        .expect("mock MCP server should list tools");
+
+    let requests = requests.lock().expect("captures lock");
+    assert!(
+        requests
+            .iter()
+            .any(|request| request.method == "tools/list"),
+        "expected a tools/list request, got {requests:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.agent_did_header.as_deref() == Some(agent_did)),
+        "opt-in MCP calls must send {AGENT_DID_HEADER}: {requests:?}"
+    );
+}
+
+#[derive(Debug)]
+struct CapturedMcpHttpRequest {
+    method: String,
+    agent_did_header: Option<String>,
+}
+
+async fn spawn_header_capture_mcp_server() -> (String, Arc<Mutex<Vec<CapturedMcpHttpRequest>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock MCP server");
+    let addr = listener.local_addr().expect("mock MCP server address");
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let captures = Arc::clone(&requests);
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let captures = Arc::clone(&captures);
+            tokio::spawn(async move {
+                let Ok(request) = read_mcp_http_request(&mut stream).await else {
+                    return;
+                };
+                let response = mcp_http_response(&request.method, request.id);
+                captures
+                    .lock()
+                    .expect("captures lock")
+                    .push(CapturedMcpHttpRequest {
+                        method: request.method,
+                        agent_did_header: request.agent_did_header,
+                    });
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    (format!("http://{addr}/mcp"), requests)
+}
+
+struct ParsedMcpHttpRequest {
+    method: String,
+    id: Option<serde_json::Value>,
+    agent_did_header: Option<String>,
+}
+
+async fn read_mcp_http_request(stream: &mut TcpStream) -> std::io::Result<ParsedMcpHttpRequest> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+    let header_end = loop {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Err(std::io::ErrorKind::UnexpectedEof.into());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = find_bytes(&buf, b"\r\n\r\n") {
+            break pos;
+        }
+    };
+
+    let headers = String::from_utf8_lossy(&buf[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse::<usize>().ok())
+                .flatten()
+        })
+        .unwrap_or(0);
+    let agent_did_header = headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case(AGENT_DID_HEADER)
+            .then(|| value.trim().to_string())
+    });
+
+    let body_start = header_end + b"\r\n\r\n".len();
+    while buf.len() < body_start + content_length {
+        let n = stream.read(&mut chunk).await?;
+        if n == 0 {
+            return Err(std::io::ErrorKind::UnexpectedEof.into());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    let body = &buf[body_start..body_start + content_length];
+    let body: serde_json::Value =
+        serde_json::from_slice(body).unwrap_or_else(|_| serde_json::json!({}));
+    let method = body
+        .get("method")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let id = body.get("id").cloned();
+
+    Ok(ParsedMcpHttpRequest {
+        method,
+        id,
+        agent_did_header,
+    })
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+fn mcp_http_response(method: &str, id: Option<serde_json::Value>) -> String {
+    if method == "notifications/initialized" {
+        return "HTTP/1.1 202 Accepted\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            .to_string();
+    }
+
+    let id = id.unwrap_or_else(|| serde_json::json!(0));
+    let result = match method {
+        "initialize" => serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": "header-capture-mcp", "version": "0.1.0" }
+        }),
+        "tools/list" => serde_json::json!({ "tools": [] }),
+        _ => serde_json::json!({}),
+    };
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+    .to_string();
+    format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
 }

--- a/crates/defra-agent/src/meta_tools.rs
+++ b/crates/defra-agent/src/meta_tools.rs
@@ -25,6 +25,7 @@ pub fn build_meta_tools(
     health: ServiceHealthMap,
     local_hostname: String,
     local_subnet: Option<String>,
+    agent_did: String,
     allowed_mcp_service_ids: Vec<String>,
 ) -> Vec<Box<dyn rig::tool::ToolDyn>> {
     let ctx = MetaToolContext {
@@ -33,6 +34,7 @@ pub fn build_meta_tools(
         health,
         local_hostname,
         local_subnet,
+        agent_did,
         allowed_mcp_service_ids,
     };
     vec![

--- a/crates/defra-agent/src/meta_tools/call.rs
+++ b/crates/defra-agent/src/meta_tools/call.rs
@@ -89,9 +89,10 @@ impl Tool for CallToolTool {
             .await
             .context("call_tool")?;
 
-        let endpoint = lookup_service(&self.ctx, &args.service_id)
+        let service = lookup_service(&self.ctx, &args.service_id)
             .await
             .context("call_tool")?;
+        let outbound_agent_did = service.outbound_agent_did(&self.ctx);
 
         let timeout_secs = if matches!(health.as_ref().map(|h| h.status), Some(HealthStatus::Stale))
         {
@@ -103,9 +104,10 @@ impl Tool for CallToolTool {
         if let Some(error) = self
             .preflight_arguments(
                 &args.service_id,
-                &endpoint,
+                &service.endpoint,
                 &args.tool_name,
                 argument_object,
+                outbound_agent_did,
             )
             .await
         {
@@ -114,9 +116,13 @@ impl Tool for CallToolTool {
 
         let result = tokio::time::timeout(
             Duration::from_secs(timeout_secs),
-            self.ctx
-                .mcp_pool
-                .call_tool(&args.service_id, &endpoint, &args.tool_name, arguments),
+            self.ctx.mcp_pool.call_tool_with_agent_did(
+                &args.service_id,
+                &service.endpoint,
+                &args.tool_name,
+                arguments,
+                outbound_agent_did,
+            ),
         )
         .await
         .map_err(|_| {
@@ -159,10 +165,13 @@ impl CallToolTool {
         endpoint: &str,
         tool_name: &str,
         arguments: &Map<String, Value>,
+        agent_did: Option<&str>,
     ) -> Option<StructuredToolError> {
         let list_result = match tokio::time::timeout(
             Duration::from_secs(30),
-            self.ctx.mcp_pool.list_tools(service_id, endpoint),
+            self.ctx
+                .mcp_pool
+                .list_tools_with_agent_did(service_id, endpoint, agent_did),
         )
         .await
         {
@@ -473,6 +482,7 @@ mod tests {
             health: ServiceHealthMap::new(),
             local_hostname: "studio-1".to_string(),
             local_subnet: None,
+            agent_did: "did:key:z-test-agent".to_string(),
             allowed_mcp_service_ids: vec!["x-data".to_string()],
         });
 

--- a/crates/defra-agent/src/meta_tools/describe.rs
+++ b/crates/defra-agent/src/meta_tools/describe.rs
@@ -87,8 +87,8 @@ impl Tool for DescribeToolTool {
             .to_result_text());
         }
 
-        let endpoint = match lookup_service(&self.ctx, &args.service_id).await {
-            Ok(endpoint) => endpoint,
+        let service = match lookup_service(&self.ctx, &args.service_id).await {
+            Ok(service) => service,
             Err(error) => {
                 return Ok(StructuredToolError::service_unavailable(
                     &args.service_id,
@@ -106,7 +106,11 @@ impl Tool for DescribeToolTool {
         let list_result = match self
             .ctx
             .mcp_pool
-            .list_tools(&args.service_id, &endpoint)
+            .list_tools_with_agent_did(
+                &args.service_id,
+                &service.endpoint,
+                service.outbound_agent_did(&self.ctx),
+            )
             .await
         {
             Ok(result) => result,
@@ -946,6 +950,7 @@ mod tests {
             health: ServiceHealthMap::new(),
             local_hostname: "studio-1".to_string(),
             local_subnet: None,
+            agent_did: "did:key:z-test-agent".to_string(),
             allowed_mcp_service_ids: vec!["x-data".to_string()],
         });
 
@@ -978,6 +983,7 @@ mod tests {
             health: ServiceHealthMap::new(),
             local_hostname: "studio-1".to_string(),
             local_subnet: None,
+            agent_did: "did:key:z-test-agent".to_string(),
             allowed_mcp_service_ids: Vec::new(),
         });
 

--- a/crates/defra-agent/src/meta_tools/discover.rs
+++ b/crates/defra-agent/src/meta_tools/discover.rs
@@ -68,6 +68,7 @@ impl Tool for DiscoverToolsTool {
     lan_ip
     mcp_port
     mcp_path
+    send_agent_did
   }
 }"#;
 
@@ -144,6 +145,10 @@ impl Tool for DiscoverToolsTool {
                 .get("mcp_path")
                 .and_then(|v| v.as_str())
                 .unwrap_or("/mcp");
+            let send_agent_did = svc
+                .get("send_agent_did")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
             let endpoint = if svc_port > 0 {
                 Ok(resolve_mcp_url(
                     svc_hostname,
@@ -158,7 +163,16 @@ impl Tool for DiscoverToolsTool {
                 Err(anyhow!("no mcp_port"))
             };
             let tool_names: Vec<(String, String)> = if let Ok(ep) = &endpoint {
-                match self.ctx.mcp_pool.list_tools(sid, ep).await {
+                match self
+                    .ctx
+                    .mcp_pool
+                    .list_tools_with_agent_did(
+                        sid,
+                        ep,
+                        send_agent_did.then_some(self.ctx.agent_did.as_str()),
+                    )
+                    .await
+                {
                     Ok(list) => list
                         .tools
                         .iter()
@@ -276,6 +290,7 @@ mod tests {
             health: ServiceHealthMap::new(),
             local_hostname: "studio-1".to_string(),
             local_subnet: None,
+            agent_did: "did:key:z-test-agent".to_string(),
             allowed_mcp_service_ids: vec!["x-data".to_string()],
         });
 

--- a/crates/defra-agent/src/meta_tools/shared.rs
+++ b/crates/defra-agent/src/meta_tools/shared.rs
@@ -15,6 +15,7 @@ pub struct MetaToolContext {
     pub health: ServiceHealthMap,
     pub local_hostname: String,
     pub local_subnet: Option<String>,
+    pub agent_did: String,
     pub allowed_mcp_service_ids: Vec<String>,
 }
 
@@ -227,6 +228,21 @@ struct RegistryServiceEntry {
     mcp_port: Option<u16>,
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
     mcp_path: String,
+    #[serde(default, deserialize_with = "crate::registry::null_as_default")]
+    send_agent_did: bool,
+}
+
+pub(super) struct ResolvedMcpService {
+    pub(super) endpoint: String,
+    pub(super) send_agent_did: bool,
+}
+
+impl ResolvedMcpService {
+    pub(super) fn outbound_agent_did<'a>(&self, ctx: &'a MetaToolContext) -> Option<&'a str> {
+        self.send_agent_did
+            .then_some(ctx.agent_did.as_str())
+            .filter(|agent_did| !agent_did.trim().is_empty())
+    }
 }
 
 pub(super) fn lookup_service_query(service_id: &str) -> String {
@@ -249,6 +265,7 @@ pub(super) fn lookup_service_query(service_id: &str) -> String {
     lan_ip
     mcp_port
     mcp_path
+    send_agent_did
   }}
 }}"#
     )
@@ -257,7 +274,7 @@ pub(super) fn lookup_service_query(service_id: &str) -> String {
 pub(super) async fn lookup_service(
     ctx: &MetaToolContext,
     service_id: &str,
-) -> anyhow::Result<String> {
+) -> anyhow::Result<ResolvedMcpService> {
     let resp = ctx.node.execute(&lookup_service_query(service_id)).await;
     if resp.has_errors() {
         anyhow::bail!("lookup_service({service_id}): {:?}", resp.errors);
@@ -295,7 +312,10 @@ pub(super) async fn lookup_service(
         ctx.local_subnet.as_deref(),
     );
 
-    Ok(endpoint)
+    Ok(ResolvedMcpService {
+        endpoint,
+        send_agent_did: entry.send_agent_did,
+    })
 }
 
 pub(super) fn extract_text(result: &rmcp::model::CallToolResult) -> String {
@@ -387,6 +407,7 @@ mod registry_parsing_tests {
             "lan_ip": null,
             "mcp_port": 9201,
             "mcp_path": null,
+            "send_agent_did": null,
         });
 
         let entry: RegistryServiceEntry =
@@ -397,5 +418,6 @@ mod registry_parsing_tests {
         assert_eq!(entry.lan_ip, "");
         assert_eq!(entry.mcp_port, Some(9201));
         assert!(entry.mcp_path.is_empty() || entry.mcp_path == "/mcp");
+        assert!(!entry.send_agent_did);
     }
 }

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -86,6 +86,10 @@ const ADD_PEER_PAIRING_DESIRED_AGENT_DID_PATCH: &str = r#"[
     {"op":"add","path":"/PeerPairingDesired/Fields/-","value":{"Name":"agent_did","Kind":11}}
 ]"#;
 
+const ADD_TOOL_SERVICE_REGISTRY_SEND_AGENT_DID_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolServiceRegistry/Fields/-","value":{"Name":"send_agent_did","Kind":2}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -524,6 +528,34 @@ pub async fn ensure_peer_pairing_desired_migrations(node: Arc<EmbeddedNode>) -> 
     tracing::info!(
         version = %next.version_id,
         "PeerPairingDesired patched with agent_did field"
+    );
+    Ok(())
+}
+
+pub async fn ensure_tool_service_registry_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("ToolServiceRegistry")
+        .context("get ToolServiceRegistry collection")?
+    else {
+        return Ok(());
+    };
+    if collection_has_field(&collection, "send_agent_did") {
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection(
+            "ToolServiceRegistry",
+            ADD_TOOL_SERVICE_REGISTRY_SEND_AGENT_DID_PATCH,
+        )
+        .await
+        .context("patch_collection ToolServiceRegistry send_agent_did")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version ToolServiceRegistry send_agent_did")?;
+    tracing::info!(
+        version = %next.version_id,
+        "ToolServiceRegistry patched with send_agent_did field"
     );
     Ok(())
 }

--- a/crates/defra-agent/src/oneshot.rs
+++ b/crates/defra-agent/src/oneshot.rs
@@ -38,9 +38,11 @@ pub async fn run_openai_oneshot_with_tools(
 ) -> Result<OneshotRunResult> {
     ensure_schemas(node.as_ref()).await?;
     crate::migration::ensure_tool_call_migrations(node.clone()).await?;
+    crate::migration::ensure_tool_service_registry_migrations(node.clone()).await?;
 
     let api_key = behavior.completion_client_api_key()?;
-    let tool_runtime = ToolRuntimeContext::oneshot(node.clone());
+    let tool_runtime =
+        ToolRuntimeContext::oneshot_with_agent_did(node.clone(), behavior.agent_did());
     let tool_surface = behavior.tools.resolve(node.as_ref()).await?;
     let prompt_builder = LayeredPromptBuilder::new(behavior, &tool_surface);
     let preamble = prompt_builder.preamble().to_string();

--- a/crates/defra-agent/src/registry.rs
+++ b/crates/defra-agent/src/registry.rs
@@ -14,5 +14,13 @@ where
     Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
 }
 
+pub(crate) fn null_as_default<'de, D, T>(deserializer: D) -> Result<T, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de> + Default,
+{
+    Ok(Option::<T>::deserialize(deserializer)?.unwrap_or_default())
+}
+
 #[cfg(test)]
 mod tests;

--- a/crates/defra-agent/src/registry/tests.rs
+++ b/crates/defra-agent/src/registry/tests.rs
@@ -8,6 +8,12 @@ struct Sample {
     value: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct DefaultSample {
+    #[serde(default, deserialize_with = "null_as_default")]
+    value: bool,
+}
+
 #[test]
 fn null_becomes_empty_string() {
     let s: Sample = serde_json::from_value(json!({ "value": null })).unwrap();
@@ -24,4 +30,10 @@ fn missing_becomes_empty_string() {
 fn string_passes_through() {
     let s: Sample = serde_json::from_value(json!({ "value": "studio-1" })).unwrap();
     assert_eq!(s.value, "studio-1");
+}
+
+#[test]
+fn null_becomes_default_bool() {
+    let s: DefaultSample = serde_json::from_value(json!({ "value": null })).unwrap();
+    assert!(!s.value);
 }

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -96,6 +96,7 @@ impl ToolSurface {
                 runtime.health_map.clone(),
                 runtime.local_hostname.clone(),
                 runtime.local_subnet.clone(),
+                runtime.agent_did.clone(),
                 self.allowed_mcp_service_ids.clone(),
             ));
         }

--- a/crates/defra-agent/src/tool_surface/runtime_context.rs
+++ b/crates/defra-agent/src/tool_surface/runtime_context.rs
@@ -12,6 +12,7 @@ pub struct ToolRuntimeContext {
     pub(super) health_map: ServiceHealthMap,
     pub(super) local_hostname: String,
     pub(super) local_subnet: Option<String>,
+    pub(super) agent_did: String,
 }
 
 impl ToolRuntimeContext {
@@ -22,22 +23,39 @@ impl ToolRuntimeContext {
         local_hostname: impl Into<String>,
         local_subnet: Option<String>,
     ) -> Self {
+        Self::new_with_agent_did(node, mcp_pool, health_map, local_hostname, local_subnet, "")
+    }
+
+    pub fn new_with_agent_did(
+        node: Arc<EmbeddedNode>,
+        mcp_pool: McpPool,
+        health_map: ServiceHealthMap,
+        local_hostname: impl Into<String>,
+        local_subnet: Option<String>,
+        agent_did: impl Into<String>,
+    ) -> Self {
         Self {
             node,
             mcp_pool,
             health_map,
             local_hostname: local_hostname.into(),
             local_subnet,
+            agent_did: agent_did.into(),
         }
     }
 
     pub fn oneshot(node: Arc<EmbeddedNode>) -> Self {
+        Self::oneshot_with_agent_did(node, "")
+    }
+
+    pub fn oneshot_with_agent_did(node: Arc<EmbeddedNode>, agent_did: impl Into<String>) -> Self {
         Self {
             node,
             mcp_pool: McpPool::default(),
             health_map: ServiceHealthMap::default(),
             local_hostname: "localhost".to_string(),
             local_subnet: None,
+            agent_did: agent_did.into(),
         }
     }
 


### PR DESCRIPTION
## Summary
- add `send_agent_did` to `ToolServiceRegistry` schema/config and migrate existing runtime schemas
- thread the trusted runtime agent DID into MCP health checks and meta-tool calls only when a registry row opts in
- send the DID as the streamable HTTP `X-Agent-DID` header while preserving default no-DID behavior

Fixes #356.

## Tests
- `cargo test -p defra-agent --lib mcp_pool::tests -- --nocapture`
- `cargo test -p defra-agent --lib mcp_pool::tests::streamable_http -- --nocapture`
- `cargo test -p defra-agent-protocol tool_service_registry_ -- --nocapture`
- `cargo test -p defra-agent-cli desired_state::tests::tool_service_registry_round_trip_preserves_send_agent_did -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_config_export_import -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_mcp_probe -- --nocapture`
- `cargo test -p defra-agent --lib registry::tests -- --nocapture`
- `cargo test -p defra-agent --lib health_checker::registry_parsing_tests -- --nocapture`
- `cargo test -p defra-agent --lib meta_tools::shared::registry_parsing_tests -- --nocapture`
- `cargo test -p defra-agent --lib meta_tools -- --nocapture`
- `cargo fmt --check`