### PR TITLE
Fix Codex shim resume and model switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-login",
  "codex-model-provider-info",
+ "codex-protocol",
  "codex-utils-absolute-path",
  "defra-agent",
  "defra-agent-lean-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ clap = { version = "4", features = ["derive", "env"] }
 codex-app-server-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-login = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
+codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.14.1" }
 defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.14.1" }

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -18,6 +18,7 @@ clap.workspace = true
 codex-app-server-protocol.workspace = true
 codex-login.workspace = true
 codex-model-provider-info.workspace = true
+codex-protocol.workspace = true
 codex-utils-absolute-path.workspace = true
 defra-agent = { path = "../defra-agent" }
 defra-native-fs-runner = { path = "../defra-native-fs-runner" }

--- a/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/bound_behavior.rs
@@ -4,8 +4,10 @@ use anyhow::{anyhow, Result};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::{
     default_behavior_id_for_agent, load_agent_behavior, load_agent_principal,
-    load_inference_profile,
+    load_inference_profile, AgentBehaviorDocument,
 };
+
+pub(super) const MODEL_SELECTION_SEPARATOR: &str = "::";
 
 /// Normalize an explicit `--codex-shim-behavior-id` override: trim whitespace and
 /// treat empty as unset.
@@ -74,11 +76,61 @@ pub(super) async fn load_bound_inference_profile_id(
     Ok(profile_id)
 }
 
-pub(super) async fn load_bound_inference_profile_id_for_state(
+pub(super) async fn load_bound_model_selection_id(
+    node: &EmbeddedNode,
+    behavior_id: &str,
+) -> Result<String> {
+    let behavior = load_agent_behavior(node, behavior_id)
+        .await?
+        .ok_or_else(|| {
+            anyhow!(
+                "Codex shim is bound to behavior {behavior_id:?}, but no AgentBehavior \
+                 document with that behavior_id exists."
+            )
+        })?;
+    model_selection_id_for_behavior(behavior_id, &behavior)
+}
+
+pub(super) async fn load_bound_model_selection_id_for_state(
     node: &EmbeddedNode,
     behavior_id: &Arc<str>,
 ) -> Result<String> {
-    load_bound_inference_profile_id(node, behavior_id.as_ref()).await
+    load_bound_model_selection_id(node, behavior_id.as_ref()).await
+}
+
+pub(super) fn model_selection_id(backend_id: &str, model_name: &str) -> String {
+    format!("{backend_id}{MODEL_SELECTION_SEPARATOR}{model_name}")
+}
+
+pub(super) fn parse_model_selection_id(value: &str) -> Option<(&str, &str)> {
+    let (backend_id, model_name) = value.split_once(MODEL_SELECTION_SEPARATOR)?;
+    let backend_id = backend_id.trim();
+    let model_name = model_name.trim();
+    (!backend_id.is_empty() && !model_name.is_empty()).then_some((backend_id, model_name))
+}
+
+fn model_selection_id_for_behavior(
+    behavior_id: &str,
+    behavior: &AgentBehaviorDocument,
+) -> Result<String> {
+    let model_name = behavior
+        .model_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|model| !model.is_empty())
+        .ok_or_else(|| {
+            anyhow!(
+                "Codex shim is bound to behavior {behavior_id:?}, but that behavior has no \
+                 model_name set."
+            )
+        })?;
+    Ok(behavior
+        .backend_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|backend| !backend.is_empty())
+        .map(|backend_id| model_selection_id(backend_id, model_name))
+        .unwrap_or_else(|| model_name.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/defra-agent-cli/src/commands/codex_shim/handlers/basic.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/handlers/basic.rs
@@ -1,15 +1,17 @@
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
 use defra_agent::{
-    list_inference_profile_records, load_agent_behavior, load_inference_profile,
-    AgentBehaviorDocument,
+    backend_registry::list_enabled_backends, load_agent_behavior, AgentBehaviorDocument,
+    InferenceBackend,
 };
 use serde_json::{json, Value};
 
-use super::super::bound_behavior::load_bound_inference_profile_id_for_state;
+use super::super::bound_behavior::{
+    load_bound_model_selection_id_for_state, model_selection_id, parse_model_selection_id,
+};
 use super::super::protocol::{
-    absolute_path, empty_rate_limits, initialize_result, model_summary, send_error, send_result,
-    send_typed_json_result,
+    absolute_path, backend_model_summary, empty_rate_limits, initialize_result, send_error,
+    send_result, send_typed_json_result,
 };
 use super::super::{Outbound, ShimState, JSONRPC_INVALID_PARAMS};
 use crate::config_writes::{write_agent_behavior_document, ConfigAccess};
@@ -51,20 +53,13 @@ pub(super) async fn handle_basic_request(
             .await
         }
         codex::ClientRequest::ModelList { request_id, .. } => {
-            let profiles = list_inference_profile_records(state.node.as_ref())
+            let behavior = load_bound_behavior(state)
                 .await
-                .context("listing InferenceProfile documents for Codex ModelList")?;
-            let current_profile_id =
-                load_bound_inference_profile_id_for_state(state.node.as_ref(), &state.behavior_id)
-                    .await
-                    .context("resolving current inference profile for ModelList")?;
-            let entries: Vec<Value> = profiles
-                .into_iter()
-                .map(|(_doc_id, profile)| {
-                    let is_default = profile.profile_id == current_profile_id;
-                    model_summary(&profile, is_default)
-                })
-                .collect();
+                .context("loading bound AgentBehavior for ModelList")?;
+            let backends = available_model_backends(state)
+                .await
+                .context("listing available backend models for ModelList")?;
+            let entries = model_list_entries(&backends, &behavior);
             send_typed_json_result::<codex::ModelListResponse>(
                 outbound,
                 request_id,
@@ -88,16 +83,16 @@ pub(super) async fn handle_basic_request(
             .await
         }
         codex::ClientRequest::ConfigRead { request_id, .. } => {
-            let profile_id =
-                load_bound_inference_profile_id_for_state(state.node.as_ref(), &state.behavior_id)
+            let model_id =
+                load_bound_model_selection_id_for_state(state.node.as_ref(), &state.behavior_id)
                     .await
-                    .context("resolving current inference profile for ConfigRead")?;
+                    .context("resolving current model selection for ConfigRead")?;
             send_typed_json_result::<codex::ConfigReadResponse>(
                 outbound,
                 request_id,
                 json!({
                     "config": {
-                        "model": profile_id,
+                        "model": model_id,
                         "model_provider": "defra",
                         "approval_policy": "never",
                         "sandbox_mode": "danger-full-access"
@@ -239,7 +234,7 @@ async fn apply_config_writes(
             // Other keys keep the existing no-op ack semantics.
             continue;
         }
-        let new_profile_id = match value.as_str() {
+        let new_model_id = match value.as_str() {
             Some(s) if !s.is_empty() => s.to_string(),
             _ => {
                 return send_error(
@@ -251,23 +246,19 @@ async fn apply_config_writes(
                 .await;
             }
         };
-        if load_inference_profile(state.node.as_ref(), &new_profile_id)
-            .await
-            .context("looking up target InferenceProfile for ConfigValueWrite")?
-            .is_none()
-        {
-            return send_error(
-                outbound,
-                request_id,
-                JSONRPC_INVALID_PARAMS,
-                format!(
-                    "InferenceProfile {new_profile_id:?} not found; available ids \
-                     are visible via ModelList"
-                ),
-            )
-            .await;
-        }
-        apply_profile_to_bound_behavior(state, &new_profile_id).await?;
+        let selection = match resolve_model_selection(state, &new_model_id).await {
+            Ok(selection) => selection,
+            Err(err) => {
+                return send_error(
+                    outbound,
+                    request_id,
+                    JSONRPC_INVALID_PARAMS,
+                    err.to_string(),
+                )
+                .await;
+            }
+        };
+        apply_model_to_bound_behavior(state, &selection).await?;
     }
     send_typed_json_result::<codex::ConfigWriteResponse>(
         outbound,
@@ -282,16 +273,142 @@ async fn apply_config_writes(
     .await
 }
 
-async fn apply_profile_to_bound_behavior(state: &ShimState, profile_id: &str) -> Result<()> {
+struct ModelSelection {
+    backend_id: String,
+    model_name: String,
+}
+
+async fn load_bound_behavior(state: &ShimState) -> Result<AgentBehaviorDocument> {
     let behavior_id = state.behavior_id.as_ref();
-    let mut behavior: AgentBehaviorDocument = load_agent_behavior(state.node.as_ref(), behavior_id)
+    load_agent_behavior(state.node.as_ref(), behavior_id)
         .await
-        .context("loading bound AgentBehavior for profile mutation")?
-        .ok_or_else(|| anyhow::anyhow!("bound AgentBehavior {behavior_id:?} disappeared"))?;
-    behavior.inference_profile_id = Some(profile_id.to_string());
+        .context("loading bound AgentBehavior")?
+        .ok_or_else(|| anyhow::anyhow!("bound AgentBehavior {behavior_id:?} disappeared"))
+}
+
+async fn available_model_backends(state: &ShimState) -> Result<Vec<InferenceBackend>> {
+    let mut backends = list_enabled_backends(state.node.as_ref()).await?;
+    backends.retain(|backend| backend.is_available());
+    backends.sort_by(|left, right| left.backend_id.cmp(&right.backend_id));
+    Ok(backends)
+}
+
+fn model_list_entries(
+    backends: &[InferenceBackend],
+    behavior: &AgentBehaviorDocument,
+) -> Vec<Value> {
+    let current_backend_id = behavior
+        .backend_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let current_model_name = behavior
+        .model_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut entries = backends
+        .iter()
+        .flat_map(|backend| {
+            backend
+                .models
+                .iter()
+                .map(move |model_name| (backend, model_name.trim()))
+        })
+        .filter(|(_, model_name)| !model_name.is_empty())
+        .map(|(backend, model_name)| {
+            let selection_id = model_selection_id(&backend.backend_id, model_name);
+            let is_default = current_backend_id == Some(backend.backend_id.as_str())
+                && current_model_name == Some(model_name);
+            backend_model_summary(backend, model_name, &selection_id, is_default)
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by(|left, right| {
+        left.get("displayName")
+            .and_then(Value::as_str)
+            .cmp(&right.get("displayName").and_then(Value::as_str))
+            .then_with(|| {
+                left.get("id")
+                    .and_then(Value::as_str)
+                    .cmp(&right.get("id").and_then(Value::as_str))
+            })
+    });
+    entries
+}
+
+async fn resolve_model_selection(
+    state: &ShimState,
+    requested_model: &str,
+) -> Result<ModelSelection> {
+    let requested_model = requested_model.trim();
+    if requested_model.is_empty() {
+        anyhow::bail!("ConfigValueWrite for `model` requires a non-empty string");
+    }
+
+    let behavior = load_bound_behavior(state).await?;
+    let current_backend_id = behavior
+        .backend_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let backends = available_model_backends(state).await?;
+    let target = if let Some((backend_id, model_name)) = parse_model_selection_id(requested_model) {
+        backends
+            .iter()
+            .find(|backend| {
+                backend.backend_id == backend_id && backend_has_model(backend, model_name)
+            })
+            .map(|backend| (backend, model_name))
+    } else {
+        backends
+            .iter()
+            .find(|backend| {
+                current_backend_id == Some(backend.backend_id.as_str())
+                    && backend_has_model(backend, requested_model)
+            })
+            .or_else(|| {
+                backends
+                    .iter()
+                    .find(|backend| backend_has_model(backend, requested_model))
+            })
+            .map(|backend| (backend, requested_model))
+    };
+    let Some((backend, model_name)) = target else {
+        let available = backends
+            .iter()
+            .flat_map(|backend| backend.models.iter())
+            .map(|model| model.trim())
+            .filter(|model| !model.is_empty())
+            .collect::<Vec<_>>()
+            .join(", ");
+        anyhow::bail!(
+            "model {requested_model:?} not found in any available InferenceBackend; available models: [{available}]"
+        );
+    };
+
+    Ok(ModelSelection {
+        backend_id: backend.backend_id.clone(),
+        model_name: model_name.to_string(),
+    })
+}
+
+fn backend_has_model(backend: &InferenceBackend, model_name: &str) -> bool {
+    backend
+        .models
+        .iter()
+        .any(|model| model.trim() == model_name)
+}
+
+async fn apply_model_to_bound_behavior(
+    state: &ShimState,
+    selection: &ModelSelection,
+) -> Result<()> {
+    let mut behavior = load_bound_behavior(state).await?;
+    behavior.backend_id = Some(selection.backend_id.clone());
+    behavior.model_name = Some(selection.model_name.clone());
     let access = ConfigAccess::Graphql(state.graphql.as_ref().to_string());
     write_agent_behavior_document(&access, &behavior)
         .await
-        .context("writing AgentBehavior with new inference_profile_id")?;
+        .context("writing AgentBehavior with selected backend model")?;
     Ok(())
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/handlers/thread.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/handlers/thread.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
 use serde_json::json;
 
-use super::super::bound_behavior::load_bound_inference_profile_id_for_state;
+use super::super::bound_behavior::load_bound_model_selection_id_for_state;
 use super::super::history_projection::{
     conversation_summary_json, load_thread_turns, thread_turn_items_list_response,
     thread_turns_list_response,
@@ -12,7 +12,7 @@ use super::super::protocol::{
 };
 use super::super::thread_projection::{
     clear_codex_thread_goal, codex_thread_json, codex_thread_json_with_turns, create_codex_thread,
-    ensure_agent_session_pinning, get_codex_thread_goal, list_codex_threads, load_codex_thread,
+    ensure_agent_session_pinning, get_codex_thread_goal, load_codex_thread,
     loaded_codex_thread_ids, resume_codex_thread, set_codex_thread_archived,
     set_codex_thread_git_info, set_codex_thread_goal, set_codex_thread_loaded,
     set_codex_thread_memory_mode, set_codex_thread_name, set_codex_thread_settings,
@@ -39,14 +39,14 @@ pub(super) async fn handle_thread_request(
                 .lock()
                 .await
                 .insert(thread_id.clone(), cwd.clone());
-            let bound_profile_id =
-                load_bound_inference_profile_id_for_state(state.node.as_ref(), &state.behavior_id)
+            let bound_model_id =
+                load_bound_model_selection_id_for_state(state.node.as_ref(), &state.behavior_id)
                     .await
-                    .context("resolving bound inference profile for ThreadStart")?;
+                    .context("resolving bound model selection for ThreadStart")?;
             send_typed_json_result::<codex::ThreadStartResponse>(
                 outbound,
                 request_id,
-                thread_start_response_json(&record, &bound_profile_id),
+                thread_start_response_json(&record, &bound_model_id),
             )
             .await
         }
@@ -69,34 +69,31 @@ pub(super) async fn handle_thread_request(
                 .lock()
                 .await
                 .insert(record.session_id.clone(), record.cwd.clone());
-            let bound_profile_id =
-                load_bound_inference_profile_id_for_state(state.node.as_ref(), &state.behavior_id)
+            let turns = if params.exclude_turns {
+                Vec::new()
+            } else {
+                load_thread_turns(state, &record).await?
+            };
+            let bound_model_id =
+                load_bound_model_selection_id_for_state(state.node.as_ref(), &state.behavior_id)
                     .await
-                    .context("resolving bound inference profile for ThreadResume")?;
+                    .context("resolving bound model selection for ThreadResume")?;
             send_typed_json_result::<codex::ThreadResumeResponse>(
                 outbound,
                 request_id,
-                thread_resume_response_json(&record, &bound_profile_id),
+                thread_resume_response_json(&record, turns, &bound_model_id),
             )
             .await
         }
-        codex::ClientRequest::ThreadList { request_id, .. } => {
-            let threads: Vec<_> = list_codex_threads(state)
-                .await?
-                .into_iter()
-                .map(|record| codex_thread_json(&record, false))
-                .collect();
-            send_typed_json_result::<codex::ThreadListResponse>(
-                outbound,
-                request_id,
-                json!({
-                    "data": threads,
-                    "nextCursor": null,
-                    "backwardsCursor": null
-                }),
-            )
-            .await
-        }
+        codex::ClientRequest::ThreadList {
+            request_id, params, ..
+        } => match thread_routes::list_threads_response(state, params).await {
+            Ok(response) => {
+                send_typed_json_result::<codex::ThreadListResponse>(outbound, request_id, response)
+                    .await
+            }
+            Err(err) => send_error(outbound, request_id, err.code, err.message).await,
+        },
         codex::ClientRequest::ThreadFork {
             request_id, params, ..
         } => match thread_routes::fork_thread_response(state, params).await {

--- a/crates/defra-agent-cli/src/commands/codex_shim/history_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/history_projection.rs
@@ -2,7 +2,9 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
+use codex_protocol::models::MessagePhase;
 use defra_agent::graphql::escape_graphql_string;
+use defra_agent_protocol::transcript::present_persisted_message;
 use serde::Deserialize;
 use serde_json::{json, Value};
 
@@ -13,7 +15,7 @@ use super::progress::{
     decode_defra_tool_call_progress, defra_tool_item, terminal_error_message, terminal_turn_status,
     DefraToolCallProgress,
 };
-use super::protocol::{absolute_path, agent_message_item, turn_value};
+use super::protocol::{absolute_path, agent_message_item_with_phase, turn_value};
 use super::store::{hydrate_materialized_response_content, query_node_json};
 use super::thread_projection::CodexThreadRecord;
 use super::ShimState;
@@ -48,6 +50,8 @@ struct ResponseRow {
     status: String,
     #[serde(default)]
     error_message: Option<String>,
+    #[serde(default)]
+    materialized_message_sequence: Option<i64>,
     #[serde(default)]
     created_at: Option<String>,
     #[serde(default)]
@@ -156,7 +160,19 @@ pub(super) async fn load_thread_turns(
         tools_by_request.entry(request_id).or_default().push(tool);
     }
 
-    let turns = project_request_turns(record, requests, &responses_by_request, &tools_by_request)?;
+    let messages_by_sequence = messages
+        .iter()
+        .cloned()
+        .map(|message| (message.sequence, message))
+        .collect::<BTreeMap<_, _>>();
+
+    let turns = project_request_turns(
+        record,
+        requests,
+        &responses_by_request,
+        &tools_by_request,
+        &messages_by_sequence,
+    )?;
 
     if turns.is_empty() && !messages.is_empty() {
         return Ok(project_message_turns(messages));
@@ -182,22 +198,26 @@ fn project_message_turns(messages: Vec<MessageRow>) -> Vec<codex::Turn> {
             );
             saw_assistant = false;
             current_id = Some(format!("defra-message-turn-{}", message.sequence));
-            current_items.push(codex::ThreadItem::UserMessage {
-                id: format!("defra-user-message-{}", message.sequence),
-                content: vec![codex::UserInput::Text {
-                    text: message.content,
-                    text_elements: Vec::new(),
-                }],
-            });
+            let presentation = present_persisted_message(&message.role, &message.content);
+            if !presentation.body_markdown.trim().is_empty() {
+                current_items.push(codex::ThreadItem::UserMessage {
+                    id: format!("defra-user-message-{}", message.sequence),
+                    content: vec![codex::UserInput::Text {
+                        text: presentation.body_markdown,
+                        text_elements: Vec::new(),
+                    }],
+                });
+            }
         } else if role.eq_ignore_ascii_case("assistant") {
             if current_id.is_none() {
                 current_id = Some(format!("defra-message-turn-{}", message.sequence));
             }
-            saw_assistant = true;
-            current_items.push(agent_message_item(
-                &format!("defra-agent-message-{}", message.sequence),
-                &message.content,
-            ));
+            saw_assistant |= append_assistant_message_items(
+                &mut current_items,
+                message.sequence,
+                &message,
+                true,
+            );
         }
     }
 
@@ -226,6 +246,7 @@ fn project_request_turns(
     requests: Vec<RequestRow>,
     responses_by_request: &BTreeMap<String, ResponseRow>,
     tools_by_request: &BTreeMap<String, Vec<ToolRow>>,
+    messages_by_sequence: &BTreeMap<i64, MessageRow>,
 ) -> Result<Vec<codex::Turn>> {
     let requests = requests
         .into_iter()
@@ -257,6 +278,7 @@ fn project_request_turns(
             &group,
             responses_by_request,
             tools_by_request,
+            messages_by_sequence,
         ));
     }
     Ok(turns)
@@ -392,6 +414,7 @@ fn project_turn_group(
     requests: &[RequestRow],
     responses_by_request: &BTreeMap<String, ResponseRow>,
     tools_by_request: &BTreeMap<String, Vec<ToolRow>>,
+    messages_by_sequence: &BTreeMap<i64, MessageRow>,
 ) -> codex::Turn {
     let Some(first_request) = requests.first() else {
         return turn_value(turn_id, codex::TurnStatus::Completed, Vec::new(), None);
@@ -406,7 +429,14 @@ fn project_turn_group(
             .get(&request.request_id)
             .cloned()
             .unwrap_or_default();
-        append_request_items(record, &mut items, request, response, tools);
+        append_request_items(
+            record,
+            &mut items,
+            request,
+            response,
+            tools,
+            messages_by_sequence,
+        );
     }
 
     let status = turn_status(tail_request, tail_response);
@@ -440,6 +470,7 @@ fn append_request_items(
     request: &RequestRow,
     response: Option<&ResponseRow>,
     mut tools: Vec<ToolRow>,
+    messages_by_sequence: &BTreeMap<i64, MessageRow>,
 ) {
     tools.sort_by(|left, right| {
         left.message_sequence
@@ -457,30 +488,85 @@ fn append_request_items(
         });
     }
 
-    if let Some(response) = response {
-        if !response.reasoning.trim().is_empty() {
-            items.push(codex::ThreadItem::Reasoning {
-                id: format!("defra-reasoning-{}", request.request_id),
-                summary: Vec::new(),
-                content: vec![response.reasoning.clone()],
-            });
-        }
-    }
-
+    let mut rendered_assistant_sequences = BTreeSet::<i64>::new();
     for tool in tools {
+        if let Some(message) = messages_by_sequence.get(&tool.message_sequence) {
+            if !rendered_assistant_sequences.contains(&tool.message_sequence)
+                && append_assistant_message_items(items, tool.message_sequence, message, false)
+            {
+                rendered_assistant_sequences.insert(tool.message_sequence);
+            }
+        }
         if let Some(item) = project_tool(record, &tool.progress) {
             items.push(item);
         }
     }
 
     if let Some(response) = response {
-        if !response.content.trim().is_empty() {
-            items.push(agent_message_item(
+        let rendered_materialized = response
+            .materialized_message_sequence
+            .and_then(|sequence| {
+                if rendered_assistant_sequences.contains(&sequence) {
+                    return Some(true);
+                }
+                let message = messages_by_sequence.get(&sequence)?;
+                append_assistant_message_items(items, sequence, message, true).then_some(true)
+            })
+            .unwrap_or(false);
+
+        if !rendered_materialized && !response.reasoning.trim().is_empty() {
+            items.push(codex::ThreadItem::Reasoning {
+                id: format!("defra-reasoning-{}", request.request_id),
+                summary: Vec::new(),
+                content: vec![response.reasoning.clone()],
+            });
+        }
+        if !rendered_materialized && !response.content.trim().is_empty() {
+            items.push(agent_message_item_with_phase(
                 &format!("defra-agent-{}", request.request_id),
                 &response.content,
+                Some(MessagePhase::FinalAnswer),
             ));
         }
     }
+}
+
+fn append_assistant_message_items(
+    items: &mut Vec<codex::ThreadItem>,
+    sequence: i64,
+    message: &MessageRow,
+    final_answer: bool,
+) -> bool {
+    if !message.role.trim().eq_ignore_ascii_case("assistant") {
+        return false;
+    }
+    let presentation = present_persisted_message(&message.role, &message.content);
+    let mut appended = false;
+    if let Some(reasoning) = presentation
+        .reasoning_markdown
+        .filter(|value| !value.trim().is_empty())
+    {
+        items.push(codex::ThreadItem::Reasoning {
+            id: format!("defra-reasoning-message-{sequence}"),
+            summary: Vec::new(),
+            content: vec![reasoning],
+        });
+        appended = true;
+    }
+    if !presentation.body_markdown.trim().is_empty() {
+        let phase = if final_answer && !presentation.has_tool_calls {
+            MessagePhase::FinalAnswer
+        } else {
+            MessagePhase::Commentary
+        };
+        items.push(agent_message_item_with_phase(
+            &format!("defra-agent-message-{sequence}"),
+            &presentation.body_markdown,
+            Some(phase),
+        ));
+        appended = true;
+    }
+    appended
 }
 
 fn project_tool(
@@ -696,4 +782,212 @@ fn codex_git_info_summary_json(raw: &str) -> Option<Value> {
             .or_else(|| object.get("origin_url"))
             .and_then(Value::as_str),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    #[test]
+    fn completed_request_overrides_error_response_status() {
+        let request = RequestRow {
+            request_id: "request-1".to_string(),
+            content: "Inspect the repo".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: "completed".to_string(),
+            failure_reason: String::new(),
+            created_at: None,
+            metadata: r#"{"codex_shim":{}}"#.to_string(),
+            execution_origin: "interactive".to_string(),
+        };
+        let response = ResponseRow {
+            request_id: request.request_id.clone(),
+            content: "Done".to_string(),
+            reasoning: String::new(),
+            status: "error".to_string(),
+            error_message: Some("stale response error".to_string()),
+            materialized_message_sequence: None,
+            created_at: None,
+            completed_at: None,
+            interrupted_at: None,
+        };
+
+        assert_eq!(
+            turn_status(&request, Some(&response)),
+            codex::TurnStatus::Completed
+        );
+    }
+
+    #[test]
+    fn append_request_items_replays_assistant_text_around_tool_calls() {
+        let record = CodexThreadRecord {
+            session_id: "thread-1".to_string(),
+            cwd: PathBuf::from("/tmp/project"),
+            archived: false,
+            loaded: true,
+            memory_mode: "enabled".to_string(),
+            name: String::new(),
+            settings_json: "{}".to_string(),
+            goal_json: "{}".to_string(),
+            git_info_json: "{}".to_string(),
+            projection_created_at: None,
+            projection_updated_at: None,
+            conversation: None,
+        };
+        let request = RequestRow {
+            request_id: "request-1".to_string(),
+            content: "Inspect the repo".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: "completed".to_string(),
+            failure_reason: String::new(),
+            created_at: None,
+            metadata: r#"{"codex_shim":{}}"#.to_string(),
+            execution_origin: "interactive".to_string(),
+        };
+        let response = ResponseRow {
+            request_id: request.request_id.clone(),
+            content: String::new(),
+            reasoning: String::new(),
+            status: "complete".to_string(),
+            error_message: None,
+            materialized_message_sequence: Some(4),
+            created_at: None,
+            completed_at: None,
+            interrupted_at: None,
+        };
+        let first_tool = ToolRow {
+            request_id: request.request_id.clone(),
+            message_sequence: 2,
+            started_at: None,
+            progress: DefraToolCallProgress {
+                tool_call_key: "thread-1:call-1".to_string(),
+                tool_name: "list_files".to_string(),
+                status: "completed".to_string(),
+                lifecycle_state: Some("completed".to_string()),
+                await_mode: None,
+                child_request_id: None,
+                args: r#"{"path":"."}"#.to_string(),
+                result: "Cargo.toml\nsrc".to_string(),
+            },
+        };
+        let second_tool = ToolRow {
+            request_id: request.request_id.clone(),
+            message_sequence: 2,
+            started_at: Some("2026-06-02T00:00:01Z".to_string()),
+            progress: DefraToolCallProgress {
+                tool_call_key: "thread-1:call-2".to_string(),
+                tool_name: "read_file".to_string(),
+                status: "completed".to_string(),
+                lifecycle_state: Some("completed".to_string()),
+                await_mode: None,
+                child_request_id: None,
+                args: r#"{"path":"Cargo.toml"}"#.to_string(),
+                result: "[package]".to_string(),
+            },
+        };
+        let messages_by_sequence = BTreeMap::from([
+            (
+                2,
+                MessageRow {
+                    sequence: 2,
+                    role: "assistant".to_string(),
+                    content: r#"{"role":"assistant","id":null,"content":[{"id":"call-1","call_id":null,"function":{"name":"list_files","arguments":{"path":"."}},"signature":null,"additional_params":null},{"text":"Before the tool call."}]}"#.to_string(),
+                },
+            ),
+            (
+                4,
+                MessageRow {
+                    sequence: 4,
+                    role: "assistant".to_string(),
+                    content: r#"{"role":"assistant","id":null,"content":[{"text":"Final answer after tools."}]}"#.to_string(),
+                },
+            ),
+        ]);
+
+        let mut items = Vec::new();
+        append_request_items(
+            &record,
+            &mut items,
+            &request,
+            Some(&response),
+            vec![first_tool, second_tool],
+            &messages_by_sequence,
+        );
+
+        let agent_messages = items
+            .iter()
+            .filter_map(|item| match item {
+                codex::ThreadItem::AgentMessage { text, phase, .. } => {
+                    Some((text.as_str(), phase.clone()))
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            agent_messages
+                .iter()
+                .any(|(text, _)| text.contains("Before the tool call.")),
+            "intermediate assistant text should be replayed; items={items:?}"
+        );
+        let intermediate_count = agent_messages
+            .iter()
+            .filter(|(text, _)| text.contains("Before the tool call."))
+            .count();
+        assert_eq!(
+            intermediate_count, 1,
+            "assistant text before sibling tool calls should only be replayed once; items={items:?}"
+        );
+        assert!(
+            agent_messages
+                .iter()
+                .any(|(text, phase)| text.contains("Before the tool call.")
+                    && *phase == Some(MessagePhase::Commentary)),
+            "intermediate assistant text should replay as commentary; items={items:?}"
+        );
+        assert!(
+            agent_messages
+                .iter()
+                .any(|(text, phase)| text.contains("Final answer after tools.")
+                    && *phase == Some(MessagePhase::FinalAnswer)),
+            "final materialized assistant text should be replayed; items={items:?}"
+        );
+    }
+
+    #[test]
+    fn project_message_turns_renders_structured_persisted_messages() {
+        let turns = project_message_turns(vec![
+            MessageRow {
+                sequence: 1,
+                role: "user".to_string(),
+                content: r#"{"role":"user","content":[{"type":"text","text":"Hello from stored user JSON."}]}"#
+                    .to_string(),
+            },
+            MessageRow {
+                sequence: 2,
+                role: "assistant".to_string(),
+                content: r#"{"role":"assistant","id":null,"content":[{"text":"Hello from stored assistant JSON."}]}"#
+                    .to_string(),
+            },
+        ]);
+
+        assert_eq!(turns.len(), 1);
+        let turn = &turns[0];
+        assert!(turn.items.iter().any(|item| matches!(
+            item,
+            codex::ThreadItem::UserMessage { content, .. }
+                if content.iter().any(|input| matches!(
+                    input,
+                    codex::UserInput::Text { text, .. }
+                        if text == "Hello from stored user JSON."
+                ))
+        )));
+        assert!(turn.items.iter().any(|item| matches!(
+            item,
+            codex::ThreadItem::AgentMessage { text, phase, .. }
+                if text == "Hello from stored assistant JSON."
+                    && *phase == Some(MessagePhase::FinalAnswer)
+        )));
+    }
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/progress.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/progress.rs
@@ -231,7 +231,9 @@ pub(super) fn terminal_turn_status(
 ) -> codex::TurnStatus {
     match (lifecycle_state, response_status) {
         ("interrupted" | "superseded", _) => codex::TurnStatus::Interrupted,
-        ("failed" | "dead", _) | (_, "error") => codex::TurnStatus::Failed,
+        ("failed" | "dead", _) => codex::TurnStatus::Failed,
+        ("completed", _) => codex::TurnStatus::Completed,
+        (_, "error") => codex::TurnStatus::Failed,
         _ => codex::TurnStatus::Completed,
     }
 }
@@ -359,6 +361,26 @@ mod tests {
         assert_eq!(
             content_delta("\n\nAnswer", "Answer with context"),
             " with context"
+        );
+    }
+
+    #[test]
+    fn terminal_turn_status_matches_codex_projection_request_precedence() {
+        assert_eq!(
+            terminal_turn_status("completed", "error"),
+            codex::TurnStatus::Completed
+        );
+        assert_eq!(
+            terminal_turn_status("processing", "error"),
+            codex::TurnStatus::Failed
+        );
+        assert_eq!(
+            terminal_turn_status("failed", "complete"),
+            codex::TurnStatus::Failed
+        );
+        assert_eq!(
+            terminal_turn_status("superseded", "error"),
+            codex::TurnStatus::Interrupted
         );
     }
 

--- a/crates/defra-agent-cli/src/commands/codex_shim/protocol.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/protocol.rs
@@ -3,6 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
+use codex_protocol::models::MessagePhase;
+use defra_agent::InferenceBackend;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{json, Value};
@@ -88,20 +90,26 @@ pub(super) fn initialize_result(state: &ShimState) -> Value {
     })
 }
 
-pub(super) fn model_summary(profile: &defra_agent::InferenceProfile, is_default: bool) -> Value {
-    let display_name = profile
-        .display_name
-        .clone()
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| profile.profile_id.clone());
+pub(super) fn backend_model_summary(
+    backend: &InferenceBackend,
+    model_name: &str,
+    selection_id: &str,
+    is_default: bool,
+) -> Value {
+    let backend_name = backend.name.trim();
+    let backend_label = if backend_name.is_empty() {
+        backend.backend_id.as_str()
+    } else {
+        backend_name
+    };
     json!({
-        "id": profile.profile_id,
-        "model": profile.profile_id,
+        "id": selection_id,
+        "model": selection_id,
         "upgrade": null,
         "upgradeInfo": null,
         "availabilityNux": null,
-        "displayName": display_name,
-        "description": describe_profile(profile),
+        "displayName": model_name,
+        "description": format!("DEFRA backend: {backend_label}"),
         "hidden": false,
         "supportedReasoningEfforts": [],
         "defaultReasoningEffort": "medium",
@@ -112,24 +120,6 @@ pub(super) fn model_summary(profile: &defra_agent::InferenceProfile, is_default:
         "defaultServiceTier": null,
         "isDefault": is_default,
     })
-}
-
-fn describe_profile(profile: &defra_agent::InferenceProfile) -> String {
-    let mut parts: Vec<String> = Vec::new();
-    if let Some(ctx) = profile.context_window {
-        parts.push(format!("ctx {ctx}"));
-    }
-    if let Some(max) = profile.max_output_tokens {
-        parts.push(format!("max {max}"));
-    }
-    if let Some(temp) = profile.temperature {
-        parts.push(format!("temp {temp:.2}"));
-    }
-    if parts.is_empty() {
-        "DEFRA inference profile".to_string()
-    } else {
-        parts.join(" · ")
-    }
 }
 
 pub(super) fn thread_json(
@@ -189,10 +179,18 @@ pub(super) fn turn_value(
 }
 
 pub(super) fn agent_message_item(item_id: &str, text: &str) -> codex::ThreadItem {
+    agent_message_item_with_phase(item_id, text, None)
+}
+
+pub(super) fn agent_message_item_with_phase(
+    item_id: &str,
+    text: &str,
+    phase: Option<MessagePhase>,
+) -> codex::ThreadItem {
     codex::ThreadItem::AgentMessage {
         id: item_id.to_string(),
         text: text.to_string(),
-        phase: None,
+        phase,
         memory_citation: None,
     }
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection.rs
@@ -39,6 +39,8 @@ pub(super) struct CodexThreadRecord {
     pub(super) settings_json: String,
     pub(super) goal_json: String,
     pub(super) git_info_json: String,
+    pub(super) projection_created_at: Option<String>,
+    pub(super) projection_updated_at: Option<String>,
     pub(super) conversation: Option<ConversationRow>,
 }
 
@@ -138,6 +140,8 @@ pub(super) async fn load_codex_thread(
             settings_json: projection.settings_json,
             goal_json: projection.goal_json,
             git_info_json: projection.git_info_json,
+            projection_created_at: projection.created_at,
+            projection_updated_at: projection.updated_at,
             conversation,
         })),
         (Some(conversation), None) => {
@@ -156,14 +160,12 @@ pub(super) async fn load_codex_thread(
                 settings_json: "{}".to_string(),
                 goal_json: "{}".to_string(),
                 git_info_json: "{}".to_string(),
+                projection_created_at: None,
+                projection_updated_at: None,
                 conversation: Some(conversation),
             }))
         }
     }
-}
-
-pub(super) async fn list_codex_threads(state: &ShimState) -> Result<Vec<CodexThreadRecord>> {
-    list_codex_threads_by_archived(state, false).await
 }
 
 pub(super) async fn list_codex_threads_by_archived(
@@ -184,6 +186,8 @@ pub(super) async fn list_codex_threads_by_archived(
             settings_json: projection.settings_json,
             goal_json: projection.goal_json,
             git_info_json: projection.git_info_json,
+            projection_created_at: projection.created_at,
+            projection_updated_at: projection.updated_at,
             conversation,
         });
     }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/json.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/json.rs
@@ -31,6 +31,12 @@ pub(in crate::commands::codex_shim) fn codex_thread_json_with_turns(
     let object = thread
         .as_object_mut()
         .expect("thread_json returns an object");
+    if let Some(created_at) = thread_created_at(record) {
+        object.insert("createdAt".to_string(), json!(created_at));
+    }
+    if let Some(updated_at) = thread_updated_at(record) {
+        object.insert("updatedAt".to_string(), json!(updated_at));
+    }
     if !record.name.trim().is_empty() {
         object.insert("name".to_string(), Value::String(record.name.clone()));
     }
@@ -66,19 +72,19 @@ pub(in crate::commands::codex_shim) fn codex_thread_json_with_turns(
 
 pub(in crate::commands::codex_shim) fn thread_start_response_json(
     record: &CodexThreadRecord,
-    bound_profile_id: &str,
+    bound_model_id: &str,
 ) -> Value {
-    thread_response_json(record, codex_thread_json(record, false), bound_profile_id)
+    thread_response_json(record, codex_thread_json(record, false), bound_model_id)
 }
 
 pub(in crate::commands::codex_shim) fn thread_response_json(
     record: &CodexThreadRecord,
     thread: Value,
-    bound_profile_id: &str,
+    bound_model_id: &str,
 ) -> Value {
     json!({
         "thread": thread,
-        "model": bound_profile_id,
+        "model": bound_model_id,
         "modelProvider": "defra",
         "serviceTier": null,
         "cwd": absolute_path(&record.cwd),
@@ -94,9 +100,14 @@ pub(in crate::commands::codex_shim) fn thread_response_json(
 
 pub(in crate::commands::codex_shim) fn thread_resume_response_json(
     record: &CodexThreadRecord,
-    bound_profile_id: &str,
+    turns: Vec<codex::Turn>,
+    bound_model_id: &str,
 ) -> Value {
-    thread_start_response_json(record, bound_profile_id)
+    thread_response_json(
+        record,
+        codex_thread_json_with_turns(record, turns),
+        bound_model_id,
+    )
 }
 
 fn codex_git_info_json(raw: &str) -> Option<Value> {
@@ -116,4 +127,35 @@ fn codex_git_info_json(raw: &str) -> Option<Value> {
         "branch": string_field("branch"),
         "originUrl": string_field("originUrl").or_else(|| string_field("origin_url")),
     }))
+}
+
+fn thread_created_at(record: &CodexThreadRecord) -> Option<i64> {
+    record
+        .conversation
+        .as_ref()
+        .and_then(|conversation| conversation.created_at.as_deref())
+        .or(record.projection_created_at.as_deref())
+        .and_then(parse_timestamp_seconds)
+}
+
+fn thread_updated_at(record: &CodexThreadRecord) -> Option<i64> {
+    record
+        .conversation
+        .as_ref()
+        .and_then(|conversation| conversation.updated_at.as_deref())
+        .or(record.projection_updated_at.as_deref())
+        .or_else(|| {
+            record
+                .conversation
+                .as_ref()
+                .and_then(|conversation| conversation.created_at.as_deref())
+        })
+        .or(record.projection_created_at.as_deref())
+        .and_then(parse_timestamp_seconds)
+}
+
+fn parse_timestamp_seconds(raw: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .ok()
+        .map(|timestamp| timestamp.timestamp())
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/storage.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/storage.rs
@@ -30,6 +30,10 @@ pub(super) struct ProjectionRow {
     pub(super) goal_json: String,
     #[serde(default = "empty_json_object")]
     pub(super) git_info_json: String,
+    #[serde(default)]
+    pub(super) created_at: Option<String>,
+    #[serde(default)]
+    pub(super) updated_at: Option<String>,
 }
 
 pub(super) struct ProjectionUpdate<'a> {
@@ -235,6 +239,7 @@ pub(super) async fn load_projection(
                 limit: 1
             ) {{
                 session_id cwd archived loaded memory_mode name settings_json goal_json git_info_json
+                created_at updated_at
             }}
         }}"#
     );
@@ -262,6 +267,7 @@ pub(super) async fn list_projection_rows(
                 order: {{ updated_at: DESC }}
             ) {{
                 session_id cwd archived loaded memory_mode name settings_json goal_json git_info_json
+                created_at updated_at
             }}
         }}"#
         ),

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_routes.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_routes.rs
@@ -6,8 +6,9 @@ use defra_agent::graphql::escape_graphql_string;
 use defra_agent::session::{fork, ForkError, ForkParams};
 use serde_json::{json, Value};
 
-use super::bound_behavior::load_bound_inference_profile_id_for_state;
+use super::bound_behavior::load_bound_model_selection_id_for_state;
 use super::history_projection::load_thread_turns;
+use super::protocol::absolute_path;
 use super::store::query_node_json;
 use super::thread_projection::{
     codex_thread_json, codex_thread_json_with_turns, list_codex_threads_by_archived,
@@ -72,12 +73,77 @@ pub(super) async fn fork_thread_response(
             .map_err(internal_error)?
     };
     let thread = codex_thread_json_with_turns(&record, turns);
-    let bound_profile_id =
-        load_bound_inference_profile_id_for_state(state.node.as_ref(), &state.behavior_id)
+    let bound_model_id =
+        load_bound_model_selection_id_for_state(state.node.as_ref(), &state.behavior_id)
             .await
             .map_err(internal_error)?;
-    let response = thread_response_json(&record, thread, &bound_profile_id);
+    let response = thread_response_json(&record, thread, &bound_model_id);
     Ok((record, response))
+}
+
+pub(super) async fn list_threads_response(
+    state: &ShimState,
+    params: codex::ThreadListParams,
+) -> std::result::Result<Value, ThreadRouteError> {
+    if !source_filter_allows_cli(params.source_kinds.as_deref())
+        || !model_provider_filter_allows_defra(params.model_providers.as_deref())
+    {
+        return Ok(json!({
+            "data": [],
+            "nextCursor": null,
+            "backwardsCursor": null
+        }));
+    }
+
+    let archived = params.archived.unwrap_or(false);
+    let mut records = list_codex_threads_by_archived(state, archived)
+        .await
+        .map_err(internal_error)?;
+    if let Some(cwd_filter) = params.cwd.as_ref() {
+        let allowed = cwd_filter_values(cwd_filter);
+        records.retain(|record| allowed.iter().any(|cwd| cwd_matches_record(cwd, record)));
+    }
+    if let Some(search_term) = params
+        .search_term
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        records.retain(|record| record_snippet(record, search_term).is_some());
+    }
+
+    sort_thread_records(&mut records, params.sort_key, params.sort_direction);
+
+    let page_size = params.limit.unwrap_or(50).clamp(1, 200) as usize;
+    let start_index = params
+        .cursor
+        .as_deref()
+        .and_then(|cursor| {
+            records
+                .iter()
+                .position(|record| record.session_id == cursor)
+                .map(|index| index + 1)
+        })
+        .unwrap_or(0);
+    let remaining = records.len().saturating_sub(start_index);
+    let page_len = remaining.min(page_size);
+    let has_more = remaining > page_size;
+    let page = records.into_iter().skip(start_index).take(page_len);
+
+    let mut data = Vec::with_capacity(page_len);
+    let mut first_id = None::<String>;
+    let mut last_id = None::<String>;
+    for record in page {
+        first_id.get_or_insert_with(|| record.session_id.clone());
+        last_id = Some(record.session_id.clone());
+        data.push(codex_thread_json(&record, false));
+    }
+
+    Ok(json!({
+        "data": data,
+        "nextCursor": if has_more { last_id } else { None },
+        "backwardsCursor": first_id
+    }))
 }
 
 pub(super) async fn search_threads_response(
@@ -117,9 +183,7 @@ pub(super) async fn search_threads_response(
         }
     }
 
-    if params.sort_direction == Some(codex::SortDirection::Asc) {
-        matches.reverse();
-    }
+    sort_thread_matches(&mut matches, params.sort_key, params.sort_direction);
 
     let page_size = params.limit.unwrap_or(50).clamp(1, 200) as usize;
     let start_index = params
@@ -154,6 +218,80 @@ pub(super) async fn search_threads_response(
         "nextCursor": if has_more { last_id } else { None },
         "backwardsCursor": first_id
     }))
+}
+
+fn model_provider_filter_allows_defra(model_providers: Option<&[String]>) -> bool {
+    model_providers
+        .filter(|providers| !providers.is_empty())
+        .is_none_or(|providers| providers.iter().any(|provider| provider == "defra"))
+}
+
+fn cwd_filter_values(filter: &codex::ThreadListCwdFilter) -> Vec<&str> {
+    match filter {
+        codex::ThreadListCwdFilter::One(cwd) => vec![cwd.as_str()],
+        codex::ThreadListCwdFilter::Many(cwds) => cwds.iter().map(String::as_str).collect(),
+    }
+}
+
+fn cwd_matches_record(cwd: &str, record: &CodexThreadRecord) -> bool {
+    let cwd = cwd.trim();
+    !cwd.is_empty() && cwd == absolute_path(&record.cwd)
+}
+
+fn sort_thread_records(
+    records: &mut [CodexThreadRecord],
+    sort_key: Option<codex::ThreadSortKey>,
+    sort_direction: Option<codex::SortDirection>,
+) {
+    let sort_key = sort_key.unwrap_or(codex::ThreadSortKey::CreatedAt);
+    let sort_direction = sort_direction.unwrap_or(codex::SortDirection::Desc);
+    records.sort_by(|left, right| compare_thread_records(left, right, sort_key, sort_direction));
+}
+
+fn sort_thread_matches(
+    matches: &mut [(CodexThreadRecord, String)],
+    sort_key: Option<codex::ThreadSortKey>,
+    sort_direction: Option<codex::SortDirection>,
+) {
+    let sort_key = sort_key.unwrap_or(codex::ThreadSortKey::CreatedAt);
+    let sort_direction = sort_direction.unwrap_or(codex::SortDirection::Desc);
+    matches.sort_by(|(left, _), (right, _)| {
+        compare_thread_records(left, right, sort_key, sort_direction)
+    });
+}
+
+fn compare_thread_records(
+    left: &CodexThreadRecord,
+    right: &CodexThreadRecord,
+    sort_key: codex::ThreadSortKey,
+    sort_direction: codex::SortDirection,
+) -> std::cmp::Ordering {
+    let left_key = thread_sort_timestamp(left, sort_key);
+    let right_key = thread_sort_timestamp(right, sort_key);
+    let ordering = match sort_direction {
+        codex::SortDirection::Asc => left_key
+            .cmp(&right_key)
+            .then_with(|| left.session_id.cmp(&right.session_id)),
+        codex::SortDirection::Desc => right_key
+            .cmp(&left_key)
+            .then_with(|| right.session_id.cmp(&left.session_id)),
+    };
+    ordering
+}
+
+fn thread_sort_timestamp(record: &CodexThreadRecord, sort_key: codex::ThreadSortKey) -> String {
+    let conversation = record.conversation.as_ref();
+    match sort_key {
+        codex::ThreadSortKey::CreatedAt => conversation
+            .and_then(|conversation| conversation.created_at.clone())
+            .or_else(|| record.projection_created_at.clone()),
+        codex::ThreadSortKey::UpdatedAt => conversation
+            .and_then(|conversation| conversation.updated_at.clone())
+            .or_else(|| record.projection_updated_at.clone())
+            .or_else(|| conversation.and_then(|conversation| conversation.created_at.clone()))
+            .or_else(|| record.projection_created_at.clone()),
+    }
+    .unwrap_or_default()
 }
 
 async fn count_user_messages(state: &ShimState, thread_id: &str) -> Result<u32> {

--- a/crates/defra-agent-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/turn/stream.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
+use codex_protocol::models::MessagePhase;
 use defra_agent::UpdateSubscriptionSource;
 use serde_json::{json, Value};
 use tokio::sync::watch;
@@ -184,12 +185,17 @@ pub(super) async fn stream_defra_turn(
                 projection.append_agent_delta(outbound, &delta).await?;
             }
 
-            let error_message = terminal_error_message(
-                response_status,
-                latest_error_message.as_deref(),
-                lifecycle_state,
-                failure_reason,
-            );
+            let turn_status = terminal_turn_status(lifecycle_state, response_status);
+            let error_message = if turn_status == codex::TurnStatus::Failed {
+                terminal_error_message(
+                    response_status,
+                    latest_error_message.as_deref(),
+                    lifecycle_state,
+                    failure_reason,
+                )
+            } else {
+                None
+            };
             if let Some(error_message) = error_message.as_deref() {
                 if !projection.rendered_agent_text().contains(error_message) {
                     projection
@@ -197,8 +203,6 @@ pub(super) async fn stream_defra_turn(
                         .await?;
                 }
             }
-
-            let turn_status = terminal_turn_status(lifecycle_state, response_status);
             if turn_status == codex::TurnStatus::Completed {
                 if let Some(next_request) =
                     next_steering_request_after(state, &current.session_id, &current.request_id)
@@ -208,7 +212,9 @@ pub(super) async fn stream_defra_turn(
                         tokio::time::sleep(state.poll_interval).await;
                         continue;
                     }
-                    projection.finish_agent_message(outbound).await?;
+                    projection
+                        .finish_agent_message_with_phase(outbound, Some(MessagePhase::FinalAnswer))
+                        .await?;
                     spawn_background_tool_watcher(
                         connection.clone(),
                         state.clone(),

--- a/crates/defra-agent-cli/src/commands/codex_shim/turn_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/turn_projection.rs
@@ -2,12 +2,15 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use codex_app_server_protocol as codex;
+use codex_protocol::models::MessagePhase;
 
 use super::command_projection::{
     command_execution_item, command_output_payload, file_change_item, ToolProjectionStatus,
 };
 use super::progress::{defra_tool_item, DefraToolCallProgress};
-use super::protocol::{agent_message_item, now_millis, send_notification, turn_value};
+use super::protocol::{
+    agent_message_item, agent_message_item_with_phase, now_millis, send_notification, turn_value,
+};
 use super::{Outbound, ShimState};
 
 pub(super) struct TurnProjection<'a> {
@@ -93,7 +96,11 @@ impl<'a> TurnProjection<'a> {
         .await
     }
 
-    pub(super) async fn finish_agent_message(&mut self, outbound: &Outbound) -> Result<()> {
+    pub(super) async fn finish_agent_message_with_phase(
+        &mut self,
+        outbound: &Outbound,
+        phase: Option<MessagePhase>,
+    ) -> Result<()> {
         let Some(item_id) = self.active_agent_item_id.take() else {
             return Ok(());
         };
@@ -101,7 +108,7 @@ impl<'a> TurnProjection<'a> {
         if text.trim().is_empty() {
             return Ok(());
         }
-        let completed_item = agent_message_item(&item_id, &text);
+        let completed_item = agent_message_item_with_phase(&item_id, &text, phase);
         send_notification(
             outbound,
             self.state,
@@ -122,7 +129,8 @@ impl<'a> TurnProjection<'a> {
         outbound: &Outbound,
         tool: &DefraToolCallProgress,
     ) -> Result<()> {
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         send_notification(
             outbound,
             self.state,
@@ -142,7 +150,8 @@ impl<'a> TurnProjection<'a> {
         tool: &DefraToolCallProgress,
         status: codex::McpToolCallStatus,
     ) -> Result<()> {
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         let completed_item = defra_tool_item(tool, status);
         send_notification(
             outbound,
@@ -165,7 +174,8 @@ impl<'a> TurnProjection<'a> {
         tool: &DefraToolCallProgress,
         status: codex::CommandExecutionStatus,
     ) -> Result<()> {
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         send_notification(
             outbound,
             self.state,
@@ -185,7 +195,8 @@ impl<'a> TurnProjection<'a> {
         tool: &DefraToolCallProgress,
         status: codex::CommandExecutionStatus,
     ) -> Result<()> {
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         if let Some(delta) = command_output_payload(tool) {
             send_notification(
                 outbound,
@@ -225,7 +236,8 @@ impl<'a> TurnProjection<'a> {
         let Some(item) = file_change_item(tool, codex::PatchApplyStatus::InProgress) else {
             return Ok(());
         };
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         send_notification(
             outbound,
             self.state,
@@ -248,7 +260,8 @@ impl<'a> TurnProjection<'a> {
         let Some(item) = file_change_item(tool, status) else {
             return Ok(());
         };
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::Commentary))
+            .await?;
         send_notification(
             outbound,
             self.state,
@@ -354,7 +367,8 @@ impl<'a> TurnProjection<'a> {
         status: codex::TurnStatus,
         error_message: Option<String>,
     ) -> Result<()> {
-        self.finish_agent_message(outbound).await?;
+        self.finish_agent_message_with_phase(outbound, Some(MessagePhase::FinalAnswer))
+            .await?;
         let turn_error = if status == codex::TurnStatus::Failed {
             Some(codex::TurnError {
                 message: error_message.unwrap_or_else(|| "DEFRA turn failed".to_string()),

--- a/crates/defra-agent-cli/tests/cli_codex_shim.rs
+++ b/crates/defra-agent-cli/tests/cli_codex_shim.rs
@@ -18,6 +18,14 @@ use uuid::Uuid;
 type ShimWebSocket = WebSocketStream<MaybeTlsStream<TcpStream>>;
 const LIVE_CODEX_SHIM_TIMEOUT_SECS: &str = "900";
 
+fn defra_model_selection_id(backend_id: &str, model_name: &str) -> String {
+    format!("{backend_id}::{model_name}")
+}
+
+fn default_backend_id(agent_did: &str) -> String {
+    format!("{agent_did}:backend")
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
@@ -42,6 +50,8 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
         ],
     )?;
     let agent_did = agent_did_from_init(&init)?;
+    let default_backend_id = default_backend_id(&agent_did);
+    let default_model_selection = defra_model_selection_id(&default_backend_id, &model_name);
     let shim_port = allocate_port()?;
     let shim_port_string = shim_port.to_string();
     let mut serve = spawn_server_with_env(
@@ -101,11 +111,10 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     )
     .await?;
     let config: codex::ConfigReadResponse = read_typed_response(&mut ws, request_id(2)).await?;
-    let expected_default_profile_id = format!("{agent_did}:default-profile");
     assert_eq!(
         config.config.model.as_deref(),
-        Some(expected_default_profile_id.as_str()),
-        "ConfigRead.model should be the bound behavior's inference_profile_id"
+        Some(default_model_selection.as_str()),
+        "ConfigRead.model should be the bound behavior's backend-qualified model selection"
     );
 
     send_client_request(
@@ -372,6 +381,62 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
 
     send_client_request(
         &mut ws,
+        codex::ClientRequest::ThreadList {
+            request_id: request_id(48),
+            params: codex::ThreadListParams {
+                cursor: None,
+                limit: Some(1),
+                sort_key: None,
+                sort_direction: None,
+                model_providers: Some(vec!["defra".to_string()]),
+                source_kinds: Some(vec![codex::ThreadSourceKind::Cli]),
+                archived: Some(true),
+                cwd: Some(codex::ThreadListCwdFilter::One(
+                    home_dir.display().to_string(),
+                )),
+                use_state_db_only: true,
+                search_term: Some("DEFRA-backed Codex thread".to_string()),
+            },
+        },
+    )
+    .await?;
+    let archived_threads: codex::ThreadListResponse = read_typed_response(&mut ws, request_id(48))
+        .await
+        .context("reading archived thread/list response")?;
+    assert_eq!(archived_threads.data.len(), 1);
+    assert_eq!(archived_threads.data[0].id, thread_id);
+    assert_eq!(
+        archived_threads.backwards_cursor.as_deref(),
+        Some(thread_id.as_str())
+    );
+
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::ThreadList {
+            request_id: request_id(49),
+            params: codex::ThreadListParams {
+                cursor: None,
+                limit: None,
+                sort_key: None,
+                sort_direction: None,
+                model_providers: Some(vec!["openai".to_string()]),
+                source_kinds: Some(vec![codex::ThreadSourceKind::Cli]),
+                archived: Some(true),
+                cwd: None,
+                use_state_db_only: true,
+                search_term: None,
+            },
+        },
+    )
+    .await?;
+    let wrong_provider_threads: codex::ThreadListResponse =
+        read_typed_response(&mut ws, request_id(49))
+            .await
+            .context("reading provider-filtered thread/list response")?;
+    assert!(wrong_provider_threads.data.is_empty());
+
+    send_client_request(
+        &mut ws,
         codex::ClientRequest::ThreadUnarchive {
             request_id: request_id(41),
             params: codex::ThreadUnarchiveParams {
@@ -444,6 +509,52 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     assert_eq!(history_turn.status, codex::TurnStatus::Completed);
     assert_turn_has_user_text(history_turn, &prompt);
     assert_turn_has_agent_text(history_turn, &expected_reply);
+
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::ThreadResume {
+            request_id: request_id(46),
+            params: codex::ThreadResumeParams {
+                thread_id: thread_id.clone(),
+                cwd: Some(home_dir.display().to_string()),
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    let resumed_history: codex::ThreadResumeResponse = read_typed_response(&mut ws, request_id(46))
+        .await
+        .context("reading history-bearing thread/resume response")?;
+    assert_eq!(resumed_history.thread.id, thread_id);
+    assert_eq!(resumed_history.thread.turns.len(), 1);
+    let resumed_turn = &resumed_history.thread.turns[0];
+    assert_eq!(resumed_turn.id, completed_turn.id);
+    assert_eq!(resumed_turn.items_view, codex::TurnItemsView::Full);
+    assert_eq!(resumed_turn.status, codex::TurnStatus::Completed);
+    assert_turn_has_user_text(resumed_turn, &prompt);
+    assert_turn_has_agent_text(resumed_turn, &expected_reply);
+
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::ThreadResume {
+            request_id: request_id(47),
+            params: codex::ThreadResumeParams {
+                thread_id: thread_id.clone(),
+                cwd: Some(home_dir.display().to_string()),
+                exclude_turns: true,
+                ..Default::default()
+            },
+        },
+    )
+    .await?;
+    let metadata_resume: codex::ThreadResumeResponse = read_typed_response(&mut ws, request_id(47))
+        .await
+        .context("reading metadata-only thread/resume response")?;
+    assert_eq!(metadata_resume.thread.id, thread_id);
+    assert!(
+        metadata_resume.thread.turns.is_empty(),
+        "excludeTurns resume should not load persisted turns"
+    );
 
     send_client_request(
         &mut ws,
@@ -2058,7 +2169,8 @@ async fn codex_shim_remote_frontend_keeps_client_codex_home_separate() -> Result
         ],
     )?;
     let agent_did = agent_did_from_init(&init)?;
-    let default_profile_id = format!("{agent_did}:default-profile");
+    let expected_model_selection =
+        defra_model_selection_id(&default_backend_id(&agent_did), &model_name);
     let shim_port = allocate_port()?;
     let shim_port_string = shim_port.to_string();
     let mut serve = spawn_server_with_env(
@@ -2146,8 +2258,8 @@ async fn codex_shim_remote_frontend_keeps_client_codex_home_separate() -> Result
     let thread_start: codex::ThreadStartResponse =
         read_typed_response(&mut ws, request_id(2)).await?;
     assert_eq!(
-        thread_start.model, default_profile_id,
-        "Defra remote runtime should use the bound behavior profile, not the client Codex model"
+        thread_start.model, expected_model_selection,
+        "Defra remote runtime should use the bound behavior model, not the client Codex model"
     );
     assert_eq!(thread_start.model_provider, "defra");
     assert_eq!(thread_start.approval_policy, codex::AskForApproval::Never);
@@ -3358,7 +3470,7 @@ async fn codex_shim_refuses_to_start_when_bound_behavior_is_missing() -> Result<
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn codex_shim_model_list_enumerates_inference_profiles() -> Result<()> {
+async fn codex_shim_model_list_enumerates_backend_models() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
@@ -3380,8 +3492,14 @@ async fn codex_shim_model_list_enumerates_inference_profiles() -> Result<()> {
         ],
     )?;
     let agent_did = agent_did_from_init(&init)?;
-    let default_profile_id = format!("{agent_did}:default-profile");
-    let extra_profile_id = format!("extra-profile-{}", Uuid::new_v4().simple());
+    let default_backend_id = default_backend_id(&agent_did);
+    let default_model_selection = defra_model_selection_id(&default_backend_id, &model_name);
+    let extra_model_name = format!("mock-codex-shim-extra-model-{}", Uuid::new_v4().simple());
+    let extra_endpoint = MockChatEndpoint::start(&extra_model_name, "irrelevant")?;
+    let extra_backend_id = format!("extra-backend-{}", Uuid::new_v4().simple());
+    let extra_model_selection = defra_model_selection_id(&extra_backend_id, &extra_model_name);
+    let duplicate_backend_id = format!("duplicate-backend-{}", Uuid::new_v4().simple());
+    let duplicate_model_selection = defra_model_selection_id(&duplicate_backend_id, &model_name);
 
     let shim_port = allocate_port()?;
     let shim_port_string = shim_port.to_string();
@@ -3395,18 +3513,35 @@ async fn codex_shim_model_list_enumerates_inference_profiles() -> Result<()> {
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
-    let create_extra = format!(
+    let create_extra_backend = format!(
         r#"mutation {{
-            create_InferenceProfile(input: {{
-                profile_id: "{extra_profile_id}",
-                display_name: "Extra Profile",
-                context_window: 8192,
-                max_output_tokens: 1024,
-                temperature: 0.5
+            create_InferenceBackend(input: {{
+                backend_id: "{extra_backend_id}",
+                name: "Extra Backend",
+                provider_kind: "OpenAiCompatible",
+                endpoint: "{}",
+                max_concurrent: 1,
+                max_queue_depth: 100,
+                enabled: true,
+                models: ["{extra_model_name}"],
+                probe_status: "healthy"
             }}) {{ _docID }}
-        }}"#
+            create_duplicate: create_InferenceBackend(input: {{
+                backend_id: "{duplicate_backend_id}",
+                name: "Duplicate Backend",
+                provider_kind: "OpenAiCompatible",
+                endpoint: "{}",
+                max_concurrent: 1,
+                max_queue_depth: 100,
+                enabled: true,
+                models: ["{model_name}"],
+                probe_status: "healthy"
+            }}) {{ _docID }}
+        }}"#,
+        escape_graphql_string(extra_endpoint.endpoint()),
+        escape_graphql_string(extra_endpoint.endpoint())
     );
-    graphql_query(&graphql, &create_extra).await?;
+    graphql_query(&graphql, &create_extra_backend).await?;
 
     let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
         .await
@@ -3447,30 +3582,46 @@ async fn codex_shim_model_list_enumerates_inference_profiles() -> Result<()> {
         .map(|entry| entry.id.as_str())
         .collect();
     assert!(
-        ids.contains(&default_profile_id.as_str()),
-        "expected default profile {default_profile_id} in model list; got {ids:?}"
+        ids.contains(&default_model_selection.as_str()),
+        "expected default model selection {default_model_selection} in model list; got {ids:?}"
     );
     assert!(
-        ids.contains(&extra_profile_id.as_str()),
-        "expected extra profile {extra_profile_id} in model list; got {ids:?}"
+        ids.contains(&extra_model_selection.as_str()),
+        "expected extra model selection {extra_model_selection} in model list; got {ids:?}"
+    );
+    assert!(
+        ids.contains(&duplicate_model_selection.as_str()),
+        "expected duplicate model selection {duplicate_model_selection} in model list; got {ids:?}"
     );
     let default_entry = model_list
         .data
         .iter()
-        .find(|entry| entry.id == default_profile_id)
-        .expect("default profile present");
+        .find(|entry| entry.id == default_model_selection)
+        .expect("default model present");
+    assert_eq!(default_entry.model, default_model_selection);
+    assert_eq!(default_entry.display_name, model_name);
     assert!(
         default_entry.is_default,
-        "default profile should be flagged as isDefault"
+        "default model should be flagged as isDefault"
     );
     let extra_entry = model_list
         .data
         .iter()
-        .find(|entry| entry.id == extra_profile_id)
-        .expect("extra profile present");
+        .find(|entry| entry.id == extra_model_selection)
+        .expect("extra model present");
     assert!(
         !extra_entry.is_default,
-        "non-default profile must not be flagged isDefault"
+        "non-default model must not be flagged isDefault"
+    );
+    let duplicate_entry = model_list
+        .data
+        .iter()
+        .find(|entry| entry.id == duplicate_model_selection)
+        .expect("duplicate backend model present");
+    assert_eq!(duplicate_entry.display_name, model_name);
+    assert!(
+        !duplicate_entry.is_default,
+        "duplicate backend model must not be flagged isDefault"
     );
     Ok(())
 }
@@ -3498,7 +3649,9 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
     )?;
     let agent_did = agent_did_from_init(&init)?;
     let default_behavior_id = format!("{agent_did}:default");
-    let alt_profile_id = format!("alt-profile-{}", Uuid::new_v4().simple());
+    let default_backend_id = default_backend_id(&agent_did);
+    let alt_model_name = format!("alt-model-{}", Uuid::new_v4().simple());
+    let alt_model_selection = defra_model_selection_id(&default_backend_id, &alt_model_name);
 
     let shim_port = allocate_port()?;
     let shim_port_string = shim_port.to_string();
@@ -3512,22 +3665,11 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
-    let create_alt = format!(
-        r#"mutation {{
-            create_InferenceProfile(input: {{
-                profile_id: "{alt_profile_id}",
-                display_name: "Alt Profile",
-                context_window: 4096
-            }}) {{ _docID }}
-        }}"#
-    );
-    graphql_query(&graphql, &create_alt).await?;
-
     let switch_behavior = format!(
         r#"mutation {{
             update_AgentBehavior(
                 filter: {{ behavior_id: {{ _eq: "{default_behavior_id}" }} }},
-                input: {{ inference_profile_id: "{alt_profile_id}" }}
+                input: {{ model_name: "{alt_model_name}" }}
             ) {{ _docID }}
         }}"#
     );
@@ -3569,8 +3711,8 @@ async fn codex_shim_config_read_reflects_doc_mutation() -> Result<()> {
     let config: codex::ConfigReadResponse = read_typed_response(&mut ws, request_id(2)).await?;
     assert_eq!(
         config.config.model.as_deref(),
-        Some(alt_profile_id.as_str()),
-        "ConfigRead should reflect the doc-mutated inference_profile_id"
+        Some(alt_model_selection.as_str()),
+        "ConfigRead should reflect the doc-mutated backend-qualified model selection"
     );
     Ok(())
 }
@@ -3598,7 +3740,11 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
     )?;
     let agent_did = agent_did_from_init(&init)?;
     let default_behavior_id = format!("{agent_did}:default");
-    let alt_profile_id = format!("alt-profile-{}", Uuid::new_v4().simple());
+    let original_profile_id = format!("{agent_did}:default-profile");
+    let alt_model_name = format!("mock-codex-shim-alt-model-{}", Uuid::new_v4().simple());
+    let alt_endpoint = MockChatEndpoint::start(&alt_model_name, "irrelevant")?;
+    let alt_backend_id = format!("alt-backend-{}", Uuid::new_v4().simple());
+    let alt_model_selection = defra_model_selection_id(&alt_backend_id, &alt_model_name);
 
     let shim_port = allocate_port()?;
     let shim_port_string = shim_port.to_string();
@@ -3612,19 +3758,23 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
     wait_for_port(shim_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
-    graphql_query(
-        &graphql,
-        &format!(
-            r#"mutation {{
-                create_InferenceProfile(input: {{
-                    profile_id: "{alt_profile_id}",
-                    display_name: "Alt Profile",
-                    context_window: 4096
-                }}) {{ _docID }}
-            }}"#
-        ),
-    )
-    .await?;
+    let create_alt_backend = format!(
+        r#"mutation {{
+            create_InferenceBackend(input: {{
+                backend_id: "{alt_backend_id}",
+                name: "Alt Backend",
+                provider_kind: "OpenAiCompatible",
+                endpoint: "{}",
+                max_concurrent: 1,
+                max_queue_depth: 100,
+                enabled: true,
+                models: ["{alt_model_name}"],
+                probe_status: "healthy"
+            }}) {{ _docID }}
+        }}"#,
+        escape_graphql_string(alt_endpoint.endpoint())
+    );
+    graphql_query(&graphql, &create_alt_backend).await?;
 
     let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
         .await
@@ -3654,7 +3804,7 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
             request_id: request_id(2),
             params: codex::ConfigValueWriteParams {
                 key_path: "model".to_string(),
-                value: serde_json::Value::String(alt_profile_id.clone()),
+                value: serde_json::Value::String(alt_model_selection),
                 merge_strategy: codex::MergeStrategy::Replace,
                 file_path: None,
                 expected_version: None,
@@ -3664,7 +3814,8 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
     .await?;
     let _write: codex::ConfigWriteResponse = read_typed_response(&mut ws, request_id(2)).await?;
 
-    // Verify the AgentBehavior doc was updated.
+    // Verify the AgentBehavior doc was updated to the selected backend model
+    // while keeping the existing inference profile limits.
     let resp = graphql_query(
         &graphql,
         &format!(
@@ -3672,25 +3823,43 @@ async fn codex_shim_config_value_write_model_mutates_behavior() -> Result<()> {
                 AgentBehavior(
                     filter: {{ behavior_id: {{ _eq: "{default_behavior_id}" }} }},
                     limit: 1
-                ) {{ inference_profile_id }}
+                ) {{ backend_id model_name inference_profile_id }}
             }}"#
         ),
     )
     .await?;
-    let stored = resp
+    let stored_backend = resp
+        .pointer("/data/AgentBehavior/0/backend_id")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    assert_eq!(
+        stored_backend, alt_backend_id,
+        "AgentBehavior.backend_id should reflect ConfigValueWrite"
+    );
+    let stored_model = resp
+        .pointer("/data/AgentBehavior/0/model_name")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    assert_eq!(
+        stored_model, alt_model_name,
+        "AgentBehavior.model_name should reflect ConfigValueWrite"
+    );
+    let stored_profile = resp
         .pointer("/data/AgentBehavior/0/inference_profile_id")
         .and_then(|v| v.as_str())
         .map(ToOwned::to_owned)
         .unwrap_or_default();
     assert_eq!(
-        stored, alt_profile_id,
-        "AgentBehavior.inference_profile_id should reflect ConfigValueWrite"
+        stored_profile, original_profile_id,
+        "AgentBehavior.inference_profile_id should remain unchanged by model selection"
     );
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn codex_shim_config_value_write_rejects_unknown_profile() -> Result<()> {
+async fn codex_shim_config_value_write_rejects_unknown_model() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
@@ -3712,6 +3881,7 @@ async fn codex_shim_config_value_write_rejects_unknown_profile() -> Result<()> {
     )?;
     let agent_did = agent_did_from_init(&init)?;
     let default_behavior_id = format!("{agent_did}:default");
+    let original_backend_id = format!("{agent_did}:backend");
     let original_profile_id = format!("{agent_did}:default-profile");
 
     let shim_port = allocate_port()?;
@@ -3764,8 +3934,8 @@ async fn codex_shim_config_value_write_rejects_unknown_profile() -> Result<()> {
     .await?;
     let error = read_error_response(&mut ws, request_id(2)).await?;
     assert!(
-        error.message.contains("InferenceProfile") || error.message.contains("not found"),
-        "expected error to mention missing InferenceProfile; got: {}",
+        error.message.contains("model") && error.message.contains("not found"),
+        "expected error to mention missing model; got: {}",
         error.message
     );
 
@@ -3776,19 +3946,37 @@ async fn codex_shim_config_value_write_rejects_unknown_profile() -> Result<()> {
                 AgentBehavior(
                     filter: {{ behavior_id: {{ _eq: "{default_behavior_id}" }} }},
                     limit: 1
-                ) {{ inference_profile_id }}
+                ) {{ backend_id model_name inference_profile_id }}
             }}"#
         ),
     )
     .await?;
-    let stored = resp
+    let stored_backend = resp
+        .pointer("/data/AgentBehavior/0/backend_id")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    assert_eq!(
+        stored_backend, original_backend_id,
+        "behavior backend_id must remain unchanged after rejected write"
+    );
+    let stored_model = resp
+        .pointer("/data/AgentBehavior/0/model_name")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    assert_eq!(
+        stored_model, model_name,
+        "behavior model_name must remain unchanged after rejected write"
+    );
+    let stored_profile = resp
         .pointer("/data/AgentBehavior/0/inference_profile_id")
         .and_then(|v| v.as_str())
         .map(ToOwned::to_owned)
         .unwrap_or_default();
     assert_eq!(
-        stored, original_profile_id,
-        "behavior doc must remain unchanged after rejected write"
+        stored_profile, original_profile_id,
+        "behavior inference_profile_id must remain unchanged after rejected write"
     );
     Ok(())
 }


### PR DESCRIPTION
## Summary
- make Codex thread/resume validate session liveness/pinning, preserve and hydrate projection state, include resumed turns, and interrupt orphan active turns
- wire the Codex model switcher path through the bound behavior profile and apply current profile sampling to subsequent turn submissions
- add Codex-shim regressions for resume hydration, non-resumable sessions, orphan active turns, and model switching

Fixes #342

## Verification
- cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_model_list_enumerates_inference_profiles -- --nocapture --test-threads=1
- cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_config_value_write_model_mutates_behavior -- --nocapture --test-threads=1
- cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_does_not_clobber_session_behavior_id -- --nocapture --test-threads=1
- cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_rejects_resume_with_mismatched_behavior -- --nocapture --test-threads=1
- cargo test -p defra-agent-cli --test cli_codex_shim -- --nocapture --test-threads=1
- cargo fmt --all --check
- git diff --check