### PR TITLE
Fix duplicate desktop chat messages

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
@@ -122,6 +122,7 @@ pub(crate) async fn probe_mcp_service(
             .mcp_port
             .and_then(|port| u16::try_from(port).ok()),
         mcp_path: registry_entry.mcp_path.unwrap_or_default(),
+        send_agent_did: registry_entry.send_agent_did,
         updated_at: registry_entry.updated_at,
     };
     let health_map = ServiceHealthMap::new();

--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/tool_service.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/tool_service.rs
@@ -56,6 +56,7 @@ pub(crate) async fn save_tool_service_config(
             lan_ip: None,
             mcp_port: None,
             mcp_path: Some("/mcp".to_string()),
+            send_agent_did: false,
             tools: Vec::new(),
             status: Some("online".to_string()),
             version: None,

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+fn assistant_message_json(text: &str) -> String {
+    serde_json::to_string(&Message::assistant(text)).expect("serialize assistant")
+}
+
 fn make_streaming_store_with_response_content(content: &str) -> ClientStore {
     ClientStore::from_rows(ClientStoreRows {
         conversations: vec![AgentConversationRow {
@@ -79,6 +83,84 @@ fn overlay_hidden_when_response_tail_is_empty() {
         .iter()
         .any(|item| matches!(item, RenderedTimelineItem::LiveAssistant { .. }));
     assert!(!has_live, "overlay must be hidden when tail is empty");
+}
+
+#[test]
+fn session_snapshot_deduplicates_persisted_rows_from_multiple_sources() {
+    let mut rows = make_streaming_store_with_response_content("").to_rows();
+    rows.responses.clear();
+
+    let duplicate_user = rows.messages[0].clone();
+    rows.messages.push(duplicate_user);
+    rows.message_source_agent_dids = vec![None, Some("did:defra:amy".to_string())];
+
+    let assistant = AgentMessageRow {
+        message_key: "msg-2".to_string(),
+        session_id: Some("sess-1".to_string()),
+        sequence: Some(2),
+        role: Some("assistant".to_string()),
+        content: Some(assistant_message_json("hello back")),
+        timestamp: Some("2026-04-21T12:00:01Z".to_string()),
+    };
+    rows.messages.push(assistant.clone());
+    rows.message_source_agent_dids.push(None);
+    rows.messages.push(assistant);
+    rows.message_source_agent_dids
+        .push(Some("did:defra:amy".to_string()));
+
+    let store = ClientStore::from_rows(rows);
+    let snapshot = build_session_snapshot_from_store_for_agent(
+        &store,
+        Some("did:defra:amy"),
+        "sess-1",
+        Some("req-1"),
+    )
+    .expect("session snapshot");
+
+    let kinds = snapshot
+        .timeline_items
+        .iter()
+        .map(|item| match item {
+            RenderedTimelineItem::UserMessage { .. } => "user",
+            RenderedTimelineItem::AssistantMessage { .. } => "assistant",
+            RenderedTimelineItem::ToolGroup { .. } => "tools",
+            RenderedTimelineItem::PendingUserTurn { .. } => "pending",
+            RenderedTimelineItem::LiveAssistant { .. } => "live",
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(kinds, vec!["user", "assistant"]);
+}
+
+#[test]
+fn session_snapshot_hides_live_overlay_matching_last_materialized_assistant() {
+    let reply = "hello back";
+    let mut rows = make_streaming_store_with_response_content(reply).to_rows();
+    rows.messages.push(AgentMessageRow {
+        message_key: "msg-2".to_string(),
+        session_id: Some("sess-1".to_string()),
+        sequence: Some(2),
+        role: Some("assistant".to_string()),
+        content: Some(assistant_message_json(reply)),
+        timestamp: Some("2026-04-21T12:00:01Z".to_string()),
+    });
+
+    let store = ClientStore::from_rows(rows);
+    let snapshot = build_session_snapshot_from_store(&store, "sess-1", Some("req-1"))
+        .expect("session snapshot");
+
+    let assistant_items = snapshot
+        .timeline_items
+        .iter()
+        .filter(|item| matches!(item, RenderedTimelineItem::AssistantMessage { .. }))
+        .count();
+    let live_items = snapshot
+        .timeline_items
+        .iter()
+        .filter(|item| matches!(item, RenderedTimelineItem::LiveAssistant { .. }))
+        .count();
+
+    assert_eq!(assistant_items, 1);
+    assert_eq!(live_items, 0, "matching live overlay must be suppressed");
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
@@ -74,6 +74,41 @@ pub(super) fn materialized_user_turn_count(messages: &[MessageView]) -> usize {
         .count()
 }
 
+fn message_presentation_key(
+    message: &MessageView,
+    role: &str,
+    content: &Option<String>,
+    reasoning: &Option<String>,
+) -> Option<(i64, String, Option<String>, Option<String>, bool, bool)> {
+    message.sequence.map(|sequence| {
+        (
+            sequence,
+            role.to_ascii_lowercase(),
+            content.clone(),
+            reasoning.clone(),
+            message.has_tool_calls,
+            message.has_tool_results,
+        )
+    })
+}
+
+fn overlay_matches_latest_assistant(
+    timeline: &[RenderedTimelineItem],
+    overlay_content: &Option<String>,
+    overlay_reasoning: &Option<String>,
+) -> bool {
+    for item in timeline.iter().rev() {
+        match item {
+            RenderedTimelineItem::AssistantMessage {
+                content, reasoning, ..
+            } => return content == overlay_content && reasoning == overlay_reasoning,
+            RenderedTimelineItem::ToolGroup { .. } => continue,
+            _ => return false,
+        }
+    }
+    false
+}
+
 pub(super) fn build_rendered_timeline(
     messages: &[MessageView],
     tool_calls: &[ToolCallView],
@@ -105,6 +140,9 @@ pub(super) fn build_rendered_timeline(
         .collect::<Vec<_>>();
     timeline_messages.sort_by_key(|message| message.sequence.unwrap_or_default());
 
+    let mut seen_message_keys = std::collections::BTreeSet::new();
+    let mut seen_presentations = std::collections::BTreeSet::new();
+
     for message in timeline_messages {
         let role = message
             .display_role
@@ -113,6 +151,16 @@ pub(super) fn build_rendered_timeline(
             .unwrap_or("assistant");
         let normalized_content = normalize_optional(message.display_content.as_deref());
         let normalized_reasoning = normalize_optional(message.reasoning.as_deref());
+        if !seen_message_keys.insert(message.message_key.clone()) {
+            continue;
+        }
+        if let Some(presentation_key) =
+            message_presentation_key(&message, role, &normalized_content, &normalized_reasoning)
+        {
+            if !seen_presentations.insert(presentation_key) {
+                continue;
+            }
+        }
 
         match role {
             "user" => {
@@ -173,7 +221,9 @@ pub(super) fn build_rendered_timeline(
         active_response_overlay.and_then(|overlay| normalize_optional(overlay.content.as_deref()));
     let overlay_reasoning = active_response_overlay
         .and_then(|overlay| normalize_optional(overlay.reasoning.as_deref()));
-    if overlay_content.is_some() || overlay_reasoning.is_some() {
+    if (overlay_content.is_some() || overlay_reasoning.is_some())
+        && !overlay_matches_latest_assistant(&timeline, &overlay_content, &overlay_reasoning)
+    {
         timeline.push(RenderedTimelineItem::LiveAssistant {
             item_key: "live-assistant".to_string(),
             content: overlay_content,


### PR DESCRIPTION
## Summary

- Deduplicate persisted transcript messages before rendering desktop timeline rows
- Suppress stale live assistant overlays when they exactly match the latest rendered assistant message
- Add desktop snapshot regressions for duplicate multi-source rows and stale live overlay duplication
- Fix desktop compile blockers for the new `send_agent_did` MCP registry field

## Testing

- `cargo test -p defra-agent-desktop-tauri session_timeline --lib`

## Notes

I also tried `cargo test -p defra-agent-desktop-tauri --lib`; it compiled and many tests passed, but I terminated it after generated Lean contract tests sat past the 60-second running notices.
