### PR TITLE
Allow read-only diagnostic command prefixes

### DIFF
--- a/crates/defra-agent-protocol/schemas/README.md
+++ b/crates/defra-agent-protocol/schemas/README.md
@@ -196,11 +196,14 @@ Some boundaries are deliberate:
   accepts `read_only`, `workspace_write`/`managed_write`, or `unrestricted`;
   `command_allowed_argv_prefixes` and `command_forbidden_argv_prefixes` refine
   argv-level allow/deny behavior; `command_network_mode` is an optional network
-  policy hint. Runtime enforcement still depends on the selected bash mode and
-  host platform. On macOS, `workspace_write` uses the seatbelt sandbox and only
-  permits same-sandbox process introspection; `unrestricted` is unsandboxed and
-  is the policy to use for host-diagnostics stewards that need `ps` or broad
-  `lsof`.
+  policy hint. In `read_only` mode, an allowed argv prefix can authorize an
+  operator-configured diagnostic command outside the built-in read-only
+  allowlist. When the allowed-prefix list is non-empty, it remains a global argv
+  gate for all commands. Runtime enforcement still depends on the selected bash
+  mode and host platform. On macOS, `workspace_write` uses the seatbelt sandbox
+  and only permits same-sandbox process introspection; `unrestricted` is
+  unsandboxed and is the policy to use for host-diagnostics stewards that need
+  `ps` or broad `lsof`.
 - backend credentials may currently be stored either directly in
   `InferenceBackend.api_key` or indirectly via `InferenceBackend.api_key_env_var`.
 - backend capability metadata is not stored in `InferenceBackend`; provider

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Cases.lean
@@ -169,6 +169,32 @@ def commandPolicyOrderingCases : List CommandPolicyCase :=
         [])
       (commandRequest "curl" "curl" ["https://example.com"])
   , validationCase
+      "allowed_prefix_authorizes_read_only_diagnostic_command"
+      "read_only_configured_prefix"
+      (commandPolicy
+        .readOnly
+        [["spctl", "--assess", "--type", "execute"]]
+        []
+        .inherit
+        defaultReadOnlyAllowlist)
+      (commandRequest
+        "spctl"
+        "spctl"
+        ["--assess", "--type", "execute", "/Applications/Defra Agent.app"])
+  , validationCase
+      "forbidden_prefix_overrides_configured_read_only_diagnostic"
+      "read_only_configured_prefix"
+      (commandPolicy
+        .readOnly
+        [["spctl", "--assess"]]
+        [["spctl", "--assess", "--raw"]]
+        .inherit
+        defaultReadOnlyAllowlist)
+      (commandRequest
+        "spctl"
+        "spctl"
+        ["--assess", "--raw", "/Applications/Defra Agent.app"])
+  , validationCase
       "read_only_allowlisted_lookup_basename_allows"
       "read_only_allowlist"
       (commandPolicy .readOnly [] [] .inherit ["cat"])

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Theorems.lean
@@ -40,20 +40,24 @@ theorem readOnly_validator_rejects_unallowlisted
     (request : CommandRequest)
     (hunallowlisted :
       commandAllowlisted request.lookupCommand allowlist = false) :
-    validateReadOnlyCommand allowlist request =
+    validateReadOnlyCommand allowlist false request =
       .deny (.readOnlyCommandNotAllowlisted request.lookupCommand) := by
   simp [validateReadOnlyCommand, hunallowlisted]
 
-theorem readOnly_validator_allows_only_allowlisted
+theorem readOnly_validator_allows_only_allowlisted_or_configured_prefix
     (allowlist : List String)
+    (allowedPrefixMatched : Bool)
     (request : CommandRequest)
-    (hallow : validateReadOnlyCommand allowlist request = .allow) :
-    commandAllowlisted request.lookupCommand allowlist = true := by
+    (hallow : validateReadOnlyCommand allowlist allowedPrefixMatched request = .allow) :
+    commandAllowlisted request.lookupCommand allowlist = true
+      ∨ allowedPrefixMatched = true := by
   cases hlisted : commandAllowlisted request.lookupCommand allowlist with
+  | true => exact Or.inl rfl
   | false =>
-      simp [validateReadOnlyCommand, hlisted] at hallow
-  | true =>
-      rfl
+      cases hprefix : allowedPrefixMatched with
+      | true => exact Or.inr rfl
+      | false =>
+          simp [validateReadOnlyCommand, hlisted, hprefix] at hallow
 
 theorem disabled_network_unrestricted_fails_closed
     (request : CommandRequest) :

--- a/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
+++ b/crates/defra-agent/proofs/Proofs/CommandPolicy/Validation.lean
@@ -298,8 +298,9 @@ def validateReadOnlyArgs (request : CommandRequest) : Decision :=
 /-- Validator used when the effective mode is `read_only`. -/
 def validateReadOnlyCommand
     (allowlist : List String)
+    (allowedPrefixMatched : Bool)
     (request : CommandRequest) : Decision :=
-  if commandAllowlisted request.lookupCommand allowlist then
+  if commandAllowlisted request.lookupCommand allowlist || allowedPrefixMatched then
     validateReadOnlyArgs request
   else
     .deny (.readOnlyCommandNotAllowlisted request.lookupCommand)
@@ -336,27 +337,36 @@ def validateNetworkMode
           else
             .allow
 
-/-- Validation once argv prefix checks have passed. -/
-def validateAfterPrefixes (policy : Policy) (request : CommandRequest) : Decision :=
+/-- Validation once argv prefix checks have passed. `allowedPrefixMatched`
+    lets read-only mode treat an operator-configured prefix as an explicit
+    diagnostic command authorization alongside the built-in allowlist. -/
+def validateAfterPrefixes
+    (policy : Policy)
+    (allowedPrefixMatched : Bool)
+    (request : CommandRequest) : Decision :=
   match validateNetworkMode policy.mode policy.networkMode request with
   | .deny reason => .deny reason
   | .allow =>
       match policy.mode with
-      | .readOnly => validateReadOnlyCommand policy.readOnlyAllowlist request
+      | .readOnly =>
+          validateReadOnlyCommand
+            policy.readOnlyAllowlist
+            allowedPrefixMatched
+            request
       | .workspaceWrite => .allow
       | .unrestricted => .allow
 
 /-- Policy validation order: forbidden prefixes, allowed-prefix list, network
-    gate, and finally the read-only allowlist. -/
+    gate, and finally the read-only allowlist or matched operator prefix. -/
 def validatePolicy (policy : Policy) (request : CommandRequest) : Decision :=
   match firstMatchingPrefix request.argv policy.forbiddenArgvPrefixes with
   | some matched => .deny (.forbiddenPrefix matched)
   | none =>
       match policy.allowedArgvPrefixes with
-      | [] => validateAfterPrefixes policy request
+      | [] => validateAfterPrefixes policy false request
       | _ :: _ =>
           match firstMatchingPrefix request.argv policy.allowedArgvPrefixes with
           | none => .deny (.allowedPrefixRequired request.argv)
-          | some _ => validateAfterPrefixes policy request
+          | some _ => validateAfterPrefixes policy true request
 
 end CommandPolicy

--- a/crates/defra-agent/src/toolset/shared/command.rs
+++ b/crates/defra-agent/src/toolset/shared/command.rs
@@ -241,9 +241,9 @@ pub(crate) fn validate_command_policy(
         ));
     }
 
-    if !policy.allowed_argv_prefixes.is_empty()
-        && first_matching_prefix(&argv, &policy.allowed_argv_prefixes).is_none()
-    {
+    let allowed_prefix_matched =
+        first_matching_prefix(&argv, &policy.allowed_argv_prefixes).is_some();
+    if !policy.allowed_argv_prefixes.is_empty() && !allowed_prefix_matched {
         return Err(policy_denial(
             policy,
             DenialReason::AllowedPrefixRequired { argv },
@@ -253,7 +253,13 @@ pub(crate) fn validate_command_policy(
     validate_network_mode(command, args, policy)?;
 
     if matches!(policy.mode, CommandExecutionMode::ReadOnly) {
-        validate_read_only_command_inner(command, args, &policy.read_only_allowlist, policy)?;
+        validate_read_only_command_inner(
+            command,
+            args,
+            &policy.read_only_allowlist,
+            allowed_prefix_matched,
+            policy,
+        )?;
     }
 
     Ok(())
@@ -298,15 +304,17 @@ fn validate_read_only_command_inner(
     command: &str,
     args: &[String],
     allowlist: &[String],
+    allowed_prefix_matched: bool,
     policy: &CommandExecutionPolicy,
 ) -> std::result::Result<(), ToolError> {
     let command_key = executable_name_lookup_key(command).unwrap_or_else(|| command.to_string());
-    if !allowlist.iter().any(|allowed| {
+    let built_in_allowlisted = allowlist.iter().any(|allowed| {
         allowed == command
             || executable_name_lookup_key(allowed)
                 .as_deref()
                 .is_some_and(|allowed_key| allowed_key == command_key)
-    }) {
+    });
+    if !built_in_allowlisted && !allowed_prefix_matched {
         return Err(policy_denial(
             policy,
             DenialReason::ReadOnlyCommandNotAllowlisted {

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -899,6 +899,57 @@ fn command_policy_applies_forbidden_and_allowed_prefixes() {
 }
 
 #[test]
+fn read_only_policy_allows_operator_configured_diagnostic_prefix() {
+    let policy = CommandExecutionPolicy::read_only(default_read_only_commands())
+        .with_allowed_argv_prefixes(vec![vec![
+            "spctl".to_string(),
+            "--assess".to_string(),
+            "--type".to_string(),
+            "execute".to_string(),
+        ]]);
+
+    validate_command_policy(
+        "spctl",
+        &[
+            String::from("--assess"),
+            String::from("--type"),
+            String::from("execute"),
+            String::from("/Applications/Defra Agent.app"),
+        ],
+        &policy,
+    )
+    .unwrap();
+    assert!(validate_command_policy(
+        "spctl",
+        &[String::from("--assess"), String::from("--raw")],
+        &policy,
+    )
+    .is_err());
+}
+
+#[test]
+fn read_only_policy_forbidden_prefix_overrides_configured_diagnostic_prefix() {
+    let policy = CommandExecutionPolicy::read_only(default_read_only_commands())
+        .with_allowed_argv_prefixes(vec![vec!["spctl".to_string(), "--assess".to_string()]])
+        .with_forbidden_argv_prefixes(vec![vec![
+            "spctl".to_string(),
+            "--assess".to_string(),
+            "--raw".to_string(),
+        ]]);
+
+    assert!(validate_command_policy(
+        "spctl",
+        &[
+            String::from("--assess"),
+            String::from("--raw"),
+            String::from("/Applications/Defra Agent.app"),
+        ],
+        &policy,
+    )
+    .is_err());
+}
+
+#[test]
 fn generated_command_policy_cases_match_rust_validation() {
     for case in lean_command_policy_cases() {
         let mode = rust_command_execution_mode(&case.mode);

--- a/crates/defra-agent/tests/state_machine_conformance/coverage.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/coverage.rs
@@ -167,7 +167,7 @@ pub(super) fn lean_executable_contracts_cover_initial_domains() {
     );
     assert_eq!(lean_contract_snapshot().tool_preflight_cases.len(), 9);
     assert_eq!(lean_contract_snapshot().tool_retry_cases.len(), 54);
-    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 46);
+    assert_eq!(lean_contract_snapshot().command_policy_cases.len(), 48);
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);

--- a/crates/defra-agent/tests/state_machine_conformance/tooling_slots_queue_command.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/tooling_slots_queue_command.rs
@@ -1318,6 +1318,19 @@ fn generated_command_policy_cases_cover_policy_sandbox_and_env_contracts() {
         Some(&vec!["curl".to_string(), "https://example.com".to_string()])
     );
 
+    let configured =
+        lean_command_policy_case("allowed_prefix_authorizes_read_only_diagnostic_command");
+    assert_eq!(configured.category, "read_only_configured_prefix");
+    assert_eq!(configured.decision, "allow");
+
+    let configured_forbidden =
+        lean_command_policy_case("forbidden_prefix_overrides_configured_read_only_diagnostic");
+    assert_eq!(configured_forbidden.decision, "deny");
+    assert_eq!(
+        configured_forbidden.denial_reason.as_deref(),
+        Some("forbiddenPrefix")
+    );
+
     let curl = lean_command_policy_case("disabled_network_read_only_curl_denies_before_allowlist");
     assert_eq!(
         curl.denial_reason.as_deref(),

--- a/docs/macos-bash-sandbox.md
+++ b/docs/macos-bash-sandbox.md
@@ -54,6 +54,44 @@ Manifest or direct DefraDB document:
 }
 ```
 
+## Read-Only Diagnostic Extensions
+
+Read-only bash has built-in host diagnostics for common steward commands such
+as `date`, `hostname`, `uptime`, `df`, `vm_stat`, `ps`, `lsof`, `curl`,
+`launchctl`, and `tailscale`.
+
+Operators can add another read-only diagnostic command family by configuring an
+allowed argv prefix on the tool selection. A matching allowed prefix authorizes
+that command for read-only bash without granting `bash_mode: Unrestricted`.
+The allowed-prefix list is still a global argv gate: when it is non-empty,
+include prefixes for every built-in read-only command shape the behavior should
+keep using. Forbidden prefixes still take precedence.
+
+```json
+{
+  "enable_bash": true,
+  "bash_mode": "ReadOnly",
+  "command_execution_policy": "read_only",
+  "command_allowed_argv_prefixes": [
+    "spctl --assess --type execute"
+  ],
+  "command_forbidden_argv_prefixes": [
+    "spctl --assess --raw"
+  ]
+}
+```
+
+The allowed prefix is an argv prefix, not a shell string. It can also be written
+as JSON when an argument contains spaces:
+
+```json
+{
+  "command_allowed_argv_prefixes": [
+    "[\"log\", \"show\", \"--last\", \"5m\"]"
+  ]
+}
+```
+
 ## macOS Seatbelt Profile
 
 The `workspace_write` policy uses a deny-by-default seatbelt profile with:


### PR DESCRIPTION
## Summary

Closes #85.

This adds support for operator-configured read-only diagnostic command prefixes. A matched `command_allowed_argv_prefixes` entry can now authorize a read-only bash command outside the built-in allowlist, while still preserving the existing command-policy ordering:

1. forbidden argv prefixes deny first
2. allowed argv prefixes gate the command when configured
3. network policy is checked
4. read-only validation allows either a built-in allowlisted command or the matched configured prefix

## Changes

- Let read-only command validation accept a matched allowed argv prefix as explicit diagnostic authorization
- Keep forbidden prefixes higher priority than configured diagnostic prefixes
- Extend Lean command-policy validation and theorem coverage for the new behavior
- Add generated command-policy cases for configured read-only diagnostics
- Update conformance coverage from 46 to 48 command-policy cases
- Document the read-only diagnostic extension semantics, including the global-gate behavior of non-empty allowed-prefix lists

## Testing

- `cargo test -p defra-agent --lib read_only_policy --no-default-features`
- `cargo test -p defra-agent --lib generated_command_policy_cases_match_rust_validation`
- `cargo test -p defra-agent --test state_machine_conformance lean_executable_contracts_cover_initial_domains`
- `cargo test -p defra-agent --test state_machine_conformance generated_command_policy_cases_cover_policy_sandbox_and_env_contracts`
- `cargo test -p defra-agent-cli --test cli_config_validate config_validate_accepts_normalized_manifest_root`
- `cargo test -p defra-agent-cli --test cli_config_tools tool_selection_upsert_defaults_enabled_modes_and_persists_command_policy`
- `git diff --check`
