### PR TITLE
Make /self a dedicated agent self-awareness endpoint

### DIFF
--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -14,8 +14,9 @@ use crate::http::fleet_slots::load_fleet_slot_snapshot;
 use crate::http::healthz::render_healthz_payload;
 use crate::http::prometheus::{
     load_metrics_query_data, render_prometheus_metrics, with_local_native_executors,
+    MetricsRuntimeRow,
 };
-use crate::http::self_view::load_self_view;
+use crate::http::self_view::{load_self_view, ContextBudget, SelfBehavior};
 use crate::http::version::version_response;
 use defra_agent::defra_query::CollectionScope;
 
@@ -53,7 +54,7 @@ pub(crate) fn runtime_contract_router(
         .route("/version", get(version_handler))
         .route("/healthz", get(healthz_handler))
         .route("/status", get(status_handler))
-        .route("/self", get(status_handler))
+        .route("/self", get(self_handler))
         .route("/fleet", get(fleet_handler))
         .route("/fleet/slots", get(fleet_slots_handler))
         .route(
@@ -180,6 +181,127 @@ async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
     (StatusCode::OK, axum::Json(body)).into_response()
 }
 
+async fn self_handler(State(state): State<RuntimeHttpState>) -> Response {
+    let (health, runtime, status_code) = match load_metrics_query_data(&state.graphql).await {
+        Ok(data) => {
+            let data = with_local_native_executors(data);
+            let health = render_healthz_payload(&state, Some(&data), None);
+            let status_code = if health.get("ok") == Some(&Value::Bool(true)) {
+                StatusCode::OK
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE
+            };
+            let runtime = data
+                .agent_runtimes
+                .iter()
+                .find(|runtime| runtime.agent_did == state.agent_did)
+                .or_else(|| data.agent_runtimes.first())
+                .cloned();
+            (health, runtime, status_code)
+        }
+        Err(error) => {
+            let health = render_healthz_payload(&state, None, Some(error.to_string()));
+            (health, None, StatusCode::SERVICE_UNAVAILABLE)
+        }
+    };
+
+    match load_self_view(&state.graphql, &state.agent_did).await {
+        Ok((behaviors, context_budget)) => {
+            let body = render_self_payload(
+                &state,
+                &health,
+                runtime.as_ref(),
+                &behaviors,
+                &context_budget,
+            );
+            (status_code, axum::Json(body)).into_response()
+        }
+        Err(error) => {
+            let mut body = json!({
+                "status": "unhealthy",
+                "ok": false,
+                "service": "defra-agent",
+                "version": version_response().version,
+                "started_at": state.started_at,
+                "uptime_seconds": state.started_instant.elapsed().as_secs(),
+                "graphql": state.graphql,
+                "agent_name": state.agent_name,
+                "agent_did": state.agent_did,
+                "process_state": "unknown",
+                "behavior": Value::Null,
+                "behaviors": [],
+                "context_budget": ContextBudget::default(),
+                "error": format!("self view query failed: {error:#}"),
+            });
+            if let Some(map) = body.as_object_mut() {
+                if let Some(health_status) = health.get("status").cloned() {
+                    map.insert("runtime_status".to_string(), health_status);
+                }
+            }
+            (StatusCode::INTERNAL_SERVER_ERROR, axum::Json(body)).into_response()
+        }
+    }
+}
+
+fn render_self_payload(
+    state: &RuntimeHttpState,
+    health: &Value,
+    runtime: Option<&MetricsRuntimeRow>,
+    behaviors: &[SelfBehavior],
+    context_budget: &ContextBudget,
+) -> Value {
+    let process_state = runtime
+        .map(|runtime| runtime.process_state.as_str())
+        .filter(|state| !state.is_empty())
+        .or_else(|| health.get("status").and_then(Value::as_str))
+        .unwrap_or("unknown");
+    let behavior = select_primary_behavior(behaviors)
+        .map(render_self_behavior)
+        .unwrap_or(Value::Null);
+    let behaviors = behaviors
+        .iter()
+        .map(render_self_behavior)
+        .collect::<Vec<_>>();
+
+    json!({
+        "status": health.get("status").cloned().unwrap_or(Value::String("unknown".to_string())),
+        "ok": health.get("ok").cloned().unwrap_or(Value::Bool(false)),
+        "service": "defra-agent",
+        "version": version_response().version,
+        "started_at": &state.started_at,
+        "uptime_seconds": state.started_instant.elapsed().as_secs(),
+        "graphql": &state.graphql,
+        "agent_name": &state.agent_name,
+        "agent_did": &state.agent_did,
+        "process_state": process_state,
+        "runtime": runtime,
+        "behavior": behavior,
+        "behaviors": behaviors,
+        "context_budget": context_budget,
+    })
+}
+
+fn select_primary_behavior(behaviors: &[SelfBehavior]) -> Option<&SelfBehavior> {
+    behaviors
+        .iter()
+        .find(|behavior| behavior.enabled)
+        .or_else(|| behaviors.first())
+}
+
+fn render_self_behavior(behavior: &SelfBehavior) -> Value {
+    json!({
+        "behavior_id": &behavior.behavior_id,
+        "display_name": &behavior.display_name,
+        "model_name": &behavior.model_name,
+        "enabled": behavior.enabled,
+        "backend_id": &behavior.backend_id,
+        "backend_provider": &behavior.provider_kind,
+        "backend_endpoint": &behavior.endpoint,
+        "inference_profile_id": &behavior.inference_profile_id,
+        "context_window": behavior.context_window,
+    })
+}
+
 async fn fleet_handler(State(state): State<RuntimeHttpState>) -> Response {
     match load_fleet_snapshot(&state.graphql).await {
         Ok(snapshot) => (StatusCode::OK, axum::Json(snapshot)).into_response(),
@@ -201,5 +323,128 @@ async fn fleet_slots_handler(State(state): State<RuntimeHttpState>) -> Response 
             format!("fleet slot snapshot failed: {error:#}"),
         )
             .into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use serde_json::json;
+
+    use super::*;
+
+    fn state() -> RuntimeHttpState {
+        RuntimeHttpState {
+            graphql: "http://127.0.0.1:9181/api/v0/graphql".to_string(),
+            agent_name: "amy".to_string(),
+            agent_did: "did:key:zAgent".to_string(),
+            started_at: "2026-06-04T00:00:00Z".to_string(),
+            started_instant: Instant::now(),
+        }
+    }
+
+    fn behavior(id: &str, enabled: bool, model_name: &str) -> SelfBehavior {
+        SelfBehavior {
+            behavior_id: id.to_string(),
+            display_name: id.to_string(),
+            model_name: model_name.to_string(),
+            enabled,
+            backend_id: format!("{id}-backend"),
+            provider_kind: "openai-compatible".to_string(),
+            endpoint: "https://api.example.test/v1".to_string(),
+            inference_profile_id: format!("{id}-profile"),
+            context_window: Some(128_000),
+        }
+    }
+
+    fn runtime(process_state: &str) -> MetricsRuntimeRow {
+        MetricsRuntimeRow {
+            agent_did: "did:key:zAgent".to_string(),
+            process_state: process_state.to_string(),
+            reconcile_phase: "idle".to_string(),
+            active_generation: 1,
+            router_generation: 1,
+            runnable_behavior_count: 1,
+            unavailable_behavior_count: 0,
+            last_reconcile_result: "applied".to_string(),
+            last_reconcile_completed_at: "2026-06-04T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn self_payload_uses_acceptance_field_names_and_primary_behavior() {
+        let behaviors = vec![
+            behavior("disabled", false, "llama-local"),
+            behavior("default", true, "gpt-4.1"),
+        ];
+        let payload = render_self_payload(
+            &state(),
+            &json!({ "status": "ok", "ok": true }),
+            Some(&runtime("ready")),
+            &behaviors,
+            &ContextBudget::default(),
+        );
+
+        assert_eq!(
+            payload.get("agent_name").and_then(Value::as_str),
+            Some("amy")
+        );
+        assert_eq!(
+            payload.get("agent_did").and_then(Value::as_str),
+            Some("did:key:zAgent")
+        );
+        assert_eq!(
+            payload.get("process_state").and_then(Value::as_str),
+            Some("ready")
+        );
+        assert_eq!(
+            payload
+                .pointer("/behavior/model_name")
+                .and_then(Value::as_str),
+            Some("gpt-4.1")
+        );
+        assert_eq!(
+            payload
+                .pointer("/behavior/backend_endpoint")
+                .and_then(Value::as_str),
+            Some("https://api.example.test/v1")
+        );
+        assert_eq!(
+            payload
+                .pointer("/behavior/backend_provider")
+                .and_then(Value::as_str),
+            Some("openai-compatible")
+        );
+        assert_eq!(
+            payload
+                .get("behaviors")
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn self_payload_falls_back_to_first_behavior_when_none_enabled() {
+        let behaviors = vec![behavior("fallback", false, "minimax")];
+        let payload = render_self_payload(
+            &state(),
+            &json!({ "status": "degraded", "ok": true }),
+            None,
+            &behaviors,
+            &ContextBudget::default(),
+        );
+
+        assert_eq!(
+            payload.get("process_state").and_then(Value::as_str),
+            Some("degraded")
+        );
+        assert_eq!(
+            payload
+                .pointer("/behavior/behavior_id")
+                .and_then(Value::as_str),
+            Some("fallback")
+        );
     }
 }

--- a/crates/defra-agent-cli/src/http/self_view.rs
+++ b/crates/defra-agent-cli/src/http/self_view.rs
@@ -2,7 +2,7 @@
 //! `InferenceBackend` (provider/endpoint) and `InferenceProfile`
 //! (`context_window`), plus an agent-scoped context-budget summary derived from
 //! persisted `CompactionEntry` rows. All of this data already exists; this is
-//! pure surfacing onto the `/status` payload (and the `/self` alias).
+//! pure surfacing for the runtime HTTP status and self-awareness endpoints.
 //!
 //! `CompactionEntry` is keyed by `session_id`, so the budget is scoped to the
 //! agent by first resolving the agent's own sessions (via `AgentRequest`


### PR DESCRIPTION
## Summary
- Wire `/self` to a dedicated handler instead of aliasing `/status`
- Return the agent identity, process state, version, uptime, primary behavior, all behaviors, and context budget
- Add `/self` behavior field names expected by observability clients: `backend_endpoint` and `backend_provider`
- Keep `/status` behavior unchanged and update stale self-view docs

Closes #367.

## Tests
- `cargo fmt`
- `git diff --check`
- `cargo test -p defra-agent-cli self_payload_`
- `cargo test -p defra-agent-cli self_view`
- `cargo check -p defra-agent-cli`

## Notes
- Attempted `cargo test -p defra-agent defra_query`, but it hung silently during compile/link and was terminated. The `defra_query` code path was not changed in this PR.