### PR TITLE
Wire opt-in config-apply --prune through the proven ApplyReconcile model (#364)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1210,6 +1210,12 @@ pub(crate) struct ConfigApplyArgs {
     pub(crate) bind_agent_did: Option<ManifestAgentDidBindingArg>,
     #[arg(long, default_value_t = false)]
     pub(crate) force_rebind_concrete_did: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Delete live-only desired-state documents absent from the manifest, routed through the proven ApplyReconcile delete-safety model"
+    )]
+    pub(crate) prune: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -24,7 +24,7 @@ pub(super) async fn config_apply(args: ConfigApplyArgs) -> Result<()> {
     })
     .await?
     .require_valid()?;
-    let report = apply_bound_desired_manifest(&args.root, &access, &bound).await?;
+    let report = apply_bound_desired_manifest(&args.root, &access, &bound, args.prune).await?;
     print_json(&serde_json::to_value(&report)?)?;
     if report.ok {
         Ok(())
@@ -37,6 +37,7 @@ pub(crate) async fn apply_bound_desired_manifest(
     root: &Path,
     access: &ConfigAccess,
     bound: &super::binding::BoundDesiredManifest,
+    prune: bool,
 ) -> Result<ConfigApplyReport> {
     let desired_manifest = &bound.manifest;
 
@@ -65,6 +66,7 @@ pub(crate) async fn apply_bound_desired_manifest(
         desired_manifest,
         live_principal.as_ref(),
         &live_manifest,
+        prune,
     );
 
     let applied = {
@@ -99,6 +101,7 @@ pub(crate) async fn apply_bound_desired_manifest(
         desired_manifest,
         remaining_principal.as_ref(),
         &remaining_manifest,
+        prune,
     );
 
     let report = ConfigApplyReport {

--- a/crates/defra-agent-cli/src/commands/config/diff.rs
+++ b/crates/defra-agent-cli/src/commands/config/diff.rs
@@ -40,5 +40,6 @@ pub(crate) async fn diff_bound_desired_manifest(
         desired_manifest,
         live_principal.as_ref(),
         &live_manifest,
+        false,
     ))
 }

--- a/crates/defra-agent-cli/src/commands/provision.rs
+++ b/crates/defra-agent-cli/src/commands/provision.rs
@@ -41,7 +41,8 @@ pub(crate) async fn provision(args: ProvisionArgs) -> Result<()> {
     .await?
     .require_valid()?;
 
-    let apply_report = apply::apply_bound_desired_manifest(&args.root, &access, &bound).await?;
+    let apply_report =
+        apply::apply_bound_desired_manifest(&args.root, &access, &bound, false).await?;
     let diff_report = diff::diff_bound_desired_manifest(&args.root, &access, &bound).await?;
     let ok = apply_report.ok && diff_report.ok;
     let report = ProvisionReport {

--- a/crates/defra-agent-cli/src/desired_state/diff.rs
+++ b/crates/defra-agent-cli/src/desired_state/diff.rs
@@ -12,13 +12,14 @@ pub(crate) fn diff_manifests(
     desired: &DesiredStateManifest,
     live_principal: Option<&DesiredAgentPrincipal>,
     live: &DesiredStateManifest,
+    prune: bool,
 ) -> DesiredStateDiffReport {
     let agent_principal = diff_single(
         &desired.agent_principal.agent_did,
         Some(&desired.agent_principal),
         live_principal,
     );
-    let collections = DesiredStateDiffCollections {
+    let mut collections = DesiredStateDiffCollections {
         agent_principal,
         agent_behaviors: diff_manifest_collection(&desired.agent_behaviors, &live.agent_behaviors),
         skills: diff_manifest_collection(&desired.skills, &live.skills),
@@ -39,6 +40,11 @@ pub(crate) fn diff_manifests(
         schedules: diff_manifest_collection(&desired.schedules, &live.schedules),
         event_triggers: diff_manifest_collection(&desired.event_triggers, &live.event_triggers),
     };
+
+    if prune {
+        let deletes = super::prune::prune_safe_deletes(desired, live);
+        collections.record_prune_deletes(&deletes);
+    }
 
     let counts = collections.counts();
     let ok = counts.is_exact_match();

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod convert;
 pub(crate) mod diff;
 pub(crate) mod load;
 pub(crate) mod normalize;
+pub(crate) mod prune;
 #[cfg(test)]
 mod tests;
 pub(crate) mod validate;
@@ -346,6 +347,37 @@ impl DesiredStateDiffCollections {
             Collection::Task => &self.tasks,
             Collection::Schedule => &self.schedules,
             Collection::EventTrigger => &self.event_triggers,
+        }
+    }
+
+    fn get_mut(&mut self, collection: Collection) -> &mut DesiredStateCollectionDiff {
+        match collection {
+            Collection::AgentPrincipal => &mut self.agent_principal,
+            Collection::AgentBehavior => &mut self.agent_behaviors,
+            Collection::Skill => &mut self.skills,
+            Collection::ToolSelection => &mut self.tool_selections,
+            Collection::InferenceBackend => &mut self.inference_backends,
+            Collection::InferenceProfile => &mut self.inference_profiles,
+            Collection::ToolServiceRegistry => &mut self.tool_service_registries,
+            Collection::Task => &mut self.tasks,
+            Collection::Schedule => &mut self.schedules,
+            Collection::EventTrigger => &mut self.event_triggers,
+        }
+    }
+
+    /// Record proven-safe prune deletes: move each pruned id from its
+    /// collection's `live_only` into `delete`. The deletes come from
+    /// `prune::prune_safe_deletes`, i.e. `apply_model::diff_prune`.
+    pub(crate) fn record_prune_deletes(
+        &mut self,
+        deletes: &[defra_agent::apply_model::DocRef],
+    ) {
+        for doc in deletes {
+            let diff = self.get_mut(doc.collection);
+            diff.live_only.retain(|id| id != &doc.id);
+            if !diff.delete.contains(&doc.id) {
+                diff.delete.push(doc.id.clone());
+            }
         }
     }
 

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -368,10 +368,7 @@ impl DesiredStateDiffCollections {
     /// Record proven-safe prune deletes: move each pruned id from its
     /// collection's `live_only` into `delete`. The deletes come from
     /// `prune::prune_safe_deletes`, i.e. `apply_model::diff_prune`.
-    pub(crate) fn record_prune_deletes(
-        &mut self,
-        deletes: &[defra_agent::apply_model::DocRef],
-    ) {
+    pub(crate) fn record_prune_deletes(&mut self, deletes: &[defra_agent::apply_model::DocRef]) {
         for doc in deletes {
             let diff = self.get_mut(doc.collection);
             diff.live_only.retain(|id| id != &doc.id);

--- a/crates/defra-agent-cli/src/desired_state/prune.rs
+++ b/crates/defra-agent-cli/src/desired_state/prune.rs
@@ -129,7 +129,10 @@ fn live_state_from_manifest(m: &DesiredStateManifest) -> LiveState {
 
     // Leaf dependencies (no outgoing structural references for prune safety).
     for s in &m.skills {
-        desired.insert(doc(Collection::Skill, &s.skill_id), DesiredFields::opaque(""));
+        desired.insert(
+            doc(Collection::Skill, &s.skill_id),
+            DesiredFields::opaque(""),
+        );
     }
     for b in &m.inference_backends {
         desired.insert(
@@ -172,7 +175,10 @@ fn manifest_from_desired(m: &DesiredStateManifest) -> Manifest {
         );
     }
     for s in &m.skills {
-        docs.insert(doc(Collection::Skill, &s.skill_id), DesiredFields::opaque(""));
+        docs.insert(
+            doc(Collection::Skill, &s.skill_id),
+            DesiredFields::opaque(""),
+        );
     }
     for ts in &m.tool_selections {
         docs.insert(

--- a/crates/defra-agent-cli/src/desired_state/prune.rs
+++ b/crates/defra-agent-cli/src/desired_state/prune.rs
@@ -1,0 +1,230 @@
+//! Production bridge from the CLI desired-state manifest to the proven
+//! `apply_model` so that config-apply `--prune` deletes live-only documents
+//! through the **same** delete-safety logic the Lean `ApplyReconcile` model
+//! pins (`t_delete_safety` / `delete_safe`), rather than an ad-hoc path.
+//!
+//! We build an `apply_model::LiveState` whose per-document `refs` capture the
+//! structural cross-document references declared by each config doc, then call
+//! `apply_model::diff_prune`. Its `.delete` is exactly the live-only set that
+//! no live document references — the proven-safe deletes.
+//!
+//! ## Reference map (REVIEW THIS — it is the safety boundary)
+//! A doc is protected from pruning while any live doc references it. We take a
+//! deliberately **conservative superset**: any FK that names another config
+//! doc counts, regardless of apply-order rank. `delete_safe` is monotone in
+//! refs, so over-inclusion can only ever *refuse* an otherwise-safe delete (the
+//! safe direction) — it can never permit deleting a referenced doc.
+//!
+//! | referrer | field(s) | referee |
+//! |---|---|---|
+//! | AgentPrincipal | `default_behavior_id` | AgentBehavior |
+//! | AgentBehavior | `backend_id` | InferenceBackend |
+//! | AgentBehavior | `inference_profile_id` | InferenceProfile |
+//! | AgentBehavior | `tool_selection_id` | ToolSelection |
+//! | AgentBehavior | `skill_refs[]` | Skill |
+//! | Task | `behavior_id` | AgentBehavior |
+//! | Schedule | `task_id` | Task |
+//! | EventTrigger | `task_id` | Task |
+//! | ToolSelection | `delegate_to[]` | AgentBehavior |
+//! | ToolSelection | `allowed_mcp_service_ids[]` | ToolServiceRegistry |
+//!
+//! ### Open questions for review
+//! - **Schedule → Task is same-rank** (both apply_order 2), so it is NOT a
+//!   `WellFormed` strictly-lower-rank reference in the Lean model. We include it
+//!   anyway for runtime safety (don't delete a task a schedule still fires).
+//!   `delete_safe` doesn't depend on rank, so this is sound at runtime; it just
+//!   means a same-rank protection lives outside the proven WellFormed invariant.
+//! - **ToolSelection → AgentBehavior** (`delegate_to`) inverts apply-order rank
+//!   (0 → 1); included for safety, same caveat as above.
+//! - **`Skill.tool_refs[]` is EXCLUDED**: its entries are tool identifiers whose
+//!   correspondence to a config doc id is not established here. If they can name
+//!   a ToolServiceRegistry, add that edge.
+//! - `agent_did` ownership fields are excluded (they name the principal, which
+//!   is the apply root, not a prunable lower-rank dependency).
+
+use std::collections::BTreeMap;
+
+use defra_agent::apply_model::{self, DesiredFields, DocRef, LiveState, Manifest};
+use defra_agent::Collection;
+
+use super::DesiredStateManifest;
+
+fn doc(collection: Collection, id: &str) -> DocRef {
+    DocRef {
+        collection,
+        id: id.to_string(),
+    }
+}
+
+/// Build the live `apply_model::LiveState`, projecting structural references
+/// (see module docs) into each doc's `refs` so `delete_safe` is faithful.
+fn live_state_from_manifest(m: &DesiredStateManifest) -> LiveState {
+    let mut desired: BTreeMap<DocRef, DesiredFields> = BTreeMap::new();
+
+    let principal_refs = m
+        .agent_principal
+        .default_behavior_id
+        .as_deref()
+        .map(|b| vec![doc(Collection::AgentBehavior, b)])
+        .unwrap_or_default();
+    desired.insert(
+        doc(Collection::AgentPrincipal, &m.agent_principal.agent_did),
+        DesiredFields::with_refs("", principal_refs),
+    );
+
+    for b in &m.agent_behaviors {
+        let mut refs = Vec::new();
+        if let Some(x) = &b.backend_id {
+            refs.push(doc(Collection::InferenceBackend, x));
+        }
+        if let Some(x) = &b.inference_profile_id {
+            refs.push(doc(Collection::InferenceProfile, x));
+        }
+        if let Some(x) = &b.tool_selection_id {
+            refs.push(doc(Collection::ToolSelection, x));
+        }
+        for s in &b.skill_refs {
+            refs.push(doc(Collection::Skill, s));
+        }
+        desired.insert(
+            doc(Collection::AgentBehavior, &b.behavior_id),
+            DesiredFields::with_refs("", refs),
+        );
+    }
+
+    for t in &m.tasks {
+        desired.insert(
+            doc(Collection::Task, &t.task_id),
+            DesiredFields::with_refs("", vec![doc(Collection::AgentBehavior, &t.behavior_id)]),
+        );
+    }
+
+    for s in &m.schedules {
+        desired.insert(
+            doc(Collection::Schedule, &s.schedule_id),
+            DesiredFields::with_refs("", vec![doc(Collection::Task, &s.task_id)]),
+        );
+    }
+
+    for e in &m.event_triggers {
+        desired.insert(
+            doc(Collection::EventTrigger, &e.trigger_id),
+            DesiredFields::with_refs("", vec![doc(Collection::Task, &e.task_id)]),
+        );
+    }
+
+    for ts in &m.tool_selections {
+        let mut refs = Vec::new();
+        for b in &ts.delegate_to {
+            refs.push(doc(Collection::AgentBehavior, b));
+        }
+        for sid in &ts.allowed_mcp_service_ids {
+            refs.push(doc(Collection::ToolServiceRegistry, sid));
+        }
+        desired.insert(
+            doc(Collection::ToolSelection, &ts.selection_id),
+            DesiredFields::with_refs("", refs),
+        );
+    }
+
+    // Leaf dependencies (no outgoing structural references for prune safety).
+    for s in &m.skills {
+        desired.insert(doc(Collection::Skill, &s.skill_id), DesiredFields::opaque(""));
+    }
+    for b in &m.inference_backends {
+        desired.insert(
+            doc(Collection::InferenceBackend, &b.backend_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for p in &m.inference_profiles {
+        desired.insert(
+            doc(Collection::InferenceProfile, &p.profile_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for r in &m.tool_service_registries {
+        desired.insert(
+            doc(Collection::ToolServiceRegistry, &r.service_id),
+            DesiredFields::opaque(""),
+        );
+    }
+
+    LiveState {
+        desired,
+        live: BTreeMap::new(),
+    }
+}
+
+/// The desired manifest as an `apply_model::Manifest`. Only DocRef identity
+/// matters for delete selection (a live doc is prunable iff absent here), so
+/// payloads are opaque.
+fn manifest_from_desired(m: &DesiredStateManifest) -> Manifest {
+    let mut docs: BTreeMap<DocRef, DesiredFields> = BTreeMap::new();
+    docs.insert(
+        doc(Collection::AgentPrincipal, &m.agent_principal.agent_did),
+        DesiredFields::opaque(""),
+    );
+    for b in &m.agent_behaviors {
+        docs.insert(
+            doc(Collection::AgentBehavior, &b.behavior_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for s in &m.skills {
+        docs.insert(doc(Collection::Skill, &s.skill_id), DesiredFields::opaque(""));
+    }
+    for ts in &m.tool_selections {
+        docs.insert(
+            doc(Collection::ToolSelection, &ts.selection_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for b in &m.inference_backends {
+        docs.insert(
+            doc(Collection::InferenceBackend, &b.backend_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for p in &m.inference_profiles {
+        docs.insert(
+            doc(Collection::InferenceProfile, &p.profile_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for r in &m.tool_service_registries {
+        docs.insert(
+            doc(Collection::ToolServiceRegistry, &r.service_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for t in &m.tasks {
+        docs.insert(doc(Collection::Task, &t.task_id), DesiredFields::opaque(""));
+    }
+    for s in &m.schedules {
+        docs.insert(
+            doc(Collection::Schedule, &s.schedule_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    for e in &m.event_triggers {
+        docs.insert(
+            doc(Collection::EventTrigger, &e.trigger_id),
+            DesiredFields::opaque(""),
+        );
+    }
+    Manifest { docs }
+}
+
+/// Proven-safe live-only deletes for pruning, in `apply_model` delete order
+/// (reverse apply-order). Routes through `apply_model::diff_prune`, so the
+/// selection is identical to what the Lean model and the apply conformance
+/// fence prove safe.
+pub(crate) fn prune_safe_deletes(
+    desired: &DesiredStateManifest,
+    live: &DesiredStateManifest,
+) -> Vec<DocRef> {
+    let m = manifest_from_desired(desired);
+    let l = live_state_from_manifest(live);
+    apply_model::diff_prune(&m, &l).delete
+}

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -139,7 +139,11 @@ fn prune_blocks_behavior_referenced_by_task() {
     live.tasks.push(task);
 
     let deletes = super::prune::prune_safe_deletes(&desired, &live);
-    assert!(deletes_contain(&deletes, defra_agent::Collection::Task, "t1"));
+    assert!(deletes_contain(
+        &deletes,
+        defra_agent::Collection::Task,
+        "t1"
+    ));
     assert!(
         !deletes_contain(&deletes, defra_agent::Collection::AgentBehavior, "b1"),
         "behavior referenced by a live task must not be pruned"
@@ -155,11 +159,16 @@ fn prune_blocks_task_referenced_by_schedule_and_trigger() {
     live.agent_behaviors.push(behavior_with("b1", None));
     live.tasks.push(task);
     live.schedules.push(sample_schedule("s1", "t1"));
-    live.event_triggers.push(sample_event_trigger_for("e1", "t1"));
+    live.event_triggers
+        .push(sample_event_trigger_for("e1", "t1"));
 
     let deletes = super::prune::prune_safe_deletes(&desired, &live);
     // schedule + trigger reference the task; task must be protected.
-    assert!(deletes_contain(&deletes, defra_agent::Collection::Schedule, "s1"));
+    assert!(deletes_contain(
+        &deletes,
+        defra_agent::Collection::Schedule,
+        "s1"
+    ));
     assert!(deletes_contain(
         &deletes,
         defra_agent::Collection::EventTrigger,

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -51,6 +51,169 @@ fn manifest_with_default_behavior() -> DesiredStateManifest {
     manifest
 }
 
+fn behavior_with(id: &str, backend_id: Option<&str>) -> DesiredAgentBehavior {
+    DesiredAgentBehavior {
+        behavior_id: id.to_string(),
+        agent_did: "did:defra-agent:test".to_string(),
+        display_name: None,
+        system_prompt: None,
+        backend_id: backend_id.map(|s| s.to_string()),
+        model_name: None,
+        tool_selection_id: None,
+        inference_profile_id: None,
+        compaction_strategy: None,
+        compaction_threshold: None,
+        enabled: true,
+        skill_refs: Vec::new(),
+        skill_excludes: Vec::new(),
+    }
+}
+
+fn backend(id: &str) -> DesiredInferenceBackend {
+    DesiredInferenceBackend {
+        backend_id: id.to_string(),
+        name: id.to_string(),
+        provider_kind: Default::default(),
+        endpoint: "http://localhost:1234".to_string(),
+        api_key: None,
+        api_key_env_var: None,
+        max_concurrent: 1,
+        max_queue_depth: 1,
+        enabled: true,
+        models: Vec::new(),
+    }
+}
+
+fn deletes_contain(
+    deletes: &[defra_agent::apply_model::DocRef],
+    collection: defra_agent::Collection,
+    id: &str,
+) -> bool {
+    deletes
+        .iter()
+        .any(|d| d.collection == collection && d.id == id)
+}
+
+#[test]
+fn prune_deletes_unreferenced_orphan_backend() {
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.inference_backends.push(backend("k-orphan"));
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    assert!(deletes_contain(
+        &deletes,
+        defra_agent::Collection::InferenceBackend,
+        "k-orphan"
+    ));
+}
+
+#[test]
+fn prune_blocks_backend_referenced_by_behavior() {
+    // Both live-only; the behavior references the backend.
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.inference_backends.push(backend("k1"));
+    live.agent_behaviors.push(behavior_with("b1", Some("k1")));
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    // The referrer (behavior) is deletable; the referenced backend is NOT.
+    assert!(deletes_contain(
+        &deletes,
+        defra_agent::Collection::AgentBehavior,
+        "b1"
+    ));
+    assert!(
+        !deletes_contain(&deletes, defra_agent::Collection::InferenceBackend, "k1"),
+        "backend referenced by a live behavior must not be pruned"
+    );
+}
+
+#[test]
+fn prune_blocks_behavior_referenced_by_task() {
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.agent_behaviors.push(behavior_with("b1", None));
+    let mut task = sample_task("t1");
+    task.behavior_id = "b1".to_string();
+    live.tasks.push(task);
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    assert!(deletes_contain(&deletes, defra_agent::Collection::Task, "t1"));
+    assert!(
+        !deletes_contain(&deletes, defra_agent::Collection::AgentBehavior, "b1"),
+        "behavior referenced by a live task must not be pruned"
+    );
+}
+
+#[test]
+fn prune_blocks_task_referenced_by_schedule_and_trigger() {
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    let mut task = sample_task("t1");
+    task.behavior_id = "b1".to_string();
+    live.agent_behaviors.push(behavior_with("b1", None));
+    live.tasks.push(task);
+    live.schedules.push(sample_schedule("s1", "t1"));
+    live.event_triggers.push(sample_event_trigger_for("e1", "t1"));
+
+    let deletes = super::prune::prune_safe_deletes(&desired, &live);
+    // schedule + trigger reference the task; task must be protected.
+    assert!(deletes_contain(&deletes, defra_agent::Collection::Schedule, "s1"));
+    assert!(deletes_contain(
+        &deletes,
+        defra_agent::Collection::EventTrigger,
+        "e1"
+    ));
+    assert!(
+        !deletes_contain(&deletes, defra_agent::Collection::Task, "t1"),
+        "task referenced by a live schedule/trigger must not be pruned"
+    );
+}
+
+#[test]
+fn diff_manifests_prune_records_deletes_in_collection_diff() {
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.inference_backends.push(backend("k-orphan"));
+
+    let report = diff_manifests(
+        &PathBuf::from("/tmp/fake-root"),
+        "local",
+        &desired,
+        Some(&live.agent_principal),
+        &live,
+        true,
+    );
+    assert_eq!(
+        report.collections.inference_backends.delete,
+        vec!["k-orphan".to_string()]
+    );
+    // Pruned doc moves out of live_only.
+    assert!(report.collections.inference_backends.live_only.is_empty());
+}
+
+#[test]
+fn diff_manifests_without_prune_records_no_deletes() {
+    let desired = empty_manifest("did:defra-agent:test");
+    let mut live = empty_manifest("did:defra-agent:test");
+    live.inference_backends.push(backend("k-orphan"));
+
+    let report = diff_manifests(
+        &PathBuf::from("/tmp/fake-root"),
+        "local",
+        &desired,
+        Some(&live.agent_principal),
+        &live,
+        false,
+    );
+    assert!(report.collections.inference_backends.delete.is_empty());
+    assert_eq!(
+        report.collections.inference_backends.live_only,
+        vec!["k-orphan".to_string()]
+    );
+}
+
 fn sample_task(task_id: &str) -> DesiredTask {
     DesiredTask {
         task_id: task_id.to_string(),
@@ -511,6 +674,7 @@ fn diff_manifests_creates_task_when_live_is_empty() {
         &desired,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(report.collections.tasks.create, vec!["summarize-inbox"]);
@@ -537,6 +701,7 @@ fn diff_manifests_creates_schedule_when_live_is_empty() {
         &desired,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(
@@ -568,6 +733,7 @@ fn diff_manifests_marks_task_update_when_prompt_changes() {
         &desired,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(report.collections.tasks.update, vec!["summarize-inbox"]);
@@ -593,6 +759,7 @@ fn diff_manifests_marks_tool_selection_update_when_mcp_allowlist_changes() {
         &desired,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(
@@ -621,6 +788,7 @@ fn diff_manifests_marks_schedule_update_when_interval_changes() {
         &desired,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(
@@ -643,6 +811,7 @@ fn diff_manifests_creates_event_trigger_when_live_is_empty() {
         &manifest,
         Some(&live.agent_principal),
         &live,
+        false,
     );
 
     assert_eq!(
@@ -669,6 +838,7 @@ fn diff_manifests_marks_event_trigger_update_when_filter_changes() {
         &manifest,
         Some(&live_manifest.agent_principal),
         &live_manifest,
+        false,
     );
 
     assert_eq!(


### PR DESCRIPTION
## Summary
Makes config-apply prune **functional and proof-backed**: wires an opt-in `--prune` flag through the **proven `apply_model::diff_prune`** so deleting live-only desired-state docs goes through the same delete-safety the Lean `ApplyReconcile` model pins (`t_delete_safety`/`delete_safe`) and the apply conformance fence guards. Completes the work #57 unblocked; supersedes the separate-prune approach in #376.

Before this, #57 landed the delete model + execution loop + fence, but the production CLI diff hardcoded `delete: Vec::new()` — so prune was inert. This adds the missing bridge.

## How it stays inside the proven boundary
- New `desired_state/prune.rs` builds an `apply_model::LiveState` from the live manifest, projecting cross-document **references** (FK fields → `DocRef`s) into each doc's `refs`, then calls `apply_model::diff_prune`. Its `.delete` is exactly the model's proven-safe set — **faithful by construction**, not a reimplementation.
- `diff_manifests(…, prune)` records those deletes into the per-collection diff (moving ids `live_only → delete`). The existing `apply_desired_state_changes` loop (from #57) executes them in `CONFIG_PRUNE_ORDER`. No new delete-execution path.
- Opt-in: `config apply --prune` (default off); `config diff` and `provision` pass `false`.

## Reference map — PLEASE REVIEW (this is the safety boundary)
A doc is protected from pruning while any live doc references it. I took a **conservative superset** — any FK naming another config doc counts, regardless of apply-order rank. `delete_safe` is monotone in refs, so over-inclusion can only ever *refuse* a safe delete (safe direction); it can never permit deleting a referenced doc.

| referrer | field(s) | referee |
|---|---|---|
| AgentPrincipal | `default_behavior_id` | AgentBehavior |
| AgentBehavior | `backend_id`, `inference_profile_id`, `tool_selection_id`, `skill_refs[]` | Backend / Profile / ToolSelection / Skill |
| Task | `behavior_id` | AgentBehavior |
| Schedule | `task_id` | Task |
| EventTrigger | `task_id` | Task |
| ToolSelection | `delegate_to[]`, `allowed_mcp_service_ids[]` | AgentBehavior / ToolServiceRegistry |

### Open questions for review
1. **`Schedule(2) → Task(2)` is same-rank**, so it is not a `WellFormed` strictly-lower-rank reference in the Lean model. Included anyway for runtime safety (don't delete a task a schedule still fires). `delete_safe` is rank-independent so it's sound at runtime, but this protection lives *outside* the proven WellFormed invariant. Same for `ToolSelection → AgentBehavior` (`delegate_to`, rank 0→1).
2. **`Skill.tool_refs[]` is EXCLUDED** — its entries are tool identifiers whose correspondence to a config doc id isn't established. Add the edge if they can name a ToolServiceRegistry.
3. `agent_did` ownership fields excluded (name the principal/apply-root, not a prunable lower-rank dep).

## Tests
`desired_state::tests`: orphan backend pruned; backend-referenced-by-behavior **protected**; behavior-referenced-by-task **protected**; task-referenced-by-schedule+trigger **protected**; `diff_manifests` prune-on records deletes (id moves out of `live_only`), prune-off records none.

## Verification (local)
- `cargo check -p defra-agent-cli --tests` — clean.
- The 6 new prune tests + the existing prune-order tests pass (`cargo test -p defra-agent-cli --bin defra-agent prune` → 9/9), including the three "referenced doc is protected" safety cases.
- **No Lean/proof files changed** (`git diff origin/main -- crates/defra-agent/proofs/` is empty), so `lake build` is unchanged from #57 (#383) where it is green.
- Convergence helpers (`is_exact_match`/`has_pending_apply`) already account for `delete`.
- Full `cargo test` suite is gated by this PR's CI (note: the repo's known #373 `cli_codex_shim` parallel-contamination flake is unrelated).

## Scope / relationship to #376
This is the proof-backed realization of #376's goal. #376's separate post-apply `prune_live_only_desired_state` (not routed through the model) should be closed as superseded.

Closes #364. Refs #57, #376.

🤖 Reviewer note: opened by request as **ready-for-review, NOT auto-merged** — destructive feature; reference map + same-rank/`Skill.tool_refs` judgment calls want a human check.
