### PR TITLE
Add context_budget observability tool + /self|/status indicator (split from #385)

### DIFF
--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -164,11 +164,12 @@ async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
     // Best-effort surfacing of the agent's own behaviors (with backend/profile
     // joined) and a context-budget summary. Failures here must not fail /status.
     if body.get("error").is_none() {
-        if let Ok((behaviors, context_budget)) =
+        if let Ok((behaviors, context_budget, context)) =
             load_self_view(&state.graphql, &state.agent_did).await
         {
             if let Some(map) = body.as_object_mut() {
                 map.insert("behaviors".to_string(), json!(behaviors));
+                map.insert("context".to_string(), json!(context));
                 map.insert("context_budget".to_string(), json!(context_budget));
             }
         }
@@ -206,7 +207,9 @@ async fn self_handler(State(state): State<RuntimeHttpState>) -> Response {
     };
 
     match load_self_view(&state.graphql, &state.agent_did).await {
-        Ok((behaviors, context_budget)) => {
+        // `/self` already returns the full `context_budget`; the compact context
+        // indicator (third tuple element, surfaced on `/status`) is redundant here.
+        Ok((behaviors, context_budget, _context_indicator)) => {
             let body = render_self_payload(
                 &state,
                 &health,

--- a/crates/defra-agent-cli/src/http/self_view.rs
+++ b/crates/defra-agent-cli/src/http/self_view.rs
@@ -54,6 +54,16 @@ pub(crate) struct ContextBudget {
     pub(crate) request_scan_limit: i64,
 }
 
+/// Compact `/status.context` indicator requested by observability clients.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub(crate) struct ContextIndicator {
+    pub(crate) max_tokens: Option<i64>,
+    pub(crate) current_estimate: Option<i64>,
+    pub(crate) utilization_percent: Option<f64>,
+    pub(crate) compaction_count: i64,
+    pub(crate) last_compacted_at: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct SelfViewEnvelope {
     #[serde(rename = "AgentBehavior", default)]
@@ -125,7 +135,7 @@ struct CompactionRow {
 pub(crate) async fn load_self_view(
     graphql: &str,
     agent_did: &str,
-) -> Result<(Vec<SelfBehavior>, ContextBudget)> {
+) -> Result<(Vec<SelfBehavior>, ContextBudget, ContextIndicator)> {
     let response = post_graphql(graphql, &self_view_query(agent_did)).await?;
     let envelope = decode::<SelfViewEnvelope>(response, "self view")?;
 
@@ -141,8 +151,9 @@ pub(crate) async fn load_self_view(
     };
     context_budget.sessions_considered = session_ids.len() as i64;
     context_budget.request_scan_limit = RECENT_REQUEST_SCAN as i64;
+    let context = build_context_indicator(&behaviors, &context_budget);
 
-    Ok((behaviors, context_budget))
+    Ok((behaviors, context_budget, context))
 }
 
 fn self_view_query(agent_did: &str) -> String {
@@ -285,6 +296,33 @@ fn aggregate_compaction(compactions: Vec<CompactionRow>) -> ContextBudget {
     }
 }
 
+fn build_context_indicator(
+    behaviors: &[SelfBehavior],
+    context_budget: &ContextBudget,
+) -> ContextIndicator {
+    let max_tokens = behaviors
+        .iter()
+        .filter(|behavior| behavior.enabled)
+        .filter_map(|behavior| behavior.context_window)
+        .filter(|value| *value > 0)
+        .max();
+    let current_estimate = context_budget
+        .latest_compacted_tokens
+        .or(context_budget.latest_original_tokens);
+    let utilization_percent = match (current_estimate, max_tokens) {
+        (Some(current), Some(max)) if max > 0 => Some((current as f64 / max as f64) * 100.0),
+        _ => None,
+    };
+
+    ContextIndicator {
+        max_tokens,
+        current_estimate,
+        utilization_percent,
+        compaction_count: context_budget.compaction_count,
+        last_compacted_at: context_budget.latest_compaction_at.clone(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -367,5 +405,52 @@ mod tests {
         let budget = aggregate_compaction(rows(json!([])));
         assert_eq!(budget.compaction_count, 0);
         assert_eq!(budget.latest_compaction_at, None);
+    }
+
+    #[test]
+    fn context_indicator_uses_enabled_behavior_window_and_latest_compaction() {
+        let behaviors = vec![
+            SelfBehavior {
+                behavior_id: "disabled".to_string(),
+                display_name: String::new(),
+                model_name: String::new(),
+                enabled: false,
+                backend_id: String::new(),
+                provider_kind: String::new(),
+                endpoint: String::new(),
+                inference_profile_id: String::new(),
+                context_window: Some(2000),
+            },
+            SelfBehavior {
+                behavior_id: "enabled".to_string(),
+                display_name: String::new(),
+                model_name: String::new(),
+                enabled: true,
+                backend_id: String::new(),
+                provider_kind: String::new(),
+                endpoint: String::new(),
+                inference_profile_id: String::new(),
+                context_window: Some(1000),
+            },
+        ];
+        let budget = ContextBudget {
+            compaction_count: 2,
+            latest_compaction_at: Some("2026-06-03T10:30:00Z".to_string()),
+            latest_original_tokens: Some(800),
+            latest_compacted_tokens: Some(400),
+            sessions_considered: 1,
+            request_scan_limit: RECENT_REQUEST_SCAN as i64,
+        };
+
+        let context = build_context_indicator(&behaviors, &budget);
+
+        assert_eq!(context.max_tokens, Some(1000));
+        assert_eq!(context.current_estimate, Some(400));
+        assert_eq!(context.utilization_percent, Some(40.0));
+        assert_eq!(context.compaction_count, 2);
+        assert_eq!(
+            context.last_compacted_at.as_deref(),
+            Some("2026-06-03T10:30:00Z")
+        );
     }
 }

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -19,8 +19,9 @@ use rig::tool::ToolDyn;
 use crate::defra_query::{build_defra_query_tool, CollectionScope, DEFRA_QUERY_TOOL_NAME};
 use crate::meta_tools::{build_meta_tools, META_TOOL_NAMES};
 use crate::toolset::{
-    background_tool_names, build_background_tools, build_delegate_tool, build_subagent_tools,
-    subagent_tool_names, CliToolConfig, ToolSet, DELEGATE_TOOL_NAME,
+    background_tool_names, build_background_tools, build_context_budget_tool, build_delegate_tool,
+    build_subagent_tools, subagent_tool_names, CliToolConfig, ToolSet, CONTEXT_BUDGET_TOOL_NAME,
+    DELEGATE_TOOL_NAME,
 };
 
 const DEFAULT_CLI_TIMEOUT_SECS: u64 = 10;
@@ -81,6 +82,7 @@ impl ToolSurface {
         names.extend(subagent_tool_names(&self.subagent_tools));
         names.extend(background_tool_names(&self.background_tools));
         names.extend(self.custom_tools.iter().map(|tool| tool.name().to_string()));
+        names.push(CONTEXT_BUDGET_TOOL_NAME.to_string());
         if self.enable_defra_query {
             names.push(DEFRA_QUERY_TOOL_NAME.to_string());
         }
@@ -111,6 +113,10 @@ impl ToolSurface {
         for tool in &self.custom_tools {
             tools.push(tool.build()?);
         }
+        tools.push(build_context_budget_tool(
+            runtime.node.clone(),
+            runtime.agent_did.clone(),
+        ));
         if self.enable_defra_query {
             tools.push(build_defra_query_tool(
                 runtime.node.clone(),

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -11,6 +11,7 @@ mod args;
 mod bash_tools;
 mod cancellable;
 mod cli_tool;
+mod context_budget;
 mod delegate;
 mod denial;
 mod file_tools;
@@ -33,6 +34,10 @@ use subagent::{
 
 use crate::tool_surface::{BackgroundToolConfig, SubagentToolConfig};
 
+pub use context_budget::{
+    build_context_budget_tool, load_context_budget_snapshot, ContextBudgetSnapshot,
+    CONTEXT_BUDGET_TOOL_NAME,
+};
 pub(crate) use denial::{CommandPolicyDenial, DenialReason};
 pub(crate) use shared::parse_argv_prefixes;
 pub use shared::{CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode};

--- a/crates/defra-agent/src/toolset/context_budget.rs
+++ b/crates/defra-agent/src/toolset/context_budget.rs
@@ -1,0 +1,363 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use defra_node::EmbeddedNode;
+use rig::completion::ToolDefinition;
+use rig::tool::{Tool, ToolDyn};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::graphql::escape_graphql_string;
+
+pub const CONTEXT_BUDGET_TOOL_NAME: &str = "context_budget";
+
+const RECENT_REQUEST_SCAN: usize = 200;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ContextBudgetParams {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ContextBudgetSnapshot {
+    pub max_tokens: Option<i64>,
+    pub current_estimate: Option<i64>,
+    pub utilization_percent: Option<f64>,
+    pub compaction_count: i64,
+    pub last_compacted_at: Option<String>,
+    pub sessions_considered: i64,
+    pub request_scan_limit: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ContextEnvelope {
+    #[serde(rename = "AgentBehavior", default)]
+    behaviors: Vec<BehaviorRow>,
+    #[serde(rename = "InferenceProfile", default)]
+    profiles: Vec<ProfileRow>,
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CompactionEnvelope {
+    #[serde(rename = "CompactionEntry", default)]
+    compactions: Vec<CompactionRow>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct BehaviorRow {
+    #[serde(default)]
+    inference_profile_id: Option<String>,
+    #[serde(default)]
+    enabled: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ProfileRow {
+    #[serde(default)]
+    profile_id: String,
+    #[serde(default)]
+    context_window: Option<i64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CompactionRow {
+    #[serde(default)]
+    created_at: Option<String>,
+    #[serde(default)]
+    original_tokens: Option<i64>,
+    #[serde(default)]
+    compacted_tokens: Option<i64>,
+}
+
+#[derive(Debug)]
+pub struct ContextBudgetToolError(anyhow::Error);
+
+impl std::fmt::Display for ContextBudgetToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+impl std::error::Error for ContextBudgetToolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.root_cause())
+    }
+}
+
+impl From<anyhow::Error> for ContextBudgetToolError {
+    fn from(error: anyhow::Error) -> Self {
+        Self(error)
+    }
+}
+
+#[derive(Clone)]
+pub struct ContextBudgetTool {
+    node: Arc<EmbeddedNode>,
+    agent_did: String,
+}
+
+impl ContextBudgetTool {
+    pub fn new(node: Arc<EmbeddedNode>, agent_did: impl Into<String>) -> Self {
+        Self {
+            node,
+            agent_did: agent_did.into(),
+        }
+    }
+}
+
+impl Tool for ContextBudgetTool {
+    const NAME: &'static str = CONTEXT_BUDGET_TOOL_NAME;
+
+    type Error = ContextBudgetToolError;
+    type Args = ContextBudgetParams;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Report this agent's persisted context-window budget signal: \
+                max context window from enabled behavior profiles, latest compaction token \
+                estimate, utilization percentage when calculable, compaction count, and latest \
+                compaction time."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "properties": {}
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let snapshot = load_context_budget_snapshot(&self.node, &self.agent_did).await?;
+        serde_json::to_string_pretty(&snapshot).map_err(|error| {
+            ContextBudgetToolError(anyhow!(
+                "failed to serialize context budget output: {error}"
+            ))
+        })
+    }
+}
+
+pub fn build_context_budget_tool(
+    node: Arc<EmbeddedNode>,
+    agent_did: impl Into<String>,
+) -> Box<dyn ToolDyn> {
+    Box::new(ContextBudgetTool::new(node, agent_did))
+}
+
+pub async fn load_context_budget_snapshot(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<ContextBudgetSnapshot> {
+    let agent_did = agent_did.trim();
+    if agent_did.is_empty() {
+        bail!("context_budget tool requires a running agent DID");
+    }
+
+    let resp = node.execute(&context_query(agent_did)).await;
+    if resp.has_errors() {
+        bail!("loading context budget failed: {:?}", resp.errors);
+    }
+    let envelope: ContextEnvelope = decode(resp.data.as_ref(), "context budget")?;
+    let max_tokens = max_context_window(&envelope.behaviors, &envelope.profiles);
+    let session_ids = distinct_session_ids(&envelope.requests);
+
+    let compactions = if session_ids.is_empty() {
+        Vec::new()
+    } else {
+        let resp = node.execute(&compaction_query(&session_ids)).await;
+        if resp.has_errors() {
+            bail!("loading context compactions failed: {:?}", resp.errors);
+        }
+        let envelope: CompactionEnvelope = decode(resp.data.as_ref(), "context compactions")?;
+        envelope.compactions
+    };
+
+    Ok(build_snapshot(
+        max_tokens,
+        session_ids.len() as i64,
+        compactions,
+    ))
+}
+
+fn context_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{
+            AgentBehavior(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}, order: {{ behavior_id: ASC }}) {{
+                inference_profile_id
+                enabled
+            }}
+            InferenceProfile(order: {{ profile_id: ASC }}) {{
+                profile_id
+                context_window
+            }}
+            AgentRequest(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}, order: {{ created_at: DESC }}, limit: {RECENT_REQUEST_SCAN}) {{
+                session_id
+            }}
+        }}"#
+    )
+}
+
+fn compaction_query(session_ids: &[String]) -> String {
+    let list = session_ids
+        .iter()
+        .map(|id| format!(r#""{}""#, escape_graphql_string(id)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        r#"{{
+            CompactionEntry(filter: {{ session_id: {{ _in: [{list}] }} }}, order: {{ created_at: DESC }}) {{
+                created_at
+                original_tokens
+                compacted_tokens
+            }}
+        }}"#
+    )
+}
+
+fn decode<T: serde::de::DeserializeOwned>(data: Option<&Value>, label: &str) -> Result<T> {
+    let data = data
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("{label} query response missing object data"))?;
+    serde_json::from_value(data).with_context(|| format!("decoding {label} query response"))
+}
+
+fn max_context_window(behaviors: &[BehaviorRow], profiles: &[ProfileRow]) -> Option<i64> {
+    let profiles = profiles
+        .iter()
+        .filter_map(|profile| {
+            let profile_id = profile.profile_id.trim();
+            let context_window = profile.context_window.filter(|value| *value > 0)?;
+            (!profile_id.is_empty()).then_some((profile_id, context_window))
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    behaviors
+        .iter()
+        .filter(|behavior| behavior.enabled.unwrap_or(true))
+        .filter_map(|behavior| behavior.inference_profile_id.as_deref())
+        .filter_map(|profile_id| profiles.get(profile_id.trim()).copied())
+        .max()
+}
+
+fn distinct_session_ids(requests: &[RequestRow]) -> Vec<String> {
+    requests
+        .iter()
+        .filter_map(|request| {
+            let session_id = request.session_id.as_deref().unwrap_or_default().trim();
+            (!session_id.is_empty()).then(|| session_id.to_string())
+        })
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn build_snapshot(
+    max_tokens: Option<i64>,
+    sessions_considered: i64,
+    compactions: Vec<CompactionRow>,
+) -> ContextBudgetSnapshot {
+    let compaction_count = compactions.len() as i64;
+    let latest = compactions
+        .iter()
+        .max_by(|a, b| a.created_at.cmp(&b.created_at));
+    let current_estimate = latest
+        .and_then(|entry| entry.compacted_tokens)
+        .or_else(|| latest.and_then(|entry| entry.original_tokens));
+    let utilization_percent = match (current_estimate, max_tokens) {
+        (Some(current), Some(max)) if max > 0 => Some((current as f64 / max as f64) * 100.0),
+        _ => None,
+    };
+
+    ContextBudgetSnapshot {
+        max_tokens,
+        current_estimate,
+        utilization_percent,
+        compaction_count,
+        last_compacted_at: latest.and_then(|entry| entry.created_at.clone()),
+        sessions_considered,
+        request_scan_limit: RECENT_REQUEST_SCAN as i64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rig::tool::Tool;
+
+    use super::*;
+
+    async fn seeded_node() -> Arc<EmbeddedNode> {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+        for mutation in [
+            r#"mutation {
+                create_InferenceProfile(input: {
+                    profile_id: "profile-context",
+                    context_window: 1000
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentBehavior(input: {
+                    behavior_id: "behavior-context",
+                    agent_did: "did:key:z-context",
+                    inference_profile_id: "profile-context",
+                    enabled: true
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "request-context",
+                    agent_did: "did:key:z-context",
+                    session_id: "session-context",
+                    status: "completed",
+                    created_at: "2026-06-03T10:00:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_CompactionEntry(input: {
+                    compaction_key: "session-context:1",
+                    session_id: "session-context",
+                    sequence: 1,
+                    original_tokens: 800,
+                    compacted_tokens: 400,
+                    created_at: "2026-06-03T10:30:00Z"
+                }) { _docID }
+            }"#,
+        ] {
+            let response = node.execute(mutation).await;
+            assert!(!response.has_errors(), "seed failed: {:?}", response.errors);
+        }
+
+        node
+    }
+
+    #[tokio::test]
+    async fn context_budget_tool_reports_persisted_context_signal() {
+        let node = seeded_node().await;
+        let tool = ContextBudgetTool::new(node, "did:key:z-context");
+
+        let output = Tool::call(&tool, ContextBudgetParams {}).await.unwrap();
+        let parsed: ContextBudgetSnapshot = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.max_tokens, Some(1000));
+        assert_eq!(parsed.current_estimate, Some(400));
+        assert_eq!(parsed.utilization_percent, Some(40.0));
+        assert_eq!(parsed.compaction_count, 1);
+        assert_eq!(
+            parsed.last_compacted_at.as_deref(),
+            Some("2026-06-03T10:30:00Z")
+        );
+        assert_eq!(parsed.sessions_considered, 1);
+    }
+}


### PR DESCRIPTION
## Summary
The **read-only `context_budget`** half of #385 (#368), split out so it can land while the agent-memory half stays parked for a design decision.

- New `context_budget` agent tool + a context-window utilization block on `/self` and `/status`: max tokens, current estimate, compaction count, last-compacted.
- Sourced from real data — `CompactionEntry` + `InferenceProfile.context_window`. **No new schema, no `AgentMemory`, no agent-writable memory.**

## Why split
#385 bundled `context_budget` (uncontroversial observability) with a free-form agent **memory** KV store. The memory model needs design work (see #385 + the KV issue + #17), so its merge is paused. This PR lands the uncontroversial half now.

## Verification
- `cargo check -p defra-agent-cli --tests` clean; full suite via CI.

Refs #368, #385.
