### PR TITLE
Add MCP pool runtime introspection endpoint

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
@@ -41,6 +41,7 @@ pub(crate) async fn load_mcp_services_with_health(
                 agent_did
                 endpoint
                 status
+                tool_count
                 failure_count
                 k_max
                 backoff_until
@@ -84,6 +85,7 @@ fn view_from_row(row: ToolServiceHealthStateRow) -> MCPServiceHealthView {
         agent_did: row.agent_did,
         endpoint: row.endpoint,
         status: row.status,
+        tool_count: row.tool_count,
         failure_count: row.failure_count,
         k_max: row.k_max,
         backoff_until: row.backoff_until,

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/mcp_health.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/mcp_health.rs
@@ -40,6 +40,7 @@ fn row_from_lean(case_name: &str, state: &str, count: usize) -> ToolServiceHealt
         agent_did: Some("did:defra:contract-agent".to_string()),
         endpoint: Some("127.0.0.1:9201/mcp".to_string()),
         status: Some(status.to_string()),
+        tool_count: Some(7),
         failure_count: Some(count as i64),
         k_max: Some(3),
         backoff_until: if status == "evicted" {
@@ -74,6 +75,7 @@ fn view_from_row(row: &ToolServiceHealthStateRow) -> MCPServiceHealthView {
         agent_did: row.agent_did.clone(),
         endpoint: row.endpoint.clone(),
         status: row.status.clone(),
+        tool_count: row.tool_count,
         failure_count: row.failure_count,
         k_max: row.k_max,
         backoff_until: row.backoff_until.clone(),

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -256,6 +256,7 @@ pub(crate) struct MCPServiceHealthView {
     pub agent_did: Option<String>,
     pub endpoint: Option<String>,
     pub status: Option<String>,
+    pub tool_count: Option<i64>,
     pub failure_count: Option<i64>,
     pub k_max: Option<i64>,
     pub backoff_until: Option<String>,

--- a/crates/defra-agent-cli/src/http/mcp_pool.rs
+++ b/crates/defra-agent-cli/src/http/mcp_pool.rs
@@ -1,0 +1,305 @@
+//! `/mcp/pool` surfacing: registered MCP services plus this agent's
+//! persisted health-probe view. This is an operator-oriented projection over
+//! `ToolServiceRegistry` and `ToolServiceHealthState`; it does not call remote
+//! MCP servers itself.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use defra_agent_protocol::graphql::escape_graphql_string;
+use defra_agent_protocol::row::{ToolServiceHealthStateRow, ToolServiceRegistryRow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::post_graphql;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolSnapshot {
+    pub(crate) generated_at: String,
+    pub(crate) agent_did: String,
+    pub(crate) totals: McpPoolTotals,
+    pub(crate) services: Vec<McpPoolService>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolTotals {
+    pub(crate) registered: usize,
+    pub(crate) online: usize,
+    pub(crate) healthy: usize,
+    pub(crate) degraded: usize,
+    pub(crate) unreachable: usize,
+    pub(crate) unknown: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolService {
+    pub(crate) service_id: String,
+    pub(crate) display_name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) hostname: Option<String>,
+    pub(crate) tailscale_ip: Option<String>,
+    pub(crate) lan_ip: Option<String>,
+    pub(crate) mcp_port: Option<i64>,
+    pub(crate) mcp_path: Option<String>,
+    pub(crate) send_agent_did: bool,
+    pub(crate) status: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) updated_at: Option<String>,
+    pub(crate) health_status: Option<String>,
+    pub(crate) tool_count: Option<i64>,
+    pub(crate) endpoint: Option<String>,
+    pub(crate) failure_count: Option<i64>,
+    pub(crate) k_max: Option<i64>,
+    pub(crate) backoff_until: Option<String>,
+    pub(crate) last_probe_at: Option<String>,
+    pub(crate) last_seen: Option<String>,
+    pub(crate) last_error_class: Option<String>,
+    pub(crate) last_error_message: Option<String>,
+    pub(crate) health_updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpPoolEnvelope {
+    #[serde(rename = "ToolServiceRegistry", default)]
+    registry: Vec<ToolServiceRegistryRow>,
+    #[serde(rename = "ToolServiceHealthState", default)]
+    health: Vec<ToolServiceHealthStateRow>,
+}
+
+pub(crate) async fn load_mcp_pool_snapshot(
+    graphql: &str,
+    agent_did: &str,
+) -> Result<McpPoolSnapshot> {
+    let generated_at = Utc::now();
+    let response = post_graphql(graphql, &mcp_pool_query(agent_did)).await?;
+    let envelope = decode_mcp_pool_response(response)?;
+    Ok(build_mcp_pool_snapshot(
+        generated_at,
+        agent_did.to_string(),
+        envelope,
+    ))
+}
+
+fn mcp_pool_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{
+            ToolServiceRegistry(order: {{ service_id: ASC }}) {{
+                service_id
+                display_name
+                description
+                hostname
+                tailscale_ip
+                lan_ip
+                mcp_port
+                mcp_path
+                send_agent_did
+                status
+                version
+                updated_at
+            }}
+            ToolServiceHealthState(
+                filter: {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                order: {{ service_id: ASC }}
+            ) {{
+                service_id
+                agent_did
+                endpoint
+                status
+                tool_count
+                failure_count
+                k_max
+                backoff_until
+                last_probe_at
+                last_seen
+                last_error_class
+                last_error_message
+                updated_at
+            }}
+        }}"#
+    )
+}
+
+fn decode_mcp_pool_response(response: Value) -> Result<McpPoolEnvelope> {
+    let data = response
+        .get("data")
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("mcp pool query response missing object data: {response}"))?;
+    serde_json::from_value(data).context("decoding mcp pool query response")
+}
+
+fn build_mcp_pool_snapshot(
+    generated_at: DateTime<Utc>,
+    agent_did: String,
+    envelope: McpPoolEnvelope,
+) -> McpPoolSnapshot {
+    let mut health_by_service = envelope
+        .health
+        .into_iter()
+        .map(|row| (row.service_id.clone(), row))
+        .collect::<BTreeMap<_, _>>();
+    let mut totals = McpPoolTotals::default();
+    let mut services = Vec::new();
+
+    for registry in envelope.registry {
+        let service_id = registry.service_id.trim().to_string();
+        if service_id.is_empty() {
+            continue;
+        }
+        totals.registered += 1;
+        if status_eq(registry.status.as_deref(), "online") {
+            totals.online += 1;
+        }
+
+        let health = health_by_service.remove(&service_id);
+        count_health_status(
+            &mut totals,
+            health.as_ref().and_then(|row| row.status.as_deref()),
+        );
+
+        services.push(McpPoolService {
+            service_id,
+            display_name: registry.display_name,
+            description: registry.description,
+            hostname: registry.hostname,
+            tailscale_ip: registry.tailscale_ip,
+            lan_ip: registry.lan_ip,
+            mcp_port: registry.mcp_port,
+            mcp_path: registry.mcp_path,
+            send_agent_did: registry.send_agent_did,
+            status: registry.status,
+            version: registry.version,
+            updated_at: registry.updated_at,
+            health_status: health.as_ref().and_then(|row| row.status.clone()),
+            tool_count: health.as_ref().and_then(|row| row.tool_count),
+            endpoint: health.as_ref().and_then(|row| row.endpoint.clone()),
+            failure_count: health.as_ref().and_then(|row| row.failure_count),
+            k_max: health.as_ref().and_then(|row| row.k_max),
+            backoff_until: health.as_ref().and_then(|row| row.backoff_until.clone()),
+            last_probe_at: health.as_ref().and_then(|row| row.last_probe_at.clone()),
+            last_seen: health.as_ref().and_then(|row| row.last_seen.clone()),
+            last_error_class: health.as_ref().and_then(|row| row.last_error_class.clone()),
+            last_error_message: health
+                .as_ref()
+                .and_then(|row| row.last_error_message.clone()),
+            health_updated_at: health.as_ref().and_then(|row| row.updated_at.clone()),
+        });
+    }
+
+    McpPoolSnapshot {
+        generated_at: generated_at.to_rfc3339(),
+        agent_did,
+        totals,
+        services,
+    }
+}
+
+fn status_eq(value: Option<&str>, expected: &str) -> bool {
+    value
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn count_health_status(totals: &mut McpPoolTotals, status: Option<&str>) {
+    match status.map(|value| value.trim().to_ascii_lowercase()) {
+        Some(status) if status == "healthy" => totals.healthy += 1,
+        Some(status) if status == "degraded" || status == "stale" => totals.degraded += 1,
+        Some(status)
+            if status == "evicted" || status == "reconnecting" || status == "unreachable" =>
+        {
+            totals.unreachable += 1;
+        }
+        Some(_) | None => totals.unknown += 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn joins_registry_with_agent_scoped_health_state() {
+        let snapshot = build_mcp_pool_snapshot(
+            at("2026-06-05T00:00:00Z"),
+            "did:key:zAgent".to_string(),
+            McpPoolEnvelope {
+                registry: vec![
+                    ToolServiceRegistryRow {
+                        service_id: "obs-mcp".to_string(),
+                        display_name: Some("Observability".to_string()),
+                        description: Some("Fleet observability".to_string()),
+                        hostname: Some("studio-1".to_string()),
+                        tailscale_ip: Some("100.64.0.10".to_string()),
+                        lan_ip: None,
+                        mcp_port: Some(9201),
+                        mcp_path: Some("/mcp".to_string()),
+                        send_agent_did: true,
+                        tools: Vec::new(),
+                        status: Some("online".to_string()),
+                        version: Some("test".to_string()),
+                        updated_at: Some("2026-06-05T00:00:00Z".to_string()),
+                    },
+                    ToolServiceRegistryRow {
+                        service_id: "silent-mcp".to_string(),
+                        display_name: None,
+                        description: None,
+                        hostname: None,
+                        tailscale_ip: None,
+                        lan_ip: None,
+                        mcp_port: None,
+                        mcp_path: None,
+                        send_agent_did: false,
+                        tools: Vec::new(),
+                        status: Some("offline".to_string()),
+                        version: None,
+                        updated_at: None,
+                    },
+                ],
+                health: vec![ToolServiceHealthStateRow {
+                    service_id: "obs-mcp".to_string(),
+                    agent_did: Some("did:key:zAgent".to_string()),
+                    endpoint: Some("http://100.64.0.10:9201/mcp".to_string()),
+                    status: Some("healthy".to_string()),
+                    tool_count: Some(12),
+                    failure_count: Some(0),
+                    k_max: Some(3),
+                    backoff_until: None,
+                    last_probe_at: Some("2026-06-05T00:00:00Z".to_string()),
+                    last_seen: Some("2026-06-05T00:00:00Z".to_string()),
+                    last_error_class: None,
+                    last_error_message: None,
+                    updated_at: Some("2026-06-05T00:00:00Z".to_string()),
+                }],
+            },
+        );
+
+        assert_eq!(snapshot.generated_at, "2026-06-05T00:00:00+00:00");
+        assert_eq!(snapshot.agent_did, "did:key:zAgent");
+        assert_eq!(
+            snapshot.totals,
+            McpPoolTotals {
+                registered: 2,
+                online: 1,
+                healthy: 1,
+                degraded: 0,
+                unreachable: 0,
+                unknown: 1,
+            }
+        );
+
+        let obs = snapshot
+            .services
+            .iter()
+            .find(|service| service.service_id == "obs-mcp")
+            .unwrap();
+        assert_eq!(obs.tool_count, Some(12));
+        assert_eq!(obs.health_status.as_deref(), Some("healthy"));
+        assert_eq!(obs.endpoint.as_deref(), Some("http://100.64.0.10:9201/mcp"));
+    }
+}

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod fleet_slots;
 pub(crate) mod healthz;
 pub(crate) mod identity_decide;
 pub(crate) mod liveness;
+pub(crate) mod mcp_pool;
 pub(crate) mod mcp_server;
 pub(crate) mod prometheus;
 pub(crate) mod r5_dispatch;

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use crate::http::fleet::load_fleet_snapshot;
 use crate::http::fleet_slots::load_fleet_slot_snapshot;
 use crate::http::healthz::render_healthz_payload;
+use crate::http::mcp_pool::load_mcp_pool_snapshot;
 use crate::http::prometheus::{
     load_metrics_query_data, render_prometheus_metrics, with_local_native_executors,
     MetricsRuntimeRow,
@@ -57,6 +58,7 @@ pub(crate) fn runtime_contract_router(
         .route("/self", get(self_handler))
         .route("/fleet", get(fleet_handler))
         .route("/fleet/slots", get(fleet_slots_handler))
+        .route("/mcp/pool", get(mcp_pool_handler))
         .route(
             "/subagents/dispatches",
             get(crate::http::r5_dispatch::subagent_dispatches_handler),
@@ -324,6 +326,18 @@ async fn fleet_slots_handler(State(state): State<RuntimeHttpState>) -> Response 
             StatusCode::INTERNAL_SERVER_ERROR,
             [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
             format!("fleet slot snapshot failed: {error:#}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn mcp_pool_handler(State(state): State<RuntimeHttpState>) -> Response {
+    match load_mcp_pool_snapshot(&state.graphql, &state.agent_did).await {
+        Ok(snapshot) => (StatusCode::OK, axum::Json(snapshot)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            format!("mcp pool snapshot failed: {error:#}"),
         )
             .into_response(),
     }

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -315,7 +315,7 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         behaviors.iter().any(|behavior| {
             behavior.get("model_name").and_then(Value::as_str) == Some(model_name.as_str())
                 && behavior
-                    .get("endpoint")
+                    .get("backend_endpoint")
                     .and_then(Value::as_str)
                     .is_some_and(|endpoint| !endpoint.is_empty())
         }),
@@ -355,6 +355,88 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
                     && agent.get("process_state").and_then(Value::as_str) == Some("ready")
             })),
         "expected /fleet to list this agent in ready state: {fleet}"
+    );
+
+    // /mcp/pool joins registered MCP services with this agent's persisted
+    // health state, including the last observed tool count.
+    let escaped_agent_did = escape_graphql_string(&agent_did);
+    for mutation in [
+        r#"mutation {
+            create_ToolServiceRegistry(input: {
+                service_id: "runtime-mcp-pool-obs",
+                display_name: "Runtime Observability",
+                description: "Runtime endpoint fixture",
+                hostname: "studio-1",
+                tailscale_ip: "100.64.0.10",
+                lan_ip: "192.168.1.10",
+                mcp_port: 9201,
+                mcp_path: "/mcp",
+                send_agent_did: true,
+                status: "online",
+                version: "test",
+                updated_at: "2026-06-05T00:00:00Z"
+            }) { _docID }
+        }"#
+        .to_string(),
+        format!(
+            r#"mutation {{
+                create_ToolServiceHealthState(input: {{
+                    service_id: "runtime-mcp-pool-obs",
+                    agent_did: "{escaped_agent_did}",
+                    endpoint: "http://100.64.0.10:9201/mcp",
+                    status: "healthy",
+                    tool_count: 3,
+                    failure_count: 0,
+                    k_max: 3,
+                    last_probe_at: "2026-06-05T00:00:00Z",
+                    last_seen: "2026-06-05T00:00:00Z",
+                    updated_at: "2026-06-05T00:00:00Z"
+                }}) {{ _docID }}
+            }}"#
+        ),
+    ] {
+        graphql_query(&graphql, &mutation)
+            .await
+            .context("seeding MCP pool fixtures")?;
+    }
+
+    let mcp_pool_response = client
+        .get(format!("http://127.0.0.1:{port}/mcp/pool"))
+        .send()
+        .await
+        .context("fetching /mcp/pool")?;
+    assert!(
+        mcp_pool_response.status().is_success(),
+        "unexpected /mcp/pool response: {mcp_pool_response:?}"
+    );
+    let mcp_pool: Value = mcp_pool_response
+        .json()
+        .await
+        .context("reading /mcp/pool body")?;
+    assert_eq!(
+        mcp_pool.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        mcp_pool.pointer("/totals/online").and_then(Value::as_i64),
+        Some(1),
+        "expected /mcp/pool totals to count the seeded online service: {mcp_pool}"
+    );
+    assert_eq!(
+        mcp_pool.pointer("/totals/healthy").and_then(Value::as_i64),
+        Some(1),
+        "expected /mcp/pool totals to count the seeded healthy service: {mcp_pool}"
+    );
+    assert!(
+        mcp_pool
+            .get("services")
+            .and_then(Value::as_array)
+            .is_some_and(|services| services.iter().any(|service| {
+                service.get("service_id").and_then(Value::as_str) == Some("runtime-mcp-pool-obs")
+                    && service.get("tool_count").and_then(Value::as_i64) == Some(3)
+                    && service.get("health_status").and_then(Value::as_str) == Some("healthy")
+            })),
+        "expected /mcp/pool to include the seeded service and tool count: {mcp_pool}"
     );
 
     // /mcp is opt-in: this server was started without --enable-mcp, so the

--- a/crates/defra-agent-protocol/schemas/services/tool_service_health_state.graphql
+++ b/crates/defra-agent-protocol/schemas/services/tool_service_health_state.graphql
@@ -9,6 +9,7 @@ type ToolServiceHealthState {
     agent_did: String @index
     endpoint: String
     status: String @index
+    tool_count: Int
     failure_count: Int
     k_max: Int
     backoff_until: DateTime

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -659,6 +659,8 @@ pub struct ToolServiceHealthStateRow {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub tool_count: Option<i64>,
+    #[serde(default)]
     pub failure_count: Option<i64>,
     #[serde(default)]
     pub k_max: Option<i64>,

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -63,6 +63,14 @@ pub(in crate::agent) async fn run_agent(
         runtime_status.publish_error(&format!("{error:#}")).await;
         return Err(error);
     }
+    if let Err(error) =
+        crate::migration::ensure_tool_service_health_state_migrations(agent.node.clone())
+            .await
+            .context("ensure ToolServiceHealthState migrations")
+    {
+        runtime_status.publish_error(&format!("{error:#}")).await;
+        return Err(error);
+    }
     let health_map = ServiceHealthMap::new();
     let tool_runtime = ToolRuntimeContext::new_with_agent_did(
         agent.node.clone(),

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -73,6 +73,7 @@ struct ServiceHealthEntry {
     health: ServiceHealth,
     model: ServiceModelInternal,
     endpoint: Option<String>,
+    tool_count: Option<i64>,
     last_probe_at: DateTime<Utc>,
 }
 
@@ -85,6 +86,7 @@ impl ServiceHealthEntry {
             health,
             model,
             endpoint: None,
+            tool_count: None,
             last_probe_at,
         }
     }
@@ -94,6 +96,7 @@ impl ServiceHealthEntry {
         last_seen: DateTime<Utc>,
         last_error: Option<String>,
         endpoint: Option<String>,
+        tool_count: Option<i64>,
         last_probe_at: DateTime<Utc>,
     ) -> Self {
         Self {
@@ -104,6 +107,7 @@ impl ServiceHealthEntry {
             },
             model,
             endpoint,
+            tool_count,
             last_probe_at,
         }
     }
@@ -201,6 +205,7 @@ pub struct MCPServiceHealthSnapshot {
     pub service_id: String,
     pub endpoint: Option<String>,
     pub status: String,
+    pub tool_count: Option<i64>,
     pub failure_count: u32,
     pub k_max: u32,
     pub backoff_until: Option<DateTime<Utc>>,
@@ -252,6 +257,7 @@ impl ServiceHealthMap {
                 service_id: service_id.clone(),
                 endpoint: entry.endpoint.clone(),
                 status: entry.model.state.to_defradb().to_string(),
+                tool_count: entry.tool_count,
                 failure_count: entry.model.failure_count,
                 k_max,
                 backoff_until: entry.model.backoff_until,
@@ -465,6 +471,7 @@ pub async fn run_health_check_cycle(
             .map(|entry| entry.health.last_seen)
             .unwrap_or(heartbeat_seen_at);
         let previous_endpoint = previous.as_ref().and_then(|entry| entry.endpoint.clone());
+        let previous_tool_count = previous.as_ref().and_then(|entry| entry.tool_count);
 
         // The Lean model (`Proofs/MCPHealth/Transition.lean`) reaches the
         // `Reconnecting` state via `ProbeEvent::BackoffExpiry` between an
@@ -487,6 +494,7 @@ pub async fn run_health_check_cycle(
                 previous_model,
                 previous_last_seen,
                 previous_endpoint,
+                previous_tool_count,
                 "registry entry missing mcp_port".to_string(),
                 now,
                 options,
@@ -506,6 +514,7 @@ pub async fn run_health_check_cycle(
                 previous_model,
                 previous_last_seen,
                 previous_endpoint,
+                previous_tool_count,
                 "registry entry missing address fields".to_string(),
                 now,
                 options,
@@ -543,7 +552,7 @@ pub async fn run_health_check_cycle(
         )
         .await
         {
-            Ok(Ok(_)) => {
+            Ok(Ok(tools)) => {
                 let next_model = step_service(
                     previous_model,
                     ProbeEvent::ProbeSuccess { stale: is_stale },
@@ -551,6 +560,7 @@ pub async fn run_health_check_cycle(
                     options,
                 )
                 .expect("probeSuccess must preserve the service model");
+                let tool_count = Some(tools.tools.len() as i64);
                 health_map
                     .set_entry(
                         service_id.clone(),
@@ -559,6 +569,7 @@ pub async fn run_health_check_cycle(
                             now,
                             None,
                             Some(endpoint.clone()),
+                            tool_count,
                             now,
                         ),
                     )
@@ -578,6 +589,7 @@ pub async fn run_health_check_cycle(
                     previous_model,
                     previous_last_seen,
                     Some(endpoint.clone()),
+                    previous_tool_count,
                     error.to_string(),
                     now,
                     options,
@@ -597,6 +609,7 @@ pub async fn run_health_check_cycle(
                     previous_model,
                     previous_last_seen,
                     Some(endpoint.clone()),
+                    previous_tool_count,
                     "probe timed out".to_string(),
                     now,
                     options,
@@ -646,6 +659,7 @@ async fn apply_probe_failure(
     previous_model: ServiceModelInternal,
     previous_last_seen: DateTime<Utc>,
     endpoint: Option<String>,
+    tool_count: Option<i64>,
     error: String,
     now: DateTime<Utc>,
     options: &HealthCheckerOptions,
@@ -663,6 +677,7 @@ async fn apply_probe_failure(
                 previous_last_seen,
                 Some(error),
                 endpoint,
+                tool_count,
                 now,
             ),
         )
@@ -803,6 +818,10 @@ async fn upsert_persisted_health_state(
     let last_seen = entry.last_seen.to_rfc3339();
     let last_probe_at = entry.last_probe_at.to_rfc3339();
     let updated_at = now.to_rfc3339();
+    let tool_count_fragment = entry
+        .tool_count
+        .map(|count| count.to_string())
+        .unwrap_or_else(|| "null".to_string());
     let backoff_until_fragment = match entry.backoff_until {
         Some(dt) => format!(r#""{}""#, dt.to_rfc3339()),
         None => "null".to_string(),
@@ -835,6 +854,7 @@ async fn upsert_persisted_health_state(
                     agent_did: "{agent_did}",
                     endpoint: "{endpoint}",
                     status: "{status}",
+                    tool_count: {tool_count_fragment},
                     failure_count: {failure_count},
                     k_max: {k_max},
                     backoff_until: {backoff_until_fragment},
@@ -847,6 +867,7 @@ async fn upsert_persisted_health_state(
                 update: {{
                     endpoint: "{endpoint}",
                     status: "{status}",
+                    tool_count: {tool_count_fragment},
                     failure_count: {failure_count},
                     k_max: {k_max},
                     backoff_until: {backoff_until_fragment},

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -90,6 +90,10 @@ const ADD_TOOL_SERVICE_REGISTRY_SEND_AGENT_DID_PATCH: &str = r#"[
     {"op":"add","path":"/ToolServiceRegistry/Fields/-","value":{"Name":"send_agent_did","Kind":2}}
 ]"#;
 
+const ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolServiceHealthState/Fields/-","value":{"Name":"tool_count","Kind":5}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -560,6 +564,34 @@ pub async fn ensure_tool_service_registry_migrations(node: Arc<EmbeddedNode>) ->
     Ok(())
 }
 
+pub async fn ensure_tool_service_health_state_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("ToolServiceHealthState")
+        .context("get ToolServiceHealthState collection")?
+    else {
+        return Ok(());
+    };
+    if collection_has_field(&collection, "tool_count") {
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection(
+            "ToolServiceHealthState",
+            ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH,
+        )
+        .await
+        .context("patch_collection ToolServiceHealthState tool_count")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version ToolServiceHealthState tool_count")?;
+    tracing::info!(
+        version = %next.version_id,
+        "ToolServiceHealthState patched with tool_count field"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod patch_kind_tests {
     use super::*;
@@ -629,6 +661,7 @@ mod patch_kind_tests {
             ADD_AGENT_TOOL_CALL_R5_PATCH,
             ADD_AGENT_TOOL_CALL_COMMAND_DENIAL_PATCH,
             ADD_TOOL_SELECTION_R5_PATCH,
+            ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH,
         ] {
             for (name, kind) in field_kinds(patch) {
                 assert_ne!(kind, 17, "field {name} uses unassigned Kind 17");

--- a/crates/defra-agent/src/oneshot.rs
+++ b/crates/defra-agent/src/oneshot.rs
@@ -39,6 +39,7 @@ pub async fn run_openai_oneshot_with_tools(
     ensure_schemas(node.as_ref()).await?;
     crate::migration::ensure_tool_call_migrations(node.clone()).await?;
     crate::migration::ensure_tool_service_registry_migrations(node.clone()).await?;
+    crate::migration::ensure_tool_service_health_state_migrations(node.clone()).await?;
 
     let api_key = behavior.completion_client_api_key()?;
     let tool_runtime =


### PR DESCRIPTION
## Summary

Adds an operator-facing `/mcp/pool` runtime endpoint for MCP service visibility.

This endpoint joins `ToolServiceRegistry` with the current agent persisted `ToolServiceHealthState` rows, returning registered services, health status, probe metadata, tool counts, and aggregate totals.

Refs #338.

## Changes

- Add `GET /mcp/pool` runtime endpoint.
- Persist `tool_count` from successful MCP `list_tools` health probes.
- Add nullable `tool_count` to `ToolServiceHealthState`.
- Add an idempotent schema migration for existing homes.
- Pass `toolCount` through the desktop MCP health bridge.
- Add unit and live server coverage for the new endpoint.

## Verification

- `cargo test -p defra-agent no_patch_uses_the_unassigned_kind_17`
- `cargo test -p defra-agent-cli mcp_pool`
- `cargo test -p defra-agent-cli server_exposes_prometheus_metrics_endpoint`
- `cargo check -p defra-agent-desktop-tauri`
- `git diff --check`

`cargo check -p defra-agent-desktop-tauri` passes with existing dead-code warnings.