### PR TITLE
Sign desktop P2P admin requests with actor DID

### DIFF
--- a/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
@@ -115,7 +115,7 @@ impl ClientCore {
 
         let (peer_statuses, _peer_errors) = {
             let records = peer_directory.read().await.records().to_vec();
-            bootstrap_saved_peers(node.as_ref(), &p2p, &records, &options).await
+            bootstrap_saved_peers(node.as_ref(), &p2p, &records, &options, &principal).await
         };
         let peer_statuses = Arc::new(std::sync::RwLock::new(peer_statuses));
         let (p2p_health, _p2p_health_rx) = watch::channel(P2PHealth::default());
@@ -129,6 +129,7 @@ impl ClientCore {
             Arc::clone(&peer_statuses),
             p2p_health.clone(),
             p2p_control_rx,
+            Arc::new(principal.clone()),
             options.install_replicators_on_bootstrap,
         );
         let materialization_supervisor = spawn_materialization_supervisor_task(
@@ -166,6 +167,7 @@ pub(super) async fn bootstrap_saved_peers(
     p2p: &Arc<dyn P2POps>,
     records: &[PeerRecord],
     options: &ClientCoreOptions,
+    actor: &PrincipalIdentity,
 ) -> (Vec<ClientPeerStatus>, Vec<String>) {
     let mut statuses = Vec::with_capacity(records.len());
     let mut errors = Vec::new();
@@ -221,7 +223,7 @@ pub(super) async fn bootstrap_saved_peers(
 
                 if let Some(graphql) = record.graphql.as_deref() {
                     if p2p_pairing_enabled {
-                        match configure_local_runtime_pairing(node, p2p, record).await {
+                        match configure_local_runtime_pairing(node, p2p, record, actor).await {
                             Ok(()) => {
                                 if branchable_pair_sync_enabled() {
                                     match sync_branchable_collections_with_retry(
@@ -295,6 +297,7 @@ pub(super) async fn configure_local_runtime_pairing(
     node: &EmbeddedNode,
     p2p: &Arc<dyn P2POps>,
     record: &PeerRecord,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     if pairing_reconcile_enabled() {
         write_peer_pairing_desired(node, record).await?;
@@ -305,12 +308,13 @@ pub(super) async fn configure_local_runtime_pairing(
         .graphql
         .as_deref()
         .context("local runtime pairing requires a GraphQL endpoint")?;
-    configure_local_runtime_pairing_legacy(p2p, graphql).await
+    configure_local_runtime_pairing_legacy(p2p, graphql, actor).await
 }
 
 pub(super) async fn configure_local_runtime_pairing_legacy(
     p2p: &Arc<dyn P2POps>,
     graphql: &str,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     let desktop_listen_address = wait_for_bootstrap_listen_address(p2p, graphql).await?;
     local_runtime::complete_runtime_pairing(
@@ -320,6 +324,7 @@ pub(super) async fn configure_local_runtime_pairing_legacy(
             .into_iter()
             .map(str::to_owned)
             .collect(),
+        actor,
     )
     .await
 }

--- a/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
@@ -10,6 +10,7 @@ use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 
 use super::super::peer_directory::{PeerDirectory, PeerRecord};
+use super::super::principal_identity::PrincipalIdentity;
 use super::super::schema::subscribed_collection_names;
 use super::bootstrap::{
     add_replicator_with_retry, configure_local_runtime_pairing_legacy, connect_peer_with_retry,
@@ -36,6 +37,7 @@ pub(super) fn spawn_p2p_supervisor_task(
     peer_statuses: Arc<StdRwLock<Vec<ClientPeerStatus>>>,
     p2p_health: watch::Sender<P2PHealth>,
     mut control_rx: mpsc::Receiver<P2PSupervisorCommand>,
+    remote_admin_actor: Arc<PrincipalIdentity>,
     install_replicators_on_bootstrap: bool,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -75,6 +77,7 @@ pub(super) fn spawn_p2p_supervisor_task(
                 &p2p,
                 &peer_directory,
                 &peer_statuses,
+                &remote_admin_actor,
                 install_replicators_on_bootstrap,
                 manual_repair,
             )
@@ -95,6 +98,7 @@ async fn run_saved_peer_repair_cycle(
     p2p: &Arc<dyn P2POps>,
     peer_directory: &Arc<RwLock<PeerDirectory>>,
     peer_statuses: &Arc<StdRwLock<Vec<ClientPeerStatus>>>,
+    remote_admin_actor: &Arc<PrincipalIdentity>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
 ) {
@@ -123,6 +127,7 @@ async fn run_saved_peer_repair_cycle(
                 current_status,
                 install_replicators_on_bootstrap,
                 force_repair,
+                Some(remote_admin_actor.as_ref()),
             )
             .await;
             still_saved = peer_directory
@@ -138,7 +143,13 @@ async fn run_saved_peer_repair_cycle(
 
         if still_saved && pairing_reconcile_enabled() {
             let desired = load_desired_for_peer(node, &record).await;
-            run_pairing_reconcile_for_peer(&record, desired, peer_statuses).await;
+            run_pairing_reconcile_for_peer(
+                &record,
+                desired,
+                peer_statuses,
+                Arc::clone(remote_admin_actor),
+            )
+            .await;
         }
     }
 }
@@ -267,6 +278,7 @@ pub(super) async fn repair_saved_peer(
     current_status: Option<ClientPeerStatus>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
+    remote_admin_actor: Option<&PrincipalIdentity>,
 ) -> ClientPeerStatus {
     let mut status = current_status.unwrap_or_else(|| ClientPeerStatus {
         peer_id: record.peer_id.clone(),
@@ -363,12 +375,22 @@ pub(super) async fn repair_saved_peer(
         if pairing_reconcile_enabled() {
             status.last_error = None;
         } else if p2p_pairing_enabled_for_graphql(graphql) {
-            match configure_local_runtime_pairing_legacy(p2p, graphql).await {
-                Ok(()) => status.last_error = None,
-                Err(error) => {
+            match remote_admin_actor {
+                Some(actor) => {
+                    match configure_local_runtime_pairing_legacy(p2p, graphql, actor).await {
+                        Ok(()) => status.last_error = None,
+                        Err(error) => {
+                            status.last_error = Some(format!(
+                                "peer {} local runtime pairing failed: {}",
+                                record.label, error
+                            ));
+                        }
+                    }
+                }
+                None => {
                     status.last_error = Some(format!(
-                        "peer {} local runtime pairing failed: {}",
-                        record.label, error
+                        "peer {} local runtime pairing failed: desktop principal identity unavailable",
+                        record.label
                     ));
                 }
             }
@@ -444,11 +466,12 @@ async fn run_pairing_reconcile_for_peer(
     record: &PeerRecord,
     desired: PairingDesired,
     peer_statuses: &Arc<StdRwLock<Vec<ClientPeerStatus>>>,
+    remote_admin_actor: Arc<PrincipalIdentity>,
 ) {
     let Some(graphql_url) = record.graphql.as_deref() else {
         return;
     };
-    let admin = match HttpRemoteP2pAdmin::new(graphql_url) {
+    let admin = match HttpRemoteP2pAdmin::new_with_actor(graphql_url, remote_admin_actor) {
         Ok(admin) => admin,
         Err(error) => {
             tracing::warn!(

--- a/crates/defra-agent-desktop-core/src/client/core/tests.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/tests.rs
@@ -304,6 +304,7 @@ async fn repair_saved_peer_refreshes_network_before_redial() {
         }),
         false,
         false,
+        None,
     )
     .await;
 
@@ -338,6 +339,7 @@ async fn repair_saved_peer_forces_reconfiguration_while_peer_is_connected() {
         }),
         true,
         true,
+        None,
     )
     .await;
 

--- a/crates/defra-agent-desktop-core/src/client/core/writes.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/writes.rs
@@ -483,6 +483,7 @@ impl ClientCore {
                     self.node.as_ref(),
                     &self.p2p,
                     &record,
+                    self.principal(),
                 )
                 .await
                 {

--- a/crates/defra-agent-desktop-core/src/client/principal_identity.rs
+++ b/crates/defra-agent-desktop-core/src/client/principal_identity.rs
@@ -2,12 +2,12 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use crypto::Key;
-use identity::{Identity as _, RawIdentity};
+use identity::{FullIdentity as _, Identity as _, RawIdentity};
 use serde::{Deserialize, Serialize};
 
 use super::paths::DesktopPaths;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrincipalIdentity {
     did: String,
     public_key_bytes: Vec<u8>,
@@ -86,6 +86,15 @@ impl PrincipalIdentity {
 
     pub fn private_key_bytes(&self) -> &[u8] {
         &self.private_key_bytes
+    }
+
+    pub(crate) fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
+        RawIdentity::from_bytes(crypto::KeyType::Ed25519, &self.private_key_bytes)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("loading principal identity for {}", self.did))?
+            .sign(payload)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("signing payload as {}", self.did))
     }
 }
 

--- a/crates/defra-agent-desktop-core/src/local_runtime/http.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/http.rs
@@ -1,7 +1,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
+
+use crate::client::PrincipalIdentity;
+use crate::remote_admin::http_impl::{
+    hex_encode, signing_payload, ACTOR_DID_HEADER, ACTOR_SIGNATURE_HEADER, ACTOR_SIGNATURE_VERSION,
+    ACTOR_SIGNATURE_VERSION_HEADER,
+};
 
 pub(super) fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
     let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
@@ -39,25 +46,35 @@ pub(super) async fn http_get_json<T: for<'de> Deserialize<'de>>(
     serde_json::from_slice(&body).with_context(|| format!("decoding JSON response from {url}"))
 }
 
-pub(super) async fn http_post_json<B: Serialize>(
+pub(super) async fn http_post_json_signed<B: Serialize>(
     client: &reqwest::Client,
     url: &str,
+    path: &str,
     body: &B,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
+    let body = serde_json::to_vec(body).with_context(|| format!("encoding POST body for {url}"))?;
+    let signature = actor
+        .sign(&signing_payload("POST", path, &body))
+        .with_context(|| format!("signing POST request to {url}"))?;
     let response = client
         .post(url)
-        .json(body)
+        .header(ACTOR_DID_HEADER, actor.did())
+        .header(ACTOR_SIGNATURE_HEADER, hex_encode(&signature))
+        .header(ACTOR_SIGNATURE_VERSION_HEADER, ACTOR_SIGNATURE_VERSION)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body)
         .send()
         .await
-        .with_context(|| format!("sending POST request to {url}"))?;
+        .with_context(|| format!("sending signed POST request to {url}"))?;
     let status = response.status();
     let bytes = response
         .bytes()
         .await
-        .with_context(|| format!("reading POST response body from {url}"))?;
+        .with_context(|| format!("reading signed POST response body from {url}"))?;
     if !status.is_success() {
         anyhow::bail!(
-            "POST {url} failed with {status}: {}",
+            "signed POST {url} failed with {status}: {}",
             String::from_utf8_lossy(&bytes)
         );
     }

--- a/crates/defra-agent-desktop-core/src/local_runtime/pairing.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/pairing.rs
@@ -4,7 +4,10 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use tokio::time::{sleep, Instant};
 
-use super::http::{http_post_json, p2p_api_base};
+use crate::client::PrincipalIdentity;
+use crate::remote_admin::http_impl::signed_admin_path;
+
+use super::http::{http_post_json_signed, p2p_api_base};
 
 const PAIRING_RETRY_TIMEOUT: Duration = Duration::from_secs(20);
 const PAIRING_RETRY_BACKOFF: Duration = Duration::from_millis(250);
@@ -14,12 +17,18 @@ pub(crate) async fn complete_runtime_pairing(
     graphql: &str,
     desktop_listen_address: &str,
     collections: Vec<String>,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(HTTP_TIMEOUT)
         .build()
         .context("building local runtime pairing HTTP client")?;
     let api_base = p2p_api_base(graphql)?;
+    let api_base_path = reqwest::Url::parse(&api_base)
+        .with_context(|| format!("parsing runtime API base URL {api_base}"))?
+        .path()
+        .trim_end_matches('/')
+        .to_string();
     let connect_addrs = vec![desktop_listen_address.to_string()];
     let replicator = P2pReplicatorRequest {
         addresses: vec![desktop_listen_address.to_string()],
@@ -29,14 +38,30 @@ pub(crate) async fn complete_runtime_pairing(
 
     loop {
         let result = async {
-            http_post_json(&client, &format!("{api_base}/p2p/connect"), &connect_addrs).await?;
-            http_post_json(
+            http_post_json_signed(
                 &client,
-                &format!("{api_base}/p2p/collections"),
-                &collections,
+                &format!("{api_base}/p2p/connect"),
+                &signed_admin_path(&api_base_path, "/p2p/connect"),
+                &connect_addrs,
+                actor,
             )
             .await?;
-            http_post_json(&client, &format!("{api_base}/p2p/replicators"), &replicator).await?;
+            http_post_json_signed(
+                &client,
+                &format!("{api_base}/p2p/collections"),
+                &signed_admin_path(&api_base_path, "/p2p/collections"),
+                &collections,
+                actor,
+            )
+            .await?;
+            http_post_json_signed(
+                &client,
+                &format!("{api_base}/p2p/replicators"),
+                &signed_admin_path(&api_base_path, "/p2p/replicators"),
+                &replicator,
+                actor,
+            )
+            .await?;
             Ok::<(), anyhow::Error>(())
         }
         .await;

--- a/crates/defra-agent-desktop-core/src/local_runtime/tests.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/tests.rs
@@ -1,3 +1,4 @@
+use super::http::http_post_json_signed;
 use super::identity::{normalize_optional_string, resolve_p2p_peer_id};
 use super::pairing::P2pReplicatorRequest;
 use super::{
@@ -6,7 +7,13 @@ use super::{
     reset_desktop_runtime_state, runtime_discovery_url, runtime_graphql_url, runtime_status_url,
     DesktopInitSummary, LOCAL_STANDARD_SOURCE,
 };
-use crate::client::DesktopPaths;
+use crate::client::{DesktopPaths, PrincipalIdentity};
+use crate::remote_admin::http_impl::{
+    hex_encode, signed_admin_path, signing_payload, ACTOR_DID_HEADER, ACTOR_SIGNATURE_HEADER,
+    ACTOR_SIGNATURE_VERSION, ACTOR_SIGNATURE_VERSION_HEADER,
+};
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn sample_summary() -> DesktopInitSummary {
     DesktopInitSummary {
@@ -166,6 +173,50 @@ fn replicator_request_serializes_runtime_api_field_names() {
             "Addresses": ["127.0.0.1:9999/p2p/example"],
         })
     );
+}
+
+#[tokio::test]
+async fn signed_post_json_attaches_actor_headers() {
+    let server = MockServer::start().await;
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let paths = DesktopPaths::from_root(tempdir.path());
+    let actor = PrincipalIdentity::load_or_create(&paths)
+        .await
+        .expect("principal");
+    let body = vec!["AgentRequest".to_string()];
+    let body_bytes = serde_json::to_vec(&body).expect("body");
+    let expected_signature = hex_encode(
+        &actor
+            .sign(&signing_payload(
+                "POST",
+                &signed_admin_path("/api/v0", "/p2p/collections"),
+                &body_bytes,
+            ))
+            .expect("signature"),
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/api/v0/p2p/collections"))
+        .and(header(ACTOR_DID_HEADER, actor.did()))
+        .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+        .and(header(
+            ACTOR_SIGNATURE_VERSION_HEADER,
+            ACTOR_SIGNATURE_VERSION,
+        ))
+        .and(body_json(serde_json::json!(["AgentRequest"])))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    http_post_json_signed(
+        &reqwest::Client::new(),
+        &format!("{}/api/v0/p2p/collections", server.uri()),
+        &signed_admin_path("/api/v0", "/p2p/collections"),
+        &body,
+        &actor,
+    )
+    .await
+    .expect("signed post");
 }
 
 #[test]

--- a/crates/defra-agent-desktop-core/src/remote_admin/http_impl.rs
+++ b/crates/defra-agent-desktop-core/src/remote_admin/http_impl.rs
@@ -1,25 +1,48 @@
 //! HTTP transport implementation for `RemoteP2pAdmin`.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{header::CONTENT_TYPE, Client, Method, RequestBuilder};
 use serde::{Deserialize, Serialize};
+
+use crate::client::PrincipalIdentity;
 
 use super::trait_def::{
     RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
 };
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+pub const ACTOR_DID_HEADER: &str = "x-defra-actor-did";
+pub const ACTOR_SIGNATURE_HEADER: &str = "x-defra-actor-signature";
+pub const ACTOR_SIGNATURE_VERSION_HEADER: &str = "x-defra-actor-signature-version";
+pub const ACTOR_SIGNATURE_VERSION: &str = "p2p-admin-v1";
 
 pub struct HttpRemoteP2pAdmin {
     /// `http://host:port/api/v0`, used to compose `/p2p/*` URLs.
     api_base: String,
+    api_base_path: String,
     client: Client,
+    actor: Option<Arc<PrincipalIdentity>>,
 }
 
 impl HttpRemoteP2pAdmin {
     pub fn new(graphql_url: &str) -> RemoteP2pAdminResult<Self> {
+        Self::new_inner(graphql_url, None)
+    }
+
+    pub fn new_with_actor(
+        graphql_url: &str,
+        actor: Arc<PrincipalIdentity>,
+    ) -> RemoteP2pAdminResult<Self> {
+        Self::new_inner(graphql_url, Some(actor))
+    }
+
+    fn new_inner(
+        graphql_url: &str,
+        actor: Option<Arc<PrincipalIdentity>>,
+    ) -> RemoteP2pAdminResult<Self> {
         let trimmed = graphql_url.trim_end_matches('/');
         let api_base = trimmed
             .strip_suffix("/graphql")
@@ -33,11 +56,61 @@ impl HttpRemoteP2pAdmin {
             .timeout(DEFAULT_RPC_TIMEOUT)
             .build()
             .map_err(|e| RemoteP2pAdminError::LocalError(format!("reqwest build: {e}")))?;
-        Ok(Self { api_base, client })
+        let api_base_path = reqwest::Url::parse(&api_base)
+            .map_err(|e| RemoteP2pAdminError::LocalError(format!("invalid API base URL: {e}")))?
+            .path()
+            .trim_end_matches('/')
+            .to_string();
+        Ok(Self {
+            api_base,
+            api_base_path,
+            client,
+            actor,
+        })
     }
 
     fn url(&self, path: &str) -> String {
         format!("{}{}", self.api_base, path)
+    }
+
+    fn request(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<Vec<u8>>,
+    ) -> RemoteP2pAdminResult<RequestBuilder> {
+        let mut request = self.client.request(method.clone(), self.url(path));
+        let body_bytes = body.as_deref().unwrap_or_default();
+
+        if let Some(actor) = self.actor.as_ref() {
+            let signed_path = signed_admin_path(&self.api_base_path, path);
+            let payload = signing_payload(method.as_str(), &signed_path, body_bytes);
+            let signature = actor.sign(&payload).map_err(|error| {
+                RemoteP2pAdminError::LocalError(format!("signing remote admin request: {error:#}"))
+            })?;
+            request = request
+                .header(ACTOR_DID_HEADER, actor.did())
+                .header(ACTOR_SIGNATURE_HEADER, hex_encode(&signature))
+                .header(ACTOR_SIGNATURE_VERSION_HEADER, ACTOR_SIGNATURE_VERSION);
+        }
+
+        if let Some(body) = body {
+            request = request.header(CONTENT_TYPE, "application/json").body(body);
+        }
+
+        Ok(request)
+    }
+
+    fn json_request<T: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: &T,
+    ) -> RemoteP2pAdminResult<RequestBuilder> {
+        let body = serde_json::to_vec(body).map_err(|error| {
+            RemoteP2pAdminError::LocalError(format!("encoding remote admin request body: {error}"))
+        })?;
+        self.request(method, path, Some(body))
     }
 }
 
@@ -84,8 +157,7 @@ struct SyncBranchableBody<'a> {
 impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
     async fn peer_info(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/info"))
+            .request(Method::GET, "/p2p/info", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -97,8 +169,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn active_peers(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/active-peers"))
+            .request(Method::GET, "/p2p/active-peers", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -110,9 +181,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn connect(&self, addresses: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/connect"))
-            .json(addresses)
+            .json_request(Method::POST, "/p2p/connect", addresses)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -132,8 +201,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
         }
 
         let resp = self
-            .client
-            .get(self.url("/p2p/replicators"))
+            .request(Method::GET, "/p2p/replicators", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -161,9 +229,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             addresses,
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/replicators"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/replicators", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -178,9 +244,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
     ) -> RemoteP2pAdminResult<()> {
         let body = DeleteReplicatorBody { collections, id };
         let resp = self
-            .client
-            .delete(self.url("/p2p/replicators"))
-            .json(&body)
+            .json_request(Method::DELETE, "/p2p/replicators", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -190,8 +254,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn list_p2p_collections(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/collections"))
+            .request(Method::GET, "/p2p/collections", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -203,9 +266,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn add_p2p_collections(&self, collections: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/collections"))
-            .json(collections)
+            .json_request(Method::POST, "/p2p/collections", collections)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -215,9 +276,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn delete_p2p_collections(&self, collections: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .delete(self.url("/p2p/collections"))
-            .json(collections)
+            .json_request(Method::DELETE, "/p2p/collections", collections)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -227,8 +286,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn list_p2p_documents(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/documents"))
+            .request(Method::GET, "/p2p/documents", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -240,9 +298,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn add_p2p_documents(&self, doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/documents"))
-            .json(doc_ids)
+            .json_request(Method::POST, "/p2p/documents", doc_ids)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -252,9 +308,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn delete_p2p_documents(&self, doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .delete(self.url("/p2p/documents"))
-            .json(doc_ids)
+            .json_request(Method::DELETE, "/p2p/documents", doc_ids)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -274,9 +328,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/documents/sync"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/documents/sync", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -294,9 +346,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/collections/sync-versions"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/collections/sync-versions", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -314,9 +364,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/collections/sync-branchable"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/collections/sync-branchable", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -330,6 +378,39 @@ fn format_timeout(t: Option<Duration>) -> String {
         Some(d) => format!("{}s", d.as_secs()),
         None => String::new(),
     }
+}
+
+pub(crate) fn signing_payload(method: &str, path: &str, body: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(
+        ACTOR_SIGNATURE_VERSION.len() + method.len() + path.len() + body.len() + 3,
+    );
+    payload.extend_from_slice(ACTOR_SIGNATURE_VERSION.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(method.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(path.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(body);
+    payload
+}
+
+pub(crate) fn signed_admin_path(api_base_path: &str, path: &str) -> String {
+    let api_base_path = api_base_path.trim_end_matches('/');
+    if api_base_path.is_empty() {
+        path.to_string()
+    } else {
+        format!("{api_base_path}{path}")
+    }
+}
+
+pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn map_reqwest_err(e: reqwest::Error) -> RemoteP2pAdminError {
@@ -362,12 +443,87 @@ async fn check_status(resp: reqwest::Response) -> RemoteP2pAdminResult<reqwest::
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{body_json, method, path};
+    use crate::client::{DesktopPaths, PrincipalIdentity};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn admin_for(server: &MockServer) -> HttpRemoteP2pAdmin {
         let graphql = format!("{}/api/v0/graphql", server.uri());
         HttpRemoteP2pAdmin::new(&graphql).expect("admin constructs")
+    }
+
+    async fn signed_admin_for(server: &MockServer) -> (HttpRemoteP2pAdmin, Arc<PrincipalIdentity>) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let paths = DesktopPaths::from_root(tempdir.path());
+        let actor = Arc::new(PrincipalIdentity::load_or_create(&paths).await.unwrap());
+        let graphql = format!("{}/api/v0/graphql", server.uri());
+        let admin =
+            HttpRemoteP2pAdmin::new_with_actor(&graphql, Arc::clone(&actor)).expect("admin signs");
+        (admin, actor)
+    }
+
+    #[tokio::test]
+    async fn signed_admin_attaches_actor_headers_to_get_request() {
+        let server = MockServer::start().await;
+        let (admin, actor) = signed_admin_for(&server).await;
+        let expected_signature = hex_encode(
+            &actor
+                .sign(&signing_payload(
+                    "GET",
+                    &signed_admin_path("/api/v0", "/p2p/info"),
+                    &[],
+                ))
+                .expect("signature"),
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/p2p/info"))
+            .and(header(ACTOR_DID_HEADER, actor.did()))
+            .and(header(
+                ACTOR_SIGNATURE_VERSION_HEADER,
+                ACTOR_SIGNATURE_VERSION,
+            ))
+            .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<String>::new()))
+            .mount(&server)
+            .await;
+
+        admin.peer_info().await.expect("signed peer_info");
+    }
+
+    #[tokio::test]
+    async fn signed_admin_attaches_actor_headers_to_json_request() {
+        let server = MockServer::start().await;
+        let (admin, actor) = signed_admin_for(&server).await;
+        let collections = vec!["c1".to_string()];
+        let body = serde_json::to_vec(&collections).expect("body");
+        let expected_signature = hex_encode(
+            &actor
+                .sign(&signing_payload(
+                    "POST",
+                    &signed_admin_path("/api/v0", "/p2p/collections"),
+                    &body,
+                ))
+                .expect("signature"),
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/api/v0/p2p/collections"))
+            .and(header(ACTOR_DID_HEADER, actor.did()))
+            .and(header(
+                ACTOR_SIGNATURE_VERSION_HEADER,
+                ACTOR_SIGNATURE_VERSION,
+            ))
+            .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+            .and(body_json(serde_json::json!(["c1"])))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        admin
+            .add_p2p_collections(&collections)
+            .await
+            .expect("signed add");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Adds actor DID/signature headers to desktop `RemoteP2pAdmin` HTTP calls
- Signs legacy local-runtime P2P pairing POSTs with the same admin auth envelope
- Threads the desktop principal identity through bootstrap, writes, and supervisor repair paths
- Adds coverage for signed GET/JSON admin requests and signed local-runtime POSTs

## Notes

This is a client-side slice of #180. It prepares the desktop/admin HTTP path to carry authenticated actor identity, but does not yet implement the server-side NAC enforcement/verification path.

Refs #180

## Tests

- `cargo test -p defra-agent-desktop-core remote_admin`
- `cargo test -p defra-agent-desktop-core local_runtime`
- `cargo test -p defra-agent-desktop-core client_core`
- `git diff --check`