### PR TITLE
Bound hook-managed tool results before rig loop reuse

### DIFF
--- a/crates/defra-agent/src/hook/persistence/background_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/background_tools.rs
@@ -256,13 +256,16 @@ impl DefraSessionHook {
             executions.remove(&execution_call_id).await;
         });
 
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "tool_call_id": background_tool_call_id,
-            "tool_name": target_tool_name,
-            "await_mode": "background",
-            "status": "running"
-        }))))
+        Ok(self.skip_tool_result(
+            BACKGROUND_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "tool_call_id": background_tool_call_id,
+                "tool_name": target_tool_name,
+                "await_mode": "background",
+                "status": "running"
+            })),
+        ))
     }
 
     pub(super) async fn persist_wait_tool_call(
@@ -282,7 +285,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<WaitToolArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    WAIT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_TOOL_NAME,
                         "/",
@@ -293,7 +297,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                WAIT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     WAIT_TOOL_NAME,
                     "/tool_call_id",
@@ -308,7 +313,8 @@ impl DefraSessionHook {
         {
             Ok(result) => result,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    WAIT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_TOOL_NAME,
                         "/tool_call_id",
@@ -317,7 +323,7 @@ impl DefraSessionHook {
                 ));
             }
         };
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(WAIT_TOOL_NAME, result))
     }
 
     pub(super) async fn persist_list_background_tools_tool_call(
@@ -337,7 +343,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ListBackgroundToolsArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    LIST_BACKGROUND_TOOLS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         LIST_BACKGROUND_TOOLS_TOOL_NAME,
                         "/",
@@ -351,7 +358,7 @@ impl DefraSessionHook {
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize list_background_tools response: {error}")
         })?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(LIST_BACKGROUND_TOOLS_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_read_tool_output_tool_call(
@@ -371,7 +378,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ReadToolOutputArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    READ_TOOL_OUTPUT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         READ_TOOL_OUTPUT_TOOL_NAME,
                         "/",
@@ -382,7 +390,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim().to_string();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_TOOL_OUTPUT_TOOL_NAME,
                     "/tool_call_id",
@@ -396,16 +405,18 @@ impl DefraSessionHook {
                 let result = serde_json::to_value(response).map_err(|error| {
                     anyhow::anyhow!("serialize read_tool_output response: {error}")
                 })?;
-                Ok(ToolCallHookAction::skip(json_string(result)))
+                Ok(self.skip_tool_result(READ_TOOL_OUTPUT_TOOL_NAME, json_string(result)))
             }
-            ReadToolOutputOutcome::NotBackgrounded => Ok(ToolCallHookAction::skip(
+            ReadToolOutputOutcome::NotBackgrounded => Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_TOOL_OUTPUT_TOOL_NAME,
                     "/tool_call_id",
                     "tool_call_id must identify an ordinary backgrounded tool call",
                 ),
             )),
-            ReadToolOutputOutcome::NotAuthorized => Ok(ToolCallHookAction::skip(
+            ReadToolOutputOutcome::NotAuthorized => Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_tool_not_allowed_payload(
                     READ_TOOL_OUTPUT_TOOL_NAME,
                     "/tool_call_id",
@@ -434,7 +445,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<CancelToolArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    CANCEL_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_TOOL_NAME,
                         "/",
@@ -445,7 +457,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                CANCEL_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_TOOL_NAME,
                     "/tool_call_id",
@@ -458,7 +471,8 @@ impl DefraSessionHook {
             .as_deref()
             .is_some_and(|reason| reason.trim().is_empty())
         {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                CANCEL_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_TOOL_NAME,
                     "/reason",
@@ -473,7 +487,8 @@ impl DefraSessionHook {
         {
             Ok(lifecycle) => lifecycle,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    CANCEL_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_TOOL_NAME,
                         "/tool_call_id",
@@ -483,10 +498,10 @@ impl DefraSessionHook {
             }
         };
         if lifecycle.is_terminal() {
-            return self
+            let result = self
                 .background_tool_envelope(lifecycle, "explicit_cancel")
-                .await
-                .map(ToolCallHookAction::skip);
+                .await?;
+            return Ok(self.skip_tool_result(CANCEL_TOOL_NAME, result));
         }
 
         let notification_tool_name = lifecycle.tool_name().to_string();
@@ -515,10 +530,13 @@ impl DefraSessionHook {
                 "failed to append explicitly cancelled background tool notification"
             );
         }
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "tool_call_id": background_tool_call_id,
-            "status": "cancelled"
-        }))))
+        Ok(self.skip_tool_result(
+            CANCEL_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "tool_call_id": background_tool_call_id,
+                "status": "cancelled"
+            })),
+        ))
     }
 }

--- a/crates/defra-agent/src/hook/persistence/helpers.rs
+++ b/crates/defra-agent/src/hook/persistence/helpers.rs
@@ -201,6 +201,26 @@ pub(super) fn truncation_mode_for(tool_name: &str) -> TruncationMode {
     }
 }
 
+pub(super) fn bounded_tool_result_for_model(
+    tool_name: &str,
+    raw_result: &str,
+    limits: &crate::truncation::TruncationLimits,
+) -> String {
+    let (bounded, trigger, truncated) =
+        truncate_text(raw_result, truncation_mode_for(tool_name), limits);
+    if truncated {
+        tracing::warn!(
+            tool_name = %tool_name,
+            truncated_by = ?trigger,
+            original_bytes = raw_result.len(),
+            max_lines = limits.max_lines,
+            max_bytes = limits.max_bytes,
+            "bounded hook-managed tool result before returning it to rig"
+        );
+    }
+    bounded
+}
+
 pub(super) fn model_observation_for_tool_result(tool_name: &str, raw_result: &str) -> String {
     if !is_read_file_tool(tool_name) {
         return raw_result.to_string();
@@ -641,6 +661,21 @@ mod tests {
         let raw = r#"{"ok":true,"content":"still structured"}"#;
 
         assert_eq!(model_observation_for_tool_result("grep", raw), raw);
+    }
+
+    #[test]
+    fn hook_managed_tool_result_is_bounded_before_model_loop() {
+        let limits = crate::truncation::TruncationLimits {
+            max_lines: 2,
+            max_bytes: 80,
+        };
+        let raw = "line 1\nline 2\nline 3\nline 4";
+
+        let bounded = bounded_tool_result_for_model("wait_subagent", raw, &limits);
+
+        assert!(bounded.contains("line 1\nline 2"));
+        assert!(!bounded.contains("line 3"));
+        assert!(bounded.contains("[Showing lines 1-2 of 4"));
     }
 
     #[test]

--- a/crates/defra-agent/src/hook/persistence/message_spawn.rs
+++ b/crates/defra-agent/src/hook/persistence/message_spawn.rs
@@ -439,7 +439,7 @@ impl DefraSessionHook {
                 .await
                 .insert(internal_call_id.to_string(), lifecycle);
 
-            return Ok(ToolCallHookAction::skip(receipt));
+            return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, receipt));
         }
 
         let child_session_id = if let Err(error) = create_subagent_request_with_request_id(
@@ -473,7 +473,7 @@ impl DefraSessionHook {
                             failure_class: FailureClass::External,
                         })
                         .await?;
-                    return Ok(ToolCallHookAction::skip(result));
+                    return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result));
                 }
                 Err(_) => {
                     let result = service_unavailable_payload(
@@ -488,7 +488,7 @@ impl DefraSessionHook {
                             failure_class: FailureClass::External,
                         })
                         .await?;
-                    return Ok(ToolCallHookAction::skip(result));
+                    return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result));
                 }
             }
         } else if let Some(child_session_id) =
@@ -508,7 +508,7 @@ impl DefraSessionHook {
                     failure_class: FailureClass::External,
                 })
                 .await?;
-            return Ok(ToolCallHookAction::skip(result));
+            return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result));
         };
 
         if await_mode == AwaitMode::Background {
@@ -520,7 +520,7 @@ impl DefraSessionHook {
                 .await
                 .insert(internal_call_id.to_string(), lifecycle);
 
-            return Ok(ToolCallHookAction::skip(receipt));
+            return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, receipt));
         }
 
         self.in_flight_lifecycles
@@ -539,7 +539,7 @@ impl DefraSessionHook {
             )
             .await?;
 
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result))
     }
 
     pub(super) async fn subagent_target_host(

--- a/crates/defra-agent/src/hook/persistence/mod.rs
+++ b/crates/defra-agent/src/hook/persistence/mod.rs
@@ -58,3 +58,22 @@ mod subagent_bridge;
 mod subagent_tools;
 
 use helpers::*;
+
+impl DefraSessionHook {
+    /// Rig 0.35 lets `on_tool_call` substitute `Skip` text, but `on_tool_result`
+    /// cannot replace the result already headed into rig's live message vector.
+    /// Bound every hook-managed skip so defra-owned control tools do not become
+    /// an in-loop context bypass.
+    pub(super) fn skip_tool_result(
+        &self,
+        tool_name: &str,
+        result: impl Into<String>,
+    ) -> ToolCallHookAction {
+        let result = result.into();
+        ToolCallHookAction::skip(bounded_tool_result_for_model(
+            tool_name,
+            &result,
+            &self.truncation_limits,
+        ))
+    }
+}

--- a/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
@@ -954,7 +954,7 @@ impl DefraSessionHook {
             deadline_at,
         );
         lifecycle.spawn_failed(failure_class, &result).await?;
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -981,6 +981,6 @@ impl DefraSessionHook {
             deadline_at,
         );
         lifecycle.spawn_failed(failure_class, &result).await?;
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(tool_name, result))
     }
 }

--- a/crates/defra-agent/src/hook/persistence/subagent_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_tools.rs
@@ -18,20 +18,26 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<WaitSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     WAIT_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid wait_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        WAIT_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid wait_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 WAIT_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    WAIT_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
 
         let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
@@ -39,14 +45,15 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    return Ok(ToolCallHookAction::skip(service_unavailable_payload(
+                    let result = service_unavailable_payload(
                         WAIT_SUBAGENT_TOOL_NAME,
                         "/child_request_id",
                         format!(
                         "child subagent request is not available to this parent request: {error}"
                     ),
                         false,
-                    )));
+                    );
+                    return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
                 }
             };
 
@@ -78,7 +85,7 @@ impl DefraSessionHook {
             )
             .await?;
 
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result))
     }
 
     pub(super) async fn persist_list_subagents_tool_call(
@@ -98,18 +105,21 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ListSubagentsArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     LIST_SUBAGENTS_TOOL_NAME,
-                    "/",
-                    format!("invalid list_subagents arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        LIST_SUBAGENTS_TOOL_NAME,
+                        "/",
+                        format!("invalid list_subagents arguments: {error}"),
+                    ),
+                ));
             }
         };
         let response =
             handle_list_subagents(&self.node, &request_id, &self.agent_did, parsed).await?;
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize list_subagents response: {error}"))?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(LIST_SUBAGENTS_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_read_subagent_transcript_tool_call(
@@ -129,37 +139,46 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ReadSubagentTranscriptArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-                    "/",
-                    format!("invalid read_subagent_transcript arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                        "/",
+                        format!("invalid read_subagent_transcript arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim().to_string();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
 
         let Some(response) =
             handle_read_subagent_transcript(&self.node, &request_id, parsed).await?
         else {
-            return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+            return Ok(self.skip_tool_result(
                 READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
-                "/child_request_id",
-                &child_request_id,
-                "child is not a background subagent owned by this parent request",
-                Vec::new(),
-            )));
+                tool_not_allowed_payload(
+                    READ_SUBAGENT_TRANSCRIPT_TOOL_NAME,
+                    "/child_request_id",
+                    &child_request_id,
+                    "child is not a background subagent owned by this parent request",
+                    Vec::new(),
+                ),
+            ));
         };
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize read_subagent_transcript response: {error}")
         })?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(READ_SUBAGENT_TRANSCRIPT_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_steer_subagent_tool_call(
@@ -179,28 +198,37 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<SteerSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid steer_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid steer_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim().to_string();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 STEER_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
         let message = parsed.message.trim().to_string();
         if message.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 STEER_SUBAGENT_TOOL_NAME,
-                "/message",
-                "message is required",
-            )));
+                invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/message",
+                    "message is required",
+                ),
+            ));
         }
 
         let edge = match load_steer_subagent_target(&self.node, &request_id, &child_request_id)
@@ -208,29 +236,36 @@ impl DefraSessionHook {
         {
             SteerSubagentTarget::Found(edge) => edge,
             SteerSubagentTarget::NotAuthorized => {
-                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/child_request_id",
-                    &child_request_id,
-                    "child not owned by this parent request",
-                    Vec::new(),
-                )));
+                    tool_not_allowed_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/child_request_id",
+                        &child_request_id,
+                        "child not owned by this parent request",
+                        Vec::new(),
+                    ),
+                ));
             }
             SteerSubagentTarget::NotBackgrounded => {
-                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/child_request_id",
-                    &child_request_id,
-                    "foreground subagents cannot be steered; call cancel_subagent first",
-                    Vec::new(),
-                )));
+                    tool_not_allowed_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/child_request_id",
+                        &child_request_id,
+                        "foreground subagents cannot be steered; call cancel_subagent first",
+                        Vec::new(),
+                    ),
+                ));
             }
             SteerSubagentTarget::Terminal(state) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                let result = invalid_tool_arguments_payload(
                     STEER_SUBAGENT_TOOL_NAME,
                     "/child_request_id",
                     format!("child is in terminal state '{state}'; spawn a new subagent instead"),
-                )));
+                );
+                return Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, result));
             }
         };
 
@@ -278,7 +313,7 @@ impl DefraSessionHook {
         .await?;
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize steer_subagent response: {error}"))?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_cancel_subagent_tool_call(
@@ -298,31 +333,40 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<CancelSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     CANCEL_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid cancel_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        CANCEL_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid cancel_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 CANCEL_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    CANCEL_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
         if parsed
             .reason
             .as_deref()
             .is_some_and(|reason| reason.trim().is_empty())
         {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 CANCEL_SUBAGENT_TOOL_NAME,
-                "/reason",
-                "reason must be omitted or non-empty",
-            )));
+                invalid_tool_arguments_payload(
+                    CANCEL_SUBAGENT_TOOL_NAME,
+                    "/reason",
+                    "reason must be omitted or non-empty",
+                ),
+            ));
         }
 
         let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
@@ -330,14 +374,15 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    return Ok(ToolCallHookAction::skip(service_unavailable_payload(
+                    let result = service_unavailable_payload(
                         CANCEL_SUBAGENT_TOOL_NAME,
                         "/child_request_id",
                         format!(
                         "child subagent request is not available to this parent request: {error}"
                     ),
                         false,
-                    )));
+                    );
+                    return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
                 }
             };
 
@@ -374,15 +419,18 @@ impl DefraSessionHook {
         )
         .await?;
 
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "child_request_id": edge.child_request_id,
-            "child_session_id": edge.child_session_id,
-            "behavior_id": edge.behavior_id,
-            "status": "cancelled",
-            "active_interrupted": active_interrupted,
-            "descendants_cancelled": descendants_cancelled,
-            "queued_drained": queued_drained
-        }))))
+        Ok(self.skip_tool_result(
+            CANCEL_SUBAGENT_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "child_request_id": edge.child_request_id,
+                "child_session_id": edge.child_session_id,
+                "behavior_id": edge.behavior_id,
+                "status": "cancelled",
+                "active_interrupted": active_interrupted,
+                "descendants_cancelled": descendants_cancelled,
+                "queued_drained": queued_drained
+            })),
+        ))
     }
 }


### PR DESCRIPTION
## Summary

- Adds a shared cap for hook-managed tool results before returning `ToolCallHookAction::Skip` text to rig
- Routes subagent/background control tool outputs through the bounded skip helper
- Adds regression coverage for line/byte bounding of hook-managed model-facing results

## Notes

This is a practical #401 guardrail for defra-owned control tools. Rig 0.35 still does not let `on_tool_result` replace the already-executed tool output before rig appends it to its live in-loop message vector, so arbitrary normal `ToolDyn` results still require the owned-loop / rig-removal follow-up.

Refs #401

## Tests

- `cargo test -p defra-agent --lib hook_managed_tool_result_is_bounded_before_model_loop`
- `cargo test -p defra-agent --lib hook::tests`
- `cargo test -p defra-agent --test r4c_read_tool_output`
- `cargo test -p defra-agent --test r4c_read_subagent_transcript`
- `cargo test -p defra-agent --test r4_subagent_tools`
- `cargo test -p defra-agent --test r4c_list_background_tools`
- `cargo test -p defra-agent --test r4c_list_subagents`
- `cargo test -p defra-agent --test r4c_steer_subagent`
- `cargo test -p defra-agent --test r6_background_tools`
- `git diff --check`