### PR TITLE
Integrate Ivan runtime and config PR stack

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/commands/mcp_health.rs
@@ -41,6 +41,7 @@ pub(crate) async fn load_mcp_services_with_health(
                 agent_did
                 endpoint
                 status
+                tool_count
                 failure_count
                 k_max
                 backoff_until
@@ -84,6 +85,7 @@ fn view_from_row(row: ToolServiceHealthStateRow) -> MCPServiceHealthView {
         agent_did: row.agent_did,
         endpoint: row.endpoint,
         status: row.status,
+        tool_count: row.tool_count,
         failure_count: row.failure_count,
         k_max: row.k_max,
         backoff_until: row.backoff_until,

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/mcp_health.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/mcp_health.rs
@@ -40,6 +40,7 @@ fn row_from_lean(case_name: &str, state: &str, count: usize) -> ToolServiceHealt
         agent_did: Some("did:defra:contract-agent".to_string()),
         endpoint: Some("127.0.0.1:9201/mcp".to_string()),
         status: Some(status.to_string()),
+        tool_count: Some(7),
         failure_count: Some(count as i64),
         k_max: Some(3),
         backoff_until: if status == "evicted" {
@@ -74,6 +75,7 @@ fn view_from_row(row: &ToolServiceHealthStateRow) -> MCPServiceHealthView {
         agent_did: row.agent_did.clone(),
         endpoint: row.endpoint.clone(),
         status: row.status.clone(),
+        tool_count: row.tool_count,
         failure_count: row.failure_count,
         k_max: row.k_max,
         backoff_until: row.backoff_until.clone(),

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -256,6 +256,7 @@ pub(crate) struct MCPServiceHealthView {
     pub agent_did: Option<String>,
     pub endpoint: Option<String>,
     pub status: Option<String>,
+    pub tool_count: Option<i64>,
     pub failure_count: Option<i64>,
     pub k_max: Option<i64>,
     pub backoff_until: Option<String>,

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -1824,14 +1824,15 @@ mod lean_apply_write_boundary_tests {
                 })
                 .map(|reference| reference.id.clone())
                 .collect(),
+            delegate_to: Vec::new(),
             backgroundable_tool_names: Vec::new(),
             enable_defra_query: true,
             defra_query_collections: Vec::new(),
-            subagent_targets: None,
-            subagent_spawn_enabled: None,
-            subagent_steering_enabled: None,
-            subagent_background_enabled: None,
-            subagent_allow_cross_deployment: None,
+            subagent_targets: Vec::new(),
+            subagent_spawn_enabled: false,
+            subagent_steering_enabled: false,
+            subagent_background_enabled: false,
+            subagent_allow_cross_deployment: false,
             cross_deployment_spawn_timeout_seconds: None,
         }
     }

--- a/crates/defra-agent-cli/src/desired_state/convert.rs
+++ b/crates/defra-agent-cli/src/desired_state/convert.rs
@@ -142,6 +142,7 @@ pub(crate) fn manifest_from_export_bundle(
                         "cli_tool_names",
                         "enable_meta_tools",
                         "allowed_mcp_service_ids",
+                        "delegate_to",
                         "backgroundable_tool_names",
                         "enable_defra_query",
                         "defra_query_collections",

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -136,21 +136,23 @@ pub(crate) struct DesiredToolSelection {
     #[serde(default)]
     pub(crate) allowed_mcp_service_ids: Vec<String>,
     #[serde(default)]
+    pub(crate) delegate_to: Vec<String>,
+    #[serde(default)]
     pub(crate) backgroundable_tool_names: Vec<String>,
     #[serde(default = "default_true")]
     pub(crate) enable_defra_query: bool,
     #[serde(default)]
     pub(crate) defra_query_collections: Vec<String>,
     #[serde(default)]
-    pub(crate) subagent_targets: Option<Vec<String>>,
+    pub(crate) subagent_targets: Vec<String>,
     #[serde(default)]
-    pub(crate) subagent_spawn_enabled: Option<bool>,
+    pub(crate) subagent_spawn_enabled: bool,
     #[serde(default)]
-    pub(crate) subagent_steering_enabled: Option<bool>,
+    pub(crate) subagent_steering_enabled: bool,
     #[serde(default)]
-    pub(crate) subagent_background_enabled: Option<bool>,
+    pub(crate) subagent_background_enabled: bool,
     #[serde(default)]
-    pub(crate) subagent_allow_cross_deployment: Option<bool>,
+    pub(crate) subagent_allow_cross_deployment: bool,
     #[serde(default)]
     pub(crate) cross_deployment_spawn_timeout_seconds: Option<i64>,
 }

--- a/crates/defra-agent-cli/src/desired_state/normalize.rs
+++ b/crates/defra-agent-cli/src/desired_state/normalize.rs
@@ -55,6 +55,8 @@ pub(crate) fn normalize_manifest(manifest: &mut DesiredStateManifest) {
         selection.allowed_mcp_service_ids.dedup();
         selection.backgroundable_tool_names.sort();
         selection.backgroundable_tool_names.dedup();
+        selection.subagent_targets.sort();
+        selection.subagent_targets.dedup();
     }
     for backend in &mut manifest.inference_backends {
         normalize_optional_string(&mut backend.api_key);

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -256,14 +256,15 @@ fn sample_tool_selection(selection_id: &str) -> DesiredToolSelection {
         cli_tool_names: Vec::new(),
         enable_meta_tools: true,
         allowed_mcp_service_ids: Vec::new(),
+        delegate_to: Vec::new(),
         backgroundable_tool_names: Vec::new(),
         enable_defra_query: true,
         defra_query_collections: Vec::new(),
-        subagent_targets: None,
-        subagent_spawn_enabled: None,
-        subagent_steering_enabled: None,
-        subagent_background_enabled: None,
-        subagent_allow_cross_deployment: None,
+        subagent_targets: Vec::new(),
+        subagent_spawn_enabled: false,
+        subagent_steering_enabled: false,
+        subagent_background_enabled: false,
+        subagent_allow_cross_deployment: false,
         cross_deployment_spawn_timeout_seconds: None,
     }
 }
@@ -366,6 +367,57 @@ fn tool_service_registry_round_trip_preserves_send_agent_did() {
     let round_tripped = manifest_from_export_bundle(bundle.as_bundle())
         .expect("manifest should parse back from bundle");
     assert!(round_tripped.tool_service_registries[0].send_agent_did);
+}
+
+#[test]
+fn tool_selection_round_trip_preserves_subagent_controls() {
+    let mut manifest = empty_manifest("did:defra-agent:test");
+    let mut selection = sample_tool_selection("default-tools");
+    selection.subagent_targets = vec!["researcher".to_string()];
+    selection.subagent_spawn_enabled = true;
+    selection.subagent_steering_enabled = true;
+    selection.subagent_background_enabled = true;
+    selection.subagent_allow_cross_deployment = true;
+    selection.cross_deployment_spawn_timeout_seconds = Some(90);
+    manifest.tool_selections.push(selection);
+
+    let bundle =
+        export_bundle_from_manifest(&manifest, "local").expect("export bundle should be produced");
+    let exported_selection = &bundle.as_bundle().tool_selections[0];
+    assert_eq!(
+        exported_selection["subagent_targets"],
+        json!(["researcher"])
+    );
+    assert_eq!(exported_selection["subagent_spawn_enabled"], json!(true));
+    assert_eq!(exported_selection["subagent_steering_enabled"], json!(true));
+    assert_eq!(
+        exported_selection["subagent_background_enabled"],
+        json!(true)
+    );
+    assert_eq!(
+        exported_selection["subagent_allow_cross_deployment"],
+        json!(true)
+    );
+    assert_eq!(
+        exported_selection["cross_deployment_spawn_timeout_seconds"],
+        json!(90)
+    );
+
+    let round_tripped = manifest_from_export_bundle(bundle.as_bundle())
+        .expect("manifest should parse back from bundle");
+    let round_tripped_selection = &round_tripped.tool_selections[0];
+    assert_eq!(
+        round_tripped_selection.subagent_targets,
+        vec!["researcher".to_string()]
+    );
+    assert!(round_tripped_selection.subagent_spawn_enabled);
+    assert!(round_tripped_selection.subagent_steering_enabled);
+    assert!(round_tripped_selection.subagent_background_enabled);
+    assert!(round_tripped_selection.subagent_allow_cross_deployment);
+    assert_eq!(
+        round_tripped_selection.cross_deployment_spawn_timeout_seconds,
+        Some(90)
+    );
 }
 
 #[test]
@@ -883,7 +935,7 @@ fn validate_rejects_empty_string_in_subagent_targets() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_targets = Some(vec!["".to_string()]);
+    sel.subagent_targets = vec!["".to_string()];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -900,8 +952,8 @@ fn validate_rejects_subagent_spawn_enabled_without_targets() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_targets = None;
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_targets = Vec::new();
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -920,8 +972,8 @@ fn validate_rejects_subagent_spawn_enabled_with_empty_targets_vec() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_targets = Some(vec![]);
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_targets = Vec::new();
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -940,13 +992,13 @@ fn validate_accepts_subagent_spawn_enabled_with_targets() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_targets = Some(vec![defra_agent::subagent_target_entry(
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_targets = vec![defra_agent::subagent_target_entry(
         "researcher",
         "did:defra-agent:test",
         "amy-research",
         None,
-    )]);
+    )];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -963,11 +1015,11 @@ fn validate_rejects_duplicate_subagent_target_name() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_targets = Some(vec![
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_targets = vec![
         defra_agent::subagent_target_entry("dup", "did:defra-agent:test", "amy-research", None),
         defra_agent::subagent_target_entry("dup", "did:defra-agent:test", "amy-code", None),
-    ]);
+    ];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -986,15 +1038,15 @@ fn validate_rejects_remote_did_target_when_cross_deployment_off() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    // Flag defaults to None (== false): cross-deployment is OFF.
-    sel.subagent_allow_cross_deployment = None;
-    sel.subagent_targets = Some(vec![defra_agent::subagent_target_entry(
+    sel.subagent_spawn_enabled = true;
+    // Flag defaults to false: cross-deployment is OFF.
+    sel.subagent_allow_cross_deployment = false;
+    sel.subagent_targets = vec![defra_agent::subagent_target_entry(
         "remote-researcher",
         "did:defra-agent:OTHER-deployment",
         "amy-research",
         None,
-    )]);
+    )];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -1013,14 +1065,14 @@ fn validate_accepts_remote_did_target_when_cross_deployment_on() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_allow_cross_deployment = Some(true);
-    sel.subagent_targets = Some(vec![defra_agent::subagent_target_entry(
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_allow_cross_deployment = true;
+    sel.subagent_targets = vec![defra_agent::subagent_target_entry(
         "remote-researcher",
         "did:defra-agent:OTHER-deployment",
         "amy-research",
         None,
-    )]);
+    )];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);
@@ -1037,15 +1089,15 @@ fn validate_accepts_local_did_target_when_cross_deployment_off() {
     let mut manifest = manifest_with_default_behavior();
     let mut sel = sample_tool_selection("agent-tools");
     sel.agent_did = "did:defra-agent:test".to_string();
-    sel.subagent_spawn_enabled = Some(true);
-    sel.subagent_allow_cross_deployment = None;
+    sel.subagent_spawn_enabled = true;
+    sel.subagent_allow_cross_deployment = false;
     // Same DID as the selection -> local target, allowed even with flag off.
-    sel.subagent_targets = Some(vec![defra_agent::subagent_target_entry(
+    sel.subagent_targets = vec![defra_agent::subagent_target_entry(
         "local-researcher",
         "did:defra-agent:test",
         "amy-research",
         None,
-    )]);
+    )];
     manifest.tool_selections.push(sel);
 
     let errors = validation_errors(&manifest);

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -110,6 +110,14 @@ pub(crate) fn validate_manifest(manifest: &DesiredStateManifest, errors: &mut Ve
                 ));
             }
         }
+        for (index, target) in selection.subagent_targets.iter().enumerate() {
+            if target.trim().is_empty() {
+                errors.push(format!(
+                    "tool selection {} has empty subagent_targets[{index}]",
+                    selection.selection_id
+                ));
+            }
+        }
         if let Some(mode) = selection.command_network_mode.as_deref() {
             if let Err(error) = CommandNetworkMode::parse(mode) {
                 errors.push(format!(
@@ -139,17 +147,12 @@ pub(crate) fn validate_manifest(manifest: &DesiredStateManifest, errors: &mut Ve
         validate_subagent_targets(
             &selection.selection_id,
             selection.agent_did.trim(),
-            selection.subagent_allow_cross_deployment.unwrap_or(false),
-            selection.subagent_targets.as_deref().unwrap_or(&[]),
+            selection.subagent_allow_cross_deployment,
+            &selection.subagent_targets,
             errors,
         );
-        if selection.subagent_spawn_enabled == Some(true) {
-            let targets_empty = selection
-                .subagent_targets
-                .as_ref()
-                .map(|t| t.is_empty())
-                .unwrap_or(true);
-            if targets_empty {
+        if selection.subagent_spawn_enabled {
+            if selection.subagent_targets.is_empty() {
                 errors.push(format!(
                     "tool selection {} sets subagent_spawn_enabled but has no subagent_targets; the tools would be inert",
                     selection.selection_id
@@ -856,14 +859,15 @@ mod live_tests {
                 cli_tool_names: Vec::new(),
                 enable_meta_tools: false,
                 allowed_mcp_service_ids: Vec::new(),
+                delegate_to: Vec::new(),
                 backgroundable_tool_names: Vec::new(),
                 enable_defra_query: true,
                 defra_query_collections: Vec::new(),
-                subagent_targets: Some(targets),
-                subagent_spawn_enabled: Some(true),
-                subagent_steering_enabled: None,
-                subagent_background_enabled: None,
-                subagent_allow_cross_deployment: None,
+                subagent_targets: targets,
+                subagent_spawn_enabled: true,
+                subagent_steering_enabled: false,
+                subagent_background_enabled: false,
+                subagent_allow_cross_deployment: false,
                 cross_deployment_spawn_timeout_seconds: None,
             }],
             inference_backends: Vec::new(),
@@ -1011,20 +1015,21 @@ mod live_tests {
                     cli_tool_names: Vec::new(),
                     enable_meta_tools: false,
                     allowed_mcp_service_ids: Vec::new(),
+                    delegate_to: Vec::new(),
                     backgroundable_tool_names: Vec::new(),
                     enable_defra_query: true,
                     defra_query_collections: Vec::new(),
-                    subagent_targets: Some(vec![SubagentTarget {
+                    subagent_targets: vec![SubagentTarget {
                         name: "researcher".to_string(),
                         agent_did: "did:key:test-subagent-idempotency".to_string(),
                         behavior_id: "amy-research".to_string(),
                         description: None,
                     }
-                    .to_entry()]),
-                    subagent_spawn_enabled: Some(true),
-                    subagent_steering_enabled: Some(true),
-                    subagent_background_enabled: Some(true),
-                    subagent_allow_cross_deployment: Some(true),
+                    .to_entry()],
+                    subagent_spawn_enabled: true,
+                    subagent_steering_enabled: true,
+                    subagent_background_enabled: true,
+                    subagent_allow_cross_deployment: true,
                     cross_deployment_spawn_timeout_seconds: Some(90),
                 }],
                 inference_backends: Vec::new(),
@@ -1069,33 +1074,33 @@ mod live_tests {
 
         assert_eq!(
             live_sel.subagent_targets,
-            Some(vec![SubagentTarget {
+            vec![SubagentTarget {
                 name: "researcher".to_string(),
                 agent_did: "did:key:test-subagent-idempotency".to_string(),
                 behavior_id: "amy-research".to_string(),
                 description: None,
             }
-            .to_entry()]),
+            .to_entry()],
             "subagent_targets must persist through apply"
         );
         assert_eq!(
             live_sel.subagent_spawn_enabled,
-            Some(true),
+            true,
             "subagent_spawn_enabled must persist through apply"
         );
         assert_eq!(
             live_sel.subagent_steering_enabled,
-            Some(true),
+            true,
             "subagent_steering_enabled must persist through apply"
         );
         assert_eq!(
             live_sel.subagent_background_enabled,
-            Some(true),
+            true,
             "subagent_background_enabled must persist through apply"
         );
         assert_eq!(
             live_sel.subagent_allow_cross_deployment,
-            Some(true),
+            true,
             "subagent_allow_cross_deployment must persist through apply"
         );
         assert_eq!(

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -1084,23 +1084,19 @@ mod live_tests {
             "subagent_targets must persist through apply"
         );
         assert_eq!(
-            live_sel.subagent_spawn_enabled,
-            true,
+            live_sel.subagent_spawn_enabled, true,
             "subagent_spawn_enabled must persist through apply"
         );
         assert_eq!(
-            live_sel.subagent_steering_enabled,
-            true,
+            live_sel.subagent_steering_enabled, true,
             "subagent_steering_enabled must persist through apply"
         );
         assert_eq!(
-            live_sel.subagent_background_enabled,
-            true,
+            live_sel.subagent_background_enabled, true,
             "subagent_background_enabled must persist through apply"
         );
         assert_eq!(
-            live_sel.subagent_allow_cross_deployment,
-            true,
+            live_sel.subagent_allow_cross_deployment, true,
             "subagent_allow_cross_deployment must persist through apply"
         );
         assert_eq!(

--- a/crates/defra-agent-cli/src/http/mcp_pool.rs
+++ b/crates/defra-agent-cli/src/http/mcp_pool.rs
@@ -1,0 +1,305 @@
+//! `/mcp/pool` surfacing: registered MCP services plus this agent's
+//! persisted health-probe view. This is an operator-oriented projection over
+//! `ToolServiceRegistry` and `ToolServiceHealthState`; it does not call remote
+//! MCP servers itself.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use defra_agent_protocol::graphql::escape_graphql_string;
+use defra_agent_protocol::row::{ToolServiceHealthStateRow, ToolServiceRegistryRow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::post_graphql;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolSnapshot {
+    pub(crate) generated_at: String,
+    pub(crate) agent_did: String,
+    pub(crate) totals: McpPoolTotals,
+    pub(crate) services: Vec<McpPoolService>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolTotals {
+    pub(crate) registered: usize,
+    pub(crate) online: usize,
+    pub(crate) healthy: usize,
+    pub(crate) degraded: usize,
+    pub(crate) unreachable: usize,
+    pub(crate) unknown: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct McpPoolService {
+    pub(crate) service_id: String,
+    pub(crate) display_name: Option<String>,
+    pub(crate) description: Option<String>,
+    pub(crate) hostname: Option<String>,
+    pub(crate) tailscale_ip: Option<String>,
+    pub(crate) lan_ip: Option<String>,
+    pub(crate) mcp_port: Option<i64>,
+    pub(crate) mcp_path: Option<String>,
+    pub(crate) send_agent_did: bool,
+    pub(crate) status: Option<String>,
+    pub(crate) version: Option<String>,
+    pub(crate) updated_at: Option<String>,
+    pub(crate) health_status: Option<String>,
+    pub(crate) tool_count: Option<i64>,
+    pub(crate) endpoint: Option<String>,
+    pub(crate) failure_count: Option<i64>,
+    pub(crate) k_max: Option<i64>,
+    pub(crate) backoff_until: Option<String>,
+    pub(crate) last_probe_at: Option<String>,
+    pub(crate) last_seen: Option<String>,
+    pub(crate) last_error_class: Option<String>,
+    pub(crate) last_error_message: Option<String>,
+    pub(crate) health_updated_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct McpPoolEnvelope {
+    #[serde(rename = "ToolServiceRegistry", default)]
+    registry: Vec<ToolServiceRegistryRow>,
+    #[serde(rename = "ToolServiceHealthState", default)]
+    health: Vec<ToolServiceHealthStateRow>,
+}
+
+pub(crate) async fn load_mcp_pool_snapshot(
+    graphql: &str,
+    agent_did: &str,
+) -> Result<McpPoolSnapshot> {
+    let generated_at = Utc::now();
+    let response = post_graphql(graphql, &mcp_pool_query(agent_did)).await?;
+    let envelope = decode_mcp_pool_response(response)?;
+    Ok(build_mcp_pool_snapshot(
+        generated_at,
+        agent_did.to_string(),
+        envelope,
+    ))
+}
+
+fn mcp_pool_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{
+            ToolServiceRegistry(order: {{ service_id: ASC }}) {{
+                service_id
+                display_name
+                description
+                hostname
+                tailscale_ip
+                lan_ip
+                mcp_port
+                mcp_path
+                send_agent_did
+                status
+                version
+                updated_at
+            }}
+            ToolServiceHealthState(
+                filter: {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                order: {{ service_id: ASC }}
+            ) {{
+                service_id
+                agent_did
+                endpoint
+                status
+                tool_count
+                failure_count
+                k_max
+                backoff_until
+                last_probe_at
+                last_seen
+                last_error_class
+                last_error_message
+                updated_at
+            }}
+        }}"#
+    )
+}
+
+fn decode_mcp_pool_response(response: Value) -> Result<McpPoolEnvelope> {
+    let data = response
+        .get("data")
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("mcp pool query response missing object data: {response}"))?;
+    serde_json::from_value(data).context("decoding mcp pool query response")
+}
+
+fn build_mcp_pool_snapshot(
+    generated_at: DateTime<Utc>,
+    agent_did: String,
+    envelope: McpPoolEnvelope,
+) -> McpPoolSnapshot {
+    let mut health_by_service = envelope
+        .health
+        .into_iter()
+        .map(|row| (row.service_id.clone(), row))
+        .collect::<BTreeMap<_, _>>();
+    let mut totals = McpPoolTotals::default();
+    let mut services = Vec::new();
+
+    for registry in envelope.registry {
+        let service_id = registry.service_id.trim().to_string();
+        if service_id.is_empty() {
+            continue;
+        }
+        totals.registered += 1;
+        if status_eq(registry.status.as_deref(), "online") {
+            totals.online += 1;
+        }
+
+        let health = health_by_service.remove(&service_id);
+        count_health_status(
+            &mut totals,
+            health.as_ref().and_then(|row| row.status.as_deref()),
+        );
+
+        services.push(McpPoolService {
+            service_id,
+            display_name: registry.display_name,
+            description: registry.description,
+            hostname: registry.hostname,
+            tailscale_ip: registry.tailscale_ip,
+            lan_ip: registry.lan_ip,
+            mcp_port: registry.mcp_port,
+            mcp_path: registry.mcp_path,
+            send_agent_did: registry.send_agent_did,
+            status: registry.status,
+            version: registry.version,
+            updated_at: registry.updated_at,
+            health_status: health.as_ref().and_then(|row| row.status.clone()),
+            tool_count: health.as_ref().and_then(|row| row.tool_count),
+            endpoint: health.as_ref().and_then(|row| row.endpoint.clone()),
+            failure_count: health.as_ref().and_then(|row| row.failure_count),
+            k_max: health.as_ref().and_then(|row| row.k_max),
+            backoff_until: health.as_ref().and_then(|row| row.backoff_until.clone()),
+            last_probe_at: health.as_ref().and_then(|row| row.last_probe_at.clone()),
+            last_seen: health.as_ref().and_then(|row| row.last_seen.clone()),
+            last_error_class: health.as_ref().and_then(|row| row.last_error_class.clone()),
+            last_error_message: health
+                .as_ref()
+                .and_then(|row| row.last_error_message.clone()),
+            health_updated_at: health.as_ref().and_then(|row| row.updated_at.clone()),
+        });
+    }
+
+    McpPoolSnapshot {
+        generated_at: generated_at.to_rfc3339(),
+        agent_did,
+        totals,
+        services,
+    }
+}
+
+fn status_eq(value: Option<&str>, expected: &str) -> bool {
+    value
+        .map(str::trim)
+        .is_some_and(|value| value.eq_ignore_ascii_case(expected))
+}
+
+fn count_health_status(totals: &mut McpPoolTotals, status: Option<&str>) {
+    match status.map(|value| value.trim().to_ascii_lowercase()) {
+        Some(status) if status == "healthy" => totals.healthy += 1,
+        Some(status) if status == "degraded" || status == "stale" => totals.degraded += 1,
+        Some(status)
+            if status == "evicted" || status == "reconnecting" || status == "unreachable" =>
+        {
+            totals.unreachable += 1;
+        }
+        Some(_) | None => totals.unknown += 1,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn joins_registry_with_agent_scoped_health_state() {
+        let snapshot = build_mcp_pool_snapshot(
+            at("2026-06-05T00:00:00Z"),
+            "did:key:zAgent".to_string(),
+            McpPoolEnvelope {
+                registry: vec![
+                    ToolServiceRegistryRow {
+                        service_id: "obs-mcp".to_string(),
+                        display_name: Some("Observability".to_string()),
+                        description: Some("Fleet observability".to_string()),
+                        hostname: Some("studio-1".to_string()),
+                        tailscale_ip: Some("100.64.0.10".to_string()),
+                        lan_ip: None,
+                        mcp_port: Some(9201),
+                        mcp_path: Some("/mcp".to_string()),
+                        send_agent_did: true,
+                        tools: Vec::new(),
+                        status: Some("online".to_string()),
+                        version: Some("test".to_string()),
+                        updated_at: Some("2026-06-05T00:00:00Z".to_string()),
+                    },
+                    ToolServiceRegistryRow {
+                        service_id: "silent-mcp".to_string(),
+                        display_name: None,
+                        description: None,
+                        hostname: None,
+                        tailscale_ip: None,
+                        lan_ip: None,
+                        mcp_port: None,
+                        mcp_path: None,
+                        send_agent_did: false,
+                        tools: Vec::new(),
+                        status: Some("offline".to_string()),
+                        version: None,
+                        updated_at: None,
+                    },
+                ],
+                health: vec![ToolServiceHealthStateRow {
+                    service_id: "obs-mcp".to_string(),
+                    agent_did: Some("did:key:zAgent".to_string()),
+                    endpoint: Some("http://100.64.0.10:9201/mcp".to_string()),
+                    status: Some("healthy".to_string()),
+                    tool_count: Some(12),
+                    failure_count: Some(0),
+                    k_max: Some(3),
+                    backoff_until: None,
+                    last_probe_at: Some("2026-06-05T00:00:00Z".to_string()),
+                    last_seen: Some("2026-06-05T00:00:00Z".to_string()),
+                    last_error_class: None,
+                    last_error_message: None,
+                    updated_at: Some("2026-06-05T00:00:00Z".to_string()),
+                }],
+            },
+        );
+
+        assert_eq!(snapshot.generated_at, "2026-06-05T00:00:00+00:00");
+        assert_eq!(snapshot.agent_did, "did:key:zAgent");
+        assert_eq!(
+            snapshot.totals,
+            McpPoolTotals {
+                registered: 2,
+                online: 1,
+                healthy: 1,
+                degraded: 0,
+                unreachable: 0,
+                unknown: 1,
+            }
+        );
+
+        let obs = snapshot
+            .services
+            .iter()
+            .find(|service| service.service_id == "obs-mcp")
+            .unwrap();
+        assert_eq!(obs.tool_count, Some(12));
+        assert_eq!(obs.health_status.as_deref(), Some("healthy"));
+        assert_eq!(obs.endpoint.as_deref(), Some("http://100.64.0.10:9201/mcp"));
+    }
+}

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod fleet_slots;
 pub(crate) mod healthz;
 pub(crate) mod identity_decide;
 pub(crate) mod liveness;
+pub(crate) mod mcp_pool;
 pub(crate) mod mcp_server;
 pub(crate) mod prometheus;
 pub(crate) mod r5_dispatch;

--- a/crates/defra-agent-cli/src/http/mod.rs
+++ b/crates/defra-agent-cli/src/http/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod prometheus;
 pub(crate) mod r5_dispatch;
 pub(crate) mod router;
 pub(crate) mod self_view;
+pub(crate) mod sessions;
 pub(crate) mod subagent_tree;
 pub(crate) mod version;
 

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -1,7 +1,7 @@
 use std::time::Instant;
 
 use axum::{
-    extract::State,
+    extract::{Query, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     routing::{get, post},
@@ -17,6 +17,7 @@ use crate::http::prometheus::{
     MetricsRuntimeRow,
 };
 use crate::http::self_view::{load_self_view, ContextBudget, SelfBehavior};
+use crate::http::sessions::{load_session_history_snapshot, SessionHistoryParams};
 use crate::http::version::version_response;
 use defra_agent::defra_query::CollectionScope;
 
@@ -55,6 +56,7 @@ pub(crate) fn runtime_contract_router(
         .route("/healthz", get(healthz_handler))
         .route("/status", get(status_handler))
         .route("/self", get(self_handler))
+        .route("/sessions", get(sessions_handler))
         .route("/fleet", get(fleet_handler))
         .route("/fleet/slots", get(fleet_slots_handler))
         .route(
@@ -243,6 +245,21 @@ async fn self_handler(State(state): State<RuntimeHttpState>) -> Response {
             }
             (StatusCode::INTERNAL_SERVER_ERROR, axum::Json(body)).into_response()
         }
+    }
+}
+
+async fn sessions_handler(
+    State(state): State<RuntimeHttpState>,
+    Query(query): Query<SessionHistoryParams>,
+) -> Response {
+    match load_session_history_snapshot(&state.graphql, &state.agent_did, query.limit).await {
+        Ok(snapshot) => (StatusCode::OK, axum::Json(snapshot)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            format!("sessions snapshot failed: {error:#}"),
+        )
+            .into_response(),
     }
 }
 

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use crate::http::fleet::load_fleet_snapshot;
 use crate::http::fleet_slots::load_fleet_slot_snapshot;
 use crate::http::healthz::render_healthz_payload;
+use crate::http::mcp_pool::load_mcp_pool_snapshot;
 use crate::http::prometheus::{
     load_metrics_query_data, render_prometheus_metrics, with_local_native_executors,
     MetricsRuntimeRow,
@@ -59,6 +60,7 @@ pub(crate) fn runtime_contract_router(
         .route("/sessions", get(sessions_handler))
         .route("/fleet", get(fleet_handler))
         .route("/fleet/slots", get(fleet_slots_handler))
+        .route("/mcp/pool", get(mcp_pool_handler))
         .route(
             "/subagents/dispatches",
             get(crate::http::r5_dispatch::subagent_dispatches_handler),
@@ -341,6 +343,18 @@ async fn fleet_slots_handler(State(state): State<RuntimeHttpState>) -> Response 
             StatusCode::INTERNAL_SERVER_ERROR,
             [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
             format!("fleet slot snapshot failed: {error:#}"),
+        )
+            .into_response(),
+    }
+}
+
+async fn mcp_pool_handler(State(state): State<RuntimeHttpState>) -> Response {
+    match load_mcp_pool_snapshot(&state.graphql, &state.agent_did).await {
+        Ok(snapshot) => (StatusCode::OK, axum::Json(snapshot)).into_response(),
+        Err(error) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            format!("mcp pool snapshot failed: {error:#}"),
         )
             .into_response(),
     }

--- a/crates/defra-agent-cli/src/http/sessions.rs
+++ b/crates/defra-agent-cli/src/http/sessions.rs
@@ -1,0 +1,444 @@
+//! `/sessions` surfacing: recent sessions for the running agent, scoped via
+//! `AgentRequest.agent_did` and joined with persisted session/message/
+//! compaction metadata. This is a recent-activity view, not an all-time
+//! exhaustive scan.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use defra_agent::graphql::escape_graphql_string;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::post_graphql;
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 50;
+const REQUEST_SCAN_LIMIT: usize = 500;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SessionHistorySnapshot {
+    pub(crate) generated_at: String,
+    pub(crate) agent_did: String,
+    pub(crate) limit: usize,
+    pub(crate) request_scan_limit: usize,
+    pub(crate) sessions: Vec<SessionHistoryRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SessionHistoryRow {
+    pub(crate) session_id: String,
+    pub(crate) agent_name: Option<String>,
+    pub(crate) behavior_id: Option<String>,
+    pub(crate) status: Option<String>,
+    pub(crate) started_at: Option<String>,
+    pub(crate) ended_at: Option<String>,
+    pub(crate) latest_request_id: Option<String>,
+    pub(crate) latest_request_status: Option<String>,
+    pub(crate) latest_request_lifecycle_state: Option<String>,
+    pub(crate) latest_request_created_at: Option<String>,
+    pub(crate) request_count: i64,
+    pub(crate) message_count: i64,
+    pub(crate) latest_message_at: Option<String>,
+    pub(crate) compaction_count: i64,
+    pub(crate) last_compacted_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct SessionHistoryParams {
+    pub(crate) limit: Option<usize>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct RecentEnvelope {
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DetailsEnvelope {
+    #[serde(rename = "AgentSession", default)]
+    sessions: Vec<SessionRow>,
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+    #[serde(rename = "AgentMessage", default)]
+    messages: Vec<MessageRow>,
+    #[serde(rename = "CompactionEntry", default)]
+    compactions: Vec<CompactionRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SessionRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    agent_name: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    started: Option<String>,
+    #[serde(default)]
+    ended: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MessageRow {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CompactionRow {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+pub(crate) async fn load_session_history_snapshot(
+    graphql: &str,
+    agent_did: &str,
+    limit: Option<usize>,
+) -> Result<SessionHistorySnapshot> {
+    let generated_at = Utc::now();
+    let limit = normalize_limit(limit);
+    let response = post_graphql(graphql, &recent_requests_query(agent_did)).await?;
+    let recent = decode::<RecentEnvelope>(response, "recent sessions")?;
+    let session_ids = recent_session_ids(&recent.requests, limit);
+
+    let details = if session_ids.is_empty() {
+        DetailsEnvelope {
+            sessions: Vec::new(),
+            requests: Vec::new(),
+            messages: Vec::new(),
+            compactions: Vec::new(),
+        }
+    } else {
+        let response =
+            post_graphql(graphql, &session_details_query(agent_did, &session_ids)).await?;
+        decode::<DetailsEnvelope>(response, "session details")?
+    };
+
+    Ok(build_session_history_snapshot(
+        generated_at,
+        agent_did.to_string(),
+        limit,
+        session_ids,
+        details,
+    ))
+}
+
+fn normalize_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+}
+
+fn recent_requests_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                order: {{ created_at: DESC }},
+                limit: {REQUEST_SCAN_LIMIT}
+            ) {{
+                request_id
+                session_id
+                behavior_id
+                status
+                lifecycle_state
+                created_at
+            }}
+        }}"#
+    )
+}
+
+fn session_details_query(agent_did: &str, session_ids: &[String]) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    let sessions = session_ids
+        .iter()
+        .map(|id| format!(r#""{}""#, escape_graphql_string(id)))
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        r#"{{
+            AgentSession(filter: {{ session_id: {{ _in: [{sessions}] }} }}) {{
+                session_id
+                agent_name
+                behavior_id
+                started
+                ended
+                status
+            }}
+            AgentRequest(
+                filter: {{ _and: [
+                    {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                    {{ session_id: {{ _in: [{sessions}] }} }}
+                ] }},
+                order: {{ created_at: DESC }}
+            ) {{
+                request_id
+                session_id
+                behavior_id
+                status
+                lifecycle_state
+                created_at
+            }}
+            AgentMessage(filter: {{ session_id: {{ _in: [{sessions}] }} }}) {{
+                session_id
+                timestamp
+            }}
+            CompactionEntry(filter: {{ session_id: {{ _in: [{sessions}] }} }}) {{
+                session_id
+                created_at
+            }}
+        }}"#
+    )
+}
+
+fn decode<T: serde::de::DeserializeOwned>(response: Value, label: &str) -> Result<T> {
+    let data = response
+        .get("data")
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("{label} query response missing object data: {response}"))?;
+    serde_json::from_value(data).with_context(|| format!("decoding {label} query response"))
+}
+
+fn recent_session_ids(requests: &[RequestRow], limit: usize) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut session_ids = Vec::new();
+    for request in requests {
+        let Some(session_id) = clean(request.session_id.as_deref()) else {
+            continue;
+        };
+        if seen.insert(session_id.clone()) {
+            session_ids.push(session_id);
+            if session_ids.len() >= limit {
+                break;
+            }
+        }
+    }
+    session_ids
+}
+
+fn build_session_history_snapshot(
+    generated_at: DateTime<Utc>,
+    agent_did: String,
+    limit: usize,
+    session_ids: Vec<String>,
+    details: DetailsEnvelope,
+) -> SessionHistorySnapshot {
+    let sessions = details
+        .sessions
+        .into_iter()
+        .filter_map(|session| {
+            let session_id = clean(Some(&session.session_id))?;
+            Some((session_id, session))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let requests = group_requests(details.requests);
+    let messages = count_latest_by_session(details.messages.into_iter().filter_map(|row| {
+        clean(row.session_id.as_deref()).map(|session_id| (session_id, row.timestamp))
+    }));
+    let compactions = count_latest_by_session(details.compactions.into_iter().filter_map(|row| {
+        clean(row.session_id.as_deref()).map(|session_id| (session_id, row.created_at))
+    }));
+
+    let sessions = session_ids
+        .into_iter()
+        .map(|session_id| {
+            let session = sessions.get(&session_id);
+            let requests = requests.get(&session_id).cloned().unwrap_or_default();
+            let latest_request = requests.first();
+            let (message_count, latest_message_at) =
+                messages.get(&session_id).cloned().unwrap_or_default();
+            let (compaction_count, last_compacted_at) =
+                compactions.get(&session_id).cloned().unwrap_or_default();
+
+            SessionHistoryRow {
+                session_id: session_id.clone(),
+                agent_name: session.and_then(|row| clean(row.agent_name.as_deref())),
+                behavior_id: session
+                    .and_then(|row| clean(row.behavior_id.as_deref()))
+                    .or_else(|| latest_request.and_then(|row| clean(row.behavior_id.as_deref()))),
+                status: session.and_then(|row| clean(row.status.as_deref())),
+                started_at: session.and_then(|row| clean(row.started.as_deref())),
+                ended_at: session.and_then(|row| clean(row.ended.as_deref())),
+                latest_request_id: latest_request.and_then(|row| clean(row.request_id.as_deref())),
+                latest_request_status: latest_request.and_then(|row| clean(row.status.as_deref())),
+                latest_request_lifecycle_state: latest_request
+                    .and_then(|row| clean(row.lifecycle_state.as_deref())),
+                latest_request_created_at: latest_request
+                    .and_then(|row| clean(row.created_at.as_deref())),
+                request_count: requests.len() as i64,
+                message_count,
+                latest_message_at,
+                compaction_count,
+                last_compacted_at,
+            }
+        })
+        .collect();
+
+    SessionHistorySnapshot {
+        generated_at: generated_at.to_rfc3339(),
+        agent_did,
+        limit,
+        request_scan_limit: REQUEST_SCAN_LIMIT,
+        sessions,
+    }
+}
+
+fn group_requests(requests: Vec<RequestRow>) -> BTreeMap<String, Vec<RequestRow>> {
+    let mut by_session = BTreeMap::<String, Vec<RequestRow>>::new();
+    for request in requests {
+        let Some(session_id) = clean(request.session_id.as_deref()) else {
+            continue;
+        };
+        by_session.entry(session_id).or_default().push(request);
+    }
+    for rows in by_session.values_mut() {
+        rows.sort_by(|left, right| right.created_at.cmp(&left.created_at));
+    }
+    by_session
+}
+
+fn count_latest_by_session(
+    rows: impl Iterator<Item = (String, Option<String>)>,
+) -> BTreeMap<String, (i64, Option<String>)> {
+    let mut by_session = BTreeMap::<String, (i64, Option<String>)>::new();
+    for (session_id, timestamp) in rows {
+        let entry = by_session.entry(session_id).or_default();
+        entry.0 += 1;
+        if timestamp > entry.1 {
+            entry.1 = timestamp;
+        }
+    }
+    by_session
+}
+
+fn clean(value: Option<&str>) -> Option<String> {
+    let value = value?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn envelope(value: Value) -> DetailsEnvelope {
+        serde_json::from_value(value).unwrap()
+    }
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn builds_agent_scoped_recent_session_history() {
+        let recent = vec![
+            RequestRow {
+                request_id: Some("req-newer".to_string()),
+                session_id: Some("session-a".to_string()),
+                behavior_id: Some("behavior-a".to_string()),
+                status: Some("completed".to_string()),
+                lifecycle_state: Some("terminal".to_string()),
+                created_at: Some("2026-06-05T10:00:00Z".to_string()),
+            },
+            RequestRow {
+                request_id: Some("req-other".to_string()),
+                session_id: Some("session-b".to_string()),
+                behavior_id: Some("behavior-b".to_string()),
+                status: Some("processing".to_string()),
+                lifecycle_state: Some("running".to_string()),
+                created_at: Some("2026-06-05T09:00:00Z".to_string()),
+            },
+            RequestRow {
+                request_id: Some("req-older".to_string()),
+                session_id: Some("session-a".to_string()),
+                behavior_id: Some("behavior-a".to_string()),
+                status: Some("completed".to_string()),
+                lifecycle_state: Some("terminal".to_string()),
+                created_at: Some("2026-06-05T08:00:00Z".to_string()),
+            },
+        ];
+        let session_ids = recent_session_ids(&recent, 2);
+        let snapshot = build_session_history_snapshot(
+            at("2026-06-05T12:00:00Z"),
+            "did:key:zAgent".to_string(),
+            2,
+            session_ids,
+            envelope(json!({
+                "AgentSession": [
+                    {
+                        "session_id": "session-a",
+                        "agent_name": "amy",
+                        "behavior_id": "behavior-a",
+                        "started": "2026-06-05T07:59:00Z",
+                        "status": "active"
+                    },
+                    {
+                        "session_id": "session-b",
+                        "agent_name": "amy",
+                        "behavior_id": "behavior-b",
+                        "started": "2026-06-05T08:59:00Z",
+                        "status": "active"
+                    }
+                ],
+                "AgentRequest": recent,
+                "AgentMessage": [
+                    { "session_id": "session-a", "timestamp": "2026-06-05T10:01:00Z" },
+                    { "session_id": "session-a", "timestamp": "2026-06-05T10:02:00Z" },
+                    { "session_id": "session-b", "timestamp": "2026-06-05T09:01:00Z" }
+                ],
+                "CompactionEntry": [
+                    { "session_id": "session-a", "created_at": "2026-06-05T10:03:00Z" }
+                ]
+            })),
+        );
+
+        assert_eq!(snapshot.agent_did, "did:key:zAgent");
+        assert_eq!(snapshot.sessions.len(), 2);
+        assert_eq!(snapshot.sessions[0].session_id, "session-a");
+        assert_eq!(
+            snapshot.sessions[0].latest_request_id.as_deref(),
+            Some("req-newer")
+        );
+        assert_eq!(snapshot.sessions[0].request_count, 2);
+        assert_eq!(snapshot.sessions[0].message_count, 2);
+        assert_eq!(snapshot.sessions[0].compaction_count, 1);
+        assert_eq!(
+            snapshot.sessions[0].last_compacted_at.as_deref(),
+            Some("2026-06-05T10:03:00Z")
+        );
+        assert_eq!(snapshot.sessions[1].session_id, "session-b");
+    }
+
+    #[test]
+    fn clamps_session_history_limit() {
+        assert_eq!(normalize_limit(None), DEFAULT_LIMIT);
+        assert_eq!(normalize_limit(Some(0)), 1);
+        assert_eq!(normalize_limit(Some(usize::MAX)), MAX_LIMIT);
+    }
+}

--- a/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_e2e.rs
@@ -586,6 +586,174 @@ async fn config_apply_reconciles_tool_services_tasks_and_schedules_end_to_end() 
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn config_apply_accepts_explicit_empty_tool_selection_lists_twice() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir.path().join("infra").join("agents").join("default");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-empty-list-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let agent_name = format!("cli-empty-list-{}", Uuid::new_v4().simple());
+
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+
+    run_cli_text(
+        &home_dir,
+        &["config", "export", "--root", &root.to_string_lossy()],
+    )?;
+    let principal = read_json_file(&root.join("agent-principal.json"))?;
+    let behavior_id = principal
+        .get("default_behavior_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing default_behavior_id after export"))?
+        .to_string();
+    let behavior = read_json_file(
+        &root
+            .join("agent-behaviors")
+            .join(&behavior_id)
+            .join("object.json"),
+    )?;
+    let selection_id = behavior
+        .get("tool_selection_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing tool_selection_id after export"))?
+        .to_string();
+    let selection_path = root
+        .join("tool-selections")
+        .join(&selection_id)
+        .join("object.json");
+    let mut selection = read_json_file(&selection_path)?;
+    selection["display_name"] = Value::String("Empty list regression".to_string());
+    for field in [
+        "command_allowed_argv_prefixes",
+        "command_forbidden_argv_prefixes",
+        "cli_tool_names",
+        "allowed_mcp_service_ids",
+        "delegate_to",
+        "backgroundable_tool_names",
+        "subagent_targets",
+        "defra_query_collections",
+    ] {
+        selection[field] = Value::Array(Vec::new());
+    }
+    selection["subagent_spawn_enabled"] = Value::Bool(false);
+    selection["subagent_steering_enabled"] = Value::Bool(false);
+    selection["subagent_background_enabled"] = Value::Bool(false);
+    selection["subagent_allow_cross_deployment"] = Value::Bool(false);
+    selection["cross_deployment_spawn_timeout_seconds"] = Value::Null;
+    write_json_file(&selection_path, &selection)?;
+
+    let root_str = root
+        .to_str()
+        .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
+    let validated = run_cli_json(&home_dir, &["config", "validate", "--root", root_str])?;
+    assert_eq!(validated.get("ok").and_then(Value::as_bool), Some(true));
+
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let applied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
+    assert_eq!(
+        applied.get("status").and_then(Value::as_str),
+        Some("applied")
+    );
+    assert_eq!(
+        applied
+            .pointer("/applied/tool_selections")
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    let reapplied = run_cli_json(&home_dir, &["config", "apply", "--root", root_str])?;
+    assert_eq!(
+        reapplied.get("status").and_then(Value::as_str),
+        Some("noop")
+    );
+    assert_eq!(
+        reapplied
+            .pointer("/applied/tool_selections")
+            .and_then(Value::as_u64),
+        Some(0)
+    );
+
+    let response = graphql_query(
+        &graphql,
+        &format!(
+            r#"{{
+                ToolSelection(filter: {{ selection_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                    selection_id
+                    display_name
+                    command_allowed_argv_prefixes
+                    command_forbidden_argv_prefixes
+                    cli_tool_names
+                    allowed_mcp_service_ids
+                    delegate_to
+                    backgroundable_tool_names
+                    subagent_targets
+                    subagent_spawn_enabled
+                    subagent_steering_enabled
+                    subagent_background_enabled
+                    subagent_allow_cross_deployment
+                    cross_deployment_spawn_timeout_seconds
+                    defra_query_collections
+                }}
+            }}"#,
+            escape_graphql_string(&selection_id),
+        ),
+    )
+    .await?;
+    let row = first_graphql_row(&response, "ToolSelection")?;
+    assert_eq!(
+        row.get("display_name").and_then(Value::as_str),
+        Some("Empty list regression")
+    );
+    for field in [
+        "command_allowed_argv_prefixes",
+        "command_forbidden_argv_prefixes",
+        "cli_tool_names",
+        "allowed_mcp_service_ids",
+        "delegate_to",
+        "backgroundable_tool_names",
+        "subagent_targets",
+        "defra_query_collections",
+    ] {
+        assert!(
+            row.get(field).is_none_or(|value| {
+                value.is_null() || value.as_array().is_some_and(Vec::is_empty)
+            }),
+            "expected {field} to query back as null or empty array, got {row}"
+        );
+    }
+    assert_eq!(
+        row.get("subagent_allow_cross_deployment")
+            .and_then(Value::as_bool),
+        Some(false),
+        "expected subagent_allow_cross_deployment to stay disabled: {row}"
+    );
+    assert!(
+        row.get("cross_deployment_spawn_timeout_seconds")
+            .is_none_or(Value::is_null),
+        "expected cross_deployment_spawn_timeout_seconds to stay null: {row}"
+    );
+
+    Ok(())
+}
+
 /// End-to-end test for the EventTrigger apply path.
 ///
 /// Covers the runtime-ownership contract for `EventTrigger`:

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -402,6 +402,88 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         "expected /fleet to list this agent in ready state: {fleet}"
     );
 
+    // /mcp/pool joins registered MCP services with this agent's persisted
+    // health state, including the last observed tool count.
+    let escaped_agent_did = escape_graphql_string(&agent_did);
+    for mutation in [
+        r#"mutation {
+            create_ToolServiceRegistry(input: {
+                service_id: "runtime-mcp-pool-obs",
+                display_name: "Runtime Observability",
+                description: "Runtime endpoint fixture",
+                hostname: "studio-1",
+                tailscale_ip: "100.64.0.10",
+                lan_ip: "192.168.1.10",
+                mcp_port: 9201,
+                mcp_path: "/mcp",
+                send_agent_did: true,
+                status: "online",
+                version: "test",
+                updated_at: "2026-06-05T00:00:00Z"
+            }) { _docID }
+        }"#
+        .to_string(),
+        format!(
+            r#"mutation {{
+                create_ToolServiceHealthState(input: {{
+                    service_id: "runtime-mcp-pool-obs",
+                    agent_did: "{escaped_agent_did}",
+                    endpoint: "http://100.64.0.10:9201/mcp",
+                    status: "healthy",
+                    tool_count: 3,
+                    failure_count: 0,
+                    k_max: 3,
+                    last_probe_at: "2026-06-05T00:00:00Z",
+                    last_seen: "2026-06-05T00:00:00Z",
+                    updated_at: "2026-06-05T00:00:00Z"
+                }}) {{ _docID }}
+            }}"#
+        ),
+    ] {
+        graphql_query(&graphql, &mutation)
+            .await
+            .context("seeding MCP pool fixtures")?;
+    }
+
+    let mcp_pool_response = client
+        .get(format!("http://127.0.0.1:{port}/mcp/pool"))
+        .send()
+        .await
+        .context("fetching /mcp/pool")?;
+    assert!(
+        mcp_pool_response.status().is_success(),
+        "unexpected /mcp/pool response: {mcp_pool_response:?}"
+    );
+    let mcp_pool: Value = mcp_pool_response
+        .json()
+        .await
+        .context("reading /mcp/pool body")?;
+    assert_eq!(
+        mcp_pool.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert_eq!(
+        mcp_pool.pointer("/totals/online").and_then(Value::as_i64),
+        Some(1),
+        "expected /mcp/pool totals to count the seeded online service: {mcp_pool}"
+    );
+    assert_eq!(
+        mcp_pool.pointer("/totals/healthy").and_then(Value::as_i64),
+        Some(1),
+        "expected /mcp/pool totals to count the seeded healthy service: {mcp_pool}"
+    );
+    assert!(
+        mcp_pool
+            .get("services")
+            .and_then(Value::as_array)
+            .is_some_and(|services| services.iter().any(|service| {
+                service.get("service_id").and_then(Value::as_str) == Some("runtime-mcp-pool-obs")
+                    && service.get("tool_count").and_then(Value::as_i64) == Some(3)
+                    && service.get("health_status").and_then(Value::as_str) == Some("healthy")
+            })),
+        "expected /mcp/pool to include the seeded service and tool count: {mcp_pool}"
+    );
+
     // /mcp is opt-in: this server was started without --enable-mcp, so the
     // endpoint must not be mounted.
     let mcp_off = client

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -150,6 +150,7 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         ],
     )?;
     let agent_did = agent_did_from_init(&init)?;
+    let default_behavior_id = default_behavior_id_for_agent(&agent_did);
 
     let mut serve = spawn_server(&home_dir, port)?;
     wait_for_port(port, &mut serve)?;
@@ -272,14 +273,19 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         Some(true)
     );
 
-    // Seed an AgentRequest (so the agent's session resolves) plus a
-    // CompactionEntry in that session, so the agent-scoped context budget has
-    // something to aggregate. This exercises the agent -> session -> compaction
-    // path end-to-end against the live schema.
+    // Seed an AgentRequest (so the agent's session resolves), an AgentSession
+    // and AgentMessage for /sessions, plus a CompactionEntry so the
+    // agent-scoped context budget has something to aggregate.
     for mutation in [
+        format!(
+            r#"mutation {{ create_AgentSession(input: {{ session_id: "self-budget-session", agent_name: "{}", behavior_id: "{}", started: "2026-06-02T09:59:00Z", status: "active" }}) {{ _docID }} }}"#,
+            escape_graphql_string(&agent_name),
+            escape_graphql_string(&default_behavior_id),
+        ),
         format!(
             r#"mutation {{ create_AgentRequest(input: {{ request_id: "self-budget-req", agent_did: "{agent_did}", session_id: "self-budget-session", status: "completed", created_at: "2026-06-02T10:00:00Z" }}) {{ _docID }} }}"#
         ),
+        r#"mutation { create_AgentMessage(input: { message_key: "self-budget-session:1", session_id: "self-budget-session", sequence: 1, role: "user", content: "hello", timestamp: "2026-06-02T10:01:00Z" }) { _docID } }"#.to_string(),
         r#"mutation { create_CompactionEntry(input: { compaction_key: "self-budget-ce", session_id: "self-budget-session", sequence: 1, original_tokens: 1234, compacted_tokens: 567, created_at: "2026-06-02T10:00:00Z" }) { _docID } }"#.to_string(),
     ] {
         let seed = client
@@ -315,7 +321,7 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         behaviors.iter().any(|behavior| {
             behavior.get("model_name").and_then(Value::as_str) == Some(model_name.as_str())
                 && behavior
-                    .get("endpoint")
+                    .get("backend_endpoint")
                     .and_then(Value::as_str)
                     .is_some_and(|endpoint| !endpoint.is_empty())
         }),
@@ -333,6 +339,45 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         budget.get("latest_original_tokens").and_then(Value::as_i64),
         Some(1234),
         "expected context_budget latest tokens from the seeded compaction: {self_view}"
+    );
+
+    let sessions_response = client
+        .get(format!("http://127.0.0.1:{port}/sessions?limit=1"))
+        .send()
+        .await
+        .context("fetching /sessions")?;
+    assert!(
+        sessions_response.status().is_success(),
+        "unexpected /sessions response: {sessions_response:?}"
+    );
+    let sessions: Value = sessions_response
+        .json()
+        .await
+        .context("reading /sessions body")?;
+    assert_eq!(
+        sessions.get("agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    let session = sessions
+        .get("sessions")
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .unwrap_or_else(|| panic!("expected /sessions to include the seeded row: {sessions}"));
+    assert_eq!(
+        session.get("session_id").and_then(Value::as_str),
+        Some("self-budget-session")
+    );
+    assert_eq!(
+        session.get("request_count").and_then(Value::as_i64),
+        Some(1)
+    );
+    assert_eq!(
+        session.get("message_count").and_then(Value::as_i64),
+        Some(1)
+    );
+    assert_eq!(
+        session.get("compaction_count").and_then(Value::as_i64),
+        Some(1)
     );
 
     // /fleet reshapes per-agent_did runtime + request counts.

--- a/crates/defra-agent-cli/tests/support/fs.rs
+++ b/crates/defra-agent-cli/tests/support/fs.rs
@@ -175,6 +175,16 @@ pub fn write_manifest_root_from_export(root: &Path, exported: &Value) -> Result<
             "cli_tool_names",
             "enable_meta_tools",
             "allowed_mcp_service_ids",
+            "delegate_to",
+            "backgroundable_tool_names",
+            "enable_defra_query",
+            "defra_query_collections",
+            "subagent_targets",
+            "subagent_spawn_enabled",
+            "subagent_steering_enabled",
+            "subagent_background_enabled",
+            "subagent_allow_cross_deployment",
+            "cross_deployment_spawn_timeout_seconds",
         ],
     )?;
     write_per_doc_collection(

--- a/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
@@ -115,7 +115,7 @@ impl ClientCore {
 
         let (peer_statuses, _peer_errors) = {
             let records = peer_directory.read().await.records().to_vec();
-            bootstrap_saved_peers(node.as_ref(), &p2p, &records, &options).await
+            bootstrap_saved_peers(node.as_ref(), &p2p, &records, &options, &principal).await
         };
         let peer_statuses = Arc::new(std::sync::RwLock::new(peer_statuses));
         let (p2p_health, _p2p_health_rx) = watch::channel(P2PHealth::default());
@@ -129,6 +129,7 @@ impl ClientCore {
             Arc::clone(&peer_statuses),
             p2p_health.clone(),
             p2p_control_rx,
+            Arc::new(principal.clone()),
             options.install_replicators_on_bootstrap,
         );
         let materialization_supervisor = spawn_materialization_supervisor_task(
@@ -166,6 +167,7 @@ pub(super) async fn bootstrap_saved_peers(
     p2p: &Arc<dyn P2POps>,
     records: &[PeerRecord],
     options: &ClientCoreOptions,
+    actor: &PrincipalIdentity,
 ) -> (Vec<ClientPeerStatus>, Vec<String>) {
     let mut statuses = Vec::with_capacity(records.len());
     let mut errors = Vec::new();
@@ -221,7 +223,7 @@ pub(super) async fn bootstrap_saved_peers(
 
                 if let Some(graphql) = record.graphql.as_deref() {
                     if p2p_pairing_enabled {
-                        match configure_local_runtime_pairing(node, p2p, record).await {
+                        match configure_local_runtime_pairing(node, p2p, record, actor).await {
                             Ok(()) => {
                                 if branchable_pair_sync_enabled() {
                                     match sync_branchable_collections_with_retry(
@@ -295,6 +297,7 @@ pub(super) async fn configure_local_runtime_pairing(
     node: &EmbeddedNode,
     p2p: &Arc<dyn P2POps>,
     record: &PeerRecord,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     if pairing_reconcile_enabled() {
         write_peer_pairing_desired(node, record).await?;
@@ -305,12 +308,13 @@ pub(super) async fn configure_local_runtime_pairing(
         .graphql
         .as_deref()
         .context("local runtime pairing requires a GraphQL endpoint")?;
-    configure_local_runtime_pairing_legacy(p2p, graphql).await
+    configure_local_runtime_pairing_legacy(p2p, graphql, actor).await
 }
 
 pub(super) async fn configure_local_runtime_pairing_legacy(
     p2p: &Arc<dyn P2POps>,
     graphql: &str,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     let desktop_listen_address = wait_for_bootstrap_listen_address(p2p, graphql).await?;
     local_runtime::complete_runtime_pairing(
@@ -320,6 +324,7 @@ pub(super) async fn configure_local_runtime_pairing_legacy(
             .into_iter()
             .map(str::to_owned)
             .collect(),
+        actor,
     )
     .await
 }

--- a/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
@@ -77,6 +77,7 @@ impl ClientCore {
             PeerDirectory::load(paths.peer_directory_path()).await?,
         ));
         ensure_runtime_schemas(node.as_ref()).await?;
+        ensure_desktop_schema_migrations(Arc::clone(&node)).await?;
         subscribe_all_collections(node.as_ref()).await?;
 
         // Open the EventName::Update subscription BEFORE reading the
@@ -160,6 +161,22 @@ impl ClientCore {
             bootstrap_errors,
         })
     }
+}
+
+async fn ensure_desktop_schema_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    defra_agent::migration::ensure_peer_pairing_desired_migrations(Arc::clone(&node))
+        .await
+        .context("ensure desktop PeerPairingDesired migrations")?;
+    defra_agent::migration::ensure_tool_service_registry_migrations(Arc::clone(&node))
+        .await
+        .context("ensure desktop ToolServiceRegistry migrations")?;
+    defra_agent::migration::ensure_tool_service_health_state_migrations(Arc::clone(&node))
+        .await
+        .context("ensure desktop ToolServiceHealthState migrations")?;
+    defra_agent::migration::ensure_agent_behavior_migrations(node)
+        .await
+        .context("ensure desktop AgentBehavior migrations")?;
+    Ok(())
 }
 
 pub(super) async fn bootstrap_saved_peers(

--- a/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
@@ -10,6 +10,7 @@ use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 
 use super::super::peer_directory::{PeerDirectory, PeerRecord};
+use super::super::principal_identity::PrincipalIdentity;
 use super::super::schema::subscribed_collection_names;
 use super::bootstrap::{
     add_replicator_with_retry, configure_local_runtime_pairing_legacy, connect_peer_with_retry,
@@ -36,6 +37,7 @@ pub(super) fn spawn_p2p_supervisor_task(
     peer_statuses: Arc<StdRwLock<Vec<ClientPeerStatus>>>,
     p2p_health: watch::Sender<P2PHealth>,
     mut control_rx: mpsc::Receiver<P2PSupervisorCommand>,
+    remote_admin_actor: Arc<PrincipalIdentity>,
     install_replicators_on_bootstrap: bool,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -75,6 +77,7 @@ pub(super) fn spawn_p2p_supervisor_task(
                 &p2p,
                 &peer_directory,
                 &peer_statuses,
+                &remote_admin_actor,
                 install_replicators_on_bootstrap,
                 manual_repair,
             )
@@ -95,6 +98,7 @@ async fn run_saved_peer_repair_cycle(
     p2p: &Arc<dyn P2POps>,
     peer_directory: &Arc<RwLock<PeerDirectory>>,
     peer_statuses: &Arc<StdRwLock<Vec<ClientPeerStatus>>>,
+    remote_admin_actor: &Arc<PrincipalIdentity>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
 ) {
@@ -123,6 +127,7 @@ async fn run_saved_peer_repair_cycle(
                 current_status,
                 install_replicators_on_bootstrap,
                 force_repair,
+                Some(remote_admin_actor.as_ref()),
             )
             .await;
             still_saved = peer_directory
@@ -138,7 +143,13 @@ async fn run_saved_peer_repair_cycle(
 
         if still_saved && pairing_reconcile_enabled() {
             let desired = load_desired_for_peer(node, &record).await;
-            run_pairing_reconcile_for_peer(&record, desired, peer_statuses).await;
+            run_pairing_reconcile_for_peer(
+                &record,
+                desired,
+                peer_statuses,
+                Arc::clone(remote_admin_actor),
+            )
+            .await;
         }
     }
 }
@@ -267,6 +278,7 @@ pub(super) async fn repair_saved_peer(
     current_status: Option<ClientPeerStatus>,
     install_replicators_on_bootstrap: bool,
     force_repair: bool,
+    remote_admin_actor: Option<&PrincipalIdentity>,
 ) -> ClientPeerStatus {
     let mut status = current_status.unwrap_or_else(|| ClientPeerStatus {
         peer_id: record.peer_id.clone(),
@@ -363,12 +375,22 @@ pub(super) async fn repair_saved_peer(
         if pairing_reconcile_enabled() {
             status.last_error = None;
         } else if p2p_pairing_enabled_for_graphql(graphql) {
-            match configure_local_runtime_pairing_legacy(p2p, graphql).await {
-                Ok(()) => status.last_error = None,
-                Err(error) => {
+            match remote_admin_actor {
+                Some(actor) => {
+                    match configure_local_runtime_pairing_legacy(p2p, graphql, actor).await {
+                        Ok(()) => status.last_error = None,
+                        Err(error) => {
+                            status.last_error = Some(format!(
+                                "peer {} local runtime pairing failed: {}",
+                                record.label, error
+                            ));
+                        }
+                    }
+                }
+                None => {
                     status.last_error = Some(format!(
-                        "peer {} local runtime pairing failed: {}",
-                        record.label, error
+                        "peer {} local runtime pairing failed: desktop principal identity unavailable",
+                        record.label
                     ));
                 }
             }
@@ -444,11 +466,12 @@ async fn run_pairing_reconcile_for_peer(
     record: &PeerRecord,
     desired: PairingDesired,
     peer_statuses: &Arc<StdRwLock<Vec<ClientPeerStatus>>>,
+    remote_admin_actor: Arc<PrincipalIdentity>,
 ) {
     let Some(graphql_url) = record.graphql.as_deref() else {
         return;
     };
-    let admin = match HttpRemoteP2pAdmin::new(graphql_url) {
+    let admin = match HttpRemoteP2pAdmin::new_with_actor(graphql_url, remote_admin_actor) {
         Ok(admin) => admin,
         Err(error) => {
             tracing::warn!(

--- a/crates/defra-agent-desktop-core/src/client/core/tests.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/tests.rs
@@ -304,6 +304,7 @@ async fn repair_saved_peer_refreshes_network_before_redial() {
         }),
         false,
         false,
+        None,
     )
     .await;
 
@@ -338,6 +339,7 @@ async fn repair_saved_peer_forces_reconfiguration_while_peer_is_connected() {
         }),
         true,
         true,
+        None,
     )
     .await;
 

--- a/crates/defra-agent-desktop-core/src/client/core/writes.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/writes.rs
@@ -483,6 +483,7 @@ impl ClientCore {
                     self.node.as_ref(),
                     &self.p2p,
                     &record,
+                    self.principal(),
                 )
                 .await
                 {

--- a/crates/defra-agent-desktop-core/src/client/principal_identity.rs
+++ b/crates/defra-agent-desktop-core/src/client/principal_identity.rs
@@ -2,12 +2,12 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use crypto::Key;
-use identity::{Identity as _, RawIdentity};
+use identity::{FullIdentity as _, Identity as _, RawIdentity};
 use serde::{Deserialize, Serialize};
 
 use super::paths::DesktopPaths;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PrincipalIdentity {
     did: String,
     public_key_bytes: Vec<u8>,
@@ -86,6 +86,15 @@ impl PrincipalIdentity {
 
     pub fn private_key_bytes(&self) -> &[u8] {
         &self.private_key_bytes
+    }
+
+    pub(crate) fn sign(&self, payload: &[u8]) -> Result<Vec<u8>> {
+        RawIdentity::from_bytes(crypto::KeyType::Ed25519, &self.private_key_bytes)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("loading principal identity for {}", self.did))?
+            .sign(payload)
+            .map_err(anyhow::Error::from)
+            .with_context(|| format!("signing payload as {}", self.did))
     }
 }
 

--- a/crates/defra-agent-desktop-core/src/local_runtime/http.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/http.rs
@@ -1,7 +1,14 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
+use reqwest::header::CONTENT_TYPE;
 use serde::{Deserialize, Serialize};
+
+use crate::client::PrincipalIdentity;
+use crate::remote_admin::http_impl::{
+    hex_encode, signing_payload, ACTOR_DID_HEADER, ACTOR_SIGNATURE_HEADER, ACTOR_SIGNATURE_VERSION,
+    ACTOR_SIGNATURE_VERSION_HEADER,
+};
 
 pub(super) fn read_json<T: for<'de> Deserialize<'de>>(path: &Path) -> Result<T> {
     let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
@@ -39,25 +46,35 @@ pub(super) async fn http_get_json<T: for<'de> Deserialize<'de>>(
     serde_json::from_slice(&body).with_context(|| format!("decoding JSON response from {url}"))
 }
 
-pub(super) async fn http_post_json<B: Serialize>(
+pub(super) async fn http_post_json_signed<B: Serialize>(
     client: &reqwest::Client,
     url: &str,
+    path: &str,
     body: &B,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
+    let body = serde_json::to_vec(body).with_context(|| format!("encoding POST body for {url}"))?;
+    let signature = actor
+        .sign(&signing_payload("POST", path, &body))
+        .with_context(|| format!("signing POST request to {url}"))?;
     let response = client
         .post(url)
-        .json(body)
+        .header(ACTOR_DID_HEADER, actor.did())
+        .header(ACTOR_SIGNATURE_HEADER, hex_encode(&signature))
+        .header(ACTOR_SIGNATURE_VERSION_HEADER, ACTOR_SIGNATURE_VERSION)
+        .header(CONTENT_TYPE, "application/json")
+        .body(body)
         .send()
         .await
-        .with_context(|| format!("sending POST request to {url}"))?;
+        .with_context(|| format!("sending signed POST request to {url}"))?;
     let status = response.status();
     let bytes = response
         .bytes()
         .await
-        .with_context(|| format!("reading POST response body from {url}"))?;
+        .with_context(|| format!("reading signed POST response body from {url}"))?;
     if !status.is_success() {
         anyhow::bail!(
-            "POST {url} failed with {status}: {}",
+            "signed POST {url} failed with {status}: {}",
             String::from_utf8_lossy(&bytes)
         );
     }

--- a/crates/defra-agent-desktop-core/src/local_runtime/pairing.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/pairing.rs
@@ -4,7 +4,10 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use tokio::time::{sleep, Instant};
 
-use super::http::{http_post_json, p2p_api_base};
+use crate::client::PrincipalIdentity;
+use crate::remote_admin::http_impl::signed_admin_path;
+
+use super::http::{http_post_json_signed, p2p_api_base};
 
 const PAIRING_RETRY_TIMEOUT: Duration = Duration::from_secs(20);
 const PAIRING_RETRY_BACKOFF: Duration = Duration::from_millis(250);
@@ -14,12 +17,18 @@ pub(crate) async fn complete_runtime_pairing(
     graphql: &str,
     desktop_listen_address: &str,
     collections: Vec<String>,
+    actor: &PrincipalIdentity,
 ) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(HTTP_TIMEOUT)
         .build()
         .context("building local runtime pairing HTTP client")?;
     let api_base = p2p_api_base(graphql)?;
+    let api_base_path = reqwest::Url::parse(&api_base)
+        .with_context(|| format!("parsing runtime API base URL {api_base}"))?
+        .path()
+        .trim_end_matches('/')
+        .to_string();
     let connect_addrs = vec![desktop_listen_address.to_string()];
     let replicator = P2pReplicatorRequest {
         addresses: vec![desktop_listen_address.to_string()],
@@ -29,14 +38,30 @@ pub(crate) async fn complete_runtime_pairing(
 
     loop {
         let result = async {
-            http_post_json(&client, &format!("{api_base}/p2p/connect"), &connect_addrs).await?;
-            http_post_json(
+            http_post_json_signed(
                 &client,
-                &format!("{api_base}/p2p/collections"),
-                &collections,
+                &format!("{api_base}/p2p/connect"),
+                &signed_admin_path(&api_base_path, "/p2p/connect"),
+                &connect_addrs,
+                actor,
             )
             .await?;
-            http_post_json(&client, &format!("{api_base}/p2p/replicators"), &replicator).await?;
+            http_post_json_signed(
+                &client,
+                &format!("{api_base}/p2p/collections"),
+                &signed_admin_path(&api_base_path, "/p2p/collections"),
+                &collections,
+                actor,
+            )
+            .await?;
+            http_post_json_signed(
+                &client,
+                &format!("{api_base}/p2p/replicators"),
+                &signed_admin_path(&api_base_path, "/p2p/replicators"),
+                &replicator,
+                actor,
+            )
+            .await?;
             Ok::<(), anyhow::Error>(())
         }
         .await;

--- a/crates/defra-agent-desktop-core/src/local_runtime/tests.rs
+++ b/crates/defra-agent-desktop-core/src/local_runtime/tests.rs
@@ -1,3 +1,4 @@
+use super::http::http_post_json_signed;
 use super::identity::{normalize_optional_string, resolve_p2p_peer_id};
 use super::pairing::P2pReplicatorRequest;
 use super::{
@@ -6,7 +7,13 @@ use super::{
     reset_desktop_runtime_state, runtime_discovery_url, runtime_graphql_url, runtime_status_url,
     DesktopInitSummary, LOCAL_STANDARD_SOURCE,
 };
-use crate::client::DesktopPaths;
+use crate::client::{DesktopPaths, PrincipalIdentity};
+use crate::remote_admin::http_impl::{
+    hex_encode, signed_admin_path, signing_payload, ACTOR_DID_HEADER, ACTOR_SIGNATURE_HEADER,
+    ACTOR_SIGNATURE_VERSION, ACTOR_SIGNATURE_VERSION_HEADER,
+};
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn sample_summary() -> DesktopInitSummary {
     DesktopInitSummary {
@@ -166,6 +173,50 @@ fn replicator_request_serializes_runtime_api_field_names() {
             "Addresses": ["127.0.0.1:9999/p2p/example"],
         })
     );
+}
+
+#[tokio::test]
+async fn signed_post_json_attaches_actor_headers() {
+    let server = MockServer::start().await;
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let paths = DesktopPaths::from_root(tempdir.path());
+    let actor = PrincipalIdentity::load_or_create(&paths)
+        .await
+        .expect("principal");
+    let body = vec!["AgentRequest".to_string()];
+    let body_bytes = serde_json::to_vec(&body).expect("body");
+    let expected_signature = hex_encode(
+        &actor
+            .sign(&signing_payload(
+                "POST",
+                &signed_admin_path("/api/v0", "/p2p/collections"),
+                &body_bytes,
+            ))
+            .expect("signature"),
+    );
+
+    Mock::given(method("POST"))
+        .and(path("/api/v0/p2p/collections"))
+        .and(header(ACTOR_DID_HEADER, actor.did()))
+        .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+        .and(header(
+            ACTOR_SIGNATURE_VERSION_HEADER,
+            ACTOR_SIGNATURE_VERSION,
+        ))
+        .and(body_json(serde_json::json!(["AgentRequest"])))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    http_post_json_signed(
+        &reqwest::Client::new(),
+        &format!("{}/api/v0/p2p/collections", server.uri()),
+        &signed_admin_path("/api/v0", "/p2p/collections"),
+        &body,
+        &actor,
+    )
+    .await
+    .expect("signed post");
 }
 
 #[test]

--- a/crates/defra-agent-desktop-core/src/remote_admin/http_impl.rs
+++ b/crates/defra-agent-desktop-core/src/remote_admin/http_impl.rs
@@ -1,25 +1,48 @@
 //! HTTP transport implementation for `RemoteP2pAdmin`.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
-use reqwest::Client;
+use reqwest::{header::CONTENT_TYPE, Client, Method, RequestBuilder};
 use serde::{Deserialize, Serialize};
+
+use crate::client::PrincipalIdentity;
 
 use super::trait_def::{
     RemoteP2pAdmin, RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
 };
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
+pub const ACTOR_DID_HEADER: &str = "x-defra-actor-did";
+pub const ACTOR_SIGNATURE_HEADER: &str = "x-defra-actor-signature";
+pub const ACTOR_SIGNATURE_VERSION_HEADER: &str = "x-defra-actor-signature-version";
+pub const ACTOR_SIGNATURE_VERSION: &str = "p2p-admin-v1";
 
 pub struct HttpRemoteP2pAdmin {
     /// `http://host:port/api/v0`, used to compose `/p2p/*` URLs.
     api_base: String,
+    api_base_path: String,
     client: Client,
+    actor: Option<Arc<PrincipalIdentity>>,
 }
 
 impl HttpRemoteP2pAdmin {
     pub fn new(graphql_url: &str) -> RemoteP2pAdminResult<Self> {
+        Self::new_inner(graphql_url, None)
+    }
+
+    pub fn new_with_actor(
+        graphql_url: &str,
+        actor: Arc<PrincipalIdentity>,
+    ) -> RemoteP2pAdminResult<Self> {
+        Self::new_inner(graphql_url, Some(actor))
+    }
+
+    fn new_inner(
+        graphql_url: &str,
+        actor: Option<Arc<PrincipalIdentity>>,
+    ) -> RemoteP2pAdminResult<Self> {
         let trimmed = graphql_url.trim_end_matches('/');
         let api_base = trimmed
             .strip_suffix("/graphql")
@@ -33,11 +56,61 @@ impl HttpRemoteP2pAdmin {
             .timeout(DEFAULT_RPC_TIMEOUT)
             .build()
             .map_err(|e| RemoteP2pAdminError::LocalError(format!("reqwest build: {e}")))?;
-        Ok(Self { api_base, client })
+        let api_base_path = reqwest::Url::parse(&api_base)
+            .map_err(|e| RemoteP2pAdminError::LocalError(format!("invalid API base URL: {e}")))?
+            .path()
+            .trim_end_matches('/')
+            .to_string();
+        Ok(Self {
+            api_base,
+            api_base_path,
+            client,
+            actor,
+        })
     }
 
     fn url(&self, path: &str) -> String {
         format!("{}{}", self.api_base, path)
+    }
+
+    fn request(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<Vec<u8>>,
+    ) -> RemoteP2pAdminResult<RequestBuilder> {
+        let mut request = self.client.request(method.clone(), self.url(path));
+        let body_bytes = body.as_deref().unwrap_or_default();
+
+        if let Some(actor) = self.actor.as_ref() {
+            let signed_path = signed_admin_path(&self.api_base_path, path);
+            let payload = signing_payload(method.as_str(), &signed_path, body_bytes);
+            let signature = actor.sign(&payload).map_err(|error| {
+                RemoteP2pAdminError::LocalError(format!("signing remote admin request: {error:#}"))
+            })?;
+            request = request
+                .header(ACTOR_DID_HEADER, actor.did())
+                .header(ACTOR_SIGNATURE_HEADER, hex_encode(&signature))
+                .header(ACTOR_SIGNATURE_VERSION_HEADER, ACTOR_SIGNATURE_VERSION);
+        }
+
+        if let Some(body) = body {
+            request = request.header(CONTENT_TYPE, "application/json").body(body);
+        }
+
+        Ok(request)
+    }
+
+    fn json_request<T: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: &str,
+        body: &T,
+    ) -> RemoteP2pAdminResult<RequestBuilder> {
+        let body = serde_json::to_vec(body).map_err(|error| {
+            RemoteP2pAdminError::LocalError(format!("encoding remote admin request body: {error}"))
+        })?;
+        self.request(method, path, Some(body))
     }
 }
 
@@ -84,8 +157,7 @@ struct SyncBranchableBody<'a> {
 impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
     async fn peer_info(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/info"))
+            .request(Method::GET, "/p2p/info", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -97,8 +169,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn active_peers(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/active-peers"))
+            .request(Method::GET, "/p2p/active-peers", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -110,9 +181,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn connect(&self, addresses: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/connect"))
-            .json(addresses)
+            .json_request(Method::POST, "/p2p/connect", addresses)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -132,8 +201,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
         }
 
         let resp = self
-            .client
-            .get(self.url("/p2p/replicators"))
+            .request(Method::GET, "/p2p/replicators", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -161,9 +229,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             addresses,
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/replicators"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/replicators", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -178,9 +244,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
     ) -> RemoteP2pAdminResult<()> {
         let body = DeleteReplicatorBody { collections, id };
         let resp = self
-            .client
-            .delete(self.url("/p2p/replicators"))
-            .json(&body)
+            .json_request(Method::DELETE, "/p2p/replicators", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -190,8 +254,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn list_p2p_collections(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/collections"))
+            .request(Method::GET, "/p2p/collections", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -203,9 +266,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn add_p2p_collections(&self, collections: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/collections"))
-            .json(collections)
+            .json_request(Method::POST, "/p2p/collections", collections)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -215,9 +276,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn delete_p2p_collections(&self, collections: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .delete(self.url("/p2p/collections"))
-            .json(collections)
+            .json_request(Method::DELETE, "/p2p/collections", collections)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -227,8 +286,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn list_p2p_documents(&self) -> RemoteP2pAdminResult<Vec<String>> {
         let resp = self
-            .client
-            .get(self.url("/p2p/documents"))
+            .request(Method::GET, "/p2p/documents", None)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -240,9 +298,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn add_p2p_documents(&self, doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .post(self.url("/p2p/documents"))
-            .json(doc_ids)
+            .json_request(Method::POST, "/p2p/documents", doc_ids)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -252,9 +308,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
 
     async fn delete_p2p_documents(&self, doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
         let resp = self
-            .client
-            .delete(self.url("/p2p/documents"))
-            .json(doc_ids)
+            .json_request(Method::DELETE, "/p2p/documents", doc_ids)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -274,9 +328,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/documents/sync"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/documents/sync", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -294,9 +346,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/collections/sync-versions"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/collections/sync-versions", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -314,9 +364,7 @@ impl RemoteP2pAdmin for HttpRemoteP2pAdmin {
             timeout: format_timeout(timeout),
         };
         let resp = self
-            .client
-            .post(self.url("/p2p/collections/sync-branchable"))
-            .json(&body)
+            .json_request(Method::POST, "/p2p/collections/sync-branchable", &body)?
             .send()
             .await
             .map_err(map_reqwest_err)?;
@@ -330,6 +378,39 @@ fn format_timeout(t: Option<Duration>) -> String {
         Some(d) => format!("{}s", d.as_secs()),
         None => String::new(),
     }
+}
+
+pub(crate) fn signing_payload(method: &str, path: &str, body: &[u8]) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(
+        ACTOR_SIGNATURE_VERSION.len() + method.len() + path.len() + body.len() + 3,
+    );
+    payload.extend_from_slice(ACTOR_SIGNATURE_VERSION.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(method.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(path.as_bytes());
+    payload.push(b'\n');
+    payload.extend_from_slice(body);
+    payload
+}
+
+pub(crate) fn signed_admin_path(api_base_path: &str, path: &str) -> String {
+    let api_base_path = api_base_path.trim_end_matches('/');
+    if api_base_path.is_empty() {
+        path.to_string()
+    } else {
+        format!("{api_base_path}{path}")
+    }
+}
+
+pub(crate) fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 fn map_reqwest_err(e: reqwest::Error) -> RemoteP2pAdminError {
@@ -362,12 +443,87 @@ async fn check_status(resp: reqwest::Response) -> RemoteP2pAdminResult<reqwest::
 #[cfg(test)]
 mod tests {
     use super::*;
-    use wiremock::matchers::{body_json, method, path};
+    use crate::client::{DesktopPaths, PrincipalIdentity};
+    use wiremock::matchers::{body_json, header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     fn admin_for(server: &MockServer) -> HttpRemoteP2pAdmin {
         let graphql = format!("{}/api/v0/graphql", server.uri());
         HttpRemoteP2pAdmin::new(&graphql).expect("admin constructs")
+    }
+
+    async fn signed_admin_for(server: &MockServer) -> (HttpRemoteP2pAdmin, Arc<PrincipalIdentity>) {
+        let tempdir = tempfile::tempdir().unwrap();
+        let paths = DesktopPaths::from_root(tempdir.path());
+        let actor = Arc::new(PrincipalIdentity::load_or_create(&paths).await.unwrap());
+        let graphql = format!("{}/api/v0/graphql", server.uri());
+        let admin =
+            HttpRemoteP2pAdmin::new_with_actor(&graphql, Arc::clone(&actor)).expect("admin signs");
+        (admin, actor)
+    }
+
+    #[tokio::test]
+    async fn signed_admin_attaches_actor_headers_to_get_request() {
+        let server = MockServer::start().await;
+        let (admin, actor) = signed_admin_for(&server).await;
+        let expected_signature = hex_encode(
+            &actor
+                .sign(&signing_payload(
+                    "GET",
+                    &signed_admin_path("/api/v0", "/p2p/info"),
+                    &[],
+                ))
+                .expect("signature"),
+        );
+
+        Mock::given(method("GET"))
+            .and(path("/api/v0/p2p/info"))
+            .and(header(ACTOR_DID_HEADER, actor.did()))
+            .and(header(
+                ACTOR_SIGNATURE_VERSION_HEADER,
+                ACTOR_SIGNATURE_VERSION,
+            ))
+            .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+            .respond_with(ResponseTemplate::new(200).set_body_json(Vec::<String>::new()))
+            .mount(&server)
+            .await;
+
+        admin.peer_info().await.expect("signed peer_info");
+    }
+
+    #[tokio::test]
+    async fn signed_admin_attaches_actor_headers_to_json_request() {
+        let server = MockServer::start().await;
+        let (admin, actor) = signed_admin_for(&server).await;
+        let collections = vec!["c1".to_string()];
+        let body = serde_json::to_vec(&collections).expect("body");
+        let expected_signature = hex_encode(
+            &actor
+                .sign(&signing_payload(
+                    "POST",
+                    &signed_admin_path("/api/v0", "/p2p/collections"),
+                    &body,
+                ))
+                .expect("signature"),
+        );
+
+        Mock::given(method("POST"))
+            .and(path("/api/v0/p2p/collections"))
+            .and(header(ACTOR_DID_HEADER, actor.did()))
+            .and(header(
+                ACTOR_SIGNATURE_VERSION_HEADER,
+                ACTOR_SIGNATURE_VERSION,
+            ))
+            .and(header(ACTOR_SIGNATURE_HEADER, expected_signature))
+            .and(body_json(serde_json::json!(["c1"])))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        admin
+            .add_p2p_collections(&collections)
+            .await
+            .expect("signed add");
     }
 
     #[tokio::test]

--- a/crates/defra-agent-desktop-core/tests/manage_view.rs
+++ b/crates/defra-agent-desktop-core/tests/manage_view.rs
@@ -85,8 +85,6 @@ async fn manage_document_saves_refresh_store() -> Result<()> {
         subagent_background_enabled: Some(true),
         subagent_allow_cross_deployment: Some(true),
         cross_deployment_spawn_timeout_seconds: Some(45),
-        enable_defra_query: Some(false),
-        defra_query_collections: Vec::new(),
     })
     .await?;
 

--- a/crates/defra-agent-protocol/schemas/services/tool_service_health_state.graphql
+++ b/crates/defra-agent-protocol/schemas/services/tool_service_health_state.graphql
@@ -9,6 +9,7 @@ type ToolServiceHealthState {
     agent_did: String @index
     endpoint: String
     status: String @index
+    tool_count: Int
     failure_count: Int
     k_max: Int
     backoff_until: DateTime

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -662,6 +662,8 @@ pub struct ToolServiceHealthStateRow {
     #[serde(default)]
     pub status: Option<String>,
     #[serde(default)]
+    pub tool_count: Option<i64>,
+    #[serde(default)]
     pub failure_count: Option<i64>,
     #[serde(default)]
     pub k_max: Option<i64>,

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -63,6 +63,14 @@ pub(in crate::agent) async fn run_agent(
         runtime_status.publish_error(&format!("{error:#}")).await;
         return Err(error);
     }
+    if let Err(error) =
+        crate::migration::ensure_tool_service_health_state_migrations(agent.node.clone())
+            .await
+            .context("ensure ToolServiceHealthState migrations")
+    {
+        runtime_status.publish_error(&format!("{error:#}")).await;
+        return Err(error);
+    }
     if let Err(error) = crate::migration::ensure_agent_behavior_migrations(agent.node.clone())
         .await
         .context("ensure AgentBehavior migrations")

--- a/crates/defra-agent/src/health_checker.rs
+++ b/crates/defra-agent/src/health_checker.rs
@@ -73,6 +73,7 @@ struct ServiceHealthEntry {
     health: ServiceHealth,
     model: ServiceModelInternal,
     endpoint: Option<String>,
+    tool_count: Option<i64>,
     last_probe_at: DateTime<Utc>,
 }
 
@@ -85,6 +86,7 @@ impl ServiceHealthEntry {
             health,
             model,
             endpoint: None,
+            tool_count: None,
             last_probe_at,
         }
     }
@@ -94,6 +96,7 @@ impl ServiceHealthEntry {
         last_seen: DateTime<Utc>,
         last_error: Option<String>,
         endpoint: Option<String>,
+        tool_count: Option<i64>,
         last_probe_at: DateTime<Utc>,
     ) -> Self {
         Self {
@@ -104,6 +107,7 @@ impl ServiceHealthEntry {
             },
             model,
             endpoint,
+            tool_count,
             last_probe_at,
         }
     }
@@ -201,6 +205,7 @@ pub struct MCPServiceHealthSnapshot {
     pub service_id: String,
     pub endpoint: Option<String>,
     pub status: String,
+    pub tool_count: Option<i64>,
     pub failure_count: u32,
     pub k_max: u32,
     pub backoff_until: Option<DateTime<Utc>>,
@@ -252,6 +257,7 @@ impl ServiceHealthMap {
                 service_id: service_id.clone(),
                 endpoint: entry.endpoint.clone(),
                 status: entry.model.state.to_defradb().to_string(),
+                tool_count: entry.tool_count,
                 failure_count: entry.model.failure_count,
                 k_max,
                 backoff_until: entry.model.backoff_until,
@@ -465,6 +471,7 @@ pub async fn run_health_check_cycle(
             .map(|entry| entry.health.last_seen)
             .unwrap_or(heartbeat_seen_at);
         let previous_endpoint = previous.as_ref().and_then(|entry| entry.endpoint.clone());
+        let previous_tool_count = previous.as_ref().and_then(|entry| entry.tool_count);
 
         // The Lean model (`Proofs/MCPHealth/Transition.lean`) reaches the
         // `Reconnecting` state via `ProbeEvent::BackoffExpiry` between an
@@ -487,6 +494,7 @@ pub async fn run_health_check_cycle(
                 previous_model,
                 previous_last_seen,
                 previous_endpoint,
+                previous_tool_count,
                 "registry entry missing mcp_port".to_string(),
                 now,
                 options,
@@ -506,6 +514,7 @@ pub async fn run_health_check_cycle(
                 previous_model,
                 previous_last_seen,
                 previous_endpoint,
+                previous_tool_count,
                 "registry entry missing address fields".to_string(),
                 now,
                 options,
@@ -543,7 +552,7 @@ pub async fn run_health_check_cycle(
         )
         .await
         {
-            Ok(Ok(_)) => {
+            Ok(Ok(tools)) => {
                 let next_model = step_service(
                     previous_model,
                     ProbeEvent::ProbeSuccess { stale: is_stale },
@@ -551,6 +560,7 @@ pub async fn run_health_check_cycle(
                     options,
                 )
                 .expect("probeSuccess must preserve the service model");
+                let tool_count = Some(tools.tools.len() as i64);
                 health_map
                     .set_entry(
                         service_id.clone(),
@@ -559,6 +569,7 @@ pub async fn run_health_check_cycle(
                             now,
                             None,
                             Some(endpoint.clone()),
+                            tool_count,
                             now,
                         ),
                     )
@@ -578,6 +589,7 @@ pub async fn run_health_check_cycle(
                     previous_model,
                     previous_last_seen,
                     Some(endpoint.clone()),
+                    previous_tool_count,
                     error.to_string(),
                     now,
                     options,
@@ -597,6 +609,7 @@ pub async fn run_health_check_cycle(
                     previous_model,
                     previous_last_seen,
                     Some(endpoint.clone()),
+                    previous_tool_count,
                     "probe timed out".to_string(),
                     now,
                     options,
@@ -646,6 +659,7 @@ async fn apply_probe_failure(
     previous_model: ServiceModelInternal,
     previous_last_seen: DateTime<Utc>,
     endpoint: Option<String>,
+    tool_count: Option<i64>,
     error: String,
     now: DateTime<Utc>,
     options: &HealthCheckerOptions,
@@ -663,6 +677,7 @@ async fn apply_probe_failure(
                 previous_last_seen,
                 Some(error),
                 endpoint,
+                tool_count,
                 now,
             ),
         )
@@ -803,6 +818,10 @@ async fn upsert_persisted_health_state(
     let last_seen = entry.last_seen.to_rfc3339();
     let last_probe_at = entry.last_probe_at.to_rfc3339();
     let updated_at = now.to_rfc3339();
+    let tool_count_fragment = entry
+        .tool_count
+        .map(|count| count.to_string())
+        .unwrap_or_else(|| "null".to_string());
     let backoff_until_fragment = match entry.backoff_until {
         Some(dt) => format!(r#""{}""#, dt.to_rfc3339()),
         None => "null".to_string(),
@@ -835,6 +854,7 @@ async fn upsert_persisted_health_state(
                     agent_did: "{agent_did}",
                     endpoint: "{endpoint}",
                     status: "{status}",
+                    tool_count: {tool_count_fragment},
                     failure_count: {failure_count},
                     k_max: {k_max},
                     backoff_until: {backoff_until_fragment},
@@ -847,6 +867,7 @@ async fn upsert_persisted_health_state(
                 update: {{
                     endpoint: "{endpoint}",
                     status: "{status}",
+                    tool_count: {tool_count_fragment},
                     failure_count: {failure_count},
                     k_max: {k_max},
                     backoff_until: {backoff_until_fragment},

--- a/crates/defra-agent/src/hook/persistence/background_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/background_tools.rs
@@ -257,7 +257,7 @@ impl DefraSessionHook {
         });
 
         Ok(self.skip_tool_result(
-            BACKGROUND_TOOL_NAME,
+            SPAWN_PROCESS_TOOL_NAME,
             json_string(json!({
                 "ok": true,
                 "tool_call_id": background_tool_call_id,
@@ -286,7 +286,7 @@ impl DefraSessionHook {
             Ok(args) => args,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    WAIT_TOOL_NAME,
+                    WAIT_PROCESS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_PROCESS_TOOL_NAME,
                         "/",
@@ -298,7 +298,7 @@ impl DefraSessionHook {
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
             return Ok(self.skip_tool_result(
-                WAIT_TOOL_NAME,
+                WAIT_PROCESS_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     WAIT_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -314,7 +314,7 @@ impl DefraSessionHook {
             Ok(result) => result,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    WAIT_TOOL_NAME,
+                    WAIT_PROCESS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_PROCESS_TOOL_NAME,
                         "/tool_call_id",
@@ -323,7 +323,7 @@ impl DefraSessionHook {
                 ));
             }
         };
-        Ok(self.skip_tool_result(WAIT_TOOL_NAME, result))
+        Ok(self.skip_tool_result(WAIT_PROCESS_TOOL_NAME, result))
     }
 
     pub(super) async fn persist_list_background_tools_tool_call(
@@ -344,7 +344,7 @@ impl DefraSessionHook {
             Ok(args) => args,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    LIST_BACKGROUND_TOOLS_TOOL_NAME,
+                    LIST_PROCESSES_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         LIST_PROCESSES_TOOL_NAME,
                         "/",
@@ -358,7 +358,7 @@ impl DefraSessionHook {
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize list_background_tools response: {error}")
         })?;
-        Ok(self.skip_tool_result(LIST_BACKGROUND_TOOLS_TOOL_NAME, json_string(result)))
+        Ok(self.skip_tool_result(LIST_PROCESSES_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_read_tool_output_tool_call(
@@ -379,7 +379,7 @@ impl DefraSessionHook {
             Ok(args) => args,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    READ_TOOL_OUTPUT_TOOL_NAME,
+                    READ_PROCESS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         READ_PROCESS_TOOL_NAME,
                         "/",
@@ -391,7 +391,7 @@ impl DefraSessionHook {
         let background_tool_call_id = parsed.tool_call_id.trim().to_string();
         if background_tool_call_id.is_empty() {
             return Ok(self.skip_tool_result(
-                READ_TOOL_OUTPUT_TOOL_NAME,
+                READ_PROCESS_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -405,10 +405,10 @@ impl DefraSessionHook {
                 let result = serde_json::to_value(response).map_err(|error| {
                     anyhow::anyhow!("serialize read_tool_output response: {error}")
                 })?;
-                Ok(self.skip_tool_result(READ_TOOL_OUTPUT_TOOL_NAME, json_string(result)))
+                Ok(self.skip_tool_result(READ_PROCESS_TOOL_NAME, json_string(result)))
             }
             ReadToolOutputOutcome::NotBackgrounded => Ok(self.skip_tool_result(
-                READ_TOOL_OUTPUT_TOOL_NAME,
+                READ_PROCESS_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -416,7 +416,7 @@ impl DefraSessionHook {
                 ),
             )),
             ReadToolOutputOutcome::NotAuthorized => Ok(self.skip_tool_result(
-                READ_TOOL_OUTPUT_TOOL_NAME,
+                READ_PROCESS_TOOL_NAME,
                 background_tool_not_allowed_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -446,7 +446,7 @@ impl DefraSessionHook {
             Ok(args) => args,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    CANCEL_TOOL_NAME,
+                    CANCEL_PROCESS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_PROCESS_TOOL_NAME,
                         "/",
@@ -458,7 +458,7 @@ impl DefraSessionHook {
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
             return Ok(self.skip_tool_result(
-                CANCEL_TOOL_NAME,
+                CANCEL_PROCESS_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -472,7 +472,7 @@ impl DefraSessionHook {
             .is_some_and(|reason| reason.trim().is_empty())
         {
             return Ok(self.skip_tool_result(
-                CANCEL_TOOL_NAME,
+                CANCEL_PROCESS_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_PROCESS_TOOL_NAME,
                     "/reason",
@@ -488,7 +488,7 @@ impl DefraSessionHook {
             Ok(lifecycle) => lifecycle,
             Err(error) => {
                 return Ok(self.skip_tool_result(
-                    CANCEL_TOOL_NAME,
+                    CANCEL_PROCESS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_PROCESS_TOOL_NAME,
                         "/tool_call_id",
@@ -501,7 +501,7 @@ impl DefraSessionHook {
             let result = self
                 .background_tool_envelope(lifecycle, "explicit_cancel")
                 .await?;
-            return Ok(self.skip_tool_result(CANCEL_TOOL_NAME, result));
+            return Ok(self.skip_tool_result(CANCEL_PROCESS_TOOL_NAME, result));
         }
 
         let notification_tool_name = lifecycle.tool_name().to_string();
@@ -531,7 +531,7 @@ impl DefraSessionHook {
             );
         }
         Ok(self.skip_tool_result(
-            CANCEL_TOOL_NAME,
+            CANCEL_PROCESS_TOOL_NAME,
             json_string(json!({
                 "ok": true,
                 "tool_call_id": background_tool_call_id,

--- a/crates/defra-agent/src/hook/persistence/background_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/background_tools.rs
@@ -256,13 +256,16 @@ impl DefraSessionHook {
             executions.remove(&execution_call_id).await;
         });
 
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "tool_call_id": background_tool_call_id,
-            "tool_name": target_tool_name,
-            "await_mode": "background",
-            "status": "running"
-        }))))
+        Ok(self.skip_tool_result(
+            BACKGROUND_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "tool_call_id": background_tool_call_id,
+                "tool_name": target_tool_name,
+                "await_mode": "background",
+                "status": "running"
+            })),
+        ))
     }
 
     pub(super) async fn persist_wait_tool_call(
@@ -282,7 +285,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<WaitToolArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    WAIT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_PROCESS_TOOL_NAME,
                         "/",
@@ -293,7 +297,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                WAIT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     WAIT_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -308,7 +313,8 @@ impl DefraSessionHook {
         {
             Ok(result) => result,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    WAIT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         WAIT_PROCESS_TOOL_NAME,
                         "/tool_call_id",
@@ -317,7 +323,7 @@ impl DefraSessionHook {
                 ));
             }
         };
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(WAIT_TOOL_NAME, result))
     }
 
     pub(super) async fn persist_list_background_tools_tool_call(
@@ -337,7 +343,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ListBackgroundToolsArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    LIST_BACKGROUND_TOOLS_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         LIST_PROCESSES_TOOL_NAME,
                         "/",
@@ -351,7 +358,7 @@ impl DefraSessionHook {
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize list_background_tools response: {error}")
         })?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(LIST_BACKGROUND_TOOLS_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_read_tool_output_tool_call(
@@ -371,7 +378,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ReadToolOutputArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    READ_TOOL_OUTPUT_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         READ_PROCESS_TOOL_NAME,
                         "/",
@@ -382,7 +390,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim().to_string();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -396,16 +405,18 @@ impl DefraSessionHook {
                 let result = serde_json::to_value(response).map_err(|error| {
                     anyhow::anyhow!("serialize read_tool_output response: {error}")
                 })?;
-                Ok(ToolCallHookAction::skip(json_string(result)))
+                Ok(self.skip_tool_result(READ_TOOL_OUTPUT_TOOL_NAME, json_string(result)))
             }
-            ReadToolOutputOutcome::NotBackgrounded => Ok(ToolCallHookAction::skip(
+            ReadToolOutputOutcome::NotBackgrounded => Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
                     "tool_call_id must identify an ordinary backgrounded tool call",
                 ),
             )),
-            ReadToolOutputOutcome::NotAuthorized => Ok(ToolCallHookAction::skip(
+            ReadToolOutputOutcome::NotAuthorized => Ok(self.skip_tool_result(
+                READ_TOOL_OUTPUT_TOOL_NAME,
                 background_tool_not_allowed_payload(
                     READ_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -434,7 +445,8 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<CancelToolArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    CANCEL_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_PROCESS_TOOL_NAME,
                         "/",
@@ -445,7 +457,8 @@ impl DefraSessionHook {
         };
         let background_tool_call_id = parsed.tool_call_id.trim();
         if background_tool_call_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                CANCEL_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_PROCESS_TOOL_NAME,
                     "/tool_call_id",
@@ -458,7 +471,8 @@ impl DefraSessionHook {
             .as_deref()
             .is_some_and(|reason| reason.trim().is_empty())
         {
-            return Ok(ToolCallHookAction::skip(
+            return Ok(self.skip_tool_result(
+                CANCEL_TOOL_NAME,
                 background_invalid_tool_arguments_payload(
                     CANCEL_PROCESS_TOOL_NAME,
                     "/reason",
@@ -473,7 +487,8 @@ impl DefraSessionHook {
         {
             Ok(lifecycle) => lifecycle,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(
+                return Ok(self.skip_tool_result(
+                    CANCEL_TOOL_NAME,
                     background_invalid_tool_arguments_payload(
                         CANCEL_PROCESS_TOOL_NAME,
                         "/tool_call_id",
@@ -483,10 +498,10 @@ impl DefraSessionHook {
             }
         };
         if lifecycle.is_terminal() {
-            return self
+            let result = self
                 .background_tool_envelope(lifecycle, "explicit_cancel")
-                .await
-                .map(ToolCallHookAction::skip);
+                .await?;
+            return Ok(self.skip_tool_result(CANCEL_TOOL_NAME, result));
         }
 
         let notification_tool_name = lifecycle.tool_name().to_string();
@@ -515,10 +530,13 @@ impl DefraSessionHook {
                 "failed to append explicitly cancelled background tool notification"
             );
         }
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "tool_call_id": background_tool_call_id,
-            "status": "cancelled"
-        }))))
+        Ok(self.skip_tool_result(
+            CANCEL_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "tool_call_id": background_tool_call_id,
+                "status": "cancelled"
+            })),
+        ))
     }
 }

--- a/crates/defra-agent/src/hook/persistence/helpers.rs
+++ b/crates/defra-agent/src/hook/persistence/helpers.rs
@@ -201,6 +201,26 @@ pub(super) fn truncation_mode_for(tool_name: &str) -> TruncationMode {
     }
 }
 
+pub(super) fn bounded_tool_result_for_model(
+    tool_name: &str,
+    raw_result: &str,
+    limits: &crate::truncation::TruncationLimits,
+) -> String {
+    let (bounded, trigger, truncated) =
+        truncate_text(raw_result, truncation_mode_for(tool_name), limits);
+    if truncated {
+        tracing::warn!(
+            tool_name = %tool_name,
+            truncated_by = ?trigger,
+            original_bytes = raw_result.len(),
+            max_lines = limits.max_lines,
+            max_bytes = limits.max_bytes,
+            "bounded hook-managed tool result before returning it to rig"
+        );
+    }
+    bounded
+}
+
 pub(super) fn model_observation_for_tool_result(tool_name: &str, raw_result: &str) -> String {
     if !is_read_file_tool(tool_name) {
         return raw_result.to_string();
@@ -641,6 +661,21 @@ mod tests {
         let raw = r#"{"ok":true,"content":"still structured"}"#;
 
         assert_eq!(model_observation_for_tool_result("grep", raw), raw);
+    }
+
+    #[test]
+    fn hook_managed_tool_result_is_bounded_before_model_loop() {
+        let limits = crate::truncation::TruncationLimits {
+            max_lines: 2,
+            max_bytes: 80,
+        };
+        let raw = "line 1\nline 2\nline 3\nline 4";
+
+        let bounded = bounded_tool_result_for_model("wait_subagent", raw, &limits);
+
+        assert!(bounded.contains("line 1\nline 2"));
+        assert!(!bounded.contains("line 3"));
+        assert!(bounded.contains("[Showing lines 1-2 of 4"));
     }
 
     #[test]

--- a/crates/defra-agent/src/hook/persistence/message_spawn.rs
+++ b/crates/defra-agent/src/hook/persistence/message_spawn.rs
@@ -535,7 +535,7 @@ impl DefraSessionHook {
 
         if await_mode == AwaitMode::Background {
             let receipt = background_receipt_payload(&child_request_id, None, behavior_id);
-            return Ok(ToolCallHookAction::skip(receipt));
+            return Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, receipt));
         }
 
         // Foreground spawns are local-only (the remote-foreground case is
@@ -552,7 +552,7 @@ impl DefraSessionHook {
             )
             .await?;
 
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result))
     }
 
     /// Classify a resolved target as local or remote by comparing the target's

--- a/crates/defra-agent/src/hook/persistence/mod.rs
+++ b/crates/defra-agent/src/hook/persistence/mod.rs
@@ -58,3 +58,22 @@ mod subagent_bridge;
 mod subagent_tools;
 
 use helpers::*;
+
+impl DefraSessionHook {
+    /// Rig 0.35 lets `on_tool_call` substitute `Skip` text, but `on_tool_result`
+    /// cannot replace the result already headed into rig's live message vector.
+    /// Bound every hook-managed skip so defra-owned control tools do not become
+    /// an in-loop context bypass.
+    pub(super) fn skip_tool_result(
+        &self,
+        tool_name: &str,
+        result: impl Into<String>,
+    ) -> ToolCallHookAction {
+        let result = result.into();
+        ToolCallHookAction::skip(bounded_tool_result_for_model(
+            tool_name,
+            &result,
+            &self.truncation_limits,
+        ))
+    }
+}

--- a/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_bridge.rs
@@ -992,7 +992,7 @@ impl DefraSessionHook {
             deadline_at,
         );
         lifecycle.spawn_failed(failure_class, &result).await?;
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(SPAWN_SUBAGENT_TOOL_NAME, result))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1019,6 +1019,6 @@ impl DefraSessionHook {
             deadline_at,
         );
         lifecycle.spawn_failed(failure_class, &result).await?;
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(tool_name, result))
     }
 }

--- a/crates/defra-agent/src/hook/persistence/subagent_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_tools.rs
@@ -18,20 +18,26 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<WaitSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     WAIT_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid wait_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        WAIT_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid wait_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 WAIT_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    WAIT_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
 
         let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
@@ -39,14 +45,15 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    return Ok(ToolCallHookAction::skip(service_unavailable_payload(
+                    let result = service_unavailable_payload(
                         WAIT_SUBAGENT_TOOL_NAME,
                         "/child_request_id",
                         format!(
                         "child subagent request is not available to this parent request: {error}"
                     ),
                         false,
-                    )));
+                    );
+                    return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
                 }
             };
 
@@ -78,7 +85,7 @@ impl DefraSessionHook {
             )
             .await?;
 
-        Ok(ToolCallHookAction::skip(result))
+        Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result))
     }
 
     pub(super) async fn persist_list_subagents_tool_call(
@@ -98,18 +105,21 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ListSubagentsArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     LIST_SUBAGENTS_TOOL_NAME,
-                    "/",
-                    format!("invalid list_subagents arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        LIST_SUBAGENTS_TOOL_NAME,
+                        "/",
+                        format!("invalid list_subagents arguments: {error}"),
+                    ),
+                ));
             }
         };
         let response =
             handle_list_subagents(&self.node, &request_id, &self.agent_did, parsed).await?;
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize list_subagents response: {error}"))?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(LIST_SUBAGENTS_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_read_subagent_tool_call(
@@ -129,34 +139,43 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<ReadSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     READ_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid read_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        READ_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid read_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim().to_string();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 READ_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    READ_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
 
         let Some(response) = handle_read_subagent(&self.node, &request_id, parsed).await? else {
-            return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+            return Ok(self.skip_tool_result(
                 READ_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                &child_request_id,
-                "child is not a background subagent owned by this parent request",
-                Vec::new(),
-            )));
+                tool_not_allowed_payload(
+                    READ_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    &child_request_id,
+                    "child is not a background subagent owned by this parent request",
+                    Vec::new(),
+                ),
+            ));
         };
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize read_subagent response: {error}"))?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(READ_SUBAGENT_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_steer_subagent_tool_call(
@@ -176,28 +195,37 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<SteerSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid steer_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid steer_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim().to_string();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 STEER_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
         let message = parsed.message.trim().to_string();
         if message.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 STEER_SUBAGENT_TOOL_NAME,
-                "/message",
-                "message is required",
-            )));
+                invalid_tool_arguments_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/message",
+                    "message is required",
+                ),
+            ));
         }
 
         let edge = match load_steer_subagent_target(&self.node, &request_id, &child_request_id)
@@ -205,29 +233,36 @@ impl DefraSessionHook {
         {
             SteerSubagentTarget::Found(edge) => edge,
             SteerSubagentTarget::NotAuthorized => {
-                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/child_request_id",
-                    &child_request_id,
-                    "child not owned by this parent request",
-                    Vec::new(),
-                )));
+                    tool_not_allowed_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/child_request_id",
+                        &child_request_id,
+                        "child not owned by this parent request",
+                        Vec::new(),
+                    ),
+                ));
             }
             SteerSubagentTarget::NotBackgrounded => {
-                return Ok(ToolCallHookAction::skip(tool_not_allowed_payload(
+                return Ok(self.skip_tool_result(
                     STEER_SUBAGENT_TOOL_NAME,
-                    "/child_request_id",
-                    &child_request_id,
-                    "foreground subagents cannot be steered; call cancel_subagent first",
-                    Vec::new(),
-                )));
+                    tool_not_allowed_payload(
+                        STEER_SUBAGENT_TOOL_NAME,
+                        "/child_request_id",
+                        &child_request_id,
+                        "foreground subagents cannot be steered; call cancel_subagent first",
+                        Vec::new(),
+                    ),
+                ));
             }
             SteerSubagentTarget::Terminal(state) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                let result = invalid_tool_arguments_payload(
                     STEER_SUBAGENT_TOOL_NAME,
                     "/child_request_id",
                     format!("child is in terminal state '{state}'; spawn a new subagent instead"),
-                )));
+                );
+                return Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, result));
             }
         };
 
@@ -275,7 +310,7 @@ impl DefraSessionHook {
         .await?;
         let result = serde_json::to_value(response)
             .map_err(|error| anyhow::anyhow!("serialize steer_subagent response: {error}"))?;
-        Ok(ToolCallHookAction::skip(json_string(result)))
+        Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, json_string(result)))
     }
 
     pub(super) async fn persist_cancel_subagent_tool_call(
@@ -295,31 +330,40 @@ impl DefraSessionHook {
         let parsed = match serde_json::from_str::<CancelSubagentArgs>(args) {
             Ok(args) => args,
             Err(error) => {
-                return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+                return Ok(self.skip_tool_result(
                     CANCEL_SUBAGENT_TOOL_NAME,
-                    "/",
-                    format!("invalid cancel_subagent arguments: {error}"),
-                )));
+                    invalid_tool_arguments_payload(
+                        CANCEL_SUBAGENT_TOOL_NAME,
+                        "/",
+                        format!("invalid cancel_subagent arguments: {error}"),
+                    ),
+                ));
             }
         };
         let child_request_id = parsed.child_request_id.trim();
         if child_request_id.is_empty() {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 CANCEL_SUBAGENT_TOOL_NAME,
-                "/child_request_id",
-                "child_request_id is required",
-            )));
+                invalid_tool_arguments_payload(
+                    CANCEL_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    "child_request_id is required",
+                ),
+            ));
         }
         if parsed
             .reason
             .as_deref()
             .is_some_and(|reason| reason.trim().is_empty())
         {
-            return Ok(ToolCallHookAction::skip(invalid_tool_arguments_payload(
+            return Ok(self.skip_tool_result(
                 CANCEL_SUBAGENT_TOOL_NAME,
-                "/reason",
-                "reason must be omitted or non-empty",
-            )));
+                invalid_tool_arguments_payload(
+                    CANCEL_SUBAGENT_TOOL_NAME,
+                    "/reason",
+                    "reason must be omitted or non-empty",
+                ),
+            ));
         }
 
         let parent_context = load_parent_subagent_context(&self.node, &request_id).await?;
@@ -327,14 +371,15 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    return Ok(ToolCallHookAction::skip(service_unavailable_payload(
+                    let result = service_unavailable_payload(
                         CANCEL_SUBAGENT_TOOL_NAME,
                         "/child_request_id",
                         format!(
                         "child subagent request is not available to this parent request: {error}"
                     ),
                         false,
-                    )));
+                    );
+                    return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
                 }
             };
 
@@ -371,15 +416,18 @@ impl DefraSessionHook {
         )
         .await?;
 
-        Ok(ToolCallHookAction::skip(json_string(json!({
-            "ok": true,
-            "child_request_id": edge.child_request_id,
-            "child_session_id": edge.child_session_id,
-            "behavior_id": edge.behavior_id,
-            "status": "cancelled",
-            "active_interrupted": active_interrupted,
-            "descendants_cancelled": descendants_cancelled,
-            "queued_drained": queued_drained
-        }))))
+        Ok(self.skip_tool_result(
+            CANCEL_SUBAGENT_TOOL_NAME,
+            json_string(json!({
+                "ok": true,
+                "child_request_id": edge.child_request_id,
+                "child_session_id": edge.child_session_id,
+                "behavior_id": edge.behavior_id,
+                "status": "cancelled",
+                "active_interrupted": active_interrupted,
+                "descendants_cancelled": descendants_cancelled,
+                "queued_drained": queued_drained
+            })),
+        ))
     }
 }

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -101,6 +101,10 @@ const ADD_TOOL_SERVICE_REGISTRY_SEND_AGENT_DID_PATCH: &str = r#"[
     {"op":"add","path":"/ToolServiceRegistry/Fields/-","value":{"Name":"send_agent_did","Kind":2}}
 ]"#;
 
+const ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH: &str = r#"[
+    {"op":"add","path":"/ToolServiceHealthState/Fields/-","value":{"Name":"tool_count","Kind":5}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -619,6 +623,34 @@ pub async fn ensure_agent_behavior_migrations(node: Arc<EmbeddedNode>) -> Result
     Ok(())
 }
 
+pub async fn ensure_tool_service_health_state_migrations(node: Arc<EmbeddedNode>) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("ToolServiceHealthState")
+        .context("get ToolServiceHealthState collection")?
+    else {
+        return Ok(());
+    };
+    if collection_has_field(&collection, "tool_count") {
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection(
+            "ToolServiceHealthState",
+            ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH,
+        )
+        .await
+        .context("patch_collection ToolServiceHealthState tool_count")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version ToolServiceHealthState tool_count")?;
+    tracing::info!(
+        version = %next.version_id,
+        "ToolServiceHealthState patched with tool_count field"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod patch_kind_tests {
     use super::*;
@@ -689,6 +721,7 @@ mod patch_kind_tests {
             ADD_AGENT_TOOL_CALL_COMMAND_DENIAL_PATCH,
             ADD_TOOL_SELECTION_R5_PATCH,
             ADD_AGENT_BEHAVIOR_DESCRIPTION_SUMMARY_PATCH,
+            ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH,
         ] {
             for (name, kind) in field_kinds(patch) {
                 assert_ne!(kind, 17, "field {name} uses unassigned Kind 17");

--- a/crates/defra-agent/src/oneshot.rs
+++ b/crates/defra-agent/src/oneshot.rs
@@ -39,6 +39,7 @@ pub async fn run_openai_oneshot_with_tools(
     ensure_schemas(node.as_ref()).await?;
     crate::migration::ensure_tool_call_migrations(node.clone()).await?;
     crate::migration::ensure_tool_service_registry_migrations(node.clone()).await?;
+    crate::migration::ensure_tool_service_health_state_migrations(node.clone()).await?;
     crate::migration::ensure_agent_behavior_migrations(node.clone()).await?;
 
     let api_key = behavior.completion_client_api_key()?;

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -21,7 +21,8 @@ use crate::document_config::SubagentTarget;
 use crate::meta_tools::{build_meta_tools, META_TOOL_NAMES};
 use crate::toolset::{
     background_tool_names, build_background_tools, build_context_budget_tool, build_subagent_tools,
-    subagent_tool_names, CliToolConfig, ToolSet, CONTEXT_BUDGET_TOOL_NAME,
+    build_session_history_tool, subagent_tool_names, CliToolConfig, ToolSet,
+    CONTEXT_BUDGET_TOOL_NAME, SESSION_HISTORY_TOOL_NAME,
 };
 
 const DEFAULT_CLI_TIMEOUT_SECS: u64 = 10;
@@ -102,6 +103,7 @@ impl ToolSurface {
         names.extend(background_tool_names(&self.background_tools));
         names.extend(self.custom_tools.iter().map(|tool| tool.name().to_string()));
         names.push(CONTEXT_BUDGET_TOOL_NAME.to_string());
+        names.push(SESSION_HISTORY_TOOL_NAME.to_string());
         if self.enable_defra_query {
             names.push(DEFRA_QUERY_TOOL_NAME.to_string());
         }
@@ -127,6 +129,10 @@ impl ToolSurface {
             tools.push(tool.build()?);
         }
         tools.push(build_context_budget_tool(
+            runtime.node.clone(),
+            runtime.agent_did.clone(),
+        ));
+        tools.push(build_session_history_tool(
             runtime.node.clone(),
             runtime.agent_did.clone(),
         ));

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -20,8 +20,8 @@ use crate::defra_query::{build_defra_query_tool, CollectionScope, DEFRA_QUERY_TO
 use crate::document_config::SubagentTarget;
 use crate::meta_tools::{build_meta_tools, META_TOOL_NAMES};
 use crate::toolset::{
-    background_tool_names, build_background_tools, build_context_budget_tool, build_subagent_tools,
-    build_session_history_tool, subagent_tool_names, CliToolConfig, ToolSet,
+    background_tool_names, build_background_tools, build_context_budget_tool,
+    build_session_history_tool, build_subagent_tools, subagent_tool_names, CliToolConfig, ToolSet,
     CONTEXT_BUDGET_TOOL_NAME, SESSION_HISTORY_TOOL_NAME,
 };
 

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -13,6 +13,7 @@ mod context_budget;
 mod denial;
 mod file_tools;
 mod native_runner;
+mod session_history;
 mod shared;
 mod subagent;
 #[cfg(test)]
@@ -35,6 +36,10 @@ pub use context_budget::{
     CONTEXT_BUDGET_TOOL_NAME,
 };
 pub(crate) use denial::{CommandPolicyDenial, DenialReason};
+pub use session_history::{
+    build_session_history_tool, load_session_history_snapshot, SessionHistoryRow,
+    SessionHistorySnapshot, SESSION_HISTORY_TOOL_NAME,
+};
 pub(crate) use shared::parse_argv_prefixes;
 pub use shared::{CommandExecutionMode, CommandExecutionPolicy, CommandNetworkMode};
 

--- a/crates/defra-agent/src/toolset/session_history.rs
+++ b/crates/defra-agent/src/toolset/session_history.rs
@@ -1,0 +1,709 @@
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use defra_node::EmbeddedNode;
+use rig::completion::ToolDefinition;
+use rig::tool::{Tool, ToolDyn};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::graphql::escape_graphql_string;
+
+pub const SESSION_HISTORY_TOOL_NAME: &str = "sessions";
+
+const DEFAULT_LIMIT: usize = 10;
+const MAX_LIMIT: usize = 50;
+const REQUEST_SCAN_LIMIT: usize = 500;
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SessionHistoryParams {
+    #[serde(default)]
+    pub action: Option<String>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionHistorySnapshot {
+    pub agent_did: String,
+    pub limit: usize,
+    pub request_scan_limit: usize,
+    pub sessions: Vec<SessionHistoryRow>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SessionHistoryRow {
+    pub session_id: String,
+    pub agent_name: Option<String>,
+    pub behavior_id: Option<String>,
+    pub status: Option<String>,
+    pub created_at: Option<String>,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub latest_request_id: Option<String>,
+    pub latest_request_status: Option<String>,
+    pub latest_request_lifecycle_state: Option<String>,
+    pub latest_request_created_at: Option<String>,
+    pub request_count: i64,
+    pub message_count: i64,
+    pub latest_message_at: Option<String>,
+    pub compaction_count: i64,
+    pub last_compacted_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RequestScanEnvelope {
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionDetailEnvelope {
+    #[serde(rename = "AgentSession", default)]
+    sessions: Vec<SessionRow>,
+    #[serde(rename = "AgentRequest", default)]
+    requests: Vec<RequestRow>,
+    #[serde(rename = "AgentMessage", default)]
+    messages: Vec<MessageRow>,
+    #[serde(rename = "CompactionEntry", default)]
+    compactions: Vec<CompactionRow>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SessionRow {
+    #[serde(default)]
+    session_id: String,
+    #[serde(default)]
+    agent_name: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    started: Option<String>,
+    #[serde(default)]
+    ended: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct RequestRow {
+    #[serde(default)]
+    request_id: Option<String>,
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    behavior_id: Option<String>,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MessageRow {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    timestamp: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct CompactionRow {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    created_at: Option<String>,
+}
+
+#[derive(Debug)]
+pub struct SessionHistoryToolError(anyhow::Error);
+
+impl std::fmt::Display for SessionHistoryToolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:#}", self.0)
+    }
+}
+
+impl std::error::Error for SessionHistoryToolError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.0.root_cause())
+    }
+}
+
+impl From<anyhow::Error> for SessionHistoryToolError {
+    fn from(error: anyhow::Error) -> Self {
+        Self(error)
+    }
+}
+
+#[derive(Clone)]
+pub struct SessionHistoryTool {
+    node: Arc<EmbeddedNode>,
+    agent_did: String,
+}
+
+impl SessionHistoryTool {
+    pub fn new(node: Arc<EmbeddedNode>, agent_did: impl Into<String>) -> Self {
+        Self {
+            node,
+            agent_did: agent_did.into(),
+        }
+    }
+}
+
+impl Tool for SessionHistoryTool {
+    const NAME: &'static str = SESSION_HISTORY_TOOL_NAME;
+
+    type Error = SessionHistoryToolError;
+    type Args = SessionHistoryParams;
+    type Output = String;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "List this agent's recent persisted sessions, including session status, \
+                latest request state, request/message counts, and compaction activity."
+                .to_string(),
+            parameters: json!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["list"],
+                        "description": "Action to run. Defaults to list."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": MAX_LIMIT,
+                        "description": "Maximum number of recent sessions to return."
+                    }
+                }
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        validate_action(args.action.as_deref())?;
+        let snapshot =
+            load_session_history_snapshot(&self.node, &self.agent_did, args.limit).await?;
+        serde_json::to_string_pretty(&snapshot).map_err(|error| {
+            SessionHistoryToolError(anyhow!(
+                "failed to serialize session history output: {error}"
+            ))
+        })
+    }
+}
+
+pub fn build_session_history_tool(
+    node: Arc<EmbeddedNode>,
+    agent_did: impl Into<String>,
+) -> Box<dyn ToolDyn> {
+    Box::new(SessionHistoryTool::new(node, agent_did))
+}
+
+pub async fn load_session_history_snapshot(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    limit: Option<usize>,
+) -> Result<SessionHistorySnapshot> {
+    let agent_did = agent_did.trim();
+    if agent_did.is_empty() {
+        bail!("sessions tool requires a running agent DID");
+    }
+
+    let limit = clamp_limit(limit);
+    let resp = node.execute(&request_scan_query(agent_did)).await;
+    if resp.has_errors() {
+        bail!(
+            "loading session history request scan failed: {:?}",
+            resp.errors
+        );
+    }
+    let envelope: RequestScanEnvelope = decode(resp.data.as_ref(), "session history request scan")?;
+    let session_ids = recent_session_ids(&envelope.requests, limit);
+
+    let sessions = if session_ids.is_empty() {
+        Vec::new()
+    } else {
+        let resp = node
+            .execute(&session_detail_query(agent_did, &session_ids))
+            .await;
+        if resp.has_errors() {
+            bail!("loading session history details failed: {:?}", resp.errors);
+        }
+        let envelope: SessionDetailEnvelope =
+            decode(resp.data.as_ref(), "session history details")?;
+        build_session_rows(&session_ids, envelope)
+    };
+
+    Ok(SessionHistorySnapshot {
+        agent_did: agent_did.to_string(),
+        limit,
+        request_scan_limit: REQUEST_SCAN_LIMIT,
+        sessions,
+    })
+}
+
+fn validate_action(action: Option<&str>) -> Result<()> {
+    match action.map(str::trim).filter(|action| !action.is_empty()) {
+        None | Some("list") => Ok(()),
+        Some(other) => bail!("unsupported sessions action '{other}'; supported action: list"),
+    }
+}
+
+fn clamp_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+}
+
+fn request_scan_query(agent_did: &str) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    format!(
+        r#"{{
+            AgentRequest(filter: {{ agent_did: {{ _eq: "{agent_did}" }} }}, order: {{ created_at: DESC }}, limit: {REQUEST_SCAN_LIMIT}) {{
+                session_id
+            }}
+        }}"#
+    )
+}
+
+fn session_detail_query(agent_did: &str, session_ids: &[String]) -> String {
+    let agent_did = escape_graphql_string(agent_did);
+    let list = quoted_graphql_list(session_ids);
+    format!(
+        r#"{{
+            AgentSession(filter: {{ session_id: {{ _in: [{list}] }} }}) {{
+                session_id
+                agent_name
+                behavior_id
+                started
+                ended
+                status
+            }}
+            AgentRequest(
+                filter: {{ _and: [
+                    {{ agent_did: {{ _eq: "{agent_did}" }} }},
+                    {{ session_id: {{ _in: [{list}] }} }}
+                ] }},
+                order: {{ created_at: DESC }}
+            ) {{
+                request_id
+                session_id
+                behavior_id
+                status
+                lifecycle_state
+                created_at
+            }}
+            AgentMessage(filter: {{ session_id: {{ _in: [{list}] }} }}) {{
+                session_id
+                timestamp
+            }}
+            CompactionEntry(filter: {{ session_id: {{ _in: [{list}] }} }}) {{
+                session_id
+                created_at
+            }}
+        }}"#
+    )
+}
+
+fn quoted_graphql_list(values: &[String]) -> String {
+    values
+        .iter()
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn decode<T: serde::de::DeserializeOwned>(data: Option<&Value>, label: &str) -> Result<T> {
+    let data = data
+        .filter(|data| data.is_object())
+        .cloned()
+        .with_context(|| format!("{label} query response missing object data"))?;
+    serde_json::from_value(data).with_context(|| format!("decoding {label} query response"))
+}
+
+fn recent_session_ids(requests: &[RequestRow], limit: usize) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut ids = Vec::new();
+    for request in requests {
+        let Some(session_id) = clean(request.session_id.as_ref()) else {
+            continue;
+        };
+        if seen.insert(session_id.clone()) {
+            ids.push(session_id);
+            if ids.len() >= limit {
+                break;
+            }
+        }
+    }
+    ids
+}
+
+fn build_session_rows(
+    session_ids: &[String],
+    envelope: SessionDetailEnvelope,
+) -> Vec<SessionHistoryRow> {
+    let SessionDetailEnvelope {
+        sessions,
+        requests,
+        messages,
+        compactions,
+    } = envelope;
+    let sessions_by_id = sessions
+        .into_iter()
+        .filter_map(|session| clean(Some(&session.session_id)).map(|id| (id, session)))
+        .collect::<BTreeMap<_, _>>();
+    let session_id_set = session_ids.iter().cloned().collect::<HashSet<_>>();
+    let aggregates = aggregate_by_session(requests, messages, compactions, &session_id_set);
+
+    session_ids
+        .iter()
+        .map(|session_id| {
+            let session = sessions_by_id.get(session_id);
+            let aggregate = aggregates.get(session_id);
+            let latest_request = aggregate.and_then(|aggregate| aggregate.latest_request.as_ref());
+            let started_at = session.and_then(|row| clean(row.started.as_ref()));
+            let latest_request_created_at =
+                latest_request.and_then(|row| clean(row.created_at.as_ref()));
+
+            SessionHistoryRow {
+                session_id: session_id.clone(),
+                agent_name: session.and_then(|row| clean(row.agent_name.as_ref())),
+                behavior_id: session
+                    .and_then(|row| clean(row.behavior_id.as_ref()))
+                    .or_else(|| latest_request.and_then(|row| clean(row.behavior_id.as_ref()))),
+                status: session
+                    .and_then(|row| clean(row.status.as_ref()))
+                    .or_else(|| latest_request.and_then(|row| clean(row.status.as_ref()))),
+                created_at: started_at
+                    .clone()
+                    .or_else(|| latest_request_created_at.clone()),
+                started_at,
+                ended_at: session.and_then(|row| clean(row.ended.as_ref())),
+                latest_request_id: latest_request.and_then(|row| clean(row.request_id.as_ref())),
+                latest_request_status: latest_request.and_then(|row| clean(row.status.as_ref())),
+                latest_request_lifecycle_state: latest_request
+                    .and_then(|row| clean(row.lifecycle_state.as_ref())),
+                latest_request_created_at,
+                request_count: aggregate
+                    .map(|aggregate| aggregate.request_count)
+                    .unwrap_or(0),
+                message_count: aggregate
+                    .map(|aggregate| aggregate.message_count)
+                    .unwrap_or(0),
+                latest_message_at: aggregate
+                    .and_then(|aggregate| aggregate.latest_message_at.clone()),
+                compaction_count: aggregate
+                    .map(|aggregate| aggregate.compaction_count)
+                    .unwrap_or(0),
+                last_compacted_at: aggregate
+                    .and_then(|aggregate| aggregate.last_compacted_at.clone()),
+            }
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Default)]
+struct SessionAggregate {
+    request_count: i64,
+    latest_request: Option<RequestRow>,
+    message_count: i64,
+    latest_message_at: Option<String>,
+    compaction_count: i64,
+    last_compacted_at: Option<String>,
+}
+
+fn aggregate_by_session(
+    requests: Vec<RequestRow>,
+    messages: Vec<MessageRow>,
+    compactions: Vec<CompactionRow>,
+    session_id_set: &HashSet<String>,
+) -> BTreeMap<String, SessionAggregate> {
+    let mut aggregates = BTreeMap::<String, SessionAggregate>::new();
+
+    for request in requests {
+        let Some(session_id) = clean(request.session_id.as_ref()) else {
+            continue;
+        };
+        if !session_id_set.contains(&session_id) {
+            continue;
+        }
+        let aggregate = aggregates.entry(session_id).or_default();
+        aggregate.request_count += 1;
+        if aggregate.latest_request.is_none()
+            || should_replace_latest(
+                aggregate
+                    .latest_request
+                    .as_ref()
+                    .and_then(|row| clean(row.created_at.as_ref()))
+                    .as_deref(),
+                clean(request.created_at.as_ref()).as_deref(),
+            )
+        {
+            aggregate.latest_request = Some(request);
+        }
+    }
+
+    for message in messages {
+        let Some(session_id) = clean(message.session_id.as_ref()) else {
+            continue;
+        };
+        if !session_id_set.contains(&session_id) {
+            continue;
+        }
+        let aggregate = aggregates.entry(session_id).or_default();
+        aggregate.message_count += 1;
+        update_latest(&mut aggregate.latest_message_at, message.timestamp.as_ref());
+    }
+
+    for compaction in compactions {
+        let Some(session_id) = clean(compaction.session_id.as_ref()) else {
+            continue;
+        };
+        if !session_id_set.contains(&session_id) {
+            continue;
+        }
+        let aggregate = aggregates.entry(session_id).or_default();
+        aggregate.compaction_count += 1;
+        update_latest(
+            &mut aggregate.last_compacted_at,
+            compaction.created_at.as_ref(),
+        );
+    }
+
+    aggregates
+}
+
+fn update_latest(current: &mut Option<String>, candidate: Option<&String>) {
+    let Some(candidate) = clean(candidate) else {
+        return;
+    };
+    if should_replace_latest(current.as_deref(), Some(candidate.as_str())) {
+        *current = Some(candidate);
+    }
+}
+
+fn should_replace_latest(current: Option<&str>, candidate: Option<&str>) -> bool {
+    match (current, candidate) {
+        (None, Some(_)) => true,
+        (Some(current), Some(candidate)) => candidate > current,
+        _ => false,
+    }
+}
+
+fn clean(value: Option<&String>) -> Option<String> {
+    value
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use rig::tool::Tool;
+
+    use super::*;
+
+    async fn seeded_node() -> Arc<EmbeddedNode> {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+        for mutation in [
+            r#"mutation {
+                create_AgentSession(input: {
+                    session_id: "session-a",
+                    agent_name: "OpenAI Agent",
+                    behavior_id: "behavior-a",
+                    started: "2026-06-03T09:55:00Z",
+                    status: "open"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentSession(input: {
+                    session_id: "session-b",
+                    agent_name: "OpenAI Agent",
+                    behavior_id: "behavior-b",
+                    started: "2026-06-03T10:55:00Z",
+                    status: "open"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "request-a-old",
+                    agent_did: "did:key:z-sessions",
+                    behavior_id: "behavior-a",
+                    session_id: "session-a",
+                    status: "completed",
+                    lifecycle_state: "completed",
+                    created_at: "2026-06-03T10:00:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "request-a-new",
+                    agent_did: "did:key:z-sessions",
+                    behavior_id: "behavior-a",
+                    session_id: "session-a",
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    created_at: "2026-06-03T10:05:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "request-b-new",
+                    agent_did: "did:key:z-sessions",
+                    behavior_id: "behavior-b",
+                    session_id: "session-b",
+                    status: "completed",
+                    lifecycle_state: "completed",
+                    created_at: "2026-06-03T11:00:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentRequest(input: {
+                    request_id: "request-other-agent",
+                    agent_did: "did:key:z-other",
+                    behavior_id: "behavior-c",
+                    session_id: "session-c",
+                    status: "completed",
+                    lifecycle_state: "completed",
+                    created_at: "2026-06-03T12:00:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentMessage(input: {
+                    message_key: "session-a:1",
+                    session_id: "session-a",
+                    sequence: 1,
+                    role: "user",
+                    content: "hello",
+                    timestamp: "2026-06-03T10:01:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_AgentMessage(input: {
+                    message_key: "session-a:2",
+                    session_id: "session-a",
+                    sequence: 2,
+                    role: "assistant",
+                    content: "hi",
+                    timestamp: "2026-06-03T10:06:00Z"
+                }) { _docID }
+            }"#,
+            r#"mutation {
+                create_CompactionEntry(input: {
+                    compaction_key: "session-a:1",
+                    session_id: "session-a",
+                    sequence: 1,
+                    original_tokens: 800,
+                    compacted_tokens: 400,
+                    created_at: "2026-06-03T10:07:00Z"
+                }) { _docID }
+            }"#,
+        ] {
+            let response = node.execute(mutation).await;
+            assert!(!response.has_errors(), "seed failed: {:?}", response.errors);
+        }
+
+        node
+    }
+
+    #[tokio::test]
+    async fn session_history_snapshot_reports_recent_agent_sessions() {
+        let node = seeded_node().await;
+
+        let snapshot = load_session_history_snapshot(&node, "did:key:z-sessions", Some(2))
+            .await
+            .unwrap();
+
+        assert_eq!(snapshot.agent_did, "did:key:z-sessions");
+        assert_eq!(snapshot.limit, 2);
+        assert_eq!(snapshot.request_scan_limit, REQUEST_SCAN_LIMIT);
+        assert_eq!(
+            snapshot
+                .sessions
+                .iter()
+                .map(|session| session.session_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["session-b", "session-a"]
+        );
+
+        let session_a = snapshot
+            .sessions
+            .iter()
+            .find(|session| session.session_id == "session-a")
+            .unwrap();
+        assert_eq!(session_a.agent_name.as_deref(), Some("OpenAI Agent"));
+        assert_eq!(session_a.behavior_id.as_deref(), Some("behavior-a"));
+        assert_eq!(session_a.status.as_deref(), Some("open"));
+        assert_eq!(
+            session_a.created_at.as_deref(),
+            Some("2026-06-03T09:55:00Z")
+        );
+        assert_eq!(
+            session_a.latest_request_id.as_deref(),
+            Some("request-a-new")
+        );
+        assert_eq!(
+            session_a.latest_request_lifecycle_state.as_deref(),
+            Some("processing")
+        );
+        assert_eq!(session_a.request_count, 2);
+        assert_eq!(session_a.message_count, 2);
+        assert_eq!(
+            session_a.latest_message_at.as_deref(),
+            Some("2026-06-03T10:06:00Z")
+        );
+        assert_eq!(session_a.compaction_count, 1);
+        assert_eq!(
+            session_a.last_compacted_at.as_deref(),
+            Some("2026-06-03T10:07:00Z")
+        );
+    }
+
+    #[tokio::test]
+    async fn sessions_tool_serializes_limited_history() {
+        let node = seeded_node().await;
+        let tool = SessionHistoryTool::new(node, "did:key:z-sessions");
+
+        let output = Tool::call(
+            &tool,
+            SessionHistoryParams {
+                action: Some("list".to_string()),
+                limit: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+        let parsed: SessionHistorySnapshot = serde_json::from_str(&output).unwrap();
+
+        assert_eq!(parsed.limit, 1);
+        assert_eq!(parsed.sessions.len(), 1);
+        assert_eq!(parsed.sessions[0].session_id, "session-b");
+    }
+
+    #[tokio::test]
+    async fn sessions_tool_rejects_unsupported_action() {
+        let node = seeded_node().await;
+        let tool = SessionHistoryTool::new(node, "did:key:z-sessions");
+
+        let error = Tool::call(
+            &tool,
+            SessionHistoryParams {
+                action: Some("read".to_string()),
+                limit: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("unsupported sessions action"));
+    }
+}

--- a/crates/defra-agent/tests/r4_subagent_tools/spawn_validation.rs
+++ b/crates/defra-agent/tests/r4_subagent_tools/spawn_validation.rs
@@ -37,6 +37,8 @@ async fn setup_ghost_behavior_fixture(test_name: &str) -> SpawnFixture {
     upsert_agent_behavior(
         db.node.as_ref(),
         &AgentBehaviorDocument {
+            skill_refs: Vec::new(),
+            skill_excludes: Vec::new(),
             behavior_id: PARENT_BEHAVIOR_ID.to_string(),
             agent_did: agent_did.clone(),
             display_name: Some("R4 parent (ghost test)".to_string()),


### PR DESCRIPTION
Integrates Ivan's runtime/config PR stack on top of the merged agent work:

- #396 MCP pool runtime introspection endpoint
- #397 runtime session history endpoint
- #398 sessions runtime tool
- #399 desktop P2P admin request signing
- #405 bounded hook-managed tool results before model loop reuse
- #406 ToolSelection apply with explicit empty list fields

Integration notes:

- Resolved #405 against the current process-tool names and subagent APIs.
- Kept the existing context/runtime config idioms from the merged agent/defer work.
- Filled the current ToolSelection desired-state shape, including subagent controls and cross-deployment fields.

Verification:

- cargo fmt --all --check
- cargo test -p defra-agent --lib hook -- --nocapture
- cargo test -p defra-agent --test r4c_read_tool_output --test r4c_read_subagent_transcript --test r4_subagent_tools --test r4c_list_background_tools --test r4c_list_subagents --test r4c_steer_subagent --test r6_background_tools -- --nocapture
- cargo test -p defra-agent-cli desired_state::tests::tool_selection_round_trip_preserves_subagent_controls -- --nocapture
- cargo test -p defra-agent-cli config_bundle::tests::empty_list_is_cleared_on_update_but_omitted_on_create -- --nocapture
- cargo test -p defra-agent-cli --test cli_config_apply_e2e config_apply_accepts_explicit_empty_tool_selection_lists_twice -- --nocapture
- cargo test -p defra-agent-cli --test cli_config_tools -- --nocapture