### PR TITLE
Add live output buffers for running background tools

### DIFF
--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -916,6 +916,7 @@ pub(crate) async fn handle_read_tool_output(
         status,
         output: slice.output,
         next_offset: slice.next_offset,
+        first_available_offset: slice.first_available_offset,
         total_bytes: slice.total_bytes,
         has_more: slice.has_more,
         exited,
@@ -943,6 +944,11 @@ fn combine_output_streams(stdout: &str, stderr: &str) -> String {
 struct CombinedOutputSlice {
     output: String,
     next_offset: u64,
+    /// Earliest byte offset still readable. 0 for terminal/persisted output
+    /// (nothing is ever evicted); for a running tool whose live ring buffer
+    /// has overflowed, this is > 0 and a caller can detect that bytes in
+    /// `[requested offset, first_available_offset)` were dropped.
+    first_available_offset: u64,
     total_bytes: u64,
     has_more: bool,
 }
@@ -1012,6 +1018,7 @@ fn read_retained_output_slice(
     CombinedOutputSlice {
         output,
         next_offset,
+        first_available_offset: first_offset,
         total_bytes,
         has_more: next_offset < total_bytes,
     }
@@ -2254,5 +2261,31 @@ mod tests {
             ]),
             vec!["alpha".to_string(), "beta".to_string()]
         );
+    }
+
+    #[test]
+    fn combined_slice_reports_zero_first_available_offset() {
+        // Terminal/persisted output is never evicted, so the earliest readable
+        // byte is always 0.
+        let slice = read_combined_output_slice("hello world", 0, 1024);
+        assert_eq!(slice.first_available_offset, 0);
+        assert_eq!(slice.output, "hello world");
+        assert_eq!(slice.total_bytes, 11);
+        assert!(!slice.has_more);
+    }
+
+    #[test]
+    fn retained_slice_surfaces_dropped_prefix() {
+        // Simulate a live ring buffer that produced 1000 bytes but retains only
+        // the last 4 (tail): first_offset = 996, total_bytes_seen = 1000.
+        let slice = read_retained_output_slice("tail", 996, 1000, 0, 1024);
+        // A read from offset 0 is clamped forward to the earliest retained
+        // byte; first_available_offset (996) exceeding the requested offset (0)
+        // is how a caller detects bytes [0, 996) were produced then evicted.
+        assert_eq!(slice.first_available_offset, 996);
+        assert_eq!(slice.output, "tail");
+        assert_eq!(slice.next_offset, 1000);
+        assert_eq!(slice.total_bytes, 1000);
+        assert!(!slice.has_more);
     }
 }

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)] // R4b lands these helpers one task ahead of their tool integrations.
 
+mod buffer;
 pub(crate) mod r4c_args;
 mod transcript_render;
 
@@ -25,6 +26,9 @@ use crate::session::execute_mutation_with_retry;
 use crate::tool_call_lifecycle::{AwaitMode, ChildTerminal, FailureClass};
 use crate::watcher::{validate_agent_request_subagent_coherence, AgentRequest};
 
+pub(crate) use self::buffer::{
+    LiveOutputStream, LiveToolOutputRegistry, LiveToolOutputSnapshot, LiveToolOutputWriter,
+};
 use self::r4c_args::{
     ListBackgroundToolsArgs, ListBackgroundToolsEntry, ListBackgroundToolsResponse,
     ListStatusFilter, ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
@@ -497,6 +501,7 @@ pub(crate) async fn handle_list_background_tools(
     node: &EmbeddedNode,
     caller_request_id: &str,
     local_deployment_id: &str,
+    live_outputs: &LiveToolOutputRegistry,
     args: ListBackgroundToolsArgs,
 ) -> Result<ListBackgroundToolsResponse> {
     let limit = args.validated_limit() as usize;
@@ -549,10 +554,17 @@ pub(crate) async fn handle_list_background_tools(
         let created_at = parse_rfc3339(row.started_at.as_deref())
             .ok_or_else(|| anyhow!("background tool call {tool_call_id} has invalid started_at"))?;
         let last_update = parse_rfc3339(row.completed_at.as_deref()).unwrap_or(created_at);
-        let stdout_bytes = row
-            .result
-            .as_deref()
-            .map_or(0, |result| result.len() as u64);
+        let (stdout_bytes, stderr_bytes) = if status == "running" {
+            live_outputs
+                .snapshot(&tool_call_id)
+                .await
+                .map(|snapshot| (snapshot.stdout_bytes, snapshot.stderr_bytes))
+                .unwrap_or((0, 0))
+        } else {
+            let persisted =
+                persisted_tool_output_streams(&row.tool_name, row.result.as_deref().unwrap_or(""));
+            (persisted.stdout.len() as u64, persisted.stderr.len() as u64)
+        };
 
         entries.push(ListBackgroundToolsEntry {
             tool_call_id,
@@ -563,7 +575,7 @@ pub(crate) async fn handle_list_background_tools(
             created_at,
             last_update,
             stdout_bytes,
-            stderr_bytes: 0,
+            stderr_bytes,
         });
     }
 
@@ -823,6 +835,7 @@ fn tool_result_identities(message: &Message) -> Vec<String> {
 pub(crate) async fn handle_read_tool_output(
     node: &EmbeddedNode,
     caller_request_id: &str,
+    live_outputs: &LiveToolOutputRegistry,
     args: ReadToolOutputArgs,
 ) -> Result<ReadToolOutputOutcome> {
     let tool_call_id = args.tool_call_id.trim();
@@ -875,19 +888,27 @@ pub(crate) async fn handle_read_tool_output(
         .to_string();
     let exited = status != "running";
     let max_bytes = args.validated_max_bytes();
-    let result = if exited {
-        row.result.as_deref().unwrap_or_default()
+    let (slice, exit_code) = if exited {
+        let result = row.result.as_deref().unwrap_or_default();
+        let persisted = persisted_tool_output_streams(&row.tool_name, result);
+        // Merge stdout + stderr into a single logical buffer behind one byte cursor.
+        // The capture stores the two streams separately with no preserved interleave
+        // order, so combining them with a stable labeled boundary (stdout first,
+        // then `STDERR_BOUNDARY`, then stderr) is the cleanest honest single-cursor
+        // model: an orchestrator pages through ALL output gap-free from `offset`.
+        let combined = combine_output_streams(&persisted.stdout, &persisted.stderr);
+        (
+            read_combined_output_slice(&combined, args.offset, max_bytes),
+            persisted.exit_code,
+        )
     } else {
-        ""
+        let slice = live_outputs
+            .snapshot(&row.tool_call_id)
+            .await
+            .map(|snapshot| read_live_output_slice(snapshot, args.offset, max_bytes))
+            .unwrap_or_else(|| read_combined_output_slice("", args.offset, max_bytes));
+        (slice, None)
     };
-    let persisted = persisted_tool_output_streams(&row.tool_name, result);
-    // Merge stdout + stderr into a single logical buffer behind one byte cursor.
-    // The capture stores the two streams separately with no preserved interleave
-    // order, so combining them with a stable labeled boundary (stdout first,
-    // then `STDERR_BOUNDARY`, then stderr) is the cleanest honest single-cursor
-    // model: an orchestrator pages through ALL output gap-free from `offset`.
-    let combined = combine_output_streams(&persisted.stdout, &persisted.stderr);
-    let slice = read_combined_output_slice(&combined, args.offset, max_bytes);
 
     Ok(ReadToolOutputOutcome::Found(ReadToolOutputResponse {
         tool_call_id: row.tool_call_id,
@@ -898,7 +919,7 @@ pub(crate) async fn handle_read_tool_output(
         total_bytes: slice.total_bytes,
         has_more: slice.has_more,
         exited,
-        exit_code: persisted.exit_code,
+        exit_code,
     }))
 }
 
@@ -936,9 +957,36 @@ fn read_combined_output_slice(
     offset: u64,
     max_bytes: usize,
 ) -> CombinedOutputSlice {
+    read_retained_output_slice(combined, 0, combined.len() as u64, offset, max_bytes)
+}
+
+fn read_live_output_slice(
+    snapshot: LiveToolOutputSnapshot,
+    offset: u64,
+    max_bytes: usize,
+) -> CombinedOutputSlice {
+    let retained = String::from_utf8_lossy(&snapshot.combined.bytes).into_owned();
+    read_retained_output_slice(
+        &retained,
+        snapshot.combined.first_offset,
+        snapshot.combined.total_bytes_seen,
+        offset,
+        max_bytes,
+    )
+}
+
+fn read_retained_output_slice(
+    combined: &str,
+    first_offset: u64,
+    total_bytes: u64,
+    offset: u64,
+    max_bytes: usize,
+) -> CombinedOutputSlice {
     let bytes = combined.as_bytes();
-    let total_bytes = bytes.len() as u64;
-    let start = (offset.min(total_bytes)) as usize;
+    let retained_end = first_offset.saturating_add(bytes.len() as u64);
+    let total_bytes = total_bytes.max(retained_end);
+    let start_offset = offset.clamp(first_offset, retained_end);
+    let start = start_offset.saturating_sub(first_offset) as usize;
     let mut start = start;
     // Snap forward to a UTF-8 char boundary so slicing never splits a codepoint.
     while start < bytes.len() && !combined.is_char_boundary(start) {
@@ -960,7 +1008,7 @@ fn read_combined_output_slice(
         }
     }
     let output = combined[start..end].to_string();
-    let next_offset = end as u64;
+    let next_offset = first_offset.saturating_add(end as u64);
     CombinedOutputSlice {
         output,
         next_offset,

--- a/crates/defra-agent/src/background_tools/buffer.rs
+++ b/crates/defra-agent/src/background_tools/buffer.rs
@@ -1,0 +1,159 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::Mutex;
+
+use super::STDERR_BOUNDARY;
+
+const LIVE_STREAM_CAPACITY_BYTES: usize = 256 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LiveOutputStream {
+    Stdout,
+    Stderr,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LiveToolOutputRegistry {
+    inner: Arc<Mutex<HashMap<String, LiveToolOutputBuffer>>>,
+}
+
+impl LiveToolOutputRegistry {
+    pub(crate) fn writer_for(&self, tool_call_id: impl Into<String>) -> LiveToolOutputWriter {
+        LiveToolOutputWriter {
+            registry: self.clone(),
+            tool_call_id: tool_call_id.into(),
+        }
+    }
+
+    pub(crate) async fn snapshot(&self, tool_call_id: &str) -> Option<LiveToolOutputSnapshot> {
+        self.inner
+            .lock()
+            .await
+            .get(tool_call_id)
+            .map(LiveToolOutputBuffer::snapshot)
+    }
+
+    pub(crate) async fn remove(&self, tool_call_id: &str) {
+        self.inner.lock().await.remove(tool_call_id);
+    }
+
+    async fn append(&self, tool_call_id: &str, stream: LiveOutputStream, bytes: &[u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+        self.inner
+            .lock()
+            .await
+            .entry(tool_call_id.to_string())
+            .or_default()
+            .append(stream, bytes);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LiveToolOutputWriter {
+    registry: LiveToolOutputRegistry,
+    tool_call_id: String,
+}
+
+impl LiveToolOutputWriter {
+    pub(crate) async fn append(&self, stream: LiveOutputStream, bytes: &[u8]) {
+        self.registry
+            .append(&self.tool_call_id, stream, bytes)
+            .await;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LiveToolOutputSnapshot {
+    pub(crate) combined: LiveOutputStreamSnapshot,
+    pub(crate) stdout_bytes: u64,
+    pub(crate) stderr_bytes: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LiveOutputStreamSnapshot {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) first_offset: u64,
+    pub(crate) total_bytes_seen: u64,
+}
+
+#[derive(Debug, Default)]
+struct LiveToolOutputBuffer {
+    combined: RingBuffer,
+    stdout: RingBuffer,
+    stderr: RingBuffer,
+    stderr_started: bool,
+}
+
+impl LiveToolOutputBuffer {
+    fn append(&mut self, stream: LiveOutputStream, bytes: &[u8]) {
+        match stream {
+            LiveOutputStream::Stdout => {
+                self.stdout.append(bytes);
+                self.combined.append(bytes);
+            }
+            LiveOutputStream::Stderr => {
+                self.stderr.append(bytes);
+                if !self.stderr_started {
+                    self.stderr_started = true;
+                    if !self.combined.is_empty() {
+                        self.combined.append(STDERR_BOUNDARY.as_bytes());
+                    }
+                }
+                self.combined.append(bytes);
+            }
+        }
+    }
+
+    fn snapshot(&self) -> LiveToolOutputSnapshot {
+        LiveToolOutputSnapshot {
+            combined: self.combined.snapshot(),
+            stdout_bytes: self.stdout.len() as u64,
+            stderr_bytes: self.stderr.len() as u64,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct RingBuffer {
+    bytes: Vec<u8>,
+    total_bytes_seen: u64,
+}
+
+impl RingBuffer {
+    fn append(&mut self, bytes: &[u8]) {
+        self.total_bytes_seen = self.total_bytes_seen.saturating_add(bytes.len() as u64);
+        if bytes.len() >= LIVE_STREAM_CAPACITY_BYTES {
+            self.bytes.clear();
+            self.bytes
+                .extend_from_slice(&bytes[bytes.len() - LIVE_STREAM_CAPACITY_BYTES..]);
+            return;
+        }
+
+        self.bytes.extend_from_slice(bytes);
+        let overflow = self.bytes.len().saturating_sub(LIVE_STREAM_CAPACITY_BYTES);
+        if overflow > 0 {
+            self.bytes.drain(..overflow);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn snapshot(&self) -> LiveOutputStreamSnapshot {
+        LiveOutputStreamSnapshot {
+            bytes: self.bytes.clone(),
+            first_offset: self
+                .total_bytes_seen
+                .saturating_sub(self.bytes.len() as u64),
+            total_bytes_seen: self.total_bytes_seen,
+        }
+    }
+}

--- a/crates/defra-agent/src/background_tools/buffer.rs
+++ b/crates/defra-agent/src/background_tools/buffer.rs
@@ -4,8 +4,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use super::STDERR_BOUNDARY;
-
-const LIVE_STREAM_CAPACITY_BYTES: usize = 256 * 1024;
+use crate::truncation::LIVE_STREAM_CAPACITY_BYTES;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum LiveOutputStream {
@@ -123,6 +122,15 @@ struct RingBuffer {
 }
 
 impl RingBuffer {
+    /// Append `bytes`, evicting from the *front* so the buffer always retains
+    /// the most recent `LIVE_STREAM_CAPACITY_BYTES`.
+    ///
+    /// This always keeps the tail, for every tool, and is a deliberate
+    /// divergence from `crate::truncation::tool_result_truncation_mode` (which
+    /// keeps the head for non-bash *finished* results). A live view of a
+    /// running tool always wants the most recent output regardless of tool, so
+    /// tail-retention is correct here; `total_bytes_seen`/`first_offset` let a
+    /// reader detect that an earlier prefix was evicted.
     fn append(&mut self, bytes: &[u8]) {
         self.total_bytes_seen = self.total_bytes_seen.saturating_add(bytes.len() as u64);
         if bytes.len() >= LIVE_STREAM_CAPACITY_BYTES {

--- a/crates/defra-agent/src/background_tools/r4c_args.rs
+++ b/crates/defra-agent/src/background_tools/r4c_args.rs
@@ -232,6 +232,12 @@ pub(crate) struct ReadToolOutputResponse {
     /// Resume cursor = `offset` + bytes returned in `output`. Pass as `offset`
     /// on the next read to continue with no gap and no overlap.
     pub(crate) next_offset: u64,
+    /// Earliest byte offset still available to read. 0 for finished tools
+    /// (their full output is persisted, nothing is ever dropped). For a
+    /// running tool the live buffer retains only the most recent output, so
+    /// this can be > 0; if it exceeds your requested `offset`, the bytes in
+    /// between were produced but evicted before you read them.
+    pub(crate) first_available_offset: u64,
     /// Total bytes captured so far across the combined stdout/stderr buffer.
     pub(crate) total_bytes: u64,
     /// True when `next_offset < total_bytes` (more output remains to be paged).

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -9,6 +9,7 @@ use rig::tool::ToolDyn;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
+use crate::background_tools::LiveToolOutputRegistry;
 use crate::session;
 use crate::tool_call_lifecycle::{
     AwaitMode, CancelCause, CascadeDispatch, ChildTerminal, ToolCallLifecycle,
@@ -310,6 +311,7 @@ pub struct DefraSessionHook {
     in_flight_lifecycles: Arc<Mutex<HashMap<String, ToolCallLifecycle>>>,
     background_tool_registry: BackgroundToolRegistry,
     background_executions: BackgroundExecutionRegistry,
+    background_live_outputs: LiveToolOutputRegistry,
 }
 
 enum PolicyDecision {
@@ -348,6 +350,7 @@ impl DefraSessionHook {
             in_flight_lifecycles: Arc::new(Mutex::new(HashMap::new())),
             background_tool_registry: BackgroundToolRegistry::default(),
             background_executions: BackgroundExecutionRegistry::default(),
+            background_live_outputs: LiveToolOutputRegistry::default(),
         }
     }
 
@@ -385,6 +388,7 @@ impl DefraSessionHook {
             in_flight_lifecycles: Arc::new(Mutex::new(HashMap::new())),
             background_tool_registry: BackgroundToolRegistry::default(),
             background_executions: BackgroundExecutionRegistry::default(),
+            background_live_outputs: LiveToolOutputRegistry::default(),
         })
     }
 

--- a/crates/defra-agent/src/hook/persistence/background_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/background_tools.rs
@@ -122,18 +122,21 @@ impl DefraSessionHook {
 
         let node = self.node.clone();
         let executions = self.background_executions.clone();
+        let live_outputs = self.background_live_outputs.clone();
         let execution_call_id = background_tool_call_id.clone();
         let execution_session_id = session_id.clone();
         let execution_request_id = request_id.clone();
         let execution_tool_name = target_tool_name.clone();
+        let live_output_writer = live_outputs.writer_for(background_tool_call_id.clone());
         let workspace_cwd = crate::tool_call_lifecycle::runtime::current_tool_runtime_context()
             .and_then(|runtime| runtime.workspace_cwd);
         tokio::spawn(async move {
             let result =
-                crate::tool_call_lifecycle::runtime::scope_request_tool_execution_with_workspace(
+                crate::tool_call_lifecycle::runtime::scope_request_tool_execution_with_workspace_and_live_output(
                     Some(deadline_at),
                     cancellation_token.clone(),
                     workspace_cwd,
+                    Some(live_output_writer),
                     async {
                         let tool = target_tool.lock().await;
                         tool.call(target_args).await
@@ -254,6 +257,7 @@ impl DefraSessionHook {
             }
 
             executions.remove(&execution_call_id).await;
+            live_outputs.remove(&execution_call_id).await;
         });
 
         Ok(self.skip_tool_result(
@@ -353,8 +357,14 @@ impl DefraSessionHook {
                 ));
             }
         };
-        let response =
-            handle_list_background_tools(&self.node, &request_id, &self.agent_did, parsed).await?;
+        let response = handle_list_background_tools(
+            &self.node,
+            &request_id,
+            &self.agent_did,
+            &self.background_live_outputs,
+            parsed,
+        )
+        .await?;
         let result = serde_json::to_value(response).map_err(|error| {
             anyhow::anyhow!("serialize list_background_tools response: {error}")
         })?;
@@ -400,7 +410,14 @@ impl DefraSessionHook {
             ));
         }
 
-        match handle_read_tool_output(&self.node, &request_id, parsed).await? {
+        match handle_read_tool_output(
+            &self.node,
+            &request_id,
+            &self.background_live_outputs,
+            parsed,
+        )
+        .await?
+        {
             ReadToolOutputOutcome::Found(response) => {
                 let result = serde_json::to_value(response).map_err(|error| {
                     anyhow::anyhow!("serialize read_tool_output response: {error}")

--- a/crates/defra-agent/src/managed_exec/process.rs
+++ b/crates/defra-agent/src/managed_exec/process.rs
@@ -7,6 +7,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
 use tokio_util::sync::CancellationToken;
 
+use crate::background_tools::LiveToolOutputWriter;
+
 use super::output::ManagedExecOutcome;
 
 mod capture;
@@ -36,6 +38,7 @@ pub(crate) struct ManagedExecRequest {
     pub(crate) max_output_bytes: usize,
     pub(crate) stdin: Vec<u8>,
     pub(crate) tool_name: Option<String>,
+    pub(crate) live_output: Option<LiveToolOutputWriter>,
 }
 
 #[cfg(unix)]
@@ -93,8 +96,22 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let stdout = child.inner.stdout.take();
     let stderr = child.inner.stderr.take();
     let max_output_bytes = request.max_output_bytes;
-    let stdout_task = tokio::spawn(read_optional_capped(stdout, max_output_bytes));
-    let stderr_task = tokio::spawn(read_optional_capped(stderr, max_output_bytes));
+    let stdout_task = tokio::spawn(read_optional_capped(
+        stdout,
+        max_output_bytes,
+        request
+            .live_output
+            .clone()
+            .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stdout)),
+    ));
+    let stderr_task = tokio::spawn(read_optional_capped(
+        stderr,
+        max_output_bytes,
+        request
+            .live_output
+            .clone()
+            .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stderr)),
+    ));
 
     let child_pgid = child.pgid();
     let mut wait = Box::pin(child.inner.wait());
@@ -202,8 +219,22 @@ pub(crate) async fn run_managed_exec(request: ManagedExecRequest) -> ManagedExec
     let stdout = child.inner.stdout.take();
     let stderr = child.inner.stderr.take();
     let max_output_bytes = request.max_output_bytes;
-    let stdout_task = tokio::spawn(read_optional_capped(stdout, max_output_bytes));
-    let stderr_task = tokio::spawn(read_optional_capped(stderr, max_output_bytes));
+    let stdout_task = tokio::spawn(read_optional_capped(
+        stdout,
+        max_output_bytes,
+        request
+            .live_output
+            .clone()
+            .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stdout)),
+    ));
+    let stderr_task = tokio::spawn(read_optional_capped(
+        stderr,
+        max_output_bytes,
+        request
+            .live_output
+            .clone()
+            .map(|writer| (writer, crate::background_tools::LiveOutputStream::Stderr)),
+    ));
 
     let job = child.job();
     let mut wait = Box::pin(child.inner.wait());

--- a/crates/defra-agent/src/managed_exec/process/capture.rs
+++ b/crates/defra-agent/src/managed_exec/process/capture.rs
@@ -2,13 +2,19 @@ use std::time::Duration;
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 
+use crate::background_tools::{LiveOutputStream, LiveToolOutputWriter};
+
 #[derive(Debug)]
 pub(super) struct OutputCapture {
     pub(super) bytes: Vec<u8>,
     pub(super) truncated: bool,
 }
 
-pub(super) async fn read_optional_capped<R>(reader: Option<R>, max_bytes: usize) -> OutputCapture
+pub(super) async fn read_optional_capped<R>(
+    reader: Option<R>,
+    max_bytes: usize,
+    live_output: Option<(LiveToolOutputWriter, LiveOutputStream)>,
+) -> OutputCapture
 where
     R: AsyncRead + Unpin,
 {
@@ -18,10 +24,14 @@ where
             truncated: false,
         };
     };
-    read_capped(reader, max_bytes).await
+    read_capped(reader, max_bytes, live_output).await
 }
 
-async fn read_capped<R>(mut reader: R, max_bytes: usize) -> OutputCapture
+async fn read_capped<R>(
+    mut reader: R,
+    max_bytes: usize,
+    live_output: Option<(LiveToolOutputWriter, LiveOutputStream)>,
+) -> OutputCapture
 where
     R: AsyncRead + Unpin,
 {
@@ -34,6 +44,9 @@ where
             Ok(read) => read,
             Err(_) => break,
         };
+        if let Some((writer, stream)) = &live_output {
+            writer.append(*stream, &buf[..read]).await;
+        }
         let remaining = max_bytes.saturating_sub(bytes.len());
         if remaining == 0 {
             truncated = true;

--- a/crates/defra-agent/src/managed_exec/tests.rs
+++ b/crates/defra-agent/src/managed_exec/tests.rs
@@ -49,6 +49,7 @@ async fn managed_exec_deadline_kills_process_group() {
             max_output_bytes: 1024,
             stdin: Vec::new(),
             tool_name: Some(tool_name.to_string()),
+            live_output: None,
         })
         .await
     });
@@ -101,6 +102,7 @@ async fn managed_exec_deadline_kills_process_group() {
         max_output_bytes: 1024,
         stdin: Vec::new(),
         tool_name: Some("r3-soak-next".to_string()),
+        live_output: None,
     })
     .await;
 
@@ -129,6 +131,7 @@ async fn managed_exec_cancellation_kills_process_group() {
             max_output_bytes: 1024,
             stdin: Vec::new(),
             tool_name: Some(tool_name.to_string()),
+            live_output: None,
         })
         .await
     });
@@ -163,6 +166,7 @@ async fn managed_exec_deadline_kills_job_object() {
                 max_output_bytes: 1024,
                 stdin: Vec::new(),
                 tool_name: Some(tool_name.to_string()),
+                live_output: None,
             })
             .await
         }
@@ -203,6 +207,7 @@ async fn managed_exec_cancellation_kills_job_object() {
                 max_output_bytes: 1024,
                 stdin: Vec::new(),
                 tool_name: Some(tool_name.to_string()),
+                live_output: None,
             })
             .await
         }
@@ -336,6 +341,7 @@ async fn managed_exec_caps_stdout() {
         max_output_bytes: 3,
         stdin: Vec::new(),
         tool_name: Some("test".to_string()),
+        live_output: None,
     })
     .await;
 

--- a/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
@@ -19,6 +19,7 @@ use rig::wasm_compat::WasmBoxedFuture;
 use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
+use crate::background_tools::LiveToolOutputWriter;
 use crate::truncation::{tool_result_truncation_mode, truncate_text, TruncationLimits};
 
 const MARKER_PREFIX: &str = "__defra_agent_tool_lifecycle__:";
@@ -37,6 +38,7 @@ struct ToolRuntimeScope {
     cancellation_token: CancellationToken,
     workspace_cwd: Option<PathBuf>,
     tool_results: ToolResultRecorder,
+    live_output: Option<LiveToolOutputWriter>,
 }
 
 #[derive(Clone)]
@@ -44,6 +46,7 @@ pub(crate) struct CurrentToolRuntimeContext {
     pub(crate) deadline_at: Option<DateTime<Utc>>,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) workspace_cwd: Option<PathBuf>,
+    pub(crate) live_output: Option<LiveToolOutputWriter>,
 }
 
 #[derive(Debug, Clone)]
@@ -143,6 +146,26 @@ pub(crate) async fn scope_request_tool_execution_with_workspace<F, T>(
 where
     F: Future<Output = T>,
 {
+    scope_request_tool_execution_with_workspace_and_live_output(
+        deadline_at,
+        cancellation_token,
+        workspace_cwd,
+        None,
+        future,
+    )
+    .await
+}
+
+pub(crate) async fn scope_request_tool_execution_with_workspace_and_live_output<F, T>(
+    deadline_at: Option<DateTime<Utc>>,
+    cancellation_token: CancellationToken,
+    workspace_cwd: Option<PathBuf>,
+    live_output: Option<LiveToolOutputWriter>,
+    future: F,
+) -> T
+where
+    F: Future<Output = T>,
+{
     TOOL_RUNTIME_SCOPE
         .scope(
             ToolRuntimeScope {
@@ -150,6 +173,7 @@ where
                 cancellation_token,
                 workspace_cwd,
                 tool_results: ToolResultRecorder::default(),
+                live_output,
             },
             future,
         )
@@ -168,6 +192,7 @@ pub(crate) fn current_tool_runtime_context() -> Option<CurrentToolRuntimeContext
             deadline_at: scope.deadline_at,
             cancellation_token: scope.cancellation_token,
             workspace_cwd: scope.workspace_cwd,
+            live_output: scope.live_output,
         })
 }
 

--- a/crates/defra-agent/src/toolset/native_runner.rs
+++ b/crates/defra-agent/src/toolset/native_runner.rs
@@ -35,8 +35,12 @@ impl NativeFsRunner {
         let runtime = current_tool_runtime_context();
         let deadline_at = runtime.as_ref().and_then(|runtime| runtime.deadline_at);
         let cancellation_token = runtime
-            .map(|runtime| runtime.cancellation_token)
+            .as_ref()
+            .map(|runtime| runtime.cancellation_token.clone())
             .unwrap_or_else(CancellationToken::new);
+        let live_output = runtime
+            .as_ref()
+            .and_then(|runtime| runtime.live_output.clone());
         let base = self.effective_base();
         let runner = resolve_runner_command(&self.root, &base)?;
         let stdin = serde_json::to_vec(&request)
@@ -50,6 +54,7 @@ impl NativeFsRunner {
             max_output_bytes: MAX_NATIVE_RUNNER_OUTPUT_BYTES,
             stdin,
             tool_name: Some(tool_name.to_string()),
+            live_output,
         })
         .await
         {

--- a/crates/defra-agent/src/toolset/shared/command.rs
+++ b/crates/defra-agent/src/toolset/shared/command.rs
@@ -5,9 +5,12 @@ use std::time::{Duration, Instant};
 
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 
 use super::context::{ToolContext, ToolError};
+use crate::background_tools::{LiveOutputStream, LiveToolOutputWriter};
+use crate::tool_call_lifecycle::runtime::current_tool_runtime_context;
 use crate::toolset::{CommandPolicyDenial, DenialReason};
 use crate::truncation::{truncate, TruncationLimits, TruncationMode};
 
@@ -165,20 +168,29 @@ pub(crate) async fn run_command(
         .kill_on_drop(true);
 
     let started = Instant::now();
-    let output = tokio::time::timeout(timeout, command.output()).await;
+    let mut child = command.spawn()?;
+    let live_output = current_tool_runtime_context().and_then(|runtime| runtime.live_output);
+    let stdout_task = tokio::spawn(read_command_stream(
+        child.stdout.take(),
+        LiveOutputStream::Stdout,
+        live_output.clone(),
+    ));
+    let stderr_task = tokio::spawn(read_command_stream(
+        child.stderr.take(),
+        LiveOutputStream::Stderr,
+        live_output,
+    ));
+    let wait_result = tokio::time::timeout(timeout, child.wait()).await;
     let duration_ms = elapsed_ms(started);
-    let (exit_code, timed_out, stdout_raw, stderr_raw) = match output {
-        Ok(output) => {
-            let output = output?;
-            (
-                output.status.code(),
-                false,
-                String::from_utf8_lossy(&output.stdout).into_owned(),
-                String::from_utf8_lossy(&output.stderr).into_owned(),
-            )
+    let (exit_code, timed_out) = match wait_result {
+        Ok(status) => (status?.code(), false),
+        Err(_) => {
+            let _ = child.kill().await;
+            (None, true)
         }
-        Err(_) => (None, true, String::new(), String::new()),
     };
+    let stdout_raw = String::from_utf8_lossy(&join_command_stream(stdout_task).await).into_owned();
+    let stderr_raw = String::from_utf8_lossy(&join_command_stream(stderr_task).await).into_owned();
 
     let stdout = truncate_stream(&stdout_raw, super::super::DEFAULT_MAX_COMMAND_CHARS);
     let stderr = truncate_stream(&stderr_raw, super::super::DEFAULT_MAX_COMMAND_CHARS);
@@ -212,6 +224,37 @@ pub(crate) async fn run_command(
     };
 
     render_command_output(&output, raw_json).map_err(Into::into)
+}
+
+async fn read_command_stream<R>(
+    reader: Option<R>,
+    stream: LiveOutputStream,
+    live_output: Option<LiveToolOutputWriter>,
+) -> Vec<u8>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+{
+    let Some(mut reader) = reader else {
+        return Vec::new();
+    };
+    let mut bytes = Vec::new();
+    let mut buf = [0u8; 8192];
+    loop {
+        let read = match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+        if let Some(writer) = &live_output {
+            writer.append(stream, &buf[..read]).await;
+        }
+        bytes.extend_from_slice(&buf[..read]);
+    }
+    bytes
+}
+
+async fn join_command_stream(task: tokio::task::JoinHandle<Vec<u8>>) -> Vec<u8> {
+    task.await.unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/truncation.rs
+++ b/crates/defra-agent/src/truncation.rs
@@ -54,6 +54,18 @@ impl Default for TruncationLimits {
     }
 }
 
+/// Per-stream capacity of the in-memory ring buffer that holds *live* output
+/// for a still-running background tool (see `background_tools::buffer`).
+///
+/// Kept here, alongside [`TruncationLimits`], so the codebase has one home for
+/// tool-output size policy. It is deliberately a *separate* budget rather than
+/// reusing `TruncationLimits`: those bound a *finished* tool result before it
+/// is replayed to the model (and spill the full copy to DefraDB as the durable
+/// record), whereas this bounds a transient streaming *window* that is never
+/// the durable record and is dropped once the tool reaches a terminal state.
+/// It is larger because a live tail view is cheap, in-memory, and short-lived.
+pub(crate) const LIVE_STREAM_CAPACITY_BYTES: usize = 256 * 1024;
+
 pub trait Truncator: Send + Sync {
     fn truncate(
         &self,

--- a/crates/defra-agent/tests/r4c_list_background_tools.rs
+++ b/crates/defra-agent/tests/r4c_list_background_tools.rs
@@ -142,13 +142,22 @@ async fn background_tool(
     internal_call_id: &str,
     tool_name: &str,
 ) -> Value {
+    background_tool_with_args(hook, internal_call_id, tool_name, json!({})).await
+}
+
+async fn background_tool_with_args(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    tool_name: &str,
+    args: Value,
+) -> Value {
     skip_reason_json(
         PromptHook::<TestModel>::on_tool_call(
             hook,
             "spawn_process",
             Some(format!("model-{internal_call_id}")),
             internal_call_id,
-            &json!({"tool_name": tool_name, "args": {}}).to_string(),
+            &json!({"tool_name": tool_name, "args": args}).to_string(),
         )
         .await,
     )
@@ -259,6 +268,57 @@ async fn list_background_tools_returns_running_bg_tools() {
         assert_eq!(entry["stdout_bytes"].as_u64(), Some(0));
         assert_eq!(entry["stderr_bytes"].as_u64(), Some(0));
     }
+}
+
+#[tokio::test]
+async fn list_background_tools_reports_running_live_output_bytes() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let tools = defra_agent::ToolSet::builder()
+        .bash_unrestricted(tempdir.path())
+        .build()
+        .build_native_tools()
+        .expect("native tools should build");
+    let (_db, hook, _session_id, _request_id) = setup_hook(
+        "r4c-list-bg-live-output",
+        registry(tools, &["bash_unrestricted"]),
+    )
+    .await;
+    let handle = background_tool_with_args(
+        &hook,
+        "bg-live-output",
+        "bash_unrestricted",
+        json!({
+            "command": "printf live; sleep 2; printf done",
+            "args": [],
+            "timeout_secs": 5
+        }),
+    )
+    .await;
+    let tool_call_id = handle["tool_call_id"].as_str().unwrap();
+
+    let mut entry = json!({});
+    for attempt in 0..40 {
+        let result =
+            list_background_tools(&hook, &format!("list-live-output-{attempt}"), json!({})).await;
+        let entries = result["entries"].as_array().expect("entries");
+        if let Some(candidate) = entries
+            .iter()
+            .find(|entry| entry["tool_call_id"].as_str() == Some(tool_call_id))
+            .filter(|entry| entry["stdout_bytes"].as_u64().unwrap_or_default() >= 4)
+        {
+            entry = candidate.clone();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    assert_eq!(entry["tool_name"].as_str(), Some("bash_unrestricted"));
+    assert_eq!(entry["status"].as_str(), Some("running"));
+    assert_eq!(entry["stdout_bytes"].as_u64(), Some(4));
+    assert_eq!(entry["stderr_bytes"].as_u64(), Some(0));
+
+    let waited = wait_tool(&hook, "wait-live-output", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/r4c_read_tool_output.rs
+++ b/crates/defra-agent/tests/r4c_read_tool_output.rs
@@ -173,13 +173,22 @@ async fn background_tool(
     internal_call_id: &str,
     tool_name: &str,
 ) -> Value {
+    background_tool_with_args(hook, internal_call_id, tool_name, json!({})).await
+}
+
+async fn background_tool_with_args(
+    hook: &DefraSessionHook,
+    internal_call_id: &str,
+    tool_name: &str,
+    args: Value,
+) -> Value {
     skip_reason_json(
         PromptHook::<TestModel>::on_tool_call(
             hook,
             "spawn_process",
             Some(format!("model-{internal_call_id}")),
             internal_call_id,
-            &json!({"tool_name": tool_name, "args": {}}).to_string(),
+            &json!({"tool_name": tool_name, "args": args}).to_string(),
         )
         .await,
     )
@@ -267,29 +276,69 @@ async fn count_tool_calls_by_name(node: &EmbeddedNode, session_id: &str, tool_na
 }
 
 #[tokio::test]
-async fn read_tool_output_running_returns_empty_live_stream_without_ring_buffer() {
+async fn read_tool_output_running_returns_live_stream_tail() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let tools = defra_agent::ToolSet::builder()
+        .bash_unrestricted(tempdir.path())
+        .build()
+        .build_native_tools()
+        .expect("native tools should build");
     let (_db, hook, _session_id, _request_id) = setup_hook(
         "r4c-read-output-running",
-        registry(vec![Box::new(PendingTool)], &["slow_tool"]),
+        registry(tools, &["bash_unrestricted"]),
     )
     .await;
-    let handle = background_tool(&hook, "bg-running", "slow_tool").await;
+    let handle = background_tool_with_args(
+        &hook,
+        "bg-running",
+        "bash_unrestricted",
+        json!({
+            "command": "printf live; sleep 2; printf done",
+            "args": [],
+            "timeout_secs": 5
+        }),
+    )
+    .await;
     let tool_call_id = handle["tool_call_id"].as_str().unwrap();
 
-    let result = read_tool_output(
-        &hook,
-        "read-running",
-        json!({ "tool_call_id": tool_call_id }),
-    )
-    .await;
+    let mut result = json!({});
+    for attempt in 0..40 {
+        result = read_tool_output(
+            &hook,
+            &format!("read-running-{attempt}"),
+            json!({ "tool_call_id": tool_call_id }),
+        )
+        .await;
+        if result["output"]
+            .as_str()
+            .is_some_and(|output| output.contains("live"))
+        {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
     assert_eq!(result["status"].as_str(), Some("running"));
-    assert_eq!(result["tool_name"].as_str(), Some("slow_tool"));
-    assert_eq!(result["output"].as_str(), Some(""));
-    assert_eq!(result["next_offset"].as_u64(), Some(0));
-    assert_eq!(result["total_bytes"].as_u64(), Some(0));
+    assert_eq!(result["tool_name"].as_str(), Some("bash_unrestricted"));
+    assert_eq!(result["output"].as_str(), Some("live"));
+    assert_eq!(result["next_offset"].as_u64(), Some(4));
+    assert_eq!(result["total_bytes"].as_u64(), Some(4));
     assert_eq!(result["has_more"].as_bool(), Some(false));
     assert_eq!(result["exited"].as_bool(), Some(false));
     assert!(result["exit_code"].is_null());
+
+    let waited = wait_tool(&hook, "wait-running-terminal", tool_call_id).await;
+    assert_eq!(waited["status"].as_str(), Some("completed"));
+    let terminal = read_tool_output(
+        &hook,
+        "read-running-terminal",
+        json!({ "tool_call_id": tool_call_id }),
+    )
+    .await;
+    assert_eq!(terminal["status"].as_str(), Some("completed"));
+    assert_eq!(terminal["output"].as_str(), Some("livedone"));
+    assert_eq!(terminal["total_bytes"].as_u64(), Some(8));
+    assert_eq!(terminal["exited"].as_bool(), Some(true));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- add bounded in-memory live output buffers for background tool executions
- thread live output writers through the background tool runtime context
- make `read_process` return running stdout/stderr output instead of empty output
- make `list_processes` report live stdout/stderr byte counts for running tools
- wire bash and managed-exec/native-runner stdout/stderr readers into the live sink
- add R4c regressions using real `bash_unrestricted` output while the process is still running

## Why

Fixes #403.

The R4c design expected running background tools to expose a live output tail, but the shipped runtime returned empty output until the tool reached a terminal state. This PR implements the missing live-buffer path without changing the public `read_process` / `list_processes` response envelopes.

## Notes

This keeps persisted terminal behavior unchanged. Terminal reads still use the persisted tool result; running reads use the in-memory live buffer.

## Tests

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p defra-agent --test r4c_read_tool_output`
- `cargo test -p defra-agent --test r4c_list_background_tools`
- `cargo test -p defra-agent --lib managed_exec`
- `cargo test -p defra-agent --lib tool_call_lifecycle::runtime`
- `cargo test -p defra-agent --lib toolset::tests::bash_timeout_reports_metadata_instead_of_error`
- `cargo test -p defra-agent --lib toolset::tests::bash_output_supports_raw_json_escape_hatch`

## Caveat

A broader `cargo test -p defra-agent managed_exec` still hits unrelated integration compile failures from `AgentBehaviorDocument` initializers missing `skill_refs` / `skill_excludes`, matching the known #407 note.