### PR TITLE
Add tool surface explain model

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -14,7 +14,7 @@ use crate::{
     FLEET_AFTER_HELP, INIT_AFTER_HELP, MCP_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP,
     REQUEST_AFTER_HELP, RESET_AFTER_HELP, RESPONSE_AFTER_HELP, SERVER_AFTER_HELP,
     SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP, SUBAGENT_AFTER_HELP,
-    SUBAGENT_LIST_AFTER_HELP, TRACE_AFTER_HELP,
+    SUBAGENT_LIST_AFTER_HELP, TOOLS_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -98,6 +98,11 @@ pub(crate) enum Command {
     },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
+    #[command(about = "Explain resolved behavior tool surfaces", after_help = TOOLS_AFTER_HELP)]
+    Tools {
+        #[command(subcommand)]
+        command: ToolsCommand,
+    },
     #[command(about = "Inspect and write runtime configuration documents", after_help = CONFIG_AFTER_HELP)]
     Config {
         #[command(subcommand)]
@@ -821,6 +826,27 @@ pub(crate) enum SkillCommand {
     Enable(SkillRefArgs),
     #[command(name = "disable", about = "Disable a Skill document")]
     Disable(SkillRefArgs),
+}
+
+#[derive(Subcommand)]
+pub(crate) enum ToolsCommand {
+    #[command(
+        name = "explain",
+        about = "Explain final model-callable tools per behavior"
+    )]
+    Explain(ToolExplainArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct ToolExplainArgs {
+    #[arg(long, help = "Agent home directory. Defaults to ~/.defra-agent")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(long, help = "GraphQL endpoint to read instead of local home state")]
+    pub(crate) graphql: Option<String>,
+    #[arg(long)]
+    pub(crate) agent_did: Option<String>,
+    #[arg(long, help = "Only explain one behavior_id")]
+    pub(crate) behavior_id: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -313,9 +313,32 @@ pub(crate) struct InitArgs {
     pub(crate) write_tools: bool,
     #[arg(
         long,
+        value_enum,
+        help = "Bootstrap a named tool package. Defaults to readonly; --write-tools is a compatibility alias for --tool-package write"
+    )]
+    pub(crate) tool_package: Option<ToolPackageArg>,
+    #[arg(
+        long,
         help = "Root directory for local file/bash tools. Defaults to the current working directory"
     )]
     pub(crate) tool_root: Option<PathBuf>,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Enable the feature-gated per-agent memory tool in the default ToolSelection"
+    )]
+    pub(crate) enable_memory: bool,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Disable the default read-only defra_query tool in the default ToolSelection"
+    )]
+    pub(crate) disable_defra_query: bool,
+    #[arg(
+        long = "defra-query-collection",
+        help = "Restrict init's default defra_query tool to these collections (repeatable); omit for all collections"
+    )]
+    pub(crate) defra_query_collections: Vec<String>,
 }
 
 impl InitArgs {
@@ -780,6 +803,14 @@ pub(crate) enum ToolCeilingArg {
     MetaOnly,
     Readonly,
     Readwrite,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, ValueEnum, PartialEq, Eq)]
+pub(crate) enum ToolPackageArg {
+    Minimal,
+    Introspection,
+    Readonly,
+    Write,
 }
 
 #[derive(Subcommand)]
@@ -1806,6 +1837,16 @@ mod tests {
                     },
             } => args,
             _ => panic!("expected `config tools set`"),
+        }
+    }
+
+    fn parse_init(extra: &[&str]) -> InitArgs {
+        let mut argv = vec!["defra-agent", "init"];
+        argv.extend_from_slice(extra);
+        let cli = Cli::try_parse_from(argv).expect("init should parse");
+        match cli.command {
+            Command::Init(args) => args,
+            _ => panic!("expected `init`"),
         }
     }
 

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1009,43 +1009,83 @@ pub(crate) struct ToolSelectionUpsertArgs {
     #[arg(long)]
     pub(crate) display_name: Option<String>,
     #[arg(long, default_value_t = false)]
-    pub(crate) enable_file_tools: bool,
+    pub(crate) clear_display_name: bool,
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_name = "BOOL",
+        help = "Enable or disable file tools. Omit to preserve existing setting"
+    )]
+    pub(crate) enable_file_tools: Option<bool>,
     #[arg(long)]
     pub(crate) file_tools_mode: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_file_tools_mode: bool,
     #[arg(
         long,
         help = "Optional per-behavior file-tool root; relative paths resolve from the daemon cwd and must stay within any node-level tool root"
     )]
     pub(crate) file_tool_root: Option<PathBuf>,
     #[arg(long, default_value_t = false)]
-    pub(crate) enable_bash: bool,
+    pub(crate) clear_file_tool_root: bool,
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_name = "BOOL",
+        help = "Enable or disable bash tools. Omit to preserve existing setting"
+    )]
+    pub(crate) enable_bash: Option<bool>,
     #[arg(long)]
     pub(crate) bash_mode: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_bash_mode: bool,
     #[arg(
         long,
         help = "Command policy for bash: read_only, workspace_write, managed_write, or unrestricted"
     )]
     pub(crate) command_execution_policy: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_command_execution_policy: bool,
     #[arg(
         long,
         help = "Network policy hint for bash commands: inherit, disabled, or enabled"
     )]
     pub(crate) command_network_mode: Option<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_command_network_mode: bool,
     #[arg(long = "command-allowed-argv-prefix")]
     pub(crate) command_allowed_argv_prefixes: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_command_allowed_argv_prefixes: bool,
     #[arg(long = "command-forbidden-argv-prefix")]
     pub(crate) command_forbidden_argv_prefixes: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_command_forbidden_argv_prefixes: bool,
     #[arg(long = "cli-tool-name")]
     pub(crate) cli_tool_names: Vec<String>,
-    #[arg(long, default_value_t = true)]
-    pub(crate) enable_meta_tools: bool,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_cli_tool_names: bool,
+    #[arg(
+        long,
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_name = "BOOL",
+        help = "Enable or disable meta MCP tools. Omit to preserve existing setting"
+    )]
+    pub(crate) enable_meta_tools: Option<bool>,
     #[arg(long = "allowed-mcp-service-id")]
     pub(crate) allowed_mcp_service_ids: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_allowed_mcp_service_ids: bool,
     #[arg(
         long = "backgroundable-tool-name",
         help = "Host tool that may be spawned as a background process via spawn_process, e.g. bash_unrestricted"
     )]
     pub(crate) backgroundable_tool_names: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_backgroundable_tool_names: bool,
     #[arg(
         long,
         help = "Enable or disable the feature-gated memory tool: --enable-memory true|false. Omit to leave the existing document setting unchanged (default is disabled)"
@@ -1066,6 +1106,46 @@ pub(crate) struct ToolSelectionUpsertArgs {
         help = "Restrict defra_query to these collections (repeatable); omit for all collections"
     )]
     pub(crate) defra_query_collections: Vec<String>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_defra_query_collections: bool,
+    #[arg(
+        long = "subagent-target",
+        help = "SubagentTarget JSON entry allowed for spawn_subagent (repeatable); omit to preserve existing targets"
+    )]
+    pub(crate) subagent_targets: Vec<String>,
+    #[arg(
+        long,
+        default_value_t = false,
+        help = "Clear existing subagent_targets when no --subagent-target values are provided"
+    )]
+    pub(crate) clear_subagent_targets: bool,
+    #[arg(
+        long,
+        help = "Enable or disable spawn_subagent: --subagent-spawn-enabled true|false. Omit to preserve existing setting"
+    )]
+    pub(crate) subagent_spawn_enabled: Option<bool>,
+    #[arg(
+        long,
+        help = "Enable or disable subagent steering tools: --subagent-steering-enabled true|false. Omit to preserve existing setting"
+    )]
+    pub(crate) subagent_steering_enabled: Option<bool>,
+    #[arg(
+        long,
+        help = "Enable or disable background subagent steering: --subagent-background-enabled true|false. Omit to preserve existing setting"
+    )]
+    pub(crate) subagent_background_enabled: Option<bool>,
+    #[arg(
+        long,
+        help = "Enable or disable remote-DID subagent targets: --subagent-allow-cross-deployment true|false. Omit to preserve existing setting"
+    )]
+    pub(crate) subagent_allow_cross_deployment: Option<bool>,
+    #[arg(
+        long,
+        help = "Cross-deployment spawn timeout in seconds. Omit to preserve existing setting"
+    )]
+    pub(crate) cross_deployment_spawn_timeout_seconds: Option<i64>,
+    #[arg(long, default_value_t = false)]
+    pub(crate) clear_cross_deployment_spawn_timeout_seconds: bool,
 }
 
 #[derive(Subcommand)]
@@ -1891,5 +1971,84 @@ mod tests {
             parse_tools_set(&["--enable-session-history-tool", "true"]).enable_session_history_tool,
             Some(true)
         );
+    }
+
+    #[test]
+    fn init_tool_audit_flags_parse() {
+        let args = parse_init(&[
+            "--enable-memory",
+            "--disable-defra-query",
+            "--tool-package",
+            "write",
+        ]);
+        assert!(args.enable_memory);
+        assert!(args.disable_defra_query);
+        assert_eq!(args.tool_package, Some(ToolPackageArg::Write));
+
+        let scoped = parse_init(&[
+            "--defra-query-collection",
+            "AgentRequest",
+            "--defra-query-collection",
+            "AgentResponse",
+        ]);
+        assert_eq!(
+            scoped.defra_query_collections,
+            vec!["AgentRequest".to_string(), "AgentResponse".to_string()]
+        );
+    }
+
+    #[test]
+    fn subagent_tool_flags_preserve_when_omitted_and_parse_when_present() {
+        let omitted = parse_tools_set(&[]);
+        assert_eq!(omitted.enable_file_tools, None);
+        assert_eq!(omitted.enable_bash, None);
+        assert_eq!(omitted.enable_meta_tools, None);
+        assert!(omitted.subagent_targets.is_empty());
+        assert!(!omitted.clear_subagent_targets);
+        assert_eq!(omitted.subagent_spawn_enabled, None);
+        assert_eq!(omitted.subagent_steering_enabled, None);
+        assert_eq!(omitted.subagent_background_enabled, None);
+        assert_eq!(omitted.subagent_allow_cross_deployment, None);
+        assert_eq!(omitted.cross_deployment_spawn_timeout_seconds, None);
+
+        let configured = parse_tools_set(&[
+            "--subagent-target",
+            r#"{"name":"worker","agent_did":"did:key:z-test","behavior_id":"worker","description":"worker"}"#,
+            "--subagent-spawn-enabled",
+            "true",
+            "--subagent-steering-enabled",
+            "true",
+            "--subagent-background-enabled",
+            "false",
+            "--subagent-allow-cross-deployment",
+            "true",
+            "--cross-deployment-spawn-timeout-seconds",
+            "90",
+        ]);
+        assert_eq!(configured.subagent_targets.len(), 1);
+        assert_eq!(configured.subagent_spawn_enabled, Some(true));
+        assert_eq!(configured.subagent_steering_enabled, Some(true));
+        assert_eq!(configured.subagent_background_enabled, Some(false));
+        assert_eq!(configured.subagent_allow_cross_deployment, Some(true));
+        assert_eq!(configured.cross_deployment_spawn_timeout_seconds, Some(90));
+    }
+
+    #[test]
+    fn legacy_tool_bool_flags_are_patch_optional() {
+        let bare = parse_tools_set(&["--enable-file-tools", "--enable-bash"]);
+        assert_eq!(bare.enable_file_tools, Some(true));
+        assert_eq!(bare.enable_bash, Some(true));
+
+        let explicit = parse_tools_set(&[
+            "--enable-file-tools",
+            "false",
+            "--enable-bash",
+            "false",
+            "--enable-meta-tools",
+            "false",
+        ]);
+        assert_eq!(explicit.enable_file_tools, Some(false));
+        assert_eq!(explicit.enable_bash, Some(false));
+        assert_eq!(explicit.enable_meta_tools, Some(false));
     }
 }

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -3,85 +3,555 @@ use defra_agent::{CommandExecutionMode, CommandNetworkMode, ToolSelectionDocumen
 use serde_json::json;
 
 use crate::cli::*;
-use crate::config_writes::{write_tool_selection_document, ConfigAccess};
+use crate::config_writes::{write_tool_selection_document_with_clear_fields, ConfigAccess};
+use crate::normalize_optional_string;
 use crate::print_json;
-use crate::{normalize_bash_mode, normalize_file_tools_mode, normalize_optional_string};
 
 pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<()> {
-    let file_tools_mode =
-        normalize_file_tools_mode(args.enable_file_tools, args.file_tools_mode.as_deref())?;
-    let bash_mode = normalize_bash_mode(args.enable_bash, args.bash_mode.as_deref())?;
-    let command_execution_policy =
-        normalize_optional_string(args.command_execution_policy.as_deref());
-    if let Some(mode) = command_execution_policy.as_deref() {
-        CommandExecutionMode::parse(mode)?;
-    }
-    let command_network_mode = normalize_optional_string(args.command_network_mode.as_deref());
-    if let Some(mode) = command_network_mode.as_deref() {
-        CommandNetworkMode::parse(mode)?;
-    }
-    let file_tool_root = args
-        .file_tool_root
-        .as_ref()
-        .map(|path| path.to_string_lossy().to_string());
+    let plan = tool_selection_command_plan(&args)?;
     let access = ConfigAccess::Graphql(args.graphql.clone());
-    let selection = ToolSelectionDocument {
-        selection_id: args.selection_id.clone(),
-        agent_did: args.agent_did.clone(),
-        display_name: args.display_name.clone(),
-        enable_file_tools: Some(args.enable_file_tools),
-        file_tools_mode: Some(file_tools_mode.clone()),
-        file_tool_root: file_tool_root.clone(),
-        enable_bash: Some(args.enable_bash),
-        bash_mode: Some(bash_mode.clone()),
-        command_execution_policy: command_execution_policy.clone(),
-        command_allowed_argv_prefixes: Some(args.command_allowed_argv_prefixes.clone()),
-        command_forbidden_argv_prefixes: Some(args.command_forbidden_argv_prefixes.clone()),
-        command_network_mode: command_network_mode.clone(),
-        cli_tool_names: Some(args.cli_tool_names.clone()),
-        enable_meta_tools: Some(args.enable_meta_tools),
-        allowed_mcp_service_ids: Some(args.allowed_mcp_service_ids.clone()),
-        backgroundable_tool_names: Some(args.backgroundable_tool_names.clone()),
-        // The imperative `config tools set` exposes no flags for subagent
-        // enablement (those are managed via `config apply` manifests). Emitting
-        // `Some(false)`/`Some(empty)` here would write those fields into the
-        // update mutation and silently clobber an apply-managed subagent
-        // config. Leave them `None` so the writer omits them: on update the
-        // stored values are preserved, on create the schema defaults apply.
-        subagent_targets: None,
-        subagent_spawn_enabled: None,
-        subagent_steering_enabled: None,
-        subagent_background_enabled: None,
-        subagent_allow_cross_deployment: None,
-        cross_deployment_spawn_timeout_seconds: None,
-        enable_memory: args.enable_memory,
-        enable_session_history_tool: args.enable_session_history_tool,
-        enable_defra_query: args.enable_defra_query,
-        defra_query_collections: Some(args.defra_query_collections.clone()),
-    };
-    let doc_id = write_tool_selection_document(&access, &selection).await?;
+    let doc_id = write_tool_selection_document_with_clear_fields(
+        &access,
+        &plan.selection,
+        &plan.clear_update_fields,
+    )
+    .await?;
     let output = json!({
         "doc_id": doc_id,
         "selection_id": args.selection_id,
         "agent_did": args.agent_did,
-        "enable_file_tools": args.enable_file_tools,
-        "file_tools_mode": file_tools_mode,
-        "file_tool_root": file_tool_root,
-        "enable_bash": args.enable_bash,
-        "bash_mode": bash_mode,
-        "command_execution_policy": command_execution_policy,
-        "command_allowed_argv_prefixes": args.command_allowed_argv_prefixes,
-        "command_forbidden_argv_prefixes": args.command_forbidden_argv_prefixes,
-        "command_network_mode": command_network_mode,
-        "cli_tool_names": args.cli_tool_names,
-        "enable_meta_tools": args.enable_meta_tools,
-        "allowed_mcp_service_ids": args.allowed_mcp_service_ids,
-        "backgroundable_tool_names": args.backgroundable_tool_names,
+        "cleared_fields": plan.clear_update_fields,
+        "display_name": plan.selection.display_name,
+        "enable_file_tools": plan.selection.enable_file_tools,
+        "file_tools_mode": plan.file_tools_mode,
+        "file_tool_root": plan.file_tool_root,
+        "enable_bash": plan.selection.enable_bash,
+        "bash_mode": plan.bash_mode,
+        "command_execution_policy": plan.command_execution_policy,
+        "command_allowed_argv_prefixes": plan.selection.command_allowed_argv_prefixes,
+        "command_forbidden_argv_prefixes": plan.selection.command_forbidden_argv_prefixes,
+        "command_network_mode": plan.command_network_mode,
+        "cli_tool_names": plan.selection.cli_tool_names,
+        "enable_meta_tools": plan.selection.enable_meta_tools,
+        "allowed_mcp_service_ids": plan.selection.allowed_mcp_service_ids,
+        "backgroundable_tool_names": plan.selection.backgroundable_tool_names,
         "enable_memory": args.enable_memory,
         "enable_session_history_tool": args.enable_session_history_tool,
         "enable_defra_query": args.enable_defra_query,
-        "defra_query_collections": args.defra_query_collections,
+        "defra_query_collections": plan.selection.defra_query_collections,
+        "subagent_targets": plan.selection.subagent_targets,
+        "subagent_spawn_enabled": args.subagent_spawn_enabled,
+        "subagent_steering_enabled": args.subagent_steering_enabled,
+        "subagent_background_enabled": args.subagent_background_enabled,
+        "subagent_allow_cross_deployment": args.subagent_allow_cross_deployment,
+        "cross_deployment_spawn_timeout_seconds": args.cross_deployment_spawn_timeout_seconds,
     });
     print_json(&output)?;
     Ok(())
+}
+
+#[derive(Debug)]
+struct ToolSelectionCommandPlan {
+    selection: ToolSelectionDocument,
+    file_tools_mode: Option<String>,
+    file_tool_root: Option<String>,
+    bash_mode: Option<String>,
+    command_execution_policy: Option<String>,
+    command_network_mode: Option<String>,
+    clear_update_fields: Vec<&'static str>,
+}
+
+fn tool_selection_command_plan(args: &ToolSelectionUpsertArgs) -> Result<ToolSelectionCommandPlan> {
+    let mut clear_update_fields = Vec::new();
+    let (enable_file_tools, file_tools_mode) = file_tools_update(args, &mut clear_update_fields)?;
+    let (enable_bash, bash_mode) = bash_update(args, &mut clear_update_fields)?;
+    let subagent_targets = subagent_targets_update(&args)?;
+    let command_execution_policy = nullable_string_update(
+        args.command_execution_policy.as_deref(),
+        args.clear_command_execution_policy,
+        "--command-execution-policy",
+        "--clear-command-execution-policy",
+        "command_execution_policy",
+        &mut clear_update_fields,
+    )?;
+    if let Some(mode) = command_execution_policy.as_deref() {
+        CommandExecutionMode::parse(mode)?;
+    }
+    let command_network_mode = nullable_string_update(
+        args.command_network_mode.as_deref(),
+        args.clear_command_network_mode,
+        "--command-network-mode",
+        "--clear-command-network-mode",
+        "command_network_mode",
+        &mut clear_update_fields,
+    )?;
+    if let Some(mode) = command_network_mode.as_deref() {
+        CommandNetworkMode::parse(mode)?;
+    }
+    let display_name = nullable_string_update(
+        args.display_name.as_deref(),
+        args.clear_display_name,
+        "--display-name",
+        "--clear-display-name",
+        "display_name",
+        &mut clear_update_fields,
+    )?;
+    let file_tool_root = nullable_path_update(
+        args.file_tool_root.as_ref(),
+        args.clear_file_tool_root,
+        "--file-tool-root",
+        "--clear-file-tool-root",
+        "file_tool_root",
+        &mut clear_update_fields,
+    )?;
+    let command_allowed_argv_prefixes = string_list_update(
+        &args.command_allowed_argv_prefixes,
+        args.clear_command_allowed_argv_prefixes,
+        "--command-allowed-argv-prefix",
+        "--clear-command-allowed-argv-prefixes",
+    )?;
+    let command_forbidden_argv_prefixes = string_list_update(
+        &args.command_forbidden_argv_prefixes,
+        args.clear_command_forbidden_argv_prefixes,
+        "--command-forbidden-argv-prefix",
+        "--clear-command-forbidden-argv-prefixes",
+    )?;
+    let cli_tool_names = string_list_update(
+        &args.cli_tool_names,
+        args.clear_cli_tool_names,
+        "--cli-tool-name",
+        "--clear-cli-tool-names",
+    )?;
+    let allowed_mcp_service_ids = string_list_update(
+        &args.allowed_mcp_service_ids,
+        args.clear_allowed_mcp_service_ids,
+        "--allowed-mcp-service-id",
+        "--clear-allowed-mcp-service-ids",
+    )?;
+    let backgroundable_tool_names = string_list_update(
+        &args.backgroundable_tool_names,
+        args.clear_backgroundable_tool_names,
+        "--backgroundable-tool-name",
+        "--clear-backgroundable-tool-names",
+    )?;
+    let defra_query_collections = string_list_update(
+        &args.defra_query_collections,
+        args.clear_defra_query_collections,
+        "--defra-query-collection",
+        "--clear-defra-query-collections",
+    )?;
+    let cross_deployment_spawn_timeout_seconds = timeout_update(args, &mut clear_update_fields)?;
+    let selection = ToolSelectionDocument {
+        selection_id: args.selection_id.clone(),
+        agent_did: args.agent_did.clone(),
+        display_name,
+        enable_file_tools,
+        file_tools_mode: file_tools_mode.clone(),
+        file_tool_root: file_tool_root.clone(),
+        enable_bash,
+        bash_mode: bash_mode.clone(),
+        command_execution_policy: command_execution_policy.clone(),
+        command_allowed_argv_prefixes,
+        command_forbidden_argv_prefixes,
+        command_network_mode: command_network_mode.clone(),
+        cli_tool_names,
+        enable_meta_tools: args.enable_meta_tools,
+        allowed_mcp_service_ids,
+        backgroundable_tool_names,
+        subagent_targets: subagent_targets.clone(),
+        subagent_spawn_enabled: args.subagent_spawn_enabled,
+        subagent_steering_enabled: args.subagent_steering_enabled,
+        subagent_background_enabled: args.subagent_background_enabled,
+        subagent_allow_cross_deployment: args.subagent_allow_cross_deployment,
+        cross_deployment_spawn_timeout_seconds,
+        enable_memory: args.enable_memory,
+        enable_session_history_tool: args.enable_session_history_tool,
+        enable_defra_query: args.enable_defra_query,
+        defra_query_collections,
+    };
+    selection.validate()?;
+    Ok(ToolSelectionCommandPlan {
+        selection,
+        file_tools_mode,
+        file_tool_root,
+        bash_mode,
+        command_execution_policy,
+        command_network_mode,
+        clear_update_fields,
+    })
+}
+
+fn file_tools_update(
+    args: &ToolSelectionUpsertArgs,
+    clear_update_fields: &mut Vec<&'static str>,
+) -> Result<(Option<bool>, Option<String>)> {
+    if args.clear_file_tools_mode {
+        if args.file_tools_mode.is_some() || args.enable_file_tools.is_some() {
+            anyhow::bail!(
+                "--clear-file-tools-mode cannot be combined with --file-tools-mode or --enable-file-tools"
+            );
+        }
+        clear_update_fields.push("file_tools_mode");
+        return Ok((None, None));
+    }
+
+    let Some(enabled) = args.enable_file_tools else {
+        let mode = normalize_optional_string(args.file_tools_mode.as_deref());
+        if let Some(mode) = mode.as_deref() {
+            defra_agent::FileToolMode::parse(mode)?;
+        }
+        return Ok((None, mode));
+    };
+
+    let mode = if enabled {
+        normalize_optional_string(args.file_tools_mode.as_deref())
+            .unwrap_or_else(|| "ReadOnly".to_string())
+    } else {
+        "Off".to_string()
+    };
+    defra_agent::FileToolMode::parse(&mode)?;
+    Ok((Some(enabled), Some(mode)))
+}
+
+fn bash_update(
+    args: &ToolSelectionUpsertArgs,
+    clear_update_fields: &mut Vec<&'static str>,
+) -> Result<(Option<bool>, Option<String>)> {
+    if args.clear_bash_mode {
+        if args.bash_mode.is_some() || args.enable_bash.is_some() {
+            anyhow::bail!("--clear-bash-mode cannot be combined with --bash-mode or --enable-bash");
+        }
+        clear_update_fields.push("bash_mode");
+        return Ok((None, None));
+    }
+
+    let Some(enabled) = args.enable_bash else {
+        let mode = normalize_optional_string(args.bash_mode.as_deref());
+        if let Some(mode) = mode.as_deref() {
+            defra_agent::BashMode::parse(mode)?;
+        }
+        return Ok((None, mode));
+    };
+
+    let mode = if enabled {
+        normalize_optional_string(args.bash_mode.as_deref())
+            .unwrap_or_else(|| "ReadOnly".to_string())
+    } else {
+        "Off".to_string()
+    };
+    defra_agent::BashMode::parse(&mode)?;
+    Ok((Some(enabled), Some(mode)))
+}
+
+fn nullable_string_update(
+    value: Option<&str>,
+    clear: bool,
+    value_flag: &str,
+    clear_flag: &str,
+    field_name: &'static str,
+    clear_update_fields: &mut Vec<&'static str>,
+) -> Result<Option<String>> {
+    if clear {
+        if normalize_optional_string(value).is_some() {
+            anyhow::bail!("{clear_flag} cannot be combined with {value_flag}");
+        }
+        clear_update_fields.push(field_name);
+        return Ok(None);
+    }
+    Ok(normalize_optional_string(value))
+}
+
+fn nullable_path_update(
+    value: Option<&std::path::PathBuf>,
+    clear: bool,
+    value_flag: &str,
+    clear_flag: &str,
+    field_name: &'static str,
+    clear_update_fields: &mut Vec<&'static str>,
+) -> Result<Option<String>> {
+    if clear {
+        if value.is_some() {
+            anyhow::bail!("{clear_flag} cannot be combined with {value_flag}");
+        }
+        clear_update_fields.push(field_name);
+        return Ok(None);
+    }
+    Ok(value.map(|path| path.to_string_lossy().to_string()))
+}
+
+fn string_list_update(
+    values: &[String],
+    clear: bool,
+    value_flag: &str,
+    clear_flag: &str,
+) -> Result<Option<Vec<String>>> {
+    if clear {
+        if !values.is_empty() {
+            anyhow::bail!("{clear_flag} cannot be combined with {value_flag}");
+        }
+        Ok(Some(Vec::new()))
+    } else if values.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(values.to_vec()))
+    }
+}
+
+fn timeout_update(
+    args: &ToolSelectionUpsertArgs,
+    clear_update_fields: &mut Vec<&'static str>,
+) -> Result<Option<i64>> {
+    if args.clear_cross_deployment_spawn_timeout_seconds {
+        if args.cross_deployment_spawn_timeout_seconds.is_some() {
+            anyhow::bail!(
+                "--clear-cross-deployment-spawn-timeout-seconds cannot be combined with --cross-deployment-spawn-timeout-seconds"
+            );
+        }
+        clear_update_fields.push("cross_deployment_spawn_timeout_seconds");
+        return Ok(None);
+    }
+
+    if let Some(timeout) = args.cross_deployment_spawn_timeout_seconds {
+        if timeout <= 0 {
+            anyhow::bail!("--cross-deployment-spawn-timeout-seconds must be greater than zero");
+        }
+        return Ok(Some(timeout));
+    }
+    Ok(None)
+}
+
+fn subagent_targets_update(args: &ToolSelectionUpsertArgs) -> Result<Option<Vec<String>>> {
+    if args.clear_subagent_targets && !args.subagent_targets.is_empty() {
+        anyhow::bail!("--clear-subagent-targets cannot be combined with --subagent-target");
+    }
+    if args.clear_subagent_targets {
+        Ok(Some(Vec::new()))
+    } else if args.subagent_targets.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(args.subagent_targets.clone()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+
+    fn default_args() -> ToolSelectionUpsertArgs {
+        ToolSelectionUpsertArgs {
+            graphql: "http://127.0.0.1:9191/api/v0/graphql".to_string(),
+            agent_did: "did:key:z-test".to_string(),
+            selection_id: "default-tools".to_string(),
+            display_name: None,
+            clear_display_name: false,
+            enable_file_tools: None,
+            file_tools_mode: None,
+            clear_file_tools_mode: false,
+            file_tool_root: None::<PathBuf>,
+            clear_file_tool_root: false,
+            enable_bash: None,
+            bash_mode: None,
+            clear_bash_mode: false,
+            command_execution_policy: None,
+            clear_command_execution_policy: false,
+            command_network_mode: None,
+            clear_command_network_mode: false,
+            command_allowed_argv_prefixes: Vec::new(),
+            clear_command_allowed_argv_prefixes: false,
+            command_forbidden_argv_prefixes: Vec::new(),
+            clear_command_forbidden_argv_prefixes: false,
+            cli_tool_names: Vec::new(),
+            clear_cli_tool_names: false,
+            enable_meta_tools: None,
+            allowed_mcp_service_ids: Vec::new(),
+            clear_allowed_mcp_service_ids: false,
+            backgroundable_tool_names: Vec::new(),
+            clear_backgroundable_tool_names: false,
+            enable_memory: None,
+            enable_session_history_tool: None,
+            enable_defra_query: None,
+            defra_query_collections: Vec::new(),
+            clear_defra_query_collections: false,
+            subagent_targets: Vec::new(),
+            clear_subagent_targets: false,
+            subagent_spawn_enabled: None,
+            subagent_steering_enabled: None,
+            subagent_background_enabled: None,
+            subagent_allow_cross_deployment: None,
+            cross_deployment_spawn_timeout_seconds: None,
+            clear_cross_deployment_spawn_timeout_seconds: false,
+        }
+    }
+
+    #[test]
+    fn subagent_flags_build_tool_selection_document() {
+        let target = defra_agent::subagent_target_entry(
+            "worker",
+            "did:key:z-test",
+            "worker",
+            Some("worker behavior".to_string()),
+        );
+        let mut args = default_args();
+        args.subagent_targets = vec![target.clone()];
+        args.subagent_spawn_enabled = Some(true);
+        args.subagent_steering_enabled = Some(true);
+        args.subagent_background_enabled = Some(false);
+        args.subagent_allow_cross_deployment = Some(true);
+        args.cross_deployment_spawn_timeout_seconds = Some(90);
+
+        let plan = tool_selection_command_plan(&args).unwrap();
+
+        assert_eq!(plan.selection.subagent_targets, Some(vec![target]));
+        assert_eq!(plan.selection.subagent_spawn_enabled, Some(true));
+        assert_eq!(plan.selection.subagent_steering_enabled, Some(true));
+        assert_eq!(plan.selection.subagent_background_enabled, Some(false));
+        assert_eq!(plan.selection.subagent_allow_cross_deployment, Some(true));
+        assert_eq!(
+            plan.selection.cross_deployment_spawn_timeout_seconds,
+            Some(90)
+        );
+    }
+
+    #[test]
+    fn omitted_subagent_flags_preserve_and_clear_is_explicit() {
+        let args = default_args();
+        let plan = tool_selection_command_plan(&args).unwrap();
+        assert_eq!(plan.selection.display_name, None);
+        assert_eq!(plan.selection.enable_file_tools, None);
+        assert_eq!(plan.selection.file_tools_mode, None);
+        assert_eq!(plan.selection.file_tool_root, None);
+        assert_eq!(plan.selection.enable_bash, None);
+        assert_eq!(plan.selection.bash_mode, None);
+        assert_eq!(plan.selection.command_execution_policy, None);
+        assert_eq!(plan.selection.command_allowed_argv_prefixes, None);
+        assert_eq!(plan.selection.command_forbidden_argv_prefixes, None);
+        assert_eq!(plan.selection.command_network_mode, None);
+        assert_eq!(plan.selection.cli_tool_names, None);
+        assert_eq!(plan.selection.enable_meta_tools, None);
+        assert_eq!(plan.selection.allowed_mcp_service_ids, None);
+        assert_eq!(plan.selection.backgroundable_tool_names, None);
+        assert_eq!(plan.selection.defra_query_collections, None);
+        assert_eq!(plan.selection.subagent_targets, None);
+        assert_eq!(plan.selection.subagent_spawn_enabled, None);
+        assert_eq!(plan.selection.subagent_steering_enabled, None);
+        assert_eq!(plan.selection.subagent_background_enabled, None);
+        assert_eq!(plan.selection.subagent_allow_cross_deployment, None);
+        assert_eq!(plan.selection.cross_deployment_spawn_timeout_seconds, None);
+        assert!(plan.clear_update_fields.is_empty());
+
+        let mut clear_args = default_args();
+        clear_args.clear_subagent_targets = true;
+        let plan = tool_selection_command_plan(&clear_args).unwrap();
+        assert_eq!(plan.selection.subagent_targets, Some(Vec::new()));
+    }
+
+    #[test]
+    fn explicit_tool_fields_update_and_clear_with_patch_semantics() {
+        let mut args = default_args();
+        args.display_name = Some("Ops".to_string());
+        args.enable_file_tools = Some(true);
+        args.file_tool_root = Some(PathBuf::from("/tmp/workspace"));
+        args.enable_bash = Some(false);
+        args.command_allowed_argv_prefixes = vec!["git status".to_string()];
+        args.cli_tool_names = vec!["rg".to_string()];
+        args.enable_meta_tools = Some(false);
+        args.allowed_mcp_service_ids = vec!["observability".to_string()];
+        args.backgroundable_tool_names = vec!["bash".to_string()];
+        args.defra_query_collections = vec!["AgentRequest".to_string()];
+
+        let plan = tool_selection_command_plan(&args).unwrap();
+
+        assert_eq!(plan.selection.display_name.as_deref(), Some("Ops"));
+        assert_eq!(plan.selection.enable_file_tools, Some(true));
+        assert_eq!(plan.selection.file_tools_mode.as_deref(), Some("ReadOnly"));
+        assert_eq!(
+            plan.selection.file_tool_root.as_deref(),
+            Some("/tmp/workspace")
+        );
+        assert_eq!(plan.selection.enable_bash, Some(false));
+        assert_eq!(plan.selection.bash_mode.as_deref(), Some("Off"));
+        assert_eq!(
+            plan.selection.command_allowed_argv_prefixes,
+            Some(vec!["git status".to_string()])
+        );
+        assert_eq!(plan.selection.cli_tool_names, Some(vec!["rg".to_string()]));
+        assert_eq!(plan.selection.enable_meta_tools, Some(false));
+        assert_eq!(
+            plan.selection.allowed_mcp_service_ids,
+            Some(vec!["observability".to_string()])
+        );
+        assert_eq!(
+            plan.selection.backgroundable_tool_names,
+            Some(vec!["bash".to_string()])
+        );
+        assert_eq!(
+            plan.selection.defra_query_collections,
+            Some(vec!["AgentRequest".to_string()])
+        );
+
+        let mut clear_args = default_args();
+        clear_args.clear_display_name = true;
+        clear_args.clear_file_tool_root = true;
+        clear_args.clear_command_execution_policy = true;
+        clear_args.clear_command_network_mode = true;
+        clear_args.clear_command_allowed_argv_prefixes = true;
+        clear_args.clear_cli_tool_names = true;
+        clear_args.clear_allowed_mcp_service_ids = true;
+        clear_args.clear_backgroundable_tool_names = true;
+        clear_args.clear_defra_query_collections = true;
+        clear_args.clear_cross_deployment_spawn_timeout_seconds = true;
+        let plan = tool_selection_command_plan(&clear_args).unwrap();
+        assert_eq!(
+            plan.clear_update_fields,
+            vec![
+                "command_execution_policy",
+                "command_network_mode",
+                "display_name",
+                "file_tool_root",
+                "cross_deployment_spawn_timeout_seconds"
+            ]
+        );
+        assert_eq!(
+            plan.selection.command_allowed_argv_prefixes,
+            Some(Vec::new())
+        );
+        assert_eq!(plan.selection.cli_tool_names, Some(Vec::new()));
+        assert_eq!(plan.selection.allowed_mcp_service_ids, Some(Vec::new()));
+        assert_eq!(plan.selection.backgroundable_tool_names, Some(Vec::new()));
+        assert_eq!(plan.selection.defra_query_collections, Some(Vec::new()));
+    }
+
+    #[test]
+    fn invalid_subagent_combinations_are_rejected() {
+        let target = defra_agent::subagent_target_entry(
+            "worker",
+            "did:key:z-test",
+            "worker",
+            Some("worker behavior".to_string()),
+        );
+        let mut args = default_args();
+        args.clear_subagent_targets = true;
+        args.subagent_targets = vec![target];
+        assert!(tool_selection_command_plan(&args)
+            .unwrap_err()
+            .to_string()
+            .contains("--clear-subagent-targets"));
+
+        let mut timeout_args = default_args();
+        timeout_args.cross_deployment_spawn_timeout_seconds = Some(0);
+        assert!(tool_selection_command_plan(&timeout_args)
+            .unwrap_err()
+            .to_string()
+            .contains("must be greater than zero"));
+
+        let mut clear_conflict_args = default_args();
+        clear_conflict_args.clear_allowed_mcp_service_ids = true;
+        clear_conflict_args.allowed_mcp_service_ids = vec!["observability".to_string()];
+        assert!(tool_selection_command_plan(&clear_conflict_args)
+            .unwrap_err()
+            .to_string()
+            .contains("--clear-allowed-mcp-service-ids"));
+    }
 }

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -25,8 +25,8 @@ use crate::config_writes::{
 use crate::shared::*;
 use crate::{
     clear_runtime_state, dangerously_overwrite_home, default_data_dir, default_key_path,
-    format_tool_ceiling, normalize_optional_string, print_json, resolve_home_dir,
-    write_init_config, BackendResolutionMode, DEFAULT_HTTP_PORT,
+    format_tool_ceiling, format_tool_package, normalize_optional_string, print_json,
+    resolve_home_dir, write_init_config, BackendResolutionMode, DEFAULT_HTTP_PORT,
 };
 
 const STANDARD_READONLY_SYSTEM_PROMPT: &str = r#"You are a terminal-native engineering and operations agent running for the user inside a local DefraDB runtime.
@@ -57,6 +57,8 @@ For long-running commands such as builds, test suites, installs, servers, and lo
 
 pub(crate) async fn init(args: InitArgs) -> Result<()> {
     let home_dir = resolve_home_dir(args.home.as_deref());
+    let tool_package = resolve_init_tool_package(args.write_tools, args.tool_package)?;
+    validate_init_tool_flags(&args, tool_package)?;
     if args.dangerously_overwrite {
         dangerously_overwrite_home(&home_dir)?;
     }
@@ -83,7 +85,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
             identity_backend: args.identity_backend,
             keychain_label: args.keychain_label.as_deref(),
             secure_enclave_label: args.secure_enclave_label.as_deref(),
-            write_tools: args.write_tools,
+            tool_package,
             tool_root: args.tool_root.as_deref(),
             reset: args.reset,
         })
@@ -95,6 +97,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
             "agent_name": summary.agent_name,
             "agent_did": summary.agent_did,
             "key_path": summary.key_path,
+            "tool_package": format_tool_package(summary.tool_package),
             "tool_ceiling": format_tool_ceiling(summary.tool_ceiling),
             "tool_root": summary.tool_root,
             "runtime_state_reset": summary.runtime_state_reset,
@@ -152,8 +155,13 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
     });
 
     let access = ConfigAccess::Local(node);
-    let summary =
-        initialize_runtime_home(&access, &args, initialized_identity.identity.did()).await?;
+    let summary = initialize_runtime_home(
+        &access,
+        &args,
+        initialized_identity.identity.did(),
+        tool_package,
+    )
+    .await?;
     let stored = StoredInitConfig {
         home: home_dir.to_string_lossy().to_string(),
         agent_name: args.agent_name.clone(),
@@ -162,6 +170,7 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         identity_backend: initialized_identity.identity_backend.clone(),
         keychain_label: initialized_identity.keychain_label.clone(),
         secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
+        tool_package: Some(tool_package),
         tool_ceiling: summary.tool_ceiling,
         tool_root: summary.tool_root.clone(),
     };
@@ -184,8 +193,12 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         "default_behavior_id": summary.default_behavior_id,
         "tool_selection_id": summary.tool_selection_id,
         "inference_profile_id": summary.inference_profile_id,
+        "tool_package": format_tool_package(summary.tool_package),
         "tool_ceiling": format_tool_ceiling(summary.tool_ceiling),
         "tool_root": summary.tool_root,
+        "enable_memory": summary.enable_memory,
+        "enable_defra_query": summary.enable_defra_query,
+        "defra_query_collections": summary.defra_query_collections,
         "runtime_state_reset": runtime_state_reset,
         "identity": {
             "agent_did": initialized_identity.identity.did(),
@@ -210,7 +223,7 @@ pub(crate) struct IdentityOnlyHomeOptions<'a> {
     pub(crate) identity_backend: IdentityBackendArg,
     pub(crate) keychain_label: Option<&'a str>,
     pub(crate) secure_enclave_label: Option<&'a str>,
-    pub(crate) write_tools: bool,
+    pub(crate) tool_package: ToolPackageArg,
     pub(crate) tool_root: Option<&'a Path>,
     pub(crate) reset: bool,
 }
@@ -243,6 +256,7 @@ pub(crate) struct IdentityOnlyHomeSummary {
     pub(crate) keychain_label: Option<String>,
     pub(crate) secure_enclave_label: Option<String>,
     pub(crate) tool_ceiling: ToolCeilingArg,
+    pub(crate) tool_package: ToolPackageArg,
     pub(crate) tool_root: Option<String>,
     pub(crate) runtime_state_reset: bool,
 }
@@ -268,16 +282,9 @@ pub(crate) async fn write_identity_only_home_metadata(
         .await
         .context("creating or loading agent identity key")?;
 
-    let tool_ceiling = if options.write_tools {
-        ToolCeilingArg::Readwrite
-    } else {
-        ToolCeilingArg::Readonly
-    };
-    let tool_root = Some(
-        resolve_default_tool_root(options.tool_root)?
-            .to_string_lossy()
-            .to_string(),
-    );
+    let tool_ceiling = tool_ceiling_for_package(options.tool_package);
+    let tool_root = resolve_tool_root_for_package(options.tool_package, options.tool_root)?
+        .map(|path| path.to_string_lossy().to_string());
     let stored = StoredInitConfig {
         home: options.home.to_string_lossy().to_string(),
         agent_name: options.agent_name.to_string(),
@@ -286,6 +293,7 @@ pub(crate) async fn write_identity_only_home_metadata(
         identity_backend: initialized_identity.identity_backend.clone(),
         keychain_label: initialized_identity.keychain_label.clone(),
         secure_enclave_label: initialized_identity.secure_enclave_label.clone(),
+        tool_package: Some(options.tool_package),
         tool_ceiling,
         tool_root: tool_root.clone(),
     };
@@ -305,6 +313,7 @@ pub(crate) async fn write_identity_only_home_metadata(
         keychain_label: initialized_identity.keychain_label,
         secure_enclave_label: initialized_identity.secure_enclave_label,
         tool_ceiling,
+        tool_package: options.tool_package,
         tool_root,
         runtime_state_reset,
     })
@@ -397,6 +406,7 @@ async fn initialize_runtime_home(
     access: &ConfigAccess,
     args: &InitArgs,
     agent_did: &str,
+    tool_package: ToolPackageArg,
 ) -> Result<InitSummary> {
     let ConfigAccess::Local(node) = access else {
         anyhow::bail!("init requires local DefraDB access");
@@ -462,12 +472,8 @@ async fn initialize_runtime_home(
     )
     .await?;
     let tool_selection_id = default_tool_selection_id_for_behavior(&default_behavior_id);
-    let tool_ceiling = if args.write_tools {
-        ToolCeilingArg::Readwrite
-    } else {
-        ToolCeilingArg::Readonly
-    };
-    let tool_root = Some(resolve_default_tool_root(args.tool_root.as_deref())?);
+    let tool_ceiling = tool_ceiling_for_package(tool_package);
+    let tool_root = resolve_tool_root_for_package(tool_package, args.tool_root.as_deref())?;
     let backend_doc = InferenceBackendUpsertDocument {
         backend_id: backend_id.clone(),
         name: backend_name.clone(),
@@ -484,7 +490,15 @@ async fn initialize_runtime_home(
     };
     write_inference_backend_document(access, &backend_doc).await?;
 
-    let tool_selection = standard_tool_selection(agent_did, &tool_selection_id, tool_ceiling);
+    let enable_defra_query = init_enable_defra_query(tool_package, args.disable_defra_query);
+    let tool_selection = tool_selection_for_package(
+        agent_did,
+        &tool_selection_id,
+        tool_package,
+        args.enable_memory,
+        enable_defra_query,
+        args.defra_query_collections.clone(),
+    );
     write_tool_selection_document(access, &tool_selection).await?;
 
     let inference_profile_id = default_inference_profile_id_for_behavior(&default_behavior_id);
@@ -497,7 +511,7 @@ async fn initialize_runtime_home(
         display_name: Some("Default".to_string()),
         description: None,
         summary: None,
-        system_prompt: Some(standard_system_prompt(tool_ceiling).to_string()),
+        system_prompt: Some(standard_system_prompt(tool_package).to_string()),
         backend_id: Some(backend_id.clone()),
         model_name: Some(model_name.to_string()),
         tool_selection_id: Some(tool_selection_id.clone()),
@@ -524,68 +538,185 @@ async fn initialize_runtime_home(
         default_behavior_id,
         tool_selection_id,
         inference_profile_id,
+        tool_package,
         tool_ceiling,
         tool_root: tool_root.map(|path| path.to_string_lossy().to_string()),
+        enable_memory: args.enable_memory,
+        enable_defra_query,
+        defra_query_collections: args.defra_query_collections.clone(),
         created_principal: existing_principal.is_none(),
         created_default_behavior: existing_default_behavior.is_none(),
     })
 }
 
-fn standard_tool_selection(
+fn tool_selection_for_package(
     agent_did: &str,
     tool_selection_id: &str,
-    tool_ceiling: ToolCeilingArg,
+    tool_package: ToolPackageArg,
+    enable_memory: bool,
+    enable_defra_query: bool,
+    defra_query_collections: Vec<String>,
 ) -> ToolSelectionDocument {
-    let (display_name, file_tools_mode, bash_mode) = match tool_ceiling {
-        ToolCeilingArg::Readwrite => ("Standard Write Tools", "ReadWrite", "Unrestricted"),
-        ToolCeilingArg::MetaOnly | ToolCeilingArg::Readonly => {
-            ("Standard Read-Only Tools", "ReadOnly", "ReadOnly")
-        }
-    };
+    let profile = tool_package_profile(tool_package);
     ToolSelectionDocument {
         selection_id: tool_selection_id.to_string(),
         agent_did: agent_did.to_string(),
-        display_name: Some(display_name.to_string()),
-        enable_file_tools: Some(true),
-        file_tools_mode: Some(file_tools_mode.to_string()),
+        display_name: Some(profile.display_name.to_string()),
+        enable_file_tools: Some(profile.enable_file_tools),
+        file_tools_mode: Some(profile.file_tools_mode.to_string()),
         file_tool_root: None,
-        enable_bash: Some(true),
-        bash_mode: Some(bash_mode.to_string()),
-        command_execution_policy: default_command_execution_policy_for_init(tool_ceiling),
+        enable_bash: Some(profile.enable_bash),
+        bash_mode: Some(profile.bash_mode.to_string()),
+        command_execution_policy: default_command_execution_policy_for_init(tool_package),
         command_allowed_argv_prefixes: Some(Vec::new()),
         command_forbidden_argv_prefixes: Some(Vec::new()),
         command_network_mode: None,
         cli_tool_names: Some(Vec::new()),
-        enable_meta_tools: Some(true),
+        enable_meta_tools: Some(profile.enable_meta_tools),
         allowed_mcp_service_ids: Some(Vec::new()),
-        backgroundable_tool_names: Some(default_backgroundable_tool_names(tool_ceiling)),
+        backgroundable_tool_names: Some(default_backgroundable_tool_names(tool_package)),
         subagent_targets: Some(Vec::new()),
         subagent_spawn_enabled: Some(false),
         subagent_steering_enabled: Some(false),
         subagent_background_enabled: Some(false),
         subagent_allow_cross_deployment: Some(false),
         cross_deployment_spawn_timeout_seconds: None,
-        enable_memory: Some(false),
+        enable_memory: Some(enable_memory),
         enable_session_history_tool: Some(false),
-        enable_defra_query: None,
-        defra_query_collections: None,
+        enable_defra_query: Some(enable_defra_query),
+        defra_query_collections: Some(defra_query_collections),
     }
 }
 
-fn default_command_execution_policy_for_init(tool_ceiling: ToolCeilingArg) -> Option<String> {
-    match tool_ceiling {
-        ToolCeilingArg::Readwrite if cfg!(target_os = "macos") => {
-            Some("workspace_write".to_string())
+fn default_command_execution_policy_for_init(tool_package: ToolPackageArg) -> Option<String> {
+    match tool_package {
+        ToolPackageArg::Write if cfg!(target_os = "macos") => Some("workspace_write".to_string()),
+        ToolPackageArg::Write => Some("unrestricted".to_string()),
+        ToolPackageArg::Minimal | ToolPackageArg::Introspection | ToolPackageArg::Readonly => None,
+    }
+}
+
+fn default_backgroundable_tool_names(tool_package: ToolPackageArg) -> Vec<String> {
+    match tool_package {
+        ToolPackageArg::Write => vec!["bash_unrestricted".to_string()],
+        ToolPackageArg::Minimal | ToolPackageArg::Introspection | ToolPackageArg::Readonly => {
+            Vec::new()
         }
-        ToolCeilingArg::Readwrite => Some("unrestricted".to_string()),
-        ToolCeilingArg::MetaOnly | ToolCeilingArg::Readonly => None,
     }
 }
 
-fn default_backgroundable_tool_names(tool_ceiling: ToolCeilingArg) -> Vec<String> {
-    match tool_ceiling {
-        ToolCeilingArg::Readwrite => vec!["bash_unrestricted".to_string()],
-        ToolCeilingArg::Readonly | ToolCeilingArg::MetaOnly => Vec::new(),
+#[derive(Clone, Copy)]
+struct ToolPackageProfile {
+    display_name: &'static str,
+    enable_file_tools: bool,
+    file_tools_mode: &'static str,
+    enable_bash: bool,
+    bash_mode: &'static str,
+    enable_meta_tools: bool,
+    enable_defra_query: bool,
+}
+
+fn tool_package_profile(tool_package: ToolPackageArg) -> ToolPackageProfile {
+    match tool_package {
+        ToolPackageArg::Minimal => ToolPackageProfile {
+            display_name: "Minimal Tools",
+            enable_file_tools: false,
+            file_tools_mode: "Off",
+            enable_bash: false,
+            bash_mode: "Off",
+            enable_meta_tools: false,
+            enable_defra_query: false,
+        },
+        ToolPackageArg::Introspection => ToolPackageProfile {
+            display_name: "Introspection Tools",
+            enable_file_tools: false,
+            file_tools_mode: "Off",
+            enable_bash: false,
+            bash_mode: "Off",
+            enable_meta_tools: true,
+            enable_defra_query: true,
+        },
+        ToolPackageArg::Readonly => ToolPackageProfile {
+            display_name: "Standard Read-Only Tools",
+            enable_file_tools: true,
+            file_tools_mode: "ReadOnly",
+            enable_bash: true,
+            bash_mode: "ReadOnly",
+            enable_meta_tools: true,
+            enable_defra_query: true,
+        },
+        ToolPackageArg::Write => ToolPackageProfile {
+            display_name: "Standard Write Tools",
+            enable_file_tools: true,
+            file_tools_mode: "ReadWrite",
+            enable_bash: true,
+            bash_mode: "Unrestricted",
+            enable_meta_tools: true,
+            enable_defra_query: true,
+        },
+    }
+}
+
+fn resolve_init_tool_package(
+    write_tools: bool,
+    explicit: Option<ToolPackageArg>,
+) -> Result<ToolPackageArg> {
+    match (write_tools, explicit) {
+        (true, Some(ToolPackageArg::Write)) | (true, None) => Ok(ToolPackageArg::Write),
+        (true, Some(other)) => anyhow::bail!(
+            "--write-tools is a compatibility alias for --tool-package write; remove --write-tools or choose --tool-package {}",
+            format_tool_package(other)
+        ),
+        (false, Some(package)) => Ok(package),
+        (false, None) => Ok(ToolPackageArg::Readonly),
+    }
+}
+
+fn validate_init_tool_flags(args: &InitArgs, tool_package: ToolPackageArg) -> Result<()> {
+    if args.identity_only
+        && (args.enable_memory
+            || args.disable_defra_query
+            || !args.defra_query_collections.is_empty())
+    {
+        anyhow::bail!(
+            "--enable-memory, --disable-defra-query, and --defra-query-collection cannot be used with --identity-only because no ToolSelection document is written"
+        );
+    }
+    if !args.defra_query_collections.is_empty() {
+        let profile = tool_package_profile(tool_package);
+        if args.disable_defra_query || !profile.enable_defra_query {
+            anyhow::bail!(
+                "--defra-query-collection requires a tool package with defra_query enabled and cannot be combined with --disable-defra-query"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn init_enable_defra_query(tool_package: ToolPackageArg, disable_defra_query: bool) -> bool {
+    tool_package_profile(tool_package).enable_defra_query && !disable_defra_query
+}
+
+fn tool_ceiling_for_package(tool_package: ToolPackageArg) -> ToolCeilingArg {
+    match tool_package {
+        ToolPackageArg::Minimal | ToolPackageArg::Introspection => ToolCeilingArg::MetaOnly,
+        ToolPackageArg::Readonly => ToolCeilingArg::Readonly,
+        ToolPackageArg::Write => ToolCeilingArg::Readwrite,
+    }
+}
+
+fn resolve_tool_root_for_package(
+    tool_package: ToolPackageArg,
+    explicit: Option<&Path>,
+) -> Result<Option<PathBuf>> {
+    let needs_root = matches!(
+        tool_package,
+        ToolPackageArg::Readonly | ToolPackageArg::Write
+    );
+    if needs_root || explicit.is_some() {
+        Ok(Some(resolve_default_tool_root(explicit)?))
+    } else {
+        Ok(None)
     }
 }
 
@@ -606,10 +737,12 @@ fn default_backend_id_for_agent(agent_did: &str) -> String {
     format!("{agent_did}:backend")
 }
 
-fn standard_system_prompt(tool_ceiling: ToolCeilingArg) -> &'static str {
-    match tool_ceiling {
-        ToolCeilingArg::Readwrite => STANDARD_READWRITE_SYSTEM_PROMPT,
-        ToolCeilingArg::MetaOnly | ToolCeilingArg::Readonly => STANDARD_READONLY_SYSTEM_PROMPT,
+fn standard_system_prompt(tool_package: ToolPackageArg) -> &'static str {
+    match tool_package {
+        ToolPackageArg::Write => STANDARD_READWRITE_SYSTEM_PROMPT,
+        ToolPackageArg::Minimal | ToolPackageArg::Introspection | ToolPackageArg::Readonly => {
+            STANDARD_READONLY_SYSTEM_PROMPT
+        }
     }
 }
 
@@ -651,4 +784,259 @@ fn resolve_default_tool_root(explicit: Option<&Path>) -> Result<PathBuf> {
         .ok()
         .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
         .ok_or_else(|| anyhow::anyhow!("unable to determine a default tool root for local tools"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn init_args() -> InitArgs {
+        InitArgs {
+            home: None,
+            data_dir: None,
+            dangerously_overwrite: false,
+            reset: false,
+            identity_only: false,
+            agent_name: "test-agent".to_string(),
+            key_path: None,
+            identity_backend: IdentityBackendArg::File,
+            keychain_label: None,
+            secure_enclave_label: None,
+            inference_endpoint: None,
+            inference_endpoint_legacy: None,
+            backend_id: None,
+            backend_name: None,
+            backend_preset: None,
+            provider_kind: None,
+            api_key: None,
+            api_key_env_var: None,
+            model_name: "test-model".to_string(),
+            max_concurrent: 2,
+            max_queue_depth: 16,
+            write_tools: false,
+            tool_package: None,
+            tool_root: None,
+            enable_memory: false,
+            disable_defra_query: false,
+            defra_query_collections: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn init_affordances_seed_tool_selection_document() {
+        let selection = tool_selection_for_package(
+            "did:key:z-init",
+            "default-tools",
+            ToolPackageArg::Readonly,
+            true,
+            true,
+            vec!["AgentRequest".to_string(), "AgentResponse".to_string()],
+        );
+
+        assert_eq!(selection.enable_memory, Some(true));
+        assert_eq!(selection.enable_defra_query, Some(true));
+        assert_eq!(
+            selection.defra_query_collections,
+            Some(vec![
+                "AgentRequest".to_string(),
+                "AgentResponse".to_string()
+            ])
+        );
+        assert_eq!(selection.enable_file_tools, Some(true));
+        assert_eq!(selection.file_tools_mode.as_deref(), Some("ReadOnly"));
+    }
+
+    #[test]
+    fn init_tool_packages_seed_expected_tool_selection_documents() {
+        struct Case {
+            package: ToolPackageArg,
+            ceiling: ToolCeilingArg,
+            display_name: &'static str,
+            enable_file_tools: bool,
+            file_tools_mode: &'static str,
+            enable_bash: bool,
+            bash_mode: &'static str,
+            enable_meta_tools: bool,
+            enable_defra_query: bool,
+            backgroundable_tools: Vec<String>,
+        }
+
+        let cases = [
+            Case {
+                package: ToolPackageArg::Minimal,
+                ceiling: ToolCeilingArg::MetaOnly,
+                display_name: "Minimal Tools",
+                enable_file_tools: false,
+                file_tools_mode: "Off",
+                enable_bash: false,
+                bash_mode: "Off",
+                enable_meta_tools: false,
+                enable_defra_query: false,
+                backgroundable_tools: Vec::new(),
+            },
+            Case {
+                package: ToolPackageArg::Introspection,
+                ceiling: ToolCeilingArg::MetaOnly,
+                display_name: "Introspection Tools",
+                enable_file_tools: false,
+                file_tools_mode: "Off",
+                enable_bash: false,
+                bash_mode: "Off",
+                enable_meta_tools: true,
+                enable_defra_query: true,
+                backgroundable_tools: Vec::new(),
+            },
+            Case {
+                package: ToolPackageArg::Readonly,
+                ceiling: ToolCeilingArg::Readonly,
+                display_name: "Standard Read-Only Tools",
+                enable_file_tools: true,
+                file_tools_mode: "ReadOnly",
+                enable_bash: true,
+                bash_mode: "ReadOnly",
+                enable_meta_tools: true,
+                enable_defra_query: true,
+                backgroundable_tools: Vec::new(),
+            },
+            Case {
+                package: ToolPackageArg::Write,
+                ceiling: ToolCeilingArg::Readwrite,
+                display_name: "Standard Write Tools",
+                enable_file_tools: true,
+                file_tools_mode: "ReadWrite",
+                enable_bash: true,
+                bash_mode: "Unrestricted",
+                enable_meta_tools: true,
+                enable_defra_query: true,
+                backgroundable_tools: vec!["bash_unrestricted".to_string()],
+            },
+        ];
+
+        for case in cases {
+            let selection = tool_selection_for_package(
+                "did:key:z-init",
+                "default-tools",
+                case.package,
+                false,
+                init_enable_defra_query(case.package, false),
+                Vec::new(),
+            );
+
+            assert_eq!(tool_ceiling_for_package(case.package), case.ceiling);
+            assert_eq!(selection.display_name.as_deref(), Some(case.display_name));
+            assert_eq!(selection.enable_file_tools, Some(case.enable_file_tools));
+            assert_eq!(
+                selection.file_tools_mode.as_deref(),
+                Some(case.file_tools_mode)
+            );
+            assert_eq!(selection.enable_bash, Some(case.enable_bash));
+            assert_eq!(selection.bash_mode.as_deref(), Some(case.bash_mode));
+            assert_eq!(selection.enable_meta_tools, Some(case.enable_meta_tools));
+            assert_eq!(selection.enable_defra_query, Some(case.enable_defra_query));
+            assert_eq!(
+                selection.backgroundable_tool_names,
+                Some(case.backgroundable_tools)
+            );
+            assert_eq!(selection.enable_memory, Some(false));
+            assert_eq!(selection.allowed_mcp_service_ids, Some(Vec::new()));
+            assert_eq!(selection.subagent_targets, Some(Vec::new()));
+            assert_eq!(selection.subagent_spawn_enabled, Some(false));
+            assert_eq!(selection.subagent_background_enabled, Some(false));
+            assert_eq!(selection.subagent_allow_cross_deployment, Some(false));
+        }
+    }
+
+    #[test]
+    fn init_can_seed_defra_query_disabled_document() {
+        let selection = tool_selection_for_package(
+            "did:key:z-init",
+            "default-tools",
+            ToolPackageArg::Write,
+            false,
+            init_enable_defra_query(ToolPackageArg::Write, true),
+            Vec::new(),
+        );
+
+        assert_eq!(selection.enable_memory, Some(false));
+        assert_eq!(selection.enable_defra_query, Some(false));
+        assert_eq!(selection.defra_query_collections, Some(Vec::new()));
+        assert_eq!(
+            selection.backgroundable_tool_names,
+            Some(vec!["bash_unrestricted".to_string()])
+        );
+    }
+
+    #[test]
+    fn init_tool_package_aliases_and_defra_query_scope_validation_match_seeded_docs() {
+        assert_eq!(
+            resolve_init_tool_package(false, None).unwrap(),
+            ToolPackageArg::Readonly
+        );
+        assert_eq!(
+            resolve_init_tool_package(true, None).unwrap(),
+            ToolPackageArg::Write
+        );
+        assert_eq!(
+            resolve_init_tool_package(true, Some(ToolPackageArg::Write)).unwrap(),
+            ToolPackageArg::Write
+        );
+        assert!(
+            resolve_init_tool_package(true, Some(ToolPackageArg::Readonly))
+                .unwrap_err()
+                .to_string()
+                .contains("--write-tools")
+        );
+
+        let mut scoped_introspection = init_args();
+        scoped_introspection.tool_package = Some(ToolPackageArg::Introspection);
+        scoped_introspection.defra_query_collections = vec!["AgentRequest".to_string()];
+        validate_init_tool_flags(&scoped_introspection, ToolPackageArg::Introspection).unwrap();
+
+        let selection = tool_selection_for_package(
+            "did:key:z-init",
+            "default-tools",
+            ToolPackageArg::Introspection,
+            true,
+            init_enable_defra_query(ToolPackageArg::Introspection, false),
+            scoped_introspection.defra_query_collections.clone(),
+        );
+        assert_eq!(selection.enable_memory, Some(true));
+        assert_eq!(selection.enable_defra_query, Some(true));
+        assert_eq!(
+            selection.defra_query_collections,
+            Some(vec!["AgentRequest".to_string()])
+        );
+    }
+
+    #[test]
+    fn init_rejects_affordances_that_would_not_write_documents() {
+        let mut identity_only = init_args();
+        identity_only.identity_only = true;
+        identity_only.enable_memory = true;
+        assert!(
+            validate_init_tool_flags(&identity_only, ToolPackageArg::Readonly)
+                .unwrap_err()
+                .to_string()
+                .contains("--identity-only")
+        );
+
+        let mut scoped_without_tool = init_args();
+        scoped_without_tool.defra_query_collections = vec!["AgentRequest".to_string()];
+        assert!(
+            validate_init_tool_flags(&scoped_without_tool, ToolPackageArg::Minimal)
+                .unwrap_err()
+                .to_string()
+                .contains("--defra-query-collection")
+        );
+
+        let mut scoped_disabled = init_args();
+        scoped_disabled.disable_defra_query = true;
+        scoped_disabled.defra_query_collections = vec!["AgentRequest".to_string()];
+        assert!(
+            validate_init_tool_flags(&scoped_disabled, ToolPackageArg::Readonly)
+                .unwrap_err()
+                .to_string()
+                .contains("--defra-query-collection")
+        );
+    }
 }

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -20,4 +20,5 @@ pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod status;
 pub(crate) mod subagent;
+pub(crate) mod tools;
 pub(crate) mod trace;

--- a/crates/defra-agent-cli/src/commands/provision.rs
+++ b/crates/defra-agent-cli/src/commands/provision.rs
@@ -169,7 +169,7 @@ async fn ensure_home_identity(
         },
         keychain_label,
         secure_enclave_label,
-        write_tools: false,
+        tool_package: ToolPackageArg::Readonly,
         tool_root: None,
         reset: false,
     })

--- a/crates/defra-agent-cli/src/commands/tools.rs
+++ b/crates/defra-agent-cli/src/commands/tools.rs
@@ -1,0 +1,210 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use defra_agent::{
+    AgentBehaviorDocument, BehaviorToolConfig, ToolCeiling, ToolSelection, ToolSelectionDocument,
+};
+use serde_json::{json, Value};
+
+use crate::cli::args::{ToolCeilingArg, ToolExplainArgs, ToolsCommand};
+use crate::shared::{ConfigExportBundle, StoredInitConfig};
+use crate::{
+    build_config_export_bundle, format_tool_ceiling, print_json, read_init_config,
+    resolve_agent_did, resolve_config_access,
+};
+
+pub(crate) async fn dispatch(command: ToolsCommand) -> Result<()> {
+    match command {
+        ToolsCommand::Explain(args) => explain(args).await,
+    }
+}
+
+async fn explain(args: ToolExplainArgs) -> Result<()> {
+    let (access, home_dir) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+    let agent_did = resolve_agent_did(args.home.as_deref(), args.agent_did.as_deref())?;
+    let init_config = read_init_config(&home_dir)?;
+    let (ceiling_arg, ceiling_source, tool_root, tool_ceiling) =
+        resolve_tool_ceiling(init_config.as_ref())?;
+    let bundle = build_config_export_bundle(&access, &agent_did).await?;
+    let mcp_services_online = has_online_mcp_services(&bundle);
+    let active_behavior_ids = active_behavior_ids(&bundle);
+    let active_behavior_id_set = active_behavior_ids.iter().cloned().collect::<HashSet<_>>();
+    let selection_rows = tool_selection_rows(&bundle)?;
+    let mut unavailable_behaviors =
+        crate::commands::status::collect_unavailable_behaviors_from_bundle(&bundle);
+    let mut behaviors = Vec::new();
+
+    for row in &bundle.agent_behaviors {
+        let behavior: AgentBehaviorDocument = serde_json::from_value(row.clone())
+            .context("decoding AgentBehavior row for tool-surface explanation")?;
+        if let Some(only_behavior_id) = args.behavior_id.as_deref() {
+            if behavior.behavior_id != only_behavior_id {
+                continue;
+            }
+        }
+
+        if !behavior.enabled {
+            unavailable_behaviors
+                .entry(behavior.behavior_id.clone())
+                .or_insert_with(|| "behavior is disabled".to_string());
+        }
+
+        let tool_selection_id = behavior
+            .tool_selection_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let (tool_selection_source, config_result) = match tool_selection_id.as_deref() {
+            Some(selection_id) => match selection_rows.get(selection_id) {
+                Some(selection) => (
+                    "document".to_string(),
+                    BehaviorToolConfig::from_tool_selection_document(
+                        &behavior.behavior_id,
+                        selection,
+                        &tool_ceiling,
+                        Vec::new(),
+                    )
+                    .with_context(|| format!("decoding ToolSelection {selection_id}")),
+                ),
+                None => {
+                    unavailable_behaviors
+                        .entry(behavior.behavior_id.clone())
+                        .or_insert_with(|| {
+                            format!("referenced ToolSelection {selection_id} is missing")
+                        });
+                    continue;
+                }
+            },
+            None => (
+                "default_missing_tool_selection_id".to_string(),
+                BehaviorToolConfig::from_selection(
+                    &behavior.behavior_id,
+                    ToolSelection::default(),
+                    &tool_ceiling,
+                    Vec::new(),
+                ),
+            ),
+        };
+
+        let config = match config_result {
+            Ok(config) => config,
+            Err(error) => {
+                unavailable_behaviors
+                    .entry(behavior.behavior_id.clone())
+                    .or_insert_with(|| error.to_string());
+                continue;
+            }
+        };
+        let explanation =
+            config.explain_with_runtime(mcp_services_online, &agent_did, &active_behavior_id_set);
+        behaviors.push(json!({
+            "behavior_id": behavior.behavior_id,
+            "display_name": behavior.display_name,
+            "enabled": behavior.enabled,
+            "tool_selection_id": tool_selection_id,
+            "tool_selection_source": tool_selection_source,
+            "surface": explanation,
+        }));
+    }
+
+    if let Some(only_behavior_id) = args.behavior_id.as_deref() {
+        let found = behaviors.iter().any(|row| {
+            row.get("behavior_id")
+                .and_then(Value::as_str)
+                .is_some_and(|value| value == only_behavior_id)
+        }) || unavailable_behaviors.contains_key(only_behavior_id);
+        if !found {
+            anyhow::bail!("behavior {only_behavior_id} was not found for agent {agent_did}");
+        }
+    }
+
+    let output = json!({
+        "agent_did": agent_did,
+        "access_mode": access.mode(),
+        "home": home_dir,
+        "host_tool_ceiling": {
+            "tool_ceiling": format_tool_ceiling(ceiling_arg),
+            "source": ceiling_source,
+            "tool_root": tool_root,
+            "scope": "host_native_file_bash_cli_only",
+            "note": "This ceiling currently clamps host-native file/bash/CLI tools, not every model-callable built-in read, MCP, subagent, or operator HTTP surface."
+        },
+        "runtime_availability": {
+            "online_mcp_services_present": mcp_services_online,
+            "active_behavior_ids": active_behavior_ids.iter().cloned().collect::<Vec<_>>(),
+        },
+        "behaviors": behaviors,
+        "unavailable_behaviors": unavailable_behaviors,
+        "operator_surfaces": {
+            "included_in_model_tool_surface": false,
+            "note": "Server HTTP routes and optional external /mcp are binary/operator surfaces; they are not included in per-behavior model-callable tool_names."
+        },
+    });
+    print_json(&output)?;
+    Ok(())
+}
+
+fn resolve_tool_ceiling(
+    init_config: Option<&StoredInitConfig>,
+) -> Result<(ToolCeilingArg, &'static str, Option<String>, ToolCeiling)> {
+    let Some(config) = init_config else {
+        return Ok((
+            ToolCeilingArg::MetaOnly,
+            "default_no_init_json",
+            None,
+            ToolCeiling::meta_only(),
+        ));
+    };
+    let tool_root = config.tool_root.clone();
+    let ceiling = match config.tool_ceiling {
+        ToolCeilingArg::MetaOnly => ToolCeiling::meta_only(),
+        ToolCeilingArg::Readonly => match tool_root.as_deref() {
+            Some(root) => ToolCeiling::readonly_at(PathBuf::from(root)),
+            None => ToolCeiling::readonly(),
+        },
+        ToolCeilingArg::Readwrite => {
+            let root = tool_root.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("init.json has readwrite tool_ceiling but no tool_root")
+            })?;
+            ToolCeiling::readwrite(PathBuf::from(root))
+        }
+    };
+    Ok((config.tool_ceiling, "init_json", tool_root, ceiling))
+}
+
+fn has_online_mcp_services(bundle: &ConfigExportBundle) -> bool {
+    bundle.tool_service_registries.iter().any(|row| {
+        row.get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("online")
+            == "online"
+    })
+}
+
+fn active_behavior_ids(bundle: &ConfigExportBundle) -> BTreeSet<String> {
+    bundle
+        .agent_behaviors
+        .iter()
+        .filter(|row| row.get("enabled").and_then(Value::as_bool).unwrap_or(false))
+        .filter_map(|row| {
+            row.get("behavior_id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .collect()
+}
+
+fn tool_selection_rows(
+    bundle: &ConfigExportBundle,
+) -> Result<BTreeMap<String, ToolSelectionDocument>> {
+    let mut rows = BTreeMap::new();
+    for row in &bundle.tool_selections {
+        let selection: ToolSelectionDocument = serde_json::from_value(row.clone())
+            .context("decoding ToolSelection row for tool-surface explanation")?;
+        rows.insert(selection.selection_id.clone(), selection);
+    }
+    Ok(rows)
+}

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -14,7 +14,9 @@ pub(crate) use inference_backend::{
 };
 pub(crate) use schedule::write_schedule_document;
 pub(crate) use task::write_task_document;
-pub(crate) use tool_selection::write_tool_selection_document;
+pub(crate) use tool_selection::{
+    write_tool_selection_document, write_tool_selection_document_with_clear_fields,
+};
 pub(crate) use txn::ConfigApplyTxn;
 
 use anyhow::Result;

--- a/crates/defra-agent-cli/src/config_writes/tool_selection.rs
+++ b/crates/defra-agent-cli/src/config_writes/tool_selection.rs
@@ -3,14 +3,34 @@ use defra_agent::graphql::escape_graphql_string;
 use defra_agent::ToolSelectionDocument;
 
 use crate::config_writes::ConfigAccess;
-use crate::{nullable_string_field, optional_bool_field, optional_string_field, string_list_field};
+use crate::{optional_bool_field, optional_string_field, string_list_field};
 
 pub(crate) async fn write_tool_selection_document(
     access: &ConfigAccess,
     selection: &ToolSelectionDocument,
 ) -> Result<String> {
+    write_tool_selection_document_with_clear_fields(access, selection, &[]).await
+}
+
+pub(crate) async fn write_tool_selection_document_with_clear_fields(
+    access: &ConfigAccess,
+    selection: &ToolSelectionDocument,
+    clear_update_fields: &[&str],
+) -> Result<String> {
     let add_fields = tool_selection_fields(selection, true);
-    let update_fields = tool_selection_fields(selection, false);
+    let mut update_fields = tool_selection_fields(selection, false);
+    if !clear_update_fields.is_empty() {
+        if !update_fields.is_empty() {
+            update_fields.push_str(",\n                    ");
+        }
+        update_fields.push_str(
+            &clear_update_fields
+                .iter()
+                .map(|field| format!("{field}: null"))
+                .collect::<Vec<_>>()
+                .join(",\n                    "),
+        );
+    }
     let mutation = format!(
         r#"mutation {{
             upsert_ToolSelection(
@@ -219,6 +239,86 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn update_with_clear_fields_nulls_nullable_config() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let data_dir = tempdir.path().join("data");
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node);
+
+        let applied = ToolSelectionDocument {
+            selection_id: "test-clear-fields".to_string(),
+            agent_did: "did:test:clear-fields".to_string(),
+            display_name: Some("Original".to_string()),
+            file_tool_root: Some("/tmp/workspace".to_string()),
+            command_execution_policy: Some("read_only".to_string()),
+            command_network_mode: Some("disabled".to_string()),
+            allowed_mcp_service_ids: Some(vec!["observability".to_string()]),
+            backgroundable_tool_names: Some(vec!["bash_unrestricted".to_string()]),
+            cli_tool_names: Some(vec!["rg".to_string()]),
+            defra_query_collections: Some(vec!["AgentRequest".to_string()]),
+            cross_deployment_spawn_timeout_seconds: Some(90),
+            ..Default::default()
+        };
+        write_tool_selection_document(&access, &applied).await?;
+
+        let clear_update = ToolSelectionDocument {
+            selection_id: "test-clear-fields".to_string(),
+            agent_did: "did:test:clear-fields".to_string(),
+            allowed_mcp_service_ids: Some(Vec::new()),
+            backgroundable_tool_names: Some(Vec::new()),
+            cli_tool_names: Some(Vec::new()),
+            defra_query_collections: Some(Vec::new()),
+            ..Default::default()
+        };
+        write_tool_selection_document_with_clear_fields(
+            &access,
+            &clear_update,
+            &[
+                "display_name",
+                "file_tool_root",
+                "command_execution_policy",
+                "command_network_mode",
+                "cross_deployment_spawn_timeout_seconds",
+            ],
+        )
+        .await?;
+
+        let node = match &access {
+            ConfigAccess::Local(n) => n,
+            ConfigAccess::Graphql(_) => unreachable!(),
+        };
+        let loaded = load_tool_selection(node, "test-clear-fields")
+            .await?
+            .expect("ToolSelection should exist after update");
+
+        assert_eq!(loaded.display_name, None);
+        assert_eq!(loaded.file_tool_root, None);
+        assert_eq!(loaded.command_execution_policy, None);
+        assert_eq!(loaded.command_network_mode, None);
+        assert!(loaded
+            .allowed_mcp_service_ids
+            .unwrap_or_default()
+            .is_empty());
+        assert!(loaded
+            .backgroundable_tool_names
+            .unwrap_or_default()
+            .is_empty());
+        assert!(loaded.cli_tool_names.unwrap_or_default().is_empty());
+        assert!(loaded
+            .defra_query_collections
+            .unwrap_or_default()
+            .is_empty());
+        assert_eq!(loaded.cross_deployment_spawn_timeout_seconds, None);
+
+        Ok(())
+    }
 }
 
 fn tool_selection_fields(selection: &ToolSelectionDocument, include_id: bool) -> String {
@@ -238,10 +338,7 @@ fn tool_selection_fields(selection: &ToolSelectionDocument, include_id: bool) ->
             optional_string_field("display_name", selection.display_name.as_deref()),
             optional_bool_field("enable_file_tools", selection.enable_file_tools),
             optional_string_field("file_tools_mode", selection.file_tools_mode.as_deref()),
-            Some(nullable_string_field(
-                "file_tool_root",
-                selection.file_tool_root.as_deref(),
-            )),
+            optional_string_field("file_tool_root", selection.file_tool_root.as_deref()),
             optional_bool_field("enable_bash", selection.enable_bash),
             optional_string_field("bash_mode", selection.bash_mode.as_deref()),
             optional_string_field(

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -85,6 +85,7 @@ Examples:
   defra-agent init --backend-preset openrouter --model-name MODEL
   defra-agent init --backend-preset openai --model-name MODEL
   defra-agent init --inference-url $INFERENCE_ENDPOINT --model-name MODEL --write-tools
+  defra-agent init --enable-memory --defra-query-collection AgentRequest
   defra-agent init --identity-only
   defra-agent init --identity-only --identity-backend macos-keychain --keychain-label LABEL
   defra-agent init --identity-only --identity-backend macos-secure-enclave --secure-enclave-label LABEL

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -246,6 +246,15 @@ Examples:
   defra-agent diagnose
   defra-agent diagnose --home /path/to/home
   defra-agent diagnose --graphql http://127.0.0.1:9191/api/v0/graphql";
+const TOOLS_AFTER_HELP: &str = "\
+Examples:
+  defra-agent tools explain
+  defra-agent tools explain --behavior-id BEHAVIOR_ID
+  defra-agent tools explain --graphql http://127.0.0.1:9191/api/v0/graphql
+
+The explain output separates model-callable tools from operator HTTP/MCP surfaces
+and includes warnings for confusing defaults such as empty allowlists that mean
+all, or built-in read tools that are always included today.";
 const CONFIG_EXPORT_AFTER_HELP: &str = "\
 Exports the desired configuration documents for one agent principal as a
 manifest root directory (per-document subdirectories, optional prompt sidecars).
@@ -352,6 +361,7 @@ async fn main() -> Result<()> {
         Command::Mcp { command } => commands::mcp::dispatch(command).await,
         Command::Fleet { command } => commands::fleet::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
+        Command::Tools { command } => commands::tools::dispatch(command).await,
         Command::Config { command } => commands::config::dispatch(command).await,
         Command::Request { command } => commands::request::dispatch(command).await,
         Command::Response { command } => commands::response::dispatch(command).await,

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -216,7 +216,9 @@ Examples:
   defra-agent config backend set --graphql URL --backend-id <backend-id> --name <name> --backend-preset openrouter --max-concurrent 2
   defra-agent config backend discover-models --backend-preset openrouter
   defra-agent config behavior set --graphql URL --agent-did <AGENT_DID> --backend-id <backend-id> --model-name MODEL
-  defra-agent config tools set --graphql URL --agent-did <AGENT_DID> --selection-id <selection-id> --enable-file-tools";
+  defra-agent config tools set --graphql URL --agent-did <AGENT_DID> --selection-id <selection-id> --enable-file-tools
+  defra-agent config tools set --graphql URL --agent-did <AGENT_DID> --selection-id <selection-id> --enable-memory true
+  defra-agent config tools set --graphql URL --agent-did <AGENT_DID> --selection-id <selection-id> --subagent-spawn-enabled true --subagent-target '<json>'";
 const REQUEST_AFTER_HELP: &str = "\
 `request` is the low-level document path. Most users should prefer `defra-agent chat`.
 

--- a/crates/defra-agent-cli/src/resolve_helpers.rs
+++ b/crates/defra-agent-cli/src/resolve_helpers.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use defra_agent::{cli_tool, BackendProviderKind, BashMode, FileToolMode};
+use defra_agent::{cli_tool, BackendProviderKind};
 
 use crate::cli::args::{BackendPresetArg, ToolCeilingArg, ToolPackageArg};
 use crate::shared::ResolvedBackendConfig;
@@ -115,32 +115,6 @@ pub(crate) fn parse_cli_tool_arg(value: &str) -> Result<defra_agent::CliToolConf
         PathBuf::from(path),
         format!("Run the approved {name} CLI."),
     ))
-}
-
-pub(crate) fn normalize_file_tools_mode(enabled: bool, explicit: Option<&str>) -> Result<String> {
-    let value = if enabled {
-        explicit
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("ReadOnly")
-    } else {
-        "Off"
-    };
-    FileToolMode::parse(value)?;
-    Ok(value.to_string())
-}
-
-pub(crate) fn normalize_bash_mode(enabled: bool, explicit: Option<&str>) -> Result<String> {
-    let value = if enabled {
-        explicit
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("ReadOnly")
-    } else {
-        "Off"
-    };
-    BashMode::parse(value)?;
-    Ok(value.to_string())
 }
 
 pub(crate) fn format_tool_ceiling(value: ToolCeilingArg) -> &'static str {

--- a/crates/defra-agent-cli/src/resolve_helpers.rs
+++ b/crates/defra-agent-cli/src/resolve_helpers.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use defra_agent::{cli_tool, BackendProviderKind, BashMode, FileToolMode};
 
-use crate::cli::args::{BackendPresetArg, ToolCeilingArg};
+use crate::cli::args::{BackendPresetArg, ToolCeilingArg, ToolPackageArg};
 use crate::shared::ResolvedBackendConfig;
 use crate::{normalize_optional_string, DEFAULT_INIT_ENDPOINT};
 
@@ -148,5 +148,14 @@ pub(crate) fn format_tool_ceiling(value: ToolCeilingArg) -> &'static str {
         ToolCeilingArg::MetaOnly => "meta-only",
         ToolCeilingArg::Readonly => "readonly",
         ToolCeilingArg::Readwrite => "readwrite",
+    }
+}
+
+pub(crate) fn format_tool_package(value: ToolPackageArg) -> &'static str {
+    match value {
+        ToolPackageArg::Minimal => "minimal",
+        ToolPackageArg::Introspection => "introspection",
+        ToolPackageArg::Readonly => "readonly",
+        ToolPackageArg::Write => "write",
     }
 }

--- a/crates/defra-agent-cli/src/shared.rs
+++ b/crates/defra-agent-cli/src/shared.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 use crate::desired_state;
 
 use crate::cli::args::BackendPresetArg;
-use crate::cli::args::ToolCeilingArg;
+use crate::cli::args::{ToolCeilingArg, ToolPackageArg};
 
 #[derive(Debug, Clone)]
 pub(crate) struct ResolvedBackendConfig {
@@ -39,8 +39,12 @@ pub(crate) struct InitSummary {
     pub(crate) default_behavior_id: String,
     pub(crate) tool_selection_id: String,
     pub(crate) inference_profile_id: String,
+    pub(crate) tool_package: ToolPackageArg,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,
+    pub(crate) enable_memory: bool,
+    pub(crate) enable_defra_query: bool,
+    pub(crate) defra_query_collections: Vec<String>,
     pub(crate) created_principal: bool,
     pub(crate) created_default_behavior: bool,
 }
@@ -60,6 +64,8 @@ pub(crate) struct StoredInitConfig {
     pub(crate) keychain_label: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) secure_enclave_label: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_package: Option<ToolPackageArg>,
     pub(crate) tool_ceiling: ToolCeilingArg,
     pub(crate) tool_root: Option<String>,
 }

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -18,13 +18,7 @@ use crate::mcp_pool::McpPool;
 use crate::migration;
 use crate::retry::RetryPolicy;
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
-use crate::tool_surface::{
-    BashMode, BehaviorToolConfig, FileToolMode, SubagentToolConfig, ToolCeiling, ToolSelection,
-};
-use crate::toolset::{
-    default_read_only_command_policy, parse_argv_prefixes, CommandExecutionMode,
-    CommandExecutionPolicy, CommandNetworkMode,
-};
+use crate::tool_surface::{BehaviorToolConfig, SubagentToolConfig, ToolCeiling, ToolSelection};
 use crate::trigger_engine::manual_source::ManualTriggerHandle;
 
 mod builder;
@@ -346,154 +340,11 @@ fn normalize_optional_string(value: Option<&str>) -> Option<&str> {
 pub(crate) fn tool_selection_from_document(
     selection: &crate::document_config::ToolSelectionDocument,
 ) -> anyhow::Result<ToolSelection> {
-    let bash = if selection.enable_bash.unwrap_or(false) {
-        BashMode::parse(selection.bash_mode.as_deref().unwrap_or("ReadOnly"))?
-    } else {
-        BashMode::Off
-    };
-    Ok(ToolSelection {
-        file_tools: if selection.enable_file_tools.unwrap_or(false) {
-            FileToolMode::parse(selection.file_tools_mode.as_deref().unwrap_or("ReadOnly"))?
-        } else {
-            FileToolMode::Off
-        },
-        file_tool_root: normalize_optional_string(selection.file_tool_root.as_deref())
-            .map(std::path::PathBuf::from),
-        bash,
-        command_policy: command_policy_from_document(selection, bash)?,
-        cli_tool_names: selection.cli_tool_names.clone().unwrap_or_default(),
-        enable_meta_tools: selection.enable_meta_tools.unwrap_or(true),
-        allowed_mcp_service_ids: selection
-            .allowed_mcp_service_ids
-            .clone()
-            .unwrap_or_default(),
-        backgroundable_tool_names: selection
-            .backgroundable_tool_names
-            .clone()
-            .unwrap_or_default(),
-        // This opt-in is intentionally default-off. The memory tool is also
-        // behind the non-default `agent-memory` Cargo feature.
-        enable_memory: selection.enable_memory.unwrap_or(false),
-        // Keep the narrower session-history convenience tool opt-in. The
-        // broader `defra_query` tool remains the default self-inspection path.
-        enable_session_history_tool: selection.enable_session_history_tool.unwrap_or(false),
-        // The `defra_query` read tool defaults on with all collections; an
-        // operator can disable it or restrict its collection scope per behavior
-        // via the ToolSelection document. (A built-in guard always blocks
-        // sensitive fields regardless of this scope.)
-        enable_defra_query: selection.enable_defra_query.unwrap_or(true),
-        defra_query_collections: selection
-            .defra_query_collections
-            .clone()
-            .unwrap_or_default(),
-    })
+    ToolSelection::from_document(selection)
 }
 
 pub(crate) fn subagent_tool_config_from_document(
     selection: &crate::document_config::ToolSelectionDocument,
 ) -> SubagentToolConfig {
-    let targets = selection
-        .subagent_targets
-        .iter()
-        .flatten()
-        .filter_map(
-            |entry| match crate::document_config::SubagentTarget::parse(entry) {
-                Ok(target) => Some(target),
-                Err(error) => {
-                    tracing::warn!(
-                        selection_id = %selection.selection_id,
-                        entry = %entry,
-                        %error,
-                        "skipping malformed subagent_targets entry"
-                    );
-                    None
-                }
-            },
-        )
-        .collect();
-    SubagentToolConfig {
-        targets,
-        spawn_enabled: selection.subagent_spawn_enabled.unwrap_or(false),
-        steering_enabled: selection.subagent_steering_enabled.unwrap_or(false),
-        background_enabled: selection.subagent_background_enabled.unwrap_or(false),
-        allow_cross_deployment: selection.subagent_allow_cross_deployment.unwrap_or(false),
-    }
-}
-
-fn command_policy_from_document(
-    selection: &crate::document_config::ToolSelectionDocument,
-    bash: BashMode,
-) -> anyhow::Result<Option<CommandExecutionPolicy>> {
-    let has_policy = selection
-        .command_execution_policy
-        .as_deref()
-        .and_then(|value| normalize_optional_string(Some(value)))
-        .is_some()
-        || selection
-            .command_network_mode
-            .as_deref()
-            .and_then(|value| normalize_optional_string(Some(value)))
-            .is_some()
-        || selection
-            .command_allowed_argv_prefixes
-            .as_ref()
-            .is_some_and(|prefixes| !prefixes.is_empty())
-        || selection
-            .command_forbidden_argv_prefixes
-            .as_ref()
-            .is_some_and(|prefixes| !prefixes.is_empty());
-    if !has_policy {
-        return if matches!(bash, BashMode::Unrestricted) {
-            Ok(Some(
-                CommandExecutionPolicy::write_capable()
-                    .with_mode(CommandExecutionMode::Unrestricted),
-            ))
-        } else {
-            Ok(None)
-        };
-    }
-
-    let requested_mode = selection
-        .command_execution_policy
-        .as_deref()
-        .and_then(|value| normalize_optional_string(Some(value)))
-        .map(CommandExecutionMode::parse)
-        .transpose()?;
-    let mode = match bash {
-        BashMode::Off => CommandExecutionMode::ReadOnly,
-        BashMode::ReadOnly => CommandExecutionMode::ReadOnly,
-        BashMode::Unrestricted => requested_mode.unwrap_or(CommandExecutionMode::Unrestricted),
-    };
-
-    let allowed = parse_argv_prefixes(
-        selection
-            .command_allowed_argv_prefixes
-            .as_deref()
-            .unwrap_or(&[]),
-    )?;
-    let forbidden = parse_argv_prefixes(
-        selection
-            .command_forbidden_argv_prefixes
-            .as_deref()
-            .unwrap_or(&[]),
-    )?;
-    let network_mode = selection
-        .command_network_mode
-        .as_deref()
-        .and_then(|value| normalize_optional_string(Some(value)))
-        .map(CommandNetworkMode::parse)
-        .transpose()?
-        .unwrap_or(CommandNetworkMode::Inherit);
-
-    let base = if matches!(mode, CommandExecutionMode::ReadOnly) {
-        default_read_only_command_policy()
-    } else {
-        CommandExecutionPolicy::write_capable()
-    };
-    Ok(Some(
-        base.with_mode(mode)
-            .with_allowed_argv_prefixes(allowed)
-            .with_forbidden_argv_prefixes(forbidden)
-            .with_network_mode(network_mode),
-    ))
+    SubagentToolConfig::from_document(selection)
 }

--- a/crates/defra-agent/src/tool_surface/behavior_config.rs
+++ b/crates/defra-agent/src/tool_surface/behavior_config.rs
@@ -60,6 +60,21 @@ impl BehaviorToolConfig {
         )
     }
 
+    pub fn from_tool_selection_document(
+        behavior_name: &str,
+        selection: &crate::document_config::ToolSelectionDocument,
+        ceiling: &ToolCeiling,
+        custom_tools: Vec<CustomToolFactory>,
+    ) -> Result<Self> {
+        Self::from_selection_with_subagent_tools(
+            behavior_name,
+            ToolSelection::from_document(selection)?,
+            ceiling,
+            SubagentToolConfig::from_document(selection),
+            custom_tools,
+        )
+    }
+
     pub(crate) fn from_selection_with_subagent_tools(
         behavior_name: &str,
         selection: ToolSelection,
@@ -132,6 +147,14 @@ impl BehaviorToolConfig {
 
     pub fn meta_tools_requested(&self) -> bool {
         self.enable_meta_tools
+    }
+
+    pub(crate) fn memory_requested(&self) -> bool {
+        self.enable_memory
+    }
+
+    pub(crate) fn defra_query_requested(&self) -> bool {
+        self.enable_defra_query
     }
 
     pub fn allowed_mcp_service_ids(&self) -> &[String] {
@@ -212,6 +235,24 @@ impl BehaviorToolConfig {
             }
         });
         self.resolve_with_subagent_tools(node, subagent_tools).await
+    }
+
+    pub(crate) fn resolve_with_available_subagent_targets_for_mcp_presence(
+        &self,
+        mcp_services_online: bool,
+        own_agent_did: &str,
+        active_behavior_ids: &HashSet<String>,
+    ) -> ToolSurface {
+        let mut subagent_tools = self.subagent_tools.clone();
+        let allow_cross_deployment = subagent_tools.allow_cross_deployment;
+        subagent_tools.targets.retain(|target| {
+            if target.agent_did == own_agent_did {
+                active_behavior_ids.contains(&target.behavior_id)
+            } else {
+                allow_cross_deployment
+            }
+        });
+        self.resolve_with_subagent_tools_for_mcp_presence(mcp_services_online, subagent_tools)
     }
 }
 

--- a/crates/defra-agent/src/tool_surface/behavior_config.rs
+++ b/crates/defra-agent/src/tool_surface/behavior_config.rs
@@ -165,13 +165,18 @@ impl BehaviorToolConfig {
         node: &EmbeddedNode,
         subagent_tools: SubagentToolConfig,
     ) -> Result<ToolSurface> {
-        let include_meta_tools = if self.enable_meta_tools {
-            has_registered_mcp_services(node).await?
-        } else {
-            false
-        };
+        let mcp_services_online = has_registered_mcp_services(node).await?;
+        Ok(self.resolve_with_subagent_tools_for_mcp_presence(mcp_services_online, subagent_tools))
+    }
 
-        Ok(ToolSurface {
+    pub(crate) fn resolve_with_subagent_tools_for_mcp_presence(
+        &self,
+        mcp_services_online: bool,
+        subagent_tools: SubagentToolConfig,
+    ) -> ToolSurface {
+        let include_meta_tools = self.enable_meta_tools && mcp_services_online;
+
+        ToolSurface {
             host_tools: self.host_tools.clone(),
             include_meta_tools,
             allowed_mcp_service_ids: self.allowed_mcp_service_ids.clone(),
@@ -182,7 +187,7 @@ impl BehaviorToolConfig {
             enable_session_history_tool: self.enable_session_history_tool,
             enable_defra_query: self.enable_defra_query,
             defra_query_collections: self.defra_query_collections.clone(),
-        })
+        }
     }
 
     /// Resolve the tool surface, dropping local-DID subagent targets whose

--- a/crates/defra-agent/src/tool_surface/explain.rs
+++ b/crates/defra-agent/src/tool_surface/explain.rs
@@ -1,0 +1,279 @@
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use serde::Serialize;
+
+use crate::defra_query::DEFRA_QUERY_TOOL_NAME;
+use crate::meta_tools::META_TOOL_NAMES;
+use crate::toolset::{
+    background_tool_names, subagent_tool_names, CONTEXT_BUDGET_TOOL_NAME, SESSION_HISTORY_TOOL_NAME,
+};
+
+use super::{BehaviorToolConfig, ToolSurface};
+
+const MEMORY_TOOL_NAME: &str = "memory";
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ToolSurfaceExplanation {
+    pub tool_names: Vec<String>,
+    pub included: BTreeMap<String, Vec<String>>,
+    pub excluded: BTreeMap<String, Vec<String>>,
+    pub unavailable: BTreeMap<String, Vec<String>>,
+    pub warnings: Vec<ToolSurfaceWarning>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ToolSurfaceWarning {
+    pub code: String,
+    pub message: String,
+}
+
+impl ToolSurfaceExplanation {
+    pub(crate) fn from_resolved(
+        config: &BehaviorToolConfig,
+        surface: &ToolSurface,
+    ) -> ToolSurfaceExplanation {
+        let mut builder = ExplanationBuilder::default();
+
+        builder.include_many("host", surface.host_tools.tool_names());
+        explain_meta(config, surface, &mut builder);
+        explain_subagents(config, surface, &mut builder);
+        explain_background(config, surface, &mut builder);
+        builder.include_many(
+            "custom",
+            surface
+                .custom_tools
+                .iter()
+                .map(|tool| tool.name().to_string()),
+        );
+        explain_memory(config, &mut builder);
+        explain_builtin_reads(config, surface, &mut builder);
+
+        let tool_names = surface.tool_names();
+        if surface.host_tools.tool_names().is_empty()
+            && tool_names.iter().any(|name| {
+                name == CONTEXT_BUDGET_TOOL_NAME
+                    || name == SESSION_HISTORY_TOOL_NAME
+                    || name == DEFRA_QUERY_TOOL_NAME
+            })
+        {
+            builder.warn(
+                "host_ceiling_not_global",
+                "ToolCeiling currently clamps host-native file/bash/CLI tools only; built-in read tools can still be model-callable.",
+            );
+        }
+
+        builder.finish(tool_names)
+    }
+}
+
+impl BehaviorToolConfig {
+    pub fn explain_with_runtime(
+        &self,
+        mcp_services_online: bool,
+        own_agent_did: &str,
+        active_behavior_ids: &HashSet<String>,
+    ) -> ToolSurfaceExplanation {
+        let surface = self.resolve_with_available_subagent_targets_for_mcp_presence(
+            mcp_services_online,
+            own_agent_did,
+            active_behavior_ids,
+        );
+        ToolSurfaceExplanation::from_resolved(self, &surface)
+    }
+}
+
+#[derive(Default)]
+struct ExplanationBuilder {
+    included: BTreeMap<String, BTreeSet<String>>,
+    excluded: BTreeMap<String, BTreeSet<String>>,
+    unavailable: BTreeMap<String, BTreeSet<String>>,
+    warnings: Vec<ToolSurfaceWarning>,
+}
+
+impl ExplanationBuilder {
+    fn include_many<I>(&mut self, category: &str, names: I)
+    where
+        I: IntoIterator<Item = String>,
+    {
+        for name in names {
+            self.insert(category, name, SurfaceStatus::Included);
+        }
+    }
+
+    fn exclude(&mut self, category: &str, name: impl Into<String>) {
+        self.insert(category, name.into(), SurfaceStatus::Excluded);
+    }
+
+    fn unavailable(&mut self, category: &str, name: impl Into<String>) {
+        self.insert(category, name.into(), SurfaceStatus::Unavailable);
+    }
+
+    fn warn(&mut self, code: impl Into<String>, message: impl Into<String>) {
+        let code = code.into();
+        if self.warnings.iter().any(|warning| warning.code == code) {
+            return;
+        }
+        self.warnings.push(ToolSurfaceWarning {
+            code,
+            message: message.into(),
+        });
+    }
+
+    fn finish(self, tool_names: Vec<String>) -> ToolSurfaceExplanation {
+        ToolSurfaceExplanation {
+            tool_names,
+            included: into_vec_map(self.included),
+            excluded: into_vec_map(self.excluded),
+            unavailable: into_vec_map(self.unavailable),
+            warnings: self.warnings,
+        }
+    }
+
+    fn insert(&mut self, category: &str, name: String, status: SurfaceStatus) {
+        let map = match status {
+            SurfaceStatus::Included => &mut self.included,
+            SurfaceStatus::Excluded => &mut self.excluded,
+            SurfaceStatus::Unavailable => &mut self.unavailable,
+        };
+        map.entry(category.to_string()).or_default().insert(name);
+    }
+}
+
+enum SurfaceStatus {
+    Included,
+    Excluded,
+    Unavailable,
+}
+
+fn into_vec_map(map: BTreeMap<String, BTreeSet<String>>) -> BTreeMap<String, Vec<String>> {
+    map.into_iter()
+        .map(|(category, names)| (category, names.into_iter().collect()))
+        .collect()
+}
+
+fn explain_meta(
+    config: &BehaviorToolConfig,
+    surface: &ToolSurface,
+    builder: &mut ExplanationBuilder,
+) {
+    if surface.include_meta_tools {
+        builder.include_many(
+            "meta_mcp",
+            META_TOOL_NAMES.iter().map(|name| (*name).to_string()),
+        );
+        if surface.allowed_mcp_service_ids.is_empty() {
+            builder.warn(
+                "mcp_empty_allowlist_all",
+                "allowed_mcp_service_ids is empty, which currently means all online MCP services.",
+            );
+        }
+        return;
+    }
+
+    for name in META_TOOL_NAMES {
+        if config.meta_tools_requested() {
+            builder.unavailable("meta_mcp", name.to_string());
+        } else {
+            builder.exclude("meta_mcp", name.to_string());
+        }
+    }
+    if config.meta_tools_requested() {
+        builder.warn(
+            "meta_requested_no_online_mcp",
+            "Meta tools are configured on, but no ToolServiceRegistry row is currently online.",
+        );
+    }
+}
+
+fn explain_subagents(
+    config: &BehaviorToolConfig,
+    surface: &ToolSurface,
+    builder: &mut ExplanationBuilder,
+) {
+    let included = subagent_tool_names(&surface.subagent_tools);
+    if !included.is_empty() {
+        builder.include_many("subagent", included);
+    } else if config.subagent_tools().tools_enabled() {
+        builder.unavailable("subagent", "spawn_subagent");
+        builder.warn(
+            "subagent_targets_unavailable",
+            "Subagent spawning is configured, but all targets were filtered out by active-behavior or cross-deployment availability.",
+        );
+    } else {
+        builder.exclude("subagent", "spawn_subagent");
+    }
+}
+
+fn explain_background(
+    config: &BehaviorToolConfig,
+    surface: &ToolSurface,
+    builder: &mut ExplanationBuilder,
+) {
+    let included = background_tool_names(&surface.background_tools);
+    if !included.is_empty() {
+        builder.include_many("background_process", included);
+    } else if config.background_tools().tools_enabled() {
+        builder.unavailable("background_process", "spawn_process");
+    } else {
+        builder.exclude("background_process", "spawn_process");
+    }
+}
+
+fn explain_memory(config: &BehaviorToolConfig, builder: &mut ExplanationBuilder) {
+    if !config.memory_requested() {
+        builder.exclude("built_in_memory", MEMORY_TOOL_NAME);
+        return;
+    }
+
+    #[cfg(feature = "agent-memory")]
+    {
+        builder.include_many(
+            "built_in_memory",
+            [crate::toolset::MEMORY_TOOL_NAME.to_string()],
+        );
+    }
+
+    #[cfg(not(feature = "agent-memory"))]
+    {
+        builder.unavailable("built_in_memory", MEMORY_TOOL_NAME);
+        builder.warn(
+            "memory_requested_compiled_out",
+            "enable_memory is true, but this binary was built without the agent-memory feature.",
+        );
+    }
+}
+
+fn explain_builtin_reads(
+    config: &BehaviorToolConfig,
+    surface: &ToolSurface,
+    builder: &mut ExplanationBuilder,
+) {
+    builder.include_many("built_in_read", [CONTEXT_BUDGET_TOOL_NAME.to_string()]);
+    builder.warn(
+        "unmanaged_builtin_read_tools",
+        "context_budget is always included; it has no ToolSelection field and is not clamped by ToolCeiling.",
+    );
+
+    // The `sessions` history tool is opt-in via the ToolSelection
+    // `enable_session_history_tool` field (default off), so report it as
+    // included only when the operator enabled it; otherwise it is excluded.
+    if surface.enable_session_history_tool {
+        builder.include_many("built_in_read", [SESSION_HISTORY_TOOL_NAME.to_string()]);
+    } else {
+        builder.exclude("built_in_read", SESSION_HISTORY_TOOL_NAME);
+    }
+
+    if surface.enable_defra_query {
+        builder.include_many("built_in_read", [DEFRA_QUERY_TOOL_NAME.to_string()]);
+        if surface.defra_query_collections.is_empty() {
+            builder.warn(
+                "defra_query_empty_scope_all",
+                "defra_query_collections is empty, which currently means all collections except hard-blocked sensitive fields.",
+            );
+        }
+    } else if config.defra_query_requested() {
+        builder.unavailable("built_in_read", DEFRA_QUERY_TOOL_NAME);
+    } else {
+        builder.exclude("built_in_read", DEFRA_QUERY_TOOL_NAME);
+    }
+}

--- a/crates/defra-agent/src/tool_surface/mod.rs
+++ b/crates/defra-agent/src/tool_surface/mod.rs
@@ -1,10 +1,12 @@
 mod behavior_config;
 mod build;
+mod explain;
 mod modes;
 mod runtime_context;
 mod selection;
 
 pub use behavior_config::BehaviorToolConfig;
+pub use explain::{ToolSurfaceExplanation, ToolSurfaceWarning};
 pub use modes::{BashMode, FileToolMode, ToolCeiling};
 pub use runtime_context::ToolRuntimeContext;
 pub(crate) use selection::{BackgroundToolConfig, SubagentToolConfig};

--- a/crates/defra-agent/src/tool_surface/selection.rs
+++ b/crates/defra-agent/src/tool_surface/selection.rs
@@ -8,7 +8,10 @@ use super::modes::{BashMode, FileToolMode};
 use std::path::PathBuf;
 
 use crate::document_config::SubagentTarget;
-use crate::toolset::CommandExecutionPolicy;
+use crate::toolset::{
+    default_read_only_command_policy, parse_argv_prefixes, CommandExecutionMode,
+    CommandExecutionPolicy, CommandNetworkMode,
+};
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct SubagentToolConfig {
@@ -24,6 +27,35 @@ pub(crate) struct SubagentToolConfig {
 }
 
 impl SubagentToolConfig {
+    pub(crate) fn from_document(selection: &crate::document_config::ToolSelectionDocument) -> Self {
+        let targets = selection
+            .subagent_targets
+            .iter()
+            .flatten()
+            .filter_map(
+                |entry| match crate::document_config::SubagentTarget::parse(entry) {
+                    Ok(target) => Some(target),
+                    Err(error) => {
+                        tracing::warn!(
+                            selection_id = %selection.selection_id,
+                            entry = %entry,
+                            %error,
+                            "skipping malformed subagent_targets entry"
+                        );
+                        None
+                    }
+                },
+            )
+            .collect();
+        Self {
+            targets,
+            spawn_enabled: selection.subagent_spawn_enabled.unwrap_or(false),
+            steering_enabled: selection.subagent_steering_enabled.unwrap_or(false),
+            background_enabled: selection.subagent_background_enabled.unwrap_or(false),
+            allow_cross_deployment: selection.subagent_allow_cross_deployment.unwrap_or(false),
+        }
+    }
+
     pub(crate) fn tools_enabled(&self) -> bool {
         self.spawn_enabled && !self.targets.is_empty()
     }
@@ -85,6 +117,131 @@ impl Default for ToolSelection {
             defra_query_collections: Vec::new(),
         }
     }
+}
+
+impl ToolSelection {
+    pub(crate) fn from_document(
+        selection: &crate::document_config::ToolSelectionDocument,
+    ) -> anyhow::Result<Self> {
+        let bash = if selection.enable_bash.unwrap_or(false) {
+            BashMode::parse(selection.bash_mode.as_deref().unwrap_or("ReadOnly"))?
+        } else {
+            BashMode::Off
+        };
+        Ok(Self {
+            file_tools: if selection.enable_file_tools.unwrap_or(false) {
+                FileToolMode::parse(selection.file_tools_mode.as_deref().unwrap_or("ReadOnly"))?
+            } else {
+                FileToolMode::Off
+            },
+            file_tool_root: selection
+                .file_tool_root
+                .as_deref()
+                .and_then(normalize_optional_string)
+                .map(PathBuf::from),
+            bash,
+            command_policy: command_policy_from_document(selection, bash)?,
+            cli_tool_names: selection.cli_tool_names.clone().unwrap_or_default(),
+            enable_meta_tools: selection.enable_meta_tools.unwrap_or(true),
+            allowed_mcp_service_ids: selection
+                .allowed_mcp_service_ids
+                .clone()
+                .unwrap_or_default(),
+            backgroundable_tool_names: selection
+                .backgroundable_tool_names
+                .clone()
+                .unwrap_or_default(),
+            enable_memory: selection.enable_memory.unwrap_or(false),
+            enable_session_history_tool: selection.enable_session_history_tool.unwrap_or(false),
+            enable_defra_query: selection.enable_defra_query.unwrap_or(true),
+            defra_query_collections: selection
+                .defra_query_collections
+                .clone()
+                .unwrap_or_default(),
+        })
+    }
+}
+
+fn command_policy_from_document(
+    selection: &crate::document_config::ToolSelectionDocument,
+    bash: BashMode,
+) -> anyhow::Result<Option<CommandExecutionPolicy>> {
+    let has_policy = selection
+        .command_execution_policy
+        .as_deref()
+        .and_then(normalize_optional_string)
+        .is_some()
+        || selection
+            .command_network_mode
+            .as_deref()
+            .and_then(normalize_optional_string)
+            .is_some()
+        || selection
+            .command_allowed_argv_prefixes
+            .as_ref()
+            .is_some_and(|prefixes| !prefixes.is_empty())
+        || selection
+            .command_forbidden_argv_prefixes
+            .as_ref()
+            .is_some_and(|prefixes| !prefixes.is_empty());
+    if !has_policy {
+        return if matches!(bash, BashMode::Unrestricted) {
+            Ok(Some(
+                CommandExecutionPolicy::write_capable()
+                    .with_mode(CommandExecutionMode::Unrestricted),
+            ))
+        } else {
+            Ok(None)
+        };
+    }
+
+    let requested_mode = selection
+        .command_execution_policy
+        .as_deref()
+        .and_then(normalize_optional_string)
+        .map(CommandExecutionMode::parse)
+        .transpose()?;
+    let mode = match bash {
+        BashMode::Off | BashMode::ReadOnly => CommandExecutionMode::ReadOnly,
+        BashMode::Unrestricted => requested_mode.unwrap_or(CommandExecutionMode::Unrestricted),
+    };
+
+    let allowed = parse_argv_prefixes(
+        selection
+            .command_allowed_argv_prefixes
+            .as_deref()
+            .unwrap_or(&[]),
+    )?;
+    let forbidden = parse_argv_prefixes(
+        selection
+            .command_forbidden_argv_prefixes
+            .as_deref()
+            .unwrap_or(&[]),
+    )?;
+    let network_mode = selection
+        .command_network_mode
+        .as_deref()
+        .and_then(normalize_optional_string)
+        .map(CommandNetworkMode::parse)
+        .transpose()?
+        .unwrap_or(CommandNetworkMode::Inherit);
+
+    let base = if matches!(mode, CommandExecutionMode::ReadOnly) {
+        default_read_only_command_policy()
+    } else {
+        CommandExecutionPolicy::write_capable()
+    };
+    Ok(Some(
+        base.with_mode(mode)
+            .with_allowed_argv_prefixes(allowed)
+            .with_forbidden_argv_prefixes(forbidden)
+            .with_network_mode(network_mode),
+    ))
+}
+
+fn normalize_optional_string(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
 }
 
 type CustomToolFactoryFn = Arc<dyn Fn() -> Result<Box<dyn ToolDyn>> + Send + Sync>;

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -516,6 +516,507 @@ async fn session_history_tool_requires_selection_opt_in() {
         .contains(&crate::toolset::SESSION_HISTORY_TOOL_NAME.to_string()));
 }
 
+fn init_like_tool_selection_document(
+    package_name: &str,
+    enable_file_tools: bool,
+    file_tools_mode: &str,
+    enable_bash: bool,
+    bash_mode: &str,
+    enable_meta_tools: bool,
+    backgroundable_tool_names: Vec<String>,
+    enable_defra_query: bool,
+) -> crate::document_config::ToolSelectionDocument {
+    crate::document_config::ToolSelectionDocument {
+        selection_id: format!("{package_name}-tools"),
+        agent_did: "did:defra-agent:test".to_string(),
+        display_name: Some(package_name.to_string()),
+        enable_file_tools: Some(enable_file_tools),
+        file_tools_mode: Some(file_tools_mode.to_string()),
+        file_tool_root: None,
+        enable_bash: Some(enable_bash),
+        bash_mode: Some(bash_mode.to_string()),
+        command_execution_policy: matches!(bash_mode, "Unrestricted")
+            .then(|| "unrestricted".to_string()),
+        command_allowed_argv_prefixes: Some(Vec::new()),
+        command_forbidden_argv_prefixes: Some(Vec::new()),
+        command_network_mode: None,
+        cli_tool_names: Some(Vec::new()),
+        enable_meta_tools: Some(enable_meta_tools),
+        allowed_mcp_service_ids: Some(Vec::new()),
+        backgroundable_tool_names: Some(backgroundable_tool_names),
+        subagent_targets: Some(Vec::new()),
+        subagent_spawn_enabled: Some(false),
+        subagent_steering_enabled: Some(false),
+        subagent_background_enabled: Some(false),
+        subagent_allow_cross_deployment: Some(false),
+        cross_deployment_spawn_timeout_seconds: None,
+        enable_memory: Some(false),
+        enable_session_history_tool: Some(false),
+        enable_defra_query: Some(enable_defra_query),
+        defra_query_collections: Some(Vec::new()),
+    }
+}
+
+fn explanation_has_warning(explanation: &ToolSurfaceExplanation, code: &str) -> bool {
+    explanation
+        .warnings
+        .iter()
+        .any(|warning| warning.code == code)
+}
+
+fn explanation_category_contains(
+    map: &std::collections::BTreeMap<String, Vec<String>>,
+    category: &str,
+    name: &str,
+) -> bool {
+    map.get(category)
+        .is_some_and(|names| names.contains(&name.to_string()))
+}
+
+#[test]
+fn explain_init_package_document_matrix_resolves_expected_surfaces() {
+    struct Case {
+        name: &'static str,
+        selection: crate::document_config::ToolSelectionDocument,
+        ceiling: ToolCeiling,
+        mcp_services_online: bool,
+        expected_tool_names: Vec<&'static str>,
+        absent_tool_names: Vec<&'static str>,
+        expected_warnings: Vec<&'static str>,
+        host_ceiling_warning: bool,
+    }
+
+    let readonly_root = temp_root("defra-agent-readonly-package-root");
+    let write_root = temp_root("defra-agent-write-package-root");
+    let cases = vec![
+        Case {
+            name: "minimal",
+            selection: init_like_tool_selection_document(
+                "minimal",
+                false,
+                "Off",
+                false,
+                "Off",
+                false,
+                Vec::new(),
+                false,
+            ),
+            ceiling: ToolCeiling::meta_only(),
+            mcp_services_online: false,
+            expected_tool_names: vec!["context_budget"],
+            absent_tool_names: vec!["call_tool", "defra_query", "read_file", "spawn_process"],
+            expected_warnings: vec!["unmanaged_builtin_read_tools", "host_ceiling_not_global"],
+            host_ceiling_warning: true,
+        },
+        Case {
+            name: "introspection-offline",
+            selection: init_like_tool_selection_document(
+                "introspection",
+                false,
+                "Off",
+                false,
+                "Off",
+                true,
+                Vec::new(),
+                true,
+            ),
+            ceiling: ToolCeiling::meta_only(),
+            mcp_services_online: false,
+            expected_tool_names: vec!["context_budget", "defra_query"],
+            absent_tool_names: vec!["call_tool", "read_file", "spawn_process"],
+            expected_warnings: vec![
+                "unmanaged_builtin_read_tools",
+                "host_ceiling_not_global",
+                "meta_requested_no_online_mcp",
+                "defra_query_empty_scope_all",
+            ],
+            host_ceiling_warning: true,
+        },
+        Case {
+            name: "introspection-online",
+            selection: init_like_tool_selection_document(
+                "introspection",
+                false,
+                "Off",
+                false,
+                "Off",
+                true,
+                Vec::new(),
+                true,
+            ),
+            ceiling: ToolCeiling::meta_only(),
+            mcp_services_online: true,
+            expected_tool_names: vec![
+                "discover_tools",
+                "call_tool",
+                "context_budget",
+                "defra_query",
+            ],
+            absent_tool_names: vec!["read_file", "spawn_process", "spawn_subagent"],
+            expected_warnings: vec![
+                "unmanaged_builtin_read_tools",
+                "host_ceiling_not_global",
+                "mcp_empty_allowlist_all",
+                "defra_query_empty_scope_all",
+            ],
+            host_ceiling_warning: true,
+        },
+        Case {
+            name: "readonly-online",
+            selection: init_like_tool_selection_document(
+                "readonly",
+                true,
+                "ReadOnly",
+                true,
+                "ReadOnly",
+                true,
+                Vec::new(),
+                true,
+            ),
+            ceiling: ToolCeiling::readonly_at(readonly_root),
+            mcp_services_online: true,
+            expected_tool_names: vec![
+                "list_files",
+                "read_file",
+                "glob",
+                "grep",
+                "bash",
+                "discover_tools",
+                "call_tool",
+                "context_budget",
+                "defra_query",
+            ],
+            absent_tool_names: vec!["write_file", "bash_unrestricted", "spawn_process"],
+            expected_warnings: vec![
+                "unmanaged_builtin_read_tools",
+                "mcp_empty_allowlist_all",
+                "defra_query_empty_scope_all",
+            ],
+            host_ceiling_warning: false,
+        },
+        Case {
+            name: "write-online",
+            selection: init_like_tool_selection_document(
+                "write",
+                true,
+                "ReadWrite",
+                true,
+                "Unrestricted",
+                true,
+                vec!["bash_unrestricted".to_string()],
+                true,
+            ),
+            ceiling: ToolCeiling::readwrite(write_root),
+            mcp_services_online: true,
+            expected_tool_names: vec![
+                "list_files",
+                "read_file",
+                "glob",
+                "grep",
+                "write_file",
+                "edit_file",
+                "bash_unrestricted",
+                "discover_tools",
+                "call_tool",
+                "spawn_process",
+                "wait_process",
+                "context_budget",
+                "defra_query",
+            ],
+            absent_tool_names: vec!["bash", "spawn_subagent"],
+            expected_warnings: vec![
+                "unmanaged_builtin_read_tools",
+                "mcp_empty_allowlist_all",
+                "defra_query_empty_scope_all",
+            ],
+            host_ceiling_warning: false,
+        },
+    ];
+
+    for case in cases {
+        let config = BehaviorToolConfig::from_tool_selection_document(
+            case.name,
+            &case.selection,
+            &case.ceiling,
+            Vec::new(),
+        )
+        .unwrap();
+        let explanation = config.explain_with_runtime(
+            case.mcp_services_online,
+            "did:defra-agent:test",
+            &std::collections::HashSet::new(),
+        );
+
+        for name in case.expected_tool_names {
+            assert!(
+                explanation.tool_names.contains(&name.to_string()),
+                "{} should expose {name}; got {:?}",
+                case.name,
+                explanation.tool_names
+            );
+        }
+        for name in case.absent_tool_names {
+            assert!(
+                !explanation.tool_names.contains(&name.to_string()),
+                "{} should not expose {name}; got {:?}",
+                case.name,
+                explanation.tool_names
+            );
+        }
+        for code in case.expected_warnings {
+            assert!(
+                explanation_has_warning(&explanation, code),
+                "{} should warn {code}; got {:?}",
+                case.name,
+                explanation.warnings
+            );
+        }
+        assert_eq!(
+            explanation_has_warning(&explanation, "host_ceiling_not_global"),
+            case.host_ceiling_warning,
+            "{} host ceiling warning should match whether only built-in read tools survived",
+            case.name
+        );
+    }
+}
+
+#[test]
+fn explain_complex_document_combination_filters_subagents_and_groups_surface() {
+    let own_agent_did = "did:defra-agent:local";
+    let mut selection = crate::document_config::ToolSelectionDocument {
+        selection_id: "complex-tools".to_string(),
+        agent_did: own_agent_did.to_string(),
+        display_name: Some("Complex Tools".to_string()),
+        enable_file_tools: Some(true),
+        file_tools_mode: Some("ReadOnly".to_string()),
+        file_tool_root: None,
+        enable_bash: Some(true),
+        bash_mode: Some("ReadOnly".to_string()),
+        command_execution_policy: None,
+        command_allowed_argv_prefixes: Some(Vec::new()),
+        command_forbidden_argv_prefixes: Some(Vec::new()),
+        command_network_mode: None,
+        cli_tool_names: Some(Vec::new()),
+        enable_meta_tools: Some(true),
+        allowed_mcp_service_ids: Some(vec![
+            "registry".to_string(),
+            "registry".to_string(),
+            "observability".to_string(),
+        ]),
+        backgroundable_tool_names: Some(vec!["bash".to_string(), "bash".to_string()]),
+        subagent_targets: Some(vec![
+            crate::document_config::subagent_target_entry(
+                "worker",
+                own_agent_did,
+                "worker",
+                Some("local worker".to_string()),
+            ),
+            crate::document_config::subagent_target_entry(
+                "inactive",
+                own_agent_did,
+                "inactive",
+                Some("inactive local worker".to_string()),
+            ),
+            crate::document_config::subagent_target_entry(
+                "remote",
+                "did:defra-agent:remote",
+                "remote-worker",
+                Some("remote worker".to_string()),
+            ),
+        ]),
+        subagent_spawn_enabled: Some(true),
+        subagent_steering_enabled: Some(true),
+        subagent_background_enabled: Some(true),
+        subagent_allow_cross_deployment: Some(false),
+        cross_deployment_spawn_timeout_seconds: Some(120),
+        enable_memory: Some(true),
+        enable_session_history_tool: Some(false),
+        enable_defra_query: Some(true),
+        defra_query_collections: Some(vec![
+            "AgentRequest".to_string(),
+            "AgentRequest".to_string(),
+            " AgentResponse ".to_string(),
+        ]),
+    };
+    let ceiling = ToolCeiling::readonly_at(temp_root("defra-agent-complex-package-root"));
+    let config = BehaviorToolConfig::from_tool_selection_document(
+        "complex",
+        &selection,
+        &ceiling,
+        Vec::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        config.allowed_mcp_service_ids(),
+        &["registry".to_string(), "observability".to_string()]
+    );
+
+    let active_behavior_ids = std::collections::HashSet::from(["worker".to_string()]);
+    let surface = config.resolve_with_available_subagent_targets_for_mcp_presence(
+        true,
+        own_agent_did,
+        &active_behavior_ids,
+    );
+    assert_eq!(
+        resolve_subagent_target_descriptions(&surface),
+        vec![("worker".to_string(), "local worker".to_string())]
+    );
+    let explanation = ToolSurfaceExplanation::from_resolved(&config, &surface);
+
+    for name in [
+        "read_file",
+        "bash",
+        "call_tool",
+        "spawn_process",
+        "spawn_subagent",
+        "steer_subagent",
+        "defra_query",
+    ] {
+        assert!(
+            explanation.tool_names.contains(&name.to_string()),
+            "complex surface should expose {name}; got {:?}",
+            explanation.tool_names
+        );
+    }
+    assert!(!explanation_has_warning(
+        &explanation,
+        "defra_query_empty_scope_all"
+    ));
+    assert!(explanation_category_contains(
+        &explanation.included,
+        "subagent",
+        "spawn_subagent"
+    ));
+    assert!(explanation_category_contains(
+        &explanation.included,
+        "background_process",
+        "spawn_process"
+    ));
+    assert!(explanation_category_contains(
+        &explanation.included,
+        "meta_mcp",
+        "call_tool"
+    ));
+
+    #[cfg(feature = "agent-memory")]
+    assert!(explanation_category_contains(
+        &explanation.included,
+        "built_in_memory",
+        "memory"
+    ));
+    #[cfg(not(feature = "agent-memory"))]
+    {
+        assert!(explanation_category_contains(
+            &explanation.unavailable,
+            "built_in_memory",
+            "memory"
+        ));
+        assert!(explanation_has_warning(
+            &explanation,
+            "memory_requested_compiled_out"
+        ));
+    }
+
+    selection.subagent_allow_cross_deployment = Some(true);
+    let config = BehaviorToolConfig::from_tool_selection_document(
+        "complex-cross-deployment",
+        &selection,
+        &ceiling,
+        Vec::new(),
+    )
+    .unwrap();
+    let surface = config.resolve_with_available_subagent_targets_for_mcp_presence(
+        true,
+        own_agent_did,
+        &active_behavior_ids,
+    );
+    assert_eq!(
+        resolve_subagent_target_descriptions(&surface),
+        vec![
+            ("worker".to_string(), "local worker".to_string()),
+            ("remote".to_string(), "remote worker".to_string())
+        ]
+    );
+}
+
+#[test]
+fn explain_default_surface_calls_out_builtin_reads_and_defra_query_scope() {
+    let config = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection::default(),
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap();
+    let explanation = config.explain_with_runtime(
+        false,
+        "did:defra-agent:test",
+        &std::collections::HashSet::new(),
+    );
+
+    assert!(explanation
+        .tool_names
+        .contains(&crate::toolset::CONTEXT_BUDGET_TOOL_NAME.to_string()));
+    // `sessions` is opt-in (enable_session_history_tool, default off), so the
+    // default surface excludes it rather than listing it as callable.
+    assert!(!explanation
+        .tool_names
+        .contains(&crate::toolset::SESSION_HISTORY_TOOL_NAME.to_string()));
+    assert!(explanation.excluded.get("built_in_read").is_some_and(
+        |names| names.contains(&crate::toolset::SESSION_HISTORY_TOOL_NAME.to_string())
+    ));
+    assert!(explanation
+        .tool_names
+        .contains(&crate::defra_query::DEFRA_QUERY_TOOL_NAME.to_string()));
+    assert!(explanation
+        .warnings
+        .iter()
+        .any(|warning| warning.code == "unmanaged_builtin_read_tools"));
+    assert!(explanation
+        .warnings
+        .iter()
+        .any(|warning| warning.code == "defra_query_empty_scope_all"));
+    assert!(explanation
+        .warnings
+        .iter()
+        .any(|warning| warning.code == "host_ceiling_not_global"));
+    assert!(explanation
+        .unavailable
+        .get("meta_mcp")
+        .is_some_and(|names| names.contains(&"discover_tools".to_string())));
+}
+
+#[test]
+fn explain_mcp_empty_allowlist_reports_all_services_when_online() {
+    let config = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection {
+            enable_meta_tools: true,
+            allowed_mcp_service_ids: Vec::new(),
+            enable_defra_query: false,
+            ..Default::default()
+        },
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap();
+    let explanation = config.explain_with_runtime(
+        true,
+        "did:defra-agent:test",
+        &std::collections::HashSet::new(),
+    );
+
+    assert!(explanation.tool_names.contains(&"call_tool".to_string()));
+    assert!(explanation
+        .warnings
+        .iter()
+        .any(|warning| warning.code == "mcp_empty_allowlist_all"));
+    assert!(explanation
+        .included
+        .get("meta_mcp")
+        .is_some_and(|names| names.contains(&"call_tool".to_string())));
+}
+
 #[cfg(feature = "agent-memory")]
 #[tokio::test]
 async fn memory_tool_requires_selection_opt_in() {

--- a/docs/superpowers/audits/2026-06-05-init-config-tool-surface-audit.md
+++ b/docs/superpowers/audits/2026-06-05-init-config-tool-surface-audit.md
@@ -1,0 +1,74 @@
+# Init/Config Tool Surface Audit
+
+Date: 2026-06-05
+
+This audit covers how recently added tool families can be initialized, configured,
+and explained from the CLI. It is intentionally scoped to operator-facing init and
+config surfaces, not the full runtime implementation.
+
+The runtime should remain document-driven: durable behavior/tool policy lives in
+DefraDB documents such as `ToolSelection`, `AgentBehavior`, and
+`ToolServiceRegistry`. CLI affordances should help users seed or update those
+documents during setup; they should not create a second policy layer that drifts
+from the database.
+
+## Current Coverage
+
+| Tool family | Init path | Config path | Runtime/operator path | Notes |
+| --- | --- | --- | --- | --- |
+| File tools | `init --tool-package readonly/write --tool-root` | `config tools set --enable-file-tools --file-tools-mode --file-tool-root` | `server --tool-ceiling --tool-root` | `ToolCeiling` clamps host-native file tools. |
+| Bash tools | `init --tool-package readonly/write` | `config tools set --enable-bash --bash-mode --command-*` | `server --tool-ceiling --tool-root` | Write package defaults to unrestricted bash plus workspace/root ceiling. |
+| Background process tools | `init --tool-package write` enables `bash_unrestricted` backgrounding | `config tools set --backgroundable-tool-name ...` | `background list`, background cancellation paths | Background tools are wrappers over already-selected model-callable tools. |
+| Memory | `init --enable-memory` | `config tools set --enable-memory true|false` | feature-gated at compile time | `tools explain` warns when selected but compiled out. |
+| `defra_query` model tool | `init --disable-defra-query`, `init --defra-query-collection ...` | `config tools set --enable-defra-query true|false --defra-query-collection ...` | `query` command is separate operator surface | Empty collection list means all collections except hard-blocked sensitive fields. |
+| Meta MCP tools | package defaults enable them except `minimal` | `config tools set --enable-meta-tools --allowed-mcp-service-id ...` | `mcp probe` inspects registered services | Empty MCP allowlist means all online `ToolServiceRegistry` rows. |
+| ToolServiceRegistry/MCP services | manifest/provision/import managed | manifest/provision/import managed | `mcp probe` | No imperative `config tool-service set` command today. |
+| External `/mcp` server | not persisted by init | not persisted by config | `server --enable-mcp --mcp-query-collection ...` | This is an operator/listener surface, not a per-behavior model tool. |
+| Subagents | not bootstrapped by init | `config tools set --subagent-*` or manifests | `subagent list/cancel`, HTTP subagent tree endpoints | Targets require explicit `SubagentTarget` JSON, so manifests remain better for multi-behavior setup. |
+| Codex shim/local control | not persisted by init | not persisted by config | `server --codex-shim ...` | Operator compatibility surface, not model-callable ToolSelection state. |
+
+## Changes Made In This Pass
+
+- Added init flags that seed the default `ToolSelection` document for the two
+  safe per-behavior built-ins that can be configured without additional
+  documents:
+  - `--enable-memory`
+  - `--disable-defra-query`
+  - `--defra-query-collection <COLLECTION>`
+- Added imperative subagent `ToolSelection` document flags while preserving
+  existing apply-managed values when omitted:
+  - `--subagent-target <SUBAGENT_TARGET_JSON>`
+  - `--clear-subagent-targets`
+  - `--subagent-spawn-enabled true|false`
+  - `--subagent-steering-enabled true|false`
+  - `--subagent-background-enabled true|false`
+  - `--subagent-allow-cross-deployment true|false`
+  - `--cross-deployment-spawn-timeout-seconds <SECONDS>`
+- Converted `config tools set` to patch-style semantics for older fields too:
+  omitted file/bash/meta/list/scalar fields now preserve existing document state,
+  while paired clear flags explicitly clear nullable scalars or list fields.
+- Kept `ToolServiceRegistry` setup document/manifest-managed. Adding an
+  imperative registry writer would be a separate command family and needs its
+  own update semantics.
+
+## Remaining Inconsistencies
+
+- Init still does not bootstrap subagent behaviors or targets. That is correct
+  for now: subagents need target behavior IDs, DIDs, descriptions, and sometimes
+  cross-deployment policy. Manifests remain the coherent setup path.
+- External `/mcp`, Codex shim, and HTTP inspection routes are server/operator
+  flags rather than per-behavior `ToolSelection` documents. `tools explain`
+  should continue to keep them separate from the model-callable tool surface.
+- Backend admission capacity is not the same as effective request concurrency.
+  Current runtime wiring has one behavior executor draining each behavior queue;
+  `InferenceBackend.max_concurrent > 1` can still be underutilized when multiple
+  background subagent children route to the same behavior. This should be made
+  explicit in operator/debug output or fixed by adding behavior executor fan-out.
+
+## Recommended Next Step
+
+Audit and simplify init/server flags around operator-only surfaces, especially
+external `/mcp`, Codex shim/local control, daemon worker fan-out, and background
+execution controls. Keep durable tool policy document-driven, but make runtime
+capacity limits visible so users can distinguish selection/config issues from
+scheduler bottlenecks.


### PR DESCRIPTION
## Summary
- add a compact structured tool-surface explanation model with grouped included/excluded/unavailable capabilities and stable warning codes
- add `defra-agent tools explain` to report per-behavior model-callable tool surfaces from local or GraphQL config
- add init `--tool-package` presets (`minimal`, `introspection`, `readonly`, `write`) while keeping `--write-tools` as a compatibility alias
- add init/config audit coverage for memory, defra_query, backgrounding, MCP service registration, external `/mcp`, subagents, Codex shim/operator surfaces, and backend-vs-executor concurrency limits
- add init flags for memory and defra_query scoping, plus optional `config tools set --subagent-*` flags
- fix `config tools set` to use patch-style semantics for older file/bash/meta/list/scalar fields, with explicit clear flags instead of clearing omitted values
- add enabled-path and combination tests for init-seeded ToolSelection docs, package presets, runtime explain surfaces, MCP availability, memory, background tools, subagent filtering, ToolSelection persistence, and clear-field updates

## Notes
- Durable tool policy remains document-driven: init/config flags seed or update DefraDB documents, not a parallel policy layer.
- `ToolCeiling` is reported as a host-native ceiling; the explain output calls out built-in read tools separately.
- ToolServiceRegistry setup remains manifest/provision/import managed in this PR; adding imperative registry writes should be a separate command family.
- Backend admission capacity is not the same as effective request concurrency. The current runtime has one behavior executor draining each behavior queue, so `max_concurrent > 1` can still be underutilized by same-behavior background subagent children.
- The new tests cover representative complex combinations; they are not a full end-to-end chat/tool execution harness for every package permutation.

## Verification
- `cargo fmt --all`
- `cargo check -p defra-agent-cli`
- `cargo check -p defra-agent-cli --bin defra-agent --tests`
- `cargo test -p defra-agent --lib tool_surface::tests`
- `cargo test -p defra-agent-cli --bin defra-agent cli::args::tests`
- `cargo test -p defra-agent-cli --bin defra-agent commands::init::tests`
- `cargo test -p defra-agent-cli --bin defra-agent commands::config::tools::tests`
- `cargo test -p defra-agent-cli --bin defra-agent config_writes::tool_selection::tests`
- `cargo test -p defra-agent --lib explain_`
