### PR TITLE
Fan out behavior executors by backend capacity

### DIFF
--- a/crates/defra-agent-cli/src/commands/status.rs
+++ b/crates/defra-agent-cli/src/commands/status.rs
@@ -41,6 +41,9 @@ pub(crate) async fn load_runtime_status_output(
                 default_behavior_id
                 runnable_behavior_count
                 unavailable_behavior_count
+                behavior_executor_capacity
+                behavior_executor_queue_depth
+                behavior_executor_status_json
                 last_reconcile_result
                 last_reconcile_error
                 last_reconcile_completed_at
@@ -80,6 +83,8 @@ pub(crate) async fn load_runtime_status_output(
             "default_behavior_id",
             "runnable_behavior_count",
             "unavailable_behavior_count",
+            "behavior_executor_capacity",
+            "behavior_executor_queue_depth",
             "last_reconcile_result",
             "last_reconcile_error",
             "last_reconcile_completed_at",
@@ -89,6 +94,12 @@ pub(crate) async fn load_runtime_status_output(
                 runtime_row.get(field).cloned().unwrap_or(Value::Null),
             );
         }
+        let behavior_executors = runtime_row
+            .get("behavior_executor_status_json")
+            .and_then(Value::as_str)
+            .and_then(|json| serde_json::from_str::<Value>(json).ok())
+            .unwrap_or(Value::Null);
+        map.insert("behavior_executors".to_string(), behavior_executors);
         let p2p_value = map.get("p2p").cloned().unwrap_or(Value::Null);
         crate::commands::p2p::flatten_p2p_fields(map, &p2p_value);
     }

--- a/crates/defra-agent-protocol/src/row.rs
+++ b/crates/defra-agent-protocol/src/row.rs
@@ -140,6 +140,12 @@ pub struct AgentRuntimeRow {
     #[serde(default)]
     pub unavailable_behavior_count: Option<i64>,
     #[serde(default)]
+    pub behavior_executor_capacity: Option<i64>,
+    #[serde(default)]
+    pub behavior_executor_queue_depth: Option<i64>,
+    #[serde(default)]
+    pub behavior_executor_status_json: Option<String>,
+    #[serde(default)]
     pub last_reconcile_result: Option<String>,
     #[serde(default)]
     pub last_reconcile_error: Option<String>,

--- a/crates/defra-agent-schemas/schemas/agent/agent_runtime.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_runtime.graphql
@@ -7,6 +7,9 @@ type AgentRuntime @branchable {
     default_behavior_id: String @index
     runnable_behavior_count: Int
     unavailable_behavior_count: Int
+    behavior_executor_capacity: Int
+    behavior_executor_queue_depth: Int
+    behavior_executor_status_json: String
     last_reconcile_result: String @index
     last_reconcile_error: String
     last_reconcile_completed_at: String @index

--- a/crates/defra-agent/src/agent/reconcile.rs
+++ b/crates/defra-agent/src/agent/reconcile.rs
@@ -18,7 +18,12 @@ mod diff;
 mod slot;
 
 use diff::diff_counts;
-use slot::{retire_slot, spawn_slot, spawn_slots, BehaviorSlot, BehaviorSlotState};
+#[cfg(test)]
+use slot::spawn_slot;
+use slot::{
+    behavior_executor_capacity, retire_slot, spawn_slot_with_capacity, spawn_slots, BehaviorSlot,
+    BehaviorSlotState,
+};
 
 pub(super) struct GenerationSupervisor<F> {
     current_snapshot: Arc<ActiveRuntimeSnapshot>,
@@ -62,7 +67,20 @@ where
             .iter()
             .map(|(behavior_id, slot)| (behavior_id.clone(), slot.dispatcher.clone()))
             .collect();
-        let current_snapshot = Arc::new(resolved_snapshot.activate(1, dispatchers));
+        let executor_capacities = active_slots
+            .iter()
+            .map(|(behavior_id, slot)| (behavior_id.clone(), slot.executor_capacity))
+            .collect();
+        let executor_queue_capacities = active_slots
+            .iter()
+            .map(|(behavior_id, slot)| (behavior_id.clone(), slot.queue_capacity))
+            .collect();
+        let current_snapshot = Arc::new(resolved_snapshot.activate_with_executor_metadata(
+            1,
+            dispatchers,
+            executor_capacities,
+            executor_queue_capacities,
+        ));
 
         Ok(Self {
             current_snapshot,
@@ -199,18 +217,21 @@ where
                 .get(behavior_id)
                 .cloned()
                 .ok_or_else(|| anyhow!("missing tool surface for behavior {behavior_id}"))?;
+            let executor_capacity =
+                behavior_executor_capacity(behavior, &resolved_snapshot.backend_admission_configs);
 
             match self.active_slots.remove(behavior_id) {
-                Some(existing) if existing.matches(behavior, &tool_surface) => {
+                Some(existing) if existing.matches(behavior, &tool_surface, executor_capacity) => {
                     next_slots.insert(behavior_id.clone(), existing);
                 }
                 Some(existing) => {
                     retired_slots.push(existing);
                     next_slots.insert(
                         behavior_id.clone(),
-                        spawn_slot(
+                        spawn_slot_with_capacity(
                             behavior.clone(),
                             tool_surface,
+                            executor_capacity,
                             self.retry_policy.clone(),
                             self.runner.clone(),
                             shutdown.clone(),
@@ -220,9 +241,10 @@ where
                 None => {
                     next_slots.insert(
                         behavior_id.clone(),
-                        spawn_slot(
+                        spawn_slot_with_capacity(
                             behavior.clone(),
                             tool_surface,
+                            executor_capacity,
                             self.retry_policy.clone(),
                             self.runner.clone(),
                             shutdown.clone(),
@@ -238,7 +260,20 @@ where
             .iter()
             .map(|(behavior_id, slot)| (behavior_id.clone(), slot.dispatcher.clone()))
             .collect();
-        let next_snapshot = Arc::new(resolved_snapshot.activate(generation, dispatchers));
+        let executor_capacities = next_slots
+            .iter()
+            .map(|(behavior_id, slot)| (behavior_id.clone(), slot.executor_capacity))
+            .collect();
+        let executor_queue_capacities = next_slots
+            .iter()
+            .map(|(behavior_id, slot)| (behavior_id.clone(), slot.queue_capacity))
+            .collect();
+        let next_snapshot = Arc::new(resolved_snapshot.activate_with_executor_metadata(
+            generation,
+            dispatchers,
+            executor_capacities,
+            executor_queue_capacities,
+        ));
         self.admission_registry
             .reconcile(generation, &next_snapshot.backend_admission_configs);
 

--- a/crates/defra-agent/src/agent/reconcile/slot.rs
+++ b/crates/defra-agent/src/agent/reconcile/slot.rs
@@ -4,8 +4,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use futures::FutureExt;
 use tokio::sync::{mpsc, watch, Mutex};
-use tokio::task::JoinHandle;
+use tokio::task::{JoinHandle, JoinSet};
 
+use crate::admission::BackendAdmissionConfig;
 use crate::config::AgentBehavior;
 use crate::retry::RetryPolicy;
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
@@ -13,6 +14,8 @@ use crate::tool_surface::ToolSurface;
 use crate::watcher::AgentRequest;
 
 use std::collections::HashMap;
+
+const BEHAVIOR_EXECUTOR_QUEUE_CAPACITY: usize = 32;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum BehaviorSlotState {
@@ -26,6 +29,8 @@ pub(super) struct BehaviorSlot {
     pub(super) handle: JoinHandle<()>,
     pub(super) behavior_fingerprint: String,
     pub(super) tool_surface_fingerprint: String,
+    pub(super) executor_capacity: usize,
+    pub(super) queue_capacity: usize,
 }
 
 impl BehaviorSlot {
@@ -33,9 +38,11 @@ impl BehaviorSlot {
         &self,
         behavior: &Arc<AgentBehavior>,
         tool_surface: &Arc<ToolSurface>,
+        executor_capacity: usize,
     ) -> bool {
         self.behavior_fingerprint == format!("{behavior:?}")
             && self.tool_surface_fingerprint == format!("{tool_surface:?}")
+            && self.executor_capacity == executor_capacity
     }
 }
 
@@ -67,9 +74,10 @@ where
             .expect("resolved snapshot should include tool surfaces for runnable behaviors");
         slots.insert(
             behavior_id.clone(),
-            spawn_slot(
+            spawn_slot_with_capacity(
                 behavior.clone(),
                 tool_surface,
+                behavior_executor_capacity(behavior, &resolved_snapshot.backend_admission_configs),
                 retry_policy.clone(),
                 runner.clone(),
                 shutdown.clone(),
@@ -79,6 +87,7 @@ where
     slots
 }
 
+#[cfg(test)]
 pub(super) fn spawn_slot<F, Fut>(
     behavior: Arc<AgentBehavior>,
     tool_surface: Arc<ToolSurface>,
@@ -99,16 +108,42 @@ where
         + 'static,
     Fut: std::future::Future<Output = Result<()>> + Send + 'static,
 {
-    let (dispatcher, request_rx) = mpsc::channel(32);
+    spawn_slot_with_capacity(behavior, tool_surface, 1, retry_policy, runner, shutdown)
+}
+
+pub(super) fn spawn_slot_with_capacity<F, Fut>(
+    behavior: Arc<AgentBehavior>,
+    tool_surface: Arc<ToolSurface>,
+    executor_capacity: usize,
+    retry_policy: RetryPolicy,
+    runner: F,
+    shutdown: watch::Receiver<bool>,
+) -> BehaviorSlot
+where
+    F: Fn(
+            Arc<AgentBehavior>,
+            Arc<ToolSurface>,
+            Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+            watch::Receiver<bool>,
+        ) -> Fut
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    Fut: std::future::Future<Output = Result<()>> + Send + 'static,
+{
+    let executor_capacity = executor_capacity.max(1);
+    let (dispatcher, request_rx) = mpsc::channel(BEHAVIOR_EXECUTOR_QUEUE_CAPACITY);
     let request_rx = Arc::new(Mutex::new(request_rx));
     let (state_tx, state_rx) = watch::channel(BehaviorSlotState::Active);
     let behavior_fingerprint = format!("{behavior:?}");
     let tool_surface_fingerprint = format!("{tool_surface:?}");
 
-    let handle = tokio::spawn(run_slot_loop(
+    let handle = tokio::spawn(run_slot_workers(
         behavior,
         tool_surface,
         request_rx,
+        executor_capacity,
         retry_policy,
         runner,
         shutdown,
@@ -121,7 +156,29 @@ where
         handle,
         behavior_fingerprint,
         tool_surface_fingerprint,
+        executor_capacity,
+        queue_capacity: BEHAVIOR_EXECUTOR_QUEUE_CAPACITY,
     }
+}
+
+pub(super) fn behavior_executor_capacity(
+    behavior: &AgentBehavior,
+    backend_admission_configs: &HashMap<String, BackendAdmissionConfig>,
+) -> usize {
+    let Some(backend_id) = behavior
+        .backend_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|backend_id| !backend_id.is_empty())
+    else {
+        return 1;
+    };
+
+    backend_admission_configs
+        .get(backend_id)
+        .filter(|config| config.is_available())
+        .map(|config| config.max_concurrent.max(1))
+        .unwrap_or(1)
 }
 
 pub(super) fn retire_slot(slot: BehaviorSlot) {
@@ -159,6 +216,10 @@ async fn run_slot_loop<F, Fut>(
 {
     let mut failure_count = 0u32;
     loop {
+        if *shutdown.borrow() || *state_rx.borrow() == BehaviorSlotState::Retiring {
+            return;
+        }
+
         let outcome = AssertUnwindSafe(runner(
             behavior.clone(),
             tool_surface.clone(),
@@ -210,6 +271,66 @@ async fn run_slot_loop<F, Fut>(
                 if !wait_for_restart(delay, &mut shutdown).await {
                     return;
                 }
+            }
+        }
+    }
+}
+
+async fn run_slot_workers<F, Fut>(
+    behavior: Arc<AgentBehavior>,
+    tool_surface: Arc<ToolSurface>,
+    request_rx: Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+    executor_capacity: usize,
+    retry_policy: RetryPolicy,
+    runner: F,
+    shutdown: watch::Receiver<bool>,
+    state_rx: watch::Receiver<BehaviorSlotState>,
+) where
+    F: Fn(
+            Arc<AgentBehavior>,
+            Arc<ToolSurface>,
+            Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+            watch::Receiver<bool>,
+        ) -> Fut
+        + Send
+        + Sync
+        + Clone
+        + 'static,
+    Fut: std::future::Future<Output = Result<()>> + Send + 'static,
+{
+    tracing::info!(
+        behavior_id = %behavior.behavior_id,
+        executor_capacity,
+        queue_capacity = BEHAVIOR_EXECUTOR_QUEUE_CAPACITY,
+        "behavior executor worker pool starting"
+    );
+    let mut workers = JoinSet::new();
+    for worker_index in 0..executor_capacity {
+        workers.spawn(run_slot_loop(
+            behavior.clone(),
+            tool_surface.clone(),
+            request_rx.clone(),
+            retry_policy.clone(),
+            runner.clone(),
+            shutdown.clone(),
+            state_rx.clone(),
+        ));
+        tracing::debug!(
+            behavior_id = %behavior.behavior_id,
+            worker_index,
+            executor_capacity,
+            "behavior executor worker spawned"
+        );
+    }
+
+    while let Some(joined) = workers.join_next().await {
+        if let Err(error) = joined {
+            if !error.is_cancelled() {
+                tracing::error!(
+                    behavior_id = %behavior.behavior_id,
+                    error = %error,
+                    "behavior executor worker task join failed"
+                );
             }
         }
     }

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -3,9 +3,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
-use tokio::sync::{mpsc, watch, Mutex};
+use tokio::sync::{mpsc, watch, Mutex, Notify};
 
 use super::*;
+use crate::admission::BackendAdmissionConfig;
 use crate::agent::PendingAgentBehavior;
 use crate::backend_provider::BackendProviderKind;
 use crate::config::AgentBehavior;
@@ -73,6 +74,64 @@ async fn snapshot_for_behaviors(
         HashMap::new(),
     )
     .with_principal(stub_principal())
+}
+
+async fn snapshot_for_behaviors_with_admission(
+    node: &defra_node::EmbeddedNode,
+    default_behavior_id: &str,
+    behaviors: Vec<Arc<AgentBehavior>>,
+    backend_admission_configs: HashMap<String, BackendAdmissionConfig>,
+) -> ResolvedRuntimeSnapshot {
+    let mut tool_surfaces = HashMap::new();
+    for behavior in &behaviors {
+        let tool_surface = behavior.tools.resolve(node).await.unwrap();
+        tool_surfaces.insert(behavior.behavior_id.clone(), Arc::new(tool_surface));
+    }
+    ResolvedRuntimeSnapshot::from_parts_with_admission_configs(
+        default_behavior_id.to_string(),
+        behaviors,
+        tool_surfaces,
+        backend_admission_configs,
+        HashMap::new(),
+    )
+    .with_principal(stub_principal())
+}
+
+fn backend_admission_config(
+    backend_id: &str,
+    max_concurrent: usize,
+    max_queue_depth: usize,
+) -> BackendAdmissionConfig {
+    BackendAdmissionConfig {
+        backend_id: backend_id.to_string(),
+        max_concurrent,
+        max_queue_depth,
+        enabled: true,
+        probe_status: crate::backend_registry::HEALTHY_PROBE_STATUS.to_string(),
+        config_fingerprint: format!("{backend_id}:{max_concurrent}:{max_queue_depth}"),
+    }
+}
+
+fn background_child_request(index: usize, behavior_id: &str) -> AgentRequest {
+    AgentRequest {
+        doc_id: format!("child-doc-{index}"),
+        request_id: format!("child-request-{index}"),
+        agent_did: "did:defra-agent:background-fanout-test".to_string(),
+        behavior_id: Some(behavior_id.to_string()),
+        session_id: format!("child-session-{index}"),
+        content: format!("background child {index}"),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
+        execution_origin: Some("interactive".to_string()),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        deadline: None,
+        subagent_depth: 1,
+        caused_by_parent_request_id: Some("parent-request".to_string()),
+        caused_by_parent_tool_call_id: Some("parent-tool-call".to_string()),
+    }
 }
 
 #[tokio::test]
@@ -263,6 +322,224 @@ async fn slot_panic_restarts_behavior(node: &defra_node::EmbeddedNode) -> bool {
     restarted
 }
 
+#[tokio::test]
+async fn behavior_slot_fans_out_background_children_to_backend_capacity() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let mut behavior = PendingAgentBehavior::new("general")
+        .build_with_identity_for_test(test_identity("background-fanout"));
+    behavior.backend_id = Some("backend-wide".to_string());
+    let snapshot = snapshot_for_behaviors_with_admission(
+        node.as_ref(),
+        "general",
+        vec![Arc::new(behavior)],
+        HashMap::from([(
+            "backend-wide".to_string(),
+            backend_admission_config("backend-wide", 3, 100),
+        )]),
+    )
+    .await;
+
+    let (started_tx, mut started_rx) = mpsc::channel::<String>(8);
+    let release = Arc::new(Notify::new());
+    let runner = {
+        let release = release.clone();
+        move |_behavior: Arc<AgentBehavior>,
+              _tool_surface: Arc<ToolSurface>,
+              request_rx: Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+              mut shutdown: watch::Receiver<bool>| {
+            let started_tx = started_tx.clone();
+            let release = release.clone();
+            async move {
+                loop {
+                    let message = tokio::select! {
+                        _ = shutdown.changed() => return Ok(()),
+                        message = async {
+                            let mut receiver = request_rx.lock().await;
+                            receiver.recv().await
+                        } => message,
+                    };
+                    let Some(request) = message else {
+                        return Ok(());
+                    };
+                    started_tx
+                        .send(request.request_id)
+                        .await
+                        .expect("test receiver should stay open");
+                    tokio::select! {
+                        _ = shutdown.changed() => return Ok(()),
+                        _ = release.notified() => {}
+                    }
+                }
+            }
+        }
+    };
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let slots = spawn_slots(
+        &snapshot,
+        crate::retry::RetryPolicy {
+            max_retries: 1,
+            base_delay_ms: 1,
+            max_delay_ms: 1,
+        },
+        runner,
+        shutdown_rx,
+    );
+    let dispatcher = slots
+        .get("general")
+        .expect("general slot")
+        .dispatcher
+        .clone();
+
+    for index in 0..3 {
+        dispatcher
+            .send(background_child_request(index, "general"))
+            .await
+            .unwrap();
+    }
+
+    let started = tokio::time::timeout(Duration::from_millis(300), async {
+        let mut request_ids = BTreeSet::new();
+        while request_ids.len() < 3 {
+            let request_id = started_rx
+                .recv()
+                .await
+                .expect("runner should report started requests");
+            request_ids.insert(request_id);
+        }
+        request_ids
+    })
+    .await
+    .expect("executor should start all same-behavior background children concurrently");
+
+    assert_eq!(
+        started,
+        BTreeSet::from([
+            "child-request-0".to_string(),
+            "child-request-1".to_string(),
+            "child-request-2".to_string(),
+        ])
+    );
+
+    release.notify_waiters();
+    let _ = shutdown_tx.send(true);
+    for slot in slots.into_values() {
+        retire_slot(slot);
+    }
+}
+
+#[tokio::test]
+async fn generation_supervisor_rotates_dispatcher_on_backend_capacity_change() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let agent_did = "did:defra-agent:reconcile-capacity-test";
+    let runtime_status = RuntimeStatusHandle::new(node.clone(), agent_did);
+
+    let mut behavior = PendingAgentBehavior::new("general")
+        .build_with_identity_for_test(test_identity("capacity-general"));
+    behavior.backend_id = Some("backend-general".to_string());
+    let behavior = Arc::new(behavior);
+    let initial_snapshot = snapshot_for_behaviors_with_admission(
+        node.as_ref(),
+        "general",
+        vec![behavior.clone()],
+        HashMap::from([(
+            "backend-general".to_string(),
+            backend_admission_config("backend-general", 1, 100),
+        )]),
+    )
+    .await;
+    let updated_snapshot = snapshot_for_behaviors_with_admission(
+        node.as_ref(),
+        "general",
+        vec![behavior],
+        HashMap::from([(
+            "backend-general".to_string(),
+            backend_admission_config("backend-general", 3, 100),
+        )]),
+    )
+    .await;
+
+    let runner = move |_behavior: Arc<AgentBehavior>,
+                       _tool_surface: Arc<ToolSurface>,
+                       request_rx: Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+                       mut shutdown: watch::Receiver<bool>| async move {
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => return Ok(()),
+                message = async {
+                    let mut receiver = request_rx.lock().await;
+                    receiver.recv().await
+                } => {
+                    if message.is_none() {
+                        return Ok(());
+                    }
+                }
+            }
+        }
+    };
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let supervisor = GenerationSupervisor::bootstrap(
+        initial_snapshot,
+        crate::admission::AdmissionRegistry::new(node.clone()),
+        crate::retry::RetryPolicy {
+            max_retries: 3,
+            base_delay_ms: 5,
+            max_delay_ms: 25,
+        },
+        runner,
+        runtime_status,
+        shutdown_rx.clone(),
+    )
+    .unwrap();
+    let active_snapshot = supervisor.current_snapshot();
+    let initial_dispatcher = active_snapshot
+        .dispatchers
+        .get("general")
+        .expect("initial general dispatcher")
+        .clone();
+    assert_eq!(
+        active_snapshot
+            .behavior_executor_capacities
+            .get("general")
+            .copied(),
+        Some(1)
+    );
+    let (active_tx, mut active_rx) = watch::channel(active_snapshot);
+    let (proposal_tx, proposal_rx) = mpsc::channel(4);
+
+    let task = tokio::spawn(supervisor.run(active_tx, proposal_rx, shutdown_rx));
+
+    proposal_tx.send(updated_snapshot).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), active_rx.changed())
+        .await
+        .expect("capacity update should publish")
+        .unwrap();
+    let updated_active = active_rx.borrow().clone();
+    let updated_dispatcher = updated_active
+        .dispatchers
+        .get("general")
+        .expect("updated general dispatcher");
+    assert!(!initial_dispatcher.same_channel(updated_dispatcher));
+    assert_eq!(
+        updated_active
+            .behavior_executor_capacities
+            .get("general")
+            .copied(),
+        Some(3)
+    );
+
+    let _ = shutdown_tx.send(true);
+    tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("supervisor should stop on shutdown")
+        .unwrap()
+        .unwrap();
+}
+
 #[derive(Debug, serde::Deserialize)]
 struct RuntimeStatusRow {
     reconcile_phase: String,
@@ -380,6 +657,24 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
     let (proposal_tx, proposal_rx) = mpsc::channel(4);
 
     let task = tokio::spawn(supervisor.run(active_tx, proposal_rx, shutdown_rx));
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if starts
+                .lock()
+                .unwrap()
+                .get("general")
+                .copied()
+                .unwrap_or_default()
+                >= 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("initial behavior slot should start");
 
     proposal_tx.send(updated_snapshot).await.unwrap();
     tokio::time::timeout(Duration::from_secs(1), active_rx.changed())

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -27,6 +27,7 @@ use crate::tool_surface::{ToolRuntimeContext, ToolSurface};
 enum BackgroundTaskResult {
     Router(Result<()>),
     RouterObserver(Result<()>),
+    ExecutorStatus(Result<()>),
     Reconcile(Result<()>),
     Control(Result<()>),
     SubagentCompletion(Result<()>),
@@ -38,6 +39,9 @@ pub(in crate::agent) async fn run_agent(
     mut shutdown: watch::Receiver<bool>,
 ) -> Result<()> {
     let cancel = CancellationToken::new();
+    crate::migration::ensure_agent_runtime_executor_status_migrations(agent.node.clone())
+        .await
+        .context("ensure AgentRuntime executor status migrations")?;
     let runtime_status =
         RuntimeStatusHandle::new(agent.node.clone(), agent.agent_did().to_string());
     runtime_status
@@ -322,6 +326,20 @@ pub(in crate::agent) async fn run_agent(
         )
     });
 
+    let executor_status_active_snapshot_rx = active_snapshot_rx.clone();
+    let executor_status_runtime_status = runtime_status.clone();
+    let executor_status_shutdown = shutdown.clone();
+    background_tasks.spawn(async move {
+        BackgroundTaskResult::ExecutorStatus(
+            crate::runtime_status::run_executor_status_observer(
+                executor_status_active_snapshot_rx,
+                executor_status_runtime_status,
+                executor_status_shutdown,
+            )
+            .await,
+        )
+    });
+
     let reconcile_active_snapshot_tx = active_snapshot_tx.clone();
     let reconcile_shutdown = shutdown.clone();
     background_tasks.spawn(async move {
@@ -366,6 +384,7 @@ pub(in crate::agent) async fn run_agent(
         Some(joined) = background_tasks.join_next() => match joined {
             Ok(BackgroundTaskResult::Router(result)) => (result, false),
             Ok(BackgroundTaskResult::RouterObserver(result)) => (result, false),
+            Ok(BackgroundTaskResult::ExecutorStatus(result)) => (result, false),
             Ok(BackgroundTaskResult::Reconcile(result)) => (result, false),
             Ok(BackgroundTaskResult::Control(result)) => (result, false),
             Ok(BackgroundTaskResult::SubagentCompletion(result)) => (result, false),

--- a/crates/defra-agent/src/agent/runtime/tests/router.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/router.rs
@@ -24,6 +24,8 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
         unavailable_event_triggers: std::collections::HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     });
     let updated_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 2,
@@ -41,6 +43,8 @@ async fn router_dispatches_first_request_after_snapshot_change_to_latest_generat
         unavailable_event_triggers: std::collections::HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     });
     let (active_tx, mut active_rx) = watch::channel(initial_snapshot);
     let (_shutdown_tx, mut shutdown_rx) = watch::channel(false);
@@ -114,6 +118,8 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
         unavailable_event_triggers: std::collections::HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     });
     let updated_snapshot = Arc::new(crate::runtime_snapshot::ActiveRuntimeSnapshot {
         generation: 2,
@@ -131,6 +137,8 @@ async fn router_publishes_observed_generation_without_waiting_for_request() {
         unavailable_event_triggers: std::collections::HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     });
     let (active_tx, active_rx) = watch::channel(initial_snapshot.clone());
     let (shutdown_tx, shutdown_rx) = watch::channel(false);

--- a/crates/defra-agent/src/lifecycle/claim.rs
+++ b/crates/defra-agent/src/lifecycle/claim.rs
@@ -293,3 +293,178 @@ impl RequestLifecycle {
         Ok(ClaimOutcome::Claimed)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    const TEST_AGENT_DID: &str = "did:defra-agent:claim-order-test";
+    const TEST_BEHAVIOR_ID: &str = "general";
+    const TEST_BACKEND_ID: &str = "backend-order";
+
+    async fn test_node() -> Arc<EmbeddedNode> {
+        let node = Arc::new(EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        node
+    }
+
+    async fn insert_pending_request(
+        node: &EmbeddedNode,
+        request_id: &str,
+        session_id: &str,
+        created_at: &str,
+    ) -> AgentRequest {
+        let escaped_request_id = escape_graphql_string(request_id);
+        let escaped_session_id = escape_graphql_string(session_id);
+        let escaped_created_at = escape_graphql_string(created_at);
+        let mutation = format!(
+            r#"mutation {{
+                create_AgentRequest(input: {{
+                    request_id: "{escaped_request_id}",
+                    agent_did: "{TEST_AGENT_DID}",
+                    behavior_id: "{TEST_BEHAVIOR_ID}",
+                    session_id: "{escaped_session_id}",
+                    retry_parent_request: "",
+                    retry_root_request: "{escaped_request_id}",
+                    superseded_by_request: "",
+                    content: "same-session request",
+                    status: "pending",
+                    lifecycle_state: "pending",
+                    backend_id: "",
+                    execution_origin: "interactive",
+                    failure_reason: "",
+                    created_at: "{escaped_created_at}",
+                    retry_count: 0,
+                    max_retries: {max_retries},
+                    subagent_depth: 0
+                }}) {{ _docID }}
+            }}"#,
+            max_retries = DEFAULT_REQUEST_MAX_RETRIES,
+        );
+        let response =
+            session::execute_mutation_with_retry(node, &mutation, "insert_pending_request")
+                .await
+                .unwrap();
+        let inline_doc_id = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("create_AgentRequest"))
+            .and_then(|value| {
+                value
+                    .get("_docID")
+                    .and_then(|doc_id| doc_id.as_str())
+                    .or_else(|| {
+                        value
+                            .as_array()
+                            .and_then(|rows| rows.first())
+                            .and_then(|row| row.get("_docID"))
+                            .and_then(|doc_id| doc_id.as_str())
+                    })
+            })
+            .map(ToOwned::to_owned);
+        let doc_id = match inline_doc_id {
+            Some(doc_id) => doc_id,
+            None => lookup_request_doc_id(node, request_id)
+                .await
+                .expect("created AgentRequest doc id"),
+        };
+
+        AgentRequest {
+            doc_id,
+            request_id: request_id.to_string(),
+            agent_did: TEST_AGENT_DID.to_string(),
+            behavior_id: Some(TEST_BEHAVIOR_ID.to_string()),
+            session_id: session_id.to_string(),
+            content: "same-session request".to_string(),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            metadata: None,
+            execution_origin: Some("interactive".to_string()),
+            created_at: created_at.to_string(),
+            deadline: None,
+            subagent_depth: 0,
+            caused_by_parent_request_id: None,
+            caused_by_parent_tool_call_id: None,
+        }
+    }
+
+    async fn lookup_request_doc_id(
+        node: &EmbeddedNode,
+        request_id: &str,
+    ) -> anyhow::Result<String> {
+        let escaped_request_id = escape_graphql_string(request_id);
+        let query = format!(
+            r#"{{
+                AgentRequest(
+                    filter: {{ request_id: {{ _eq: "{escaped_request_id}" }} }},
+                    limit: 1
+                ) {{ _docID }}
+            }}"#
+        );
+        let response = node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!("query created AgentRequest failed: {:?}", response.errors);
+        }
+        response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("AgentRequest"))
+            .and_then(|value| value.as_array())
+            .and_then(|rows| rows.first())
+            .and_then(|row| row.get("_docID"))
+            .and_then(|value| value.as_str())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("AgentRequest {request_id} not found"))
+    }
+
+    #[tokio::test]
+    async fn claim_preserves_same_session_ordering() {
+        let node = test_node().await;
+        let first = insert_pending_request(
+            node.as_ref(),
+            "same-session-request-1",
+            "same-session",
+            "2026-01-01T00:00:00Z",
+        )
+        .await;
+        let second = insert_pending_request(
+            node.as_ref(),
+            "same-session-request-2",
+            "same-session",
+            "2026-01-01T00:00:01Z",
+        )
+        .await;
+
+        let mut first_lifecycle = RequestLifecycle::new_with_execution_binding(
+            node.clone(),
+            TEST_BEHAVIOR_ID,
+            TEST_AGENT_DID,
+            first,
+            60,
+            ExecutionOrigin::Interactive,
+            TEST_BACKEND_ID,
+        );
+        let mut second_lifecycle = RequestLifecycle::new_with_execution_binding(
+            node,
+            TEST_BEHAVIOR_ID,
+            TEST_AGENT_DID,
+            second,
+            60,
+            ExecutionOrigin::Interactive,
+            TEST_BACKEND_ID,
+        );
+
+        assert_eq!(
+            first_lifecycle.claim_with_identity().await.unwrap(),
+            ClaimOutcome::Claimed
+        );
+        assert_eq!(
+            second_lifecycle.claim_with_identity().await.unwrap(),
+            ClaimOutcome::Queued
+        );
+    }
+}

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -105,6 +105,12 @@ const ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH: &str = r#"[
     {"op":"add","path":"/ToolServiceHealthState/Fields/-","value":{"Name":"tool_count","Kind":5}}
 ]"#;
 
+const ADD_AGENT_RUNTIME_EXECUTOR_STATUS_PATCH: &str = r#"[
+    {"op":"add","path":"/AgentRuntime/Fields/-","value":{"Name":"behavior_executor_capacity","Kind":5}},
+    {"op":"add","path":"/AgentRuntime/Fields/-","value":{"Name":"behavior_executor_queue_depth","Kind":5}},
+    {"op":"add","path":"/AgentRuntime/Fields/-","value":{"Name":"behavior_executor_status_json","Kind":11}}
+]"#;
+
 /// WASM lens bytes embedded at compile time. Built by build.rs.
 const LENS_WASM_BYTES: &[u8] =
     include_bytes!(env!("AGENT_TOOL_CALL_LIFECYCLE_V1_TO_V2_LENS_WASM_PATH"));
@@ -651,6 +657,33 @@ pub async fn ensure_tool_service_health_state_migrations(node: Arc<EmbeddedNode>
     Ok(())
 }
 
+pub async fn ensure_agent_runtime_executor_status_migrations(
+    node: Arc<EmbeddedNode>,
+) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("AgentRuntime")
+        .context("get AgentRuntime collection")?
+    else {
+        return Ok(());
+    };
+    if collection_has_field(&collection, "behavior_executor_status_json") {
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection("AgentRuntime", ADD_AGENT_RUNTIME_EXECUTOR_STATUS_PATCH)
+        .await
+        .context("patch_collection AgentRuntime executor status fields")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version AgentRuntime executor status fields")?;
+    tracing::info!(
+        version = %next.version_id,
+        "AgentRuntime patched with behavior executor status fields"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod patch_kind_tests {
     use super::*;
@@ -722,6 +755,7 @@ mod patch_kind_tests {
             ADD_TOOL_SELECTION_R5_PATCH,
             ADD_AGENT_BEHAVIOR_DESCRIPTION_SUMMARY_PATCH,
             ADD_TOOL_SERVICE_HEALTH_STATE_TOOL_COUNT_PATCH,
+            ADD_AGENT_RUNTIME_EXECUTOR_STATUS_PATCH,
         ] {
             for (name, kind) in field_kinds(patch) {
                 assert_ne!(kind, 17, "field {name} uses unassigned Kind 17");
@@ -740,5 +774,18 @@ mod patch_kind_tests {
                 "AgentBehavior field '{name}' must be NillableString (11), got {kind}"
             );
         }
+    }
+
+    #[test]
+    fn agent_runtime_executor_status_field_kinds_match_sdl() {
+        let fields = field_kinds(ADD_AGENT_RUNTIME_EXECUTOR_STATUS_PATCH);
+        assert_eq!(
+            fields,
+            vec![
+                ("behavior_executor_capacity".to_string(), 5),
+                ("behavior_executor_queue_depth".to_string(), 5),
+                ("behavior_executor_status_json".to_string(), 11),
+            ]
+        );
     }
 }

--- a/crates/defra-agent/src/runtime_snapshot.rs
+++ b/crates/defra-agent/src/runtime_snapshot.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::Result;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use serde::Serialize;
 use tokio::sync::mpsc;
 #[cfg(test)]
 use tokio::sync::watch;
@@ -274,10 +275,34 @@ impl ResolvedRuntimeSnapshot {
         self
     }
 
+    #[cfg(test)]
     pub(crate) fn activate(
         self,
         generation: u64,
         dispatchers: DispatcherMap,
+    ) -> ActiveRuntimeSnapshot {
+        let behavior_executor_capacities = dispatchers
+            .keys()
+            .map(|behavior_id| (behavior_id.clone(), 1))
+            .collect();
+        let behavior_executor_queue_capacities = dispatchers
+            .iter()
+            .map(|(behavior_id, dispatcher)| (behavior_id.clone(), dispatcher.max_capacity()))
+            .collect();
+        self.activate_with_executor_metadata(
+            generation,
+            dispatchers,
+            behavior_executor_capacities,
+            behavior_executor_queue_capacities,
+        )
+    }
+
+    pub(crate) fn activate_with_executor_metadata(
+        self,
+        generation: u64,
+        dispatchers: DispatcherMap,
+        behavior_executor_capacities: HashMap<String, usize>,
+        behavior_executor_queue_capacities: HashMap<String, usize>,
     ) -> ActiveRuntimeSnapshot {
         debug_assert!(
             self.principal.is_some(),
@@ -301,6 +326,8 @@ impl ResolvedRuntimeSnapshot {
             unavailable_event_triggers: self.unavailable_event_triggers,
             active_tasks: self.active_tasks,
             dispatchers,
+            behavior_executor_capacities,
+            behavior_executor_queue_capacities,
         }
     }
 
@@ -339,6 +366,15 @@ pub struct ActiveRuntimeSnapshot {
     pub unavailable_event_triggers: HashSet<String>,
     pub active_tasks: HashMap<String, ResolvedTask>,
     pub dispatchers: DispatcherMap,
+    pub behavior_executor_capacities: HashMap<String, usize>,
+    pub behavior_executor_queue_capacities: HashMap<String, usize>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct BehaviorExecutorStatus {
+    pub(crate) worker_capacity: usize,
+    pub(crate) queue_depth: usize,
+    pub(crate) queue_capacity: usize,
 }
 
 impl ActiveRuntimeSnapshot {
@@ -368,6 +404,46 @@ impl ActiveRuntimeSnapshot {
         self.unavailable_behaviors
             .get(behavior_id)
             .map(String::as_str)
+    }
+
+    pub(crate) fn behavior_executor_statuses(&self) -> BTreeMap<String, BehaviorExecutorStatus> {
+        let mut behavior_ids = self
+            .behaviors
+            .keys()
+            .chain(self.dispatchers.keys())
+            .chain(self.behavior_executor_capacities.keys())
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        behavior_ids.extend(self.behavior_executor_queue_capacities.keys().cloned());
+
+        behavior_ids
+            .into_iter()
+            .map(|behavior_id| {
+                let dispatcher = self.dispatchers.get(&behavior_id);
+                let queue_capacity = self
+                    .behavior_executor_queue_capacities
+                    .get(&behavior_id)
+                    .copied()
+                    .or_else(|| dispatcher.map(mpsc::Sender::max_capacity))
+                    .unwrap_or_default();
+                let queue_depth = dispatcher
+                    .map(|dispatcher| queue_capacity.saturating_sub(dispatcher.capacity()))
+                    .unwrap_or_default();
+                let worker_capacity = self
+                    .behavior_executor_capacities
+                    .get(&behavior_id)
+                    .copied()
+                    .unwrap_or_else(|| if dispatcher.is_some() { 1 } else { 0 });
+                (
+                    behavior_id,
+                    BehaviorExecutorStatus {
+                        worker_capacity,
+                        queue_depth,
+                        queue_capacity,
+                    },
+                )
+            })
+            .collect()
     }
 
     pub(crate) fn configuration_fingerprint(&self) -> String {

--- a/crates/defra-agent/src/runtime_snapshot/tests.rs
+++ b/crates/defra-agent/src/runtime_snapshot/tests.rs
@@ -43,6 +43,8 @@ fn snapshot(generation: u64, default_behavior_id: &str) -> Arc<ActiveRuntimeSnap
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     })
 }
 

--- a/crates/defra-agent/src/runtime_status.rs
+++ b/crates/defra-agent/src/runtime_status.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::Utc;
-use tokio::sync::Mutex;
+use tokio::sync::{watch, Mutex};
+use tokio::time::MissedTickBehavior;
 
 use crate::agent::ProcessLifecycleState;
 use crate::graphql::escape_graphql_string;
@@ -58,6 +60,9 @@ struct RuntimeStatusRow {
     default_behavior_id: String,
     runnable_behavior_count: i64,
     unavailable_behavior_count: i64,
+    behavior_executor_capacity: i64,
+    behavior_executor_queue_depth: i64,
+    behavior_executor_status_json: String,
     last_reconcile_result: String,
     last_reconcile_error: String,
     last_reconcile_completed_at: String,
@@ -76,6 +81,9 @@ impl RuntimeStatusRow {
             default_behavior_id: String::new(),
             runnable_behavior_count: 0,
             unavailable_behavior_count: 0,
+            behavior_executor_capacity: 0,
+            behavior_executor_queue_depth: 0,
+            behavior_executor_status_json: "{}".to_string(),
             last_reconcile_result: String::new(),
             last_reconcile_error: String::new(),
             last_reconcile_completed_at: String::new(),
@@ -174,7 +182,14 @@ impl RuntimeStatusHandle {
         .await;
     }
 
+    pub(crate) async fn publish_executor_snapshot(&self, snapshot: &ActiveRuntimeSnapshot) {
+        let executor_status = executor_status_fields(snapshot);
+        self.update(|row| apply_executor_status(row, &executor_status))
+            .await;
+    }
+
     async fn publish_snapshot(&self, snapshot: &ActiveRuntimeSnapshot, result: ReconcileResult) {
+        let executor_status = executor_status_fields(snapshot);
         self.update(|row| {
             let mut changed = false;
             let generation = i64::try_from(snapshot.generation).unwrap_or(i64::MAX);
@@ -204,6 +219,9 @@ impl RuntimeStatusHandle {
             }
             if row.unavailable_behavior_count != unavailable_behavior_count {
                 row.unavailable_behavior_count = unavailable_behavior_count;
+                changed = true;
+            }
+            if apply_executor_status(row, &executor_status) {
                 changed = true;
             }
             if row.last_reconcile_result != result.as_str() {
@@ -262,6 +280,9 @@ async fn upsert_runtime_status(
                     default_behavior_id: "{default_behavior_id}",
                     runnable_behavior_count: {runnable_behavior_count},
                     unavailable_behavior_count: {unavailable_behavior_count},
+                    behavior_executor_capacity: {behavior_executor_capacity},
+                    behavior_executor_queue_depth: {behavior_executor_queue_depth},
+                    behavior_executor_status_json: "{behavior_executor_status_json}",
                     last_reconcile_result: "{last_reconcile_result}",
                     last_reconcile_error: "{last_reconcile_error}",
                     last_reconcile_completed_at: "{last_reconcile_completed_at}",
@@ -275,6 +296,9 @@ async fn upsert_runtime_status(
                     default_behavior_id: "{default_behavior_id}",
                     runnable_behavior_count: {runnable_behavior_count},
                     unavailable_behavior_count: {unavailable_behavior_count},
+                    behavior_executor_capacity: {behavior_executor_capacity},
+                    behavior_executor_queue_depth: {behavior_executor_queue_depth},
+                    behavior_executor_status_json: "{behavior_executor_status_json}",
                     last_reconcile_result: "{last_reconcile_result}",
                     last_reconcile_error: "{last_reconcile_error}",
                     last_reconcile_completed_at: "{last_reconcile_completed_at}",
@@ -290,6 +314,9 @@ async fn upsert_runtime_status(
         default_behavior_id = escape_graphql_string(&row.default_behavior_id),
         runnable_behavior_count = row.runnable_behavior_count,
         unavailable_behavior_count = row.unavailable_behavior_count,
+        behavior_executor_capacity = row.behavior_executor_capacity,
+        behavior_executor_queue_depth = row.behavior_executor_queue_depth,
+        behavior_executor_status_json = escape_graphql_string(&row.behavior_executor_status_json),
         last_reconcile_result = escape_graphql_string(&row.last_reconcile_result),
         last_reconcile_error = escape_graphql_string(&row.last_reconcile_error),
         last_reconcile_completed_at = escape_graphql_string(&row.last_reconcile_completed_at),
@@ -300,6 +327,78 @@ async fn upsert_runtime_status(
         anyhow::bail!("upsert AgentRuntime failed: {:?}", response.errors);
     }
     Ok(())
+}
+
+struct ExecutorStatusFields {
+    capacity: i64,
+    queue_depth: i64,
+    status_json: String,
+}
+
+fn executor_status_fields(snapshot: &ActiveRuntimeSnapshot) -> ExecutorStatusFields {
+    let statuses = snapshot.behavior_executor_statuses();
+    let capacity = statuses
+        .values()
+        .map(|status| status.worker_capacity)
+        .sum::<usize>();
+    let queue_depth = statuses
+        .values()
+        .map(|status| status.queue_depth)
+        .sum::<usize>();
+    let status_json = serde_json::to_string(&statuses).unwrap_or_else(|_| "{}".to_string());
+
+    ExecutorStatusFields {
+        capacity: i64::try_from(capacity).unwrap_or(i64::MAX),
+        queue_depth: i64::try_from(queue_depth).unwrap_or(i64::MAX),
+        status_json,
+    }
+}
+
+fn apply_executor_status(row: &mut RuntimeStatusRow, status: &ExecutorStatusFields) -> bool {
+    let mut changed = false;
+    if row.behavior_executor_capacity != status.capacity {
+        row.behavior_executor_capacity = status.capacity;
+        changed = true;
+    }
+    if row.behavior_executor_queue_depth != status.queue_depth {
+        row.behavior_executor_queue_depth = status.queue_depth;
+        changed = true;
+    }
+    if row.behavior_executor_status_json != status.status_json {
+        row.behavior_executor_status_json = status.status_json.clone();
+        changed = true;
+    }
+    changed
+}
+
+pub(crate) async fn run_executor_status_observer(
+    mut active_snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
+    runtime_status: RuntimeStatusHandle,
+    mut shutdown: watch::Receiver<bool>,
+) -> anyhow::Result<()> {
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+    interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        if *shutdown.borrow() {
+            return Ok(());
+        }
+
+        let snapshot = active_snapshot_rx.borrow().clone();
+        runtime_status
+            .publish_executor_snapshot(snapshot.as_ref())
+            .await;
+
+        tokio::select! {
+            _ = shutdown.changed() => return Ok(()),
+            changed = active_snapshot_rx.changed() => {
+                if changed.is_err() {
+                    return Ok(());
+                }
+            }
+            _ = interval.tick() => {}
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/runtime_status/tests.rs
+++ b/crates/defra-agent/src/runtime_status/tests.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use serde::Deserialize;
+use tokio::sync::mpsc;
 
 use super::*;
 use crate::ensure_runtime_schemas;
@@ -21,12 +22,37 @@ struct AgentRuntimeRow {
     default_behavior_id: String,
     runnable_behavior_count: i64,
     unavailable_behavior_count: i64,
+    behavior_executor_capacity: i64,
+    behavior_executor_queue_depth: i64,
+    behavior_executor_status_json: String,
     last_reconcile_result: String,
     last_reconcile_error: String,
 }
 
 async fn test_node() -> Arc<defra_node::EmbeddedNode> {
     Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap())
+}
+
+fn status_test_request(request_id: &str) -> crate::watcher::AgentRequest {
+    crate::watcher::AgentRequest {
+        doc_id: format!("{request_id}-doc"),
+        request_id: request_id.to_string(),
+        agent_did: "did:defra-agent:status-test".to_string(),
+        behavior_id: Some("general".to_string()),
+        session_id: format!("{request_id}-session"),
+        content: "status test".to_string(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
+        execution_origin: Some("interactive".to_string()),
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        deadline: None,
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
+    }
 }
 
 async fn fetch_runtime_row(node: &defra_node::EmbeddedNode, agent_did: &str) -> AgentRuntimeRow {
@@ -41,6 +67,9 @@ async fn fetch_runtime_row(node: &defra_node::EmbeddedNode, agent_did: &str) -> 
                 default_behavior_id
                 runnable_behavior_count
                 unavailable_behavior_count
+                behavior_executor_capacity
+                behavior_executor_queue_depth
+                behavior_executor_status_json
                 last_reconcile_result
                 last_reconcile_error
             }}
@@ -282,6 +311,8 @@ async fn runtime_status_persists_process_and_reconcile_state() {
             unavailable_event_triggers: HashSet::new(),
             active_tasks: HashMap::new(),
             dispatchers: HashMap::new(),
+            behavior_executor_capacities: HashMap::new(),
+            behavior_executor_queue_capacities: HashMap::new(),
         })
         .await;
     status.publish_router_generation(1).await;
@@ -297,6 +328,56 @@ async fn runtime_status_persists_process_and_reconcile_state() {
     assert_eq!(row.unavailable_behavior_count, 1);
     assert_eq!(row.last_reconcile_result, "startup");
     assert!(row.last_reconcile_error.is_empty());
+}
+
+#[tokio::test]
+async fn runtime_status_persists_behavior_executor_capacity_and_queue_depth() {
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+
+    let (tx, _rx) = mpsc::channel(4);
+    tx.try_send(status_test_request("queued-1")).unwrap();
+    tx.try_send(status_test_request("queued-2")).unwrap();
+
+    let status = RuntimeStatusHandle::new(node.clone(), "did:defra-agent:executor-status");
+    status
+        .publish_startup_snapshot(&ActiveRuntimeSnapshot {
+            generation: 1,
+            principal: None,
+            local_did: String::new(),
+            paired_peer_dids: HashSet::new(),
+            default_behavior_id: "general".to_string(),
+            behaviors: HashMap::new(),
+            tool_surfaces: HashMap::new(),
+            backend_admission_configs: HashMap::new(),
+            unavailable_behaviors: HashMap::new(),
+            active_schedules: HashMap::new(),
+            unavailable_schedules: HashSet::new(),
+            active_event_triggers: HashMap::new(),
+            unavailable_event_triggers: HashSet::new(),
+            active_tasks: HashMap::new(),
+            dispatchers: HashMap::from([("general".to_string(), tx)]),
+            behavior_executor_capacities: HashMap::from([("general".to_string(), 3)]),
+            behavior_executor_queue_capacities: HashMap::from([("general".to_string(), 4)]),
+        })
+        .await;
+
+    let row = fetch_runtime_row(node.as_ref(), "did:defra-agent:executor-status").await;
+    assert_eq!(row.behavior_executor_capacity, 3);
+    assert_eq!(row.behavior_executor_queue_depth, 2);
+
+    let executor_status: serde_json::Value =
+        serde_json::from_str(&row.behavior_executor_status_json).unwrap();
+    assert_eq!(
+        executor_status,
+        serde_json::json!({
+            "general": {
+                "worker_capacity": 3,
+                "queue_depth": 2,
+                "queue_capacity": 4
+            }
+        })
+    );
 }
 
 #[tokio::test]
@@ -321,6 +402,8 @@ async fn runtime_status_serializes_persisted_generation_updates() {
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     };
     let applied = ActiveRuntimeSnapshot {
         generation: 2,
@@ -338,6 +421,8 @@ async fn runtime_status_serializes_persisted_generation_updates() {
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     };
 
     status.publish_startup_snapshot(&startup).await;
@@ -385,6 +470,8 @@ async fn runtime_status_generation_updates_match_lean_runtime_reconcile_cases() 
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     };
     let applied = ActiveRuntimeSnapshot {
         generation: publish.post_active_generation as u64,
@@ -402,6 +489,8 @@ async fn runtime_status_generation_updates_match_lean_runtime_reconcile_cases() 
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     };
 
     status.publish_startup_snapshot(&startup).await;

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -420,6 +420,8 @@ mod tests {
             unavailable_event_triggers: HashSet::new(),
             active_tasks: HashMap::new(),
             dispatchers: HashMap::new(),
+            behavior_executor_capacities: HashMap::new(),
+            behavior_executor_queue_capacities: HashMap::new(),
         })
     }
 

--- a/crates/defra-agent/tests/event_source_subscription_factory_smoke.rs
+++ b/crates/defra-agent/tests/event_source_subscription_factory_smoke.rs
@@ -32,6 +32,8 @@ async fn integration_can_construct_event_source_and_mock_delivers_updates() {
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     });
     let (_snapshot_tx, snapshot_rx) = watch::channel(snapshot);
 

--- a/crates/defra-agent/tests/state_machine_conformance/event_delivery.rs
+++ b/crates/defra-agent/tests/state_machine_conformance/event_delivery.rs
@@ -768,6 +768,8 @@ fn active_snapshot(
         unavailable_event_triggers: HashSet::new(),
         active_tasks,
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     })
 }
 

--- a/crates/defra-agent/tests/support/fixtures.rs
+++ b/crates/defra-agent/tests/support/fixtures.rs
@@ -94,6 +94,8 @@ pub fn spawn_subagent_source_with_paired_peers(
         unavailable_event_triggers: HashSet::new(),
         active_tasks: HashMap::new(),
         dispatchers: HashMap::new(),
+        behavior_executor_capacities: HashMap::new(),
+        behavior_executor_queue_capacities: HashMap::new(),
     };
     let (snapshot_tx, snapshot_rx) = watch::channel(Arc::new(snapshot));
     let cancel = CancellationToken::new();


### PR DESCRIPTION
## Summary
- Fan out each behavior slot into a worker pool sized from available backend admission `max_concurrent`, while keeping backend admission as the inference contention gate.
- Rotate slots when backend executor capacity changes and expose aggregate/per-behavior executor capacity and queue depth in `AgentRuntime` status and CLI output.
- Add deterministic coverage for same-behavior background child fan-out, same-session ordering, executor status persistence, and migration field kinds.

## Verification
- `cargo test -p defra-agent --lib -- --nocapture`
- `cargo check -p defra-agent-cli`
- Sparks live smoke: not run; no Sparks-specific config/env was present in this workspace. Only `OPENAI_API_KEY` was set.

Fixes #414