### PR TITLE
Bound foreground tool results before rig reuses them

### DIFF
--- a/crates/defra-agent/src/hook/persistence/helpers.rs
+++ b/crates/defra-agent/src/hook/persistence/helpers.rs
@@ -195,10 +195,7 @@ pub(super) async fn load_stored_tool_call_result(
 }
 
 pub(super) fn truncation_mode_for(tool_name: &str) -> TruncationMode {
-    match tool_name {
-        "bash" | "shell" | "command" => TruncationMode::Tail,
-        _ => TruncationMode::Head,
-    }
+    crate::truncation::tool_result_truncation_mode(tool_name)
 }
 
 pub(super) fn bounded_tool_result_for_model(

--- a/crates/defra-agent/src/hook/persistence/prompt_hook.rs
+++ b/crates/defra-agent/src/hook/persistence/prompt_hook.rs
@@ -267,6 +267,12 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                 None,
                 tool_call_id.as_deref(),
             );
+            crate::tool_call_lifecycle::runtime::register_pending_tool_result(
+                tool_name,
+                args,
+                internal_call_id,
+            )
+            .await;
 
             let mut lc = crate::tool_call_lifecycle::ToolCallLifecycle::new(
                 self.node.clone(),
@@ -366,11 +372,18 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
 
             let truncator =
                 DefraSpillTruncator::new(self.node.clone(), &self.agent_did, &session_id);
+            let recorded =
+                crate::tool_call_lifecycle::runtime::take_recorded_tool_result(internal_call_id)
+                    .await;
+            let result_for_persistence = recorded
+                .as_ref()
+                .map(|record| record.full_result.as_str())
+                .unwrap_or(result);
             let truncated = truncator
                 .truncate(
                     tool_name,
                     args,
-                    result,
+                    result_for_persistence,
                     truncation_mode_for(tool_name),
                     &self.truncation_limits,
                     None,
@@ -388,7 +401,7 @@ impl<M: CompletionModel> PromptHook<M> for DefraSessionHook {
                     )
                 })?;
 
-            if let Some(failure) = classify_runtime_failure(result) {
+            if let Some(failure) = classify_runtime_failure(result_for_persistence) {
                 if let Some(denial) = failure.command_denial.as_ref() {
                     lc.fail_with_command_denial(&truncated.text, denial).await?;
                 } else {

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -11,6 +11,8 @@ use rig::completion::{
 };
 use rig::one_or_many::OneOrMany;
 use rig::streaming::StreamingCompletionResponse;
+use rig::tool::{ToolDyn, ToolError};
+use rig::wasm_compat::WasmBoxedFuture;
 use serde_json::json;
 
 use super::*;
@@ -48,6 +50,40 @@ impl CompletionModel for TestModel {
         Err(CompletionError::ProviderError(
             "streaming is unused in hook tests".to_string(),
         ))
+    }
+}
+
+struct OversizedHookTool {
+    output: String,
+}
+
+impl OversizedHookTool {
+    fn new(output: String) -> Self {
+        Self { output }
+    }
+}
+
+impl ToolDyn for OversizedHookTool {
+    fn name(&self) -> String {
+        "oversized".to_string()
+    }
+
+    fn definition<'a>(
+        &'a self,
+        _prompt: String,
+    ) -> WasmBoxedFuture<'a, rig::completion::ToolDefinition> {
+        Box::pin(async {
+            rig::completion::ToolDefinition {
+                name: "oversized".to_string(),
+                description: "test tool".to_string(),
+                parameters: json!({"type":"object"}),
+            }
+        })
+    }
+
+    fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+        let output = self.output.clone();
+        Box::pin(async move { Ok(output) })
     }
 }
 
@@ -450,6 +486,44 @@ async fn fetch_tool_call_row(
         .expect("tool call row")
 }
 
+async fn fetch_tool_result_spill_row(
+    node: &defra_node::EmbeddedNode,
+    session_id: &str,
+    tool_name: &str,
+) -> serde_json::Value {
+    let session_id = crate::graphql::escape_graphql_string(session_id);
+    let tool_name = crate::graphql::escape_graphql_string(tool_name);
+    let resp = node
+        .execute(&format!(
+            r#"{{
+                AgentToolResult(
+                    filter: {{
+                        session_id: {{ _eq: "{session_id}" }},
+                        tool_name: {{ _eq: "{tool_name}" }}
+                    }},
+                    limit: 1
+                ) {{
+                    output_text
+                    truncated
+                    truncation_metadata
+                }}
+            }}"#
+        ))
+        .await;
+    assert!(
+        !resp.has_errors(),
+        "query spilled tool result failed: {:?}",
+        resp.errors
+    );
+    resp.data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolResult"))
+        .and_then(|value| value.as_array())
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("spilled tool result row")
+}
+
 #[tokio::test]
 async fn hook_attaches_active_request_deadline_to_tool_call_lifecycle() {
     let data_path =
@@ -562,6 +636,127 @@ async fn hook_maps_managed_timeout_result_to_timed_out_lifecycle() {
         .get("result")
         .and_then(|value| value.as_str())
         .is_some_and(|result| result.contains("deadline exceeded")));
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+#[tokio::test]
+async fn hook_spills_recorded_full_tool_output_after_bounded_runtime_result() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-full-spill-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        PromptHook::<TestModel>::on_completion_call(
+            &hook,
+            &user_text_message("Run an oversized tool"),
+            &[],
+        )
+        .await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+    hook.set_active_request_id(Some("req-oversized".to_string()))
+        .await;
+
+    let full_output = (0..2101)
+        .map(|index| format!("line-{index}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tool_args = "{}";
+    let tool = crate::tool_call_lifecycle::runtime::wrap_tool(Box::new(OversizedHookTool::new(
+        full_output.clone(),
+    )));
+
+    let bounded_result = crate::tool_call_lifecycle::runtime::scope_request_tool_execution(
+        None,
+        tokio_util::sync::CancellationToken::new(),
+        async {
+            assert!(matches!(
+                PromptHook::<TestModel>::on_tool_call(
+                    &hook,
+                    "oversized",
+                    None,
+                    "internal-oversized",
+                    tool_args,
+                )
+                .await,
+                ToolCallHookAction::Continue
+            ));
+
+            let bounded_result = tool
+                .call(tool_args.to_string())
+                .await
+                .expect("oversized tool should complete");
+            assert!(bounded_result.contains("[Showing lines 1-2000 of 2101"));
+            assert!(!bounded_result.contains("line-2100"));
+            assert!(!bounded_result.contains("[Full output: DefraDB doc"));
+
+            assert!(matches!(
+                PromptHook::<TestModel>::on_tool_result(
+                    &hook,
+                    "oversized",
+                    None,
+                    "internal-oversized",
+                    tool_args,
+                    &bounded_result,
+                )
+                .await,
+                HookAction::Continue
+            ));
+            bounded_result
+        },
+    )
+    .await;
+
+    let tool_call = fetch_tool_call_row(&node, &session_id, "internal-oversized").await;
+    let persisted_result = tool_call
+        .get("result")
+        .and_then(|value| value.as_str())
+        .expect("persisted tool call result");
+    assert!(persisted_result.contains("[Showing lines 1-2000 of 2101"));
+    assert!(persisted_result.contains("[Full output: DefraDB doc"));
+    assert!(!persisted_result.contains("line-2100"));
+    assert_ne!(
+        persisted_result, bounded_result,
+        "hook persistence should append the spill pointer after seeing the full result"
+    );
+
+    let spill = fetch_tool_result_spill_row(&node, &session_id, "oversized").await;
+    assert_eq!(
+        spill.get("truncated").and_then(|value| value.as_bool()),
+        Some(true)
+    );
+    assert_eq!(
+        spill.get("output_text").and_then(|value| value.as_str()),
+        Some(full_output.as_str())
+    );
+    let metadata: serde_json::Value = serde_json::from_str(
+        spill
+            .get("truncation_metadata")
+            .and_then(|value| value.as_str())
+            .expect("truncation metadata"),
+    )
+    .expect("metadata json");
+    assert_eq!(
+        metadata
+            .get("original_lines")
+            .and_then(|value| value.as_u64()),
+        Some(2101)
+    );
 
     let _ = std::fs::remove_dir_all(&data_path);
 }

--- a/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/runtime.rs
@@ -6,15 +6,20 @@
 //! deadline/cancellation outcomes become explicit tool results that the hook
 //! can map to `timedOut` / `cancelled` terminal states.
 
+use std::collections::{HashMap, VecDeque};
 use std::future::Future;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use rig::completion::ToolDefinition;
 use rig::tool::{ToolDyn, ToolError};
 use rig::wasm_compat::WasmBoxedFuture;
+use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
+
+use crate::truncation::{tool_result_truncation_mode, truncate_text, TruncationLimits};
 
 const MARKER_PREFIX: &str = "__defra_agent_tool_lifecycle__:";
 const TIMEOUT_MARKER: &str = "__defra_agent_tool_lifecycle__:timedOut";
@@ -31,6 +36,7 @@ struct ToolRuntimeScope {
     deadline_at: Option<DateTime<Utc>>,
     cancellation_token: CancellationToken,
     workspace_cwd: Option<PathBuf>,
+    tool_results: ToolResultRecorder,
 }
 
 #[derive(Clone)]
@@ -38,6 +44,71 @@ pub(crate) struct CurrentToolRuntimeContext {
     pub(crate) deadline_at: Option<DateTime<Utc>>,
     pub(crate) cancellation_token: CancellationToken,
     pub(crate) workspace_cwd: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RecordedToolResult {
+    pub(crate) full_result: String,
+    pub(crate) bounded_result: String,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+struct ToolCallKey {
+    tool_name: String,
+    args: String,
+}
+
+#[derive(Debug, Default)]
+struct ToolResultRecorderInner {
+    pending: HashMap<ToolCallKey, VecDeque<String>>,
+    recorded: HashMap<String, RecordedToolResult>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ToolResultRecorder {
+    inner: Arc<Mutex<ToolResultRecorderInner>>,
+}
+
+impl ToolResultRecorder {
+    async fn register(&self, tool_name: &str, args: &str, internal_call_id: &str) {
+        let mut inner = self.inner.lock().await;
+        inner
+            .pending
+            .entry(ToolCallKey {
+                tool_name: tool_name.to_string(),
+                args: args.to_string(),
+            })
+            .or_default()
+            .push_back(internal_call_id.to_string());
+    }
+
+    async fn claim(&self, tool_name: &str, args: &str) -> Option<String> {
+        let key = ToolCallKey {
+            tool_name: tool_name.to_string(),
+            args: args.to_string(),
+        };
+        let mut inner = self.inner.lock().await;
+        let pending = inner.pending.get_mut(&key)?;
+        let internal_call_id = pending.pop_front();
+        if pending.is_empty() {
+            inner.pending.remove(&key);
+        }
+        internal_call_id
+    }
+
+    async fn record(&self, internal_call_id: String, full_result: String, bounded_result: String) {
+        self.inner.lock().await.recorded.insert(
+            internal_call_id,
+            RecordedToolResult {
+                full_result,
+                bounded_result,
+            },
+        );
+    }
+
+    async fn take(&self, internal_call_id: &str) -> Option<RecordedToolResult> {
+        self.inner.lock().await.recorded.remove(internal_call_id)
+    }
 }
 
 tokio::task_local! {
@@ -78,6 +149,7 @@ where
                 deadline_at,
                 cancellation_token,
                 workspace_cwd,
+                tool_results: ToolResultRecorder::default(),
             },
             future,
         )
@@ -97,6 +169,28 @@ pub(crate) fn current_tool_runtime_context() -> Option<CurrentToolRuntimeContext
             cancellation_token: scope.cancellation_token,
             workspace_cwd: scope.workspace_cwd,
         })
+}
+
+pub(crate) async fn register_pending_tool_result(
+    tool_name: &str,
+    args: &str,
+    internal_call_id: &str,
+) {
+    if let Some(recorder) = TOOL_RUNTIME_SCOPE
+        .try_with(|scope| scope.tool_results.clone())
+        .ok()
+    {
+        recorder.register(tool_name, args, internal_call_id).await;
+    }
+}
+
+pub(crate) async fn take_recorded_tool_result(
+    internal_call_id: &str,
+) -> Option<RecordedToolResult> {
+    let recorder = TOOL_RUNTIME_SCOPE
+        .try_with(|scope| scope.tool_results.clone())
+        .ok()?;
+    recorder.take(internal_call_id).await
 }
 
 pub(crate) fn classify_managed_tool_result(result: &str) -> Option<ManagedToolTerminal> {
@@ -138,9 +232,12 @@ impl ToolDyn for RuntimeManagedTool {
 
     fn call<'a>(&'a self, args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
         Box::pin(async move {
+            let tool_name = self.inner.name();
+            let call_args = args.clone();
             let Some(scope) = TOOL_RUNTIME_SCOPE.try_with(Clone::clone).ok() else {
                 return self.inner.call(args).await;
             };
+            let result_slot = scope.tool_results.claim(&tool_name, &call_args).await;
 
             if deadline_remaining(scope.deadline_at).is_some_and(|remaining| remaining.is_zero()) {
                 return Ok(timeout_result(scope.deadline_at));
@@ -162,11 +259,65 @@ impl ToolDyn for RuntimeManagedTool {
                     Ok(timeout_result(scope.deadline_at))
                 }
                 result = self.inner.call(args) => {
-                    result
+                    let Some(internal_call_id) = result_slot else {
+                        return result;
+                    };
+                    match result {
+                        Ok(output) => Ok(bound_output_for_registered_call(
+                            &scope,
+                            internal_call_id,
+                            &tool_name,
+                            output,
+                        )
+                        .await),
+                        Err(error) => {
+                            let output = error.to_string();
+                            tracing::warn!(
+                                tool_name = %tool_name,
+                                tool_call_id = %internal_call_id,
+                                error = %output,
+                                "tool execution returned an error; returning bounded error text to rig"
+                            );
+                            Ok(bound_output_for_registered_call(
+                                &scope,
+                                internal_call_id,
+                                &tool_name,
+                                output,
+                            )
+                            .await)
+                        }
+                    }
                 }
             }
         })
     }
+}
+
+async fn bound_output_for_registered_call(
+    scope: &ToolRuntimeScope,
+    internal_call_id: String,
+    tool_name: &str,
+    output: String,
+) -> String {
+    let limits = TruncationLimits::default();
+    let (bounded, trigger, truncated) =
+        truncate_text(&output, tool_result_truncation_mode(tool_name), &limits);
+    if truncated {
+        tracing::warn!(
+            tool_name = %tool_name,
+            tool_call_id = %internal_call_id,
+            truncated_by = ?trigger,
+            original_bytes = output.len(),
+            max_lines = limits.max_lines,
+            max_bytes = limits.max_bytes,
+            "bounded tool result before returning it to rig"
+        );
+        scope
+            .tool_results
+            .record(internal_call_id, output, bounded.clone())
+            .await;
+    }
+    bounded
 }
 
 fn deadline_remaining(deadline_at: Option<DateTime<Utc>>) -> Option<Duration> {
@@ -224,6 +375,37 @@ mod tests {
 
         fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
             Box::pin(async { Ok("ok".to_string()) })
+        }
+    }
+
+    struct LargeTool {
+        output: String,
+    }
+
+    impl LargeTool {
+        fn new(output: String) -> Self {
+            Self { output }
+        }
+    }
+
+    impl ToolDyn for LargeTool {
+        fn name(&self) -> String {
+            "large".to_string()
+        }
+
+        fn definition<'a>(&'a self, _prompt: String) -> WasmBoxedFuture<'a, ToolDefinition> {
+            Box::pin(async {
+                ToolDefinition {
+                    name: "large".to_string(),
+                    description: "test tool".to_string(),
+                    parameters: serde_json::json!({"type":"object"}),
+                }
+            })
+        }
+
+        fn call<'a>(&'a self, _args: String) -> WasmBoxedFuture<'a, Result<String, ToolError>> {
+            let output = self.output.clone();
+            Box::pin(async move { Ok(output) })
         }
     }
 
@@ -290,5 +472,33 @@ mod tests {
 
         assert_eq!(result, "ok");
         assert_eq!(classify_managed_tool_result(&result), None);
+    }
+
+    #[tokio::test]
+    async fn wrapped_tool_bounds_registered_result_and_records_full_output() {
+        let full_output = (0..2101)
+            .map(|index| format!("line-{index}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tool = wrap_tool(Box::new(LargeTool::new(full_output.clone())));
+
+        scope_request_tool_execution(None, CancellationToken::new(), async {
+            register_pending_tool_result("large", "{}", "internal-large").await;
+
+            let result = tool
+                .call("{}".to_string())
+                .await
+                .expect("large tool should complete");
+
+            assert!(result.contains("[Showing lines 1-2000 of 2101"));
+            assert!(!result.contains("line-2100"));
+
+            let recorded = take_recorded_tool_result("internal-large")
+                .await
+                .expect("full output should be retained for persistence");
+            assert_eq!(recorded.full_result, full_output);
+            assert_eq!(recorded.bounded_result, result);
+        })
+        .await;
     }
 }

--- a/crates/defra-agent/src/truncation.rs
+++ b/crates/defra-agent/src/truncation.rs
@@ -16,6 +16,13 @@ pub enum TruncationMode {
     Tail,
 }
 
+pub(crate) fn tool_result_truncation_mode(tool_name: &str) -> TruncationMode {
+    match tool_name {
+        "bash" | "shell" | "command" => TruncationMode::Tail,
+        _ => TruncationMode::Head,
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct TruncationResult {
     pub text: String,


### PR DESCRIPTION
## Summary

- bound registered foreground tool results before rig appends them to the same-request working messages
- keep the full unbounded tool output in the request runtime scope for hook persistence
- make `on_tool_result` spill/classify the full recorded output while persisting the bounded model-facing result
- share the tool-result truncation mode between the hook and runtime wrapper
- add runtime and hook regressions for oversized tool output

## Why

Fixes #401.

The persistence hook already truncates and spills oversized tool results, but rig receives the raw tool output first and can reuse it inside the same request's tool loop. This closes that in-loop context bypass without changing persisted terminal semantics.

## Notes

This only applies when the hook registers a foreground tool call in the active request runtime scope. Background or otherwise unregistered tool executions keep their existing behavior.

The full result remains available to the hook so `AgentToolResult` spill rows still archive the original oversized output.

## Tests

- `cargo test -p defra-agent --lib tool_call_lifecycle::runtime`
- `cargo test -p defra-agent --lib hook::tests`
- `cargo fmt --check`
- `git diff --check`