### PR TITLE
Add backend model discovery tracing

### DIFF
--- a/crates/defra-agent/src/backend_provider.rs
+++ b/crates/defra-agent/src/backend_provider.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use tracing::Instrument;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum BackendProviderKind {
@@ -102,62 +103,109 @@ pub async fn discover_models(
     };
     let models_url = format!("{}{}", endpoint, MODEL_DISCOVERY_PATH);
     let provider_name = provider_display_name(kind);
-    let mut request = client.get(&models_url);
-    if kind == BackendProviderKind::ChatGptCodex {
-        let (_codex_home, auth) = crate::chatgpt_codex::load_default_chatgpt_auth().await?;
-        let access_token = auth
-            .get_token()
-            .context("ChatGPT Codex auth did not expose a bearer token")?;
-        request = request.bearer_auth(access_token);
-        for (name, value) in crate::chatgpt_codex::build_chatgpt_codex_headers(&auth)? {
-            if let Some(name) = name {
-                request = request.header(name, value);
+    async {
+        let mut request = client.get(&models_url);
+        if kind == BackendProviderKind::ChatGptCodex {
+            let (_codex_home, auth) = match crate::chatgpt_codex::load_default_chatgpt_auth().await
+            {
+                Ok(auth) => auth,
+                Err(error) => {
+                    tracing::Span::current().record("failure_class", "auth");
+                    return Err(error);
+                }
+            };
+            let access_token = match auth.get_token() {
+                Ok(token) => token,
+                Err(error) => {
+                    tracing::Span::current().record("failure_class", "auth");
+                    return Err(error).context("ChatGPT Codex auth did not expose a bearer token");
+                }
+            };
+            request = request.bearer_auth(access_token);
+            let headers = match crate::chatgpt_codex::build_chatgpt_codex_headers(&auth) {
+                Ok(headers) => headers,
+                Err(error) => {
+                    tracing::Span::current().record("failure_class", "auth");
+                    return Err(error);
+                }
+            };
+            for (name, value) in headers {
+                if let Some(name) = name {
+                    request = request.header(name, value);
+                }
             }
+            request = request.query(&[("client_version", env!("CARGO_PKG_VERSION"))]);
+        } else if let Some(api_key) = api_key {
+            request = request.bearer_auth(api_key);
         }
-        request = request.query(&[("client_version", env!("CARGO_PKG_VERSION"))]);
-    } else if let Some(api_key) = api_key {
-        request = request.bearer_auth(api_key);
-    }
-    for (name, value) in crate::runtime_trace::current_trace_context_headers() {
-        let Ok(name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) else {
-            continue;
+        for (name, value) in crate::runtime_trace::current_trace_context_headers() {
+            let Ok(name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) else {
+                continue;
+            };
+            let Ok(value) = reqwest::header::HeaderValue::from_str(&value) else {
+                continue;
+            };
+            request = request.header(name, value);
+        }
+        let response = match request.send().await {
+            Ok(response) => response,
+            Err(error) => {
+                tracing::Span::current().record("failure_class", "transport");
+                return Err(error).with_context(|| {
+                    format!("querying {provider_name} models endpoint {models_url}")
+                });
+            }
         };
-        let Ok(value) = reqwest::header::HeaderValue::from_str(&value) else {
-            continue;
+        let status = response.status();
+        tracing::Span::current().record("http_status", status.as_u16() as i64);
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<unreadable body>".to_string());
+        if !status.is_success() {
+            tracing::Span::current().record("failure_class", "http_status");
+            anyhow::bail!(
+                "{} model discovery failed at {}: {} {}",
+                provider_name,
+                models_url,
+                status,
+                truncate_probe_body(&body)
+            );
+        }
+
+        let models: OpenAiModelsResponse = match serde_json::from_str(&body) {
+            Ok(models) => models,
+            Err(error) => {
+                tracing::Span::current().record("failure_class", "decode");
+                return Err(error).with_context(|| {
+                    format!(
+                        "decoding {} model discovery response from {}: {}",
+                        provider_name,
+                        models_url,
+                        truncate_probe_body(&body)
+                    )
+                });
+            }
         };
-        request = request.header(name, value);
-    }
-    let response = request
-        .send()
-        .await
-        .with_context(|| format!("querying {} models endpoint {}", provider_name, models_url))?;
-    let status = response.status();
-    let body = response
-        .text()
-        .await
-        .unwrap_or_else(|_| "<unreadable body>".to_string());
-    if !status.is_success() {
-        anyhow::bail!(
-            "{} model discovery failed at {}: {} {}",
-            provider_name,
-            models_url,
-            status,
-            truncate_probe_body(&body)
-        );
-    }
 
-    let models: OpenAiModelsResponse = serde_json::from_str(&body).with_context(|| {
-        format!(
-            "decoding {} model discovery response from {}: {}",
-            provider_name,
-            models_url,
-            truncate_probe_body(&body)
-        )
-    })?;
-
-    let openai_models = models.data.into_iter().map(|model| model.id);
-    let chatgpt_codex_models = models.models.into_iter().map(|model| model.slug);
-    Ok(openai_models.chain(chatgpt_codex_models).collect())
+        let openai_models = models.data.into_iter().map(|model| model.id);
+        let chatgpt_codex_models = models.models.into_iter().map(|model| model.slug);
+        let models = openai_models
+            .chain(chatgpt_codex_models)
+            .collect::<Vec<_>>();
+        tracing::Span::current().record("model_count", models.len() as i64);
+        Ok(models)
+    }
+    .instrument(tracing::info_span!(
+        "backend.model_discovery",
+        provider_kind = %kind,
+        endpoint = %endpoint,
+        has_api_key = api_key.is_some(),
+        http_status = tracing::field::Empty,
+        model_count = tracing::field::Empty,
+        failure_class = tracing::field::Empty,
+    ))
+    .await
 }
 
 pub fn truncate_probe_body(body: &str) -> String {
@@ -166,4 +214,113 @@ pub fn truncate_probe_body(body: &str) -> String {
         return body.to_string();
     }
     format!("{}...", &body[..LIMIT])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::{TcpListener, TcpStream};
+
+    #[tokio::test]
+    async fn discover_models_reads_openai_models_and_sends_api_key() {
+        let (endpoint, requests) =
+            spawn_model_discovery_server(r#"{"data":[{"id":"gpt-4.1-mini"},{"id":"o3"}]}"#).await;
+
+        let models = discover_models(
+            &Client::new(),
+            BackendProviderKind::OpenAiCompatible,
+            &format!("{endpoint}/v1/"),
+            Some("sk-test"),
+        )
+        .await
+        .expect("model discovery should succeed");
+
+        assert_eq!(models, vec!["gpt-4.1-mini", "o3"]);
+        let requests = requests.lock().expect("requests lock");
+        let request = requests.first().expect("captured request");
+        assert!(
+            request.starts_with("GET /v1/models "),
+            "unexpected request: {request}"
+        );
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer sk-test"),
+            "authorization header missing from {request}"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_models_decodes_chatgpt_codex_models_shape() {
+        let (endpoint, _requests) =
+            spawn_model_discovery_server(r#"{"models":[{"slug":"codex-mini-latest"}]}"#).await;
+
+        let models = discover_models(
+            &Client::new(),
+            BackendProviderKind::OpenAiCompatible,
+            &endpoint,
+            None,
+        )
+        .await
+        .expect("model discovery should accept the Codex-compatible models shape");
+
+        assert_eq!(models, vec!["codex-mini-latest"]);
+    }
+
+    async fn spawn_model_discovery_server(body: &'static str) -> (String, Arc<Mutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock model-discovery server");
+        let addr = listener
+            .local_addr()
+            .expect("mock model-discovery server address");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captures = Arc::clone(&requests);
+
+        tokio::spawn(async move {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let Ok(request) = read_http_request(&mut stream).await else {
+                return;
+            };
+            captures
+                .lock()
+                .expect("requests lock")
+                .push(request.to_string());
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        });
+
+        (format!("http://{addr}"), requests)
+    }
+
+    async fn read_http_request(stream: &mut TcpStream) -> std::io::Result<String> {
+        let mut buf = Vec::new();
+        let mut chunk = [0u8; 1024];
+        loop {
+            let n = stream.read(&mut chunk).await?;
+            if n == 0 {
+                return Err(std::io::ErrorKind::UnexpectedEof.into());
+            }
+            buf.extend_from_slice(&chunk[..n]);
+            if find_bytes(&buf, b"\r\n\r\n").is_some() {
+                break;
+            }
+        }
+        Ok(String::from_utf8_lossy(&buf).to_string())
+    }
+
+    fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
 }


### PR DESCRIPTION
## Summary

Refs #22.

Adds a focused backend observability slice for outbound model discovery calls. The runtime already propagates trace context through this path; this PR wraps the call in an explicit span with safe operational attributes.

## Changes

- Add `backend.model_discovery` span around `/models` discovery requests.
- Record payload-free fields:
  - `provider_kind`
  - `endpoint`
  - `has_api_key`
  - `http_status`
  - `model_count`
  - `failure_class`
- Classify discovery failures as:
  - `auth`
  - `transport`
  - `http_status`
  - `decode`
- Preserve existing trace-context propagation headers.
- Add local HTTP tests covering:
  - OpenAI-compatible `/models` URL construction
  - bearer auth forwarding
  - `data[].id` model parsing
  - alternate `models[].slug` response parsing

## Notes

This does not log model response bodies, prompts, tool payloads, or API key values. Existing error messages continue to use the current truncated probe body helper.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p defra-agent --lib backend_provider`
- `cargo test -p defra-agent --lib backend_registry`

The test run still reports existing unrelated unused-import warnings in `toolset/tests.rs`.