### PR TITLE
Record session load counts on request spans

### DIFF
--- a/crates/defra-agent/src/agent/daemon/request.rs
+++ b/crates/defra-agent/src/agent/daemon/request.rs
@@ -55,6 +55,7 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                         request_id = %request.request_id,
                         session_id = %request.session_id,
                         behavior_id = %behavior_name,
+                        history_message_count = tracing::field::Empty,
                     ))
                     .await?;
                 let (stripped_history, file_activity) =
@@ -72,12 +73,14 @@ impl<M: rig::completion::CompletionModel + 'static> BehaviorDaemon<M> {
                 let compaction_entries =
                     session::load_compaction_entries(&self.node, &request.session_id)
                         .instrument(tracing::info_span!(
-                            "request.load_compaction_entries",
-                            request_id = %request.request_id,
-                            session_id = %request.session_id,
-                            behavior_id = %behavior_name,
-                        ))
-                        .await?;
+                        "request.load_compaction_entries",
+                        request_id = %request.request_id,
+                        session_id = %request.session_id,
+                        behavior_id = %behavior_name,
+                        compaction_entry_count = tracing::field::Empty,
+                        compacted_message_count = tracing::field::Empty,
+                    ))
+                    .await?;
                 let mut history = drop_compacted_prefix(
                     stripped_history,
                     total_compacted_messages(&compaction_entries),

--- a/crates/defra-agent/src/session/compaction_entries.rs
+++ b/crates/defra-agent/src/session/compaction_entries.rs
@@ -44,7 +44,17 @@ pub async fn load_compaction_entries(
         None => Vec::new(),
     };
 
-    rows.into_iter().map(CompactionEntry::try_from).collect()
+    let entries = rows
+        .into_iter()
+        .map(CompactionEntry::try_from)
+        .collect::<Result<Vec<_>>>()?;
+    let compacted_message_count = entries
+        .iter()
+        .map(|entry| entry.messages_compacted as i64)
+        .sum::<i64>();
+    tracing::Span::current().record("compaction_entry_count", entries.len() as i64);
+    tracing::Span::current().record("compacted_message_count", compacted_message_count);
+    Ok(entries)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/defra-agent/src/session/history.rs
+++ b/crates/defra-agent/src/session/history.rs
@@ -42,6 +42,7 @@ pub async fn load_history(node: &EmbeddedNode, session_id: &str) -> Result<Vec<M
         ));
     }
 
+    tracing::Span::current().record("history_message_count", history.len() as i64);
     tracing::debug!(session_id = %session_id, count = history.len(), "loaded history");
     Ok(history)
 }


### PR DESCRIPTION
## Summary

Adds result-count attributes to the existing request preparation spans for session history and compaction loading.

This makes OTLP request traces more useful during debugging without adding prompt, message, summary, or tool payload content to telemetry.

New span attributes:

- history_message_count on request.load_history
- compaction_entry_count on request.load_compaction_entries
- compacted_message_count on request.load_compaction_entries

Refs #22.

## Testing

- cargo test -p defra-agent session::tests
- cargo test -p defra-agent runtime_trace::tests
- cargo fmt --check
- git diff --check