### PR TITLE
Bound background subagent child liveness before bridge projection

### DIFF
--- a/crates/defra-agent/src/background_completion.rs
+++ b/crates/defra-agent/src/background_completion.rs
@@ -514,7 +514,30 @@ pub async fn project_background_subagent_completion(
     child_request_id: &str,
     local_did: &str,
 ) -> Result<BackgroundCompletionOutcome> {
-    let Some(linkage) = load_child_linkage(node.as_ref(), child_request_id).await? else {
+    project_background_subagent_completion_inner(
+        node.as_ref(),
+        Some(node.clone()),
+        child_request_id,
+        local_did,
+    )
+    .await
+}
+
+pub(crate) async fn ensure_background_subagent_completion_side_effects(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    local_did: &str,
+) -> Result<BackgroundCompletionOutcome> {
+    project_background_subagent_completion_inner(node, None, child_request_id, local_did).await
+}
+
+async fn project_background_subagent_completion_inner(
+    node: &EmbeddedNode,
+    lifecycle_node: Option<Arc<EmbeddedNode>>,
+    child_request_id: &str,
+    local_did: &str,
+) -> Result<BackgroundCompletionOutcome> {
+    let Some(linkage) = load_child_linkage(node, child_request_id).await? else {
         return Ok(BackgroundCompletionOutcome::Unlinked);
     };
     let Some(parent_request_id) = non_empty(linkage.caused_by_parent_request_id.as_deref()) else {
@@ -523,11 +546,11 @@ pub async fn project_background_subagent_completion(
     if non_empty(linkage.caused_by_parent_tool_call_id.as_deref()).is_none() {
         return Ok(BackgroundCompletionOutcome::Unlinked);
     }
-    if !request_is_locally_owned(node.as_ref(), parent_request_id, local_did).await? {
+    if !request_is_locally_owned(node, parent_request_id, local_did).await? {
         return Ok(BackgroundCompletionOutcome::NotLocalOwner);
     }
 
-    let Some(terminal_row) = load_child_terminal_row(node.as_ref(), child_request_id).await? else {
+    let Some(terminal_row) = load_child_terminal_row(node, child_request_id).await? else {
         return Ok(BackgroundCompletionOutcome::Unlinked);
     };
     let completed = child_request_completed(&terminal_row);
@@ -540,15 +563,15 @@ pub async fn project_background_subagent_completion(
         Some(terminal)
     };
 
-    let parent_context = load_parent_subagent_context(node.as_ref(), parent_request_id).await?;
-    let edge = load_authorized_child_edge(node.as_ref(), &parent_context, child_request_id).await?;
+    let parent_context = load_parent_subagent_context(node, parent_request_id).await?;
+    let edge = load_authorized_child_edge(node, &parent_context, child_request_id).await?;
     if edge.await_mode != AwaitMode::Background {
         return Ok(BackgroundCompletionOutcome::NotBackground);
     }
 
     let (status, summary, bridge_result, terminal) = if completed {
         let Some(final_response) =
-            load_projected_final_response(node.as_ref(), &parent_context.session_id, &edge).await?
+            load_projected_final_response(node, &parent_context.session_id, &edge).await?
         else {
             return Ok(BackgroundCompletionOutcome::MissingFinalResponse);
         };
@@ -563,8 +586,11 @@ pub async fn project_background_subagent_completion(
 
     let mut transitioned = false;
     if edge.lifecycle_state == "running" {
+        let Some(lifecycle_node) = lifecycle_node else {
+            return Ok(BackgroundCompletionOutcome::NotTerminal);
+        };
         let mut lifecycle = match ToolCallLifecycle::load(
-            node.clone(),
+            lifecycle_node,
             &parent_context.session_id,
             &edge.parent_tool_call_id,
         )
@@ -584,7 +610,7 @@ pub async fn project_background_subagent_completion(
     }
 
     let side_effects = ensure_projection_side_effects(
-        node.as_ref(),
+        node,
         &parent_context.session_id,
         &parent_context.request_id,
         &edge,

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -5,11 +5,12 @@ use chrono::{DateTime, Utc};
 use defra_node::EmbeddedNode;
 use serde::Deserialize;
 
+use crate::background_completion::ensure_background_subagent_completion_side_effects;
 use crate::background_tools::{
     child_request_completed, fail_running_subagent_tool_call, load_parent_subagent_authorization,
     project_child_terminal, subagent_spawn_denial, subagent_tool_not_allowed_payload,
 };
-use crate::graphql::escape_graphql_string;
+use crate::graphql::{escape_graphql_string, response_has_documents};
 use crate::interrupt::interrupt_request;
 use crate::session::execute_mutation_with_retry;
 
@@ -59,6 +60,27 @@ struct ParentRequestRow {
     lifecycle_state: Option<String>,
     #[serde(default)]
     subagent_depth: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ChildRequestLivenessRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    agent_did: String,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    lifecycle_state: Option<String>,
+    #[serde(default)]
+    deadline: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct StreamingChildResponseRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
+    #[serde(default)]
+    content: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -344,7 +366,11 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
             None => None,
         };
 
-        if recover_bridge_terminal_child(node, &row).await? {
+        if child_request_id(&row).is_some() {
+            let _ = terminalize_expired_local_child_request(node, agent_did, &row).await?;
+        }
+
+        if recover_bridge_terminal_child(node, agent_did, &row).await? {
             recovered += 1;
             continue;
         }
@@ -568,6 +594,7 @@ async fn child_request_exists(node: &EmbeddedNode, request_id: &str) -> Result<b
 
 async fn recover_bridge_terminal_child(
     node: &EmbeddedNode,
+    agent_did: &str,
     row: &RunningToolCallRow,
 ) -> Result<bool> {
     let Some(child_request_id) = child_request_id(row) else {
@@ -584,6 +611,8 @@ async fn recover_bridge_terminal_child(
             .await?
             .unwrap_or_else(|| format!("child request {child_request_id} completed"));
         recover_bridge_completed_row(node, row, &result).await?;
+        ensure_background_subagent_projection_side_effects(node, agent_did, row, child_request_id)
+            .await?;
         return Ok(true);
     }
 
@@ -591,7 +620,213 @@ async fn recover_bridge_terminal_child(
         return Ok(false);
     };
     recover_bridge_failed_row(node, row, &terminal).await?;
+    ensure_background_subagent_projection_side_effects(node, agent_did, row, child_request_id)
+        .await?;
     Ok(true)
+}
+
+async fn ensure_background_subagent_projection_side_effects(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    row: &RunningToolCallRow,
+    child_request_id: &str,
+) -> Result<()> {
+    if !is_background_subagent_tool(row) {
+        return Ok(());
+    }
+    let outcome =
+        ensure_background_subagent_completion_side_effects(node, child_request_id, agent_did)
+            .await?;
+    tracing::debug!(
+        doc_id = %row.doc_id,
+        request_id = row.request_id.as_deref().unwrap_or(""),
+        session_id = %row.session_id,
+        tool_call_id = %row.tool_call_id,
+        child_request_id,
+        outcome = ?outcome,
+        "ensured recovered background subagent projection side effects"
+    );
+    Ok(())
+}
+
+async fn terminalize_expired_local_child_request(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    row: &RunningToolCallRow,
+) -> Result<bool> {
+    let Some(child_request_id) = child_request_id(row) else {
+        return Ok(false);
+    };
+    let Some(child) = load_child_liveness_row(node, child_request_id).await? else {
+        return Ok(false);
+    };
+    if child.agent_did != agent_did {
+        return Ok(false);
+    }
+    if request_status_or_lifecycle_is_terminal(
+        child.status.as_deref(),
+        child.lifecycle_state.as_deref(),
+    ) {
+        return Ok(false);
+    }
+    let Some(deadline_at) = parse_datetime(child.deadline.as_deref()) else {
+        return Ok(false);
+    };
+    if Utc::now() < deadline_at {
+        return Ok(false);
+    }
+
+    let reason = format!(
+        "child request deadline exceeded at {} before terminal response",
+        deadline_at.to_rfc3339()
+    );
+    if !mark_child_request_dead(node, &child, &reason).await? {
+        return Ok(false);
+    }
+    finalize_streaming_child_response(node, child_request_id, &reason).await?;
+    tracing::info!(
+        doc_id = %row.doc_id,
+        request_id = row.request_id.as_deref().unwrap_or(""),
+        session_id = %row.session_id,
+        tool_call_id = %row.tool_call_id,
+        child_request_id,
+        child_deadline_at = %deadline_at,
+        "terminalized expired subagent child request during tool-call recovery"
+    );
+    Ok(true)
+}
+
+async fn load_child_liveness_row(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> Result<Option<ChildRequestLivenessRow>> {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped_child_request_id}" }} }},
+                limit: 1
+            ) {{
+                _docID
+                agent_did
+                status
+                lifecycle_state
+                deadline
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query child AgentRequest liveness for {child_request_id} failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(|value| {
+            serde_json::from_value::<Vec<ChildRequestLivenessRow>>(value.clone()).ok()
+        })
+        .and_then(|mut rows| rows.pop()))
+}
+
+async fn mark_child_request_dead(
+    node: &EmbeddedNode,
+    child: &ChildRequestLivenessRow,
+    reason: &str,
+) -> Result<bool> {
+    let active_runtime_states = crate::lifecycle::active_runtime_lifecycle_state_graphql_list();
+    let escaped_doc_id = escape_graphql_string(&child.doc_id);
+    let escaped_agent_did = escape_graphql_string(&child.agent_did);
+    let escaped_reason = escape_graphql_string(reason);
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{
+                    _docID: {{ _eq: "{escaped_doc_id}" }},
+                    agent_did: {{ _eq: "{escaped_agent_did}" }},
+                    lifecycle_state: {{ _in: {active_runtime_states} }},
+                    status: {{ _nin: ["completed", "interrupted", "dead", "superseded", "error"] }}
+                }},
+                input: {{
+                    status: "dead",
+                    lifecycle_state: "dead",
+                    failure_reason: "{escaped_reason}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response =
+        execute_mutation_with_retry(node, &mutation, "terminalize_expired_child_request").await?;
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("update_AgentRequest"))
+        .is_some_and(response_has_documents))
+}
+
+async fn finalize_streaming_child_response(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    reason: &str,
+) -> Result<()> {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{
+                    request_id: {{ _eq: "{escaped_child_request_id}" }},
+                    status: {{ _eq: "streaming" }}
+                }}
+            ) {{
+                _docID
+                content
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query streaming child AgentResponse {child_request_id} failed: {:?}",
+            response.errors
+        );
+    }
+    let rows: Vec<StreamingChildResponseRow> = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentResponse"))
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_default();
+    let now = Utc::now().to_rfc3339();
+    let escaped_reason = escape_graphql_string(reason);
+    for row in rows {
+        let content = row.content.unwrap_or_default();
+        let final_content = if content.trim().is_empty() {
+            format!("Error: {reason}")
+        } else {
+            format!("{content}\n\n[Response interrupted - {reason}]")
+        };
+        let escaped_doc_id = escape_graphql_string(&row.doc_id);
+        let escaped_content = escape_graphql_string(&final_content);
+        let escaped_now = escape_graphql_string(&now);
+        let mutation = format!(
+            r#"mutation {{
+                update_AgentResponse(
+                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    input: {{
+                        content: "{escaped_content}",
+                        status: "error",
+                        error_message: "{escaped_reason}",
+                        completed_at: "{escaped_now}"
+                    }}
+                ) {{ _docID }}
+            }}"#
+        );
+        execute_mutation_with_retry(node, &mutation, "finalize_expired_child_response").await?;
+    }
+    Ok(())
 }
 
 async fn load_child_completion_result(
@@ -825,12 +1060,22 @@ fn request_is_interrupted(parent: &ParentRequestRow) -> bool {
 }
 
 fn request_is_terminal(parent: &ParentRequestRow) -> bool {
-    matches!(
-        parent.status.as_str(),
-        "completed" | "error" | "superseded" | "dead" | "interrupted"
-    ) || matches!(
+    request_status_or_lifecycle_is_terminal(
+        Some(parent.status.as_str()),
         parent.lifecycle_state.as_deref(),
-        Some("completed" | "failed" | "superseded" | "dead" | "interrupted")
+    )
+}
+
+fn request_status_or_lifecycle_is_terminal(
+    status: Option<&str>,
+    lifecycle_state: Option<&str>,
+) -> bool {
+    matches!(
+        status,
+        Some("completed" | "complete" | "error" | "failed" | "superseded" | "dead" | "interrupted")
+    ) || matches!(
+        lifecycle_state,
+        Some("completed" | "complete" | "failed" | "error" | "superseded" | "dead" | "interrupted")
     )
 }
 

--- a/crates/defra-agent/tests/r4_subagent_completion.rs
+++ b/crates/defra-agent/tests/r4_subagent_completion.rs
@@ -98,6 +98,20 @@ struct WakeRequestRow {
     metadata: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct ChildRequestStateRow {
+    status: Option<String>,
+    lifecycle_state: Option<String>,
+    failure_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponseStateRow {
+    status: Option<String>,
+    content: Option<String>,
+    error_message: Option<String>,
+}
+
 async fn setup_fixture(test_name: &str) -> (support::TestDb, String, String) {
     let db = test_db(test_name).await;
     upsert_tool_selection(
@@ -416,6 +430,108 @@ async fn set_request_lifecycle(node: &EmbeddedNode, request_id: &str, state: &st
         "set request lifecycle failed: {:?}",
         response.errors
     );
+}
+
+async fn set_child_processing_deadline(
+    node: &EmbeddedNode,
+    request_id: &str,
+    deadline: chrono::DateTime<chrono::Utc>,
+) {
+    let request_id = escape_graphql_string(request_id);
+    let deadline = escape_graphql_string(&deadline.to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentRequest(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                input: {{
+                    status: "processing",
+                    lifecycle_state: "processing",
+                    deadline: "{deadline}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "set child processing deadline failed: {:?}",
+        response.errors
+    );
+}
+
+async fn create_streaming_child_response(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    child_session_id: &str,
+    content: &str,
+) {
+    let escaped_child_request_id = escape_graphql_string(child_request_id);
+    let escaped_child_session_id = escape_graphql_string(child_session_id);
+    let escaped_content = escape_graphql_string(content);
+    let escaped_agent_did = escape_graphql_string(AGENT_DID);
+    let escaped_behavior_id = escape_graphql_string(CHILD_BEHAVIOR_ID);
+    let now = chrono::Utc::now().to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentResponse(input: {{
+                response_key: "{escaped_child_request_id}",
+                request_id: "{escaped_child_request_id}",
+                agent_did: "{escaped_agent_did}",
+                behavior_id: "{escaped_behavior_id}",
+                session_id: "{escaped_child_session_id}",
+                content: "{escaped_content}",
+                reasoning: "",
+                status: "streaming",
+                error_message: "",
+                token_count: 0,
+                progress_seq: 1,
+                created_at: "{now}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create streaming child AgentResponse failed: {:?}",
+        response.errors
+    );
+}
+
+async fn fetch_child_request_state(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+) -> ChildRequestStateRow {
+    let child_request_id = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{child_request_id}" }} }},
+                limit: 1
+            ) {{
+                status
+                lifecycle_state
+                failure_reason
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentRequest")
+}
+
+async fn fetch_response_state(node: &EmbeddedNode, request_id: &str) -> ResponseStateRow {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                limit: 1
+            ) {{
+                status
+                content
+                error_message
+            }}
+        }}"#
+    );
+    first_row(&node.execute(&query).await, "AgentResponse")
 }
 
 async fn fetch_tool_call(node: &EmbeddedNode, session_id: &str, tool_call_id: &str) -> ToolCallRow {
@@ -947,6 +1063,88 @@ async fn recovery_fails_running_background_bridge_after_parent_completes() {
     assert!(
         interrupt.is_some(),
         "cascade background child should be interrupted once recovery fails the parent bridge"
+    );
+}
+
+#[tokio::test]
+async fn recovery_terminalizes_expired_background_child_before_projection() {
+    let (db, session_id, parent_request_id) =
+        setup_fixture("background_completion_expired_child").await;
+    let (child_request_id, child_session_id) = create_child_and_bridge(
+        &db.node,
+        &parent_request_id,
+        &session_id,
+        "spawn-bg-expired-child",
+        AwaitMode::Background,
+        1,
+    )
+    .await;
+    let expired_deadline = chrono::Utc::now() - chrono::Duration::seconds(1);
+    set_child_processing_deadline(db.node.as_ref(), &child_request_id, expired_deadline).await;
+    create_streaming_child_response(
+        db.node.as_ref(),
+        &child_request_id,
+        &child_session_id,
+        "partial child output",
+    )
+    .await;
+
+    let report = ToolCallLifecycle::recover_all(db.node.as_ref(), AGENT_DID)
+        .await
+        .unwrap();
+    assert_eq!(report.tool_calls_recovered, 1);
+
+    let child = fetch_child_request_state(db.node.as_ref(), &child_request_id).await;
+    assert_eq!(child.status.as_deref(), Some("dead"));
+    assert_eq!(child.lifecycle_state.as_deref(), Some("dead"));
+    assert!(
+        child
+            .failure_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("child request deadline exceeded")),
+        "child failure reason should explain deadline expiry: {:?}",
+        child.failure_reason
+    );
+
+    let response = fetch_response_state(db.node.as_ref(), &child_request_id).await;
+    assert_eq!(response.status.as_deref(), Some("error"));
+    assert!(
+        response
+            .content
+            .as_deref()
+            .is_some_and(|content| content.contains("partial child output")
+                && content.contains("Response interrupted")),
+        "streaming child response should be finalized with prior content: {:?}",
+        response.content
+    );
+    assert!(
+        response
+            .error_message
+            .as_deref()
+            .is_some_and(|message| message.contains("child request deadline exceeded")),
+        "response error message should explain deadline expiry: {:?}",
+        response.error_message
+    );
+
+    let tool = fetch_tool_call(db.node.as_ref(), &session_id, "spawn-bg-expired-child").await;
+    assert_eq!(tool.lifecycle_state.as_deref(), Some("failed"));
+    assert_eq!(tool.await_mode.as_deref(), Some("background"));
+
+    let messages = fetch_parent_messages(db.node.as_ref(), &session_id).await;
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].content.contains(r#"<subagent-notification"#));
+    assert!(messages[0].content.contains(r#"status="dead""#));
+    assert!(messages[0].content.contains(&child_request_id));
+
+    let wakes = fetch_scheduled_wakes(db.node.as_ref(), &session_id).await;
+    assert_eq!(wakes.len(), 1);
+    assert_eq!(wakes[0].content, WAKE_PROMPT);
+    let metadata: serde_json::Value =
+        serde_json::from_str(wakes[0].metadata.as_deref().unwrap()).unwrap();
+    assert_eq!(metadata["queue"]["source"], "background_completion");
+    assert_eq!(
+        metadata["queue"]["queued_after_request_id"],
+        parent_request_id
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes a recovery gap where a background `spawn_subagent` bridge could remain `running` when its child request was still non-terminal but had already exceeded its child deadline.

This PR:

- terminalizes expired local subagent child requests during tool-call recovery
- finalizes any still-streaming child `AgentResponse` as `error`
- projects the now-terminal child onto the parent background bridge
- ensures recovered background subagent projections append the parent notification and enqueue the background-completion wakeup
- adds a regression for the stuck state shape from #428

## Why

Previously, startup/tool-call recovery projected terminal children, but did not first bound a child request that was stuck `processing` / `streaming`. Since tool-call recovery runs before request recovery, the parent bridge could be inspected too early and left running.

## Verification

- `cargo test -p defra-agent --test r4_subagent_completion recovery_terminalizes_expired_background_child_before_projection`
- `cargo test -p defra-agent --test r4_subagent_completion`
- `cargo test -p defra-agent --test lifecycle_recovery`
- `cargo test -p defra-agent --test r6_background_recovery`
- `cargo test -p defra-agent tool_call_lifecycle::recovery::tests`
- `git diff --cached --check`

Closes #428