### PR TITLE
test: consolidate LLM test mocks onto robust axum fakes (remove hand-rolled flaky servers)

### DIFF
--- a/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
+++ b/crates/defra-agent-cli/tests/cli_subagent_cancel.rs
@@ -2,12 +2,7 @@ mod support;
 use support::*;
 
 use std::fs;
-use std::io::Write;
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread;
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -579,88 +574,45 @@ async fn request_lifecycle_state(graphql: &str, request_id: &str) -> Result<Stri
         .ok_or_else(|| anyhow!("AgentRequest {request_id} missing lifecycle_state: {row}"))
 }
 
+/// Mock backend for cascade-cancel tests: the first turn whose user prompt
+/// matches `target_prompt` (and carries no tool result yet) replies with a
+/// `spawn_subagent` tool call naming the configured behavior id; every other
+/// request hangs until the mock is dropped. Built on the shared robust
+/// [`support::mocks::fake_llm::FakeLlm`].
 struct BlockingSpawnEndpoint {
-    endpoint: String,
-    port: u16,
+    inner: support::mocks::fake_llm::FakeLlm,
     behavior_id: Arc<Mutex<String>>,
-    stop: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
 }
 
 impl BlockingSpawnEndpoint {
     fn start(model_name: &str, target_prompt: &str, child_prompt: &str) -> Result<Self> {
-        let listener =
-            TcpListener::bind(("127.0.0.1", 0)).context("binding blocking spawn mock")?;
-        listener
-            .set_nonblocking(true)
-            .context("marking blocking spawn mock nonblocking")?;
-        let port = listener.local_addr()?.port();
+        use support::mocks::fake_llm::{ChatAction, FakeLlm};
+
         let behavior_id = Arc::new(Mutex::new("default".to_string()));
-        let stop = Arc::new(AtomicBool::new(false));
-        let behavior_id_for_thread = behavior_id.clone();
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
+        let behavior_for_responder = behavior_id.clone();
         let target_prompt = target_prompt.to_string();
         let child_prompt = child_prompt.to_string();
-
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match support::mocks::read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-                        match (request.method.as_str(), request.path.as_str()) {
-                            ("GET", "/v1/models") => {
-                                let body = format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#);
-                                let _ = support::mocks::write_http_response(
-                                    &mut stream,
-                                    "200 OK",
-                                    "application/json",
-                                    &body,
-                                );
-                            }
-                            ("POST", "/v1/chat/completions") => {
-                                handle_chat_request(
-                                    &mut stream,
-                                    &request.body,
-                                    &target_prompt,
-                                    &child_prompt,
-                                    &behavior_id_for_thread,
-                                    &stop_for_thread,
-                                );
-                            }
-                            _ => {
-                                let _ = support::mocks::write_http_response(
-                                    &mut stream,
-                                    "404 Not Found",
-                                    "application/json",
-                                    r#"{"error":"not found"}"#,
-                                );
-                            }
-                        }
-                        let _ = stream.flush();
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
+        let responder = Arc::new(move |request: &Value| {
+            if support::mocks::request_contains_role_text(request, "user", &target_prompt)
+                && !support::mocks::request_has_tool_result_message(request)
+            {
+                let behavior = behavior_for_responder
+                    .lock()
+                    .expect("behavior id lock poisoned")
+                    .clone();
+                let args = json!({
+                    "name": behavior,
+                    "prompt": child_prompt,
+                    "await_mode": "background"
+                })
+                .to_string();
+                ChatAction::Sse(support::mocks::tool_call_sse("spawn_subagent", &args))
+            } else {
+                ChatAction::Hang
             }
         });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            behavior_id,
-            stop,
-            handle: Some(handle),
-        })
+        let inner = FakeLlm::start(model_name, None, responder)?;
+        Ok(Self { inner, behavior_id })
     }
 
     fn set_behavior_id(&self, behavior_id: String) {
@@ -668,66 +620,6 @@ impl BlockingSpawnEndpoint {
     }
 
     fn endpoint(&self) -> &str {
-        &self.endpoint
+        self.inner.endpoint()
     }
-}
-
-impl Drop for BlockingSpawnEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-fn handle_chat_request(
-    stream: &mut TcpStream,
-    body: &[u8],
-    target_prompt: &str,
-    child_prompt: &str,
-    behavior_id: &Arc<Mutex<String>>,
-    stop: &AtomicBool,
-) {
-    let request_json: Value = match serde_json::from_slice(body) {
-        Ok(value) => value,
-        Err(_) => {
-            let _ = support::mocks::write_http_response(
-                stream,
-                "400 Bad Request",
-                "application/json",
-                r#"{"error":"invalid json"}"#,
-            );
-            return;
-        }
-    };
-
-    if request_contains_role_text(&request_json, "user", target_prompt)
-        && !request_has_tool_result_message(&request_json)
-    {
-        let behavior_id = behavior_id
-            .lock()
-            .expect("behavior id lock poisoned")
-            .clone();
-        let args = serde_json::json!({
-            "name": behavior_id,
-            "prompt": child_prompt,
-            "await_mode": "background"
-        })
-        .to_string();
-        let sse = tool_call_sse("spawn_subagent", &args);
-        let _ = support::mocks::write_http_response(stream, "200 OK", "text/event-stream", &sse);
-        return;
-    }
-
-    while !stop.load(Ordering::Relaxed) {
-        thread::sleep(Duration::from_millis(50));
-    }
-    let _ = support::mocks::write_http_response(
-        stream,
-        "503 Service Unavailable",
-        "application/json",
-        r#"{"error":"mock stopped"}"#,
-    );
 }

--- a/crates/defra-agent-cli/tests/support/mocks/chat.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/chat.rs
@@ -1,34 +1,17 @@
-use std::collections::VecDeque;
-use std::io::Write;
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::thread::JoinHandle;
+//! `MockChatEndpoint`: a thin wrapper over the shared robust [`FakeLlm`] fake
+//! that replies to chat completions with a fixed behavior (text completion,
+//! routed-by-content-with-delay, or hang). Public API is unchanged.
+
+use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use serde_json::Value;
 
-use super::{read_http_request, write_http_response};
+use super::fake_llm::{completion_text_sse, ChatAction, FakeLlm};
 
 pub struct MockChatEndpoint {
-    pub endpoint: String,
-    pub port: u16,
-    pub stop: Arc<AtomicBool>,
-    pub captured_chat_requests: Arc<Mutex<Vec<Value>>>,
-    pub handle: Option<JoinHandle<()>>,
-}
-
-#[derive(Clone)]
-enum MockChatCompletion {
-    Complete(String),
-    RoutedDelayed {
-        routes: Vec<(String, String)>,
-        default_text: String,
-        delay: Duration,
-    },
-    Hang,
+    inner: FakeLlm,
 }
 
 impl MockChatEndpoint {
@@ -37,7 +20,8 @@ impl MockChatEndpoint {
     }
 
     pub fn start_hanging(model_name: &str) -> Result<Self> {
-        Self::start_with_completion(model_name, None, MockChatCompletion::Hang)
+        let inner = FakeLlm::start(model_name, None, Arc::new(|_: &Value| ChatAction::Hang))?;
+        Ok(Self { inner })
     }
 
     pub fn start_routed_delayed(
@@ -46,15 +30,13 @@ impl MockChatEndpoint {
         default_text: String,
         delay: Duration,
     ) -> Result<Self> {
-        Self::start_with_completion(
-            model_name,
-            None,
-            MockChatCompletion::RoutedDelayed {
-                routes,
-                default_text,
-                delay,
-            },
-        )
+        let responder = Arc::new(move |request: &Value| {
+            let text =
+                routed_completion_text(request, &routes).unwrap_or_else(|| default_text.clone());
+            ChatAction::DelayThenSse(delay, completion_text_sse(&text))
+        });
+        let inner = FakeLlm::start(model_name, None, responder)?;
+        Ok(Self { inner })
     }
 
     pub fn start_with_required_bearer(
@@ -62,195 +44,19 @@ impl MockChatEndpoint {
         final_text: &str,
         required_bearer: Option<&str>,
     ) -> Result<Self> {
-        Self::start_with_completion(
-            model_name,
-            required_bearer,
-            MockChatCompletion::Complete(final_text.to_string()),
-        )
-    }
-
-    fn start_with_completion(
-        model_name: &str,
-        required_bearer: Option<&str>,
-        completion: MockChatCompletion,
-    ) -> Result<Self> {
-        Self::start_with_completions(model_name, required_bearer, vec![completion])
-    }
-
-    fn start_with_completions(
-        model_name: &str,
-        required_bearer: Option<&str>,
-        completions: Vec<MockChatCompletion>,
-    ) -> Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).context("binding mock chat port")?;
-        listener
-            .set_nonblocking(true)
-            .context("marking mock chat listener nonblocking")?;
-        let port = listener
-            .local_addr()
-            .context("reading mock chat port")?
-            .port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
-        let required_bearer = required_bearer.map(ToOwned::to_owned);
-        let captured_chat_requests = Arc::new(Mutex::new(Vec::new()));
-        let captured_chat_requests_for_thread = captured_chat_requests.clone();
-        let default_completion = completions
-            .last()
-            .cloned()
-            .unwrap_or(MockChatCompletion::Hang);
-        let completions = Arc::new(Mutex::new(VecDeque::from(completions)));
-        let completions_for_thread = completions.clone();
-
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-
-                        let authorized = required_bearer.as_ref().is_none_or(|expected| {
-                            request
-                                .headers
-                                .get("authorization")
-                                .is_some_and(|value| value == &format!("Bearer {expected}"))
-                        });
-
-                        match (request.method.as_str(), request.path.as_str()) {
-                            ("GET", "/v1/models") => {
-                                let (status, body) = if authorized {
-                                    ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                                } else {
-                                    (
-                                        "401 Unauthorized",
-                                        r#"{"error":"unauthorized"}"#.to_string(),
-                                    )
-                                };
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    status,
-                                    "application/json",
-                                    &body,
-                                );
-                            }
-                            ("POST", "/v1/chat/completions") => {
-                                if !authorized {
-                                    let _ = write_http_response(
-                                        &mut stream,
-                                        "401 Unauthorized",
-                                        "application/json",
-                                        r#"{"error":"unauthorized"}"#,
-                                    );
-                                    let _ = stream.shutdown(Shutdown::Both);
-                                    continue;
-                                }
-                                let request_json: Value =
-                                    match serde_json::from_slice(&request.body) {
-                                        Ok(value) => value,
-                                        Err(_) => {
-                                            let _ = write_http_response(
-                                                &mut stream,
-                                                "400 Bad Request",
-                                                "application/json",
-                                                r#"{"error":"invalid json"}"#,
-                                            );
-                                            let _ = stream.shutdown(Shutdown::Both);
-                                            continue;
-                                        }
-                                    };
-                                captured_chat_requests_for_thread
-                                    .lock()
-                                    .expect("captured chat request mutex poisoned")
-                                    .push(request_json.clone());
-
-                                let completion = completions_for_thread
-                                    .lock()
-                                    .expect("mock chat completion queue mutex poisoned")
-                                    .pop_front()
-                                    .unwrap_or_else(|| default_completion.clone());
-
-                                match completion {
-                                    MockChatCompletion::Complete(final_text) => {
-                                        let _ = write_http_response(
-                                            &mut stream,
-                                            "200 OK",
-                                            "text/event-stream",
-                                            &completion_text_sse(&final_text),
-                                        );
-                                    }
-                                    MockChatCompletion::RoutedDelayed {
-                                        routes,
-                                        default_text,
-                                        delay,
-                                    } => {
-                                        let final_text =
-                                            routed_completion_text(&request_json, &routes)
-                                                .unwrap_or(default_text);
-                                        let deadline = std::time::Instant::now() + delay;
-                                        while std::time::Instant::now() < deadline
-                                            && !stop_for_thread.load(Ordering::Relaxed)
-                                        {
-                                            thread::sleep(Duration::from_millis(25));
-                                        }
-                                        let _ = write_http_response(
-                                            &mut stream,
-                                            "200 OK",
-                                            "text/event-stream",
-                                            &completion_text_sse(&final_text),
-                                        );
-                                    }
-                                    MockChatCompletion::Hang => {
-                                        while !stop_for_thread.load(Ordering::Relaxed) {
-                                            thread::sleep(Duration::from_millis(25));
-                                        }
-                                    }
-                                }
-                            }
-                            _ => {
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    "404 Not Found",
-                                    "application/json",
-                                    r#"{"error":"not found"}"#,
-                                );
-                            }
-                        }
-
-                        let _ = stream.flush();
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            captured_chat_requests,
-            handle: Some(handle),
-        })
+        let final_text = final_text.to_string();
+        let responder =
+            Arc::new(move |_: &Value| ChatAction::Sse(completion_text_sse(&final_text)));
+        let inner = FakeLlm::start(model_name, required_bearer, responder)?;
+        Ok(Self { inner })
     }
 
     pub fn endpoint(&self) -> &str {
-        &self.endpoint
+        self.inner.endpoint()
     }
 
     pub fn captured_chat_requests(&self) -> Vec<Value> {
-        self.captured_chat_requests
-            .lock()
-            .expect("captured chat request mutex poisoned")
-            .clone()
+        self.inner.captured_chat_requests()
     }
 }
 
@@ -260,100 +66,4 @@ fn routed_completion_text(request_json: &Value, routes: &[(String, String)]) -> 
         .iter()
         .find(|(needle, _)| request.contains(needle))
         .map(|(_, response)| response.clone())
-}
-
-impl Drop for MockChatEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-pub fn tool_call_sse(tool_name: &str, arguments: &str) -> String {
-    let chunk_1 = serde_json::json!({
-        "choices": [{
-            "delta": {
-                "tool_calls": [{
-                    "index": 0,
-                    "id": "call-read-file",
-                    "function": {
-                        "name": tool_name,
-                        "arguments": ""
-                    }
-                }]
-            },
-            "finish_reason": null
-        }],
-        "usage": null
-    });
-    let chunk_2 = serde_json::json!({
-        "choices": [{
-            "delta": {
-                "tool_calls": [{
-                    "index": 0,
-                    "id": null,
-                    "function": {
-                        "name": null,
-                        "arguments": arguments
-                    }
-                }]
-            },
-            "finish_reason": null
-        }],
-        "usage": null
-    });
-    let chunk_3 = serde_json::json!({
-        "choices": [{
-            "delta": {
-                "content": null,
-                "tool_calls": []
-            },
-            "finish_reason": "tool_calls"
-        }],
-        "usage": {
-            "prompt_tokens": 16,
-            "completion_tokens": 4,
-            "total_tokens": 20
-        }
-    });
-    format!(
-        "data: {}\n\ndata: {}\n\ndata: {}\n\ndata: [DONE]\n\n",
-        serde_json::to_string(&chunk_1).expect("serialize tool-call chunk 1"),
-        serde_json::to_string(&chunk_2).expect("serialize tool-call chunk 2"),
-        serde_json::to_string(&chunk_3).expect("serialize tool-call chunk 3"),
-    )
-}
-
-pub fn completion_text_sse(text: &str) -> String {
-    let chunk_1 = serde_json::json!({
-        "choices": [{
-            "delta": {
-                "content": text
-            },
-            "finish_reason": null
-        }],
-        "usage": null
-    });
-    let chunk_2 = serde_json::json!({
-        "choices": [{
-            "delta": {
-                "content": null,
-                "tool_calls": []
-            },
-            "finish_reason": "stop"
-        }],
-        "usage": {
-            "prompt_tokens": 24,
-            "completion_tokens": 6,
-            "total_tokens": 30
-        }
-    });
-    format!(
-        "data: {}\n\ndata: {}\n\ndata: [DONE]\n\n",
-        serde_json::to_string(&chunk_1).expect("serialize completion chunk 1"),
-        serde_json::to_string(&chunk_2).expect("serialize completion chunk 2"),
-    )
 }

--- a/crates/defra-agent-cli/tests/support/mocks/fake_llm.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/fake_llm.rs
@@ -1,0 +1,304 @@
+//! One robust axum-based fake OpenAI-compatible endpoint shared by every CLI
+//! mock. Replaces the several hand-rolled nonblocking `TcpListener` accept
+//! loops (whose `Err(_) => break` arm killed the listener on any transient
+//! accept error under CI load). The server runs on its own current-thread
+//! tokio runtime in a background thread, so it works whether the consuming
+//! test is `#[tokio::test]` or a blocking CLI-subprocess test.
+//!
+//! Behavior is supplied per construction via a chat `Responder` closure, so the
+//! thin `MockChatEndpoint` / `MockModelEndpoint` / `MockOpenAIEndpoint` /
+//! spawn-mock wrappers keep their exact public APIs while sharing this one
+//! robust server. SSE bodies are written whole (matching the previous mocks),
+//! so no incremental streaming is needed.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::Value;
+use tokio::sync::{oneshot, Notify};
+
+/// What the chat endpoint should do for a given request.
+pub enum ChatAction {
+    /// Respond immediately with this complete SSE body.
+    Sse(String),
+    /// Sleep, then respond with this complete SSE body (cut short on shutdown).
+    DelayThenSse(Duration, String),
+    /// Never respond (the client is expected to time out); returns once the
+    /// mock is dropped.
+    Hang,
+}
+
+/// `Fn(&request_json) -> ChatAction`, invoked per authorized chat request.
+pub type Responder = Arc<dyn Fn(&Value) -> ChatAction + Send + Sync>;
+
+struct FakeState {
+    model_name: String,
+    required_bearer: Option<String>,
+    captured: Arc<Mutex<Vec<Value>>>,
+    responder: Responder,
+    stop: Arc<Notify>,
+    stopped: Arc<AtomicBool>,
+}
+
+pub struct FakeLlm {
+    endpoint: String,
+    captured: Arc<Mutex<Vec<Value>>>,
+    stop: Arc<Notify>,
+    stopped: Arc<AtomicBool>,
+    shutdown: Option<oneshot::Sender<()>>,
+    join: Option<std::thread::JoinHandle<()>>,
+}
+
+impl FakeLlm {
+    pub fn start(
+        model_name: &str,
+        required_bearer: Option<&str>,
+        responder: Responder,
+    ) -> Result<Self> {
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let stop = Arc::new(Notify::new());
+        let stopped = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(FakeState {
+            model_name: model_name.to_string(),
+            required_bearer: required_bearer.map(ToOwned::to_owned),
+            captured: captured.clone(),
+            responder,
+            stop: stop.clone(),
+            stopped: stopped.clone(),
+        });
+
+        let (port_tx, port_rx) = std::sync::mpsc::channel::<u16>();
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let join = std::thread::spawn(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(_) => return,
+            };
+            runtime.block_on(async move {
+                let listener = match tokio::net::TcpListener::bind(("127.0.0.1", 0)).await {
+                    Ok(listener) => listener,
+                    Err(_) => return,
+                };
+                let port = listener.local_addr().map(|addr| addr.port()).unwrap_or(0);
+                let _ = port_tx.send(port);
+                let app = Router::new()
+                    .route("/v1/models", get(handle_models))
+                    .route("/models", get(handle_models))
+                    .route("/v1/chat/completions", post(handle_chat))
+                    .route("/chat/completions", post(handle_chat))
+                    .fallback(handle_fallback)
+                    .with_state(state);
+                let _ = axum::serve(listener, app)
+                    .with_graceful_shutdown(async move {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await;
+            });
+        });
+
+        let port = port_rx
+            .recv()
+            .context("mock fake-llm server failed to bind a port")?;
+
+        Ok(Self {
+            endpoint: format!("http://127.0.0.1:{port}/v1"),
+            captured,
+            stop,
+            stopped,
+            shutdown: Some(shutdown_tx),
+            join: Some(join),
+        })
+    }
+
+    pub fn endpoint(&self) -> &str {
+        &self.endpoint
+    }
+
+    pub fn captured_chat_requests(&self) -> Vec<Value> {
+        self.captured
+            .lock()
+            .expect("captured chat request mutex poisoned")
+            .clone()
+    }
+}
+
+impl Drop for FakeLlm {
+    fn drop(&mut self) {
+        // Release any hanging/delayed handler, stop the server, join the thread.
+        self.stopped.store(true, Ordering::Relaxed);
+        self.stop.notify_waiters();
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn bearer_authorized(state: &FakeState, headers: &HeaderMap) -> bool {
+    match &state.required_bearer {
+        None => true,
+        Some(expected) => {
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                == Some(format!("Bearer {expected}").as_str())
+        }
+    }
+}
+
+fn json_response(status: StatusCode, body: String) -> Response {
+    (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
+}
+
+fn sse_response(body: String) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/event-stream")],
+        body,
+    )
+        .into_response()
+}
+
+fn unauthorized() -> Response {
+    json_response(
+        StatusCode::UNAUTHORIZED,
+        r#"{"error":"unauthorized"}"#.to_string(),
+    )
+}
+
+async fn handle_models(State(state): State<Arc<FakeState>>, headers: HeaderMap) -> Response {
+    if !bearer_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    json_response(
+        StatusCode::OK,
+        format!(r#"{{"data":[{{"id":"{}"}}]}}"#, state.model_name),
+    )
+}
+
+async fn handle_chat(
+    State(state): State<Arc<FakeState>>,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    if !bearer_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    let request_json: Value = match serde_json::from_str(&body) {
+        Ok(value) => value,
+        Err(_) => {
+            return json_response(
+                StatusCode::BAD_REQUEST,
+                r#"{"error":"invalid json"}"#.to_string(),
+            )
+        }
+    };
+    state
+        .captured
+        .lock()
+        .expect("captured chat request mutex poisoned")
+        .push(request_json.clone());
+
+    match (state.responder)(&request_json) {
+        ChatAction::Sse(body) => sse_response(body),
+        ChatAction::DelayThenSse(delay, body) => {
+            // Sleep for `delay`, but wake early on shutdown.
+            let _ = tokio::time::timeout(delay, state.stop.notified()).await;
+            sse_response(body)
+        }
+        ChatAction::Hang => {
+            // Never respond until the mock is dropped; the client times out.
+            while !state.stopped.load(Ordering::Relaxed) {
+                let _ =
+                    tokio::time::timeout(Duration::from_millis(50), state.stop.notified()).await;
+            }
+            json_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                r#"{"error":"shutting down"}"#.to_string(),
+            )
+        }
+    }
+}
+
+async fn handle_fallback() -> Response {
+    json_response(
+        StatusCode::NOT_FOUND,
+        r#"{"error":"not found"}"#.to_string(),
+    )
+}
+
+/// SSE body for a single assistant tool call (`tool_calls` delta then a
+/// `finish_reason: "tool_calls"` terminal chunk and `[DONE]`).
+pub fn tool_call_sse(tool_name: &str, arguments: &str) -> String {
+    let chunk_1 = serde_json::json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": "call-read-file",
+                    "function": { "name": tool_name, "arguments": "" }
+                }]
+            },
+            "finish_reason": null
+        }],
+        "usage": null
+    });
+    let chunk_2 = serde_json::json!({
+        "choices": [{
+            "delta": {
+                "tool_calls": [{
+                    "index": 0,
+                    "id": null,
+                    "function": { "name": null, "arguments": arguments }
+                }]
+            },
+            "finish_reason": null
+        }],
+        "usage": null
+    });
+    let chunk_3 = serde_json::json!({
+        "choices": [{
+            "delta": { "content": null, "tool_calls": [] },
+            "finish_reason": "tool_calls"
+        }],
+        "usage": { "prompt_tokens": 16, "completion_tokens": 4, "total_tokens": 20 }
+    });
+    format!(
+        "data: {}\n\ndata: {}\n\ndata: {}\n\ndata: [DONE]\n\n",
+        serde_json::to_string(&chunk_1).expect("serialize tool-call chunk 1"),
+        serde_json::to_string(&chunk_2).expect("serialize tool-call chunk 2"),
+        serde_json::to_string(&chunk_3).expect("serialize tool-call chunk 3"),
+    )
+}
+
+/// SSE body for a single assistant text completion.
+pub fn completion_text_sse(text: &str) -> String {
+    let chunk_1 = serde_json::json!({
+        "choices": [{ "delta": { "content": text }, "finish_reason": null }],
+        "usage": null
+    });
+    let chunk_2 = serde_json::json!({
+        "choices": [{
+            "delta": { "content": null, "tool_calls": [] },
+            "finish_reason": "stop"
+        }],
+        "usage": { "prompt_tokens": 24, "completion_tokens": 6, "total_tokens": 30 }
+    });
+    format!(
+        "data: {}\n\ndata: {}\n\ndata: [DONE]\n\n",
+        serde_json::to_string(&chunk_1).expect("serialize completion chunk 1"),
+        serde_json::to_string(&chunk_2).expect("serialize completion chunk 2"),
+    )
+}

--- a/crates/defra-agent-cli/tests/support/mocks/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/mod.rs
@@ -1,10 +1,7 @@
-use std::io::Read;
-use std::net::TcpStream;
-
-use anyhow::{anyhow, Context, Result};
 use serde_json::Value;
 
 pub mod chat;
+pub mod fake_llm;
 pub mod model;
 pub mod openai;
 
@@ -13,114 +10,7 @@ pub use model::MockModelEndpoint;
 pub use openai::MockOpenAIEndpoint;
 
 // Re-export SSE helpers so callers that use `mocks::tool_call_sse` etc. continue to work.
-pub use chat::{completion_text_sse, tool_call_sse};
-
-pub struct HttpRequestData {
-    pub method: String,
-    pub path: String,
-    pub headers: std::collections::HashMap<String, String>,
-    pub body: Vec<u8>,
-}
-
-pub fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequestData> {
-    let mut buffer = Vec::new();
-    let mut chunk = [0_u8; 4096];
-    let mut header_end = None;
-    let mut content_length = 0_usize;
-
-    loop {
-        let read = stream.read(&mut chunk).context("reading mock request")?;
-        if read == 0 {
-            break;
-        }
-        buffer.extend_from_slice(&chunk[..read]);
-
-        if header_end.is_none() {
-            if let Some(offset) = find_header_end(&buffer) {
-                let end = offset + 4;
-                let headers = String::from_utf8_lossy(&buffer[..end]);
-                header_end = Some(end);
-                content_length = parse_content_length(&headers).unwrap_or(0);
-                if buffer.len() >= end + content_length {
-                    break;
-                }
-            }
-        } else if let Some(end) = header_end {
-            if buffer.len() >= end + content_length {
-                break;
-            }
-        }
-    }
-
-    let header_end = header_end.ok_or_else(|| anyhow!("missing request headers"))?;
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-    let request_line = header_text
-        .lines()
-        .next()
-        .ok_or_else(|| anyhow!("missing request line"))?;
-    let mut parts = request_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| anyhow!("missing HTTP method"))?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow!("missing HTTP path"))?
-        .to_string();
-    let headers = header_text
-        .lines()
-        .skip(1)
-        .filter_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            Some((name.trim().to_ascii_lowercase(), value.trim().to_string()))
-        })
-        .collect();
-    let body_end = header_end + content_length;
-    let body = if buffer.len() >= body_end {
-        buffer[header_end..body_end].to_vec()
-    } else {
-        Vec::new()
-    };
-
-    Ok(HttpRequestData {
-        method,
-        path,
-        headers,
-        body,
-    })
-}
-
-pub fn find_header_end(buffer: &[u8]) -> Option<usize> {
-    buffer.windows(4).position(|window| window == b"\r\n\r\n")
-}
-
-pub fn parse_content_length(headers: &str) -> Option<usize> {
-    headers.lines().find_map(|line| {
-        let (name, value) = line.split_once(':')?;
-        if name.eq_ignore_ascii_case("content-length") {
-            value.trim().parse().ok()
-        } else {
-            None
-        }
-    })
-}
-
-pub fn write_http_response(
-    stream: &mut TcpStream,
-    status: &str,
-    content_type: &str,
-    body: &str,
-) -> Result<()> {
-    use std::io::Write;
-    let response = format!(
-        "HTTP/1.1 {status}\r\ncontent-type: {content_type}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream
-        .write_all(response.as_bytes())
-        .context("writing mock response")?;
-    Ok(())
-}
+pub use fake_llm::{completion_text_sse, tool_call_sse};
 
 pub fn request_has_tool_result_message(request: &Value) -> bool {
     request

--- a/crates/defra-agent-cli/tests/support/mocks/model.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/model.rs
@@ -1,19 +1,16 @@
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
+//! `MockModelEndpoint`: a thin wrapper over the shared robust [`FakeLlm`] fake
+//! that only needs to answer the `/v1/models` discovery probe (optionally
+//! bearer-gated). Public API is unchanged.
+
 use std::sync::Arc;
-use std::thread;
-use std::thread::JoinHandle;
-use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::Result;
+use serde_json::Value;
 
-use super::{read_http_request, write_http_response};
+use super::fake_llm::{ChatAction, FakeLlm};
 
 pub struct MockModelEndpoint {
-    pub endpoint: String,
-    pub port: u16,
-    pub stop: Arc<AtomicBool>,
-    pub handle: Option<JoinHandle<()>>,
+    inner: FakeLlm,
 }
 
 impl MockModelEndpoint {
@@ -25,80 +22,17 @@ impl MockModelEndpoint {
         model_name: &str,
         required_bearer: Option<&str>,
     ) -> Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).context("binding mock model port")?;
-        listener
-            .set_nonblocking(true)
-            .context("marking mock model listener nonblocking")?;
-        let port = listener
-            .local_addr()
-            .context("reading mock model port")?
-            .port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
-        let required_bearer = required_bearer.map(ToOwned::to_owned);
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-
-                        let authorized = required_bearer.as_ref().is_none_or(|expected| {
-                            request
-                                .headers
-                                .get("authorization")
-                                .is_some_and(|value| value == &format!("Bearer {expected}"))
-                        });
-                        let (status, body) = if request.method == "GET"
-                            && (request.path == "/v1/models" || request.path == "/models")
-                        {
-                            if authorized {
-                                ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                            } else {
-                                (
-                                    "401 Unauthorized",
-                                    r#"{"error":"unauthorized"}"#.to_string(),
-                                )
-                            }
-                        } else {
-                            ("404 Not Found", r#"{"error":"not found"}"#.to_string())
-                        };
-                        let _ = write_http_response(&mut stream, status, "application/json", &body);
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            handle: Some(handle),
-        })
+        // Discovery-only endpoint; chat is never driven through it, so the chat
+        // responder is inert.
+        let inner = FakeLlm::start(
+            model_name,
+            required_bearer,
+            Arc::new(|_: &Value| ChatAction::Hang),
+        )?;
+        Ok(Self { inner })
     }
 
     pub fn endpoint(&self) -> &str {
-        &self.endpoint
-    }
-}
-
-impl Drop for MockModelEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
+        self.inner.endpoint()
     }
 }

--- a/crates/defra-agent-cli/tests/support/mocks/openai.rs
+++ b/crates/defra-agent-cli/tests/support/mocks/openai.rs
@@ -1,144 +1,39 @@
-use std::io::Write;
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::thread::JoinHandle;
-use std::time::Duration;
+//! `MockOpenAIEndpoint`: a thin wrapper over the shared robust [`FakeLlm`] fake
+//! that drives a two-turn tool loop — it answers the first chat request with a
+//! `read_file` tool call and, once the conversation carries a tool result, with
+//! a final text completion. Public API is unchanged.
 
-use anyhow::{Context, Result};
+use std::sync::Arc;
+
+use anyhow::Result;
 use serde_json::Value;
 
-use super::chat::{completion_text_sse, tool_call_sse};
-use super::{read_http_request, request_has_tool_result_message, write_http_response};
+use super::fake_llm::{completion_text_sse, tool_call_sse, ChatAction, FakeLlm};
+use super::request_has_tool_result_message;
 
 pub struct MockOpenAIEndpoint {
-    pub endpoint: String,
-    pub port: u16,
-    pub stop: Arc<AtomicBool>,
-    pub captured_chat_requests: Arc<Mutex<Vec<Value>>>,
-    pub handle: Option<JoinHandle<()>>,
+    inner: FakeLlm,
 }
 
 impl MockOpenAIEndpoint {
     pub fn start(model_name: &str, final_token: &str) -> Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0)).context("binding mock OpenAI port")?;
-        listener
-            .set_nonblocking(true)
-            .context("marking mock OpenAI listener nonblocking")?;
-        let port = listener
-            .local_addr()
-            .context("reading mock OpenAI port")?
-            .port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
         let final_token = final_token.to_string();
-        let captured_chat_requests = Arc::new(Mutex::new(Vec::new()));
-        let captured_chat_requests_for_thread = captured_chat_requests.clone();
-
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-
-                        match (request.method.as_str(), request.path.as_str()) {
-                            ("GET", "/v1/models") => {
-                                let body = format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#);
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    "200 OK",
-                                    "application/json",
-                                    &body,
-                                );
-                            }
-                            ("POST", "/v1/chat/completions") => {
-                                let request_json: Value =
-                                    match serde_json::from_slice(&request.body) {
-                                        Ok(value) => value,
-                                        Err(_) => {
-                                            let _ = write_http_response(
-                                                &mut stream,
-                                                "400 Bad Request",
-                                                "application/json",
-                                                r#"{"error":"invalid json"}"#,
-                                            );
-                                            let _ = stream.shutdown(Shutdown::Both);
-                                            continue;
-                                        }
-                                    };
-                                captured_chat_requests_for_thread
-                                    .lock()
-                                    .expect("captured chat request mutex poisoned")
-                                    .push(request_json.clone());
-
-                                let sse_body = if request_has_tool_result_message(&request_json) {
-                                    completion_text_sse(&final_token)
-                                } else {
-                                    tool_call_sse("read_file", r#"{"path":"notes.txt"}"#)
-                                };
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    "200 OK",
-                                    "text/event-stream",
-                                    &sse_body,
-                                );
-                            }
-                            _ => {
-                                let _ = write_http_response(
-                                    &mut stream,
-                                    "404 Not Found",
-                                    "application/json",
-                                    r#"{"error":"not found"}"#,
-                                );
-                            }
-                        }
-
-                        let _ = stream.flush();
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
+        let responder = Arc::new(move |request: &Value| {
+            if request_has_tool_result_message(request) {
+                ChatAction::Sse(completion_text_sse(&final_token))
+            } else {
+                ChatAction::Sse(tool_call_sse("read_file", r#"{"path":"notes.txt"}"#))
             }
         });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            captured_chat_requests,
-            handle: Some(handle),
-        })
+        let inner = FakeLlm::start(model_name, None, responder)?;
+        Ok(Self { inner })
     }
 
     pub fn endpoint(&self) -> &str {
-        &self.endpoint
+        self.inner.endpoint()
     }
 
     pub fn captured_chat_requests(&self) -> Vec<Value> {
-        self.captured_chat_requests
-            .lock()
-            .expect("captured chat request mutex poisoned")
-            .clone()
-    }
-}
-
-impl Drop for MockOpenAIEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
+        self.inner.captured_chat_requests()
     }
 }

--- a/crates/defra-agent-cli/tests/support/mod.rs
+++ b/crates/defra-agent-cli/tests/support/mod.rs
@@ -16,7 +16,7 @@ pub use graphql::{doc_id_for_selection, escape_graphql_string, first_graphql_row
 pub use mocks::{
     completion_text_sse, request_contains_role_text, request_has_tool_result_message,
     request_system_message, request_tool_names, request_tool_result_text, tool_call_sse,
-    HttpRequestData, MockChatEndpoint, MockModelEndpoint, MockOpenAIEndpoint,
+    MockChatEndpoint, MockModelEndpoint, MockOpenAIEndpoint,
 };
 pub use ports::{allocate_port, graphql_url};
 pub use process::{

--- a/crates/defra-agent/tests/backend_auth_startup.rs
+++ b/crates/defra-agent/tests/backend_auth_startup.rs
@@ -1,11 +1,6 @@
 mod support;
 
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
-use std::thread;
-use std::thread::JoinHandle;
-use std::time::Duration;
 
 use anyhow::Result;
 use defra_agent::defra_node::EmbeddedNode;
@@ -18,16 +13,8 @@ use serde_json::Value;
 use tokio::sync::watch;
 
 use support::fixtures::{bind_default_behavior_backend, test_behavior, test_identity};
-use support::http_mock::{read_http_request, write_http_response, HttpRequestData};
+use support::mock_endpoint::MockModelEndpoint;
 use support::waits::wait_for_runtime_process_state;
-
-struct MockModelEndpoint {
-    endpoint: String,
-    port: u16,
-    stop: Arc<AtomicBool>,
-    requests: Arc<Mutex<Vec<HttpRequestData>>>,
-    handle: Option<JoinHandle<()>>,
-}
 
 #[derive(Default)]
 struct RecordingObserver {
@@ -40,146 +27,6 @@ impl ProcessLifecycleObserver for RecordingObserver {
             .lock()
             .expect("recording observer mutex poisoned")
             .push(state);
-    }
-}
-
-impl MockModelEndpoint {
-    fn start_with_required_bearer(
-        model_name: &str,
-        required_bearer: Option<&str>,
-    ) -> anyhow::Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0))?;
-        listener.set_nonblocking(true)?;
-        let port = listener.local_addr()?.port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let requests = Arc::new(Mutex::new(Vec::new()));
-        let requests_for_thread = requests.clone();
-        let model_name = model_name.to_string();
-        let required_bearer = required_bearer.map(ToOwned::to_owned);
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-                        requests_for_thread
-                            .lock()
-                            .expect("mock request log mutex poisoned")
-                            .push(request.clone());
-                        let authorized = required_bearer.as_ref().is_none_or(|expected| {
-                            request
-                                .headers
-                                .get("authorization")
-                                .is_some_and(|value| value == &format!("Bearer {expected}"))
-                        });
-                        let (status, body) = if request.method == "GET"
-                            && (request.path == "/v1/models" || request.path == "/models")
-                        {
-                            if authorized {
-                                ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                            } else {
-                                (
-                                    "401 Unauthorized",
-                                    r#"{"error":"unauthorized"}"#.to_string(),
-                                )
-                            }
-                        } else if request.method == "GET"
-                            && (request.path == "/v1/key" || request.path == "/key")
-                        {
-                            if authorized {
-                                ("200 OK", r#"{"data":{"label":"test-key"}}"#.to_string())
-                            } else {
-                                (
-                                    "401 Unauthorized",
-                                    r#"{"error":"unauthorized"}"#.to_string(),
-                                )
-                            }
-                        } else if request.method == "POST"
-                            && (request.path == "/v1/chat/completions"
-                                || request.path == "/chat/completions")
-                        {
-                            if authorized {
-                                (
-                                    "200 OK",
-                                    format!(
-                                        r#"{{
-                                            "id":"chatcmpl-test",
-                                            "provider":"Mock",
-                                            "object":"chat.completion",
-                                            "created":1710000000,
-                                            "model":"{model_name}",
-                                            "choices":[{{
-                                                "index":0,
-                                                "finish_reason":"stop",
-                                                "message":{{
-                                                    "role":"assistant",
-                                                    "content":"mock response",
-                                                    "refusal":null,
-                                                    "reasoning":null
-                                                }}
-                                            }}],
-                                            "usage":{{
-                                                "prompt_tokens":10,
-                                                "completion_tokens":2,
-                                                "total_tokens":12
-                                            }}
-                                        }}"#
-                                    ),
-                                )
-                            } else {
-                                (
-                                    "401 Unauthorized",
-                                    r#"{"error":"unauthorized"}"#.to_string(),
-                                )
-                            }
-                        } else {
-                            ("404 Not Found", r#"{"error":"not found"}"#.to_string())
-                        };
-                        let _ = write_http_response(&mut stream, status, "application/json", &body);
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            requests,
-            handle: Some(handle),
-        })
-    }
-
-    fn endpoint(&self) -> &str {
-        &self.endpoint
-    }
-
-    fn recorded_requests(&self) -> Vec<HttpRequestData> {
-        self.requests
-            .lock()
-            .expect("mock request log mutex poisoned")
-            .clone()
-    }
-}
-
-impl Drop for MockModelEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
     }
 }
 

--- a/crates/defra-agent/tests/runtime_observability.rs
+++ b/crates/defra-agent/tests/runtime_observability.rs
@@ -1,12 +1,5 @@
 use std::sync::Arc;
 use std::time::Duration;
-use std::{
-    io::{Read, Write},
-    net::{Shutdown, TcpListener, TcpStream},
-    sync::atomic::{AtomicBool, Ordering},
-    thread,
-    thread::JoinHandle,
-};
 
 use defra_agent::{
     ensure_agent_principal, load_agent_behavior, upsert_agent_behavior, AgentIdentity, DefraAgent,
@@ -15,136 +8,13 @@ use defra_agent::{
 
 mod support;
 
+use support::mock_endpoint::MockModelEndpoint;
 use support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
 use support::test_db;
 
 fn test_identity(name: &str) -> KeyIdentity {
     let path = std::env::temp_dir().join(format!("{name}-{}.key", uuid::Uuid::new_v4()));
     KeyIdentity::load_or_create(path, None).unwrap()
-}
-
-struct MockModelEndpoint {
-    endpoint: String,
-    port: u16,
-    stop: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
-}
-
-impl MockModelEndpoint {
-    fn start(model_name: &str) -> anyhow::Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0))?;
-        listener.set_nonblocking(true)?;
-        let port = listener.local_addr()?.port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-                        let (status, body) = if request.method == "GET"
-                            && (request.path == "/v1/models" || request.path == "/models")
-                        {
-                            ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                        } else {
-                            ("404 Not Found", r#"{"error":"not found"}"#.to_string())
-                        };
-                        let _ = write_http_response(&mut stream, status, "application/json", &body);
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            handle: Some(handle),
-        })
-    }
-
-    fn endpoint(&self) -> &str {
-        &self.endpoint
-    }
-}
-
-impl Drop for MockModelEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-struct HttpRequestData {
-    method: String,
-    path: String,
-}
-
-fn read_http_request(stream: &mut TcpStream) -> anyhow::Result<HttpRequestData> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 1024];
-    let header_end = loop {
-        let read = stream.read(&mut temp)?;
-        if read == 0 {
-            anyhow::bail!("connection closed before headers");
-        }
-        buffer.extend_from_slice(&temp[..read]);
-        if let Some(index) = find_subslice(&buffer, b"\r\n\r\n") {
-            break index + 4;
-        }
-    };
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request line"))?;
-    let mut parts = request_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request method"))?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request path"))?
-        .to_string();
-    Ok(HttpRequestData { method, path })
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
-
-fn write_http_response(
-    stream: &mut TcpStream,
-    status: &str,
-    content_type: &str,
-    body: &str,
-) -> anyhow::Result<()> {
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream.write_all(response.as_bytes())?;
-    stream.flush()?;
-    Ok(())
 }
 
 async fn bind_default_behavior_backend(

--- a/crates/defra-agent/tests/schedule_snapshot_reconcile.rs
+++ b/crates/defra-agent/tests/schedule_snapshot_reconcile.rs
@@ -28,13 +28,6 @@
 
 use std::sync::Arc;
 use std::time::Duration;
-use std::{
-    io::{Read, Write},
-    net::{Shutdown, TcpListener, TcpStream},
-    sync::atomic::{AtomicBool, Ordering},
-    thread,
-    thread::JoinHandle,
-};
 
 use defra_agent::{
     ensure_agent_principal, graphql::escape_graphql_string, load_agent_behavior,
@@ -44,136 +37,13 @@ use defra_agent::{
 
 mod support;
 
+use support::mock_endpoint::MockModelEndpoint;
 use support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
 use support::test_db;
 
 fn test_identity(name: &str) -> KeyIdentity {
     let path = std::env::temp_dir().join(format!("{name}-{}.key", uuid::Uuid::new_v4()));
     KeyIdentity::load_or_create(path, None).unwrap()
-}
-
-struct MockModelEndpoint {
-    endpoint: String,
-    port: u16,
-    stop: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
-}
-
-impl MockModelEndpoint {
-    fn start(model_name: &str) -> anyhow::Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0))?;
-        listener.set_nonblocking(true)?;
-        let port = listener.local_addr()?.port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-                        let (status, body) = if request.method == "GET"
-                            && (request.path == "/v1/models" || request.path == "/models")
-                        {
-                            ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                        } else {
-                            ("404 Not Found", r#"{"error":"not found"}"#.to_string())
-                        };
-                        let _ = write_http_response(&mut stream, status, "application/json", &body);
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
-        });
-
-        Ok(Self {
-            endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            handle: Some(handle),
-        })
-    }
-
-    fn endpoint(&self) -> &str {
-        &self.endpoint
-    }
-}
-
-impl Drop for MockModelEndpoint {
-    fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
-        }
-    }
-}
-
-struct HttpRequestData {
-    method: String,
-    path: String,
-}
-
-fn read_http_request(stream: &mut TcpStream) -> anyhow::Result<HttpRequestData> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 1024];
-    let header_end = loop {
-        let read = stream.read(&mut temp)?;
-        if read == 0 {
-            anyhow::bail!("connection closed before headers");
-        }
-        buffer.extend_from_slice(&temp[..read]);
-        if let Some(index) = find_subslice(&buffer, b"\r\n\r\n") {
-            break index + 4;
-        }
-    };
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request line"))?;
-    let mut parts = request_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request method"))?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request path"))?
-        .to_string();
-    Ok(HttpRequestData { method, path })
-}
-
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
-
-fn write_http_response(
-    stream: &mut TcpStream,
-    status: &str,
-    content_type: &str,
-    body: &str,
-) -> anyhow::Result<()> {
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream.write_all(response.as_bytes())?;
-    stream.flush()?;
-    Ok(())
 }
 
 async fn bind_default_behavior_backend(

--- a/crates/defra-agent/tests/support/http_mock.rs
+++ b/crates/defra-agent/tests/support/http_mock.rs
@@ -1,9 +1,11 @@
-use std::collections::HashMap;
-use std::io::{Read, Write};
-use std::net::TcpStream;
-use std::time::Duration;
+//! Shared request type for recorded mock-backend traffic.
+//!
+//! The mock servers are now axum-based (see `mock_endpoint` / `streaming_backend`),
+//! so the previous hand-rolled `read_http_request` / `write_http_response`
+//! helpers are gone. `HttpRequestData` survives as the shape
+//! `MockModelEndpoint::recorded_requests` returns for assertion in tests.
 
-use anyhow::Result;
+use std::collections::HashMap;
 
 #[derive(Clone)]
 pub struct HttpRequestData {
@@ -11,80 +13,4 @@ pub struct HttpRequestData {
     pub path: String,
     pub headers: HashMap<String, String>,
     pub body: String,
-}
-
-pub fn read_http_request(stream: &mut TcpStream) -> Result<HttpRequestData> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 1024];
-    let header_end = loop {
-        let read = stream.read(&mut temp)?;
-        if read == 0 {
-            anyhow::bail!("connection closed before headers");
-        }
-        buffer.extend_from_slice(&temp[..read]);
-        if let Some(index) = find_subslice(&buffer, b"\r\n\r\n") {
-            break index + 4;
-        }
-    };
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request line"))?;
-    let mut parts = request_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request method"))?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request path"))?
-        .to_string();
-    let headers: HashMap<String, String> = lines
-        .filter_map(|line| {
-            let (name, value) = line.split_once(':')?;
-            Some((name.trim().to_ascii_lowercase(), value.trim().to_string()))
-        })
-        .collect();
-    let content_length = headers
-        .get("content-length")
-        .and_then(|value: &String| value.parse::<usize>().ok())
-        .unwrap_or(0);
-    let mut body = buffer[header_end..].to_vec();
-    while body.len() < content_length {
-        let read = stream.read(&mut temp)?;
-        if read == 0 {
-            anyhow::bail!("connection closed before request body");
-        }
-        body.extend_from_slice(&temp[..read]);
-    }
-
-    Ok(HttpRequestData {
-        method,
-        path,
-        headers,
-        body: String::from_utf8_lossy(&body[..content_length]).to_string(),
-    })
-}
-
-pub fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
-
-pub fn write_http_response(
-    stream: &mut TcpStream,
-    status: &str,
-    content_type: &str,
-    body: &str,
-) -> Result<()> {
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream.write_all(response.as_bytes())?;
-    stream.flush()?;
-    Ok(())
 }

--- a/crates/defra-agent/tests/support/mock_endpoint.rs
+++ b/crates/defra-agent/tests/support/mock_endpoint.rs
@@ -1,138 +1,227 @@
-//! Minimal mock OpenAI-compatible backend used by schedule / runtime
-//! conformance tests.
+//! Robust shared mock OpenAI-compatible backend for full-daemon tests.
 //!
-//! The probe during startup only needs a `/models` endpoint to return a
-//! successful JSON payload so that the default behavior resolves as healthy
-//! and runnable. No inference traffic is driven through this endpoint in the
-//! current conformance suites — they assert persistence-layer state only.
+//! Built on `axum` rather than a hand-rolled `TcpListener` accept loop so it
+//! cannot flake the way the previous nonblocking-poll servers did (a transient
+//! `accept()` error there killed the listener via `Err(_) => break`, causing
+//! "error sending request" failures under CI load). One robust implementation
+//! replaces the several near-identical hand-rolled copies that used to live in
+//! this support module and inline in individual test files.
+//!
+//! Serves the routes the startup probe and oneshot/inference paths touch:
+//! `GET /v1/models` (+ `/models`), `GET /v1/key` (+ `/key`), and
+//! `POST /v1/chat/completions` (+ `/chat/completions`) with a fixed
+//! non-streaming completion. An optional required bearer token gates every
+//! route (401 on mismatch), and every request is recorded for inspection.
 
-use std::io::{Read, Write};
-use std::net::{Shutdown, TcpListener, TcpStream};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
+use serde_json::json;
+use tokio::sync::oneshot;
+
+use super::http_mock::HttpRequestData;
+
+#[derive(Clone)]
+struct MockState {
+    model_name: String,
+    required_bearer: Option<String>,
+    recorded: Arc<Mutex<Vec<HttpRequestData>>>,
+}
 
 pub struct MockModelEndpoint {
     endpoint: String,
-    port: u16,
-    stop: Arc<AtomicBool>,
-    handle: Option<JoinHandle<()>>,
+    recorded: Arc<Mutex<Vec<HttpRequestData>>>,
+    shutdown: Option<oneshot::Sender<()>>,
 }
 
 impl MockModelEndpoint {
+    /// Start a mock backend with no auth requirement (the common case: the
+    /// startup probe just needs `/models` to answer so the backend promotes to
+    /// healthy).
     pub fn start(model_name: &str) -> anyhow::Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        Self::start_with_required_bearer(model_name, None)
+    }
+
+    /// Start a mock backend that requires `Authorization: Bearer <token>` on
+    /// every route when `required_bearer` is `Some`, returning 401 otherwise.
+    pub fn start_with_required_bearer(
+        model_name: &str,
+        required_bearer: Option<&str>,
+    ) -> anyhow::Result<Self> {
+        let recorded = Arc::new(Mutex::new(Vec::new()));
+        let state = MockState {
+            model_name: model_name.to_string(),
+            required_bearer: required_bearer.map(ToOwned::to_owned),
+            recorded: recorded.clone(),
+        };
+        let app = Router::new()
+            .route("/v1/models", get(handle_models))
+            .route("/models", get(handle_models))
+            .route("/v1/key", get(handle_key))
+            .route("/key", get(handle_key))
+            .route("/v1/chat/completions", post(handle_chat))
+            .route("/chat/completions", post(handle_chat))
+            .fallback(handle_fallback)
+            .with_state(state);
+
+        // Bind synchronously so the port is reserved before we return, then
+        // serve on the ambient tokio runtime (every consumer is a
+        // `#[tokio::test]`). `from_std` requires the listener be nonblocking.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
         listener.set_nonblocking(true)?;
         let port = listener.local_addr()?.port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let stop_for_thread = stop.clone();
-        let model_name = model_name.to_string();
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((mut stream, _)) => {
-                        let request = match read_http_request(&mut stream) {
-                            Ok(request) => request,
-                            Err(_) => {
-                                let _ = stream.shutdown(Shutdown::Both);
-                                continue;
-                            }
-                        };
-                        let (status, body) = if request.method == "GET"
-                            && (request.path == "/v1/models" || request.path == "/models")
-                        {
-                            ("200 OK", format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#))
-                        } else {
-                            ("404 Not Found", r#"{"error":"not found"}"#.to_string())
-                        };
-                        let _ = write_http_response(&mut stream, status, "application/json", &body);
-                        let _ = stream.shutdown(Shutdown::Both);
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(25));
-                    }
-                    Err(_) => break,
-                }
-            }
+        let listener = tokio::net::TcpListener::from_std(listener)?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
         });
 
         Ok(Self {
             endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
-            handle: Some(handle),
+            recorded,
+            shutdown: Some(shutdown_tx),
         })
     }
 
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }
+
+    pub fn recorded_requests(&self) -> Vec<HttpRequestData> {
+        self.recorded
+            .lock()
+            .expect("mock recorded-requests mutex poisoned")
+            .clone()
+    }
 }
 
 impl Drop for MockModelEndpoint {
     fn drop(&mut self) {
-        self.stop.store(true, Ordering::Relaxed);
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
         }
     }
 }
 
-struct HttpRequestData {
-    method: String,
-    path: String,
+fn headers_to_map(headers: &HeaderMap) -> HashMap<String, String> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            (
+                name.as_str().to_string(),
+                value.to_str().unwrap_or_default().to_string(),
+            )
+        })
+        .collect()
 }
 
-fn read_http_request(stream: &mut TcpStream) -> anyhow::Result<HttpRequestData> {
-    stream.set_read_timeout(Some(Duration::from_secs(2)))?;
-    let mut buffer = Vec::new();
-    let mut temp = [0u8; 1024];
-    let header_end = loop {
-        let read = stream.read(&mut temp)?;
-        if read == 0 {
-            anyhow::bail!("connection closed before headers");
+fn record(state: &MockState, method: &str, path: &str, headers: &HeaderMap, body: String) {
+    state
+        .recorded
+        .lock()
+        .expect("mock recorded-requests mutex poisoned")
+        .push(HttpRequestData {
+            method: method.to_string(),
+            path: path.to_string(),
+            headers: headers_to_map(headers),
+            body,
+        });
+}
+
+fn bearer_authorized(state: &MockState, headers: &HeaderMap) -> bool {
+    match &state.required_bearer {
+        None => true,
+        Some(expected) => {
+            headers
+                .get(header::AUTHORIZATION)
+                .and_then(|value| value.to_str().ok())
+                == Some(format!("Bearer {expected}").as_str())
         }
-        buffer.extend_from_slice(&temp[..read]);
-        if let Some(index) = find_subslice(&buffer, b"\r\n\r\n") {
-            break index + 4;
+    }
+}
+
+fn json_response(status: StatusCode, body: String) -> Response {
+    (status, [(header::CONTENT_TYPE, "application/json")], body).into_response()
+}
+
+fn unauthorized() -> Response {
+    json_response(
+        StatusCode::UNAUTHORIZED,
+        r#"{"error":"unauthorized"}"#.to_string(),
+    )
+}
+
+async fn handle_models(State(state): State<MockState>, uri: Uri, headers: HeaderMap) -> Response {
+    record(&state, "GET", uri.path(), &headers, String::new());
+    if !bearer_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    json_response(
+        StatusCode::OK,
+        format!(r#"{{"data":[{{"id":"{}"}}]}}"#, state.model_name),
+    )
+}
+
+async fn handle_key(State(state): State<MockState>, uri: Uri, headers: HeaderMap) -> Response {
+    record(&state, "GET", uri.path(), &headers, String::new());
+    if !bearer_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    json_response(
+        StatusCode::OK,
+        r#"{"data":{"label":"test-key"}}"#.to_string(),
+    )
+}
+
+async fn handle_chat(
+    State(state): State<MockState>,
+    uri: Uri,
+    headers: HeaderMap,
+    body: String,
+) -> Response {
+    record(&state, "POST", uri.path(), &headers, body);
+    if !bearer_authorized(&state, &headers) {
+        return unauthorized();
+    }
+    let completion = json!({
+        "id": "chatcmpl-test",
+        "provider": "Mock",
+        "object": "chat.completion",
+        "created": 1_710_000_000_u64,
+        "model": state.model_name,
+        "choices": [{
+            "index": 0,
+            "finish_reason": "stop",
+            "message": {
+                "role": "assistant",
+                "content": "mock response",
+                "refusal": null,
+                "reasoning": null
+            }
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 2,
+            "total_tokens": 12
         }
-    };
-    let header_text = String::from_utf8_lossy(&buffer[..header_end]);
-    let mut lines = header_text.split("\r\n").filter(|line| !line.is_empty());
-    let request_line = lines
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request line"))?;
-    let mut parts = request_line.split_whitespace();
-    let method = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request method"))?
-        .to_string();
-    let path = parts
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("missing request path"))?
-        .to_string();
-    Ok(HttpRequestData { method, path })
+    });
+    json_response(StatusCode::OK, completion.to_string())
 }
 
-fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack
-        .windows(needle.len())
-        .position(|window| window == needle)
-}
-
-fn write_http_response(
-    stream: &mut TcpStream,
-    status: &str,
-    content_type: &str,
-    body: &str,
-) -> anyhow::Result<()> {
-    let response = format!(
-        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
-        body.len()
-    );
-    stream.write_all(response.as_bytes())?;
-    stream.flush()?;
-    Ok(())
+async fn handle_fallback(State(state): State<MockState>, uri: Uri, headers: HeaderMap) -> Response {
+    record(&state, "OTHER", uri.path(), &headers, String::new());
+    json_response(
+        StatusCode::NOT_FOUND,
+        r#"{"error":"not found"}"#.to_string(),
+    )
 }

--- a/crates/defra-agent/tests/support/streaming_backend.rs
+++ b/crates/defra-agent/tests/support/streaming_backend.rs
@@ -1,16 +1,26 @@
 //! Deterministic OpenAI-compatible streaming backend for full-daemon tests.
+//!
+//! Built on `axum` (a real async HTTP server) rather than a hand-rolled
+//! nonblocking `TcpListener` accept loop, so it cannot flake the way the
+//! previous server did (its `Err(_) => break` arm killed the listener on any
+//! transient accept error under CI load). The SSE byte format, the
+//! `StreamScript` pause/release semantics, and the chunk-count accounting are
+//! preserved exactly so existing consumers are unchanged.
 
 use std::collections::{HashMap, HashSet};
-use std::io::Write;
-use std::net::{Shutdown, TcpListener, TcpStream};
+use std::convert::Infallible;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
-use std::thread::{self, JoinHandle};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::sse::{Event, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::Router;
 use serde_json::json;
-
-use super::http_mock::{read_http_request, write_http_response};
+use tokio::sync::{oneshot, Notify};
 
 #[derive(Clone, Debug)]
 pub struct StreamScript {
@@ -45,47 +55,48 @@ impl StreamScript {
 
 pub struct MockStreamingBackend {
     endpoint: String,
-    port: u16,
-    stop: Arc<AtomicBool>,
     state: Arc<StreamingState>,
-    handle: Option<JoinHandle<()>>,
+    stop: Arc<AtomicBool>,
+    shutdown: Option<oneshot::Sender<()>>,
 }
 
 impl MockStreamingBackend {
     pub fn start(model_name: &str, scripts: Vec<StreamScript>) -> anyhow::Result<Self> {
-        let listener = TcpListener::bind(("127.0.0.1", 0))?;
+        let stop = Arc::new(AtomicBool::new(false));
+        let state = Arc::new(StreamingState::new(
+            model_name.to_string(),
+            scripts,
+            stop.clone(),
+        ));
+        let app = Router::new()
+            .route("/v1/models", get(handle_models))
+            .route("/models", get(handle_models))
+            .route("/v1/chat/completions", post(handle_chat))
+            .route("/chat/completions", post(handle_chat))
+            .fallback(handle_fallback)
+            .with_state(state.clone());
+
+        // Bind synchronously, serve on the ambient tokio runtime (consumers are
+        // `#[tokio::test]`); `from_std` requires the listener be nonblocking.
+        let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
         listener.set_nonblocking(true)?;
         let port = listener.local_addr()?.port();
-        let stop = Arc::new(AtomicBool::new(false));
-        let state = Arc::new(StreamingState::new(scripts));
-        let model_name = model_name.to_string();
-        let stop_for_thread = stop.clone();
-        let state_for_thread = state.clone();
-        let handle = thread::spawn(move || {
-            while !stop_for_thread.load(Ordering::Relaxed) {
-                match listener.accept() {
-                    Ok((stream, _)) => {
-                        let stop = stop_for_thread.clone();
-                        let state = state_for_thread.clone();
-                        let model_name = model_name.clone();
-                        thread::spawn(move || {
-                            let _ = handle_connection(stream, &model_name, state, stop);
-                        });
-                    }
-                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
-                        thread::sleep(Duration::from_millis(10));
-                    }
-                    Err(_) => break,
-                }
-            }
+        let listener = tokio::net::TcpListener::from_std(listener)?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
         });
 
         Ok(Self {
             endpoint: format!("http://127.0.0.1:{port}/v1"),
-            port,
-            stop,
             state,
-            handle: Some(handle),
+            stop,
+            shutdown: Some(shutdown_tx),
         })
     }
 
@@ -102,14 +113,10 @@ impl MockStreamingBackend {
     }
 
     pub async fn wait_for_chunks(&self, marker: &str, expected: usize) {
-        let state = self.state.clone();
-        let marker = marker.to_string();
-        let marker_for_wait = marker.clone();
-        let observed = tokio::task::spawn_blocking(move || {
-            state.wait_for_chunk_count(&marker_for_wait, expected, Duration::from_secs(5))
-        })
-        .await
-        .expect("streaming backend chunk wait task should join");
+        let observed = self
+            .state
+            .wait_for_chunk_count(marker, expected, Duration::from_secs(5))
+            .await;
         assert!(
             observed >= expected,
             "timed out waiting for {expected} chunk(s) for marker {marker}, observed {observed}"
@@ -119,19 +126,22 @@ impl MockStreamingBackend {
 
 impl Drop for MockStreamingBackend {
     fn drop(&mut self) {
+        // Wake any paused stream so in-flight SSE responses can finish, then
+        // stop the server.
         self.stop.store(true, Ordering::Relaxed);
-        self.state.notify_all();
-        let _ = TcpStream::connect(("127.0.0.1", self.port));
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.join();
+        self.state.notify.notify_waiters();
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
         }
     }
 }
 
 struct StreamingState {
+    model_name: String,
     scripts: Vec<StreamScript>,
+    stop: Arc<AtomicBool>,
     inner: Mutex<StreamingStateInner>,
-    condvar: Condvar,
+    notify: Notify,
 }
 
 #[derive(Default)]
@@ -141,25 +151,29 @@ struct StreamingStateInner {
 }
 
 impl StreamingState {
-    fn new(scripts: Vec<StreamScript>) -> Self {
+    fn new(model_name: String, scripts: Vec<StreamScript>, stop: Arc<AtomicBool>) -> Self {
         Self {
+            model_name,
             scripts,
+            stop,
             inner: Mutex::new(StreamingStateInner::default()),
-            condvar: Condvar::new(),
+            notify: Notify::new(),
         }
     }
 
-    fn find_script(&self, body: &str) -> Option<StreamScript> {
+    fn find_script(&self, body: &str) -> StreamScript {
         self.scripts
             .iter()
             .find(|script| body.contains(&script.marker))
             .cloned()
+            .unwrap_or_else(|| StreamScript::completes("__default__", ["mock streamed response"]))
     }
 
     fn record_chunk(&self, marker: &str) {
         let mut inner = self.inner.lock().expect("streaming backend mutex poisoned");
         *inner.chunk_counts.entry(marker.to_string()).or_default() += 1;
-        self.condvar.notify_all();
+        drop(inner);
+        self.notify.notify_waiters();
     }
 
     fn chunk_count(&self, marker: &str) -> usize {
@@ -172,22 +186,19 @@ impl StreamingState {
             .unwrap_or_default()
     }
 
-    fn wait_for_chunk_count(&self, marker: &str, expected: usize, timeout: Duration) -> usize {
+    async fn wait_for_chunk_count(
+        &self,
+        marker: &str,
+        expected: usize,
+        timeout: Duration,
+    ) -> usize {
         let started = Instant::now();
-        let mut inner = self.inner.lock().expect("streaming backend mutex poisoned");
         loop {
-            let actual = inner.chunk_counts.get(marker).copied().unwrap_or_default();
+            let actual = self.chunk_count(marker);
             if actual >= expected || started.elapsed() >= timeout {
                 return actual;
             }
-            let remaining = timeout
-                .checked_sub(started.elapsed())
-                .unwrap_or(Duration::ZERO);
-            inner = self
-                .condvar
-                .wait_timeout(inner, remaining.min(Duration::from_millis(25)))
-                .expect("streaming backend condvar poisoned")
-                .0;
+            let _ = tokio::time::timeout(Duration::from_millis(25), self.notify.notified()).await;
         }
     }
 
@@ -197,69 +208,22 @@ impl StreamingState {
             .expect("streaming backend mutex poisoned")
             .releases
             .insert(marker.to_string());
-        self.condvar.notify_all();
+        self.notify.notify_waiters();
     }
 
-    fn wait_for_release_or_stop(&self, marker: &str, stop: &AtomicBool) {
-        let mut inner = self.inner.lock().expect("streaming backend mutex poisoned");
-        while !stop.load(Ordering::Relaxed) && !inner.releases.contains(marker) {
-            inner = self
-                .condvar
-                .wait_timeout(inner, Duration::from_millis(25))
-                .expect("streaming backend condvar poisoned")
-                .0;
+    fn is_released(&self, marker: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("streaming backend mutex poisoned")
+            .releases
+            .contains(marker)
+    }
+
+    async fn wait_for_release_or_stop(&self, marker: &str) {
+        while !self.stop.load(Ordering::Relaxed) && !self.is_released(marker) {
+            let _ = tokio::time::timeout(Duration::from_millis(25), self.notify.notified()).await;
         }
     }
-
-    fn notify_all(&self) {
-        self.condvar.notify_all();
-    }
-}
-
-fn handle_connection(
-    mut stream: TcpStream,
-    model_name: &str,
-    state: Arc<StreamingState>,
-    stop: Arc<AtomicBool>,
-) -> anyhow::Result<()> {
-    let request = match read_http_request(&mut stream) {
-        Ok(request) => request,
-        Err(error) => {
-            let _ = stream.shutdown(Shutdown::Both);
-            return Err(error);
-        }
-    };
-
-    if request.method == "GET" && (request.path == "/v1/models" || request.path == "/models") {
-        let body = format!(r#"{{"data":[{{"id":"{model_name}"}}]}}"#);
-        write_http_response(&mut stream, "200 OK", "application/json", &body)?;
-        let _ = stream.shutdown(Shutdown::Both);
-        return Ok(());
-    }
-
-    if request.method == "POST"
-        && (request.path == "/v1/chat/completions" || request.path == "/chat/completions")
-    {
-        if request_is_streaming(&request.body) {
-            let script = state.find_script(&request.body).unwrap_or_else(|| {
-                StreamScript::completes("__default__", ["mock streamed response"])
-            });
-            write_streaming_response(&mut stream, &script, state, stop)?;
-        } else {
-            write_completion_response(&mut stream, model_name)?;
-        }
-        let _ = stream.shutdown(Shutdown::Both);
-        return Ok(());
-    }
-
-    write_http_response(
-        &mut stream,
-        "404 Not Found",
-        "application/json",
-        r#"{"error":"not found"}"#,
-    )?;
-    let _ = stream.shutdown(Shutdown::Both);
-    Ok(())
 }
 
 fn request_is_streaming(body: &str) -> bool {
@@ -269,12 +233,27 @@ fn request_is_streaming(body: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn write_completion_response(stream: &mut TcpStream, model_name: &str) -> anyhow::Result<()> {
-    let body = json!({
+async fn handle_models(State(state): State<Arc<StreamingState>>) -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        format!(r#"{{"data":[{{"id":"{}"}}]}}"#, state.model_name),
+    )
+        .into_response()
+}
+
+async fn handle_chat(State(state): State<Arc<StreamingState>>, body: String) -> Response {
+    if request_is_streaming(&body) {
+        let script = state.find_script(&body);
+        return streaming_response(script, state);
+    }
+
+    // Non-streaming completion (title generation and similar).
+    let completion = json!({
         "id": "chatcmpl-title",
         "object": "chat.completion",
-        "created": 1710000000_u64,
-        "model": model_name,
+        "created": 1_710_000_000_u64,
+        "model": state.model_name,
         "choices": [{
             "index": 0,
             "finish_reason": "stop",
@@ -290,45 +269,86 @@ fn write_completion_response(stream: &mut TcpStream, model_name: &str) -> anyhow
             "completion_tokens": 1,
             "total_tokens": 5
         }
-    })
-    .to_string();
-    write_http_response(stream, "200 OK", "application/json", &body)
+    });
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/json")],
+        completion.to_string(),
+    )
+        .into_response()
 }
 
-fn write_streaming_response(
-    stream: &mut TcpStream,
-    script: &StreamScript,
-    state: Arc<StreamingState>,
-    stop: Arc<AtomicBool>,
-) -> anyhow::Result<()> {
-    stream.write_all(
-        b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n",
-    )?;
-    stream.flush()?;
-
-    for chunk in &script.chunks {
-        if stop.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-        write_sse_chunk(stream, chunk)?;
-        state.record_chunk(&script.marker);
-    }
-
-    if script.pause_after_chunks {
-        state.wait_for_release_or_stop(&script.marker, &stop);
-        if stop.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-    }
-
-    write_sse_usage(stream)?;
-    stream.write_all(b"data: [DONE]\n\n")?;
-    stream.flush()?;
-    Ok(())
+async fn handle_fallback() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        [(header::CONTENT_TYPE, "application/json")],
+        r#"{"error":"not found"}"#,
+    )
+        .into_response()
 }
 
-fn write_sse_chunk(stream: &mut TcpStream, content: &str) -> anyhow::Result<()> {
-    let data = json!({
+/// Drive one scripted SSE response. Mirrors the previous hand-rolled byte
+/// output: one `data: {chunk}` event per scripted chunk, an optional pause
+/// until `release(marker)` (or shutdown), a terminal usage event, and
+/// `data: [DONE]`.
+fn streaming_response(script: StreamScript, state: Arc<StreamingState>) -> Response {
+    #[derive(Clone, Copy)]
+    enum Phase {
+        Chunk(usize),
+        AwaitRelease,
+        Usage,
+        Done,
+        Finished,
+    }
+
+    let init = (Phase::Chunk(0), script, state);
+    let stream = futures::stream::unfold(init, |(phase, script, state)| async move {
+        let mut phase = phase;
+        loop {
+            match phase {
+                Phase::Chunk(index) => {
+                    if state.stop.load(Ordering::Relaxed) {
+                        return None;
+                    }
+                    if index < script.chunks.len() {
+                        let event = Event::default().data(chunk_payload(&script.chunks[index]));
+                        state.record_chunk(&script.marker);
+                        return Some((
+                            Ok::<Event, Infallible>(event),
+                            (Phase::Chunk(index + 1), script, state),
+                        ));
+                    }
+                    phase = if script.pause_after_chunks {
+                        Phase::AwaitRelease
+                    } else {
+                        Phase::Usage
+                    };
+                }
+                Phase::AwaitRelease => {
+                    state.wait_for_release_or_stop(&script.marker).await;
+                    if state.stop.load(Ordering::Relaxed) {
+                        return None;
+                    }
+                    phase = Phase::Usage;
+                }
+                Phase::Usage => {
+                    let event = Event::default().data(usage_payload());
+                    return Some((Ok(event), (Phase::Done, script, state)));
+                }
+                Phase::Done => {
+                    let event = Event::default().data("[DONE]");
+                    return Some((Ok(event), (Phase::Finished, script, state)));
+                }
+                Phase::Finished => return None,
+            }
+        }
+    });
+
+    Sse::new(stream).into_response()
+}
+
+fn chunk_payload(content: &str) -> String {
+    json!({
         "choices": [{
             "delta": {
                 "content": content,
@@ -337,22 +357,18 @@ fn write_sse_chunk(stream: &mut TcpStream, content: &str) -> anyhow::Result<()> 
             "finish_reason": null
         }],
         "usage": null
-    });
-    write!(stream, "data: {data}\n\n")?;
-    stream.flush()?;
-    Ok(())
+    })
+    .to_string()
 }
 
-fn write_sse_usage(stream: &mut TcpStream) -> anyhow::Result<()> {
-    let data = json!({
+fn usage_payload() -> String {
+    json!({
         "choices": [],
         "usage": {
             "prompt_tokens": 8,
             "completion_tokens": 3,
             "total_tokens": 11
         }
-    });
-    write!(stream, "data: {data}\n\n")?;
-    stream.flush()?;
-    Ok(())
+    })
+    .to_string()
 }


### PR DESCRIPTION
## What

Replaces **9 hand-rolled mock LLM servers** (nonblocking `TcpListener` accept loops, all sharing the flaky `Err(_) => break` arm that killed the listener on any transient `accept()` error under CI load → "error sending request" failures) with **3 robust `axum`-based fakes** (1 in the CLI crate; 2 in defra-agent: non-streaming + streaming). Public APIs are preserved, so consumers are unchanged.

This is **Phase 1** of the LLM-mock cleanup discussed in #440's neighborhood (test-double smell + flakiness). It fixes the flakiness class; the further "push down to the `CompletionModel` trait seam" is deferred (see follow-up issue).

## Why

These mock servers run only in the full lib/integration + full CLI suites, which execute on **main-push CI, not on PRs** — so the flaky accept loop accumulated intermittent failures on `main` (e.g. `backend_auth_startup::openrouter_oneshot_...`). The fix is one robust server, not nine hand-rolled ones.

## Changes

**`defra-agent` crate** (`a7a648ab`, `a8be9589`)
- `tests/support/mock_endpoint.rs` → axum `MockModelEndpoint` (models / key / bearer / non-streaming chat / request recording). Deletes 3 byte-identical inlined copies (`backend_auth_startup`, `schedule_snapshot_reconcile`, `runtime_observability`).
- `tests/support/streaming_backend.rs` → axum SSE (`futures::stream::unfold`), preserving exact SSE bytes + `StreamScript` pause/release + chunk-count semantics.
- `tests/support/http_mock.rs` trimmed to just `HttpRequestData` (the recorded-request shape); dead hand-rolled reader/writer removed.

**`defra-agent-cli` crate** (`83c160b5`)
- New `tests/support/mocks/fake_llm.rs`: one `FakeLlm` axum server (own current-thread runtime in a background thread, so it works for `#[tokio::test]` *and* blocking CLI-subprocess tests) parameterized by a chat `Responder` (`Sse` / `DelayThenSse` / `Hang`).
- `MockChatEndpoint`, `MockModelEndpoint`, `MockOpenAIEndpoint`, and the inline `BlockingSpawnEndpoint` become thin wrappers over it (APIs unchanged: `start*`, `endpoint`, `captured_chat_requests`, `set_behavior_id`, …). SSE builders moved into `fake_llm`; dead `read_http_request`/`write_http_response`/`HttpRequestData` plumbing removed (the `request_*` JSON inspectors stay).

## Validation

Full both-crate suites pass locally (the same commands main-push CI runs):
- `cargo test -p defra-agent --lib --tests` — green (incl. backend_auth_startup, schedule_snapshot_reconcile, runtime_observability, write_tool_trigger_e2e, interruption_integration, state_machine_conformance/streaming_compaction).
- `cargo test -p defra-agent-cli -- --test-threads=1` — green (incl. cli_chat, cli_subagent_cancel, cli_codex_shim, cli_server, cli_init, cli_request).

Note: flake elimination can only be fully confirmed over repeated main-push CI runs (these pass locally regardless); the robustness change (no nonblocking-poll, no break-on-transient, real framework) is the mechanism.

## Follow-up (deferred)

Phase 2 — push response-only tests down to rig's `CompletionModel` trait seam (inject an in-process fake instead of an HTTP server) + a startup-probe bypass — tracked separately; it's an architecture-purity improvement for ~2 tests now that flakiness is resolved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
