### PR TITLE
feat(inference): emit x-session-id for sticky-session routing

### DIFF
--- a/crates/defra-agent/src/admission/client.rs
+++ b/crates/defra-agent/src/admission/client.rs
@@ -169,6 +169,9 @@ pub(crate) struct AdmissionCallContext {
     pub(super) backend_id: String,
     pub(super) behavior_id: String,
     pub(super) agent_did: String,
+    /// Stable per-conversation id, emitted as `x-session-id` on inference
+    /// requests for sticky-session load-balancer routing (issue #447).
+    pub(super) session_id: String,
     pub(super) call_kind: CallKind,
     pub(super) attempt: i64,
     pub(super) call_seq: Arc<AtomicU64>,
@@ -195,6 +198,7 @@ impl AdmissionCallContext {
             backend_id: backend_id.into(),
             behavior_id: behavior_id.into(),
             agent_did: request.agent_did.clone(),
+            session_id: request.session_id.clone(),
             call_kind: CallKind::Inference,
             attempt: 1,
             call_seq: Arc::new(AtomicU64::new(0)),
@@ -295,4 +299,13 @@ pub(super) fn current_context() -> Result<AdmissionCallContext, CompletionError>
     ADMISSION_CALL_CONTEXT
         .try_with(Clone::clone)
         .map_err(|_| CompletionError::ProviderError("missing inference admission context".into()))
+}
+
+/// The session id of the in-flight inference request, if called within a
+/// request scope. Used to tag outbound inference requests with `x-session-id`
+/// for sticky-session routing (issue #447); returns `None` outside a scope.
+pub(crate) fn current_session_id() -> Option<String> {
+    ADMISSION_CALL_CONTEXT
+        .try_with(|context| context.session_id.clone())
+        .ok()
 }

--- a/crates/defra-agent/src/admission/mod.rs
+++ b/crates/defra-agent/src/admission/mod.rs
@@ -10,7 +10,7 @@ mod slot_accounting;
 pub(crate) mod stream_guard;
 
 pub(crate) use client::{
-    scope_call, scope_call_with_token_and_failure_reason, scope_request,
+    current_session_id, scope_call, scope_call_with_token_and_failure_reason, scope_request,
     set_terminal_failure_reason, terminal_failure_reason_observer, AdmissionCallContext,
     AdmittedCompletionClient, CallKind,
 };

--- a/crates/defra-agent/src/admission/registry.rs
+++ b/crates/defra-agent/src/admission/registry.rs
@@ -160,6 +160,7 @@ impl AdmissionRegistry {
             backend_id: backend_id.into(),
             behavior_id: behavior_id.into(),
             agent_did: agent_did.into(),
+            session_id: "session-test".to_string(),
             call_kind,
             attempt: 1,
             call_seq: Arc::new(AtomicU64::new(0)),

--- a/crates/defra-agent/src/admission/tests.rs
+++ b/crates/defra-agent/src/admission/tests.rs
@@ -67,6 +67,25 @@ fn request(request_id: &str) -> AgentRequest {
     }
 }
 
+#[tokio::test]
+async fn current_session_id_reflects_request_scope() {
+    // Outside any admission scope there is no session id to attach.
+    assert_eq!(super::current_session_id(), None);
+
+    let context = AdmissionCallContext::for_request(&request("req-x"), "default", "backend-1");
+    scope_request(context, async {
+        assert_eq!(
+            super::current_session_id().as_deref(),
+            Some("session-req-x"),
+            "the in-flight request's session id must be visible for x-session-id tagging"
+        );
+    })
+    .await;
+
+    // It is cleared again once the request scope ends.
+    assert_eq!(super::current_session_id(), None);
+}
+
 const ADMISSION_TERMINAL_REASON_SOURCES: &[&str] = &[
     include_str!("controller.rs"),
     include_str!("permit.rs"),

--- a/crates/defra-agent/src/agent/runtime/context.rs
+++ b/crates/defra-agent/src/agent/runtime/context.rs
@@ -128,12 +128,14 @@ impl RuntimeContext {
                     "building OpenAI-compatible completion client for behavior {} against {}",
                     behavior.behavior_id, behavior.backend_endpoint
                 );
-                let client: rig::providers::openai::CompletionsClient =
-                    rig::providers::openai::CompletionsClient::builder()
-                        .api_key(&api_key)
-                        .base_url(&behavior.backend_endpoint)
-                        .build()
-                        .with_context(|| build_context.clone())?;
+                let client: rig::providers::openai::CompletionsClient<
+                    crate::inference_http::SessionTaggingHttpClient,
+                > = rig::providers::openai::CompletionsClient::builder()
+                    .api_key(&api_key)
+                    .base_url(&behavior.backend_endpoint)
+                    .http_client(crate::inference_http::SessionTaggingHttpClient::default())
+                    .build()
+                    .with_context(|| build_context.clone())?;
                 self.run_behavior_with_client(
                     behavior,
                     request_rx,

--- a/crates/defra-agent/src/inference_http.rs
+++ b/crates/defra-agent/src/inference_http.rs
@@ -1,0 +1,105 @@
+//! HTTP client wrapper that tags outbound inference requests with the current
+//! agent session id.
+//!
+//! Emitting `x-session-id` lets a load balancer in front of a multi-replica,
+//! prefix-caching inference backend pin every turn of a conversation to the
+//! same replica (sticky-session routing), keeping that replica's prefix cache
+//! warm so only the new turn's delta is prefilled instead of paying the full
+//! prefill tax on each hop. See issue #447.
+//!
+//! The session id is resolved per request from the admission task-local request
+//! context, because the rig completion client is built once per behavior while
+//! the session id varies per request. This mirrors the per-request injection
+//! seam already used by [`crate::chatgpt_codex::ChatGptCodexHttpClient`].
+
+use std::future::Future;
+
+use bytes::Bytes;
+use rig::http_client::{
+    self, HeaderValue, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient, Response,
+    StreamingResponse,
+};
+use rig::wasm_compat::WasmCompatSend;
+
+/// Header carrying the agent session id on outbound inference requests.
+const SESSION_ID_HEADER: &str = "x-session-id";
+
+/// A [`HttpClientExt`] that injects [`SESSION_ID_HEADER`] from the current
+/// admission request context onto each outbound request, then delegates to the
+/// inner reqwest client. When there is no active session context (e.g. one-shot
+/// calls outside the daemon scope) the request is passed through unchanged.
+#[derive(Clone, Debug, Default)]
+pub struct SessionTaggingHttpClient {
+    inner: ReqwestClient,
+}
+
+impl SessionTaggingHttpClient {
+    fn tag<T>(req: Request<T>) -> Request<Bytes>
+    where
+        T: Into<Bytes>,
+    {
+        let (mut parts, body) = req.into_parts();
+        if let Some(session_id) = crate::admission::current_session_id() {
+            if let Ok(value) = HeaderValue::from_str(&session_id) {
+                parts.headers.insert(SESSION_ID_HEADER, value);
+            }
+        }
+        Request::from_parts(parts, body.into())
+    }
+}
+
+impl HttpClientExt for SessionTaggingHttpClient {
+    fn send<T, U>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        T: Into<Bytes> + WasmCompatSend,
+        U: From<Bytes>,
+        U: WasmCompatSend + 'static,
+    {
+        let inner = self.inner.clone();
+        let req = Self::tag(req);
+        async move { HttpClientExt::send(&inner, req).await }
+    }
+
+    fn send_multipart<U>(
+        &self,
+        req: Request<MultipartForm>,
+    ) -> impl Future<Output = http_client::Result<Response<LazyBody<U>>>> + WasmCompatSend + 'static
+    where
+        U: From<Bytes>,
+        U: WasmCompatSend + 'static,
+    {
+        let inner = self.inner.clone();
+        async move { HttpClientExt::send_multipart(&inner, req).await }
+    }
+
+    fn send_streaming<T>(
+        &self,
+        req: Request<T>,
+    ) -> impl Future<Output = http_client::Result<StreamingResponse>> + WasmCompatSend
+    where
+        T: Into<Bytes>,
+    {
+        let inner = self.inner.clone();
+        let req = Self::tag(req);
+        async move { HttpClientExt::send_streaming(&inner, req).await }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tag_is_noop_without_session_context() {
+        // Outside any admission scope there is no session id to attach.
+        let req = Request::new(Bytes::from_static(b""));
+        let tagged = SessionTaggingHttpClient::tag(req);
+        assert!(
+            !tagged.headers().contains_key(SESSION_ID_HEADER),
+            "x-session-id must not be set when there is no active session context"
+        );
+    }
+}

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -25,6 +25,7 @@ pub mod graphql;
 pub mod health_checker;
 pub mod hook;
 pub mod identity;
+pub mod inference_http;
 pub mod interrupt;
 #[cfg(test)]
 pub(crate) mod lean_vocab_test;


### PR DESCRIPTION
Closes #447.

Tags outbound OpenAI-compatible inference requests with `x-session-id` (the in-flight request's session id) so a load balancer in front of a multi-replica prefix-caching backend can pin a conversation to one replica and keep its prefix cache warm — avoiding the full prefill tax on each hop (agentic loops run ~28:1 prefill:decode).

**How:** a small `SessionTaggingHttpClient: HttpClientExt` (mirrors the existing `ChatGptCodexHttpClient` per-request injection seam) wired into the OpenAiCompatible rig builder via `.http_client(...)`; the session id is read per request from the `admission` task-local (`current_session_id()`), since clients are built once per behavior but the session varies per request. No-op when there's no active session scope.

**Tests:** `current_session_id_reflects_request_scope` (admission task-local), `tag_is_noop_without_session_context`. `cargo check` + both tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)