### PR TITLE
Propagate trace context on inference HTTP requests

### DIFF
--- a/crates/defra-agent/src/inference_http.rs
+++ b/crates/defra-agent/src/inference_http.rs
@@ -1,5 +1,5 @@
 //! HTTP client wrapper that tags outbound inference requests with the current
-//! agent session id.
+//! agent session id and trace context.
 //!
 //! Emitting `x-session-id` lets a load balancer in front of a multi-replica,
 //! prefix-caching inference backend pin every turn of a conversation to the
@@ -12,12 +12,14 @@
 //! the session id varies per request. This mirrors the per-request injection
 //! seam already used by [`crate::chatgpt_codex::ChatGptCodexHttpClient`].
 
+use std::collections::HashMap;
 use std::future::Future;
 
 use bytes::Bytes;
+use reqwest::header::HeaderName;
 use rig::http_client::{
-    self, HeaderValue, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient, Response,
-    StreamingResponse,
+    self, HeaderMap, HeaderValue, HttpClientExt, LazyBody, MultipartForm, Request, ReqwestClient,
+    Response, StreamingResponse,
 };
 use rig::wasm_compat::WasmCompatSend;
 
@@ -38,13 +40,55 @@ impl SessionTaggingHttpClient {
     where
         T: Into<Bytes>,
     {
+        Self::tag_with_trace_context_headers(
+            req,
+            crate::runtime_trace::current_trace_context_headers(),
+        )
+    }
+
+    fn tag_with_trace_context_headers<T>(
+        req: Request<T>,
+        trace_context_headers: HashMap<String, String>,
+    ) -> Request<Bytes>
+    where
+        T: Into<Bytes>,
+    {
         let (mut parts, body) = req.into_parts();
+        Self::inject_headers(&mut parts.headers, trace_context_headers);
+        Request::from_parts(parts, body.into())
+    }
+
+    fn tag_multipart(req: Request<MultipartForm>) -> Request<MultipartForm> {
+        let (mut parts, body) = req.into_parts();
+        Self::inject_headers(
+            &mut parts.headers,
+            crate::runtime_trace::current_trace_context_headers(),
+        );
+        Request::from_parts(parts, body)
+    }
+
+    fn inject_headers(headers: &mut HeaderMap, trace_context_headers: HashMap<String, String>) {
         if let Some(session_id) = crate::admission::current_session_id() {
             if let Ok(value) = HeaderValue::from_str(&session_id) {
-                parts.headers.insert(SESSION_ID_HEADER, value);
+                headers.insert(SESSION_ID_HEADER, value);
             }
         }
-        Request::from_parts(parts, body.into())
+        Self::insert_trace_context_headers(headers, trace_context_headers);
+    }
+
+    fn insert_trace_context_headers(
+        headers: &mut HeaderMap,
+        trace_context_headers: HashMap<String, String>,
+    ) {
+        for (name, value) in trace_context_headers {
+            let Ok(name) = HeaderName::from_bytes(name.as_bytes()) else {
+                continue;
+            };
+            let Ok(value) = HeaderValue::from_str(value.as_str()) else {
+                continue;
+            };
+            headers.entry(name).or_insert(value);
+        }
     }
 }
 
@@ -72,6 +116,7 @@ impl HttpClientExt for SessionTaggingHttpClient {
         U: WasmCompatSend + 'static,
     {
         let inner = self.inner.clone();
+        let req = Self::tag_multipart(req);
         async move { HttpClientExt::send_multipart(&inner, req).await }
     }
 
@@ -101,5 +146,39 @@ mod tests {
             !tagged.headers().contains_key(SESSION_ID_HEADER),
             "x-session-id must not be set when there is no active session context"
         );
+    }
+
+    #[test]
+    fn tag_adds_valid_trace_context_headers() {
+        let req = Request::new(Bytes::from_static(b""));
+        let tagged = SessionTaggingHttpClient::tag_with_trace_context_headers(
+            req,
+            HashMap::from([
+                (
+                    "traceparent".to_string(),
+                    "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".to_string(),
+                ),
+                ("tracestate".to_string(), "vendor=value".to_string()),
+                ("bad header".to_string(), "ignored".to_string()),
+                ("x-bad-value".to_string(), "bad\nvalue".to_string()),
+            ]),
+        );
+
+        assert_eq!(
+            tagged
+                .headers()
+                .get("traceparent")
+                .and_then(|value| value.to_str().ok()),
+            Some("00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+        );
+        assert_eq!(
+            tagged
+                .headers()
+                .get("tracestate")
+                .and_then(|value| value.to_str().ok()),
+            Some("vendor=value")
+        );
+        assert!(!tagged.headers().contains_key("bad header"));
+        assert!(!tagged.headers().contains_key("x-bad-value"));
     }
 }


### PR DESCRIPTION
## Summary

Part of #22.

Extends the rig-compatible inference HTTP client wrapper so outbound inference requests carry the active W3C trace context, matching the existing propagation behavior on MCP and backend-provider HTTP paths.

- inject current trace context headers such as `traceparent` / `tracestate` on inference HTTP requests
- route multipart inference requests through the same shared header injection path
- preserve existing `x-session-id` sticky-session tagging
- ignore invalid propagated header names/values safely

This improves production request forensics by letting downstream inference infrastructure correlate work back to the originating Defra Agent request without exporting prompts, tool payloads, API keys, or other sensitive request content.

## Validation

- `cargo fmt --check`
- `cargo test -p defra-agent --lib inference_http::tests`
- `cargo test -p defra-agent inference_http`