### PR TITLE
Harden provider inference retry classification

### DIFF
--- a/crates/defra-agent/src/error.rs
+++ b/crates/defra-agent/src/error.rs
@@ -151,28 +151,37 @@ pub fn classify_completion_error(error: &rig::agent::StreamingError) -> Inferenc
                     }
                 }
                 rig::completion::CompletionError::ProviderError(provider_msg) => {
-                    if provider_msg.contains("rate_limit") || provider_msg.contains("429") {
+                    let provider_msg_lower = provider_msg.to_ascii_lowercase();
+                    if provider_msg_lower.contains("rate_limit")
+                        || provider_msg_lower.contains("rate limit")
+                        || error_message_has_status(provider_msg, 429)
+                    {
                         InferenceError::RateLimited {
                             retry_after_secs: 60,
                         }
-                    } else if error_message_has_status(provider_msg, 404) {
+                    } else if provider_message_has_any_status(
+                        provider_msg,
+                        &[400, 401, 403, 404, 422],
+                    ) {
                         InferenceError::PermanentFailure { reason }
-                    } else if provider_msg.contains("401")
-                        || provider_msg.contains("invalid_api_key")
-                        || provider_msg.contains("authentication")
-                        || provider_msg.contains("unauthorized")
+                    } else if provider_msg_lower.contains("invalid_api_key")
+                        || provider_msg_lower.contains("invalid api key")
+                        || provider_msg_lower.contains("authentication")
+                        || provider_msg_lower.contains("unauthorized")
                     {
                         // Auth errors are permanent — retrying won't help.
                         InferenceError::PermanentFailure { reason }
-                    } else if provider_msg.contains("400")
-                        || provider_msg.contains("invalid_request")
+                    } else if provider_msg_lower.contains("invalid_request")
+                        || provider_msg_lower.contains("invalid request")
                     {
                         // Bad request errors are permanent.
                         InferenceError::PermanentFailure { reason }
-                    } else if provider_msg.contains("500")
-                        || provider_msg.contains("502")
-                        || provider_msg.contains("503")
-                        || provider_msg.contains("overloaded")
+                    } else if provider_message_has_any_status(
+                        provider_msg,
+                        &[408, 500, 502, 503, 504],
+                    ) || provider_message_is_transport_failure(&provider_msg_lower)
+                        || provider_msg_lower.contains("overloaded")
+                        || provider_msg_lower.contains("temporarily unavailable")
                     {
                         // Server errors are transient.
                         InferenceError::TransientFailure { reason }
@@ -201,6 +210,31 @@ fn error_message_has_status(message: &str, status: u16) -> bool {
         || message.contains(&format!("Invalid status code: {status}"))
         || message.contains(&format!("status code {status}"))
         || message.contains(&format!("HTTP status {status}"))
+}
+
+fn provider_message_has_any_status(message: &str, statuses: &[u16]) -> bool {
+    statuses
+        .iter()
+        .any(|status| error_message_has_status(message, *status))
+}
+
+fn provider_message_is_transport_failure(message_lower: &str) -> bool {
+    [
+        "error sending request",
+        "connection refused",
+        "connection reset",
+        "connection closed",
+        "connection aborted",
+        "operation timed out",
+        "request timed out",
+        "timed out",
+        "timeout",
+        "deadline has elapsed",
+        "temporary failure in name resolution",
+        "dns error",
+    ]
+    .iter()
+    .any(|needle| message_lower.contains(needle))
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/error/tests.rs
+++ b/crates/defra-agent/src/error/tests.rs
@@ -72,6 +72,99 @@ fn openai_compatible_404_is_permanent_backend_configuration() {
 }
 
 #[test]
+fn provider_transport_send_failure_is_retryable_even_with_status_like_url_digits() {
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Http client error: error sending request for url \
+             (http://127.0.0.1:4000/v1/chat/completions)"
+                .into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::TransientFailure { .. }
+    ));
+    assert!(
+        classified.is_retryable(),
+        "transport send failures should retry even when the URL contains 400-like digits"
+    );
+}
+
+#[test]
+fn provider_transport_connection_reset_is_retryable_even_with_auth_like_url_digits() {
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Http client error: connection reset by peer while sending request to \
+             http://127.0.0.1:4010/v1/chat/completions"
+                .into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::TransientFailure { .. }
+    ));
+    assert!(
+        classified.is_retryable(),
+        "connection resets should retry even when the URL contains 401-like digits"
+    );
+}
+
+#[test]
+fn provider_error_uses_precise_status_matching_for_permanent_statuses() {
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "InvalidStatusCodeWithMessage(400, \"duplicate field `max_tokens`\")".into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::PermanentFailure { .. }
+    ));
+    assert!(
+        !classified.is_retryable(),
+        "precise provider 400 statuses are still permanent request-shape failures"
+    );
+}
+
+#[test]
+fn provider_error_loose_status_digits_do_not_force_permanent_failure() {
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "upstream worker closed after writing 400 bytes".into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::TransientFailure { .. }
+    ));
+    assert!(
+        classified.is_retryable(),
+        "plain numeric substrings must not be treated as HTTP status codes"
+    );
+}
+
+#[test]
+fn provider_error_precise_429_is_rate_limited() {
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Invalid status code 429: too many requests".into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(classified, InferenceError::RateLimited { .. }));
+    assert!(classified.is_retryable());
+}
+
+#[test]
 fn openai_compatible_http_400_is_permanent_bad_request() {
     let error =
         rig::agent::StreamingError::Completion(rig::completion::CompletionError::HttpError(


### PR DESCRIPTION
## Summary

Fixes #464.

This hardens inference retry classification for provider errors that represent transport failures. rig can surface send failures as CompletionError::ProviderError, so the provider branch now avoids loose numeric substring checks and classifies common transport failures as transient/retryable.

## Changes

- Replaces loose provider status checks like "400" / "401" with precise HTTP status matching.
- Treats provider transport messages like error sending request, connection reset/refused, DNS, and timeout failures as transient.
- Preserves permanent classification for precise 400/401/403/404/422 provider statuses and auth/request-shape errors.
- Adds regression coverage for status-like URL digits such as :4000 and :4010.

## Validation

- cargo fmt --check
- cargo test -p defra-agent --lib error::tests
- cargo test -p defra-agent --lib agent::daemon::inference::tests