### PR TITLE
Expand task CLI operator workflow

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1291,12 +1291,20 @@ pub(crate) enum InferenceProfileCommand {
 
 #[derive(Subcommand)]
 pub(crate) enum ConfigTaskCommand {
+    #[command(name = "list", about = "List configured Task documents")]
+    List(TaskListArgs),
+    #[command(name = "show", about = "Show a configured Task document")]
+    Show(TaskShowArgs),
     #[command(name = "run", about = "Run a configured Task once, now")]
     Run(ConfigTaskRunArgs),
 }
 
 #[derive(Subcommand)]
 pub(crate) enum TaskCommand {
+    #[command(name = "list", about = "List configured Task documents")]
+    List(TaskListArgs),
+    #[command(name = "show", about = "Show a configured Task document")]
+    Show(TaskShowArgs),
     #[command(
         name = "run",
         about = "Run a configured Task once, now",
@@ -1306,10 +1314,46 @@ pub(crate) enum TaskCommand {
 }
 
 #[derive(Debug, clap::Args)]
+pub(crate) struct TaskListArgs {
+    /// GraphQL endpoint of the running agent's DefraDB. Defaults to local.
+    #[arg(long)]
+    pub(crate) graphql: Option<String>,
+
+    /// Path to the agent home. Used to resolve GraphQL endpoint when
+    /// `--graphql` is not set.
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct TaskShowArgs {
+    /// The task_id of the task to show.
+    #[arg(long = "task-id")]
+    pub(crate) task_id_flag: Option<String>,
+
+    /// The task_id of the task to show.
+    #[arg(value_name = "TASK_ID")]
+    pub(crate) task_id: Option<String>,
+
+    /// GraphQL endpoint of the running agent's DefraDB. Defaults to local.
+    #[arg(long)]
+    pub(crate) graphql: Option<String>,
+
+    /// Path to the agent home. Used to resolve GraphQL endpoint when
+    /// `--graphql` is not set.
+    #[arg(long)]
+    pub(crate) home: Option<PathBuf>,
+}
+
+#[derive(Debug, clap::Args)]
 pub(crate) struct ConfigTaskRunArgs {
     /// The task_id of the task to run.
-    #[arg(long)]
-    pub(crate) task_id: String,
+    #[arg(long = "task-id")]
+    pub(crate) task_id_flag: Option<String>,
+
+    /// The task_id of the task to run.
+    #[arg(value_name = "TASK_ID")]
+    pub(crate) task_id: Option<String>,
 
     /// JSON object of arguments bound as the `args.*` template scope.
     /// Example: `--args '{"name": "Amy"}'`.
@@ -1324,6 +1368,18 @@ pub(crate) struct ConfigTaskRunArgs {
     /// `--graphql` is not set.
     #[arg(long)]
     pub(crate) home: Option<PathBuf>,
+
+    /// Wait for the created AgentRequest to reach a terminal response.
+    #[arg(long, default_value_t = false)]
+    pub(crate) wait: bool,
+
+    /// Idle timeout while waiting for a terminal response.
+    #[arg(long, default_value_t = crate::DEFAULT_INTERACTIVE_WAIT_TIMEOUT_SECS)]
+    pub(crate) timeout_secs: u64,
+
+    /// Poll interval while waiting for a terminal response.
+    #[arg(long, default_value_t = 1)]
+    pub(crate) poll_secs: u64,
 }
 
 #[derive(clap::Args)]
@@ -2171,13 +2227,20 @@ mod tests {
     }
 
     fn assert_task_run_args(args: ConfigTaskRunArgs) {
-        assert_eq!(args.task_id, "host-check");
+        assert_eq!(args.task_id.as_deref(), None);
+        assert_eq!(args.task_id_flag.as_deref(), Some("host-check"));
         assert_eq!(args.args, r#"{"scope":"host"}"#);
         assert_eq!(
             args.graphql.as_deref(),
             Some("http://127.0.0.1:9191/api/v0/graphql")
         );
         assert!(args.home.is_none());
+        assert!(!args.wait);
+        assert_eq!(
+            args.timeout_secs,
+            crate::DEFAULT_INTERACTIVE_WAIT_TIMEOUT_SECS
+        );
+        assert_eq!(args.poll_secs, 1);
     }
 
     #[test]
@@ -2326,6 +2389,71 @@ mod tests {
     }
 
     #[test]
+    fn top_level_task_run_accepts_positional_task_id_and_wait() {
+        let cli = Cli::try_parse_from([
+            "defra-agent",
+            "task",
+            "run",
+            "host-check",
+            "--args",
+            r#"{"scope":"host"}"#,
+            "--wait",
+            "--timeout-secs",
+            "60",
+            "--poll-secs",
+            "2",
+        ])
+        .expect("task run positional form should parse");
+
+        match cli.command {
+            Command::Task {
+                command: TaskCommand::Run(args),
+            } => {
+                assert_eq!(args.task_id.as_deref(), Some("host-check"));
+                assert_eq!(args.task_id_flag, None);
+                assert_eq!(args.args, r#"{"scope":"host"}"#);
+                assert!(args.wait);
+                assert_eq!(args.timeout_secs, 60);
+                assert_eq!(args.poll_secs, 2);
+            }
+            _ => panic!("expected `task run`"),
+        }
+    }
+
+    #[test]
+    fn top_level_task_list_and_show_parse() {
+        let list = Cli::try_parse_from([
+            "defra-agent",
+            "task",
+            "list",
+            "--graphql",
+            "http://127.0.0.1:9191/api/v0/graphql",
+        ])
+        .expect("task list should parse");
+        match list.command {
+            Command::Task {
+                command: TaskCommand::List(args),
+            } => assert_eq!(
+                args.graphql.as_deref(),
+                Some("http://127.0.0.1:9191/api/v0/graphql")
+            ),
+            _ => panic!("expected `task list`"),
+        }
+
+        let show = Cli::try_parse_from(["defra-agent", "task", "show", "host-check"])
+            .expect("task show should parse");
+        match show.command {
+            Command::Task {
+                command: TaskCommand::Show(args),
+            } => {
+                assert_eq!(args.task_id.as_deref(), Some("host-check"));
+                assert_eq!(args.task_id_flag, None);
+            }
+            _ => panic!("expected `task show`"),
+        }
+    }
+
+    #[test]
     fn config_task_run_remains_available_as_compatibility_path() {
         let cli = Cli::try_parse_from([
             "defra-agent",
@@ -2349,6 +2477,43 @@ mod tests {
                     },
             } => assert_task_run_args(args),
             _ => panic!("expected `config task run`"),
+        }
+    }
+
+    #[test]
+    fn config_task_list_and_show_remain_available() {
+        let list = Cli::try_parse_from(["defra-agent", "config", "task", "list"])
+            .expect("config task list should parse");
+        match list.command {
+            Command::Config {
+                command:
+                    ConfigCommand::Task {
+                        command: ConfigTaskCommand::List(_),
+                    },
+            } => {}
+            _ => panic!("expected `config task list`"),
+        }
+
+        let show = Cli::try_parse_from([
+            "defra-agent",
+            "config",
+            "task",
+            "show",
+            "--task-id",
+            "host-check",
+        ])
+        .expect("config task show should parse");
+        match show.command {
+            Command::Config {
+                command:
+                    ConfigCommand::Task {
+                        command: ConfigTaskCommand::Show(args),
+                    },
+            } => {
+                assert_eq!(args.task_id, None);
+                assert_eq!(args.task_id_flag.as_deref(), Some("host-check"));
+            }
+            _ => panic!("expected `config task show`"),
         }
     }
 }

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -14,7 +14,7 @@ use crate::{
     FLEET_AFTER_HELP, INIT_AFTER_HELP, MCP_AFTER_HELP, P2P_AFTER_HELP, PROVISION_AFTER_HELP,
     REQUEST_AFTER_HELP, RESET_AFTER_HELP, RESPONSE_AFTER_HELP, SCHEMA_AFTER_HELP,
     SERVER_AFTER_HELP, SESSION_AFTER_HELP, SHOW_AFTER_HELP, STATUS_AFTER_HELP, SUBAGENT_AFTER_HELP,
-    SUBAGENT_LIST_AFTER_HELP, TOOLS_AFTER_HELP, TRACE_AFTER_HELP,
+    SUBAGENT_LIST_AFTER_HELP, TASK_AFTER_HELP, TOOLS_AFTER_HELP, TRACE_AFTER_HELP,
 };
 
 use crate::default_backend_max_queue_depth;
@@ -100,6 +100,14 @@ pub(crate) enum Command {
     Fleet {
         #[command(subcommand)]
         command: FleetCommand,
+    },
+    #[command(
+        about = "Trigger configured Task documents on demand",
+        after_help = TASK_AFTER_HELP
+    )]
+    Task {
+        #[command(subcommand)]
+        command: TaskCommand,
     },
     #[command(about = "Run local configuration and runtime diagnostics", after_help = DIAGNOSE_AFTER_HELP)]
     Diagnose(DiagnoseArgs),
@@ -1287,6 +1295,16 @@ pub(crate) enum ConfigTaskCommand {
     Run(ConfigTaskRunArgs),
 }
 
+#[derive(Subcommand)]
+pub(crate) enum TaskCommand {
+    #[command(
+        name = "run",
+        about = "Run a configured Task once, now",
+        visible_alias = "trigger"
+    )]
+    Run(ConfigTaskRunArgs),
+}
+
 #[derive(Debug, clap::Args)]
 pub(crate) struct ConfigTaskRunArgs {
     /// The task_id of the task to run.
@@ -2152,6 +2170,16 @@ mod tests {
         }
     }
 
+    fn assert_task_run_args(args: ConfigTaskRunArgs) {
+        assert_eq!(args.task_id, "host-check");
+        assert_eq!(args.args, r#"{"scope":"host"}"#);
+        assert_eq!(
+            args.graphql.as_deref(),
+            Some("http://127.0.0.1:9191/api/v0/graphql")
+        );
+        assert!(args.home.is_none());
+    }
+
     #[test]
     fn enable_defra_query_flag_accepts_false_true_and_omission() {
         // Omitted -> None, so an unrelated `config tools set` preserves the
@@ -2272,5 +2300,55 @@ mod tests {
         assert_eq!(explicit.enable_file_tools, Some(false));
         assert_eq!(explicit.enable_bash, Some(false));
         assert_eq!(explicit.enable_meta_tools, Some(false));
+    }
+
+    #[test]
+    fn top_level_task_run_parses_operator_affordance() {
+        let cli = Cli::try_parse_from([
+            "defra-agent",
+            "task",
+            "run",
+            "--task-id",
+            "host-check",
+            "--args",
+            r#"{"scope":"host"}"#,
+            "--graphql",
+            "http://127.0.0.1:9191/api/v0/graphql",
+        ])
+        .expect("task run should parse");
+
+        match cli.command {
+            Command::Task {
+                command: TaskCommand::Run(args),
+            } => assert_task_run_args(args),
+            _ => panic!("expected `task run`"),
+        }
+    }
+
+    #[test]
+    fn config_task_run_remains_available_as_compatibility_path() {
+        let cli = Cli::try_parse_from([
+            "defra-agent",
+            "config",
+            "task",
+            "run",
+            "--task-id",
+            "host-check",
+            "--args",
+            r#"{"scope":"host"}"#,
+            "--graphql",
+            "http://127.0.0.1:9191/api/v0/graphql",
+        ])
+        .expect("config task run should parse");
+
+        match cli.command {
+            Command::Config {
+                command:
+                    ConfigCommand::Task {
+                        command: ConfigTaskCommand::Run(args),
+                    },
+            } => assert_task_run_args(args),
+            _ => panic!("expected `config task run`"),
+        }
     }
 }

--- a/crates/defra-agent-cli/src/commands/config/mod.rs
+++ b/crates/defra-agent-cli/src/commands/config/mod.rs
@@ -34,6 +34,8 @@ pub(crate) async fn dispatch(command: ConfigCommand) -> Result<()> {
             InferenceProfileCommand::Set(args) => profile::inference_profile_set(args).await,
         },
         ConfigCommand::Task { command } => match command {
+            ConfigTaskCommand::List(args) => crate::commands::task::task_list(args).await,
+            ConfigTaskCommand::Show(args) => crate::commands::task::task_show(args).await,
             ConfigTaskCommand::Run(args) => task_run::config_task_run(args).await,
         },
         ConfigCommand::Skill { command } => match command {

--- a/crates/defra-agent-cli/src/commands/config/task_run.rs
+++ b/crates/defra-agent-cli/src/commands/config/task_run.rs
@@ -30,7 +30,7 @@ use crate::{print_json, resolve_config_access};
 /// re-exported.
 const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 
-pub(super) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
+pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
     // 1. Parse --args as a JSON object.
     let args_value: Value =
         serde_json::from_str(&args.args).map_err(|e| anyhow!("--args is not valid JSON: {e}"))?;

--- a/crates/defra-agent-cli/src/commands/config/task_run.rs
+++ b/crates/defra-agent-cli/src/commands/config/task_run.rs
@@ -17,12 +17,13 @@
 use anyhow::{anyhow, Result};
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::template::{render_template, TemplateScope};
+use serde::Serialize;
 use serde_json::Value;
 
 use crate::cli::ConfigTaskRunArgs;
 use crate::config_writes::ConfigAccess;
-use crate::request_helpers::metadata_with_prompt_selected_skill_ids;
-use crate::{print_json, resolve_config_access};
+use crate::request_helpers::{metadata_with_prompt_selected_skill_ids, wait_for_terminal_response};
+use crate::{print_json, resolve_config_access, resolve_graphql_endpoint};
 
 /// Must match `lifecycle::DEFAULT_REQUEST_MAX_RETRIES` and the value written by
 /// `write_manual_agent_request`. Kept inline here so the CLI mutation is a
@@ -31,6 +32,48 @@ use crate::{print_json, resolve_config_access};
 const DEFAULT_REQUEST_MAX_RETRIES: u32 = 3;
 
 pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
+    let output = enqueue_task_run(&args).await?;
+    let mut value = serde_json::to_value(&output)?;
+    if args.wait {
+        let graphql = resolve_graphql_endpoint(args.graphql.as_deref(), args.home.as_deref())?;
+        let response = wait_for_terminal_response(
+            &graphql,
+            &output.request_id,
+            args.timeout_secs,
+            args.poll_secs,
+        )
+        .await?;
+        if let Some(object) = value.as_object_mut() {
+            object.insert(
+                "wait".to_string(),
+                serde_json::json!({
+                    "timeout_secs": args.timeout_secs,
+                    "poll_secs": args.poll_secs,
+                    "response": response,
+                }),
+            );
+        }
+    }
+    print_json(&value)?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct TaskRunOutput {
+    pub(crate) task_id: String,
+    pub(crate) behavior_id: String,
+    pub(crate) agent_did: String,
+    pub(crate) request_id: String,
+    pub(crate) session_id: String,
+    pub(crate) request_doc_id: String,
+    pub(crate) metadata: Option<String>,
+    pub(crate) status: &'static str,
+}
+
+pub(crate) async fn enqueue_task_run(args: &ConfigTaskRunArgs) -> Result<TaskRunOutput> {
+    let task_id =
+        resolve_task_id_for("run", args.task_id.as_deref(), args.task_id_flag.as_deref())?;
+
     // 1. Parse --args as a JSON object.
     let args_value: Value =
         serde_json::from_str(&args.args).map_err(|e| anyhow!("--args is not valid JSON: {e}"))?;
@@ -58,7 +101,7 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
                 enabled
             }}
         }}"#,
-        id = escape_graphql_string(&args.task_id),
+        id = escape_graphql_string(&task_id),
     );
     let task_response = access.execute(&task_query).await?;
     let task_row = task_response
@@ -66,12 +109,12 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
         .and_then(|d| d.get("Task"))
         .and_then(|arr| arr.as_array())
         .and_then(|arr| arr.first())
-        .ok_or_else(|| anyhow!("no Task with task_id = {}", args.task_id))?;
+        .ok_or_else(|| anyhow!("no Task with task_id = {}", task_id))?;
     let behavior_id = task_row
         .get("behavior_id")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| anyhow!("Task {} has no behavior_id", args.task_id))?
+        .ok_or_else(|| anyhow!("Task {} has no behavior_id", task_id))?
         .to_string();
     let prompt_template = task_row
         .get("prompt_template")
@@ -83,7 +126,7 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
     if !enabled {
-        anyhow::bail!("Task {} is disabled; cannot run", args.task_id);
+        anyhow::bail!("Task {} is disabled; cannot run", task_id);
     }
 
     // 4. Fetch the AgentBehavior to get agent_did and confirm it's enabled.
@@ -106,7 +149,7 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
             anyhow!(
                 "no AgentBehavior with behavior_id = {} (referenced by task {})",
                 behavior_id,
-                args.task_id
+                task_id
             )
         })?;
     let agent_did = behavior_row
@@ -136,7 +179,7 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
         args: Some(args_value),
     };
     let content = render_template(&prompt_template, &scope)
-        .map_err(|e| anyhow!("render manual template for task {}: {e}", args.task_id))?;
+        .map_err(|e| anyhow!("render manual template for task {}: {e}", task_id))?;
 
     // 6. Issue the same create_AgentRequest mutation as
     //    `write_manual_agent_request`: same field set, same lineage.
@@ -172,23 +215,43 @@ pub(crate) async fn config_task_run(args: ConfigTaskRunArgs) -> Result<()> {
             .ok_or_else(|| {
                 anyhow!(
                     "manual AgentRequest for task {} persisted but _docID lookup by request_id returned nothing",
-                    args.task_id
+                    task_id
                 )
             })?,
     };
 
-    // 7. Print the structured result.
-    print_json(&serde_json::json!({
-        "task_id": args.task_id,
-        "behavior_id": behavior_id,
-        "agent_did": agent_did,
-        "request_id": request_id,
-        "session_id": session_id,
-        "request_doc_id": doc_id,
-        "metadata": metadata,
-        "status": "pending",
-    }))?;
-    Ok(())
+    Ok(TaskRunOutput {
+        task_id,
+        behavior_id,
+        agent_did,
+        request_id,
+        session_id,
+        request_doc_id: doc_id,
+        metadata,
+        status: "pending",
+    })
+}
+
+pub(crate) fn resolve_task_id_for(
+    command: &str,
+    positional: Option<&str>,
+    flag: Option<&str>,
+) -> Result<String> {
+    let positional = positional.map(str::trim).filter(|value| !value.is_empty());
+    let flag = flag.map(str::trim).filter(|value| !value.is_empty());
+    match (positional, flag) {
+        (Some(positional), Some(flag)) if positional != flag => {
+            anyhow::bail!(
+                "conflicting task ids provided: positional={} and --task-id={}\nNext:\n  1. Pass the task id once: `defra-agent task {command} TASK_ID`\n  2. Or use `--task-id TASK_ID`, but not both",
+                positional,
+                flag
+            );
+        }
+        (Some(task_id), _) | (_, Some(task_id)) => Ok(task_id.to_string()),
+        (None, None) => anyhow::bail!(
+            "missing task id\nNext:\n  1. Pass it positionally: `defra-agent task {command} TASK_ID`\n  2. Or use `--task-id TASK_ID`"
+        ),
+    }
 }
 
 struct CreateManualRequestInput<'a> {
@@ -403,5 +466,23 @@ mod tests {
             "data": { "add_AgentRequest": [ { "_docID": "doc-4" } ] }
         });
         assert_eq!(extract_doc_id(&add_array), Some("doc-4".to_string()));
+    }
+
+    #[test]
+    fn resolve_task_id_accepts_positional_or_flag_and_rejects_conflict() {
+        assert_eq!(
+            resolve_task_id_for("run", Some("host-check"), None).unwrap(),
+            "host-check"
+        );
+        assert_eq!(
+            resolve_task_id_for("run", None, Some("host-check")).unwrap(),
+            "host-check"
+        );
+        assert_eq!(
+            resolve_task_id_for("run", Some("host-check"), Some("host-check")).unwrap(),
+            "host-check"
+        );
+        assert!(resolve_task_id_for("run", Some("host-check"), Some("other")).is_err());
+        assert!(resolve_task_id_for("run", None, None).is_err());
     }
 }

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -21,5 +21,6 @@ pub(crate) mod session;
 pub(crate) mod show;
 pub(crate) mod status;
 pub(crate) mod subagent;
+pub(crate) mod task;
 pub(crate) mod tools;
 pub(crate) mod trace;

--- a/crates/defra-agent-cli/src/commands/task.rs
+++ b/crates/defra-agent-cli/src/commands/task.rs
@@ -1,9 +1,417 @@
-use anyhow::Result;
+use std::collections::BTreeMap;
 
-use crate::cli::TaskCommand;
+use anyhow::Result;
+use defra_agent::graphql::escape_graphql_string;
+use serde_json::{json, Value};
+
+use crate::cli::{TaskCommand, TaskListArgs, TaskShowArgs};
+use crate::commands::config::task_run::{config_task_run, resolve_task_id_for};
+use crate::config_writes::ConfigAccess;
+use crate::{print_json, resolve_config_access};
+
+const TASK_FIELDS: &str =
+    "task_id name description behavior_id prompt_template enabled output_schema_ref created_at updated_at";
+const BEHAVIOR_FIELDS: &str = "behavior_id agent_did display_name description summary backend_id model_name tool_selection_id inference_profile_id compaction_strategy compaction_threshold enabled created_at";
+const SCHEDULE_FIELDS: &str = "schedule_id task_id interval_secs cron timezone missed_run_policy enabled concurrency next_run_at last_attempt_at last_status last_error fire_count created_at updated_at";
+const EVENT_TRIGGER_FIELDS: &str = "trigger_id task_id source_collection event_kind filter enabled concurrency last_attempt_at last_fired_source_doc_id last_status last_error fire_count created_at updated_at";
 
 pub(crate) async fn dispatch(command: TaskCommand) -> Result<()> {
     match command {
-        TaskCommand::Run(args) => crate::commands::config::task_run::config_task_run(args).await,
+        TaskCommand::List(args) => task_list(args).await,
+        TaskCommand::Show(args) => task_show(args).await,
+        TaskCommand::Run(args) => config_task_run(args).await,
+    }
+}
+
+pub(crate) async fn task_list(args: TaskListArgs) -> Result<()> {
+    let (access, _) = resolve_config_access(
+        args.home.as_deref(),
+        args.graphql.as_deref(),
+        /* ensure_local_schemas */ false,
+    )
+    .await?;
+    let inventory = load_task_inventory(&access, None).await?;
+    let tasks = inventory.task_summaries();
+    print_json(&json!({
+        "count": tasks.len(),
+        "tasks": tasks,
+    }))?;
+    Ok(())
+}
+
+pub(crate) async fn task_show(args: TaskShowArgs) -> Result<()> {
+    let task_id = resolve_task_id_for(
+        "show",
+        args.task_id.as_deref(),
+        args.task_id_flag.as_deref(),
+    )?;
+    let (access, _) = resolve_config_access(
+        args.home.as_deref(),
+        args.graphql.as_deref(),
+        /* ensure_local_schemas */ false,
+    )
+    .await?;
+    let inventory = load_task_inventory(&access, Some(&task_id)).await?;
+    let Some(task) = inventory.tasks.first() else {
+        anyhow::bail!("no Task with task_id = {task_id}");
+    };
+    print_json(&inventory.task_detail(task))?;
+    Ok(())
+}
+
+struct TaskInventory {
+    tasks: Vec<Value>,
+    behaviors_by_id: BTreeMap<String, Value>,
+    schedules: Vec<Value>,
+    event_triggers: Vec<Value>,
+}
+
+impl TaskInventory {
+    fn task_summaries(&self) -> Vec<Value> {
+        self.tasks
+            .iter()
+            .map(|task| self.task_summary(task))
+            .collect()
+    }
+
+    fn task_summary(&self, task: &Value) -> Value {
+        let task_id = string_field(task, "task_id").unwrap_or_default();
+        let behavior_id = string_field(task, "behavior_id");
+        let behavior = behavior_id
+            .as_deref()
+            .and_then(|id| self.behaviors_by_id.get(id));
+        let schedules = self.schedules_for_task(&task_id);
+        let event_triggers = self.event_triggers_for_task(&task_id);
+        let (runnable, unavailable_reason) = runnable_status(task, behavior);
+
+        json!({
+            "task_id": task_id,
+            "name": task.get("name").cloned().unwrap_or(Value::Null),
+            "description": task.get("description").cloned().unwrap_or(Value::Null),
+            "behavior_id": behavior_id,
+            "enabled": bool_field(task, "enabled").unwrap_or(false),
+            "runnable": runnable,
+            "unavailable_reason": unavailable_reason,
+            "behavior": behavior.and_then(behavior_summary).unwrap_or(Value::Null),
+            "schedule_count": schedules.len(),
+            "schedule_ids": schedules.iter().filter_map(|row| string_field(row, "schedule_id")).collect::<Vec<_>>(),
+            "event_trigger_count": event_triggers.len(),
+            "event_trigger_ids": event_triggers.iter().filter_map(|row| string_field(row, "trigger_id")).collect::<Vec<_>>(),
+        })
+    }
+
+    fn task_detail(&self, task: &Value) -> Value {
+        let task_id = string_field(task, "task_id").unwrap_or_default();
+        let behavior = string_field(task, "behavior_id")
+            .as_deref()
+            .and_then(|id| self.behaviors_by_id.get(id));
+        let schedules = self.schedules_for_task(&task_id);
+        let event_triggers = self.event_triggers_for_task(&task_id);
+        let (runnable, unavailable_reason) = runnable_status(task, behavior);
+
+        json!({
+            "task": task,
+            "behavior": behavior.cloned().unwrap_or(Value::Null),
+            "runnable": runnable,
+            "unavailable_reason": unavailable_reason,
+            "schedule_count": schedules.len(),
+            "schedules": schedules,
+            "event_trigger_count": event_triggers.len(),
+            "event_triggers": event_triggers,
+        })
+    }
+
+    fn schedules_for_task(&self, task_id: &str) -> Vec<Value> {
+        let mut rows = self
+            .schedules
+            .iter()
+            .filter(|row| string_field(row, "task_id").as_deref() == Some(task_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        sort_rows_by_string_field(&mut rows, "schedule_id");
+        rows
+    }
+
+    fn event_triggers_for_task(&self, task_id: &str) -> Vec<Value> {
+        let mut rows = self
+            .event_triggers
+            .iter()
+            .filter(|row| string_field(row, "task_id").as_deref() == Some(task_id))
+            .cloned()
+            .collect::<Vec<_>>();
+        sort_rows_by_string_field(&mut rows, "trigger_id");
+        rows
+    }
+}
+
+async fn load_task_inventory(
+    access: &ConfigAccess,
+    task_id_filter: Option<&str>,
+) -> Result<TaskInventory> {
+    let query = task_inventory_query(task_id_filter);
+    let response = access.execute(&query).await?;
+    ensure_no_graphql_errors(&response, "query task inventory")?;
+
+    let mut tasks = rows(&response, "Task");
+    sort_rows_by_string_field(&mut tasks, "task_id");
+
+    let behaviors_by_id = rows(&response, "AgentBehavior")
+        .into_iter()
+        .filter_map(|row| string_field(&row, "behavior_id").map(|id| (id, row)))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut schedules = rows(&response, "Schedule");
+    sort_rows_by_string_field(&mut schedules, "schedule_id");
+
+    let mut event_triggers = rows(&response, "EventTrigger");
+    sort_rows_by_string_field(&mut event_triggers, "trigger_id");
+
+    Ok(TaskInventory {
+        tasks,
+        behaviors_by_id,
+        schedules,
+        event_triggers,
+    })
+}
+
+fn task_inventory_query(task_id_filter: Option<&str>) -> String {
+    let task_args = task_id_filter
+        .map(|task_id| {
+            format!(
+                r#"(filter: {{ task_id: {{ _eq: "{}" }} }}, limit: 1)"#,
+                escape_graphql_string(task_id)
+            )
+        })
+        .unwrap_or_default();
+    let related_args = task_id_filter
+        .map(|task_id| {
+            format!(
+                r#"(filter: {{ task_id: {{ _eq: "{}" }} }})"#,
+                escape_graphql_string(task_id)
+            )
+        })
+        .unwrap_or_default();
+
+    format!(
+        r#"{{
+            Task{task_args} {{
+                {TASK_FIELDS}
+            }}
+            AgentBehavior {{
+                {BEHAVIOR_FIELDS}
+            }}
+            Schedule{related_args} {{
+                {SCHEDULE_FIELDS}
+            }}
+            EventTrigger{related_args} {{
+                {EVENT_TRIGGER_FIELDS}
+            }}
+        }}"#
+    )
+}
+
+fn ensure_no_graphql_errors(response: &Value, context: &str) -> Result<()> {
+    if let Some(errors) = response
+        .get("errors")
+        .and_then(Value::as_array)
+        .filter(|errors| !errors.is_empty())
+    {
+        anyhow::bail!("{context} failed: {errors:?}");
+    }
+    Ok(())
+}
+
+fn rows(response: &Value, collection: &str) -> Vec<Value> {
+    response
+        .get("data")
+        .and_then(|data| data.get(collection))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+fn string_field(row: &Value, field: &str) -> Option<String> {
+    row.get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn bool_field(row: &Value, field: &str) -> Option<bool> {
+    row.get(field).and_then(Value::as_bool)
+}
+
+fn sort_rows_by_string_field(rows: &mut [Value], field: &str) {
+    rows.sort_by(|left, right| {
+        string_field(left, field)
+            .unwrap_or_default()
+            .cmp(&string_field(right, field).unwrap_or_default())
+    });
+}
+
+fn behavior_summary(behavior: &Value) -> Option<Value> {
+    let behavior_id = string_field(behavior, "behavior_id")?;
+    Some(json!({
+        "behavior_id": behavior_id,
+        "agent_did": behavior.get("agent_did").cloned().unwrap_or(Value::Null),
+        "display_name": behavior.get("display_name").cloned().unwrap_or(Value::Null),
+        "enabled": bool_field(behavior, "enabled").unwrap_or(false),
+        "backend_id": behavior.get("backend_id").cloned().unwrap_or(Value::Null),
+        "model_name": behavior.get("model_name").cloned().unwrap_or(Value::Null),
+    }))
+}
+
+fn runnable_status(task: &Value, behavior: Option<&Value>) -> (bool, Option<&'static str>) {
+    if !bool_field(task, "enabled").unwrap_or(false) {
+        return (false, Some("task_disabled"));
+    }
+    if string_field(task, "behavior_id").is_none() {
+        return (false, Some("missing_behavior_id"));
+    }
+    let Some(behavior) = behavior else {
+        return (false, Some("behavior_missing"));
+    };
+    if !bool_field(behavior, "enabled").unwrap_or(false) {
+        return (false, Some("behavior_disabled"));
+    }
+    (true, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_inventory() -> TaskInventory {
+        TaskInventory {
+            tasks: vec![
+                json!({
+                    "task_id": "disabled",
+                    "name": "Disabled",
+                    "description": null,
+                    "behavior_id": "default",
+                    "prompt_template": "noop",
+                    "enabled": false,
+                    "output_schema_ref": null,
+                    "created_at": null,
+                    "updated_at": null
+                }),
+                json!({
+                    "task_id": "host-check",
+                    "name": "Host check",
+                    "description": "Sweep host status",
+                    "behavior_id": "default",
+                    "prompt_template": "check",
+                    "enabled": true,
+                    "output_schema_ref": null,
+                    "created_at": null,
+                    "updated_at": null
+                }),
+            ],
+            behaviors_by_id: BTreeMap::from([(
+                "default".to_string(),
+                json!({
+                    "behavior_id": "default",
+                    "agent_did": "did:key:z-test",
+                    "display_name": "Default",
+                    "description": null,
+                    "summary": null,
+                    "backend_id": "local",
+                    "model_name": "model",
+                    "tool_selection_id": "default",
+                    "inference_profile_id": null,
+                    "compaction_strategy": null,
+                    "compaction_threshold": null,
+                    "enabled": true,
+                    "created_at": null
+                }),
+            )]),
+            schedules: vec![json!({
+                "schedule_id": "every-six-hours",
+                "task_id": "host-check",
+                "interval_secs": 21600,
+                "cron": null,
+                "timezone": null,
+                "missed_run_policy": "skip",
+                "enabled": true,
+                "concurrency": "skip",
+                "next_run_at": "2026-06-10T00:00:00Z",
+                "last_attempt_at": null,
+                "last_status": null,
+                "last_error": null,
+                "fire_count": 0,
+                "created_at": null,
+                "updated_at": null
+            })],
+            event_triggers: vec![json!({
+                "trigger_id": "host-doc-created",
+                "task_id": "host-check",
+                "source_collection": "Host",
+                "event_kind": "created",
+                "filter": null,
+                "enabled": true,
+                "concurrency": "parallel",
+                "last_attempt_at": null,
+                "last_fired_source_doc_id": null,
+                "last_status": null,
+                "last_error": null,
+                "fire_count": 0,
+                "created_at": null,
+                "updated_at": null
+            })],
+        }
+    }
+
+    #[test]
+    fn task_summary_marks_runnable_and_counts_triggers() {
+        let inventory = sample_inventory();
+        let summary = inventory.task_summary(&inventory.tasks[1]);
+
+        assert_eq!(
+            summary.get("task_id").and_then(Value::as_str),
+            Some("host-check")
+        );
+        assert_eq!(summary.get("runnable").and_then(Value::as_bool), Some(true));
+        assert!(summary
+            .get("unavailable_reason")
+            .is_some_and(Value::is_null));
+        assert_eq!(
+            summary.get("schedule_count").and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            summary.get("event_trigger_count").and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            summary
+                .pointer("/behavior/model_name")
+                .and_then(Value::as_str),
+            Some("model")
+        );
+    }
+
+    #[test]
+    fn task_summary_marks_disabled_task_unavailable() {
+        let inventory = sample_inventory();
+        let summary = inventory.task_summary(&inventory.tasks[0]);
+
+        assert_eq!(
+            summary.get("runnable").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            summary.get("unavailable_reason").and_then(Value::as_str),
+            Some("task_disabled")
+        );
+    }
+
+    #[test]
+    fn task_inventory_query_filters_task_and_related_rows_for_show() {
+        let query = task_inventory_query(Some("host-check"));
+        assert!(query.contains("Task(filter:"));
+        assert!(query.contains(r#"task_id: { _eq: "host-check" }"#));
+        assert!(query.contains("limit: 1"));
+        assert!(query.contains("Schedule(filter:"));
+        assert!(query.contains("EventTrigger(filter:"));
     }
 }

--- a/crates/defra-agent-cli/src/commands/task.rs
+++ b/crates/defra-agent-cli/src/commands/task.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+use crate::cli::TaskCommand;
+
+pub(crate) async fn dispatch(command: TaskCommand) -> Result<()> {
+    match command {
+        TaskCommand::Run(args) => crate::commands::config::task_run::config_task_run(args).await,
+    }
+}

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -68,6 +68,7 @@ Inspect the local runtime:
   defra-agent status
   defra-agent show runtime
   defra-agent show response REQUEST_ID
+  defra-agent task run --task-id TASK_ID
   defra-agent background list
   defra-agent mcp probe --all
   defra-agent reset
@@ -207,6 +208,13 @@ Examples:
   defra-agent fleet slots
   defra-agent fleet slots --home /path/to/home
   defra-agent fleet slots --graphql http://127.0.0.1:9191/api/v0/graphql";
+const TASK_AFTER_HELP: &str = "\
+Creates a pending AgentRequest for a configured Task with manual trigger lineage.
+
+Examples:
+  defra-agent task run --task-id host-check
+  defra-agent task run --task-id host-check --args '{\"scope\":\"host\"}'
+  defra-agent task run --task-id host-check --graphql http://127.0.0.1:9191/api/v0/graphql";
 const SHOW_AFTER_HELP: &str = "\
 Examples:
   defra-agent show runtime
@@ -388,6 +396,7 @@ async fn main() -> Result<()> {
         Command::Background { command } => commands::background::dispatch(command).await,
         Command::Mcp { command } => commands::mcp::dispatch(command).await,
         Command::Fleet { command } => commands::fleet::dispatch(command).await,
+        Command::Task { command } => commands::task::dispatch(command).await,
         Command::Diagnose(args) => commands::diagnose::diagnose(args).await,
         Command::Tools { command } => commands::tools::dispatch(command).await,
         Command::Config { command } => commands::config::dispatch(command).await,

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -68,7 +68,9 @@ Inspect the local runtime:
   defra-agent status
   defra-agent show runtime
   defra-agent show response REQUEST_ID
-  defra-agent task run --task-id TASK_ID
+  defra-agent task list
+  defra-agent task show TASK_ID
+  defra-agent task run TASK_ID --wait
   defra-agent background list
   defra-agent mcp probe --all
   defra-agent reset
@@ -209,11 +211,13 @@ Examples:
   defra-agent fleet slots --home /path/to/home
   defra-agent fleet slots --graphql http://127.0.0.1:9191/api/v0/graphql";
 const TASK_AFTER_HELP: &str = "\
-Creates a pending AgentRequest for a configured Task with manual trigger lineage.
+Inspect configured Task documents and create pending AgentRequests with manual trigger lineage.
 
 Examples:
-  defra-agent task run --task-id host-check
-  defra-agent task run --task-id host-check --args '{\"scope\":\"host\"}'
+  defra-agent task list
+  defra-agent task show host-check
+  defra-agent task run host-check
+  defra-agent task run host-check --args '{\"scope\":\"host\"}' --wait
   defra-agent task run --task-id host-check --graphql http://127.0.0.1:9191/api/v0/graphql";
 const SHOW_AFTER_HELP: &str = "\
 Examples:

--- a/crates/defra-agent-cli/tests/cli_config_task_run.rs
+++ b/crates/defra-agent-cli/tests/cli_config_task_run.rs
@@ -116,6 +116,41 @@ async fn config_task_run_matches_lean_manual_dispatch_contract() -> Result<()> {
         Some(1)
     );
 
+    let list = run_cli_json(&home_dir, &["task", "list", "--graphql", &graphql])?;
+    let listed_task = list
+        .get("tasks")
+        .and_then(Value::as_array)
+        .and_then(|tasks| {
+            tasks
+                .iter()
+                .find(|task| task.get("task_id").and_then(Value::as_str) == Some(task_id.as_str()))
+        })
+        .ok_or_else(|| anyhow!("task list output missing {task_id}: {list}"))?;
+    assert_eq!(
+        listed_task.get("runnable").and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        listed_task
+            .pointer("/behavior/behavior_id")
+            .and_then(Value::as_str),
+        Some(behavior_id.as_str())
+    );
+
+    let shown = run_cli_json(
+        &home_dir,
+        &["task", "show", &task_id, "--graphql", &graphql],
+    )?;
+    assert_eq!(
+        shown.pointer("/task/task_id").and_then(Value::as_str),
+        Some(task_id.as_str())
+    );
+    assert_eq!(shown.get("runnable").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        shown.pointer("/behavior/agent_did").and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+
     // Fire the manual run via the new CLI subcommand.
     let fire = run_cli_json(
         &home_dir,


### PR DESCRIPTION
## Summary

- add `defra-agent task list` and `defra-agent task show TASK_ID`
- allow `defra-agent task run TASK_ID` while preserving `--task-id`
- add `task run --wait` using the existing terminal response waiter
- expose runnable status by joining Task, AgentBehavior, Schedule, and EventTrigger rows
- keep compatibility paths under `config task list/show/run`

## Notes

This builds on the existing task-run CLI work by making the task surface usable as an operator workflow:

```sh
defra-agent task list
defra-agent task show host-check
defra-agent task run host-check --wait
```

`task list/show` are read-only. `task run` keeps the existing manual AgentRequest lineage behavior.

## Validation

- `cargo fmt --check`
- `cargo test -p defra-agent-cli cli::args::tests`
- `cargo test -p defra-agent-cli commands::config::task_run::tests`
- `cargo test -p defra-agent-cli commands::task::tests`
- `cargo test -p defra-agent-cli --test cli_config_task_run`
- `cargo build -p defra-agent-cli`