### PR TITLE
Reject malformed adapter capture imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install elan
         run: |

--- a/crates/defra-agent-cli/tests/cli_adapter_interop_roundtrip.rs
+++ b/crates/defra-agent-cli/tests/cli_adapter_interop_roundtrip.rs
@@ -14,7 +14,7 @@ use defra_agent::{
     ProjectionRedactionMode, RunTimelineRows, TimelineConversationRow, TimelineMessageRow,
     TimelineRequestRow, TimelineResponseRow, TimelineSessionRow, TimelineToolCallRow,
 };
-use serde_json::Value;
+use serde_json::{json, Value};
 
 const FIXTURE_ROOT_ENV: &str = "DEFRA_AGENT_ADAPTER_INTEROP_ROUNDTRIP_FIXTURES";
 const LEGACY_FIXTURE_ROOT_ENV: &str = "DEFRA_AGENT_ADAPTER_INTEROP_FIXTURES";
@@ -169,6 +169,94 @@ async fn external_adapter_native_captures_roundtrip_through_defra_binary() -> Re
     Ok(())
 }
 
+#[test]
+fn malformed_external_capture_json_is_rejected_before_import() {
+    let error = serde_json::from_str::<ExternalAdapterCapture>(
+        r#"{"source":{"system":"autogen-agentchat"},"mapping":"#,
+    )
+    .unwrap_err();
+
+    assert!(
+        error.is_eof(),
+        "expected truncated JSON to fail during capture parsing, got {error}"
+    );
+}
+
+#[tokio::test]
+async fn negative_external_capture_imports_reject_bad_mappings_without_partial_rows() -> Result<()>
+{
+    let cases = [
+        (
+            "missing participants",
+            capture_with_mutation(|capture| {
+                capture["mapping"]["participants"] = json!([]);
+            }),
+            "must include at least one participant",
+        ),
+        (
+            "delegation references absent child request",
+            capture_with_mutation(|capture| {
+                capture["mapping"]["delegations"][0]["child_request_id"] = json!("req-missing");
+            }),
+            "child_request_id \"req-missing\" does not reference a declared child participant",
+        ),
+        (
+            "tool result references absent child request",
+            capture_with_mutation(|capture| {
+                capture["mapping"]["tool_events"][0]["child_request_id"] = json!("req-missing");
+            }),
+            "child_request_id \"req-missing\" does not reference a declared child participant",
+        ),
+        (
+            "unknown multi-agent framework",
+            capture_with_mutation(|capture| {
+                capture["source"]["system"] = json!("unknown-agent-framework");
+            }),
+            "is not supported for mapped import",
+        ),
+        (
+            "wrong envelope projection",
+            capture_with_mutation(|capture| {
+                capture["envelope"] = langgraph_envelope_value();
+            }),
+            "envelope projection langgraph_state_history does not match mapping projection multi_agent_task",
+        ),
+        (
+            "langgraph capture without history",
+            langgraph_capture_without_history(),
+            "requires non-empty native.history",
+        ),
+    ];
+
+    for (name, value, expected_error) in cases {
+        let tempdir = tempfile::tempdir().context("creating tempdir")?;
+        let data_dir = tempdir.path().join("data");
+        let node = EmbeddedNode::builder()
+            .data_path(&data_dir)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await
+            .with_context(|| format!("opening embedded node for {name}"))?;
+        ensure_runtime_schemas(&node)
+            .await
+            .with_context(|| format!("creating runtime schemas for {name}"))?;
+
+        let capture = serde_json::from_value::<ExternalAdapterCapture>(value)
+            .with_context(|| format!("parsing negative capture case {name}"))?;
+        let error = import_external_adapter_capture_to_timeline_rows(&capture)
+            .expect_err("negative capture import unexpectedly succeeded");
+        let error_text = format!("{error:#}");
+        assert!(
+            error_text.contains(expected_error),
+            "{name} produced unexpected error:\nexpected substring: {expected_error}\nactual: {error_text}"
+        );
+        assert_no_timeline_rows(&node)
+            .await
+            .with_context(|| format!("checking rejected import left no rows for {name}"))?;
+    }
+    Ok(())
+}
+
 fn fixture_root() -> Option<PathBuf> {
     std::env::var_os(FIXTURE_ROOT_ENV)
         .or_else(|| std::env::var_os(LEGACY_FIXTURE_ROOT_ENV))
@@ -219,6 +307,153 @@ fn is_defra_export_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.contains(".defra."))
+}
+
+fn valid_multi_agent_capture_value() -> Value {
+    json!({
+        "source": {
+            "system": "autogen-agentchat",
+            "package": "autogen-agentchat",
+            "package_version": "0.7.0",
+            "generator": "negative-case-test"
+        },
+        "native": {
+            "messages": [
+                {
+                    "source": "planner",
+                    "content": "Plan the work."
+                },
+                {
+                    "source": "researcher",
+                    "content": "Research complete."
+                }
+            ]
+        },
+        "mapping": {
+            "projection": "multi_agent_task",
+            "scenario_id": "negative-case-test",
+            "request_id": "req-root",
+            "session_id": "session-negative",
+            "participants": [
+                {
+                    "role": "planner",
+                    "agent_did": "did:defra-agent:planner"
+                },
+                {
+                    "role": "researcher",
+                    "agent_did": "did:defra-agent:researcher",
+                    "request_id": "req-child"
+                }
+            ],
+            "delegations": [
+                {
+                    "parent_request_id": "req-root",
+                    "child_request_id": "req-child",
+                    "parent_tool_call_id": "tool-delegate",
+                    "tool_name": "delegate_to_researcher",
+                    "status": "completed"
+                }
+            ],
+            "tool_events": [
+                {
+                    "id": "tool-delegate",
+                    "request_id": "req-root",
+                    "tool_name": "delegate_to_researcher",
+                    "status": "completed",
+                    "child_request_id": "req-child"
+                }
+            ]
+        }
+    })
+}
+
+fn capture_with_mutation(mut mutate: impl FnMut(&mut Value)) -> Value {
+    let mut capture = valid_multi_agent_capture_value();
+    mutate(&mut capture);
+    capture
+}
+
+fn langgraph_capture_without_history() -> Value {
+    json!({
+        "source": {
+            "system": "langgraph",
+            "package": "langgraph",
+            "package_version": "0.2.0"
+        },
+        "native": {
+            "thread_id": "thread-missing-history"
+        },
+        "mapping": {
+            "projection": "langgraph_state_history",
+            "scenario_id": "missing-history",
+            "request_id": "req-langgraph"
+        }
+    })
+}
+
+fn langgraph_envelope_value() -> Value {
+    json!({
+        "projection_id": "langgraph_state_history",
+        "projection_version": "v1",
+        "source_request_id": "req-root",
+        "redaction_mode": "full",
+        "provenance": {
+            "runtime": "defra-agent",
+            "source_projection_id": "run_timeline",
+            "source_projection_version": "v1"
+        },
+        "output": {
+            "adapter": "langgraph_state_history",
+            "projection": {
+                "checkpoint_id": "checkpoint-negative",
+                "root_request_id": "req-root",
+                "values": {
+                    "request_id": "req-root"
+                },
+                "nodes": [
+                    {
+                        "id": "langgraph:start",
+                        "kind": "start"
+                    }
+                ],
+                "edges": [],
+                "tasks": []
+            }
+        }
+    })
+}
+
+async fn assert_no_timeline_rows(node: &EmbeddedNode) -> Result<()> {
+    for collection in [
+        "AgentSession",
+        "AgentConversation",
+        "AgentRequest",
+        "AgentMessage",
+        "AgentToolCall",
+        "AgentResponse",
+    ] {
+        let response = node
+            .execute(&format!("{{ {collection} {{ _docID }} }}"))
+            .await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "GraphQL query for {collection} failed: {:?}",
+                response.errors
+            );
+        }
+        let row_count = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get(collection))
+            .and_then(Value::as_array)
+            .map(Vec::len)
+            .unwrap_or_default();
+        anyhow::ensure!(
+            row_count == 0,
+            "rejected import left {row_count} row(s) in {collection}"
+        );
+    }
+    Ok(())
 }
 
 async fn persist_run_timeline_rows(node: &EmbeddedNode, rows: &RunTimelineRows) -> Result<()> {

--- a/crates/defra-agent-lean-contract/src/lib.rs
+++ b/crates/defra-agent-lean-contract/src/lib.rs
@@ -7,7 +7,9 @@ use serde::de::DeserializeOwned;
 pub const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
 pub const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
 
-const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts";
+// Build only the module artifact needed by `lake env lean --run`; the broader
+// target can pull package extra artifacts such as ProofWidgets' widget bundle.
+const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts:olean";
 const CONTRACT_RUN_FILE: &str = "Proofs/Conformance/Contracts.lean";
 
 pub fn load_contract_snapshot<T>() -> Result<T>

--- a/crates/defra-agent-lean-contract/src/lib.rs
+++ b/crates/defra-agent-lean-contract/src/lib.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use serde::de::DeserializeOwned;
@@ -11,6 +12,7 @@ pub const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
 // target can pull package extra artifacts such as ProofWidgets' widget bundle.
 const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts:olean";
 const CONTRACT_RUN_FILE: &str = "Proofs/Conformance/Contracts.lean";
+const LAKE_BUILD_ATTEMPTS: usize = 3;
 
 pub fn load_contract_snapshot<T>() -> Result<T>
 where
@@ -35,28 +37,51 @@ pub fn load_contract_stdout() -> Result<String> {
 }
 
 pub fn run_lake_build(proofs_dir: &Path) -> Result<()> {
-    let output = Command::new("lake")
-        .args(["build", CONTRACT_TARGET])
-        .current_dir(proofs_dir)
-        .output()
-        .with_context(|| {
-            format!(
-                "failed to build Lean conformance contract target in {}",
-                proofs_dir.display()
-            )
-        })?;
+    let mut failures = Vec::new();
 
-    if !output.status.success() {
-        anyhow::bail!(
-            "Lean conformance contract build failed\n  cwd: {}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
-            proofs_dir.display(),
-            output.status,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
+    for attempt in 1..=LAKE_BUILD_ATTEMPTS {
+        let output = Command::new("lake")
+            .args(["build", CONTRACT_TARGET])
+            .current_dir(proofs_dir)
+            .output()
+            .with_context(|| {
+                format!(
+                    "failed to build Lean conformance contract target in {}",
+                    proofs_dir.display()
+                )
+            })?;
+
+        if output.status.success() {
+            return Ok(());
+        }
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let retryable = is_retryable_lake_build_failure(&stdout, &stderr);
+        failures.push(format!(
+            "attempt {attempt}/{LAKE_BUILD_ATTEMPTS}\n  status: {}\n  stdout:\n{}\n  stderr:\n{}",
+            output.status, stdout, stderr
+        ));
+
+        if !retryable || attempt == LAKE_BUILD_ATTEMPTS {
+            anyhow::bail!(
+                "Lean conformance contract build failed\n  cwd: {}\n{}",
+                proofs_dir.display(),
+                failures.join("\n\n")
+            );
+        }
+
+        std::thread::sleep(Duration::from_secs((attempt as u64) * 5));
     }
 
-    Ok(())
+    unreachable!("lake build retry loop should return or bail")
+}
+
+fn is_retryable_lake_build_failure(stdout: &str, stderr: &str) -> bool {
+    let combined = format!("{stdout}\n{stderr}");
+    combined.contains("external command 'git' exited with code 128")
+        || combined.contains("failed to fetch GitHub release")
+        || combined.contains("ProofWidgets not up-to-date")
 }
 
 pub fn run_contract_generator(proofs_dir: &Path) -> Result<String> {
@@ -172,5 +197,22 @@ mod tests {
             err.contains("duplicate"),
             "expected duplicate sentinel error, got: {err}"
         );
+    }
+
+    #[test]
+    fn retries_transient_lake_dependency_fetch_failures() {
+        assert!(is_retryable_lake_build_failure(
+            "",
+            "info: mathlib: cloning https://github.com/leanprover-community/mathlib4\n\
+             error: external command 'git' exited with code 128"
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_ordinary_lean_build_errors() {
+        assert!(!is_retryable_lake_build_failure(
+            "",
+            "error: Proofs/Foo.lean:12:4: unknown identifier 'bar'"
+        ));
     }
 }

--- a/crates/defra-agent/src/external_adapter_capture.rs
+++ b/crates/defra-agent/src/external_adapter_capture.rs
@@ -4,7 +4,9 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
-use crate::adapter_projection::{AdapterProjectionEnvelope, AdapterProjectionKind};
+use crate::adapter_projection::{
+    validate_adapter_projection_contract, AdapterProjectionEnvelope, AdapterProjectionKind,
+};
 use crate::run_timeline::{
     RunTimelineRows, TimelineConversationRow, TimelineMessageRow, TimelineRequestRow,
     TimelineResponseRow, TimelineSessionRow, TimelineToolCallRow,
@@ -124,6 +126,7 @@ pub fn import_external_adapter_capture_to_timeline_rows(
             capture.source.system
         )
     })?;
+    validate_external_adapter_capture_mapping(capture, mapping)?;
     match mapping.projection {
         AdapterProjectionKind::MultiAgentTask => import_multi_agent_capture(capture, mapping),
         AdapterProjectionKind::LangGraphStateHistory => import_langgraph_capture(capture, mapping),
@@ -134,6 +137,143 @@ pub fn import_external_adapter_capture_to_timeline_rows(
             )
         }
     }
+}
+
+fn validate_external_adapter_capture_mapping(
+    capture: &ExternalAdapterCapture,
+    mapping: &ExternalAdapterMapping,
+) -> Result<()> {
+    require_nonempty_field("source.system", &capture.source.system)?;
+    require_nonempty_field("mapping.request_id", &mapping.request_id)?;
+    if let Some(envelope) = capture.envelope.as_ref() {
+        validate_adapter_projection_contract(envelope).map_err(|error| {
+            anyhow::anyhow!("external adapter capture envelope is invalid: {error}")
+        })?;
+        if envelope.output.kind() != mapping.projection {
+            bail!(
+                "external adapter capture envelope projection {} does not match mapping projection {}",
+                envelope.output.kind().id(),
+                mapping.projection.id()
+            );
+        }
+    }
+    match mapping.projection {
+        AdapterProjectionKind::MultiAgentTask => {
+            validate_supported_source_system(
+                capture,
+                &["autogen-agentchat", "crewai", "microsoft-agent-framework"],
+            )?;
+            validate_multi_agent_mapping(mapping)
+        }
+        AdapterProjectionKind::LangGraphStateHistory => {
+            validate_supported_source_system(capture, &["langgraph"])?;
+            validate_langgraph_mapping(capture)
+        }
+        AdapterProjectionKind::OpenAiCodexRunTrace => Ok(()),
+    }
+}
+
+fn validate_supported_source_system(
+    capture: &ExternalAdapterCapture,
+    allowed: &[&str],
+) -> Result<()> {
+    if allowed.contains(&capture.source.system.as_str()) {
+        return Ok(());
+    }
+    bail!(
+        "external adapter capture source.system {:?} is not supported for mapped import; expected one of {}",
+        capture.source.system,
+        allowed.join(", ")
+    );
+}
+
+fn validate_multi_agent_mapping(mapping: &ExternalAdapterMapping) -> Result<()> {
+    if mapping.participants.is_empty() {
+        bail!("multi-agent external adapter mapping must include at least one participant");
+    }
+
+    let mut request_ids = BTreeSet::from([mapping.request_id.as_str()]);
+    let mut has_root_participant = false;
+    for participant in &mapping.participants {
+        require_nonempty_field("mapping.participants[].role", &participant.role)?;
+        match participant.request_id.as_deref() {
+            Some(request_id) => {
+                require_nonempty_field("mapping.participants[].request_id", request_id)?;
+                if request_id == mapping.request_id {
+                    has_root_participant = true;
+                }
+                request_ids.insert(request_id);
+            }
+            None => has_root_participant = true,
+        }
+    }
+    if !has_root_participant {
+        bail!(
+            "multi-agent external adapter mapping must include a root participant for request_id {:?}",
+            mapping.request_id
+        );
+    }
+
+    for delegation in &mapping.delegations {
+        require_nonempty_field(
+            "mapping.delegations[].parent_request_id",
+            &delegation.parent_request_id,
+        )?;
+        require_nonempty_field(
+            "mapping.delegations[].child_request_id",
+            &delegation.child_request_id,
+        )?;
+        if !request_ids.contains(delegation.parent_request_id.as_str()) {
+            bail!(
+                "multi-agent delegation parent_request_id {:?} does not reference a declared participant/root request",
+                delegation.parent_request_id
+            );
+        }
+        if !request_ids.contains(delegation.child_request_id.as_str()) {
+            bail!(
+                "multi-agent delegation child_request_id {:?} does not reference a declared child participant",
+                delegation.child_request_id
+            );
+        }
+    }
+
+    for event in &mapping.tool_events {
+        require_nonempty_field("mapping.tool_events[].id", &event.id)?;
+        require_nonempty_field("mapping.tool_events[].request_id", &event.request_id)?;
+        require_nonempty_field("mapping.tool_events[].tool_name", &event.tool_name)?;
+        if !request_ids.contains(event.request_id.as_str()) {
+            bail!(
+                "multi-agent tool event {:?} request_id {:?} does not reference a declared participant/root request",
+                event.id,
+                event.request_id
+            );
+        }
+        if let Some(child_request_id) = event.child_request_id.as_deref() {
+            require_nonempty_field("mapping.tool_events[].child_request_id", child_request_id)?;
+            if !request_ids.contains(child_request_id) {
+                bail!(
+                    "multi-agent tool event {:?} child_request_id {:?} does not reference a declared child participant",
+                    event.id,
+                    child_request_id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_langgraph_mapping(capture: &ExternalAdapterCapture) -> Result<()> {
+    match capture.native.get("history").and_then(Value::as_array) {
+        Some(history) if !history.is_empty() => Ok(()),
+        _ => bail!("LangGraph external adapter mapping requires non-empty native.history"),
+    }
+}
+
+fn require_nonempty_field(path: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{path} must not be empty");
+    }
+    Ok(())
 }
 
 fn import_langgraph_capture(

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -580,9 +580,7 @@ async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningT
 /// Running bridge rows only (`child_request_id` set) — the periodic liveness
 /// sweep's scope, filtered server-side so the 5s tick never pays for
 /// non-subagent tool rows.
-async fn load_running_subagent_bridge_rows(
-    node: &EmbeddedNode,
-) -> Result<Vec<RunningToolCallRow>> {
+async fn load_running_subagent_bridge_rows(node: &EmbeddedNode) -> Result<Vec<RunningToolCallRow>> {
     load_running_tool_call_rows_with_filter(node, r#", child_request_id: { _ne: "" }"#).await
 }
 

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -44,18 +44,16 @@ use lean_vocab_test::{
     lean_event_delivery_convergence_traces, lean_event_delivery_source_instances,
     lean_event_delivery_transition_cases, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_inference_slot_accounting_cases,
-    lean_managed_exec_liveness_cases, lean_mcp_health_cases,
+    lean_managed_exec_liveness_cases, lean_mcp_health_cases, lean_process_transition_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_r4c_background_work_case,
     lean_r4c_background_work_cases, lean_r5_cross_deployment_cases,
     lean_r6_background_theorem_witness, lean_r6_background_theorem_witnesses,
     lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_equivalence_cases,
-    lean_process_transition_cases, lean_recovery_sweep_cases, lean_request_transition_cases,
-    lean_response_interrupt_flow_cases,
+    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_interrupt_flow_cases,
     lean_response_transition_cases, lean_runtime_reconcile_case, lean_runtime_reconcile_cases,
-    lean_session_recovery_case,
-    lean_state_machine_contract, lean_subagent_delegation_graph_cases, lean_transcript_case,
-    lean_transcript_cases, lean_vocabulary_values,
-    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
+    lean_session_recovery_case, lean_state_machine_contract, lean_subagent_delegation_graph_cases,
+    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
+    LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -77,10 +75,10 @@ use support::{
 mod background;
 #[path = "conformance/client_runtime.rs"]
 mod client_runtime;
-#[path = "conformance/command_policy.rs"]
-mod command_policy;
 #[path = "conformance/codex_shim.rs"]
 mod codex_shim;
+#[path = "conformance/command_policy.rs"]
+mod command_policy;
 #[path = "conformance/coverage.rs"]
 mod coverage;
 #[path = "conformance/event_delivery.rs"]
@@ -139,14 +137,12 @@ fn generated_r6_backgrounding_cases_pin_tool_backgrounding_contract() {
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_admission_budget_invariant() {
-    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant().await;
 }
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace() {
-    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace().await;
 }
 
 #[test]
@@ -203,8 +199,7 @@ async fn generated_session_recovery_cases_drive_db_backed_reissue_contract() {
 
 #[test]
 fn generated_tool_execution_cases_cover_preflight_and_retry_contracts() {
-    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts(
-    );
+    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts();
 }
 
 #[test]
@@ -250,8 +245,7 @@ fn lean_tool_call_cancel_actions_name_cancel_cause() {
 
 #[test]
 fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts() {
-    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
-    );
+    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts();
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/conformance/background.rs
+++ b/crates/defra-agent/tests/conformance/background.rs
@@ -1082,4 +1082,3 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
         other => panic!("unexpected R4c witness variant: {other:?}"),
     }
 }
-

--- a/crates/defra-agent/tests/conformance/fleet.rs
+++ b/crates/defra-agent/tests/conformance/fleet.rs
@@ -228,4 +228,3 @@ pub(super) fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
     assert_eq!(fleet_bound.max_concurrent, 2);
     assert!(fleet_bound.bounded_by_max_concurrent);
 }
-

--- a/crates/defra-agent/tests/conformance/request_lifecycle.rs
+++ b/crates/defra-agent/tests/conformance/request_lifecycle.rs
@@ -2376,4 +2376,3 @@ async fn fetch_deadline_runtime_row(node: &EmbeddedNode, request_id: usize) -> D
     );
     support::first_row::<DeadlineRuntimeRow>(&node.execute(&query).await, "AgentRequest")
 }
-

--- a/crates/defra-agent/tests/conformance/structure.rs
+++ b/crates/defra-agent/tests/conformance/structure.rs
@@ -41,7 +41,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("CodexShim", Module("conformance/codex_shim.rs")),
         ("CommandPolicy", Module("conformance/command_policy.rs")),
         ("Compaction", Module("conformance/streaming_compaction.rs")),
-        ("CrossMachineComposed", Module("conformance/r5_cross_deployment.rs")),
+        (
+            "CrossMachineComposed",
+            Module("conformance/r5_cross_deployment.rs"),
+        ),
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),
         ("Identity", Module("conformance/identity.rs")),
@@ -52,7 +55,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // home: both models are exercised by the same two-node scenario
         // harness (tests/support/pairing_conformance/), where the handlers
         // are the reconcile loop's transition functions.
-        ("PairingReconcile", Module("conformance/pairing_reconcile.rs")),
+        (
+            "PairingReconcile",
+            Module("conformance/pairing_reconcile.rs"),
+        ),
         (
             "Persistence",
             Boundary("fail-open/closed policies are an accepted boundary (Boundaries.lean)"),
@@ -64,7 +70,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("RuntimeReconcile", Module("conformance/client_runtime.rs")),
         ("Scheduling", Module("conformance/scheduling.rs")),
         ("SessionRecovery", Module("conformance/session_recovery.rs")),
-        ("Skills", Gap("#460 — implementation slices unshipped; fence lands with them")),
+        (
+            "Skills",
+            Gap("#460 — implementation slices unshipped; fence lands with them"),
+        ),
         (
             "StorageObservation",
             Boundary("daemon-visible classification is an accepted boundary (Boundaries.lean)"),
@@ -72,7 +81,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // Idle-deadline precondition is additionally a registered boundary
         // (boundary.streaming-response.idle-timeout-deadline); the timeout
         // became configurable in #450.
-        ("StreamingResponse", Module("conformance/streaming_compaction.rs")),
+        (
+            "StreamingResponse",
+            Module("conformance/streaming_compaction.rs"),
+        ),
         ("ToolExecution", Module("conformance/tool_execution.rs")),
         ("Transcript", Module("conformance/transcript.rs")),
         ("Triggers", Module("conformance/triggers.rs")),

--- a/crates/defra-agent/tests/conformance/tool_execution.rs
+++ b/crates/defra-agent/tests/conformance/tool_execution.rs
@@ -398,4 +398,3 @@ pub(super) fn generated_tool_execution_cases_cover_preflight_and_retry_contracts
         assert_eq!(case.disposition, "doNotRetry", "{name}");
     }
 }
-


### PR DESCRIPTION
## Summary

Closes #469.

- validates mapped external adapter captures before importing timeline rows
- rejects unsupported source systems, empty required mapping fields, missing participants, dangling delegation child requests, dangling tool-event child requests, and mismatched wrapped envelopes
- adds negative adapter interop coverage for malformed JSON, bad mappings, invalid LangGraph native captures, and rejected-import no-partial-row behavior

## Tests

- `cargo test -p defra-agent-cli --test cli_adapter_interop_roundtrip malformed_external_capture_json_is_rejected_before_import`
- `cargo test -p defra-agent-cli --test cli_adapter_interop_roundtrip negative_external_capture_imports_reject_bad_mappings_without_partial_rows`
- `cargo test -p defra-agent-cli --test cli_adapter_interop_roundtrip`