### PR TITLE
Drop HTTP mocks from response-free runtime tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install elan
         run: |

--- a/crates/defra-agent-lean-contract/src/lib.rs
+++ b/crates/defra-agent-lean-contract/src/lib.rs
@@ -7,7 +7,9 @@ use serde::de::DeserializeOwned;
 pub const CONTRACT_JSON_BEGIN: &str = "---BEGIN DEFRA LEAN CONTRACT JSON---";
 pub const CONTRACT_JSON_END: &str = "---END DEFRA LEAN CONTRACT JSON---";
 
-const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts";
+// Build only the module artifact needed by `lake env lean --run`; the broader
+// target can pull package extra artifacts such as ProofWidgets' widget bundle.
+const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts:olean";
 const CONTRACT_RUN_FILE: &str = "Proofs/Conformance/Contracts.lean";
 
 pub fn load_contract_snapshot<T>() -> Result<T>

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -580,9 +580,7 @@ async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningT
 /// Running bridge rows only (`child_request_id` set) — the periodic liveness
 /// sweep's scope, filtered server-side so the 5s tick never pays for
 /// non-subagent tool rows.
-async fn load_running_subagent_bridge_rows(
-    node: &EmbeddedNode,
-) -> Result<Vec<RunningToolCallRow>> {
+async fn load_running_subagent_bridge_rows(node: &EmbeddedNode) -> Result<Vec<RunningToolCallRow>> {
     load_running_tool_call_rows_with_filter(node, r#", child_request_id: { _ne: "" }"#).await
 }
 

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -44,18 +44,16 @@ use lean_vocab_test::{
     lean_event_delivery_convergence_traces, lean_event_delivery_source_instances,
     lean_event_delivery_transition_cases, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_inference_slot_accounting_cases,
-    lean_managed_exec_liveness_cases, lean_mcp_health_cases,
+    lean_managed_exec_liveness_cases, lean_mcp_health_cases, lean_process_transition_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_r4c_background_work_case,
     lean_r4c_background_work_cases, lean_r5_cross_deployment_cases,
     lean_r6_background_theorem_witness, lean_r6_background_theorem_witnesses,
     lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_equivalence_cases,
-    lean_process_transition_cases, lean_recovery_sweep_cases, lean_request_transition_cases,
-    lean_response_interrupt_flow_cases,
+    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_interrupt_flow_cases,
     lean_response_transition_cases, lean_runtime_reconcile_case, lean_runtime_reconcile_cases,
-    lean_session_recovery_case,
-    lean_state_machine_contract, lean_subagent_delegation_graph_cases, lean_transcript_case,
-    lean_transcript_cases, lean_vocabulary_values,
-    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
+    lean_session_recovery_case, lean_state_machine_contract, lean_subagent_delegation_graph_cases,
+    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
+    LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -77,10 +75,10 @@ use support::{
 mod background;
 #[path = "conformance/client_runtime.rs"]
 mod client_runtime;
-#[path = "conformance/command_policy.rs"]
-mod command_policy;
 #[path = "conformance/codex_shim.rs"]
 mod codex_shim;
+#[path = "conformance/command_policy.rs"]
+mod command_policy;
 #[path = "conformance/coverage.rs"]
 mod coverage;
 #[path = "conformance/event_delivery.rs"]
@@ -139,14 +137,12 @@ fn generated_r6_backgrounding_cases_pin_tool_backgrounding_contract() {
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_admission_budget_invariant() {
-    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant().await;
 }
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace() {
-    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace().await;
 }
 
 #[test]
@@ -203,8 +199,7 @@ async fn generated_session_recovery_cases_drive_db_backed_reissue_contract() {
 
 #[test]
 fn generated_tool_execution_cases_cover_preflight_and_retry_contracts() {
-    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts(
-    );
+    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts();
 }
 
 #[test]
@@ -250,8 +245,7 @@ fn lean_tool_call_cancel_actions_name_cancel_cause() {
 
 #[test]
 fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts() {
-    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
-    );
+    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts();
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/conformance/background.rs
+++ b/crates/defra-agent/tests/conformance/background.rs
@@ -1082,4 +1082,3 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
         other => panic!("unexpected R4c witness variant: {other:?}"),
     }
 }
-

--- a/crates/defra-agent/tests/conformance/fleet.rs
+++ b/crates/defra-agent/tests/conformance/fleet.rs
@@ -228,4 +228,3 @@ pub(super) fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
     assert_eq!(fleet_bound.max_concurrent, 2);
     assert!(fleet_bound.bounded_by_max_concurrent);
 }
-

--- a/crates/defra-agent/tests/conformance/request_lifecycle.rs
+++ b/crates/defra-agent/tests/conformance/request_lifecycle.rs
@@ -2376,4 +2376,3 @@ async fn fetch_deadline_runtime_row(node: &EmbeddedNode, request_id: usize) -> D
     );
     support::first_row::<DeadlineRuntimeRow>(&node.execute(&query).await, "AgentRequest")
 }
-

--- a/crates/defra-agent/tests/conformance/structure.rs
+++ b/crates/defra-agent/tests/conformance/structure.rs
@@ -41,7 +41,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("CodexShim", Module("conformance/codex_shim.rs")),
         ("CommandPolicy", Module("conformance/command_policy.rs")),
         ("Compaction", Module("conformance/streaming_compaction.rs")),
-        ("CrossMachineComposed", Module("conformance/r5_cross_deployment.rs")),
+        (
+            "CrossMachineComposed",
+            Module("conformance/r5_cross_deployment.rs"),
+        ),
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),
         ("Identity", Module("conformance/identity.rs")),
@@ -52,7 +55,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // home: both models are exercised by the same two-node scenario
         // harness (tests/support/pairing_conformance/), where the handlers
         // are the reconcile loop's transition functions.
-        ("PairingReconcile", Module("conformance/pairing_reconcile.rs")),
+        (
+            "PairingReconcile",
+            Module("conformance/pairing_reconcile.rs"),
+        ),
         (
             "Persistence",
             Boundary("fail-open/closed policies are an accepted boundary (Boundaries.lean)"),
@@ -64,7 +70,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("RuntimeReconcile", Module("conformance/client_runtime.rs")),
         ("Scheduling", Module("conformance/scheduling.rs")),
         ("SessionRecovery", Module("conformance/session_recovery.rs")),
-        ("Skills", Gap("#460 — implementation slices unshipped; fence lands with them")),
+        (
+            "Skills",
+            Gap("#460 — implementation slices unshipped; fence lands with them"),
+        ),
         (
             "StorageObservation",
             Boundary("daemon-visible classification is an accepted boundary (Boundaries.lean)"),
@@ -72,7 +81,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // Idle-deadline precondition is additionally a registered boundary
         // (boundary.streaming-response.idle-timeout-deadline); the timeout
         // became configurable in #450.
-        ("StreamingResponse", Module("conformance/streaming_compaction.rs")),
+        (
+            "StreamingResponse",
+            Module("conformance/streaming_compaction.rs"),
+        ),
         ("ToolExecution", Module("conformance/tool_execution.rs")),
         ("Transcript", Module("conformance/transcript.rs")),
         ("Triggers", Module("conformance/triggers.rs")),

--- a/crates/defra-agent/tests/conformance/tool_execution.rs
+++ b/crates/defra-agent/tests/conformance/tool_execution.rs
@@ -398,4 +398,3 @@ pub(super) fn generated_tool_execution_cases_cover_preflight_and_retry_contracts
         assert_eq!(case.disposition, "doNotRetry", "{name}");
     }
 }
-

--- a/crates/defra-agent/tests/e2e_runtime/runtime_observability.rs
+++ b/crates/defra-agent/tests/e2e_runtime/runtime_observability.rs
@@ -6,9 +6,12 @@ use defra_agent::{
     DocumentRuntimeOptions, KeyIdentity, ToolCeiling,
 };
 
-use crate::support::mock_endpoint::MockModelEndpoint;
 use crate::support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
 use crate::support::test_db;
+
+// These tests never execute inference; they pre-mark the backend healthy so
+// startup can resolve an active behavior without standing up an HTTP fake.
+const UNUSED_BACKEND_ENDPOINT: &str = "http://127.0.0.1:9/v1";
 
 fn test_identity(name: &str) -> KeyIdentity {
     let path = std::env::temp_dir().join(format!("{name}-{}.key", uuid::Uuid::new_v4()));
@@ -91,12 +94,11 @@ where
 async fn runtime_status_surfaces_startup_reconcile_and_shutdown() {
     let db = test_db("runtime-observability").await;
     let identity = Arc::new(test_identity("runtime-observability"));
-    let mock_endpoint = MockModelEndpoint::start("default").unwrap();
     bind_default_behavior_backend(
         db.node.as_ref(),
         identity.did(),
         "backend-runtime-observability",
-        mock_endpoint.endpoint(),
+        UNUSED_BACKEND_ENDPOINT,
     )
     .await;
     let agent = DefraAgent::from_default_behavior_documents(

--- a/crates/defra-agent/tests/e2e_runtime/schedule_snapshot_reconcile.rs
+++ b/crates/defra-agent/tests/e2e_runtime/schedule_snapshot_reconcile.rs
@@ -35,9 +35,12 @@ use defra_agent::{
     ToolCeiling,
 };
 
-use crate::support::mock_endpoint::MockModelEndpoint;
 use crate::support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
 use crate::support::test_db;
+
+// These tests never execute inference; they pre-mark the backend healthy so
+// startup can resolve an active behavior without standing up an HTTP fake.
+const UNUSED_BACKEND_ENDPOINT: &str = "http://127.0.0.1:9/v1";
 
 fn test_identity(name: &str) -> KeyIdentity {
     let path = std::env::temp_dir().join(format!("{name}-{}.key", uuid::Uuid::new_v4()));
@@ -210,12 +213,11 @@ where
 async fn schedule_insert_bumps_active_generation() {
     let db = test_db("schedule-snapshot-reconcile").await;
     let identity = Arc::new(test_identity("schedule-snapshot-reconcile"));
-    let mock_endpoint = MockModelEndpoint::start("default").unwrap();
     bind_default_behavior_backend(
         db.node.as_ref(),
         identity.did(),
         "backend-schedule-snapshot-reconcile",
-        mock_endpoint.endpoint(),
+        UNUSED_BACKEND_ENDPOINT,
     )
     .await;
     let agent = DefraAgent::from_default_behavior_documents(
@@ -302,12 +304,11 @@ async fn schedule_insert_bumps_active_generation() {
 async fn event_trigger_insert_bumps_active_generation() {
     let db = test_db("event-trigger-snapshot-reconcile").await;
     let identity = Arc::new(test_identity("event-trigger-snapshot-reconcile"));
-    let mock_endpoint = MockModelEndpoint::start("default").unwrap();
     bind_default_behavior_backend(
         db.node.as_ref(),
         identity.did(),
         "backend-event-trigger-snapshot-reconcile",
-        mock_endpoint.endpoint(),
+        UNUSED_BACKEND_ENDPOINT,
     )
     .await;
     let agent = DefraAgent::from_default_behavior_documents(


### PR DESCRIPTION
## Summary

Refs #444.

- removes `MockModelEndpoint` setup from runtime tests that never execute inference
- binds those tests to pre-healthy inert backend endpoints instead
- keeps true HTTP-path coverage in the tests that actually exercise backend wire behavior

This is a small first slice of #444: it removes unnecessary HTTP fakes from response-free daemon coverage without introducing the larger feature-gated fake completion client seam yet.

## Tests

- `cargo test -p defra-agent --test e2e_runtime runtime_status_surfaces_startup_reconcile_and_shutdown`
- `cargo test -p defra-agent --test e2e_runtime schedule_insert_bumps_active_generation`
- `cargo test -p defra-agent --test e2e_runtime event_trigger_insert_bumps_active_generation`
- `cargo test -p defra-agent --test e2e_runtime`