### PR TITLE
Retry vLLM tool-call JSON parse 400s instead of failing fast

### DIFF
--- a/crates/defra-agent/src/error.rs
+++ b/crates/defra-agent/src/error.rs
@@ -159,6 +159,14 @@ pub fn classify_completion_error(error: &rig::agent::StreamingError) -> Inferenc
                         InferenceError::RateLimited {
                             retry_after_secs: 60,
                         }
+                    } else if provider_message_is_tool_call_json_parse_failure(provider_msg) {
+                        // vLLM returns 400 (type "BadRequestError") when its server-side
+                        // tool-call parser fails to json.loads the model's streamed tool
+                        // arguments — e.g. a single-backslash regex/path the model emits in
+                        // an array/object-typed argument that the raw-mode parser does not
+                        // repair. This is intermittent and sampling-dependent (a fresh
+                        // generation usually parses cleanly), so retry rather than fail fast.
+                        InferenceError::TransientFailure { reason }
                     } else if provider_message_has_any_status(
                         provider_msg,
                         &[400, 401, 403, 404, 422],
@@ -216,6 +224,22 @@ fn provider_message_has_any_status(message: &str, statuses: &[u16]) -> bool {
     statuses
         .iter()
         .any(|status| error_message_has_status(message, *status))
+}
+
+/// Detects vLLM's intermittent 400 raised when its tool-call parser cannot
+/// `json.loads` the model's streamed tool arguments. The response body carries a
+/// Python `json.decoder.JSONDecodeError`, which always renders with the positional
+/// signature `"... line L column C (char N)"`, wrapped in a `"BadRequestError"`
+/// envelope. We key off that signature rather than the variable leading phrase
+/// (`Expecting ',' delimiter`, `Invalid \escape`, `Expecting property name`, ...) so
+/// every decode variant is covered without depending on backslash escaping in the
+/// wire body. Genuine request-shape 400s (e.g. `duplicate field max_tokens`) lack the
+/// JSONDecodeError signature and stay permanent.
+fn provider_message_is_tool_call_json_parse_failure(message: &str) -> bool {
+    message.contains("BadRequestError")
+        && message.contains(" line ")
+        && message.contains(" column ")
+        && message.contains("(char ")
 }
 
 fn provider_message_is_transport_failure(message_lower: &str) -> bool {

--- a/crates/defra-agent/src/error/tests.rs
+++ b/crates/defra-agent/src/error/tests.rs
@@ -133,6 +133,71 @@ fn provider_error_uses_precise_status_matching_for_permanent_statuses() {
 }
 
 #[test]
+fn vllm_tool_call_json_parse_400_is_retryable() {
+    // vLLM's tool-call parser fails to json.loads the model's streamed tool arguments
+    // (here a missing delimiter deep in an array-typed argument) and returns 400. This
+    // is intermittent/sampling-dependent, so it should retry rather than fail fast.
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Invalid status code 400 Bad Request with message: {\"error\":{\"message\":\
+             \"Expecting ',' delimiter: line 8 column 61 (char 4982)\",\"type\":\
+             \"BadRequestError\",\"param\":null,\"code\":400}}"
+                .into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::TransientFailure { .. }
+    ));
+    assert!(
+        classified.is_retryable(),
+        "intermittent vLLM tool-call JSON parse 400s should retry on a fresh generation"
+    );
+}
+
+#[test]
+fn vllm_tool_call_invalid_escape_400_is_retryable() {
+    // The `Invalid \escape` variant — the wire body double-escapes the backslash, which
+    // is why the matcher keys off the line/column/(char ...) signature, not the phrase.
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Invalid status code 400 Bad Request with message: {\"error\":{\"message\":\
+             \"Invalid \\\\escape: line 1 column 34 (char 33)\",\"type\":\"BadRequestError\"}}"
+                .into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::TransientFailure { .. }
+    ));
+    assert!(classified.is_retryable());
+}
+
+#[test]
+fn provider_400_without_json_decode_signature_stays_permanent() {
+    // Regression guard: a genuine request-shape 400 lacks the JSONDecodeError signature
+    // and must remain a permanent failure, unaffected by the tool-parse retry carve-out.
+    let error =
+        rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(
+            "Invalid status code 400 Bad Request with message: {\"error\":{\"message\":\
+             \"duplicate field `max_tokens`\",\"type\":\"BadRequestError\"}}"
+                .into(),
+        ));
+
+    let classified = classify_completion_error(&error);
+
+    assert!(matches!(
+        classified,
+        InferenceError::PermanentFailure { .. }
+    ));
+    assert!(!classified.is_retryable());
+}
+
+#[test]
 fn provider_error_loose_status_digits_do_not_force_permanent_failure() {
     let error =
         rig::agent::StreamingError::Completion(rig::completion::CompletionError::ProviderError(

--- a/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/recovery.rs
@@ -580,9 +580,7 @@ async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningT
 /// Running bridge rows only (`child_request_id` set) — the periodic liveness
 /// sweep's scope, filtered server-side so the 5s tick never pays for
 /// non-subagent tool rows.
-async fn load_running_subagent_bridge_rows(
-    node: &EmbeddedNode,
-) -> Result<Vec<RunningToolCallRow>> {
+async fn load_running_subagent_bridge_rows(node: &EmbeddedNode) -> Result<Vec<RunningToolCallRow>> {
     load_running_tool_call_rows_with_filter(node, r#", child_request_id: { _ne: "" }"#).await
 }
 

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -44,18 +44,16 @@ use lean_vocab_test::{
     lean_event_delivery_convergence_traces, lean_event_delivery_source_instances,
     lean_event_delivery_transition_cases, lean_fleet_slot_accounting_case,
     lean_inference_slot_accounting_case, lean_inference_slot_accounting_cases,
-    lean_managed_exec_liveness_cases, lean_mcp_health_cases,
+    lean_managed_exec_liveness_cases, lean_mcp_health_cases, lean_process_transition_cases,
     lean_queue_deadline_case, lean_queue_deadline_cases, lean_r4c_background_work_case,
     lean_r4c_background_work_cases, lean_r5_cross_deployment_cases,
     lean_r6_background_theorem_witness, lean_r6_background_theorem_witnesses,
     lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_equivalence_cases,
-    lean_process_transition_cases, lean_recovery_sweep_cases, lean_request_transition_cases,
-    lean_response_interrupt_flow_cases,
+    lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_interrupt_flow_cases,
     lean_response_transition_cases, lean_runtime_reconcile_case, lean_runtime_reconcile_cases,
-    lean_session_recovery_case,
-    lean_state_machine_contract, lean_subagent_delegation_graph_cases, lean_transcript_case,
-    lean_transcript_cases, lean_vocabulary_values,
-    LeanEventDeliveryAction, LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
+    lean_session_recovery_case, lean_state_machine_contract, lean_subagent_delegation_graph_cases,
+    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
+    LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -77,10 +75,10 @@ use support::{
 mod background;
 #[path = "conformance/client_runtime.rs"]
 mod client_runtime;
-#[path = "conformance/command_policy.rs"]
-mod command_policy;
 #[path = "conformance/codex_shim.rs"]
 mod codex_shim;
+#[path = "conformance/command_policy.rs"]
+mod command_policy;
 #[path = "conformance/coverage.rs"]
 mod coverage;
 #[path = "conformance/event_delivery.rs"]
@@ -139,14 +137,12 @@ fn generated_r6_backgrounding_cases_pin_tool_backgrounding_contract() {
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_admission_budget_invariant() {
-    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_admission_budget_invariant().await;
 }
 
 #[tokio::test]
 async fn generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace() {
-    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace()
-        .await;
+    background::generated_r6_background_theorem_witnesses_drive_cascade_cancellation_trace().await;
 }
 
 #[test]
@@ -203,8 +199,7 @@ async fn generated_session_recovery_cases_drive_db_backed_reissue_contract() {
 
 #[test]
 fn generated_tool_execution_cases_cover_preflight_and_retry_contracts() {
-    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts(
-    );
+    tool_execution::generated_tool_execution_cases_cover_preflight_and_retry_contracts();
 }
 
 #[test]
@@ -250,8 +245,7 @@ fn lean_tool_call_cancel_actions_name_cancel_cause() {
 
 #[test]
 fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts() {
-    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
-    );
+    fleet::generated_slot_accounting_cases_pin_inference_and_fleet_contracts();
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/conformance/background.rs
+++ b/crates/defra-agent/tests/conformance/background.rs
@@ -1082,4 +1082,3 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
         other => panic!("unexpected R4c witness variant: {other:?}"),
     }
 }
-

--- a/crates/defra-agent/tests/conformance/fleet.rs
+++ b/crates/defra-agent/tests/conformance/fleet.rs
@@ -228,4 +228,3 @@ pub(super) fn generated_slot_accounting_cases_pin_inference_and_fleet_contracts(
     assert_eq!(fleet_bound.max_concurrent, 2);
     assert!(fleet_bound.bounded_by_max_concurrent);
 }
-

--- a/crates/defra-agent/tests/conformance/request_lifecycle.rs
+++ b/crates/defra-agent/tests/conformance/request_lifecycle.rs
@@ -2376,4 +2376,3 @@ async fn fetch_deadline_runtime_row(node: &EmbeddedNode, request_id: usize) -> D
     );
     support::first_row::<DeadlineRuntimeRow>(&node.execute(&query).await, "AgentRequest")
 }
-

--- a/crates/defra-agent/tests/conformance/structure.rs
+++ b/crates/defra-agent/tests/conformance/structure.rs
@@ -41,7 +41,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("CodexShim", Module("conformance/codex_shim.rs")),
         ("CommandPolicy", Module("conformance/command_policy.rs")),
         ("Compaction", Module("conformance/streaming_compaction.rs")),
-        ("CrossMachineComposed", Module("conformance/r5_cross_deployment.rs")),
+        (
+            "CrossMachineComposed",
+            Module("conformance/r5_cross_deployment.rs"),
+        ),
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),
         ("Identity", Module("conformance/identity.rs")),
@@ -52,7 +55,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // home: both models are exercised by the same two-node scenario
         // harness (tests/support/pairing_conformance/), where the handlers
         // are the reconcile loop's transition functions.
-        ("PairingReconcile", Module("conformance/pairing_reconcile.rs")),
+        (
+            "PairingReconcile",
+            Module("conformance/pairing_reconcile.rs"),
+        ),
         (
             "Persistence",
             Boundary("fail-open/closed policies are an accepted boundary (Boundaries.lean)"),
@@ -64,7 +70,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ("RuntimeReconcile", Module("conformance/client_runtime.rs")),
         ("Scheduling", Module("conformance/scheduling.rs")),
         ("SessionRecovery", Module("conformance/session_recovery.rs")),
-        ("Skills", Gap("#460 — implementation slices unshipped; fence lands with them")),
+        (
+            "Skills",
+            Gap("#460 — implementation slices unshipped; fence lands with them"),
+        ),
         (
             "StorageObservation",
             Boundary("daemon-visible classification is an accepted boundary (Boundaries.lean)"),
@@ -72,7 +81,10 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         // Idle-deadline precondition is additionally a registered boundary
         // (boundary.streaming-response.idle-timeout-deadline); the timeout
         // became configurable in #450.
-        ("StreamingResponse", Module("conformance/streaming_compaction.rs")),
+        (
+            "StreamingResponse",
+            Module("conformance/streaming_compaction.rs"),
+        ),
         ("ToolExecution", Module("conformance/tool_execution.rs")),
         ("Transcript", Module("conformance/transcript.rs")),
         ("Triggers", Module("conformance/triggers.rs")),

--- a/crates/defra-agent/tests/conformance/tool_execution.rs
+++ b/crates/defra-agent/tests/conformance/tool_execution.rs
@@ -398,4 +398,3 @@ pub(super) fn generated_tool_execution_cases_cover_preflight_and_retry_contracts
         assert_eq!(case.disposition, "doNotRetry", "{name}");
     }
 }
-


### PR DESCRIPTION
## Problem

Stewards whose tool calls carry filesystem paths or regexes (e.g. the `strangenas` and `spark-2` host stewards) intermittently fail with:

```
agent stream failed: CompletionError: ProviderError: Invalid status code 400 Bad Request
with message: {"error":{"message":"Expecting ',' delimiter: line 8 column 61 (char 4982)",
"type":"BadRequestError"}}
```

**Root cause (reproduced, ~20% rate at temp 0.85 against DeepSeek-V4-Flash):** the steward `post_status` tool types `findings` as an **array of objects**. Array/object-typed arguments take vLLM's DSML tool-parser **raw streaming mode**, which trusts the model to emit valid JSON inline and does no escaping/repair. When a finding `details` string contains a regex metachar (`\s`, `\d`, `\|`, `\w`) or a single-backslash path (`\share`), the model writes a *single* backslash — natural in prose, but an **invalid JSON escape**. vLLM's `json.loads` of the assembled arguments then throws, and the server returns 400. It is sampling-dependent: a fresh generation usually escapes correctly.

`classify_completion_error` bucketed **every** provider 400 as `PermanentFailure`, so the run died at `agent stream failed` instead of using the request-level retry loop that already exists in `inference.rs` (3× exponential backoff, gated on `InferenceError::is_retryable()`).

## Fix

Reclassify *only* this intermittent tool-parse 400 as `TransientFailure`, so the existing retry machinery picks it up — no new retry code. Detection keys off the Python `json.decoder.JSONDecodeError` positional signature (`... line L column C (char N)`) inside a `BadRequestError` envelope. That:

- covers every decode variant (`Expecting ',' delimiter`, `Invalid \escape`, `Expecting property name`, …) without depending on backslash escaping in the wire body, and
- stays narrow: genuine request-shape 400s (e.g. `duplicate field max_tokens`) lack the signature and remain `PermanentFailure`.

At a ~20% per-attempt failure rate, 3 retries drop the per-turn odds to ~0.16%.

## Tests

`cargo test -p defra-agent --lib` → **687 passed, 0 failed**. Added:
- `vllm_tool_call_json_parse_400_is_retryable` — delimiter variant → `TransientFailure`
- `vllm_tool_call_invalid_escape_400_is_retryable` — `Invalid \escape` variant (double-escaped wire form)
- `provider_400_without_json_decode_signature_stays_permanent` — regression guard

Existing permanent-400 tests (`provider_error_uses_precise_status_matching_for_permanent_statuses`, `openai_compatible_http_400_is_permanent_bad_request`) still pass unchanged.

## Notes

This is the client-side stopgap for an upstream vLLM bug — the raw-mode tool-parser should json-repair stray escapes before `json.loads`. A separate upstream issue/report to vLLM + the lucifer image maintainer is warranted for the real cure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)