### PR TITLE
Fix Codex shim queued steering drain race

### DIFF
--- a/crates/defra-agent-cli/src/commands/codex_shim/turn/active.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/turn/active.rs
@@ -86,9 +86,17 @@ pub(super) async fn next_steering_request_after(
     queued_after_request_id: &str,
 ) -> Result<Option<NextSteeringRequest>> {
     let rows = load_thread_request_rows(state, thread_id).await?;
-    Ok(rows
-        .iter()
-        .filter(|row| row.lifecycle_state_is_active())
+    Ok(next_steering_request_after_from_rows(
+        &rows,
+        queued_after_request_id,
+    ))
+}
+
+fn next_steering_request_after_from_rows(
+    rows: &[RequestRow],
+    queued_after_request_id: &str,
+) -> Option<NextSteeringRequest> {
+    rows.iter()
         .filter(|row| steering_parent_id(row).as_deref() == Some(queued_after_request_id))
         .min_by(|left, right| {
             left.created_at
@@ -98,7 +106,7 @@ pub(super) async fn next_steering_request_after(
         .map(|row| NextSteeringRequest {
             request_id: row.request_id.clone(),
             lifecycle_state: row.lifecycle_state.clone(),
-        }))
+        })
 }
 
 pub(super) async fn steering_request_ids_for_turn_interrupt_cleanup(
@@ -505,5 +513,33 @@ mod tests {
         assert_eq!(active.turn_id, "turn-1");
         assert_eq!(active.interrupt_request_id, "turn-1");
         assert_eq!(active.current_request_id, "steer-1");
+    }
+
+    #[test]
+    fn next_steering_request_includes_already_completed_child() {
+        let rows = vec![
+            row("turn-1", "completed", None),
+            row("steer-1", "completed", Some("turn-1")),
+        ];
+
+        let next = next_steering_request_after_from_rows(&rows, "turn-1").unwrap();
+
+        assert_eq!(next.request_id, "steer-1");
+        assert_eq!(next.lifecycle_state, "completed");
+        assert!(!next.is_pending());
+    }
+
+    #[test]
+    fn next_steering_request_preserves_queue_order_across_terminal_children() {
+        let rows = vec![
+            row("turn-1", "completed", None),
+            row("steer-2", "completed", Some("turn-1")),
+            row("steer-1", "failed", Some("turn-1")),
+        ];
+
+        let next = next_steering_request_after_from_rows(&rows, "turn-1").unwrap();
+
+        assert_eq!(next.request_id, "steer-1");
+        assert_eq!(next.lifecycle_state, "failed");
     }
 }


### PR DESCRIPTION
## Summary

Fixes #475 by making the Codex shim drain the next steering child even when that child has already reached a terminal lifecycle state before the parent turn stream observes it.

Previously, `next_steering_request_after` only considered active steering requests. If a queued steer completed quickly, the shim could miss it, complete the Codex turn, and never emit the committed user-message item that clears Codex TUI’s pending/queued input row.

## Changes

- Select the next steering child by queue ancestry and creation order, regardless of lifecycle state.
- Preserve the existing wait behavior for still-pending steering requests.
- Add unit coverage for already-completed and failed steering children.

## Verification

- `cargo test -p defra-agent-cli next_steering_request -- --nocapture`
- `cargo test -p defra-agent-cli codex_shim_turn_steer_drains_queued_request_before_completing_turn --test cli_codex_shim -- --nocapture`
- `cargo test -p defra-agent-cli codex_shim_turn_steer_queues_defra_request_on_active_turn --test cli_codex_shim -- --nocapture`
- `git diff --check`