### PR TITLE
Skills: resolve native slash selection UX

### DIFF
--- a/crates/defra-agent-cli/src/commands/config/task_run.rs
+++ b/crates/defra-agent-cli/src/commands/config/task_run.rs
@@ -22,7 +22,9 @@ use serde_json::Value;
 
 use crate::cli::ConfigTaskRunArgs;
 use crate::config_writes::ConfigAccess;
-use crate::request_helpers::{metadata_with_prompt_selected_skill_ids, wait_for_terminal_response};
+use crate::request_helpers::{
+    content_and_metadata_with_prompt_selected_skill_ids, wait_for_terminal_response,
+};
 use crate::{print_json, resolve_config_access, resolve_graphql_endpoint};
 
 /// Must match `lifecycle::DEFAULT_REQUEST_MAX_RETRIES` and the value written by
@@ -185,7 +187,7 @@ pub(crate) async fn enqueue_task_run(args: &ConfigTaskRunArgs) -> Result<TaskRun
     //    `write_manual_agent_request`: same field set, same lineage.
     let request_id = uuid::Uuid::new_v4().to_string();
     let session_id = uuid::Uuid::new_v4().to_string();
-    let metadata = metadata_with_prompt_selected_skill_ids(None, &content);
+    let (content, metadata) = content_and_metadata_with_prompt_selected_skill_ids(None, &content);
     let mutation = build_create_manual_request_mutation(CreateManualRequestInput {
         request_id: &request_id,
         session_id: &session_id,

--- a/crates/defra-agent-cli/src/request_helpers.rs
+++ b/crates/defra-agent-cli/src/request_helpers.rs
@@ -4,9 +4,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
-use defra_agent::{
-    graphql::escape_graphql_string, skills::selected_skill_ids_from_prompt_slash_commands,
-};
+use defra_agent::{graphql::escape_graphql_string, skills::prompt_slash_skill_selection};
 use defra_agent_protocol::transcript::present_persisted_message;
 use serde_json::Value;
 
@@ -203,8 +201,8 @@ pub(crate) async fn create_agent_request(
     behavior_id: Option<&str>,
     options: RequestSubmitOptions,
 ) -> Result<SubmittedRequest> {
-    let request_metadata =
-        metadata_with_prompt_selected_skill_ids(options.metadata.as_deref(), content);
+    let (request_content, request_metadata) =
+        content_and_metadata_with_prompt_selected_skill_ids(options.metadata.as_deref(), content);
     let request_id = uuid::Uuid::new_v4().to_string();
     let session_id = session_id
         .map(ToOwned::to_owned)
@@ -286,7 +284,7 @@ pub(crate) async fn create_agent_request(
         session_id = escape_graphql_string(&session_id),
         retry_parent = escape_graphql_string(retry_parent_value),
         retry_root = escape_graphql_string(&retry_root_value),
-        content = escape_graphql_string(content),
+        content = escape_graphql_string(&request_content),
         request_override_fields = request_override_fields,
     );
     post_graphql(graphql, &mutation).await?;
@@ -307,44 +305,55 @@ pub(crate) async fn create_agent_request(
     })
 }
 
-pub(crate) fn metadata_with_prompt_selected_skill_ids(
+pub(crate) fn content_and_metadata_with_prompt_selected_skill_ids(
     metadata: Option<&str>,
     content: &str,
-) -> Option<String> {
-    let selected = selected_skill_ids_from_prompt_slash_commands(content);
+) -> (String, Option<String>) {
+    let selection = prompt_slash_skill_selection(content);
+    let Some(metadata) = metadata_with_selected_skill_ids(metadata, &selection.selected_skill_ids)
+    else {
+        return (content.to_string(), metadata.map(ToOwned::to_owned));
+    };
+    (selection.prompt, metadata)
+}
+
+fn metadata_with_selected_skill_ids(
+    metadata: Option<&str>,
+    selected: &[String],
+) -> Option<Option<String>> {
     if selected.is_empty() {
-        return metadata.map(ToOwned::to_owned);
+        return Some(metadata.map(ToOwned::to_owned));
     }
 
     let mut value = match metadata.map(str::trim).filter(|value| !value.is_empty()) {
         Some(raw) => match serde_json::from_str::<Value>(raw) {
             Ok(value) if value.is_object() => value,
-            _ => return metadata.map(ToOwned::to_owned),
+            _ => return None,
         },
         None => serde_json::json!({}),
     };
 
     let Some(object) = value.as_object_mut() else {
-        return metadata.map(ToOwned::to_owned);
+        return None;
     };
     let entry = object
         .entry("selected_skill_ids".to_string())
         .or_insert_with(|| serde_json::json!([]));
     if !entry.is_array() {
-        return metadata.map(ToOwned::to_owned);
+        return None;
     }
     let Some(ids) = entry.as_array_mut() else {
-        return metadata.map(ToOwned::to_owned);
+        return None;
     };
     for id in selected {
         let already_present = ids
             .iter()
             .any(|existing| existing.as_str() == Some(id.as_str()));
         if !already_present {
-            ids.push(Value::String(id));
+            ids.push(Value::String(id.clone()));
         }
     }
-    Some(value.to_string())
+    Some(Some(value.to_string()))
 }
 
 /// Poll both `AgentRequest.lifecycle_state` and the latest `AgentResponse`
@@ -660,11 +669,12 @@ pub(crate) async fn fetch_request_view(
 
 #[cfg(test)]
 mod tests {
-    use super::metadata_with_prompt_selected_skill_ids;
+    use super::content_and_metadata_with_prompt_selected_skill_ids;
 
     #[test]
     fn slash_prompt_adds_selected_skill_ids_metadata() {
-        let metadata = metadata_with_prompt_selected_skill_ids(None, "/vuln-scan /work");
+        let (_content, metadata) =
+            content_and_metadata_with_prompt_selected_skill_ids(None, "/vuln-scan /work");
         assert_eq!(
             metadata.as_deref(),
             Some(r#"{"selected_skill_ids":["vuln-scan"]}"#)
@@ -673,11 +683,11 @@ mod tests {
 
     #[test]
     fn slash_prompt_merges_existing_selected_skill_ids() {
-        let metadata = metadata_with_prompt_selected_skill_ids(
+        let (_content, metadata) = content_and_metadata_with_prompt_selected_skill_ids(
             Some(r#"{"codex_shim":{},"selected_skill_ids":["triage"]}"#),
             "/vuln-scan /work",
-        )
-        .expect("metadata");
+        );
+        let metadata = metadata.expect("metadata");
         assert!(metadata.contains(r#""codex_shim":{}"#));
         assert!(metadata.contains(r#""triage""#));
         assert!(metadata.contains(r#""vuln-scan""#));
@@ -685,9 +695,21 @@ mod tests {
 
     #[test]
     fn invalid_existing_metadata_is_preserved() {
+        let (content, metadata) =
+            content_and_metadata_with_prompt_selected_skill_ids(Some("not json"), "/vuln-scan");
+        assert_eq!(content, "/vuln-scan");
+        assert_eq!(metadata, Some("not json".to_string()));
+    }
+
+    #[test]
+    fn slash_prompt_strips_control_syntax_from_request_content() {
+        let (content, metadata) =
+            content_and_metadata_with_prompt_selected_skill_ids(None, "/vuln-scan\nReview /work");
+
+        assert_eq!(content, "Review /work");
         assert_eq!(
-            metadata_with_prompt_selected_skill_ids(Some("not json"), "/vuln-scan"),
-            Some("not json".to_string())
+            metadata.as_deref(),
+            Some(r#"{"selected_skill_ids":["vuln-scan"]}"#)
         );
     }
 }

--- a/crates/defra-agent/src/lifecycle/manual.rs
+++ b/crates/defra-agent/src/lifecycle/manual.rs
@@ -183,7 +183,7 @@ mod tests {
             "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK",
             "behavior-1",
             "task-1",
-            "/vuln-scan /work",
+            "/vuln-scan\nReview /work",
             serde_json::json!({}),
         )
         .await
@@ -211,7 +211,7 @@ mod tests {
             .and_then(|rows| rows.first())
             .expect("expected request row");
 
-        assert_eq!(row["content"].as_str(), Some("/vuln-scan /work"));
+        assert_eq!(row["content"].as_str(), Some("Review /work"));
         assert_eq!(
             row["metadata"].as_str(),
             Some(r#"{"selected_skill_ids":["vuln-scan"]}"#)

--- a/crates/defra-agent/src/lifecycle/materialize.rs
+++ b/crates/defra-agent/src/lifecycle/materialize.rs
@@ -60,16 +60,17 @@ pub(crate) async fn write_pending_agent_request_with_lineage_and_conversation_ti
     let escaped_agent_did = escape_graphql_string(agent_did);
     let escaped_behavior_id = escape_graphql_string(behavior_id);
     let escaped_session_id = escape_graphql_string(&session_id);
+    let prompt_selection = crate::skills::prompt_slash_skill_selection(content);
+    let content = prompt_selection.prompt.as_str();
     let escaped_content = escape_graphql_string(content);
     let escaped_created_at = escape_graphql_string(&now);
     let execution_origin = execution_origin.as_str();
     let lineage_fields = trigger_lineage_graphql_fields(&trigger_lineage);
-    let selected_skill_ids = crate::skills::selected_skill_ids_from_prompt_slash_commands(content);
-    let metadata_field = if selected_skill_ids.is_empty() {
+    let metadata_field = if prompt_selection.selected_skill_ids.is_empty() {
         String::new()
     } else {
         let metadata = serde_json::json!({
-            "selected_skill_ids": selected_skill_ids,
+            "selected_skill_ids": prompt_selection.selected_skill_ids,
         })
         .to_string();
         format!(

--- a/crates/defra-agent/src/skills.rs
+++ b/crates/defra-agent/src/skills.rs
@@ -260,52 +260,184 @@ pub fn find_skill<'a>(skills: &'a [Skill], needle: &str) -> Option<&'a Skill> {
         })
 }
 
-/// Extract skill ids named by leading slash commands in a prompt.
-///
-/// This is intentionally only a reference extractor. It does not resolve the
-/// skill or edit the prompt text; the runtime later resolves each id against
-/// the behavior's effective skill set before injecting any skill body. Keeping
-/// the prompt unchanged avoids corrupting legitimate prompts that happen to
-/// start with an absolute path.
-pub fn selected_skill_ids_from_prompt_slash_commands(prompt: &str) -> Vec<String> {
-    let mut selected = Vec::new();
-    let mut saw_command = false;
-
-    for line in prompt.lines() {
-        if line.trim().is_empty() && !saw_command {
-            continue;
-        }
-        let Some(skill_id) = leading_slash_skill_id(line) else {
-            break;
-        };
-        if !selected.iter().any(|existing| existing == &skill_id) {
-            selected.push(skill_id);
-        }
-        saw_command = true;
-    }
-
-    selected
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptSlashSkillSelection {
+    pub selected_skill_ids: Vec<String>,
+    pub prompt: String,
 }
 
-fn leading_slash_skill_id(line: &str) -> Option<String> {
+/// Extract native leading skill selectors from a prompt.
+///
+/// The selector is request-control syntax, not user text: selected ids are
+/// recorded as metadata, and the returned prompt has selector tokens removed so
+/// they do not reach the provider. The runtime later resolves ids against the
+/// behavior's effective skill set before injecting any skill body.
+pub fn prompt_slash_skill_selection(prompt: &str) -> PromptSlashSkillSelection {
+    let mut selected = Vec::new();
+    let mut body_lines = Vec::new();
+    let mut saw_selector = false;
+
+    let mut lines = prompt.lines();
+    while let Some(line) = lines.next() {
+        if line.trim().is_empty() && !saw_selector {
+            continue;
+        }
+
+        let Some(selector) = leading_slash_skill_selector(line) else {
+            if !saw_selector {
+                return PromptSlashSkillSelection {
+                    selected_skill_ids: Vec::new(),
+                    prompt: prompt.to_string(),
+                };
+            }
+            body_lines.push(line.to_string());
+            body_lines.extend(lines.map(ToOwned::to_owned));
+            break;
+        };
+
+        if !selected
+            .iter()
+            .any(|existing| existing == &selector.skill_id)
+        {
+            selected.push(selector.skill_id);
+        }
+        if !selector.remainder.is_empty() {
+            body_lines.push(selector.remainder);
+        }
+        saw_selector = true;
+    }
+
+    if !saw_selector {
+        return PromptSlashSkillSelection {
+            selected_skill_ids: Vec::new(),
+            prompt: prompt.to_string(),
+        };
+    }
+
+    PromptSlashSkillSelection {
+        selected_skill_ids: selected,
+        prompt: body_lines.join("\n"),
+    }
+}
+
+/// Extract skill ids named by leading slash selectors in a prompt.
+pub fn selected_skill_ids_from_prompt_slash_commands(prompt: &str) -> Vec<String> {
+    prompt_slash_skill_selection(prompt).selected_skill_ids
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SlashSkillSelector {
+    skill_id: String,
+    remainder: String,
+}
+
+fn leading_slash_skill_selector(line: &str) -> Option<SlashSkillSelector> {
     let trimmed = line.trim_start();
     let rest = trimmed.strip_prefix('/')?;
     let end = rest
         .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
         .unwrap_or(rest.len());
-    let skill_id = &rest[..end];
-    if skill_id.is_empty() {
+    let command = &rest[..end];
+    if command.is_empty() {
         return None;
     }
 
-    // Treat `/work/file.rs` and similar as a path, not a slash command. If this
-    // rejects a path-shaped skill id, the model can still load it through the
-    // normal catalog-driven `load_skill` tool.
+    let after_command = &rest[end..];
+    if command.eq_ignore_ascii_case("skill") {
+        let remainder = after_command.trim_start();
+        return parse_skill_command_argument(remainder);
+    }
+
+    if is_reserved_client_slash_command(command) {
+        return None;
+    }
+
+    // Treat `/work/file.rs` and similar as a path, not a slash selector. If
+    // this rejects a path-shaped skill id, the model can still load it through
+    // the normal catalog-driven `load_skill` tool or the caller can use
+    // structured metadata.
     if rest[end..].starts_with('/') {
         return None;
     }
 
-    Some(skill_id.to_string())
+    Some(SlashSkillSelector {
+        skill_id: command.to_string(),
+        remainder: after_command.trim_start().to_string(),
+    })
+}
+
+fn parse_skill_command_argument(input: &str) -> Option<SlashSkillSelector> {
+    let end = input
+        .find(|ch: char| !(ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')))
+        .unwrap_or(input.len());
+    let skill_id = &input[..end];
+    if skill_id.is_empty() || input[end..].starts_with('/') {
+        return None;
+    }
+    Some(SlashSkillSelector {
+        skill_id: skill_id.to_string(),
+        remainder: input[end..].trim_start().to_string(),
+    })
+}
+
+fn is_reserved_client_slash_command(command: &str) -> bool {
+    matches!(
+        command.to_ascii_lowercase().as_str(),
+        "agent"
+            | "apps"
+            | "approve"
+            | "btw"
+            | "clean"
+            | "clear"
+            | "compact"
+            | "copy"
+            | "debug-config"
+            | "debug-m-drop"
+            | "debug-m-update"
+            | "diff"
+            | "exit"
+            | "experimental"
+            | "feedback"
+            | "fork"
+            | "goal"
+            | "hooks"
+            | "ide"
+            | "init"
+            | "keymap"
+            | "logout"
+            | "mcp"
+            | "memories"
+            | "mention"
+            | "model"
+            | "new"
+            | "permissions"
+            | "personality"
+            | "pet"
+            | "pets"
+            | "plan"
+            | "plugins"
+            | "ps"
+            | "quit"
+            | "raw"
+            | "realtime"
+            | "rename"
+            | "resume"
+            | "review"
+            | "rollout"
+            | "sandbox-add-read-dir"
+            | "settings"
+            | "setup-default-sandbox"
+            | "side"
+            | "skills"
+            | "status"
+            | "statusline"
+            | "stop"
+            | "subagents"
+            | "test-approval"
+            | "theme"
+            | "title"
+            | "vim"
+    )
 }
 
 /// Error type for [`LoadSkillTool`]. A missing skill is returned as readable
@@ -625,11 +757,12 @@ mod tests {
     }
 
     #[test]
-    fn leading_slash_commands_select_skills_without_rewriting_prompt() {
-        let ids = selected_skill_ids_from_prompt_slash_commands(
+    fn leading_slash_commands_select_skills_and_strip_control_syntax() {
+        let selection = prompt_slash_skill_selection(
             "\n/vuln-scan /work --focus parser\n/triage\nRun the task.",
         );
-        assert_eq!(ids, vec!["vuln-scan", "triage"]);
+        assert_eq!(selection.selected_skill_ids, vec!["vuln-scan", "triage"]);
+        assert_eq!(selection.prompt, "/work --focus parser\nRun the task.");
 
         assert!(
             selected_skill_ids_from_prompt_slash_commands("Run /vuln-scan as plain text",)
@@ -639,6 +772,14 @@ mod tests {
             selected_skill_ids_from_prompt_slash_commands("/work/entry.c is an absolute path",)
                 .is_empty()
         );
+
+        let explicit = prompt_slash_skill_selection("/skill review inspect the diff");
+        assert_eq!(explicit.selected_skill_ids, vec!["review"]);
+        assert_eq!(explicit.prompt, "inspect the diff");
+
+        let codex_command = prompt_slash_skill_selection("/review inspect the diff");
+        assert!(codex_command.selected_skill_ids.is_empty());
+        assert_eq!(codex_command.prompt, "/review inspect the diff");
     }
 
     #[test]

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -180,11 +180,13 @@ async fn create_subagent_request_inner(
     let escaped_agent_did = escape_graphql_string(&agent_did);
     let escaped_behavior_id = escape_graphql_string(&behavior_id);
     let escaped_session_id = escape_graphql_string(&new_session_id);
+    let prompt_selection = crate::skills::prompt_slash_skill_selection(&prompt);
+    let prompt = prompt_selection.prompt;
     let escaped_prompt = escape_graphql_string(&prompt);
     let escaped_created_at = escape_graphql_string(&now);
     let escaped_parent_request_id = escape_graphql_string(&parent_request_id);
     let escaped_parent_tool_call_id = escape_graphql_string(&parent_tool_call_id);
-    let metadata_field = selected_skill_metadata_field(&prompt);
+    let metadata_field = selected_skill_metadata_field(&prompt_selection.selected_skill_ids);
 
     let deadline_field = deadline
         .map(|d| {
@@ -233,8 +235,7 @@ async fn create_subagent_request_inner(
     Ok(request_id)
 }
 
-fn selected_skill_metadata_field(prompt: &str) -> String {
-    let selected_skill_ids = crate::skills::selected_skill_ids_from_prompt_slash_commands(prompt);
+fn selected_skill_metadata_field(selected_skill_ids: &[String]) -> String {
     if selected_skill_ids.is_empty() {
         return String::new();
     }
@@ -323,7 +324,8 @@ mod tests {
 
     #[test]
     fn subagent_prompt_slash_command_adds_selected_skill_metadata() {
-        let field = selected_skill_metadata_field("/vuln-scan /work");
+        let selected = vec!["vuln-scan".to_string()];
+        let field = selected_skill_metadata_field(&selected);
 
         assert!(field.contains("metadata:"));
         assert!(field.contains(r#"\"selected_skill_ids\":[\"vuln-scan\"]"#));
@@ -331,9 +333,6 @@ mod tests {
 
     #[test]
     fn subagent_prompt_without_leading_slash_keeps_metadata_absent() {
-        assert_eq!(
-            selected_skill_metadata_field("Review /vuln-scan mention"),
-            ""
-        );
+        assert_eq!(selected_skill_metadata_field(&[]), "");
     }
 }


### PR DESCRIPTION
Follow-up to #468 for #340. PR #468 is already merged, so these review fixes are carried as a one-commit follow-up.

Summary:
- Treat leading native skill selectors as request-control syntax: record selected ids in metadata and strip the selector from persisted/provider content.
- Reserve Codex/client slash commands such as /review; use /skill <id> for colliding skill ids.
- Apply the same parsing path to CLI request helpers, config task run, lifecycle materialize/manual coverage, and subagent request creation.
- Preserve original prompt content when selected ids cannot be merged into malformed existing metadata, avoiding silent activation loss.

Verification:
- cargo fmt --check
- cargo test -p defra-agent leading_slash_commands_select_skills_and_strip_control_syntax
- cargo test -p defra-agent-cli slash_prompt
- cargo test -p defra-agent-cli invalid_existing_metadata_is_preserved

Notes:
- No Lean files were changed; this remains request-boundary parsing/plumbing over the existing Skills.lean privilege algebra and runtime consumer path.
- Earlier full gate results before the rebase: cargo test -p defra-agent-cli passed; exact parallel cargo test -p defra-agent hung in unrelated admission tests, while cargo test -p defra-agent -- --test-threads=1 passed.