### PR TITLE
docs: install the demo binary from the v0.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,22 +21,12 @@ defra-agent server    # start the runtime (embedded DefraDB + GraphQL + P2P)
 defra-agent codex     # chat in the Codex terminal UI (no Codex install needed)
 ```
 
-The release binary is signed and notarized. Building from source instead:
-`cargo install --profile dev-install --locked --path crates/defra-agent-cli`
-from a checkout.
-
-Want the agent to actually change things? Re-run `defra-agent init --write`
-(writes sandboxed under the directory you ran `init` from) or `--yolo`
-(unrestricted, full host access).
-
-`init` defaults to llama.cpp's server (`http://127.0.0.1:8080/v1`). Point it
-at anything OpenAI-compatible: `defra-agent init --inference-url
-http://HOST:PORT/v1 --model-name MODEL`, or use a preset
-(`--backend-preset ollama|llama-cpp|openai|openrouter|chatgpt-codex|vllm`).
-
-The full walkthrough, what each permission preset guarantees, and the fallback
-`chat` REPL: **[docs/demo.md](docs/demo.md)**. Desktop app, fleet bring-up,
-and P2P pairing: **[docs/operations.md](docs/operations.md)**.
+**[The getting-started guide](docs/demo.md)** walks every step and the paths
+off it: letting the agent change things (`init --write` / `--yolo`, and what
+each preset guarantees), pointing `init` at other OpenAI-compatible backends,
+verifying the signed binary, building from source, and the fallback `chat`
+REPL. Desktop app, fleet bring-up, and P2P pairing:
+[docs/operations.md](docs/operations.md).
 
 ## Why this exists
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,18 @@ Everything local, on a Mac, in a few minutes:
 brew install llama.cpp
 llama-server -hf google/gemma-4-12B-it-qat-q4_0-gguf   # local inference on :8080
 
-cargo install --profile dev-install --locked --path crates/defra-agent-cli
+gh release download v0.4.0 --repo sourcenetwork/defra-agent -p 'defra-agent-aarch64-apple-darwin.tar.gz'
+tar -xzf defra-agent-aarch64-apple-darwin.tar.gz
+sudo install defra-agent-aarch64-apple-darwin/defra-agent /usr/local/bin/defra-agent
 
 defra-agent init      # provision a safe read-only agent under ~/.defra-agent
 defra-agent server    # start the runtime (embedded DefraDB + GraphQL + P2P)
 defra-agent codex     # chat in the Codex terminal UI (no Codex install needed)
 ```
+
+The release binary is signed and notarized. Building from source instead:
+`cargo install --profile dev-install --locked --path crates/defra-agent-cli`
+from a checkout.
 
 Want the agent to actually change things? Re-run `defra-agent init --write`
 (writes sandboxed under the directory you ran `init` from) or `--yolo`

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -9,14 +9,16 @@ machine.
 brew install llama.cpp
 llama-server -hf google/gemma-4-12B-it-qat-q4_0-gguf
 
-cargo install --profile dev-install --locked --path crates/defra-agent-cli
+gh release download v0.4.0 --repo sourcenetwork/defra-agent -p 'defra-agent-aarch64-apple-darwin.tar.gz'
+tar -xzf defra-agent-aarch64-apple-darwin.tar.gz
+sudo install defra-agent-aarch64-apple-darwin/defra-agent /usr/local/bin/defra-agent
 
 defra-agent init
 defra-agent server
 defra-agent codex
 ```
 
-The rest of this document walks those six commands, then the permission
+The rest of this document walks those commands, then the permission
 presets, then the paths off the happy path. Desktop app, fleet bring-up, and
 P2P pairing live in [operations.md](operations.md).
 
@@ -24,7 +26,9 @@ P2P pairing live in [operations.md](operations.md).
 
 - macOS on Apple silicon
 - [Homebrew](https://brew.sh)
-- A Rust toolchain (`rustup`), for `cargo install`
+- The [GitHub CLI](https://cli.github.com) (`brew install gh`), authenticated
+  with access to this repository (`gh auth login`) — releases live on a
+  private repo
 
 ## 1. Start local inference
 
@@ -47,11 +51,24 @@ curl -s http://127.0.0.1:8080/v1/models | head -c 200
 
 ## 2. Install defra-agent
 
+Download the signed, notarized binary from the release:
+
+```bash
+gh release download v0.4.0 --repo sourcenetwork/defra-agent -p 'defra-agent-aarch64-apple-darwin.tar.gz'
+tar -xzf defra-agent-aarch64-apple-darwin.tar.gz
+sudo install defra-agent-aarch64-apple-darwin/defra-agent /usr/local/bin/defra-agent
+```
+
+To verify the download, fetch the matching `.sha256` asset and run
+`shasum -a 256 -c` against it.
+
+Building from source instead (needs a Rust toolchain and a checkout):
+
 ```bash
 cargo install --profile dev-install --locked --path crates/defra-agent-cli
 ```
 
-This installs the `defra-agent` binary into `~/.cargo/bin`.
+That installs the `defra-agent` binary into `~/.cargo/bin`.
 
 ## 3. Initialize the agent
 


### PR DESCRIPTION
## Summary

The README "Get running" block and the `docs/demo.md` walkthrough now lead with downloading the signed/notarized v0.4.0 binary instead of `cargo install` from a checkout:

- `gh release download v0.4.0 ... -p 'defra-agent-aarch64-apple-darwin.tar.gz'` → untar → `sudo install` to `/usr/local/bin` (the `gh` route because the repo is private; raw asset URLs need auth).
- Checksum verification via the published `.sha256` asset is mentioned in the install step.
- `cargo install --profile dev-install --locked --path crates/defra-agent-cli` stays as the explicit from-source alternative.
- Prerequisites: Rust toolchain replaced by an authenticated GitHub CLI.

The macOS asset is published and verified present on the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)