### PR TITLE
Use ThinLTO for Linux release builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -17,6 +17,12 @@ env:
   CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '4' }}
   CARGO_INCREMENTAL: "0"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+  # The workspace release profile uses fat LTO + one codegen unit. That has
+  # repeatedly OOM-killed the self-hosted Linux release runners during the final
+  # link, especially on spark. Keep Linux artifacts optimized, but use the same
+  # lower-memory ThinLTO shape as the local install profile.
+  CARGO_PROFILE_RELEASE_LTO: "thin"
+  CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
   RUST_BACKTRACE: "1"
 
 jobs:


### PR DESCRIPTION
## Summary

- override the Linux release workflow’s release profile to use ThinLTO
- raise release codegen units for Linux packaging to reduce final-link memory pressure
- leave the workspace release profile and macOS release workflow unchanged

Closes #486.

## Notes

The workspace release profile still uses fat LTO and `codegen-units = 1`. This PR only changes the Linux release workflow via Cargo profile environment overrides, targeting the observed OOM on the self-hosted Linux runners while preserving the existing profile for other release paths.

## Tests

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-linux.yml"); puts "yaml ok"'`
- `CARGO_PROFILE_RELEASE_LTO=thin CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 cargo metadata --no-deps --format-version=1`

`actionlint` is not installed locally, so I could not run it.