### PR TITLE
Unify OpenAI Responses client construction

### DIFF
--- a/crates/defra-agent/src/agent/runtime/context.rs
+++ b/crates/defra-agent/src/agent/runtime/context.rs
@@ -16,26 +16,6 @@ use crate::retry::RetryPolicy;
 use crate::tool_surface::{self, ToolRuntimeContext, ToolSurface};
 use crate::watcher::AgentRequest;
 
-/// Force the legacy Chat Completions client for OpenAI-compatible backends
-/// (`DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS=1`). Default (unset) is the Responses
-/// API. Used by backends that don't serve `/v1/responses` and by the CLI
-/// integration tests whose mock + assertions are chat-format.
-fn force_chat_completions() -> bool {
-    // defra-agent's own lib unit tests (compiled with `cfg(test)`) boot in-process
-    // agents against Chat Completions mocks, so default to chat there. Integration
-    // tests link defra-agent WITHOUT `cfg(test)`, so they set the env explicitly;
-    // production + the real CLI binary default to the Responses API.
-    if cfg!(test) {
-        return true;
-    }
-    matches!(
-        std::env::var("DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS")
-            .ok()
-            .as_deref(),
-        Some("1") | Some("true")
-    )
-}
-
 #[derive(Clone)]
 pub(super) struct RuntimeContext {
     pub(super) node: Arc<defra_node::EmbeddedNode>,
@@ -148,28 +128,17 @@ impl RuntimeContext {
                     "building OpenAI-compatible completion client for behavior {} against {}",
                     behavior.behavior_id, behavior.backend_endpoint
                 );
-                // Default OpenAI-compatible inference to the Responses API:
-                // rig's `openai::Client` defaults `Completion = Capable<ResponsesCompletionModel>`
-                // (vs `CompletionsClient` = Chat Completions). The owned loop already
-                // drives a `ResponsesCompletionModel` today via the ChatGptCodex path
-                // (`build_responses_client`), so this swap reuses that machinery. The
-                // Responses API gives first-class, round-trippable structured reasoning
-                // (`encrypted_content`) instead of the unstandardized chat side-channel.
-                //
-                // `DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS=1` forces the legacy Chat
-                // Completions client (`CompletionsClient`) — for OpenAI-compatible
-                // backends that don't serve `/v1/responses`, and for the CLI
-                // integration tests whose mock + assertions are chat-format. The
-                // owned loop is identical for both, so this only changes the wire API.
-                if force_chat_completions() {
+                // The owned loop is identical for Responses and Chat Completions;
+                // this branch only chooses the OpenAI-compatible wire API.
+                if crate::inference_http::force_openai_chat_completions() {
                     let client: rig::providers::openai::CompletionsClient<
                         crate::inference_http::SessionTaggingHttpClient,
-                    > = rig::providers::openai::CompletionsClient::builder()
-                        .api_key(&api_key)
-                        .base_url(&behavior.backend_endpoint)
-                        .http_client(crate::inference_http::SessionTaggingHttpClient::default())
-                        .build()
-                        .with_context(|| build_context.clone())?;
+                    > = crate::inference_http::build_openai_chat_completions_client(
+                        &api_key,
+                        &behavior.backend_endpoint,
+                        crate::inference_http::SessionTaggingHttpClient::default(),
+                    )
+                    .with_context(|| build_context.clone())?;
                     self.run_behavior_with_client(
                         behavior,
                         request_rx,
@@ -184,12 +153,13 @@ impl RuntimeContext {
                 } else {
                     let client: rig::providers::openai::Client<
                         crate::inference_http::SessionTaggingHttpClient,
-                    > = rig::providers::openai::Client::builder()
-                        .api_key(&api_key)
-                        .base_url(&behavior.backend_endpoint)
-                        .http_client(crate::inference_http::SessionTaggingHttpClient::default())
-                        .build()
-                        .with_context(|| build_context.clone())?;
+                    > = crate::inference_http::build_openai_responses_client(
+                        &api_key,
+                        &behavior.backend_endpoint,
+                        crate::inference_http::SessionTaggingHttpClient::default(),
+                        Default::default(),
+                    )
+                    .with_context(|| build_context.clone())?;
                     self.run_behavior_with_client(
                         behavior,
                         request_rx,

--- a/crates/defra-agent/src/chatgpt_codex.rs
+++ b/crates/defra-agent/src/chatgpt_codex.rs
@@ -392,13 +392,14 @@ pub async fn build_responses_client(
         )
     })?;
     let headers = build_chatgpt_codex_headers(&auth)?;
-    rig::providers::openai::Client::builder()
-        .api_key(access_token)
-        .base_url(normalize_endpoint(endpoint))
-        .http_headers(headers)
-        .http_client(ChatGptCodexHttpClient::default())
-        .build()
-        .context("building ChatGPT Codex Responses client")
+    let endpoint = normalize_endpoint(endpoint);
+    crate::inference_http::build_openai_responses_client(
+        &access_token,
+        &endpoint,
+        ChatGptCodexHttpClient::default(),
+        headers,
+    )
+    .context("building ChatGPT Codex Responses client")
 }
 
 #[cfg(test)]

--- a/crates/defra-agent/src/inference_http.rs
+++ b/crates/defra-agent/src/inference_http.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::future::Future;
 
+use anyhow::{Context, Result};
 use bytes::Bytes;
 use reqwest::header::HeaderName;
 use rig::http_client::{
@@ -25,6 +26,65 @@ use rig::wasm_compat::WasmCompatSend;
 
 /// Header carrying the agent session id on outbound inference requests.
 const SESSION_ID_HEADER: &str = "x-session-id";
+
+/// Force the legacy Chat Completions client for OpenAI-compatible backends.
+///
+/// Default production behavior is the Responses API. The override keeps
+/// compatibility with backends that do not serve `/v1/responses` and with test
+/// mocks whose assertions are chat-format.
+pub(crate) fn force_openai_chat_completions() -> bool {
+    // defra-agent's own lib unit tests (compiled with `cfg(test)`) boot
+    // in-process agents against Chat Completions mocks, so default to chat
+    // there. Integration tests link defra-agent WITHOUT `cfg(test)`, so they
+    // set the env explicitly; production + the real CLI binary default to the
+    // Responses API.
+    if cfg!(test) {
+        return true;
+    }
+    openai_chat_completions_override_enabled(
+        std::env::var("DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS")
+            .ok()
+            .as_deref(),
+    )
+}
+
+fn openai_chat_completions_override_enabled(value: Option<&str>) -> bool {
+    matches!(value, Some("1") | Some("true"))
+}
+
+pub(crate) fn build_openai_responses_client<H>(
+    api_key: &str,
+    base_url: &str,
+    http_client: H,
+    http_headers: HeaderMap,
+) -> Result<rig::providers::openai::Client<H>>
+where
+    H: Default + HttpClientExt,
+{
+    rig::providers::openai::Client::builder()
+        .api_key(api_key)
+        .base_url(base_url)
+        .http_headers(http_headers)
+        .http_client(http_client)
+        .build()
+        .context("building OpenAI Responses client")
+}
+
+pub(crate) fn build_openai_chat_completions_client<H>(
+    api_key: &str,
+    base_url: &str,
+    http_client: H,
+) -> Result<rig::providers::openai::CompletionsClient<H>>
+where
+    H: Default + HttpClientExt,
+{
+    rig::providers::openai::CompletionsClient::builder()
+        .api_key(api_key)
+        .base_url(base_url)
+        .http_client(http_client)
+        .build()
+        .context("building OpenAI Chat Completions client")
+}
 
 /// A [`HttpClientExt`] that injects [`SESSION_ID_HEADER`] from the current
 /// admission request context onto each outbound request, then delegates to the
@@ -136,6 +196,36 @@ impl HttpClientExt for SessionTaggingHttpClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn chat_completions_override_parses_only_explicit_true_values() {
+        assert!(openai_chat_completions_override_enabled(Some("1")));
+        assert!(openai_chat_completions_override_enabled(Some("true")));
+        assert!(!openai_chat_completions_override_enabled(Some("TRUE")));
+        assert!(!openai_chat_completions_override_enabled(Some("0")));
+        assert!(!openai_chat_completions_override_enabled(Some("false")));
+        assert!(!openai_chat_completions_override_enabled(None));
+    }
+
+    #[test]
+    fn openai_client_builders_accept_session_tagging_transport() {
+        let _responses: rig::providers::openai::Client<SessionTaggingHttpClient> =
+            build_openai_responses_client(
+                "test-key",
+                "http://example.test/v1",
+                SessionTaggingHttpClient::default(),
+                HeaderMap::default(),
+            )
+            .expect("Responses client should build");
+
+        let _chat_completions: rig::providers::openai::CompletionsClient<SessionTaggingHttpClient> =
+            build_openai_chat_completions_client(
+                "test-key",
+                "http://example.test/v1",
+                SessionTaggingHttpClient::default(),
+            )
+            .expect("Chat Completions client should build");
+    }
 
     #[test]
     fn tag_is_noop_without_session_context() {

--- a/crates/defra-agent/src/oneshot.rs
+++ b/crates/defra-agent/src/oneshot.rs
@@ -69,23 +69,48 @@ pub async fn run_openai_oneshot_with_tools(
                 "building OpenAI-compatible completion client for behavior {} against {}",
                 behavior.behavior_id, behavior.backend_endpoint
             );
-            let client: rig::providers::openai::CompletionsClient =
-                rig::providers::openai::CompletionsClient::builder()
-                    .api_key(&api_key)
-                    .base_url(&behavior.backend_endpoint)
-                    .build()
-                    .with_context(|| build_context.clone())?;
-            run_oneshot_with_completion_client(
-                node,
-                behavior,
-                prompt,
-                prompt_builder,
-                preamble,
-                tools,
-                background_tool_registry,
-                client,
-            )
-            .await
+            if crate::inference_http::force_openai_chat_completions() {
+                let client: rig::providers::openai::CompletionsClient<
+                    crate::inference_http::SessionTaggingHttpClient,
+                > = crate::inference_http::build_openai_chat_completions_client(
+                    &api_key,
+                    &behavior.backend_endpoint,
+                    crate::inference_http::SessionTaggingHttpClient::default(),
+                )
+                .with_context(|| build_context.clone())?;
+                run_oneshot_with_completion_client(
+                    node,
+                    behavior,
+                    prompt,
+                    prompt_builder,
+                    preamble,
+                    tools,
+                    background_tool_registry,
+                    client,
+                )
+                .await
+            } else {
+                let client: rig::providers::openai::Client<
+                    crate::inference_http::SessionTaggingHttpClient,
+                > = crate::inference_http::build_openai_responses_client(
+                    &api_key,
+                    &behavior.backend_endpoint,
+                    crate::inference_http::SessionTaggingHttpClient::default(),
+                    Default::default(),
+                )
+                .with_context(|| build_context.clone())?;
+                run_oneshot_with_completion_client(
+                    node,
+                    behavior,
+                    prompt,
+                    prompt_builder,
+                    preamble,
+                    tools,
+                    background_tool_registry,
+                    client,
+                )
+                .await
+            }
         }
         BackendProviderKind::OpenRouter => {
             let build_context = format!(


### PR DESCRIPTION
## Summary

Closes #493.

- Add shared OpenAI-compatible client builders for Responses API and Chat Completions.
- Route both daemon runtime and one-shot OpenAI-compatible execution through the shared builder/override path.
- Keep ChatGPT Codex auth and request patching provider-specific, but delegate final Responses client construction to the shared builder.
- Add focused unit coverage for the OpenAI client builder seam and chat-completions override parsing.

## Tests

- `cargo test -p defra-agent inference_http -- --nocapture`
- `cargo test -p defra-agent chatgpt_codex -- --nocapture`
- `cargo test -p defra-agent oneshot -- --nocapture`
- `git diff --check`

Note: I also attempted `cargo test -p defra-agent`; it compiled and began running, but was interrupted locally after sitting silent for several minutes in the admission/contract section. No failures were reported before interruption.