### PR TITLE
Derive Codex thread cwd from runtime state

### DIFF
--- a/crates/defra-agent-cli/src/commands/codex_shim/handlers/thread.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/handlers/thread.rs
@@ -12,7 +12,7 @@ use super::super::protocol::{
 };
 use super::super::thread_projection::{
     clear_codex_thread_goal, codex_thread_json, codex_thread_json_with_turns, create_codex_thread,
-    ensure_agent_session_pinning, get_codex_thread_goal, load_codex_thread,
+    ensure_agent_session_pinning, get_codex_thread_goal, load_codex_thread_with_cwd_hint,
     loaded_codex_thread_ids, resume_codex_thread, set_codex_thread_archived,
     set_codex_thread_git_info, set_codex_thread_goal, set_codex_thread_loaded,
     set_codex_thread_memory_mode, set_codex_thread_name, set_codex_thread_settings,
@@ -87,53 +87,68 @@ pub(super) async fn handle_thread_request(
         }
         codex::ClientRequest::ThreadList {
             request_id, params, ..
-        } => match thread_routes::list_threads_response(state, params).await {
-            Ok(response) => {
-                send_typed_json_result::<codex::ThreadListResponse>(outbound, request_id, response)
+        } => {
+            let cwd_hints = connection.thread_cwds.lock().await.clone();
+            match thread_routes::list_threads_response(state, params, &cwd_hints).await {
+                Ok(response) => {
+                    send_typed_json_result::<codex::ThreadListResponse>(
+                        outbound, request_id, response,
+                    )
                     .await
+                }
+                Err(err) => send_error(outbound, request_id, err.code, err.message).await,
             }
-            Err(err) => send_error(outbound, request_id, err.code, err.message).await,
-        },
+        }
         codex::ClientRequest::ThreadFork {
             request_id, params, ..
-        } => match thread_routes::fork_thread_response(state, params).await {
-            Ok((record, response)) => {
-                let thread_for_notification: codex::Thread = serde_json::from_value(
-                    response
-                        .get("thread")
-                        .cloned()
-                        .unwrap_or_else(|| codex_thread_json(&record, false)),
-                )
-                .context("validating forked thread notification")?;
-                connection
-                    .thread_cwds
-                    .lock()
-                    .await
-                    .insert(record.session_id.clone(), record.cwd.clone());
-                send_typed_json_result::<codex::ThreadForkResponse>(outbound, request_id, response)
+        } => {
+            let cwd_hints = connection.thread_cwds.lock().await.clone();
+            match thread_routes::fork_thread_response(state, params, &cwd_hints).await {
+                Ok((record, response)) => {
+                    let thread_for_notification: codex::Thread = serde_json::from_value(
+                        response
+                            .get("thread")
+                            .cloned()
+                            .unwrap_or_else(|| codex_thread_json(&record, false)),
+                    )
+                    .context("validating forked thread notification")?;
+                    connection
+                        .thread_cwds
+                        .lock()
+                        .await
+                        .insert(record.session_id.clone(), record.cwd.clone());
+                    send_typed_json_result::<codex::ThreadForkResponse>(
+                        outbound, request_id, response,
+                    )
                     .await?;
-                send_notification(
-                    outbound,
-                    state,
-                    codex::ServerNotification::ThreadStarted(codex::ThreadStartedNotification {
-                        thread: thread_for_notification,
-                    }),
-                )
-                .await
+                    send_notification(
+                        outbound,
+                        state,
+                        codex::ServerNotification::ThreadStarted(
+                            codex::ThreadStartedNotification {
+                                thread: thread_for_notification,
+                            },
+                        ),
+                    )
+                    .await
+                }
+                Err(err) => send_error(outbound, request_id, err.code, err.message).await,
             }
-            Err(err) => send_error(outbound, request_id, err.code, err.message).await,
-        },
+        }
         codex::ClientRequest::ThreadSearch {
             request_id, params, ..
-        } => match thread_routes::search_threads_response(state, params).await {
-            Ok(response) => {
-                send_typed_json_result::<codex::ThreadSearchResponse>(
-                    outbound, request_id, response,
-                )
-                .await
+        } => {
+            let cwd_hints = connection.thread_cwds.lock().await.clone();
+            match thread_routes::search_threads_response(state, params, &cwd_hints).await {
+                Ok(response) => {
+                    send_typed_json_result::<codex::ThreadSearchResponse>(
+                        outbound, request_id, response,
+                    )
+                    .await
+                }
+                Err(err) => send_error(outbound, request_id, err.code, err.message).await,
             }
-            Err(err) => send_error(outbound, request_id, err.code, err.message).await,
-        },
+        }
         codex::ClientRequest::ThreadLoadedList { request_id, .. } => {
             send_result(
                 outbound,
@@ -148,7 +163,16 @@ pub(super) async fn handle_thread_request(
         codex::ClientRequest::ThreadRead {
             request_id, params, ..
         } => {
-            let Some(record) = load_codex_thread(state, &params.thread_id).await? else {
+            let cwd_hint = connection
+                .thread_cwds
+                .lock()
+                .await
+                .get(&params.thread_id)
+                .cloned();
+            let Some(record) =
+                load_codex_thread_with_cwd_hint(state, &params.thread_id, cwd_hint.as_deref())
+                    .await?
+            else {
                 return send_error(
                     outbound,
                     request_id,
@@ -174,7 +198,16 @@ pub(super) async fn handle_thread_request(
         codex::ClientRequest::ThreadTurnsList {
             request_id, params, ..
         } => {
-            let Some(record) = load_codex_thread(state, &params.thread_id).await? else {
+            let cwd_hint = connection
+                .thread_cwds
+                .lock()
+                .await
+                .get(&params.thread_id)
+                .cloned();
+            let Some(record) =
+                load_codex_thread_with_cwd_hint(state, &params.thread_id, cwd_hint.as_deref())
+                    .await?
+            else {
                 return send_error(
                     outbound,
                     request_id,
@@ -196,7 +229,16 @@ pub(super) async fn handle_thread_request(
         codex::ClientRequest::ThreadTurnsItemsList {
             request_id, params, ..
         } => {
-            let Some(record) = load_codex_thread(state, &params.thread_id).await? else {
+            let cwd_hint = connection
+                .thread_cwds
+                .lock()
+                .await
+                .get(&params.thread_id)
+                .cloned();
+            let Some(record) =
+                load_codex_thread_with_cwd_hint(state, &params.thread_id, cwd_hint.as_deref())
+                    .await?
+            else {
                 return send_error(
                     outbound,
                     request_id,
@@ -286,9 +328,20 @@ pub(super) async fn handle_thread_request(
         codex::ClientRequest::ThreadMetadataUpdate {
             request_id, params, ..
         } => {
-            let record = set_codex_thread_git_info(state, &params.thread_id, &params.git_info)
-                .await?
-                .with_context(|| format!("unknown Codex thread `{}`", params.thread_id))?;
+            let cwd_hint = connection
+                .thread_cwds
+                .lock()
+                .await
+                .get(&params.thread_id)
+                .cloned();
+            let record = set_codex_thread_git_info(
+                state,
+                &params.thread_id,
+                &params.git_info,
+                cwd_hint.as_deref(),
+            )
+            .await?
+            .with_context(|| format!("unknown Codex thread `{}`", params.thread_id))?;
             send_typed_json_result::<codex::ThreadMetadataUpdateResponse>(
                 outbound,
                 request_id,
@@ -324,7 +377,10 @@ pub(super) async fn handle_thread_request(
         } => match params {
             codex::GetConversationSummaryParams::ThreadId { conversation_id } => {
                 let thread_id = conversation_id.to_string();
-                let Some(record) = load_codex_thread(state, &thread_id).await? else {
+                let cwd_hint = connection.thread_cwds.lock().await.get(&thread_id).cloned();
+                let Some(record) =
+                    load_codex_thread_with_cwd_hint(state, &thread_id, cwd_hint.as_deref()).await?
+                else {
                     return send_error(
                         outbound,
                         request_id,

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -23,8 +24,8 @@ pub(super) use mutations::{
 
 pub(super) use storage::ensure_agent_session_pinning;
 use storage::{
-    ensure_agent_session, list_projection_rows, load_conversation, load_projection,
-    update_projection_loaded_cwd, upsert_projection, ProjectionUpdate,
+    derive_thread_cwd, ensure_agent_session, list_projection_rows, load_conversation,
+    load_projection, update_projection_loaded, upsert_projection, ProjectionRow, ProjectionUpdate,
 };
 
 #[allow(dead_code)]
@@ -71,12 +72,12 @@ pub(super) async fn create_codex_thread(
     ensure_agent_session(state, thread_id).await?;
     upsert_projection(
         state,
-        &ProjectionUpdate::new(thread_id, cwd)
+        &ProjectionUpdate::new(thread_id)
             .loaded(true)
             .memory_mode("enabled"),
     )
     .await?;
-    load_codex_thread(state, thread_id)
+    load_codex_thread_with_cwd_hint(state, thread_id, Some(cwd))
         .await?
         .with_context(|| format!("loading newly-created Codex thread {thread_id}"))
 }
@@ -98,61 +99,55 @@ pub(super) async fn resume_codex_thread(
     }
 
     match load_projection(state, thread_id).await? {
-        Some(existing) => {
-            let cwd = cwd_override
+        Some(_) => {
+            let cwd_hint = cwd_override
                 .filter(|value| !value.trim().is_empty())
-                .map(PathBuf::from)
-                .unwrap_or_else(|| PathBuf::from(existing.cwd));
-            update_projection_loaded_cwd(state, thread_id, true, &cwd).await?;
+                .map(PathBuf::from);
+            update_projection_loaded(state, thread_id, true).await?;
+            load_codex_thread_with_cwd_hint(state, thread_id, cwd_hint.as_deref())
+                .await?
+                .with_context(|| format!("loading resumed Codex thread {thread_id}"))
         }
         None => {
             upsert_projection(
                 state,
-                &ProjectionUpdate::new(thread_id, &cwd)
+                &ProjectionUpdate::new(thread_id)
                     .loaded(true)
                     .memory_mode("enabled"),
             )
             .await?;
+            load_codex_thread_with_cwd_hint(state, thread_id, Some(&cwd))
+                .await?
+                .with_context(|| format!("loading resumed Codex thread {thread_id}"))
         }
     }
-
-    load_codex_thread(state, thread_id)
-        .await?
-        .with_context(|| format!("loading resumed Codex thread {thread_id}"))
 }
 
-pub(super) async fn load_codex_thread(
+pub(super) async fn load_codex_thread_with_cwd_hint(
     state: &ShimState,
     thread_id: &str,
+    cwd_hint: Option<&Path>,
 ) -> Result<Option<CodexThreadRecord>> {
     let conversation = load_conversation(state, thread_id).await?;
     let projection = load_projection(state, thread_id).await?;
 
     match (conversation, projection) {
         (None, None) => Ok(None),
-        (conversation, Some(projection)) => Ok(Some(CodexThreadRecord {
-            session_id: projection.session_id,
-            cwd: PathBuf::from(projection.cwd),
-            archived: projection.archived,
-            loaded: projection.loaded,
-            memory_mode: projection.memory_mode,
-            name: projection.name,
-            settings_json: projection.settings_json,
-            goal_json: projection.goal_json,
-            git_info_json: projection.git_info_json,
-            projection_created_at: projection.created_at,
-            projection_updated_at: projection.updated_at,
-            conversation,
-        })),
+        (conversation, Some(projection)) => {
+            record_from_projection(state, thread_id, conversation, projection, cwd_hint)
+                .await
+                .map(Some)
+        }
         (Some(conversation), None) => {
             upsert_projection(
                 state,
-                &ProjectionUpdate::new(thread_id, &state.cwd).memory_mode("enabled"),
+                &ProjectionUpdate::new(thread_id).memory_mode("enabled"),
             )
             .await?;
+            let cwd = derive_thread_cwd(state, thread_id, None, cwd_hint).await?;
             Ok(Some(CodexThreadRecord {
                 session_id: thread_id.to_string(),
-                cwd: state.cwd.clone(),
+                cwd,
                 archived: false,
                 loaded: false,
                 memory_mode: "enabled".to_string(),
@@ -168,28 +163,44 @@ pub(super) async fn load_codex_thread(
     }
 }
 
+async fn record_from_projection(
+    state: &ShimState,
+    thread_id: &str,
+    conversation: Option<ConversationRow>,
+    projection: ProjectionRow,
+    cwd_hint: Option<&Path>,
+) -> Result<CodexThreadRecord> {
+    let cwd = derive_thread_cwd(state, thread_id, Some(&projection), cwd_hint).await?;
+    Ok(CodexThreadRecord {
+        session_id: projection.session_id,
+        cwd,
+        archived: projection.archived,
+        loaded: projection.loaded,
+        memory_mode: projection.memory_mode,
+        name: projection.name,
+        settings_json: projection.settings_json,
+        goal_json: projection.goal_json,
+        git_info_json: projection.git_info_json,
+        projection_created_at: projection.created_at,
+        projection_updated_at: projection.updated_at,
+        conversation,
+    })
+}
+
 pub(super) async fn list_codex_threads_by_archived(
     state: &ShimState,
     archived: bool,
+    cwd_hints: &BTreeMap<String, PathBuf>,
 ) -> Result<Vec<CodexThreadRecord>> {
     let rows = list_projection_rows(state, archived).await?;
     let mut records = Vec::with_capacity(rows.len());
     for projection in rows {
         let conversation = load_conversation(state, &projection.session_id).await?;
-        records.push(CodexThreadRecord {
-            session_id: projection.session_id,
-            cwd: PathBuf::from(projection.cwd),
-            archived: projection.archived,
-            loaded: projection.loaded,
-            memory_mode: projection.memory_mode,
-            name: projection.name,
-            settings_json: projection.settings_json,
-            goal_json: projection.goal_json,
-            git_info_json: projection.git_info_json,
-            projection_created_at: projection.created_at,
-            projection_updated_at: projection.updated_at,
-            conversation,
-        });
+        let thread_id = projection.session_id.clone();
+        let cwd_hint = cwd_hints.get(&thread_id).map(PathBuf::as_path);
+        records.push(
+            record_from_projection(state, &thread_id, conversation, projection, cwd_hint).await?,
+        );
     }
     Ok(records)
 }
@@ -202,14 +213,14 @@ pub(super) async fn store_forked_codex_thread(
 ) -> Result<CodexThreadRecord> {
     upsert_projection(
         state,
-        &ProjectionUpdate::new(child_session_id, cwd)
+        &ProjectionUpdate::new(child_session_id)
             .loaded(true)
             .memory_mode(&source.memory_mode)
             .settings_json(&source.settings_json)
             .git_info_json(&source.git_info_json),
     )
     .await?;
-    load_codex_thread(state, child_session_id)
+    load_codex_thread_with_cwd_hint(state, child_session_id, Some(cwd))
         .await?
         .with_context(|| format!("loading forked Codex thread {child_session_id}"))
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/mutations.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/mutations.rs
@@ -1,13 +1,14 @@
+use std::path::Path;
+
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
 use defra_agent::graphql::escape_graphql_string;
 use serde_json::Value;
 
-use crate::commands::codex_shim::protocol::absolute_path;
 use crate::commands::codex_shim::store::query_node_json;
 use crate::commands::codex_shim::ShimState;
 
-use super::{load_codex_thread, CodexThreadRecord};
+use super::{load_codex_thread_with_cwd_hint, CodexThreadRecord};
 
 pub(in crate::commands::codex_shim) async fn loaded_codex_thread_ids(
     state: &ShimState,
@@ -122,26 +123,11 @@ pub(in crate::commands::codex_shim) async fn set_codex_thread_settings(
     let settings_json =
         serde_json::to_string(settings).context("encoding Codex thread settings")?;
     let escaped_settings = escape_graphql_string(&settings_json);
-    let cwd_update = settings
-        .cwd
-        .as_deref()
-        .map(|cwd| {
-            let cwd = if cwd.is_absolute() {
-                cwd.to_path_buf()
-            } else {
-                state.cwd.join(cwd)
-            };
-            format!(
-                r#", cwd: "{}""#,
-                escape_graphql_string(&absolute_path(&cwd))
-            )
-        })
-        .unwrap_or_default();
     let mutation = format!(
         r#"mutation {{
             update_CodexThreadProjection(
                 filter: {{ session_id: {{ _eq: "{escaped_thread_id}" }} }},
-                input: {{ settings_json: "{escaped_settings}"{cwd_update}, updated_at: "{now}" }}
+                input: {{ settings_json: "{escaped_settings}", updated_at: "{now}" }}
             ) {{ _docID }}
         }}"#,
         now = chrono::Utc::now().to_rfc3339(),
@@ -154,6 +140,7 @@ pub(in crate::commands::codex_shim) async fn set_codex_thread_git_info(
     state: &ShimState,
     thread_id: &str,
     git_info: &Option<codex::ThreadMetadataGitInfoUpdateParams>,
+    cwd_hint: Option<&Path>,
 ) -> Result<Option<CodexThreadRecord>> {
     let git_info_json = serde_json::to_string(git_info).context("encoding Codex git metadata")?;
     let escaped_thread_id = escape_graphql_string(thread_id);
@@ -168,5 +155,5 @@ pub(in crate::commands::codex_shim) async fn set_codex_thread_git_info(
         now = chrono::Utc::now().to_rfc3339(),
     );
     query_node_json(&state.node, &mutation).await?;
-    load_codex_thread(state, thread_id).await
+    load_codex_thread_with_cwd_hint(state, thread_id, cwd_hint).await
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/storage.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_projection/storage.rs
@@ -1,11 +1,10 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use defra_agent::graphql::escape_graphql_string;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::commands::codex_shim::protocol::absolute_path;
 use crate::commands::codex_shim::store::query_node_json;
 use crate::commands::codex_shim::ShimState;
 
@@ -15,7 +14,7 @@ use super::ConversationRow;
 pub(super) struct ProjectionRow {
     pub(super) session_id: String,
     #[serde(default)]
-    pub(super) cwd: String,
+    pub(super) cwd: Option<String>,
     #[serde(default)]
     pub(super) archived: bool,
     #[serde(default)]
@@ -38,7 +37,6 @@ pub(super) struct ProjectionRow {
 
 pub(super) struct ProjectionUpdate<'a> {
     session_id: &'a str,
-    cwd: &'a Path,
     archived: bool,
     loaded: bool,
     memory_mode: &'a str,
@@ -50,10 +48,9 @@ pub(super) struct ProjectionUpdate<'a> {
 }
 
 impl<'a> ProjectionUpdate<'a> {
-    pub(super) fn new(session_id: &'a str, cwd: &'a Path) -> Self {
+    pub(super) fn new(session_id: &'a str) -> Self {
         Self {
             session_id,
-            cwd,
             archived: false,
             loaded: false,
             memory_mode: "enabled",
@@ -160,7 +157,6 @@ pub(super) async fn upsert_projection(
 ) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     let escaped_session_id = escape_graphql_string(update.session_id);
-    let escaped_cwd = escape_graphql_string(&absolute_path(update.cwd));
     let escaped_memory_mode = escape_graphql_string(update.memory_mode);
     let escaped_name = escape_graphql_string(update.name);
     let escaped_settings_json = escape_graphql_string(update.settings_json);
@@ -172,7 +168,6 @@ pub(super) async fn upsert_projection(
                 filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
                 add: {{
                     session_id: "{escaped_session_id}",
-                    cwd: "{escaped_cwd}",
                     archived: {archived},
                     loaded: {loaded},
                     memory_mode: "{escaped_memory_mode}",
@@ -185,7 +180,6 @@ pub(super) async fn upsert_projection(
                     updated_at: "{now}"
                 }},
                 update: {{
-                    cwd: "{escaped_cwd}",
                     archived: {archived},
                     loaded: {loaded},
                     memory_mode: "{escaped_memory_mode}",
@@ -206,19 +200,17 @@ pub(super) async fn upsert_projection(
     Ok(())
 }
 
-pub(super) async fn update_projection_loaded_cwd(
+pub(super) async fn update_projection_loaded(
     state: &ShimState,
     thread_id: &str,
     loaded: bool,
-    cwd: &Path,
 ) -> Result<()> {
     let escaped_thread_id = escape_graphql_string(thread_id);
-    let escaped_cwd = escape_graphql_string(&absolute_path(cwd));
     let mutation = format!(
         r#"mutation {{
             update_CodexThreadProjection(
                 filter: {{ session_id: {{ _eq: "{escaped_thread_id}" }} }},
-                input: {{ loaded: {loaded}, cwd: "{escaped_cwd}", updated_at: "{now}" }}
+                input: {{ loaded: {loaded}, updated_at: "{now}" }}
             ) {{ _docID }}
         }}"#,
         now = chrono::Utc::now().to_rfc3339(),
@@ -312,6 +304,96 @@ pub(super) async fn load_conversation(
         .context("decoding AgentConversation row")
 }
 
+pub(super) async fn derive_thread_cwd(
+    state: &ShimState,
+    thread_id: &str,
+    projection: Option<&ProjectionRow>,
+    cwd_hint: Option<&Path>,
+) -> Result<PathBuf> {
+    if let Some(cwd) = cwd_hint {
+        return Ok(absolute_cwd(&state.cwd, cwd));
+    }
+    if let Some(cwd) = latest_request_metadata_cwd(state, thread_id).await? {
+        return Ok(cwd);
+    }
+    if let Some(cwd) =
+        projection.and_then(|projection| settings_json_cwd(&state.cwd, &projection.settings_json))
+    {
+        return Ok(cwd);
+    }
+    if let Some(cwd) = projection
+        .and_then(|projection| projection.cwd.as_deref())
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+    {
+        return Ok(PathBuf::from(cwd));
+    }
+    Ok(state.cwd.clone())
+}
+
+async fn latest_request_metadata_cwd(
+    state: &ShimState,
+    thread_id: &str,
+) -> Result<Option<PathBuf>> {
+    let escaped_thread_id = escape_graphql_string(thread_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ session_id: {{ _eq: "{escaped_thread_id}" }} }},
+                order: {{ created_at: DESC }},
+                limit: 10
+            ) {{
+                metadata
+            }}
+        }}"#
+    );
+    let response = query_node_json(&state.node, &query).await?;
+    let rows = response
+        .pointer("/data/AgentRequest")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for row in rows {
+        let Some(metadata) = row.get("metadata").and_then(Value::as_str) else {
+            continue;
+        };
+        if let Some(cwd) = metadata_json_cwd(&state.cwd, metadata) {
+            return Ok(Some(cwd));
+        }
+    }
+    Ok(None)
+}
+
+fn settings_json_cwd(base_cwd: &Path, settings_json: &str) -> Option<PathBuf> {
+    json_path_cwd(base_cwd, settings_json, &["cwd"])
+}
+
+fn metadata_json_cwd(base_cwd: &Path, metadata: &str) -> Option<PathBuf> {
+    json_path_cwd(base_cwd, metadata, &["codex_shim", "cwd"])
+}
+
+fn json_path_cwd(base_cwd: &Path, raw: &str, path: &[&str]) -> Option<PathBuf> {
+    let parsed = serde_json::from_str::<Value>(raw).ok()?;
+    let mut value = &parsed;
+    for segment in path {
+        value = value.get(*segment)?;
+    }
+    value
+        .as_str()
+        .map(str::trim)
+        .filter(|cwd| !cwd.is_empty())
+        .map(Path::new)
+        .map(|cwd| absolute_cwd(base_cwd, cwd))
+}
+
+fn absolute_cwd(base_cwd: &Path, cwd: &Path) -> PathBuf {
+    if cwd.is_absolute() {
+        cwd.to_path_buf()
+    } else {
+        base_cwd.join(cwd)
+    }
+}
+
 fn behavior_id(state: &ShimState) -> String {
     state.behavior_id.as_ref().to_string()
 }
@@ -326,4 +408,44 @@ fn default_memory_mode() -> String {
 
 fn empty_json_object() -> String {
     "{}".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_json_cwd_reads_codex_shim_cwd() {
+        let base_cwd = Path::new("/workspace");
+        assert_eq!(
+            metadata_json_cwd(base_cwd, r#"{"codex_shim":{"cwd":"/repo"}}"#),
+            Some(PathBuf::from("/repo"))
+        );
+        assert_eq!(
+            metadata_json_cwd(base_cwd, r#"{"codex_shim":{"cwd":"repo"}}"#),
+            Some(PathBuf::from("/workspace/repo"))
+        );
+    }
+
+    #[test]
+    fn settings_json_cwd_reads_thread_settings_cwd() {
+        let base_cwd = Path::new("/workspace");
+        assert_eq!(
+            settings_json_cwd(base_cwd, r#"{"cwd":"/repo-from-settings"}"#),
+            Some(PathBuf::from("/repo-from-settings"))
+        );
+        assert_eq!(settings_json_cwd(base_cwd, "{}"), None);
+    }
+
+    #[test]
+    fn projection_row_accepts_null_legacy_cwd() {
+        let row: ProjectionRow = serde_json::from_value(serde_json::json!({
+            "session_id": "thread-1",
+            "cwd": null
+        }))
+        .expect("row with null cwd should decode");
+
+        assert_eq!(row.session_id, "thread-1");
+        assert_eq!(row.cwd, None);
+    }
 }

--- a/crates/defra-agent-cli/src/commands/codex_shim/thread_routes.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/thread_routes.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -12,7 +13,8 @@ use super::protocol::absolute_path;
 use super::store::query_node_json;
 use super::thread_projection::{
     codex_thread_json, codex_thread_json_with_turns, list_codex_threads_by_archived,
-    load_codex_thread, store_forked_codex_thread, thread_response_json, CodexThreadRecord,
+    load_codex_thread_with_cwd_hint, store_forked_codex_thread, thread_response_json,
+    CodexThreadRecord,
 };
 use super::{ShimState, JSONRPC_INTERNAL_ERROR, JSONRPC_INVALID_PARAMS};
 
@@ -25,6 +27,7 @@ pub(super) struct ThreadRouteError {
 pub(super) async fn fork_thread_response(
     state: &ShimState,
     params: codex::ThreadForkParams,
+    cwd_hints: &BTreeMap<String, PathBuf>,
 ) -> std::result::Result<(CodexThreadRecord, Value), ThreadRouteError> {
     if params.path.is_some() {
         return Err(invalid_params(
@@ -37,10 +40,14 @@ pub(super) async fn fork_thread_response(
         ));
     }
 
-    let source = load_codex_thread(state, &params.thread_id)
-        .await
-        .map_err(internal_error)?
-        .ok_or_else(|| invalid_params(format!("unknown Codex thread `{}`", params.thread_id)))?;
+    let source = load_codex_thread_with_cwd_hint(
+        state,
+        &params.thread_id,
+        cwd_hints.get(&params.thread_id).map(PathBuf::as_path),
+    )
+    .await
+    .map_err(internal_error)?
+    .ok_or_else(|| invalid_params(format!("unknown Codex thread `{}`", params.thread_id)))?;
     let fork_at_user_turn = count_user_messages(state, &params.thread_id)
         .await
         .map_err(internal_error)?;
@@ -84,6 +91,7 @@ pub(super) async fn fork_thread_response(
 pub(super) async fn list_threads_response(
     state: &ShimState,
     params: codex::ThreadListParams,
+    cwd_hints: &BTreeMap<String, PathBuf>,
 ) -> std::result::Result<Value, ThreadRouteError> {
     if !source_filter_allows_cli(params.source_kinds.as_deref())
         || !model_provider_filter_allows_defra(params.model_providers.as_deref())
@@ -96,7 +104,7 @@ pub(super) async fn list_threads_response(
     }
 
     let archived = params.archived.unwrap_or(false);
-    let mut records = list_codex_threads_by_archived(state, archived)
+    let mut records = list_codex_threads_by_archived(state, archived, cwd_hints)
         .await
         .map_err(internal_error)?;
     if let Some(cwd_filter) = params.cwd.as_ref() {
@@ -149,6 +157,7 @@ pub(super) async fn list_threads_response(
 pub(super) async fn search_threads_response(
     state: &ShimState,
     params: codex::ThreadSearchParams,
+    cwd_hints: &BTreeMap<String, PathBuf>,
 ) -> std::result::Result<Value, ThreadRouteError> {
     let search_term = params.search_term.trim();
     if search_term.is_empty() {
@@ -166,7 +175,7 @@ pub(super) async fn search_threads_response(
 
     let mut matches = Vec::<(CodexThreadRecord, String)>::new();
     let archived = params.archived.unwrap_or(false);
-    let records = list_codex_threads_by_archived(state, archived)
+    let records = list_codex_threads_by_archived(state, archived, cwd_hints)
         .await
         .map_err(internal_error)?;
     for record in records {

--- a/crates/defra-agent-cli/tests/cli_codex_shim.rs
+++ b/crates/defra-agent-cli/tests/cli_codex_shim.rs
@@ -179,6 +179,16 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     let thread_id = thread_start.thread.id.clone();
     Uuid::parse_str(&thread_id)
         .with_context(|| format!("Codex TUI requires UUID thread ids, got {thread_id}"))?;
+    assert_eq!(
+        thread_start.cwd.as_path(),
+        home_dir.as_path(),
+        "thread/start should return the effective cwd without persisting it as sidecar state"
+    );
+    assert_eq!(
+        thread_start.thread.cwd.as_path(),
+        home_dir.as_path(),
+        "thread payload should carry the effective cwd"
+    );
 
     let projection_response = graphql_query(
         &graphql,
@@ -186,7 +196,6 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
             r#"{{
                 CodexThreadProjection(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
                     session_id
-                    cwd
                     archived
                     loaded
                 }}
@@ -205,11 +214,6 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     assert_eq!(
         projection.get("session_id").and_then(Value::as_str),
         Some(thread_id.as_str())
-    );
-    let expected_cwd = home_dir.display().to_string();
-    assert_eq!(
-        projection.get("cwd").and_then(Value::as_str),
-        Some(expected_cwd.as_str())
     );
     assert_eq!(
         projection.get("archived").and_then(Value::as_bool),
@@ -278,6 +282,7 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
     let thread_read: codex::ThreadReadResponse =
         read_typed_response(&mut ws, request_id(32)).await?;
     assert_eq!(thread_read.thread.id, thread_id);
+    assert_eq!(thread_read.thread.cwd.as_path(), home_dir.as_path());
 
     send_client_request(
         &mut ws,
@@ -1811,7 +1816,6 @@ async fn codex_shim_live_thread_projection_survives_real_backend_turn() -> Resul
             r#"{{
                 CodexThreadProjection(filter: {{ session_id: {{ _eq: "{}" }} }}, limit: 1) {{
                     session_id
-                    cwd
                     archived
                     loaded
                     memory_mode
@@ -1835,10 +1839,6 @@ async fn codex_shim_live_thread_projection_survives_real_backend_turn() -> Resul
     assert_eq!(
         projection.get("session_id").and_then(Value::as_str),
         Some(thread_id.as_str())
-    );
-    assert_eq!(
-        projection.get("cwd").and_then(Value::as_str),
-        Some(expected_cwd.as_str())
     );
     assert_eq!(
         projection.get("archived").and_then(Value::as_bool),
@@ -1918,6 +1918,7 @@ async fn codex_shim_live_thread_projection_survives_real_backend_turn() -> Resul
     let thread_read: codex::ThreadReadResponse =
         read_typed_response(&mut ws, request_id(406)).await?;
     assert_eq!(thread_read.thread.id, thread_id);
+    assert_eq!(thread_read.thread.cwd.as_path(), smoke.home_dir.as_path());
     assert_eq!(
         thread_read.thread.name.as_deref(),
         Some(thread_name.as_str())


### PR DESCRIPTION
## Summary

- stop writing `cwd` as authoritative state in `CodexThreadProjection`
- derive Codex thread cwd from connection/runtime state, latest request metadata, thread settings, legacy projection rows, then shim default cwd
- thread list/read/search/fork/metadata routes now pass cwd hints through projection loading
- update tests to assert client-visible cwd instead of persisted projection cwd

## Notes

This is a scoped slice of #494. It removes `cwd` from the projection's owned state, but does not fully remove or rename `CodexThreadProjection` yet because it still stores Codex UI-local fields like archived/loaded/name/memory mode/settings/goal/git metadata.

Refs #494

## Tests

- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli commands::codex_shim::thread_projection::storage::tests -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_protocol_turn_streams_defra_response -- --nocapture`
- `cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_thread_fork_and_search_project_defra_sessions -- --nocapture`
- `git diff --check`