### PR TITLE
Network-membership Lean model + decision fns (cut 1/6)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
@@ -4,227 +4,90 @@ import Mathlib.Data.Finset.Image
 /-!
 # Peer Registry Discovery — Derivation properties
 
-The four obligations from the spec's "Discovery reconciler" section, plus the
-signed-invite guard. Every transition-level theorem is discharged by `cases`
-over the full `Transition` relation, so no convenient case is silently skipped.
+The carried-over derivation/ownership/nonce/reciprocal theorems, re-proven
+against the **signed network-membership** model (`deriveMaterializable`,
+`Membership`, `joinState`). Every transition-level theorem is discharged by
+`cases` over the full `Transition` relation, so no convenient case is silently
+skipped.
+
+The new membership obligations (O1–O5) live in a separate task; this file only
+carries the prior proven content onto the new derivation.
 -/
 
 namespace PeerRegistryDiscovery
 
 open DiscoveryState
 
-/-! ## Membership characterization of the derivation -/
+/-! ## Derivation lemmas -/
 
-/-- `p` is derived iff some live, non-self registry entry carries peer `p`. -/
-theorem mem_deriveRegistryDesired {self : PeerId} {reg : Registry} {p : PeerId} :
-    p ∈ deriveRegistryDesired self reg ↔
-      ∃ e ∈ reg, e.live = true ∧ e.peer ≠ self ∧ e.peer = p := by
-  unfold deriveRegistryDesired
-  simp only [Finset.mem_image, Finset.mem_filter]
-  constructor
-  · rintro ⟨e, ⟨he_mem, he_live, he_self⟩, he_peer⟩
-    exact ⟨e, he_mem, he_live, he_self, he_peer⟩
-  · rintro ⟨e, he_mem, he_live, he_self, he_peer⟩
-    exact ⟨e, ⟨he_mem, he_live, he_self⟩, he_peer⟩
-
-/-- Self is never derived. (Sanity: the filter excludes it.) -/
-theorem self_not_mem_derive {self : PeerId} {reg : Registry} :
-    self ∉ deriveRegistryDesired self reg := by
-  rw [mem_deriveRegistryDesired]
-  rintro ⟨e, _, _, he_self, he_peer⟩
-  exact he_self (he_peer.trans rfl)
+/-- Self is never derived. (Sanity: the filter carries `ep.peer ≠ s.self`.) -/
+theorem self_not_mem_derive {s : DiscoveryState} :
+    s.self ∉ deriveMaterializable s := by
+  rw [mem_deriveMaterializable]
+  rintro ⟨ep, _, ⟨_, _, hself⟩, hpeer⟩
+  exact hself (hpeer.trans rfl)
 
 /-! ## (1) Idempotence -/
 
-/-- Deriving twice equals deriving once: the registry is the sole input and a
-derive step does not change it. -/
+/-- Deriving twice equals deriving once: the membership world is the sole input
+and a derive step does not change it. -/
 theorem derive_idempotent (s : DiscoveryState) :
     deriveStep (deriveStep s) = deriveStep s := by
   unfold deriveStep
   rfl
 
-/-- The function-level idempotence the Rust derivation mirrors. -/
-theorem deriveRegistryDesired_idempotent (self : PeerId) (reg : Registry) :
-    deriveRegistryDesired self (deriveStep ⟨self, reg, ∅, ∅, ∅⟩).registry
-      = deriveRegistryDesired self reg := rfl
+/-- The function-level idempotence the Rust derivation mirrors: re-deriving over
+the same membership world yields the same set. -/
+theorem deriveMaterializable_idempotent (s : DiscoveryState) :
+    deriveMaterializable (deriveStep s) = deriveMaterializable s := rfl
 
 /-! ## (2) Convergence
 
-The derived set is a *pure function of the registry*, so it converges in a
-single derive step: the post-state is settled, and any further derive over an
-unchanged registry is a fixpoint. We state exactly this and do not claim a
+The derived set is a *pure function of the membership world*, so it converges in
+a single derive step: the post-state is settled, and any further derive over an
+unchanged world is a fixpoint. We state exactly this and do not claim a
 multi-step reachability result over arbitrary interleavings. -/
 
-/-- One derive step settles the registry-owned partition. -/
+/-- One derive step settles the network-owned partition. -/
 theorem derive_settles (s : DiscoveryState) : (deriveStep s).settled := by
   unfold settled deriveStep
   rfl
 
-/-- A settled state with an unchanged registry is a derive fixpoint: re-running
-the derivation changes nothing. This is the convergence content — stability of
-the derived set across ticks given a stable registry. -/
+/-- A settled state with an unchanged membership world is a derive fixpoint:
+re-running the derivation changes nothing. This is the convergence content —
+stability of the derived set across ticks given a stable world. -/
 theorem derive_convergent {s : DiscoveryState} (h : s.settled) :
     deriveStep s = s := by
   unfold settled at h
   unfold deriveStep
   rw [← h]
 
-/-! ## (3) Ownership safety
+/-! ## (3) Ownership safety (= obligation O4)
 
-Quantified over ALL transitions. The discovery step (and registry edits) never
-touch the operator partition; only an explicit `operatorWrite` does — and that
-IS the operator, by construction not the discovery step. So: every non-operator
-transition preserves `operatorDesired`, and `operatorWrite` is the sole
-exception (named honestly). -/
+Quantified over ALL transitions. The discovery step (and every membership /
+request / nonce edit) leaves the operator partition byte-identical — each such
+mutator is a `{s with …}` that does not name `operatorDesired`. The ONE
+transition that does change `operatorDesired` is `operatorWrite` itself, by
+construction (the operator writing its own set is not a discovery step), and it
+is excluded by hypothesis. So: every non-operator transition preserves
+`operatorDesired`, and `operatorWrite` is the sole named exception. -/
 
-/-- No derivation/retraction/join transition mutates an operator-owned row. The
-only transition that changes `operatorDesired` is `operatorWrite` itself. -/
+/-- No derivation / membership / request / nonce transition mutates an
+operator-owned row. The only transition that changes `operatorDesired` is
+`operatorWrite` itself, excluded here by `h_not_operator`. -/
 theorem ownership_safe {pre post : DiscoveryState} (h : Transition pre post)
     (h_not_operator : ∀ d, post ≠ operatorWriteState pre d) :
     post.operatorDesired = pre.operatorDesired := by
   cases h with
   | derive h_post => subst h_post; rfl
-  | join tok e tofu _ h_post => subst h_post; rfl
-  | reciprocalJoin tok e tofu _ h_post => subst h_post; rfl
-  | removeEntry e h_post => subst h_post; rfl
-  | operatorWrite d h_post =>
-      exact absurd h_post (h_not_operator d)
-
-/-- Sharper form: the derive step specifically preserves the operator partition
-*and* the registry, mutating only `registryDesired`. -/
-theorem derive_preserves_operator_and_registry (s : DiscoveryState) :
-    (deriveStep s).operatorDesired = s.operatorDesired ∧
-    (deriveStep s).registry = s.registry := ⟨rfl, rfl⟩
-
-/-- The operator partition flows untouched into the effective desired set under
-a derive step (operator intent survives derivation). -/
-theorem derive_preserves_operator_in_effective (s : DiscoveryState) :
-    s.operatorDesired ⊆ (deriveStep s).effectiveDesired := by
-  intro p hp
-  exact Finset.mem_union_left _ hp
-
-/-! ## (4) Retraction soundness
-
-Removing/staling entry `e` then re-deriving removes exactly `e`'s registry-owned
-derived row(s) and no others. Made precise as a membership characterization of
-the post-derivation set in terms of the pre-registry, plus the corollaries that
-(a) an unrelated derived peer survives, and (b) `e.peer` is dropped exactly when
-`e` was its sole live, non-self source. -/
-
-/-- After removing `e` and deriving, `p` is derived iff some live non-self
-entry *other than `e`* carries `p`. -/
-theorem retraction_characterization {self : PeerId} {reg : Registry}
-    {e : RegistryEntry} {p : PeerId} :
-    p ∈ deriveRegistryDesired self (reg.erase e) ↔
-      ∃ e' ∈ reg, e' ≠ e ∧ e'.live = true ∧ e'.peer ≠ self ∧ e'.peer = p := by
-  rw [mem_deriveRegistryDesired]
-  constructor
-  · rintro ⟨e', he'_mem, he'_live, he'_self, he'_peer⟩
-    have hne : e' ≠ e := (Finset.ne_of_mem_erase he'_mem)
-    exact ⟨e', Finset.mem_of_mem_erase he'_mem, hne, he'_live, he'_self, he'_peer⟩
-  · rintro ⟨e', he'_mem, hne, he'_live, he'_self, he'_peer⟩
-    exact ⟨e', Finset.mem_erase.mpr ⟨hne, he'_mem⟩, he'_live, he'_self, he'_peer⟩
-
-/-- Retraction is targeted: any derived peer backed by a *different* live entry
-survives the removal of `e`. No collateral retraction. -/
-theorem retraction_preserves_others {self : PeerId} {reg : Registry}
-    {e e' : RegistryEntry} (hne : e' ≠ e) (he'_mem : e' ∈ reg)
-    (he'_live : e'.live = true) (he'_self : e'.peer ≠ self) :
-    e'.peer ∈ deriveRegistryDesired self (reg.erase e) := by
-  rw [retraction_characterization]
-  exact ⟨e', he'_mem, hne, he'_live, he'_self, rfl⟩
-
-/-- Retraction is exact: `e.peer` is dropped precisely when `e` was the *only*
-live, non-self entry carrying it. (If another live entry carries `e.peer`, it
-survives by `retraction_preserves_others`.) -/
-theorem retraction_drops_unique_source {self : PeerId} {reg : Registry}
-    {e : RegistryEntry}
-    (h_unique : ∀ e' ∈ reg, e' ≠ e → e'.live = true → e'.peer ≠ self →
-                  e'.peer ≠ e.peer) :
-    e.peer ∉ deriveRegistryDesired self (reg.erase e) := by
-  rw [retraction_characterization]
-  rintro ⟨e', he'_mem, hne, he'_live, he'_self, he'_peer⟩
-  exact (h_unique e' he'_mem hne he'_live he'_self) he'_peer
-
-/-- Whole-state corollary: a `removeEntry` step followed by `derive` retracts
-only registry-owned rows; the operator partition is byte-identical throughout. -/
-theorem retraction_sound {pre post post' : DiscoveryState} {e : RegistryEntry}
-    (h_remove : post = removeEntryState pre e)
-    (h_derive : post' = deriveStep post) :
-    post'.operatorDesired = pre.operatorDesired ∧
-    post'.registryDesired = deriveRegistryDesired pre.self (pre.registry.erase e) := by
-  subst h_remove
-  subst h_derive
-  exact ⟨rfl, rfl⟩
-
-/-! ## (5) Signed-invite guard
-
-A `join` step is enabled only when the issuer is a live member, or the
-TOFU-bootstrap flag holds. This fences "non-member invite rejected". -/
-
-/-- A `join` is the ONLY transition that can grow the registry, and it can fire
-only with a member-signed token. So any step that admitted a new entry — its
-post-state registry is not a subset of the pre-state registry — must have
-carried a member signature.
-
-This is the positive authorization fact, and it is genuinely non-vacuous: we
-case on the relation and read the signature witness out of the `join`
-constructor itself (it is NOT supplied as a hypothesis the caller had to already
-prove), while `derive` / `removeEntry` / `operatorWrite` never grow the registry
-and so are refuted by `h_grew`. The hypothesis is satisfiable — a real join of a
-fresh entry makes the registry grow — and the conclusion is not contained in it.
-Together with `no_join_without_admissible_token` (the refutation direction) and
-`non_member_invite_rejected` (the leaf guard), this fences "a node enters the
-trust set only via a member-signed invite".
-
-Scope (see `Transition.join`): the signature gates WHETHER a node is admitted,
-not WHICH identity — the inserted entry is self-asserted under the trusted-fleet
-TOFU model, so this does not claim `e.did` is bound to the token issuer. -/
-theorem registry_growth_requires_member_signature {pre post : DiscoveryState}
-    (h : Transition pre post)
-    (h_grew : ¬ post.registry ⊆ pre.registry) :
-    ∃ (tok : Token) (tofu : Bool), signedByMember tok pre.registry pre.self tofu := by
-  cases h with
-  | derive hp =>
-      refine absurd ?_ h_grew
-      rw [hp]; exact subset_rfl
-  | join tok e tofu hsig _hp =>
-      exact ⟨tok, tofu, hsig.1⟩
-  | reciprocalJoin tok e tofu hsig _hp =>
-      exact ⟨tok, tofu, hsig.1⟩
-  | removeEntry e hp =>
-      refine absurd ?_ h_grew
-      rw [hp]; exact Finset.erase_subset e pre.registry
-  | operatorWrite d hp =>
-      refine absurd ?_ h_grew
-      rw [hp]; exact subset_rfl
-
-/-- The contrapositive teeth: if NO token is admissible in `pre` (every signed
-token is from a non-member and TOFU bootstrap is off), then NO join transition
-out of `pre` exists. "Non-member invite rejected" as a refutation. -/
-theorem no_join_without_admissible_token {pre post : DiscoveryState}
-    (h_none : ∀ (tok : Token) (tofu : Bool), ¬ signedByMember tok pre.registry pre.self tofu)
-    (h : Transition pre post) :
-    ∀ (tok : Token) (e : RegistryEntry) (tofu : Bool)
-      (hadm : admitsJoin pre tok tofu)
-      (hpost : post = joinState pre e tok),
-      h ≠ Transition.join tok e tofu hadm hpost := by
-  intro tok e tofu hadm _ _
-  exact absurd hadm.1 (h_none tok tofu)
-
-/-- A non-member, signature-invalid, non-bootstrap token is never admissible:
-the join guard rejects it. This is the leaf "forged/non-member invite" fact. -/
-theorem non_member_invite_rejected
-    {tok : Token} {reg : Registry} {self : PeerId}
-    (h_unsigned_or_nonmember : tok.sigValid = false ∨ ¬ isMember tok.issuer reg) :
-    ¬ signedByMember tok reg self false := by
-  unfold signedByMember
-  rintro ⟨hsig, hor⟩
-  rcases h_unsigned_or_nonmember with h_unsig | h_nonmem
-  · exact absurd hsig (by simp [h_unsig])
-  · rcases hor with h_mem | h_boot
-    · exact h_nonmem h_mem
-    · exact absurd h_boot.1 (by simp)
+  | join tok tofu _ h_post => subst h_post; rfl
+  | reciprocalJoin tok tofu _ h_post => subst h_post; rfl
+  | submitRequest req h_post => subst h_post; rfl
+  | approveRequest req m _ _ _ _ _ _ h_post =>
+      subst h_post; unfold approveMembershipState upsertMembership; rfl
+  | revoke tomb _ _ h_post =>
+      subst h_post; unfold revokeState upsertMembership; rfl
+  | operatorWrite d h_post => exact absurd h_post (h_not_operator d)
 
 /-! ## (6) Single-use invite (replay rejection)
 
@@ -236,15 +99,15 @@ This upgrades the runtime's 1h freshness window from "time-bounded" to
 
 /-- The join mutator does record the nonce as consumed. (The structural fact
 `replay_rejected` leans on.) -/
-theorem joinState_consumes_nonce (s : DiscoveryState) (e : RegistryEntry) (tok : Token) :
-    tok.nonce ∈ (joinState s e tok).consumedNonces := by
+theorem joinState_consumes_nonce (s : DiscoveryState) (tok : Token) :
+    tok.nonce ∈ (joinState s tok).consumedNonces := by
   unfold joinState
   simp
 
 /-- **Replay rejected.** If a join with token `tok` is admitted from `pre`
-(`hadm : admitsJoin pre tok tofu`) and steps to `post = joinState pre e tok`,
-then the SAME token can no longer be admitted from `post`: `admitsJoin post tok`
-is false for every bootstrap choice.
+(`hadm : admitsJoin pre tok tofu`) and steps to `post = joinState pre tok`, then
+the SAME token can no longer be admitted from `post`: `admitsJoin post tok` is
+false for every bootstrap choice.
 
 Non-vacuous: the hypothesis `admitsJoin pre tok tofu` is satisfiable — it is
 exactly the precondition discharged by the `Transition.join` constructor, and is
@@ -253,38 +116,45 @@ admitted. The conclusion is a genuine consequence, not a restatement: we prove
 `¬ admitsJoin post tok` by unfolding `admitsJoin` and refuting its freshness
 conjunct using `joinState_consumes_nonce` — i.e. the second admission fails
 *because* the first join consumed the nonce, never touching the signature arm. -/
-theorem replay_rejected {pre post : DiscoveryState} {tok : Token} {e : RegistryEntry}
+theorem replay_rejected {pre post : DiscoveryState} {tok : Token}
     {tofu : Bool} (_hadm : admitsJoin pre tok tofu)
-    (hpost : post = joinState pre e tok) :
+    (hpost : post = joinState pre tok) :
     ∀ tofu', ¬ admitsJoin post tok tofu' := by
   intro tofu' hadm'
   -- `admitsJoin post tok` requires `tok.nonce ∉ post.consumedNonces`,
   -- but the join that produced `post` consumed exactly `tok.nonce`.
   have h_consumed : tok.nonce ∈ post.consumedNonces := by
-    rw [hpost]; exact joinState_consumes_nonce pre e tok
+    rw [hpost]; exact joinState_consumes_nonce pre tok
   exact hadm'.2 h_consumed
 
 /-- Witness that `replay_rejected`'s hypothesis is satisfiable: a concrete state
 in which a fresh, member-signed token IS admitted for a first join. This pins the
 theorem as non-vacuous — there really is a `(pre, tok, tofu)` with
-`admitsJoin pre tok tofu`. -/
+`admitsJoin pre tok tofu`.
+
+The witness state has one valid network (`adminSigValid = true`), one active
+admin-signed membership for `did:key:a`, an empty `consumedNonces`, and a token
+issued by `did:key:a` with a fresh nonce and a valid signature. -/
 theorem replay_rejected_witness :
     ∃ (pre : DiscoveryState) (tok : Token) (tofu : Bool),
       admitsJoin pre tok tofu := by
-  -- A registry holding one live member; a token signed by that member with a
-  -- never-before-seen nonce; no consumed nonces yet.
-  let member : RegistryEntry := ⟨"peer-a", "did:key:a", true⟩
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let membership : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", true⟩
   let pre : DiscoveryState :=
     { self := "peer-self"
-    , registry := {member}
+    , network := network
+    , memberships := {membership}
+    , endpoints := ∅
+    , requests := ∅
     , operatorDesired := ∅
     , registryDesired := ∅
     , consumedNonces := ∅ }
   let tok : Token := ⟨"did:key:a", true, "nonce-1"⟩
   refine ⟨pre, tok, false, ?_, ?_⟩
-  · -- signedByMember: signature valid and issuer is the live member.
+  · -- signedByMember: signature valid and issuer is an admitted member.
     refine ⟨rfl, Or.inl ?_⟩
-    exact ⟨member, Finset.mem_singleton_self member, rfl, rfl⟩
+    refine ⟨rfl, membership, Finset.mem_singleton_self membership, rfl, rfl, ?_⟩
+    exact ⟨rfl, rfl, rfl⟩
   · -- freshness: the nonce is not in the (empty) consumed set.
     exact Finset.not_mem_empty _
 
@@ -298,8 +168,8 @@ theorems prove the reciprocal flag changes only *what is wired*, never *whether
 the join is admitted*. -/
 
 /-- **A reciprocal join is gated by `admitsJoin`.** If a transition `h` from
-`pre` to `post` is a reciprocal join of `tok`/`e`/`tofu` (i.e. it is equal to
-*some* application of the `reciprocalJoin` constructor on those arguments), then
+`pre` to `post` is a reciprocal join of `tok`/`tofu` (i.e. it is equal to *some*
+application of the `reciprocalJoin` constructor on those arguments), then
 `admitsJoin pre tok tofu` holds. The admission proof is the constructor's own
 precondition, bound existentially in the hypothesis and pulled back out — it is
 NOT handed to the theorem as a free fact, so the conclusion genuinely rides on
@@ -309,11 +179,11 @@ Non-vacuous: `reciprocal_join_witness` exhibits a concrete `(pre, post, tok,
 tofu)` for which such a transition really exists, so the hypothesis space is
 inhabited and the implication is not vacuously true. -/
 theorem reciprocal_join_still_gated {pre post : DiscoveryState}
-    {tok : Token} {e : RegistryEntry} {tofu : Bool}
+    {tok : Token} {tofu : Bool}
     (h : Transition pre post)
     (h_is_reciprocal :
-      ∃ (hadm : admitsJoin pre tok tofu) (hpost : post = joinState pre e tok),
-        h = Transition.reciprocalJoin tok e tofu hadm hpost) :
+      ∃ (hadm : admitsJoin pre tok tofu) (hpost : post = joinState pre tok),
+        h = Transition.reciprocalJoin tok tofu hadm hpost) :
     admitsJoin pre tok tofu :=
   -- The admission proof is precisely the precondition the constructor demanded.
   h_is_reciprocal.choose
@@ -324,20 +194,24 @@ token). Without this the gating theorem could be vacuous. -/
 theorem reciprocal_join_witness :
     ∃ (pre post : DiscoveryState) (tok : Token) (tofu : Bool),
       Transition pre post ∧ admitsJoin pre tok tofu := by
-  let member : RegistryEntry := ⟨"peer-a", "did:key:a", true⟩
-  let joiner : RegistryEntry := ⟨"peer-b", "did:key:b", true⟩
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let membership : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", true⟩
   let pre : DiscoveryState :=
     { self := "peer-self"
-    , registry := {member}
+    , network := network
+    , memberships := {membership}
+    , endpoints := ∅
+    , requests := ∅
     , operatorDesired := ∅
     , registryDesired := ∅
     , consumedNonces := ∅ }
   let tok : Token := ⟨"did:key:a", true, "nonce-1"⟩
   have hadm : admitsJoin pre tok false := by
     refine ⟨⟨rfl, Or.inl ?_⟩, Finset.not_mem_empty _⟩
-    exact ⟨member, Finset.mem_singleton_self member, rfl, rfl⟩
-  exact ⟨pre, joinState pre joiner tok, tok, false,
-    Transition.reciprocalJoin tok joiner false hadm rfl, hadm⟩
+    refine ⟨rfl, membership, Finset.mem_singleton_self membership, rfl, rfl, ?_⟩
+    exact ⟨rfl, rfl, rfl⟩
+  exact ⟨pre, joinState pre tok, tok, false,
+    Transition.reciprocalJoin tok false hadm rfl, hadm⟩
 
 /-- **Refutation teeth (signature-invalid case).** If a token's signature is
 invalid (`tok.sigValid = false`), then it is not admissible, so the
@@ -373,9 +247,60 @@ applies the same `joinState` mutator, so it burns the nonce identically and the
 same token can never be re-admitted (by any subsequent join OR reciprocal join).
 Reuses `replay_rejected` — no separate single-use argument needed. -/
 theorem reciprocal_replay_rejected {pre post : DiscoveryState} {tok : Token}
-    {e : RegistryEntry} {tofu : Bool} (hadm : admitsJoin pre tok tofu)
-    (hpost : post = joinState pre e tok) :
+    {tofu : Bool} (hadm : admitsJoin pre tok tofu)
+    (hpost : post = joinState pre tok) :
     ∀ tofu', ¬ admitsJoin post tok tofu' :=
   replay_rejected hadm hpost
+
+/-! ## (8) `wellFormed` preservation
+
+`wellFormed` is "at most one membership per `(networkId, memberDid)`".
+`upsertMembership` filters out every same-key row before inserting `m`, so the
+result keeps the invariant; the membership-writing transitions route through it,
+and the rest never touch `memberships`. -/
+
+/-- `upsertMembership` preserves `wellFormed`: after filtering out every
+same-`(networkId, memberDid)` row and inserting `m`, any two rows sharing the key
+are either both `m` (equal) or one is `m` and the other survived the filter — but
+a surviving row sharing `m`'s key contradicts the filter predicate. -/
+theorem upsertMembership_wellFormed {s : DiscoveryState} (m : Membership)
+    (hwf : s.wellFormed) : (upsertMembership s m).wellFormed := by
+  unfold DiscoveryState.wellFormed upsertMembership
+  intro m₁ hm₁ m₂ hm₂ hnet hdid
+  simp only [Finset.mem_insert, Finset.mem_filter] at hm₁ hm₂
+  -- Each of m₁, m₂ is either `m` itself, or a filtered survivor (a member of
+  -- `s.memberships` whose key differs from `m`'s).
+  rcases hm₁ with rfl | ⟨hm₁_mem, hm₁_key⟩ <;> rcases hm₂ with rfl | ⟨hm₂_mem, hm₂_key⟩
+  · rfl
+  · -- m₁ = m, m₂ survived: but m₂ shares m's key (hnet/hdid), contradicting filter.
+    exact absurd ⟨hnet.symm, hdid.symm⟩ hm₂_key
+  · -- symmetric.
+    exact absurd ⟨hnet, hdid⟩ hm₁_key
+  · -- both survived: original wellFormed applies.
+    exact hwf m₁ hm₁_mem m₂ hm₂_mem hnet hdid
+
+/-- Every `Transition` preserves `wellFormed`. `approveRequest`/`revoke` write
+memberships through `upsertMembership` (covered by `upsertMembership_wellFormed`);
+`derive`/`join`/`reciprocalJoin`/`submitRequest`/`operatorWrite` never touch
+`memberships`, so they preserve the invariant by `simp`/structure equality. -/
+theorem transition_preserves_wellFormed {pre post : DiscoveryState}
+    (hwf : pre.wellFormed) (h : Transition pre post) : post.wellFormed := by
+  cases h with
+  | derive h_post =>
+      subst h_post; unfold DiscoveryState.wellFormed deriveStep at *; exact hwf
+  | join tok tofu _ h_post =>
+      subst h_post; unfold DiscoveryState.wellFormed joinState at *; exact hwf
+  | reciprocalJoin tok tofu _ h_post =>
+      subst h_post; unfold DiscoveryState.wellFormed joinState at *; exact hwf
+  | submitRequest req h_post =>
+      subst h_post; unfold DiscoveryState.wellFormed submitRequestState at *; exact hwf
+  | approveRequest req m _ _ _ _ _ _ h_post =>
+      subst h_post; unfold approveMembershipState
+      exact upsertMembership_wellFormed m hwf
+  | revoke tomb _ _ h_post =>
+      subst h_post; unfold revokeState
+      exact upsertMembership_wellFormed tomb hwf
+  | operatorWrite d h_post =>
+      subst h_post; unfold DiscoveryState.wellFormed operatorWriteState at *; exact hwf
 
 end PeerRegistryDiscovery

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
@@ -303,4 +303,347 @@ theorem transition_preserves_wellFormed {pre post : DiscoveryState}
   | operatorWrite d h_post =>
       subst h_post; unfold DiscoveryState.wellFormed operatorWriteState at *; exact hwf
 
+/-! ## Core obligations (O1–O5)
+
+The membership obligations the model was built to discharge. O4 (`ownership_safe`)
+is above; O1/O2/O3/O5 follow, each with a realizing witness so no implication is
+vacuously true. -/
+
+/-! ### O1 — soundness
+
+Nothing materializes without an admitted, member-signed endpoint. This is the
+forward direction of `mem_deriveMaterializable`, restated standalone in the
+`admittedMember ∧ memberSignedEndpoint` shape (the conjuncts of
+`materializableEndpoint`). -/
+
+/-- **O1 (soundness).** If a peer `p` is in the derived materializable set, then
+some announced endpoint witnesses it: an endpoint in `s.endpoints` whose DID is an
+admitted member, whose announcement is member-signed, and whose peer is `p`. So a
+materialized peer always traces back to an admitted, member-signed endpoint.
+
+Non-vacuous: the hypothesis `p ∈ deriveMaterializable s` is realized by the
+positive witness `materializable_is_derived_witness` (a state with a genuinely
+derived peer); the unadmitted-endpoint scenario is realized by
+`materialized_implies_admitted_witness` (an endpoint that is NOT materialized,
+precisely because its DID is not admitted). The conclusion is a real consequence:
+it is extracted by unfolding the derivation's filter/image, not assumed. -/
+theorem materialized_implies_admitted {s : DiscoveryState} {p : PeerId}
+    (h : p ∈ deriveMaterializable s) :
+    ∃ ep ∈ s.endpoints, admittedMember ep.did s ∧ memberSignedEndpoint ep ∧ ep.peer = p := by
+  rw [mem_deriveMaterializable] at h
+  obtain ⟨ep, hep_mem, ⟨hadm, hsig, _⟩, hpeer⟩ := h
+  exact ⟨ep, hep_mem, hadm, hsig, hpeer⟩
+
+/-- Witness that the unadmitted-endpoint scenario of O1 is realizable: a concrete
+state with an endpoint whose announcing DID has NO admitted membership (its only
+membership row has `adminSigValid = false`), and whose peer is consequently NOT in
+`deriveMaterializable`. This is the `_neg` companion: it proves "an endpoint can
+exist whose peer is not materialized because its DID is not admitted", so O1's
+conclusion is not trivially always satisfiable by every endpoint. -/
+theorem materialized_implies_admitted_witness :
+    ∃ (s : DiscoveryState) (ep : Endpoint),
+      ep ∈ s.endpoints ∧ ¬ admittedMember ep.did s ∧ ep.peer ∉ deriveMaterializable s := by
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  -- A membership row that is NOT admin-signed: its admin signature does not verify.
+  let badMembership : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", false⟩
+  let ep : Endpoint := ⟨"did:key:a", "peer-a", true, true⟩
+  let s : DiscoveryState :=
+    { self := "peer-self"
+    , network := network
+    , memberships := {badMembership}
+    , endpoints := {ep}
+    , requests := ∅
+    , operatorDesired := ∅
+    , registryDesired := ∅
+    , consumedNonces := ∅ }
+  refine ⟨s, ep, Finset.mem_singleton_self ep, ?_, ?_⟩
+  · -- Not admitted: the only membership has adminSigValid = false.
+    rintro ⟨_, m, hm_mem, _, _, hadminsig, _, _⟩
+    rw [Finset.mem_singleton] at hm_mem
+    subst hm_mem
+    exact Bool.false_ne_true hadminsig
+  · -- peer-a is not derived: the only endpoint announcing it is not materializable.
+    rw [mem_deriveMaterializable]
+    rintro ⟨ep', hep'_mem, ⟨⟨_, m, hm_mem, _, _, hadminsig, _, _⟩, _, _⟩, _⟩
+    rw [Finset.mem_singleton] at hm_mem
+    subst hm_mem
+    exact Bool.false_ne_true hadminsig
+
+/-! ### O2 — completeness
+
+An active admin-signed membership plus a fresh member-signed endpoint (not self)
+materializes. This is the backward direction of `mem_deriveMaterializable`. -/
+
+/-- **O2 (completeness).** If an endpoint is announced (`ep ∈ s.endpoints`) and is
+`materializableEndpoint ep s` (admitted DID + member-signed + not self), then its
+peer is in the derived set. Together with O1 this pins the derivation as exactly
+the materializable-endpoint peers.
+
+Non-vacuous: `materializable_is_derived_witness` exhibits a concrete state whose
+hypothesis `materializableEndpoint ep s` genuinely holds and whose peer is
+derived — a true positive. The conclusion is a real consequence discharged
+through `mem_deriveMaterializable`. -/
+theorem materializable_is_derived {s : DiscoveryState} {ep : Endpoint}
+    (hep : ep ∈ s.endpoints) (h : materializableEndpoint ep s) :
+    ep.peer ∈ deriveMaterializable s := by
+  rw [mem_deriveMaterializable]
+  exact ⟨ep, hep, h, rfl⟩
+
+/-- Witness that O2's hypothesis is realizable as a genuine POSITIVE: a valid
+network, an active admin-signed membership for `did:key:a` (signed by the network
+admin, `adminSigValid = true`, `active = true`), and a fresh member-signed
+endpoint announcing `peer-a ≠ peer-self`. The peer IS derived. This is the
+anti-vacuity guard for O1: it proves the derived set is not always empty, so the
+"not materialized" conclusions elsewhere are not trivially true. -/
+theorem materializable_is_derived_witness :
+    ∃ (s : DiscoveryState) (ep : Endpoint),
+      ep ∈ s.endpoints ∧ materializableEndpoint ep s ∧ ep.peer ∈ deriveMaterializable s := by
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let membership : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", true⟩
+  let ep : Endpoint := ⟨"did:key:a", "peer-a", true, true⟩
+  let s : DiscoveryState :=
+    { self := "peer-self"
+    , network := network
+    , memberships := {membership}
+    , endpoints := {ep}
+    , requests := ∅
+    , operatorDesired := ∅
+    , registryDesired := ∅
+    , consumedNonces := ∅ }
+  have hmat : materializableEndpoint ep s := by
+    refine ⟨⟨rfl, membership, Finset.mem_singleton_self membership, rfl, rfl, ?_⟩, ⟨rfl, rfl⟩, ?_⟩
+    · exact ⟨rfl, rfl, rfl⟩
+    · decide
+  exact ⟨s, ep, Finset.mem_singleton_self ep, hmat, materializable_is_derived (Finset.mem_singleton_self ep) hmat⟩
+
+/-! ### O3 — revocation retracts exactly
+
+Revoking `tomb.memberDid` retracts ONLY peers that were materialized *exclusively*
+via that DID. A peer also reachable via a different admitted DID must survive.
+
+The argument: `revokeState pre tomb = upsertMembership pre tomb` replaces the
+single (by `wellFormed`) `(networkId, memberDid)` row with the `active = false`
+tombstone. After revoke, NO active admin-signed membership exists for
+`tomb.memberDid`, so endpoints with `did = tomb.memberDid` are no longer
+materializable; endpoints with `did ≠ tomb.memberDid` keep their membership rows
+untouched, so their `admittedMember` status is unchanged. We bridge both sides
+through `mem_deriveMaterializable`. -/
+
+/-- An endpoint whose DID equals the revoked member's is NOT materializable in the
+post-state: after revoke NO active `(networkId, memberDid)` row for that key
+survives, so `admittedMember` fails.
+
+NOTE: this does NOT need `wellFormed`. `upsertMembership` filters out *every*
+same-key row (not just one) before inserting the inactive tombstone, so even if
+`pre` had multiple rows for `tomb.memberDid` they are all dropped — the
+"at most one row" invariant is sufficient but not necessary here. O3 still carries
+`wellFormed` in its signature per the obligation spec. -/
+private theorem revoked_did_not_materializable {pre : DiscoveryState} {tomb : Membership}
+    (hsig : adminSignedMembership tomb pre.network)
+    (hrev : tomb.active = false) {ep : Endpoint} (hdid : ep.did = tomb.memberDid) :
+    ¬ materializableEndpoint ep (revokeState pre tomb) := by
+  rintro ⟨⟨_, m, hm_mem, hmdid, hmactive, hmadminsig, hmsignedby, hmnet⟩, _, _⟩
+  -- m is an active admin-signed membership for ep.did = tomb.memberDid in post.
+  unfold revokeState upsertMembership at hm_mem
+  rw [Finset.mem_insert, Finset.mem_filter] at hm_mem
+  -- m's key matches tomb's key.
+  have hm_net_tomb : m.networkId = tomb.networkId := by
+    rw [hmnet]; exact hsig.2.2.symm
+  have hm_did_tomb : m.memberDid = tomb.memberDid := by rw [hmdid, hdid]
+  rcases hm_mem with rfl | ⟨_, hkey⟩
+  · -- m = tomb: but tomb.active = false contradicts hmactive.
+    rw [hrev] at hmactive
+    exact Bool.false_ne_true hmactive
+  · -- m survived the filter, so its key ≠ tomb's key — contradiction.
+    exact hkey ⟨hm_net_tomb, hm_did_tomb⟩
+
+/-- An endpoint whose DID differs from the revoked member's keeps its
+materializability across revoke: the membership rows for `ep.did` are untouched
+(the upsert only filters out `tomb.memberDid`'s key and inserts the tombstone). -/
+private theorem unrevoked_did_materializable_iff {pre : DiscoveryState} {tomb : Membership}
+    {ep : Endpoint} (hdid : ep.did ≠ tomb.memberDid) :
+    materializableEndpoint ep (revokeState pre tomb) ↔ materializableEndpoint ep pre := by
+  unfold materializableEndpoint admittedMember validNetwork revokeState upsertMembership
+  simp only
+  constructor
+  · rintro ⟨⟨hnet, m, hm_mem, hmdid, hrest⟩, hsig, hself⟩
+    rw [Finset.mem_insert, Finset.mem_filter] at hm_mem
+    refine ⟨⟨hnet, m, ?_, hmdid, hrest⟩, hsig, hself⟩
+    rcases hm_mem with rfl | ⟨hm_orig, _⟩
+    · -- m = tomb, but then tomb.memberDid = ep.did, contradicting hdid.
+      exact absurd hmdid.symm hdid
+    · exact hm_orig
+  · rintro ⟨⟨hnet, m, hm_mem, hmdid, hrest⟩, hsig, hself⟩
+    refine ⟨⟨hnet, m, ?_, hmdid, hrest⟩, hsig, hself⟩
+    rw [Finset.mem_insert, Finset.mem_filter]
+    refine Or.inr ⟨hm_mem, ?_⟩
+    -- m's key ≠ tomb's key because m.memberDid = ep.did ≠ tomb.memberDid.
+    rintro ⟨_, hmd⟩
+    exact hdid (hmdid ▸ hmd)
+
+/-- **O3 (revocation retracts exactly).** Under `wellFormed`, revoking `tomb`
+yields a post-derivation equal to the pre-derivation FILTERED to the peers still
+backed by some materializable endpoint whose DID is NOT the revoked one. Peers
+materialized only via the revoked DID drop; peers also reachable via another
+admitted DID survive.
+
+Non-vacuous: `revoke_retracts_exactly_witness` realizes the hypothesis (a
+well-formed state, an admin-signed inactive tombstone) and exhibits BOTH the
+distinct-peer case (revoke A drops A's peer, keeps B's) and the shared-peer case
+(A and B both materialize peer `p`; revoke A leaves `p` materialized via B). The
+shared-peer case is what makes "exactly/exclusively" precise — the filter is not
+just "drop everything `tomb.memberDid` touched".
+
+FINDING: the proof does NOT actually require `wellFormed`. The spec's reasoning
+appealed to "at most one membership row per key" to argue no active row survives
+revoke. But `upsertMembership` filters out *every* same-key row before inserting
+the tombstone, so the retraction holds even if `pre` had several rows for
+`tomb.memberDid`. `wellFormed` (`_hwf`) is retained in the signature per the
+obligation spec, but is unused — uniqueness is sufficient, not necessary. -/
+theorem revoke_retracts_exactly {pre post : DiscoveryState} {tomb : Membership}
+    (_hwf : pre.wellFormed) (hsig : adminSignedMembership tomb pre.network)
+    (hrev : tomb.active = false) (h : post = revokeState pre tomb) :
+    deriveMaterializable post =
+      (deriveMaterializable pre).filter (fun p =>
+        ∃ ep ∈ pre.endpoints,
+          ep.did ≠ tomb.memberDid ∧ ep.peer = p ∧ materializableEndpoint ep pre) := by
+  subst h
+  ext p
+  rw [Finset.mem_filter, mem_deriveMaterializable]
+  -- revokeState only edits memberships, so endpoints/self are shared with pre.
+  have hendpoints : (revokeState pre tomb).endpoints = pre.endpoints := rfl
+  constructor
+  · -- p materialized in post ⇒ via an endpoint with did ≠ tomb.memberDid, which is
+    -- then also materializable in pre, so p ∈ pre-derivation AND satisfies the filter.
+    rintro ⟨ep, hep_mem, hmat_post, hpeer⟩
+    rw [hendpoints] at hep_mem
+    -- ep.did ≠ tomb.memberDid, else it couldn't be materializable in post.
+    have hdid : ep.did ≠ tomb.memberDid := by
+      intro hdid_eq
+      exact revoked_did_not_materializable hsig hrev hdid_eq hmat_post
+    have hmat_pre : materializableEndpoint ep pre :=
+      (unrevoked_did_materializable_iff hdid).mp hmat_post
+    refine ⟨?_, ep, hep_mem, hdid, hpeer, hmat_pre⟩
+    rw [mem_deriveMaterializable]
+    exact ⟨ep, hep_mem, hmat_pre, hpeer⟩
+  · -- The filter side gives an endpoint with did ≠ tomb.memberDid materializable in
+    -- pre; it survives revoke, so p is materialized in post.
+    rintro ⟨_, ep, hep_mem, hdid, hpeer, hmat_pre⟩
+    refine ⟨ep, ?_, ?_, hpeer⟩
+    · rw [hendpoints]; exact hep_mem
+    · exact (unrevoked_did_materializable_iff hdid).mpr hmat_pre
+
+/-- Witness for O3 covering BOTH cases. Case (a) distinct peers: members A and B
+announce different peers; revoking A drops A's peer but keeps B's. Case (b) shared
+peer: A and B both announce the SAME peer `p`; revoking A leaves `p` materialized
+via B. The shared-peer case is the one that pins "exclusively". -/
+theorem revoke_retracts_exactly_witness :
+    ∃ (pre : DiscoveryState) (tomb : Membership),
+      pre.wellFormed ∧ adminSignedMembership tomb pre.network ∧ tomb.active = false ∧
+      -- (a) distinct peers: A's peer drops, B's stays.
+      ("peer-a" ∉ deriveMaterializable (revokeState pre tomb) ∧
+       "peer-b" ∈ deriveMaterializable (revokeState pre tomb)) ∧
+      -- (b) shared peer: also materialized via B, so it STAYS after revoking A.
+      "peer-shared" ∈ deriveMaterializable (revokeState pre tomb) := by
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let memA : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", true⟩
+  let memB : Membership := ⟨"net-1", "did:key:b", true, "did:key:admin", true⟩
+  -- A announces peer-a and peer-shared; B announces peer-b and peer-shared.
+  let epA : Endpoint := ⟨"did:key:a", "peer-a", true, true⟩
+  let epAshared : Endpoint := ⟨"did:key:a", "peer-shared", true, true⟩
+  let epB : Endpoint := ⟨"did:key:b", "peer-b", true, true⟩
+  let epBshared : Endpoint := ⟨"did:key:b", "peer-shared", true, true⟩
+  -- The tombstone: revoke A.
+  let tomb : Membership := ⟨"net-1", "did:key:a", false, "did:key:admin", true⟩
+  let pre : DiscoveryState :=
+    { self := "peer-self"
+    , network := network
+    , memberships := {memA, memB}
+    , endpoints := {epA, epAshared, epB, epBshared}
+    , requests := ∅
+    , operatorDesired := ∅
+    , registryDesired := ∅
+    , consumedNonces := ∅ }
+  -- Every conjunct is a decidable proposition over fully-concrete finsets
+  -- (`wellFormed`, `adminSignedMembership`, and three `deriveMaterializable`
+  -- membership facts all have `Decidable` instances), so `decide` discharges the
+  -- entire witness once the existential is instantiated.
+  refine ⟨pre, tomb, ?_⟩
+  decide
+
+/-! ### O5 — a grant requires an admin signature
+
+The only membership-creating transition is `approveRequest`, which demands
+`adminSignedMembership m pre.network`. (`revoke` also adds a row — the tombstone —
+which is admin-signed by its own precondition.) A forged/unsigned join request
+alone produces no membership. -/
+
+/-- **O5 (grant requires admin signature).** If a transition adds a membership row
+`m` (`m ∈ post.memberships`, `m ∉ pre.memberships`), then `m` is admin-signed for
+the pre-state network. So no transition can introduce an unsigned grant: a forged
+or unsigned join request cannot produce a membership.
+
+Non-vacuous: the hypothesis (a transition that genuinely adds a fresh membership)
+is realized by `approveRequest`/`revoke`; the negative witness
+`membership_grant_requires_admin_signature_witness` shows a `submitRequest` with
+`reqSigValid = false` adds NO membership, confirming a candidate request alone
+cannot grant. The conclusion is a real consequence: the only membership-adding
+cases (`approveRequest`, `revoke`) carry `adminSignedMembership` as a precondition;
+all others are refuted by the disjoint `hnew`/`hold` hypotheses. -/
+theorem membership_grant_requires_admin_signature {pre post : DiscoveryState}
+    (h : Transition pre post) {m : Membership}
+    (hnew : m ∈ post.memberships) (hold : m ∉ pre.memberships) :
+    adminSignedMembership m pre.network := by
+  cases h with
+  | derive h_post =>
+      subst h_post; unfold deriveStep at hnew; exact absurd hnew hold
+  | join tok tofu _ h_post =>
+      subst h_post; unfold joinState at hnew; exact absurd hnew hold
+  | reciprocalJoin tok tofu _ h_post =>
+      subst h_post; unfold joinState at hnew; exact absurd hnew hold
+  | submitRequest req h_post =>
+      subst h_post; unfold submitRequestState at hnew; exact absurd hnew hold
+  | approveRequest req m' _ _ _ hadminsig _ _ h_post =>
+      -- post adds m' via upsert; a "new" row in post is the inserted m' (filter only removes).
+      subst h_post
+      unfold approveMembershipState upsertMembership at hnew
+      rw [Finset.mem_insert, Finset.mem_filter] at hnew
+      rcases hnew with rfl | ⟨hmem, _⟩
+      · exact hadminsig
+      · exact absurd hmem hold
+  | revoke tomb hadminsig _ h_post =>
+      subst h_post
+      unfold revokeState upsertMembership at hnew
+      rw [Finset.mem_insert, Finset.mem_filter] at hnew
+      rcases hnew with rfl | ⟨hmem, _⟩
+      · exact hadminsig
+      · exact absurd hmem hold
+  | operatorWrite d h_post =>
+      subst h_post; unfold operatorWriteState at hnew; exact absurd hnew hold
+
+/-- Negative witness for O5: a `submitRequest` transition (even with an invalid
+request signature) leaves `memberships` unchanged, so it adds NO new membership —
+a candidate request alone never grants. Realizes the "forged/unsigned request"
+scenario and confirms the only grant path is an admin-signed `approveRequest`. -/
+theorem membership_grant_requires_admin_signature_witness :
+    ∃ (pre post : DiscoveryState) (req : JoinRequest),
+      req.reqSigValid = false ∧ Transition pre post ∧
+      post.memberships = pre.memberships := by
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let pre : DiscoveryState :=
+    { self := "peer-self"
+    , network := network
+    , memberships := ∅
+    , endpoints := ∅
+    , requests := ∅
+    , operatorDesired := ∅
+    , registryDesired := ∅
+    , consumedNonces := ∅ }
+  -- A forged/unsigned join request.
+  let req : JoinRequest := ⟨"net-1", "did:key:forger", false⟩
+  refine ⟨pre, submitRequestState pre req, req, rfl,
+    Transition.submitRequest req rfl, ?_⟩
+  unfold submitRequestState
+  rfl
+
 end PeerRegistryDiscovery

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Derivation.lean
@@ -242,6 +242,80 @@ theorem reciprocal_join_rejected_witness :
     ∃ tok : Token, tok.sigValid = false := by
   exact ⟨⟨"did:key:x", false, "nonce-x"⟩, rfl⟩
 
+/-! ## Join-gate leaf theorems (the "non-member rejected" guarantee)
+
+These two leaves make the `Transition.lean` docstring claim — "non-member invite
+rejected is a theorem, not prose" — literally true against the live
+`signedByMember`/`admitsJoin` gate, and are the live symbols the conformance
+module cites. -/
+
+/-- **Non-member invite rejected.** On the membership/registry arm (no TOFU
+bootstrap, `tofuBootstrap = false`), a token whose signature is invalid OR whose
+issuer is not an admitted member is NOT signed-by-member: `signedByMember` fails.
+So a non-member's invite (or a forged one) cannot be admitted through the
+membership arm — exactly the property `join_gate_rejects_non_live_member_when_registry_nonempty`
+exercises.
+
+Non-vacuous: the hypothesis (`tok.sigValid = false ∨ ¬ admittedMember tok.issuer s`)
+is realizable (e.g. a token issued by a non-member of a populated network), and the
+conclusion is a genuine consequence — `signedByMember` with `tofuBootstrap = false`
+requires BOTH `sigValid` and `admittedMember` (the bootstrap disjunct is
+unavailable when the flag is off), so failing either kills it. The positive case
+(an actual admitted member IS admitted) is witnessed by `replay_rejected_witness`,
+so this is not vacuously "everything is rejected". -/
+theorem non_member_invite_rejected {tok : Token} {s : DiscoveryState}
+    (h : tok.sigValid = false ∨ ¬ admittedMember tok.issuer s) :
+    ¬ signedByMember tok s false := by
+  rintro ⟨hsig, harm⟩
+  rcases h with hbad | hnm
+  · rw [hbad] at hsig; exact Bool.false_ne_true hsig
+  · rcases harm with hadm | ⟨htofu, _, _⟩
+    · exact hnm hadm
+    · exact Bool.false_ne_true htofu
+
+/-- **No join without an admissible token.** A `Transition.join` step from `pre`
+to `post` of `tok`/`tofu` (i.e. `h` equals *some* application of the `join`
+constructor on those arguments) implies `admitsJoin pre tok tofu` held. The plain
+`join` analogue of `reciprocal_join_still_gated`: the admission proof is the
+constructor's own precondition, pulled back out — it is NOT handed in as a free
+fact, so the conclusion genuinely rides on the constructor having been firable.
+
+Non-vacuous: `no_join_without_admissible_token_witness` exhibits a concrete join
+transition whose hypothesis holds, so the implication is not vacuously true. -/
+theorem no_join_without_admissible_token {pre post : DiscoveryState}
+    {tok : Token} {tofu : Bool}
+    (h : Transition pre post)
+    (h_is_join :
+      ∃ (hadm : admitsJoin pre tok tofu) (hpost : post = joinState pre tok),
+        h = Transition.join tok tofu hadm hpost) :
+    admitsJoin pre tok tofu :=
+  h_is_join.choose
+
+/-- Witness that `no_join_without_admissible_token`'s hypothesis space is
+inhabited: a concrete join transition that IS admissible (fresh, member-signed
+token). Without this the gating theorem could be vacuous. -/
+theorem no_join_without_admissible_token_witness :
+    ∃ (pre post : DiscoveryState) (tok : Token) (tofu : Bool),
+      Transition pre post ∧ admitsJoin pre tok tofu := by
+  let network : Network := ⟨"net-1", "did:key:admin", true⟩
+  let membership : Membership := ⟨"net-1", "did:key:a", true, "did:key:admin", true⟩
+  let pre : DiscoveryState :=
+    { self := "peer-self"
+    , network := network
+    , memberships := {membership}
+    , endpoints := ∅
+    , requests := ∅
+    , operatorDesired := ∅
+    , registryDesired := ∅
+    , consumedNonces := ∅ }
+  let tok : Token := ⟨"did:key:a", true, "nonce-1"⟩
+  have hadm : admitsJoin pre tok false := by
+    refine ⟨⟨rfl, Or.inl ?_⟩, Finset.not_mem_empty _⟩
+    refine ⟨rfl, membership, Finset.mem_singleton_self membership, rfl, rfl, ?_⟩
+    exact ⟨rfl, rfl, rfl⟩
+  exact ⟨pre, joinState pre tok, tok, false,
+    Transition.join tok false hadm rfl, hadm⟩
+
 /-- Replay rejection extends to reciprocal joins for free: a reciprocal join
 applies the same `joinState` mutator, so it burns the nonce identically and the
 same token can never be re-admitted (by any subsequent join OR reciprocal join).

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Executable.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Executable.lean
@@ -35,7 +35,9 @@ theorem fromContract_toContract (phase : DiscoveryPhase) :
 
 end DiscoveryPhase
 
-/-- Stringly-typed transition kinds emitted by the discovery reconciler. -/
+/-- Stringly-typed transition kinds emitted by the discovery reconciler. One
+constructor per `Transition` constructor (`derive`, `join`, `reciprocalJoin`,
+`submitRequest`, `approveRequest`, `revoke`, `operatorWrite`). -/
 inductive TransitionKind where
   | derive
   | join
@@ -44,7 +46,9 @@ inductive TransitionKind where
   distinct kind so the Rust bridge cannot route a reciprocal join down a path
   that skips `decideAdmitsJoin` — it shares `join`'s admission decision. -/
   | reciprocalJoin
-  | removeEntry
+  | submitRequest
+  | approveRequest
+  | revoke
   | operatorWrite
   deriving DecidableEq, Repr
 
@@ -54,7 +58,9 @@ def fromString? : String → Option TransitionKind
   | "derive" => some .derive
   | "join" => some .join
   | "reciprocalJoin" => some .reciprocalJoin
-  | "removeEntry" => some .removeEntry
+  | "submitRequest" => some .submitRequest
+  | "approveRequest" => some .approveRequest
+  | "revoke" => some .revoke
   | "operatorWrite" => some .operatorWrite
   | _ => none
 
@@ -62,7 +68,9 @@ def toString : TransitionKind → String
   | .derive => "derive"
   | .join => "join"
   | .reciprocalJoin => "reciprocalJoin"
-  | .removeEntry => "removeEntry"
+  | .submitRequest => "submitRequest"
+  | .approveRequest => "approveRequest"
+  | .revoke => "revoke"
   | .operatorWrite => "operatorWrite"
 
 theorem fromString_toString (k : TransitionKind) :
@@ -72,13 +80,16 @@ theorem fromString_toString (k : TransitionKind) :
 end TransitionKind
 
 /-- Executable coarse transition relation for conformance extraction. A derive
-step settles; a registry edit (join/removeEntry) unsettles the derived view;
-an operator write leaves the derived view as-is. -/
+step settles; any membership/request edit (join, reciprocalJoin, submitRequest,
+approveRequest, revoke) unsettles the derived view; an operator write leaves the
+derived view as-is. -/
 def step? : DiscoveryPhase → TransitionKind → Option DiscoveryPhase
   | _, .derive => some .settled
   | _, .join => some .unsettled
   | _, .reciprocalJoin => some .unsettled
-  | _, .removeEntry => some .unsettled
+  | _, .submitRequest => some .unsettled
+  | _, .approveRequest => some .unsettled
+  | _, .revoke => some .unsettled
   | phase, .operatorWrite => some phase
 
 /-! ## Executable join-admission decision (mirrors Rust `decide_join_admission`)
@@ -102,5 +113,35 @@ theorem decideAdmitsJoin_agrees (s : DiscoveryState) (tok : Token) (tofuBootstra
     decideAdmitsJoin s tok tofuBootstrap = true ↔ admitsJoin s tok tofuBootstrap := by
   unfold decideAdmitsJoin
   exact decide_eq_true_iff
+
+/-! ## Executable membership / derivation decisions
+
+The Rust bridge also decides, with single booleans, whether a network's admin
+self-attestation verifies, whether a DID is an admitted member, and whether an
+endpoint is materializable. These mirror the corresponding Props, each fenced by
+an `_agrees` lemma so the executable decision and the relation cannot diverge. -/
+
+/-- The network record's admin self-attestation verifies. -/
+def decideValidNetwork (n : Network) : Bool := n.adminSigValid
+
+/-- A DID is an admitted member of `s`'s network. -/
+def decideAdmittedMember (did : Did) (s : DiscoveryState) : Bool := decide (admittedMember did s)
+
+/-- An endpoint the derivation materializes. -/
+def decideMaterializable (ep : Endpoint) (s : DiscoveryState) : Bool := decide (materializableEndpoint ep s)
+
+/-- `decideValidNetwork` agrees with the `validNetwork` predicate. -/
+theorem decideValidNetwork_agrees (n : Network) :
+    decideValidNetwork n = true ↔ validNetwork n := by
+  unfold decideValidNetwork validNetwork
+  exact Iff.rfl
+
+theorem decideAdmittedMember_agrees (did) (s) :
+    decideAdmittedMember did s = true ↔ admittedMember did s := by
+  unfold decideAdmittedMember; exact decide_eq_true_iff
+
+theorem decideMaterializable_agrees (ep) (s) :
+    decideMaterializable ep s = true ↔ materializableEndpoint ep s := by
+  unfold decideMaterializable; exact decide_eq_true_iff
 
 end PeerRegistryDiscovery

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/State.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/State.lean
@@ -7,30 +7,34 @@ import Mathlib.Data.Finset.Image
 # Peer Registry Discovery — State
 
 Service-discovery derivation that sits *above* the proven `PairingReconcile`
-machine. A replicated `PeerRegistry` (one self-registered row per node) is read
-by a discovery step which **materializes registry-owned `PeerPairingDesired`
-rows**; the existing pairing reconciler then wires them, unchanged.
+machine. Instead of self-asserted registry rows, the desired peer set is derived
+from a **signed network-membership** world: a `Network` with an admin DID, a set
+of admin-signed `Membership` rows, a global set of member-signed `Endpoint`
+announcements, and pending `JoinRequest`s. A discovery step **materializes
+network-owned `PeerPairingDesired` rows**; the existing pairing reconciler then
+wires them, unchanged.
 
 ## Ownership representation (the deliverable that binds R5's Rust schema)
 
-The desired peer set is a union of **operator-owned** and **registry-owned**
-rows. We model ownership as **two separate finsets** (`operatorDesired` /
-`registryDesired`) rather than a `source : Owner` tag on each row.
+The desired peer set is a union of **operator-owned** and **network-owned** rows.
+We model ownership as **two separate finsets** (`operatorDesired` /
+`registryDesired`) rather than a `source : Owner` tag on each row. (The name
+`registryDesired` is kept to limit churn; it now means "network-derived".)
 
 **Why two finsets, not a tag.** Every ownership obligation in this model is a
 statement about the *operator partition only* — "no derivation step mutates an
-operator-owned row" (`ownership_safe`) and "retracting a registry entry removes
-exactly its registry-owned rows, no others" (`retraction_sound`). With two
+operator-owned row" (`ownership_safe`) and "retracting a membership removes
+exactly its network-owned rows, no others" (`retraction_sound`). With two
 finsets those are `rfl`-shaped facts: the derivation rewrites `registryDesired`
 and never names `operatorDesired`, so operator-invariance is definitional and
 discharged by `cases`/`simp`, not by a per-row `filter`/`source = operator`
 side-condition that every theorem would have to thread. A `source` tag would
 force every ownership lemma to reason about a `Finset.filter (·.source = …)`
-projection and to carry "the operator never wrote a row tagged registry"
+projection and to carry "the operator never wrote a row tagged network"
 well-formedness hypotheses — strictly more proof surface for the same content.
 The disjoint-union *is* the invariant, so we make it structural.
 
-**Binding consequence for R5.** The Rust schema should keep registry-owned
+**Binding consequence for R5.** The Rust schema should keep network-owned
 desired rows in a record distinct from operator-authored rows (a parallel
 applied-style table / `source` discriminator that is *queried as a partition*),
 mirroring the `PeerPairingApplied` ownership pattern — NOT an in-place mutable
@@ -48,43 +52,100 @@ v2 signed `InviteToken`; the model only needs to compare equality and track whic
 ones have been consumed, so a `String` is enough. -/
 abbrev Nonce := String
 
-/-- One self-registered registry row. `live` folds the heartbeat-freshness and
-`status` hint that the runtime computes into a single observed-liveness bit
-(the reader derives effective liveness from `updated_at` age; the model takes
-that decision as given). -/
-structure RegistryEntry where
-  peer : PeerId
-  did : Did
-  live : Bool
+abbrev NetworkId := String
+
+/-- A network, identified by `networkId`, governed by a single admin DID. The
+`adminSigValid` bit records whether the admin's self-attestation of the network
+record verifies; a network whose admin signature does not verify can authorize
+nothing. -/
+structure Network where
+  networkId : NetworkId
+  adminDid  : Did
+  adminSigValid : Bool
   deriving DecidableEq, Repr
 
-/-- The replicated discovery registry: a set of rows. Keyed conceptually on
-`peer`; the model does not assume uniqueness, and the derivation is correct
-regardless (it is a pure image-filter over the set). -/
-abbrev Registry := Finset RegistryEntry
+/-- A membership row: a claim that `memberDid` is a member of `networkId`. It is
+**only** authoritative when `signedBy` is this network's admin DID *and*
+`adminSigValid` is true — together those two facts mean "signed by this network's
+admin". `active` is the admin's revocation bit. A `Membership` is what admits a
+DID into a network; nothing else does. -/
+structure Membership where
+  networkId : NetworkId
+  memberDid : Did
+  active    : Bool
+  signedBy  : Did
+  adminSigValid : Bool
+  deriving DecidableEq, Repr
 
-/-- Registry-owned desired peer set = live entries that are not self.
+/-- An endpoint announcement: node `did` is reachable at `peer`. Endpoints are
+**GLOBAL per-node**, not network-scoped — a node announces one address regardless
+of how many networks it belongs to. `fresh` is the heartbeat-freshness bit (the
+reader derives effective liveness from `updated_at` age; the model takes that
+decision as given). `memberSigValid` records that the announcement is signed by
+the node itself; an endpoint with an invalid member signature is ignored. -/
+structure Endpoint where
+  did   : Did
+  peer  : PeerId
+  fresh : Bool
+  memberSigValid : Bool
+  deriving DecidableEq, Repr
 
-This is the pure derivation `registry → desiredₘ`. It is a function of the
-registry alone, which is what makes convergence immediate (see `Derivation`). -/
-def deriveRegistryDesired (self : PeerId) (reg : Registry) : Finset PeerId :=
-  (reg.filter (fun e => e.live = true ∧ e.peer ≠ self)).image RegistryEntry.peer
+/-- A pending request to join `networkId`. `reqSigValid` records whether the
+candidate's request signature verifies. A `JoinRequest` alone NEVER creates a
+membership — it is an input to an admin decision, not an admission. Only the
+admin writing a signed `Membership` admits the candidate. -/
+structure JoinRequest where
+  networkId    : NetworkId
+  candidateDid : Did
+  reqSigValid  : Bool
+  deriving DecidableEq, Repr
 
 /-- Full discovery state. Ownership is a *structural partition*: operator-owned
-desired rows and registry-owned desired rows are distinct finsets. The discovery
+desired rows and network-owned desired rows are distinct finsets. The discovery
 step only ever rewrites `registryDesired`. -/
 structure DiscoveryState where
   self : PeerId
-  registry : Registry
+  network : Network
+  memberships : Finset Membership
+  endpoints : Finset Endpoint
+  requests : Finset JoinRequest
   /-- Operator-authored desired peers. The discovery step NEVER touches these. -/
   operatorDesired : Finset PeerId
-  /-- Registry-derived desired peers, owned by the discovery step. -/
+  /-- Network-derived desired peers, owned by the discovery step. (Name kept from
+  the prior registry model to limit churn.) -/
   registryDesired : Finset PeerId
   /-- Nonces of invite tokens already redeemed by a join. A join is admitted only
   if its token's nonce is NOT in this set; the join inserts it, so the same token
   cannot be redeemed twice (single-use enforcement — see `replay_rejected`). -/
   consumedNonces : Finset Nonce
   deriving DecidableEq
+
+/-- Well-formedness: at most one membership per `(networkId, memberDid)`. The
+admin maintains a single authoritative membership row per (network, member); the
+model carries this as an explicit invariant rather than a keyed map. -/
+def DiscoveryState.wellFormed (s : DiscoveryState) : Prop :=
+  ∀ m₁ ∈ s.memberships, ∀ m₂ ∈ s.memberships,
+    m₁.networkId = m₂.networkId → m₁.memberDid = m₂.memberDid → m₁ = m₂
+
+instance (s : DiscoveryState) : Decidable s.wellFormed := by
+  unfold DiscoveryState.wellFormed
+  infer_instance
+
+/-- Network-owned desired peer set = endpoints that are fresh, self-signed, not
+self, and whose announcing DID has an **active, admin-signed membership** in this
+network. The membership carries the network scope; the endpoint stays global.
+
+This is the pure derivation `(network, memberships, endpoints) → desiredₘ`. It is
+a function of the membership world alone, which is what makes convergence
+immediate (see `Derivation`). -/
+def deriveMaterializable (s : DiscoveryState) : Finset PeerId :=
+  (s.endpoints.filter (fun ep =>
+      ep.fresh = true ∧ ep.memberSigValid = true ∧ ep.peer ≠ s.self ∧
+      s.network.adminSigValid = true ∧
+      (s.memberships.filter (fun m =>
+        m.memberDid = ep.did ∧ m.active = true ∧
+        m.adminSigValid = true ∧ m.signedBy = s.network.adminDid ∧
+        m.networkId = s.network.networkId)).Nonempty)).image Endpoint.peer
 
 namespace DiscoveryState
 
@@ -93,11 +154,11 @@ ownership partitions. -/
 def effectiveDesired (s : DiscoveryState) : Finset PeerId :=
   s.operatorDesired ∪ s.registryDesired
 
-/-- A discovery state is *settled* when its registry-owned rows already equal
-the derivation of its registry. (Operator rows are out of scope: the discovery
-step has no opinion on them.) -/
+/-- A discovery state is *settled* when its network-owned rows already equal the
+derivation of its membership world. (Operator rows are out of scope: the
+discovery step has no opinion on them.) -/
 def settled (s : DiscoveryState) : Prop :=
-  s.registryDesired = deriveRegistryDesired s.self s.registry
+  s.registryDesired = deriveMaterializable s
 
 instance (s : DiscoveryState) : Decidable s.settled := by
   unfold settled
@@ -105,7 +166,7 @@ instance (s : DiscoveryState) : Decidable s.settled := by
 
 /-- Canonical settled state: run the derivation once. -/
 def settle (s : DiscoveryState) : DiscoveryState :=
-  { s with registryDesired := deriveRegistryDesired s.self s.registry }
+  { s with registryDesired := deriveMaterializable s }
 
 theorem settle_settled (s : DiscoveryState) : (settle s).settled := by
   unfold settled settle

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Transition.lean
@@ -3,117 +3,210 @@ import Proofs.PeerRegistryDiscovery.State
 /-!
 # Peer Registry Discovery — Transitions
 
-The discovery step is the only mutator of the registry-owned partition. It
-materializes registry-owned desired rows by running the pure derivation; it
-never touches the operator partition. Registry edits (a member appearing, a
-member staling/leaving) and operator edits are also modeled so the ownership
-and retraction theorems are quantified over *every* legal step.
+The discovery step is the only mutator of the network-owned partition. It
+materializes network-owned desired rows by running the pure derivation
+(`deriveMaterializable`); it never touches the operator partition. Membership
+edits (an admin admitting or revoking a member), join-request submissions, and
+operator edits are also modeled so the ownership and retraction theorems are
+quantified over *every* legal step.
 
-A `Join` transition (a node entering the registry's trust set) is gated by a
+A `join` transition (a node redeeming a single-use invite) is gated by a
 signature predicate so "non-member invite rejected" is a theorem, not prose.
+
+## Why these predicates
+
+The membership world is signed end-to-end. Five predicates name the trust
+conditions the derivation depends on, so that the obligation theorems in later
+tasks can quantify over them rather than re-spell the conjunctions:
+
+* `validNetwork` — the network record's admin self-attestation verifies.
+* `adminSignedMembership` — a membership row is signed by *this* network's admin.
+* `memberSignedEndpoint` — an endpoint announcement is self-signed and fresh.
+* `admittedMember` — a DID has an active, admin-signed membership in a valid
+  network (the predicate-level twin of `deriveMaterializable`'s `Nonempty` arm).
+* `materializableEndpoint` — an endpoint that the derivation materializes.
 -/
 
 namespace PeerRegistryDiscovery
 
-/-! ## Signed-invite authorization (abstract) -/
+/-! ## Membership / endpoint trust predicates -/
+
+/-- The network record's admin self-attestation verifies. A network whose admin
+signature does not verify can authorize nothing. -/
+def validNetwork (n : Network) : Prop := n.adminSigValid = true
+
+instance (n : Network) : Decidable (validNetwork n) := by
+  unfold validNetwork
+  infer_instance
+
+/-- A membership row is authoritative for `n`: signed by `n`'s admin (matching
+`signedBy` and a verifying `adminSigValid`) and scoped to `n`'s network id. -/
+def adminSignedMembership (m : Membership) (n : Network) : Prop :=
+  m.adminSigValid = true ∧ m.signedBy = n.adminDid ∧ m.networkId = n.networkId
+
+instance (m : Membership) (n : Network) : Decidable (adminSignedMembership m n) := by
+  unfold adminSignedMembership
+  infer_instance
+
+/-- An endpoint announcement is self-signed by the announcing node and fresh
+(heartbeat within window). An endpoint failing either bit is ignored. -/
+def memberSignedEndpoint (ep : Endpoint) : Prop :=
+  ep.memberSigValid = true ∧ ep.fresh = true
+
+instance (ep : Endpoint) : Decidable (memberSignedEndpoint ep) := by
+  unfold memberSignedEndpoint
+  infer_instance
+
+/-- `did` is an admitted member of `s`'s network: the network is valid and there
+is an active membership row for `did` signed by the network's admin. This is the
+predicate-level twin of the `Nonempty`-of-filtered-memberships arm of
+`deriveMaterializable`. -/
+def admittedMember (did : Did) (s : DiscoveryState) : Prop :=
+  validNetwork s.network ∧
+    ∃ m ∈ s.memberships, m.memberDid = did ∧ m.active = true ∧
+      adminSignedMembership m s.network
+
+instance (did : Did) (s : DiscoveryState) : Decidable (admittedMember did s) := by
+  unfold admittedMember adminSignedMembership validNetwork
+  infer_instance
+
+/-- An endpoint the derivation materializes: its announcing DID is an admitted
+member, the announcement is member-signed and fresh, and it is not self. -/
+def materializableEndpoint (ep : Endpoint) (s : DiscoveryState) : Prop :=
+  admittedMember ep.did s ∧ memberSignedEndpoint ep ∧ ep.peer ≠ s.self
+
+instance (ep : Endpoint) (s : DiscoveryState) : Decidable (materializableEndpoint ep s) := by
+  unfold materializableEndpoint admittedMember adminSignedMembership validNetwork
+    memberSignedEndpoint
+  infer_instance
+
+/-! ## Bridge: predicate ↔ derivation
+
+`deriveMaterializable` is the executable derivation; `materializableEndpoint` is
+its declarative spec. This lemma links them so the obligation theorems can be
+stated against the predicate and discharged against the derivation. -/
+
+/-- A peer is in the derived network-owned set iff some endpoint announcing it is
+`materializableEndpoint`. The proof reconciles `admittedMember`'s
+`∃ m ∈ memberships, …` with `deriveMaterializable`'s `(memberships.filter …).Nonempty`:
+membership in the filtered finset is exactly that existential. -/
+theorem mem_deriveMaterializable {s : DiscoveryState} {p : PeerId} :
+    p ∈ deriveMaterializable s ↔
+      ∃ ep ∈ s.endpoints, materializableEndpoint ep s ∧ ep.peer = p := by
+  unfold deriveMaterializable
+  rw [Finset.mem_image]
+  constructor
+  · rintro ⟨ep, hep_filt, hpeer⟩
+    rw [Finset.mem_filter] at hep_filt
+    obtain ⟨hep_mem, hfresh, hsig, hself, hadmin, hne⟩ := hep_filt
+    refine ⟨ep, hep_mem, ?_, hpeer⟩
+    refine ⟨⟨hadmin, ?_⟩, ⟨hsig, hfresh⟩, hself⟩
+    obtain ⟨m, hm_filt⟩ := hne
+    rw [Finset.mem_filter] at hm_filt
+    obtain ⟨hm_mem, hmdid, hmactive, hmadminsig, hmsignedby, hmnet⟩ := hm_filt
+    exact ⟨m, hm_mem, hmdid, hmactive, hmadminsig, hmsignedby, hmnet⟩
+  · rintro ⟨ep, hep_mem, ⟨⟨hadmin, m, hm_mem, hmdid, hmactive, hmadminsig, hmsignedby, hmnet⟩,
+      ⟨hsig, hfresh⟩, hne⟩, hpeer⟩
+    refine ⟨ep, ?_, hpeer⟩
+    rw [Finset.mem_filter]
+    refine ⟨hep_mem, hfresh, hsig, hne, hadmin, ?_⟩
+    refine ⟨m, ?_⟩
+    rw [Finset.mem_filter]
+    exact ⟨hm_mem, hmdid, hmactive, hmadminsig, hmsignedby, hmnet⟩
+
+/-! ## Signed-invite authorization (abstract)
+
+A join redeems a single-use invite. The model needs the token's issuer (to check
+it is an admitted member), whether its signature verifies, and its nonce (to make
+the freshness window single-use). -/
 
 /-- Opaque invite token. Concretely a v2 signed `InviteToken`; the model only
-needs its issuer and whether its signature verifies.
+needs its issuer, whether its signature verifies, and its single-use nonce.
 
 SCOPE: the token carries no *invitee* field. It authorizes WHETHER a join may
-happen (a live member sanctioned it), not WHICH identity is admitted — see
-`Transition.join`. This matches the trusted-fleet TOFU model where the admitted
-entry is self-asserted; binding the inserted entry to a token-authorized invitee
-would require adding an `invitee` field here (and to the wire `InviteToken`) and
-is deliberately out of scope. -/
+happen (an admitted member sanctioned it), not WHICH identity is admitted. -/
 structure Token where
   issuer : Did
   /-- The signature over the canonical payload verifies against `issuer`'s
   `did:key`. A forged/absent signature is `false`. -/
   sigValid : Bool
   /-- The token's single-use nonce. Two redemptions of the *same* physical invite
-  carry the same nonce; the join admission rejects a nonce already in
-  `consumedNonces`, which is what makes the freshness window single-use rather
-  than merely time-bounded. -/
+  carry the same nonce; join admission rejects a nonce already in
+  `consumedNonces`, which makes the freshness window single-use. -/
   nonce : Nonce
   deriving DecidableEq, Repr
 
-/-- `issuer` is a live member of the registry. This is the registry-checked
-arm of the join policy. -/
-def isMember (issuer : Did) (reg : Registry) : Prop :=
-  ∃ e ∈ reg, e.did = issuer ∧ e.live = true
+/-- The network has an admitted member OTHER than `self`. The TOFU bootstrap arm
+is only legitimate when this is false: an empty membership set has no peer trust
+set to check an invite against. Without this guard `tofuBootstrap` would be a free
+flag bypassing the membership check on a populated network. -/
+def hasPeerMember (s : DiscoveryState) : Prop :=
+  ∃ ep ∈ s.endpoints, admittedMember ep.did s ∧ ep.peer ≠ s.self
 
-instance (issuer : Did) (reg : Registry) : Decidable (isMember issuer reg) := by
-  unfold isMember
-  infer_instance
-
-/-- The registry holds a live member OTHER than `self`. The TOFU bootstrap arm is
-only legitimate when this is false: an empty registry — or one holding only this
-node's own self-registration row — has no peer trust set to check an invite
-against. Without this guard `tofuBootstrap` would be a free flag a caller could
-set to bypass `isMember` on a populated registry, draining the membership check.
-Self is identified by `peer` here (the model's convention, matching
-`deriveRegistryDesired`'s self-exclusion); the Rust `decide_join_admission`
-excludes self by DID — the same intent under the per-node peer↔did identity. -/
-def hasPeerMember (reg : Registry) (self : PeerId) : Prop :=
-  ∃ e ∈ reg, e.live = true ∧ e.peer ≠ self
-
-instance (reg : Registry) (self : PeerId) : Decidable (hasPeerMember reg self) := by
-  unfold hasPeerMember
+instance (s : DiscoveryState) : Decidable (hasPeerMember s) := by
+  unfold hasPeerMember admittedMember adminSignedMembership validNetwork
   infer_instance
 
 /-- Admission predicate on a join. Authorized iff the token's signature verifies
-AND either (registry-checked arm) the issuer is a live member, or (TOFU bootstrap
-arm) the bootstrap flag is set AND the registry has no peer members besides
-`self`. The bootstrap conjunct with `¬ hasPeerMember` is what stops the flag from
-bypassing `isMember` on a populated registry. At runtime the bootstrap bit is not
-attacker-chosen: it is computed from registry state by the conformance-fenced
-`decide_join_admission` (Rust), which takes the bootstrap arm only when no peer
-members exist. -/
-def signedByMember (tok : Token) (reg : Registry) (self : PeerId) (tofuBootstrap : Bool) : Prop :=
+AND either (membership-checked arm) the issuer is an admitted member, or (TOFU
+bootstrap arm) the bootstrap flag is set AND the network has no memberships yet.
+The bootstrap conjunct (`s.memberships = ∅`) is what stops the flag from bypassing
+the membership check on a populated network. -/
+def signedByMember (tok : Token) (s : DiscoveryState) (tofuBootstrap : Bool) : Prop :=
   tok.sigValid = true ∧
-    (isMember tok.issuer reg ∨ (tofuBootstrap = true ∧ ¬ hasPeerMember reg self))
+    (admittedMember tok.issuer s ∨ (tofuBootstrap = true ∧ s.memberships = ∅))
 
-instance (tok : Token) (reg : Registry) (self : PeerId) (tofuBootstrap : Bool) :
-    Decidable (signedByMember tok reg self tofuBootstrap) := by
-  unfold signedByMember
+instance (tok : Token) (s : DiscoveryState) (tofuBootstrap : Bool) :
+    Decidable (signedByMember tok s tofuBootstrap) := by
+  unfold signedByMember admittedMember adminSignedMembership validNetwork
   infer_instance
 
-/-- Full join admission. Wraps the existing `signedByMember` authorization with
-the single-use freshness check: the token's nonce must not already have been
-redeemed. Deliberately a *wrapper* — `signedByMember` is left intact so the
-existing authorization theorems (`registry_growth_requires_member_signature`,
-`non_member_invite_rejected`, …) keep holding; replay rejection is the strictly
-additional `tok.nonce ∉ s.consumedNonces` conjunct. -/
+/-- Full join admission. Wraps `signedByMember` with the single-use freshness
+check: the token's nonce must not already have been redeemed. -/
 def admitsJoin (s : DiscoveryState) (tok : Token) (tofuBootstrap : Bool) : Prop :=
-  signedByMember tok s.registry s.self tofuBootstrap ∧ tok.nonce ∉ s.consumedNonces
+  signedByMember tok s tofuBootstrap ∧ tok.nonce ∉ s.consumedNonces
 
 instance (s : DiscoveryState) (tok : Token) (tofuBootstrap : Bool) :
     Decidable (admitsJoin s tok tofuBootstrap) := by
-  unfold admitsJoin
+  unfold admitsJoin signedByMember admittedMember adminSignedMembership validNetwork
   infer_instance
 
 /-! ## State mutators -/
 
-/-- Run the derivation: materialize registry-owned rows. Operator rows untouched. -/
+/-- Run the derivation: materialize network-owned rows. Operator rows untouched. -/
 def deriveStep (s : DiscoveryState) : DiscoveryState :=
-  { s with registryDesired := deriveRegistryDesired s.self s.registry }
+  { s with registryDesired := deriveMaterializable s }
 
-/-- A member joins: its self-registered row enters the registry AND the redeemed
-token's nonce is consumed. Gated by `admitsJoin` in the transition relation
-below. Consuming the nonce here (not in a separate step) is what makes the join
-atomic with respect to replay: the very transition that admits `tok` also burns
-`tok.nonce`, so `admitsJoin post tok` can never hold again (see
-`replay_rejected`). -/
-def joinState (s : DiscoveryState) (e : RegistryEntry) (tok : Token) : DiscoveryState :=
-  { s with registry := insert e s.registry
-         , consumedNonces := insert tok.nonce s.consumedNonces }
+/-- Key-based upsert over `(networkId, memberDid)`: drop any existing membership
+for the same key, then insert `m`. This preserves `wellFormed` by construction —
+after the upsert there is at most one row per key — so every membership mutator
+(admit, revoke) routes through it. -/
+def upsertMembership (s : DiscoveryState) (m : Membership) : DiscoveryState :=
+  { s with memberships :=
+      insert m (s.memberships.filter (fun x =>
+        ¬ (x.networkId = m.networkId ∧ x.memberDid = m.memberDid))) }
 
-/-- A registry entry is removed or staled (heartbeat lapsed / deregistered).
-Staling is modeled as removal of the live row; a stale row contributes nothing
-to the derivation, exactly like an absent one. -/
-def removeEntryState (s : DiscoveryState) (e : RegistryEntry) : DiscoveryState :=
-  { s with registry := s.registry.erase e }
+/-- A candidate submits a join request. Pure additive insert into `requests`;
+nothing else moves. A request alone never admits anyone. -/
+def submitRequestState (s : DiscoveryState) (req : JoinRequest) : DiscoveryState :=
+  { s with requests := insert req s.requests }
+
+/-- The admin approves a request by writing a signed membership row. -/
+def approveMembershipState (s : DiscoveryState) (m : Membership) : DiscoveryState :=
+  upsertMembership s m
+
+/-- The admin revokes a membership by writing a tombstone row (`active = false`)
+for the same key. Routed through the same upsert, so the live row is replaced. -/
+def revokeState (s : DiscoveryState) (tomb : Membership) : DiscoveryState :=
+  upsertMembership s tomb
+
+/-- A join redeems a single-use token: consumes the nonce, mutates NOTHING else.
+Consuming the nonce here (not in a separate step) makes the join atomic w.r.t.
+replay — the very transition that admits `tok` burns `tok.nonce`, so
+`admitsJoin post tok` can never hold again. The admitted endpoint is a
+self-asserted announcement (TOFU model); the join itself only burns the nonce. -/
+def joinState (s : DiscoveryState) (tok : Token) : DiscoveryState :=
+  { s with consumedNonces := insert tok.nonce s.consumedNonces }
 
 /-- Operator writes its own desired set. Only the operator partition moves. -/
 def operatorWriteState (s : DiscoveryState) (d : Finset PeerId) : DiscoveryState :=
@@ -122,41 +215,48 @@ def operatorWriteState (s : DiscoveryState) (d : Finset PeerId) : DiscoveryState
 /-! ## Transition relation -/
 
 inductive Transition : DiscoveryState → DiscoveryState → Prop where
-  /-- The discovery reconciler materializes registry-owned rows. -/
+  /-- The discovery reconciler materializes network-owned rows. -/
   | derive {pre post : DiscoveryState} :
       post = deriveStep pre →
       Transition pre post
-  /-- A node joins the trust set. ENABLED ONLY when the invite is signed by a
-  member (or TOFU bootstrap). This is the fenced authorization gate.
-
-  The admitted entry `e` is unconstrained relative to `tok.issuer`: the gate
-  fences WHETHER a join is admitted (a member sanctioned it), not WHICH identity
-  `e` carries. Under the trusted-fleet TOFU model `e` is self-asserted by the
-  joining node; binding `e.did` to a token-authorized invitee is intentionally
-  not modeled (the `Token` has no invitee field — see its docstring). -/
-  | join {pre post : DiscoveryState} (tok : Token) (e : RegistryEntry) (tofuBootstrap : Bool) :
+  /-- A node redeems an invite. ENABLED ONLY when the invite is signed by an
+  admitted member (or TOFU bootstrap) and its nonce is unconsumed. This is the
+  fenced authorization gate; the join burns the nonce. -/
+  | join {pre post : DiscoveryState} (tok : Token) (tofuBootstrap : Bool) :
       admitsJoin pre tok tofuBootstrap →
-      post = joinState pre e tok →
+      post = joinState pre tok →
       Transition pre post
-  /-- A **reciprocal** join: the joiner admits the entry AND wires a return
-  replicator back toward the inviter (`--reciprocal`). The reciprocal flag only
-  changes WHAT gets wired (the return leg), never WHETHER the join is admitted —
-  so its precondition is the SAME `admitsJoin pre tok tofuBootstrap` gate as the
-  plain `join`, and it applies the SAME `joinState` mutator (registry insert +
-  nonce burn). The return-leg wiring lives outside the modeled discovery state
-  (it is a `PairingReconcile`-level replicator edit), so at this layer a
-  reciprocal join is state-indistinguishable from a plain join — by design: the
-  Rust defect this fences was a reciprocal leg that skipped the admission gate,
-  and modeling it through `admitsJoin` is exactly the proof that it cannot.
-
-  See `reciprocal_join_still_gated` / `no_reciprocal_join_without_admissible_token`. -/
-  | reciprocalJoin {pre post : DiscoveryState} (tok : Token) (e : RegistryEntry) (tofuBootstrap : Bool) :
+  /-- A **reciprocal** join: wires a return replicator (`--reciprocal`). The
+  reciprocal flag only changes WHAT gets wired (the return leg, outside this
+  state), never WHETHER the join is admitted — so its precondition is the SAME
+  `admitsJoin` gate and it applies the SAME `joinState` mutator. At this layer a
+  reciprocal join is state-indistinguishable from a plain join, by design: it
+  cannot skip the admission gate. -/
+  | reciprocalJoin {pre post : DiscoveryState} (tok : Token) (tofuBootstrap : Bool) :
       admitsJoin pre tok tofuBootstrap →
-      post = joinState pre e tok →
+      post = joinState pre tok →
       Transition pre post
-  /-- A registry entry stales or is removed. -/
-  | removeEntry {pre post : DiscoveryState} (e : RegistryEntry) :
-      post = removeEntryState pre e →
+  /-- A candidate submits a join request. -/
+  | submitRequest {pre post : DiscoveryState} (req : JoinRequest) :
+      post = submitRequestState pre req →
+      Transition pre post
+  /-- The admin approves a pending, well-signed request whose target network is
+  this one, by writing an active admin-signed membership for the candidate. -/
+  | approveRequest {pre post : DiscoveryState} (req : JoinRequest) (m : Membership) :
+      req ∈ pre.requests →
+      req.reqSigValid = true →
+      req.networkId = pre.network.networkId →
+      adminSignedMembership m pre.network →
+      m.memberDid = req.candidateDid →
+      m.active = true →
+      post = approveMembershipState pre m →
+      Transition pre post
+  /-- The admin revokes a membership by writing an admin-signed tombstone
+  (`active = false`) for the key. -/
+  | revoke {pre post : DiscoveryState} (tomb : Membership) :
+      adminSignedMembership tomb pre.network →
+      tomb.active = false →
+      post = revokeState pre tomb →
       Transition pre post
   /-- The operator edits its own desired set. -/
   | operatorWrite {pre post : DiscoveryState} (d : Finset PeerId) :

--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/Transition.lean
@@ -136,25 +136,29 @@ structure Token where
   nonce : Nonce
   deriving DecidableEq, Repr
 
-/-- The network has an admitted member OTHER than `self`. The TOFU bootstrap arm
-is only legitimate when this is false: an empty membership set has no peer trust
-set to check an invite against. Without this guard `tofuBootstrap` would be a free
-flag bypassing the membership check on a populated network. -/
-def hasPeerMember (s : DiscoveryState) : Prop :=
-  ∃ ep ∈ s.endpoints, admittedMember ep.did s ∧ ep.peer ≠ s.self
-
-instance (s : DiscoveryState) : Decidable (hasPeerMember s) := by
-  unfold hasPeerMember admittedMember adminSignedMembership validNetwork
-  infer_instance
-
 /-- Admission predicate on a join. Authorized iff the token's signature verifies
 AND either (membership-checked arm) the issuer is an admitted member, or (TOFU
-bootstrap arm) the bootstrap flag is set AND the network has no memberships yet.
-The bootstrap conjunct (`s.memberships = ∅`) is what stops the flag from bypassing
-the membership check on a populated network. -/
+bootstrap arm) the bootstrap flag is set, the network has no memberships yet, AND
+the token's issuer is the network admin.
+
+The bootstrap guard is `s.memberships = ∅`: an empty membership set has no peer
+trust set to check an invite against, so a one-time admin-issued invite seeds the
+network. The conjunct stops `tofuBootstrap` from being a free flag that bypasses
+the membership check on a populated network — once a single membership row exists,
+the TOFU arm is dead and admission falls back to `admittedMember`.
+
+Bootstrap is admin-only: the `tok.issuer = s.network.adminDid` conjunct means only
+the network admin can seed an empty network; a non-admin cannot use the bootstrap
+flag to inject the first membership-less join.
+
+FORWARD-NOTE (cut 5): the membership reconciler's join-gate (the successor to the
+registry-era `decide_join_admission` in `discovery.rs`, which keyed bootstrap off
+`!any_members`) must mirror THIS guard — `s.memberships = ∅` AND issuer = admin —
+not the registry-era `!any_members` shape it supersedes. -/
 def signedByMember (tok : Token) (s : DiscoveryState) (tofuBootstrap : Bool) : Prop :=
   tok.sigValid = true ∧
-    (admittedMember tok.issuer s ∨ (tofuBootstrap = true ∧ s.memberships = ∅))
+    (admittedMember tok.issuer s ∨
+      (tofuBootstrap = true ∧ s.memberships = ∅ ∧ tok.issuer = s.network.adminDid))
 
 instance (tok : Token) (s : DiscoveryState) (tofuBootstrap : Bool) :
     Decidable (signedByMember tok s tofuBootstrap) := by

--- a/crates/defra-agent/src/agent/p2p_reconcile/mod.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/mod.rs
@@ -5,6 +5,7 @@ pub mod discovery;
 pub mod embedded_impl;
 pub mod engine;
 pub mod error_class;
+pub mod network_membership;
 pub mod profiles;
 pub mod registry;
 pub mod templates;

--- a/crates/defra-agent/src/agent/p2p_reconcile/network_membership.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/network_membership.rs
@@ -1,0 +1,218 @@
+//! Pure network-membership decision functions: the Rust mirror of the
+//! membership / endpoint trust predicates in the Lean model
+//! `Proofs/PeerRegistryDiscovery/` (`Transition.lean`).
+//!
+//! These are *pure decision functions* — no DB, no GraphQL, no reconciler.
+//! Each fn is a boolean conjunction matching its Lean predicate exactly, and is
+//! fenced by the conformance suite. The single-row vs. existential split mirrors
+//! the Lean shape: `admittedMember` is existential over the membership set, so
+//! the per-row trust check ([`membership_admits_did`]) is factored out from the
+//! existential wrapper ([`admitted_member`]).
+//!
+//! Mirrored Lean predicates:
+//! - [`valid_network`] ↔ `validNetwork`
+//! - [`admin_signed_membership`] ↔ `adminSignedMembership`
+//! - [`membership_admits_did`] ↔ the per-row body of `admittedMember`'s ∃
+//! - [`admitted_member`] ↔ `admittedMember` (existential over memberships)
+//! - [`member_signed_endpoint`] ↔ `memberSignedEndpoint`
+//! - [`materializable_endpoint`] ↔ `materializableEndpoint`
+
+/// The network record as seen by the membership trust predicates. Mirrors the
+/// fields of the Lean `Network` that the membership predicates read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkDecision {
+    /// The network admin's DID (`Network.adminDid`).
+    pub admin_did: String,
+    /// Whether the network record's admin self-attestation verifies
+    /// (`Network.adminSigValid`).
+    pub admin_sig_valid: bool,
+}
+
+/// One membership row as seen by the membership trust predicates. Mirrors the
+/// fields of the Lean `Membership` the predicates read. `network_match` models
+/// the Lean `m.networkId = n.networkId` equality (resolved by the caller).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MembershipDecision {
+    /// The DID this membership row is for (`Membership.memberDid`).
+    pub member_did: String,
+    /// Whether this row's network id equals the network's (`m.networkId =
+    /// n.networkId`).
+    pub network_match: bool,
+    /// Whether the membership is active (`Membership.active`).
+    pub active: bool,
+    /// Whether the membership's admin signature verifies
+    /// (`Membership.adminSigValid`).
+    pub admin_sig_valid: bool,
+    /// The DID that signed this membership row (`Membership.signedBy`).
+    pub signed_by: String,
+}
+
+/// One endpoint announcement as seen by the endpoint trust predicates. Mirrors
+/// the fields of the Lean `Endpoint` the predicates read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointDecision {
+    /// The announcing node's DID (`Endpoint.did`).
+    pub did: String,
+    /// The announced peer address (`Endpoint.peer`).
+    pub peer: String,
+    /// Whether the endpoint's member self-signature verifies
+    /// (`Endpoint.memberSigValid`).
+    pub member_sig_valid: bool,
+    /// Whether the announcement is fresh — heartbeat within window
+    /// (`Endpoint.fresh`).
+    pub fresh: bool,
+    /// Whether the announced peer is self (`ep.peer = s.self`).
+    pub peer_is_self: bool,
+}
+
+/// Mirrors Lean `PeerRegistryDiscovery.validNetwork`:
+/// `validNetwork n := n.adminSigValid = true`.
+pub fn valid_network(n: &NetworkDecision) -> bool {
+    n.admin_sig_valid
+}
+
+/// Mirrors Lean `PeerRegistryDiscovery.adminSignedMembership`:
+/// `adminSignedMembership m n := m.adminSigValid = true ∧ m.signedBy = n.adminDid
+/// ∧ m.networkId = n.networkId`. (`network_match` models the networkId equality.)
+pub fn admin_signed_membership(n: &NetworkDecision, m: &MembershipDecision) -> bool {
+    m.admin_sig_valid && m.signed_by == n.admin_did && m.network_match
+}
+
+/// Mirrors the per-row body of the existential in Lean
+/// `PeerRegistryDiscovery.admittedMember`: a single membership row admits `did`
+/// iff it is admin-signed for `n`, active, and is for `did`
+/// (`adminSignedMembership m n ∧ m.active = true ∧ m.memberDid = did`).
+pub fn membership_admits_did(n: &NetworkDecision, m: &MembershipDecision, did: &str) -> bool {
+    admin_signed_membership(n, m) && m.active && m.member_did == did
+}
+
+/// Mirrors Lean `PeerRegistryDiscovery.admittedMember`:
+/// `admittedMember did s := validNetwork s.network ∧ ∃ m ∈ s.memberships,
+/// m.memberDid = did ∧ m.active = true ∧ adminSignedMembership m s.network`.
+/// The existential is realized as `iter().any(..)` over the membership slice.
+pub fn admitted_member(n: &NetworkDecision, memberships: &[MembershipDecision], did: &str) -> bool {
+    valid_network(n) && memberships.iter().any(|m| membership_admits_did(n, m, did))
+}
+
+/// Mirrors Lean `PeerRegistryDiscovery.memberSignedEndpoint`:
+/// `memberSignedEndpoint ep := ep.memberSigValid = true ∧ ep.fresh = true`.
+pub fn member_signed_endpoint(ep: &EndpointDecision) -> bool {
+    ep.member_sig_valid && ep.fresh
+}
+
+/// Mirrors Lean `PeerRegistryDiscovery.materializableEndpoint`:
+/// `materializableEndpoint ep s := admittedMember ep.did s ∧ memberSignedEndpoint
+/// ep ∧ ep.peer ≠ s.self`.
+pub fn materializable_endpoint(
+    n: &NetworkDecision,
+    memberships: &[MembershipDecision],
+    ep: &EndpointDecision,
+) -> bool {
+    admitted_member(n, memberships, &ep.did) && member_signed_endpoint(ep) && !ep.peer_is_self
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn admitted_is_existential_over_signed_active_memberships() {
+        let net = NetworkDecision { admin_did: "did:a".into(), admin_sig_valid: true };
+        let good = MembershipDecision {
+            member_did: "did:x".into(),
+            network_match: true,
+            active: true,
+            admin_sig_valid: true,
+            signed_by: "did:a".into(),
+        };
+        assert!(membership_admits_did(&net, &good, "did:x"));
+        assert!(!membership_admits_did(
+            &net,
+            &MembershipDecision { signed_by: "did:evil".into(), ..good.clone() },
+            "did:x"
+        ));
+        assert!(!membership_admits_did(
+            &net,
+            &MembershipDecision { active: false, ..good.clone() },
+            "did:x"
+        ));
+        assert!(!admitted_member(&net, &[], "did:x"));
+        assert!(admitted_member(&net, &[good.clone()], "did:x"));
+        assert!(!admitted_member(&net, &[good.clone()], "did:other"));
+        assert!(!admitted_member(
+            &NetworkDecision { admin_sig_valid: false, ..net.clone() },
+            &[good],
+            "did:x"
+        ));
+    }
+
+    #[test]
+    fn network_match_and_member_signature_gate_admission() {
+        let net = NetworkDecision { admin_did: "did:a".into(), admin_sig_valid: true };
+        let base = MembershipDecision {
+            member_did: "did:x".into(),
+            network_match: true,
+            active: true,
+            admin_sig_valid: true,
+            signed_by: "did:a".into(),
+        };
+        // networkId mismatch denies even an active, admin-signed row.
+        assert!(!membership_admits_did(
+            &net,
+            &MembershipDecision { network_match: false, ..base.clone() },
+            "did:x"
+        ));
+        // membership admin signature must verify.
+        assert!(!membership_admits_did(
+            &net,
+            &MembershipDecision { admin_sig_valid: false, ..base },
+            "did:x"
+        ));
+    }
+
+    #[test]
+    fn materializable_requires_admitted_signed_and_not_self() {
+        let net = NetworkDecision { admin_did: "did:a".into(), admin_sig_valid: true };
+        let good = MembershipDecision {
+            member_did: "did:x".into(),
+            network_match: true,
+            active: true,
+            admin_sig_valid: true,
+            signed_by: "did:a".into(),
+        };
+        let ep = EndpointDecision {
+            did: "did:x".into(),
+            peer: "peerX".into(),
+            member_sig_valid: true,
+            fresh: true,
+            peer_is_self: false,
+        };
+        assert!(member_signed_endpoint(&ep));
+        assert!(materializable_endpoint(&net, &[good.clone()], &ep));
+        // not member-signed.
+        assert!(!member_signed_endpoint(&EndpointDecision { member_sig_valid: false, ..ep.clone() }));
+        assert!(!materializable_endpoint(
+            &net,
+            &[good.clone()],
+            &EndpointDecision { member_sig_valid: false, ..ep.clone() }
+        ));
+        // not fresh.
+        assert!(!materializable_endpoint(
+            &net,
+            &[good.clone()],
+            &EndpointDecision { fresh: false, ..ep.clone() }
+        ));
+        // self peer.
+        assert!(!materializable_endpoint(
+            &net,
+            &[good.clone()],
+            &EndpointDecision { peer_is_self: true, ..ep.clone() }
+        ));
+        // announcing DID is not an admitted member.
+        assert!(!materializable_endpoint(
+            &net,
+            &[good],
+            &EndpointDecision { did: "did:other".into(), ..ep }
+        ));
+    }
+}

--- a/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
+++ b/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
@@ -7,6 +7,7 @@
 //! touch — the Rust analogue of the Lean two-finset partition.
 
 use std::collections::BTreeSet;
+use std::path::Path;
 use std::sync::Mutex;
 use std::time::Duration;
 
@@ -32,8 +33,12 @@ fn entry(peer: &str, live: bool) -> DiscoveredEntry {
     }
 }
 
-/// Mirrors Lean `mem_deriveRegistryDesired` + `self_not_mem_derive`: a peer is
-/// derived iff it is a live, non-self registry entry.
+/// Fences the soon-to-be-replaced registry-era reconciler `derive_registry_desired`
+/// (from #490, carried until cut 5's membership reconciler lands). The Lean analogue
+/// is the derivation soundness/completeness pair `materialized_implies_admitted` +
+/// `materializable_is_derived` (bridged by `mem_deriveMaterializable`) and the
+/// "self never derived" lemma `self_not_mem_derive`: a peer is derived iff it is a
+/// live, non-self materializable entry.
 #[test]
 fn derive_matches_live_non_self_membership() {
     let reg = vec![
@@ -45,8 +50,10 @@ fn derive_matches_live_non_self_membership() {
     assert_eq!(d, BTreeSet::from(["peerA".to_string()]));
 }
 
-/// Mirrors Lean `derive_idempotent` / `derive_convergent`: the derivation is a
-/// pure function of the registry, so it is stable across ticks.
+/// Mirrors Lean `derive_idempotent` / `deriveMaterializable_idempotent` /
+/// `derive_convergent`: the derivation is a pure function of the membership world,
+/// so it is stable across ticks. (Fences the registry-era `derive_registry_desired`
+/// carried until cut 5.)
 #[test]
 fn derive_is_idempotent_and_convergent_over_stable_registry() {
     let reg = vec![entry("peerA", true), entry("peerB", true)];
@@ -144,9 +151,11 @@ async fn ownership_safe_operator_rows_never_touched() {
     }
 }
 
-/// Mirrors Lean `retraction_sound` / `retraction_drops_unique_source` /
-/// `retraction_preserves_others`: staling an entry retracts exactly its
-/// registry-owned row, and an operator-owned row for a different peer survives.
+/// Mirrors Lean `revoke_retracts_exactly` (O3): retracting a member removes
+/// EXACTLY its network-owned rows and no others — here staling an entry retracts
+/// exactly its registry-owned row, and an operator-owned row for a different peer
+/// survives (the cross-partition analogue of O3's "peers reachable via another
+/// admitted DID survive"). Fences the registry-era reconciler carried until cut 5.
 #[tokio::test]
 async fn retraction_sound_removes_only_staled_registry_row() {
     let store = PartitionStore::new(
@@ -169,12 +178,14 @@ async fn retraction_sound_removes_only_staled_registry_row() {
 }
 
 // ---------------------------------------------------------------------------
-// Signed-invite membership gate (Lean `signedByMember` / `isMember`).
+// Signed-invite membership gate (Lean `signedByMember` / `admitsJoin` and the
+// leaf theorems `non_member_invite_rejected` / `no_join_without_admissible_token`).
 //
 // These fence the registry-membership half of the join authorization gate via
-// the real `decide_join_admission` engine fn — the same predicate the CLI join
-// path calls. Token signature validity (`sigValid`) is checked separately at
-// token decode (defra-agent-protocol::pairing_token) and is out of this fence.
+// the real `decide_join_admission` engine fn — the registry-era reconciler from
+// #490, carried until cut 5's membership reconciler supersedes it. Token signature
+// validity (`sigValid`) is checked separately at token decode
+// (defra-agent-protocol::pairing_token) and is out of this fence.
 // ---------------------------------------------------------------------------
 
 fn member_row(did: &str, status: &str, age: ChronoDuration) -> RegistryMemberRow {
@@ -211,7 +222,8 @@ fn join_gate_empty_or_self_only_registry_is_tofu_bootstrap() {
     );
 }
 
-/// Mirrors `isMember`: a live (online + fresh) issuer row admits the join.
+/// Mirrors the registry/member arm of Lean `signedByMember` (`admittedMember
+/// tok.issuer s`): a live (online + fresh) issuer row admits the join.
 #[test]
 fn join_gate_admits_live_member_issuer() {
     let rows = [member_row("did:key:issuer", "online", FRESH)];
@@ -227,9 +239,10 @@ fn join_gate_admits_live_member_issuer() {
     );
 }
 
-/// Mirrors `non_member_invite_rejected`: with a non-empty registry, an issuer
-/// that is absent, offline, or stale is NOT a live member, so the join is
-/// rejected (the TOFU arm does not apply once peers exist).
+/// Mirrors Lean `non_member_invite_rejected` over the registry/member arm of
+/// `signedByMember`: with a non-empty registry, an issuer that is absent, offline,
+/// or stale is NOT a live member, so the join is rejected (the TOFU arm does not
+/// apply once peers exist — Lean guards it with `s.memberships = ∅`).
 #[test]
 fn join_gate_rejects_non_live_member_when_registry_nonempty() {
     let now = Utc::now();
@@ -460,4 +473,108 @@ fn materializable_endpoint_truth_table() {
             ..ep
         }
     ));
+}
+
+// ---------------------------------------------------------------------------
+// Stale-citation guard.
+//
+// This module's doc-comments cite Lean theorems/defs by name as the contract
+// each test fences. When the model is rewritten (as in cut 1, which deleted
+// `mem_deriveRegistryDesired`, the `retraction_*` family, `isMember`, and
+// `hasPeerMember`), those citations can silently rot — pointing at symbols that
+// no longer exist in `Proofs/`. This test makes that class of drift loud: every
+// name in `CITED` below MUST appear as a `theorem`/`def`/`abbrev`/`structure`/
+// `inductive` declaration somewhere under `Proofs/PeerRegistryDiscovery/`.
+//
+// LIMITS (by design, kept honest):
+//   * `CITED` is maintained by hand next to the comments — it is NOT auto-scraped
+//     from the doc-text, so a NEW citation added to a comment without being added
+//     here is not checked. The payoff is no false positives from prose that
+//     merely mentions a Lean concept in passing.
+//   * It checks EXISTENCE, not that the right test cites the right theorem. It
+//     catches deletion/rename drift (the cut-1 failure mode), not mis-attribution.
+//   * Matching is a declaration-keyword + name scan; it would accept a same-named
+//     decl in any file under the model dir, which is acceptable here.
+const CITED: &[&str] = &[
+    // derivation / ownership / convergence
+    "materialized_implies_admitted",
+    "materializable_is_derived",
+    "mem_deriveMaterializable",
+    "self_not_mem_derive",
+    "derive_idempotent",
+    "deriveMaterializable_idempotent",
+    "derive_convergent",
+    "ownership_safe",
+    "revoke_retracts_exactly",
+    // signed-invite join gate
+    "signedByMember",
+    "admitsJoin",
+    "non_member_invite_rejected",
+    "no_join_without_admissible_token",
+    // membership / endpoint trust predicates
+    "admittedMember",
+    "materializableEndpoint",
+];
+
+/// Guard: every Lean symbol cited in this module's doc-comments must still exist
+/// in `Proofs/PeerRegistryDiscovery/`. Fails loudly on the cut-1 deletion/rename
+/// drift class. See the `CITED` block above for what is (and is not) checked.
+#[test]
+fn cited_lean_symbols_exist_in_proofs() {
+    let model_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("repo root")
+        .join("crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery");
+
+    // Concatenate every .lean source under the model directory.
+    let mut sources = String::new();
+    for entry in std::fs::read_dir(&model_dir)
+        .expect("read PeerRegistryDiscovery/")
+        .flatten()
+    {
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == "lean") {
+            sources.push_str(&std::fs::read_to_string(&path).expect("read .lean"));
+            sources.push('\n');
+        }
+    }
+
+    // A symbol "exists" if it appears as the name in a declaration. We accept any
+    // of the Lean declaration keywords; private/protected/noncomputable modifiers
+    // sit before the keyword, so keyword-then-name still matches the decl line.
+    let decl_keywords = [
+        "theorem", "lemma", "def", "abbrev", "structure", "inductive", "instance",
+    ];
+    let declares = |name: &str| -> bool {
+        decl_keywords.iter().any(|kw| {
+            sources.lines().any(|line| {
+                let t = line.trim_start();
+                t.strip_prefix(kw)
+                    .and_then(|rest| rest.strip_prefix(' '))
+                    .map(|rest| rest.trim_start())
+                    .is_some_and(|rest| {
+                        rest.strip_prefix(name).is_some_and(|after| {
+                            // Next char must be a non-identifier boundary so
+                            // `derive_idempotent` does not match
+                            // `derive_idempotent_extra`.
+                            after
+                                .chars()
+                                .next()
+                                .map(|c| !(c.is_alphanumeric() || c == '_' || c == '\''))
+                                .unwrap_or(true)
+                        })
+                    })
+            })
+        })
+    };
+
+    let missing: Vec<&str> = CITED.iter().copied().filter(|n| !declares(n)).collect();
+    assert!(
+        missing.is_empty(),
+        "doc-comments in peer_registry_discovery.rs cite Lean symbols absent from \
+         Proofs/PeerRegistryDiscovery/ (a deleted/renamed theorem — repoint the \
+         citation and update CITED):\n{}",
+        missing.join("\n")
+    );
 }

--- a/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
+++ b/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
@@ -17,6 +17,10 @@ use defra_agent::agent::p2p_reconcile::discovery::{
     decide_join_admission, derive_registry_desired, reconcile_discovery_tick, DiscoveredEntry,
     DiscoveryStore, JoinAdmission, RegistryMemberRow,
 };
+use defra_agent::agent::p2p_reconcile::network_membership::{
+    admitted_member, materializable_endpoint, membership_admits_did, EndpointDecision,
+    MembershipDecision, NetworkDecision,
+};
 
 fn entry(peer: &str, live: bool) -> DiscoveredEntry {
     DiscoveredEntry {
@@ -247,4 +251,213 @@ fn join_gate_rejects_non_live_member_when_registry_nonempty() {
         decide_join_admission("did:key:issuer", "did:key:self", &stale, now, STALE_AFTER),
         JoinAdmission::Rejected
     );
+}
+
+// ---------------------------------------------------------------------------
+// Membership / endpoint trust predicates (Lean `Transition.lean`):
+// `membershipAdmitsDid` (the per-row body of `admittedMember`'s ∃),
+// `admittedMember`, and `materializableEndpoint`.
+//
+// These fence the pure decision fns in
+// `agent::p2p_reconcile::network_membership` against the Lean predicates. The
+// model is the source of truth; each assertion states the value the Lean
+// predicate specifies for the same inputs and checks the Rust fn agrees.
+// ---------------------------------------------------------------------------
+
+/// A network whose admin self-attestation verifies (`validNetwork = true`),
+/// admin DID `did:a`.
+fn valid_net() -> NetworkDecision {
+    NetworkDecision {
+        admin_did: "did:a".to_string(),
+        admin_sig_valid: true,
+    }
+}
+
+/// A membership row that admits `did:x`: admin-signed by `did:a`, network-scoped,
+/// active. Every "false" case below flips exactly one bit off this baseline.
+fn admitting_membership() -> MembershipDecision {
+    MembershipDecision {
+        member_did: "did:x".to_string(),
+        network_match: true,
+        active: true,
+        admin_sig_valid: true,
+        signed_by: "did:a".to_string(),
+    }
+}
+
+/// An endpoint announcing `did:x`'s peer: member-signed, fresh, not self. Every
+/// "false" case below flips exactly one bit off this baseline.
+fn announcing_endpoint() -> EndpointDecision {
+    EndpointDecision {
+        did: "did:x".to_string(),
+        peer: "peerX".to_string(),
+        member_sig_valid: true,
+        fresh: true,
+        peer_is_self: false,
+    }
+}
+
+/// Mirrors the per-row body of the ∃ in Lean `admittedMember`
+/// (`membership_admits_did`): admin-signed (`adminSigValid ∧ signedBy = adminDid
+/// ∧ networkId match`) ∧ `active` ∧ `memberDid = did`. Truth table: every single
+/// flipped bit denies.
+#[test]
+fn membership_admits_did_single_row_truth_table() {
+    let net = valid_net();
+    let base = admitting_membership();
+
+    // All conjuncts hold ⇒ admits.
+    assert!(membership_admits_did(&net, &base, "did:x"));
+
+    // adminSigValid = false ⇒ deny.
+    assert!(!membership_admits_did(
+        &net,
+        &MembershipDecision {
+            admin_sig_valid: false,
+            ..base.clone()
+        },
+        "did:x"
+    ));
+    // signedBy ≠ adminDid (wrong admin) ⇒ deny.
+    assert!(!membership_admits_did(
+        &net,
+        &MembershipDecision {
+            signed_by: "did:evil".to_string(),
+            ..base.clone()
+        },
+        "did:x"
+    ));
+    // networkId mismatch ⇒ deny.
+    assert!(!membership_admits_did(
+        &net,
+        &MembershipDecision {
+            network_match: false,
+            ..base.clone()
+        },
+        "did:x"
+    ));
+    // active = false (revoked) ⇒ deny.
+    assert!(!membership_admits_did(
+        &net,
+        &MembershipDecision {
+            active: false,
+            ..base.clone()
+        },
+        "did:x"
+    ));
+    // memberDid ≠ did (row is for someone else) ⇒ deny.
+    assert!(!membership_admits_did(&net, &base, "did:other"));
+}
+
+/// Mirrors Lean `admittedMember` (`validNetwork ∧ ∃ m ∈ memberships, …`): the
+/// existential over the membership slice plus the valid-network guard.
+#[test]
+fn admitted_member_existential_truth_table() {
+    let net = valid_net();
+    let good = admitting_membership();
+
+    // Valid network + one admitting row ⇒ admitted.
+    assert!(admitted_member(&net, &[good.clone()], "did:x"));
+
+    // adminSigValid = false on the membership ⇒ not admitted.
+    assert!(!admitted_member(
+        &net,
+        &[MembershipDecision {
+            admin_sig_valid: false,
+            ..good.clone()
+        }],
+        "did:x"
+    ));
+    // Wrong admin signed the membership ⇒ not admitted.
+    assert!(!admitted_member(
+        &net,
+        &[MembershipDecision {
+            signed_by: "did:evil".to_string(),
+            ..good.clone()
+        }],
+        "did:x"
+    ));
+    // Revoked (active = false) ⇒ not admitted.
+    assert!(!admitted_member(
+        &net,
+        &[MembershipDecision {
+            active: false,
+            ..good.clone()
+        }],
+        "did:x"
+    ));
+    // networkId mismatch ⇒ not admitted.
+    assert!(!admitted_member(
+        &net,
+        &[MembershipDecision {
+            network_match: false,
+            ..good.clone()
+        }],
+        "did:x"
+    ));
+    // Empty membership slice ⇒ existential is vacuously false ⇒ not admitted.
+    assert!(!admitted_member(&net, &[], "did:x"));
+    // DID not present (only a row for someone else) ⇒ not admitted.
+    assert!(!admitted_member(&net, &[good.clone()], "did:other"));
+    // Invalid network (admin self-attestation fails) denies even a good row.
+    assert!(!admitted_member(
+        &NetworkDecision {
+            admin_sig_valid: false,
+            ..net.clone()
+        },
+        &[good],
+        "did:x"
+    ));
+}
+
+/// Mirrors Lean `materializableEndpoint` (`admittedMember ep.did s ∧
+/// memberSignedEndpoint ep ∧ ep.peer ≠ s.self`): admitted member, member-signed,
+/// fresh, and not self. Truth table: every single flipped bit denies.
+#[test]
+fn materializable_endpoint_truth_table() {
+    let net = valid_net();
+    let good = admitting_membership();
+    let ep = announcing_endpoint();
+
+    // All conjuncts hold ⇒ materializable.
+    assert!(materializable_endpoint(&net, &[good.clone()], &ep));
+
+    // Announcing DID is not an admitted member (empty memberships) ⇒ deny.
+    assert!(!materializable_endpoint(&net, &[], &ep));
+    // Announcing DID has no admitting row (row is for someone else) ⇒ deny.
+    assert!(!materializable_endpoint(
+        &net,
+        &[good.clone()],
+        &EndpointDecision {
+            did: "did:other".to_string(),
+            ..ep.clone()
+        }
+    ));
+    // memberSigValid = false ⇒ deny.
+    assert!(!materializable_endpoint(
+        &net,
+        &[good.clone()],
+        &EndpointDecision {
+            member_sig_valid: false,
+            ..ep.clone()
+        }
+    ));
+    // fresh = false ⇒ deny.
+    assert!(!materializable_endpoint(
+        &net,
+        &[good.clone()],
+        &EndpointDecision {
+            fresh: false,
+            ..ep.clone()
+        }
+    ));
+    // peer is self ⇒ deny.
+    assert!(!materializable_endpoint(
+        &net,
+        &[good],
+        &EndpointDecision {
+            peer_is_self: true,
+            ..ep
+        }
+    ));
 }

--- a/crates/defra-agent/tests/conformance/structure.rs
+++ b/crates/defra-agent/tests/conformance/structure.rs
@@ -61,8 +61,9 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
         ),
         // Discovery derivation + signed-invite guard. peer_registry_discovery.rs
         // fences the derivation/ownership properties AND the membership half of
-        // the join gate (`signedByMember`/`isMember`) via the real
-        // `decide_join_admission` engine fn. The signature half (`sigValid`) is
+        // the join gate (`signedByMember` and the leaf theorem
+        // `non_member_invite_rejected`) via the real `decide_join_admission`
+        // engine fn. The signature half (`sigValid`) is
         // fenced separately by defra-agent-protocol::pairing_token verify/tamper
         // tests; identity-binding of the admitted entry is intentionally out of
         // scope (trusted-fleet TOFU — see Transition.join docstring).

--- a/docs/superpowers/plans/2026-06-15-network-membership-cut1-lean-model.md
+++ b/docs/superpowers/plans/2026-06-15-network-membership-cut1-lean-model.md
@@ -1,0 +1,367 @@
+# Network-Membership PR Cut 1 — Lean Model + Conformance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the self-asserted peer-registry derivation in the Lean discovery model with a **signed network-membership** derivation, including explicit request/approve transitions, proving the design spec §9 obligations, and fence the predicates against pure Rust decision functions.
+
+**Architecture:** Evolve `Proofs/PeerRegistryDiscovery/` in place (keep the namespace, barrel, and `structure.rs` registration unchanged). The proven ownership/nonce machinery is reused; only the *derivation source* changes — from live registry rows (`deriveRegistryDesired`) to membership materialization (`validNetwork ∧ adminSignedMembership ∧ memberSignedEndpoint`). Signatures are modeled as **abstract booleans** on the records, never crypto, with an explicit `signedBy : Did` so "signed by *this network's* admin" is checkable. Cut 1 ships the model + a small pure Rust decision module the model fences (the full reconciler is cut 5).
+
+**Tech Stack:** Lean 4 + Mathlib (`crates/defra-agent/proofs`), Rust decision module (`crates/defra-agent/src/agent/p2p_reconcile/`), conformance tests (`crates/defra-agent/tests/conformance/`).
+
+**Proof-body note (read once):** Lean theorem *statements*, definitions, and non-vacuity *witnesses* are written literally here. Theorem *proof bodies* (tactic blocks) are developed interactively against the build gate — the fence is `lake build` with **zero `sorry`** plus a satisfiable witness for every implication. A theorem that builds only because its hypothesis is unsatisfiable is a failure; each obligation pairs with a `*_witness`. Mirrors how `replay_rejected`/`reciprocal_join_still_gated` were built.
+
+**Build-gate note (Finding 6):** Intermediate tasks that knowingly leave downstream files broken use **module-level** builds (`lake build Proofs.PeerRegistryDiscovery.State`), which compile only the named module + its deps. The **full** `lake build` (whole library, zero-sorry) is reserved for the first coherent point — end of Task 5.
+
+**Open decision (Finding 4 — endpoint scoping):** Plan as written keeps `PeerEndpoint` **global / `did`-unique** per the finalized spec §78–79 (reachability is one per-node fact; materialization is network-scoped via the *membership's* `networkId`, so a DID materializes only where admitted). If the spec is revised to network-scope endpoints, add `ep.networkId = s.network.networkId` to `memberSignedEndpoint`/`deriveMaterializable` and a `networkId` field to `Endpoint`/`EndpointDecision` — a one-conjunct change isolated to Tasks 1–2 and 6.
+
+**Worktree:** `defra-agent-network-membership` (branch `network-membership`, off merged main `c9640301`).
+
+---
+
+## File Structure
+
+- `proofs/Proofs/PeerRegistryDiscovery/State.lean` — network-membership entities (`Network`, `Membership`, `Endpoint`, `JoinRequest`) with abstract sig bits + `signedBy`; membership/endpoint/network/request fields on `DiscoveryState`; `wellFormed` uniqueness invariant; `deriveMaterializable`. Remove `RegistryEntry`/`deriveRegistryDesired` and their theorems.
+- `proofs/Proofs/PeerRegistryDiscovery/Transition.lean` — the five predicates + `Decidable`; `submitRequest`/`approveRequest`/`revoke` transitions; rewrite `deriveStep` to `deriveMaterializable`; keep join/nonce/reciprocal transitions.
+- `proofs/Proofs/PeerRegistryDiscovery/Derivation.lean` — obligations O1–O5 + witnesses; carry over `ownership_safe`, `replay_rejected`, reciprocal theorems (re-prove against the new derivation); `wellFormed` preservation lemmas.
+- `proofs/Proofs/PeerRegistryDiscovery/Executable.lean` — decision mirrors + agreement lemmas.
+- `crates/defra-agent/src/agent/p2p_reconcile/network_membership.rs` (CREATE) — pure decision fns over plain structs (incl. `signed_by`). No DB, no reconciler.
+- `crates/defra-agent/tests/conformance/peer_registry_discovery.rs` — **fold** the membership decision-fn fences into this existing module (Finding 7: `Home::Module` allows one path per model; do NOT add a new module file or touch `structure.rs`/`conformance.rs`).
+
+---
+
+## Task 1: Network-membership state model + well-formedness (Lean)
+
+**Files:** Modify `proofs/Proofs/PeerRegistryDiscovery/State.lean`.
+
+- [ ] **Step 1: Add entity records.** After the `Nonce` abbrev:
+
+```lean
+abbrev NetworkId := String
+
+/-- The network document. `adminSigValid` abstracts "admin_sig verifies for adminDid". -/
+structure Network where
+  networkId : NetworkId
+  adminDid  : Did
+  adminSigValid : Bool
+  deriving DecidableEq, Repr
+
+/-- Admin-authored membership grant. `signedBy` is the DID that signed it and
+`adminSigValid` abstracts that signature's validity — so "signed by THIS network's
+admin" is `adminSigValid ∧ signedBy = network.adminDid` (Finding 5). `active=false`
+is a revoked tombstone. -/
+structure Membership where
+  networkId : NetworkId
+  memberDid : Did
+  active    : Bool
+  signedBy  : Did
+  adminSigValid : Bool
+  deriving DecidableEq, Repr
+
+/-- Member-self-asserted transport binding (global per node — Finding 4 / spec §78).
+`memberSigValid` abstracts the member's DID signature; `fresh` folds liveness. -/
+structure Endpoint where
+  did   : Did
+  peer  : PeerId
+  fresh : Bool
+  memberSigValid : Bool
+  deriving DecidableEq, Repr
+
+/-- Candidate-authored join request (Finding 3). `reqSigValid` abstracts the
+candidate's signature. A request alone NEVER creates a membership; only an admin
+`approveRequest` does. -/
+structure JoinRequest where
+  networkId    : NetworkId
+  candidateDid : Did
+  reqSigValid  : Bool
+  deriving DecidableEq, Repr
+```
+
+- [ ] **Step 2: Replace `DiscoveryState`'s registry with the membership world:**
+
+```lean
+structure DiscoveryState where
+  self : PeerId
+  network : Network
+  memberships : Finset Membership
+  endpoints : Finset Endpoint
+  requests : Finset JoinRequest
+  operatorDesired : Finset PeerId
+  registryDesired : Finset PeerId   -- now network-derived; name kept to limit churn
+  consumedNonces : Finset Nonce
+  deriving DecidableEq
+```
+
+- [ ] **Step 3: Add the well-formedness invariant (Finding 2 / Invariant 1):** at most one membership per `(networkId, memberDid)`.
+
+```lean
+/-- Schema-level invariant: NetworkMembership is unique on (networkId, memberDid). -/
+def wellFormed (s : DiscoveryState) : Prop :=
+  ∀ m₁ ∈ s.memberships, ∀ m₂ ∈ s.memberships,
+    m₁.networkId = m₂.networkId → m₁.memberDid = m₂.memberDid → m₁ = m₂
+
+instance (s : DiscoveryState) : Decidable s.wellFormed := by unfold wellFormed; infer_instance
+```
+
+- [ ] **Step 4: Add `deriveMaterializable`** (replaces `deriveRegistryDesired`). Membership carries the network scope; the endpoint stays global:
+
+```lean
+/-- Network-owned desired peers = peers of endpoints whose DID has an active,
+admin-signed membership in this valid network, with a fresh member-signed binding,
+peer ≠ self. The network scope lives on the membership (Finding 4: endpoint global). -/
+def deriveMaterializable (s : DiscoveryState) : Finset PeerId :=
+  (s.endpoints.filter (fun ep =>
+      ep.fresh = true ∧ ep.memberSigValid = true ∧ ep.peer ≠ s.self ∧
+      s.network.adminSigValid = true ∧
+      s.memberships.toList.any (fun m =>
+        m.memberDid = ep.did ∧ m.active = true ∧
+        m.adminSigValid = true ∧ m.signedBy = s.network.adminDid ∧
+        m.networkId = s.network.networkId))).image Endpoint.peer
+```
+
+- [ ] **Step 5: Re-home `settled`/`settle`/`effectiveDesired`** to `deriveMaterializable`; delete `RegistryEntry`, `Registry`, `deriveRegistryDesired`.
+- [ ] **Step 6: Module-level build.** `cd crates/defra-agent/proofs && lake build Proofs.PeerRegistryDiscovery.State` — State compiles. (Downstream files still broken; full build deferred to Task 5 per the build-gate note.)
+- [ ] **Step 7: Commit.** `proof(network): membership/endpoint/request state model + wellFormed + deriveMaterializable`
+
+## Task 2: Predicates + request/approve/revoke transitions (Lean)
+
+**Files:** Modify `proofs/Proofs/PeerRegistryDiscovery/Transition.lean`.
+
+- [ ] **Step 1: The five predicates** (spec §9), each with `Decidable` via `unfold; infer_instance`:
+
+```lean
+def validNetwork (n : Network) : Prop := n.adminSigValid = true
+
+def adminSignedMembership (m : Membership) (n : Network) : Prop :=
+  m.adminSigValid = true ∧ m.signedBy = n.adminDid ∧ m.networkId = n.networkId   -- Finding 5
+
+def memberSignedEndpoint (ep : Endpoint) : Prop :=
+  ep.memberSigValid = true ∧ ep.fresh = true
+
+def admittedMember (did : Did) (s : DiscoveryState) : Prop :=
+  validNetwork s.network ∧
+  ∃ m ∈ s.memberships, m.memberDid = did ∧ m.active = true ∧ adminSignedMembership m s.network
+
+def materializableEndpoint (ep : Endpoint) (s : DiscoveryState) : Prop :=
+  admittedMember ep.did s ∧ memberSignedEndpoint ep ∧ ep.peer ≠ s.self
+```
+
+- [ ] **Step 2: The bridge lemma** (used by O1/O2):
+
+```lean
+theorem mem_deriveMaterializable {s : DiscoveryState} {p : PeerId} :
+    p ∈ deriveMaterializable s ↔
+      ∃ ep ∈ s.endpoints, materializableEndpoint ep s ∧ ep.peer = p
+```
+
+- [ ] **Step 3: Mutators + transitions.** Define mutators as **key-based upserts over `(networkId, memberDid)`** (Finding 3 — matches the schema's unique index, so `wellFormed` is preserved by construction, not by a side hypothesis):
+
+```lean
+/-- Remove any membership for the same (networkId, memberDid), then insert `m`.
+Key-based upsert ⇒ at most one row per key ⇒ wellFormed preserved. -/
+def upsertMembership (s : DiscoveryState) (m : Membership) : DiscoveryState :=
+  { s with memberships :=
+      insert m (s.memberships.filter (fun x =>
+        ¬ (x.networkId = m.networkId ∧ x.memberDid = m.memberDid))) }
+
+def submitRequestState (s : DiscoveryState) (req : JoinRequest) : DiscoveryState :=
+  { s with requests := insert req s.requests }            -- touches requests ONLY
+
+def approveMembershipState (s : DiscoveryState) (m : Membership) : DiscoveryState :=
+  upsertMembership s m
+
+/-- Revocation is an admin-signed status=revoked UPSERT (spec §4): the tombstone
+`tomb` carries active=false and the admin signature; it REPLACES the active grant. -/
+def revokeState (s : DiscoveryState) (tomb : Membership) : DiscoveryState :=
+  upsertMembership s tomb
+
+/-- A join redeems a single-use token: it consumes the nonce and mutates NOTHING
+ELSE (no membership growth — grants come only via approveRequest). Keeps
+`replay_rejected` meaningful without reintroducing registry-growth (Finding 7). -/
+def joinState (s : DiscoveryState) (tok : Token) : DiscoveryState :=
+  { s with consumedNonces := insert tok.nonce s.consumedNonces }
+```
+
+Extend the `Transition` inductive (note the network-id matching on `approveRequest`, Finding 2, and the admin-signature carried by `revoke`, Finding 4):
+
+```lean
+  | submitRequest {pre post} (req : JoinRequest) :
+      post = submitRequestState pre req → Transition pre post     -- changes requests only
+  | approveRequest {pre post} (req : JoinRequest) (m : Membership) :
+      req ∈ pre.requests →
+      req.reqSigValid = true →                          -- valid candidate request
+      req.networkId = pre.network.networkId →           -- request is FOR this network (Finding 2)
+      adminSignedMembership m pre.network →             -- grant signed by THIS admin (⇒ m.networkId = network.networkId)
+      m.memberDid = req.candidateDid → m.active = true →
+      post = approveMembershipState pre m → Transition pre post
+  | revoke {pre post} (tomb : Membership) :
+      adminSignedMembership tomb pre.network →           -- revocation is admin-signed (Finding 4)
+      tomb.active = false →                              -- status = revoked
+      post = revokeState pre tomb → Transition pre post
+```
+
+Keep `join`/`reciprocalJoin` (now `joinState`-based: nonce-only) and `operatorWrite`. Point `deriveStep` at `deriveMaterializable`. The join admission gate's membership arm uses `admittedMember` (issuer is an admitted member) or TOFU bootstrap on empty `memberships`.
+
+- [ ] **Step 4: Module-level build.** `lake build Proofs.PeerRegistryDiscovery.Transition`.
+- [ ] **Step 5: Commit.** `proof(network): membership predicates + request/approve/revoke transitions`
+
+## Task 3: Carry over ownership/nonce/reciprocal + wellFormed preservation (Lean)
+
+**Files:** Modify `proofs/Proofs/PeerRegistryDiscovery/Derivation.lean`.
+
+- [ ] **Step 1: Re-prove derivation lemmas** against `deriveMaterializable`: `self_not_mem_derive`, `deriveMaterializable_idempotent`, `derive_settles`, `derive_convergent`.
+- [ ] **Step 2: Keep `ownership_safe` (= O4):** every `Transition` leaves `operatorDesired` untouched — re-run `cases` over the constructors (now incl. `submitRequest`/`approveRequest`/`revoke`, all of which leave `operatorDesired` by `rfl`).
+- [ ] **Step 3: Keep nonce/reciprocal theorems:** `replay_rejected` + `replay_rejected_witness`, `reciprocal_join_still_gated` + witnesses, `reciprocal_replay_rejected`. Re-prove witnesses using an admitted state built from a `Membership` (not a `RegistryEntry`).
+- [ ] **Step 4: `wellFormed` preservation:** prove every transition preserves `wellFormed`. Because `approveRequest`/`revoke` go through `upsertMembership` (key-based — removes any same-key row before insert), uniqueness holds **by construction**; the key lemma is `upsertMembership_wellFormed` (an upsert into a well-formed set is well-formed). `submitRequest`/`join`/`reciprocalJoin`/`operatorWrite` don't touch `memberships`, so they preserve it trivially.
+
+```lean
+theorem upsertMembership_wellFormed {s : DiscoveryState} (m : Membership)
+    (hwf : s.wellFormed) : (upsertMembership s m).wellFormed
+theorem transition_preserves_wellFormed {pre post : DiscoveryState}
+    (hwf : pre.wellFormed) (h : Transition pre post) : post.wellFormed
+```
+
+- [ ] **Step 5: Module-level build** `lake build Proofs.PeerRegistryDiscovery.Derivation`; `grep -rn sorry Proofs/PeerRegistryDiscovery/Derivation.lean` clean.
+- [ ] **Step 6: Commit.** `proof(network): ownership/nonce/reciprocal carried over; wellFormed preservation`
+
+## Task 4: Obligations O1–O5 + witnesses (Lean)
+
+**Files:** Modify `proofs/Proofs/PeerRegistryDiscovery/Derivation.lean`.
+
+- [ ] **Step 1: O1 — soundness (Finding 1: nothing materializes without an admitted, signed endpoint).** This is the forward direction of `mem_deriveMaterializable`; state it standalone + a witness:
+
+```lean
+theorem materialized_implies_admitted {s : DiscoveryState} {p : PeerId}
+    (h : p ∈ deriveMaterializable s) :
+    ∃ ep ∈ s.endpoints, admittedMember ep.did s ∧ memberSignedEndpoint ep ∧ ep.peer = p
+-- O1_witness: a state with an unsigned/unadmitted endpoint whose peer is NOT in
+--   deriveMaterializable s (no other endpoint covers that peer) — realizable hypothesis.
+```
+
+- [ ] **Step 2: O2 — completeness (active admin-signed + fresh member-signed ⇒ materialized):**
+
+```lean
+theorem materializable_is_derived {s : DiscoveryState} {ep : Endpoint}
+    (hep : ep ∈ s.endpoints) (h : materializableEndpoint ep s) :
+    ep.peer ∈ deriveMaterializable s
+-- O2_witness: concrete valid network + active membership (signedBy = adminDid) +
+--   fresh signed endpoint ⇒ peer IS derived (genuine positive, not vacuous).
+```
+
+- [ ] **Step 3: O3 — revocation retracts only the peers *exclusively* materialized via the revoked DID (Finding 1 + 2), under `wellFormed`.** A peer materialized *both* via the revoked DID and via another admitted DID must NOT drop — so the filter keeps `p` iff a *surviving* (non-revoked-DID) endpoint still materializes it:
+
+```lean
+theorem revoke_retracts_exactly {pre post : DiscoveryState} {tomb : Membership}
+    (hwf : pre.wellFormed) (hsig : adminSignedMembership tomb pre.network)
+    (hrev : tomb.active = false) (h : post = revokeState pre tomb) :
+    deriveMaterializable post =
+      (deriveMaterializable pre).filter (fun p =>
+        ∃ ep ∈ pre.endpoints,
+          ep.did ≠ tomb.memberDid ∧ ep.peer = p ∧ materializableEndpoint ep pre)
+-- Peers materialized ONLY via tomb.memberDid drop; peers also reachable via another
+-- admitted DID stay (Finding 1: a co-peer admitted endpoint preserves p).
+-- O3_witness: members A,B with DISTINCT peers, revoke A ⇒ A's peer drops, B's stays;
+--   plus a shared-peer case: A,B both materialize peer p, revoke A ⇒ p stays (via B).
+```
+
+- [ ] **Step 4: O5 — a forged/unsigned join request cannot produce a grant (Finding 3):** the only membership-creating transition is `approveRequest`, which demands `adminSignedMembership m pre.network` (so `m.signedBy = adminDid ∧ m.adminSigValid`) and a `reqSigValid` request.
+
+```lean
+theorem membership_grant_requires_admin_signature {pre post : DiscoveryState}
+    (h : Transition pre post) {m : Membership}
+    (hnew : m ∈ post.memberships) (hold : m ∉ pre.memberships) :
+    adminSignedMembership m pre.network
+-- O5_witness_neg: a submitRequest with reqSigValid=false leaves memberships unchanged
+--   (no grant); a submitRequest alone (no approve) leaves memberships unchanged.
+```
+
+- [ ] **Step 5: Module-level build.** `lake build Proofs.PeerRegistryDiscovery.Derivation`; `grep -rn sorry Proofs/PeerRegistryDiscovery/Derivation.lean` clean. (Executable.lean still references the old `TransitionKind`, so the *full* library build is deferred to Task 5 — the first point all four files are coherent.) Audit non-vacuity: O2/O3 witnesses are genuine positives; O1/O5 hypotheses are realizable.
+- [ ] **Step 6: Commit.** `proof(network): obligations O1-O5 (soundness, completeness, revocation, admission) with witnesses`
+
+## Task 5: Executable mirror + agreement (Lean)
+
+**Files:** Modify `proofs/Proofs/PeerRegistryDiscovery/Executable.lean`.
+
+- [ ] **Step 1: Decision fns + agreement** (mirror `decideAdmitsJoin`/`_agrees`):
+
+```lean
+def decideValidNetwork (n : Network) : Bool := n.adminSigValid
+def decideAdmittedMember (did : Did) (s : DiscoveryState) : Bool := decide (admittedMember did s)
+def decideMaterializable (ep : Endpoint) (s : DiscoveryState) : Bool := decide (materializableEndpoint ep s)
+theorem decideAdmittedMember_agrees (did) (s) :
+    decideAdmittedMember did s = true ↔ admittedMember did s := by
+  unfold decideAdmittedMember; exact decide_eq_true_iff
+theorem decideMaterializable_agrees (ep) (s) :
+    decideMaterializable ep s = true ↔ materializableEndpoint ep s := by
+  unfold decideMaterializable; exact decide_eq_true_iff
+```
+
+- [ ] **Step 2: Update `TransitionKind`** for the new constructors (`submitRequest`/`approveRequest`/`revoke`); keep `fromString_toString` by `cases k <;> rfl`.
+- [ ] **Step 3: Full build** `lake build` zero-sorry.
+- [ ] **Step 4: Commit.** `proof(network): executable membership decisions + agreement lemmas`
+
+## Task 6: Rust decision module (pure)
+
+**Files:** Create `crates/defra-agent/src/agent/p2p_reconcile/network_membership.rs`; add `mod network_membership;` to `mod.rs`.
+
+- [ ] **Step 1: Failing test** (module `#[cfg(test)]`). The Lean `admittedMember` is **existential over memberships**, so the Rust API splits into a single-row predicate (`membership_admits_did`, ↔ Lean `adminSignedMembership ∧ active ∧ memberDid=did`) and the existential wrapper (`admitted_member`, ↔ Lean `admittedMember`) over a slice (Finding 6):
+
+```rust
+#[test]
+fn admitted_is_existential_over_signed_active_memberships() {
+    let net = NetworkDecision { admin_did: "did:a".into(), admin_sig_valid: true };
+    let good = MembershipDecision {
+        member_did: "did:x".into(), network_match: true, active: true,
+        admin_sig_valid: true, signed_by: "did:a".into(),
+    };
+    // single-row predicate
+    assert!(membership_admits_did(&net, &good, "did:x"));
+    assert!(!membership_admits_did(&net, &MembershipDecision { signed_by: "did:evil".into(), ..good.clone() }, "did:x"));
+    assert!(!membership_admits_did(&net, &MembershipDecision { active: false, ..good.clone() }, "did:x"));
+    // existential wrapper: false on empty / no-match, true when some row admits
+    assert!(!admitted_member(&net, &[], "did:x"));
+    assert!(admitted_member(&net, &[good.clone()], "did:x"));
+    assert!(!admitted_member(&net, &[good.clone()], "did:other"));
+    // invalid network ⇒ never admitted regardless of memberships
+    assert!(!admitted_member(&NetworkDecision { admin_sig_valid: false, ..net.clone() }, &[good], "did:x"));
+}
+```
+
+- [ ] **Step 2: Run, confirm fail.** `cargo test -p defra-agent network_membership`.
+- [ ] **Step 3: Implement** the pure fns over `Clone` input structs (`NetworkDecision`, `MembershipDecision`, `EndpointDecision`), boolean conjunctions matching the Lean predicates exactly. No DB/GraphQL; mirror `decide_join_admission`'s placement.
+  - `valid_network(&NetworkDecision) -> bool` = `admin_sig_valid`.
+  - `admin_signed_membership(&NetworkDecision, &MembershipDecision) -> bool` = `admin_sig_valid && signed_by == admin_did && network_match`.
+  - `membership_admits_did(&NetworkDecision, &MembershipDecision, did) -> bool` = `admin_signed_membership(..) && m.active && m.member_did == did`.
+  - `admitted_member(&NetworkDecision, &[MembershipDecision], did) -> bool` = `valid_network(net) && memberships.iter().any(|m| membership_admits_did(net, m, did))` (the existential wrapper ↔ Lean `admittedMember`).
+  - `member_signed_endpoint(&EndpointDecision) -> bool` = `member_sig_valid && fresh`.
+  - `materializable_endpoint(net, memberships, &EndpointDecision) -> bool` = `admitted_member(net, memberships, ep.did) && member_signed_endpoint(ep) && !ep.peer_is_self`.
+- [ ] **Step 4: Run, confirm pass.** `cargo test -p defra-agent network_membership`.
+- [ ] **Step 5: Commit.** `feat(p2p): pure network-membership decision functions (model-fenced)`
+
+## Task 7: Conformance fence (folded) + final gate
+
+**Files:** Modify `crates/defra-agent/tests/conformance/peer_registry_discovery.rs` (fold in — Finding 7; no new file, no `structure.rs`/`conformance.rs` change).
+
+- [ ] **Step 1: Add conformance tests** in `peer_registry_discovery.rs` mirroring each predicate's truth table against the Rust decision fn: enumerate the deciding boolean/`signed_by` combinations for `admitted_member`/`materializable_endpoint` and assert Rust == the Lean predicate's expected value; include the revocation case (`active=false ⇒ not materializable`), the wrong-admin case (`signed_by != admin_did ⇒ not admitted`), and the forged case (`admin_sig_valid=false ⇒ not admitted`).
+- [ ] **Step 2: Final gate.** `cd crates/defra-agent/proofs && lake build` (zero sorry; `grep -rn sorry Proofs/PeerRegistryDiscovery/` clean) + `cargo test -p defra-agent --test conformance peer_registry` + `cargo test -p defra-agent` (full package).
+- [ ] **Step 3: Commit.** `test(network): fold membership decision fences into peer_registry_discovery conformance`
+
+---
+
+## Self-Review (spec §9 coverage + review findings)
+
+| Item | Task | Note |
+|---|---|---|
+| `validNetwork`/`adminSignedMembership`/`memberSignedEndpoint`/`admittedMember`/`materializableEndpoint` | T2 S1 | `adminSignedMembership` requires `signedBy = adminDid` (Finding 5) |
+| O1 forged/unsigned never materialized | T4 S1 | restated as soundness `materialized_implies_admitted` (Finding 1) |
+| O2 active+fresh ⇒ materialized | T4 S2 | non-vacuous positive |
+| O3 revocation retracts exactly | T4 S3 | by (networkId, memberDid) under `wellFormed` (Finding 2) |
+| O4 ownership-safe | T3 S2 | `ownership_safe` |
+| O5 forged request ⇏ grant | T4 S4 | real `submitRequest`/`approveRequest` transitions (Finding 3) |
+| Executable mirror + agreement | T5 | |
+| Conformance fence | T6 + T7 | folded into one module (Finding 7) |
+| Build gates | all | module-level intermediate, full at T4/T5 (Finding 6) |
+| Endpoint scoping | T1/T2 | global per spec §78; flagged open decision (Finding 4) |
+
+Carried over (re-proven, not new obligations): `replay_rejected`, reciprocal gating, `wellFormed` preservation (T3). Deferred to later cuts: the SDL collections + protocol signing helpers (cut 2), CLI (cuts 3–4), reconciler wiring `deriveMaterializable` over real documents (cut 5), revoke/list/rm + e2e (cut 6).
+
+**Placeholder scan:** proof bodies per the proof-body note; all definitions, statements, witnesses, Rust signatures, gates concrete. **Type consistency:** Rust `NetworkDecision{admin_did,admin_sig_valid}` / `MembershipDecision{member_did,network_match,active,admin_sig_valid,signed_by}` / `EndpointDecision{did,peer,member_sig_valid,fresh,peer_is_self}` ↔ Lean `Network`/`Membership`/`Endpoint` (`signed_by`↔`signedBy`, `admin_sig_valid`↔`adminSigValid`, `member_sig_valid`↔`memberSigValid`, `member_did`↔`memberDid`). The Lean existential `admittedMember` ↔ Rust `admitted_member(net, &[Membership], did)`; the single-row `adminSignedMembership` ↔ Rust `membership_admits_did`. Transition mutators (`upsertMembership`/`submitRequestState`/`approveMembershipState`/`revokeState`/`joinState`) are referenced consistently across Tasks 2–4.


### PR DESCRIPTION
First slice of the network-document membership feature (design: `docs/superpowers/specs/2026-06-15-network-document-membership-design.md`). Replaces the self-asserted peer-registry trust model with a **signed network-membership** model — **Lean model + pure decision functions + conformance only**; no SDL, reconciler, or CLI yet (those are cuts 2–6).

## What this cut delivers
- **Lean model** (`proofs/Proofs/PeerRegistryDiscovery/`, evolved in place): entities `Network` / `Membership` / `Endpoint` (global, did-unique) / `JoinRequest`; predicates `validNetwork`, `adminSignedMembership` (requires `signedBy = adminDid`), `memberSignedEndpoint`, `admittedMember` (existential), `materializableEndpoint`; key-based `upsertMembership` so the `(networkId, memberDid)` uniqueness invariant holds by construction; nonce-only `joinState`; admin-signed `revoke` tombstone. Self-asserted registry rows (`RegistryEntry`/`deriveRegistryDesired`/`removeEntry`) removed.
- **Obligations O1–O5** with witnesses: O1 soundness (`materialized_implies_admitted`), O2 completeness (`materializable_is_derived`), O3 revocation retracts *only* peers exclusively materialized via the revoked DID (shared-peer witness), O4 `ownership_safe`, O5 `membership_grant_requires_admin_signature` (+ negative request witness). Verified non-vacuous (`#print axioms` → no `sorryAx`).
- **Rust** `crates/defra-agent/src/agent/p2p_reconcile/network_membership.rs`: pure decision fns mirroring each Lean predicate conjunct-for-conjunct (single-row `membership_admits_did` + existential `admitted_member`).
- **Conformance**: folded into `tests/conformance/peer_registry_discovery.rs` (one `Home::Module` per model) — predicate truth tables via single-bit-flip.

## Cut roadmap (each its own PR)
1. **This PR** — Lean model + decision fns + conformance.
2. SDL collections (`AgentNetwork`/`NetworkMembership`/`PeerEndpoint`/`NetworkJoinRequest`) + canonical protocol signing helpers + `discovery` template.
3. CLI `network create` / `invite` (danet1- pointer).
4. CLI `join` / `requests` / `approve` / `deny`.
5. Runtime: `PeerEndpoint` heartbeat + discovery reconciler wiring `deriveMaterializable` over real documents.
6. `revoke` / `list` / `rm` + multi-node e2e.

## Test plan
- [x] `cd crates/defra-agent/proofs && lake build` — zero `sorry`
- [x] `cargo test -p defra-agent --test conformance` — 225 passed / 0 failed
- [x] `cargo test -p defra-agent network_membership` — decision-fn unit tests pass
- [x] Rebased onto `origin/main`; final branch review ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)