### PR TITLE
Add periodic recovery sweep registry

### DIFF
--- a/crates/defra-agent/src/background_completion.rs
+++ b/crates/defra-agent/src/background_completion.rs
@@ -1105,17 +1105,20 @@ impl BackgroundCompletionObserver {
     }
 
     async fn run_reconcilers(&self) -> Result<()> {
-        // #465: terminalize expired subagent children (and project their
-        // background bridges), and interrupt queued descendants of terminal
-        // parents, on the live tick — startup recovery alone leaves a
-        // mid-run wedge in place until the next restart.
-        let liveness = crate::tool_call_lifecycle::ToolCallLifecycle::reconcile_subagent_liveness(
+        for run in crate::periodic_recovery::run_periodic_recovery_sweeps(
             self.node.as_ref(),
             &self.local_did,
         )
-        .await?;
-        if !liveness.is_noop() {
-            tracing::debug!(?liveness, "subagent liveness reconciliation applied");
+        .await?
+        {
+            if !run.is_noop() {
+                tracing::debug!(
+                    sweep_ids = ?run.metadata.sweep_ids,
+                    rust_function = run.metadata.rust_function,
+                    outcome = ?run.outcome,
+                    "periodic recovery sweep applied"
+                );
+            }
         }
         let unclaimed =
             reconcile_unclaimed_cross_deployment_spawns(self.node.clone(), &self.local_did).await?;

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -49,6 +49,7 @@ pub mod meta_tools;
 pub mod migration;
 pub mod native_executor_status;
 pub mod oneshot;
+pub mod periodic_recovery;
 pub mod prompt;
 pub(crate) mod registry;
 pub mod retry;
@@ -132,6 +133,10 @@ pub use mcp_pool::McpPool;
 pub use meta_tools::build_meta_tools;
 pub use native_executor_status::{active_native_executors, NativeExecutorStatus};
 pub use oneshot::{run_openai_oneshot, run_openai_oneshot_with_tools, OneshotRunResult};
+pub use periodic_recovery::{
+    periodic_recovery_sweep_metadata, run_periodic_recovery_sweeps, PeriodicRecoverySweepMetadata,
+    PeriodicRecoverySweepOutcome, PeriodicRecoverySweepRun,
+};
 pub use prompt::{LayeredPromptBuilder, PromptBuilder};
 pub use run_timeline::{
     build_run_timeline, RunTimeline, RunTimelineEvent, RunTimelineRows, TimelineConversationRow,

--- a/crates/defra-agent/src/periodic_recovery.rs
+++ b/crates/defra-agent/src/periodic_recovery.rs
@@ -1,0 +1,105 @@
+//! Registry for recovery sweeps that must run on the live daemon tick.
+//!
+//! Lean owns the sweep vocabulary (`RecoverySweep.sweepId`, cadence, and
+//! `rustFunction`). Rust owns the executable registry the daemon iterates.
+//! Keeping the mapping explicit here makes new periodic sweeps discoverable by
+//! conformance tests instead of burying them as ad hoc calls in the observer.
+
+use anyhow::Result;
+use defra_node::EmbeddedNode;
+
+use crate::llm::tool::BoxFuture;
+use crate::tool_call_lifecycle::{SubagentLivenessReport, ToolCallLifecycle};
+
+const SUBAGENT_LIVENESS_SWEEP_IDS: &[&str] = &[
+    "subagent_liveness_terminalize_expired_children",
+    "subagent_liveness_interrupt_queued_descendants",
+];
+
+/// Lean-facing metadata for one Rust periodic recovery executor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PeriodicRecoverySweepMetadata {
+    /// Lean sweep IDs covered by this executor. Multiple Lean sweeps may share
+    /// one Rust reconciler when a single database pass maintains both
+    /// predicates.
+    pub sweep_ids: &'static [&'static str],
+    /// Fully-qualified Rust function name emitted in the Lean contract.
+    pub rust_function: &'static str,
+}
+
+/// Outcome from a periodic recovery executor.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PeriodicRecoverySweepOutcome {
+    SubagentLiveness(SubagentLivenessReport),
+}
+
+impl PeriodicRecoverySweepOutcome {
+    pub fn is_noop(&self) -> bool {
+        match self {
+            Self::SubagentLiveness(report) => report.is_noop(),
+        }
+    }
+}
+
+/// One executed periodic recovery registry entry.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PeriodicRecoverySweepRun {
+    pub metadata: PeriodicRecoverySweepMetadata,
+    pub outcome: PeriodicRecoverySweepOutcome,
+}
+
+impl PeriodicRecoverySweepRun {
+    pub fn is_noop(&self) -> bool {
+        self.outcome.is_noop()
+    }
+}
+
+type PeriodicRecoverySweepFn =
+    for<'a> fn(&'a EmbeddedNode, &'a str) -> BoxFuture<'a, Result<PeriodicRecoverySweepOutcome>>;
+
+struct PeriodicRecoverySweepExecutor {
+    metadata_index: usize,
+    run: PeriodicRecoverySweepFn,
+}
+
+const PERIODIC_RECOVERY_SWEEP_METADATA: &[PeriodicRecoverySweepMetadata] =
+    &[PeriodicRecoverySweepMetadata {
+        sweep_ids: SUBAGENT_LIVENESS_SWEEP_IDS,
+        rust_function: "ToolCallLifecycle::reconcile_subagent_liveness",
+    }];
+
+const PERIODIC_RECOVERY_SWEEP_EXECUTORS: &[PeriodicRecoverySweepExecutor] =
+    &[PeriodicRecoverySweepExecutor {
+        metadata_index: 0,
+        run: reconcile_subagent_liveness,
+    }];
+
+/// Registry metadata consumed by conformance tests and operator projections.
+pub fn periodic_recovery_sweep_metadata() -> &'static [PeriodicRecoverySweepMetadata] {
+    PERIODIC_RECOVERY_SWEEP_METADATA
+}
+
+/// Run every registered periodic recovery sweep once.
+pub async fn run_periodic_recovery_sweeps(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<Vec<PeriodicRecoverySweepRun>> {
+    let mut runs = Vec::with_capacity(PERIODIC_RECOVERY_SWEEP_EXECUTORS.len());
+    for executor in PERIODIC_RECOVERY_SWEEP_EXECUTORS {
+        let metadata = PERIODIC_RECOVERY_SWEEP_METADATA[executor.metadata_index];
+        let outcome = (executor.run)(node, agent_did).await?;
+        runs.push(PeriodicRecoverySweepRun { metadata, outcome });
+    }
+    Ok(runs)
+}
+
+fn reconcile_subagent_liveness<'a>(
+    node: &'a EmbeddedNode,
+    agent_did: &'a str,
+) -> BoxFuture<'a, Result<PeriodicRecoverySweepOutcome>> {
+    Box::pin(async move {
+        ToolCallLifecycle::reconcile_subagent_liveness(node, agent_did)
+            .await
+            .map(PeriodicRecoverySweepOutcome::SubagentLiveness)
+    })
+}

--- a/crates/defra-agent/tests/conformance/recovery_sweeps.rs
+++ b/crates/defra-agent/tests/conformance/recovery_sweeps.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 const RECOVERY_CREATED_AT: &str = "2026-03-23T00:00:00Z";
@@ -30,6 +31,7 @@ pub(super) async fn generated_recovery_sweep_cases_drive_startup_recovery_contra
         actual_sweep_ids, expected_sweep_ids,
         "Lean recovery sweep registry drifted"
     );
+    assert_periodic_recovery_registry_matches_lean(cases);
 
     for case in cases {
         assert_recovery_case_metadata(case);
@@ -144,10 +146,10 @@ fn expected_recovery_equivalence_theorem(sweep_id: &str) -> &'static str {
 }
 
 fn assert_recovery_case_metadata(case: &lean_vocab_test::LeanRecoverySweepCase) {
-    let expected_cadence = match case.sweep_id.as_str() {
-        "subagent_liveness_terminalize_expired_children"
-        | "subagent_liveness_interrupt_queued_descendants" => "periodic",
-        _ => "startup",
+    let expected_cadence = if rust_periodic_recovery_sweep_ids().contains(case.sweep_id.as_str()) {
+        "periodic"
+    } else {
+        "startup"
     };
     assert_eq!(case.cadence.as_str(), expected_cadence, "{}", case.name);
     assert_eq!(
@@ -177,6 +179,61 @@ fn assert_recovery_case_metadata(case: &lean_vocab_test::LeanRecoverySweepCase) 
         "recovery case {} must name its audit reference",
         case.name
     );
+}
+
+fn assert_periodic_recovery_registry_matches_lean(
+    cases: &[lean_vocab_test::LeanRecoverySweepCase],
+) {
+    let mut lean_periodic_by_id = BTreeMap::new();
+    for case in cases.iter().filter(|case| case.cadence == "periodic") {
+        if let Some(previous) =
+            lean_periodic_by_id.insert(case.sweep_id.as_str(), case.rust_function.as_str())
+        {
+            assert_eq!(
+                previous,
+                case.rust_function.as_str(),
+                "Lean emitted conflicting Rust functions for periodic recovery sweep {}",
+                case.sweep_id
+            );
+        }
+    }
+
+    let mut rust_periodic_by_id = BTreeMap::new();
+    for metadata in defra_agent::periodic_recovery_sweep_metadata() {
+        assert!(
+            !metadata.sweep_ids.is_empty(),
+            "periodic recovery registry entry {} must name at least one Lean sweep id",
+            metadata.rust_function
+        );
+        for sweep_id in metadata.sweep_ids {
+            assert!(
+                rust_periodic_by_id
+                    .insert(*sweep_id, metadata.rust_function)
+                    .is_none(),
+                "periodic recovery sweep id {sweep_id} registered more than once"
+            );
+        }
+    }
+
+    assert_eq!(
+        rust_periodic_by_id.keys().copied().collect::<BTreeSet<_>>(),
+        lean_periodic_by_id.keys().copied().collect::<BTreeSet<_>>(),
+        "Rust periodic recovery registry drifted from Lean cadence=periodic sweeps"
+    );
+    for (sweep_id, rust_function) in rust_periodic_by_id {
+        assert_eq!(
+            Some(&rust_function),
+            lean_periodic_by_id.get(sweep_id),
+            "periodic recovery registry Rust function drifted for {sweep_id}"
+        );
+    }
+}
+
+fn rust_periodic_recovery_sweep_ids() -> BTreeSet<&'static str> {
+    defra_agent::periodic_recovery_sweep_metadata()
+        .iter()
+        .flat_map(|metadata| metadata.sweep_ids.iter().copied())
+        .collect()
 }
 
 async fn drive_recovery_sweep_case(case: &lean_vocab_test::LeanRecoverySweepCase) {


### PR DESCRIPTION
## Summary

- add a Rust registry for periodic recovery sweep executors
- route the background completion observer through the registry instead of hardcoding subagent liveness recovery
- add conformance coverage that compares Lean `cadence = periodic` sweep metadata against the Rust registry, including sweep IDs and Rust function names

This keeps the current subagent liveness behavior unchanged while making future periodic recovery sweeps explicit and test-covered. The registry maps both Lean subagent liveness sweep IDs to the single Rust reconciler so the daemon does not run the same database pass twice per tick.

Fixes #477

## Testing

- `cargo check -p defra-agent --tests`
- `cargo test -p defra-agent --test conformance generated_recovery_sweep_cases_drive_startup_recovery_contract -- --nocapture`
- `cargo test -p defra-agent --test conformance subagent_liveness_reconciliation_converges_expired_processing_to_zero -- --nocapture`
- `cargo fmt --check`
- `git diff --check`