### PR TITLE
test(codex): prove Codex thread list reconstructs from durable data (follow-up to #505)

### DIFF
--- a/crates/defra-agent-cli/tests/cli_codex_shim.rs
+++ b/crates/defra-agent-cli/tests/cli_codex_shim.rs
@@ -716,6 +716,184 @@ async fn codex_shim_protocol_turn_streams_defra_response() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_shim_thread_list_reconstructs_turned_threads_from_durable_data() -> Result<()> {
+    // Codex is a presentation layer: thread ownership is NOT persisted with a
+    // marker. A thread that has any turn carries a durable codex_shim-marked
+    // AgentRequest, so a fresh shim process (e.g. after restart, with an empty
+    // in-process sidecar) reconstructs it in thread/list purely from the data.
+    // A never-turned session carries no durable Codex interaction and is
+    // intentionally not surfaced. This test simulates "after restart" by seeding
+    // both kinds directly in the DB — neither is in this process's `created` set.
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-codex-shim-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start(&model_name, "unused")?;
+    let server_port = allocate_port()?;
+    let graphql = graphql_url(server_port);
+    let agent_name = format!("cli-codex-shim-{}", Uuid::new_v4().simple());
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let behavior_id = format!("{agent_did}:default");
+    let shim_port = allocate_port()?;
+    let shim_port_string = shim_port.to_string();
+    let mut serve = spawn_server_with_env(
+        &home_dir,
+        server_port,
+        &[
+            "--codex-shim",
+            "--codex-shim-port",
+            &shim_port_string,
+            "--codex-shim-poll-ms",
+            "100",
+            "--codex-shim-timeout-secs",
+            "60",
+        ],
+        &[],
+    )?;
+    wait_for_port(server_port, &mut serve)?;
+    wait_for_port(shim_port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    // A "previous session" Codex thread: AgentSession + a durable codex_shim
+    // request + conversation, none of it created by this shim process.
+    let turned_session_id = Uuid::new_v4().to_string();
+    for mutation in [
+        format!(
+            r#"mutation {{ create_AgentSession(input: {{
+                session_id: "{s}", agent_name: "{behavior_id}", agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}", started: "2026-01-01T00:00:00Z", status: "active"
+            }}) {{ _docID }} }}"#,
+            s = escape_graphql_string(&turned_session_id),
+            behavior_id = escape_graphql_string(&behavior_id),
+            agent_did = escape_graphql_string(&agent_did),
+        ),
+        format!(
+            r#"mutation {{ create_AgentRequest(input: {{
+                request_id: "{r}", agent_did: "{agent_did}", behavior_id: "{behavior_id}",
+                session_id: "{s}", metadata: "{{\"codex_shim\":{{}}}}",
+                execution_origin: "interactive", created_at: "2026-01-01T00:00:00Z"
+            }}) {{ _docID }} }}"#,
+            r = escape_graphql_string(&Uuid::new_v4().to_string()),
+            agent_did = escape_graphql_string(&agent_did),
+            behavior_id = escape_graphql_string(&behavior_id),
+            s = escape_graphql_string(&turned_session_id),
+        ),
+        format!(
+            r#"mutation {{ create_AgentConversation(input: {{
+                session_id: "{s}", agent_name: "{behavior_id}", agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}", title: "Earlier Codex thread", title_source: "user",
+                status: "active", created_at: "2026-01-01T00:00:00Z", updated_at: "2026-01-01T00:00:00Z"
+            }}) {{ _docID }} }}"#,
+            s = escape_graphql_string(&turned_session_id),
+            behavior_id = escape_graphql_string(&behavior_id),
+            agent_did = escape_graphql_string(&agent_did),
+        ),
+    ] {
+        graphql_query(&graphql, &mutation).await?;
+    }
+
+    // A "previous session" never-turned thread: a bare AgentSession, no request.
+    let zero_turn_session_id = Uuid::new_v4().to_string();
+    graphql_query(
+        &graphql,
+        &format!(
+            r#"mutation {{ create_AgentSession(input: {{
+                session_id: "{s}", agent_name: "{behavior_id}", agent_did: "{agent_did}",
+                behavior_id: "{behavior_id}", started: "2026-01-01T00:00:00Z", status: "active"
+            }}) {{ _docID }} }}"#,
+            s = escape_graphql_string(&zero_turn_session_id),
+            behavior_id = escape_graphql_string(&behavior_id),
+            agent_did = escape_graphql_string(&agent_did),
+        ),
+    )
+    .await?;
+
+    let (mut ws, _) = connect_async(format!("ws://127.0.0.1:{shim_port}/"))
+        .await
+        .context("connecting to codex-shim websocket")?;
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::Initialize {
+            request_id: request_id(1),
+            params: codex::InitializeParams {
+                client_info: codex::ClientInfo {
+                    name: "defra-agent-test".to_string(),
+                    title: None,
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                },
+                capabilities: None,
+            },
+        },
+    )
+    .await?;
+    let _: codex::InitializeResponse = read_typed_response(&mut ws, request_id(1)).await?;
+    send_client_notification(&mut ws, codex::ClientNotification::Initialized).await?;
+
+    send_client_request(
+        &mut ws,
+        codex::ClientRequest::ThreadList {
+            request_id: request_id(2),
+            params: codex::ThreadListParams {
+                cursor: None,
+                limit: None,
+                sort_key: None,
+                sort_direction: None,
+                model_providers: None,
+                source_kinds: None,
+                archived: None,
+                cwd: None,
+                use_state_db_only: true,
+                search_term: None,
+            },
+        },
+    )
+    .await?;
+    let listed: codex::ThreadListResponse = read_typed_response(&mut ws, request_id(2)).await?;
+    assert!(
+        listed
+            .data
+            .iter()
+            .any(|thread| thread.id == turned_session_id),
+        "a turned Codex thread must be reconstructed from its durable codex_shim request, \
+         with no in-process marker: {listed:?}"
+    );
+    assert!(
+        !listed
+            .data
+            .iter()
+            .any(|thread| thread.id == zero_turn_session_id),
+        "a never-turned session holds no durable Codex data and must not be surfaced \
+         after restart: {listed:?}"
+    );
+
+    // Reconstruction rebuilds the thread's identity from durable data — the name
+    // comes from the persisted conversation title, not any in-process state.
+    let turned = listed
+        .data
+        .iter()
+        .find(|thread| thread.id == turned_session_id)
+        .expect("turned thread present");
+    assert_eq!(
+        turned.name.as_deref(),
+        Some("Earlier Codex thread"),
+        "reconstructed thread name should come from the durable conversation title"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn codex_shim_derives_git_info_and_persists_early_rename() -> Result<()> {
     // Regression guards for #494: git metadata is DERIVED from the thread cwd at
     // read time (no ThreadMetadataUpdate round-trip), a non-git cwd yields no

--- a/docs/superpowers/specs/2026-06-15-remove-codex-thread-projection-design.md
+++ b/docs/superpowers/specs/2026-06-15-remove-codex-thread-projection-design.md
@@ -244,6 +244,21 @@ No `lake build` (no Lean / ApplyReconcile touched — verified).
 
 ## Accepted tradeoffs
 
+**Codex is a presentation layer; threads reconstruct from durable data.** A
+Codex thread is not a persisted entity with an ownership marker — it is a view
+over durable DEFRA records. A thread with **any** turn carries a durable
+`codex_shim`-marked `AgentRequest`, so a fresh shim process (e.g. after restart,
+with an empty in-process sidecar) reconstructs it in `thread/list` purely from
+the data: ownership from the marked request (`codex_marked_session_ids`), cwd
+from that request's metadata (`derive_thread_cwd`), name from
+`AgentConversation.title`, history from the messages. The in-process `created`
+set is only a same-session presentation cache so a just-started thread appears in
+the sidebar before its first turn; it is deliberately **not** durable. A
+never-turned start or fork holds no durable Codex interaction, so it is not
+surfaced after a restart — and no DEFRA data is lost (a fork's copied messages
+remain in the DB; re-forking is free). This is why no durable ownership marker
+is introduced.
+
 **Restart resets UI sugar.** Restarting the embedded node resets Codex-only UI
 sugar (archive flag, memory toggle, goal, thread settings) to defaults.
 Conversations, history, and titles (including user-set names, now on


### PR DESCRIPTION
## Summary
Follow-up to #505 (merged). Adds the restart-style regression coverage requested in review and documents the design rationale. **No code change** — the merged implementation already behaves correctly.

Codex threads are a presentation layer over durable DEFRA records, not a persisted entity with an ownership marker:
- A thread with **any** turn carries a durable `codex_shim`-marked `AgentRequest`, so a fresh shim process (empty in-process sidecar, i.e. after restart) reconstructs it in `thread/list` purely from the data — ownership via `codex_marked_session_ids`, cwd via `derive_thread_cwd`, name via `AgentConversation.title`.
- The in-process `created` set is only a same-session presentation cache (so a just-started thread shows in the sidebar before its first turn); it is deliberately **not** durable.
- A never-turned start or fork holds no durable Codex interaction, so it is not surfaced after a restart — and no DEFRA data is lost (a fork's copied messages remain in the DB).

## What's here
- New `codex_shim_thread_list_reconstructs_turned_threads_from_durable_data`: seeds a "previous-session" turned thread (AgentSession + `codex_shim` request + conversation) **directly in the DB** — not via `ThreadStart`, so it's absent from this process's `created` set — and asserts `thread/list` rebuilds it (and its name) from the data, while a bare zero-turn `AgentSession` is correctly absent. This validates the behavior without fragile process-restart machinery.
- Spec `Accepted tradeoffs` documents the presentation-layer / reconstruct-from-data model.

## Tests
- `cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_thread_list_reconstructs_turned_threads_from_durable_data` ✅
- Full `cli_codex_shim` suite: 26 passed, 8 live ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)