### PR TITLE
Add desktop UI harness with Playwright and Bombadil coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,3 +136,55 @@ jobs:
       - name: Build proofs
         working-directory: crates/defra-agent/proofs
         run: lake build
+
+  desktop-ui:
+    runs-on: [self-hosted, macOS, ARM64, studio]
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/desktop-tauri/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: apps/desktop-tauri
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: apps/desktop-tauri
+        run: npx playwright install chromium
+
+      - name: Check desktop formatting
+        working-directory: apps/desktop-tauri
+        run: npm run format:check
+
+      - name: Build desktop frontend
+        working-directory: apps/desktop-tauri
+        run: npm run build
+
+      - name: Run desktop unit tests
+        working-directory: apps/desktop-tauri
+        run: npm test
+
+      - name: Run desktop browser journeys
+        working-directory: apps/desktop-tauri
+        run: npm run test:ui:e2e
+
+      - name: Run desktop Bombadil smoke
+        working-directory: apps/desktop-tauri
+        run: npm run test:ui:fuzz -- --time-limit 30s
+
+      - name: Upload desktop UI artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: desktop-ui-artifacts
+          if-no-files-found: ignore
+          path: |
+            apps/desktop-tauri/test-results
+            apps/desktop-tauri/playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,12 @@ jobs:
           cache: npm
           cache-dependency-path: apps/desktop-tauri/package-lock.json
 
+      - name: Install elan
+        run: |
+          curl https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh -sSf | sh -s -- -y
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+          "$HOME/.elan/bin/elan" --version
+
       - name: Install frontend dependencies
         working-directory: apps/desktop-tauri
         run: npm ci

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -25,6 +25,9 @@ env:
   DEFRA_AGENT_CLI_E2E_MODEL_ENDPOINT: ${{ github.event.inputs.inference_endpoint }}
   DEFRA_AGENT_CLI_E2E_MODEL_NAME: ${{ github.event.inputs.model_name }}
   DEFRA_AGENT_CLI_E2E_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
+  DEFRA_AGENT_TAURI_LIVE_INFERENCE_URL: ${{ github.event.inputs.inference_endpoint }}
+  DEFRA_AGENT_TAURI_LIVE_MODEL_NAME: ${{ github.event.inputs.model_name }}
+  DEFRA_AGENT_TAURI_LIVE_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
   AGENT_DAEMON_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
 
 jobs:
@@ -83,6 +86,97 @@ jobs:
 
       - name: Run live CLI smoke test
         run: cargo test -p defra-agent-cli --test cli_live standard_onboarding_live_demo_runs_real_conversation_with_filesystem_tools -- --ignored --nocapture --test-threads=1
+
+      - name: Cleanup git auth
+        if: always()
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
+        run: |
+          git config --global --remove-section "url.https://x-access-token:${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
+          git config --global --remove-section "url.https://${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
+
+      - name: Show Rust build cache stats
+        if: always()
+        run: .github/scripts/show-sccache-stats.sh
+
+  desktop-live-smoke:
+    runs-on: [self-hosted, macOS, ARM64, studio]
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Rewrite Git SSH dependencies to HTTPS
+        env:
+          PRIVATE_REPO_PAT: ${{ secrets.PRIVATE_REPO_PAT }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${PRIVATE_REPO_PAT}" ]]; then
+            echo "::error::Missing PRIVATE_REPO_PAT; required to fetch private Source Network git dependencies."
+            exit 1
+          fi
+          auth_url="https://x-access-token:${PRIVATE_REPO_PAT}@github.com/sourcenetwork/"
+          git config --global --add url."${auth_url}".insteadOf "https://github.com/sourcenetwork/"
+          git config --global --add url."${auth_url}".insteadOf "ssh://git@github.com/sourcenetwork/"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: apps/desktop-tauri/package-lock.json
+
+      - name: Install protobuf compiler
+        run: |
+          set -euo pipefail
+
+          protoc_path=""
+          if [[ -x "/opt/homebrew/bin/protoc" ]]; then
+            protoc_path="/opt/homebrew/bin/protoc"
+          elif command -v protoc >/dev/null 2>&1; then
+            protoc_path="$(command -v protoc)"
+          else
+            if ! command -v brew >/dev/null 2>&1; then
+              echo "::error::protoc is missing and Homebrew is not available to install protobuf."
+              exit 1
+            fi
+            brew install protobuf
+            protoc_path="$(brew --prefix protobuf)/bin/protoc"
+          fi
+
+          if [[ ! -x "${protoc_path}" ]]; then
+            echo "::error::protoc was not found at ${protoc_path}."
+            exit 1
+          fi
+
+          echo "$(dirname "${protoc_path}")" >> "${GITHUB_PATH}"
+          echo "PROTOC=${protoc_path}" >> "${GITHUB_ENV}"
+          "${protoc_path}" --version
+
+      - name: Prepare disk-backed Rust build cache
+        run: .github/scripts/setup-rust-build-cache.sh
+
+      - name: Install frontend dependencies
+        working-directory: apps/desktop-tauri
+        run: npm ci
+
+      - name: Run live desktop chat smoke
+        working-directory: apps/desktop-tauri
+        run: npm run test:live:chat
+
+      - name: Run live desktop config smoke
+        working-directory: apps/desktop-tauri
+        run: npm run test:live:config
+
+      - name: Run live desktop operations smoke
+        working-directory: apps/desktop-tauri
+        run: npm run test:live:operations
+
+      - name: Run live desktop interrupt smoke
+        working-directory: apps/desktop-tauri
+        run: npm run test:live:interrupt
 
       - name: Cleanup git auth
         if: always()

--- a/apps/desktop-tauri/.gitignore
+++ b/apps/desktop-tauri/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+playwright-report
+test-results
 *.local
 
 # Editor directories and files

--- a/apps/desktop-tauri/README.md
+++ b/apps/desktop-tauri/README.md
@@ -12,31 +12,31 @@ and fleet views from that local store.
 Prerequisites:
 
 - Rust toolchain
-- Bun
+- Node.js 22+ and npm
 - a running or discoverable `defra-agent` runtime for live chat flows
 
 Install frontend dependencies:
 
 ```bash
-bun install
+npm ci
 ```
 
 Run the frontend-only Vite app:
 
 ```bash
-bun run dev
+npm run dev
 ```
 
 Run the full Tauri shell:
 
 ```bash
-bun run tauri dev
+npm run tauri dev
 ```
 
 Build the frontend:
 
 ```bash
-bun run build
+npm run build
 ```
 
 Build the desktop binary from the repo root:
@@ -69,24 +69,56 @@ status bar to report `replication: subscriptions armed`.
 
 ## Tests
 
-Frontend/unit tests:
+The deterministic desktop UI gate is layered so failures point at the right
+surface:
 
 ```bash
-bun run test
+npm run test:ui
 ```
+
+That command checks formatting, builds the frontend, runs Vitest component/model
+tests, runs Playwright browser journeys, and finishes with a short Bombadil
+smoke run.
+
+Individual layers:
+
+```bash
+npm run test:ui:unit
+npm run test:ui:e2e
+npm run test:ui:fuzz -- --time-limit 30s
+npm run test:ui:fuzz:long
+```
+
+The Playwright suite serves `tests/ui-harness/harness.html` with Vite and renders
+the real React shell against a deterministic in-memory `DesktopApiAdapter`. It
+covers fleet, chat, config, operations, interrupt, sad-path, and responsive
+journeys across desktop, laptop, and narrow viewports.
+
+Bombadil uses the same harness and checks persistent invariants while exploring
+the UI:
+
+```bash
+npm run test:ui:fuzz
+npm run test:ui:fuzz -- --time-limit 2m
+```
+
+Artifacts are written under `test-results/` and Playwright's HTML report under
+`playwright-report/`.
 
 Live UI smoke tests:
 
 ```bash
-bun run test:live
-bun run test:live:chat
-bun run test:live:config
+npm run test:live
+npm run test:live:chat
+npm run test:live:config
+npm run test:live:operations
+npm run test:live:interrupt
 ```
 
 Remote fleet smoke:
 
 ```bash
-bun run smoke:remote-fleet
+npm run smoke:remote-fleet
 ```
 
 The live tests expect real runtime connectivity and should be treated as manual

--- a/apps/desktop-tauri/package-lock.json
+++ b/apps/desktop-tauri/package-lock.json
@@ -16,6 +16,8 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@antithesishq/bombadil": "^0.6.0",
+        "@playwright/test": "^1.61.0",
         "@tauri-apps/cli": "^2",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -37,6 +39,16 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@antithesishq/bombadil": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@antithesishq/bombadil/-/bombadil-0.6.0.tgz",
+      "integrity": "sha512-7XVk10FJult7P5wVzKXfCo69oaZEGCJDRICnJzXsGy0rWv+HZe1zF/w/QNaLHvaUTMTQEjD+zqEq0wCYYfRqRQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bombadil": "bin/bombadil.js"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -906,6 +918,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3512,6 +3540,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -6,9 +6,15 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "format": "prettier --write \"src/**/*.{css,json,ts,tsx}\" \"tests/**/*.{mjs,ts,tsx}\" \"*.json\"",
-    "format:check": "prettier --check \"src/**/*.{css,json,ts,tsx}\" \"tests/**/*.{mjs,ts,tsx}\" \"*.json\"",
+    "format": "prettier --write \"src/**/*.{css,json,ts,tsx}\" \"tests/**/*.{html,mjs,ts,tsx}\" \"*.{json,ts}\"",
+    "format:check": "prettier --check \"src/**/*.{css,json,ts,tsx}\" \"tests/**/*.{html,mjs,ts,tsx}\" \"*.{json,ts}\"",
     "test": "vitest run",
+    "test:ui": "npm run format:check && npm run build && npm run test:ui:unit && npm run test:ui:e2e && npm run test:ui:fuzz -- --time-limit 20s",
+    "test:ui:unit": "vitest run",
+    "test:ui:e2e": "playwright test",
+    "test:ui:fuzz": "node ./tests/bombadil/run-bombadil.mjs",
+    "test:ui:fuzz:long": "node ./tests/bombadil/run-bombadil.mjs --time-limit 5m",
+    "test:ui:bombadil": "node ./tests/bombadil/run-bombadil.mjs",
     "test:live": "node ./tests/run-live-test.mjs",
     "test:live:behavior-config": "node ./tests/run-live-test.mjs --suite behavior",
     "test:live:config": "node ./tests/run-live-test.mjs --suite config",
@@ -25,14 +31,16 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@antithesishq/bombadil": "^0.6.0",
+    "@playwright/test": "^1.61.0",
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/apps/desktop-tauri/playwright.config.ts
+++ b/apps/desktop-tauri/playwright.config.ts
@@ -1,0 +1,56 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.DESKTOP_UI_E2E_PORT ?? 1421);
+const baseURL = process.env.DESKTOP_UI_E2E_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/playwright",
+  outputDir: "./test-results/playwright",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI
+    ? [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
+    : "list",
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL,
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+    video: "retain-on-failure",
+  },
+  webServer: {
+    command: `node ./node_modules/vite/bin/vite.js --host 127.0.0.1 --port ${port} --strictPort --clearScreen false`,
+    url: `${baseURL}/tests/ui-harness/harness.html`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+  projects: [
+    {
+      name: "chromium-desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 900 },
+      },
+    },
+    {
+      name: "chromium-laptop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    {
+      name: "chromium-narrow",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+});

--- a/apps/desktop-tauri/src/components/chat/ChatHeader.tsx
+++ b/apps/desktop-tauri/src/components/chat/ChatHeader.tsx
@@ -69,6 +69,7 @@ export function ChatHeader({
               <input
                 autoFocus
                 className="title-rename-input"
+                data-testid="conversation-title-input"
                 onBlur={() => void submitTitleRename()}
                 onChange={(event) => setTitleDraft(event.currentTarget.value)}
                 onKeyDown={(event) => {
@@ -85,6 +86,7 @@ export function ChatHeader({
               <h2>{visibleConversationTitle}</h2>
               <button
                 className="icon-button"
+                data-testid="conversation-title-edit"
                 disabled={renamingTitle}
                 onClick={() => setIsRenamingTitle(true)}
                 type="button"

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -122,8 +122,11 @@ export function ScheduleConfigEditor({
     );
     setEnabled(schedule?.enabled ?? true);
     setConcurrency(schedule?.concurrency ?? "serial");
-    setRunStatus(null);
   }, [schedule, selectedTask?.taskId]);
+
+  useEffect(() => {
+    setRunStatus(null);
+  }, [schedule?.scheduleId]);
 
   const intervalValid = isOptionalInt(intervalSecs, { min: 1 });
 

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -121,8 +121,11 @@ export function TaskConfigEditor({
     setPromptTemplate(task?.promptTemplate ?? "");
     setOutputSchemaRef(task?.outputSchemaRef ?? "");
     setEnabled(task?.enabled ?? true);
-    setRunStatus(null);
   }, [selectedBehavior?.behaviorId, task]);
+
+  useEffect(() => {
+    setRunStatus(null);
+  }, [selectedBehavior?.behaviorId, task?.taskId]);
 
   const runArgsValid = isJsonObject(runArgs);
 

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -185,7 +185,9 @@ export function ToolSelectionConfigEditor({
     setCommandForbiddenArgvPrefixes(
       (toolSelection?.commandForbiddenArgvPrefixes ?? []).join("\n"),
     );
-    setCommandNetworkMode(normalizeCommandNetworkMode(toolSelection?.commandNetworkMode));
+    setCommandNetworkMode(
+      normalizeCommandNetworkMode(toolSelection?.commandNetworkMode),
+    );
     setCliToolNames((toolSelection?.cliToolNames ?? []).join("\n"));
     setEnableMetaTools(toolSelection?.enableMetaTools ?? false);
     const knownServiceIds = new Set(toolServiceIdKey.split("\n").filter(Boolean));

--- a/apps/desktop-tauri/tests/bombadil/run-bombadil.mjs
+++ b/apps/desktop-tauri/tests/bombadil/run-bombadil.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
 import { createServer } from "node:net";
-import { mkdir } from "node:fs/promises";
-import { dirname, resolve } from "node:path";
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { delimiter, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -44,6 +45,7 @@ try {
   await waitForVite(vite, harnessUrl);
   await mkdir(defaultOutputPath, { recursive: true });
 
+  const chromeEnv = await chromePathEnvironment(defaultOutputPath);
   const bombadilArgs = ["browser", "test", harnessUrl, "tests/bombadil/spec.ts"];
   if (!headed) {
     bombadilArgs.push("--headless");
@@ -66,6 +68,7 @@ try {
     cwd: rootDir,
     env: {
       ...process.env,
+      ...chromeEnv,
       RUST_LOG: process.env.BOMBADIL_RUST_LOG ?? "error",
     },
     stdio: "inherit",
@@ -88,6 +91,64 @@ try {
   }
 } finally {
   await stopProcess(vite);
+}
+
+async function resolveChromeExecutable() {
+  const explicit =
+    process.env.BOMBADIL_CHROME_EXECUTABLE ??
+    process.env.CHROME ??
+    process.env.CHROME_PATH ??
+    process.env.CHROME_BIN;
+  if (explicit) {
+    if (!existsSync(explicit)) {
+      throw new Error(`configured Chrome executable does not exist: ${explicit}`);
+    }
+    return explicit;
+  }
+
+  try {
+    const { chromium } = await import("playwright");
+    const executablePath = chromium.executablePath();
+    if (existsSync(executablePath)) {
+      return executablePath;
+    }
+  } catch {
+    // Fall through to Bombadil's managed-browser path below.
+  }
+
+  if (process.env.CI) {
+    throw new Error(
+      "Playwright Chromium is not installed; run `npx playwright install chromium` before Bombadil.",
+    );
+  }
+  return null;
+}
+
+async function chromePathEnvironment(outputPath) {
+  const chromeExecutable = await resolveChromeExecutable();
+  if (!chromeExecutable) {
+    return {};
+  }
+
+  const binDir = resolve(outputPath, "chrome-bin");
+  await mkdir(binDir, { recursive: true });
+  for (const name of ["chromium-browser", "chromium", "google-chrome", "chrome"]) {
+    const wrapper = resolve(binDir, name);
+    await writeFile(wrapper, `#!/bin/sh\nexec ${shellQuote(chromeExecutable)} "$@"\n`);
+    await chmod(wrapper, 0o755);
+  }
+
+  console.log(`[bombadil] chrome: ${chromeExecutable}`);
+  return {
+    PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+    CHROME: process.env.CHROME ?? chromeExecutable,
+    CHROME_PATH: process.env.CHROME_PATH ?? chromeExecutable,
+    CHROME_BIN: process.env.CHROME_BIN ?? chromeExecutable,
+  };
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
 }
 
 function resolveBin(name) {

--- a/apps/desktop-tauri/tests/bombadil/run-bombadil.mjs
+++ b/apps/desktop-tauri/tests/bombadil/run-bombadil.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const args = process.argv.slice(2);
+const headed = consumeFlag(args, "--headed");
+const keepRunning = consumeFlag(args, "--no-exit-on-violation");
+const port = await choosePort(process.env.BOMBADIL_VITE_PORT);
+const origin = `http://127.0.0.1:${port}`;
+const harnessUrl = `${origin}/tests/ui-harness/harness.html`;
+const defaultOutputPath = process.env.BOMBADIL_OUTPUT_PATH
+  ? resolve(process.env.BOMBADIL_OUTPUT_PATH)
+  : resolve(rootDir, "test-results", "bombadil", String(Date.now()));
+let bombadilProcess = null;
+
+const vite = spawn(
+  process.execPath,
+  [
+    resolve(rootDir, "node_modules/vite/bin/vite.js"),
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(port),
+    "--strictPort",
+    "--clearScreen",
+    "false",
+  ],
+  {
+    cwd: rootDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  },
+);
+
+const viteOutput = [];
+vite.stdout.on("data", (chunk) => bufferViteOutput(viteOutput, chunk));
+vite.stderr.on("data", (chunk) => bufferViteOutput(viteOutput, chunk));
+installSignalHandlers();
+
+try {
+  await waitForVite(vite, harnessUrl);
+  await mkdir(defaultOutputPath, { recursive: true });
+
+  const bombadilArgs = ["browser", "test", harnessUrl, "tests/bombadil/spec.ts"];
+  if (!headed) {
+    bombadilArgs.push("--headless");
+  }
+  if (!keepRunning) {
+    bombadilArgs.push("--exit-on-violation");
+  }
+  if (!hasOption(args, "--time-limit") && !hasOption(args, "--reproduce")) {
+    bombadilArgs.push("--time-limit", process.env.BOMBADIL_TIME_LIMIT ?? "20s");
+  }
+  if (!hasOption(args, "--output-path")) {
+    bombadilArgs.push("--output-path", defaultOutputPath);
+  }
+  bombadilArgs.push(...args);
+
+  console.log(`[bombadil] harness: ${harnessUrl}`);
+  console.log(`[bombadil] output: ${outputPathFromArgs(bombadilArgs)}`);
+
+  bombadilProcess = spawn(resolveBin("bombadil"), bombadilArgs, {
+    cwd: rootDir,
+    env: {
+      ...process.env,
+      RUST_LOG: process.env.BOMBADIL_RUST_LOG ?? "error",
+    },
+    stdio: "inherit",
+  });
+  const runnerTimeoutMs = runnerTimeoutMillis(bombadilArgs);
+  const result = await waitForExitWithTimeout(bombadilProcess, runnerTimeoutMs);
+  if (result.kind === "timeout") {
+    await stopProcess(bombadilProcess);
+    throw new Error(
+      `Bombadil did not exit before the runner watchdog (${runnerTimeoutMs}ms)`,
+    );
+  }
+  process.exitCode = result.code ?? 1;
+} catch (error) {
+  process.exitCode = 1;
+  console.error(`[bombadil] ${error instanceof Error ? error.message : String(error)}`);
+  if (viteOutput.length > 0) {
+    console.error("[vite output]");
+    console.error(viteOutput.join(""));
+  }
+} finally {
+  await stopProcess(vite);
+}
+
+function resolveBin(name) {
+  const suffix = process.platform === "win32" ? ".cmd" : "";
+  return resolve(rootDir, "node_modules", ".bin", `${name}${suffix}`);
+}
+
+function consumeFlag(values, flag) {
+  const index = values.indexOf(flag);
+  if (index < 0) {
+    return false;
+  }
+  values.splice(index, 1);
+  return true;
+}
+
+function hasOption(values, option) {
+  return values.some((value) => value === option || value.startsWith(`${option}=`));
+}
+
+function outputPathFromArgs(values) {
+  const index = values.indexOf("--output-path");
+  if (index >= 0 && values[index + 1]) {
+    return values[index + 1];
+  }
+  const assigned = values.find((value) => value.startsWith("--output-path="));
+  return assigned ? assigned.slice("--output-path=".length) : "(bombadil default)";
+}
+
+function bufferViteOutput(buffer, chunk) {
+  buffer.push(String(chunk));
+  while (buffer.length > 20) {
+    buffer.shift();
+  }
+}
+
+async function choosePort(explicitPort) {
+  const requested = explicitPort ? Number(explicitPort) : 0;
+  if (!Number.isInteger(requested) || requested < 0 || requested > 65535) {
+    throw new Error(`invalid BOMBADIL_VITE_PORT: ${explicitPort}`);
+  }
+  return new Promise((resolvePort, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: requested }, () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === "object") {
+          resolvePort(address.port);
+        } else {
+          reject(new Error("could not allocate a Vite port"));
+        }
+      });
+    });
+  });
+}
+
+function runnerTimeoutMillis(values) {
+  if (process.env.BOMBADIL_RUNNER_TIMEOUT_MS) {
+    const value = Number(process.env.BOMBADIL_RUNNER_TIMEOUT_MS);
+    if (Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    throw new Error(
+      `invalid BOMBADIL_RUNNER_TIMEOUT_MS: ${process.env.BOMBADIL_RUNNER_TIMEOUT_MS}`,
+    );
+  }
+
+  const timeLimitMs = timeLimitMillis(values);
+  if (timeLimitMs === null) {
+    return null;
+  }
+  return Math.max(timeLimitMs * 3, timeLimitMs + 30_000);
+}
+
+function timeLimitMillis(values) {
+  const index = values.indexOf("--time-limit");
+  if (index >= 0) {
+    return parseDurationMillis(values[index + 1]);
+  }
+  const assigned = values.find((value) => value.startsWith("--time-limit="));
+  if (assigned) {
+    return parseDurationMillis(assigned.slice("--time-limit=".length));
+  }
+  return null;
+}
+
+function parseDurationMillis(value) {
+  const match = /^(\d+(?:\.\d+)?)([smhd])$/.exec(value ?? "");
+  if (!match) {
+    throw new Error(`invalid --time-limit: ${value}`);
+  }
+  const amount = Number(match[1]);
+  const unit = match[2];
+  const scale =
+    unit === "s"
+      ? 1_000
+      : unit === "m"
+        ? 60_000
+        : unit === "h"
+          ? 3_600_000
+          : 86_400_000;
+  return amount * scale;
+}
+
+async function waitForVite(process, url) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (process.exitCode !== null) {
+      throw new Error(`Vite exited early with status ${process.exitCode}`);
+    }
+    try {
+      const response = await fetch(url, { method: "HEAD" });
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Server is not ready yet.
+    }
+    await delay(200);
+  }
+  throw new Error(`timed out waiting for Vite at ${url}`);
+}
+
+function waitForExitWithTimeout(process, timeoutMs) {
+  if (timeoutMs === null) {
+    return waitForExit(process).then((code) => ({ kind: "exit", code }));
+  }
+  return new Promise((resolveExit) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      resolveExit({ kind: "timeout" });
+    }, timeoutMs);
+    process.once("exit", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      resolveExit({ kind: "exit", code });
+    });
+  });
+}
+
+function waitForExit(process) {
+  return new Promise((resolveExit) => {
+    process.once("exit", (code) => resolveExit(code));
+  });
+}
+
+async function stopProcess(process) {
+  if (!process) {
+    return;
+  }
+  if (process.exitCode !== null || process.signalCode !== null) {
+    return;
+  }
+  process.kill("SIGTERM");
+  const code = await Promise.race([
+    waitForExit(process),
+    delay(2_000).then(() => null),
+  ]);
+  if (code === null && process.exitCode === null) {
+    process.kill("SIGKILL");
+  }
+}
+
+function delay(ms) {
+  return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
+}
+
+function installSignalHandlers() {
+  for (const signal of ["SIGINT", "SIGTERM"]) {
+    process.once(signal, () => {
+      void (async () => {
+        await stopProcess(bombadilProcess);
+        await stopProcess(vite);
+        process.exit(signal === "SIGINT" ? 130 : 143);
+      })();
+    });
+  }
+}

--- a/apps/desktop-tauri/tests/bombadil/spec.ts
+++ b/apps/desktop-tauri/tests/bombadil/spec.ts
@@ -1,0 +1,86 @@
+import { always } from "@antithesishq/bombadil";
+import { extract } from "@antithesishq/bombadil/browser";
+export * from "@antithesishq/bombadil/browser/defaults";
+
+const shellState = extract((state) => {
+  const document = state.document;
+  const surfaceSelectors = [
+    '[data-testid="fleet-dashboard"]',
+    '[data-testid="fleet-empty"]',
+    '[data-testid="transcript-panel"]',
+    ".config-workspace",
+  ];
+  return {
+    shellMounted: Boolean(document.querySelector(".app-shell")),
+    errorBanner:
+      document.querySelector('[data-testid="error-banner"]')?.textContent ?? "",
+    primarySurfaceCount: surfaceSelectors.filter((selector) =>
+      document.querySelector(selector),
+    ).length,
+  };
+});
+
+const transcriptCards = extract((state) => {
+  return Array.from(
+    state.document.querySelectorAll('[data-testid="transcript-panel"] .message-card'),
+  ).map((card) => {
+    const role = normalizeText(card.querySelector(".message-role")?.textContent ?? "");
+    const content = normalizeText(
+      card.querySelector(".message-content")?.textContent ?? "",
+    );
+    return { role, content };
+  });
+});
+
+const unnamedButtons = extract((state) => {
+  return Array.from(state.document.querySelectorAll("button"))
+    .filter((button) => !button.disabled)
+    .map((button) => {
+      const label =
+        button.getAttribute("aria-label") ??
+        button.getAttribute("title") ??
+        button.textContent ??
+        "";
+      return normalizeText(label);
+    })
+    .filter((label) => label.length === 0);
+});
+
+export const desktop_shell_stays_mounted = always(
+  () => shellState.current.shellMounted,
+);
+
+export const desktop_shell_has_one_primary_surface = always(
+  () => shellState.current.primarySurfaceCount === 1,
+);
+
+export const desktop_shell_does_not_show_global_errors = always(
+  () => shellState.current.errorBanner.length === 0,
+);
+
+export const transcript_does_not_render_adjacent_duplicate_messages = always(() => {
+  const rows = transcriptCards.current;
+  for (let index = 1; index < rows.length; index += 1) {
+    const previous = rows[index - 1];
+    const current = rows[index];
+    if (
+      previous.role &&
+      current.role &&
+      previous.content &&
+      current.content &&
+      previous.role === current.role &&
+      previous.content === current.content
+    ) {
+      return false;
+    }
+  }
+  return true;
+});
+
+export const enabled_buttons_have_accessible_names = always(
+  () => unnamedButtons.current.length === 0,
+);
+
+function normalizeText(value: string) {
+  return value.replace(/\s+/g, " ").trim();
+}

--- a/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
@@ -1,0 +1,308 @@
+import { expect, test as base, type Page, type TestInfo } from "@playwright/test";
+
+type HarnessScenario =
+  | "default"
+  | "empty-fleet"
+  | "loading"
+  | "bridge-unavailable"
+  | "save-error"
+  | "backend-health-error"
+  | "long-content"
+  | "active-turn"
+  | "cascade-turn";
+
+const PEER_ID = "peer-bombadil-local";
+
+const test = base.extend<{ browserLogs: string[] }>({
+  browserLogs: async ({ page }, use, testInfo) => {
+    const logs: string[] = [];
+    page.on("console", (message) => {
+      logs.push(`[console:${message.type()}] ${message.text()}`);
+    });
+    page.on("pageerror", (error) => {
+      logs.push(`[pageerror] ${error.stack ?? error.message}`);
+    });
+
+    await use(logs);
+
+    if (testInfo.status !== testInfo.expectedStatus && logs.length > 0) {
+      await testInfo.attach("browser-console.log", {
+        body: logs.join("\n"),
+        contentType: "text/plain",
+      });
+    }
+  },
+});
+
+test.describe("desktop UI harness", () => {
+  test("fleet dashboard connects a local runtime and opens chat/config", async ({
+    page,
+  }, testInfo) => {
+    await gotoHarness(page);
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toBeVisible();
+    await attachStableScreenshot(page, testInfo, "fleet-dashboard");
+
+    await page.getByRole("button", { name: "Add Agent", exact: true }).click();
+    await page.getByTestId("fleet-connect-local").click();
+    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toBeVisible();
+    await page.getByRole("button", { name: "Add Agent", exact: true }).click();
+
+    await openChat(page);
+    await expect(page.getByTestId("transcript-panel")).toContainText(
+      "desktop UI test agent",
+    );
+    await attachStableScreenshot(page, testInfo, "chat-with-transcript");
+
+    await page.getByRole("button", { name: "Configure" }).click();
+    await expect(page.locator(".config-workspace")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Bombadil UI Agent" }),
+    ).toBeVisible();
+  });
+
+  test("chat sends a message, creates a new conversation, renames, and avoids duplicate adjacent messages", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+    await openChat(page);
+
+    await expect(page.getByTestId("transcript-panel")).toContainText(
+      "desktop UI test agent",
+    );
+    await expect(adjacentDuplicateTranscriptRows(page)).resolves.toEqual([]);
+
+    await page.getByTestId("sidebar-new-chat-ops").click();
+    await expect(
+      page.getByRole("heading", { name: "Start a conversation" }),
+    ).toBeVisible();
+    await page.getByTestId("composer-input").fill("Check the harness fleet status");
+    await page.getByTestId("composer-send").click();
+
+    await expect(page.getByTestId("transcript-panel")).toContainText(
+      "Check the harness fleet status",
+    );
+    await expect(page.getByTestId("transcript-panel")).toContainText(
+      "Bombadil harness response",
+    );
+    await expect(adjacentDuplicateTranscriptRows(page)).resolves.toEqual([]);
+
+    await page.getByTestId("conversation-title-edit").click();
+    await page.getByTestId("conversation-title-input").fill("manual ops check");
+    await page.keyboard.press("Enter");
+    await expect(page.getByRole("heading", { name: "manual ops check" })).toBeVisible();
+  });
+
+  test("config workspace supports core CRUD and run flows", async ({
+    page,
+  }, testInfo) => {
+    await gotoHarness(page);
+    await openConfig(page);
+    await attachStableScreenshot(page, testInfo, "config-workspace");
+
+    await openConfigTab(page, "behavior");
+    await page
+      .getByTestId("behavior-system-prompt")
+      .fill("You are a deterministic Playwright-managed behavior.");
+    await saveConfig(page, "behavior-save");
+
+    await openConfigTab(page, "backends");
+    await page.getByTestId("backend-name").fill("OpenAI Harness Edited");
+    await page.getByTestId("backend-endpoint").fill("http://127.0.0.1:9000/v1");
+    await page.getByTestId("backend-models").fill("gpt-4.1-mini, gpt-4.1");
+    await saveConfig(page, "backend-save");
+
+    await openConfigTab(page, "profiles");
+    await page.getByTestId("profile-display-name").fill("Playwright profile");
+    await page.getByTestId("profile-context-window").fill("64000");
+    await saveConfig(page, "profile-save");
+
+    await openConfigTab(page, "toolSelections");
+    await page.getByTestId("tool-selection-display-name").fill("Playwright tools");
+    await page.getByTestId("tool-command-allowed-argv-prefixes").fill("rg\ngit status");
+    await saveConfig(page, "tool-selection-save");
+
+    await openConfigTab(page, "metaTools");
+    await page.getByTestId("tool-service-display-name").fill("Observability MCP");
+    await page.getByTestId("tool-service-test").click();
+    await expect(page.getByTestId("tool-service-test-result")).toContainText("whoami");
+    await saveConfig(page, "tool-service-save");
+
+    await openConfigTab(page, "tasks");
+    await page.getByTestId("task-name").fill("Playwright host check");
+    await page
+      .getByTestId("task-prompt-template")
+      .fill("Inspect this test host and summarize health.");
+    await saveConfig(page, "task-save");
+    await page.getByTestId("task-run").click();
+    await expect(page.getByTestId("task-run-status")).toContainText("request-");
+    await expect(page.getByTestId("task-run-history")).toContainText("completed");
+
+    await openConfigTab(page, "timerTriggers");
+    await page.getByTestId("schedule-interval-secs").fill("120");
+    await saveConfig(page, "schedule-save");
+    await page.getByTestId("schedule-run").click();
+    await expect(page.getByTestId("schedule-run-status")).toContainText("request-");
+
+    await openConfigTab(page, "eventTriggers");
+    await page.getByTestId("event-trigger-new").click();
+    await page.getByTestId("event-trigger-id").fill("playwright-trigger");
+    await saveConfig(page, "event-trigger-save");
+  });
+
+  test("operations drawer exposes background, lineage, backend, and MCP health tabs", async ({
+    page,
+  }, testInfo) => {
+    await gotoHarness(page);
+    await openChat(page);
+    await page.getByRole("button", { name: /open operations drawer/i }).click();
+    await expect(page.getByRole("complementary", { name: "Operations" })).toBeVisible();
+    await attachStableScreenshot(page, testInfo, "operations-drawer-open");
+
+    await expect(page.getByRole("tab", { name: /Background/ })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(page.getByText("No backgrounded tools.")).toBeVisible();
+
+    await page.getByRole("tab", { name: /Lineage/ }).click();
+    await expect(page.getByRole("tree", { name: "Subagent lineage" })).toBeVisible();
+
+    await page.getByRole("tab", { name: /Backends/ }).click();
+    await expect(page.getByRole("heading", { name: "Backend health" })).toBeVisible();
+    await expect(page.getByText("OpenAI Harness")).toBeVisible();
+
+    await page.getByRole("tab", { name: /MCP health/ }).click();
+    await expect(
+      page.getByRole("heading", { name: "MCP services / health" }),
+    ).toBeVisible();
+    await expect(page.getByText("mcp-observability")).toBeVisible();
+  });
+
+  test("interrupt cancellation handles direct and cascade flows", async ({ page }) => {
+    await gotoHarness(page, "active-turn");
+    await openChat(page);
+    await page.getByTestId("cancel-button").click();
+    await expect(page.getByRole("status")).toContainText("Interrupt accepted");
+
+    await gotoHarness(page, "cascade-turn");
+    await openChat(page);
+    await page.getByTestId("cancel-button").click();
+    await expect(
+      page.getByRole("dialog", { name: /interrupt parent request/i }),
+    ).toBeVisible();
+    await expect(page.getByText("Will request interrupt by cascade")).toBeVisible();
+    await page.getByRole("button", { name: /interrupt parent and cascade/i }).click();
+    await expect(page.getByRole("status")).toContainText("Interrupt accepted");
+  });
+
+  test("sad path scenarios surface empty, bridge, save, and backend-health errors", async ({
+    page,
+  }, testInfo) => {
+    await gotoHarness(page, "empty-fleet");
+    await expect(page.getByTestId("fleet-empty")).toBeVisible();
+    await attachStableScreenshot(page, testInfo, "empty-fleet");
+
+    await gotoHarness(page, "bridge-unavailable");
+    await expect(page.getByTestId("error-banner")).toContainText(
+      "Desktop native bridge is unavailable",
+    );
+
+    await gotoHarness(page, "save-error");
+    await openConfig(page);
+    await openConfigTab(page, "behavior");
+    await page
+      .getByTestId("behavior-system-prompt")
+      .fill("This save intentionally fails in the harness.");
+    await page.getByTestId("behavior-save").click();
+    await expect(page.getByTestId("error-banner")).toContainText(
+      "Harness rejected behavior save",
+    );
+
+    await gotoHarness(page, "backend-health-error");
+    await openChat(page);
+    await page.getByRole("button", { name: /open operations drawer/i }).click();
+    await page.getByRole("tab", { name: /Backends/ }).click();
+    await expect(page.getByRole("alert")).toContainText(
+      "Harness backend health bridge unavailable",
+    );
+  });
+
+  test("long transcript content remains readable and keeps composer usable", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "long-content");
+    await openChat(page);
+    await expect(page.getByTestId("transcript-panel")).toContainText(
+      "deliberately long transcript row",
+    );
+    await expect(page.getByTestId("composer-input")).toBeVisible();
+    await expect(page.getByTestId("composer-send")).toBeVisible();
+  });
+});
+
+async function gotoHarness(page: Page, scenario: HarnessScenario = "default") {
+  await page.goto(`/tests/ui-harness/harness.html?scenario=${scenario}`);
+  await expect(page.locator(".app-shell")).toBeVisible();
+}
+
+async function openChat(page: Page) {
+  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
+  await expect(page.getByTestId("composer-input")).toBeVisible();
+}
+
+async function openConfig(page: Page) {
+  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
+  await expect(page.getByTestId("composer-input")).toBeVisible();
+  await page.getByRole("button", { name: "Configure" }).click();
+  await expect(page.locator(".config-workspace")).toBeVisible();
+}
+
+async function openConfigTab(page: Page, tabId: string) {
+  const tab = page.getByTestId(`config-tab-${tabId}`);
+  await tab.click();
+  await expect(tab).toHaveClass(/selected/);
+}
+
+async function saveConfig(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
+  await expect(page.locator(".config-editor").getByText("Saved")).toBeVisible();
+}
+
+async function adjacentDuplicateTranscriptRows(page: Page) {
+  return page
+    .locator('[data-testid="transcript-panel"] .message-card')
+    .evaluateAll((cards) => {
+      const rows = cards.map((card) => {
+        const roleText = card.querySelector(".message-role")?.textContent ?? "";
+        const contentText = card.querySelector(".message-content")?.textContent ?? "";
+        const role = roleText.replace(/\s+/g, " ").trim();
+        const content = contentText.replace(/\s+/g, " ").trim();
+        return { role, content };
+      });
+      const duplicates: string[] = [];
+      for (let index = 1; index < rows.length; index += 1) {
+        const previous = rows[index - 1];
+        const current = rows[index];
+        if (
+          previous.role &&
+          previous.content &&
+          previous.role === current.role &&
+          previous.content === current.content
+        ) {
+          duplicates.push(`${current.role}: ${current.content}`);
+        }
+      }
+      return duplicates;
+    });
+}
+
+async function attachStableScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  const body = await page.screenshot({ fullPage: true });
+  await testInfo.attach(`${name}.png`, {
+    body,
+    contentType: "image/png",
+  });
+}

--- a/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
+++ b/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
@@ -1,0 +1,965 @@
+import type { BackendHealth } from "../../src/components/backendHealth/types";
+import type { DesktopApiAdapter } from "../../src/lib/desktop-api";
+import type {
+  DesktopClientUpdatedHandler,
+  DesktopClientUpdatedListenerFactory,
+} from "../../src/lib/desktop-events";
+import type {
+  CascadeCancelPreview,
+  DesktopClientSnapshot,
+  DesktopOperationsSnapshot,
+  DesktopSessionSnapshot,
+  DeploymentView,
+  InitSummary,
+  InterruptRequestResult,
+  MCPServiceHealthView,
+  McpServiceProbeResult,
+  PeerAddRequest,
+  SubagentTreeView,
+  TaskRunResult,
+  ToolServiceTestResult,
+} from "../../src/lib/types";
+
+const AGENT_DID = "did:key:z6MkBombadilAgent";
+const DEFAULT_BEHAVIOR_ID = "default";
+const STARTED_AT = "2026-06-17T00:00:00.000Z";
+
+export type DesktopUiHarnessScenario =
+  | "default"
+  | "empty-fleet"
+  | "loading"
+  | "bridge-unavailable"
+  | "save-error"
+  | "backend-health-error"
+  | "long-content"
+  | "active-turn"
+  | "cascade-turn";
+
+export type DesktopUiHarnessOptions = {
+  scenario?: string | null;
+};
+
+type DesktopUiHarness = {
+  adapter: DesktopApiAdapter;
+  listenerFactory: DesktopClientUpdatedListenerFactory;
+  scenario: DesktopUiHarnessScenario;
+};
+
+export function createDesktopUiHarness(
+  options: DesktopUiHarnessOptions = {},
+): DesktopUiHarness {
+  const scenario = normalizeScenario(options.scenario);
+  const listeners = new Set<DesktopClientUpdatedHandler>();
+  const sessions = new Map<string, DesktopSessionSnapshot>();
+  let requestSeq = 1;
+  let sessionSeq = 1;
+  let rowCount = 42;
+  let deployment = createDeployment();
+
+  const greeting =
+    scenario === "long-content"
+      ? longHarnessMessage()
+      : "I am your desktop UI test agent. This seeded turn gives the transcript a stable row for duplicate-message checks.";
+  const activeTurn = scenario === "active-turn" || scenario === "cascade-turn";
+  sessions.set("session-intro", {
+    sessionId: "session-intro",
+    agentDid: AGENT_DID,
+    behaviorId: DEFAULT_BEHAVIOR_ID,
+    title: "introduction-and-greetings",
+    previewText: greeting,
+    status: activeTurn ? "processing" : "completed",
+    turnState: activeTurn ? "processing" : "completed",
+    latestRequestId: "request-intro",
+    latestResponse: {
+      status: activeTurn ? "streaming" : "completed",
+      content: greeting,
+      tokenCount: 24,
+      materializedMessageSequence: 1,
+      materializedAt: STARTED_AT,
+      completedAt: activeTurn ? null : STARTED_AT,
+      backendId: "backend-openai",
+    },
+    pendingTurn: null,
+    activeResponseOverlay: null,
+    timelineItems: [
+      {
+        kind: "assistantMessage",
+        itemKey: "intro-assistant",
+        sequence: 1,
+        content: greeting,
+      },
+    ],
+  });
+  syncConversations();
+
+  function notify(reason: string) {
+    window.setTimeout(() => {
+      for (const listener of listeners) {
+        void listener({ reason });
+      }
+    }, 0);
+  }
+
+  function snapshot() {
+    const deployments = scenario === "empty-fleet" ? [] : [deployment];
+    const health = {
+      status: "healthy",
+      connectedPeerCount: 1,
+      replicatorCount: 1,
+      consecutiveFailures: 0,
+      lastOkAt: STARTED_AT,
+      lastError: null,
+      lastFailureAt: null,
+    };
+    const next: DesktopClientSnapshot = {
+      bootstrap: {
+        defaultAgentHome: "/tmp/defra-agent-bombadil/agent",
+        initAgentName: "Bombadil UI Agent",
+        initAgentDid: AGENT_DID,
+        initToolCeiling: "ReadWrite",
+        initToolRoot: "/tmp/defra-agent-bombadil/workspace",
+        desktopHome: "/tmp/defra-agent-bombadil/desktop",
+        peerDirectoryPath: "/tmp/defra-agent-bombadil/peers.json",
+        nodeDataDir: "/tmp/defra-agent-bombadil/node",
+        logFilePath: "/tmp/defra-agent-bombadil/desktop.log",
+        agentHomeExists: true,
+        desktopHomeExists: true,
+        peerDirectoryExists: true,
+        savedPeers:
+          scenario === "empty-fleet"
+            ? []
+            : [
+                {
+                  peerId: deployment.peerId,
+                  label: deployment.label,
+                  agentDid: deployment.agentDid,
+                  addr: deployment.addr,
+                  graphql: deployment.graphql,
+                  source: deployment.source,
+                },
+              ],
+      },
+      client: {
+        localPeerId: "peer-bombadil-local",
+        listenAddresses: ["/ip4/127.0.0.1/tcp/9292"],
+        p2pHealth: health,
+        bootstrapErrors: [],
+        lastMutationError: null,
+        focusedRequestId: null,
+        configuredPeerCount: deployments.length,
+        dialedPeerCount: deployments.length,
+        peerIssueCount: 0,
+        rowCount,
+        approxSerializedBytes: rowCount * 512,
+        deployments,
+      },
+    };
+    return clone(next);
+  }
+
+  function syncConversations() {
+    deployment = {
+      ...deployment,
+      conversations: Array.from(sessions.values()).map((session) => ({
+        sessionId: session.sessionId,
+        title: session.title,
+        previewText: session.previewText,
+        status: session.status,
+        behaviorId: session.behaviorId,
+        latestRequestId: session.latestRequestId,
+        createdAt: STARTED_AT,
+        updatedAt: STARTED_AT,
+        turnState: session.turnState,
+        messageCount: session.timelineItems.filter(
+          (item) => item.kind === "userMessage" || item.kind === "assistantMessage",
+        ).length,
+        toolCallCount: session.timelineItems.filter((item) => item.kind === "toolGroup")
+          .length,
+      })),
+    };
+  }
+
+  function upsertDeployment(nextPeer: PeerAddRequest) {
+    deployment = {
+      ...deployment,
+      peerId: nextPeer.agentDid === AGENT_DID ? deployment.peerId : "peer-added",
+      label: nextPeer.label.trim() || deployment.label,
+      agentDid: nextPeer.agentDid.trim() || deployment.agentDid,
+      addr: nextPeer.addr.trim() || deployment.addr,
+      graphql: nextPeer.graphql?.trim() || deployment.graphql,
+      agentPrincipal: {
+        ...deployment.agentPrincipal,
+        agentDid: nextPeer.agentDid.trim() || deployment.agentDid,
+        displayName: nextPeer.label.trim() || deployment.label,
+      },
+    };
+  }
+
+  function createSessionFromPrompt(prompt: string, behaviorId?: string | null) {
+    const sessionId = `session-${++sessionSeq}`;
+    const requestId = `request-${++requestSeq}`;
+    const title = prompt.trim().slice(0, 48) || "manual-task-run";
+    const response = `Bombadil harness response ${requestSeq}: received "${title}".`;
+    const session: DesktopSessionSnapshot = {
+      sessionId,
+      agentDid: deployment.agentDid,
+      behaviorId: behaviorId || deployment.defaultBehaviorId,
+      title,
+      previewText: response,
+      status: "completed",
+      turnState: "completed",
+      latestRequestId: requestId,
+      latestResponse: {
+        status: "completed",
+        content: response,
+        tokenCount: 32,
+        materializedMessageSequence: 2,
+        materializedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        backendId: "backend-openai",
+      },
+      pendingTurn: null,
+      activeResponseOverlay: null,
+      timelineItems: [
+        {
+          kind: "userMessage",
+          itemKey: `${requestId}-user`,
+          sequence: 1,
+          content: prompt,
+        },
+        {
+          kind: "assistantMessage",
+          itemKey: `${requestId}-assistant`,
+          sequence: 2,
+          content: response,
+        },
+      ],
+    };
+    sessions.set(sessionId, session);
+    rowCount += 4;
+    syncConversations();
+    notify("store");
+    return { session, requestId };
+  }
+
+  const adapter: DesktopApiAdapter = {
+    async fetchDesktopSnapshot() {
+      if (scenario === "bridge-unavailable") {
+        throw new Error(
+          "Desktop native bridge is unavailable in the UI harness scenario.",
+        );
+      }
+      if (scenario === "loading") {
+        await wait(250);
+      }
+      return snapshot();
+    },
+    async initLocalStandardRuntime(request) {
+      const label = request.label.trim() || "Bombadil UI Agent";
+      const summary: InitSummary = {
+        status: "ready",
+        source: "bombadil-harness",
+        statusEndpoint: "http://127.0.0.1:9181/status",
+        agentHome: "/tmp/defra-agent-bombadil/agent",
+        desktopHome: "/tmp/defra-agent-bombadil/desktop",
+        peerDirectory: "/tmp/defra-agent-bombadil/peers.json",
+        label,
+        agentName: label,
+        agentDid: AGENT_DID,
+        graphql: "http://127.0.0.1:9181/api/v0/graphql",
+        p2pTransport: "memory",
+        p2pPeerId: "peer-bombadil-local",
+        p2pListenAddress: "/ip4/127.0.0.1/tcp/9292",
+        peerRecordId: "peer-record-bombadil",
+        nextSteps: [],
+      };
+      return summary;
+    },
+    async startDesktopClient() {
+      notify("runtime");
+      return snapshot();
+    },
+    async shutdownDesktopClient() {
+      notify("runtime");
+      return snapshot();
+    },
+    async setSelectedAgent() {
+      return undefined;
+    },
+    async addPeer(request) {
+      upsertDeployment(request);
+      notify("peers");
+      return snapshot();
+    },
+    async fetchPeerStatus() {
+      return {
+        label: "Bombadil UI Agent",
+        agentDid: AGENT_DID,
+        addr: "/ip4/127.0.0.1/tcp/9292",
+        graphql: "http://127.0.0.1:9181/api/v0/graphql",
+      };
+    },
+    async repairP2P() {
+      notify("runtime");
+      return snapshot();
+    },
+    async fetchSessionSnapshot(sessionId) {
+      const session = sessions.get(sessionId);
+      return session ? clone(session) : null;
+    },
+    async sendChatMessage(request) {
+      const content = request.content.trim();
+      if (!content) {
+        throw new Error("message content is required");
+      }
+
+      if (request.sessionId && sessions.has(request.sessionId)) {
+        const existing = sessions.get(request.sessionId)!;
+        const nextSequence = existing.timelineItems.length + 1;
+        const requestId = `request-${++requestSeq}`;
+        const response = `Bombadil harness response ${requestSeq}: received "${content.slice(
+          0,
+          48,
+        )}".`;
+        const updated: DesktopSessionSnapshot = {
+          ...existing,
+          previewText: response,
+          status: "completed",
+          turnState: "completed",
+          latestRequestId: requestId,
+          latestResponse: {
+            status: "completed",
+            content: response,
+            tokenCount: 32,
+            materializedMessageSequence: nextSequence + 1,
+            materializedAt: new Date().toISOString(),
+            completedAt: new Date().toISOString(),
+            backendId: "backend-openai",
+          },
+          timelineItems: [
+            ...existing.timelineItems,
+            {
+              kind: "userMessage",
+              itemKey: `${requestId}-user`,
+              sequence: nextSequence,
+              content,
+            },
+            {
+              kind: "assistantMessage",
+              itemKey: `${requestId}-assistant`,
+              sequence: nextSequence + 1,
+              content: response,
+            },
+          ],
+        };
+        sessions.set(request.sessionId, updated);
+        rowCount += 4;
+        syncConversations();
+        notify("store");
+        return {
+          sessionId: request.sessionId,
+          requestId,
+          agentDid: request.agentDid,
+          behaviorId: request.behaviorId ?? null,
+        };
+      }
+
+      const { session, requestId } = createSessionFromPrompt(
+        content,
+        request.behaviorId,
+      );
+      const result: TaskRunResult = {
+        requestDocId: `${requestId}-doc`,
+        requestId,
+        sessionId: session.sessionId,
+        agentDid: request.agentDid,
+        behaviorId: request.behaviorId || DEFAULT_BEHAVIOR_ID,
+        status: "completed",
+        lifecycleState: "completed",
+      };
+      return result;
+    },
+    async renameConversation(request) {
+      const session = sessions.get(request.sessionId);
+      if (session) {
+        sessions.set(request.sessionId, {
+          ...session,
+          title: request.title.trim() || session.title,
+        });
+        syncConversations();
+        notify("store");
+      }
+    },
+    async saveAgentConfig(request) {
+      deployment = {
+        ...deployment,
+        label: request.displayName.trim() || deployment.label,
+        defaultBehaviorId: request.defaultBehaviorId || deployment.defaultBehaviorId,
+        agentPrincipal: {
+          ...deployment.agentPrincipal,
+          displayName: request.displayName.trim() || deployment.label,
+          defaultBehaviorId: request.defaultBehaviorId || deployment.defaultBehaviorId,
+          enabled: request.enabled ?? deployment.agentPrincipal.enabled,
+        },
+      };
+      return snapshot();
+    },
+    async saveBehaviorConfig(request) {
+      if (scenario === "save-error") {
+        throw new Error("Harness rejected behavior save for sad-path coverage.");
+      }
+      const behaviorId = request.behaviorId.trim() || `behavior-${requestSeq}`;
+      const nextBehavior = {
+        behaviorId,
+        displayName: request.displayName.trim() || behaviorId,
+        systemPrompt: request.systemPrompt,
+        backendId: request.backendId,
+        modelName: null,
+        toolSelectionId: request.toolSelectionId,
+        inferenceProfileId: request.inferenceProfileId,
+        compactionStrategy: request.compactionStrategy,
+        compactionThreshold: request.compactionThreshold,
+        enabled: request.enabled ?? true,
+        isDefault: behaviorId === deployment.defaultBehaviorId,
+      };
+      deployment = {
+        ...deployment,
+        behaviors: upsertBy(
+          deployment.behaviors,
+          "behaviorId",
+          behaviorId,
+          nextBehavior,
+        ),
+      };
+      return snapshot();
+    },
+    async saveBackendConfig(request) {
+      const backendId = request.backendId.trim() || `backend-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        inferenceBackends: upsertBy(
+          deployment.inferenceBackends,
+          "backendId",
+          backendId,
+          {
+            backendId,
+            name: request.name.trim() || backendId,
+            providerKind: request.providerKind,
+            endpoint: request.endpoint,
+            apiKeyConfigured: Boolean(request.apiKey),
+            apiKeyEnvVar: request.apiKeyEnvVar,
+            maxConcurrent: request.maxConcurrent,
+            maxQueueDepth: request.maxQueueDepth,
+            enabled: request.enabled ?? true,
+            models: request.models,
+            probeStatus: "healthy",
+          },
+        ),
+      };
+      return snapshot();
+    },
+    async saveInferenceProfileConfig(request) {
+      const profileId = request.profileId.trim() || `profile-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        inferenceProfiles: upsertBy(
+          deployment.inferenceProfiles,
+          "profileId",
+          profileId,
+          {
+            ...request,
+            profileId,
+            displayName: request.displayName.trim() || profileId,
+          },
+        ),
+      };
+      return snapshot();
+    },
+    async saveToolSelectionConfig(request) {
+      const selectionId = request.selectionId.trim() || `tools-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        toolSelections: upsertBy(
+          deployment.toolSelections,
+          "selectionId",
+          selectionId,
+          {
+            ...request,
+            selectionId,
+            displayName: request.displayName.trim() || selectionId,
+          },
+        ),
+      };
+      return snapshot();
+    },
+    async saveToolServiceConfig(request) {
+      const serviceId = request.serviceId.trim() || `service-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        toolServiceRegistries: upsertBy(
+          deployment.toolServiceRegistries,
+          "serviceId",
+          serviceId,
+          {
+            ...request,
+            serviceId,
+            displayName: request.displayName.trim() || serviceId,
+          },
+        ),
+      };
+      return snapshot();
+    },
+    async testToolService(request) {
+      const result: ToolServiceTestResult = {
+        serviceId: request.serviceId,
+        endpoint: `http://${request.hostname || "localhost"}:${request.mcpPort || 7331}${
+          request.mcpPath || "/mcp"
+        }`,
+        status: "ok",
+        toolCount: 1,
+        tools: [{ name: "whoami", description: "Returns bound caller identity" }],
+      };
+      return result;
+    },
+    async saveTaskConfig(request) {
+      const taskId = request.taskId.trim() || `task-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        tasks: upsertBy(deployment.tasks, "taskId", taskId, {
+          ...request,
+          taskId,
+          name: request.name.trim() || taskId,
+          recentRuns: {
+            totalFires: 0,
+            scheduleCount: deployment.schedules.filter((s) => s.taskId === taskId)
+              .length,
+            eventTriggerCount: deployment.eventTriggers.filter(
+              (trigger) => trigger.taskId === taskId,
+            ).length,
+          },
+          runHistory: [],
+        }),
+      };
+      return snapshot();
+    },
+    async saveScheduleConfig(request) {
+      const scheduleId = request.scheduleId.trim() || `schedule-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        schedules: upsertBy(deployment.schedules, "scheduleId", scheduleId, {
+          ...request,
+          scheduleId,
+          fireCount: 0,
+        }),
+      };
+      return snapshot();
+    },
+    async runSchedule(request) {
+      const schedule = deployment.schedules.find(
+        (row) => row.scheduleId === request.scheduleId,
+      );
+      return runHarnessTask(schedule?.taskId ?? "scheduled-task");
+    },
+    async saveEventTriggerConfig(request) {
+      const triggerId = request.triggerId.trim() || `trigger-${requestSeq}`;
+      deployment = {
+        ...deployment,
+        eventTriggers: upsertBy(deployment.eventTriggers, "triggerId", triggerId, {
+          ...request,
+          triggerId,
+          fireCount: 0,
+        }),
+      };
+      return snapshot();
+    },
+    async runTask(request) {
+      return runHarnessTask(request.taskId);
+    },
+    async listSubagentTree(request) {
+      const tree: SubagentTreeView = {
+        rootRequestId: request.rootRequestId,
+        truncated: false,
+        nodes: [
+          {
+            requestId: request.rootRequestId,
+            sessionId: findSessionByRequest(request.rootRequestId)?.sessionId ?? null,
+            agentDid: deployment.agentDid,
+            behaviorId: deployment.defaultBehaviorId,
+            lifecycleState: "completed",
+            status: "completed",
+            subagentDepth: 0,
+          },
+        ],
+        edges: [],
+      };
+      return tree;
+    },
+    async listBackendsWithHealth() {
+      if (scenario === "backend-health-error") {
+        throw new Error("Harness backend health bridge unavailable.");
+      }
+      const rows: BackendHealth[] = deployment.inferenceBackends.map((backend) => ({
+        backendId: backend.backendId,
+        name: backend.name ?? backend.backendId,
+        providerKind: backend.providerKind ?? "openai",
+        endpoint: backend.endpoint ?? "http://127.0.0.1:8000/v1",
+        enabled: backend.enabled ?? true,
+        probeStatus: backend.probeStatus ?? "healthy",
+        displayState: backend.enabled === false ? "disabled" : "available",
+        lastProbe: STARTED_AT,
+        maxConcurrent: backend.maxConcurrent ?? 4,
+        maxQueueDepth: backend.maxQueueDepth ?? 16,
+        models: backend.models,
+        recentCalls: [],
+      }));
+      return rows;
+    },
+    async listMcpServicesWithHealth() {
+      const services: MCPServiceHealthView[] = deployment.toolServiceRegistries.map(
+        (service) => ({
+          serviceId: service.serviceId,
+          agentDid: deployment.agentDid,
+          endpoint: `${service.hostname ?? "localhost"}:${service.mcpPort ?? 7331}${
+            service.mcpPath ?? "/mcp"
+          }`,
+          status: "healthy",
+          failureCount: 0,
+          kMax: 3,
+          backoffUntil: null,
+          lastProbeAt: STARTED_AT,
+          lastSeen: STARTED_AT,
+          updatedAt: STARTED_AT,
+          lastErrorClass: null,
+          lastErrorMessage: null,
+        }),
+      );
+      return services;
+    },
+    async probeMcpService(serviceId) {
+      const result: McpServiceProbeResult = {
+        serviceId,
+        status: "healthy",
+        latencyMs: 3,
+        lastError: null,
+      };
+      return result;
+    },
+    async fetchOperationsSnapshot(request) {
+      const operations: DesktopOperationsSnapshot = {
+        fetchedAt: new Date().toISOString(),
+        agentDid: request.agentDid ?? deployment.agentDid,
+        liveness: {
+          expiredProcessingCount: 0,
+          requests: [],
+          activeToolCalls: [],
+          activeNativeExecutorsAvailable: true,
+          activeNativeExecutors: [],
+        },
+        livenessUnavailableReason: null,
+        backgroundedTools: [],
+        stuckDiagnostics: [],
+        lineage: request.rootRequestId
+          ? {
+              rootRequestId: request.rootRequestId,
+              nodes: [],
+              edges: [],
+              truncated: false,
+            }
+          : null,
+      };
+      return operations;
+    },
+    async previewInterruptCascade(request) {
+      const cascadeChildren =
+        scenario === "cascade-turn"
+          ? [
+              {
+                requestId: "request-child-1",
+                sessionId: "session-child-1",
+                behaviorId: "ops",
+                lifecycleState: "processing",
+                parentRequestId: request.requestId,
+                parentToolCallId: "tool-call-child-1",
+                toolName: "delegate",
+                awaitMode: "foreground",
+                cancelPolicy: "cascade",
+              },
+            ]
+          : [];
+      const preview: CascadeCancelPreview = {
+        rootRequestId: request.requestId,
+        previewSignature: `preview-${request.requestId}`,
+        rootState: activeTurn ? "processing" : "completed",
+        willInterrupt: cascadeChildren,
+        willDetach: [],
+        alreadyTerminal: [
+          ...(activeTurn
+            ? []
+            : [
+                {
+                  requestId: request.requestId,
+                  lifecycleState: "completed",
+                  behaviorId: deployment.defaultBehaviorId,
+                },
+              ]),
+        ],
+        unknownPolicy: [],
+      };
+      return preview;
+    },
+    async interruptRequest(request) {
+      const result: InterruptRequestResult = {
+        requestId: request.requestId,
+        accepted: true,
+        interruptRequestedAt: new Date().toISOString(),
+        alreadyInterrupted: false,
+        stalePreview: false,
+        preview: null,
+      };
+      return result;
+    },
+  };
+
+  const listenerFactory: DesktopClientUpdatedListenerFactory = async (handler) => {
+    listeners.add(handler);
+    return () => {
+      listeners.delete(handler);
+    };
+  };
+
+  function runHarnessTask(taskId: string): TaskRunResult {
+    const { session, requestId } = createSessionFromPrompt(
+      `Run task ${taskId}`,
+      deployment.defaultBehaviorId,
+    );
+    return {
+      requestDocId: `${requestId}-doc`,
+      requestId,
+      sessionId: session.sessionId,
+      agentDid: deployment.agentDid,
+      behaviorId: deployment.defaultBehaviorId ?? DEFAULT_BEHAVIOR_ID,
+      status: "completed",
+      lifecycleState: "completed",
+    };
+  }
+
+  function findSessionByRequest(requestId: string) {
+    return Array.from(sessions.values()).find(
+      (session) => session.latestRequestId === requestId,
+    );
+  }
+
+  return { adapter, listenerFactory, scenario };
+}
+
+export const createBombadilDesktopHarness = createDesktopUiHarness;
+
+function createDeployment(): DeploymentView {
+  return {
+    peerId: "peer-bombadil-local",
+    label: "Bombadil UI Agent",
+    agentDid: AGENT_DID,
+    addr: "/ip4/127.0.0.1/tcp/9292",
+    source: "bombadil-harness",
+    graphql: "http://127.0.0.1:9181/api/v0/graphql",
+    dialSucceeded: true,
+    lastError: null,
+    defaultBehaviorId: DEFAULT_BEHAVIOR_ID,
+    agentPrincipal: {
+      agentDid: AGENT_DID,
+      displayName: "Bombadil UI Agent",
+      defaultBehaviorId: DEFAULT_BEHAVIOR_ID,
+      enabled: true,
+      createdAt: STARTED_AT,
+      createdBy: "bombadil",
+    },
+    runtime: {
+      processState: "running",
+      reconcilePhase: "idle",
+      lastReconcileResult: "ok",
+      lastReconcileError: null,
+      updatedAt: STARTED_AT,
+    },
+    behaviors: [
+      {
+        behaviorId: DEFAULT_BEHAVIOR_ID,
+        displayName: "Default",
+        systemPrompt: "You are a deterministic UI-test agent.",
+        backendId: "backend-openai",
+        modelName: "gpt-4.1-mini",
+        toolSelectionId: "tools-default",
+        inferenceProfileId: "profile-default",
+        compactionStrategy: "rolling",
+        compactionThreshold: 0.75,
+        enabled: true,
+        isDefault: true,
+      },
+      {
+        behaviorId: "ops",
+        displayName: "Ops",
+        systemPrompt: "You inspect runtime and fleet health.",
+        backendId: "backend-openai",
+        modelName: "gpt-4.1-mini",
+        toolSelectionId: "tools-default",
+        inferenceProfileId: "profile-default",
+        compactionStrategy: "rolling",
+        compactionThreshold: 0.75,
+        enabled: true,
+        isDefault: false,
+      },
+    ],
+    inferenceBackends: [
+      {
+        backendId: "backend-openai",
+        name: "OpenAI Harness",
+        providerKind: "openai",
+        endpoint: "http://127.0.0.1:8000/v1",
+        apiKeyConfigured: true,
+        apiKeyEnvVar: "OPENAI_API_KEY",
+        maxConcurrent: 4,
+        maxQueueDepth: 16,
+        enabled: true,
+        models: ["gpt-4.1-mini"],
+        probeStatus: "healthy",
+      },
+    ],
+    inferenceProfiles: [
+      {
+        profileId: "profile-default",
+        displayName: "Default profile",
+        contextWindow: 128000,
+        maxOutputTokens: 4096,
+        maxTurns: 24,
+        temperature: 0.2,
+        streamBatchMs: 100,
+        streamLivenessTimeoutSecs: 30,
+        deadlineDurationSecs: 300,
+      },
+    ],
+    toolSelections: [
+      {
+        selectionId: "tools-default",
+        agentDid: AGENT_DID,
+        displayName: "Default tools",
+        enableFileTools: true,
+        fileToolsMode: "ReadOnly",
+        fileToolRoot: "/tmp/defra-agent-bombadil/workspace",
+        enableBash: true,
+        bashMode: "ReadOnly",
+        commandExecutionPolicy: "AllowListed",
+        commandAllowedArgvPrefixes: ["rg", "git status", "cargo test"],
+        commandForbiddenArgvPrefixes: ["rm -rf", "git reset --hard"],
+        commandNetworkMode: "Disabled",
+        cliToolNames: ["rg", "git"],
+        enableMetaTools: true,
+        allowedMcpServiceIds: ["mcp-observability"],
+        delegateTo: [],
+        backgroundableToolNames: ["cargo test"],
+        subagentTargets: [],
+        subagentSpawnEnabled: true,
+        subagentSteeringEnabled: true,
+        subagentBackgroundEnabled: true,
+        crossDeploymentSpawnTimeoutSeconds: 30,
+        enableMemory: false,
+        enableSessionHistoryTool: true,
+      },
+    ],
+    toolServiceRegistries: [
+      {
+        serviceId: "mcp-observability",
+        displayName: "Observability MCP",
+        description: "Fleet health MCP service",
+        hostname: "localhost",
+        tailscaleIp: null,
+        lanIp: "127.0.0.1",
+        mcpPort: 7331,
+        mcpPath: "/mcp",
+        status: "healthy",
+        version: "0.1.0",
+        updatedAt: STARTED_AT,
+      },
+    ],
+    tasks: [
+      {
+        taskId: "host-check",
+        name: "Host check",
+        description: "Inspect host health and summarize findings.",
+        behaviorId: DEFAULT_BEHAVIOR_ID,
+        promptTemplate: "Inspect this host and report health.",
+        enabled: true,
+        outputSchemaRef: null,
+        recentRuns: {
+          totalFires: 0,
+          lastAttemptAt: null,
+          lastStatus: null,
+          lastError: null,
+          scheduleCount: 1,
+          eventTriggerCount: 0,
+        },
+        runHistory: [],
+      },
+    ],
+    schedules: [
+      {
+        scheduleId: "host-check-every-6h",
+        taskId: "host-check",
+        intervalSecs: 21600,
+        enabled: true,
+        concurrency: "serial",
+        nextRunAt: null,
+        lastAttemptAt: null,
+        lastStatus: null,
+        lastError: null,
+        fireCount: 0,
+      },
+    ],
+    eventTriggers: [],
+    conversations: [],
+  };
+}
+
+function upsertBy<T extends Record<K, string>, K extends keyof T>(
+  rows: T[],
+  key: K,
+  value: string,
+  next: T,
+) {
+  const index = rows.findIndex((row) => row[key] === value);
+  if (index < 0) {
+    return [...rows, next];
+  }
+  return rows.map((row, i) => (i === index ? next : row));
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value);
+}
+
+function normalizeScenario(value?: string | null): DesktopUiHarnessScenario {
+  switch (value) {
+    case "empty-fleet":
+    case "loading":
+    case "bridge-unavailable":
+    case "save-error":
+    case "backend-health-error":
+    case "long-content":
+    case "active-turn":
+    case "cascade-turn":
+      return value;
+    default:
+      return "default";
+  }
+}
+
+function longHarnessMessage() {
+  return [
+    "I am your desktop UI test agent with a deliberately long transcript row.",
+    "This content exercises wrapping, scrolling, markdown layout, and composer stability without relying on a real model.",
+    "The message keeps going so deterministic browser tests can capture a stable long-content chat state.",
+    "Observation: fleet healthy, backend available, MCP service reachable, no duplicate assistant rows expected.",
+  ].join("\n\n");
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => window.setTimeout(resolve, ms));
+}

--- a/apps/desktop-tauri/tests/ui-harness/harness.html
+++ b/apps/desktop-tauri/tests/ui-harness/harness.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>defra-agent desktop UI harness</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/tests/ui-harness/harness.tsx"></script>
+  </body>
+</html>

--- a/apps/desktop-tauri/tests/ui-harness/harness.tsx
+++ b/apps/desktop-tauri/tests/ui-harness/harness.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+
+import App from "../../src/App";
+import { setDesktopApiAdapterForTests } from "../../src/lib/desktop-api";
+import { setDesktopClientUpdatedListenerFactoryForTests } from "../../src/lib/desktop-events";
+import { setDesktopShellTimingConfigForTests } from "../../src/hooks/useDesktopShell";
+import { createDesktopUiHarness } from "./desktopHarness";
+
+const scenario = new URLSearchParams(window.location.search).get("scenario");
+const {
+  adapter,
+  listenerFactory,
+  scenario: resolvedScenario,
+} = createDesktopUiHarness({
+  scenario,
+});
+
+document.documentElement.dataset.desktopUiHarnessScenario = resolvedScenario;
+
+setDesktopApiAdapterForTests(adapter);
+setDesktopClientUpdatedListenerFactoryForTests(listenerFactory);
+setDesktopShellTimingConfigForTests({
+  clientRestartBackoffMs: 1,
+  clientRestartMaxAttempts: 2,
+  p2pAutoRestartCooldownMs: 10,
+});
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);


### PR DESCRIPTION
## Summary
- Adds a shared desktop UI harness with a deterministic fake `DesktopApiAdapter`
- Adds Playwright browser journeys across desktop, laptop, and narrow viewports
- Adds Bombadil smoke/fuzz commands using the same harness
- Adds a dedicated `desktop-ui` CI job with artifact upload on failure
- Extends live smoke workflow with manual desktop live bridge checks
- Fixes task/schedule run-status reset after same-document snapshot refreshes

## Test Plan
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run test:ui:e2e`
- `npm run test:ui:fuzz -- --time-limit 30s`

Note: live bridge/runtime tests were not run locally; they remain manual workflow smoke checks.