### PR TITLE
Polish desktop UI test harness coverage

### DIFF
--- a/apps/desktop-tauri/README.md
+++ b/apps/desktop-tauri/README.md
@@ -85,6 +85,8 @@ Individual layers:
 ```bash
 npm run test:ui:unit
 npm run test:ui:e2e
+npm run test:ui:invariants
+npm run test:ui:screenshots
 npm run test:ui:fuzz -- --time-limit 30s
 npm run test:ui:fuzz:long
 ```
@@ -103,7 +105,20 @@ npm run test:ui:fuzz -- --time-limit 2m
 ```
 
 Artifacts are written under `test-results/` and Playwright's HTML report under
-`playwright-report/`.
+`playwright-report/`. Playwright failures include screenshots, videos, traces,
+and browser console logs when the browser emitted errors. Stable screenshot
+captures are diagnostic review artifacts, not visual golden snapshots.
+
+Useful artifact commands:
+
+```bash
+npx playwright show-report
+npx playwright show-trace test-results/playwright/<failed-test>/trace.zip
+```
+
+Use screenshots for quick visual triage, then use traces for the full timeline:
+DOM snapshots, clicked elements, network/console signals, and the exact failed
+assertion.
 
 Live UI smoke tests:
 

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -12,6 +12,8 @@
     "test:ui": "npm run format:check && npm run build && npm run test:ui:unit && npm run test:ui:e2e && npm run test:ui:fuzz -- --time-limit 20s",
     "test:ui:unit": "vitest run",
     "test:ui:e2e": "playwright test",
+    "test:ui:invariants": "playwright test tests/playwright/desktop-invariants.spec.ts",
+    "test:ui:screenshots": "playwright test tests/playwright/desktop-screenshots.spec.ts",
     "test:ui:fuzz": "node ./tests/bombadil/run-bombadil.mjs",
     "test:ui:fuzz:long": "node ./tests/bombadil/run-bombadil.mjs --time-limit 5m",
     "test:ui:bombadil": "node ./tests/bombadil/run-bombadil.mjs",

--- a/apps/desktop-tauri/tests/playwright/desktop-invariants.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-invariants.spec.ts
@@ -1,0 +1,54 @@
+import {
+  adjacentDuplicateTranscriptRows,
+  enabledButtonsWithoutAccessibleNames,
+  expect,
+  gotoHarness,
+  openChat,
+  primarySurfaceCount,
+  test,
+  type HarnessScenario,
+} from "./desktopTest";
+
+const healthyScenarios: HarnessScenario[] = [
+  "default",
+  "empty-fleet",
+  "loading",
+  "long-content",
+  "active-turn",
+  "cascade-turn",
+];
+
+test.describe("desktop UI invariants", () => {
+  for (const scenario of healthyScenarios) {
+    test(`${scenario} keeps shell invariants`, async ({ page }) => {
+      await gotoHarness(page, scenario);
+
+      await expect(page.getByTestId("error-banner")).toHaveCount(0);
+      await expect(primarySurfaceCount(page)).resolves.toBe(1);
+      await expect(enabledButtonsWithoutAccessibleNames(page)).resolves.toEqual([]);
+
+      if (scenario !== "empty-fleet") {
+        await openChat(page);
+        await expect(adjacentDuplicateTranscriptRows(page)).resolves.toEqual([]);
+      }
+    });
+  }
+
+  test("sad-path scenarios show handled errors without crashing the shell", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "bridge-unavailable");
+    await expect(page.locator(".app-shell")).toBeVisible();
+    await expect(page.getByTestId("error-banner")).toContainText(
+      "Desktop native bridge is unavailable",
+    );
+
+    await gotoHarness(page, "backend-health-error");
+    await openChat(page);
+    await page.getByRole("button", { name: /open operations drawer/i }).click();
+    await page.getByRole("tab", { name: /Backends/ }).click();
+    await expect(page.getByRole("alert")).toContainText(
+      "Harness backend health bridge unavailable",
+    );
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-screenshots.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-screenshots.spec.ts
@@ -1,0 +1,37 @@
+import {
+  captureStableScreenshot,
+  expect,
+  gotoHarness,
+  openChat,
+  openConfig,
+  test,
+} from "./desktopTest";
+
+test.describe("desktop stable screenshot states", () => {
+  test("captures core shell states", async ({ page }, testInfo) => {
+    await gotoHarness(page);
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-fleet-dashboard");
+
+    await openChat(page);
+    await expect(page.getByTestId("transcript-panel")).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-chat-transcript");
+
+    await page.getByRole("button", { name: /open operations drawer/i }).click();
+    await expect(page.getByRole("complementary", { name: "Operations" })).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-operations-drawer");
+
+    await gotoHarness(page);
+    await openConfig(page);
+    await expect(page.locator(".config-workspace")).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-config-workspace");
+
+    await gotoHarness(page, "empty-fleet");
+    await expect(page.getByTestId("fleet-empty")).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-empty-fleet");
+
+    await gotoHarness(page, "bridge-unavailable");
+    await expect(page.getByTestId("error-banner")).toBeVisible();
+    await captureStableScreenshot(page, testInfo, "stable-bridge-error");
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
@@ -1,38 +1,15 @@
-import { expect, test as base, type Page, type TestInfo } from "@playwright/test";
-
-type HarnessScenario =
-  | "default"
-  | "empty-fleet"
-  | "loading"
-  | "bridge-unavailable"
-  | "save-error"
-  | "backend-health-error"
-  | "long-content"
-  | "active-turn"
-  | "cascade-turn";
-
-const PEER_ID = "peer-bombadil-local";
-
-const test = base.extend<{ browserLogs: string[] }>({
-  browserLogs: async ({ page }, use, testInfo) => {
-    const logs: string[] = [];
-    page.on("console", (message) => {
-      logs.push(`[console:${message.type()}] ${message.text()}`);
-    });
-    page.on("pageerror", (error) => {
-      logs.push(`[pageerror] ${error.stack ?? error.message}`);
-    });
-
-    await use(logs);
-
-    if (testInfo.status !== testInfo.expectedStatus && logs.length > 0) {
-      await testInfo.attach("browser-console.log", {
-        body: logs.join("\n"),
-        contentType: "text/plain",
-      });
-    }
-  },
-});
+import {
+  adjacentDuplicateTranscriptRows,
+  captureStableScreenshot,
+  expect,
+  gotoHarness,
+  openChat,
+  openConfig,
+  openConfigTab,
+  PEER_ID,
+  saveConfig,
+  test,
+} from "./desktopTest";
 
 test.describe("desktop UI harness", () => {
   test("fleet dashboard connects a local runtime and opens chat/config", async ({
@@ -41,7 +18,7 @@ test.describe("desktop UI harness", () => {
     await gotoHarness(page);
     await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
     await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toBeVisible();
-    await attachStableScreenshot(page, testInfo, "fleet-dashboard");
+    await captureStableScreenshot(page, testInfo, "fleet-dashboard");
 
     await page.getByRole("button", { name: "Add Agent", exact: true }).click();
     await page.getByTestId("fleet-connect-local").click();
@@ -52,7 +29,7 @@ test.describe("desktop UI harness", () => {
     await expect(page.getByTestId("transcript-panel")).toContainText(
       "desktop UI test agent",
     );
-    await attachStableScreenshot(page, testInfo, "chat-with-transcript");
+    await captureStableScreenshot(page, testInfo, "chat-with-transcript");
 
     await page.getByRole("button", { name: "Configure" }).click();
     await expect(page.locator(".config-workspace")).toBeVisible();
@@ -98,7 +75,7 @@ test.describe("desktop UI harness", () => {
   }, testInfo) => {
     await gotoHarness(page);
     await openConfig(page);
-    await attachStableScreenshot(page, testInfo, "config-workspace");
+    await captureStableScreenshot(page, testInfo, "config-workspace");
 
     await openConfigTab(page, "behavior");
     await page
@@ -157,7 +134,7 @@ test.describe("desktop UI harness", () => {
     await openChat(page);
     await page.getByRole("button", { name: /open operations drawer/i }).click();
     await expect(page.getByRole("complementary", { name: "Operations" })).toBeVisible();
-    await attachStableScreenshot(page, testInfo, "operations-drawer-open");
+    await captureStableScreenshot(page, testInfo, "operations-drawer-open");
 
     await expect(page.getByRole("tab", { name: /Background/ })).toHaveAttribute(
       "aria-selected",
@@ -201,7 +178,7 @@ test.describe("desktop UI harness", () => {
   }, testInfo) => {
     await gotoHarness(page, "empty-fleet");
     await expect(page.getByTestId("fleet-empty")).toBeVisible();
-    await attachStableScreenshot(page, testInfo, "empty-fleet");
+    await captureStableScreenshot(page, testInfo, "empty-fleet");
 
     await gotoHarness(page, "bridge-unavailable");
     await expect(page.getByTestId("error-banner")).toContainText(
@@ -240,69 +217,3 @@ test.describe("desktop UI harness", () => {
     await expect(page.getByTestId("composer-send")).toBeVisible();
   });
 });
-
-async function gotoHarness(page: Page, scenario: HarnessScenario = "default") {
-  await page.goto(`/tests/ui-harness/harness.html?scenario=${scenario}`);
-  await expect(page.locator(".app-shell")).toBeVisible();
-}
-
-async function openChat(page: Page) {
-  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
-  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
-  await expect(page.getByTestId("composer-input")).toBeVisible();
-}
-
-async function openConfig(page: Page) {
-  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
-  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
-  await expect(page.getByTestId("composer-input")).toBeVisible();
-  await page.getByRole("button", { name: "Configure" }).click();
-  await expect(page.locator(".config-workspace")).toBeVisible();
-}
-
-async function openConfigTab(page: Page, tabId: string) {
-  const tab = page.getByTestId(`config-tab-${tabId}`);
-  await tab.click();
-  await expect(tab).toHaveClass(/selected/);
-}
-
-async function saveConfig(page: Page, testId: string) {
-  await page.getByTestId(testId).click();
-  await expect(page.locator(".config-editor").getByText("Saved")).toBeVisible();
-}
-
-async function adjacentDuplicateTranscriptRows(page: Page) {
-  return page
-    .locator('[data-testid="transcript-panel"] .message-card')
-    .evaluateAll((cards) => {
-      const rows = cards.map((card) => {
-        const roleText = card.querySelector(".message-role")?.textContent ?? "";
-        const contentText = card.querySelector(".message-content")?.textContent ?? "";
-        const role = roleText.replace(/\s+/g, " ").trim();
-        const content = contentText.replace(/\s+/g, " ").trim();
-        return { role, content };
-      });
-      const duplicates: string[] = [];
-      for (let index = 1; index < rows.length; index += 1) {
-        const previous = rows[index - 1];
-        const current = rows[index];
-        if (
-          previous.role &&
-          previous.content &&
-          previous.role === current.role &&
-          previous.content === current.content
-        ) {
-          duplicates.push(`${current.role}: ${current.content}`);
-        }
-      }
-      return duplicates;
-    });
-}
-
-async function attachStableScreenshot(page: Page, testInfo: TestInfo, name: string) {
-  const body = await page.screenshot({ fullPage: true });
-  await testInfo.attach(`${name}.png`, {
-    body,
-    contentType: "image/png",
-  });
-}

--- a/apps/desktop-tauri/tests/playwright/desktopTest.ts
+++ b/apps/desktop-tauri/tests/playwright/desktopTest.ts
@@ -1,0 +1,161 @@
+import { expect, test as base, type Page, type TestInfo } from "@playwright/test";
+
+export type HarnessScenario =
+  | "default"
+  | "empty-fleet"
+  | "loading"
+  | "bridge-unavailable"
+  | "save-error"
+  | "backend-health-error"
+  | "long-content"
+  | "active-turn"
+  | "cascade-turn";
+
+export const PEER_ID = "peer-bombadil-local";
+
+type DesktopFixtures = {
+  browserLogs: string[];
+};
+
+export const test = base.extend<DesktopFixtures>({
+  browserLogs: async ({ page }, use, testInfo) => {
+    const logs: string[] = [];
+    page.on("console", (message) => {
+      logs.push(`[console:${message.type()}] ${message.text()}`);
+    });
+    page.on("pageerror", (error) => {
+      logs.push(`[pageerror] ${error.stack ?? error.message}`);
+    });
+
+    await use(logs);
+
+    const unexpected = logs.filter(
+      (line) => line.startsWith("[pageerror]") || line.startsWith("[console:error]"),
+    );
+    if (testInfo.status !== testInfo.expectedStatus || unexpected.length > 0) {
+      await testInfo.attach("browser-console.log", {
+        body: logs.join("\n") || "(no browser console output)",
+        contentType: "text/plain",
+      });
+    }
+    expect(unexpected).toEqual([]);
+  },
+});
+
+export { expect };
+
+export async function gotoHarness(page: Page, scenario: HarnessScenario = "default") {
+  await page.goto(`/tests/ui-harness/harness.html?scenario=${scenario}`);
+  await expect(page.locator(".app-shell")).toBeVisible();
+  await expect(
+    page
+      .locator(
+        [
+          '[data-testid="fleet-dashboard"]',
+          '[data-testid="fleet-empty"]',
+          '[data-testid="transcript-panel"]',
+          ".config-workspace",
+          '[data-testid="error-banner"]',
+        ].join(", "),
+      )
+      .first(),
+  ).toBeVisible();
+}
+
+export async function openChat(page: Page) {
+  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
+  await expect(page.getByTestId("composer-input")).toBeVisible();
+}
+
+export async function openConfig(page: Page) {
+  await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+  await page.getByTestId(`fleet-chat-name-${PEER_ID}`).click();
+  await expect(page.getByTestId("composer-input")).toBeVisible();
+  await page.getByRole("button", { name: "Configure" }).click();
+  await expect(page.locator(".config-workspace")).toBeVisible();
+}
+
+export async function openConfigTab(page: Page, tabId: string) {
+  const tab = page.getByTestId(`config-tab-${tabId}`);
+  await tab.click();
+  await expect(tab).toHaveClass(/selected/);
+}
+
+export async function saveConfig(page: Page, testId: string) {
+  await page.getByTestId(testId).click();
+  await expect(page.locator(".config-editor").getByText("Saved")).toBeVisible();
+}
+
+export async function primarySurfaceCount(page: Page) {
+  return page.evaluate(() => {
+    const selectors = [
+      '[data-testid="fleet-dashboard"]',
+      '[data-testid="fleet-empty"]',
+      '[data-testid="transcript-panel"]',
+      ".config-workspace",
+    ];
+    return selectors.filter((selector) => document.querySelector(selector)).length;
+  });
+}
+
+export async function enabledButtonsWithoutAccessibleNames(page: Page) {
+  return page.evaluate(() => {
+    return Array.from(document.querySelectorAll("button"))
+      .filter((button) => !button.disabled)
+      .map((button) => {
+        const label =
+          button.getAttribute("aria-label") ??
+          button.getAttribute("title") ??
+          button.textContent ??
+          "";
+        return {
+          html: button.outerHTML,
+          label: label.replace(/\s+/g, " ").trim(),
+        };
+      })
+      .filter((button) => button.label.length === 0)
+      .map((button) => button.html);
+  });
+}
+
+export async function adjacentDuplicateTranscriptRows(page: Page) {
+  return page
+    .locator('[data-testid="transcript-panel"] .message-card')
+    .evaluateAll((cards) => {
+      const rows = cards.map((card) => {
+        const roleText = card.querySelector(".message-role")?.textContent ?? "";
+        const contentText = card.querySelector(".message-content")?.textContent ?? "";
+        const role = roleText.replace(/\s+/g, " ").trim();
+        const content = contentText.replace(/\s+/g, " ").trim();
+        return { role, content };
+      });
+      const duplicates: string[] = [];
+      for (let index = 1; index < rows.length; index += 1) {
+        const previous = rows[index - 1];
+        const current = rows[index];
+        if (
+          previous.role &&
+          previous.content &&
+          previous.role === current.role &&
+          previous.content === current.content
+        ) {
+          duplicates.push(`${current.role}: ${current.content}`);
+        }
+      }
+      return duplicates;
+    });
+}
+
+export async function captureStableScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+) {
+  const path = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ fullPage: true, path });
+  await testInfo.attach(`${name}.png`, {
+    path,
+    contentType: "image/png",
+  });
+}


### PR DESCRIPTION
## Summary
- factor shared Playwright desktop harness helpers for deterministic fixture loading and repeated UI assertions
- add invariant-oriented browser coverage across fleet, chat, config, operations, sad-path, loading, and long-content states
- add stable screenshot capture states and document how to inspect Playwright/Bombadil artifacts
- add focused npm scripts for invariants and screenshots alongside the existing e2e/fuzz commands

## Notes
- stacked on #515 / `iverc/desktop-bombadil-ui-tests` so the diff only shows the second wave of UI testing work
- the full e2e script intentionally covers journeys, invariants, and screenshot states across desktop/laptop/narrow projects

## Test plan
- `npm run format:check`
- `npm run build`
- `npm test`
- `npm run test:ui:e2e`
- `npm run test:ui:fuzz -- --time-limit 30s`