### PR TITLE
fix(template): handle minijinja 2.20 Expr::Compare

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13553,9 +13553,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.19.0"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
+checksum = "2929e494b2280e1e18959bb2e121da03347ae896896fdfaceaab43c88a02803f"
 dependencies = [
  "memo-map",
  "serde",

--- a/crates/defra-agent/src/template/reads.rs
+++ b/crates/defra-agent/src/template/reads.rs
@@ -199,6 +199,12 @@ fn collect_request_expr(expr: &Expr<'_>, reads: &mut BTreeSet<String>) {
             collect_request_expr(&b.left, reads);
             collect_request_expr(&b.right, reads);
         }
+        Expr::Compare(c) => {
+            collect_request_expr(&c.expr, reads);
+            for op in &c.ops {
+                collect_request_expr(&op.expr, reads);
+            }
+        }
         Expr::IfExpr(i) => {
             collect_request_expr(&i.test_expr, reads);
             collect_request_expr(&i.true_expr, reads);


### PR DESCRIPTION
#506 (cache-safe templating) bumped minijinja to 2.x, which added the new `Expr::Compare` AST variant. The exhaustive (no `_` arm) request-context expr collector in `template/reads.rs` was missing the arm, breaking `cargo build -p defra-agent` with E0004.

Adds the recurse-into-operands `Compare` arm (left `expr` + each `op.expr`), mirroring the existing `BinOp` arm. The restrictive system collector (`collect_expr`) continues to reject `Compare` via its `_ => Err` arm, consistent with its allowlist intent. Pins minijinja 2.20.0 in the lock so the variant is present.

Unblocks downstream path-dep consumers (zanzibar-rl), whose `policy-agent` build was failing through this sibling path-dep.