### PR TITLE
Gate embedded Codex TUI behind a CLI feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,119 @@
+SHELL := /bin/sh
+
+CARGO ?= cargo
+LAKE ?= lake
+NPM ?= npm
+
+DESKTOP_DIR := apps/desktop-tauri
+PROOFS_DIR := crates/defra-agent/proofs
+FUZZ_TIME ?= 30s
+
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help:
+	@echo "Build:"
+	@echo "  make build                 Build default Rust workspace members"
+	@echo "  make build-cli             Build the defra-agent CLI"
+	@echo "  make build-cli-headless    Build CLI without embedded Codex TUI"
+	@echo "  make build-desktop         Build the Tauri Rust shell"
+	@echo "  make build-desktop-ui      Build the desktop frontend"
+	@echo
+	@echo "Checks:"
+	@echo "  make fmt                   Format Rust and desktop UI code"
+	@echo "  make fmt-check             Check Rust and desktop UI formatting"
+	@echo "  make check-cli-headless    Check CLI without embedded Codex TUI"
+	@echo "  make proofs                Build Lean proofs"
+	@echo
+	@echo "Tests:"
+	@echo "  make test                  Run core Rust and CLI tests"
+	@echo "  make test-agent            Run defra-agent tests"
+	@echo "  make test-agent-conformance  Run runtime conformance tests"
+	@echo "  make test-agent-e2e        Run deterministic agent E2E tests"
+	@echo "  make test-cli              Run CLI tests"
+	@echo
+	@echo "Desktop UI:"
+	@echo "  make desktop-ui            Run full desktop UI suite"
+	@echo "  make desktop-ui-unit       Run desktop unit tests"
+	@echo "  make desktop-ui-e2e        Run desktop Playwright journeys"
+	@echo "  make desktop-ui-fuzz       Run desktop Bombadil smoke (FUZZ_TIME=$(FUZZ_TIME))"
+	@echo
+	@echo "Live:"
+	@echo "  make live-cli              Run live CLI smoke test"
+	@echo "  make live-agent            Run ignored live runtime tests"
+	@echo "  make live-desktop-smoke    Run live desktop smoke suites"
+
+.PHONY: build build-cli build-cli-headless build-desktop build-desktop-ui
+build:
+	$(CARGO) build
+
+build-cli:
+	$(CARGO) build -p defra-agent-cli
+
+build-cli-headless:
+	$(CARGO) build -p defra-agent-cli --no-default-features
+
+build-desktop:
+	$(CARGO) build -p defra-agent-desktop-tauri
+
+build-desktop-ui:
+	$(NPM) --prefix $(DESKTOP_DIR) run build
+
+.PHONY: fmt fmt-check check-cli-headless proofs
+fmt:
+	$(CARGO) fmt --all
+	$(NPM) --prefix $(DESKTOP_DIR) run format
+
+fmt-check:
+	$(CARGO) fmt --all --check
+	$(NPM) --prefix $(DESKTOP_DIR) run format:check
+
+check-cli-headless:
+	$(CARGO) check -p defra-agent-cli --no-default-features
+
+proofs:
+	cd $(PROOFS_DIR) && $(LAKE) build
+
+.PHONY: test test-agent test-agent-conformance test-agent-e2e test-cli
+test: test-agent test-cli
+
+test-agent:
+	$(CARGO) test -p defra-agent
+
+test-agent-conformance:
+	$(CARGO) test -p defra-agent --test conformance
+
+test-agent-e2e:
+	$(CARGO) test -p defra-agent --test e2e_lifecycle
+	$(CARGO) test -p defra-agent --test e2e_runtime
+	$(CARGO) test -p defra-agent --test e2e_subagent
+	$(CARGO) test -p defra-agent --test e2e_triggers
+
+test-cli:
+	$(CARGO) test -p defra-agent-cli -- --nocapture --test-threads=1
+
+.PHONY: desktop-ui desktop-ui-unit desktop-ui-e2e desktop-ui-fuzz
+desktop-ui:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:ui
+
+desktop-ui-unit:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:ui:unit
+
+desktop-ui-e2e:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:ui:e2e
+
+desktop-ui-fuzz:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:ui:fuzz -- --time-limit $(FUZZ_TIME)
+
+.PHONY: live-cli live-agent live-desktop-smoke
+live-cli:
+	$(CARGO) test -p defra-agent-cli --test cli_live standard_onboarding_live_demo_runs_real_conversation_with_filesystem_tools -- --ignored --nocapture --test-threads=1
+
+live-agent:
+	$(CARGO) test -p defra-agent --test e2e_live -- --ignored --nocapture --test-threads=1
+
+live-desktop-smoke:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:live:chat
+	$(NPM) --prefix $(DESKTOP_DIR) run test:live:config
+	$(NPM) --prefix $(DESKTOP_DIR) run test:live:operations
+	$(NPM) --prefix $(DESKTOP_DIR) run test:live:interrupt

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Subagents are requests: a parent's tool call spawns a child request — possibly
 ```bash
 cargo test -p defra-agent                    # runtime suite (lib + integration)
 cargo test --workspace                       # everything
+cargo build -p defra-agent-cli --no-default-features  # CLI without embedded Codex TUI
 cd crates/defra-agent/proofs && lake build   # the Lean proofs
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Subagents are requests: a parent's tool call spawns a child request — possibly
 ## Development
 
 ```bash
+make help                                    # curated build/test targets
 cargo test -p defra-agent                    # runtime suite (lib + integration)
 cargo test --workspace                       # everything
 cargo build -p defra-agent-cli --no-default-features  # CLI without embedded Codex TUI

--- a/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type { FormEvent } from "react";
 
 import type {
@@ -35,16 +35,15 @@ export function SkillConfigPanel({
   onDeleteSkillConfig,
   onSaveSkillConfig,
 }: SkillConfigPanelProps) {
-  const selectedSkill = useMemo(
-    () => deployment.skills.find((skill) => skill.skillId === selectedSkillId) ?? null,
-    [deployment.skills, selectedSkillId],
-  );
+  const skills = deployment.skills ?? [];
+  const selectedSkill =
+    skills.find((skill) => skill.skillId === selectedSkillId) ?? null;
 
   return (
     <section className="config-layout">
       <ConfigDocumentList
         eyebrow="Skills"
-        items={deployment.skills.map((skill) => {
+        items={skills.map((skill) => {
           const title = displaySkillListTitle(skill);
           return {
             id: skill.skillId,

--- a/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
+++ b/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
@@ -421,6 +421,8 @@ export function createDesktopUiHarness(
         compactionThreshold: request.compactionThreshold,
         enabled: request.enabled ?? true,
         isDefault: behaviorId === deployment.defaultBehaviorId,
+        skillRefs: request.skillRefs,
+        skillExcludes: request.skillExcludes,
       };
       deployment = {
         ...deployment,
@@ -430,6 +432,37 @@ export function createDesktopUiHarness(
           behaviorId,
           nextBehavior,
         ),
+      };
+      return snapshot();
+    },
+    async saveSkillConfig(request) {
+      const skillId = request.skillId.trim() || `skill-${requestSeq}`;
+      const name = request.name.trim() || skillId;
+      deployment = {
+        ...deployment,
+        skills: upsertBy(deployment.skills ?? [], "skillId", skillId, {
+          ...request,
+          skillId,
+          agentDid: request.agentDid || deployment.agentDid,
+          scope: request.scope || "behavior",
+          name,
+          displayName: request.displayName?.trim() || name,
+          enabled: request.enabled ?? true,
+          createdAt: STARTED_AT,
+        }),
+      };
+      return snapshot();
+    },
+    async deleteSkillConfig(request) {
+      const skillId = request.skillId.trim();
+      deployment = {
+        ...deployment,
+        skills: (deployment.skills ?? []).filter((skill) => skill.skillId !== skillId),
+        behaviors: deployment.behaviors.map((behavior) => ({
+          ...behavior,
+          skillRefs: (behavior.skillRefs ?? []).filter((id) => id !== skillId),
+          skillExcludes: (behavior.skillExcludes ?? []).filter((id) => id !== skillId),
+        })),
       };
       return snapshot();
     },
@@ -793,6 +826,8 @@ function createDeployment(): DeploymentView {
         compactionThreshold: 0.75,
         enabled: true,
         isDefault: true,
+        skillRefs: ["host-diagnostics"],
+        skillExcludes: [],
       },
       {
         behaviorId: "ops",
@@ -806,6 +841,8 @@ function createDeployment(): DeploymentView {
         compactionThreshold: 0.75,
         enabled: true,
         isDefault: false,
+        skillRefs: [],
+        skillExcludes: [],
       },
     ],
     inferenceBackends: [
@@ -877,6 +914,33 @@ function createDeployment(): DeploymentView {
         status: "healthy",
         version: "0.1.0",
         updatedAt: STARTED_AT,
+      },
+    ],
+    skills: [
+      {
+        skillId: "host-diagnostics",
+        agentDid: AGENT_DID,
+        scope: "behavior",
+        name: "Host diagnostics",
+        description: "Inspect host health and write a concise operational report.",
+        instructions: "Inspect host health, telemetry freshness, and recent errors.",
+        toolRefs: ["mcp-observability.inspect_host", "mcp-observability.query_logs"],
+        displayName: "Host diagnostics",
+        enabled: true,
+        createdAt: STARTED_AT,
+      },
+      {
+        skillId: "fleet-summary",
+        agentDid: AGENT_DID,
+        scope: "principal",
+        name: "Fleet summary",
+        description: "Summarize fleet state for operator handoff.",
+        instructions:
+          "Compare backend health, silent hosts, and posted steward status.",
+        toolRefs: ["mcp-observability.fleet_status"],
+        displayName: "Fleet summary",
+        enabled: true,
+        createdAt: STARTED_AT,
       },
     ],
     tasks: [

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -6,6 +6,10 @@ license.workspace = true
 description = "Consumer CLI for the defra-agent library"
 autobins = false
 
+[features]
+default = ["codex-tui"]
+codex-tui = ["dep:codex-arg0", "dep:codex-config", "dep:codex-tui"]
+
 [[bin]]
 name = "defra-agent"
 path = "src/main.rs"
@@ -18,12 +22,12 @@ chrono.workspace = true
 ciborium = "0.2"
 clap.workspace = true
 codex-app-server-protocol.workspace = true
-codex-arg0.workspace = true
-codex-config.workspace = true
+codex-arg0 = { workspace = true, optional = true }
+codex-config = { workspace = true, optional = true }
 codex-login.workspace = true
 codex-model-provider-info.workspace = true
 codex-protocol.workspace = true
-codex-tui.workspace = true
+codex-tui = { workspace = true, optional = true }
 codex-utils-absolute-path.workspace = true
 defra-agent = { path = "../defra-agent" }
 defra-native-fs-runner = { path = "../defra-native-fs-runner" }

--- a/crates/defra-agent-cli/src/commands/codex.rs
+++ b/crates/defra-agent-cli/src/commands/codex.rs
@@ -8,19 +8,27 @@
 //! owns tool gating — the tool preset chosen at `init` is the real
 //! permission boundary.
 
-use std::io::IsTerminal;
-use std::time::Duration;
+#[cfg(feature = "codex-tui")]
+use std::{io::IsTerminal, time::Duration};
 
-use anyhow::{anyhow, bail, Context, Result};
+#[cfg(feature = "codex-tui")]
+use anyhow::{anyhow, Context};
+use anyhow::{bail, Result};
+#[cfg(feature = "codex-tui")]
 use clap::Parser;
+#[cfg(feature = "codex-tui")]
 use codex_arg0::Arg0DispatchPaths;
+#[cfg(feature = "codex-tui")]
 use codex_tui::{Cli as CodexTuiCli, ExitReason, RemoteAppServerEndpoint};
+#[cfg(feature = "codex-tui")]
 use tokio::net::TcpStream;
 
 use crate::cli::args::CodexArgs;
 
+#[cfg(feature = "codex-tui")]
 const SHIM_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[cfg(feature = "codex-tui")]
 pub(crate) async fn codex(args: CodexArgs) -> Result<()> {
     if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
         bail!("`defra-agent codex` is interactive and needs a terminal; use `defra-agent chat` for scripted turns");
@@ -50,11 +58,20 @@ pub(crate) async fn codex(args: CodexArgs) -> Result<()> {
     }
 }
 
+#[cfg(not(feature = "codex-tui"))]
+pub(crate) async fn codex(_args: CodexArgs) -> Result<()> {
+    bail!(
+        "`defra-agent codex` was built without the `codex-tui` feature; rebuild with default features or connect an external Codex client to the running shim"
+    )
+}
+
+#[cfg(feature = "codex-tui")]
 fn resolve_endpoint(remote: &str) -> Result<RemoteAppServerEndpoint> {
     codex_tui::resolve_remote_addr(remote)
         .map_err(|error| anyhow!("invalid --remote address {remote:?}: {error}"))
 }
 
+#[cfg(feature = "codex-tui")]
 fn build_tui_cli(args: &CodexArgs) -> CodexTuiCli {
     let mut cli = CodexTuiCli::parse_from(["codex"]);
     cli.dangerously_bypass_approvals_and_sandbox = true;
@@ -63,6 +80,7 @@ fn build_tui_cli(args: &CodexArgs) -> CodexTuiCli {
     cli
 }
 
+#[cfg(feature = "codex-tui")]
 async fn probe_shim(endpoint: &RemoteAppServerEndpoint) -> Result<()> {
     let Some(authority) = probe_authority(endpoint) else {
         return Ok(());
@@ -82,6 +100,7 @@ async fn probe_shim(endpoint: &RemoteAppServerEndpoint) -> Result<()> {
 /// Host:port to TCP-probe before launching the TUI, when the endpoint names
 /// one explicitly. Endpoints without a probeable authority (unix sockets,
 /// portless URLs) skip the probe and let the TUI surface connect errors.
+#[cfg(feature = "codex-tui")]
 fn probe_authority(endpoint: &RemoteAppServerEndpoint) -> Option<String> {
     let RemoteAppServerEndpoint::WebSocket { websocket_url, .. } = endpoint else {
         return None;
@@ -98,7 +117,7 @@ fn probe_authority(endpoint: &RemoteAppServerEndpoint) -> Option<String> {
     Some(authority.to_string())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "codex-tui"))]
 mod tests {
     use super::*;
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -69,6 +69,8 @@ cargo install --profile dev-install --locked --path crates/defra-agent-cli
 ```
 
 That installs the `defra-agent` binary into `~/.cargo/bin`.
+For a headless build without the embedded Codex TUI, add
+`--no-default-features`; the server shim and `chat` command still build.
 
 ## 3. Initialize the agent
 


### PR DESCRIPTION
## Summary
- Add a default-on `codex-tui` feature to `defra-agent-cli`
- Make the embedded `defra-agent codex` TUI dependencies optional
- Document the lean CLI build path with `--no-default-features`

## Why
The embedded Codex TUI is useful, but it pulls in a large terminal UI dependency tree. Headless/server-style CLI builds do not need that weight.

Default builds keep existing behavior. Lean builds can now skip `codex-tui`, `ratatui`, and `crossterm` while keeping the server shim and `chat` command available.

## Test Plan
- `cargo check -p defra-agent-cli --no-default-features`
- `cargo check -p defra-agent-cli`
- `cargo test -p defra-agent-cli commands::codex`
- `cargo fmt --all --check`