### PR TITLE
ci(release): per-arch LTO + Makefile-driven Linux release builds

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -14,14 +14,14 @@ permissions:
   contents: write
 
 env:
-  CARGO_BUILD_JOBS: ${{ vars.CARGO_BUILD_JOBS || '4' }}
   CARGO_INCREMENTAL: "0"
   CARGO_NET_GIT_FETCH_WITH_CLI: "true"
-  # The workspace release profile uses fat LTO + one codegen unit. That has
-  # repeatedly OOM-killed the self-hosted Linux release runners during the final
-  # link, especially on spark. Keep Linux artifacts optimized, but use the same
-  # lower-memory ThinLTO shape as the local install profile.
-  CARGO_PROFILE_RELEASE_LTO: "thin"
+  # The workspace release profile uses fat LTO + one codegen unit, which holds
+  # the whole dependency graph in memory at link time and OOM-kills the
+  # self-hosted Linux runners. LTO and build parallelism are set per-arch in the
+  # matrix below: workstation-1 (x86_64) has ample RAM and uses ThinLTO; the
+  # sparks (aarch64) serve a resident model and have only a few GB free, so they
+  # disable LTO and cap parallelism.
   CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
   RUST_BACKTRACE: "1"
 
@@ -36,9 +36,18 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             runner_arch: X64
             runner_label: workstation-1
+            # ~228 GB free; ThinLTO links comfortably.
+            release_lto: "thin"
+            cargo_jobs: "8"
           - target: aarch64-unknown-linux-gnu
             runner_arch: ARM64
             runner_label: spark
+            # spark-1/2 serve the resident d4f vLLM model in unified memory,
+            # leaving only ~7-9 GB free. Disable LTO and cap parallelism so the
+            # link fits. Cross-compiling on workstation-1 is the tracked
+            # long-term fix (see the build-flavors epic).
+            release_lto: "off"
+            cargo_jobs: "2"
     runs-on:
       - self-hosted
       - Linux
@@ -48,6 +57,8 @@ jobs:
     env:
       GIT_CONFIG_GLOBAL: /tmp/defra-agent-release-${{ github.run_id }}-${{ matrix.target }}.gitconfig
       TARGET_TRIPLE: ${{ matrix.target }}
+      CARGO_PROFILE_RELEASE_LTO: ${{ matrix.release_lto }}
+      CARGO_BUILD_JOBS: ${{ matrix.cargo_jobs }}
 
     steps:
       - uses: actions/checkout@v4
@@ -92,7 +103,7 @@ jobs:
             echo "::error::Expected native ${TARGET_TRIPLE} runner, got ${host_triple}."
             exit 1
           fi
-          cargo build -p defra-agent-cli --release
+          make release-cli
           file target/release/defra-agent
 
       - name: Verify binary
@@ -112,23 +123,13 @@ jobs:
           set -euo pipefail
 
           artifact_basename="defra-agent-${TARGET_TRIPLE}"
-          package_parent="${RUNNER_TEMP}/package"
-          package_root="${package_parent}/${artifact_basename}"
           dist_dir="${RUNNER_TEMP}/dist"
+          rm -rf "${dist_dir}"
+
+          make dist-cli DIST_DIR="${dist_dir}"
+
           tarball="${dist_dir}/${artifact_basename}.tar.gz"
           checksum_file="${tarball}.sha256"
-
-          rm -rf "${package_parent}" "${dist_dir}"
-          mkdir -p "${package_root}" "${dist_dir}"
-          cp target/release/defra-agent "${package_root}/defra-agent"
-          chmod 0755 "${package_root}/defra-agent"
-
-          tar -C "${package_parent}" -czf "${tarball}" "${artifact_basename}"
-          (
-            cd "${dist_dir}"
-            sha256sum "${artifact_basename}.tar.gz" > "${artifact_basename}.tar.gz.sha256"
-          )
-
           echo "tarball=${tarball}" >> "${GITHUB_OUTPUT}"
           echo "checksum_file=${checksum_file}" >> "${GITHUB_OUTPUT}"
           echo "artifact_basename=${artifact_basename}" >> "${GITHUB_OUTPUT}"

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,11 @@ help:
 	@echo "  make build-desktop         Build the Tauri Rust shell"
 	@echo "  make build-desktop-ui      Build the desktop frontend"
 	@echo
+	@echo "Release (CI calls these; TARGET=<triple> optional, defaults to host):"
+	@echo "  make release-cli           Build the release CLI (full features)"
+	@echo "  make release-cli-headless  Build the release CLI without embedded Codex TUI"
+	@echo "  make dist-cli              Build + package $(DIST_DIR)/defra-agent-<triple>.tar.gz(+sha256)"
+	@echo
 	@echo "Checks:"
 	@echo "  make fmt                   Format Rust and desktop UI code"
 	@echo "  make fmt-check             Check Rust and desktop UI formatting"
@@ -58,6 +63,36 @@ build-desktop:
 
 build-desktop-ui:
 	$(NPM) --prefix $(DESKTOP_DIR) run build
+
+# ---- Release / packaging ----
+# Produces the Linux release artifacts; the release workflow calls these so CI
+# and local builds run the same commands. LTO, codegen-units and build
+# parallelism are controlled by the caller's environment
+# (CARGO_PROFILE_RELEASE_LTO, CARGO_BUILD_JOBS) — per-arch memory tuning lives
+# in .github/workflows/release-linux.yml, not here.
+TARGET ?=
+DIST_DIR ?= dist
+CARGO_TARGET_FLAG := $(if $(TARGET),--target $(TARGET),)
+TARGET_TRIPLE := $(if $(TARGET),$(TARGET),$(shell rustc -Vv | awk '/^host:/ { print $$2 }'))
+RELEASE_BIN := target/$(if $(TARGET),$(TARGET)/,)release/defra-agent
+RELEASE_ARTIFACT := defra-agent-$(TARGET_TRIPLE)
+
+.PHONY: release-cli release-cli-headless dist-cli
+release-cli:
+	$(CARGO) build -p defra-agent-cli --release $(CARGO_TARGET_FLAG)
+
+release-cli-headless:
+	$(CARGO) build -p defra-agent-cli --release --no-default-features $(CARGO_TARGET_FLAG)
+
+dist-cli: release-cli
+	@rm -rf "$(DIST_DIR)/$(RELEASE_ARTIFACT)"
+	@mkdir -p "$(DIST_DIR)/$(RELEASE_ARTIFACT)"
+	cp "$(RELEASE_BIN)" "$(DIST_DIR)/$(RELEASE_ARTIFACT)/defra-agent"
+	chmod 0755 "$(DIST_DIR)/$(RELEASE_ARTIFACT)/defra-agent"
+	tar -C "$(DIST_DIR)" -czf "$(DIST_DIR)/$(RELEASE_ARTIFACT).tar.gz" "$(RELEASE_ARTIFACT)"
+	cd "$(DIST_DIR)" && sha256sum "$(RELEASE_ARTIFACT).tar.gz" > "$(RELEASE_ARTIFACT).tar.gz.sha256"
+	@rm -rf "$(DIST_DIR)/$(RELEASE_ARTIFACT)"
+	@ls -lh "$(DIST_DIR)/$(RELEASE_ARTIFACT).tar.gz"*
 
 .PHONY: fmt fmt-check check-cli-headless proofs
 fmt:


### PR DESCRIPTION
## Problem

No Linux asset has ever published — every tagged `release-linux.yml` run OOM-killed during the **fat-LTO link** (`[profile.release] lto=true, codegen-units=1`). v0.4.0 shipped only `aarch64-apple-darwin`.

Root cause (verified by SSHing the self-hosted runners):
- **workstation-1** (x86_64): ~228 GB free — never the problem; it only got *cancelled* as matrix collateral.
- **spark-1/2** (aarch64): only ~7–9 GB free. ~110 GB of the 119 GB unified memory is the resident tensor-parallel **d4f vLLM model** (the live-inference cluster). Fat-LTO holds the whole dep graph in memory at link → OOM. Even ThinLTO is marginal at ~9 GB.

## Fix

- **Per-arch tuning in the matrix:** x86_64 → ThinLTO + 8 jobs; aarch64 → **LTO off** + 2 jobs so the link fits alongside the live model. Full features on both (no feature-stripping — this is not an OOM workaround).
- **Makefile is the build contract:** new `release-cli` / `release-cli-headless` / `dist-cli` targets (build + tar.gz + sha256). The workflow now calls `make release-cli` / `make dist-cli`, so CI and local builds run identical commands. LTO/jobs stay env-driven so per-arch tuning lives in the workflow, not the Makefile.

## Validation

`workflow_dispatch` on this branch (builds + packages, does **not** publish — upload is gated on `refs/tags/v*`): [run 27833085345](https://github.com/sourcenetwork/defra-agent/actions/runs/27833085345) — **both arches green**.

| Job | Artifact | Size | Duration |
|---|---|---|---|
| x86_64 | `defra-agent-x86_64-unknown-linux-gnu.tar.gz` | 102 MB | ~15 min |
| aarch64 | `defra-agent-aarch64-unknown-linux-gnu.tar.gz` | 87 MB | ~34 min |

The real test is the next `v*` tag.

## Follow-ups (tracked in #527)
- Cross-compile aarch64 on workstation-1 to remove the spark from the build path entirely (the durable fix).
- `release-macos.yml` still ships only `aarch64-apple-darwin` (no x86_64 mac).

Refs #527. Closes the long-standing gap behind #486 / #353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)