### PR TITLE
Add native macOS Tauri QA lane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,9 @@ help:
 	@echo "  make desktop-ui-fuzz-long  Run longer desktop Bombadil sweep"
 	@echo "  make desktop-ui-visual     Run desktop visual baseline checks"
 	@echo "  make desktop-ui-live-e2e   Run live browser-to-runtime desktop smoke"
+	@echo "  make desktop-native-preflight  Build frontend/Rust shell and print Tauri CLI version"
+	@echo "  make desktop-native-dev    Launch the native Tauri dev app for manual QA"
+	@echo "  make desktop-native-build  Build the native Tauri app bundle"
 	@echo
 	@echo "Live:"
 	@echo "  make live-cli              Run live CLI smoke test"
@@ -131,7 +134,7 @@ test-agent-e2e:
 test-cli:
 	$(CARGO) test -p defra-agent-cli -- --nocapture --test-threads=1
 
-.PHONY: desktop-ui desktop-ui-qa-sweep desktop-ui-unit desktop-ui-e2e desktop-ui-fuzz desktop-ui-fuzz-long desktop-ui-visual desktop-ui-live-e2e
+.PHONY: desktop-ui desktop-ui-qa-sweep desktop-ui-unit desktop-ui-e2e desktop-ui-fuzz desktop-ui-fuzz-long desktop-ui-visual desktop-ui-live-e2e desktop-native-preflight desktop-native-dev desktop-native-build
 desktop-ui:
 	$(NPM) --prefix $(DESKTOP_DIR) run test:ui
 
@@ -155,6 +158,15 @@ desktop-ui-visual:
 
 desktop-ui-live-e2e:
 	$(NPM) --prefix $(DESKTOP_DIR) run test:ui:live:e2e
+
+desktop-native-preflight:
+	$(NPM) --prefix $(DESKTOP_DIR) run test:ui:native:preflight
+
+desktop-native-dev:
+	$(NPM) --prefix $(DESKTOP_DIR) run tauri -- dev
+
+desktop-native-build:
+	$(NPM) --prefix $(DESKTOP_DIR) run tauri -- build
 
 .PHONY: live-cli live-agent live-desktop-smoke
 live-cli:

--- a/apps/desktop-tauri/README.md
+++ b/apps/desktop-tauri/README.md
@@ -30,13 +30,27 @@ npm run dev
 Run the full Tauri shell:
 
 ```bash
-npm run tauri dev
+npm run tauri -- dev
 ```
 
 Build the frontend:
 
 ```bash
 npm run build
+```
+
+Build the Tauri app:
+
+```bash
+npm run tauri -- build
+```
+
+From the repo root, the Makefile exposes the native app QA commands:
+
+```bash
+make desktop-native-preflight
+make desktop-native-dev
+make desktop-native-build
 ```
 
 Build the desktop binary from the repo root:
@@ -89,6 +103,7 @@ npm run test:ui:invariants
 npm run test:ui:screenshots
 npm run test:ui:fuzz -- --time-limit 30s
 npm run test:ui:fuzz:long
+npm run test:ui:native:preflight
 ```
 
 The Playwright suite serves `tests/ui-harness/harness.html` with Vite and renders
@@ -138,3 +153,7 @@ npm run smoke:remote-fleet
 
 The live tests expect real runtime connectivity and should be treated as manual
 or release validation, not the default fast correctness gate.
+
+Native macOS/Tauri smoke coverage is intentionally smaller than the browser
+matrix. See [tests/NATIVE_QA.md](./tests/NATIVE_QA.md) for the app-window,
+WebView, menu/window chrome, runtime handoff, and clean-quit checklist.

--- a/apps/desktop-tauri/package.json
+++ b/apps/desktop-tauri/package.json
@@ -21,6 +21,7 @@
     "test:ui:fuzz:long": "node ./tests/bombadil/run-bombadil.mjs --time-limit 5m",
     "test:ui:bombadil": "node ./tests/bombadil/run-bombadil.mjs",
     "test:ui:live:e2e": "node ./tests/run-live-playwright.mjs",
+    "test:ui:native:preflight": "npm run build && cargo build -p defra-agent-desktop-tauri && npm run tauri -- --version",
     "test:live": "node ./tests/run-live-test.mjs",
     "test:live:behavior-config": "node ./tests/run-live-test.mjs --suite behavior",
     "test:live:config": "node ./tests/run-live-test.mjs --suite config",

--- a/apps/desktop-tauri/src-tauri/Cargo.toml
+++ b/apps/desktop-tauri/src-tauri/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "defra-agent-desktop-tauri"
+default-run = "defra-agent-desktop-tauri"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "com.sourcenetwork.defra-agent-desktop",
   "build": {
-    "beforeDevCommand": "bun run dev",
+    "beforeDevCommand": "npm run dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "bun run build",
+    "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },
   "app": {

--- a/apps/desktop-tauri/src/components/fleet/AddPeerForm.tsx
+++ b/apps/desktop-tauri/src/components/fleet/AddPeerForm.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from "react";
 
+import { formatPeerConnectionError } from "../../lib/peerConnectionErrors";
 import type { PeerAddRequest } from "../../lib/types";
 import { parsePeerConnectionJson } from "./peerConnectionImport";
 
@@ -70,7 +71,7 @@ export function AddPeerForm({
       setImportStatus("Fetched /status");
       return request;
     } catch (error) {
-      setImportStatus(String(error));
+      setImportStatus(formatPeerConnectionError(error, "peer-status"));
       throw error;
     } finally {
       setFetchingStatus(false);

--- a/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
@@ -6,6 +6,7 @@ import type {
   P2PHealth,
   PeerAddRequest,
 } from "../../lib/types";
+import { formatPeerConnectionError } from "../../lib/peerConnectionErrors";
 import { AddPeerForm } from "./AddPeerForm";
 import { BrandLockup } from "./BrandLockup";
 import { FleetRow } from "./FleetRow";
@@ -66,7 +67,7 @@ export function FleetDashboard({
       setPeerForm(DEFAULT_PEER_FORM);
       setShowAddPeer(false);
     } catch (error) {
-      setPeerFormError(String(error));
+      setPeerFormError(formatPeerConnectionError(error, "add-peer"));
     }
   }
 
@@ -76,7 +77,7 @@ export function FleetDashboard({
     try {
       await onInitLocalRuntime(bootstrap?.initAgentName ?? "Local Agent");
     } catch (error) {
-      setLocalRuntimeError(String(error));
+      setLocalRuntimeError(formatPeerConnectionError(error, "local-runtime"));
     }
   }
 

--- a/apps/desktop-tauri/src/hooks/desktopShellPeerActions.ts
+++ b/apps/desktop-tauri/src/hooks/desktopShellPeerActions.ts
@@ -7,6 +7,7 @@ import {
   repairP2P,
   startDesktopClient,
 } from "../lib/desktop-api";
+import { formatPeerConnectionError } from "../lib/peerConnectionErrors";
 import type { DesktopClientSnapshot, PeerAddRequest } from "../lib/types";
 
 type PeerActionParams = {
@@ -51,8 +52,9 @@ export function createDesktopShellPeerActions({
       setSelectedAgentDid(summary.agentDid);
       return summary;
     } catch (err) {
-      setError(String(err));
-      throw err;
+      const message = formatPeerConnectionError(err, "local-runtime");
+      setError(message);
+      throw new Error(message);
     } finally {
       setStarting(false);
       setAddingPeer(false);
@@ -73,8 +75,9 @@ export function createDesktopShellPeerActions({
       setSelectedAgentDid(request.agentDid);
       return next;
     } catch (err) {
-      setError(String(err));
-      throw err;
+      const message = formatPeerConnectionError(err, "add-peer");
+      setError(message);
+      throw new Error(message);
     } finally {
       setStarting(false);
       setAddingPeer(false);
@@ -86,8 +89,9 @@ export function createDesktopShellPeerActions({
     try {
       return await fetchPeerStatus(serverAddress);
     } catch (err) {
-      setError(String(err));
-      throw err;
+      const message = formatPeerConnectionError(err, "peer-status");
+      setError(message);
+      throw new Error(message);
     }
   }
 
@@ -99,8 +103,9 @@ export function createDesktopShellPeerActions({
       setSnapshot(next);
       return next;
     } catch (err) {
-      setError(String(err));
-      throw err;
+      const message = formatPeerConnectionError(err, "repair-p2p");
+      setError(message);
+      throw new Error(message);
     } finally {
       setRepairingP2P(false);
     }

--- a/apps/desktop-tauri/src/lib/peerConnectionErrors.ts
+++ b/apps/desktop-tauri/src/lib/peerConnectionErrors.ts
@@ -1,0 +1,55 @@
+export type PeerConnectionAction =
+  | "add-peer"
+  | "local-runtime"
+  | "peer-status"
+  | "repair-p2p";
+
+export function formatPeerConnectionError(
+  error: unknown,
+  action: PeerConnectionAction,
+): string {
+  const message = errorMessage(error);
+  const url = requestUrlFromMessage(message);
+  if (!url) {
+    return message;
+  }
+
+  const endpoint = endpointLabel(url);
+  if (action === "local-runtime") {
+    return `Could not reach the local defra-agent runtime at ${endpoint}. Start \`defra-agent server\` and try again.`;
+  }
+
+  if (action === "peer-status") {
+    return `Could not fetch runtime connection details from ${endpoint}. Check that the runtime is running and the address is reachable.`;
+  }
+
+  return message;
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function requestUrlFromMessage(message: string): string | null {
+  const match = message.match(/\b(?:sending|reading) GET request to (https?:\/\/\S+)/i);
+  if (!match) {
+    return null;
+  }
+  return stripTrailingPunctuation(match[1]);
+}
+
+function stripTrailingPunctuation(value: string): string {
+  return value.replace(/[),.;]+$/g, "");
+}
+
+function endpointLabel(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return parsed.origin;
+  } catch {
+    return url;
+  }
+}

--- a/apps/desktop-tauri/tests/NATIVE_QA.md
+++ b/apps/desktop-tauri/tests/NATIVE_QA.md
@@ -1,0 +1,106 @@
+# Native macOS/Tauri QA
+
+The desktop app has two UI layers:
+
+- Browser QA exercises the React/HTML/CSS shell in Chromium. It is the fast
+  inner loop for layout, accessibility, console errors, adapter behavior, visual
+  baselines, and most interaction flows.
+- Native macOS/Tauri QA exercises the real `.app` shell, system WebView,
+  windowing, menus, process lifecycle, and runtime handoff. Keep this lane small
+  and focused on things browser tests cannot prove.
+
+## When To Use Each Layer
+
+Use browser QA for:
+
+- component/model correctness
+- viewport and layout regressions
+- transcript/config/operations workflows
+- visual baselines
+- Bombadil exploration
+- browser-to-runtime smoke through `bridge_runner`
+
+Use native QA for:
+
+- app launch and foreground window behavior
+- blank WebView or framework overlay failures in the real Tauri shell
+- macOS menu/window chrome and close/quit behavior
+- local runtime discovery and bootstrap handoff
+- packaged/dev app process cleanup
+- signing, entitlements, and bundle-specific regressions
+
+## Manual Native Smoke
+
+Run from the repo root.
+
+1. Run the non-GUI preflight:
+
+   ```bash
+   make desktop-native-preflight
+   ```
+
+   This builds the frontend, builds the Tauri Rust shell, and verifies the local
+   Tauri CLI is available.
+
+2. Launch the Tauri dev app:
+
+   ```bash
+   make desktop-native-dev
+   ```
+
+   The direct npm form is:
+
+   ```bash
+   npm --prefix apps/desktop-tauri run tauri -- dev
+   ```
+
+3. Verify the native app window:
+   - The app opens as `defra-agent desktop`.
+   - The window is not blank.
+   - There is no Vite/React framework error overlay.
+   - The first visible shell state is either a usable fleet/chat surface or a
+     handled runtime/bridge error.
+   - The title bar, resize behavior, and app menu feel normal on macOS.
+
+4. Verify the main entry points:
+   - Fleet dashboard opens.
+   - Chat composer is reachable.
+   - Configure opens the config workspace.
+   - Operations drawer opens and tabs switch.
+   - If a local runtime is configured, send one short message and confirm the UI
+     reaches a terminal state.
+
+5. Quit cleanly:
+   - Quit from the macOS app menu or `Cmd+Q`.
+   - Confirm the app process exits.
+   - Confirm no unexpected Vite/Tauri helper process remains from the dev run.
+
+## Artifacts
+
+Do not commit ad hoc native screenshots. Store manual screenshots/traces outside
+the repo, then file confirmed defects as GitHub issues with:
+
+- expected vs. actual
+- exact launch command
+- macOS version and architecture
+- runtime/backend configuration
+- screenshot or log path
+
+Stable browser visual baselines remain in
+`tests/playwright-visual/*-snapshots/`; native screenshots are diagnostic
+evidence unless we later add a dedicated native automation workflow.
+
+## Automation Decision
+
+Native automation should stay thin. Before adding it to CI, prove that it can
+reliably launch the real Tauri app on the macOS runner, observe a nonblank
+WebView, and shut down without orphaning processes. Keep broad UI interaction
+coverage in Playwright browser tests.
+
+Useful commands:
+
+```bash
+make desktop-native-preflight
+make desktop-native-dev
+make desktop-native-build
+```

--- a/apps/desktop-tauri/tests/README.md
+++ b/apps/desktop-tauri/tests/README.md
@@ -1,7 +1,8 @@
 # Desktop UI test layers
 
 See [QA.md](./QA.md) for the desktop UI QA sweep, artifact review, and bug
-issue workflow.
+issue workflow. See [NATIVE_QA.md](./NATIVE_QA.md) for the native macOS/Tauri
+app smoke layer.
 
 The desktop test stack has three layers:
 
@@ -18,6 +19,7 @@ The desktop test stack has three layers:
   `bridge_runner`. It uses a local OpenAI-compatible mock inference endpoint by
   default; pass `-- --inference-url <url> --model-name <model>` or set the live
   backend env vars to exercise a real provider.
+- `npm run test:ui:native:preflight` runs the non-GUI native Tauri preflight.
 
 The browser harness also has an explicit live-backend seam:
 

--- a/apps/desktop-tauri/tests/peer-connection-errors.test.ts
+++ b/apps/desktop-tauri/tests/peer-connection-errors.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { formatPeerConnectionError } from "../src/lib/peerConnectionErrors";
+
+describe("formatPeerConnectionError", () => {
+  it("turns local runtime transport context into operator-facing copy", () => {
+    expect(
+      formatPeerConnectionError(
+        "sending GET request to http://127.0.0.1:9191/api/v0/p2p/shareable-address",
+        "local-runtime",
+      ),
+    ).toBe(
+      "Could not reach the local defra-agent runtime at http://127.0.0.1:9191. Start `defra-agent server` and try again.",
+    );
+  });
+
+  it("turns peer status transport context into discovery copy", () => {
+    expect(
+      formatPeerConnectionError(
+        new Error(
+          "sending GET request to http://127.0.0.1:9181/api/v0/p2p/shareable-address.",
+        ),
+        "peer-status",
+      ),
+    ).toBe(
+      "Could not fetch runtime connection details from http://127.0.0.1:9181. Check that the runtime is running and the address is reachable.",
+    );
+  });
+
+  it("keeps already useful errors unchanged", () => {
+    expect(
+      formatPeerConnectionError(
+        "no running local defra-agent runtime found at /tmp/runtime.json; run `defra-agent server` first",
+        "local-runtime",
+      ),
+    ).toBe(
+      "no running local defra-agent runtime found at /tmp/runtime.json; run `defra-agent server` first",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused native macOS/Tauri QA lane for the desktop client, alongside the
existing browser-based UI harness.

This also fixes two issues found while exercising the native app:

- `tauri dev` failed because Cargo could not choose between `bridge_runner` and
  `defra-agent-desktop-tauri`
- the fleet screen showed raw transport error text when local runtime discovery
  failed

Closes #538.
Closes #546.
Closes #547.

## Changes

- Add native desktop QA docs in `apps/desktop-tauri/tests/NATIVE_QA.md`
- Add native QA commands:
  - `make desktop-native-preflight`
  - `make desktop-native-dev`
  - `make desktop-native-build`
  - `npm run test:ui:native:preflight`
- Switch Tauri dev/build config from `bun` to `npm`
- Set `default-run = "defra-agent-desktop-tauri"` in the Tauri crate manifest
- Add friendly runtime/peer discovery error formatting for the fleet UI
- Add Vitest coverage for the new peer connection error copy

## Test Plan

- `make desktop-native-preflight`
- `npm --prefix apps/desktop-tauri run test:ui:unit -- tests/peer-connection-errors.test.ts tests/fleet-dashboard.test.tsx`
- Prettier check on touched frontend files
- `git diff --check`

## Notes

This branch is currently stacked on #537 / `iverc/desktop-ui-qa-epic`.

The native app was manually launched during QA and reached the Tauri app binary
after the `default-run` fix. macOS blocked automated screenshot capture from the
agent process, so pixel-level native review remains manual/user-assisted for
now.
