### PR TITLE
Start provider wire replay harness

### DIFF
--- a/crates/defra-agent/src/chatgpt_codex.rs
+++ b/crates/defra-agent/src/chatgpt_codex.rs
@@ -613,12 +613,12 @@ impl BearerSource for DbCredentialBearer {
     }
 }
 
-pub struct ChatGptCodexHttpClient<S: BearerSource> {
-    inner: ReqwestClient,
+pub struct ChatGptCodexHttpClient<S: BearerSource, H = ReqwestClient> {
+    inner: H,
     bearer: Option<Arc<S>>,
 }
 
-impl<S: BearerSource> Clone for ChatGptCodexHttpClient<S> {
+impl<S: BearerSource, H: Clone> Clone for ChatGptCodexHttpClient<S, H> {
     fn clone(&self) -> Self {
         Self {
             inner: self.inner.clone(),
@@ -627,7 +627,7 @@ impl<S: BearerSource> Clone for ChatGptCodexHttpClient<S> {
     }
 }
 
-impl<S: BearerSource> fmt::Debug for ChatGptCodexHttpClient<S> {
+impl<S: BearerSource, H: fmt::Debug> fmt::Debug for ChatGptCodexHttpClient<S, H> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("ChatGptCodexHttpClient")
             .field("inner", &self.inner)
@@ -636,19 +636,28 @@ impl<S: BearerSource> fmt::Debug for ChatGptCodexHttpClient<S> {
     }
 }
 
-impl<S: BearerSource> Default for ChatGptCodexHttpClient<S> {
+impl<S: BearerSource, H: Default> Default for ChatGptCodexHttpClient<S, H> {
     fn default() -> Self {
         Self {
-            inner: ReqwestClient::default(),
+            inner: H::default(),
             bearer: None,
         }
     }
 }
 
-impl<S: BearerSource> ChatGptCodexHttpClient<S> {
+impl<S: BearerSource> ChatGptCodexHttpClient<S, ReqwestClient> {
     pub fn new(bearer: Arc<S>) -> Self {
         Self {
             inner: ReqwestClient::default(),
+            bearer: Some(bearer),
+        }
+    }
+}
+
+impl<S: BearerSource, H> ChatGptCodexHttpClient<S, H> {
+    pub fn with_inner(bearer: Arc<S>, inner: H) -> Self {
+        Self {
+            inner,
             bearer: Some(bearer),
         }
     }
@@ -696,7 +705,11 @@ impl<S: BearerSource> ChatGptCodexHttpClient<S> {
     }
 }
 
-impl<S: BearerSource + 'static> HttpClientExt for ChatGptCodexHttpClient<S> {
+impl<S, H> HttpClientExt for ChatGptCodexHttpClient<S, H>
+where
+    S: BearerSource + 'static,
+    H: Clone + HttpClientExt + fmt::Debug + 'static,
+{
     fn send<T, U>(
         &self,
         req: Request<T>,
@@ -712,7 +725,7 @@ impl<S: BearerSource + 'static> HttpClientExt for ChatGptCodexHttpClient<S> {
         let req = Request::from_parts(parts, body.into());
         async move {
             let req = this.prepare(req).await?;
-            send_reqwest(inner, req).await
+            send_inner(inner, req).await
         }
     }
 
@@ -768,45 +781,27 @@ fn ensure_event_stream_content_type(headers: &mut HeaderMap) {
     }
 }
 
-async fn send_reqwest<U>(
-    inner: ReqwestClient,
+async fn send_inner<H, U>(
+    inner: H,
     req: Request<Bytes>,
 ) -> http_client::Result<Response<LazyBody<U>>>
 where
+    H: HttpClientExt,
     U: From<Bytes>,
     U: WasmCompatSend + 'static,
 {
     let is_responses_request = req.uri().path().ends_with("/responses");
     let request_body = req.body().clone();
-    let (parts, body) = req.into_parts();
-    let response = inner
-        .request(parts.method, parts.uri.to_string())
-        .headers(parts.headers)
-        .body(body)
-        .send()
-        .await
-        .map_err(|error| http_client::Error::Instance(error.into()))?;
+    let response = HttpClientExt::send::<Bytes, Bytes>(&inner, req).await?;
 
     let status = response.status();
     let headers = response.headers().clone();
-    if !status.is_success() {
-        return Err(http_client::Error::InvalidStatusCodeWithMessage(
-            status,
-            response.text().await.unwrap_or_default(),
-        ));
-    }
-
+    let response_body = response.into_body().await?;
     let body = if is_responses_request {
-        let text = response
-            .text()
-            .await
-            .map_err(|error| http_client::Error::Instance(error.into()))?;
+        let text = String::from_utf8_lossy(&response_body);
         synthesize_completion_response(&request_body, &text)
     } else {
-        response
-            .bytes()
-            .await
-            .map_err(|error| http_client::Error::Instance(error.into()))?
+        response_body
     };
 
     let mut response_builder = Response::builder().status(status);

--- a/crates/defra-agent/src/inference_http.rs
+++ b/crates/defra-agent/src/inference_http.rs
@@ -91,11 +91,15 @@ where
 /// inner reqwest client. When there is no active session context (e.g. one-shot
 /// calls outside the daemon scope) the request is passed through unchanged.
 #[derive(Clone, Debug, Default)]
-pub struct SessionTaggingHttpClient {
-    inner: ReqwestClient,
+pub struct SessionTaggingHttpClient<H = ReqwestClient> {
+    inner: H,
 }
 
-impl SessionTaggingHttpClient {
+impl<H> SessionTaggingHttpClient<H> {
+    pub fn new(inner: H) -> Self {
+        Self { inner }
+    }
+
     fn tag<T>(req: Request<T>) -> Request<Bytes>
     where
         T: Into<Bytes>,
@@ -152,7 +156,10 @@ impl SessionTaggingHttpClient {
     }
 }
 
-impl HttpClientExt for SessionTaggingHttpClient {
+impl<H> HttpClientExt for SessionTaggingHttpClient<H>
+where
+    H: Clone + HttpClientExt + 'static,
+{
     fn send<T, U>(
         &self,
         req: Request<T>,
@@ -164,7 +171,7 @@ impl HttpClientExt for SessionTaggingHttpClient {
     {
         let inner = self.inner.clone();
         let req = Self::tag(req);
-        async move { HttpClientExt::send(&inner, req).await }
+        async move { HttpClientExt::send::<Bytes, U>(&inner, req).await }
     }
 
     fn send_multipart<U>(
@@ -228,10 +235,15 @@ mod tests {
     }
 
     #[test]
+    fn session_tagging_client_can_wrap_inner_transport() {
+        let _wrapped = SessionTaggingHttpClient::new(ReqwestClient::default());
+    }
+
+    #[test]
     fn tag_is_noop_without_session_context() {
         // Outside any admission scope there is no session id to attach.
         let req = Request::new(Bytes::from_static(b""));
-        let tagged = SessionTaggingHttpClient::tag(req);
+        let tagged = SessionTaggingHttpClient::<ReqwestClient>::tag(req);
         assert!(
             !tagged.headers().contains_key(SESSION_ID_HEADER),
             "x-session-id must not be set when there is no active session context"
@@ -241,7 +253,7 @@ mod tests {
     #[test]
     fn tag_adds_valid_trace_context_headers() {
         let req = Request::new(Bytes::from_static(b""));
-        let tagged = SessionTaggingHttpClient::tag_with_trace_context_headers(
+        let tagged = SessionTaggingHttpClient::<ReqwestClient>::tag_with_trace_context_headers(
             req,
             HashMap::from([
                 (

--- a/crates/defra-agent/tests/e2e_runtime.rs
+++ b/crates/defra-agent/tests/e2e_runtime.rs
@@ -21,9 +21,17 @@ mod fork_invariants;
 mod peer_pairing_desired_query;
 #[path = "e2e_runtime/projection_acp_policy_lifecycle.rs"]
 mod projection_acp_policy_lifecycle;
+#[path = "e2e_runtime/provider_fixture_redaction.rs"]
+mod provider_fixture_redaction;
 #[path = "e2e_runtime/runtime_observability.rs"]
 mod runtime_observability;
 #[path = "e2e_runtime/schedule_snapshot_reconcile.rs"]
 mod schedule_snapshot_reconcile;
 #[path = "e2e_runtime/tool_call_migration.rs"]
 mod tool_call_migration;
+
+#[test]
+fn provider_wire_fixtures_do_not_contain_credentials() {
+    provider_fixture_redaction::provider_wire_fixtures_do_not_contain_credentials()
+        .expect("provider wire fixtures should be redacted");
+}

--- a/crates/defra-agent/tests/e2e_runtime.rs
+++ b/crates/defra-agent/tests/e2e_runtime.rs
@@ -23,6 +23,8 @@ mod peer_pairing_desired_query;
 mod projection_acp_policy_lifecycle;
 #[path = "e2e_runtime/provider_fixture_redaction.rs"]
 mod provider_fixture_redaction;
+#[path = "e2e_runtime/provider_fixture_replay.rs"]
+mod provider_fixture_replay;
 #[path = "e2e_runtime/runtime_observability.rs"]
 mod runtime_observability;
 #[path = "e2e_runtime/schedule_snapshot_reconcile.rs"]
@@ -34,4 +36,16 @@ mod tool_call_migration;
 fn provider_wire_fixtures_do_not_contain_credentials() {
     provider_fixture_redaction::provider_wire_fixtures_do_not_contain_credentials()
         .expect("provider wire fixtures should be redacted");
+}
+
+#[test]
+fn provider_wire_fixture_replay_consumes_every_recorded_exchange_once() {
+    provider_fixture_replay::provider_wire_fixture_replay_consumes_every_recorded_exchange_once()
+        .expect("provider wire fixture replay should consume all exchanges");
+}
+
+#[test]
+fn provider_wire_fixture_replay_rejects_unmatched_and_leftover_requests() {
+    provider_fixture_replay::provider_wire_fixture_replay_rejects_unmatched_and_leftover_requests()
+        .expect("provider wire fixture replay should reject unmatched and leftover requests");
 }

--- a/crates/defra-agent/tests/e2e_runtime/provider_fixture_redaction.rs
+++ b/crates/defra-agent/tests/e2e_runtime/provider_fixture_redaction.rs
@@ -1,0 +1,101 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+const PROVIDER_FIXTURE_ROOT: &str = "tests/fixtures/providers";
+
+pub fn provider_wire_fixtures_do_not_contain_credentials() -> Result<()> {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(PROVIDER_FIXTURE_ROOT);
+    if !root.exists() {
+        return Ok(());
+    }
+
+    let mut files = Vec::new();
+    collect_fixture_files(&root, &mut files)?;
+    for path in files {
+        let text = fs::read_to_string(&path)
+            .with_context(|| format!("reading provider fixture {}", path.display()))?;
+        assert_no_secret_patterns(&path, &text);
+    }
+    Ok(())
+}
+
+fn collect_fixture_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("reading {}", dir.display()))? {
+        let entry = entry.with_context(|| format!("reading entry in {}", dir.display()))?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_fixture_files(&path, out)?;
+        } else if is_fixture_file(&path) {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn is_fixture_file(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("json" | "jsonl" | "http" | "sse" | "txt")
+    )
+}
+
+fn assert_no_secret_patterns(path: &Path, text: &str) {
+    let lower = text.to_ascii_lowercase();
+    let forbidden_substrings = [
+        "authorization: bearer ",
+        "\"authorization\":\"bearer ",
+        "\"authorization\": \"bearer ",
+        "sk-proj-",
+        "sk-",
+        "xoxb-",
+        "xoxp-",
+        "ghp_",
+        "github_pat_",
+        "acct_",
+        "refresh_token",
+        "access_token",
+        "id_token",
+    ];
+
+    for pattern in forbidden_substrings {
+        assert!(
+            !lower.contains(pattern),
+            "provider fixture {} contains unredacted credential-looking pattern `{pattern}`",
+            path.display()
+        );
+    }
+
+    for key in [
+        "key",
+        "api_key",
+        "access_token",
+        "refresh_token",
+        "id_token",
+    ] {
+        assert!(
+            !contains_unredacted_query_param(&lower, key),
+            "provider fixture {} contains unredacted `{key}` query parameter",
+            path.display()
+        );
+    }
+}
+
+fn contains_unredacted_query_param(text: &str, key: &str) -> bool {
+    let query_key = format!("{key}=");
+    let mut rest = text;
+    while let Some(index) = rest.find(&query_key) {
+        let value_start = index + query_key.len();
+        let value = &rest[value_start..];
+        let value = value
+            .split(&['&', ' ', '\n', '\r', '"', '\''][..])
+            .next()
+            .unwrap_or_default();
+        if !matches!(value, "" | "<redacted>" | "redacted" | "[redacted]") {
+            return true;
+        }
+        rest = &rest[value_start..];
+    }
+    false
+}

--- a/crates/defra-agent/tests/e2e_runtime/provider_fixture_replay.rs
+++ b/crates/defra-agent/tests/e2e_runtime/provider_fixture_replay.rs
@@ -1,0 +1,176 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+use serde_json::Value;
+
+const PROVIDER_FIXTURE_ROOT: &str = "tests/fixtures/providers";
+
+#[derive(Debug, Deserialize)]
+struct ProviderFixtureCorpus {
+    provider: String,
+    scenario: String,
+    exchanges: Vec<ProviderFixtureExchange>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ProviderFixtureExchange {
+    request_key: String,
+    ordinal: u32,
+    request: ProviderFixtureRequest,
+    response: ProviderFixtureResponse,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ProviderFixtureRequest {
+    method: String,
+    path: String,
+    body: Value,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ProviderFixtureResponse {
+    status: u16,
+    headers: BTreeMap<String, String>,
+    body: String,
+}
+
+struct ProviderFixtureReplayer {
+    provider: String,
+    scenario: String,
+    pending: BTreeMap<String, VecDeque<ProviderFixtureExchange>>,
+}
+
+impl ProviderFixtureReplayer {
+    fn from_file(path: &Path) -> Result<Self> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("reading provider fixture {}", path.display()))?;
+        let corpus: ProviderFixtureCorpus = serde_json::from_str(&raw)
+            .with_context(|| format!("parsing provider fixture {}", path.display()))?;
+        Self::from_corpus(corpus)
+    }
+
+    fn from_corpus(corpus: ProviderFixtureCorpus) -> Result<Self> {
+        let mut seen = BTreeSet::new();
+        let mut pending: BTreeMap<String, Vec<_>> = BTreeMap::new();
+        for exchange in corpus.exchanges {
+            anyhow::ensure!(
+                !exchange.request_key.trim().is_empty(),
+                "provider fixture {}:{} has an empty request key",
+                corpus.provider,
+                corpus.scenario
+            );
+            anyhow::ensure!(
+                seen.insert((exchange.request_key.clone(), exchange.ordinal)),
+                "provider fixture {}:{} repeats key {} ordinal {}",
+                corpus.provider,
+                corpus.scenario,
+                exchange.request_key,
+                exchange.ordinal
+            );
+            pending
+                .entry(exchange.request_key.clone())
+                .or_default()
+                .push(exchange);
+        }
+
+        Ok(Self {
+            provider: corpus.provider,
+            scenario: corpus.scenario,
+            pending: pending
+                .into_iter()
+                .map(|(key, mut exchanges)| {
+                    exchanges.sort_by_key(|exchange| exchange.ordinal);
+                    (key, VecDeque::from(exchanges))
+                })
+                .collect(),
+        })
+    }
+
+    fn next(&mut self, request_key: &str) -> Result<ProviderFixtureExchange> {
+        let Some(exchanges) = self.pending.get_mut(request_key) else {
+            anyhow::bail!(
+                "no provider fixture for {}:{} request key {}",
+                self.provider,
+                self.scenario,
+                request_key
+            );
+        };
+        let Some(exchange) = exchanges.pop_front() else {
+            anyhow::bail!(
+                "provider fixture {}:{} exhausted request key {}",
+                self.provider,
+                self.scenario,
+                request_key
+            );
+        };
+        Ok(exchange)
+    }
+
+    fn assert_fully_consumed(&self) -> Result<()> {
+        let leftovers = self
+            .pending
+            .iter()
+            .filter_map(|(key, exchanges)| (!exchanges.is_empty()).then_some((key, exchanges)))
+            .map(|(key, exchanges)| format!("{key}:{} left", exchanges.len()))
+            .collect::<Vec<_>>();
+        anyhow::ensure!(
+            leftovers.is_empty(),
+            "provider fixture {}:{} had unconsumed exchanges: {}",
+            self.provider,
+            self.scenario,
+            leftovers.join(", ")
+        );
+        Ok(())
+    }
+}
+
+pub fn provider_wire_fixture_replay_consumes_every_recorded_exchange_once() -> Result<()> {
+    let mut replay = ProviderFixtureReplayer::from_file(&fixture_path("synthetic/basic.json"))?;
+
+    let first = replay.next("chat-turn")?;
+    assert_eq!(first.ordinal, 0);
+    assert_eq!(first.request.method, "POST");
+    assert_eq!(first.request.path, "/v1/responses");
+    assert_eq!(first.request.body["model"], "fixture-model");
+    assert_eq!(first.response.status, 200);
+    assert_eq!(
+        first
+            .response
+            .headers
+            .get("content-type")
+            .map(String::as_str),
+        Some("text/event-stream")
+    );
+    assert!(first.response.body.contains("first"));
+
+    let second = replay.next("chat-turn")?;
+    assert_eq!(second.ordinal, 1);
+    assert!(second.response.body.contains("second"));
+
+    replay.assert_fully_consumed()
+}
+
+pub fn provider_wire_fixture_replay_rejects_unmatched_and_leftover_requests() -> Result<()> {
+    let mut replay = ProviderFixtureReplayer::from_file(&fixture_path("synthetic/basic.json"))?;
+
+    let missing = replay
+        .next("missing-key")
+        .expect_err("unmatched request keys should fail replay");
+    assert!(missing.to_string().contains("missing-key"));
+
+    let _ = replay.next("chat-turn")?;
+    let leftovers = replay
+        .assert_fully_consumed()
+        .expect_err("leftover fixture entries should fail replay");
+    assert!(leftovers.to_string().contains("chat-turn:1 left"));
+    Ok(())
+}
+
+fn fixture_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(PROVIDER_FIXTURE_ROOT)
+        .join(relative)
+}

--- a/crates/defra-agent/tests/fixtures/providers/README.md
+++ b/crates/defra-agent/tests/fixtures/providers/README.md
@@ -1,0 +1,18 @@
+# Provider Wire Fixtures
+
+This directory is reserved for provider request/response replay fixtures (#545).
+
+Fixtures are recorded from live providers, redacted before they touch disk, then
+replayed offline in CI. They are the provider wire contract for future native
+provider clients and rig-removal work.
+
+Rules:
+
+- Commit only redacted fixtures.
+- Do not commit access tokens, refresh tokens, API keys, account ids, bearer
+  values, or provider-specific credential query parameters.
+- Keep provider fixtures versioned by provider and scenario.
+- Refresh fixtures through a live/operator workflow, not normal PR CI.
+
+The `provider_wire_fixtures_do_not_contain_credentials` test scans committed
+fixture files in this directory for common credential patterns.

--- a/crates/defra-agent/tests/fixtures/providers/synthetic/basic.json
+++ b/crates/defra-agent/tests/fixtures/providers/synthetic/basic.json
@@ -1,0 +1,54 @@
+{
+  "provider": "synthetic",
+  "scenario": "basic",
+  "exchanges": [
+    {
+      "request_key": "chat-turn",
+      "ordinal": 0,
+      "request": {
+        "method": "POST",
+        "path": "/v1/responses",
+        "body": {
+          "model": "fixture-model",
+          "input": [
+            {
+              "role": "user",
+              "content": "first"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "body": "event: response.output_text.delta\ndata: {\"delta\":\"first\"}\n\n"
+      }
+    },
+    {
+      "request_key": "chat-turn",
+      "ordinal": 1,
+      "request": {
+        "method": "POST",
+        "path": "/v1/responses",
+        "body": {
+          "model": "fixture-model",
+          "input": [
+            {
+              "role": "user",
+              "content": "second"
+            }
+          ]
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "content-type": "text/event-stream"
+        },
+        "body": "event: response.output_text.delta\ndata: {\"delta\":\"second\"}\n\n"
+      }
+    }
+  ]
+}

--- a/docs/backends.md
+++ b/docs/backends.md
@@ -1,8 +1,43 @@
 # Backends
 
-> This page is the home for the committed backend support matrix (#509). It
-> starts with the ChatGPT-subscription (OAuth) backend; provider rows are added
-> as #509 lands each one.
+This page is the committed backend support matrix for defra-agent. It tracks
+which providers are supported, which wire API each provider uses, what request
+and response shaping defra-agent applies, and whether a provider has an offline
+wire fixture replay fence.
+
+The runtime owns provider-input assembly before any provider-specific client is
+called. Provider-specific shaping should stay small, explicit, and tested at the
+HTTP seam because live provider bugs tend to appear in headers, unsupported
+parameters, response content types, and tool schema details rather than in the
+agent loop itself.
+
+## Support Matrix
+
+| Provider kind | Wire API | Auth | Streaming | Tools | Reasoning | Request shaping | Response shaping | Fixture status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `OpenAiCompatible` | OpenAI Responses by default; Chat Completions fallback for compatible local servers | API key or local/no-auth | SSE | Function tools through rig | `reasoning.effort` plus local `chat_template_kwargs.enable_thinking` default | Adds cache-scope `user` when available; OpenAI-style params pass through | Standard rig OpenAI handling | Planned by #545 |
+| `ChatGptCodex` | ChatGPT Codex Responses endpoint | `OAuthCredential` document, refreshed by owner runtime | SSE | Function tools, forced `strict: false` to match Codex CLI | `reasoning.effort` currently fixed at `medium` | Strips unsupported `max_output_tokens`, `temperature`, `top_p`; injects instructions/store/stream defaults; adds Codex `version` and `Accept` headers | Adds missing `Content-Type: text/event-stream` only when the backend omits it; synthesizes completion body from SSE for non-streaming probes | Unit-pinned in #530; replay corpus planned by #545 |
+| `OpenRouter` | Chat Completions | API key | SSE | Function tools through rig | Provider-dependent | Adds OpenRouter provider preference `require_parameters: true` | Standard rig OpenRouter handling | Planned by #545 |
+| local OpenAI-compatible servers | Responses or Chat Completions depending on server support | Usually none/local key | SSE varies by server | Function tools when server supports them | Reasoning parser support varies; `enable_thinking` is sent for vLLM-style servers | Same as `OpenAiCompatible`; operators may need Chat Completions fallback for servers without `/v1/responses` | Standard rig OpenAI handling | Planned by #545 |
+
+## Wire Fixture Policy
+
+Provider fixture replay is tracked in #545. Recorded fixtures live under
+`crates/defra-agent/tests/fixtures/providers/` and must be safe to commit.
+
+Rules:
+
+- No access tokens, refresh tokens, API keys, account ids, or bearer strings in
+  fixtures.
+- Redaction happens before writing fixtures to disk.
+- Fixture replay should assert every recorded request is consumed exactly once.
+- Fixture refresh is a live/operator action; CI should replay committed fixtures
+  offline.
+
+The fixture directory has a regression test that scans committed fixture files
+for common credential patterns. The scanner is intentionally conservative: if a
+new provider introduces another credential shape, add it to the scanner before
+committing fixtures.
 
 ## ChatGPT subscription (ChatGptCodex, OAuth)
 
@@ -52,6 +87,20 @@ as an `OAuthCredential` DefraDB document scoped by `agent_did` and provider
   set `DEFRA_CHATGPT_CODEX_CLIENT_VERSION` — one knob moves it everywhere.
 - **Reasoning effort** is currently fixed at `medium`; per-behavior effort selection
   (e.g. `xhigh`) is tracked in #540.
+
+### Wire-shaping guarantees
+
+The ChatGPT Codex path is stricter than hosted OpenAI Responses in several
+places. Regression tests pin these details:
+
+- unsupported top-level params are stripped: `max_output_tokens`, `temperature`,
+  `top_p`
+- function tools are sent as `strict: false`
+- the Codex client version is sourced from one accessor and used for both the
+  request `version` header and `/models?client_version=...`
+- `Accept: text/event-stream, application/json` is sent
+- a missing SSE `Content-Type` is filled as `text/event-stream`, while a
+  backend-supplied content type is preserved
 
 ### Credential storage
 


### PR DESCRIPTION
## Summary
- document the committed backend support matrix and provider fixture policy
- add a provider fixture redaction gate so committed wire fixtures cannot include obvious credentials
- make the OpenAI session-tagging and ChatGPT Codex HTTP wrappers composable over an inner transport
- add offline provider replay contract tests for ordered per-key consumption, unmatched request rejection, and leftover fixture detection

## Test Plan
- cargo test -p defra-agent --lib inference_http::tests:: -- --nocapture
- cargo test -p defra-agent --lib chatgpt_codex::tests:: -- --nocapture
- cargo test -p defra-agent --test e2e_runtime provider_wire_fixture_replay -- --nocapture
- cargo test -p defra-agent --test e2e_runtime provider_wire_fixtures_do_not_contain_credentials -- --nocapture
- cargo fmt --all -- --check
- git diff --check

Stacked on #530 because the provider wire replay work builds on the ChatGPT Codex provider seam.

Refs #545