### PR TITLE
fix(conformance): route JSON string emission through the escaping serializer

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractTypes.lean
@@ -67,6 +67,11 @@ def jsonEscape (s : String) : String :=
 def jsonString (s : String) : String :=
   "\"" ++ jsonEscape s ++ "\""
 
+/-- Regression guard (#553): the single emitted-JSON string serializer escapes
+    quotes and backslashes. All conformance modules route through this, so a
+    field value containing `"`/`\\` cannot emit malformed JSON. -/
+example : jsonString "a\"b\\c" = "\"a\\\"b\\\\c\"" := by native_decide
+
 def jsonArray (values : List String) : String :=
   "[" ++ String.intercalate "," values ++ "]"
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/EventDelivery.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/EventDelivery.lean
@@ -1,8 +1,10 @@
 import Proofs.EventDelivery
+import Proofs.Conformance.ContractTypes
 
 namespace Conformance.EventDelivery
 
 open _root_.EventDelivery
+open Conformance.Contracts
 
 /-! ## Family 1 — Transition cases -/
 
@@ -198,15 +200,13 @@ def convergenceTraces : List ConvergenceTraceRow :=
 
 def convergenceTraceCount : Nat := convergenceTraces.length
 
-/-! ## JSON serializers (local; mirrored after `Conformance.TriggerContracts`) -/
+/-! ## JSON serializers
 
-def jsonString (s : String) : String := "\"" ++ s ++ "\""
+`jsonString`/`jsonArray`/`jsonStringArray` come from `Conformance.Contracts`
+(the single escaping implementation, see #553). `jsonOptionString` is a thin
+name-adapter for the shared `jsonOptionalString`. -/
 
-def jsonArray (vs : List String) : String := "[" ++ String.intercalate "," vs ++ "]"
-
-def jsonOptionString : Option String → String
-  | none => "null"
-  | some s => jsonString s
+def jsonOptionString : Option String → String := jsonOptionalString
 
 def docIdJson (d : DocId) : String := jsonString d.raw
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Triggers/Contracts.lean
@@ -1,4 +1,5 @@
 import Proofs.Conformance.Triggers.Trace
+import Proofs.Conformance.ContractTypes
 
 /-!
 # Trigger Dispatch Conformance Contracts
@@ -9,6 +10,8 @@ exercise the same branch matrix without hand-maintaining expected outcomes.
 -/
 
 namespace Conformance.TriggerContracts
+
+open Conformance.Contracts
 
 structure TriggerScenario where
   name : String
@@ -21,18 +24,10 @@ def concurrencyName : ConcurrencyMode → String
   | .serial => "serial"
   | .latestOnly => "latest_only"
 
-def jsonString (s : String) : String :=
-  "\"" ++ s ++ "\""
-
-def jsonArray (values : List String) : String :=
-  "[" ++ String.intercalate "," values ++ "]"
-
-def jsonStringArray (values : List String) : String :=
-  jsonArray (values.map jsonString)
-
-def jsonOptionString : Option String → String
-  | none => "null"
-  | some value => jsonString value
+-- `jsonString`/`jsonArray`/`jsonStringArray` come from `Conformance.Contracts`
+-- (the single escaping implementation, see #553). `jsonOptionString` is a thin
+-- name-adapter for the shared `jsonOptionalString`.
+def jsonOptionString : Option String → String := jsonOptionalString
 
 def jsonOptionNat : Option Nat → String
   | none => "null"


### PR DESCRIPTION
Closes #553. Part of the Lean-model review umbrella #551.

## Problem

Two conformance modules defined their own `jsonString` that quoted **without escaping** (`"\"" ++ s ++ "\""`), bypassing the canonical escaping serializer in `Proofs/Conformance/ContractTypes.lean` (`jsonEscape` → `jsonString`):

- `Proofs/Conformance/EventDelivery.lean` → emitted JSON consumed by `crates/defra-agent/tests/conformance/event_delivery.rs`
- `Proofs/Conformance/Triggers/Contracts.lean` → emitted via `Contracts/Json/Snapshot.lean`, consumed by `crates/defra-agent/tests/conformance/triggers.rs`

A field value containing `"`, `\`, or a control char would have emitted malformed JSON with no compile-time guard. Latent today only because all current field values are safe identifiers.

A full sweep of `Proofs/Conformance/` confirmed these were the **only** two divergent serializers and there is no other inline-quoting bypass.

## Fix

- Both modules now `open Conformance.Contracts` and drop their local `jsonString`/`jsonArray`/`jsonStringArray`; only a thin `jsonOptionString` name-adapter for the shared `jsonOptionalString` remains.
- Escaping logic now lives in exactly one place (`jsonEscape`).
- Added a regression `example` in `ContractTypes.lean` pinning that `jsonString` escapes quotes/backslashes.

Net `+19/-19`, three files.

## Verification

- `lake build` green (878 targets, incl. the regression guard).
- Emitted contract JSON parses as a valid object (`jq -e 'type'`).
- `cargo test -p defra-agent --test conformance` → **249 passed, 0 failed**.
- Output is byte-identical for all current values (none contain escapable chars), so the Rust-consumed contract is unchanged — this hardens against a future field value, it does not alter today's wire shape.

## Follow-up (not in this PR)

The reviewer's stronger long-term fix is a typed JSON AST / single serializer rather than string concatenation across call sites. This PR does the lower-effort centralization; a typed-AST refactor could be its own issue if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)