### PR TITLE
Make EventDelivery rescans substantive

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -249,6 +249,9 @@ def boundaryCoverageLedgerReviewDisciplineId : String :=
 def boundaryEventDeliveryFairSubstrateId : String :=
   "boundary.event-delivery.fair-substrate"
 
+def boundaryEventDeliveryRescanDocCapId : String :=
+  "boundary.event-delivery.rescan-doc-cap"
+
 def boundaryStreamingResponseIdleTimeoutDeadlineId : String :=
   "boundary.streaming-response.idle-timeout-deadline"
 
@@ -367,6 +370,22 @@ def boundaries : List Boundary :=
         "is taken as an axiom; the substrate model lives in tla/ReversePairing.tla."
     , acceptedFollowUp :=
         some "Substrate fairness is proved separately in tla/ReversePairing.tla; see also #162."
+    }
+  , { id := boundaryEventDeliveryRescanDocCapId
+    , domain := "event_delivery"
+    , subject := "EventSource introspection rescan completeness"
+    , statement :=
+        "The Lean rescanTick transition models a complete rescan that surfaces " ++
+        "every unprocessed persistent doc. The live EventSource rescan seeds and " ++
+        "re-queries at most SEEN_DOCS_SEED_LIMIT (10_000) docs per source " ++
+        "collection with no pagination, so for collections larger than that cap " ++
+        "the tail beyond the first 10_000 docs is not surfaced by rescan and " ++
+        "stays dependent on the lossy subscription path. v1 does not target " ++
+        "catalog-scale source collections. SubagentSource's running-bridge rescan " ++
+        "is not subject to this cap."
+    , acceptedFailureMode := some "missed_event_observation"
+    , acceptedFollowUp :=
+        some "Paginate EventSource rescan past SEEN_DOCS_SEED_LIMIT to eliminate the residual missed_event_observation mode; tracked in #564."
     }
   , { id := boundaryStreamingResponseIdleTimeoutDeadlineId
     , domain := "StreamingResponse"

--- a/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Deviations.lean
@@ -23,30 +23,7 @@ structure Deviation where
   deriving Repr
 
 def deviations : List Deviation :=
-  [ { id := "event_source_lacks_periodic_rescan"
-    , domain := "event_delivery"
-    , subject := "EventSource"
-    , statement :=
-        "EventSource has no periodic introspection rescan in the live process. " ++
-        "EventDelivery.D1 closes vacuously for this instance (rescanBoundedBy = 0). " ++
-        "Adding a periodic rescan flips the binding to substantive D1."
-    , acceptedFailureMode := some "missed_event_observation"
-    , acceptedFollowUp :=
-        some "Track at #187 PR description; deadline-audit followup #8."
-    }
-  , { id := "subagent_source_lacks_live_rescan"
-    , domain := "event_delivery"
-    , subject := "SubagentSource"
-    , statement :=
-        "SubagentSource has recover_orphan_subagent_children only at startup, " ++
-        "not as a periodic loop in the live process. EventDelivery.D1 closes " ++
-        "vacuously for this instance (rescanBoundedBy = 0). Lifting the existing " ++
-        "recovery primitive to a periodic timer makes D1 substantive."
-    , acceptedFailureMode := some "missed_subagent_spawn_observation_in_live_process"
-    , acceptedFollowUp :=
-        some "Track at #187 PR description; deadline-audit followup #5."
-    }
-  ]
+  []
 
 def Deviation.toJson (deviation : Deviation) : String :=
   "{"

--- a/crates/defra-agent/proofs/Proofs/Conformance/EventDelivery.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/EventDelivery.lean
@@ -128,13 +128,13 @@ def sourceInstances : List SourceInstanceRow :=
     }
   , { name := "EventSource"
     , dedupePolicy := DedupePolicy.toContract .monotoneOnce
-    , rescanBoundedBy := SourceInstance.unboundedRescan
-    , deviation := some "event_source_lacks_periodic_rescan"
+    , rescanBoundedBy := EventSource.eventSourceSrc.rescanBoundedBy
+    , deviation := none
     }
   , { name := "SubagentSource"
     , dedupePolicy := DedupePolicy.toContract .monotoneOnce
-    , rescanBoundedBy := SourceInstance.unboundedRescan
-    , deviation := some "subagent_source_lacks_live_rescan"
+    , rescanBoundedBy := SubagentSource.subagentSourceSrc.rescanBoundedBy
+    , deviation := none
     }
   ]
 
@@ -148,8 +148,9 @@ structure ConvergenceTraceRow where
   initialWorld   : World
   actions        : List Action
   finalWorld     : World
-  /-- "substantive" (D1 closes with real witness today) or "deviation" (D1
-      vacuous; Rust should be in the documented deviation state). -/
+  /-- Expected runtime status for the finite witness. Current live source rows
+      should be "substantive"; "deviation" is retained only as legacy JSON
+      vocabulary for future documented gaps. -/
   status         : String
 
 /-- Worked convergence trace for the watcher: persist + rescanTick + handle
@@ -166,33 +167,32 @@ def watcherTrace : ConvergenceTraceRow :=
   , status := "substantive"
   }
 
-/-- EventSource trace today: persist event observed, subscription drops it,
-    no live rescan. Rust consumer asserts the runtime is in this deviation
-    state. -/
+/-- EventSource convergence trace: a doc is persisted, the periodic
+    introspection rescan observes it, and the source emits a fire intent. -/
 def eventSourceTrace : ConvergenceTraceRow :=
-  { name := "event_source_drop_then_no_resync"
+  { name := "event_source_persist_rescan_handle"
   , instanceName := "EventSource"
   , initialWorld := World.empty
   , actions :=
       [ .persist (doc "doc-1")
-      , .enqueue (doc "doc-1")
-      , .drop (doc "doc-1") ]
-  , finalWorld := mkWorld [doc "doc-1"] [] [] []
-  , status := "deviation"
+      , .rescanTick
+      , .handle (doc "doc-1") ]
+  , finalWorld := mkWorld [doc "doc-1"] [] [doc "doc-1"] [doc "doc-1"]
+  , status := "substantive"
   }
 
-/-- SubagentSource trace today: orphan child persists, dropped event,
-    no live rescan in this process. Rust consumer asserts deviation state. -/
+/-- SubagentSource convergence trace: a running bridge row is persisted, the
+    periodic scan observes the orphan child, and the source materializes it. -/
 def subagentSourceTrace : ConvergenceTraceRow :=
-  { name := "subagent_orphan_no_live_rescan"
+  { name := "subagent_orphan_rescan_handle"
   , instanceName := "SubagentSource"
   , initialWorld := World.empty
   , actions :=
       [ .persist (doc "tool-call-1")
-      , .enqueue (doc "tool-call-1")
-      , .drop (doc "tool-call-1") ]
-  , finalWorld := mkWorld [doc "tool-call-1"] [] [] []
-  , status := "deviation"
+      , .rescanTick
+      , .handle (doc "tool-call-1") ]
+  , finalWorld := mkWorld [doc "tool-call-1"] [] [doc "tool-call-1"] [doc "tool-call-1"]
+  , status := "substantive"
   }
 
 def convergenceTraces : List ConvergenceTraceRow :=

--- a/crates/defra-agent/proofs/Proofs/EventDelivery/Contract.lean
+++ b/crates/defra-agent/proofs/Proofs/EventDelivery/Contract.lean
@@ -120,9 +120,9 @@ inductive Trace : World → World → Prop where
 /-- `SourceInstance` binds the contract to a concrete runtime subsystem.
     `rescanBoundedBy : Nat` is the maximum number of non-rescanTick actions
     that may occur between two consecutive `rescanTick`s in a `Fair` sequence
-    (see `Properties.lean`). The sentinel `unboundedRescan = 0` records
-    "no bounded rescan in the live process today"; D1 holds vacuously for
-    such instances. -/
+    (see `Properties.lean`). Live source bindings that claim D1 must use a
+    positive bound; `unboundedRescan = 0` is retained only as vocabulary for
+    explicitly documented non-live or future deviation instances. -/
 structure SourceInstance where
   name            : String
   dedupePolicy    : DedupePolicy

--- a/crates/defra-agent/proofs/Proofs/EventDelivery/EventSource.lean
+++ b/crates/defra-agent/proofs/Proofs/EventDelivery/EventSource.lean
@@ -7,13 +7,6 @@ namespace EventDelivery.EventSource
 
 /-- EventSource instance.
 
-Uses the `unboundedRescan` sentinel because the Rust EventSource has no
-periodic rescan today. D1 holds vacuously: `Fair eventSourceSrc actions` is
-unsatisfiable on non-trivial action lists (`rescanBoundedBy = 0` forces
-every action to be `rescanTick`, which cannot include `persist`/`handle`).
-The corresponding `Conformance/Deviations.lean` entry names the gap and the
-follow-up issue that closes it.
-
 Binding (operational mapping):
 - `persistentSet` = `(collection, doc_id)` pairs in `desired_collections`
   not yet in `seen_docs`.
@@ -21,22 +14,33 @@ Binding (operational mapping):
   enforces the forward-only semantic: pre-existing docs do not fire as
   "created" because their first observation finds them in `processedSet`,
   and `Transition.handle` requires `d ∉ processedSet`.
-- `rescan` = the periodic introspection query this PR asks Rust to grow.
+- `rescan` = the live periodic introspection query over desired collections.
 
-When Rust adds the periodic rescan, flip `rescanBoundedBy` to a positive
-`Nat` and the substantive `D1_delivery_convergence` specialization becomes
-provable for EventSource (mirroring `Proofs/EventDelivery/Watcher.lean`). -/
+The bound is intentionally `1` in the executable model: the emitted
+conformance witness `persist → rescanTick → handle` contains a checked
+two-action fairness window on each side of the rescan. -/
 def eventSourceSrc : SourceInstance :=
   { name := "EventSource"
   , dedupePolicy := .monotoneOnce
-  , rescanBoundedBy := SourceInstance.unboundedRescan
+  , rescanBoundedBy := 1
   }
 
-/-- Sentinel record: EventSource currently uses the unbounded-rescan
-    sentinel. Lands the binding's current state into conformance metadata
-    without trying to prove a vacuous D1 specialization. The deviation
-    entry in `Conformance/Deviations.lean` carries the load. -/
-theorem eventSourceSrc_rescanBoundedBy_is_sentinel :
-    eventSourceSrc.rescanBoundedBy = SourceInstance.unboundedRescan := rfl
+/-- EventSource now binds to a positive live rescan cadence. -/
+theorem eventSourceSrc_rescanBoundedBy_pos :
+    0 < eventSourceSrc.rescanBoundedBy := by
+  decide
+
+/-- EventSource specialization of D1, now substantive for the live binding. -/
+theorem E1_event_source_delivery_convergence
+    (w₀ : World) (d : DocId)
+    (h_persisted : d ∈ w₀.persistentSet)
+    (h_unprocessed : d ∉ w₀.processedSet) :
+    ∃ (actions : List Action) (w' : World),
+      TraceOf w₀ actions w' ∧
+      Fair eventSourceSrc actions ∧
+      d ∈ w'.handled :=
+  D1_delivery_convergence
+    eventSourceSrc w₀ d h_persisted h_unprocessed
+    eventSourceSrc_rescanBoundedBy_pos
 
 end EventDelivery.EventSource

--- a/crates/defra-agent/proofs/Proofs/EventDelivery/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/EventDelivery/Properties.lean
@@ -12,11 +12,14 @@ def pendingWork (w : World) : Nat :=
     `inst.rescanBoundedBy + 1` consecutive actions contains at least one
     `rescanTick`.
 
-    When `inst.rescanBoundedBy = 0` (the `unboundedRescan` sentinel), every
-    window of size `1` must contain a `rescanTick`, i.e. EVERY action must
-    be `rescanTick`. Since real action lists also contain `persist`, etc.,
-    the sentinel makes `Fair` unsatisfiable for any non-trivial trace —
-    that's exactly what closes D1 vacuously for deviation instances. -/
+    This remains a finite-prefix predicate because the conformance boundary
+    emits executable finite traces. Short prefixes whose length is below the
+    window size are vacuously fair; the live source bindings therefore use
+    `rescanBoundedBy = 1` and emit concrete `persist → rescanTick → handle`
+    witnesses so D1's rescan window is exercised. The `0` sentinel remains
+    unsatisfiable for non-trivial traces and must not be used by live D1
+    source bindings. Infinite-stream or tick-indexed latency refinements belong
+    in the liveness taxonomy layer rather than this executable trace contract. -/
 def Fair (inst : SourceInstance) (actions : List Action) : Prop :=
   ∀ i : Nat, i + inst.rescanBoundedBy < actions.length →
     ∃ j : Nat, i ≤ j ∧ j ≤ i + inst.rescanBoundedBy ∧
@@ -53,12 +56,11 @@ inductive TraceOf : World → List Action → World → Prop where
     persistent doc into the subscription queue, after which `handle d` is
     enabled and lands `d` in `handled`. Fairness holds because
     `rescanBoundedBy ≥ 1` makes the window check either trivially closed
-    (`b ≥ 2` → vacuous) or satisfied by the leading `rescanTick` (`b = 1`).
-
-    For instances using `SourceInstance.unboundedRescan = 0`, this theorem is
-    vacuous (`Fair` becomes unsatisfiable for any 2-action list); that is
-    exactly the deviation that the Rust gap-fill in EventSource /
-    SubagentSource closes operationally. -/
+    (`b ≥ 2` → the two-action witness is shorter than the checked window) or
+    satisfied by the leading `rescanTick` (`b = 1`). The executable
+    conformance rows use the stronger three-action `persist → rescanTick →
+    handle` shape with `b = 1`, which prevents live EventSource and
+    SubagentSource bindings from closing D1 by the old `0`-sentinel gap. -/
 theorem D1_delivery_convergence
     (inst : SourceInstance)
     (w₀ : World) (d : DocId)

--- a/crates/defra-agent/proofs/Proofs/EventDelivery/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/EventDelivery/Properties.lean
@@ -18,8 +18,10 @@ def pendingWork (w : World) : Nat :=
     `rescanBoundedBy = 1` and emit concrete `persist → rescanTick → handle`
     witnesses so D1's rescan window is exercised. The `0` sentinel remains
     unsatisfiable for non-trivial traces and must not be used by live D1
-    source bindings. Infinite-stream or tick-indexed latency refinements belong
-    in the liveness taxonomy layer rather than this executable trace contract. -/
+    source bindings. Infinite-stream or tick-indexed latency refinements — the
+    universal "every fair schedule delivers within bound" form, as opposed to
+    this existential reachability witness — belong in the liveness taxonomy layer
+    (#557) rather than this executable trace contract. -/
 def Fair (inst : SourceInstance) (actions : List Action) : Prop :=
   ∀ i : Nat, i + inst.rescanBoundedBy < actions.length →
     ∃ j : Nat, i ≤ j ∧ j ≤ i + inst.rescanBoundedBy ∧

--- a/crates/defra-agent/proofs/Proofs/EventDelivery/SubagentSource.lean
+++ b/crates/defra-agent/proofs/Proofs/EventDelivery/SubagentSource.lean
@@ -7,23 +7,22 @@ namespace EventDelivery.SubagentSource
 
 /-- SubagentSource instance.
 
-Same `unboundedRescan` sentinel as EventSource. The existing operational
-recovery primitive `recover_orphan_subagent_children` runs only at
-startup; lifting it to a periodic loop in the live process closes the
-deviation entry filed in `Conformance/Deviations.lean`.
-
 Binding:
 - `persistentSet` = running `AgentToolCall` rows with `child_request_id`
   set whose child `AgentRequest` row doesn't yet exist (the orphan
   condition).
 - `processedSet` ⊇ tool-call ids already materialized in this process.
-- `rescan` = `recover_orphan_subagent_children` lifted to a periodic
-  timer (Rust gap-fill named in the deviation entry). -/
+- `rescan` = the live periodic scan over running bridge rows. -/
 def subagentSourceSrc : SourceInstance :=
   { name := "SubagentSource"
   , dedupePolicy := .monotoneOnce
-  , rescanBoundedBy := SourceInstance.unboundedRescan
+  , rescanBoundedBy := 1
   }
+
+/-- SubagentSource now binds to a positive live rescan cadence. -/
+theorem subagentSourceSrc_rescanBoundedBy_pos :
+    0 < subagentSourceSrc.rescanBoundedBy := by
+  decide
 
 /-- **O1 — Orphan-child materialization** (SubagentSource specialization).
 
@@ -32,26 +31,18 @@ not yet present as an `AgentRequest` row, then under a fair trace `c`
 eventually appears.
 
 Stated unconditionally as a corollary of `D1_delivery_convergence` for the
-SubagentSource instance. Substantive when `subagentSourceSrc.rescanBoundedBy
-> 0`; vacuous today (deviation entry records the gap). The hypothesis
-`h_inst_pos : 0 < subagentSourceSrc.rescanBoundedBy` is the explicit
-witness that flips this property substantive when Rust adds the periodic
-loop. -/
+SubagentSource instance. The positive bound is part of the binding, so this
+is no longer guarded by an external non-vacuity hypothesis. -/
 theorem O1_orphan_child_materialization
     (w₀ : World) (d : DocId)
     (h_persisted : d ∈ w₀.persistentSet)
-    (h_unprocessed : d ∉ w₀.processedSet)
-    (h_inst_pos : 0 < subagentSourceSrc.rescanBoundedBy) :
+    (h_unprocessed : d ∉ w₀.processedSet) :
     ∃ (actions : List Action) (w' : World),
       TraceOf w₀ actions w' ∧
       Fair subagentSourceSrc actions ∧
       d ∈ w'.handled :=
-  D1_delivery_convergence subagentSourceSrc w₀ d h_persisted h_unprocessed h_inst_pos
-
-/-- Sentinel record: SubagentSource currently uses the unbounded-rescan
-    sentinel. The `Conformance/Deviations.lean` entry names the
-    live-rescan gap and the follow-up issue. -/
-theorem subagentSourceSrc_rescanBoundedBy_is_sentinel :
-    subagentSourceSrc.rescanBoundedBy = SourceInstance.unboundedRescan := rfl
+  D1_delivery_convergence
+    subagentSourceSrc w₀ d h_persisted h_unprocessed
+    subagentSourceSrc_rescanBoundedBy_pos
 
 end EventDelivery.SubagentSource

--- a/crates/defra-agent/src/trigger_engine/event_source.rs
+++ b/crates/defra-agent/src/trigger_engine/event_source.rs
@@ -21,7 +21,9 @@ use std::time::Duration;
 
 use chrono::{SecondsFormat, Utc};
 use defra_node::EmbeddedNode;
+use serde::Deserialize;
 use tokio::sync::watch;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 use crate::event_delivery_contract::{EventDeliveryRuntimeContract, EventDeliverySourceContract};
@@ -39,6 +41,7 @@ use super::{FireIntent, TriggerKind, TriggerSource};
 /// next event); v1 doesn't target catalog-scale source collections, so a
 /// conservative limit is fine.
 const SEEN_DOCS_SEED_LIMIT: usize = 10_000;
+const EVENT_SOURCE_RESCAN_INTERVAL: Duration = Duration::from_secs(5);
 
 /// `TriggerSource` that fans DefraDB document events out to
 /// `active_event_triggers`.
@@ -106,6 +109,16 @@ pub struct EventSource {
     /// (`pop_front` / `push_back`) with no `.await` inside, so it will never
     /// actually contend.
     pending_intents: Mutex<VecDeque<FireIntent>>,
+    /// Periodic live rescan that closes the lossy-subscription gap. The
+    /// interval is stored on the source so a busy stream of `next_fire()` calls
+    /// does not reset the cadence.
+    rescan_tick: tokio::time::Interval,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceDocIdRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
 }
 
 /// Per-source-collection schema cache.
@@ -196,6 +209,17 @@ fn is_defradb_aggregate_field(name: &str) -> bool {
     )
 }
 
+fn event_source_rescan_tick(interval: Duration) -> tokio::time::Interval {
+    let interval = if interval.is_zero() {
+        EVENT_SOURCE_RESCAN_INTERVAL
+    } else {
+        interval
+    };
+    let mut tick = tokio::time::interval(interval);
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    tick
+}
+
 impl EventSource {
     /// Build an event source wired to the given snapshot receiver and
     /// embedded node.
@@ -230,7 +254,17 @@ impl EventSource {
             collection_id_to_name: HashMap::new(),
             seen_docs: HashMap::new(),
             pending_intents: Mutex::new(VecDeque::new()),
+            rescan_tick: event_source_rescan_tick(EVENT_SOURCE_RESCAN_INTERVAL),
         }
+    }
+
+    /// Override the periodic rescan cadence. Exposed for integration tests
+    /// that need to drive the live rescan path without waiting for the
+    /// production interval.
+    #[doc(hidden)]
+    pub fn with_rescan_interval(mut self, interval: Duration) -> Self {
+        self.rescan_tick = event_source_rescan_tick(interval);
+        self
     }
 
     /// Override the reconciliation debounce. Test-only hook mirroring
@@ -400,6 +434,36 @@ impl EventSource {
             .or_default()
             .extend(doc_ids);
         Ok(())
+    }
+
+    async fn load_doc_ids_for_collection(&self, collection: &str) -> anyhow::Result<Vec<String>> {
+        let query = format!(
+            r#"query {{ {collection}(limit: {limit}) {{ _docID }} }}"#,
+            collection = collection,
+            limit = SEEN_DOCS_SEED_LIMIT,
+        );
+        let response = self.node.execute(&query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "event source rescan query for {} failed: {:?}",
+                collection,
+                response.errors
+            );
+        }
+        let rows: Vec<SourceDocIdRow> = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get(collection))
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default();
+        if rows.len() >= SEEN_DOCS_SEED_LIMIT {
+            tracing::warn!(
+                source_collection = %collection,
+                limit = %SEEN_DOCS_SEED_LIMIT,
+                "event source rescan hit limit; older unseen docs may wait for a later event"
+            );
+        }
+        Ok(rows.into_iter().map(|row| row.doc_id).collect())
     }
 
     /// Record that `(collection, doc_id)` has been observed and return
@@ -761,14 +825,72 @@ impl EventSource {
         }
         intents
     }
+
+    fn take_first_and_queue_rest(&self, mut intents: Vec<FireIntent>) -> Option<FireIntent> {
+        if intents.is_empty() {
+            return None;
+        }
+        let first = intents.remove(0);
+        let mut queue = self
+            .pending_intents
+            .lock()
+            .expect("pending_intents mutex poisoned");
+        for intent in intents {
+            queue.push_back(intent);
+        }
+        Some(first)
+    }
+
+    async fn rescan_created_docs(&mut self) -> Option<FireIntent> {
+        let mut collections: Vec<String> = self.desired_collections.iter().cloned().collect();
+        collections.sort();
+        let snapshot = self.snapshot_rx.borrow().clone();
+
+        for collection in collections {
+            let doc_ids = match self.load_doc_ids_for_collection(&collection).await {
+                Ok(doc_ids) => doc_ids,
+                Err(err) => {
+                    tracing::warn!(
+                        source_collection = %collection,
+                        %err,
+                        "event source periodic rescan failed for collection",
+                    );
+                    continue;
+                }
+            };
+
+            for doc_id in doc_ids {
+                if !self.is_first_seen(&collection, &doc_id) {
+                    continue;
+                }
+                let intents = self
+                    .build_intents_for_all_matching(
+                        snapshot.as_ref(),
+                        &collection,
+                        &doc_id,
+                        "created",
+                    )
+                    .await;
+                if let Some(first) = self.take_first_and_queue_rest(intents) {
+                    tracing::info!(
+                        source_collection = %collection,
+                        source_doc_id = %doc_id,
+                        "event source periodic rescan emitted fire intent",
+                    );
+                    return Some(first);
+                }
+            }
+        }
+        None
+    }
 }
 
 impl EventDeliveryRuntimeContract for EventSource {
     const EVENT_DELIVERY_CONTRACT: EventDeliverySourceContract = EventDeliverySourceContract {
         name: "EventSource",
         dedupe_policy: "monotone_once",
-        rescan_bounded_by: 0,
-        deviation: Some("event_source_lacks_periodic_rescan"),
+        rescan_bounded_by: 1,
+        deviation: None,
     };
 }
 
@@ -829,48 +951,66 @@ impl TriggerSource for EventSource {
                 // Step 3: race the subscription against snapshot changes and
                 // cancel. Subscription is guaranteed Some here by the check
                 // above, so we can take a &mut borrow for the recv poll.
-                let subscription = self
-                    .subscription
-                    .as_mut()
-                    .expect("subscription is Some when desired_collections is non-empty");
-                let message = tokio::select! {
-                    biased;
-                    _ = self.cancel.cancelled() => return None,
-                    res = self.snapshot_rx.changed() => {
-                        if res.is_err() {
-                            return None;
-                        }
-                        // New snapshot — loop back to reconcile. Any event
-                        // in-flight on the subscription will be seen on the
-                        // next tick (events::Subscription buffers behind the
-                        // mpsc receiver, so no loss).
-                        continue;
-                    }
-                    msg = subscription.recv() => {
-                        match msg {
-                            Some(m) => m,
-                            None => {
-                                // The subscription channel closed. This is
-                                // effectively source death; returning None so
-                                // the engine drops us.
-                                tracing::warn!(
-                                    "event source subscription channel closed; \
-                                     source exiting",
-                                );
+                let mut message = None;
+                let mut dropped = 0;
+                let rescan_due = {
+                    let subscription = self
+                        .subscription
+                        .as_mut()
+                        .expect("subscription is Some when desired_collections is non-empty");
+                    let rescan_due = tokio::select! {
+                        biased;
+                        _ = self.cancel.cancelled() => return None,
+                        res = self.snapshot_rx.changed() => {
+                            if res.is_err() {
                                 return None;
                             }
+                            // New snapshot — loop back to reconcile. Any event
+                            // in-flight on the subscription will be seen on the
+                            // next tick (events::Subscription buffers behind the
+                            // mpsc receiver, so no loss).
+                            continue;
                         }
+                        _ = self.rescan_tick.tick() => true,
+                        msg = subscription.recv() => {
+                            match msg {
+                                Some(m) => {
+                                    message = Some(m);
+                                    false
+                                }
+                                None => {
+                                    // The subscription channel closed. This is
+                                    // effectively source death; returning None so
+                                    // the engine drops us.
+                                    tracing::warn!(
+                                        "event source subscription channel closed; \
+                                         source exiting",
+                                    );
+                                    return None;
+                                }
+                            }
+                        }
+                    };
+                    if !rescan_due {
+                        dropped = subscription.check_and_reset_dropped();
                     }
+                    rescan_due
                 };
+                if rescan_due {
+                    if let Some(intent) = self.rescan_created_docs().await {
+                        return Some(intent);
+                    }
+                    continue;
+                }
+                let message = message.expect("subscription recv branch sets message");
 
-                let dropped = subscription.check_and_reset_dropped();
                 if dropped > 0 {
-                    // Dropped events are a correctness hazard for this
-                    // source — without a full-resync path we can't know what
-                    // we missed. Log loudly; Task 22+ may add a resync hook.
+                    // Dropped events are a correctness hazard. The periodic
+                    // rescan closes the gap for created docs, and this log
+                    // keeps the lossy event visible operationally.
                     tracing::warn!(
                         dropped = dropped,
-                        "event source dropped messages; may have missed event triggers",
+                        "event source dropped messages; periodic rescan will recover created docs",
                     );
                 }
 
@@ -937,7 +1077,7 @@ impl TriggerSource for EventSource {
                 // — all writes go through Update, distinguished only by
                 // block contents) to the right string.
                 let event_kind = "created";
-                let mut intents = self
+                let intents = self
                     .build_intents_for_all_matching(
                         snapshot.as_ref(),
                         &collection_name,
@@ -959,17 +1099,7 @@ impl TriggerSource for EventSource {
                 // before reading another event off the subscription. Order
                 // is deterministic (sorted by trigger_id in
                 // `build_intents_for_all_matching`).
-                let first = intents.remove(0);
-                {
-                    let mut queue = self
-                        .pending_intents
-                        .lock()
-                        .expect("pending_intents mutex poisoned");
-                    for intent in intents {
-                        queue.push_back(intent);
-                    }
-                }
-                return Some(first);
+                return self.take_first_and_queue_rest(intents);
             }
         })
     }

--- a/crates/defra-agent/src/trigger_engine/subagent_source.rs
+++ b/crates/defra-agent/src/trigger_engine/subagent_source.rs
@@ -8,11 +8,13 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use defra_node::EmbeddedNode;
 use serde::Deserialize;
 use tokio::sync::watch;
+use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 use crate::background_tools::{
@@ -33,6 +35,7 @@ use crate::UpdateSubscriptionSource;
 use super::{FireIntent, FireResult, TriggerKind, TriggerSource};
 
 const TOOL_CALL_COLLECTION: &str = "AgentToolCall";
+const SUBAGENT_SOURCE_RESCAN_INTERVAL: Duration = Duration::from_secs(5);
 
 pub struct SubagentSource {
     snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
@@ -42,6 +45,9 @@ pub struct SubagentSource {
     cancel: CancellationToken,
     collection_id_to_name: HashMap<String, String>,
     processed_tool_calls: HashSet<String>,
+    /// Periodic scan over running bridge rows. This closes the event-drop gap
+    /// for child materialization without bypassing the normal source path.
+    rescan_tick: tokio::time::Interval,
 }
 
 #[derive(Debug, Deserialize)]
@@ -69,6 +75,12 @@ struct ToolCallRow {
     cancel_policy: Option<String>,
     #[serde(default)]
     child_request_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallDocIdRow {
+    #[serde(rename = "_docID")]
+    doc_id: String,
 }
 
 impl ToolCallRow {
@@ -148,6 +160,17 @@ impl SpawnArgs {
     }
 }
 
+fn subagent_source_rescan_tick(interval: Duration) -> tokio::time::Interval {
+    let interval = if interval.is_zero() {
+        SUBAGENT_SOURCE_RESCAN_INTERVAL
+    } else {
+        interval
+    };
+    let mut tick = tokio::time::interval(interval);
+    tick.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    tick
+}
+
 impl SubagentSource {
     pub fn new(
         snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
@@ -171,7 +194,17 @@ impl SubagentSource {
             cancel,
             collection_id_to_name: HashMap::new(),
             processed_tool_calls: HashSet::new(),
+            rescan_tick: subagent_source_rescan_tick(SUBAGENT_SOURCE_RESCAN_INTERVAL),
         }
+    }
+
+    /// Override the periodic rescan cadence. Exposed for integration tests
+    /// that need to drive the live rescan path without waiting for the
+    /// production interval.
+    #[doc(hidden)]
+    pub fn with_rescan_interval(mut self, interval: Duration) -> Self {
+        self.rescan_tick = subagent_source_rescan_tick(interval);
+        self
     }
 
     fn ensure_subscription(&mut self) {
@@ -344,6 +377,65 @@ impl SubagentSource {
             .and_then(|data| data.get("AgentRequest"))
             .and_then(serde_json::Value::as_array)
             .is_some_and(|rows| !rows.is_empty()))
+    }
+
+    async fn load_running_bridge_doc_ids(&self) -> anyhow::Result<Vec<String>> {
+        let query = r#"{
+            AgentToolCall(
+                filter: {
+                    lifecycle_state: { _eq: "running" },
+                    child_request_id: { _ne: "" }
+                }
+            ) { _docID }
+        }"#;
+        let response = self.node.execute(query).await;
+        if response.has_errors() {
+            anyhow::bail!(
+                "query running AgentToolCall bridge rows for SubagentSource rescan failed: {:?}",
+                response.errors
+            );
+        }
+        let rows: Vec<ToolCallDocIdRow> = response
+            .data
+            .as_ref()
+            .and_then(|data| data.get(TOOL_CALL_COLLECTION))
+            .and_then(|value| serde_json::from_value(value.clone()).ok())
+            .unwrap_or_default();
+        Ok(rows.into_iter().map(|row| row.doc_id).collect())
+    }
+
+    async fn rescan_running_bridge_rows(&mut self) -> Option<FireIntent> {
+        let doc_ids = match self.load_running_bridge_doc_ids().await {
+            Ok(doc_ids) => doc_ids,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "subagent source periodic rescan failed to load running bridge rows",
+                );
+                return None;
+            }
+        };
+
+        for doc_id in doc_ids {
+            match self.build_intent_for_tool_call_doc(&doc_id).await {
+                Ok(Some(intent)) => {
+                    tracing::info!(
+                        doc_id = %doc_id,
+                        "subagent source periodic rescan emitted fire intent",
+                    );
+                    return Some(intent);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        doc_id = %doc_id,
+                        %error,
+                        "subagent source periodic rescan failed to process AgentToolCall row",
+                    );
+                }
+            }
+        }
+        None
     }
 
     async fn fail_unauthorized_tool_call(
@@ -766,8 +858,8 @@ impl EventDeliveryRuntimeContract for SubagentSource {
     const EVENT_DELIVERY_CONTRACT: EventDeliverySourceContract = EventDeliverySourceContract {
         name: "SubagentSource",
         dedupe_policy: "monotone_once",
-        rescan_bounded_by: 0,
-        deviation: Some("subagent_source_lacks_live_rescan"),
+        rescan_bounded_by: 1,
+        deviation: None,
     };
 }
 
@@ -778,12 +870,14 @@ impl TriggerSource for SubagentSource {
         Box::pin(async move {
             self.ensure_subscription();
             loop {
-                let message = {
+                let mut message = None;
+                let mut dropped = 0;
+                let rescan_due = {
                     let subscription = self
                         .subscription
                         .as_mut()
                         .expect("subagent source subscription opened before polling");
-                    tokio::select! {
+                    let rescan_due = tokio::select! {
                         biased;
                         _ = self.cancel.cancelled() => return None,
                         res = self.snapshot_rx.changed() => {
@@ -792,9 +886,13 @@ impl TriggerSource for SubagentSource {
                             }
                             continue;
                         }
+                        _ = self.rescan_tick.tick() => true,
                         msg = subscription.recv() => {
                             match msg {
-                                Some(message) => message,
+                                Some(received) => {
+                                    message = Some(received);
+                                    false
+                                }
                                 None => {
                                     tracing::warn!(
                                         "subagent source subscription channel closed; source exiting",
@@ -803,18 +901,24 @@ impl TriggerSource for SubagentSource {
                                 }
                             }
                         }
+                    };
+                    if !rescan_due {
+                        dropped = subscription.check_and_reset_dropped();
                     }
+                    rescan_due
                 };
+                if rescan_due {
+                    if let Some(intent) = self.rescan_running_bridge_rows().await {
+                        return Some(intent);
+                    }
+                    continue;
+                }
+                let message = message.expect("subscription recv branch sets message");
 
-                let dropped = self
-                    .subscription
-                    .as_mut()
-                    .expect("subagent source subscription remains open")
-                    .check_and_reset_dropped();
                 if dropped > 0 {
                     tracing::warn!(
                         dropped,
-                        "subagent source dropped messages; may have missed child spawns",
+                        "subagent source dropped messages; periodic rescan will recover child spawns",
                     );
                 }
 

--- a/crates/defra-agent/tests/conformance/coverage.rs
+++ b/crates/defra-agent/tests/conformance/coverage.rs
@@ -275,6 +275,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
         "boundary.session-recovery.client-retry-surface",
         "boundary.coverage-ledger.review-discipline",
         "boundary.event-delivery.fair-substrate",
+        "boundary.event-delivery.rescan-doc-cap",
         "boundary.streaming-response.idle-timeout-deadline",
         "boundary.prompt-assembly.provider-input-sanitization",
     ]

--- a/crates/defra-agent/tests/conformance/event_delivery.rs
+++ b/crates/defra-agent/tests/conformance/event_delivery.rs
@@ -16,6 +16,7 @@ const EVENT_SOURCE_COLLECTION: &str = "EventDeliveryDoc";
 const EVENT_SOURCE_TRIGGER_ID: &str = "event-delivery-trigger";
 const EVENT_SOURCE_TASK_ID: &str = "event-delivery-task";
 const DELIVERY_TIMEOUT: Duration = Duration::from_secs(2);
+const RESCAN_TEST_INTERVAL: Duration = Duration::from_millis(50);
 
 pub(super) async fn event_delivery_transition_cases_match_contract() {
     let cases = lean_event_delivery_transition_cases();
@@ -95,24 +96,10 @@ pub(super) async fn event_delivery_convergence_traces_match_runtime_or_deviation
                     trace.name
                 );
             }
-            "deviation" => {
-                assert!(
-                    source.deviation.is_some(),
-                    "deviation trace `{}` must name a runtime source with a documented deviation",
-                    trace.name
-                );
-                assert_eq!(
-                    source.rescan_bounded_by, 0,
-                    "deviation trace `{}` must run against an unbounded-rescan source",
-                    trace.name
-                );
-                assert!(
-                    !runtime.unhandled_persistent_docs().await.is_empty(),
-                    "deviation trace `{}` did not witness the documented \
-                     deviation state (no orphan persistent doc remaining)",
-                    trace.name,
-                );
-            }
+            "deviation" => panic!(
+                "event-delivery deviation trace `{}` is retired; live sources must emit substantive convergence traces",
+                trace.name,
+            ),
             other => panic!(
                 "trace `{}` has unknown status `{}` (expected 'substantive' or 'deviation')",
                 trace.name, other,
@@ -205,6 +192,9 @@ impl ProductionEventDeliveryDriver {
                 }
             }
             "SubagentSource" => {
+                install_subagent_source_fixture(db.node.as_ref())
+                    .await
+                    .expect("install SubagentSource event-delivery fixture");
                 let (runner, emitted_rx, snapshot_tx) = spawn_subagent_source_runner(
                     db.node.clone(),
                     mock_subs.clone(),
@@ -289,7 +279,7 @@ impl ProductionEventDeliveryDriver {
             LeanEventDeliveryAction::RescanTick => {
                 if self.source.rescan_bounded_by == 0 {
                     return Err(format!(
-                        "source {} has no bounded live rescan",
+                        "source {} does not advertise a positive bounded live rescan",
                         self.source.name
                     ));
                 }
@@ -428,23 +418,46 @@ impl ProductionEventDeliveryDriver {
     async fn create_subagent_tool_call_doc(&self, doc: &str) -> Result<String, String> {
         let tool_call_id = escape_graphql_string(doc);
         let tool_call_key = escape_graphql_string(&format!("event-delivery-session:{doc}"));
+        let parent_request_id = format!("event-delivery-parent-{doc}");
+        let parent_session_id = format!("event-delivery-session-{doc}");
+        let child_request_id = format!("event-delivery-child-{doc}");
+        create_request(
+            self.db.node.as_ref(),
+            &parent_request_id,
+            &parent_session_id,
+            "processing",
+            "2026-05-20T00:00:00Z",
+        )
+        .await;
+        let parent_request_id = escape_graphql_string(&parent_request_id);
+        let parent_session_id = escape_graphql_string(&parent_session_id);
+        let child_request_id = escape_graphql_string(&child_request_id);
+        let args = escape_graphql_string(
+            &serde_json::json!({
+                "name": AGENT_NAME,
+                "agent_did": AGENT_DID,
+                "behavior_id": AGENT_NAME,
+                "prompt": "materialize event-delivery child",
+            })
+            .to_string(),
+        );
         let mutation = format!(
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
-                    request_id: "",
-                    session_id: "event-delivery-session",
+                    request_id: "{parent_request_id}",
+                    session_id: "{parent_session_id}",
                     message_sequence: 1,
                     tool_name: "spawn_subagent",
                     tool_call_id: "{tool_call_id}",
-                    args: "{{}}",
+                    args: "{args}",
                     result: "",
                     status: "called",
                     lifecycle_state: "running",
                     started_at: "2026-05-20T00:00:00Z",
                     await_mode: "foreground",
                     cancel_policy: "cascade",
-                    child_request_id: "",
+                    child_request_id: "{child_request_id}",
                     selected_service_id: null,
                     selected_tool_name: null,
                     tool_failure_class: null,
@@ -521,14 +534,12 @@ impl ProductionEventDeliveryDriver {
                 Ok(())
             }
             ProductionRuntime::EventSource | ProductionRuntime::SubagentSource => {
-                if expected_docs.is_empty() {
-                    Ok(())
-                } else {
-                    Err(format!(
-                        "source {} has no bounded live rescan",
-                        self.source.name
-                    ))
+                for expected in expected_docs {
+                    let expected = self.production_doc_id(expected)?;
+                    self.wait_for_emitted_doc_buffered(&expected, DELIVERY_TIMEOUT)
+                        .await?;
                 }
+                Ok(())
             }
         }
     }
@@ -576,11 +587,12 @@ impl ProductionEventDeliveryDriver {
     fn production_doc_id(&self, doc: &str) -> Result<String, String> {
         match self.source.name {
             "Watcher" => Ok(doc.to_string()),
-            "EventSource" | "SubagentSource" => self
+            "EventSource" => self
                 .doc_ids
                 .get(doc)
                 .cloned()
                 .ok_or_else(|| format!("doc {doc:?} has no runtime row")),
+            "SubagentSource" => Ok(doc.to_string()),
             other => Err(format!("unsupported source {other:?}")),
         }
     }
@@ -598,6 +610,34 @@ impl ProductionEventDeliveryDriver {
             match self.wait_for_any_emitted_doc_until(deadline).await? {
                 Some(emitted) if emitted == expected => return Ok(()),
                 Some(emitted) => self.emitted_buffer.push(emitted),
+                None => {
+                    return Err(format!(
+                        "{} did not emit expected runtime doc {:?}",
+                        self.source.name, expected
+                    ));
+                }
+            }
+        }
+    }
+
+    async fn wait_for_emitted_doc_buffered(
+        &mut self,
+        expected: &str,
+        timeout: Duration,
+    ) -> Result<(), String> {
+        if self.emitted_buffer.iter().any(|doc| doc == expected) {
+            return Ok(());
+        }
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match self.wait_for_any_emitted_doc_until(deadline).await? {
+                Some(emitted) => {
+                    let matched = emitted == expected;
+                    self.emitted_buffer.push(emitted);
+                    if matched {
+                        return Ok(());
+                    }
+                }
                 None => {
                     return Err(format!(
                         "{} did not emit expected runtime doc {:?}",
@@ -652,7 +692,8 @@ fn spawn_event_source_runner(
     let snapshot = active_snapshot_with_event_trigger();
     let (snapshot_tx, snapshot_rx) = watch::channel(snapshot);
     let mut source =
-        EventSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel);
+        EventSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel)
+            .with_rescan_interval(RESCAN_TEST_INTERVAL);
     let (tx, rx) = mpsc::channel(16);
     let runner = tokio::spawn(async move {
         while let Some(intent) = source.next_fire().await {
@@ -682,7 +723,8 @@ fn spawn_subagent_source_runner(
     let snapshot = active_snapshot_without_event_triggers();
     let (snapshot_tx, snapshot_rx) = watch::channel(snapshot);
     let mut source =
-        SubagentSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel);
+        SubagentSource::with_subscription_source(Arc::new(mock_subs), snapshot_rx, node, cancel)
+            .with_rescan_interval(RESCAN_TEST_INTERVAL);
     let (tx, rx) = mpsc::channel(16);
     let runner = tokio::spawn(async move {
         while let Some(intent) = source.next_fire().await {
@@ -718,6 +760,53 @@ async fn install_event_delivery_source_schema(node: &EmbeddedNode) {
     node.add_schema(schema)
         .await
         .expect("add_schema for EventDeliveryDoc");
+}
+
+async fn install_subagent_source_fixture(node: &EmbeddedNode) -> Result<(), String> {
+    const TOOL_SELECTION_ID: &str = "event-delivery-subagent-tools";
+
+    upsert_tool_selection(
+        node,
+        &ToolSelectionDocument {
+            selection_id: TOOL_SELECTION_ID.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            subagent_targets: Some(vec![defra_agent::subagent_target_entry(
+                AGENT_NAME, AGENT_DID, AGENT_NAME, None,
+            )]),
+            subagent_spawn_enabled: Some(true),
+            subagent_background_enabled: Some(true),
+            ..Default::default()
+        },
+    )
+    .await
+    .map_err(|err| format!("upsert ToolSelection failed: {err}"))?;
+
+    upsert_agent_behavior(
+        node,
+        &AgentBehaviorDocument {
+            behavior_id: AGENT_NAME.to_string(),
+            agent_did: AGENT_DID.to_string(),
+            display_name: Some("Event delivery subagent fixture".to_string()),
+            description: None,
+            summary: None,
+            system_prompt: None,
+            request_context_template: None,
+            backend_id: None,
+            model_name: None,
+            tool_selection_id: Some(TOOL_SELECTION_ID.to_string()),
+            inference_profile_id: None,
+            compaction_strategy: None,
+            compaction_threshold: None,
+            skill_refs: Vec::new(),
+            skill_excludes: Vec::new(),
+            enabled: true,
+            created_at: Some("2026-05-20T00:00:00Z".to_string()),
+        },
+    )
+    .await
+    .map_err(|err| format!("upsert AgentBehavior failed: {err}"))?;
+
+    Ok(())
 }
 
 fn active_snapshot_with_event_trigger() -> Arc<ActiveRuntimeSnapshot> {
@@ -758,7 +847,7 @@ fn active_snapshot(
         local_did: AGENT_DID.to_string(),
         paired_peer_dids: HashSet::new(),
         default_behavior_id: AGENT_NAME.to_string(),
-        behaviors: HashMap::new(),
+        behaviors: HashMap::from([(AGENT_NAME.to_string(), runtime_behavior(AGENT_NAME))]),
         tool_surfaces: HashMap::new(),
         backend_admission_configs: HashMap::new(),
         unavailable_behaviors: HashMap::new(),
@@ -771,6 +860,23 @@ fn active_snapshot(
         behavior_executor_capacities: HashMap::new(),
         behavior_executor_queue_capacities: HashMap::new(),
     })
+}
+
+fn runtime_behavior(behavior_id: &str) -> Arc<defra_agent::AgentBehavior> {
+    let identity: Arc<dyn defra_agent::AgentIdentity> = Arc::new(
+        crate::support::fixtures::test_identity(&format!("event-delivery-{behavior_id}")),
+    );
+    let principal = Arc::new(defra_agent::AgentPrincipal {
+        agent_did: AGENT_DID.to_string(),
+        identity,
+        default_behavior_id: AGENT_NAME.to_string(),
+        display_name: None,
+        enabled: true,
+    });
+    Arc::new(crate::support::fixtures::test_behavior_for_principal(
+        behavior_id,
+        principal,
+    ))
 }
 
 fn empty_event_delivery_world() -> lean_vocab_test::LeanEventDeliveryWorld {

--- a/crates/defra-agent/tests/conformance/subagent_source.rs
+++ b/crates/defra-agent/tests/conformance/subagent_source.rs
@@ -988,9 +988,8 @@ async fn subagent_source_refuses_cross_deployment_child_when_target_flag_off() {
     )
     .await;
 
-    // Spawn the source FIRST so its global Update subscription is open before the
-    // bridge is written (the source has no live rescan; a create event written
-    // before subscription would be missed).
+    // Spawn the source first so this test exercises the subscription path
+    // deterministically rather than waiting for the periodic rescan.
     let mut paired = std::collections::HashSet::new();
     paired.insert(remote_parent_did.to_string());
     let _source = crate::support::fixtures::spawn_subagent_source_with_paired_peers(
@@ -1648,9 +1647,8 @@ async fn recovery_rejects_background_orphan_when_background_disabled() {
 }
 
 /// The fixture `SubagentSource` opens its global Update subscription lazily on
-/// the first `next_fire` poll and has no live rescan, so a bridge written before
-/// the subscription is open would be missed. Give the spawned source task a
-/// moment to open its subscription before writing the bridge.
+/// the first `next_fire` poll. Give the spawned source task a moment to open
+/// its subscription when a test wants to exercise the event path directly.
 async fn wait_for_subagent_source_subscription() {
     tokio::time::sleep(Duration::from_millis(250)).await;
 }


### PR DESCRIPTION
## Summary
- make EventSource/SubagentSource D1 contracts advertise positive bounded rescans and remove retired deviation metadata
- add periodic runtime rescans for EventSource document creates and SubagentSource running bridge rows
- update EventDelivery conformance traces/tests to drive `persist -> rescanTick -> handle` as substantive behavior

## Tests
- `lake build`
- `cargo fmt --all`
- `cargo test -p defra-agent event_delivery --test conformance -- --nocapture`
- `cargo test -p defra-agent`

Closes #552
