### PR TITLE
Add verified two-node P2P demo runbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ help:
 	@echo "  make live-cli              Run live CLI smoke test"
 	@echo "  make live-agent            Run ignored live runtime tests"
 	@echo "  make live-desktop-smoke    Run live desktop smoke suites"
+	@echo
+	@echo "Demos:"
+	@echo "  make demo-p2p-two-node     Run the local two-node P2P pairing demo"
 
 .PHONY: build build-cli build-cli-headless build-desktop build-desktop-ui
 build:
@@ -192,3 +195,7 @@ live-desktop-smoke:
 	$(NPM) --prefix $(DESKTOP_DIR) run test:live:config
 	$(NPM) --prefix $(DESKTOP_DIR) run test:live:operations
 	$(NPM) --prefix $(DESKTOP_DIR) run test:live:interrupt
+
+.PHONY: demo-p2p-two-node
+demo-p2p-two-node:
+	scripts/demo-p2p-two-node.sh

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ verifying the signed binary, building from source, and the fallback `chat`
 REPL. Desktop app, fleet bring-up, and P2P pairing:
 [docs/operations.md](docs/operations.md).
 
+For the local two-node P2P demo from source, run `make demo-p2p-two-node`.
+It starts Amy + Coding, enrolls Coding through a signed `network-control`
+invite, adds the conversation data plane, and proves request replication.
+
 ## Why this exists
 
 Agent frameworks bolt persistence, identity, and coordination onto a loop. defra-agent inverts that: the loop is thin and formally specified, and the hard properties come from the substrate.

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -184,7 +184,7 @@ Examples:
   defra-agent p2p pairings rm --peer <peer-id>
   defra-agent p2p network create --name \"Fleet One\"
   defra-agent p2p network grant <member-did>
-  defra-agent p2p pairings invite --member-did <member-did> --template conversation
+  defra-agent p2p pairings invite --member-did <member-did> --template network-control
   defra-agent p2p pairings join <invite-token>
 
   # Service discovery:

--- a/crates/defra-agent-cli/tests/cli_p2p.rs
+++ b/crates/defra-agent-cli/tests/cli_p2p.rs
@@ -36,10 +36,18 @@ fn grant_member(home: &std::path::Path, member_did: &str) -> Result<Value> {
     Ok(out)
 }
 
-fn mint_invite_for(home: &std::path::Path, member_did: &str) -> Result<Value> {
+fn mint_network_control_invite_for(home: &std::path::Path, member_did: &str) -> Result<Value> {
     run_cli_json(
         home,
-        &["p2p", "pairings", "invite", "--member-did", member_did],
+        &[
+            "p2p",
+            "pairings",
+            "invite",
+            "--member-did",
+            member_did,
+            "--template",
+            "network-control",
+        ],
     )
 }
 
@@ -133,7 +141,7 @@ async fn p2p_invite_is_single_use_replay_rejected() -> Result<()> {
     grant_member(&home_a, &agent_did_b)?;
 
     // Mint exactly ONE invite from A for B's active membership grant.
-    let invite_a = mint_invite_for(&home_a, &agent_did_b)?;
+    let invite_a = mint_network_control_invite_for(&home_a, &agent_did_b)?;
     let token_a = invite_a
         .get("token")
         .and_then(Value::as_str)
@@ -688,7 +696,7 @@ async fn p2p_invite_join_round_trips_pairing_rows() -> Result<()> {
     create_network(&home_a, "Invite Fleet")?;
     grant_member(&home_a, &agent_did_b)?;
 
-    let invite_a = mint_invite_for(&home_a, &agent_did_b)?;
+    let invite_a = mint_network_control_invite_for(&home_a, &agent_did_b)?;
     assert_eq!(
         invite_a.get("status").and_then(Value::as_str),
         Some("invite_created")
@@ -735,19 +743,18 @@ async fn p2p_invite_join_round_trips_pairing_rows() -> Result<()> {
         Some(agent_did_a.as_str())
     );
 
-    // The `conversation` template (the invite/join default) is filtered-PUSH
-    // delivery: the reconciler installs a filtered replicator toward the peer
-    // and deliberately does NOT subscribe the collections (no gossip leak of
-    // the unfiltered collection). So the applied row carries replicator
-    // addresses, not subscribed collections.
+    // The v5 invite seeds the narrow network-control substrate only. The
+    // full conversation data-plane flow is exercised by
+    // `scripts/demo-p2p-two-node.sh`, which writes DataPlanePairingDesired rows
+    // and proves AgentRequest replication.
     let applied_b =
-        wait_for_pairing_applied(&graphql_b, peer_id_a, Duration::from_secs(70)).await?;
+        wait_for_pairing_applied(&graphql_b, peer_id_a, Duration::from_secs(90)).await?;
     assert!(
         applied_b
-            .get("replicator_addresses")
+            .get("collections")
             .and_then(Value::as_array)
-            .is_some_and(|rows| !rows.is_empty()),
-        "B applied row missing a replicator toward A after joining: {applied_b}"
+            .is_some_and(|rows| rows.iter().any(|row| row.as_str() == Some("AgentNetwork"))),
+        "B applied row missing network-control collections after joining: {applied_b}"
     );
 
     Ok(())

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -230,11 +230,38 @@ toward it** — connecting, subscribing collections, installing replicators,
 and recording what it did. The same idea as `kubectl apply`, applied to
 gossip replication.
 
-## The two documents
+## The presentable local demo
+
+From a checkout, run the scripted two-node demo:
+
+```bash
+make demo-p2p-two-node
+```
+
+It starts two isolated homes under `/tmp`, creates an admin-signed network on
+Amy, grants Coding membership, joins Coding with a v5 `network-control`
+invite, writes the bidirectional conversation data-plane rows, waits for the
+runtime reconcilers to install replicators, then submits one no-wait request on
+Coding and verifies that Amy sees the replicated `AgentRequest` document.
+
+Useful knobs:
+
+```bash
+DEFRA_AGENT_DEMO_KEEP=1 make demo-p2p-two-node
+DEFRA_AGENT_DEMO_INFERENCE_URL=http://127.0.0.1:8080/v1 \
+DEFRA_AGENT_DEMO_MODEL=google/gemma-4-12B-it-qat-q4_0-gguf \
+  make demo-p2p-two-node
+```
+
+`DEFRA_AGENT_DEMO_KEEP=1` leaves both runtimes running and prints the exact
+follow-up commands for manual inspection.
+
+## The operator/reconciler documents
 
 | Document | Who writes it | Meaning |
 |---|---|---|
-| `PeerPairingDesired` | you (the operator) | the pairing you want: which peer, which DID you expect it to have, which collections/profiles to replicate |
+| `PeerPairingDesired` | you (or the network materializer) | the control-plane pairing you want: which peer, which DID you expect it to have, and which narrow network documents should replicate |
+| `DataPlanePairingDesired` | you (the operator) | the application edge you want: which admitted peer should receive this agent's conversation/subagent documents |
 | `PeerPairingApplied` | the runtime reconciler | what it actually installed for that peer — the **ownership record** |
 
 The split matters. The reconciler only ever tears down wiring it finds in
@@ -252,53 +279,73 @@ P2P to loopback for the demo:
 ```bash
 defra-agent init  --home /tmp/coding --agent-name coding \
   --inference-url http://127.0.0.1:8080/v1 --model-name "$MODEL"
-defra-agent server --home /tmp/coding --p2p-bind-addr 127.0.0.1 --p2p-port 0
+defra-agent server --home /tmp/coding --no-codex-shim \
+  --p2p-bind-addr 127.0.0.1 --p2p-port 0 \
+  --p2p-relay-mode disabled --p2p-discovery disabled
 ```
 
 Use Part 1's home (say `~/.defra-agent`) as the first node, "Amy", and
 `/tmp/coding` as the second, "Coding".
 
-## 2. Exchange a pairing invite
+## 2. Create the network and grant membership
 
 Pairing carries the remote agent's **DID** — the identity that is the
 permission and audit boundary for everything that replicates. The
-invite/join flow moves the DID for you, so you never hand-type it.
+invite/join flow moves the DID for you, but v5 invites are membership-gated:
+the issuer must first create an `AgentNetwork` and grant the joining DID.
 
-On Amy, mint an invite token. It encodes Amy's shareable P2P address, peer id,
-DID, and the collection profiles it offers:
-
-```bash
-AMY_INVITE=$(defra-agent p2p pairings invite | jq -r .token)
-```
-
-On Coding, accept it. This writes Coding's `PeerPairingDesired` row for Amy
-and — because this is the first leg — prints a **reciprocal token** so Amy can
-pair back:
+On Amy:
 
 ```bash
-CODING_JOIN=$(defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE")
-CODING_INVITE=$(printf '%s\n' "$CODING_JOIN" | jq -r .reciprocal_token)
+CODING_DID=$(jq -r .agent_did /tmp/coding/init.json)
+defra-agent p2p network create --name "Two Node Demo"
+defra-agent p2p network grant "$CODING_DID"
 ```
 
-Pairing is **directional**: Coding now wants documents from Amy, but Amy
-doesn't yet know about Coding. Close the loop by joining the reciprocal token
-on Amy:
+Then mint a signed network-control invite for Coding:
 
 ```bash
-defra-agent p2p pairings join "$CODING_INVITE"
+AMY_INVITE=$(
+  defra-agent p2p pairings invite \
+    --member-did "$CODING_DID" \
+    --template network-control \
+    | jq -r .token
+)
 ```
 
-## 3. Watch the runtime reconcile
+On Coding, accept it:
+
+```bash
+defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE"
+```
+
+This writes Coding's control-plane `PeerPairingDesired` row for Amy, imports
+the signed network root and membership grant, burns the single-use invite
+nonce, and lets the reconciler install the network-control replicator.
+
+## 3. Add the conversation data plane
+
+The network-control edge moves membership and endpoint documents. Conversation
+traffic lives in a separate operator-owned `DataPlanePairingDesired` row so it
+can be filtered by local `agent_did` and gated by the same membership decision.
+
+The demo script writes the two data-plane rows for you. If you are driving the
+flow by hand, use the script with `DEFRA_AGENT_DEMO_KEEP=1` first and inspect
+the generated GraphQL in `scripts/demo-p2p-two-node.sh`; a dedicated CLI sugar
+command for data-plane rows is the next operator-ergonomics step.
+
+## 4. Watch the runtime reconcile
 
 You wrote documents; you installed nothing. Watch the reconciler converge:
 
 ```bash
+defra-agent p2p pairings list --output table
 defra-agent p2p pairings list --home /tmp/coding --output table
 ```
 
 ```
-PEER       DID            PROFILES       CONNECTED  SUBSCRIBED  REPLICATING
-12D3Koo…   did:key:amy…   chat-requests  yes        yes         yes
+PEER       DID            PROFILES  CONNECTED  SUBSCRIBED  REPLICATING
+12D3Koo…   did:key:amy…   -         no         yes         yes
 ```
 
 Those last three columns are the health of the pairing, each derived from a
@@ -310,24 +357,34 @@ different source so you can see *where* a stuck pairing is stuck:
 - **REPLICATING** — every desired replicator address appears in
   `PeerPairingApplied` (the push replicator is installed).
 
-All three flip to `yes` on their own, on the runtime's pairing sweep — no
-further commands. If one stays `no`, that column tells you whether the problem
-is connectivity, subscription, or replication.
+For this loopback/no-relay demo, `SUBSCRIBED` and `REPLICATING` are the
+durable pass criteria. `CONNECTED` is a point-in-time live peer-list check and
+can read `no` between short-lived direct dials even after the reconciler has
+installed the subscription and push replicator. The final proof is the
+replicated `AgentRequest` in the next step.
 
-## 4. Confirm replication
+## 5. Confirm replication
 
-Send a chat on one node and read it on the other. Because the `chat-requests`
-profile replicates the request/response/message collections, a request created
-on Coding and its streamed response are visible from Amy:
+Submit a no-wait request on Coding and read the replicated request row from
+Amy. This proves the data-plane replicator moved a real application document;
+it does not require the model backend to answer.
 
 ```bash
-defra-agent chat --home /tmp/coding "Say hello to the other node."
-defra-agent request submit --graphql http://127.0.0.1:9191/api/v0/graphql \
-  --agent-did "$CODING_DID" --content "ping" | jq -r '.request_id'
-# read the replicated row back from Amy's endpoint
+REQ=$(
+  defra-agent request submit \
+    --graphql http://127.0.0.1:19392/api/v0/graphql \
+    --agent-did "$CODING_DID" \
+    --content "two-node p2p demo ping from Coding" \
+    --no-wait \
+    | jq -r .request_id
+)
+
+defra-agent request show \
+  --graphql http://127.0.0.1:19391/api/v0/graphql \
+  "$REQ" --output json | jq .request
 ```
 
-## 5. Unpair
+## 6. Unpair
 
 Delete the desired row. The runtime sees the row gone, reads its
 `PeerPairingApplied` record, tears down **only** what it installed for that
@@ -356,132 +413,88 @@ across deployments unless `subagent_allow_cross_deployment: true` is set on
 both sides — that gate is off by default and deferred. Pairing is the
 transport; trust is still configured explicitly.
 
-# Part 3 — Join a network
+# Part 3 — Grow the link into a fleet
 
-Part 2 pairs two nodes you wired by hand. A real fleet has many nodes, and you
-do not want to hand-exchange an invite with each one. Part 3 turns pairwise
-pairing into a **network**: join one member, and you discover — and can pair
-with — the whole network. Three layers do this, and the point is that they stay
-distinct:
+Part 2 showed the two-node flow. A real fleet repeats the same pattern for
+each member, with two separate layers:
 
-| Layer | Document | Question it answers |
+| Layer | Documents | What it does |
 |---|---|---|
-| **Discovery** | `PeerRegistry` | *Who is out there?* |
-| **Replication** | `PeerPairingDesired` + reconciler | *Move the documents.* (Part 2) |
-| **Authorization** | signed invite · `subagent_allow_cross_deployment` | *Who may join? Who may delegate?* |
+| **Network control** | `AgentNetwork`, `NetworkMembership`, `PeerEndpoint`, `PeerPairingDesired` | admits a DID into the fleet and gossips only membership/endpoint state |
+| **Conversation data plane** | `DataPlanePairingDesired` | declares which application documents should replicate between two admitted members |
 
-Discovery makes a peer *visible*. It does not make it *authorized*. Those are
-different documents, gated separately — that separation is the whole design.
+That split is the important bit. The invite/join command is now for the narrow
+`network-control` substrate. Chat, subagent, and trace documents move only
+after an operator writes the data-plane edge for that relationship.
 
-## 1. Self-register into the registry
+## 1. Create the fleet root
 
-Each running node writes (and heartbeats) its own row in `PeerRegistry`, keyed
-by its peer id. The runtime does this automatically; the explicit command is
-for a manual refresh, a display name, or to advertise the profiles it offers:
+The fleet admin creates one signed network root, then grants each joining DID.
+On Amy:
 
 ```bash
-defra-agent p2p network register --profile discovery --display-name amy
+defra-agent p2p network create --name "Fleet One"
+defra-agent p2p network grant "$CODING_DID"
 ```
 
-The registry travels in the `discovery` profile. So the moment a node pairs
-with a member over `discovery`, it replicates `PeerRegistry` and sees every
-member that member already knows.
+`network create` writes the singleton `AgentNetwork` document and the admin's
+own membership. `network grant` writes an active, admin-signed
+`NetworkMembership` for Coding's DID.
 
-## 2. Mint a signed invite — the credential
+## 2. Enroll the member
 
-In Part 2 any reachable node could join. A network gates membership on a
-member's cryptographic say-so. `p2p pairings invite` now signs the token with
-the local agent's DID and **carries the chosen scope template** (default:
-`conversation`) so the joining peer knows exactly what to replicate:
+Mint a v5 invite for the granted DID. Use `network-control` for fleet
+enrollment:
 
 ```bash
-AMY_INVITE=$(defra-agent p2p pairings invite --template conversation | jq -r .token)
-```
+AMY_INVITE=$(
+  defra-agent p2p pairings invite \
+    --member-did "$CODING_DID" \
+    --template network-control \
+    | jq -r .token
+)
 
-Pair by intent, not by schema: `--template` selects a named bundle of
-collections, scoping policy, and delivery mode. The runtime resolves the
-collections and filtering at reconcile time so operators never hand-author
-collection lists. Use `defra-agent p2p templates list` to see the built-in
-catalog (`conversation`, `agent-config`, `backup`).
-
-`p2p pairings join` verifies that signature and reads the template from the
-token. Because a `did:key` embeds its own public key, verification needs
-nothing but the token — no lookup, no registry:
-
-```bash
 defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE"
 ```
 
-`join` reads the template from the token and writes it as the desired pairing's
-template. If both `--template` and a token template are present, the explicit
-`--template` wins (document it in your script if you override):
+The token embeds the signed network root and the signed membership grant.
+`join` verifies both, burns the single-use nonce, writes Coding's
+`PeerPairingDesired` row for Amy, and lets the runtime reconcile the
+network-control edge. v5 joins do not mint a reciprocal token.
+
+## 3. Add an application edge
+
+Network membership answers "may this node belong to the fleet?" It does not
+answer "which application documents should move?" For chat and subagent demos,
+write `DataPlanePairingDesired` rows for the exact pair of agents you want to
+link.
+
+The local demo script does this today:
 
 ```bash
-# Override to backup template regardless of what the token offers:
-defra-agent p2p pairings join --home /tmp/coding --template backup "$AMY_INVITE"
+make demo-p2p-two-node
 ```
 
-The rule has two arms:
+It writes Amy→Coding and Coding→Amy conversation data-plane rows, waits until
+both reconcilers install push replicators, then submits a request on Coding and
+confirms Amy sees the replicated `AgentRequest`.
 
-- **Bootstrap (trust-on-first-use).** Your registry has no other members yet,
-  so a valid signature over a well-formed token is enough. The issuer's DID is
-  recorded as `invited_by` — an audit trail of how you entered the trust set.
-- **Subsequent invites.** Once your registry holds live members, an invite is
-  admitted only if its issuer is one of them. A signature from a non-member (or
-  an evicted one) is rejected. A tampered signature is rejected outright.
+## 4. Optional registry discovery
 
-A reciprocal join (the `--reciprocal` token a first join prints, so the issuer
-pairs back) completes a handshake both sides already agreed to, so it verifies
-the signature but skips the membership arm.
+`p2p network register` and `p2p network list` still operate on the
+`PeerRegistry` discovery view: useful names, offered templates, heartbeat
+freshness, and "visible but not paired" diagnostics. Discovery makes a peer
+visible; it does not grant membership and it does not create conversation
+authority by itself.
 
-## 3. Watch transitive pairing
+## 5. The authorization boundary, again
 
-Pairing Coding to Amy replicated Amy's `PeerRegistry`. List what Coding can now
-see:
-
-```bash
-defra-agent p2p network list --home /tmp/coding --output table
-```
-
-```
-PEER       DID            NAME   NETWORK  ONLINE  PAIRED  PROFILES
-12D3Koo…   did:key:amy…   amy    default  yes     yes     discovery
-12D3Koo…   did:key:dana…  dana   default  yes     no      discovery
-```
-
-`ONLINE` is derived from the heartbeat age, not the self-reported `status` —
-the timestamp is the truth, the field is a hint. `PAIRED` shows whether a
-`PeerPairingDesired` row already exists for that peer.
-
-Dana is *visible* but not *paired*: discovery found her through Amy's registry,
-but nobody has paired with her yet. Turn on auto-pair and the discovery
-reconciler closes that gap:
-
-```bash
-DEFRA_AGENT_DISCOVERY_AUTO_PAIR=1 defra-agent server --home /tmp/coding \
-  --p2p-bind-addr 127.0.0.1 --p2p-port 0
-```
-
-Now, for each live member that Coding has *not* already paired with by hand,
-the reconciler writes a **registry-owned** `PeerPairingDesired` row
-(`source: "registry"`) and the Part 2 pairing reconciler wires it — no invite,
-no operator command. Auto-pair is off by default; with it off, `network list`
-shows the peers and you pair explicitly.
-
-Ownership stays clean across the two sources of desired rows:
-
-- A registry entry going stale or removed retracts **only** its registry-owned
-  rows. Your hand-authored `pairings set` rows are never touched.
-- The discovery step never overwrites an operator-authored row for the same
-  peer — operator intent wins.
-
-## 4. The authorization boundary, again
-
-Discovery and replication moved documents and wired transport. They did **not**
-grant permission. A peer Coding auto-paired with still cannot run a delegated
-subagent on Coding's behalf unless `subagent_allow_cross_deployment: true` is
-set on both behaviors' tool selections — exactly the Part 2 boundary, now at
-network scale. Visible ≠ paired ≠ authorized; each is its own document.
+Network-control and data-plane replication moved documents and wired
+transport. They did **not** grant tool permission. A peer Coding is linked to
+still cannot run a delegated subagent on Coding's behalf unless
+`subagent_allow_cross_deployment: true` is set on both behaviors' tool
+selections. Visible ≠ admitted ≠ replicating ≠ authorized; each is its own
+document.
 
 ## How this is wired (for the curious)
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -56,21 +56,50 @@ defra-agent server \
 
 ## Connected runtime bring-up
 
-To bring up two runtimes and pair them through the operator CLI:
+For the scripted local version, run:
 
 ```bash
-defra-agent server --home /tmp/amy --p2p-bind-addr 127.0.0.1 --p2p-port 4017
-defra-agent server --home /tmp/coding --p2p-bind-addr 127.0.0.1 --p2p-port 4018
+make demo-p2p-two-node
 ```
 
-Create an invite on Amy and join it from Coding:
+To bring up two runtimes manually and enroll Coding into Amy's signed network:
 
 ```bash
-AMY_INVITE=$(defra-agent p2p pairings invite --home /tmp/amy | jq -r .token)
-CODING_JOIN=$(defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE")
-CODING_INVITE=$(printf '%s\n' "$CODING_JOIN" | jq -r .reciprocal_token)
-defra-agent p2p pairings join --home /tmp/amy "$CODING_INVITE"
+defra-agent init --home /tmp/amy --agent-name amy
+defra-agent init --home /tmp/coding --agent-name coding
+
+defra-agent server --home /tmp/amy --no-codex-shim \
+  --p2p-bind-addr 127.0.0.1 --p2p-port 4017 \
+  --p2p-relay-mode disabled --p2p-discovery disabled
+defra-agent server --home /tmp/coding --no-codex-shim \
+  --p2p-bind-addr 127.0.0.1 --p2p-port 4018 \
+  --p2p-relay-mode disabled --p2p-discovery disabled
 ```
+
+Create the network root on Amy, grant Coding's DID, then join Coding with a
+signed `network-control` invite:
+
+```bash
+CODING_DID=$(jq -r .agent_did /tmp/coding/init.json)
+
+defra-agent p2p network create --home /tmp/amy --name "Two Node Demo"
+defra-agent p2p network grant --home /tmp/amy "$CODING_DID"
+
+AMY_INVITE=$(
+  defra-agent p2p pairings invite \
+    --home /tmp/amy \
+    --member-did "$CODING_DID" \
+    --template network-control \
+    | jq -r .token
+)
+
+defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE"
+```
+
+The join wires the narrow control-plane substrate only. To move chat,
+subagent, and trace rows, add `DataPlanePairingDesired` rows for the
+conversation edge. The scripted demo writes those rows and then proves
+replication by submitting a no-wait request on Coding and reading it from Amy.
 
 Inspect desired pairing rows and live connectivity from either runtime:
 
@@ -112,13 +141,21 @@ Built-in templates:
 | `conversation` (default) | Requests, responses, messages, tool calls/results, sessions, conversations, compaction | `agent_did` equality | Push |
 | `agent-config` | Behaviors, tool selections, backends, profiles, tool services, skills | Unscoped | Replicate |
 | `backup` | Same collection set as `conversation` | Unscoped (all docs) | Replicate |
+| `discovery` | Network membership + agent config bootstrap docs | Unscoped | Replicate |
+| `network-control` | Network root, membership, endpoints, join requests | Unscoped | Replicate |
 
-Pass `--template` to `invite` and `join` to select the intent:
+Use `network-control` for signed fleet enrollment and `conversation` for
+application data-plane rows:
 
 ```bash
-AMY_INVITE=$(defra-agent p2p pairings invite --template conversation | jq -r .token)
+AMY_INVITE=$(
+  defra-agent p2p pairings invite \
+    --member-did "$CODING_DID" \
+    --template network-control \
+    | jq -r .token
+)
 defra-agent p2p pairings join --home /tmp/coding "$AMY_INVITE"
-# join reads the template from the token; pass --template to override
+# join reads the template from the token; pass --template only to override
 ```
 
 ## Admin filtered replication
@@ -140,17 +177,21 @@ defra-agent p2p admin replicators add \
 Format: `<Collection>:<field>=<value>`. Parse errors (missing `:` or `=`,
 empty component) are hard failures with a clear message.
 
-## Service discovery — joining a network
+## Service discovery and signed networks
 
-Beyond pairwise pairing, the `p2p network` commands target the replicated
-`PeerRegistry` collection so that joining one member surfaces the whole
-network. Pairing over the `discovery` collection profile replicates
-`PeerRegistry`, and `p2p pairings invite`/`join` mint and verify a member
-**signature** on the invite token (trust-on-first-use for the bootstrap join;
-registry-membership-checked thereafter).
+There are two related network surfaces:
+
+- `p2p network create|grant|revoke` writes the admin-signed
+  `AgentNetwork`/`NetworkMembership` control plane used by v5 invite/join.
+- `p2p network register|list|rm` writes and reads the `PeerRegistry`
+  discovery view: display names, offered templates, heartbeat freshness, and
+  pairing diagnostics.
 
 ```bash
-defra-agent p2p network register --home /tmp/amy --template conversation   # self-register, advertise template
+defra-agent p2p network create --home /tmp/amy --name "Fleet One"
+defra-agent p2p network grant --home /tmp/amy "$CODING_DID"
+
+defra-agent p2p network register --home /tmp/amy --template conversation   # self-register in discovery
 defra-agent p2p network list --home /tmp/coding --output table              # discovered members + liveness + paired/auto-pair
 defra-agent p2p network rm --home /tmp/amy                                  # deregister this node's row
 ```
@@ -162,9 +203,9 @@ the discovery reconciler materialize registry-owned `PeerPairingDesired` rows
 discovered peers and you pair explicitly. Registry-owned rows are retracted
 when their entry stales/removed and never touch operator-authored pairings.
 
-For the narrated walkthrough — the three layers (discovery / replication /
-authorization) and transitive pairing — see [Part 3 of the getting-started
-walkthrough](demo.md#part-3--join-a-network).
+For the narrated walkthrough — the network-control and conversation data-plane
+layers — see [Part 3 of the getting-started
+walkthrough](demo.md#part-3--grow-the-link-into-a-fleet).
 
 ## Remote Codex clients
 

--- a/scripts/demo-p2p-two-node.sh
+++ b/scripts/demo-p2p-two-node.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Run a local two-node defra-agent P2P demo.
+
+The demo starts two isolated runtimes, creates an admin-signed network on Amy,
+grants Coding membership, joins Coding with a v5 network-control invite, adds
+conversation data-plane rows in both directions, waits for reconciled
+replicators, then submits one no-wait request on Coding and verifies the
+AgentRequest document appears on Amy.
+
+Environment:
+  DEFRA_AGENT_BIN                 Path to defra-agent binary. Defaults to
+                                  target/debug/defra-agent, then PATH, then
+                                  cargo build -p defra-agent-cli.
+  DEFRA_AGENT_DEMO_ROOT           Demo state root. Defaults to mktemp under /tmp.
+  DEFRA_AGENT_DEMO_KEEP=1         Keep homes/logs and leave servers running.
+  DEFRA_AGENT_DEMO_INFERENCE_URL  Backend URL used by init.
+                                  Default: http://127.0.0.1:8080/v1
+  DEFRA_AGENT_DEMO_MODEL          Model name used by init. Default: demo-model
+  AMY_HTTP_PORT                   Amy HTTP port. Default: 19391
+  CODING_HTTP_PORT                Coding HTTP port. Default: 19392
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+need curl
+need jq
+
+if [[ -n "${DEFRA_AGENT_BIN:-}" ]]; then
+  BIN="$DEFRA_AGENT_BIN"
+elif [[ -x "target/debug/defra-agent" ]]; then
+  BIN="target/debug/defra-agent"
+elif command -v defra-agent >/dev/null 2>&1; then
+  BIN="$(command -v defra-agent)"
+else
+  echo "building defra-agent CLI..." >&2
+  cargo build -p defra-agent-cli
+  BIN="target/debug/defra-agent"
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  echo "defra-agent binary is not executable: $BIN" >&2
+  exit 1
+fi
+
+ROOT="${DEFRA_AGENT_DEMO_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/defra-agent-p2p-demo.XXXXXX")}"
+KEEP="${DEFRA_AGENT_DEMO_KEEP:-0}"
+MODEL_URL="${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://127.0.0.1:8080/v1}"
+MODEL_NAME="${DEFRA_AGENT_DEMO_MODEL:-demo-model}"
+AMY_HTTP_PORT="${AMY_HTTP_PORT:-19391}"
+CODING_HTTP_PORT="${CODING_HTTP_PORT:-19392}"
+
+AMY_HOME="$ROOT/amy"
+CODING_HOME="$ROOT/coding"
+AMY_WORK="$ROOT/amy-work"
+CODING_WORK="$ROOT/coding-work"
+LOG_DIR="$ROOT/logs"
+AMY_GRAPHQL="http://127.0.0.1:${AMY_HTTP_PORT}/api/v0/graphql"
+CODING_GRAPHQL="http://127.0.0.1:${CODING_HTTP_PORT}/api/v0/graphql"
+
+PIDS=()
+
+cleanup() {
+  if [[ "$KEEP" == "1" ]]; then
+    echo
+    echo "Keeping demo state and running servers:"
+    echo "  $ROOT"
+    echo "Stop servers manually with:"
+    for pid in "${PIDS[@]:-}"; do
+      echo "  kill $pid"
+    done
+    return
+  fi
+
+  for pid in "${PIDS[@]:-}"; do
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill "$pid" >/dev/null 2>&1 || true
+    fi
+  done
+  for pid in "${PIDS[@]:-}"; do
+    wait "$pid" >/dev/null 2>&1 || true
+  done
+  rm -rf "$ROOT"
+}
+trap cleanup EXIT
+
+say() {
+  echo
+  echo "==> $*"
+}
+
+run_json() {
+  "$BIN" "$@"
+}
+
+graphql_escape() {
+  jq -Rn --arg value "$1" '$value' | sed 's/^"//; s/"$//'
+}
+
+post_graphql() {
+  local graphql="$1"
+  local query="$2"
+  local response
+  response="$(jq -n --arg query "$query" '{query: $query}' \
+    | curl -fsS -H 'content-type: application/json' --data-binary @- "$graphql")"
+  if jq -e '.errors? // empty' >/dev/null <<<"$response"; then
+    echo "$response" | jq . >&2
+    return 1
+  fi
+  printf '%s\n' "$response"
+}
+
+wait_http() {
+  local url="$1"
+  local pid="$2"
+  local label="$3"
+  for _ in $(seq 1 300); do
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$pid" >/dev/null 2>&1; then
+      echo "$label exited before becoming ready" >&2
+      return 1
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for $label at $url" >&2
+  return 1
+}
+
+start_server() {
+  local name="$1"
+  local home="$2"
+  local port="$3"
+  local log="$LOG_DIR/${name}.log"
+  if [[ "$KEEP" == "1" ]]; then
+    nohup env \
+      RUST_LOG="warn,defra_agent::agent::p2p_reconcile=debug" \
+      DEFRA_AGENT_REGISTRY_HEARTBEAT_MS=1000 \
+      DEFRA_AGENT_PAIRING_SWEEP_MS=1000 \
+      DEFRA_AGENT_REGISTRY_STALE_MS=300000 \
+      DEFRA_AGENT_ENDPOINT_HEARTBEAT_MS=1000 \
+      "$BIN" server \
+        --home "$home" \
+        --http-port "$port" \
+        --no-codex-shim \
+        --p2p-bind-addr 127.0.0.1 \
+        --p2p-port 0 \
+        --p2p-relay-mode disabled \
+        --p2p-discovery disabled \
+        >"$log" 2>&1 &
+  else
+    env \
+      RUST_LOG="warn,defra_agent::agent::p2p_reconcile=debug" \
+      DEFRA_AGENT_REGISTRY_HEARTBEAT_MS=1000 \
+      DEFRA_AGENT_PAIRING_SWEEP_MS=1000 \
+      DEFRA_AGENT_REGISTRY_STALE_MS=300000 \
+      DEFRA_AGENT_ENDPOINT_HEARTBEAT_MS=1000 \
+      "$BIN" server \
+        --home "$home" \
+        --http-port "$port" \
+        --no-codex-shim \
+        --p2p-bind-addr 127.0.0.1 \
+        --p2p-port 0 \
+        --p2p-relay-mode disabled \
+        --p2p-discovery disabled \
+        >"$log" 2>&1 &
+  fi
+  local pid=$!
+  PIDS+=("$pid")
+  wait_http "http://127.0.0.1:${port}/healthz" "$pid" "$name"
+  echo "  $name ready on http://127.0.0.1:${port} (pid $pid, log $log)"
+}
+
+p2p_status() {
+  local home="$1"
+  run_json p2p status --home "$home"
+}
+
+upsert_data_plane() {
+  local graphql="$1"
+  local peer_id="$2"
+  local local_did="$3"
+  local peer_address="$4"
+  local now
+  local mutation
+  peer_id="$(graphql_escape "$peer_id")"
+  local_did="$(graphql_escape "$local_did")"
+  peer_address="$(graphql_escape "$peer_address")"
+  now="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  now="$(graphql_escape "$now")"
+  mutation=$(cat <<EOF
+mutation {
+  upsert_DataPlanePairingDesired(
+    filter: { peer_id: { _eq: "$peer_id" } },
+    add: {
+      peer_id: "$peer_id",
+      agent_did: "$local_did",
+      collections: [
+        "AgentRequest",
+        "AgentResponse",
+        "AgentMessage",
+        "AgentToolCall",
+        "AgentToolResult",
+        "AgentSession",
+        "AgentConversation",
+        "CompactionEntry"
+      ],
+      replicator_addresses: ["$peer_address"],
+      template: "conversation",
+      created_at: "$now",
+      updated_at: "$now"
+    },
+    update: {
+      agent_did: "$local_did",
+      collections: [
+        "AgentRequest",
+        "AgentResponse",
+        "AgentMessage",
+        "AgentToolCall",
+        "AgentToolResult",
+        "AgentSession",
+        "AgentConversation",
+        "CompactionEntry"
+      ],
+      replicator_addresses: ["$peer_address"],
+      template: "conversation",
+      updated_at: "$now"
+    }
+  ) { _docID }
+}
+EOF
+)
+  post_graphql "$graphql" "$mutation" >/dev/null
+}
+
+wait_replicator() {
+  local graphql="$1"
+  local peer_id="$2"
+  local label="$3"
+  local escaped
+  escaped="$(graphql_escape "$peer_id")"
+  local query
+  query=$(cat <<EOF
+{
+  PeerPairingApplied(filter: { peer_id: { _eq: "$escaped" } }, limit: 1) {
+    peer_id
+    collections
+    replicator_addresses
+    replicator_filter
+  }
+}
+EOF
+)
+  for _ in $(seq 1 240); do
+    local response
+    response="$(post_graphql "$graphql" "$query")"
+    if jq -e '
+      .data.PeerPairingApplied[0] as $row
+      | ($row.replicator_addresses | type == "array" and length > 0)
+      and ($row.replicator_filter | type == "string" and contains("AgentRequest"))
+    ' >/dev/null <<<"$response"; then
+      echo "  $label reconciled"
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "timed out waiting for $label replicator" >&2
+  post_graphql "$graphql" "$query" | jq . >&2 || true
+  return 1
+}
+
+wait_request_on_peer() {
+  local graphql="$1"
+  local request_id="$2"
+  local label="$3"
+  local escaped
+  escaped="$(graphql_escape "$request_id")"
+  local query
+  query=$(cat <<EOF
+{
+  AgentRequest(filter: { request_id: { _eq: "$escaped" } }, limit: 1) {
+    request_id
+    agent_did
+    content
+  }
+}
+EOF
+)
+  for _ in $(seq 1 120); do
+    local response
+    response="$(post_graphql "$graphql" "$query")"
+    if jq -e '.data.AgentRequest | length == 1' >/dev/null <<<"$response"; then
+      echo "  $label saw replicated AgentRequest $request_id"
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "timed out waiting for replicated AgentRequest $request_id on $label" >&2
+  return 1
+}
+
+mkdir -p "$AMY_HOME" "$CODING_HOME" "$AMY_WORK" "$CODING_WORK" "$LOG_DIR"
+
+say "Initializing isolated nodes"
+AMY_INIT="$(run_json init --home "$AMY_HOME" --dangerously-overwrite --agent-name amy --tool-root "$AMY_WORK" --inference-url "$MODEL_URL" --model-name "$MODEL_NAME")"
+CODING_INIT="$(run_json init --home "$CODING_HOME" --dangerously-overwrite --agent-name coding --tool-root "$CODING_WORK" --inference-url "$MODEL_URL" --model-name "$MODEL_NAME")"
+AMY_DID="$(jq -r '.agent_did' <<<"$AMY_INIT")"
+CODING_DID="$(jq -r '.agent_did' <<<"$CODING_INIT")"
+echo "  Amy DID:    $AMY_DID"
+echo "  Coding DID: $CODING_DID"
+
+say "Starting two loopback P2P runtimes"
+start_server "amy" "$AMY_HOME" "$AMY_HTTP_PORT"
+start_server "coding" "$CODING_HOME" "$CODING_HTTP_PORT"
+
+say "Reading live P2P identities"
+AMY_P2P="$(p2p_status "$AMY_HOME")"
+CODING_P2P="$(p2p_status "$CODING_HOME")"
+AMY_PEER="$(jq -r '.p2p_peer_id' <<<"$AMY_P2P")"
+CODING_PEER="$(jq -r '.p2p_peer_id' <<<"$CODING_P2P")"
+AMY_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$AMY_P2P")"
+CODING_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$CODING_P2P")"
+echo "  Amy peer:        $AMY_PEER"
+echo "  Coding peer:     $CODING_PEER"
+echo "  Amy shareable:   $AMY_SHAREABLE"
+echo "  Coding shareable: $CODING_SHAREABLE"
+
+say "Creating the network and granting Coding membership"
+run_json p2p network create --home "$AMY_HOME" --name "Two Node Demo" --output json | jq .
+run_json p2p network grant --home "$AMY_HOME" "$CODING_DID" --output json | jq .
+
+say "Joining Coding to Amy with a signed network-control invite"
+AMY_INVITE="$(run_json p2p pairings invite --home "$AMY_HOME" --member-did "$CODING_DID" --template network-control)"
+TOKEN="$(jq -r '.token' <<<"$AMY_INVITE")"
+run_json p2p pairings join --home "$CODING_HOME" "$TOKEN" | jq .
+
+say "Adding bidirectional conversation data-plane rows"
+upsert_data_plane "$AMY_GRAPHQL" "$CODING_PEER" "$AMY_DID" "$CODING_SHAREABLE"
+upsert_data_plane "$CODING_GRAPHQL" "$AMY_PEER" "$CODING_DID" "$AMY_SHAREABLE"
+
+say "Waiting for reconciled replicators"
+wait_replicator "$CODING_GRAPHQL" "$AMY_PEER" "Coding -> Amy"
+wait_replicator "$AMY_GRAPHQL" "$CODING_PEER" "Amy -> Coding"
+
+say "Reconciled data-plane state"
+echo "  Amy -> Coding: network-control subscribed, conversation replicator installed"
+echo "  Coding -> Amy: network-control subscribed, conversation replicator installed"
+
+say "Proving document replication with one no-wait request"
+REQUEST="$(run_json request submit --graphql "$CODING_GRAPHQL" --agent-did "$CODING_DID" --content "two-node p2p demo ping from Coding" --no-wait)"
+REQUEST_ID="$(jq -r '.request_id' <<<"$REQUEST")"
+echo "  Coding created AgentRequest $REQUEST_ID"
+wait_request_on_peer "$AMY_GRAPHQL" "$REQUEST_ID" "Amy"
+
+say "Demo complete"
+echo "  Root:        $ROOT"
+echo "  Amy home:    $AMY_HOME"
+echo "  Coding home: $CODING_HOME"
+echo "  Logs:        $LOG_DIR"
+echo
+if [[ "$KEEP" == "1" ]]; then
+  echo "Try manually:"
+  echo "  $BIN p2p pairings list --home $AMY_HOME --output table"
+  echo "  $BIN p2p pairings list --home $CODING_HOME --output table"
+  echo "  $BIN request show --graphql $AMY_GRAPHQL $REQUEST_ID --output json | jq .request"
+else
+  echo "Run with DEFRA_AGENT_DEMO_KEEP=1 to keep the runtimes for manual inspection."
+fi


### PR DESCRIPTION
## Summary

Adds a working local two-node P2P demo that brings up two isolated `defra-agent` runtimes, joins them through the current signed `network-control` invite flow, reconciles the conversation data plane, and verifies request replication end-to-end.

## Changes

- Add `scripts/demo-p2p-two-node.sh` and `make demo-p2p-two-node`.
- Document the current v5 P2P flow in `docs/demo.md` and `docs/operations.md`.
- Update CLI help/examples from stale reciprocal-token language to `network-control` invites.
- Tighten the CLI P2P test around v5 invite behavior.
- Make the demo wait for the actual conversation data-plane filter containing `AgentRequest`, then prove replication by submitting a request on one node and observing it on the other.

## Notes

The demo intentionally avoids treating point-in-time `CONNECTED` state as the pass condition. In local loopback/no-relay runs, durable success is proven by reconciled pairings, active replication filters, and replicated `AgentRequest` documents.

## Test Plan

- `cargo fmt --all --check`
- `bash -n scripts/demo-p2p-two-node.sh`
- `git diff --check`
- `cargo test -p defra-agent-cli --test cli_p2p p2p_invite_join_round_trips_pairing_rows -- --nocapture --test-threads=1`
- `DEFRA_AGENT_BIN=target/debug/defra-agent make demo-p2p-two-node`