### PR TITLE
feat(demo): native desktop two-node fleet demo with cross-node delegation + tight tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ help:
 	@echo
 	@echo "Demos:"
 	@echo "  make demo-p2p-two-node     Run the local two-node P2P pairing demo"
+	@echo "  make demo-desktop-two-node Run the local two-node demo in the desktop fleet UI"
 
 .PHONY: build build-cli build-cli-headless build-desktop build-desktop-ui
 build:
@@ -196,6 +197,9 @@ live-desktop-smoke:
 	$(NPM) --prefix $(DESKTOP_DIR) run test:live:operations
 	$(NPM) --prefix $(DESKTOP_DIR) run test:live:interrupt
 
-.PHONY: demo-p2p-two-node
+.PHONY: demo-p2p-two-node demo-desktop-two-node
 demo-p2p-two-node:
 	scripts/demo-p2p-two-node.sh
+
+demo-desktop-two-node:
+	scripts/demo-desktop-two-node.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,20 @@ REPL. Desktop app, fleet bring-up, and P2P pairing:
 
 For the local two-node P2P demo from source, run `make demo-p2p-two-node`.
 It starts Amy + Coding, enrolls Coding through a signed `network-control`
-invite, adds the conversation data plane, and proves request replication.
+invite, adds the conversation data plane, and proves request plus conversation
+replication.
+To see the same two-node substrate through the native fleet UI, run
+`make demo-desktop-two-node`; it launches the Tauri shell with two runtimes —
+**Orchestrator** and **Worker** — in the Fleet Dashboard, each with a tightened
+tool surface (no `defra_query`). Ask the Orchestrator to use its worker subagent
+and it delegates a child request that runs on the **Worker node** over P2P, with
+the result replicating back.
+New chat turns use the configured model backend. For working chat with no
+external model, add `DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1` to start a bundled
+OpenAI-compatible mock (canned replies; it even fires the subagent call).
+Otherwise keep the local `llama-server` above running or launch with a hosted
+preset and model, e.g.
+`DEFRA_AGENT_DEMO_BACKEND_PRESET=openai DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini`.
 
 ## Why this exists
 

--- a/apps/desktop-tauri/README.md
+++ b/apps/desktop-tauri/README.md
@@ -81,6 +81,38 @@ The saved deployment stores both GraphQL and P2P connection metadata. The app
 finishes replication bootstrap after launch; chat views should wait for the
 status bar to report `replication: subscriptions armed`.
 
+For isolated demo or QA runs, set `DEFRA_AGENT_DESKTOP_HOME` before launching
+the Tauri app. The bootstrap summary, peer directory, embedded desktop node,
+and logs all resolve under that directory:
+
+```bash
+DEFRA_AGENT_DESKTOP_HOME=/tmp/defra-agent-desktop-demo/desktop npm run tauri -- dev
+```
+
+From the repo root, `make demo-desktop-two-node` starts two runtimes,
+**Orchestrator** and **Worker**, tightens their tool surface (drops
+`defra_query`), and lets the Orchestrator delegate to the Worker on node B via a
+cross-node subagent (the child runs on the Worker and its result replicates
+back). It seeds that isolated desktop home and opens the Fleet Dashboard demo.
+Live chat uses the model backend configured during runtime init, and it must be
+reachable on **both** nodes since the Worker now executes the delegated child.
+For working chat with no external model, start the bundled OpenAI-compatible
+mock — it also fires the cross-node delegation (canned replies):
+
+```bash
+DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1 make demo-desktop-two-node
+```
+
+Otherwise keep `llama-server` running on `http://127.0.0.1:8080/v1`, or use a
+hosted preset:
+
+```bash
+DEFRA_AGENT_DEMO_BACKEND_PRESET=openai \
+DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini \
+OPENAI_API_KEY=... \
+  make demo-desktop-two-node
+```
+
 ## Tests
 
 The deterministic desktop UI gate is layered so failures point at the right

--- a/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/bootstrap.rs
@@ -564,15 +564,32 @@ pub(super) fn branchable_pair_sync_enabled() -> bool {
 }
 
 pub(super) fn p2p_pairing_enabled_for_graphql(graphql: &str) -> bool {
-    graphql_endpoint_is_loopback_or_unspecified(graphql) || env_flag_enabled(REMOTE_P2P_PAIRING_ENV)
+    let env_value = std::env::var(REMOTE_P2P_PAIRING_ENV).ok();
+    p2p_pairing_enabled_for_graphql_with_env(graphql, env_value.as_deref())
+}
+
+fn p2p_pairing_enabled_for_graphql_with_env(graphql: &str, env_value: Option<&str>) -> bool {
+    if let Some(enabled) = env_flag_value(env_value) {
+        return enabled;
+    }
+
+    graphql_endpoint_is_loopback_or_unspecified(graphql)
 }
 
 fn env_flag_enabled(name: &str) -> bool {
     let Ok(value) = std::env::var(name) else {
         return false;
     };
+    env_flag_value(Some(&value)).unwrap_or(false)
+}
+
+fn env_flag_value(value: Option<&str>) -> Option<bool> {
+    let value = value?;
     let value = value.trim().to_ascii_lowercase();
-    matches!(value.as_str(), "1" | "true" | "yes" | "on")
+    if value.is_empty() {
+        return None;
+    }
+    Some(matches!(value.as_str(), "1" | "true" | "yes" | "on"))
 }
 
 pub(super) async fn is_connected_peer(p2p: &Arc<dyn P2POps>, peer_id: &str) -> Result<bool> {
@@ -621,4 +638,41 @@ fn graphql_endpoint_is_loopback_or_unspecified(graphql: &str) -> bool {
     host.parse::<std::net::IpAddr>()
         .map(|addr| addr.is_loopback() || addr.is_unspecified())
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_graphql_pairs_by_default() {
+        assert!(p2p_pairing_enabled_for_graphql_with_env(
+            "http://127.0.0.1:9191/api/v0/graphql",
+            None
+        ));
+    }
+
+    #[test]
+    fn explicit_pairing_env_false_disables_loopback_pairing() {
+        assert!(!p2p_pairing_enabled_for_graphql_with_env(
+            "http://127.0.0.1:9191/api/v0/graphql",
+            Some("0")
+        ));
+        assert!(!p2p_pairing_enabled_for_graphql_with_env(
+            "http://localhost:9191/api/v0/graphql",
+            Some("false")
+        ));
+    }
+
+    #[test]
+    fn explicit_pairing_env_true_enables_remote_pairing() {
+        assert!(p2p_pairing_enabled_for_graphql_with_env(
+            "http://agent-host:9191/api/v0/graphql",
+            Some("1")
+        ));
+        assert!(p2p_pairing_enabled_for_graphql_with_env(
+            "http://agent-host:9191/api/v0/graphql",
+            Some("yes")
+        ));
+    }
 }

--- a/crates/defra-agent-desktop-core/src/client/paths.rs
+++ b/crates/defra-agent-desktop-core/src/client/paths.rs
@@ -1,6 +1,9 @@
+use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Result};
+
+pub const DESKTOP_HOME_ENV: &str = "DEFRA_AGENT_DESKTOP_HOME";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DesktopPaths {
@@ -14,6 +17,14 @@ pub struct DesktopPaths {
 
 impl DesktopPaths {
     pub fn discover() -> Result<Self> {
+        Self::discover_with_env(std::env::var_os(DESKTOP_HOME_ENV))
+    }
+
+    fn discover_with_env(env_root: Option<OsString>) -> Result<Self> {
+        if let Some(root) = env_root.filter(|value| !value.is_empty()) {
+            return Ok(Self::from_root(root));
+        }
+
         let root = dirs::data_local_dir()
             .ok_or_else(|| anyhow!("unable to resolve a local application data directory"))?
             .join("defra-agent")
@@ -67,5 +78,24 @@ impl DesktopPaths {
 
     pub fn iroh_secret_key_path(&self) -> &Path {
         &self.iroh_secret_key_path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_uses_desktop_home_env_when_set() {
+        let tempdir = tempfile::tempdir().expect("tempdir");
+
+        let paths = DesktopPaths::discover_with_env(Some(tempdir.path().as_os_str().to_owned()))
+            .expect("paths");
+
+        assert_eq!(paths.root(), tempdir.path());
+        assert_eq!(
+            paths.peer_directory_path(),
+            tempdir.path().join("peers.json")
+        );
     }
 }

--- a/crates/defra-agent-desktop/src/main.rs
+++ b/crates/defra-agent-desktop/src/main.rs
@@ -228,6 +228,8 @@ fn init_tracing() {
         .with(env_filter)
         .with(
             tracing_subscriber::fmt::layer()
+                // Diagnostics go to stderr so stdout stays clean for `init --json`.
+                .with_writer(std::io::stderr)
                 .with_target(false)
                 .compact()
                 .without_time(),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,6 +38,17 @@ to render in the UI.
 If you isolated the agent home, pass the same path as
 `--agent-home /some/path` to `defra-agent-desktop init`.
 
+For an isolated desktop data directory — useful for demos and QA runs — set
+`DEFRA_AGENT_DESKTOP_HOME` before launching the Tauri app:
+
+```bash
+DEFRA_AGENT_DESKTOP_HOME=/tmp/defra-agent-desktop-demo/desktop \
+  npm --prefix apps/desktop-tauri run tauri -- dev
+```
+
+The launcher, bootstrap summary, logs, peer directory, and embedded desktop
+node all use that directory when the variable is set.
+
 ## P2P defaults and pinning
 
 The standard server path always starts the IROH P2P transport for local
@@ -60,6 +71,69 @@ For the scripted local version, run:
 
 ```bash
 make demo-p2p-two-node
+```
+
+To run the same two-node substrate and open it in the native desktop fleet UI:
+
+```bash
+make demo-desktop-two-node
+```
+
+For working chat with **no external model**, start the bundled mock backend.
+It is a real, zero-dependency OpenAI-compatible server (canned replies) that
+exercises the full request → runtime → response → replication path:
+
+```bash
+DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1 make demo-desktop-two-node
+```
+
+The default desktop demo otherwise expects a local OpenAI-compatible inference
+server at `http://127.0.0.1:8080/v1`, matching the getting-started
+`llama-server` command:
+
+```bash
+llama-server -hf google/gemma-4-12B-it-qat-q4_0-gguf
+```
+
+For hosted inference, select a preset and a provider model before launching:
+
+```bash
+DEFRA_AGENT_DEMO_BACKEND_PRESET=openai \
+DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini \
+OPENAI_API_KEY=... \
+  make demo-desktop-two-node
+```
+
+That command:
+
+- starts two runtimes, **Orchestrator** and **Worker**, through the two-node
+  P2P script;
+- tightens each agent's tool surface — drops the `defra_query` tool — and
+  enables the Orchestrator to delegate to the **Worker on node B** via a
+  cross-node subagent (it prints the resolved surface via
+  `defra-agent tools explain`);
+- seeds an isolated desktop peer directory with both runtimes;
+- launches the Tauri dev app with `DEFRA_AGENT_DESKTOP_HOME` pointed at the
+  demo desktop home.
+
+In the app, open **Fleet Dashboard** to see both deployments. Open Chat for the
+**Orchestrator** and ask it to use its worker subagent: it calls
+`spawn_subagent` (background await), the runtime materializes a child request
+**on the Worker node** (`agent_did` = the Worker), the Worker runs it, and its
+result replicates back to the Orchestrator over P2P. Open the Worker's Chat to
+watch the delegated child run there. Cross-node delegation uses background await
+(foreground remote spawns are rejected) and is enabled for the trusted local
+loopback fleet via `subagent_allow_cross_deployment` on both runtimes. Set
+`DEFRA_AGENT_DESKTOP_DEMO_LAUNCH=0` to prepare
+the demo without launching the app, or `DEFRA_AGENT_DESKTOP_DEMO_KEEP=1` to keep
+runtimes and data after exit. By default the launcher refuses to open the GUI if
+the local model backend is unreachable; set
+`DEFRA_AGENT_DESKTOP_DEMO_ALLOW_UNAVAILABLE_BACKEND=1` only when you want to
+inspect the seeded fleet UI without sending live chat turns:
+
+```bash
+DEFRA_AGENT_DESKTOP_DEMO_ALLOW_UNAVAILABLE_BACKEND=1 \
+  make demo-desktop-two-node
 ```
 
 To bring up two runtimes manually and enroll Coding into Amy's signed network:

--- a/scripts/demo-desktop-two-node.sh
+++ b/scripts/demo-desktop-two-node.sh
@@ -1,0 +1,572 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Run the local two-node P2P demo and launch the desktop fleet UI on top.
+
+The demo reuses scripts/demo-p2p-two-node.sh as two runtimes named Orchestrator
+and Worker, tightens their tool surface (drops defra_query) and lets the
+Orchestrator delegate to the Worker on node B via a cross-node 'worker'
+subagent, then launches the Tauri dev app. The Fleet Dashboard shows both
+runtimes; ask the Orchestrator to use its worker subagent and watch the child
+request run on the Worker node and its result replicate back.
+
+Environment:
+  DEFRA_AGENT_BIN                    Path to defra-agent. Default:
+                                     target/debug/defra-agent.
+  DEFRA_AGENT_DESKTOP_BIN            Path to defra-agent-desktop. Default:
+                                     target/debug/defra-agent-desktop.
+  DEFRA_AGENT_DESKTOP_DEMO_ROOT      Demo state root. Defaults to mktemp.
+  DEFRA_AGENT_DESKTOP_DEMO_KEEP=1    Keep homes/logs/runtimes after exit.
+  DEFRA_AGENT_DESKTOP_DEMO_LAUNCH=0  Seed the demo but do not launch Tauri.
+                                     Keeps state by default unless KEEP=0 is
+                                     explicitly set.
+  DEFRA_AGENT_DESKTOP_DEMO_ALLOW_UNAVAILABLE_BACKEND=1
+                                     Launch even when the configured model
+                                     backend cannot be checked locally.
+  DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1
+                                     Start a bundled zero-dependency mock
+                                     OpenAI-compatible backend so chat works
+                                     end-to-end with no external model. Canned
+                                     replies; overrides any backend preset.
+  DEFRA_AGENT_DEMO_BACKEND_PRESET    Passed through to the two-node demo.
+                                     Use openai with OPENAI_API_KEY for hosted chat.
+  DEFRA_AGENT_DEMO_INFERENCE_URL     Passed through to the two-node demo.
+  DEFRA_AGENT_DEMO_MODEL             Passed through to the two-node demo.
+  DEFRA_AGENT_DEMO_API_KEY_ENV_VAR   Passed through to the two-node demo.
+  AGENT_A_HTTP_PORT                  Orchestrator HTTP port. Default: 19791.
+  AGENT_B_HTTP_PORT                  Worker HTTP port. Default: 19792.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+STEP=0
+say() {
+  STEP=$((STEP + 1))
+  echo
+  echo "==> [step $STEP] $*"
+}
+
+truthy() {
+  case "${1:-}" in
+    1 | true | TRUE | yes | YES | on | ON) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+need jq
+need curl
+
+ROOT="${DEFRA_AGENT_DESKTOP_DEMO_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/defra-agent-desktop-demo.XXXXXX")}"
+KEEP_WAS_SET="${DEFRA_AGENT_DESKTOP_DEMO_KEEP+x}"
+KEEP="${DEFRA_AGENT_DESKTOP_DEMO_KEEP:-0}"
+LAUNCH="${DEFRA_AGENT_DESKTOP_DEMO_LAUNCH:-1}"
+P2P_ROOT="$ROOT/p2p"
+DESKTOP_HOME="$ROOT/desktop"
+STATE_FILE="$P2P_ROOT/demo-state.json"
+PID_FILE="$P2P_ROOT/demo-pids.txt"
+AGENT_A_HTTP_PORT="${AGENT_A_HTTP_PORT:-${AMY_HTTP_PORT:-19791}}"
+AGENT_B_HTTP_PORT="${AGENT_B_HTTP_PORT:-${CODING_HTTP_PORT:-19792}}"
+DESKTOP_BIN="${DEFRA_AGENT_DESKTOP_BIN:-target/debug/defra-agent-desktop}"
+AGENT_BIN="${DEFRA_AGENT_BIN:-target/debug/defra-agent}"
+MODEL_URL="${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://127.0.0.1:8080/v1}"
+DEFAULT_LOCAL_MODEL_NAME="google/gemma-4-12B-it-qat-q4_0-gguf"
+MODEL_NAME="${DEFRA_AGENT_DEMO_MODEL:-}"
+BACKEND_PRESET="${DEFRA_AGENT_DEMO_BACKEND_PRESET:-}"
+ALLOW_UNAVAILABLE_BACKEND="${DEFRA_AGENT_DESKTOP_DEMO_ALLOW_UNAVAILABLE_BACKEND:-0}"
+MOCK_BACKEND="${DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND:-0}"
+MOCK_PID=""
+if [[ -z "$BACKEND_PRESET" && -z "$MODEL_NAME" ]]; then
+  MODEL_NAME="$DEFAULT_LOCAL_MODEL_NAME"
+fi
+
+if [[ -z "$ROOT" || "$ROOT" == "/" || "$ROOT" == "$HOME" ]]; then
+  echo "refusing unsafe demo root: $ROOT" >&2
+  exit 1
+fi
+
+should_keep_demo() {
+  if [[ "$KEEP" == "1" ]]; then
+    return 0
+  fi
+  if [[ -z "$KEEP_WAS_SET" ]] && ! truthy "$LAUNCH"; then
+    return 0
+  fi
+  return 1
+}
+
+stop_pid() {
+  local pid="$1"
+  [[ -n "$pid" ]] || return 0
+  kill -0 "$pid" >/dev/null 2>&1 || return 0
+  kill "$pid" >/dev/null 2>&1 || true
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$pid" >/dev/null 2>&1 || return 0
+    sleep 0.2
+  done
+  kill -9 "$pid" >/dev/null 2>&1 || true
+}
+
+stop_runtimes() {
+  local pid_source=""
+  if [[ -f "$STATE_FILE" ]]; then
+    pid_source="$STATE_FILE"
+    while read -r pid; do
+      stop_pid "$pid"
+    done < <(jq -r '.pids[]?' "$STATE_FILE")
+  elif [[ -f "$PID_FILE" ]]; then
+    pid_source="$PID_FILE"
+    while read -r pid; do
+      stop_pid "$pid"
+    done <"$PID_FILE"
+  fi
+  if [[ -n "$pid_source" ]]; then
+    echo "  Stopped P2P runtimes recorded in $pid_source"
+  fi
+}
+
+cleanup() {
+  # Teardown is best-effort; don't let a failing kill re-enter the traps or
+  # let set -e abort partway through.
+  trap - EXIT INT TERM ERR
+  set +e
+  # Only preserve state if we actually seeded a demo; an early failure (e.g. a
+  # busy port) leaves nothing worth keeping.
+  if should_keep_demo && [[ -f "$STATE_FILE" ]]; then
+    echo
+    echo "Keeping desktop demo state:"
+    echo "  $ROOT"
+    echo "Stop P2P runtimes manually with:"
+    jq -r '.pids[]? | "  kill \(.)"' "$STATE_FILE"
+    [[ -n "${MOCK_PID:-}" ]] && echo "  kill ${MOCK_PID}  # bundled mock inference backend"
+    return
+  fi
+
+  echo
+  echo "Cleaning up desktop demo"
+  [[ -n "${MOCK_PID:-}" ]] && stop_pid "$MOCK_PID"
+  stop_runtimes
+  rm -rf "$ROOT"
+  echo "  Removed $ROOT"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'status=$?; echo "demo-desktop-two-node failed (exit $status); see logs under $P2P_ROOT/logs if present" >&2' ERR
+
+print_live_chat_backend_note() {
+  local endpoint
+  endpoint="$(effective_backend_url)"
+  local model_label="${MODEL_NAME:-"(preset default)"}"
+
+  echo
+  if [[ -n "$BACKEND_PRESET" ]]; then
+    echo "Live chat backend: preset=$BACKEND_PRESET endpoint=$endpoint model=$model_label"
+    local key_var
+    key_var="$(backend_api_key_env_var)"
+    if [[ -n "$key_var" && -z "${!key_var:-}" ]]; then
+      echo "  $key_var is not set, so live chat will fail until you export it."
+    fi
+    return
+  fi
+
+  echo "Live chat backend: endpoint=$endpoint model=$model_label"
+  if is_local_backend_url "$endpoint"; then
+    if curl -fsS --max-time 2 "$endpoint/models" >/dev/null 2>&1; then
+      echo "  Local inference endpoint is reachable."
+    else
+      echo "  Local inference endpoint is not reachable."
+      echo "  Start it before sending chat messages:"
+      echo "    llama-server -hf $MODEL_NAME"
+      echo "  Or rerun with hosted inference:"
+      echo "    DEFRA_AGENT_DEMO_BACKEND_PRESET=openai DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini OPENAI_API_KEY=... make demo-desktop-two-node"
+    fi
+  fi
+}
+
+effective_backend_url() {
+  case "$BACKEND_PRESET" in
+    openai)
+      echo "${DEFRA_AGENT_DEMO_INFERENCE_URL:-https://api.openai.com/v1}"
+      ;;
+    openrouter)
+      echo "${DEFRA_AGENT_DEMO_INFERENCE_URL:-https://openrouter.ai/api/v1}"
+      ;;
+    ollama)
+      echo "${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://localhost:11434/v1}"
+      ;;
+    vllm)
+      echo "${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://127.0.0.1:8000/v1}"
+      ;;
+    llama-cpp)
+      echo "${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://127.0.0.1:8080/v1}"
+      ;;
+    *)
+      echo "$MODEL_URL"
+      ;;
+  esac
+}
+
+backend_api_key_env_var() {
+  if [[ -n "${DEFRA_AGENT_DEMO_API_KEY_ENV_VAR:-}" ]]; then
+    echo "$DEFRA_AGENT_DEMO_API_KEY_ENV_VAR"
+    return
+  fi
+  case "$BACKEND_PRESET" in
+    openai)
+      echo "OPENAI_API_KEY"
+      ;;
+    openrouter)
+      echo "OPENROUTER_API_KEY"
+      ;;
+  esac
+}
+
+backend_requires_explicit_model() {
+  case "$BACKEND_PRESET" in
+    generic-openai-compatible | openai | openrouter | vllm) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_local_backend_url() {
+  case "$1" in
+    http://127.0.0.1:* | http://localhost:*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+ensure_live_chat_backend_ready() {
+  if ! truthy "$LAUNCH" || truthy "$ALLOW_UNAVAILABLE_BACKEND"; then
+    return
+  fi
+
+  if backend_requires_explicit_model && [[ -z "$MODEL_NAME" ]]; then
+    cat >&2 <<EOF
+The desktop demo is configured with backend preset '$BACKEND_PRESET', but no model was set.
+
+Set DEFRA_AGENT_DEMO_MODEL to a model supported by that provider, for example:
+  DEFRA_AGENT_DEMO_BACKEND_PRESET=openai \\
+  DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini \\
+  OPENAI_API_KEY=... \\
+    make demo-desktop-two-node
+EOF
+    exit 1
+  fi
+
+  if [[ "$BACKEND_PRESET" == "chatgpt-codex" ]]; then
+    cat >&2 <<EOF
+The desktop demo is configured with backend preset 'chatgpt-codex'.
+
+That backend needs a DefraDB OAuthCredential document for each runtime before
+live chat can work. Prepare the demo without launching, then run codex-login for
+the printed Amy/Coding homes and agent DIDs:
+
+  DEFRA_AGENT_DEMO_BACKEND_PRESET=chatgpt-codex \\
+  DEFRA_AGENT_DESKTOP_DEMO_LAUNCH=0 \\
+  DEFRA_AGENT_DESKTOP_DEMO_KEEP=1 \\
+    make demo-desktop-two-node
+
+For a one-command hosted demo, use OpenAI API auth instead:
+  DEFRA_AGENT_DEMO_BACKEND_PRESET=openai \\
+  DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini \\
+  OPENAI_API_KEY=... \\
+    make demo-desktop-two-node
+EOF
+    exit 1
+  fi
+
+  local key_var
+  key_var="$(backend_api_key_env_var)"
+  if [[ -n "$key_var" && -z "${!key_var:-}" ]]; then
+    cat >&2 <<EOF
+The desktop demo is configured with backend preset '$BACKEND_PRESET', but $key_var is not set.
+
+Export the key before launching:
+  export $key_var=...
+EOF
+    exit 1
+  fi
+
+  local endpoint
+  endpoint="$(effective_backend_url)"
+  if is_local_backend_url "$endpoint" && ! curl -fsS --max-time 2 "$endpoint/models" >/dev/null 2>&1; then
+    cat >&2 <<EOF
+The desktop demo is configured to use $endpoint, but that local inference server is not reachable.
+
+Start local inference first:
+  llama-server -hf $DEFAULT_LOCAL_MODEL_NAME
+
+Or run the demo with hosted inference:
+  DEFRA_AGENT_DEMO_BACKEND_PRESET=openai \\
+  DEFRA_AGENT_DEMO_MODEL=gpt-4.1-mini \\
+  OPENAI_API_KEY=... \\
+    make demo-desktop-two-node
+
+To inspect the seeded fleet UI without sending live chat, set:
+  DEFRA_AGENT_DESKTOP_DEMO_ALLOW_UNAVAILABLE_BACKEND=1
+EOF
+    exit 1
+  fi
+}
+
+port_in_use() {
+  # Connect to a loopback listener using bash's /dev/tcp; success means busy.
+  local port="$1"
+  (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null
+}
+
+ensure_ports_available() {
+  if [[ "$AGENT_A_HTTP_PORT" == "$AGENT_B_HTTP_PORT" ]]; then
+    echo "AGENT_A_HTTP_PORT and AGENT_B_HTTP_PORT must differ (both are $AGENT_A_HTTP_PORT)" >&2
+    exit 1
+  fi
+  local conflict=0 entry name port
+  for entry in "orchestrator:${AGENT_A_HTTP_PORT}" "worker:${AGENT_B_HTTP_PORT}"; do
+    name="${entry%%:*}"
+    port="${entry##*:}"
+    if port_in_use "$port"; then
+      echo "HTTP port $port (for $name) is already in use" >&2
+      conflict=1
+    fi
+  done
+  if [[ "$conflict" == "1" ]]; then
+    cat >&2 <<EOF
+Refusing to start: a demo HTTP port is busy (a previous demo may still be running).
+Free the port, or choose different ports:
+  AGENT_A_HTTP_PORT=<free> AGENT_B_HTTP_PORT=<free> make demo-desktop-two-node
+Inspect a listener with:
+  lsof -nP -iTCP:<port> -sTCP:LISTEN
+EOF
+    exit 1
+  fi
+}
+
+maybe_start_mock_backend() {
+  truthy "$MOCK_BACKEND" || return 0
+  need python3
+  local mock_model="${DEFRA_AGENT_DEMO_MODEL:-mock-model}"
+  local mock_log="$ROOT/mock-inference.log"
+  mkdir -p "$ROOT"
+  say "Starting bundled mock inference backend"
+  python3 scripts/demo-mock-inference.py --port 0 --model "$mock_model" \
+    >"$mock_log" 2>&1 &
+  MOCK_PID=$!
+  local port=""
+  for _ in $(seq 1 50); do
+    port="$(sed -n 's/.*port=\([0-9]*\).*/\1/p' "$mock_log" 2>/dev/null | head -1)"
+    [[ -n "$port" ]] && break
+    if ! kill -0 "$MOCK_PID" >/dev/null 2>&1; then
+      echo "mock inference backend exited before binding a port:" >&2
+      cat "$mock_log" >&2
+      exit 1
+    fi
+    sleep 0.1
+  done
+  if [[ -z "$port" ]]; then
+    echo "mock inference backend did not report a listening port" >&2
+    exit 1
+  fi
+  # Make the mock authoritative over any preset/hosted configuration.
+  MODEL_URL="http://127.0.0.1:${port}/v1"
+  MODEL_NAME="$mock_model"
+  BACKEND_PRESET=""
+  unset DEFRA_AGENT_DEMO_BACKEND_PRESET DEFRA_AGENT_DEMO_API_KEY_ENV_VAR
+  export DEFRA_AGENT_DEMO_INFERENCE_URL="$MODEL_URL"
+  export DEFRA_AGENT_DEMO_MODEL="$mock_model"
+  # The runtime must use the chat-completions route the mock serves.
+  export DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS=1
+  echo "  Mock backend ready: $MODEL_URL (model $mock_model, pid $MOCK_PID)"
+  echo "  Replies are canned; attach OpenAI or llama-server for real responses."
+}
+
+# Fail fast on configuration before doing any slow work (build, node bring-up).
+maybe_start_mock_backend
+ensure_live_chat_backend_ready
+say "Checking demo HTTP ports are free"
+ensure_ports_available
+echo "  Orchestrator port: $AGENT_A_HTTP_PORT free"
+echo "  Worker port:         $AGENT_B_HTTP_PORT free"
+
+if [[ ! -x "$DESKTOP_BIN" ]]; then
+  say "Building defra-agent-desktop launcher"
+  cargo build -p defra-agent-desktop
+fi
+
+say "Starting the two-node P2P substrate (orchestrator + worker, ~30-60s)"
+# Capture the substrate's verbose runbook output to a log; surface it only on
+# failure so the desktop demo's own output stays focused.
+if DEFRA_AGENT_BIN="$AGENT_BIN" \
+   DEFRA_AGENT_DEMO_KEEP=1 \
+   DEFRA_AGENT_DEMO_ROOT="$P2P_ROOT" \
+   DEFRA_AGENT_DEMO_AGENT_A_NAME=orchestrator \
+   DEFRA_AGENT_DEMO_AGENT_B_NAME=worker \
+   AGENT_A_HTTP_PORT="$AGENT_A_HTTP_PORT" \
+   AGENT_B_HTTP_PORT="$AGENT_B_HTTP_PORT" \
+     scripts/demo-p2p-two-node.sh >"$ROOT/substrate.log" 2>&1; then
+  echo "  Substrate up: orchestrator + worker paired, conversation data-plane replicating"
+else
+  echo "two-node substrate failed; tail of $ROOT/substrate.log:" >&2
+  tail -n 30 "$ROOT/substrate.log" >&2
+  exit 1
+fi
+
+if [[ ! -f "$STATE_FILE" ]]; then
+  echo "two-node demo did not write state file: $STATE_FILE" >&2
+  exit 1
+fi
+
+# node_a = orchestrator (delegates work over P2P),
+# node_b = worker (runs the delegated cross-node subagent child).
+ORCH_GRAPHQL="$(jq -r '.node_a.graphql' "$STATE_FILE")"
+ORCH_DID="$(jq -r '.node_a.agent_did' "$STATE_FILE")"
+WORKER_GRAPHQL="$(jq -r '.node_b.graphql' "$STATE_FILE")"
+WORKER_DID="$(jq -r '.node_b.agent_did' "$STATE_FILE")"
+REQUEST_ID="$(jq -r '.request.id' "$STATE_FILE")"
+REQUEST_SESSION_ID="$(jq -r '.request.session_id' "$STATE_FILE")"
+
+say "Seeding isolated desktop fleet state"
+# Capture --json stdout to a file, then pretty-print non-fatally: a cosmetic jq
+# display must never abort the demo (only a failing init should).
+seed_summary() {
+  local file="$1"
+  jq '{label, agent_did, graphql, peer_directory}' "$file" 2>/dev/null \
+    || { echo "  (raw init summary)"; cat "$file"; }
+}
+
+"$DESKTOP_BIN" init \
+  --desktop-home "$DESKTOP_HOME" \
+  --status-endpoint "$ORCH_GRAPHQL" \
+  --label "Orchestrator" \
+  --dangerously-overwrite \
+  --json >"$ROOT/desktop-init-orchestrator.json"
+seed_summary "$ROOT/desktop-init-orchestrator.json"
+
+"$DESKTOP_BIN" init \
+  --desktop-home "$DESKTOP_HOME" \
+  --status-endpoint "$WORKER_GRAPHQL" \
+  --label "Worker" \
+  --json >"$ROOT/desktop-init-worker.json"
+seed_summary "$ROOT/desktop-init-worker.json"
+
+say "Tightening tool surface + enabling cross-node delegation"
+# config tools set updates the ToolSelection document; the runtime must then
+# reconcile before new chat turns see the updated surface.
+gql() { curl -gfsS -H 'content-type: application/json' --data-binary "$(jq -n --arg q "$1" '{query:$q}')" "$2"; }
+runtime_generation() { gql '{ AgentRuntime { active_generation } }' "$1" | jq -r '.data.AgentRuntime[0].active_generation // 0'; }
+wait_reconcile() {
+  local ep="$1" prev="$2" label="$3" row gen phase
+  for _ in $(seq 1 80); do
+    row="$(gql '{ AgentRuntime { active_generation reconcile_phase } }' "$ep" | jq -c '.data.AgentRuntime[0] // {}')"
+    gen="$(jq -r '.active_generation // 0' <<<"$row")"
+    phase="$(jq -r '.reconcile_phase // ""' <<<"$row")"
+    if [[ "$gen" -gt "$prev" && "$phase" == "idle" ]]; then
+      echo "  $label reconciled (generation $gen)"
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "  warning: $label reconcile not confirmed; continuing" >&2
+}
+
+# Worker (node B, the delegate): drop defra_query and accept cross-deployment
+# spawns from the paired orchestrator (the receiver-side gate, #377).
+WORKER_GEN="$(runtime_generation "$WORKER_GRAPHQL")"
+"$AGENT_BIN" config tools set --graphql "$WORKER_GRAPHQL" --agent-did "$WORKER_DID" \
+  --selection-id "$WORKER_DID:default-tools" \
+  --enable-defra-query false \
+  --subagent-allow-cross-deployment true >/dev/null \
+  && echo "  worker: defra_query disabled, cross-deployment spawns accepted"
+wait_reconcile "$WORKER_GRAPHQL" "$WORKER_GEN" "worker"
+
+# Orchestrator (node A): drop defra_query and delegate to the worker on node B.
+# Cross-node delegation requires background await (foreground remote spawns are
+# rejected), so background must be enabled and the target points at the worker DID.
+ORCH_GEN="$(runtime_generation "$ORCH_GRAPHQL")"
+"$AGENT_BIN" config tools set --graphql "$ORCH_GRAPHQL" --agent-did "$ORCH_DID" \
+  --selection-id "$ORCH_DID:default-tools" \
+  --enable-defra-query false \
+  --subagent-spawn-enabled true \
+  --subagent-background-enabled true \
+  --subagent-allow-cross-deployment true \
+  --subagent-target "{\"name\":\"worker\",\"agent_did\":\"$WORKER_DID\",\"behavior_id\":\"$WORKER_DID:default\",\"description\":\"Remote worker subagent on the worker node\"}" \
+  >/dev/null \
+  && echo "  orchestrator: defra_query disabled, cross-node spawn_subagent -> worker enabled"
+wait_reconcile "$ORCH_GRAPHQL" "$ORCH_GEN" "orchestrator"
+
+echo
+echo "Resolved model-callable tool surface (defra-agent tools explain):"
+printf '  orchestrator: '
+"$AGENT_BIN" tools explain --graphql "$ORCH_GRAPHQL" --agent-did "$ORCH_DID" 2>/dev/null \
+  | jq -r '.behaviors[0].surface.tool_names | join(", ")' 2>/dev/null || echo "(unavailable)"
+printf '  worker:       '
+"$AGENT_BIN" tools explain --graphql "$WORKER_GRAPHQL" --agent-did "$WORKER_DID" 2>/dev/null \
+  | jq -r '.behaviors[0].surface.tool_names | join(", ")' 2>/dev/null || echo "(unavailable)"
+
+# Pre-seed a delegation conversation so the Fleet UI has one to inspect. Best
+# effort: it only completes once a tool-calling backend is reachable (the
+# bundled mock fires spawn_subagent in background mode; a real model decides on
+# its own — see the suggested prompts below).
+SUBAGENT_SEED="$("$AGENT_BIN" request submit --graphql "$ORCH_GRAPHQL" --agent-did "$ORCH_DID" \
+  --content "Delegate to the worker subagent: ask it to describe the worker node, then summarize its reply." --no-wait 2>/dev/null || true)"
+SUBAGENT_SESSION_ID="$(jq -r '.session_id // empty' <<<"$SUBAGENT_SEED" 2>/dev/null)"
+
+say "Desktop demo ready"
+echo "  Root:               $ROOT"
+echo "  Desktop home:       $DESKTOP_HOME"
+echo "  Peer file:          $DESKTOP_HOME/peers.json"
+echo "  Orchestrator GraphQL: $ORCH_GRAPHQL"
+echo "  Worker GraphQL:       $WORKER_GRAPHQL"
+echo "  Seed request:       $REQUEST_ID (session $REQUEST_SESSION_ID)"
+[[ -n "$SUBAGENT_SESSION_ID" ]] && echo "  Delegation session: $SUBAGENT_SESSION_ID (orchestrator -> worker on node B)"
+print_live_chat_backend_note
+echo
+echo "Suggested prompts for the Orchestrator (crafted to elicit cross-node delegation):"
+echo "  - Delegate to the worker subagent: ask it to summarize what a worker node does, then report back."
+echo "  - Use your worker subagent to draft a one-line status, then return it to me."
+echo
+echo "Manual checks:"
+echo "  jq . $DESKTOP_HOME/peers.json"
+echo "  $AGENT_BIN tools explain --graphql $ORCH_GRAPHQL --agent-did $ORCH_DID | jq .behaviors[0].surface"
+echo "  $AGENT_BIN request show --graphql $ORCH_GRAPHQL $REQUEST_ID --output json | jq .request"
+echo
+echo "In the app:"
+echo "  1. Open Fleet Dashboard and confirm Orchestrator + Worker are listed."
+echo "  2. Open Chat for the Orchestrator and use a suggested prompt above; watch the"
+echo "     spawn_subagent tool call delegate to the worker."
+echo "  3. Open Chat for the Worker (node B) to see the child request run there and"
+echo "     its result replicate back to the Orchestrator over P2P."
+echo "  4. For live responses, make sure the chat backend above is reachable on BOTH"
+echo "     nodes (the worker now executes the delegated child)."
+
+if ! truthy "$LAUNCH"; then
+  echo
+  echo "Launch manually with:"
+  echo "  cd apps/desktop-tauri"
+  echo "  DEFRA_AGENT_DESKTOP_HOME=$DESKTOP_HOME DEFRA_AGENT_DESKTOP_PAIR_REMOTE_P2P=0 npm run tauri -- dev"
+  exit 0
+fi
+
+need npm
+if [[ ! -d apps/desktop-tauri/node_modules ]]; then
+  echo "desktop npm dependencies are missing; run \`npm --prefix apps/desktop-tauri ci\` first" >&2
+  exit 1
+fi
+
+say "Launching Tauri desktop app"
+cd apps/desktop-tauri
+DEFRA_AGENT_DESKTOP_HOME="$DESKTOP_HOME" \
+DEFRA_AGENT_DESKTOP_PAIR_REMOTE_P2P=0 \
+  npm run tauri -- dev

--- a/scripts/demo-mock-inference.py
+++ b/scripts/demo-mock-inference.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Minimal OpenAI-compatible mock inference server for the local demos.
+
+This is a *real* HTTP backend that speaks the subset of the OpenAI API the
+defra-agent runtime uses, so the desktop/two-node demos can show chat working
+end-to-end without an external model (llama-server, ollama, OpenAI, ...).
+
+It returns canned, deterministic completions, so it proves the request ->
+daemon -> owned loop -> response -> replication pipeline, not model quality.
+Swap in a hosted preset or a local llama-server for real responses.
+
+The response shape mirrors the project's own live test fixture
+(apps/desktop-tauri/src-tauri/src/runner/live_fixture.rs): a content delta
+chunk, a finish_reason=stop chunk, then `data: [DONE]`. The runtime must be
+told to use the chat-completions route via DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS=1.
+
+Routes:
+  GET  /v1/models, /models               -> {"data":[{"id":"<model>"}]}
+  POST /v1/chat/completions,
+       /chat/completions                 -> text/event-stream SSE completion
+  GET  /healthz                          -> 200 ok
+
+Usage:
+  demo-mock-inference.py [--host 127.0.0.1] [--port 0] [--model mock-model]
+Environment overrides: MOCK_HOST, MOCK_PORT, MOCK_MODEL.
+When --port 0 (the default) the chosen port is printed as `listening port=<n>`.
+"""
+
+import argparse
+import json
+import os
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def build_completion_sse(text: str) -> bytes:
+    """Two SSE data chunks plus the [DONE] sentinel, OpenAI streaming shape."""
+    chunk_1 = {
+        "choices": [{"delta": {"content": text}, "finish_reason": None}],
+        "usage": None,
+    }
+    chunk_2 = {
+        "choices": [
+            {
+                "delta": {"content": None, "tool_calls": []},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 24, "completion_tokens": 6, "total_tokens": 30},
+    }
+    body = "data: {}\n\ndata: {}\n\ndata: [DONE]\n\n".format(
+        json.dumps(chunk_1), json.dumps(chunk_2)
+    )
+    return body.encode("utf-8")
+
+
+def build_tool_call_sse(tool_name: str, arguments: dict) -> bytes:
+    """OpenAI streaming shape for a single function/tool call."""
+    chunk_1 = {
+        "choices": [
+            {
+                "delta": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_mock_0",
+                            "type": "function",
+                            "function": {
+                                "name": tool_name,
+                                "arguments": json.dumps(arguments),
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": None,
+            }
+        ],
+        "usage": None,
+    }
+    chunk_2 = {
+        "choices": [{"delta": {}, "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 24, "completion_tokens": 6, "total_tokens": 30},
+    }
+    body = "data: {}\n\ndata: {}\n\ndata: [DONE]\n\n".format(
+        json.dumps(chunk_1), json.dumps(chunk_2)
+    )
+    return body.encode("utf-8")
+
+
+def last_user_text(request_json: dict) -> str:
+    last_user = ""
+    for message in request_json.get("messages", []):
+        if message.get("role") == "user":
+            content = message.get("content", "")
+            if isinstance(content, list):
+                # Some clients send content as an array of parts.
+                content = "".join(
+                    part.get("text", "")
+                    for part in content
+                    if isinstance(part, dict)
+                )
+            last_user = content or last_user
+    return (last_user or "").strip()
+
+
+def reply_for(request_json: dict) -> str:
+    """Echo the last user message so the demo chat feels responsive."""
+    last_user = last_user_text(request_json)
+    if not last_user:
+        return "Mock inference backend online. Send a message to see it reply."
+    return f'Mock backend reply. You said: "{last_user}"'
+
+
+def offered_tool(request_json: dict, name: str) -> dict:
+    """Return the offered tool's function schema by name, or {} if absent."""
+    for tool in request_json.get("tools", []) or []:
+        fn = tool.get("function", {}) if isinstance(tool, dict) else {}
+        if fn.get("name") == name:
+            return fn
+    return {}
+
+
+def first_subagent_target(spawn_fn: dict) -> str:
+    """Pull the first allowed subagent name from the spawn_subagent schema enum."""
+    enum = (
+        spawn_fn.get("parameters", {})
+        .get("properties", {})
+        .get("name", {})
+        .get("enum", [])
+    )
+    return enum[0] if enum else "worker"
+
+
+def wants_subagent(text: str) -> bool:
+    return "subagent" in text.lower() or "delegate" in text.lower()
+
+
+def planned_tool_call(request_json: dict):
+    """Decide whether this turn should call spawn_subagent.
+
+    Fires only when the tool is actually offered, the user asked for delegation,
+    and no tool result has come back yet (so the post-result turn answers in
+    text). The child prompt deliberately omits the trigger word so a same-DID
+    target cannot recurse.
+    """
+    spawn_fn = offered_tool(request_json, "spawn_subagent")
+    if not spawn_fn:
+        return None
+    messages = request_json.get("messages", []) or []
+    if any(m.get("role") == "tool" for m in messages):
+        return None
+    if not wants_subagent(last_user_text(request_json)):
+        return None
+    target = first_subagent_target(spawn_fn)
+    call = {
+        "name": target,
+        "prompt": "Reply with one short sentence describing the worker node.",
+    }
+    # Cross-deployment (remote) targets require background await; foreground is
+    # rejected. Prefer background whenever the schema offers it.
+    await_enum = (
+        spawn_fn.get("parameters", {})
+        .get("properties", {})
+        .get("await_mode", {})
+        .get("enum", [])
+    )
+    if "background" in await_enum:
+        call["await_mode"] = "background"
+    return call
+
+
+class Handler(BaseHTTPRequestHandler):
+    # Quiet by default; the launcher captures stderr to a log file.
+    def log_message(self, *_args):
+        return
+
+    def _send_json(self, status: int, payload: dict):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path in ("/v1/models", "/models"):
+            self._send_json(200, {"data": [{"id": self.server.model_name}]})
+        elif path == "/healthz":
+            self._send_json(200, {"status": "ok"})
+        else:
+            self._send_json(404, {"error": "not found"})
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        if path not in ("/v1/chat/completions", "/chat/completions"):
+            self._send_json(404, {"error": "not found"})
+            return
+        length = int(self.headers.get("content-length", 0) or 0)
+        raw = self.rfile.read(length) if length else b""
+        try:
+            request_json = json.loads(raw or b"{}")
+        except json.JSONDecodeError:
+            self._send_json(400, {"error": "invalid json"})
+            return
+        call = planned_tool_call(request_json)
+        if call is not None:
+            sse = build_tool_call_sse("spawn_subagent", call)
+        else:
+            sse = build_completion_sse(reply_for(request_json))
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("cache-control", "no-cache")
+        self.send_header("content-length", str(len(sse)))
+        self.end_headers()
+        self.wfile.write(sse)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="OpenAI-compatible mock backend")
+    parser.add_argument("--host", default=os.environ.get("MOCK_HOST", "127.0.0.1"))
+    parser.add_argument(
+        "--port", type=int, default=int(os.environ.get("MOCK_PORT", "0"))
+    )
+    parser.add_argument(
+        "--model", default=os.environ.get("MOCK_MODEL", "mock-model")
+    )
+    args = parser.parse_args()
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    server.model_name = args.model
+    host, port = server.server_address[0], server.server_address[1]
+    # Stable, parseable line so a launcher can capture the chosen ephemeral port.
+    print(f"listening host={host} port={port} model={args.model}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/demo-p2p-two-node.sh
+++ b/scripts/demo-p2p-two-node.sh
@@ -17,11 +17,18 @@ Environment:
                                   cargo build -p defra-agent-cli.
   DEFRA_AGENT_DEMO_ROOT           Demo state root. Defaults to mktemp under /tmp.
   DEFRA_AGENT_DEMO_KEEP=1         Keep homes/logs and leave servers running.
+  DEFRA_AGENT_DEMO_BACKEND_PRESET Backend preset passed to init (for example:
+                                  openai, openrouter, llama-cpp, vllm).
   DEFRA_AGENT_DEMO_INFERENCE_URL  Backend URL used by init.
                                   Default: http://127.0.0.1:8080/v1
-  DEFRA_AGENT_DEMO_MODEL          Model name used by init. Default: demo-model
-  AMY_HTTP_PORT                   Amy HTTP port. Default: 19391
-  CODING_HTTP_PORT                Coding HTTP port. Default: 19392
+  DEFRA_AGENT_DEMO_MODEL          Model name used by init. The default local
+                                  path uses google/gemma-4-12B-it-qat-q4_0-gguf;
+                                  backend presets use their CLI defaults unless
+                                  this is set.
+  DEFRA_AGENT_DEMO_API_KEY_ENV_VAR
+                                  API-key env var stored in the backend document.
+  AGENT_A_HTTP_PORT                   Amy HTTP port. Default: 19391
+  AGENT_B_HTTP_PORT                Coding HTTP port. Default: 19392
 EOF
 }
 
@@ -60,17 +67,38 @@ fi
 ROOT="${DEFRA_AGENT_DEMO_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/defra-agent-p2p-demo.XXXXXX")}"
 KEEP="${DEFRA_AGENT_DEMO_KEEP:-0}"
 MODEL_URL="${DEFRA_AGENT_DEMO_INFERENCE_URL:-http://127.0.0.1:8080/v1}"
-MODEL_NAME="${DEFRA_AGENT_DEMO_MODEL:-demo-model}"
-AMY_HTTP_PORT="${AMY_HTTP_PORT:-19391}"
-CODING_HTTP_PORT="${CODING_HTTP_PORT:-19392}"
+DEFAULT_LOCAL_MODEL_NAME="google/gemma-4-12B-it-qat-q4_0-gguf"
+MODEL_NAME="${DEFRA_AGENT_DEMO_MODEL:-}"
+BACKEND_PRESET="${DEFRA_AGENT_DEMO_BACKEND_PRESET:-}"
+if [[ -z "$BACKEND_PRESET" && -z "$MODEL_NAME" ]]; then
+  MODEL_NAME="$DEFAULT_LOCAL_MODEL_NAME"
+fi
+API_KEY_ENV_VAR="${DEFRA_AGENT_DEMO_API_KEY_ENV_VAR:-}"
+# Agent names are parameterized so wrappers (e.g. the desktop demo) can relabel
+# the two runtimes; the standalone runbook keeps amy/coding.
+AGENT_A_NAME="${DEFRA_AGENT_DEMO_AGENT_A_NAME:-amy}"
+AGENT_B_NAME="${DEFRA_AGENT_DEMO_AGENT_B_NAME:-coding}"
+AGENT_A_HTTP_PORT="${AGENT_A_HTTP_PORT:-${AMY_HTTP_PORT:-19391}}"
+AGENT_B_HTTP_PORT="${AGENT_B_HTTP_PORT:-${CODING_HTTP_PORT:-19392}}"
 
-AMY_HOME="$ROOT/amy"
-CODING_HOME="$ROOT/coding"
-AMY_WORK="$ROOT/amy-work"
-CODING_WORK="$ROOT/coding-work"
+if [[ -z "$ROOT" || "$ROOT" == "/" || "$ROOT" == "$HOME" ]]; then
+  echo "refusing unsafe demo root: '$ROOT'" >&2
+  exit 1
+fi
+if [[ "$AGENT_A_HTTP_PORT" == "$AGENT_B_HTTP_PORT" ]]; then
+  echo "AGENT_A_HTTP_PORT and AGENT_B_HTTP_PORT must differ (both are $AGENT_A_HTTP_PORT)" >&2
+  exit 1
+fi
+
+AGENT_A_HOME="$ROOT/$AGENT_A_NAME"
+AGENT_B_HOME="$ROOT/$AGENT_B_NAME"
+AGENT_A_WORK="$ROOT/$AGENT_A_NAME-work"
+AGENT_B_WORK="$ROOT/$AGENT_B_NAME-work"
 LOG_DIR="$ROOT/logs"
-AMY_GRAPHQL="http://127.0.0.1:${AMY_HTTP_PORT}/api/v0/graphql"
-CODING_GRAPHQL="http://127.0.0.1:${CODING_HTTP_PORT}/api/v0/graphql"
+STATE_FILE="$ROOT/demo-state.json"
+PID_FILE="$ROOT/demo-pids.txt"
+AGENT_A_GRAPHQL="http://127.0.0.1:${AGENT_A_HTTP_PORT}/api/v0/graphql"
+AGENT_B_GRAPHQL="http://127.0.0.1:${AGENT_B_HTTP_PORT}/api/v0/graphql"
 
 PIDS=()
 
@@ -97,10 +125,14 @@ cleanup() {
   rm -rf "$ROOT"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
+STEP=0
 say() {
+  STEP=$((STEP + 1))
   echo
-  echo "==> $*"
+  echo "==> [step $STEP] $*"
 }
 
 run_json() {
@@ -124,22 +156,61 @@ post_graphql() {
   printf '%s\n' "$response"
 }
 
+dump_log_tail() {
+  local log="$1"
+  [[ -n "$log" && -f "$log" ]] || return 0
+  echo "  --- last 20 lines of $log ---" >&2
+  tail -n 20 "$log" | sed 's/^/  | /' >&2
+  echo "  --- end of log ---" >&2
+}
+
 wait_http() {
   local url="$1"
   local pid="$2"
   local label="$3"
+  local log="${4:-}"
   for _ in $(seq 1 300); do
     if curl -fsS "$url" >/dev/null 2>&1; then
       return 0
     fi
     if ! kill -0 "$pid" >/dev/null 2>&1; then
       echo "$label exited before becoming ready" >&2
+      dump_log_tail "$log"
       return 1
     fi
     sleep 0.2
   done
   echo "timed out waiting for $label at $url" >&2
+  dump_log_tail "$log"
   return 1
+}
+
+port_in_use() {
+  # Connect to a loopback listener using bash's /dev/tcp; success means busy.
+  local port="$1"
+  (exec 3<>"/dev/tcp/127.0.0.1/${port}") 2>/dev/null
+}
+
+ensure_ports_available() {
+  local conflict=0 entry name port
+  for entry in "${AGENT_A_NAME}:${AGENT_A_HTTP_PORT}" "${AGENT_B_NAME}:${AGENT_B_HTTP_PORT}"; do
+    name="${entry%%:*}"
+    port="${entry##*:}"
+    if port_in_use "$port"; then
+      echo "HTTP port $port (for $name) is already in use" >&2
+      conflict=1
+    fi
+  done
+  if [[ "$conflict" == "1" ]]; then
+    cat >&2 <<EOF
+Refusing to start: a demo HTTP port is busy (a previous demo may still be running).
+Free the port, or choose different ports:
+  AGENT_A_HTTP_PORT=<free> AGENT_B_HTTP_PORT=<free> $0
+Inspect a listener with:
+  lsof -nP -iTCP:<port> -sTCP:LISTEN
+EOF
+    exit 1
+  fi
 }
 
 start_server() {
@@ -149,7 +220,7 @@ start_server() {
   local log="$LOG_DIR/${name}.log"
   if [[ "$KEEP" == "1" ]]; then
     nohup env \
-      RUST_LOG="warn,defra_agent::agent::p2p_reconcile=debug" \
+      RUST_LOG="${DEFRA_AGENT_DEMO_RUST_LOG:-warn,defra_agent::agent::p2p_reconcile=debug}" \
       DEFRA_AGENT_REGISTRY_HEARTBEAT_MS=1000 \
       DEFRA_AGENT_PAIRING_SWEEP_MS=1000 \
       DEFRA_AGENT_REGISTRY_STALE_MS=300000 \
@@ -165,7 +236,7 @@ start_server() {
         >"$log" 2>&1 &
   else
     env \
-      RUST_LOG="warn,defra_agent::agent::p2p_reconcile=debug" \
+      RUST_LOG="${DEFRA_AGENT_DEMO_RUST_LOG:-warn,defra_agent::agent::p2p_reconcile=debug}" \
       DEFRA_AGENT_REGISTRY_HEARTBEAT_MS=1000 \
       DEFRA_AGENT_PAIRING_SWEEP_MS=1000 \
       DEFRA_AGENT_REGISTRY_STALE_MS=300000 \
@@ -182,7 +253,8 @@ start_server() {
   fi
   local pid=$!
   PIDS+=("$pid")
-  wait_http "http://127.0.0.1:${port}/healthz" "$pid" "$name"
+  echo "$pid" >>"$PID_FILE"
+  wait_http "http://127.0.0.1:${port}/healthz" "$pid" "$name" "$log"
   echo "  $name ready on http://127.0.0.1:${port} (pid $pid, log $log)"
 }
 
@@ -314,70 +386,177 @@ EOF
   return 1
 }
 
-mkdir -p "$AMY_HOME" "$CODING_HOME" "$AMY_WORK" "$CODING_WORK" "$LOG_DIR"
+wait_conversation_on_peer() {
+  local graphql="$1"
+  local session_id="$2"
+  local label="$3"
+  local escaped
+  escaped="$(graphql_escape "$session_id")"
+  local query
+  query=$(cat <<EOF
+{
+  AgentConversation(filter: { session_id: { _eq: "$escaped" } }, limit: 1) {
+    session_id
+    title
+    preview_text
+    status
+    latest_request_id
+  }
+}
+EOF
+)
+  for _ in $(seq 1 120); do
+    local response
+    response="$(post_graphql "$graphql" "$query")"
+    if jq -e '.data.AgentConversation | length == 1' >/dev/null <<<"$response"; then
+      echo "  $label saw AgentConversation $session_id"
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "timed out waiting for AgentConversation $session_id on $label" >&2
+  return 1
+}
+
+say "Checking demo HTTP ports are free"
+ensure_ports_available
+echo "  Amy port:    $AGENT_A_HTTP_PORT free"
+echo "  Coding port: $AGENT_B_HTTP_PORT free"
+
+mkdir -p "$AGENT_A_HOME" "$AGENT_B_HOME" "$AGENT_A_WORK" "$AGENT_B_WORK" "$LOG_DIR"
+: >"$PID_FILE"
+
+INIT_BACKEND_ARGS=()
+if [[ -n "$MODEL_NAME" ]]; then
+  INIT_BACKEND_ARGS+=(--model-name "$MODEL_NAME")
+fi
+if [[ -n "$BACKEND_PRESET" ]]; then
+  INIT_BACKEND_ARGS+=(--backend-preset "$BACKEND_PRESET")
+  if [[ -n "${DEFRA_AGENT_DEMO_INFERENCE_URL:-}" ]]; then
+    INIT_BACKEND_ARGS+=(--inference-url "$MODEL_URL")
+  fi
+else
+  INIT_BACKEND_ARGS+=(--inference-url "$MODEL_URL")
+fi
+if [[ -n "$API_KEY_ENV_VAR" ]]; then
+  INIT_BACKEND_ARGS+=(--api-key-env-var "$API_KEY_ENV_VAR")
+fi
 
 say "Initializing isolated nodes"
-AMY_INIT="$(run_json init --home "$AMY_HOME" --dangerously-overwrite --agent-name amy --tool-root "$AMY_WORK" --inference-url "$MODEL_URL" --model-name "$MODEL_NAME")"
-CODING_INIT="$(run_json init --home "$CODING_HOME" --dangerously-overwrite --agent-name coding --tool-root "$CODING_WORK" --inference-url "$MODEL_URL" --model-name "$MODEL_NAME")"
-AMY_DID="$(jq -r '.agent_did' <<<"$AMY_INIT")"
-CODING_DID="$(jq -r '.agent_did' <<<"$CODING_INIT")"
-echo "  Amy DID:    $AMY_DID"
-echo "  Coding DID: $CODING_DID"
+AGENT_A_INIT="$(run_json init --home "$AGENT_A_HOME" --dangerously-overwrite --agent-name "$AGENT_A_NAME" --tool-root "$AGENT_A_WORK" "${INIT_BACKEND_ARGS[@]}")"
+AGENT_B_INIT="$(run_json init --home "$AGENT_B_HOME" --dangerously-overwrite --agent-name "$AGENT_B_NAME" --tool-root "$AGENT_B_WORK" "${INIT_BACKEND_ARGS[@]}")"
+AGENT_A_DID="$(jq -r '.agent_did' <<<"$AGENT_A_INIT")"
+AGENT_B_DID="$(jq -r '.agent_did' <<<"$AGENT_B_INIT")"
+echo "  Amy DID:    $AGENT_A_DID"
+echo "  Coding DID: $AGENT_B_DID"
 
 say "Starting two loopback P2P runtimes"
-start_server "amy" "$AMY_HOME" "$AMY_HTTP_PORT"
-start_server "coding" "$CODING_HOME" "$CODING_HTTP_PORT"
+start_server "$AGENT_A_NAME" "$AGENT_A_HOME" "$AGENT_A_HTTP_PORT"
+start_server "$AGENT_B_NAME" "$AGENT_B_HOME" "$AGENT_B_HTTP_PORT"
 
 say "Reading live P2P identities"
-AMY_P2P="$(p2p_status "$AMY_HOME")"
-CODING_P2P="$(p2p_status "$CODING_HOME")"
-AMY_PEER="$(jq -r '.p2p_peer_id' <<<"$AMY_P2P")"
-CODING_PEER="$(jq -r '.p2p_peer_id' <<<"$CODING_P2P")"
-AMY_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$AMY_P2P")"
-CODING_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$CODING_P2P")"
-echo "  Amy peer:        $AMY_PEER"
-echo "  Coding peer:     $CODING_PEER"
-echo "  Amy shareable:   $AMY_SHAREABLE"
-echo "  Coding shareable: $CODING_SHAREABLE"
+AGENT_A_P2P="$(p2p_status "$AGENT_A_HOME")"
+AGENT_B_P2P="$(p2p_status "$AGENT_B_HOME")"
+AGENT_A_PEER="$(jq -r '.p2p_peer_id' <<<"$AGENT_A_P2P")"
+AGENT_B_PEER="$(jq -r '.p2p_peer_id' <<<"$AGENT_B_P2P")"
+AGENT_A_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$AGENT_A_P2P")"
+AGENT_B_SHAREABLE="$(jq -r '.p2p_shareable_address' <<<"$AGENT_B_P2P")"
+echo "  Amy peer:        $AGENT_A_PEER"
+echo "  Coding peer:     $AGENT_B_PEER"
+echo "  Amy shareable:   $AGENT_A_SHAREABLE"
+echo "  Coding shareable: $AGENT_B_SHAREABLE"
 
 say "Creating the network and granting Coding membership"
-run_json p2p network create --home "$AMY_HOME" --name "Two Node Demo" --output json | jq .
-run_json p2p network grant --home "$AMY_HOME" "$CODING_DID" --output json | jq .
+run_json p2p network create --home "$AGENT_A_HOME" --name "Two Node Demo" --output json | jq .
+run_json p2p network grant --home "$AGENT_A_HOME" "$AGENT_B_DID" --output json | jq .
 
 say "Joining Coding to Amy with a signed network-control invite"
-AMY_INVITE="$(run_json p2p pairings invite --home "$AMY_HOME" --member-did "$CODING_DID" --template network-control)"
-TOKEN="$(jq -r '.token' <<<"$AMY_INVITE")"
-run_json p2p pairings join --home "$CODING_HOME" "$TOKEN" | jq .
+AGENT_A_INVITE="$(run_json p2p pairings invite --home "$AGENT_A_HOME" --member-did "$AGENT_B_DID" --template network-control)"
+TOKEN="$(jq -r '.token' <<<"$AGENT_A_INVITE")"
+run_json p2p pairings join --home "$AGENT_B_HOME" "$TOKEN" | jq .
 
 say "Adding bidirectional conversation data-plane rows"
-upsert_data_plane "$AMY_GRAPHQL" "$CODING_PEER" "$AMY_DID" "$CODING_SHAREABLE"
-upsert_data_plane "$CODING_GRAPHQL" "$AMY_PEER" "$CODING_DID" "$AMY_SHAREABLE"
+upsert_data_plane "$AGENT_A_GRAPHQL" "$AGENT_B_PEER" "$AGENT_A_DID" "$AGENT_B_SHAREABLE"
+upsert_data_plane "$AGENT_B_GRAPHQL" "$AGENT_A_PEER" "$AGENT_B_DID" "$AGENT_A_SHAREABLE"
 
 say "Waiting for reconciled replicators"
-wait_replicator "$CODING_GRAPHQL" "$AMY_PEER" "Coding -> Amy"
-wait_replicator "$AMY_GRAPHQL" "$CODING_PEER" "Amy -> Coding"
+wait_replicator "$AGENT_B_GRAPHQL" "$AGENT_A_PEER" "Coding -> Amy"
+wait_replicator "$AGENT_A_GRAPHQL" "$AGENT_B_PEER" "Amy -> Coding"
 
 say "Reconciled data-plane state"
 echo "  Amy -> Coding: network-control subscribed, conversation replicator installed"
 echo "  Coding -> Amy: network-control subscribed, conversation replicator installed"
 
 say "Proving document replication with one no-wait request"
-REQUEST="$(run_json request submit --graphql "$CODING_GRAPHQL" --agent-did "$CODING_DID" --content "two-node p2p demo ping from Coding" --no-wait)"
+REQUEST="$(run_json request submit --graphql "$AGENT_B_GRAPHQL" --agent-did "$AGENT_B_DID" --content "two-node p2p demo ping from Coding" --no-wait)"
 REQUEST_ID="$(jq -r '.request_id' <<<"$REQUEST")"
+REQUEST_SESSION_ID="$(jq -r '.session_id' <<<"$REQUEST")"
 echo "  Coding created AgentRequest $REQUEST_ID"
-wait_request_on_peer "$AMY_GRAPHQL" "$REQUEST_ID" "Amy"
+wait_conversation_on_peer "$AGENT_B_GRAPHQL" "$REQUEST_SESSION_ID" "Coding"
+wait_request_on_peer "$AGENT_A_GRAPHQL" "$REQUEST_ID" "Amy"
+wait_conversation_on_peer "$AGENT_A_GRAPHQL" "$REQUEST_SESSION_ID" "Amy"
+
+PIDS_JSON="$(printf '%s\n' "${PIDS[@]}" | jq -R 'select(length > 0) | tonumber' | jq -s '.')"
+jq -n \
+  --arg root "$ROOT" \
+  --arg logs "$LOG_DIR" \
+  --arg requestId "$REQUEST_ID" \
+  --arg requestSessionId "$REQUEST_SESSION_ID" \
+  --arg amyHome "$AGENT_A_HOME" \
+  --arg amyWork "$AGENT_A_WORK" \
+  --arg amyDid "$AGENT_A_DID" \
+  --arg amyPeer "$AGENT_A_PEER" \
+  --arg amyShareable "$AGENT_A_SHAREABLE" \
+  --arg amyGraphql "$AGENT_A_GRAPHQL" \
+  --arg codingHome "$AGENT_B_HOME" \
+  --arg codingWork "$AGENT_B_WORK" \
+  --arg codingDid "$AGENT_B_DID" \
+  --arg codingPeer "$AGENT_B_PEER" \
+  --arg codingShareable "$AGENT_B_SHAREABLE" \
+  --arg codingGraphql "$AGENT_B_GRAPHQL" \
+  --arg nameA "$AGENT_A_NAME" \
+  --arg nameB "$AGENT_B_NAME" \
+  --argjson pids "$PIDS_JSON" \
+  '{
+    root: $root,
+    logs: $logs,
+    pids: $pids,
+    request: {
+      id: $requestId,
+      session_id: $requestSessionId
+    },
+    node_a: {
+      name: $nameA,
+      home: $amyHome,
+      work: $amyWork,
+      agent_did: $amyDid,
+      peer_id: $amyPeer,
+      shareable_address: $amyShareable,
+      graphql: $amyGraphql
+    },
+    node_b: {
+      name: $nameB,
+      home: $codingHome,
+      work: $codingWork,
+      agent_did: $codingDid,
+      peer_id: $codingPeer,
+      shareable_address: $codingShareable,
+      graphql: $codingGraphql
+    }
+  }' >"$STATE_FILE"
 
 say "Demo complete"
 echo "  Root:        $ROOT"
-echo "  Amy home:    $AMY_HOME"
-echo "  Coding home: $CODING_HOME"
+echo "  Amy home:    $AGENT_A_HOME"
+echo "  Coding home: $AGENT_B_HOME"
 echo "  Logs:        $LOG_DIR"
+echo "  State:       $STATE_FILE"
 echo
 if [[ "$KEEP" == "1" ]]; then
   echo "Try manually:"
-  echo "  $BIN p2p pairings list --home $AMY_HOME --output table"
-  echo "  $BIN p2p pairings list --home $CODING_HOME --output table"
-  echo "  $BIN request show --graphql $AMY_GRAPHQL $REQUEST_ID --output json | jq .request"
+  echo "  $BIN p2p pairings list --home $AGENT_A_HOME --output table"
+  echo "  $BIN p2p pairings list --home $AGENT_B_HOME --output table"
+  echo "  $BIN request show --graphql $AGENT_A_GRAPHQL $REQUEST_ID --output json | jq .request"
 else
   echo "Run with DEFRA_AGENT_DEMO_KEEP=1 to keep the runtimes for manual inspection."
 fi


### PR DESCRIPTION
Stacked on #569 (two-node P2P runbook) — review/merge #569 first; the diff here is desktop-only.

## What

`make demo-desktop-two-node` launches the Tauri fleet UI on top of a two-node P2P
substrate and makes chat plus **cross-node delegation** work end-to-end once a backend is
attached. Two runtimes — **Orchestrator** and **Worker** — appear in the Fleet Dashboard
with a tightened tool surface; the Orchestrator delegates to the Worker on node B, and the
result replicates back.

## Relationship to #576

This is the script/Makefile prototype of the two-node fleet demo. #576 tracks promoting it
into a first-class `defra-agent demo` subcommand runnable from a release binary, and will
supersede these scripts. The cross-node delegation here validates #576's blessed topology.

## Cross-node delegation (orchestrator → worker on node B)

The Orchestrator delegates a child request that the runtime materializes **on the Worker**
(`agent_did` = Worker); the Worker runs it and the result replicates back to the
Orchestrator over P2P.

Requirements (configured by the demo, verified end-to-end):
- both runtimes: `subagent_allow_cross_deployment=true`
- orchestrator: `subagent_spawn_enabled` + **`subagent_background_enabled`** + target → worker DID
- the spawn uses **`await_mode=background`** — foreground remote spawns are rejected
  (`message_spawn.rs:523`). This (not DAC/ACP) was the gating requirement.

Tool config is applied post-init with `config tools set`, then the demo waits for each
runtime to reconcile before the surface goes live.

## Tool surface

Both demo agents drop `defra_query`; the Orchestrator gains the subagent tools, the Worker
is a leaf. The demo prints the resolved surface via `defra-agent tools explain`:

- orchestrator: `list_files, read_file, glob, grep, bash, spawn_subagent, wait_subagent, list_subagents, cancel_subagent, context_budget`
- worker: `list_files, read_file, glob, grep, bash, context_budget`

## Backends

- Default path: real user inference (URL/preset/model passthrough) plus suggested prompts
  crafted to elicit delegation. Both nodes must reach the backend (the Worker executes the
  delegated child).
- `DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1` (opt-in) starts a bundled zero-dependency
  OpenAI-compatible mock (`scripts/demo-mock-inference.py`) that emits a background
  `spawn_subagent` — turnkey/CI verification with no external model.

## Runtime / desktop-core

- `DesktopPaths` honors `DEFRA_AGENT_DESKTOP_HOME` for an isolated desktop data dir (unit-tested).
- P2P pairing toggle: explicit `DEFRA_AGENT_DESKTOP_PAIR_REMOTE_P2P=0/1` overrides the
  loopback heuristic (unit-tested).
- Desktop launcher logs diagnostics to **stderr**, keeping `init --json` stdout clean.

## Scripts

- Two demo agents named via `DEFRA_AGENT_DEMO_AGENT_A_NAME`/`_B_NAME` (default amy/coding so
  the #569 runbook is unchanged); internal vars renamed `AGENT_A_*`/`AGENT_B_*`;
  `AMY_HTTP_PORT`/`CODING_HTTP_PORT` kept as back-compat aliases; overridable
  `DEFRA_AGENT_DEMO_RUST_LOG`.
- Hardening (both scripts): `/dev/tcp` port-conflict preflight, INT/TERM traps, TERM→KILL
  teardown, server-log tail on health-check failure, unsafe-root guard, numbered steps.

## Test plan

Verified against the real `defra-agent` binary (mock backend, no GUI):
- `make demo-desktop-two-node` runs to completion; `peers.json` carries Orchestrator +
  Worker each with their GraphQL endpoint.
- A delegation request to the Orchestrator fires a background `spawn_subagent`; the child
  request runs **on the Worker node** (`agent_did`=worker, completed) and replicates back to
  the Orchestrator.
- Resolved tool surface confirmed via `tools explain` (no `defra_query`; subagent tools on
  the orchestrator only).
- `cargo test -p defra-agent-desktop-core --lib` — 98 passed (incl. new paths/bootstrap tests).
- Port-conflict preflight fails fast on a busy port.

```bash
# turnkey cross-node delegation, no external model:
DEFRA_AGENT_DESKTOP_DEMO_MOCK_BACKEND=1 make demo-desktop-two-node
```
