### PR TITLE
feat(demo): paired desktop delegation demo

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bin/bridge_runner/http/routes.rs
+++ b/apps/desktop-tauri/src-tauri/src/bin/bridge_runner/http/routes.rs
@@ -131,7 +131,21 @@ pub(super) fn handle_request(
             let core = fixture.desktop_core();
             core.set_selected_agent_did(did.clone());
             if let Some(did) = did {
-                runtime.block_on(core.ensure_agent_loaded(&did))?;
+                let loaded_remote = match runtime.block_on(core.refresh_remote_agent(&did)) {
+                    Ok(Some(_version)) => true,
+                    Ok(None) => false,
+                    Err(error) => {
+                        tracing::warn!(
+                            error = %error,
+                            agent_did = %did,
+                            "remote selection refresh failed"
+                        );
+                        false
+                    }
+                };
+                if !loaded_remote {
+                    runtime.block_on(core.ensure_agent_loaded(&did))?;
+                }
             }
             Ok(HttpResponse::json_ok(serde_json::json!({}).to_string()))
         }

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot.rs
@@ -94,8 +94,8 @@ fn read_stored_init_config(agent_home: &std::path::Path) -> Option<StoredInitCon
 mod runtime_tasks;
 #[cfg(test)]
 use runtime_tasks::{
-    conversation_task_tag, recent_runs_for_task_views, retain_latest_conversation_summaries,
-    task_run_history,
+    conversation_task_tag, recent_runs_for_task_views, request_backed_conversation_summaries,
+    retain_latest_conversation_summaries, task_run_history,
 };
 use runtime_tasks::{request_matches_agent, source_matches_agent};
 

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime.rs
@@ -9,8 +9,8 @@ use super::super::types::{
     ToolServiceRegistryView,
 };
 use super::runtime_tasks::{
-    conversation_task_tag, recent_runs_for_task_views, retain_latest_conversation_summaries,
-    source_matches_agent, task_run_history,
+    conversation_task_tag, recent_runs_for_task_views, request_backed_conversation_summaries,
+    retain_latest_conversation_summaries, source_matches_agent, task_run_history,
 };
 use super::to_health_view;
 
@@ -410,6 +410,14 @@ pub(crate) async fn build_runtime_snapshot(core: &ClientCore) -> DesktopRuntimeS
                     }
                 })
                 .collect::<Vec<_>>();
+            conversations.extend(request_backed_conversation_summaries(
+                store.as_ref(),
+                &peer.agent_did,
+                require_source_scope,
+                &tasks,
+                &schedules,
+                &event_triggers,
+            ));
             conversations.sort_by(|left, right| {
                 right
                     .updated_at

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime_tasks.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/runtime_tasks.rs
@@ -1,11 +1,11 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use defra_agent_desktop_core::client::{ClientStore, TaskRecentRuns};
 use defra_agent_protocol::row::AgentRequestRow;
 
 use super::super::types::{
-    normalize_optional, ConversationSummary, EventTriggerView, ScheduleView, TaskRecentRunsView,
-    TaskRunSummaryView, TaskView,
+    normalize_optional, turn_state_label, ConversationSummary, EventTriggerView, ScheduleView,
+    TaskRecentRunsView, TaskRunSummaryView, TaskView,
 };
 
 fn recent_runs_view(runs: &TaskRecentRuns) -> TaskRecentRunsView {
@@ -104,6 +104,99 @@ pub(super) fn recent_runs_for_task_views(
 pub(super) fn retain_latest_conversation_summaries(conversations: &mut Vec<ConversationSummary>) {
     let mut seen_sessions = HashSet::new();
     conversations.retain(|conversation| seen_sessions.insert(conversation.session_id.clone()));
+}
+
+pub(super) fn request_backed_conversation_summaries(
+    store: &ClientStore,
+    agent_did: &str,
+    require_source_scope: bool,
+    tasks: &[TaskView],
+    schedules: &[ScheduleView],
+    event_triggers: &[EventTriggerView],
+) -> Vec<ConversationSummary> {
+    let existing_sessions = store
+        .conversation_rows(agent_did)
+        .into_iter()
+        .map(|row| row.session_id.clone())
+        .collect::<HashSet<_>>();
+    let mut latest_requests_by_session: HashMap<String, &AgentRequestRow> = HashMap::new();
+
+    for request in &store.requests {
+        if !request_matches_agent(request, agent_did, require_source_scope) {
+            continue;
+        }
+        let Some(session_id) = normalize_optional(request.session_id.as_deref()) else {
+            continue;
+        };
+        if existing_sessions.contains(&session_id) {
+            continue;
+        }
+
+        let replace = latest_requests_by_session
+            .get(&session_id)
+            .is_none_or(|current| compare_request_freshness(request, current).is_gt());
+        if replace {
+            latest_requests_by_session.insert(session_id, request);
+        }
+    }
+
+    latest_requests_by_session
+        .into_iter()
+        .map(|(session_id, request)| {
+            let transcript = store.transcript_for_agent(&session_id, agent_did);
+            let task_tag = conversation_task_tag(
+                store,
+                agent_did,
+                require_source_scope,
+                &session_id,
+                tasks,
+                schedules,
+                event_triggers,
+            );
+            let latest_request_id = store
+                .latest_request_id_for_session_for_agent(&session_id, agent_did)
+                .unwrap_or_else(|| request.request_id.clone());
+            let latest_response =
+                store.latest_response_for_request_for_agent(&latest_request_id, agent_did);
+            let updated_at = latest_response
+                .and_then(|row| {
+                    normalize_optional(row.completed_at.as_deref())
+                        .or_else(|| normalize_optional(row.created_at.as_deref()))
+                })
+                .or_else(|| normalize_optional(request.created_at.as_deref()));
+
+            ConversationSummary {
+                session_id,
+                title: None,
+                preview_text: normalize_optional(request.content.as_deref()),
+                status: normalize_optional(request.status.as_deref())
+                    .or_else(|| normalize_optional(request.lifecycle_state.as_deref())),
+                behavior_id: normalize_optional(request.behavior_id.as_deref()),
+                latest_request_id: Some(latest_request_id.clone()),
+                task_id: task_tag.as_ref().map(|tag| tag.task_id.clone()),
+                task_name: task_tag.as_ref().and_then(|tag| tag.task_name.clone()),
+                trigger_id: task_tag.as_ref().and_then(|tag| tag.trigger_id.clone()),
+                trigger_kind: task_tag.as_ref().and_then(|tag| tag.trigger_kind.clone()),
+                created_at: normalize_optional(request.created_at.as_deref()),
+                updated_at,
+                turn_state: store
+                    .derive_turn_for_request(&latest_request_id)
+                    .map(turn_state_label)
+                    .map(str::to_owned),
+                message_count: transcript.messages.len(),
+                tool_call_count: transcript.tool_calls.len(),
+            }
+        })
+        .collect()
+}
+
+fn compare_request_freshness(
+    left: &AgentRequestRow,
+    right: &AgentRequestRow,
+) -> std::cmp::Ordering {
+    left.created_at
+        .cmp(&right.created_at)
+        .then_with(|| left.request_id.cmp(&right.request_id))
 }
 
 #[derive(Debug)]

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests.rs
@@ -11,6 +11,7 @@ use super::build_session_snapshot_from_store;
 use super::build_session_snapshot_from_store_for_agent;
 use super::conversation_task_tag;
 use super::recent_runs_for_task_views;
+use super::request_backed_conversation_summaries;
 use super::retain_latest_conversation_summaries;
 use super::task_run_history;
 

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/runtime.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/runtime.rs
@@ -23,6 +23,55 @@ fn conversation_summaries_keep_newest_row_per_session() {
 }
 
 #[test]
+fn request_backed_conversation_summaries_include_in_flight_sessions() {
+    let store = ClientStore::from_rows(ClientStoreRows {
+        requests: vec![AgentRequestRow {
+            request_id: "req-live".to_string(),
+            agent_did: Some("did:defra:amy".to_string()),
+            behavior_id: Some("amy-default".to_string()),
+            session_id: Some("session-live".to_string()),
+            retry_parent_request: None,
+            retry_root_request: None,
+            superseded_by_request: None,
+            content: Some("inspect your environment".to_string()),
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            max_tokens: None,
+            metadata: None,
+            status: Some("pending".to_string()),
+            lifecycle_state: Some("pending".to_string()),
+            backend_id: None,
+            execution_origin: Some("interactive".to_string()),
+            failure_reason: None,
+            created_at: Some("2026-04-21T12:00:00Z".to_string()),
+            claimed_at: None,
+            deadline: None,
+            retry_count: Some(0),
+            max_retries: Some(3),
+            caused_by_trigger_id: None,
+            caused_by_trigger_kind: None,
+            caused_by_parent_request_id: None,
+            interrupt_requested_at: None,
+            valid_until: None,
+        }],
+        ..ClientStoreRows::default()
+    });
+
+    let summaries =
+        request_backed_conversation_summaries(&store, "did:defra:amy", true, &[], &[], &[]);
+
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].session_id, "session-live");
+    assert_eq!(summaries[0].latest_request_id.as_deref(), Some("req-live"));
+    assert_eq!(
+        summaries[0].preview_text.as_deref(),
+        Some("inspect your environment")
+    );
+    assert_eq!(summaries[0].turn_state.as_deref(), Some("waitingForClaim"));
+}
+
+#[test]
 fn conversation_task_tag_uses_latest_schedule_lineage() {
     let store = ClientStore::from_rows(ClientStoreRows {
         requests: vec![

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/lifecycle.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/lifecycle.rs
@@ -132,14 +132,37 @@ pub(crate) fn desktop_set_selected_agent(
         .filter(|s| !s.is_empty());
     core.set_selected_agent_did(did.clone());
 
-    // Lazy-load the new scope's rows. Best-effort: log a warning on failure
-    // but don't fail the selection update — the next refresh or event will
-    // converge.
+    // Lazy-load the new scope's rows. GraphQL-managed demo peers need a remote
+    // refresh; otherwise the scoped reload hits only the desktop's embedded
+    // node and can miss fresh worker conversations.
     if let Some(did_str) = did {
         let core_arc = Arc::clone(&core);
         tauri::async_runtime::spawn(async move {
-            if let Err(err) = core_arc.ensure_agent_loaded(&did_str).await {
-                tracing::warn!(error = %err, agent_did = %did_str, "ensure_agent_loaded failed");
+            match core_arc.refresh_remote_agent(&did_str).await {
+                Ok(Some(_version)) => {}
+                Ok(None) => {
+                    if let Err(err) = core_arc.ensure_agent_loaded(&did_str).await {
+                        tracing::warn!(
+                            error = %err,
+                            agent_did = %did_str,
+                            "ensure_agent_loaded failed"
+                        );
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        agent_did = %did_str,
+                        "remote selection refresh failed"
+                    );
+                    if let Err(err) = core_arc.ensure_agent_loaded(&did_str).await {
+                        tracing::warn!(
+                            error = %err,
+                            agent_did = %did_str,
+                            "ensure_agent_loaded failed after remote refresh failure"
+                        );
+                    }
+                }
             }
         });
     }

--- a/apps/desktop-tauri/src/hooks/desktopShellEffects.ts
+++ b/apps/desktop-tauri/src/hooks/desktopShellEffects.ts
@@ -45,15 +45,6 @@ type DesktopShellEffectsArgs = {
   onStartClient: () => Promise<void>;
 };
 
-function isTerminalTurnState(turnState?: string | null) {
-  return (
-    turnState === "completed" ||
-    turnState === "failed" ||
-    turnState === "superseded" ||
-    turnState === "interrupted"
-  );
-}
-
 export function useDesktopShellEffects({
   autoRestartInFlight,
   autostartAttempted,
@@ -164,11 +155,9 @@ export function useDesktopShellEffects({
         return;
       }
       if (event.reason === "store" && selectedAgentDid) {
+        await refreshSnapshot();
         if (selectedSessionId) {
-          const nextSession = await refreshSession(selectedSessionId);
-          if (isTerminalTurnState(nextSession?.turnState)) {
-            await refreshSnapshot();
-          }
+          await refreshSession(selectedSessionId);
         }
         return;
       }

--- a/crates/defra-agent-cli/src/commands/demo/mod.rs
+++ b/crates/defra-agent-cli/src/commands/demo/mod.rs
@@ -14,8 +14,11 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 
+use defra_agent::graphql::escape_graphql_string;
+
 use crate::cli::args::DemoArgs;
 use crate::commands::chat::submit_chat_turn;
+use crate::graphql_access::post_graphql;
 
 const NODE_A_NAME: &str = "demo";
 
@@ -33,16 +36,20 @@ pub(crate) async fn demo(args: DemoArgs) -> Result<()> {
     }
     let work = home.join("work");
 
-    // First run sets up; later runs resume the saved agent.
-    let (agent_did, first_run) = match read_agent_did(&home) {
+    // First run sets up; later runs resume the saved agent. The backend args are
+    // persisted so a resumed session (and a paired node B) reuse the same backend.
+    let backend_file = home.join("demo-backend.json");
+    let (agent_did, first_run, backend_init_args) = match read_agent_did(&home) {
         Some(did) => {
             println!("Resuming your demo agent ({}).", short(&did));
-            (did, false)
+            (did, false, read_backend_args(&backend_file))
         }
         None => {
             let backend = resolve_backend(&args).await?;
             println!("\nSetting up your demo agent (backend: {})…", backend.label);
-            (init_agent(&bin, &home, &work, &backend).await?, true)
+            let did = init_agent(&bin, &home, &work, &backend).await?;
+            write_backend_args(&backend_file, &backend.init_args);
+            (did, true, backend.init_args)
         }
     };
 
@@ -60,12 +67,64 @@ pub(crate) async fn demo(args: DemoArgs) -> Result<()> {
         seed_demo_skills(&bin, &graphql, &agent_did).await;
     }
 
+    let mut fleet = Fleet {
+        bin: bin.clone(),
+        home_a: home.clone(),
+        graphql_a: graphql.clone(),
+        did_a: agent_did.clone(),
+        base_port: port,
+        backend_init_args,
+        node_b: None,
+    };
     print_welcome(&graphql);
-    let result = run_shell(&graphql, &agent_did).await;
+    let mut reader = BufReader::new(tokio::io::stdin()).lines();
+    let result = run_shell(&mut fleet, &mut reader).await;
 
+    fleet.teardown();
     let _ = server.start_kill();
-    println!("Stopped. Your demo agent is saved at {} (run `defra-agent demo` again to resume, or `--reset` to start over).", home.display());
+    println!(
+        "Stopped. Your demo agent is saved at {} (run `defra-agent demo` again to resume, or `--reset` to start over).",
+        home.display()
+    );
     result
+}
+
+/// The running demo fleet: node A (always) plus an optional paired node B.
+struct Fleet {
+    bin: PathBuf,
+    home_a: PathBuf,
+    graphql_a: String,
+    did_a: String,
+    base_port: u16,
+    backend_init_args: Vec<String>,
+    node_b: Option<NodeB>,
+}
+
+struct NodeB {
+    graphql: String,
+    did: String,
+    server: Child,
+}
+
+impl Fleet {
+    fn teardown(&mut self) {
+        if let Some(b) = self.node_b.as_mut() {
+            let _ = b.server.start_kill();
+        }
+    }
+}
+
+fn write_backend_args(path: &Path, args: &[String]) {
+    if let Ok(json) = serde_json::to_string(args) {
+        let _ = std::fs::write(path, json);
+    }
+}
+
+fn read_backend_args(path: &Path) -> Vec<String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
 }
 
 fn resolve_home(explicit: Option<PathBuf>) -> PathBuf {
@@ -290,6 +349,11 @@ fn spawn_server(bin: &Path, home: &Path, port: u16, log: &Path) -> Result<Child>
     ]);
     // The demo backends use the OpenAI chat-completions wire.
     cmd.env("DEFRA_AGENT_OPENAI_CHAT_COMPLETIONS", "1");
+    // Fast pairing reconcile so `pair` converges in seconds, not minutes.
+    cmd.env("DEFRA_AGENT_REGISTRY_HEARTBEAT_MS", "1000");
+    cmd.env("DEFRA_AGENT_PAIRING_SWEEP_MS", "1000");
+    cmd.env("DEFRA_AGENT_REGISTRY_STALE_MS", "300000");
+    cmd.env("DEFRA_AGENT_ENDPOINT_HEARTBEAT_MS", "1000");
     cmd.stdout(file).stderr(errfile).kill_on_drop(true);
     cmd.spawn().context("spawning demo server")
 }
@@ -371,8 +435,10 @@ fn print_welcome(graphql: &str) {
     println!("Type `chat` to talk to your agent, or `help` for the full list.");
 }
 
-async fn run_shell(graphql: &str, agent_did: &str) -> Result<()> {
-    let mut reader = BufReader::new(tokio::io::stdin()).lines();
+async fn run_shell(
+    fleet: &mut Fleet,
+    reader: &mut tokio::io::Lines<BufReader<tokio::io::Stdin>>,
+) -> Result<()> {
     loop {
         prompt("demo> ");
         let Some(line) = reader.next_line().await? else {
@@ -381,18 +447,341 @@ async fn run_shell(graphql: &str, agent_did: &str) -> Result<()> {
         match line.trim() {
             "" => continue,
             "help" | "?" => print_help(),
-            "chat" => chat_loop(graphql, agent_did, &mut reader).await?,
-            "status" => println!("  node A: live · agent {} · {graphql}", short(agent_did)),
+            "chat" => chat_loop(&fleet.graphql_a, &fleet.did_a, reader).await?,
+            "status" => print_status(fleet),
             "skill" | "skills" => {
                 println!("  skills: summarize, fleet-guide (ask the agent to use one in `chat`)")
             }
-            "pair" => println!("  `pair` (add a 2nd node) lands in the next stage."),
-            "delegate" => println!("  `delegate` (cross-node subagent) lands in a later stage."),
+            "pair" => {
+                if let Err(error) = pair(fleet).await {
+                    println!("  pair failed: {error}");
+                }
+            }
+            "delegate" => {
+                if let Err(error) = delegate(fleet).await {
+                    println!("  delegate failed: {error}");
+                }
+            }
             "down" | "quit" | "exit" => break,
             other => println!("  unknown command: {other} (try `help`)"),
         }
     }
     Ok(())
+}
+
+fn print_status(fleet: &Fleet) {
+    println!(
+        "  node A: live · agent {} · {}",
+        short(&fleet.did_a),
+        fleet.graphql_a
+    );
+    match &fleet.node_b {
+        Some(b) => {
+            println!("  node B: live · agent {} · {}", short(&b.did), b.graphql);
+            println!("  paired: yes · run `delegate` for cross-node subagent delegation");
+        }
+        None => println!("  node B: not paired (run `pair` to add a 2nd node)"),
+    }
+}
+
+// ---- pair (2-node fleet) ----------------------------------------------------
+
+async fn pair(fleet: &mut Fleet) -> Result<()> {
+    if fleet.node_b.is_some() {
+        println!("  already paired.");
+        return Ok(());
+    }
+    let bin = fleet.bin.clone();
+    let home_a = fleet.home_a.clone();
+    let home_b = home_a.join("node-b");
+    let work_b = home_b.join("work");
+    let port_b = fleet.base_port + 1;
+    let graphql_b = format!("http://127.0.0.1:{port_b}/api/v0/graphql");
+
+    println!("  initializing node B (worker)…");
+    let mut init_b: Vec<String> = vec![
+        "init".into(),
+        "--home".into(),
+        path_arg(&home_b),
+        "--dangerously-overwrite".into(),
+        "--agent-name".into(),
+        "worker".into(),
+        "--tool-root".into(),
+        path_arg(&work_b),
+        "--disable-defra-query".into(),
+    ];
+    init_b.extend(fleet.backend_init_args.iter().cloned());
+    let did_b = run_cli_json(&bin, &init_b)
+        .await?
+        .get("agent_did")
+        .and_then(Value::as_str)
+        .context("node B init did not return agent_did")?
+        .to_string();
+    std::fs::create_dir_all(&work_b)?;
+
+    println!("  starting node B…");
+    let mut server_b = spawn_server(&bin, &home_b, port_b, &home_b.join("server.log"))?;
+    wait_http(&format!("http://127.0.0.1:{port_b}/healthz"), &mut server_b).await?;
+
+    let (peer_a, addr_a) = p2p_identity(&bin, &home_a).await?;
+    let (peer_b, addr_b) = p2p_identity(&bin, &home_b).await?;
+
+    println!("  creating the network and enrolling node B…");
+    run_cli_text(
+        &bin,
+        &cli(&[
+            "p2p",
+            "network",
+            "create",
+            "--home",
+            &path_arg(&home_a),
+            "--name",
+            "Demo Fleet",
+            "--output",
+            "json",
+        ]),
+    )
+    .await?;
+    run_cli_text(
+        &bin,
+        &cli(&[
+            "p2p",
+            "network",
+            "grant",
+            "--home",
+            &path_arg(&home_a),
+            &did_b,
+            "--output",
+            "json",
+        ]),
+    )
+    .await?;
+    let token = run_cli_json(
+        &bin,
+        &cli(&[
+            "p2p",
+            "pairings",
+            "invite",
+            "--home",
+            &path_arg(&home_a),
+            "--member-did",
+            &did_b,
+            "--template",
+            "network-control",
+        ]),
+    )
+    .await?
+    .get("token")
+    .and_then(Value::as_str)
+    .context("invite missing token")?
+    .to_string();
+    run_cli_text(
+        &bin,
+        &cli(&[
+            "p2p",
+            "pairings",
+            "join",
+            "--home",
+            &path_arg(&home_b),
+            &token,
+        ]),
+    )
+    .await?;
+
+    println!("  installing the conversation data plane…");
+    upsert_data_plane(&fleet.graphql_a, &peer_b, &fleet.did_a, &addr_b).await?;
+    upsert_data_plane(&graphql_b, &peer_a, &did_b, &addr_a).await?;
+
+    println!("  waiting for replicators…");
+    wait_replicator(&graphql_b, &peer_a).await?;
+    wait_replicator(&fleet.graphql_a, &peer_b).await?;
+
+    fleet.node_b = Some(NodeB {
+        graphql: graphql_b,
+        did: did_b,
+        server: server_b,
+    });
+    println!(
+        "  ✓ paired. Node B (worker) is live; run `delegate` to enable cross-node delegation."
+    );
+    Ok(())
+}
+
+async fn p2p_identity(bin: &Path, home: &Path) -> Result<(String, String)> {
+    let status = run_cli_json(bin, &cli(&["p2p", "status", "--home", &path_arg(home)])).await?;
+    let peer = status
+        .get("p2p_peer_id")
+        .and_then(Value::as_str)
+        .context("p2p status missing p2p_peer_id")?
+        .to_string();
+    let addr = status
+        .get("p2p_shareable_address")
+        .and_then(Value::as_str)
+        .context("p2p status missing p2p_shareable_address")?
+        .to_string();
+    Ok((peer, addr))
+}
+
+const DATA_PLANE_COLLECTIONS: &str = r#"["AgentRequest","AgentResponse","AgentMessage","AgentToolCall","AgentToolResult","AgentSession","AgentConversation","CompactionEntry"]"#;
+
+async fn upsert_data_plane(
+    graphql: &str,
+    peer_id: &str,
+    local_did: &str,
+    address: &str,
+) -> Result<()> {
+    let peer = escape_graphql_string(peer_id);
+    let did = escape_graphql_string(local_did);
+    let addr = escape_graphql_string(address);
+    let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    let cols = DATA_PLANE_COLLECTIONS;
+    let mutation = format!(
+        r#"mutation {{
+  upsert_DataPlanePairingDesired(
+    filter: {{ peer_id: {{ _eq: "{peer}" }} }},
+    add: {{ peer_id: "{peer}", agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "conversation", created_at: "{now}", updated_at: "{now}" }},
+    update: {{ agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "conversation", updated_at: "{now}" }}
+  ) {{ _docID }}
+}}"#
+    );
+    post_graphql(graphql, &mutation).await?;
+    Ok(())
+}
+
+async fn wait_replicator(graphql: &str, peer_id: &str) -> Result<()> {
+    let query = format!(
+        r#"{{ PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{}" }} }}, limit: 1) {{ replicator_addresses replicator_filter }} }}"#,
+        escape_graphql_string(peer_id)
+    );
+    for _ in 0..240 {
+        if let Ok(resp) = post_graphql(graphql, &query).await {
+            let armed = resp
+                .pointer("/data/PeerPairingApplied/0/replicator_addresses")
+                .and_then(Value::as_array)
+                .map(|addresses| !addresses.is_empty())
+                .unwrap_or(false);
+            if armed {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("timed out waiting for the replicator for peer {peer_id}")
+}
+
+// ---- delegate (cross-node subagent) -----------------------------------------
+
+async fn delegate(fleet: &Fleet) -> Result<()> {
+    let Some(worker) = &fleet.node_b else {
+        bail!("not paired — run `pair` first");
+    };
+    println!("  configuring cross-node delegation…");
+    // Worker (node B) must accept cross-deployment spawns from the orchestrator.
+    config_tools(
+        &fleet.bin,
+        &worker.graphql,
+        &worker.did,
+        &[
+            "--enable-defra-query",
+            "false",
+            "--subagent-allow-cross-deployment",
+            "true",
+        ],
+    )
+    .await?;
+    let worker_gen = runtime_generation(&worker.graphql).await;
+    wait_runtime_reconcile(&worker.graphql, worker_gen).await;
+
+    // Orchestrator (node A): background spawn of a remote `worker` target.
+    let target = format!(
+        r#"{{"name":"worker","agent_did":"{}","behavior_id":"{}:default","description":"Remote worker subagent"}}"#,
+        worker.did, worker.did
+    );
+    let orch_gen = runtime_generation(&fleet.graphql_a).await;
+    config_tools(
+        &fleet.bin,
+        &fleet.graphql_a,
+        &fleet.did_a,
+        &[
+            "--enable-defra-query",
+            "false",
+            "--subagent-spawn-enabled",
+            "true",
+            "--subagent-background-enabled",
+            "true",
+            "--subagent-allow-cross-deployment",
+            "true",
+            "--subagent-target",
+            &target,
+        ],
+    )
+    .await?;
+    wait_runtime_reconcile(&fleet.graphql_a, orch_gen).await;
+
+    println!("  ✓ cross-node delegation enabled.");
+    println!("  In `chat`, ask the orchestrator to use its worker subagent, e.g.:");
+    println!(
+        "    Delegate to the worker subagent: summarize what a worker node does, then report back."
+    );
+    println!("  The child runs on node B (the worker) and its result replicates back.");
+    Ok(())
+}
+
+async fn config_tools(bin: &Path, graphql: &str, did: &str, extra: &[&str]) -> Result<()> {
+    let mut args: Vec<String> = vec![
+        "config".into(),
+        "tools".into(),
+        "set".into(),
+        "--graphql".into(),
+        graphql.into(),
+        "--agent-did".into(),
+        did.into(),
+        "--selection-id".into(),
+        format!("{did}:default-tools"),
+    ];
+    args.extend(extra.iter().map(|value| value.to_string()));
+    run_cli_text(bin, &args).await?;
+    Ok(())
+}
+
+async fn runtime_generation(graphql: &str) -> i64 {
+    post_graphql(graphql, "{ AgentRuntime { active_generation } }")
+        .await
+        .ok()
+        .and_then(|r| {
+            r.pointer("/data/AgentRuntime/0/active_generation")
+                .and_then(Value::as_i64)
+        })
+        .unwrap_or(0)
+}
+
+async fn wait_runtime_reconcile(graphql: &str, prev_generation: i64) {
+    for _ in 0..80 {
+        if let Ok(resp) = post_graphql(
+            graphql,
+            "{ AgentRuntime { active_generation reconcile_phase } }",
+        )
+        .await
+        {
+            let generation = resp
+                .pointer("/data/AgentRuntime/0/active_generation")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            let phase = resp
+                .pointer("/data/AgentRuntime/0/reconcile_phase")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if generation > prev_generation && phase == "idle" {
+                return;
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+/// Build an owned arg vector from string slices (paths must already be strings).
+fn cli(args: &[&str]) -> Vec<String> {
+    args.iter().map(|value| value.to_string()).collect()
 }
 
 async fn chat_loop(

--- a/crates/defra-agent-cli/src/commands/demo/mod.rs
+++ b/crates/defra-agent-cli/src/commands/demo/mod.rs
@@ -1,9 +1,9 @@
 //! `defra-agent demo` — an interactive, self-contained fleet demo that ships in
-//! the binary. Stage 1: boot a single curated local agent (read-only tools +
-//! demo skills) backed by a real model (interactive first-run backend picker,
-//! persisted), and drop into an interactive `demo>` shell. `pair`/`delegate`
-//! (2-node + cross-node delegation) and `desktop` (paired desktop client) come
-//! in later stages.
+//! the binary. It boots a single curated local agent (read-only tools + demo
+//! skills) backed by a real model (interactive first-run backend picker,
+//! persisted), and drops into an interactive `demo>` shell: `chat` with the
+//! agent, `pair` a 2nd node (worker), `delegate` cross-node subagent work, and
+//! `desktop` to open the paired desktop client.
 
 use std::io::{BufRead, Write as _};
 use std::path::{Path, PathBuf};
@@ -431,7 +431,7 @@ fn print_welcome(graphql: &str) {
     println!("  skills:  summarize, fleet-guide");
     println!("  graphql: {graphql}");
     println!();
-    println!("Commands: chat · skill · status · pair · delegate · help · down");
+    println!("Commands: chat · skill · status · pair · delegate · desktop · help · down");
     println!("Type `chat` to talk to your agent, or `help` for the full list.");
 }
 
@@ -460,6 +460,11 @@ async fn run_shell(
             "delegate" => {
                 if let Err(error) = delegate(fleet).await {
                     println!("  delegate failed: {error}");
+                }
+            }
+            "desktop" => {
+                if let Err(error) = desktop(fleet).await {
+                    println!("  desktop failed: {error}");
                 }
             }
             "down" | "quit" | "exit" => break,
@@ -784,6 +789,100 @@ fn cli(args: &[&str]) -> Vec<String> {
     args.iter().map(|value| value.to_string()).collect()
 }
 
+// ---- desktop (paired desktop client) ----------------------------------------
+
+async fn desktop(fleet: &Fleet) -> Result<()> {
+    let Some(desktop_bin) = resolve_desktop_bin() else {
+        println!("  The desktop app (`defra-agent-desktop`) was not found.");
+        println!("  Install it, or set DEFRA_AGENT_DESKTOP_BIN, then run `desktop` again.");
+        println!(
+            "  To seed it by hand: defra-agent-desktop init --status-endpoint {}",
+            fleet.graphql_a
+        );
+        return Ok(());
+    };
+    let desktop_home = fleet.home_a.join("desktop");
+
+    println!("  seeding desktop deployment(s)…");
+    seed_desktop(
+        &desktop_bin,
+        &desktop_home,
+        &fleet.graphql_a,
+        "demo (orchestrator)",
+        true,
+    )
+    .await?;
+    if let Some(worker) = &fleet.node_b {
+        seed_desktop(
+            &desktop_bin,
+            &desktop_home,
+            &worker.graphql,
+            "worker",
+            false,
+        )
+        .await?;
+    }
+
+    println!("  launching the desktop app…");
+    let mut cmd = std::process::Command::new(&desktop_bin);
+    cmd.env("DEFRA_AGENT_DESKTOP_HOME", path_arg(&desktop_home));
+    // Loopback demo nodes are already paired by the CLI; don't re-pair remotely.
+    cmd.env("DEFRA_AGENT_DESKTOP_PAIR_REMOTE_P2P", "0");
+    cmd.spawn().context("launching the desktop app")?;
+
+    println!("  ✓ Desktop app launched — it pairs with your demo node(s) over P2P.");
+    println!("    It opens in a separate window; keep this demo running. Open the Fleet");
+    println!("    Dashboard to see your node(s); Chat mirrors what you do here.");
+    Ok(())
+}
+
+async fn seed_desktop(
+    desktop_bin: &Path,
+    desktop_home: &Path,
+    graphql: &str,
+    label: &str,
+    overwrite: bool,
+) -> Result<()> {
+    let mut args: Vec<String> = vec![
+        "init".into(),
+        "--desktop-home".into(),
+        path_arg(desktop_home),
+        "--status-endpoint".into(),
+        graphql.into(),
+        "--label".into(),
+        label.into(),
+    ];
+    if overwrite {
+        args.push("--dangerously-overwrite".into());
+    }
+    run_cli_text(desktop_bin, &args).await?;
+    Ok(())
+}
+
+/// Locate the `defra-agent-desktop` launcher: explicit env, then a sibling of
+/// this binary, then PATH.
+fn resolve_desktop_bin() -> Option<PathBuf> {
+    if let Some(explicit) = std::env::var_os("DEFRA_AGENT_DESKTOP_BIN") {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return Some(path);
+        }
+    }
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(sibling) = exe.parent().map(|dir| dir.join("defra-agent-desktop")) {
+            if sibling.is_file() {
+                return Some(sibling);
+            }
+        }
+    }
+    let name = "defra-agent-desktop";
+    std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path)
+            .map(|dir| dir.join(name))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
 async fn chat_loop(
     graphql: &str,
     agent_did: &str,
@@ -817,8 +916,9 @@ fn print_help() {
     println!("  chat      talk to your agent (skills available; `/back` to exit)");
     println!("  skill     list the demo skills");
     println!("  status    show the fleet state");
-    println!("  pair      spin up a 2nd node and pair it (next stage)");
-    println!("  delegate  cross-node subagent delegation (later stage)");
+    println!("  pair      spin up a 2nd node (worker) and pair it");
+    println!("  delegate  enable cross-node subagent delegation (run after `pair`)");
+    println!("  desktop   open the desktop app paired to your demo node(s)");
     println!("  down      stop and exit (state is saved; `--reset` to wipe)");
 }
 

--- a/crates/defra-agent-cli/src/commands/demo/mod.rs
+++ b/crates/defra-agent-cli/src/commands/demo/mod.rs
@@ -14,6 +14,7 @@ use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::{Child, Command};
 
+use defra_agent::agent::p2p_reconcile::resolve_template;
 use defra_agent::graphql::escape_graphql_string;
 
 use crate::cli::args::DemoArgs;
@@ -101,6 +102,7 @@ struct Fleet {
 }
 
 struct NodeB {
+    home: PathBuf,
     graphql: String,
     did: String,
     server: Child,
@@ -594,14 +596,22 @@ async fn pair(fleet: &mut Fleet) -> Result<()> {
     .await?;
 
     println!("  installing the conversation data plane…");
-    upsert_data_plane(&fleet.graphql_a, &peer_b, &fleet.did_a, &addr_b).await?;
-    upsert_data_plane(&graphql_b, &peer_a, &did_b, &addr_a).await?;
+    upsert_data_plane(
+        &fleet.graphql_a,
+        &peer_b,
+        &fleet.did_a,
+        &addr_b,
+        "conversation",
+    )
+    .await?;
+    upsert_data_plane(&graphql_b, &peer_a, &did_b, &addr_a, "conversation").await?;
 
     println!("  waiting for replicators…");
     wait_replicator(&graphql_b, &peer_a).await?;
     wait_replicator(&fleet.graphql_a, &peer_b).await?;
 
     fleet.node_b = Some(NodeB {
+        home: home_b,
         graphql: graphql_b,
         did: did_b,
         server: server_b,
@@ -627,30 +637,42 @@ async fn p2p_identity(bin: &Path, home: &Path) -> Result<(String, String)> {
     Ok((peer, addr))
 }
 
-const DATA_PLANE_COLLECTIONS: &str = r#"["AgentRequest","AgentResponse","AgentMessage","AgentToolCall","AgentToolResult","AgentSession","AgentConversation","CompactionEntry"]"#;
-
 async fn upsert_data_plane(
     graphql: &str,
     peer_id: &str,
     local_did: &str,
     address: &str,
+    template: &str,
 ) -> Result<()> {
     let peer = escape_graphql_string(peer_id);
     let did = escape_graphql_string(local_did);
     let addr = escape_graphql_string(address);
+    let cols = data_plane_collections_literal(template)?;
+    let template = escape_graphql_string(template);
     let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
-    let cols = DATA_PLANE_COLLECTIONS;
     let mutation = format!(
         r#"mutation {{
   upsert_DataPlanePairingDesired(
     filter: {{ peer_id: {{ _eq: "{peer}" }} }},
-    add: {{ peer_id: "{peer}", agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "conversation", created_at: "{now}", updated_at: "{now}" }},
-    update: {{ agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "conversation", updated_at: "{now}" }}
+    add: {{ peer_id: "{peer}", agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "{template}", created_at: "{now}", updated_at: "{now}" }},
+    update: {{ agent_did: "{did}", collections: {cols}, replicator_addresses: ["{addr}"], template: "{template}", updated_at: "{now}" }}
   ) {{ _docID }}
 }}"#
     );
     post_graphql(graphql, &mutation).await?;
     Ok(())
+}
+
+fn data_plane_collections_literal(template: &str) -> Result<String> {
+    let template = resolve_template(template)
+        .with_context(|| format!("unknown data-plane template {template:?}"))?;
+    let collections = template
+        .collections
+        .iter()
+        .map(|collection| format!(r#""{}""#, escape_graphql_string(collection)))
+        .collect::<Vec<_>>()
+        .join(",");
+    Ok(format!("[{collections}]"))
 }
 
 async fn wait_replicator(graphql: &str, peer_id: &str) -> Result<()> {
@@ -674,6 +696,31 @@ async fn wait_replicator(graphql: &str, peer_id: &str) -> Result<()> {
     bail!("timed out waiting for the replicator for peer {peer_id}")
 }
 
+async fn wait_replicator_filter(graphql: &str, peer_id: &str, needles: &[String]) -> Result<()> {
+    let query = format!(
+        r#"{{ PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{}" }} }}, limit: 1) {{ replicator_addresses replicator_filter }} }}"#,
+        escape_graphql_string(peer_id)
+    );
+    for _ in 0..240 {
+        if let Ok(resp) = post_graphql(graphql, &query).await {
+            let armed = resp
+                .pointer("/data/PeerPairingApplied/0/replicator_addresses")
+                .and_then(Value::as_array)
+                .map(|addresses| !addresses.is_empty())
+                .unwrap_or(false);
+            let filter = resp
+                .pointer("/data/PeerPairingApplied/0/replicator_filter")
+                .and_then(Value::as_str)
+                .unwrap_or("");
+            if armed && needles.iter().all(|needle| filter.contains(needle)) {
+                return Ok(());
+            }
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("timed out waiting for the data-plane filter for peer {peer_id}")
+}
+
 // ---- delegate (cross-node subagent) -----------------------------------------
 
 async fn delegate(fleet: &Fleet) -> Result<()> {
@@ -681,6 +728,43 @@ async fn delegate(fleet: &Fleet) -> Result<()> {
         bail!("not paired — run `pair` first");
     };
     println!("  configuring cross-node delegation…");
+    let (peer_a, addr_a) = p2p_identity(&fleet.bin, &fleet.home_a).await?;
+    let (peer_b, addr_b) = p2p_identity(&fleet.bin, &worker.home).await?;
+
+    println!("  switching the data plane to subagent delegation templates…");
+    upsert_data_plane(
+        &fleet.graphql_a,
+        &peer_b,
+        &fleet.did_a,
+        &addr_b,
+        "subagent-coordinator",
+    )
+    .await?;
+    upsert_data_plane(
+        &worker.graphql,
+        &peer_a,
+        &worker.did,
+        &addr_a,
+        "subagent-host",
+    )
+    .await?;
+    wait_replicator_filter(
+        &fleet.graphql_a,
+        &peer_b,
+        &[
+            "AgentToolCall".to_string(),
+            "spawn_target_did".to_string(),
+            worker.did.clone(),
+        ],
+    )
+    .await?;
+    wait_replicator_filter(
+        &worker.graphql,
+        &peer_a,
+        &["AgentRequest".to_string(), worker.did.clone()],
+    )
+    .await?;
+
     // Worker (node B) must accept cross-deployment spawns from the orchestrator.
     config_tools(
         &fleet.bin,

--- a/crates/defra-agent-desktop-core/src/client/core.rs
+++ b/crates/defra-agent-desktop-core/src/client/core.rs
@@ -448,6 +448,15 @@ impl ClientCore {
         let Some(record) = record else {
             return Ok(None);
         };
+        if record
+            .graphql
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+        {
+            return Ok(None);
+        }
 
         self.refresh_remote_peer_record(&record).await.map(Some)
     }

--- a/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
@@ -708,6 +708,7 @@ mod pairing_reconcile_tests {
         let stub = StubRemoteAdmin::new();
         let desired = PairingDesired {
             collections: ["c1", "c2"].iter().map(|s| s.to_string()).collect(),
+            template_ids: Default::default(),
             replicator_collections: ["c1", "c2"].iter().map(|s| s.to_string()).collect(),
             replicator_addresses: ["/ip4/1/p2p/p"].iter().map(|s| s.to_string()).collect(),
             replicator_filter: Default::default(),

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -710,9 +710,52 @@ fn data_plane_desired_from_pairing_row(
         }
     }
 
-    row.agent_did = Some(self_did.to_string());
+    let template_id = row
+        .template
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .unwrap_or(DEFAULT_PAIRING_TEMPLATE);
+    let template = resolve_template(template_id).unwrap_or_else(|| {
+        tracing::warn!(
+            template = template_id,
+            "unknown data-plane pairing scope template; falling back to default \"{DEFAULT_PAIRING_TEMPLATE}\""
+        );
+        resolve_template(DEFAULT_PAIRING_TEMPLATE)
+            .expect("default pairing template is in the catalog")
+    });
+    let peer_did = signed_endpoint.agent_did.trim();
+    if data_plane_scope_requires_signed_peer_did(&template.scope) && peer_did.is_empty() {
+        anyhow::bail!(
+            "DataPlanePairingDesired for peer {} uses template {template_id:?} but the signed \
+             PeerEndpoint has a blank agent_did",
+            signed_endpoint.peer_id
+        );
+    }
+
     row.replicator_addresses = Some(vec![signed_endpoint.address.clone()]);
-    desired_from_pairing_row(row, self_did)
+    let replicator_addresses = row
+        .replicator_addresses
+        .unwrap_or_default()
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>();
+    let replicator_collections = template
+        .collections
+        .iter()
+        .map(|&c| c.to_string())
+        .collect::<BTreeSet<_>>();
+    let replicator_filter =
+        data_plane_scope_filter(&template.scope, template.collections, peer_did, self_did);
+
+    Ok(PairingDesired {
+        collections: BTreeSet::new(),
+        replicator_addresses,
+        replicator_collections,
+        replicator_filter,
+        template_ids: BTreeSet::from([template.id.to_string()]),
+    })
 }
 
 fn scope_requires_peer_did(scope: &Scope) -> bool {
@@ -722,6 +765,54 @@ fn scope_requires_peer_did(scope: &Scope) -> bool {
         Scope::PerCollection(rules) => rules
             .iter()
             .any(|rule| matches!(rule.source, DidSource::PeerDid)),
+    }
+}
+
+fn data_plane_scope_requires_signed_peer_did(scope: &Scope) -> bool {
+    match scope {
+        Scope::PeerDid { .. } | Scope::Unscoped => false,
+        Scope::PerCollection(rules) => rules
+            .iter()
+            .any(|rule| matches!(rule.source, DidSource::PeerDid)),
+    }
+}
+
+fn data_plane_scope_filter(
+    scope: &Scope,
+    collections: &[&str],
+    signed_peer_did: &str,
+    local_did: &str,
+) -> PairingFilters {
+    match scope {
+        Scope::PeerDid { field } => collections
+            .iter()
+            .map(|&col| {
+                (
+                    col.to_string(),
+                    super::templates::FilterPredicate {
+                        field: (*field).to_string(),
+                        value: local_did.to_string(),
+                    },
+                )
+            })
+            .collect(),
+        Scope::Unscoped => BTreeMap::new(),
+        Scope::PerCollection(rules) => rules
+            .iter()
+            .map(|rule| {
+                let value = match rule.source {
+                    DidSource::LocalDid => local_did,
+                    DidSource::PeerDid => signed_peer_did,
+                };
+                (
+                    rule.collection.to_string(),
+                    super::templates::FilterPredicate {
+                        field: rule.field.to_string(),
+                        value: value.to_string(),
+                    },
+                )
+            })
+            .collect(),
     }
 }
 
@@ -938,6 +1029,69 @@ mod tests {
                 .map(|filter| (filter.field.as_str(), filter.value.as_str())),
             Some(("agent_did", "did:key:self"))
         );
+    }
+
+    #[test]
+    fn data_plane_subagent_coordinator_uses_signed_peer_for_targeted_bridge() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:host".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let desired = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:coord".to_string()),
+                collections: None,
+                replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
+                template: Some("subagent-coordinator".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:coord",
+        )
+        .expect("data-plane coordinator desired");
+
+        assert_eq!(
+            desired
+                .replicator_filter
+                .get("AgentRequest")
+                .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            Some(("agent_did", "did:key:coord"))
+        );
+        assert_eq!(
+            desired
+                .replicator_filter
+                .get("AgentToolCall")
+                .map(|filter| (filter.field.as_str(), filter.value.as_str())),
+            Some(("spawn_target_did", "did:key:host"))
+        );
+    }
+
+    #[test]
+    fn data_plane_subagent_host_scopes_child_conversation_to_local_host() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-a".to_string(),
+            agent_did: "did:key:coord".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-a".to_string(),
+        };
+        let desired = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:host".to_string()),
+                collections: None,
+                replicator_addresses: Some(vec![signed_endpoint.address.clone()]),
+                template: Some("subagent-host".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:host",
+        )
+        .expect("data-plane host desired");
+
+        assert_eq!(desired.replicator_filter.len(), 8);
+        for predicate in desired.replicator_filter.values() {
+            assert_eq!(predicate.field, "agent_did");
+            assert_eq!(predicate.value, "did:key:host");
+        }
     }
 
     #[test]

--- a/crates/defra-agent/src/hook/persistence/message_spawn.rs
+++ b/crates/defra-agent/src/hook/persistence/message_spawn.rs
@@ -603,6 +603,24 @@ impl DefraSessionHook {
         }
 
         if let Some(child_deadline) = parsed.deadline.as_ref() {
+            if *child_deadline <= chrono::Utc::now() {
+                return self
+                    .fail_spawn_subagent_tool_call(
+                        session_id,
+                        request_id,
+                        parent_context.request_deadline_at,
+                        seq,
+                        internal_call_id,
+                        args,
+                        FailureClass::ArgumentInvalid,
+                        invalid_tool_arguments_payload(
+                            SPAWN_SUBAGENT_TOOL_NAME,
+                            "/deadline",
+                            "deadline must be in the future",
+                        ),
+                    )
+                    .await;
+            }
             if *child_deadline > parent_context.request_deadline_at {
                 return self
                     .fail_spawn_subagent_tool_call(

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -187,11 +187,6 @@ impl Tool for SpawnSubagentTool {
                         "enum": await_modes,
                         "default": self.config.default_await_mode.as_str(),
                         "description": "Use foreground to wait for the child result. Use background only when the schema exposes it."
-                    },
-                    "deadline": {
-                        "type": "string",
-                        "format": "date-time",
-                        "description": "Optional RFC3339 deadline for the child, bounded by the parent request deadline."
                     }
                 },
                 "required": ["name", "prompt"]

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -401,6 +401,10 @@ async fn subagent_tool_definitions_register_expected_surface() {
         spawn_def.parameters["properties"]["await_mode"]["enum"],
         serde_json::json!(["foreground"])
     );
+    assert!(
+        spawn_def.parameters["properties"].get("deadline").is_none(),
+        "spawn_subagent should not advertise model-supplied absolute deadlines"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Combines the remaining demo stack into one PR. This supersedes the old staged split:

- #585: `pair` + `delegate` two-node cross-node delegation
- #586: `desktop` launch + delegated desktop demo hardening

## What changed

- Adds `pair` to bring up node B (worker), enroll it with signed network-control data, install the conversation data plane, and wait for replication.
- Adds `delegate` to configure cross-node subagent delegation from the orchestrator to the worker.
- Adds `desktop` to seed an isolated desktop home with demo deployments and launch the Tauri desktop shell against the demo node(s).
- Fixes demo pairing/reconcile wiring so the worker is visible and usable from desktop over the GraphQL-backed remote snapshot path.
- Makes desktop agent selection refresh remote GraphQL snapshots instead of relying on the startup snapshot.
- Shows in-flight sidebar sessions immediately from `AgentRequest` rows, even before `AgentConversation` materialization catches up.
- Hides stale `spawn_subagent.deadline` from the model-facing tool schema while still accepting older args at the parser boundary.

## Verified

- `cargo fmt --check`
- `cargo test -p defra-agent data_plane_subagent -- --nocapture`
- `cargo test -p defra-agent subagent_tool_definitions_register_expected_surface -- --nocapture`
- `cargo test -p defra-agent-desktop-core selected_agent_did_channel_updates_subscribers -- --nocapture`
- `cargo test -p defra-agent-desktop-core ensure_agent_loaded -- --nocapture`
- `cargo test -p defra-agent-desktop-tauri request_backed_conversation_summaries_include_in_flight_sessions -- --nocapture`
- `cargo test -p defra-agent-desktop-tauri session_snapshot_stays_renderable_across_single_turn_observation_updates -- --nocapture`
- `cargo build -p defra-agent-cli --bin defra-agent`
- `cargo build -p defra-agent-desktop --bin defra-agent-desktop`
- `cargo check -p defra-agent-desktop-tauri`
- `npm run build`
- `npm run tauri -- build --no-bundle`

## Demo

```sh
defra-agent demo --reset --backend-preset vllm \
  --inference-url http://100.87.27.25:8000/v1 \
  --model nex-n2
```

Then in the demo prompt:

```text
pair
delegate
desktop
```
