### PR TITLE
desktop: fix #583, gate the tauri crate in CI, and harden the UI test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,15 @@ jobs:
           cargo test -p defra-agent-cli --test cli_server server_startup_with_iroh_p2p_reports_runtime_connectivity -- --nocapture --test-threads=1
           cargo test -p defra-agent-cli --test cli_status -- --nocapture --test-threads=1
           cargo test -p defra-agent-cli --test cli_reconciliation reconciled_runtime_sends_generation_two_tools_and_completes_tool_loop -- --nocapture --test-threads=1
+          cargo test -p defra-agent-desktop-tauri --lib
 
       - name: Run full library and integration tests
         if: github.event_name != 'pull_request'
         run: cargo test -p defra-agent --lib --tests
+
+      - name: Run desktop Tauri crate tests
+        if: github.event_name != 'pull_request'
+        run: cargo test -p defra-agent-desktop-tauri --lib
 
       - name: Run full CLI test suite
         if: github.event_name != 'pull_request'

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_state.rs
@@ -494,7 +494,7 @@ fn session_snapshot_transcript_rendering_consumes_generated_transcript_cases() {
     let cases = lean_transcript_cases();
     assert_eq!(
         cases.len(),
-        6,
+        7,
         "desktop transcript rendering should consume every generated Lean transcript case"
     );
 
@@ -1210,6 +1210,37 @@ fn transcript_contract_messages(case: &LeanTranscriptCase) -> Vec<AgentMessageRo
             transcript_assistant_tool_call_message_json("result-drain"),
         )],
         "drop_abandon_not_strong_drain" => Vec::new(),
+        // Three parallel tool calls accumulate in ONE assistant turn (sequence 2),
+        // then each streamed result appends its own user row (sequences 3..5).
+        "parallel_results_share_assistant_turn" => {
+            let result_ids = transcript_contract_result_ids(case);
+            let mut rows = vec![
+                transcript_message_row(
+                    "msg-user",
+                    1,
+                    "user",
+                    user_message_json(&format!("{} prompt", case.name)),
+                ),
+                transcript_message_row(
+                    "msg-assistant-parallel-tools",
+                    case.assistant_sequence,
+                    "assistant",
+                    transcript_assistant_parallel_tool_call_message_json(&result_ids),
+                ),
+            ];
+            for (index, result_id) in result_ids.iter().enumerate() {
+                rows.push(transcript_message_row(
+                    &format!("msg-tool-result-{index}"),
+                    case.result_sequence + index,
+                    "user",
+                    transcript_tool_result_message_json(
+                        result_id,
+                        &format!("payload-{}", case.payload_hash),
+                    ),
+                ));
+            }
+            rows
+        }
         other => panic!("unsupported Lean transcript case {other:?}"),
     }
 }
@@ -1220,6 +1251,7 @@ fn transcript_contract_request_content(case: &LeanTranscriptCase) -> Option<Stri
         "ordering_user_assistant_tool_result"
             | "dedupe_duplicate_reuses_sequence"
             | "completed_tool_pair_closed"
+            | "parallel_results_share_assistant_turn"
     )
     .then(|| format!("{} prompt", case.name))
 }
@@ -1228,6 +1260,7 @@ fn transcript_contract_tool_calls(
     case: &LeanTranscriptCase,
 ) -> Vec<defra_agent_protocol::row::AgentToolCallRow> {
     let lifecycle_state = transcript_contract_tool_lifecycle(case);
+    let result_ids = transcript_contract_result_ids(case);
     (0..case.post_tool_call_count)
         .map(|index| defra_agent_protocol::row::AgentToolCallRow {
             tool_call_key: format!("tool-{}-{index}", case.name),
@@ -1235,7 +1268,7 @@ fn transcript_contract_tool_calls(
             request_id: Some("req-1".to_string()),
             message_sequence: transcript_contract_tool_group_sequence(case),
             tool_name: Some("read".to_string()),
-            tool_call_id: Some(transcript_contract_result_id(case)),
+            tool_call_id: Some(result_ids[index].clone()),
             args: Some(r#"{"file_path":"/tmp/transcript-contract.txt"}"#.to_string()),
             result: (lifecycle_state == "completed")
                 .then(|| format!("payload-{}", case.payload_hash)),
@@ -1299,6 +1332,28 @@ fn transcript_assistant_tool_call_message_json(model_call_id: &str) -> String {
     .expect("serialize assistant tool-call message")
 }
 
+fn transcript_assistant_parallel_tool_call_message_json(call_ids: &[String]) -> String {
+    serde_json::to_string(&Message::Assistant {
+        id: None,
+        content: call_ids
+            .iter()
+            .map(|call_id| {
+                AssistantContent::ToolCall(ToolCall {
+                    id: call_id.clone(),
+                    call_id: Some(call_id.clone()),
+                    function: ToolFunction {
+                        name: "read".to_string(),
+                        arguments: json!({ "file_path": "/tmp/transcript-contract.txt" }),
+                    },
+                    signature: None,
+                    additional_params: None,
+                })
+            })
+            .collect(),
+    })
+    .expect("serialize parallel assistant tool-call message")
+}
+
 fn transcript_tool_result_message_json(result_id: &str, text: &str) -> String {
     serde_json::to_string(&Message::User {
         content: vec![UserContent::ToolResult(ToolResult {
@@ -1320,6 +1375,18 @@ fn transcript_contract_result_id(case: &LeanTranscriptCase) -> String {
     }
 }
 
+/// Result ids for a case's tool calls. Single-result cases reuse the one logical
+/// result id; the parallel case derives its siblings by offset from the first
+/// (`logical_result_id`, `+1`, `+2`), matching the Lean driver's parallel turn.
+fn transcript_contract_result_ids(case: &LeanTranscriptCase) -> Vec<String> {
+    if case.post_tool_call_count <= 1 {
+        return vec![transcript_contract_result_id(case)];
+    }
+    (0..case.post_tool_call_count)
+        .map(|index| format!("result-{}", case.logical_result_id as usize + index))
+        .collect()
+}
+
 fn transcript_contract_tool_lifecycle(case: &LeanTranscriptCase) -> &'static str {
     match case.action.as_str() {
         "cancel_fail_or_timeout_in_flight" => "cancelled",
@@ -1339,6 +1406,7 @@ fn transcript_contract_tool_result_rows(case: &LeanTranscriptCase) -> usize {
         | "dedupe_duplicate_reuses_sequence"
         | "completed_tool_pair_closed" => 1,
         "distinct_result_ids_append_distinct_rows" => 2,
+        "parallel_results_share_assistant_turn" => 3,
         "explicit_drain_terminalizes_ownership" | "drop_abandon_not_strong_drain" => 0,
         other => panic!("unsupported Lean transcript case {other:?}"),
     }
@@ -1348,7 +1416,8 @@ fn transcript_contract_rendered_kinds(case: &LeanTranscriptCase) -> Vec<&'static
     match case.name.as_str() {
         "ordering_user_assistant_tool_result"
         | "dedupe_duplicate_reuses_sequence"
-        | "completed_tool_pair_closed" => vec!["user", "tools"],
+        | "completed_tool_pair_closed"
+        | "parallel_results_share_assistant_turn" => vec!["user", "tools"],
         "distinct_result_ids_append_distinct_rows" => Vec::new(),
         "explicit_drain_terminalizes_ownership" | "drop_abandon_not_strong_drain" => {
             vec!["tools"]

--- a/apps/desktop-tauri/src-tauri/src/bridge/tests/support.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tests/support.rs
@@ -6,7 +6,6 @@ use tempfile::TempDir;
 
 /// Minimal projection of an `AgentRequest` row used in interrupt tests.
 pub(crate) struct AgentRequestRowLite {
-    pub request_id: String,
     pub interrupt_requested_at: Option<String>,
 }
 
@@ -381,7 +380,6 @@ pub(crate) async fn fetch_request_row(
                 filter: {{ request_id: {{ _eq: "{escaped}" }} }},
                 limit: 1
             ) {{
-                request_id
                 interrupt_requested_at
             }}
         }}"#
@@ -402,12 +400,6 @@ pub(crate) async fn fetch_request_row(
         .cloned()
         .unwrap_or_else(|| panic!("fetch_request_row: request {request_id} not found"));
 
-    let request_id_out = row
-        .get("request_id")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
-
     let interrupt_requested_at = row
         .get("interrupt_requested_at")
         .and_then(|v| v.as_str())
@@ -416,7 +408,6 @@ pub(crate) async fn fetch_request_row(
         .map(ToOwned::to_owned);
 
     AgentRequestRowLite {
-        request_id: request_id_out,
         interrupt_requested_at,
     }
 }

--- a/apps/desktop-tauri/tests/add-peer-form.test.tsx
+++ b/apps/desktop-tauri/tests/add-peer-form.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AddPeerForm,
+  type AddPeerFormProps,
+} from "../src/components/fleet/AddPeerForm";
+import type { PeerAddRequest } from "../src/lib/types";
+
+function renderForm(overrides: Partial<AddPeerFormProps> = {}) {
+  const peerForm: PeerAddRequest = {
+    label: "worker-a",
+    agentDid: "did:key:z6MkWorkerA",
+    addr: "/ip4/100.73.235.39/tcp/9161/p2p/12D3KooWorker",
+    graphql: "http://127.0.0.1:9181/api/v0/graphql",
+  };
+  const props: AddPeerFormProps = {
+    addingPeer: false,
+    disabled: false,
+    localError: null,
+    peerForm,
+    onPeerFormChange: vi.fn(),
+    onFetchPeerStatus: vi.fn(async () => ({})),
+    onSubmit: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  render(<AddPeerForm {...props} />);
+  return props;
+}
+
+describe("AddPeerForm", () => {
+  it("submits a complete manual peer via onSubmit without fetching /status", async () => {
+    const props = renderForm();
+    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith({
+        label: "worker-a",
+        agentDid: "did:key:z6MkWorkerA",
+        addr: "/ip4/100.73.235.39/tcp/9161/p2p/12D3KooWorker",
+        graphql: "http://127.0.0.1:9181/api/v0/graphql",
+      });
+    });
+    expect(props.onFetchPeerStatus).not.toHaveBeenCalled();
+  });
+
+  it("fetches /status then submits the discovered peer when the manual triple is incomplete", async () => {
+    // /status returns a runtime descriptor; the form parses it into a peer and
+    // submits THAT (fetch -> parse -> submit), not the empty manual form.
+    const discovered = {
+      agent_name: "discovered-worker",
+      agent_did: "did:key:z6MkDiscovered",
+      p2p_shareable_address: "/ip4/1.2.3.4/tcp/9161/p2p/12D3KooDiscovered",
+    };
+    const props = renderForm({
+      peerForm: { label: "", agentDid: "", addr: "", graphql: null },
+      onFetchPeerStatus: vi.fn(async () => discovered),
+    });
+    fireEvent.change(screen.getByTestId("fleet-add-server-address"), {
+      target: { value: "http://127.0.0.1:9181" },
+    });
+    fireEvent.click(screen.getByTestId("fleet-add-submit"));
+
+    await waitFor(() => {
+      expect(props.onFetchPeerStatus).toHaveBeenCalledWith("http://127.0.0.1:9181");
+    });
+    await waitFor(() => {
+      expect(props.onSubmit).toHaveBeenCalledWith({
+        label: "discovered-worker",
+        agentDid: "did:key:z6MkDiscovered",
+        addr: "/ip4/1.2.3.4/tcp/9161/p2p/12D3KooDiscovered",
+      });
+    });
+  });
+
+  it("renders a local error", () => {
+    renderForm({ localError: "peer already exists" });
+    expect(screen.getByText("peer already exists")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop-tauri/tests/fleet-row.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-row.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FleetRow, type FleetRowProps } from "../src/components/fleet/FleetRow";
+import type { DeploymentView } from "../src/lib/types";
+import { deployment } from "./config-panel-wiring/fixtures";
+
+function renderRow(
+  overrides: Partial<FleetRowProps> = {},
+  dep: DeploymentView = deployment,
+) {
+  const props: FleetRowProps = {
+    bootstrap: null,
+    deployment: dep,
+    p2pHealth: null,
+    repairingP2P: false,
+    onOpenChat: vi.fn(),
+    onOpenConfig: vi.fn(),
+    onRepairP2P: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  render(
+    <table>
+      <tbody>
+        <FleetRow {...props} />
+      </tbody>
+    </table>,
+  );
+  return props;
+}
+
+describe("FleetRow", () => {
+  it("renders the three action buttons keyed by peerId", () => {
+    renderRow();
+    expect(screen.getByTestId("fleet-chat-peer-1")).toBeInTheDocument();
+    expect(screen.getByTestId("fleet-config-peer-1")).toBeInTheDocument();
+    expect(screen.getByTestId("fleet-repair-peer-1")).toBeInTheDocument();
+  });
+
+  it("calls onOpenChat with the agent DID when the chat button is clicked", () => {
+    const props = renderRow();
+    fireEvent.click(screen.getByTestId("fleet-chat-peer-1"));
+    expect(props.onOpenChat).toHaveBeenCalledWith(deployment.agentDid);
+  });
+
+  it("calls onOpenConfig with the agent DID when the config button is clicked", () => {
+    const props = renderRow();
+    fireEvent.click(screen.getByTestId("fleet-config-peer-1"));
+    expect(props.onOpenConfig).toHaveBeenCalledWith(deployment.agentDid);
+  });
+
+  it("disables repair when the peer dialed successfully with no error", () => {
+    renderRow({}, { ...deployment, dialSucceeded: true, lastError: null });
+    expect(screen.getByTestId("fleet-repair-peer-1")).toBeDisabled();
+  });
+
+  it("enables repair and fires onRepairP2P (no args) when the peer has not dialed", () => {
+    const props = renderRow({}, { ...deployment, dialSucceeded: false });
+    const repair = screen.getByTestId("fleet-repair-peer-1");
+    expect(repair).toBeEnabled();
+    fireEvent.click(repair);
+    expect(props.onRepairP2P).toHaveBeenCalledTimes(1);
+    // Repair is fired with NO args (unlike chat/config which pass the DID).
+    expect(props.onRepairP2P).toHaveBeenCalledWith();
+  });
+
+  it("enables repair when the peer dialed but reported a last error", () => {
+    renderRow({}, { ...deployment, dialSucceeded: true, lastError: "dial timeout" });
+    expect(screen.getByTestId("fleet-repair-peer-1")).toBeEnabled();
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-async-states.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-async-states.spec.ts
@@ -1,0 +1,91 @@
+import {
+  expect,
+  gotoHarness,
+  openChat,
+  openConfig,
+  openConfigTab,
+  PEER_ID,
+  saveConfig,
+  test,
+} from "./desktopTest";
+
+// Exercises the three harness scenarios that were defined but never driven:
+// `loading`, `save-error`, `backend-health-error`. Assertions go deeper than the
+// existing single-banner sad-path check — convergence, recovery, and failure
+// isolation — so a regression in async/error handling can't ship unseen.
+test.describe("desktop async states", () => {
+  test("loading scenario converges from a busy fleet-empty to the dashboard", async ({
+    page,
+  }) => {
+    // The `loading` scenario delays the snapshot fetch by 250ms; gotoHarness
+    // resolves on the transient fleet-empty. The invariant we lock in is that a
+    // slow-but-successful load converges to the full fleet with no error surfaced.
+    await gotoHarness(page, "loading");
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toBeVisible();
+    await expect(page.getByTestId("error-banner")).toHaveCount(0);
+  });
+
+  test("save-error surfaces the banner, suppresses the Saved chip, and recovers", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "save-error");
+    await openConfig(page);
+    await openConfigTab(page, "behavior");
+
+    await page
+      .getByTestId("behavior-system-prompt")
+      .fill("This behavior save is rejected by the harness.");
+    await page.getByTestId("behavior-save").click();
+
+    // The failed save routes through the shell error banner (String(err) prefix).
+    await expect(page.getByTestId("error-banner")).toContainText(
+      "Harness rejected behavior save",
+    );
+    // Negative invariant: no "Saved" confirmation chip on a failed save.
+    await expect(
+      page.locator(".config-editor").getByText("Saved", { exact: true }),
+    ).toHaveCount(0);
+    // The button must recover, not stay stuck in the disabled "Saving..." state.
+    const saveButton = page.getByTestId("behavior-save");
+    await expect(saveButton).toBeEnabled();
+    await expect(saveButton).toHaveText("Save Behavior");
+
+    // `save-error` is scoped to behavior saves only: a backend save still succeeds
+    // and clears the banner (setError(null) at the start of the next action).
+    await openConfigTab(page, "backends");
+    await page.getByTestId("backend-name").fill("OpenAI Harness Recovered");
+    await saveConfig(page, "backend-save");
+    await expect(page.getByTestId("error-banner")).toHaveCount(0);
+  });
+
+  test("backend-health-error is isolated to the Backends tab; other ops tabs still work", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "backend-health-error");
+    await openChat(page);
+
+    await page.getByRole("button", { name: /open operations drawer/i }).click();
+    await expect(page.getByRole("complementary", { name: "Operations" })).toBeVisible();
+
+    // Backends tab: the panel heading still renders, but the fetch shows an alert.
+    await page.getByRole("tab", { name: /Backends/ }).click();
+    await expect(page.getByRole("heading", { name: "Backend health" })).toBeVisible();
+    await expect(page.locator(".backend-health__error")).toHaveText(
+      "Failed to load backend health: Harness backend health bridge unavailable.",
+    );
+
+    // Isolation: the other operations tabs are unaffected by the backend failure.
+    await page.getByRole("tab", { name: /MCP health/ }).click();
+    await expect(
+      page.getByRole("heading", { name: "MCP services / health" }),
+    ).toBeVisible();
+    await expect(page.getByText("mcp-observability")).toBeVisible();
+
+    await page.getByRole("tab", { name: /Lineage/ }).click();
+    await expect(page.getByRole("tree", { name: "Subagent lineage" })).toBeVisible();
+
+    // The failure is panel-local — it never routes through the shell error banner.
+    await expect(page.getByTestId("error-banner")).toHaveCount(0);
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-fleet-actions.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-fleet-actions.spec.ts
@@ -1,0 +1,42 @@
+import { expect, gotoHarness, PEER_ID, test } from "./desktopTest";
+
+// The fleet-row navigation is exercised elsewhere via the agent NAME
+// (`fleet-chat-name-*`). These tests click the three per-row ACTION buttons
+// directly, so a regression that breaks the buttons (but not the name) cannot
+// ship silently — the class of defect behind "the row buttons do nothing".
+test.describe("fleet row action buttons", () => {
+  test("chat action button opens the chat workspace", async ({ page }) => {
+    await gotoHarness(page, "default");
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+
+    const chatAction = page.getByTestId(`fleet-chat-${PEER_ID}`);
+    await expect(chatAction).toBeEnabled();
+    await chatAction.click();
+
+    await expect(page.getByTestId("composer-input")).toBeVisible();
+  });
+
+  test("config action button opens the config workspace", async ({ page }) => {
+    await gotoHarness(page, "default");
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+
+    const configAction = page.getByTestId(`fleet-config-${PEER_ID}`);
+    await expect(configAction).toBeEnabled();
+    await configAction.click();
+
+    await expect(page.locator(".config-workspace")).toBeVisible();
+  });
+
+  test("repair action button is present and disabled while P2P is healthy", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "default");
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+
+    const repairAction = page.getByTestId(`fleet-repair-${PEER_ID}`);
+    await expect(repairAction).toBeVisible();
+    // The default fixture dials successfully with no last error, so repairing
+    // P2P is intentionally unavailable — the button is disabled, not broken.
+    await expect(repairAction).toBeDisabled();
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-layout.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-layout.spec.ts
@@ -5,6 +5,7 @@ import {
   openChat,
   openConfig,
   openConfigTab,
+  PEER_ID,
   test,
 } from "./desktopTest";
 
@@ -60,5 +61,56 @@ test.describe("desktop responsive layout guardrails", () => {
       ).toBeVisible();
       await expectNoPageHorizontalOverflow(page);
     }
+  });
+
+  test("fleet row action buttons stay reachable at any width", async ({ page }) => {
+    await gotoHarness(page); // default scenario renders peer-bombadil-local
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+    await expect(page.getByTestId(`fleet-row-${PEER_ID}`)).toBeVisible();
+
+    const chatButton = page.getByTestId(`fleet-chat-${PEER_ID}`);
+    const configButton = page.getByTestId(`fleet-config-${PEER_ID}`);
+    const repairButton = page.getByTestId(`fleet-repair-${PEER_ID}`);
+
+    // All three action buttons exist even when scrolled off-screen at 390px.
+    await expect(chatButton).toBeAttached();
+    await expect(configButton).toBeAttached();
+    await expect(repairButton).toBeAttached();
+
+    // Reachability mechanism: the actions cell lives inside a horizontally
+    // scrollable container (.fleet-table-wrap { overflow: auto }) — NOT an
+    // overflow:hidden clip that would make the buttons permanently unreachable.
+    const scrollableAncestor = await configButton.evaluate((el) => {
+      let node: HTMLElement | null = el.closest("td");
+      while (node) {
+        const overflowX = getComputedStyle(node).overflowX;
+        if (overflowX === "auto" || overflowX === "scroll") {
+          return { className: node.className, overflowX };
+        }
+        node = node.parentElement;
+      }
+      return null;
+    });
+    expect(scrollableAncestor?.className ?? "").toContain("fleet-table-wrap");
+
+    // A real user can reach every action button: scroll it into view, then it is
+    // visible and hit-testable (trial click proves it is not clipped/covered).
+    for (const button of [chatButton, configButton]) {
+      await button.scrollIntoViewIfNeeded();
+      await expect(button).toBeVisible();
+      await button.click({ trial: true });
+    }
+    // Repair is disabled in the default scenario (dialSucceeded=true, no error).
+    await repairButton.scrollIntoViewIfNeeded();
+    await expect(repairButton).toBeVisible();
+    await expect(repairButton).toBeDisabled();
+
+    // Reaching the actions must never introduce page-level horizontal overflow.
+    await expectNoPageHorizontalOverflow(page);
+
+    // The config action actually works once reached (reach + activate contract).
+    await configButton.click();
+    await expect(page.locator(".config-workspace")).toBeVisible();
+    await expectNoPageHorizontalOverflow(page);
   });
 });


### PR DESCRIPTION
Desktop-perfection epic, stages 1–2. Closes #583.

## Stage 1 — correctness + close the CI hole
- **Fix #583** — the desktop transcript snapshot test consumed only 6 of the 7 Lean transcript conformance cases; the 7th (`parallel_results_share_assistant_turn` — three parallel tool calls sharing one assistant turn) was missing, so `cargo test -p defra-agent-desktop-tauri` was red. Wired the case into the test fixtures (the renderer already groups parallel tool calls, so this is a test-only fix).
- **Close the CI hole** — the tauri crate was never `cargo test`'d in CI, which is exactly why #583 shipped red. Added `cargo test -p defra-agent-desktop-tauri --lib` to the `rust-and-cli` job (PR smoke + main).
- **Guard the fleet row buttons** — Playwright spec clicks the three per-row action buttons directly (chat/config navigate; repair disabled while healthy). Previously only the agent name was exercised.
- **Cleanup** — removed a never-read field the new gate surfaced.

## Stage 2 — harden the UI test harness
- **Scenario coverage** (`desktop-async-states.spec.ts`) for the three previously-undriven harness scenarios: `loading` (delayed-load convergence, no error), `save-error` (banner + no Saved chip + button recovery + failure scoped to behavior saves), `backend-health-error` (Backends-tab failure is isolated; other ops tabs still work).
- **Responsive reachability** (`desktop-layout.spec.ts`) — locks in that the fleet row action buttons stay reachable at 390px (via the scrollable `.fleet-table-wrap`, without widening the page). A future `overflow: hidden`/clip regression flips it red.
- **Component units** — `FleetRow` (three action buttons, DID-passing handlers, repair enable/disable logic) and `AddPeerForm` (manual submit vs `/status` fetch→parse→submit discovery).

Verified: tauri 109 lib tests; desktop **136 unit / 111 e2e** (+21); fmt/prettier clean; non-flaky repeat. Two adversarial review passes — the 2 confirmed test-quality findings were fixed.
