### PR TITLE
feat(desktop): editable defra_query allowlist + tool-policy facts (#580)

### DIFF
--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -148,6 +148,7 @@ export function ToolSelectionConfigEditor({
   const [subagentBackgroundEnabled, setSubagentBackgroundEnabled] = useState(false);
   const [crossDeploymentSpawnTimeoutSeconds, setCrossDeploymentSpawnTimeoutSeconds] =
     useState("");
+  const [defraQueryCollections, setDefraQueryCollections] = useState("");
   const ceiling = normalizeToolCeiling(toolCeiling);
   const fileToolsDisabledByCeiling = ceiling === "MetaOnly";
   const writeToolsDisabledByCeiling = ceiling !== "Readwrite";
@@ -218,6 +219,7 @@ export function ToolSelectionConfigEditor({
         ? String(toolSelection.crossDeploymentSpawnTimeoutSeconds)
         : "",
     );
+    setDefraQueryCollections((toolSelection?.defraQueryCollections ?? []).join("\n"));
   }, [toolSelection, toolServiceIdKey]);
 
   function toggleAllowedMcpService(serviceId: string, checked: boolean) {
@@ -258,6 +260,10 @@ export function ToolSelectionConfigEditor({
         commandForbiddenArgvPrefixes: linesToArray(commandForbiddenArgvPrefixes),
         commandNetworkMode,
         cliToolNames: linesToArray(cliToolNames),
+        // defra_query read-scope allowlist; an empty list clears it (the bridge
+        // emits null). write_tools and tool_policy_version are preserve-only and
+        // are deliberately never sent — see lib/types/requests.ts.
+        defraQueryCollections: linesToArray(defraQueryCollections),
         enableMetaTools,
         allowedMcpServiceIds: linesToArray(allowedMcpServiceIds),
         delegateTo: linesToArray(delegateTo),
@@ -295,6 +301,20 @@ export function ToolSelectionConfigEditor({
         <div>
           <dt>Agent DID</dt>
           <dd className="mono">{agentDid}</dd>
+        </div>
+        <div>
+          <dt>Policy version</dt>
+          <dd className="mono" data-testid="tool-policy-version">
+            {toolSelection?.toolPolicyVersion ?? "legacy (unversioned)"}
+          </dd>
+        </div>
+        <div>
+          <dt>Managed write tools</dt>
+          <dd className="mono" data-testid="tool-write-tools">
+            {toolSelection?.writeTools?.length
+              ? toolSelection.writeTools.map(describeWriteTool).join(", ")
+              : "none"}
+          </dd>
         </div>
       </div>
       <div className="grid-2">
@@ -449,6 +469,16 @@ export function ToolSelectionConfigEditor({
           value={cliToolNames}
         />
       </label>
+      <label className="field">
+        <span>Defra query collections</span>
+        <textarea
+          className="config-small-textarea"
+          data-testid="tool-defra-query-collections"
+          onChange={(event) => setDefraQueryCollections(event.currentTarget.value)}
+          placeholder="One collection per line (empty = all collections)"
+          value={defraQueryCollections}
+        />
+      </label>
       <div className="grid-2">
         <label className="checkbox">
           <input
@@ -577,6 +607,27 @@ export function ToolSelectionConfigEditor({
       </div>
     </form>
   );
+}
+
+// Each `writeTools` entry is a JSON-serialized `WriteToolDecl`
+// ({ tool_name, collection, ... }); render a friendly `name → collection`
+// instead of the raw blob. Falls back to the raw string for legacy/plain decls.
+function describeWriteTool(decl: string): string {
+  try {
+    const parsed = JSON.parse(decl) as {
+      tool_name?: unknown;
+      collection?: unknown;
+    };
+    const name = typeof parsed?.tool_name === "string" ? parsed.tool_name : null;
+    const collection =
+      typeof parsed?.collection === "string" ? parsed.collection : null;
+    if (name) {
+      return collection ? `${name} → ${collection}` : name;
+    }
+  } catch {
+    // Not JSON — a legacy/plain decl; show it verbatim.
+  }
+  return decl;
 }
 
 function normalizeToolCeiling(value?: string | null) {

--- a/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
+++ b/apps/desktop-tauri/tests/config-panel-buttons.test.tsx
@@ -256,6 +256,82 @@ describe("config panel action buttons", () => {
     );
   });
 
+  it("edits defra_query_collections and keeps write_tools / policy version read-only", async () => {
+    const onSaveToolSelectionConfig = vi.fn<
+      [(request: ToolSelectionSaveRequest) => Promise<unknown>]
+    >(() => Promise.resolve());
+
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={{
+          ...toolSelection,
+          defraQueryCollections: ["AgentRequest"],
+          writeTools: [
+            '{"tool_name":"upsert_note","collection":"Note","description":"","fields":[]}',
+          ],
+          toolPolicyVersion: "tool-policy/v1",
+        }}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={onSaveToolSelectionConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    // Editable allowlist round-trips the loaded value; facts render read-only.
+    expect(screen.getByTestId("tool-defra-query-collections")).toHaveValue(
+      "AgentRequest",
+    );
+    expect(screen.getByTestId("tool-policy-version")).toHaveTextContent(
+      "tool-policy/v1",
+    );
+    // The managed write-tools row decodes the WriteToolDecl JSON — a friendly
+    // "name → collection", never the raw JSON blob.
+    const writeToolsRow = screen.getByTestId("tool-write-tools");
+    expect(writeToolsRow).toHaveTextContent("upsert_note → Note");
+    expect(writeToolsRow).not.toHaveTextContent("tool_name");
+
+    fireEvent.change(screen.getByTestId("tool-defra-query-collections"), {
+      target: { value: "AgentRequest\nAgentResponse" },
+    });
+    fireEvent.click(screen.getByTestId("tool-selection-save"));
+
+    await waitFor(() =>
+      expect(onSaveToolSelectionConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          defraQueryCollections: ["AgentRequest", "AgentResponse"],
+        }),
+      ),
+    );
+    // write_tools / tool_policy_version are preserve-only — never sent.
+    const [[request]] = onSaveToolSelectionConfig.mock.calls;
+    expect(request).not.toHaveProperty("writeTools");
+    expect(request).not.toHaveProperty("toolPolicyVersion");
+  });
+
+  it("shows a legacy fallback for an unversioned tool policy", () => {
+    render(
+      <ToolSelectionConfigEditor
+        agentDid="did:key:z6MkAgent"
+        savedStatus={null}
+        saving={false}
+        toolCeiling="Readwrite"
+        toolRoot="/tmp/work"
+        toolSelection={{ ...toolSelection, toolPolicyVersion: null }}
+        toolServiceRegistries={[toolService]}
+        onSaveToolSelectionConfig={vi.fn(() => Promise.resolve())}
+        onSaved={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("tool-policy-version")).toHaveTextContent(
+      "legacy (unversioned)",
+    );
+  });
+
   it("normalizes command policy choices when saving tool selections", async () => {
     const onSaveToolSelectionConfig = vi.fn<
       [(request: ToolSelectionSaveRequest) => Promise<unknown>]

--- a/apps/desktop-tauri/tests/config-panel-buttons/fixtures.ts
+++ b/apps/desktop-tauri/tests/config-panel-buttons/fixtures.ts
@@ -41,6 +41,13 @@ export const toolSelection: ToolSelectionView = {
   enableMetaTools: true,
   allowedMcpServiceIds: ["mcp-local"],
   delegateTo: [],
+  enableDefraQuery: true,
+  defraQueryCollections: ["AgentRequest"],
+  // Each entry is a JSON-serialized WriteToolDecl, as the real bridge emits.
+  writeTools: [
+    '{"tool_name":"upsert_note","collection":"Note","description":"","fields":[]}',
+  ],
+  toolPolicyVersion: "tool-policy/v1",
 };
 
 export const toolService: ToolServiceRegistryView = {

--- a/apps/desktop-tauri/tests/playwright/desktop-config-advanced.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-config-advanced.spec.ts
@@ -98,4 +98,35 @@ test.describe("desktop config workspace advanced flows", () => {
     ).toBeVisible();
     await expectNoPageHorizontalOverflow(page);
   });
+
+  test("defra_query allowlist edits persist and policy facts stay read-only", async ({
+    page,
+  }) => {
+    await gotoHarness(page);
+    await openConfig(page);
+    await openConfigTab(page, "toolSelections");
+
+    // Read-only policy facts render from the loaded selection; the write-tools
+    // row decodes the WriteToolDecl JSON (friendly name, not a raw blob).
+    await expect(page.getByTestId("tool-policy-version")).toHaveText("tool-policy/v1");
+    await expect(page.getByTestId("tool-write-tools")).toContainText("upsert_note");
+    await expect(page.getByTestId("tool-write-tools")).not.toContainText("tool_name");
+
+    // Edit the read-scope allowlist and save.
+    await page
+      .getByTestId("tool-defra-query-collections")
+      .fill("AgentRequest\nAgentResponse\nAgentSession");
+    await saveConfig(page, "tool-selection-save");
+
+    // Round-trip: navigate away and back — the edit persisted in the snapshot,
+    // and preserve-on-absent kept the display-only facts across the save.
+    await openConfigTab(page, "behavior");
+    await openConfigTab(page, "toolSelections");
+    await expect(page.getByTestId("tool-defra-query-collections")).toHaveValue(
+      "AgentRequest\nAgentResponse\nAgentSession",
+    );
+    await expect(page.getByTestId("tool-policy-version")).toHaveText("tool-policy/v1");
+    await expect(page.getByTestId("tool-write-tools")).toContainText("upsert_note");
+    await expectNoPageHorizontalOverflow(page);
+  });
 });

--- a/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
+++ b/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
@@ -541,6 +541,12 @@ export function createDesktopUiHarness(
     },
     async saveToolSelectionConfig(request) {
       const selectionId = request.selectionId.trim() || `tools-${requestSeq}`;
+      const prior = deployment.toolSelections.find(
+        (selection) => selection.selectionId === selectionId,
+      );
+      // Mirror the bridge's preserve-on-absent semantics: overlay the request on
+      // the prior row so display-only fields the panel never sends (writeTools,
+      // toolPolicyVersion) survive a save.
       deployment = {
         ...deployment,
         toolSelections: upsertBy(
@@ -548,6 +554,7 @@ export function createDesktopUiHarness(
           "selectionId",
           selectionId,
           {
+            ...prior,
             ...request,
             selectionId,
             displayName: request.displayName.trim() || selectionId,
@@ -1137,6 +1144,14 @@ function createDeployment(): DeploymentView {
         crossDeploymentSpawnTimeoutSeconds: 30,
         enableMemory: false,
         enableSessionHistoryTool: true,
+        enableDefraQuery: true,
+        defraQueryCollections: ["AgentRequest", "AgentResponse"],
+        // JSON-serialized WriteToolDecl entries, as the real bridge emits.
+        writeTools: [
+          '{"tool_name":"upsert_note","collection":"Note","description":"","fields":[]}',
+          '{"tool_name":"delete_task","collection":"Task","description":"","fields":[]}',
+        ],
+        toolPolicyVersion: "tool-policy/v1",
       },
     ],
     toolServiceRegistries: [


### PR DESCRIPTION
Immediate slice of #580 (desktop tool-configuration for the unified tool-policy). The #568 model, bridge, and TS types already carry these fields end-to-end; this exposes the UI. Frontend-only — no type or Rust-bridge changes.

- **Editable `defra_query_collections` allowlist** in the Tool Selections panel (textarea, one collection per line; empty = all collections). Saved through the existing preserve-on-absent path — an empty list clears it, and the bridge emits `null`, never `[]`.
- **Read-only policy-version row** (`toolPolicyVersion ?? "legacy (unversioned)"`).
- **Display-only managed write-tools row** — decodes each JSON `WriteToolDecl` into a friendly `name → collection` rather than a raw JSON blob. `write_tools` is apply-managed and never sent from the UI.

Tests: unit (allowlist edit round-trips; save payload asserts `defraQueryCollections` and never `writeTools`/`toolPolicyVersion`; write-tools decoding; legacy-version fallback) + e2e round-trip (edit → save → reopen → persisted; display-only facts survive). The harness `saveToolSelectionConfig` now mirrors the bridge's preserve-on-absent.

**Deferred (larger scope of #580):** surfacing the `ToolSurfaceExplanation` trace needs a new Rust bridge command (none exists today) + a snake→camel view — a follow-up.

Verified: build (tsc) + 129 unit + 93 e2e green, non-flaky; adversarial review (its one confirmed finding — a raw-JSON write-tools display — is fixed by the decoder).
