### PR TITLE
test(conformance): wait for cascade child interrupt latch (#591)

### DIFF
--- a/crates/defra-agent/tests/conformance/subagent_source.rs
+++ b/crates/defra-agent/tests/conformance/subagent_source.rs
@@ -208,6 +208,30 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
     }
 }
 
+/// Bounded wait for the parent-interrupt latch to propagate to a child
+/// request. Propagation is async relative to the caller: the booted daemon's
+/// live cascade, the source's post-create re-check, and recovery all race to
+/// write the latch, so a single post-call snapshot is not a valid observation
+/// (#591). The contract stays exact — the latch must land within the bound.
+async fn wait_for_child_interrupt_latch(
+    node: &EmbeddedNode,
+    child_request_id: &str,
+    failure_message: &str,
+) {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if fetch_interrupt_requested_at(node, child_request_id)
+            .await
+            .unwrap()
+            .is_some()
+        {
+            return;
+        }
+        assert!(tokio::time::Instant::now() < deadline, "{failure_message}");
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
 async fn assert_no_child_request_for_tool(
     node: &EmbeddedNode,
     parent_tool_call_id: &str,
@@ -797,13 +821,12 @@ async fn cascade_after_source_spawn_reaches_child_request() {
         .await
         .unwrap();
 
-    let child_interrupt = fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
-        .await
-        .unwrap();
-    assert!(
-        child_interrupt.is_some(),
-        "cascade recovery should latch child interrupt_requested_at"
-    );
+    wait_for_child_interrupt_latch(
+        db.node.as_ref(),
+        child_request_id,
+        "cascade recovery should latch child interrupt_requested_at",
+    )
+    .await;
 
     running.booted.shutdown().await;
 }
@@ -999,21 +1022,12 @@ async fn subagent_source_interrupts_child_when_parent_already_interrupted() {
 
     // The child gets materialized, then immediately interrupted by the source.
     let _child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
-            .await
-            .unwrap()
-            .is_some()
-        {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "child was created but never interrupted despite parent cancel-before-materialize",
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    wait_for_child_interrupt_latch(
+        db.node.as_ref(),
+        child_request_id,
+        "child was created but never interrupted despite parent cancel-before-materialize",
+    )
+    .await;
 
     running.booted.shutdown().await;
 }
@@ -1480,21 +1494,12 @@ async fn subagent_source_interrupts_child_on_concurrent_parent_cancel() {
     interrupt_task.await.unwrap();
 
     let _child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
-            .await
-            .unwrap()
-            .is_some()
-        {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "child created but never interrupted despite concurrent parent cancel",
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    wait_for_child_interrupt_latch(
+        db.node.as_ref(),
+        child_request_id,
+        "child created but never interrupted despite concurrent parent cancel",
+    )
+    .await;
 
     running.booted.shutdown().await;
 }
@@ -1550,21 +1555,12 @@ async fn subagent_source_interrupts_cascade_child_when_parent_reaches_dead_termi
     lifecycle.start_running().await.unwrap();
 
     let _child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    loop {
-        if fetch_interrupt_requested_at(db.node.as_ref(), child_request_id)
-            .await
-            .unwrap()
-            .is_some()
-        {
-            break;
-        }
-        assert!(
-            tokio::time::Instant::now() < deadline,
-            "Cascade child created but never interrupted despite dead (cancel-worthy) parent",
-        );
-        tokio::time::sleep(Duration::from_millis(50)).await;
-    }
+    wait_for_child_interrupt_latch(
+        db.node.as_ref(),
+        child_request_id,
+        "Cascade child created but never interrupted despite dead (cancel-worthy) parent",
+    )
+    .await;
 
     running.booted.shutdown().await;
 }


### PR DESCRIPTION
## What

Fixes the CI flake in `subagent_source::cascade_after_source_spawn_reaches_child_request` (#591): the test asserted the child request's `interrupt_requested_at` from a single snapshot immediately after `ToolCallLifecycle::recover_all`.

## Why it flaked

`recover_all`'s cascade (`recovery.rs`) does await the child `interrupt_request` before returning — but this test boots a live agent daemon, and the daemon's own cascade paths (live latch cascade / persisted-latch fallback) race the test's `recover_all` call. Under parallel CI load the daemon can flip the `AgentToolCall` bridge row out of `running` before the test's `recover_all` queries it; the test's call then no-ops and the child latch is written asynchronously by the daemon a moment later — after the test's single read. A lost observation race, not a contract violation: it passes 3/3 in isolation and only failed in the parallel conformance job.

## The fix

The contract is unchanged — parent interrupt + recovery must latch the child's `interrupt_requested_at`. The test now waits (bounded, 5s / 50ms poll) for the async propagation it already depends on, instead of asserting one post-`recover_all` snapshot. On timeout it fails with the same message as before, so this is not weakened to "eventually maybe".

The identical bounded poll already existed inline three times in this file; it's factored into a `wait_for_child_interrupt_latch` helper and used at all four sites. No runtime or Lean change — the implementation contract is correct; only the test's observation timing was wrong.

## Verification

- `cargo test -p defra-agent --test conformance cascade_after_source_spawn_reaches_child_request` — pass
- `cargo test -p defra-agent --test conformance subagent_source` — 26/26 pass
- Full package gate `cargo test -p defra-agent` — 1384 passed / 0 failed across all test binaries
- `cargo fmt --check` clean

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)