### PR TITLE
fix(subagents): expose background bridge before child materialization (#593)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/ContractCases/Types.lean
@@ -410,6 +410,40 @@ structure SteerInterruptComposes where
   queueInterruptedRequestId : String
   deriving Repr
 
+/-- #593: after a successful BACKGROUND spawn receipt the returned
+`child_request_id` must never disappear from the parent's control plane,
+even while the child `AgentRequest` is not yet materialized (spawn
+convergence #377 materializes it asynchronously via `SubagentSource`, and a
+cross-deployment child may replicate later or never be claimed).
+
+Boundary note: `awaiting_child_materialization` is a read-side PROJECTION of
+(bridge `await_mode = background` ∧ bridge non-terminal ∧ child row absent).
+It is never persisted as a bridge `lifecycle_state` and adds no transition
+to the Background bridge state machine (`Proofs/Background/Transition.lean`);
+once the child materializes, the projection collapses back to the bridge
+lifecycle state and the happy path is unchanged. -/
+structure UnmaterializedChildVisible where
+  callerRequestId : String
+  bridgeToolCallId : String
+  childRequestId : String
+  /-- The child `AgentRequest` row is absent in this scenario. -/
+  childMaterialized : Bool
+  /-- Persisted bridge state stays `running`; the projection never mutates it. -/
+  bridgeLifecycleState : String
+  /-- `list_subagents` entry status projected for the missing child. -/
+  listedStatus : String
+  /-- The handle must be visible under `status="all"`. -/
+  listedUnderAllFilter : Bool
+  /-- The projection is non-terminal, so the default `running` filter shows it. -/
+  listedUnderRunningFilter : Bool
+  /-- `read_subagent` reports the projection instead of not-authorized. -/
+  readLifecycleState : String
+  /-- Never fake a terminal outcome for an unmaterialized child. -/
+  readTerminal : Bool
+  /-- `wait_subagent` explains the bridge state with a retryable payload. -/
+  waitRetryable : Bool
+  deriving Repr
+
 end R4cWitnesses
 
 structure TranscriptCase where

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/BackgroundWork.lean
@@ -79,6 +79,27 @@ def r4cSteerAppendPreservesLineageJson
     ++ "\"queue_policy\":" ++ jsonString witness.queuePolicy
     ++ "}"
 
+def r4cUnmaterializedChildVisibleJson
+    (witness : R4cWitnesses.UnmaterializedChildVisible) : String :=
+  "{"
+    ++ "\"witness\":"
+      ++ jsonString "r4c.list_subagents.unmaterialized_child_visible" ++ ","
+    ++ "\"caller_request_id\":" ++ jsonString witness.callerRequestId ++ ","
+    ++ "\"bridge_tool_call_id\":" ++ jsonString witness.bridgeToolCallId ++ ","
+    ++ "\"child_request_id\":" ++ jsonString witness.childRequestId ++ ","
+    ++ "\"child_materialized\":" ++ boolString witness.childMaterialized ++ ","
+    ++ "\"bridge_lifecycle_state\":"
+      ++ jsonString witness.bridgeLifecycleState ++ ","
+    ++ "\"listed_status\":" ++ jsonString witness.listedStatus ++ ","
+    ++ "\"listed_under_all_filter\":"
+      ++ boolString witness.listedUnderAllFilter ++ ","
+    ++ "\"listed_under_running_filter\":"
+      ++ boolString witness.listedUnderRunningFilter ++ ","
+    ++ "\"read_lifecycle_state\":" ++ jsonString witness.readLifecycleState ++ ","
+    ++ "\"read_terminal\":" ++ boolString witness.readTerminal ++ ","
+    ++ "\"wait_retryable\":" ++ boolString witness.waitRetryable
+    ++ "}"
+
 def r4cSteerInterruptComposesJson
     (witness : R4cWitnesses.SteerInterruptComposes) : String :=
   "{"
@@ -140,6 +161,26 @@ def r4cReadToolOutputDispatchesByState :
   , terminalPayload := "persisted-completion-stdout"
   }
 
+-- #593 fixed witness: the bridge exists and is `running`, the child row is
+-- absent, and every parent-facing surface stays observable — the list entry
+-- projects `awaiting_child_materialization` (visible under both the `all`
+-- and default `running` filters), the read explains the same projection
+-- without faking a terminal outcome, and the wait payload is retryable.
+def r4cUnmaterializedChildVisible :
+    R4cWitnesses.UnmaterializedChildVisible :=
+  { callerRequestId := "r4c-w7-caller"
+  , bridgeToolCallId := "r4c-w7-bridge-call"
+  , childRequestId := "r4c-w7-child"
+  , childMaterialized := false
+  , bridgeLifecycleState := "running"
+  , listedStatus := "awaiting_child_materialization"
+  , listedUnderAllFilter := true
+  , listedUnderRunningFilter := true
+  , readLifecycleState := "awaiting_child_materialization"
+  , readTerminal := false
+  , waitRetryable := true
+  }
+
 def r4cSteerAppendPreservesLineage :
     R4cWitnesses.SteerAppendPreservesLineage :=
   { callerRequestId := "r4c-w5-caller"
@@ -168,6 +209,7 @@ def r4cBackgroundWorkCasesJson : List String :=
   , r4cReadToolOutputDispatchesByStateJson r4cReadToolOutputDispatchesByState
   , r4cSteerAppendPreservesLineageJson r4cSteerAppendPreservesLineage
   , r4cSteerInterruptComposesJson r4cSteerInterruptComposes
+  , r4cUnmaterializedChildVisibleJson r4cUnmaterializedChildVisible
   ]
 
 def r6BackgroundingCaseJson (witness : R6BackgroundingCase) : String :=

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -815,7 +815,12 @@ async fn load_readable_background_child_edge(
     }
 }
 
-fn authorization_lookup_error(
+/// True for the error class where the child edge could not be RESOLVED for
+/// this caller (child row absent or not linked). Deliberately excludes
+/// child-present corruption (e.g. missing `behavior_id`) and query failures,
+/// so callers gating the #593 bridge fallback on this predicate never mask
+/// data/storage problems as materialization lag.
+pub(crate) fn authorization_lookup_error(
     error: &anyhow::Error,
     caller_request_id: &str,
     child_request_id: &str,
@@ -1938,6 +1943,33 @@ mod cross_deployment_timeout_tests {
         let (message, retryable) = failed.unmaterialized_child_explanation("child-1");
         assert!(!retryable, "terminal bridge must not be retryable");
         assert!(message.contains("'failed'"));
+    }
+
+    #[test]
+    fn authorization_lookup_error_excludes_child_present_corruption() {
+        // Resolution failures (child absent / unlinked) are probe-eligible…
+        assert!(authorization_lookup_error(
+            &anyhow!("child AgentRequest c-1 not found"),
+            "p-1",
+            "c-1"
+        ));
+        assert!(authorization_lookup_error(
+            &anyhow!("child AgentRequest c-1 is not linked to parent request p-1"),
+            "p-1",
+            "c-1"
+        ));
+        // …child-present corruption and query failures are NOT: the #593
+        // bridge fallback must never mask them as materialization lag.
+        assert!(!authorization_lookup_error(
+            &anyhow!("child AgentRequest c-1 has no behavior_id"),
+            "p-1",
+            "c-1"
+        ));
+        assert!(!authorization_lookup_error(
+            &anyhow!("query child AgentRequest c-1 failed: storage down"),
+            "p-1",
+            "c-1"
+        ));
     }
 
     #[test]

--- a/crates/defra-agent/src/background_tools.rs
+++ b/crates/defra-agent/src/background_tools.rs
@@ -39,6 +39,16 @@ use self::transcript_render::{
     render_transcript, MessageKindView, MessageRoleView, MessageView, RenderOptions,
 };
 
+/// #593: projected status served by `list_subagents`/`read_subagent` for a
+/// background spawn bridge whose child `AgentRequest` has not materialized
+/// yet (spawn convergence #377 creates the child asynchronously via
+/// `SubagentSource`; a cross-deployment child appears only after the owning
+/// peer claims and replicates it). This is a read-side projection of
+/// (bridge `await_mode = background` ∧ bridge non-terminal ∧ child row
+/// absent) — it is never persisted as a bridge `lifecycle_state`. Pinned by
+/// the Lean witness `r4c.list_subagents.unmaterialized_child_visible`.
+pub const AWAITING_CHILD_MATERIALIZATION: &str = "awaiting_child_materialization";
+
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct SpawnSubagentArgs {
     /// Friendly, model-facing name of an allowed subagent target. The runtime
@@ -223,7 +233,7 @@ pub(crate) fn subagent_spawn_denial(
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct ChildEdge {
+pub struct ChildEdge {
     pub parent_tool_call_id: String,
     pub child_request_id: String,
     pub child_session_id: String,
@@ -273,6 +283,7 @@ struct ListSubagentBridgeRow {
     await_mode: Option<String>,
     started_at: Option<String>,
     completed_at: Option<String>,
+    unclaimed_deadline_at: Option<String>,
     /// Raw JSON bridge args — we extract the `name` field here.
     args: Option<String>,
 }
@@ -365,10 +376,17 @@ pub(crate) enum ReadToolOutputOutcome {
     NotBackgrounded,
 }
 
-pub(crate) enum SteerSubagentTarget {
+#[derive(Debug)]
+pub enum SteerSubagentTarget {
     Found(ChildEdge),
     NotAuthorized,
     NotBackgrounded,
+    /// #593: the caller owns a background spawn bridge for this child, but
+    /// the child `AgentRequest` has not materialized yet. The message
+    /// explains the bridge state instead of collapsing into not-authorized.
+    AwaitingMaterialization {
+        message: String,
+    },
     Terminal(String),
 }
 
@@ -396,6 +414,7 @@ pub async fn handle_list_subagents(
                 await_mode
                 started_at
                 completed_at
+                unclaimed_deadline_at
                 args
             }}
         }}"#
@@ -446,50 +465,99 @@ pub async fn handle_list_subagents(
         let Some(child_request_id) = non_empty_string(bridge.child_request_id.as_deref()) else {
             continue;
         };
-        let status = bridge
+        let bridge_status = bridge
             .lifecycle_state
             .as_deref()
             .filter(|state| !state.trim().is_empty())
             .unwrap_or("running");
-        if !list_subagent_status_matches(args.status, status) {
-            continue;
-        }
-        let Some(child) = children_by_request.get(&child_request_id) else {
-            continue;
-        };
-        let created_at = parse_rfc3339(Some(&child.created_at)).ok_or_else(|| {
-            anyhow!("child AgentRequest {child_request_id} has invalid created_at")
-        })?;
-        let last_update = parse_rfc3339(bridge.completed_at.as_deref())
-            .or_else(|| parse_rfc3339(bridge.started_at.as_deref()))
-            .unwrap_or(created_at);
 
-        // Extract the model-facing `name` from the bridge args JSON. The
-        // named-target redesign (#377) always writes `name` into the bridge
-        // args payload; older or malformed records fall back to empty string.
-        let target_name = bridge
+        // Extract the model-facing `name` (and, for a bridge-level entry, the
+        // resolved `behavior_id`) from the bridge args JSON. The named-target
+        // redesign (#377) always writes both into the bridge args payload;
+        // older or malformed records fall back to empty string.
+        let bridge_args = bridge
             .args
             .as_deref()
-            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
-            .and_then(|v| {
-                v.get("name")
-                    .and_then(serde_json::Value::as_str)
-                    .map(str::to_owned)
-            })
-            .and_then(|s| non_empty_string(Some(&s)))
-            .unwrap_or_default();
-        entries.push(ListSubagentsEntry {
-            child_request_id,
-            child_session_id: child.session_id.clone(),
-            name: target_name,
-            behavior_id: non_empty_string(child.behavior_id.as_deref()).unwrap_or_default(),
-            deployment_id: local_deployment_id.to_string(),
-            await_mode: "background".to_string(),
-            status: status.to_string(),
-            created_at,
-            last_update,
-            depth: child.subagent_depth.unwrap_or_default(),
-        });
+            .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok());
+        let bridge_arg = |key: &str| {
+            bridge_args
+                .as_ref()
+                .and_then(|v| v.get(key).and_then(serde_json::Value::as_str))
+                .and_then(|s| non_empty_string(Some(s)))
+                .unwrap_or_default()
+        };
+
+        let entry = match children_by_request.get(&child_request_id) {
+            Some(child) => {
+                if !list_subagent_status_matches(args.status, bridge_status) {
+                    continue;
+                }
+                let created_at = parse_rfc3339(Some(&child.created_at)).ok_or_else(|| {
+                    anyhow!("child AgentRequest {child_request_id} has invalid created_at")
+                })?;
+                let last_update = parse_rfc3339(bridge.completed_at.as_deref())
+                    .or_else(|| parse_rfc3339(bridge.started_at.as_deref()))
+                    .unwrap_or(created_at);
+                ListSubagentsEntry {
+                    child_request_id,
+                    child_session_id: child.session_id.clone(),
+                    name: bridge_arg("name"),
+                    behavior_id: non_empty_string(child.behavior_id.as_deref()).unwrap_or_default(),
+                    deployment_id: local_deployment_id.to_string(),
+                    await_mode: "background".to_string(),
+                    status: bridge_status.to_string(),
+                    created_at,
+                    last_update,
+                    depth: child.subagent_depth.unwrap_or_default(),
+                    diagnostic: None,
+                }
+            }
+            None => {
+                // #593: the child `AgentRequest` has not materialized (it is
+                // created asynchronously by the claiming deployment; a
+                // cross-deployment child appears only after replication). A
+                // returned background child id must never disappear from the
+                // control plane, so surface the bridge-level handle with a
+                // projected status instead of dropping it.
+                let status = if bridge_state_is_terminal(bridge_status) {
+                    bridge_status.to_string()
+                } else {
+                    AWAITING_CHILD_MATERIALIZATION.to_string()
+                };
+                if !list_subagent_status_matches(args.status, &status) {
+                    continue;
+                }
+                let created_at = parse_rfc3339(bridge.started_at.as_deref())
+                    .or_else(|| parse_rfc3339(bridge.completed_at.as_deref()))
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "bridge AgentToolCall {} has invalid started_at",
+                            bridge.tool_call_id
+                        )
+                    })?;
+                let last_update =
+                    parse_rfc3339(bridge.completed_at.as_deref()).unwrap_or(created_at);
+                let diagnostic = unmaterialized_child_diagnostic(
+                    &bridge.tool_call_id,
+                    bridge_status,
+                    bridge.unclaimed_deadline_at.as_deref(),
+                );
+                ListSubagentsEntry {
+                    child_request_id,
+                    child_session_id: String::new(),
+                    name: bridge_arg("name"),
+                    behavior_id: bridge_arg("behavior_id"),
+                    deployment_id: local_deployment_id.to_string(),
+                    await_mode: "background".to_string(),
+                    status,
+                    created_at,
+                    last_update,
+                    depth: 0,
+                    diagnostic: Some(diagnostic),
+                }
+            }
+        };
+        entries.push(entry);
     }
 
     let truncated = entries.len() > limit;
@@ -592,7 +660,7 @@ pub(crate) async fn handle_list_background_tools(
     })
 }
 
-pub(crate) async fn handle_read_subagent(
+pub async fn handle_read_subagent(
     node: &EmbeddedNode,
     caller_request_id: &str,
     args: ReadSubagentArgs,
@@ -601,7 +669,40 @@ pub(crate) async fn handle_read_subagent(
     let Some(edge) =
         load_readable_background_child_edge(node, caller_request_id, child_request_id).await?
     else {
-        return Ok(None);
+        // #593: distinguish "no such child edge for this caller" from "the
+        // caller owns a background spawn bridge whose child has not
+        // materialized". The bridge-level handle stays readable: an empty
+        // transcript with the projected (never faked-terminal) state.
+        let Some(bridge) = load_spawn_bridge_row(node, caller_request_id, child_request_id).await?
+        else {
+            return Ok(None);
+        };
+        if !bridge.is_background() {
+            return Ok(None);
+        }
+        let terminal = bridge.is_terminal();
+        let lifecycle_state = if terminal {
+            bridge.status().to_string()
+        } else {
+            AWAITING_CHILD_MATERIALIZATION.to_string()
+        };
+        let diagnostic = unmaterialized_child_diagnostic(
+            &bridge.tool_call_id,
+            bridge.status(),
+            bridge.unclaimed_deadline_at.as_deref(),
+        );
+        return Ok(Some(ReadSubagentResponse {
+            child_request_id: child_request_id.to_string(),
+            child_session_id: String::new(),
+            from_sequence: 0,
+            through_sequence: 0,
+            next_sequence: 0,
+            has_more: false,
+            terminal,
+            lifecycle_state,
+            diagnostic: Some(diagnostic),
+            transcript: String::new(),
+        }));
     };
 
     // Project the child's terminal status so the model knows whether to keep
@@ -690,6 +791,7 @@ pub(crate) async fn handle_read_subagent(
         has_more: rendered.has_more,
         terminal,
         lifecycle_state,
+        diagnostic: None,
         transcript: rendered.transcript,
     }))
 }
@@ -1028,7 +1130,7 @@ fn read_retained_output_slice(
     }
 }
 
-pub(crate) async fn load_steer_subagent_target(
+pub async fn load_steer_subagent_target(
     node: &EmbeddedNode,
     caller_request_id: &str,
     child_request_id: &str,
@@ -1040,7 +1142,21 @@ pub(crate) async fn load_steer_subagent_target(
     let edge = match load_authorized_child_edge(node, &parent_context, child_request_id).await {
         Ok(edge) => edge,
         Err(error) if authorization_lookup_error(&error, caller_request_id, child_request_id) => {
-            return Ok(SteerSubagentTarget::NotAuthorized);
+            // #593: if the caller owns a spawn bridge for this child, the id
+            // is real — report the bridge state instead of not-authorized.
+            let Some(bridge) =
+                load_spawn_bridge_row(node, caller_request_id, child_request_id).await?
+            else {
+                return Ok(SteerSubagentTarget::NotAuthorized);
+            };
+            if !bridge.is_background() {
+                return Ok(SteerSubagentTarget::NotBackgrounded);
+            }
+            if bridge.is_terminal() {
+                return Ok(SteerSubagentTarget::Terminal(bridge.status().to_string()));
+            }
+            let (message, _retryable) = bridge.unmaterialized_child_explanation(child_request_id);
+            return Ok(SteerSubagentTarget::AwaitingMaterialization { message });
         }
         Err(error) => return Err(error),
     };
@@ -1339,23 +1455,55 @@ fn persisted_stream_body(value: &str) -> String {
 }
 
 fn list_subagent_status_matches(filter: ListStatusFilter, status: &str) -> bool {
-    list_status_matches(filter, status)
+    match filter {
+        // #593: the awaiting-materialization projection is non-terminal, so
+        // the default `running` filter must show the handle.
+        ListStatusFilter::Running => {
+            status == "running" || status == AWAITING_CHILD_MATERIALIZATION
+        }
+        _ => list_status_matches(filter, status),
+    }
 }
 
 fn list_status_matches(filter: ListStatusFilter, status: &str) -> bool {
     match filter {
         ListStatusFilter::Running => status == "running",
-        ListStatusFilter::Terminal => matches!(
-            status,
-            "completed"
-                | "failed"
-                | "timedOut"
-                | "cancelled"
-                | "dead"
-                | "interrupted"
-                | "superseded"
-        ),
+        ListStatusFilter::Terminal => bridge_state_is_terminal(status),
         ListStatusFilter::All => !status.trim().is_empty(),
+    }
+}
+
+fn bridge_state_is_terminal(status: &str) -> bool {
+    matches!(
+        status,
+        "completed" | "failed" | "timedOut" | "cancelled" | "dead" | "interrupted" | "superseded"
+    )
+}
+
+/// #593: parent-facing explanation for a background spawn bridge whose child
+/// `AgentRequest` row is absent.
+fn unmaterialized_child_diagnostic(
+    tool_call_id: &str,
+    bridge_status: &str,
+    unclaimed_deadline_at: Option<&str>,
+) -> String {
+    if bridge_state_is_terminal(bridge_status) {
+        format!(
+            "spawn bridge {tool_call_id} reached terminal state '{bridge_status}' without a \
+             materialized child request (e.g. no paired deployment claimed the spawn)"
+        )
+    } else {
+        let deadline_clause = unclaimed_deadline_at
+            .filter(|value| !value.trim().is_empty())
+            .map(|deadline| {
+                format!("; the spawn fails as no_peer_claimed_spawn if unclaimed by {deadline}")
+            })
+            .unwrap_or_default();
+        format!(
+            "spawn bridge {tool_call_id} is running but the child request has not materialized \
+             yet (it is created asynchronously by the claiming deployment; a cross-deployment \
+             child appears only after peer replication){deadline_clause}"
+        )
     }
 }
 
@@ -1765,6 +1913,61 @@ mod cross_deployment_timeout_tests {
                 .expect("empty local DID must be treated as remote and denied");
         assert!(denial.message.contains("cross-deployment"));
     }
+
+    #[test]
+    fn unmaterialized_explanation_is_retryable_until_bridge_terminal() {
+        let running = SpawnBridgeRow {
+            tool_call_id: "tc-running".to_string(),
+            lifecycle_state: Some("running".to_string()),
+            await_mode: Some("background".to_string()),
+            unclaimed_deadline_at: Some("2026-07-01T00:01:00Z".to_string()),
+        };
+        let (message, retryable) = running.unmaterialized_child_explanation("child-1");
+        assert!(retryable, "non-terminal bridge must be retryable");
+        assert!(message.contains("child-1"));
+        assert!(message.contains("tc-running"));
+        assert!(message.contains("no_peer_claimed_spawn"));
+        assert!(message.contains("2026-07-01T00:01:00Z"));
+
+        let failed = SpawnBridgeRow {
+            tool_call_id: "tc-failed".to_string(),
+            lifecycle_state: Some("failed".to_string()),
+            await_mode: Some("background".to_string()),
+            unclaimed_deadline_at: None,
+        };
+        let (message, retryable) = failed.unmaterialized_child_explanation("child-1");
+        assert!(!retryable, "terminal bridge must not be retryable");
+        assert!(message.contains("'failed'"));
+    }
+
+    #[test]
+    fn awaiting_materialization_is_nonterminal_in_list_filters() {
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::Running,
+            AWAITING_CHILD_MATERIALIZATION
+        ));
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::All,
+            AWAITING_CHILD_MATERIALIZATION
+        ));
+        assert!(!list_subagent_status_matches(
+            ListStatusFilter::Terminal,
+            AWAITING_CHILD_MATERIALIZATION
+        ));
+        // Unchanged: plain running and terminal bridge states.
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::Running,
+            "running"
+        ));
+        assert!(!list_subagent_status_matches(
+            ListStatusFilter::Running,
+            "failed"
+        ));
+        assert!(list_subagent_status_matches(
+            ListStatusFilter::Terminal,
+            "failed"
+        ));
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -1807,6 +2010,96 @@ pub(crate) async fn try_load_authorized_child_edge(
         }
         Err(error) => Err(error),
     }
+}
+
+/// #593: the caller-owned spawn bridge pointing at a child request id,
+/// loadable regardless of whether the child `AgentRequest` exists. This is
+/// the durable receipt behind a background spawn: when the child row is
+/// absent, the bridge is what keeps the returned `child_request_id`
+/// observable on the parent control plane.
+#[derive(Debug, Deserialize)]
+pub(crate) struct SpawnBridgeRow {
+    pub(crate) tool_call_id: String,
+    pub(crate) lifecycle_state: Option<String>,
+    pub(crate) await_mode: Option<String>,
+    pub(crate) unclaimed_deadline_at: Option<String>,
+}
+
+impl SpawnBridgeRow {
+    pub(crate) fn status(&self) -> &str {
+        self.lifecycle_state
+            .as_deref()
+            .filter(|state| !state.trim().is_empty())
+            .unwrap_or("running")
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        bridge_state_is_terminal(self.status())
+    }
+
+    pub(crate) fn is_background(&self) -> bool {
+        self.await_mode.as_deref().map(str::trim) == Some("background")
+    }
+
+    /// Explanation served by `wait_subagent`/`cancel_subagent` for a child
+    /// that has not materialized: `(message, retryable)`. Retryable while the
+    /// bridge is non-terminal (the child may still materialize or the
+    /// unclaimed projection will fail the bridge); not retryable once the
+    /// bridge is terminal.
+    pub(crate) fn unmaterialized_child_explanation(
+        &self,
+        child_request_id: &str,
+    ) -> (String, bool) {
+        let diagnostic = unmaterialized_child_diagnostic(
+            &self.tool_call_id,
+            self.status(),
+            self.unclaimed_deadline_at.as_deref(),
+        );
+        (
+            format!("child request {child_request_id} has no materialized row yet: {diagnostic}"),
+            !self.is_terminal(),
+        )
+    }
+}
+
+/// Load the caller-owned `spawn_subagent` bridge whose `child_request_id`
+/// matches, independent of child materialization. Ownership is enforced by
+/// filtering on the caller's `request_id`, so a caller can never observe a
+/// sibling's bridge through this path.
+pub(crate) async fn load_spawn_bridge_row(
+    node: &EmbeddedNode,
+    caller_request_id: &str,
+    child_request_id: &str,
+) -> Result<Option<SpawnBridgeRow>> {
+    if child_request_id.trim().is_empty() {
+        return Ok(None);
+    }
+    let escaped_caller = escape_graphql_string(caller_request_id);
+    let escaped_child = escape_graphql_string(child_request_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(
+                filter: {{
+                    request_id: {{ _eq: "{escaped_caller}" }},
+                    child_request_id: {{ _eq: "{escaped_child}" }}
+                }},
+                limit: 1
+            ) {{
+                tool_call_id
+                lifecycle_state
+                await_mode
+                unclaimed_deadline_at
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        anyhow::bail!(
+            "query spawn bridge for child {child_request_id} failed: {:?}",
+            response.errors
+        );
+    }
+    Ok(first_row(response.data.as_ref(), "AgentToolCall"))
 }
 
 pub(crate) async fn load_authorized_child_edge(

--- a/crates/defra-agent/src/background_tools/r4c_args.rs
+++ b/crates/defra-agent/src/background_tools/r4c_args.rs
@@ -74,7 +74,7 @@ impl ListBackgroundToolsArgs {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub(crate) struct ReadSubagentArgs {
+pub struct ReadSubagentArgs {
     pub(crate) child_request_id: String,
     /// Resume cursor: first transcript sequence to include (default 0 = start).
     #[serde(default)]
@@ -168,6 +168,13 @@ pub struct ListSubagentsEntry {
     pub created_at: DateTime<Utc>,
     pub last_update: DateTime<Utc>,
     pub depth: u32,
+    /// #593: present only on a bridge-level entry whose child `AgentRequest`
+    /// has not materialized (status `awaiting_child_materialization`) or
+    /// whose bridge went terminal without one; explains the bridge state.
+    /// Materialized children never carry it, so the happy-path shape is
+    /// unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -198,24 +205,30 @@ pub(crate) struct ListBackgroundToolsResponse {
 }
 
 #[derive(Debug, Clone, Serialize)]
-pub(crate) struct ReadSubagentResponse {
-    pub(crate) child_request_id: String,
-    pub(crate) child_session_id: String,
-    pub(crate) from_sequence: u64,
-    pub(crate) through_sequence: u64,
+pub struct ReadSubagentResponse {
+    pub child_request_id: String,
+    pub child_session_id: String,
+    pub from_sequence: u64,
+    pub through_sequence: u64,
     /// Resume cursor: pass as `since_sequence` on the next read to continue
     /// gap-free from exactly where this page stopped.
-    pub(crate) next_sequence: u64,
+    pub next_sequence: u64,
     /// True when the token budget (or per-page block ceiling) capped this read
     /// and more messages exist at or after `next_sequence`.
-    pub(crate) has_more: bool,
+    pub has_more: bool,
     /// True when the subagent has reached a terminal lifecycle state and will
     /// produce no further transcript output (stop polling once drained).
-    pub(crate) terminal: bool,
+    pub terminal: bool,
     /// The subagent's current lifecycle state (e.g. "running", "completed",
-    /// "failed"), so the model can decide whether to keep polling.
-    pub(crate) lifecycle_state: String,
-    pub(crate) transcript: String,
+    /// "failed"), so the model can decide whether to keep polling. #593: for
+    /// a background bridge whose child has not materialized, this is the
+    /// projected `awaiting_child_materialization` (non-terminal).
+    pub lifecycle_state: String,
+    /// #593: present only when the child `AgentRequest` has not materialized;
+    /// explains the bridge state behind the empty transcript.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostic: Option<String>,
+    pub transcript: String,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/defra-agent/src/hook/persistence/mod.rs
+++ b/crates/defra-agent/src/hook/persistence/mod.rs
@@ -16,10 +16,11 @@ use crate::background_tools::{
     effective_context_cross_deployment_spawn_timeout_seconds, handle_list_background_tools,
     handle_list_subagents, handle_read_subagent, handle_read_tool_output,
     load_authorized_child_edge, load_child_final_response, load_child_terminal_row,
-    load_parent_subagent_context, load_steer_subagent_target, pending_automated_wakeup_request_ids,
-    project_child_terminal, resolve_context_target, try_load_authorized_child_edge,
-    BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs, ParentSubagentContext,
-    ReadToolOutputOutcome, SpawnSubagentArgs, SteerSubagentTarget, WaitSubagentArgs, WaitToolArgs,
+    load_parent_subagent_context, load_spawn_bridge_row, load_steer_subagent_target,
+    pending_automated_wakeup_request_ids, project_child_terminal, resolve_context_target,
+    try_load_authorized_child_edge, BackgroundToolArgs, CancelSubagentArgs, CancelToolArgs,
+    ParentSubagentContext, ReadToolOutputOutcome, SpawnSubagentArgs, SteerSubagentTarget,
+    WaitSubagentArgs, WaitToolArgs,
 };
 use crate::config::DEFAULT_DEADLINE_DURATION_SECS;
 use crate::document_config::{load_agent_behavior, SubagentTarget};

--- a/crates/defra-agent/src/hook/persistence/mod.rs
+++ b/crates/defra-agent/src/hook/persistence/mod.rs
@@ -11,8 +11,8 @@ use crate::background_tools::r4c_args::{
     SteerSubagentArgs,
 };
 use crate::background_tools::{
-    active_session_request_id, append_steering_request, child_request_completed,
-    context_allowed_target_names, drain_automated_wakeups_returning_ids,
+    active_session_request_id, append_steering_request, authorization_lookup_error,
+    child_request_completed, context_allowed_target_names, drain_automated_wakeups_returning_ids,
     effective_context_cross_deployment_spawn_timeout_seconds, handle_list_background_tools,
     handle_list_subagents, handle_read_subagent, handle_read_tool_output,
     load_authorized_child_edge, load_child_final_response, load_child_terminal_row,

--- a/crates/defra-agent/src/hook/persistence/subagent_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_tools.rs
@@ -45,22 +45,26 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    // #593: if the caller owns a spawn bridge for this child,
-                    // the id is real — explain the bridge state (retryable
-                    // while non-terminal) instead of a bare not-available.
-                    // A probe failure falls through to the generic payload.
-                    if let Ok(Some(bridge)) =
-                        load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
-                    {
-                        let (message, retryable) =
-                            bridge.unmaterialized_child_explanation(child_request_id);
-                        let result = service_unavailable_payload(
-                            WAIT_SUBAGENT_TOOL_NAME,
-                            "/child_request_id",
-                            message,
-                            retryable,
-                        );
-                        return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+                    // #593: if the edge failed to RESOLVE (child absent or
+                    // unlinked) and the caller owns a spawn bridge for this
+                    // child, the id is real — explain the bridge state
+                    // (retryable while non-terminal). Child-present
+                    // corruption and query failures keep the original error;
+                    // a probe failure falls through to the generic payload.
+                    if authorization_lookup_error(&error, &request_id, child_request_id) {
+                        if let Ok(Some(bridge)) =
+                            load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
+                        {
+                            let (message, retryable) =
+                                bridge.unmaterialized_child_explanation(child_request_id);
+                            let result = service_unavailable_payload(
+                                WAIT_SUBAGENT_TOOL_NAME,
+                                "/child_request_id",
+                                message,
+                                retryable,
+                            );
+                            return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+                        }
                     }
                     let result = service_unavailable_payload(
                         WAIT_SUBAGENT_TOOL_NAME,
@@ -400,19 +404,22 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
-                    // #593: same bridge-state explanation as wait_subagent.
-                    if let Ok(Some(bridge)) =
-                        load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
-                    {
-                        let (message, retryable) =
-                            bridge.unmaterialized_child_explanation(child_request_id);
-                        let result = service_unavailable_payload(
-                            CANCEL_SUBAGENT_TOOL_NAME,
-                            "/child_request_id",
-                            message,
-                            retryable,
-                        );
-                        return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+                    // #593: same resolution-gated bridge-state explanation as
+                    // wait_subagent.
+                    if authorization_lookup_error(&error, &request_id, child_request_id) {
+                        if let Ok(Some(bridge)) =
+                            load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
+                        {
+                            let (message, retryable) =
+                                bridge.unmaterialized_child_explanation(child_request_id);
+                            let result = service_unavailable_payload(
+                                CANCEL_SUBAGENT_TOOL_NAME,
+                                "/child_request_id",
+                                message,
+                                retryable,
+                            );
+                            return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+                        }
                     }
                     let result = service_unavailable_payload(
                         CANCEL_SUBAGENT_TOOL_NAME,

--- a/crates/defra-agent/src/hook/persistence/subagent_tools.rs
+++ b/crates/defra-agent/src/hook/persistence/subagent_tools.rs
@@ -45,6 +45,23 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
+                    // #593: if the caller owns a spawn bridge for this child,
+                    // the id is real — explain the bridge state (retryable
+                    // while non-terminal) instead of a bare not-available.
+                    // A probe failure falls through to the generic payload.
+                    if let Ok(Some(bridge)) =
+                        load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
+                    {
+                        let (message, retryable) =
+                            bridge.unmaterialized_child_explanation(child_request_id);
+                        let result = service_unavailable_payload(
+                            WAIT_SUBAGENT_TOOL_NAME,
+                            "/child_request_id",
+                            message,
+                            retryable,
+                        );
+                        return Ok(self.skip_tool_result(WAIT_SUBAGENT_TOOL_NAME, result));
+                    }
                     let result = service_unavailable_payload(
                         WAIT_SUBAGENT_TOOL_NAME,
                         "/child_request_id",
@@ -256,6 +273,18 @@ impl DefraSessionHook {
                     ),
                 ));
             }
+            SteerSubagentTarget::AwaitingMaterialization { message } => {
+                // #593: the bridge exists but the child has not materialized;
+                // steering needs a child session, so explain and let the
+                // model retry once the child appears.
+                let result = service_unavailable_payload(
+                    STEER_SUBAGENT_TOOL_NAME,
+                    "/child_request_id",
+                    message,
+                    true,
+                );
+                return Ok(self.skip_tool_result(STEER_SUBAGENT_TOOL_NAME, result));
+            }
             SteerSubagentTarget::Terminal(state) => {
                 let result = invalid_tool_arguments_payload(
                     STEER_SUBAGENT_TOOL_NAME,
@@ -371,6 +400,20 @@ impl DefraSessionHook {
             match load_authorized_child_edge(&self.node, &parent_context, child_request_id).await {
                 Ok(edge) => edge,
                 Err(error) => {
+                    // #593: same bridge-state explanation as wait_subagent.
+                    if let Ok(Some(bridge)) =
+                        load_spawn_bridge_row(&self.node, &request_id, child_request_id).await
+                    {
+                        let (message, retryable) =
+                            bridge.unmaterialized_child_explanation(child_request_id);
+                        let result = service_unavailable_payload(
+                            CANCEL_SUBAGENT_TOOL_NAME,
+                            "/child_request_id",
+                            message,
+                            retryable,
+                        );
+                        return Ok(self.skip_tool_result(CANCEL_SUBAGENT_TOOL_NAME, result));
+                    }
                     let result = service_unavailable_payload(
                         CANCEL_SUBAGENT_TOOL_NAME,
                         "/child_request_id",

--- a/crates/defra-agent/src/lean_vocab_test/background_transcript.rs
+++ b/crates/defra-agent/src/lean_vocab_test/background_transcript.rs
@@ -55,6 +55,20 @@ pub(crate) enum LeanR4cBackgroundWorkCase {
         queued_request_id: String,
         queue_interrupted_request_id: String,
     },
+    #[serde(rename = "r4c.list_subagents.unmaterialized_child_visible")]
+    UnmaterializedChildVisible {
+        caller_request_id: String,
+        bridge_tool_call_id: String,
+        child_request_id: String,
+        child_materialized: bool,
+        bridge_lifecycle_state: String,
+        listed_status: String,
+        listed_under_all_filter: bool,
+        listed_under_running_filter: bool,
+        read_lifecycle_state: String,
+        read_terminal: bool,
+        wait_retryable: bool,
+    },
 }
 
 impl LeanR4cBackgroundWorkCase {
@@ -74,6 +88,9 @@ impl LeanR4cBackgroundWorkCase {
                 "r4c.steer_subagent.append_preserves_lineage"
             }
             Self::SteerInterruptComposes { .. } => "r4c.steer_subagent.interrupt_composes",
+            Self::UnmaterializedChildVisible { .. } => {
+                "r4c.list_subagents.unmaterialized_child_visible"
+            }
         }
     }
 }

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -206,9 +206,13 @@ pub mod __test_internals {
     pub use crate::agent::principal_assembly::{
         assemble_principal_and_behaviors, BehaviorBuildError,
     };
-    pub use crate::background_tools::handle_list_subagents;
     pub use crate::background_tools::r4c_args::{
-        ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse,
+        ListSubagentsArgs, ListSubagentsEntry, ListSubagentsResponse, ReadSubagentArgs,
+        ReadSubagentResponse,
+    };
+    pub use crate::background_tools::{
+        handle_list_subagents, handle_read_subagent, load_steer_subagent_target, ChildEdge,
+        SteerSubagentTarget, AWAITING_CHILD_MATERIALIZATION,
     };
     pub use crate::trigger_engine::run_subagent_source_for_test;
 }

--- a/crates/defra-agent/src/toolset/subagent.rs
+++ b/crates/defra-agent/src/toolset/subagent.rs
@@ -287,7 +287,10 @@ impl Tool for ListSubagentsTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "List this parent request's visible background child subagents."
+            description: "List this parent request's visible background child subagents. \
+A background child spawned by this request stays listed even before its child request \
+materializes: such an entry has status `awaiting_child_materialization` (matched by the \
+`running` and `all` filters) and a `diagnostic` explaining the bridge state."
                 .to_string(),
             parameters: serde_json::json!({
                 "type": "object",
@@ -331,7 +334,9 @@ impl Tool for ReadSubagentTool {
 Paging is cursor-based and content-honest: pass `since_sequence` to resume, and the response \
 returns `next_sequence` (the exact cursor to pass next), `has_more` (true when the token budget \
 capped the read and more messages remain past `next_sequence`), and `terminal`/`lifecycle_state` \
-(whether the subagent has finished). Output is never SILENTLY dropped: when `has_more` is true, \
+(whether the subagent has finished). If the child request has not materialized yet, the response \
+has an empty transcript, `lifecycle_state = \"awaiting_child_materialization\"`, and a \
+`diagnostic` explaining the bridge state — keep polling. Output is never SILENTLY dropped: when `has_more` is true, \
 read again with `since_sequence = next_sequence` to continue. One case is truncated rather than \
 paged, but always explicitly marked: a single message larger than the entire budget is cut with a \
 `[truncated: showed N of M chars]` marker and the cursor advances past it, so that one message's \

--- a/crates/defra-agent/tests/conformance/background.rs
+++ b/crates/defra-agent/tests/conformance/background.rs
@@ -923,7 +923,7 @@ pub(super) fn generated_subagent_delegation_graph_cases_pin_gap2_contract() {
 
 pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
     let cases = lean_r4c_background_work_cases();
-    assert_eq!(cases.len(), 6);
+    assert_eq!(cases.len(), 7);
 
     let names = cases
         .iter()
@@ -933,6 +933,7 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
         names,
         [
             "r4c.list_subagents.lineage_rejects",
+            "r4c.list_subagents.unmaterialized_child_visible",
             "r4c.read_subagent_transcript.cursor_advances",
             "r4c.read_subagent_transcript.hides_bridge_rows",
             "r4c.read_tool_output.dispatch_by_state",
@@ -1049,6 +1050,53 @@ pub(super) fn generated_r4c_background_work_cases_pin_observable_shapes() {
             assert_eq!(caused_by_parent_request_id, caller_request_id);
             assert_eq!(queue_source, "steering");
             assert_eq!(queue_policy, "append");
+        }
+        other => panic!("unexpected R4c witness variant: {other:?}"),
+    }
+
+    // #593: a returned background child id never disappears from the parent
+    // control plane. The projected status must be the exact string the runtime
+    // serves from `list_subagents`/`read_subagent`, the projection must be
+    // non-terminal (never fake a terminal outcome for an unmaterialized
+    // child), and the wait payload must be retryable.
+    match lean_r4c_background_work_case("r4c.list_subagents.unmaterialized_child_visible") {
+        LeanR4cBackgroundWorkCase::UnmaterializedChildVisible {
+            caller_request_id,
+            bridge_tool_call_id,
+            child_request_id,
+            child_materialized,
+            bridge_lifecycle_state,
+            listed_status,
+            listed_under_all_filter,
+            listed_under_running_filter,
+            read_lifecycle_state,
+            read_terminal,
+            wait_retryable,
+        } => {
+            assert_eq!(caller_request_id, "r4c-w7-caller");
+            assert_eq!(bridge_tool_call_id, "r4c-w7-bridge-call");
+            assert_eq!(child_request_id, "r4c-w7-child");
+            assert!(!*child_materialized);
+            assert_eq!(bridge_lifecycle_state, "running");
+            assert_eq!(
+                listed_status,
+                defra_agent::__test_internals::AWAITING_CHILD_MATERIALIZATION,
+                "Lean witness and runtime must agree on the projected status string"
+            );
+            assert_eq!(read_lifecycle_state, listed_status);
+            assert!(
+                *listed_under_all_filter,
+                "list_subagents(all) must show the unmaterialized handle"
+            );
+            assert!(
+                *listed_under_running_filter,
+                "the projection is non-terminal, so the default running filter shows it"
+            );
+            assert!(
+                !*read_terminal,
+                "an unmaterialized child must never read as terminal"
+            );
+            assert!(*wait_retryable, "wait_subagent must explain-and-retry");
         }
         other => panic!("unexpected R4c witness variant: {other:?}"),
     }

--- a/crates/defra-agent/tests/e2e_subagent/r4_subagent_tools_cases/cancel_subagent.rs
+++ b/crates/defra-agent/tests/e2e_subagent/r4_subagent_tools_cases/cancel_subagent.rs
@@ -224,3 +224,69 @@ async fn cancel_subagent_rejects_unlinked_child_without_lifecycle_row() {
         0
     );
 }
+
+/// #593: cancelling a background child whose `AgentRequest` has not
+/// materialized (remote spawn target — the local `SubagentSource` skips it)
+/// must explain the bridge state with a RETRYABLE payload instead of a bare
+/// not-available error.
+#[tokio::test]
+async fn cancel_subagent_explains_unmaterialized_child_bridge() {
+    let fixture = setup_spawn_fixture(
+        "cancel_subagent_unmaterialized",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    let db = &fixture.db;
+    let hook = fixture.hook.clone();
+
+    let child_request_id = "cancel-unmat-child";
+    let bridge_tool_call_id = "cancel-unmat-bridge";
+    let args = json!({
+        "name": "remote-coder",
+        "agent_did": "did:key:z6MkRemoteUnclaimed",
+        "behavior_id": "remote-coder-behavior",
+        "prompt": "cross-deployment work",
+        "await_mode": "background"
+    })
+    .to_string();
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        fixture.request_id.clone(),
+        fixture.session_id.clone(),
+        fixture.agent_did.clone(),
+        bridge_tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        args,
+        fixture.parent_deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+        "did:key:z6MkRemoteUnclaimed".to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let action = hook
+        .on_tool_call(
+            "cancel_subagent",
+            Some("model-call-cancel-unmat".to_string()),
+            "internal-cancel-unmat",
+            &json!({ "child_request_id": child_request_id }).to_string(),
+        )
+        .await;
+    let error = skip_reason_json(action);
+    assert_eq!(error["ok"], false);
+    assert_eq!(error["failure_class"], "service_unavailable");
+    assert_eq!(error["retryable"], true);
+    let message = error["message"].as_str().expect("message");
+    assert!(
+        message.contains("has no materialized row yet"),
+        "explains materialization: {message}"
+    );
+    assert!(
+        message.contains(bridge_tool_call_id),
+        "names the bridge: {message}"
+    );
+}

--- a/crates/defra-agent/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
+++ b/crates/defra-agent/tests/e2e_subagent/r4_subagent_tools_cases/wait_subagent.rs
@@ -278,6 +278,168 @@ async fn wait_subagent_rejects_unlinked_child_without_lifecycle_row() {
     );
 }
 
+/// #593: waiting on a background child whose `AgentRequest` has not
+/// materialized (remote spawn target — the local `SubagentSource` skips it)
+/// must explain the bridge state with a RETRYABLE payload instead of a bare
+/// not-available error.
+#[tokio::test]
+async fn wait_subagent_explains_unmaterialized_child_bridge() {
+    let fixture = setup_spawn_fixture(
+        "wait_subagent_unmaterialized",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    let db = &fixture.db;
+    let hook = fixture.hook.clone();
+
+    let child_request_id = "wait-unmat-child";
+    let bridge_tool_call_id = "wait-unmat-bridge";
+    let args = json!({
+        "name": "remote-coder",
+        "agent_did": "did:key:z6MkRemoteUnclaimed",
+        "behavior_id": "remote-coder-behavior",
+        "prompt": "cross-deployment work",
+        "await_mode": "background"
+    })
+    .to_string();
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        fixture.request_id.clone(),
+        fixture.session_id.clone(),
+        fixture.agent_did.clone(),
+        bridge_tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        args,
+        fixture.parent_deadline,
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+        "did:key:z6MkRemoteUnclaimed".to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    let action = hook
+        .on_tool_call(
+            "wait_subagent",
+            Some("model-call-wait-unmat".to_string()),
+            "internal-wait-unmat",
+            &json!({ "child_request_id": child_request_id }).to_string(),
+        )
+        .await;
+    let error = skip_reason_json(action);
+    assert_eq!(error["ok"], false);
+    assert_eq!(error["failure_class"], "service_unavailable");
+    assert_eq!(error["retryable"], true);
+    let message = error["message"].as_str().expect("message");
+    assert!(
+        message.contains("has no materialized row yet"),
+        "explains materialization: {message}"
+    );
+    assert!(
+        message.contains(bridge_tool_call_id),
+        "names the bridge: {message}"
+    );
+}
+
+/// #593 boundary: the bridge fallback is gated on RESOLUTION failures only.
+/// A child row that exists but is corrupt (here: empty `behavior_id`) must
+/// keep the original non-retryable error — never be masked as
+/// materialization lag.
+#[tokio::test]
+async fn wait_subagent_preserves_error_for_corrupt_materialized_child() {
+    let fixture = setup_spawn_fixture(
+        "wait_subagent_corrupt_child",
+        vec![CHILD_BEHAVIOR_ID],
+        0,
+        true,
+    )
+    .await;
+    let db = &fixture.db;
+    let hook = fixture.hook.clone();
+
+    let child_request_id = "wait-corrupt-child";
+    let child_session_id = "wait-corrupt-child-session";
+    let bridge_tool_call_id = "wait-corrupt-bridge";
+    let parent_request_id = escape_graphql_string(&fixture.request_id);
+    let session_id = escape_graphql_string(&fixture.session_id);
+    let agent_did = escape_graphql_string(&fixture.agent_did);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentRequest(input: {{
+                request_id: "{child_request_id}",
+                agent_did: "{agent_did}",
+                behavior_id: "",
+                session_id: "{child_session_id}",
+                retry_parent_request: "",
+                retry_root_request: "{child_request_id}",
+                superseded_by_request: "",
+                content: "corrupt child",
+                status: "processing",
+                lifecycle_state: "processing",
+                backend_id: "",
+                execution_origin: "interactive",
+                metadata: "",
+                failure_reason: "",
+                created_at: "2026-07-01T00:00:00Z",
+                deadline: "2026-07-01T00:10:00Z",
+                retry_count: 0,
+                max_retries: 3,
+                subagent_depth: 1,
+                caused_by_parent_request_id: "{parent_request_id}",
+                caused_by_parent_tool_call_id: "{bridge_tool_call_id}"
+            }}) {{ _docID }}
+            create_AgentToolCall(input: {{
+                tool_call_key: "{session_id}:{bridge_tool_call_id}",
+                request_id: "{parent_request_id}",
+                session_id: "{session_id}",
+                message_sequence: 1,
+                tool_name: "spawn_subagent",
+                tool_call_id: "{bridge_tool_call_id}",
+                args: "{{}}",
+                result: "",
+                status: "running",
+                lifecycle_state: "running",
+                started_at: "2026-07-01T00:00:00Z",
+                deadline_at: "2026-07-01T00:10:00Z",
+                await_mode: "background",
+                cancel_policy: "cascade",
+                child_request_id: "{child_request_id}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = db.node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create corrupt child edge failed: {:?}",
+        response.errors
+    );
+
+    let action = hook
+        .on_tool_call(
+            "wait_subagent",
+            Some("model-call-wait-corrupt".to_string()),
+            "internal-wait-corrupt",
+            &json!({ "child_request_id": child_request_id }).to_string(),
+        )
+        .await;
+    let error = skip_reason_json(action);
+    assert_eq!(error["ok"], false);
+    assert_eq!(error["failure_class"], "service_unavailable");
+    assert_eq!(error["retryable"], false);
+    let message = error["message"].as_str().expect("message");
+    assert!(
+        message.contains("has no behavior_id"),
+        "preserves the original error: {message}"
+    );
+    assert!(
+        !message.contains("has no materialized row yet"),
+        "must not be masked as materialization lag: {message}"
+    );
+}
+
 #[tokio::test]
 async fn wait_subagent_from_resumed_hook_cascades_parent_interrupt() {
     let fixture = setup_spawn_fixture(

--- a/crates/defra-agent/tests/e2e_subagent/subagent_convergence.rs
+++ b/crates/defra-agent/tests/e2e_subagent/subagent_convergence.rs
@@ -15,7 +15,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use defra_agent::__test_internals::{handle_list_subagents, ListSubagentsArgs};
+use defra_agent::__test_internals::{
+    handle_list_subagents, handle_read_subagent, load_steer_subagent_target, ListSubagentsArgs,
+    ReadSubagentArgs, SteerSubagentTarget, AWAITING_CHILD_MATERIALIZATION,
+};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::tool_call_lifecycle::{AwaitMode, CancelPolicy, ToolCallLifecycle};
@@ -171,6 +174,39 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
 }
 
 #[derive(Debug, Deserialize)]
+struct RequestDeadlineRow {
+    deadline: Option<String>,
+}
+
+/// Wait for the runtime watcher to claim a request (it stamps `deadline` at
+/// claim time, which parent-context loading requires).
+async fn wait_for_request_deadline(node: &EmbeddedNode, request_id: &str) {
+    let escaped = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ request_id: {{ _eq: "{escaped}" }} }},
+                limit: 1
+            ) {{ deadline }}
+        }}"#
+    );
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    loop {
+        let response = node.execute(&query).await;
+        if let Some(row) = first_optional_row::<RequestDeadlineRow>(&response, "AgentRequest") {
+            if row.deadline.is_some_and(|value| !value.trim().is_empty()) {
+                return;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for request {request_id} to be claimed (deadline stamped)"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+#[derive(Debug, Deserialize)]
 struct ToolCallStateRow {
     lifecycle_state: Option<String>,
 }
@@ -276,6 +312,189 @@ async fn local_background_spawn_materializes_child_with_lineage_and_lists() {
         .find(|e| e.child_request_id == child_request_id)
         .expect("list_subagents must reflect the running background child");
     assert_eq!(entry.behavior_id, running.behavior_id);
+
+    running.booted.shutdown().await;
+}
+
+/// REGRESSION (#593): a successful BACKGROUND spawn receipt must stay
+/// observable at the bridge level even while the child `AgentRequest` has not
+/// materialized. The bridge targets a REMOTE agent DID, so the local
+/// `SubagentSource` never creates the child — the durable analog of the live
+/// cross-deployment gap where the parent was told `status: running` and then
+/// `list_subagents(all)` returned `entries: []`.
+#[tokio::test]
+async fn unmaterialized_background_child_stays_observable_in_list() {
+    let db = test_db("convergence-unmaterialized").await;
+    let running = boot_self_spawn_agent(&db, "convergence-unmaterialized").await;
+
+    let parent_request_id = "unmat-bg-parent";
+    let parent_session_id = "unmat-bg-session";
+    let parent_tool_call_id = "unmat-bg-tc";
+    let child_request_id = "unmat-bg-child";
+
+    create_runtime_request(
+        db.node.as_ref(),
+        &running.booted.agent_did,
+        &running.behavior_id,
+        parent_request_id,
+        parent_session_id,
+        "parent prompt unmaterialized",
+    )
+    .await;
+    // read/steer load the parent context, which requires the claim-time
+    // deadline stamp — wait for the watcher before exercising them.
+    wait_for_request_deadline(db.node.as_ref(), parent_request_id).await;
+
+    let args = serde_json::json!({
+        "name": "remote-coder",
+        "agent_did": "did:key:z6MkUnclaimedRemoteTarget",
+        "behavior_id": "remote-coder-behavior",
+        "prompt": "cross-deployment child work",
+        "await_mode": "background"
+    })
+    .to_string();
+    let mut lifecycle = ToolCallLifecycle::new_subagent(
+        db.node.clone(),
+        parent_request_id.to_string(),
+        parent_session_id.to_string(),
+        "did:defra-agent:test".to_string(),
+        parent_tool_call_id.to_string(),
+        1,
+        "spawn_subagent".to_string(),
+        args,
+        chrono::Utc::now() + chrono::Duration::minutes(5),
+        AwaitMode::Background,
+        CancelPolicy::Cascade,
+        child_request_id.to_string(),
+        "did:key:z6MkUnclaimedRemoteTarget".to_string(),
+    );
+    lifecycle.start_running().await.unwrap();
+
+    // The child must NOT have materialized (remote target, no paired peer).
+    let escaped_child = escape_graphql_string(child_request_id);
+    let child_query = format!(
+        r#"{{ AgentRequest(filter: {{ request_id: {{ _eq: "{escaped_child}" }} }}, limit: 1) {{ request_id behavior_id content subagent_depth caused_by_parent_request_id caused_by_parent_tool_call_id caused_by_trigger_id caused_by_trigger_kind }} }}"#
+    );
+    let child_row =
+        first_optional_row::<ChildRequestRow>(&db.node.execute(&child_query).await, "AgentRequest");
+    assert!(
+        child_row.is_none(),
+        "test premise: remote-target child must not materialize locally"
+    );
+
+    // list_subagents(status="all") must return the bridge-level handle.
+    let all: ListSubagentsArgs =
+        serde_json::from_value(serde_json::json!({ "status": "all" })).unwrap();
+    let resp = handle_list_subagents(
+        db.node.as_ref(),
+        parent_request_id,
+        &running.booted.agent_did,
+        all,
+    )
+    .await
+    .expect("handle_list_subagents must not error");
+    let entry = resp
+        .entries
+        .iter()
+        .find(|e| e.child_request_id == child_request_id)
+        .expect("a returned background child id must never disappear from list_subagents(all)");
+    assert_eq!(entry.status, AWAITING_CHILD_MATERIALIZATION);
+    assert_eq!(entry.status, "awaiting_child_materialization");
+    assert_eq!(entry.await_mode, "background");
+    assert_eq!(entry.name, "remote-coder");
+    assert_eq!(entry.behavior_id, "remote-coder-behavior");
+    assert!(
+        entry.child_session_id.is_empty(),
+        "no session exists until the child materializes"
+    );
+    let list_diagnostic = entry
+        .diagnostic
+        .as_deref()
+        .expect("bridge-level entry must carry a diagnostic");
+    assert!(
+        list_diagnostic.contains(parent_tool_call_id),
+        "diagnostic names the bridge: {list_diagnostic}"
+    );
+
+    // The projection is non-terminal, so the DEFAULT (running) filter shows it.
+    let resp = handle_list_subagents(
+        db.node.as_ref(),
+        parent_request_id,
+        &running.booted.agent_did,
+        ListSubagentsArgs::default(),
+    )
+    .await
+    .expect("handle_list_subagents must not error");
+    assert!(
+        resp.entries
+            .iter()
+            .any(|e| e.child_request_id == child_request_id),
+        "the unmaterialized handle must be visible under the default running filter"
+    );
+
+    // read_subagent must explain the bridge state instead of not-authorized,
+    // and must never fake a terminal outcome for an unmaterialized child.
+    let read_args: ReadSubagentArgs =
+        serde_json::from_value(serde_json::json!({ "child_request_id": child_request_id }))
+            .unwrap();
+    let read = handle_read_subagent(db.node.as_ref(), parent_request_id, read_args)
+        .await
+        .expect("handle_read_subagent must not error")
+        .expect("the bridge-level handle must be readable before materialization");
+    assert!(!read.terminal);
+    assert_eq!(read.lifecycle_state, AWAITING_CHILD_MATERIALIZATION);
+    assert!(read.transcript.is_empty());
+    assert!(read.child_session_id.is_empty());
+    assert!(!read.has_more);
+    let read_diagnostic = read
+        .diagnostic
+        .as_deref()
+        .expect("bridge-state read must carry a diagnostic");
+    assert!(
+        read_diagnostic.contains(parent_tool_call_id),
+        "diagnostic names the bridge: {read_diagnostic}"
+    );
+
+    // steer_subagent target resolution must explain materialization, not deny.
+    match load_steer_subagent_target(db.node.as_ref(), parent_request_id, child_request_id)
+        .await
+        .expect("load_steer_subagent_target must not error")
+    {
+        SteerSubagentTarget::AwaitingMaterialization { message } => {
+            assert!(
+                message.contains(child_request_id),
+                "steer explanation names the child: {message}"
+            );
+        }
+        other => panic!("expected AwaitingMaterialization, got {other:?}"),
+    }
+
+    // A parent request that does NOT own the bridge still gets nothing:
+    // lineage rejection is unchanged (r4c.list_subagents.lineage_rejects).
+    create_runtime_request(
+        db.node.as_ref(),
+        &running.booted.agent_did,
+        &running.behavior_id,
+        "unmat-other-parent",
+        "unmat-other-session",
+        "unrelated parent prompt",
+    )
+    .await;
+    // The watcher stamps the request deadline at claim time; parent-context
+    // loading requires it, so wait for the claim before reading.
+    wait_for_request_deadline(db.node.as_ref(), "unmat-other-parent").await;
+    let stranger = handle_read_subagent(
+        db.node.as_ref(),
+        "unmat-other-parent",
+        serde_json::from_value(serde_json::json!({ "child_request_id": child_request_id }))
+            .unwrap(),
+    )
+    .await
+    .expect("handle_read_subagent must not error");
+    assert!(
+        stranger.is_none(),
+        "a non-owning caller must not see the bridge-level handle"
+    );
 
     running.booted.shutdown().await;
 }


### PR DESCRIPTION
Closes #593.

## The invariant

**A returned background child id never disappears from the parent control plane.** After `spawn_subagent` returns `ok: true, status: running, child_request_id: X`, every parent-facing control tool must observe a durable state for `X` — even while the child `AgentRequest` is unmaterialized (spawn convergence #377 creates it asynchronously via `SubagentSource`; a cross-deployment child appears only after the owning peer claims and replicates it, or never, in which case the unclaimed reconciler fails the bridge as `no_peer_claimed_spawn`).

The live Amy session in #593 hit the gap: 2/2 spawned children invisible to `list_subagents(all)` immediately after a successful receipt, leaving read/wait/steer/cancel with no handle.

## Root cause

The bridge `AgentToolCall` is persisted synchronously at spawn (`message_spawn.rs`), but every read-side surface required the child row:

- `handle_list_subagents` silently dropped any bridge whose `child_request_id` had no matching `AgentRequest` (`background_tools.rs:457`).
- `read_subagent` collapsed the missing child into "not a background subagent owned by this parent request".
- `wait_subagent`/`cancel_subagent` collapsed it into a non-retryable "not available to this parent request".
- `steer_subagent` resolved it to `NotAuthorized`.

## Fix shape: a projection, not a new state

`awaiting_child_materialization` is a read-side **projection** of (bridge `await_mode = background` ∧ bridge non-terminal ∧ child row absent). It is never persisted and adds no transition to the Background bridge state machine — once the child materializes the projection collapses back to the bridge lifecycle state, so the local happy path is byte-identical (the optional `diagnostic` field is skipped when absent).

**Lean first** (`proofs` builds clean, zero `sorry`s): new R4c witness `r4c.list_subagents.unmaterialized_child_visible` (`ContractCases/Types.lean` + `Contracts/Json/BackgroundWork.lean`) pins the contract: listed under both `all` and the default `running` filter with the exact projected status string, read is never faked-terminal, wait is retryable. The conformance consumer (`tests/conformance/background.rs`, 6→7 cases) ties the witness string to the runtime constant.

**Runtime**:
- `list_subagents`: a background bridge without a child row now yields a bridge-level entry — status `awaiting_child_materialization` while the bridge runs (matched by `running` and `all` filters), or the bridge terminal state (e.g. `failed` after the unclaimed projection) under `terminal`/`all`; `name`/`behavior_id` come from the resolved bridge args, plus a `diagnostic` naming the bridge and the unclaimed deadline.
- `read_subagent`: returns the projected state (`terminal: false`, empty transcript, `diagnostic`) instead of not-authorized; a terminal bridge without a child reads as that terminal state — never a faked success.
- `wait_subagent`/`cancel_subagent`: when the caller owns a spawn bridge for the id, the error explains the bridge state and is `retryable` while the bridge is non-terminal.
- `steer_subagent`: new `AwaitingMaterialization` resolution → retryable `service_unavailable` explaining the bridge state.
- Ownership is enforced in the bridge probe (filtered by the caller's `request_id`), so lineage rejection (`r4c.list_subagents.lineage_rejects`) is unchanged — verified in the regression test.

## Tests

- **Red-first regression** (`subagent_convergence.rs::unmaterialized_background_child_stays_observable_in_list`): bridge targets a remote DID so the local `SubagentSource` never materializes the child — the durable analog of the Amy cross-deployment gap. Failed on the old code at exactly the reported symptom (`entries: []`); now asserts list (both filters), read, steer, and non-owner rejection. 3× stable.
- Unit tests pin the retryable-until-bridge-terminal explanation and the filter semantics of the projected status.
- Existing convergence happy paths (materialized child lists normally, foreground completion) unchanged and green.
- Gates: full `lake build` green; focused subagent e2e + conformance + unit suites green (3× stable); fmt clean; clippy introduces no new warnings. Full `cargo test -p defra-agent` is running locally at PR-open time — result will be confirmed in a comment.

## Notes

- A full 2-node cross-deployment e2e of this path belongs to the #575 declarative-pairing work; this PR pins the parent-facing contract with a deterministic single-node reproduction of the same gap.
- Model-facing tool descriptions for `list_subagents`/`read_subagent` document the new projected status so orchestrating models keep polling instead of concluding the child vanished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
