### PR TITLE
ci: glibc 2.36 baseline for the x86_64 Linux release artifact

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -39,6 +39,13 @@ jobs:
             # ~228 GB free; ThinLTO links comfortably.
             release_lto: "thin"
             cargo_jobs: "8"
+            # Build inside Debian 12 (glibc 2.36) so the published artifact
+            # runs on the oldest supported x86_64 host (Synology DSM ships
+            # glibc 2.36; newer hosts are forward compatible). Building
+            # natively on the Ubuntu 24.04 runner links glibc 2.38/2.39
+            # symbols and the artifact fails on DSM — see #572.
+            container_image: rust:1-bookworm
+            glibc_baseline: "2.36"
           - target: aarch64-unknown-linux-gnu
             runner_arch: ARM64
             runner_label: spark
@@ -48,11 +55,14 @@ jobs:
             # long-term fix (see the build-flavors epic).
             release_lto: "off"
             cargo_jobs: "2"
+            container_image: ""
+            glibc_baseline: ""
     runs-on:
       - self-hosted
       - Linux
       - ${{ matrix.runner_arch }}
       - ${{ matrix.runner_label }}
+    container: ${{ matrix.container_image }}
 
     env:
       GIT_CONFIG_GLOBAL: /tmp/defra-agent-release-${{ github.run_id }}-${{ matrix.target }}.gitconfig
@@ -85,10 +95,17 @@ jobs:
       - name: Install native build dependencies
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
+          SUDO="sudo"
+          if [[ "$(id -u)" == "0" ]]; then
+            SUDO=""
+          fi
+          ${SUDO} apt-get update
+          ${SUDO} apt-get install -y --no-install-recommends \
+            binutils \
             build-essential \
             clang \
+            cmake \
+            libclang-dev \
             libssl-dev \
             pkg-config \
             protobuf-compiler
@@ -114,6 +131,21 @@ jobs:
           printf '%s\n' "${version_output}"
           if [[ -z "${version_output}" ]]; then
             echo "::error::defra-agent version produced no output."
+            exit 1
+          fi
+
+      - name: Verify glibc baseline
+        if: matrix.glibc_baseline != ''
+        env:
+          GLIBC_BASELINE: ${{ matrix.glibc_baseline }}
+        run: |
+          set -euo pipefail
+          binary_path="target/release/defra-agent"
+          required="$(objdump -T "${binary_path}" | grep -oE 'GLIBC_[0-9]+\.[0-9]+(\.[0-9]+)?' | sed 's/GLIBC_//' | sort -Vu | tail -1)"
+          echo "max required glibc: ${required} (baseline: ${GLIBC_BASELINE})"
+          newest="$(printf '%s\n%s\n' "${GLIBC_BASELINE}" "${required}" | sort -V | tail -1)"
+          if [[ "${newest}" != "${GLIBC_BASELINE}" ]]; then
+            echo "::error::Binary requires glibc ${required}, newer than the ${GLIBC_BASELINE} baseline. It will not run on Synology DSM hosts (#572)."
             exit 1
           fi
 
@@ -144,24 +176,6 @@ jobs:
             ${{ steps.package.outputs.checksum_file }}
           if-no-files-found: error
 
-      - name: Attach artifacts to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARBALL: ${{ steps.package.outputs.tarball }}
-          CHECKSUM_FILE: ${{ steps.package.outputs.checksum_file }}
-        run: |
-          set -euo pipefail
-
-          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            gh release create "${GITHUB_REF_NAME}" \
-              --verify-tag \
-              --title "${GITHUB_REF_NAME}" \
-              --notes "defra-agent release artifacts." \
-              || gh release view "${GITHUB_REF_NAME}" >/dev/null
-          fi
-          gh release upload "${GITHUB_REF_NAME}" "${TARBALL}" "${CHECKSUM_FILE}" --clobber
-
       - name: Cleanup git auth
         if: always()
         env:
@@ -170,3 +184,43 @@ jobs:
           git config --global --remove-section "url.https://x-access-token:${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
           git config --global --remove-section "url.https://${PRIVATE_REPO_PAT:-}@github.com/sourcenetwork/" 2>/dev/null || true
           rm -f "${GIT_CONFIG_GLOBAL}"
+
+  # Runs on the host (not in the build container) because it needs the gh CLI,
+  # which the rust:1-bookworm build container does not ship.
+  attach-release:
+    name: Attach artifacts to GitHub Release
+    # not `success()`: attach whatever legs produced artifacts even when the
+    # other matrix leg failed, matching the old per-leg attach behavior.
+    if: ${{ !cancelled() && startsWith(github.ref, 'refs/tags/v') }}
+    needs: build-package
+    timeout-minutes: 15
+    runs-on:
+      - self-hosted
+      - Linux
+      - X64
+      - workstation-1
+
+    steps:
+      - name: Download workflow artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Attach artifacts to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          ls -lh dist
+
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --verify-tag \
+              --title "${GITHUB_REF_NAME}" \
+              --notes "defra-agent release artifacts." \
+              || gh release view "${GITHUB_REF_NAME}" >/dev/null
+          fi
+          gh release upload "${GITHUB_REF_NAME}" dist/*.tar.gz dist/*.tar.gz.sha256 --clobber


### PR DESCRIPTION
## Problem

The `x86_64-unknown-linux-gnu` release artifact is built natively on the workstation-1 runner (Ubuntu 24.04) and links glibc 2.38/2.39 symbols, so it cannot run on Synology DSM (glibc 2.36). Fixes #572.

## Change

- The x86_64 build-package leg now runs in a `rust:1-bookworm` job container (Debian 12 = glibc 2.36) on the same runner. glibc symbol versioning is forward compatible, so the one artifact now covers every fleet x86_64 host from DSM up (verified: a binary built this way in the same container runs on DSM where the v0.6.x release artifacts fail, and newer-glibc hosts are unaffected).
- New **Verify glibc baseline** step fails the build if the binary's max required `GLIBC_*` symbol ever exceeds 2.36 again, so this can't silently regress.
- Release attachment moves to a host-side `attach-release` job because the build container doesn't ship `gh`. It runs unless cancelled and attaches whatever legs produced artifacts, so one failed leg no longer blocks publishing the other (matches the old per-leg attach behavior).
- Build deps gain `libclang-dev`, `cmake`, `binutils` (needed inside the minimal container for librocksdb-sys bindgen and the objdump check; no-ops on the hosts).
- The aarch64 spark leg is unchanged (no container).

## Build-dep discovery trail (from reproducing the container build by hand on workstation-2)

1. private git deps → already handled by the PAT URL-rewrite step
2. `librocksdb-sys` → needs libclang (bindgen)
3. `iroh-bitswap` → needs `protoc` (already in the dep list)
4. lens wasm modules in `crates/defra-agent/build.rs` → needs the `wasm32-unknown-unknown` target (already installed by the toolchain step)

## Requirements / verification notes

- The workstation-1 runner user must be able to use docker (container jobs). Suggest a `workflow_dispatch` run of this workflow before the next tag to shake out the container leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)