### PR TITLE
feat(desktop): chat-driven Code mode — diffs, terminal output, boundary header

### DIFF
--- a/apps/desktop-tauri/src/App.css
+++ b/apps/desktop-tauri/src/App.css
@@ -15,6 +15,7 @@
 @import "./styles/sidebar/nav.css";
 @import "./styles/sidebar/conversations.css";
 @import "./styles/chat.css";
+@import "./styles/code-context.css";
 @import "./styles/fleet/layout.css";
 @import "./styles/fleet/table.css";
 @import "./styles/mcp-health.css";

--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { ChatWorkspace } from "./components/ChatWorkspace";
+import { CodeContextHeader } from "./components/code/CodeContextHeader";
 import { ConfigWorkspace } from "./components/ConfigWorkspace";
 import { FleetDashboard } from "./components/fleet/FleetDashboard";
 import { Sidebar } from "./components/Sidebar";
@@ -9,15 +10,22 @@ import "./App.css";
 
 function App() {
   const shell = useDesktopShell();
-  const [workspaceView, setWorkspaceView] = useState<"fleet" | "chat" | "config">(
-    "fleet",
-  );
+  const [workspaceView, setWorkspaceView] = useState<
+    "fleet" | "chat" | "config" | "code"
+  >("fleet");
 
   function openChat(agentDid?: string) {
     if (agentDid) {
       shell.setSelectedAgentDid(agentDid);
     }
     setWorkspaceView("chat");
+  }
+
+  function openCode(agentDid?: string) {
+    if (agentDid) {
+      shell.setSelectedAgentDid(agentDid);
+    }
+    setWorkspaceView("code");
   }
 
   function openConfig(agentDid?: string) {
@@ -51,13 +59,14 @@ function App() {
           onOpenConfig={openConfig}
           onRepairP2P={shell.onRepairP2P}
         />
-      ) : workspaceView === "chat" ? (
+      ) : workspaceView === "chat" || workspaceView === "code" ? (
         <section className="workspace">
           <Sidebar
             behaviorOptions={shell.behaviorOptions}
             conversations={shell.selectedDeployment?.conversations ?? []}
             deployments={shell.deployments}
             onConfigureDeployment={(agentDid) => openConfig(agentDid)}
+            onOpenCode={(agentDid) => openCode(agentDid)}
             onOpenFleet={() => setWorkspaceView("fleet")}
             onSelectBehavior={shell.setSelectedBehaviorId}
             onSelectSession={shell.onSelectSession}
@@ -68,6 +77,13 @@ function App() {
           />
 
           <section className="chat-column">
+            {workspaceView === "code" ? (
+              <CodeContextHeader
+                deployment={shell.selectedDeployment ?? null}
+                selectedBehaviorId={shell.selectedBehaviorId}
+                onBackToChat={() => setWorkspaceView("chat")}
+              />
+            ) : null}
             <ChatWorkspace
               approxSerializedBytes={shell.snapshot?.client?.approxSerializedBytes ?? 0}
               canSend={shell.canSendMessage}

--- a/apps/desktop-tauri/src/components/Sidebar.tsx
+++ b/apps/desktop-tauri/src/components/Sidebar.tsx
@@ -14,6 +14,7 @@ export type SidebarProps = {
   selectedSessionId: string | null;
   onOpenFleet: () => void;
   onConfigureDeployment: (agentDid: string) => void;
+  onOpenCode?: (agentDid: string) => void;
   onSelectBehavior: (behaviorId: string) => void;
   onSelectSession: (sessionId: string) => void;
   onStartNewConversation: (behaviorId: string) => void;
@@ -28,6 +29,7 @@ export function Sidebar({
   selectedSessionId,
   onOpenFleet,
   onConfigureDeployment,
+  onOpenCode,
   onSelectBehavior,
   onSelectSession,
   onStartNewConversation,
@@ -38,6 +40,7 @@ export function Sidebar({
         deployments={deployments}
         selectedAgentDid={selectedAgentDid}
         onConfigureDeployment={onConfigureDeployment}
+        onOpenCode={onOpenCode}
         onOpenFleet={onOpenFleet}
       />
 

--- a/apps/desktop-tauri/src/components/Transcript.tsx
+++ b/apps/desktop-tauri/src/components/Transcript.tsx
@@ -9,6 +9,8 @@ import type {
 } from "../lib/types";
 import type { DerivedCancelCauseView } from "../lib/types/operations";
 import { CancelCauseBadge, CancelCauseDetails } from "./cancelUx";
+import { CodeToolItem } from "./codeTools/CodeToolItem";
+import { toCodeToolView } from "./codeTools/codeTools";
 import { CommandDenialToolItem } from "./commandDenial";
 
 function MarkdownContent({ value }: { value: string }) {
@@ -88,6 +90,19 @@ function ToolGroups({ tools }: { tools: RenderedToolCallView[] }) {
           return (
             <CommandDenialToolItem key={tool.itemKey} tool={tool} denial={denial} />
           );
+        }
+        // Code-aware rendering: file edits become diffs, bash becomes a terminal
+        // block. Only completed, uncancelled calls are projected — errored,
+        // running, and cancelled calls keep the generic disclosure (with its
+        // cancel-cause details), so a failed edit never reads as an applied diff.
+        // A completed bash with a non-zero/timeout envelope still projects; the
+        // envelope drives its failed badge.
+        const codeView =
+          (tool.statusKind ?? "").toLowerCase() === "success" && !tool.cancelCause
+            ? toCodeToolView(tool)
+            : null;
+        if (codeView) {
+          return <CodeToolItem key={tool.itemKey} view={codeView} />;
         }
         return (
           <details className="tool-item" key={tool.itemKey}>

--- a/apps/desktop-tauri/src/components/code/CodeContextHeader.tsx
+++ b/apps/desktop-tauri/src/components/code/CodeContextHeader.tsx
@@ -1,0 +1,156 @@
+import type { DeploymentView, ToolSelectionView } from "../../lib/types";
+
+// The multi-agent crux: an agent codes in ITS OWN tool root on ITS host, within
+// its permission/sandbox boundary. This header makes that boundary explicit
+// before the operator directs a coding task — resolved entirely from data
+// already on DeploymentView (no bridge work).
+//
+// Honesty notes: the boundary shown is the selection governing the behavior the
+// next send will use (the selected behavior, falling back to the deployment
+// default). If that behavior resolves no tool selection, file/bash tools are
+// off — we say so rather than showing some other selection's boundary. What's
+// shown is the PERSISTED selection; the host's operator ceiling may clamp it
+// further at reconcile time.
+function governingToolSelection(
+  deployment: DeploymentView | null,
+  selectedBehaviorId: string | null,
+): ToolSelectionView | null {
+  if (!deployment) {
+    return null;
+  }
+  const behaviorId =
+    selectedBehaviorId ??
+    deployment.defaultBehaviorId ??
+    deployment.agentPrincipal.defaultBehaviorId;
+  const behavior =
+    deployment.behaviors.find((candidate) => candidate.behaviorId === behaviorId) ??
+    deployment.behaviors.find(
+      (candidate) =>
+        candidate.behaviorId ===
+        (deployment.defaultBehaviorId ?? deployment.agentPrincipal.defaultBehaviorId),
+    );
+  if (!behavior?.toolSelectionId) {
+    return null;
+  }
+  return (
+    deployment.toolSelections.find(
+      (selection) => selection.selectionId === behavior.toolSelectionId,
+    ) ?? null
+  );
+}
+
+function fileModeLabel(selection: ToolSelectionView | null): string {
+  if (!selection?.enableFileTools) {
+    return "off";
+  }
+  switch (selection.fileToolsMode) {
+    case "ReadWrite":
+      return "read / write";
+    case "ReadOnly":
+    case undefined:
+    case null:
+      return "read-only";
+    case "Off":
+      return "off";
+    default:
+      return selection.fileToolsMode;
+  }
+}
+
+function bashModeLabel(selection: ToolSelectionView | null): string {
+  if (!selection?.enableBash) {
+    return "off";
+  }
+  switch (selection.bashMode) {
+    case "Unrestricted":
+    case "ReadWrite":
+      return "unrestricted";
+    case "ReadOnly":
+    case undefined:
+    case null:
+      return "read-only";
+    case "Off":
+      return "off";
+    default:
+      return selection.bashMode;
+  }
+}
+
+function shortPeerId(peerId: string): string {
+  return peerId.length > 12 ? `${peerId.slice(0, 12)}…` : peerId;
+}
+
+export function CodeContextHeader({
+  deployment,
+  selectedBehaviorId,
+  onBackToChat,
+}: {
+  deployment: DeploymentView | null;
+  selectedBehaviorId?: string | null;
+  onBackToChat: () => void;
+}) {
+  const selection = governingToolSelection(deployment, selectedBehaviorId ?? null);
+  // The P2P identity is the honest "where it runs" answer: saved GraphQL
+  // endpoints can be agent-relative (loopback on the AGENT's machine), so an
+  // endpoint host would misleadingly read as the operator's machine.
+  const host = deployment
+    ? `${deployment.label} · ${shortPeerId(deployment.peerId)}`
+    : null;
+  const workingDir = selection?.fileToolRoot?.trim() || null;
+
+  return (
+    <header className="code-context" data-testid="code-context-header">
+      <div className="code-context-main">
+        <div className="code-context-title">
+          <span className="eyebrow">Code</span>
+          <h2>
+            {deployment?.agentPrincipal.displayName ??
+              deployment?.label ??
+              "No agent selected"}
+          </h2>
+        </div>
+        <button
+          className="ghost-button"
+          data-testid="code-back-to-chat"
+          onClick={onBackToChat}
+          type="button"
+        >
+          Back to Chat
+        </button>
+      </div>
+      <dl className="code-context-facts">
+        <div>
+          <dt>Agent host</dt>
+          <dd className="mono" data-testid="code-context-host">
+            {host ?? "—"}
+          </dd>
+        </div>
+        <div>
+          <dt>Working directory</dt>
+          <dd className="mono" data-testid="code-context-workdir">
+            {selection
+              ? (workingDir ?? "host operator root")
+              : "none (files & bash off)"}
+          </dd>
+        </div>
+        <div>
+          <dt>Files</dt>
+          <dd data-testid="code-context-files">{fileModeLabel(selection)}</dd>
+        </div>
+        <div>
+          <dt>Bash</dt>
+          <dd data-testid="code-context-bash">{bashModeLabel(selection)}</dd>
+        </div>
+        <div>
+          <dt>Command network</dt>
+          <dd>{selection ? (selection.commandNetworkMode ?? "inherit") : "—"}</dd>
+        </div>
+      </dl>
+      <p className="code-context-note muted small">
+        The agent edits files and runs commands on its own host, within the boundary
+        persisted above — the host operator&apos;s tool ceiling may restrict it further.
+        Direct it below; edits and command output stream back.
+      </p>
+    </header>
+  );
+}

--- a/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
+++ b/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
@@ -1,0 +1,91 @@
+import type { CodeToolView } from "./codeTools";
+
+// Renders a code tool call as a diff (file edits) or a terminal block (bash),
+// instead of the generic args/result disclosure. Foundation-aligned: the data
+// is already on the persisted tool call; this is a projection, not new state.
+export function CodeToolItem({ view }: { view: CodeToolView }) {
+  if (view.kind === "fileEdit") {
+    return (
+      <details className="tool-item code-tool" data-testid="code-file-edit" open>
+        <summary className="tool-item-summary">
+          <span className="tool-item-summary-left">
+            <span aria-hidden="true" className="tool-item-dot tool-item-dot-success" />
+            <span className="code-tool-kind">
+              {view.created ? "created" : "edited"}
+            </span>
+            <span className="code-tool-path mono">{view.path}</span>
+            {view.replacementsApplied > 1 ? (
+              <span className="code-tool-kind" data-testid="code-replacements">
+                ×{view.replacementsApplied}
+              </span>
+            ) : null}
+          </span>
+          <span className="tool-item-action">diff</span>
+        </summary>
+        <pre className="code-diff" data-testid="code-diff">
+          {view.diff.map((line, index) => (
+            <div
+              className={`code-diff-line code-diff-${line.kind}`}
+              key={`${line.kind}-${index}`}
+            >
+              <span aria-hidden="true" className="code-diff-gutter">
+                {line.kind === "add" ? "+" : "-"}
+              </span>
+              <span className="code-diff-text">{line.text}</span>
+            </div>
+          ))}
+        </pre>
+      </details>
+    );
+  }
+
+  return (
+    <details className="tool-item code-tool" data-testid="code-command" open>
+      <summary className="tool-item-summary">
+        <span className="tool-item-summary-left">
+          <span
+            aria-hidden="true"
+            className={`tool-item-dot ${
+              view.failed ? "tool-item-dot-error" : "tool-item-dot-success"
+            }`}
+          />
+          <span aria-hidden="true" className="code-tool-prompt mono">
+            $
+          </span>
+          <span className="code-tool-command mono">{view.command}</span>
+        </span>
+        <span
+          className={`code-exit ${view.failed ? "code-exit-fail" : "code-exit-ok"}`}
+          data-testid="code-exit"
+        >
+          {view.timedOut
+            ? "timed out"
+            : view.exitCode != null
+              ? `exit ${view.exitCode}`
+              : view.failed
+                ? "failed"
+                : "ok"}
+        </span>
+      </summary>
+      <div className="tool-item-body">
+        {view.executionMode || view.networkMode ? (
+          <div className="code-command-meta muted small">
+            {view.executionMode ? <span>sandbox: {view.executionMode}</span> : null}
+            {view.networkMode ? <span>network: {view.networkMode}</span> : null}
+          </div>
+        ) : null}
+        {view.stdout ? (
+          <pre className="code-terminal" data-testid="code-terminal">
+            {view.stdout}
+          </pre>
+        ) : null}
+        {view.stderr ? (
+          <div className="code-stderr" data-testid="code-stderr">
+            <div className="tool-detail-label">stderr</div>
+            <pre className="code-terminal">{view.stderr}</pre>
+          </div>
+        ) : null}
+      </div>
+    </details>
+  );
+}

--- a/apps/desktop-tauri/src/components/codeTools/codeTools.ts
+++ b/apps/desktop-tauri/src/components/codeTools/codeTools.ts
@@ -1,0 +1,186 @@
+import type { RenderedToolCallView } from "../../lib/types";
+
+// Code-aware projection of the agent's file/command tool calls. Everything is
+// derived client-side from the tool args (raw JSON) + the runtime's result
+// envelopes (`defra_exec: {json}` / `defra_fs: {json}` head line) that the
+// transcript already carries — no bridge changes. File edits become diffs;
+// bash calls become terminal blocks. The agent runs these ON ITS host, inside
+// its tool-root/sandbox. Only successful, uncancelled calls are projected —
+// failed/running/cancelled calls keep the generic disclosure (with its denial
+// and cancel-cause rendering) so a failed edit never reads as an applied diff.
+
+export type DiffLineKind = "add" | "del";
+export type DiffLine = { kind: DiffLineKind; text: string };
+
+export type FileEditView = {
+  kind: "fileEdit";
+  path: string;
+  created: boolean;
+  /** >1 when edit_file replace_all touched multiple sites. */
+  replacementsApplied: number;
+  diff: DiffLine[];
+};
+
+export type CommandRunView = {
+  kind: "command";
+  command: string;
+  exitCode: number | null;
+  executionMode: string | null;
+  networkMode: string | null;
+  timedOut: boolean;
+  failed: boolean;
+  stdout: string;
+  stderr: string;
+};
+
+export type CodeToolView = FileEditView | CommandRunView;
+
+const FILE_EDIT_TOOLS = new Set(["write_file", "edit_file"]);
+const COMMAND_TOOLS = new Set(["bash", "bash_unrestricted"]);
+
+function safeJsonObject(text?: string | null): Record<string, unknown> | null {
+  if (!text) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(text);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(
+  record: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  const value = record?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * Split a `<prefix>{json}\n<body>` metadata envelope (defra_exec / defra_fs)
+ * into its parsed JSON head and the remaining output body.
+ */
+function splitEnvelope(
+  result: string,
+  prefix: string,
+): { meta: Record<string, unknown> | null; body: string } {
+  if (!result.startsWith(prefix)) {
+    return { meta: null, body: result };
+  }
+  const newline = result.indexOf("\n");
+  const head =
+    newline === -1 ? result.slice(prefix.length) : result.slice(prefix.length, newline);
+  const body = newline === -1 ? "" : result.slice(newline + 1);
+  return { meta: safeJsonObject(head), body };
+}
+
+/**
+ * Parse the runtime's command body framing:
+ * `stdout:\n<stdout-or-(empty)>\nstderr:\n<stderr-or-(empty)>`
+ * (see render_command_output in toolset/shared/command.rs). Falls back to
+ * treating the whole body as stdout when the framing is absent.
+ */
+function splitCommandStreams(body: string): { stdout: string; stderr: string } {
+  const stdoutPrefix = "stdout:\n";
+  const stderrMarker = "\nstderr:\n";
+  if (!body.startsWith(stdoutPrefix)) {
+    return { stdout: normalizeStream(body), stderr: "" };
+  }
+  const stderrAt = body.indexOf(stderrMarker);
+  if (stderrAt === -1) {
+    return { stdout: normalizeStream(body.slice(stdoutPrefix.length)), stderr: "" };
+  }
+  return {
+    stdout: normalizeStream(body.slice(stdoutPrefix.length, stderrAt)),
+    stderr: normalizeStream(body.slice(stderrAt + stderrMarker.length)),
+  };
+}
+
+function normalizeStream(value: string): string {
+  const trimmed = value.replace(/\s+$/, "");
+  return trimmed === "(empty)" ? "" : trimmed;
+}
+
+/** Split file text into diff lines, tolerating CRLF and a trailing newline. */
+function toDiffLines(text: string, kind: DiffLineKind): DiffLine[] {
+  return text
+    .replace(/\r?\n$/, "")
+    .split(/\r?\n/)
+    .map((line) => ({
+      kind,
+      text: line,
+    }));
+}
+
+/** Project a code tool call into a diff/terminal view, or null if not one. */
+export function toCodeToolView(tool: RenderedToolCallView): CodeToolView | null {
+  const name = tool.toolName.toLowerCase();
+  if (FILE_EDIT_TOOLS.has(name)) {
+    return toFileEditView(tool, name);
+  }
+  if (COMMAND_TOOLS.has(name)) {
+    return toCommandRunView(tool);
+  }
+  return null;
+}
+
+function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView | null {
+  const args = safeJsonObject(tool.args?.rawText);
+  const path = stringField(args, "path");
+  if (!path) {
+    return null;
+  }
+  const { meta } = splitEnvelope(tool.result?.rawText ?? "", "defra_fs: ");
+  // Only write_file's metadata carries `created`; edit_file edits by contract.
+  const created = name === "write_file" && meta?.["created"] === true;
+  const replacementsRaw = meta?.["replacements_applied"];
+  const replacementsApplied =
+    typeof replacementsRaw === "number" && replacementsRaw > 0 ? replacementsRaw : 1;
+  let diff: DiffLine[];
+  if (name === "write_file") {
+    diff = toDiffLines(stringField(args, "content") ?? "", "add");
+  } else {
+    diff = [
+      ...toDiffLines(stringField(args, "old_text") ?? "", "del"),
+      ...toDiffLines(stringField(args, "new_text") ?? "", "add"),
+    ];
+  }
+  return { kind: "fileEdit", path, created, replacementsApplied, diff };
+}
+
+function toCommandRunView(tool: RenderedToolCallView): CommandRunView | null {
+  const args = safeJsonObject(tool.args?.rawText);
+  const { meta, body } = splitEnvelope(tool.result?.rawText ?? "", "defra_exec: ");
+  // The envelope's `command` is the full shell-joined argv; the raw arg may be
+  // just the executable when an args array was used.
+  const command = stringField(meta, "command") ?? stringField(args, "command");
+  if (!command) {
+    return null;
+  }
+  const exitRaw = meta?.["exit_code"];
+  const exitCode = typeof exitRaw === "number" ? exitRaw : null;
+  const status = stringField(meta, "status");
+  const timedOut = meta?.["timed_out"] === true || status === "timeout";
+  const failed =
+    (tool.statusKind ?? "").toLowerCase() === "error" ||
+    meta?.["ok"] === false ||
+    timedOut ||
+    status === "exit_nonzero" ||
+    (exitCode != null && exitCode !== 0);
+  const { stdout, stderr } = splitCommandStreams(body);
+  return {
+    kind: "command",
+    command,
+    exitCode,
+    executionMode: stringField(meta, "execution_mode"),
+    networkMode: stringField(meta, "network_mode"),
+    timedOut,
+    failed,
+    stdout,
+    stderr,
+  };
+}

--- a/apps/desktop-tauri/src/components/codeTools/codeTools.ts
+++ b/apps/desktop-tauri/src/components/codeTools/codeTools.ts
@@ -8,6 +8,10 @@ import type { RenderedToolCallView } from "../../lib/types";
 // its tool-root/sandbox. Only successful, uncancelled calls are projected —
 // failed/running/cancelled calls keep the generic disclosure (with its denial
 // and cancel-cause rendering) so a failed edit never reads as an applied diff.
+// The same honesty rule covers the result metadata itself: raw_json=true
+// results are rescued from their bare-JSON shape, but a call whose metadata
+// cannot be parsed at all (missing, malformed, or tail-truncated away) keeps
+// the generic disclosure rather than projecting a fabricated ok badge.
 
 export type DiffLineKind = "add" | "del";
 export type DiffLine = { kind: DiffLineKind; text: string };
@@ -58,6 +62,22 @@ function stringField(
 ): string | null {
   const value = record?.[key];
   return typeof value === "string" ? value : null;
+}
+
+/**
+ * Rescue a `raw_json=true` result: the runtime then emits one bare JSON
+ * object with the same metadata fields flattened to the top level
+ * (CommandOutput / WriteFileOutput / EditFileOutput all serde-flatten their
+ * metadata). Returns null unless the whole result parses to an object
+ * carrying the metadata's `ok`/`status` pair.
+ */
+function bareJsonMeta(result: string): Record<string, unknown> | null {
+  const parsed = safeJsonObject(result);
+  return parsed &&
+    typeof parsed["ok"] === "boolean" &&
+    typeof parsed["status"] === "string"
+    ? parsed
+    : null;
 }
 
 /**
@@ -134,10 +154,16 @@ function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView 
   if (!path) {
     return null;
   }
-  const { meta } = splitEnvelope(tool.result?.rawText ?? "", "defra_fs: ");
+  const raw = tool.result?.rawText ?? "";
+  const meta = splitEnvelope(raw, "defra_fs: ").meta ?? bareJsonMeta(raw);
+  // No trustworthy metadata (missing, malformed, or truncated away): keep the
+  // generic disclosure rather than guess at what was applied.
+  if (!meta || meta["ok"] === false) {
+    return null;
+  }
   // Only write_file's metadata carries `created`; edit_file edits by contract.
-  const created = name === "write_file" && meta?.["created"] === true;
-  const replacementsRaw = meta?.["replacements_applied"];
+  const created = name === "write_file" && meta["created"] === true;
+  const replacementsRaw = meta["replacements_applied"];
   const replacementsApplied =
     typeof replacementsRaw === "number" && replacementsRaw > 0 ? replacementsRaw : 1;
   let diff: DiffLine[];
@@ -154,24 +180,40 @@ function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView 
 
 function toCommandRunView(tool: RenderedToolCallView): CommandRunView | null {
   const args = safeJsonObject(tool.args?.rawText);
-  const { meta, body } = splitEnvelope(tool.result?.rawText ?? "", "defra_exec: ");
+  const raw = tool.result?.rawText ?? "";
+  const envelope = splitEnvelope(raw, "defra_exec: ");
+  let meta = envelope.meta;
+  let streams: { stdout: string; stderr: string };
+  if (meta) {
+    streams = splitCommandStreams(envelope.body);
+  } else if ((meta = bareJsonMeta(raw))) {
+    // raw_json=true: the streams are top-level JSON fields, not body framing.
+    streams = {
+      stdout: normalizeStream(stringField(meta, "stdout") ?? ""),
+      stderr: normalizeStream(stringField(meta, "stderr") ?? ""),
+    };
+  } else {
+    // No trustworthy envelope (missing, malformed, or truncated away): keep
+    // the generic disclosure rather than fabricate an ok badge.
+    return null;
+  }
   // The envelope's `command` is the full shell-joined argv; the raw arg may be
   // just the executable when an args array was used.
   const command = stringField(meta, "command") ?? stringField(args, "command");
   if (!command) {
     return null;
   }
-  const exitRaw = meta?.["exit_code"];
+  const exitRaw = meta["exit_code"];
   const exitCode = typeof exitRaw === "number" ? exitRaw : null;
   const status = stringField(meta, "status");
-  const timedOut = meta?.["timed_out"] === true || status === "timeout";
+  const timedOut = meta["timed_out"] === true || status === "timeout";
   const failed =
     (tool.statusKind ?? "").toLowerCase() === "error" ||
-    meta?.["ok"] === false ||
+    meta["ok"] === false ||
     timedOut ||
     status === "exit_nonzero" ||
     (exitCode != null && exitCode !== 0);
-  const { stdout, stderr } = splitCommandStreams(body);
+  const { stdout, stderr } = streams;
   return {
     kind: "command",
     command,

--- a/apps/desktop-tauri/src/components/sidebar-widgets/ConnectedPeerSection.tsx
+++ b/apps/desktop-tauri/src/components/sidebar-widgets/ConnectedPeerSection.tsx
@@ -6,6 +6,7 @@ export type ConnectedPeerSectionProps = {
   selectedAgentDid: string | null;
   onOpenFleet: () => void;
   onConfigureDeployment: (agentDid: string) => void;
+  onOpenCode?: (agentDid: string) => void;
 };
 
 export function ConnectedPeerSection({
@@ -13,6 +14,7 @@ export function ConnectedPeerSection({
   selectedAgentDid,
   onOpenFleet,
   onConfigureDeployment,
+  onOpenCode,
 }: ConnectedPeerSectionProps) {
   const selectedDeployment =
     deployments.find((deployment) => deployment.agentDid === selectedAgentDid) ?? null;
@@ -55,6 +57,21 @@ export function ConnectedPeerSection({
           >
             Fleet Dashboard
           </button>
+          {onOpenCode ? (
+            <button
+              className="ghost-button connected-peer-action"
+              data-testid="sidebar-open-code"
+              disabled={!selectedDeployment}
+              onClick={() => {
+                if (selectedDeployment) {
+                  onOpenCode(selectedDeployment.agentDid);
+                }
+              }}
+              type="button"
+            >
+              Code
+            </button>
+          ) : null}
           <button
             className="ghost-button connected-peer-action"
             disabled={!selectedDeployment}

--- a/apps/desktop-tauri/src/styles/code-context.css
+++ b/apps/desktop-tauri/src/styles/code-context.css
@@ -1,0 +1,47 @@
+@layer chat {
+  .code-context {
+    display: grid;
+    gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    margin-bottom: var(--space-4);
+    border: 1px solid rgb(var(--source-green-rgb) / 0.14);
+    border-radius: var(--radius-lg);
+    background: var(--color-surface-deep);
+  }
+
+  .code-context-main {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--space-4);
+  }
+
+  .code-context-title h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+
+  .code-context-facts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: var(--space-2) var(--space-5);
+    margin: 0;
+  }
+
+  .code-context-facts dt {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-muted);
+  }
+
+  .code-context-facts dd {
+    margin: 2px 0 0;
+    font-size: 0.85rem;
+    word-break: break-all;
+  }
+
+  .code-context-note {
+    margin: 0;
+  }
+}

--- a/apps/desktop-tauri/src/styles/transcript/tools.css
+++ b/apps/desktop-tauri/src/styles/transcript/tools.css
@@ -254,4 +254,98 @@
     padding: 0 4px;
     border-radius: 4px;
   }
+
+  /* ---- code-aware tool rendering (diffs + terminal) ---- */
+  .code-tool > summary .code-tool-kind {
+    text-transform: uppercase;
+    font-size: 0.72rem;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+  }
+
+  .code-tool-path,
+  .code-tool-command,
+  .code-tool-prompt {
+    font-size: 0.82rem;
+  }
+
+  .code-tool-prompt {
+    color: rgb(var(--source-green-rgb) / 0.75);
+  }
+
+  .code-diff {
+    margin: 0;
+    padding: var(--space-3) 0;
+    overflow-x: auto;
+    background: var(--color-surface-deep);
+    border-radius: var(--radius-md, 8px);
+    font-size: 0.8rem;
+    line-height: 1.5;
+  }
+
+  .code-diff-line {
+    display: flex;
+    gap: var(--space-3);
+    padding: 0 var(--space-4);
+    white-space: pre;
+  }
+
+  .code-diff-gutter {
+    flex: none;
+    width: 1ch;
+    text-align: center;
+    opacity: 0.7;
+    user-select: none;
+  }
+
+  .code-diff-add {
+    background: rgb(var(--source-green-rgb) / 0.12);
+    color: var(--color-text, inherit);
+  }
+
+  .code-diff-add .code-diff-gutter {
+    color: rgb(var(--source-green-rgb) / 0.9);
+  }
+
+  .code-diff-del {
+    background: rgb(var(--source-orange-rgb) / 0.12);
+  }
+
+  .code-diff-del .code-diff-gutter {
+    color: var(--color-warning-soft, #ffd089);
+  }
+
+  .code-exit {
+    font-size: 0.72rem;
+    letter-spacing: 0.03em;
+    padding: 1px 8px;
+    border-radius: var(--radius-pill, 999px);
+  }
+
+  .code-exit-ok {
+    background: rgb(var(--source-green-rgb) / 0.14);
+    color: rgb(var(--source-green-rgb) / 0.95);
+  }
+
+  .code-exit-fail {
+    background: rgb(var(--source-orange-rgb) / 0.18);
+    color: var(--color-warning-soft, #ffd089);
+  }
+
+  .code-command-meta {
+    display: flex;
+    gap: var(--space-4);
+    padding: 0 var(--space-5) var(--space-2);
+  }
+
+  .code-terminal {
+    margin: 0;
+    padding: var(--space-3) var(--space-5);
+    overflow-x: auto;
+    background: var(--color-surface-deep);
+    border-radius: var(--radius-md, 8px);
+    font-size: 0.8rem;
+    line-height: 1.5;
+    white-space: pre-wrap;
+  }
 }

--- a/apps/desktop-tauri/tests/code-context-header.test.tsx
+++ b/apps/desktop-tauri/tests/code-context-header.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CodeContextHeader } from "../src/components/code/CodeContextHeader";
+import { deployment } from "./config-panel-wiring/fixtures";
+
+describe("CodeContextHeader", () => {
+  it("surfaces the working directory and permission boundary of the governing selection", () => {
+    const codingDeployment = {
+      ...deployment,
+      toolSelections: [
+        {
+          ...deployment.toolSelections[0],
+          fileToolRoot: "/srv/project",
+          fileToolsMode: "ReadWrite",
+          bashMode: "ReadOnly",
+          commandNetworkMode: "disabled",
+        },
+        deployment.toolSelections[1],
+      ],
+    };
+    render(<CodeContextHeader deployment={codingDeployment} onBackToChat={vi.fn()} />);
+    expect(screen.getByTestId("code-context-workdir")).toHaveTextContent(
+      "/srv/project",
+    );
+    expect(screen.getByTestId("code-context-files")).toHaveTextContent("read / write");
+    expect(screen.getByTestId("code-context-bash")).toHaveTextContent("read-only");
+    // The honest host identity is the peer, not a (possibly agent-relative)
+    // GraphQL endpoint.
+    expect(screen.getByTestId("code-context-host")).toHaveTextContent("Local Agent");
+    expect(screen.getByTestId("code-context-host")).toHaveTextContent("peer-1");
+  });
+
+  it("resolves the SELECTED behavior's tool selection, not the default or [0]", () => {
+    // Fixture: behavior "default" -> tools-a (files on), behavior "ops" ->
+    // tools-b (files off). A regression to "always default" or "always
+    // toolSelections[0]" would show tools-a's boundary and fail here.
+    render(
+      <CodeContextHeader
+        deployment={deployment}
+        selectedBehaviorId="ops"
+        onBackToChat={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("code-context-files")).toHaveTextContent("off");
+    expect(screen.getByTestId("code-context-bash")).toHaveTextContent("off");
+  });
+
+  it("reports files & bash off when the governing behavior resolves no selection", () => {
+    const noSelection = {
+      ...deployment,
+      behaviors: [{ ...deployment.behaviors[0], toolSelectionId: null }],
+    };
+    render(<CodeContextHeader deployment={noSelection} onBackToChat={vi.fn()} />);
+    expect(screen.getByTestId("code-context-workdir")).toHaveTextContent(
+      "none (files & bash off)",
+    );
+    expect(screen.getByTestId("code-context-files")).toHaveTextContent("off");
+  });
+
+  it("falls back gracefully when no agent is selected", () => {
+    render(<CodeContextHeader deployment={null} onBackToChat={vi.fn()} />);
+    expect(screen.getByTestId("code-context-host")).toHaveTextContent("—");
+    expect(screen.getByTestId("code-context-workdir")).toHaveTextContent(
+      "none (files & bash off)",
+    );
+  });
+
+  it("returns to chat when Back to Chat is clicked", () => {
+    const onBackToChat = vi.fn();
+    render(<CodeContextHeader deployment={deployment} onBackToChat={onBackToChat} />);
+    fireEvent.click(screen.getByTestId("code-back-to-chat"));
+    expect(onBackToChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop-tauri/tests/code-tools.test.tsx
+++ b/apps/desktop-tauri/tests/code-tools.test.tsx
@@ -1,0 +1,245 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CodeToolItem } from "../src/components/codeTools/CodeToolItem";
+import { toCodeToolView } from "../src/components/codeTools/codeTools";
+import type { RenderedToolCallView } from "../src/lib/types";
+
+function toolCall(overrides: Partial<RenderedToolCallView>): RenderedToolCallView {
+  return {
+    itemKey: "tool-1",
+    toolName: "bash",
+    statusKind: "success",
+    args: null,
+    result: null,
+    ...overrides,
+  };
+}
+
+function detail(rawText: string) {
+  return { rawText, fields: [] };
+}
+
+// Result fixtures mirror the runtime's envelopes exactly: `defra_fs: {json}` +
+// a human body line (toolset/file_tools.rs) and `defra_exec: {json}` +
+// `stdout:\n…\nstderr:\n…` framing (toolset/shared/command.rs).
+describe("toCodeToolView", () => {
+  it("projects edit_file into a replacement diff", () => {
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "edit_file",
+        args: detail(
+          JSON.stringify({
+            path: "src/main.rs",
+            old_text: "let x = 1;",
+            new_text: "let x = 2;",
+          }),
+        ),
+        result: detail(
+          'defra_fs: {"ok":true,"status":"success","tool":"edit_file","path":"src/main.rs","returned_count":1,"total_count":1,"truncated":false,"replacements_applied":1,"replace_all":false,"bytes_written":10}\nedit_file: edited src/main.rs (1 replacement)',
+        ),
+      }),
+    );
+    expect(view).toEqual({
+      kind: "fileEdit",
+      path: "src/main.rs",
+      created: false,
+      replacementsApplied: 1,
+      diff: [
+        { kind: "del", text: "let x = 1;" },
+        { kind: "add", text: "let x = 2;" },
+      ],
+    });
+  });
+
+  it("surfaces replace_all multi-site replacements", () => {
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "edit_file",
+        args: detail(
+          JSON.stringify({
+            path: "src/lib.rs",
+            old_text: "foo",
+            new_text: "bar",
+            replace_all: true,
+          }),
+        ),
+        result: detail(
+          'defra_fs: {"ok":true,"status":"success","tool":"edit_file","path":"src/lib.rs","returned_count":12,"total_count":12,"truncated":false,"replacements_applied":12,"replace_all":true,"bytes_written":240}\nedit_file: edited src/lib.rs (12 replacements)',
+        ),
+      }),
+    );
+    expect(view).toMatchObject({ kind: "fileEdit", replacementsApplied: 12 });
+  });
+
+  it("labels write_file created only when the envelope says so", () => {
+    const base = {
+      toolName: "write_file",
+      args: detail(JSON.stringify({ path: "README.md", content: "line 1\nline 2\n" })),
+    };
+    const created = toCodeToolView(
+      toolCall({
+        ...base,
+        result: detail(
+          'defra_fs: {"ok":true,"status":"success","tool":"write_file","path":"README.md","returned_count":0,"total_count":0,"truncated":false,"bytes_written":14,"created":true}\nwrite_file: wrote 14 bytes to README.md',
+        ),
+      }),
+    );
+    expect(created).toMatchObject({
+      kind: "fileEdit",
+      created: true,
+      // Trailing newline in content must not produce a spurious blank line.
+      diff: [
+        { kind: "add", text: "line 1" },
+        { kind: "add", text: "line 2" },
+      ],
+    });
+
+    const overwrote = toCodeToolView(
+      toolCall({
+        ...base,
+        result: detail(
+          'defra_fs: {"ok":true,"status":"success","tool":"write_file","path":"README.md","returned_count":0,"total_count":0,"truncated":false,"bytes_written":14,"created":false}\nwrite_file: wrote 14 bytes to README.md',
+        ),
+      }),
+    );
+    expect(overwrote).toMatchObject({ kind: "fileEdit", created: false });
+  });
+
+  it("parses the stdout/stderr framing and prefers the envelope's full command line", () => {
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "bash",
+        // Exec-style: the raw arg carries only the executable.
+        args: detail(JSON.stringify({ command: "cargo", args: ["test", "--release"] })),
+        result: detail(
+          'defra_exec: {"ok":true,"status":"success","command":"cargo test --release","exit_code":0,"timed_out":false,"execution_mode":"read_only","network_mode":"disabled"}\nstdout:\ntest result: ok. 3 passed\nstderr:\n(empty)',
+        ),
+      }),
+    );
+    expect(view).toEqual({
+      kind: "command",
+      command: "cargo test --release",
+      exitCode: 0,
+      executionMode: "read_only",
+      networkMode: "disabled",
+      timedOut: false,
+      failed: false,
+      stdout: "test result: ok. 3 passed",
+      stderr: "",
+    });
+  });
+
+  it("marks a non-zero exit as failed and keeps stderr separate", () => {
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "bash",
+        args: detail(JSON.stringify({ command: "cargo build" })),
+        result: detail(
+          'defra_exec: {"ok":false,"status":"exit_nonzero","command":"cargo build","exit_code":101,"timed_out":false}\nstdout:\n(empty)\nstderr:\nerror[E0425]',
+        ),
+      }),
+    );
+    expect(view).toMatchObject({
+      kind: "command",
+      exitCode: 101,
+      failed: true,
+      stdout: "",
+      stderr: "error[E0425]",
+    });
+  });
+
+  it("marks a timed-out command as failed even with a null exit code", () => {
+    // Timeouts complete the tool call (statusKind success) with exit_code null;
+    // the envelope is the only failure signal.
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "bash",
+        statusKind: "success",
+        args: detail(JSON.stringify({ command: "sleep 999" })),
+        result: detail(
+          'defra_exec: {"ok":false,"status":"timeout","command":"sleep 999","exit_code":null,"timed_out":true}\nstdout:\n(empty)\nstderr:\n(empty)',
+        ),
+      }),
+    );
+    expect(view).toMatchObject({
+      kind: "command",
+      exitCode: null,
+      timedOut: true,
+      failed: true,
+    });
+  });
+
+  it("returns null for a non-code tool", () => {
+    expect(
+      toCodeToolView(toolCall({ toolName: "web_search", args: detail("{}") })),
+    ).toBeNull();
+  });
+});
+
+describe("CodeToolItem", () => {
+  it("renders a file edit as a diff with the path and replacement count", () => {
+    render(
+      <CodeToolItem
+        view={{
+          kind: "fileEdit",
+          path: "src/main.rs",
+          created: false,
+          replacementsApplied: 12,
+          diff: [
+            { kind: "del", text: "old line" },
+            { kind: "add", text: "new line" },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByTestId("code-file-edit")).toHaveTextContent("src/main.rs");
+    expect(screen.getByTestId("code-replacements")).toHaveTextContent("×12");
+    const diff = screen.getByTestId("code-diff");
+    expect(diff).toHaveTextContent("old line");
+    expect(diff).toHaveTextContent("new line");
+  });
+
+  it("renders a command as a terminal block with exit code, output, and stderr", () => {
+    render(
+      <CodeToolItem
+        view={{
+          kind: "command",
+          command: "cargo test",
+          exitCode: 0,
+          executionMode: "read_only",
+          networkMode: "disabled",
+          timedOut: false,
+          failed: false,
+          stdout: "test result: ok",
+          stderr: "warning: unused import",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("code-command")).toHaveTextContent("cargo test");
+    expect(screen.getByTestId("code-exit")).toHaveTextContent("exit 0");
+    expect(screen.getByTestId("code-terminal")).toHaveTextContent("test result: ok");
+    expect(screen.getByTestId("code-stderr")).toHaveTextContent(
+      "warning: unused import",
+    );
+  });
+
+  it("badges a timed-out command", () => {
+    render(
+      <CodeToolItem
+        view={{
+          kind: "command",
+          command: "sleep 999",
+          exitCode: null,
+          executionMode: null,
+          networkMode: null,
+          timedOut: true,
+          failed: true,
+          stdout: "",
+          stderr: "",
+        }}
+      />,
+    );
+    expect(screen.getByTestId("code-exit")).toHaveTextContent("timed out");
+  });
+});

--- a/apps/desktop-tauri/tests/code-tools.test.tsx
+++ b/apps/desktop-tauri/tests/code-tools.test.tsx
@@ -170,6 +170,125 @@ describe("toCodeToolView", () => {
     });
   });
 
+  it("marks a raw_json non-zero exit as failed (no defra_exec envelope)", () => {
+    // raw_json=true makes render_command_output emit the bare CommandOutput
+    // JSON — flattened metadata plus stdout/stderr fields, no envelope head —
+    // while the call still completes (statusKind success). The failure signal
+    // must be rescued from the bare JSON, never defaulted to ok.
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "bash",
+        statusKind: "success",
+        args: detail(
+          JSON.stringify({ command: "cargo", args: ["build"], raw_json: true }),
+        ),
+        result: detail(
+          JSON.stringify({
+            ok: false,
+            status: "exit_nonzero",
+            command: "cargo build",
+            argv: ["cargo", "build"],
+            cwd: "/work",
+            exit_code: 101,
+            timed_out: false,
+            duration_ms: 4200,
+            timeout_ms: 120000,
+            execution_mode: "read_only",
+            network_mode: "disabled",
+            sandbox: "none",
+            stdout_truncation: {
+              returned_bytes: 0,
+              total_bytes: 0,
+              max_bytes: 16000,
+              truncated: false,
+            },
+            stderr_truncation: {
+              returned_bytes: 12,
+              total_bytes: 12,
+              max_bytes: 16000,
+              truncated: false,
+            },
+            stdout: "",
+            stderr: "error[E0425]",
+          }),
+        ),
+      }),
+    );
+    expect(view).toMatchObject({
+      kind: "command",
+      command: "cargo build",
+      exitCode: 101,
+      failed: true,
+      executionMode: "read_only",
+      networkMode: "disabled",
+      stdout: "",
+      stderr: "error[E0425]",
+    });
+  });
+
+  it("labels a raw_json write_file created from the bare JSON metadata", () => {
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "write_file",
+        args: detail(
+          JSON.stringify({ path: "README.md", content: "hello\n", raw_json: true }),
+        ),
+        result: detail(
+          JSON.stringify({
+            ok: true,
+            status: "success",
+            tool: "write_file",
+            path: "README.md",
+            returned_count: 0,
+            total_count: 0,
+            truncated: false,
+            bytes_written: 6,
+            created: true,
+          }),
+        ),
+      }),
+    );
+    expect(view).toMatchObject({ kind: "fileEdit", created: true });
+  });
+
+  it("keeps the generic disclosure when the envelope was truncated away", () => {
+    // Tail truncation for bash keeps the LAST lines, dropping the defra_exec
+    // head; without trustworthy metadata the call must not project (a nonzero
+    // exit would otherwise badge ok).
+    const view = toCodeToolView(
+      toolCall({
+        toolName: "bash",
+        statusKind: "success",
+        args: detail(JSON.stringify({ command: "cargo test" })),
+        result: detail(
+          "[Showing lines 1001-3000 of 3000 (14000 bytes total)]\n\ntest tail line\ntest result: FAILED. 1 failed",
+        ),
+      }),
+    );
+    expect(view).toBeNull();
+  });
+
+  it("keeps the generic disclosure for a missing or empty result", () => {
+    expect(
+      toCodeToolView(
+        toolCall({
+          toolName: "bash",
+          args: detail(JSON.stringify({ command: "true" })),
+          result: null,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      toCodeToolView(
+        toolCall({
+          toolName: "write_file",
+          args: detail(JSON.stringify({ path: "a.txt", content: "x" })),
+          result: detail(""),
+        }),
+      ),
+    ).toBeNull();
+  });
+
   it("returns null for a non-code tool", () => {
     expect(
       toCodeToolView(toolCall({ toolName: "web_search", args: detail("{}") })),

--- a/apps/desktop-tauri/tests/playwright/desktop-code.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-code.spec.ts
@@ -1,0 +1,42 @@
+import { expect, gotoHarness, openChat, test } from "./desktopTest";
+
+test.describe("desktop code experience", () => {
+  test("renders file edits as diffs and commands as terminal output", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "coding");
+    await openChat(page);
+
+    // Code-aware transcript rendering (applies in chat too): the agent's file
+    // edit becomes a diff and its bash call becomes a terminal block.
+    const fileEdit = page.getByTestId("code-file-edit");
+    await expect(fileEdit).toContainText("src/parser.rs");
+    await expect(page.getByTestId("code-diff")).toContainText("Ast::default()");
+
+    await expect(page.getByTestId("code-command")).toContainText("cargo test parser");
+    await expect(page.getByTestId("code-exit")).toHaveText("exit 0");
+    await expect(page.getByTestId("code-terminal")).toContainText("2 passed");
+  });
+
+  test("Code mode surfaces the agent's working directory and permission boundary", async ({
+    page,
+  }) => {
+    await gotoHarness(page, "coding");
+    await openChat(page);
+    await page.getByTestId("sidebar-open-code").click();
+
+    const header = page.getByTestId("code-context-header");
+    await expect(header).toBeVisible();
+    await expect(page.getByTestId("code-context-workdir")).toContainText(
+      "/tmp/defra-agent-bombadil/workspace",
+    );
+    await expect(page.getByTestId("code-context-files")).toHaveText("read-only");
+    // The code-aware diff renders inside Code mode as well.
+    await expect(page.getByTestId("code-diff")).toBeVisible();
+
+    // Back to Chat returns to the plain chat surface (header gone, composer live).
+    await page.getByTestId("code-back-to-chat").click();
+    await expect(page.getByTestId("code-context-header")).toHaveCount(0);
+    await expect(page.getByTestId("composer-input")).toBeVisible();
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktopTest.ts
+++ b/apps/desktop-tauri/tests/playwright/desktopTest.ts
@@ -10,7 +10,8 @@ export type HarnessScenario =
   | "long-content"
   | "operations-rich"
   | "active-turn"
-  | "cascade-turn";
+  | "cascade-turn"
+  | "coding";
 
 export const PEER_ID = "peer-bombadil-local";
 

--- a/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
+++ b/apps/desktop-tauri/tests/ui-harness/desktopHarness.ts
@@ -36,7 +36,8 @@ export type DesktopUiHarnessScenario =
   | "long-content"
   | "operations-rich"
   | "active-turn"
-  | "cascade-turn";
+  | "cascade-turn"
+  | "coding";
 
 export type DesktopUiHarnessOptions = {
   scenario?: string | null;
@@ -103,6 +104,53 @@ export function createDesktopUiHarness(
         sequence: 1,
         content: greeting,
       },
+      ...(scenario === "coding"
+        ? [
+            {
+              kind: "toolGroup" as const,
+              itemKey: "intro-code-tools",
+              messageSequence: 1,
+              tools: [
+                {
+                  itemKey: "intro-edit-file",
+                  toolName: "edit_file",
+                  statusKind: "success",
+                  args: {
+                    rawText: JSON.stringify({
+                      path: "src/parser.rs",
+                      old_text: "fn parse() -> Ast { todo!() }",
+                      new_text: "fn parse() -> Ast { Ast::default() }",
+                    }),
+                    fields: [],
+                  },
+                  result: {
+                    // Mirrors the runtime's edit_file envelope (EditFileMetadata
+                    // + human body line) — see toolset/file_tools.rs.
+                    rawText:
+                      'defra_fs: {"ok":true,"status":"success","tool":"edit_file","path":"src/parser.rs","returned_count":1,"total_count":1,"truncated":false,"replacements_applied":1,"replace_all":false,"bytes_written":36}\nedit_file: edited src/parser.rs (1 replacement)',
+                    fields: [],
+                  },
+                },
+                {
+                  itemKey: "intro-bash",
+                  toolName: "bash",
+                  statusKind: "success",
+                  args: {
+                    rawText: JSON.stringify({ command: "cargo test parser" }),
+                    fields: [],
+                  },
+                  result: {
+                    // Mirrors the runtime's command envelope framing
+                    // (render_command_output in toolset/shared/command.rs).
+                    rawText:
+                      'defra_exec: {"ok":true,"status":"success","command":"cargo test parser","exit_code":0,"timed_out":false,"execution_mode":"read_only","network_mode":"disabled"}\nstdout:\ntest result: ok. 2 passed\nstderr:\n(empty)',
+                    fields: [],
+                  },
+                },
+              ],
+            },
+          ]
+        : []),
     ],
   });
   syncConversations();
@@ -1263,6 +1311,7 @@ function normalizeScenario(value?: string | null): DesktopUiHarnessScenario {
     case "operations-rich":
     case "active-turn":
     case "cascade-turn":
+    case "coding":
       return value;
     default:
       return "default";


### PR DESCRIPTION
Stacks on #595. Stage 4 of the desktop-perfection epic: a chat-driven **Code** experience.

The desktop had no coding surface — agents' file edits and command runs rendered as opaque args/result JSON blobs. This adds one, shaped for the multi-agent reality: an agent codes **on its own host**, in **its own tool root**, within **its permission/sandbox boundary**; the desktop directs and observes. No local editor, no new bridge commands — pure frontend over data already in the transcript and deployment views.

**Code-aware transcript rendering** (benefits chat too)
- `edit_file`/`write_file` render as diffs (±lines, path, created-vs-edited from the real `defra_fs` envelope, `×N` for `replace_all`).
- `bash`/`bash_unrestricted` render as terminal blocks: full shell-joined command line, exit-code badge, sandbox/network chips, and the runtime's `stdout:`/`stderr:` framing parsed into separate streams. Timeouts and `ok:false` envelopes badge as failed even with a null exit code.
- Only completed, uncancelled calls are projected; errored/running/cancelled calls keep the generic disclosure (with denial + cancel-cause UX), so a failed edit never reads as an applied diff.

**Code mode + boundary header**
- A `Code` entry on the sidebar peer card opens a code view reusing the chat surface, headed by the agent's boundary: **agent host** (peer identity — not a possibly agent-relative GraphQL endpoint), **working directory** (`fileToolRoot`), file/bash/command-network modes.
- The boundary is resolved from the **selected behavior's** tool selection (falling back to the deployment default); if none resolves, it honestly reports files & bash off. Copy notes the host operator's tool ceiling may clamp the persisted selection.

**Tests**: a `coding` harness scenario with envelope fixtures that mirror the runtime byte-for-byte (`render_command_output` framing, `EditFileMetadata`/`WriteFileMetadata`); 18 unit tests + 2 e2e journeys (×3 viewports).

Deferred (needs new bridge commands): live file tree, remote-host ceiling read, working-dir scoping control from the Code header.

Verified: build (tsc) + 144 unit + 99 e2e green, non-flaky; adversarial review pass — all 21 confirmed findings fixed (envelope parsing, failure semantics, boundary honesty, fixture fidelity).
