### PR TITLE
feat(defra-query): surface schema fields on invalid queries (#592)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -427,12 +427,12 @@ pub(crate) struct InitArgs {
     #[arg(
         long,
         default_value_t = false,
-        help = "Disable the default read-only defra_query tool in the default ToolSelection"
+        help = "Disable the read-only defra_query tool even when the tool package enables it (only the introspection package does; defra_query is otherwise opt-in)"
     )]
     pub(crate) disable_defra_query: bool,
     #[arg(
         long = "defra-query-collection",
-        help = "Restrict init's default defra_query tool to these collections (repeatable); omit for all collections"
+        help = "Restrict the defra_query tool to these collections when a package enables it (repeatable); omit for all collections"
     )]
     pub(crate) defra_query_collections: Vec<String>,
 }

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -666,7 +666,9 @@ fn tool_package_profile(tool_package: ToolPackageArg) -> ToolPackageProfile {
             enable_bash: true,
             bash_mode: "ReadOnly",
             enable_meta_tools: true,
-            enable_defra_query: true,
+            // defra_query is opt-in (#592); the introspection package is the
+            // only one that turns it on by default.
+            enable_defra_query: false,
         },
         ToolPackageArg::Write => ToolPackageProfile {
             display_name: "Standard Write Tools",
@@ -675,7 +677,7 @@ fn tool_package_profile(tool_package: ToolPackageArg) -> ToolPackageProfile {
             enable_bash: true,
             bash_mode: "Unrestricted",
             enable_meta_tools: true,
-            enable_defra_query: true,
+            enable_defra_query: false,
         },
         // Yolo's tool surface IS the write surface; only the execution policy
         // (default_command_execution_policy_for_init) differs.
@@ -967,7 +969,7 @@ mod tests {
                 enable_bash: true,
                 bash_mode: "ReadOnly",
                 enable_meta_tools: true,
-                enable_defra_query: true,
+                enable_defra_query: false,
                 backgroundable_tools: Vec::new(),
             },
             Case {
@@ -979,7 +981,7 @@ mod tests {
                 enable_bash: true,
                 bash_mode: "Unrestricted",
                 enable_meta_tools: true,
-                enable_defra_query: true,
+                enable_defra_query: false,
                 backgroundable_tools: vec!["bash_unrestricted".to_string()],
             },
         ];

--- a/crates/defra-agent-cli/src/commands/query.rs
+++ b/crates/defra-agent-cli/src/commands/query.rs
@@ -7,31 +7,95 @@
 //! so the CLI and MCP surfaces are guaranteed to behave identically.
 
 use anyhow::{Context, Result};
-use defra_agent::defra_query::{build_query, CollectionScope, DefraQueryParams};
+use defra_agent::defra_query::{
+    build_query, diagnose_failed_query, discovery_payload, introspection_query,
+    parse_collection_schema, unknown_collection_message, CollectionSchema, CollectionScope,
+    DefraQueryParams,
+};
 use serde_json::{json, Value};
 
 use crate::cli::args::QueryArgs;
 use crate::{post_graphql, print_json, resolve_graphql_endpoint};
 
-/// Build + execute a structured query over GraphQL-over-HTTP and return the
-/// `{collection, count, results}` envelope. Shared by the CLI command and the
-/// MCP tool so both honor the same secret guard + scope.
-pub(crate) async fn run_defra_query(
+/// Introspect a collection's field set over GraphQL-over-HTTP. `Ok(None)`
+/// means the collection (GraphQL type) does not exist on the node.
+async fn fetch_collection_schema(
     graphql: &str,
-    params: &DefraQueryParams,
-    scope: &CollectionScope,
-) -> Result<Value> {
-    let query = build_query(params, scope)?;
+    collection: &str,
+) -> Result<Option<CollectionSchema>> {
+    let query = introspection_query(collection)?;
     let response = post_graphql(graphql, &query).await?;
     if let Some(errors) = response
         .get("errors")
         .and_then(Value::as_array)
         .filter(|errors| !errors.is_empty())
     {
-        anyhow::bail!(
-            "defra_query against {:?} failed: {errors:?}",
-            params.collection
-        );
+        anyhow::bail!("schema introspection for {collection:?} failed: {errors:?}");
+    }
+    Ok(parse_collection_schema(response.get("data")))
+}
+
+/// Turn a failed query into an agent-usable diagnostic by introspecting the
+/// collection; when introspection itself fails (e.g. the failure was
+/// transport-level), the original error text is preserved unchanged.
+async fn enriched_query_failure(
+    graphql: &str,
+    params: &DefraQueryParams,
+    raw: String,
+) -> anyhow::Error {
+    let diagnostic = match fetch_collection_schema(graphql, &params.collection).await {
+        Ok(schema) => diagnose_failed_query(params, schema.as_ref(), &raw),
+        Err(_) => raw,
+    };
+    anyhow::anyhow!(
+        "defra_query against {:?} failed: {diagnostic}",
+        params.collection
+    )
+}
+
+/// Build + execute a structured query over GraphQL-over-HTTP and return the
+/// `{collection, count, results}` envelope. Shared by the CLI command and the
+/// MCP tool so both honor the same secret guard + scope.
+///
+/// `fields: ["*"]` is discovery mode and returns the collection's queryable
+/// field inventory instead of documents. On a GraphQL failure the collection
+/// is introspected and the error enriched into a field-level diagnostic; if
+/// introspection itself fails, the raw errors are surfaced unchanged.
+pub(crate) async fn run_defra_query(
+    graphql: &str,
+    params: &DefraQueryParams,
+    scope: &CollectionScope,
+) -> Result<Value> {
+    if params.is_discovery() {
+        scope.ensure_allowed(&params.collection)?;
+        let schema = fetch_collection_schema(graphql, &params.collection)
+            .await?
+            .with_context(|| {
+                format!(
+                    "defra_query against {:?} failed: {}",
+                    params.collection,
+                    unknown_collection_message(&params.collection)
+                )
+            })?;
+        return Ok(discovery_payload(&params.collection, &schema));
+    }
+
+    let query = build_query(params, scope)?;
+    // `post_graphql` bails when the response carries GraphQL errors, so the
+    // enrichment hook is its Err path (transport failures fall back to the
+    // original error because introspection then fails too).
+    let response = match post_graphql(graphql, &query).await {
+        Ok(response) => response,
+        Err(error) => {
+            return Err(enriched_query_failure(graphql, params, format!("{error:#}")).await);
+        }
+    };
+    if let Some(errors) = response
+        .get("errors")
+        .and_then(Value::as_array)
+        .filter(|errors| !errors.is_empty())
+    {
+        return Err(enriched_query_failure(graphql, params, format!("{errors:?}")).await);
     }
     let rows = response
         .get("data")

--- a/crates/defra-agent-cli/src/http/mcp_server.rs
+++ b/crates/defra-agent-cli/src/http/mcp_server.rs
@@ -30,7 +30,8 @@ use crate::commands::query::run_defra_query;
 struct McpQueryArgs {
     /// Collection (GraphQL type) to read, e.g. "AgentRequest".
     collection: String,
-    /// Field names to return; at least one is required.
+    /// Field names to return; at least one is required. Pass ["*"] to list the
+    /// collection's queryable fields instead of documents.
     #[serde(default)]
     fields: Vec<String>,
     /// Optional DefraDB filter object, e.g. {"status": {"_eq": "completed"}}.
@@ -61,7 +62,7 @@ impl DefraQueryMcp {
 #[tool_router]
 impl DefraQueryMcp {
     #[tool(
-        description = "Read-only structured query over a DefraDB collection. Provide a collection name, the fields to return, an optional DefraDB filter object (operators _eq/_gt/_in/_and/_or/_not), and an optional limit. Returns JSON {collection, count, results}. Sensitive fields (e.g. inference backend API keys) are always blocked."
+        description = "Read-only structured query over a DefraDB collection. Provide a collection name, the fields to return, an optional DefraDB filter object (operators _eq/_gt/_in/_and/_or/_not), and an optional limit. Returns JSON {collection, count, results}. Call with fields: [\"*\"] to discover a collection's queryable fields (names and types) before guessing; invalid field names fail with a diagnostic listing the allowed fields and close-match suggestions. Sensitive fields (e.g. inference backend API keys) are always blocked."
     )]
     async fn defra_query(
         &self,

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -1461,6 +1461,55 @@ async fn query_command_reconstructs_a_trace() -> Result<()> {
         "expected secret guard to fire: {denied}"
     );
 
+    // Invalid field → agent-usable diagnostic with suggestions + inventory (#592).
+    let diagnostic = run_cli_failure_stderr(
+        &home_dir,
+        &[
+            "query",
+            "--graphql",
+            &graphql,
+            "--collection",
+            "AgentToolCall",
+            "--field",
+            "created_at",
+        ],
+    )?;
+    assert!(diagnostic.contains("created_at"), "{diagnostic}");
+    assert!(
+        diagnostic.contains("started_at") && diagnostic.contains("completed_at"),
+        "suggestions missing: {diagnostic}"
+    );
+    assert!(
+        diagnostic.contains("tool_call_key"),
+        "field inventory missing: {diagnostic}"
+    );
+
+    // Discovery mode: fields ["*"] returns the field inventory, secrets excluded.
+    let inventory = run_cli_json(
+        &home_dir,
+        &[
+            "query",
+            "--graphql",
+            &graphql,
+            "--collection",
+            "InferenceBackend",
+            "--field",
+            "*",
+        ],
+    )?;
+    assert_eq!(inventory["discovery"], Value::Bool(true), "{inventory}");
+    let field_names: Vec<&str> = inventory["fields"]
+        .as_array()
+        .context("discovery fields array")?
+        .iter()
+        .filter_map(|f| f["name"].as_str())
+        .collect();
+    assert!(field_names.contains(&"backend_id"), "{field_names:?}");
+    assert!(
+        !field_names.contains(&"api_key") && !field_names.contains(&"api_key_env_var"),
+        "secret leaked into discovery inventory: {field_names:?}"
+    );
+
     Ok(())
 }
 

--- a/crates/defra-agent/src/defra_query/mod.rs
+++ b/crates/defra-agent/src/defra_query/mod.rs
@@ -76,8 +76,13 @@ pub(crate) fn truncate_field_strings(value: &mut serde_json::Value) -> bool {
 
 pub(crate) mod query;
 pub(crate) mod render;
+pub(crate) mod schema;
 
 pub use query::{build_query, CollectionScope, DefraQueryParams, DEFAULT_LIMIT, MAX_LIMIT};
+pub use schema::{
+    diagnose_failed_query, discovery_payload, introspection_query, parse_collection_schema,
+    unknown_collection_message, CollectionSchema, SchemaField,
+};
 
 /// The model-facing tool name.
 pub const DEFRA_QUERY_TOOL_NAME: &str = "defra_query";
@@ -139,7 +144,10 @@ impl Tool for DefraQueryTool {
                  object, and an optional limit. Returns JSON: {{collection, count, results}}. \
                  Use this to inspect agent state and traces (e.g. AgentRequest, AgentResponse, \
                  AgentMessage, AgentToolCall, AgentSession) instead of hand-writing GraphQL. \
-                 {scope_note}"
+                 To discover a collection's queryable fields before guessing, call with \
+                 fields: [\"*\"] — this returns the field inventory (names and types) instead \
+                 of documents. Invalid field names fail with a diagnostic listing the allowed \
+                 fields and close-match suggestions. {scope_note}"
             ),
             parameters: json!({
                 "type": "object",
@@ -151,7 +159,7 @@ impl Tool for DefraQueryTool {
                     "fields": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Field names to return, e.g. [\"request_id\", \"status\"]. Required, non-empty."
+                        "description": "Field names to return, e.g. [\"request_id\", \"status\"]. Required, non-empty. Pass [\"*\"] to list the collection's queryable fields instead of documents."
                     },
                     "filter": {
                         "type": "object",
@@ -168,6 +176,22 @@ impl Tool for DefraQueryTool {
     }
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        if args.is_discovery() {
+            self.scope.ensure_allowed(&args.collection)?;
+            let schema = query::fetch_collection_schema(&self.node, &args.collection)
+                .await?
+                .ok_or_else(|| {
+                    anyhow!(
+                        "defra_query against {:?} failed: {}",
+                        args.collection,
+                        schema::unknown_collection_message(&args.collection)
+                    )
+                })?;
+            let payload = schema::discovery_payload(&args.collection, &schema);
+            return serde_json::to_string_pretty(&payload)
+                .map_err(|e| DefraQueryError(anyhow!("failed to serialize field inventory: {e}")));
+        }
+
         let mut rows = query::execute_query(&self.node, &args, &self.scope).await?;
         let count = rows.as_array().map(|a| a.len()).unwrap_or(0);
 

--- a/crates/defra-agent/src/defra_query/query.rs
+++ b/crates/defra-agent/src/defra_query/query.rs
@@ -25,7 +25,7 @@ const RESTRICTED_FIELDS: &[(&str, &str)] = &[
     ("OAuthCredential", "id_token"),
 ];
 
-fn is_restricted_field(collection: &str, field: &str) -> bool {
+pub(crate) fn is_restricted_field(collection: &str, field: &str) -> bool {
     RESTRICTED_FIELDS
         .iter()
         .any(|(c, f)| *c == collection && *f == field)
@@ -35,7 +35,7 @@ fn is_restricted_field(collection: &str, field: &str) -> bool {
 /// object keys that are not operators (operators start with `_`, e.g. `_eq`,
 /// `_and`). Used to block filtering on restricted fields (which would otherwise
 /// allow probing a secret value with boolean/`_like` predicates).
-fn collect_filter_field_keys(value: &Value, out: &mut Vec<String>) {
+pub(crate) fn collect_filter_field_keys(value: &Value, out: &mut Vec<String>) {
     match value {
         Value::Object(map) => {
             for (key, nested) in map {
@@ -66,6 +66,14 @@ pub struct DefraQueryParams {
     /// Maximum rows to return (defaults to [`DEFAULT_LIMIT`], capped at [`MAX_LIMIT`]).
     #[serde(default)]
     pub limit: Option<u32>,
+}
+
+impl DefraQueryParams {
+    /// True when the caller asked for discovery mode (`fields: ["*"]`): return
+    /// the collection's queryable field inventory instead of documents.
+    pub fn is_discovery(&self) -> bool {
+        self.fields.len() == 1 && self.fields[0] == "*"
+    }
 }
 
 /// Which collections a query surface is permitted to read.
@@ -135,6 +143,12 @@ pub fn build_query(params: &DefraQueryParams, scope: &CollectionScope) -> Result
     if params.fields.is_empty() {
         bail!("`fields` must list at least one field to return");
     }
+    if params.fields.iter().any(|f| f == "*") {
+        bail!(
+            "wildcard field \"*\" must be the only entry: call with fields: [\"*\"] \
+             to list the collection's queryable fields"
+        );
+    }
     for field in &params.fields {
         validate_identifier(field).map_err(|e| anyhow!("invalid field name: {e}"))?;
         if is_restricted_field(&params.collection, field) {
@@ -174,8 +188,30 @@ pub fn build_query(params: &DefraQueryParams, scope: &CollectionScope) -> Result
     ))
 }
 
+/// Introspect a collection's field set. `Ok(None)` means the collection
+/// (GraphQL type) does not exist on the node.
+pub(crate) async fn fetch_collection_schema(
+    node: &EmbeddedNode,
+    collection: &str,
+) -> Result<Option<super::schema::CollectionSchema>> {
+    let query = super::schema::introspection_query(collection)?;
+    let resp = node.execute(&query).await;
+    if resp.has_errors() {
+        bail!(
+            "schema introspection for {collection:?} failed: {:?}",
+            resp.errors
+        );
+    }
+    Ok(super::schema::parse_collection_schema(resp.data.as_ref()))
+}
+
 /// Execute the structured query against `node` and return the result rows
 /// (a JSON array) for the requested collection.
+///
+/// On a GraphQL failure the collection is introspected and the error is
+/// enriched into an agent-usable diagnostic (invalid fields, the allowed
+/// inventory, close-match suggestions); if introspection itself fails, the raw
+/// GraphQL errors are surfaced unchanged.
 pub(crate) async fn execute_query(
     node: &EmbeddedNode,
     params: &DefraQueryParams,
@@ -184,10 +220,14 @@ pub(crate) async fn execute_query(
     let query = build_query(params, scope)?;
     let resp = node.execute(&query).await;
     if resp.has_errors() {
+        let raw = format!("{:?}", resp.errors);
+        let diagnostic = match fetch_collection_schema(node, &params.collection).await {
+            Ok(schema) => super::schema::diagnose_failed_query(params, schema.as_ref(), &raw),
+            Err(_) => raw,
+        };
         bail!(
-            "defra_query against {:?} failed: {:?}",
-            params.collection,
-            resp.errors
+            "defra_query against {:?} failed: {diagnostic}",
+            params.collection
         );
     }
     let rows = resp

--- a/crates/defra-agent/src/defra_query/schema.rs
+++ b/crates/defra-agent/src/defra_query/schema.rs
@@ -1,0 +1,448 @@
+//! Collection-field discovery and invalid-field diagnostics for `defra_query`.
+//!
+//! When a query fails (or the caller asks for `fields: ["*"]`), the collection
+//! is introspected via GraphQL `__type` and the schema field set is turned into
+//! agent-usable output: the allowed field inventory (restricted sensitive
+//! fields excluded) and, for invalid fields, close-match suggestions. This
+//! keeps the diagnostics structural — no hard-coded per-collection field lists.
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use std::collections::BTreeSet;
+
+use super::query::{collect_filter_field_keys, is_restricted_field, DefraQueryParams};
+use super::render::validate_identifier;
+use crate::graphql::escape_graphql_string;
+
+/// A field on a collection as reported by GraphQL introspection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaField {
+    pub name: String,
+    /// Best-effort type display: the named type when present (e.g. `String`,
+    /// `DateTime`), otherwise the type kind (e.g. `LIST`).
+    pub type_name: String,
+}
+
+/// The introspected field set of one collection.
+#[derive(Debug, Clone)]
+pub struct CollectionSchema {
+    pub fields: Vec<SchemaField>,
+}
+
+impl CollectionSchema {
+    /// Every introspected field name, including DefraDB internals and
+    /// aggregate pseudo-fields. This is the *validity* set: anything outside
+    /// it is definitively not queryable.
+    pub(crate) fn field_names(&self) -> BTreeSet<&str> {
+        self.fields.iter().map(|f| f.name.as_str()).collect()
+    }
+
+    /// The *display* set: fields worth advertising to an agent. Excludes
+    /// restricted sensitive fields, aggregate pseudo-fields (`AVG`, `COUNT`,
+    /// ...), and `_`-prefixed internals except `_docID`.
+    pub(crate) fn visible_fields(&self, collection: &str) -> Vec<&SchemaField> {
+        self.fields
+            .iter()
+            .filter(|f| !is_restricted_field(collection, &f.name))
+            .filter(|f| !f.name.chars().all(|c| c.is_ascii_uppercase()))
+            .filter(|f| !f.name.starts_with('_') || f.name == "_docID")
+            .collect()
+    }
+}
+
+/// Build the `__type` introspection query for a collection. The name is
+/// validated as an identifier and escaped, so untrusted input cannot inject.
+pub fn introspection_query(collection: &str) -> Result<String> {
+    validate_identifier(collection).map_err(|e| anyhow!("invalid collection name: {e}"))?;
+    Ok(format!(
+        r#"{{ __type(name: "{name}") {{ fields {{ name type {{ name kind }} }} }} }}"#,
+        name = escape_graphql_string(collection)
+    ))
+}
+
+/// Parse the `data` of an introspection response into a [`CollectionSchema`].
+/// Returns `None` when the type does not exist (`__type` is `null`).
+pub fn parse_collection_schema(data: Option<&Value>) -> Option<CollectionSchema> {
+    let fields = data?.get("__type")?.get("fields")?.as_array()?;
+    Some(CollectionSchema {
+        fields: fields
+            .iter()
+            .filter_map(|f| {
+                let name = f.get("name")?.as_str()?.to_string();
+                let ty = f.get("type");
+                let type_name = ty
+                    .and_then(|t| t.get("name"))
+                    .and_then(Value::as_str)
+                    .or_else(|| ty.and_then(|t| t.get("kind")).and_then(Value::as_str))
+                    .unwrap_or("unknown")
+                    .to_string();
+                Some(SchemaField { name, type_name })
+            })
+            .collect(),
+    })
+}
+
+/// The shared "no such collection" message, used by both the failure
+/// diagnostic and discovery mode.
+pub fn unknown_collection_message(collection: &str) -> String {
+    format!(
+        "collection {collection:?} does not exist; check the collection (GraphQL type) name, e.g. \"AgentRequest\""
+    )
+}
+
+/// Suggest close matches for an invalid field name from the candidate set,
+/// nearest first, at most three, only when reasonably close (edit distance at
+/// most half the invalid name's length).
+pub(crate) fn suggest_fields(invalid: &str, candidates: &[String]) -> Vec<String> {
+    let threshold = (invalid.chars().count() / 2).max(2);
+    let mut scored: Vec<(usize, &String)> = candidates
+        .iter()
+        .map(|c| (levenshtein(invalid, c), c))
+        .filter(|(distance, _)| *distance > 0 && *distance <= threshold)
+        .collect();
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(b.1)));
+    scored.into_iter().take(3).map(|(_, c)| c.clone()).collect()
+}
+
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    let mut row: Vec<usize> = (0..=b.len()).collect();
+    for (i, ca) in a.iter().enumerate() {
+        let mut previous_diagonal = row[0];
+        row[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let substitution = previous_diagonal + usize::from(ca != cb);
+            previous_diagonal = row[j + 1];
+            row[j + 1] = substitution.min(row[j] + 1).min(previous_diagonal + 1);
+        }
+    }
+    row[b.len()]
+}
+
+/// Build the enriched failure message for a query that DefraDB rejected.
+///
+/// With a schema in hand, requested selection fields and filter field keys are
+/// checked against the introspected field set; any misses produce a diagnostic
+/// with the allowed inventory and suggestions. When the collection itself does
+/// not exist (`schema` is `None`) that is said plainly. When nothing looks
+/// field-shaped (all names valid), falls back to `raw_errors`.
+pub fn diagnose_failed_query(
+    params: &DefraQueryParams,
+    schema: Option<&CollectionSchema>,
+    raw_errors: &str,
+) -> String {
+    let Some(schema) = schema else {
+        return unknown_collection_message(&params.collection);
+    };
+    let known = schema.field_names();
+    let visible: Vec<String> = schema
+        .visible_fields(&params.collection)
+        .iter()
+        .map(|f| f.name.clone())
+        .collect();
+
+    let mut requested: Vec<String> = params.fields.clone();
+    if let Some(filter) = params.filter.as_ref() {
+        collect_filter_field_keys(filter, &mut requested);
+    }
+    let mut invalid: Vec<&str> = Vec::new();
+    for field in &requested {
+        if !known.contains(field.as_str()) && !invalid.contains(&field.as_str()) {
+            invalid.push(field);
+        }
+    }
+    if invalid.is_empty() {
+        return raw_errors.to_string();
+    }
+
+    let clauses: Vec<String> = invalid
+        .iter()
+        .map(|field| {
+            let suggestions = suggest_fields(field, &visible);
+            if suggestions.is_empty() {
+                format!("unknown field {field:?}")
+            } else {
+                let alternatives: Vec<String> =
+                    suggestions.iter().map(|s| format!("{s:?}")).collect();
+                format!(
+                    "unknown field {field:?} (did you mean {}?)",
+                    alternatives.join(" or ")
+                )
+            }
+        })
+        .collect();
+    format!(
+        "{clauses} on collection {collection:?}; queryable fields: [{fields}]. \
+         Tip: call defra_query with fields: [\"*\"] to list a collection's fields",
+        clauses = clauses.join("; "),
+        collection = params.collection,
+        fields = visible.join(", "),
+    )
+}
+
+/// The success payload for discovery mode (`fields: ["*"]`): the queryable
+/// field inventory for the collection, restricted fields excluded.
+pub fn discovery_payload(collection: &str, schema: &CollectionSchema) -> Value {
+    let fields: Vec<Value> = schema
+        .visible_fields(collection)
+        .iter()
+        .map(|f| json!({ "name": f.name, "type": f.type_name }))
+        .collect();
+    json!({
+        "collection": collection,
+        "discovery": true,
+        "count": fields.len(),
+        "fields": fields,
+        "note": "Field inventory (restricted fields excluded). Call defra_query again with specific field names.",
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn schema_from(names_and_types: &[(&str, &str)]) -> CollectionSchema {
+        CollectionSchema {
+            fields: names_and_types
+                .iter()
+                .map(|(n, t)| SchemaField {
+                    name: n.to_string(),
+                    type_name: t.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    /// The introspected AgentToolCall-ish fixture used across tests: internals,
+    /// aggregates, and real fields, matching what DefraDB actually returns.
+    fn tool_call_schema() -> CollectionSchema {
+        schema_from(&[
+            ("AVG", "Float"),
+            ("COUNT", "Int"),
+            ("GROUP", "LIST"),
+            ("_deleted", "Boolean"),
+            ("_docID", "ID"),
+            ("_version", "LIST"),
+            ("tool_call_key", "String"),
+            ("tool_name", "String"),
+            ("status", "String"),
+            ("started_at", "DateTime"),
+            ("completed_at", "DateTime"),
+            ("deadline_at", "DateTime"),
+            ("request_id", "String"),
+        ])
+    }
+
+    fn params(collection: &str, fields: &[&str]) -> DefraQueryParams {
+        DefraQueryParams {
+            collection: collection.to_string(),
+            filter: None,
+            fields: fields.iter().map(|f| f.to_string()).collect(),
+            limit: None,
+        }
+    }
+
+    #[test]
+    fn introspection_query_targets_the_collection() {
+        let q = introspection_query("AgentToolCall").unwrap();
+        assert!(q.contains(r#"__type(name: "AgentToolCall")"#), "{q}");
+        assert!(q.contains("fields"), "{q}");
+    }
+
+    #[test]
+    fn introspection_query_rejects_injection() {
+        let err = introspection_query("X\") { } evil").unwrap_err();
+        assert!(err.to_string().contains("invalid"), "{err}");
+    }
+
+    #[test]
+    fn parse_extracts_field_names_and_types() {
+        let data = json!({
+            "__type": {
+                "fields": [
+                    { "name": "status", "type": { "kind": "SCALAR", "name": "String" } },
+                    { "name": "started_at", "type": { "kind": "SCALAR", "name": "DateTime" } },
+                    { "name": "_version", "type": { "kind": "LIST", "name": null } }
+                ]
+            }
+        });
+        let schema = parse_collection_schema(Some(&data)).expect("type exists");
+        assert_eq!(
+            schema.fields,
+            vec![
+                SchemaField {
+                    name: "status".into(),
+                    type_name: "String".into()
+                },
+                SchemaField {
+                    name: "started_at".into(),
+                    type_name: "DateTime".into()
+                },
+                SchemaField {
+                    name: "_version".into(),
+                    type_name: "LIST".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_returns_none_for_unknown_type() {
+        let data = json!({ "__type": null });
+        assert!(parse_collection_schema(Some(&data)).is_none());
+        assert!(parse_collection_schema(None).is_none());
+    }
+
+    #[test]
+    fn visible_fields_hide_aggregates_and_internals_but_keep_docid() {
+        let schema = tool_call_schema();
+        let visible: Vec<&str> = schema
+            .visible_fields("AgentToolCall")
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert!(visible.contains(&"_docID"), "{visible:?}");
+        assert!(visible.contains(&"tool_name"), "{visible:?}");
+        assert!(visible.contains(&"started_at"), "{visible:?}");
+        for hidden in ["AVG", "COUNT", "GROUP", "_version", "_deleted"] {
+            assert!(!visible.contains(&hidden), "{hidden} should be hidden");
+        }
+    }
+
+    #[test]
+    fn visible_fields_exclude_restricted_secrets() {
+        let schema = schema_from(&[
+            ("backend_id", "String"),
+            ("endpoint", "String"),
+            ("api_key", "String"),
+            ("api_key_env_var", "String"),
+        ]);
+        let visible: Vec<&str> = schema
+            .visible_fields("InferenceBackend")
+            .iter()
+            .map(|f| f.name.as_str())
+            .collect();
+        assert_eq!(visible, vec!["backend_id", "endpoint"]);
+    }
+
+    #[test]
+    fn suggests_timestamp_neighbours_for_created_at() {
+        let candidates: Vec<String> = tool_call_schema()
+            .visible_fields("AgentToolCall")
+            .iter()
+            .map(|f| f.name.clone())
+            .collect();
+        let suggestions = suggest_fields("created_at", &candidates);
+        assert!(
+            suggestions.contains(&"started_at".to_string()),
+            "{suggestions:?}"
+        );
+        assert!(
+            suggestions.contains(&"completed_at".to_string()),
+            "{suggestions:?}"
+        );
+        assert!(
+            !suggestions.contains(&"deadline_at".to_string()),
+            "deadline_at is too far: {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn suggests_agent_did_for_agent_name() {
+        let candidates = vec![
+            "agent_did".to_string(),
+            "behavior_id".to_string(),
+            "request_id".to_string(),
+            "status".to_string(),
+        ];
+        assert_eq!(suggest_fields("agent_name", &candidates), vec!["agent_did"]);
+    }
+
+    #[test]
+    fn no_suggestions_for_nonsense() {
+        let candidates = vec!["request_id".to_string(), "status".to_string()];
+        assert!(suggest_fields("zzzqqqxxx", &candidates).is_empty());
+    }
+
+    #[test]
+    fn suggestions_never_include_restricted_fields() {
+        // Candidates come from the visible set, so a near-miss on a secret
+        // field must not resurrect it.
+        let schema = schema_from(&[
+            ("backend_id", "String"),
+            ("api_key", "String"),
+            ("api_key_env_var", "String"),
+        ]);
+        let candidates: Vec<String> = schema
+            .visible_fields("InferenceBackend")
+            .iter()
+            .map(|f| f.name.clone())
+            .collect();
+        assert!(suggest_fields("api_keys", &candidates).is_empty());
+    }
+
+    #[test]
+    fn diagnose_reports_invalid_selection_fields_with_inventory_and_suggestions() {
+        let schema = tool_call_schema();
+        let msg = diagnose_failed_query(
+            &params("AgentToolCall", &["tool_name", "created_at"]),
+            Some(&schema),
+            "raw",
+        );
+        assert!(msg.contains("created_at"), "{msg}");
+        assert!(msg.contains("AgentToolCall"), "{msg}");
+        assert!(msg.contains("started_at"), "{msg}");
+        assert!(msg.contains("completed_at"), "{msg}");
+        // Inventory present: a valid field the caller did NOT request.
+        assert!(msg.contains("tool_call_key"), "{msg}");
+        // Aggregates are not advertised.
+        assert!(!msg.contains("AVG"), "{msg}");
+    }
+
+    #[test]
+    fn diagnose_reports_invalid_filter_keys() {
+        let schema = tool_call_schema();
+        let mut p = params("AgentToolCall", &["tool_name"]);
+        p.filter = Some(json!({ "_and": [{ "created_at": { "_gt": "2026" } }] }));
+        let msg = diagnose_failed_query(&p, Some(&schema), "raw");
+        assert!(msg.contains("created_at"), "{msg}");
+        assert!(msg.contains("started_at"), "{msg}");
+    }
+
+    #[test]
+    fn diagnose_reports_unknown_collection() {
+        let msg = diagnose_failed_query(&params("NoSuchThing", &["x"]), None, "raw");
+        assert!(msg.contains("NoSuchThing"), "{msg}");
+        assert!(msg.contains("does not exist"), "{msg}");
+    }
+
+    #[test]
+    fn diagnose_falls_back_to_raw_errors_when_fields_all_valid() {
+        let schema = tool_call_schema();
+        let msg = diagnose_failed_query(
+            &params("AgentToolCall", &["tool_name"]),
+            Some(&schema),
+            "some backend explosion",
+        );
+        assert!(msg.contains("some backend explosion"), "{msg}");
+    }
+
+    #[test]
+    fn discovery_payload_lists_visible_fields_with_types() {
+        let schema = tool_call_schema();
+        let payload = discovery_payload("AgentToolCall", &schema);
+        assert_eq!(payload["collection"], "AgentToolCall");
+        assert_eq!(payload["discovery"], true);
+        let fields = payload["fields"].as_array().expect("fields array");
+        let names: Vec<&str> = fields.iter().map(|f| f["name"].as_str().unwrap()).collect();
+        assert!(names.contains(&"started_at"), "{names:?}");
+        assert!(!names.contains(&"AVG"), "{names:?}");
+        let started = fields
+            .iter()
+            .find(|f| f["name"] == "started_at")
+            .expect("started_at present");
+        assert_eq!(started["type"], "DateTime");
+    }
+}

--- a/crates/defra-agent/src/defra_query/tests.rs
+++ b/crates/defra-agent/src/defra_query/tests.rs
@@ -157,3 +157,231 @@ async fn rejects_query_against_collection_outside_scope() {
         "{err}"
     );
 }
+
+/// Selecting a field that does not exist on the collection must produce an
+/// agent-usable diagnostic: the collection name, the invalid field, close-match
+/// suggestions, and the allowed field inventory — not just DefraDB's raw
+/// "Cannot query field" error.
+#[tokio::test]
+async fn invalid_tool_call_created_at_suggests_started_and_completed_at() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentToolCall".to_string(),
+            filter: None,
+            fields: vec!["tool_name".to_string(), "created_at".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("invalid field must fail");
+
+    let msg = err.to_string();
+    assert!(msg.contains("AgentToolCall"), "{msg}");
+    assert!(msg.contains("created_at"), "{msg}");
+    assert!(msg.contains("started_at"), "suggestion missing: {msg}");
+    assert!(msg.contains("completed_at"), "suggestion missing: {msg}");
+    // Inventory: a valid field the caller did not mention must be listed.
+    assert!(msg.contains("tool_call_key"), "inventory missing: {msg}");
+}
+
+/// `AgentRequest.agent_name` (lives on AgentConversation, not AgentRequest)
+/// and `AgentRequest.updated_at` (only `created_at` exists) are the canonical
+/// operator mistakes from #592 — both must get suggestions.
+#[tokio::test]
+async fn invalid_agent_request_fields_get_suggestions() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentRequest".to_string(),
+            filter: None,
+            fields: vec!["agent_name".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("invalid field must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("agent_name"), "{msg}");
+    assert!(msg.contains("agent_did"), "suggestion missing: {msg}");
+    assert!(msg.contains("request_id"), "inventory missing: {msg}");
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentRequest".to_string(),
+            filter: None,
+            fields: vec!["request_id".to_string(), "updated_at".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("invalid field must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("updated_at"), "{msg}");
+    assert!(msg.contains("created_at"), "suggestion missing: {msg}");
+}
+
+/// An invalid field referenced only in the filter gets the same diagnostic.
+#[tokio::test]
+async fn invalid_filter_key_gets_diagnostics() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentToolCall".to_string(),
+            filter: Some(json!({ "created_at": { "_gt": "2026-01-01" } })),
+            fields: vec!["tool_name".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("invalid filter key must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("created_at"), "{msg}");
+    assert!(msg.contains("started_at"), "suggestion missing: {msg}");
+}
+
+/// `fields: ["*"]` is discovery mode: return the queryable field inventory
+/// (with types) instead of documents.
+#[tokio::test]
+async fn wildcard_fields_returns_field_inventory() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let output = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentRequest".to_string(),
+            filter: None,
+            fields: vec!["*".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect("discovery must succeed");
+
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(parsed["collection"], "AgentRequest");
+    assert_eq!(parsed["discovery"], true);
+    let names: Vec<&str> = parsed["fields"]
+        .as_array()
+        .expect("fields array")
+        .iter()
+        .map(|f| f["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"request_id"), "{names:?}");
+    assert!(names.contains(&"status"), "{names:?}");
+    assert!(!names.contains(&"AVG"), "aggregates hidden: {names:?}");
+    assert!(!names.contains(&"_version"), "internals hidden: {names:?}");
+}
+
+/// Discovery must not advertise restricted secret fields.
+#[tokio::test]
+async fn discovery_excludes_restricted_fields() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let output = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "InferenceBackend".to_string(),
+            filter: None,
+            fields: vec!["*".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect("discovery must succeed");
+
+    let parsed: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let names: Vec<&str> = parsed["fields"]
+        .as_array()
+        .expect("fields array")
+        .iter()
+        .map(|f| f["name"].as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"backend_id"), "{names:?}");
+    assert!(!names.contains(&"api_key"), "secret leaked: {names:?}");
+    assert!(
+        !names.contains(&"api_key_env_var"),
+        "secret leaked: {names:?}"
+    );
+}
+
+/// Discovery still honors the collection scope.
+#[tokio::test]
+async fn discovery_respects_collection_scope() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(
+        node,
+        CollectionScope::restricted(vec!["AgentSession".to_string()]),
+    );
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentRequest".to_string(),
+            filter: None,
+            fields: vec!["*".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("discovery outside scope must fail");
+    assert!(
+        err.to_string()
+            .contains("not within the allowed query scope"),
+        "{err}"
+    );
+}
+
+/// Querying a collection that does not exist says so plainly.
+#[tokio::test]
+async fn unknown_collection_reports_does_not_exist() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "NoSuchCollection".to_string(),
+            filter: None,
+            fields: vec!["x".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("unknown collection must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("NoSuchCollection"), "{msg}");
+    assert!(msg.contains("does not exist"), "{msg}");
+}
+
+/// Mixing "*" with concrete fields is rejected with a pointer at discovery.
+#[tokio::test]
+async fn wildcard_mixed_with_fields_is_rejected_with_hint() {
+    let node = seeded_node().await;
+    let tool = DefraQueryTool::new(node, CollectionScope::all());
+
+    let err = Tool::call(
+        &tool,
+        DefraQueryParams {
+            collection: "AgentRequest".to_string(),
+            filter: None,
+            fields: vec!["request_id".to_string(), "*".to_string()],
+            limit: None,
+        },
+    )
+    .await
+    .expect_err("mixed wildcard must fail");
+    assert!(err.to_string().contains("[\"*\"]"), "{err}");
+}

--- a/crates/defra-agent/src/document_config/tool_selection.rs
+++ b/crates/defra-agent/src/document_config/tool_selection.rs
@@ -321,11 +321,16 @@ impl ToolSelectionDocument {
             return backfilled;
         }
 
-        // The three legacy default-TRUE capabilities (see `ToolSelection::from_document`,
-        // which version-gates exactly these via `default_enabled(true)`): materialize
-        // them as `true` so a backfilled V1 doc reproduces today's permissive surface
-        // bit-for-bit. Omitting `enable_context_budget` here would silently drop the
-        // (always-on) context-budget tool on the secure-default flip.
+        // The legacy default-TRUE capabilities: materialize them as `true` so a
+        // backfilled V1 doc reproduces the historical permissive surface
+        // bit-for-bit. `enable_meta_tools` and `enable_context_budget` are still
+        // version-gated in `ToolSelection::from_document` via
+        // `default_enabled(true)`; `enable_defra_query` is opt-in for every
+        // policy version since #592, so this materialized `true` is the ONLY
+        // thing keeping the wide-open preset (and legacy-doc upgrades)
+        // defra_query-enabled. Omitting `enable_context_budget` here would
+        // silently drop the (always-on) context-budget tool on the
+        // secure-default flip.
         backfilled.enable_meta_tools.get_or_insert(true);
         backfilled.enable_defra_query.get_or_insert(true);
         backfilled.enable_context_budget.get_or_insert(true);

--- a/crates/defra-agent/src/tool_surface/behavior_config.rs
+++ b/crates/defra-agent/src/tool_surface/behavior_config.rs
@@ -40,6 +40,13 @@ pub struct BehaviorToolConfig {
 
 impl BehaviorToolConfig {
     pub fn meta_only() -> Self {
+        // defra_query is opt-in (#592): the meta-only baseline behavior policy
+        // disables it, while the ceiling stays permissive so an explicit
+        // selection can still enable it.
+        let mut behavior_policy =
+            ToolPolicySurface::legacy_non_host_wide(super::FileToolMode::Off, super::BashMode::Off);
+        behavior_policy.defra_query = false;
+        behavior_policy.defra_collections = EndpointScope::none();
         Self {
             host_tools: ToolSet::meta_only(),
             enable_meta_tools: true,
@@ -51,21 +58,15 @@ impl BehaviorToolConfig {
             enable_memory: false,
             enable_context_budget_tool: true,
             enable_session_history_tool: false,
-            enable_defra_query: true,
+            enable_defra_query: false,
             defra_query_collections: Vec::new(),
             write_tools: Vec::new(),
-            behavior_policy: ToolPolicySurface::legacy_non_host_wide(
-                super::FileToolMode::Off,
-                super::BashMode::Off,
-            ),
+            behavior_policy: behavior_policy.clone(),
             ceiling_policy: ToolPolicySurface::legacy_non_host_wide(
                 super::FileToolMode::Off,
                 super::BashMode::Off,
             ),
-            static_policy: ToolPolicySurface::legacy_non_host_wide(
-                super::FileToolMode::Off,
-                super::BashMode::Off,
-            ),
+            static_policy: behavior_policy,
         }
     }
 

--- a/crates/defra-agent/src/tool_surface/selection.rs
+++ b/crates/defra-agent/src/tool_surface/selection.rs
@@ -140,7 +140,9 @@ impl Default for ToolSelection {
             enable_memory: false,
             enable_session_history_tool: false,
             enable_context_budget: true,
-            enable_defra_query: true,
+            // defra_query is opt-in (#592): an unscoped read tool dominates the
+            // surface, so only an explicit enable turns it on.
+            enable_defra_query: false,
             defra_query_collections: Vec::new(),
             write_tools: Vec::new(),
         }
@@ -188,9 +190,11 @@ impl ToolSelection {
             enable_context_budget: selection
                 .enable_context_budget
                 .unwrap_or(policy_version.default_enabled(true)),
-            enable_defra_query: selection
-                .enable_defra_query
-                .unwrap_or(policy_version.default_enabled(true)),
+            // defra_query is opt-in for every policy version (#592): legacy
+            // docs are NOT grandfathered — the legacy backfill / wide-open
+            // preset materialize an explicit `true` where the permissive
+            // surface is intended.
+            enable_defra_query: selection.enable_defra_query.unwrap_or(false),
             defra_query_collections: selection
                 .defra_query_collections
                 .clone()

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -711,7 +711,10 @@ fn tool_policy_version_controls_nullable_default_decode() {
     };
     let legacy = ToolSelection::from_document(&legacy_doc).unwrap();
     assert!(legacy.enable_meta_tools);
-    assert!(legacy.enable_defra_query);
+    // defra_query is opt-in for every policy version (#592): legacy docs are
+    // NOT grandfathered; only the backfill's materialized `true` (below)
+    // carries the historical permissive surface forward.
+    assert!(!legacy.enable_defra_query);
 
     let backfilled = legacy_doc.with_legacy_policy_defaults_backfilled();
     assert_eq!(
@@ -922,6 +925,9 @@ fn explain_init_package_document_matrix_resolves_expected_surfaces() {
             ],
             host_ceiling_warning: true,
         },
+        // readonly/write mirror the init packages, which no longer enable
+        // defra_query (#592: opt-in only; introspection is the package that
+        // turns it on).
         Case {
             name: "readonly-online",
             selection: init_like_tool_selection_document(
@@ -932,7 +938,7 @@ fn explain_init_package_document_matrix_resolves_expected_surfaces() {
                 "ReadOnly",
                 true,
                 Vec::new(),
-                true,
+                false,
             ),
             ceiling: ToolCeiling::readonly_at(readonly_root),
             mcp_services_online: true,
@@ -945,10 +951,14 @@ fn explain_init_package_document_matrix_resolves_expected_surfaces() {
                 "discover_tools",
                 "call_tool",
                 "context_budget",
+            ],
+            absent_tool_names: vec![
+                "write_file",
+                "bash_unrestricted",
+                "spawn_process",
                 "defra_query",
             ],
-            absent_tool_names: vec!["write_file", "bash_unrestricted", "spawn_process"],
-            expected_warnings: vec!["mcp_empty_allowlist_all", "defra_query_empty_scope_all"],
+            expected_warnings: vec!["mcp_empty_allowlist_all"],
             host_ceiling_warning: false,
         },
         Case {
@@ -961,7 +971,7 @@ fn explain_init_package_document_matrix_resolves_expected_surfaces() {
                 "Unrestricted",
                 true,
                 vec!["bash_unrestricted".to_string()],
-                true,
+                false,
             ),
             ceiling: ToolCeiling::readwrite(write_root),
             mcp_services_online: true,
@@ -978,10 +988,9 @@ fn explain_init_package_document_matrix_resolves_expected_surfaces() {
                 "spawn_process",
                 "wait_process",
                 "context_budget",
-                "defra_query",
             ],
-            absent_tool_names: vec!["bash", "spawn_subagent"],
-            expected_warnings: vec!["mcp_empty_allowlist_all", "defra_query_empty_scope_all"],
+            absent_tool_names: vec!["bash", "spawn_subagent", "defra_query"],
+            expected_warnings: vec!["mcp_empty_allowlist_all"],
             host_ceiling_warning: false,
         },
     ];
@@ -1229,10 +1238,12 @@ fn explain_default_surface_calls_out_builtin_reads_and_defra_query_scope() {
     assert!(explanation.excluded.get("built_in_read").is_some_and(
         |names| names.contains(&crate::toolset::SESSION_HISTORY_TOOL_NAME.to_string())
     ));
-    assert!(explanation
+    // defra_query is opt-in (#592): the default surface excludes it, and with
+    // the tool off the empty-scope warning has nothing to warn about.
+    assert!(!explanation
         .tool_names
         .contains(&crate::defra_query::DEFRA_QUERY_TOOL_NAME.to_string()));
-    assert!(explanation
+    assert!(!explanation
         .warnings
         .iter()
         .any(|warning| warning.code == "defra_query_empty_scope_all"));
@@ -1355,4 +1366,65 @@ async fn memory_tool_requires_selection_opt_in() {
     assert!(enabled
         .tool_names()
         .contains(&crate::toolset::MEMORY_TOOL_NAME.to_string()));
+}
+
+/// #592: `defra_query` must be OFF unless explicitly enabled. The programmatic
+/// default, the legacy document decode (no `tool_policy_version`), and the
+/// meta-only baseline all exclude it; only an explicit
+/// `enable_defra_query: true` (or the wide-open preset, which materializes one)
+/// surfaces the tool.
+#[tokio::test]
+async fn defra_query_is_off_by_default() {
+    let node = defra_node::EmbeddedNode::builder().build().await.unwrap();
+    crate::ensure_runtime_schemas(&node).await.unwrap();
+
+    // Programmatic default surface.
+    let default_surface = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection::default(),
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap()
+    .resolve(&node)
+    .await
+    .unwrap();
+    assert!(
+        !default_surface
+            .tool_names()
+            .contains(&"defra_query".to_string()),
+        "default ToolSelection must not surface defra_query: {:?}",
+        default_surface.tool_names()
+    );
+
+    // Legacy documents (no tool_policy_version, field absent) are NOT
+    // grandfathered into defra_query.
+    let legacy = crate::document_config::ToolSelectionDocument::default();
+    assert!(
+        !ToolSelection::from_document(&legacy)
+            .unwrap()
+            .enable_defra_query
+    );
+
+    // Explicit opt-in still decodes to enabled.
+    let explicit = crate::document_config::ToolSelectionDocument {
+        enable_defra_query: Some(true),
+        ..Default::default()
+    };
+    assert!(
+        ToolSelection::from_document(&explicit)
+            .unwrap()
+            .enable_defra_query
+    );
+
+    // The meta-only baseline excludes it too.
+    let meta_only = BehaviorToolConfig::meta_only()
+        .resolve(&node)
+        .await
+        .unwrap();
+    assert!(
+        !meta_only.tool_names().contains(&"defra_query".to_string()),
+        "meta_only baseline must not surface defra_query: {:?}",
+        meta_only.tool_names()
+    );
 }


### PR DESCRIPTION
Closes #592.

`defra_query` now turns invalid-field failures into agent-usable diagnostics and gives agents a way to discover a collection's fields before guessing.

## What changed

- **New `defra_query::schema` module** — `__type` introspection parsed into a `CollectionSchema`; no hard-coded per-collection field lists. The *validity* set is the full introspected field set; the *display* set excludes restricted secret fields (`InferenceBackend.api_key`, OAuth tokens, …), DefraDB aggregate pseudo-fields (`AVG`, `COUNT`, …), and `_`-prefixed internals except `_docID`. Suggestions come from an edit-distance heuristic over the display set only, so a near-miss on a secret never advertises it.
- **Lazy on-error enrichment on both surfaces.** The embedded-node `execute_query` (runtime tool) and the shared CLI/MCP `run_defra_query` introspect the collection only *after* a GraphQL failure — the happy path pays nothing. Filter field keys are checked as well as selected fields. If introspection itself fails, the raw GraphQL errors are surfaced unchanged. On the CLI surface the hook is `post_graphql`'s `Err` path (it bails on GraphQL errors itself; the previous in-function errors check was unreachable).
- **Discovery mode:** `fields: ["*"]` returns the queryable field inventory (names + types) instead of documents. Collection scope and the secret guard still apply; unknown collections are reported plainly. Mixing `"*"` with concrete fields is rejected with a pointer at discovery. The brief suggested *rejecting* `["*"]` with the inventory attached; this returns it as a **success** payload instead, so an agent that asked for exactly this doesn't record a failed tool call.
- **Tool descriptions** (model-facing + MCP) now tell agents to discover fields before guessing.
- **`defra_query` is now opt-in everywhere.** An unscoped read tool dominates the surface (the demo tool-surface audit finding), so the default flips off at every layer: `ToolSelection::default()`, the legacy document decode (docs without `tool_policy_version` are **not** grandfathered), the `meta_only()` baseline behavior policy, and the `readonly`/`write`/`yolo` init packages. The `introspection` package still enables it (that's its purpose), the wide-open preset and legacy backfill keep materializing an explicit `true` (so upgraded legacy docs and the permissive preset keep their surface bit-for-bit), and ceiling presets stay permissive — an explicit `enable_defra_query: true` surfaces the tool everywhere it did before.

Identifier validation, `escape_graphql_string` on all interpolations, the restricted-field guard for selection *and* filtering, and the `Only(∅) ≠ All` scope semantics are unchanged. No Lean change: no transition legality or invariant is touched — this is tool-surface plumbing and error rendering.

## Before / after

Query: `{collection: "AgentToolCall", fields: ["tool_name", "created_at"]}`

**Before**
```
defra_query against "AgentToolCall" failed: [QueryResponseError { message: "Cannot query field \"created_at\" on type \"AgentToolCall\".", path: None, locations: None }]
```

**After**
```
defra_query against "AgentToolCall" failed: unknown field "created_at" (did you mean "started_at" or "completed_at"?) on collection "AgentToolCall"; queryable fields: [_docID, agent_did, args, await_mode, cancel_cascade_intent_at, cancel_cause, cancel_pending_remote_ack, cancel_policy, child_request_id, completed_at, deadline_at, denial_reason, denied_argument, denied_argv, denied_command, denied_prefix, denied_subcommand, latency_ms, lifecycle_state, message_sequence, policy_mode, policy_network, request_id, result, selected_service_id, selected_tool_name, session_id, spawn_target_did, started_at, status, stuck_since, tool_call_id, tool_call_key, tool_failure_class, tool_name, unclaimed_deadline_at, workflow_group_id, workflow_role]. Tip: call defra_query with fields: ["*"] to list a collection's fields
```

And discovery (`fields: ["*"]` on `AgentRequest`) returns:
```json
{
  "collection": "AgentRequest",
  "count": 31,
  "discovery": true,
  "fields": [
    { "name": "_docID", "type": "ID" },
    { "name": "agent_did", "type": "String" },
    { "name": "created_at", "type": "String" },
    ...
  ],
  "note": "Field inventory (restricted fields excluded). Call defra_query again with specific field names."
}
```

## Testing

TDD throughout (all new tests watched failing first against the raw-error behavior):

- 15 unit tests on the schema module (introspection query injection-safety, parsing, display filtering, suggestion heuristics incl. the #592 canonical cases `AgentRequest.agent_name → agent_did`, `AgentRequest.updated_at → created_at`, `AgentToolCall.created_at → started_at/completed_at`, secrets never suggested).
- 8 embedded-node integration tests through the real tool (diagnostics for selection + filter keys, discovery inventory, secrets excluded from discovery, scope enforcement on discovery, unknown collection, mixed-wildcard rejection).
- CLI coverage extended in `cli_server::query_command_reconstructs_a_trace` (diagnostic on stderr + discovery envelope over HTTP, secrets excluded).
- Off-by-default fence: `tool_surface::tests::defra_query_is_off_by_default` (programmatic default, legacy decode, explicit opt-in, meta-only baseline), plus updated legacy-decode/default-surface-explanation tests and init-package expectations (readonly/write mirror cases now assert `defra_query` absent).
- Gates: `cargo test -p defra-agent` full package suite green (897 lib + all integration binaries); `cli_server::query_command_reconstructs_a_trace` and `cli_server::mcp_endpoint_serves_defra_query` green; `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
