### PR TITLE
fix(runtime): normalize tool-call arguments at provider boundary (#589, #590)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/PromptAssembly.lean
+++ b/crates/defra-agent/proofs/Proofs/PromptAssembly.lean
@@ -2,6 +2,7 @@ import Proofs.PromptAssembly.State
 import Proofs.PromptAssembly.Executable
 import Proofs.PromptAssembly.Template
 import Proofs.PromptAssembly.Properties
+import Proofs.PromptAssembly.ToolArgs
 
 /-!
 # PromptAssembly (barrel) — issue #448
@@ -13,6 +14,11 @@ provider format. See `Proofs/PromptAssembly/Properties.lean` for the
 contract theorems (T1 soundness — which subsumes T4 split-stability, T2
 fixpoint/preservation, T3 idempotence, T5 loop-threading validity, and the
 assembly-order lemmas).
+
+Below row granularity, `Proofs/PromptAssembly/ToolArgs.lean` (issues
+#589/#590) carries the value-granular argument-shape contract: tool-call
+`arguments` are normalized to a JSON object at both rig-converter seams
+(N1 soundness, N2 object fixpoint, N3 idempotence, N4 salvage).
 
 Rust conformance: `crates/defra-agent/tests/conformance/prompt_assembly.rs`.
 -/

--- a/crates/defra-agent/proofs/Proofs/PromptAssembly/ToolArgs.lean
+++ b/crates/defra-agent/proofs/Proofs/PromptAssembly/ToolArgs.lean
@@ -1,0 +1,146 @@
+import Proofs.Basic
+
+/-!
+# PromptAssembly ToolArgs (issues #589 / #590)
+
+Value-granular model of the tool-call **argument-shape** invariant at the
+provider boundary: every `tool_calls[].function.arguments` a provider
+receives must be a JSON **object**. Backends render history through
+templates that iterate `arguments.items()`, so a non-object value —
+`Value::String` (the #589/#590 production poison), `Array`, scalar, or
+`null` — deterministically crashes template rendering before any token is
+generated.
+
+This module is BELOW the row granularity of `PromptAssembly.State`: a
+`Transcript.MessageRow` carries only the call-id set of an assistant turn,
+so argument payloads are invisible to `sanitize` and its theorems (T1–T5).
+Argument normalization is applied POINTWISE to each tool call and never
+adds, drops, or reorders rows, so the row-granular theorems are untouched
+by construction; this module carries the value-granular contract instead.
+
+The abstraction: a payload type `P` stands for the (opaque) content of a
+JSON object, and the one JSON-specific fact the model needs — whether a
+string re-parses to an object after the tolerant escape-only repair pass
+(Rust `llm::tool::repair_tool_arguments`) — is baked into the constructor:
+`.str (some p)` is a string that salvages to object `p`; `.str none` is a
+string that does not (non-object JSON or unparseable even after repair).
+
+Rust mirror: `llm::tool::normalize_tool_call_arguments`, applied at BOTH
+seams of the rig converter — `rig_compat::from_rig_tool_call` (ingest:
+nothing non-object is ever accumulated into durable history) and
+`rig_compat::to_rig_tool_call` (egress: pre-existing poisoned durable
+history self-heals at request build). The theorems:
+
+- **N1 `normalize_isObject`** — normalization always yields an object
+  (provider-shape soundness; egress can never emit a non-object).
+- **N2 `normalize_fixpoint_of_isObject`** — an object passes through
+  UNCHANGED (the healthy tool-call flow has no regression).
+- **N3 `normalize_idempotent`** — ingest-then-egress normalization
+  collapses; double application is harmless.
+- **N4 `normalize_salvages_str`** — a string that (post-repair) parses to
+  an object recovers THAT object, not the empty fallback (the #589
+  corrupt-payload salvage: the intended call survives).
+
+Rust conformance: `crates/defra-agent/tests/conformance/prompt_assembly.rs`
+(the `PromptAssembly` home in the structure fence).
+-/
+
+namespace PromptAssembly
+
+/-- A tool-call `arguments` value, abstracted to its provider-relevant
+shape. `P` is the opaque payload of a JSON object. `.str (some p)` models a
+JSON string that re-parses (after the escape-only repair pass) to the
+object `p`; `.str none` models a string that does not. `.array`, `.scalar`
+and `.null` cover the remaining non-object JSON shapes. -/
+inductive ToolArgs (P : Type) where
+  | object (payload : P)
+  | str (parsed : Option P)
+  | array
+  | scalar
+  | null
+
+/-- Provider-valid argument shape: a JSON object. -/
+def ToolArgs.IsObject {P : Type} : ToolArgs P → Prop
+  | .object _ => True
+  | _ => False
+
+@[simp] theorem ToolArgs.isObject_object {P : Type} (p : P) :
+    (ToolArgs.object p).IsObject := trivial
+
+/-- The shared normalization policy (Rust
+`llm::tool::normalize_tool_call_arguments`): an object is unchanged; a
+string that salvages to an object becomes that object; every other shape —
+unsalvageable string, array, scalar, null — becomes the empty object
+`empty`. -/
+def normalizeArgs {P : Type} (empty : P) : ToolArgs P → ToolArgs P
+  | .object p => .object p
+  | .str (some p) => .object p
+  | .str none => .object empty
+  | .array => .object empty
+  | .scalar => .object empty
+  | .null => .object empty
+
+/-- **N1 (soundness).** Normalization always yields an object: no egress
+path can hand the provider a non-object `arguments` value. -/
+theorem normalize_isObject {P : Type} (empty : P) (v : ToolArgs P) :
+    (normalizeArgs empty v).IsObject := by
+  cases v with
+  | object p => trivial
+  | str parsed => cases parsed <;> trivial
+  | array => trivial
+  | scalar => trivial
+  | null => trivial
+
+/-- N1 in existential form: the normalized value IS `.object` of some
+payload. -/
+theorem normalize_eq_object {P : Type} (empty : P) (v : ToolArgs P) :
+    ∃ p, normalizeArgs empty v = .object p := by
+  cases v with
+  | object p => exact ⟨p, rfl⟩
+  | str parsed => cases parsed with
+    | none => exact ⟨empty, rfl⟩
+    | some p => exact ⟨p, rfl⟩
+  | array => exact ⟨empty, rfl⟩
+  | scalar => exact ⟨empty, rfl⟩
+  | null => exact ⟨empty, rfl⟩
+
+/-- **N2 (object fixpoint).** A well-formed object passes through
+unchanged: the healthy tool-call flow is untouched by the boundary. -/
+theorem normalize_fixpoint_of_isObject {P : Type} (empty : P)
+    {v : ToolArgs P} (h : v.IsObject) : normalizeArgs empty v = v := by
+  cases v with
+  | object p => rfl
+  | str parsed => exact absurd h not_false
+  | array => exact absurd h not_false
+  | scalar => exact absurd h not_false
+  | null => exact absurd h not_false
+
+/-- **N3 (idempotence).** Normalizing twice is normalizing once: the ingest
+seam and the egress seam compose without drift, so a value persisted
+normalized re-egresses byte-identical. -/
+theorem normalize_idempotent {P : Type} (empty : P) (v : ToolArgs P) :
+    normalizeArgs empty (normalizeArgs empty v) = normalizeArgs empty v :=
+  normalize_fixpoint_of_isObject empty (normalize_isObject empty v)
+
+/-- **N4 (salvage).** A stringified object recovers its own payload — the
+intended call survives the boundary rather than collapsing to the empty
+fallback. This is the #589 recovery guarantee for the salvageable class. -/
+theorem normalize_salvages_str {P : Type} (empty : P) (p : P) :
+    normalizeArgs empty (.str (some p)) = .object p := rfl
+
+/-- Non-object shapes collapse to the EMPTY object — never to some other
+payload. Together with N4 this pins the entire coercion table. -/
+theorem normalize_nonobject_to_empty {P : Type} (empty : P)
+    (v : ToolArgs P) (hobj : ¬ v.IsObject)
+    (hsalvage : ∀ p, v ≠ .str (some p)) :
+    normalizeArgs empty v = .object empty := by
+  cases v with
+  | object p => exact absurd trivial hobj
+  | str parsed => cases parsed with
+    | none => rfl
+    | some p => exact absurd rfl (hsalvage p)
+  | array => rfl
+  | scalar => rfl
+  | null => rfl
+
+end PromptAssembly

--- a/crates/defra-agent/src/agent/loop_stream/tests.rs
+++ b/crates/defra-agent/src/agent/loop_stream/tests.rs
@@ -1397,3 +1397,217 @@ async fn unparseable_tool_args_notify_model_and_terminalize_failed() {
         "the started tool call must terminalize failed/argumentInvalid, got rows: {rows:?}"
     );
 }
+
+/// #589/#590 incident regression, salvageable half: the model emits the exact
+/// production corrupt-arguments payload (leaked `</think`, stray CJK, nested
+/// Hermes fragment, literal newlines, duplicated keys). The escape-only repair
+/// salvages the intended object, so (a) the typed tool RUNS with the intended
+/// `tool_name`, (b) the durable `AgentMessage` history carries object-shaped
+/// arguments — never the raw corrupt string that jammed Amy's session — and
+/// (c) the next provider request sees object-shaped arguments.
+#[tokio::test]
+async fn corrupt_589_tool_args_salvage_runs_and_history_stays_object_shaped() {
+    use crate::llm::tool::{Tool, ToolDefinition};
+
+    struct DescribeTool;
+    #[derive(Debug, thiserror::Error)]
+    #[error("describe tool error")]
+    struct DescribeToolError;
+    #[derive(serde::Deserialize)]
+    struct DescribeArgs {
+        tool_name: String,
+    }
+    impl Tool for DescribeTool {
+        const NAME: &'static str = "describe_tool";
+        type Error = DescribeToolError;
+        type Args = DescribeArgs;
+        type Output = String;
+        async fn definition(&self, _prompt: String) -> ToolDefinition {
+            ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+            Ok(format!("described:{}", args.tool_name))
+        }
+    }
+
+    let (node, hook) = test_hook().await;
+    ready_hook_for(&hook).await;
+
+    // The wire parser could not parse the corrupt bytes, so rig carries them as
+    // a raw Value::String — exactly the shape persisted in the production store.
+    let poison = serde_json::Value::String(crate::test_support::CORRUPT_TOOL_ARGS_589.to_string());
+    let model = ScriptedModel::new_turns(vec![
+        vec![
+            RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                "call-1".to_string(),
+                "describe_tool".to_string(),
+                poison,
+            )),
+            RawStreamingChoice::FinalResponse(()),
+        ],
+        vec![
+            RawStreamingChoice::Message("done".to_string()),
+            RawStreamingChoice::FinalResponse(()),
+        ],
+    ]);
+    let tools: Vec<Box<dyn ToolDyn>> = vec![Box::new(DescribeTool)];
+
+    let stream = run_loop_stream(
+        model.clone(),
+        Some(hook),
+        Message::user("describe list_hosts"),
+        Vec::new(),
+        Arc::new(tools),
+        config(4),
+    );
+    futures::pin_mut!(stream);
+
+    let mut tool_results = Vec::new();
+    while let Some(item) = stream.next().await {
+        if let MultiTurnStreamItem::StreamUserItem(StreamedUserContent::ToolResult {
+            tool_result,
+            ..
+        }) = item.expect("loop item should be Ok")
+        {
+            tool_results.push(
+                tool_result_text(&crate::llm::rig_compat::from_rig_tool_result_content(
+                    &tool_result.content.first(),
+                ))
+                .to_string(),
+            );
+        }
+    }
+
+    // (a) The intended call ran: salvage recovered `tool_name: list_hosts`.
+    assert_eq!(
+        tool_results,
+        vec!["described:list_hosts".to_string()],
+        "the salvageable #589 payload must run the intended call, not waste a turn"
+    );
+
+    // (b) The next provider request carries object-shaped arguments. (The
+    // durable AgentMessage fence lives in the StreamProcessor harness —
+    // `stream_processor::tests::corrupt_tool_call_arguments_persist_object_shaped`
+    // — since the bare generator does not persist assistant turns.)
+    let histories = model.seen_histories().await;
+    assert_eq!(histories.len(), 2);
+    assert_all_history_tool_args_object_shaped(&histories[1]);
+    drop(node);
+}
+
+/// #590 incident regression, non-salvageable half: arguments that are valid
+/// JSON but not an object (the `"[]"` reproduction). The call must fail
+/// `argumentInvalid` with the model notified (never run), and neither the
+/// durable history nor the next provider request may carry the non-object.
+#[tokio::test]
+async fn nonobject_tool_args_never_reach_durable_history_or_provider() {
+    use crate::llm::tool::{Tool, ToolDefinition};
+
+    struct StrictTool;
+    #[derive(Debug, thiserror::Error)]
+    #[error("strict tool error")]
+    struct StrictToolError;
+    #[derive(serde::Deserialize)]
+    struct StrictArgs {
+        #[allow(dead_code)]
+        tool_name: String,
+    }
+    impl Tool for StrictTool {
+        const NAME: &'static str = "describe_tool";
+        type Error = StrictToolError;
+        type Args = StrictArgs;
+        type Output = String;
+        async fn definition(&self, _prompt: String) -> ToolDefinition {
+            ToolDefinition {
+                name: Self::NAME.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({"type": "object"}),
+            }
+        }
+        async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+            panic!("the tool must not run on non-object arguments");
+        }
+    }
+
+    let (node, hook) = test_hook().await;
+    ready_hook_for(&hook).await;
+
+    let model = ScriptedModel::new_turns(vec![
+        vec![
+            RawStreamingChoice::ToolCall(RawStreamingToolCall::new(
+                "call-1".to_string(),
+                "describe_tool".to_string(),
+                serde_json::json!([]),
+            )),
+            RawStreamingChoice::FinalResponse(()),
+        ],
+        vec![
+            RawStreamingChoice::Message("ok".to_string()),
+            RawStreamingChoice::FinalResponse(()),
+        ],
+    ]);
+    let tools: Vec<Box<dyn ToolDyn>> = vec![Box::new(StrictTool)];
+
+    let stream = run_loop_stream(
+        model.clone(),
+        Some(hook),
+        Message::user("describe"),
+        Vec::new(),
+        Arc::new(tools),
+        config(4),
+    );
+    futures::pin_mut!(stream);
+    while let Some(item) = stream.next().await {
+        item.expect("loop must not fail; non-object args are notified, not raised");
+    }
+
+    // The started call terminalized failed/argumentInvalid — never a live
+    // completed call carrying poison (#589's persist gate).
+    let resp = node
+        .execute("query { AgentToolCall { tool_name lifecycle_state tool_failure_class } }")
+        .await;
+    assert!(!resp.has_errors(), "query failed: {:?}", resp.errors);
+    let rows = resp
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|value| value.as_array())
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        rows.iter().any(|row| {
+            row.get("tool_name").and_then(|v| v.as_str()) == Some("describe_tool")
+                && row.get("lifecycle_state").and_then(|v| v.as_str()) == Some("failed")
+                && row.get("tool_failure_class").and_then(|v| v.as_str()) == Some("argumentInvalid")
+        }),
+        "a non-object-args call must terminalize failed/argumentInvalid, got: {rows:?}"
+    );
+
+    // The next provider request carries object-shaped args — the [] never
+    // re-egresses.
+    let histories = model.seen_histories().await;
+    assert_eq!(histories.len(), 2);
+    assert_all_history_tool_args_object_shaped(&histories[1]);
+}
+
+/// Every tool call inside a (native) history must carry object-shaped
+/// arguments — the provider-render precondition (#590).
+fn assert_all_history_tool_args_object_shaped(history: &[Message]) {
+    for message in history {
+        if let Message::Assistant { content, .. } = message {
+            for item in content {
+                if let AssistantContent::ToolCall(tool_call) = item {
+                    assert!(
+                        tool_call.function.arguments.is_object(),
+                        "non-object tool-call arguments reached the provider: {:?}",
+                        tool_call.function.arguments
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/defra-agent/src/agent/stream_processor/tests.rs
+++ b/crates/defra-agent/src/agent/stream_processor/tests.rs
@@ -1050,3 +1050,163 @@ async fn post_tool_resumed_resets_response_tail() {
 
     let _ = std::fs::remove_dir_all(&data_path);
 }
+
+/// #589 durable-history fence: a streamed tool call whose `arguments` the wire
+/// parser left as a raw corrupt string (the production poison shape) must
+/// persist OBJECT-shaped into `AgentMessage` — the salvageable payload as its
+/// intended object, never as a `Value::String` that would jam every subsequent
+/// render of the session (#590).
+#[tokio::test]
+async fn corrupt_tool_call_arguments_persist_object_shaped() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-stream-processor-corrupt-args-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:test",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        hook.on_completion_call(&user_text_message("describe list_hosts"), &[])
+            .await,
+        HookAction::Continue
+    ));
+    let session_id = hook.session_id().await.expect("session id");
+
+    let request_id = uuid::Uuid::new_v4().to_string();
+    let request_doc_id = create_pending_request(&node, &request_id, &session_id).await;
+    hook.set_active_request_id(Some(request_id.clone())).await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::seconds(60)))
+        .await;
+    let request = AgentRequest {
+        doc_id: request_doc_id,
+        request_id: request_id.clone(),
+        agent_did: "did:defra-agent:test".to_string(),
+        behavior_id: Some("general".to_string()),
+        session_id: session_id.clone(),
+        content: "describe list_hosts".to_string(),
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        max_tokens: None,
+        metadata: None,
+        execution_origin: None,
+        created_at: chrono::Utc::now().to_rfc3339(),
+        deadline: None,
+        subagent_depth: 0,
+        caused_by_parent_request_id: None,
+        caused_by_parent_tool_call_id: None,
+    };
+    let mut lifecycle = RequestLifecycle::new_with_execution_binding(
+        node.clone(),
+        "general",
+        "did:defra-agent:test",
+        request,
+        30,
+        ExecutionOrigin::Interactive,
+        "test-backend",
+    );
+    assert_eq!(lifecycle.claim().await.unwrap(), ClaimOutcome::Claimed);
+    let stream_writer = DefraStreamWriter::new(
+        node.clone(),
+        "did:defra-agent:test",
+        Duration::from_millis(0),
+    );
+    let response_doc_id = stream_writer
+        .begin(&session_id, &request_id, "general")
+        .await
+        .unwrap();
+    lifecycle.set_response_doc_id(&response_doc_id);
+    let mut processor =
+        StreamProcessor::new(&hook, &stream_writer, &mut lifecycle, &response_doc_id);
+
+    // The wire parser could not shape the corrupt bytes, so the streamed rig
+    // ToolCall carries them as a raw Value::String — the exact production shape.
+    let corrupt_call: Result<MultiTurnStreamItem<()>, rig::agent::StreamingError> = Ok(
+        MultiTurnStreamItem::StreamAssistantItem(StreamedAssistantContent::ToolCall {
+            tool_call: rig::completion::message::ToolCall {
+                id: "result-1".to_string(),
+                call_id: Some("call-1".to_string()),
+                function: rig::completion::message::ToolFunction {
+                    name: "describe_tool".to_string(),
+                    arguments: serde_json::Value::String(
+                        crate::test_support::CORRUPT_TOOL_ARGS_589.to_string(),
+                    ),
+                },
+                signature: None,
+                additional_params: None,
+            },
+            internal_call_id: "internal-1".to_string(),
+        }),
+    );
+    processor.process_item(corrupt_call).await.unwrap();
+
+    assert!(matches!(
+        hook.on_tool_call(
+            "describe_tool",
+            Some("call-1".to_string()),
+            "internal-1",
+            crate::test_support::CORRUPT_TOOL_ARGS_589,
+        )
+        .await,
+        crate::llm::ToolCallHookAction::Continue
+    ));
+    assert!(matches!(
+        hook.on_tool_result(
+            "describe_tool",
+            Some("call-1".to_string()),
+            "internal-1",
+            crate::test_support::CORRUPT_TOOL_ARGS_589,
+            "described:list_hosts",
+        )
+        .await,
+        HookAction::Continue
+    ));
+
+    processor
+        .process_item(tool_result_item_with_call_id(
+            "result-1",
+            Some("call-1"),
+            "described:list_hosts",
+            "internal-1",
+        ))
+        .await
+        .unwrap();
+
+    // The durable history's assistant turn carries the SALVAGED object — the
+    // intended call — not the raw corrupt string.
+    let history = crate::session::load_history(&node, &session_id)
+        .await
+        .unwrap();
+    let arguments = history
+        .iter()
+        .find_map(|message| match message {
+            Message::Assistant { content, .. } => content.iter().find_map(|item| match item {
+                AssistantContent::ToolCall(tool_call) => Some(&tool_call.function.arguments),
+                _ => None,
+            }),
+            _ => None,
+        })
+        .expect("a persisted assistant tool-call message");
+    assert!(
+        arguments.is_object(),
+        "non-object tool-call arguments persisted to durable history: {arguments:?}"
+    );
+    assert_eq!(
+        arguments["tool_name"], "list_hosts",
+        "the salvageable #589 payload must persist its intended object"
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -42,6 +42,19 @@ pub(crate) mod test_support {
     pub(crate) fn first_content<T>(items: &[T]) -> &T {
         items.first().expect("non-empty content")
     }
+
+    /// The #589 production poison, byte-faithful to Amy's persisted
+    /// `AgentToolCall` row `Rrt-HmhWfFSmkh1HSUmHt`: a model tool-call
+    /// `arguments` string contaminated by out-of-channel tokens — a stray CJK
+    /// `房` and a leaked `</think` reasoning boundary inside a key, a nested
+    /// Hermes `<tool_call>`/`<function=...>` fragment as its value, duplicated
+    /// keys, and LITERAL newlines inside the strings (the control characters
+    /// `serde_json` rejects at "line 2 column 0"). The intended call survives
+    /// as the final `tool_name: list_hosts`.
+    pub(crate) const CORRUPT_TOOL_ARGS_589: &str = "{\"raw_schema\": false, \
+         \"service_id\": \"observability-mcp\", \"tool房\n</think\": \"\n<tool_call>\n\
+         <function=describe_tool>\", \"raw_schema\": false, \
+         \"service_id\": \"observability-mcp\", \"tool_name\": \"list_hosts\"}";
 }
 pub mod lifecycle;
 pub mod llm;

--- a/crates/defra-agent/src/llm/rig_compat.rs
+++ b/crates/defra-agent/src/llm/rig_compat.rs
@@ -207,7 +207,15 @@ pub(crate) fn to_rig_tool_call(call: &message::ToolCall) -> rig::completion::mes
         call_id: call.call_id.clone(),
         function: rig::completion::message::ToolFunction {
             name: call.function.name.clone(),
-            arguments: call.function.arguments.clone(),
+            // Egress half of the #589/#590 argument-shape boundary: the
+            // durable transcript is permissive, so already-persisted poison
+            // (a non-object `arguments` Value) is normalized here at request
+            // build — a jammed session self-heals on its next turn.
+            arguments: super::tool::normalize_tool_call_arguments(
+                "egress",
+                &call.function.name,
+                &call.function.arguments,
+            ),
         },
         signature: call.signature.clone(),
         additional_params: call.additional_params.clone(),
@@ -383,7 +391,18 @@ pub(crate) fn from_rig_tool_call(call: &rig::completion::message::ToolCall) -> m
         call_id: call.call_id.clone(),
         function: message::ToolFunction {
             name: call.function.name.clone(),
-            arguments: call.function.arguments.clone(),
+            // Ingest half of the #589/#590 argument-shape boundary: a wire
+            // payload the provider parser could not shape into an object (a
+            // raw corrupt string, `[]`, a scalar) is normalized before it can
+            // be accumulated into durable history. Dispatch reads the RAW rig
+            // value separately (`loop_stream`), so an unsalvageable payload
+            // still fails `parse_tool_args` and terminalizes
+            // `failed(ArgumentInvalid)` with the model notified.
+            arguments: super::tool::normalize_tool_call_arguments(
+                "ingest",
+                &call.function.name,
+                &call.function.arguments,
+            ),
         },
         signature: call.signature.clone(),
         additional_params: call.additional_params.clone(),
@@ -709,6 +728,111 @@ mod tests {
             !any_annotations,
             "without normalization the captured body must not carry output_text annotations"
         );
+    }
+
+    // ===== #589/#590: argument-shape normalization at both converter seams =====
+
+    fn native_tool_call(arguments: Value) -> message::ToolCall {
+        message::ToolCall {
+            id: "call-1".to_string(),
+            call_id: Some("call-1".to_string()),
+            function: message::ToolFunction {
+                name: "describe_tool".to_string(),
+                arguments,
+            },
+            signature: None,
+            additional_params: None,
+        }
+    }
+
+    fn rig_tool_call(arguments: Value) -> rig::completion::message::ToolCall {
+        rig::completion::message::ToolCall {
+            id: "call-1".to_string(),
+            call_id: Some("call-1".to_string()),
+            function: rig::completion::message::ToolFunction {
+                name: "describe_tool".to_string(),
+                arguments,
+            },
+            signature: None,
+            additional_params: None,
+        }
+    }
+
+    /// Ingest seam (#589): nothing non-object is ever accumulated into durable
+    /// history. A wire `"[]"` (rig parses it to `Value::Array`) and a raw
+    /// corrupt string both normalize; a healthy object is untouched.
+    #[test]
+    fn from_rig_tool_call_normalizes_arguments_to_object_shape() {
+        let object = json!({"city": "NYC"});
+        assert_eq!(
+            from_rig_tool_call(&rig_tool_call(object.clone()))
+                .function
+                .arguments,
+            object,
+            "object arguments must pass through unchanged"
+        );
+
+        assert_eq!(
+            from_rig_tool_call(&rig_tool_call(json!([])))
+                .function
+                .arguments,
+            json!({}),
+            "a non-object array must never be persisted"
+        );
+
+        let salvaged = from_rig_tool_call(&rig_tool_call(Value::String(
+            crate::test_support::CORRUPT_TOOL_ARGS_589.into(),
+        )))
+        .function
+        .arguments;
+        assert!(
+            salvaged.is_object(),
+            "the #589 corrupt raw string must not reach history as a string"
+        );
+        assert_eq!(salvaged["tool_name"], "list_hosts");
+    }
+
+    /// Egress seam (#590): already-poisoned durable history self-heals at
+    /// request build — the provider can never receive a non-object
+    /// `arguments`, so the deterministic template-render jam clears on the
+    /// next turn without a DB edit.
+    #[test]
+    fn to_rig_tool_call_normalizes_persisted_poison_on_egress() {
+        let object = json!({"city": "NYC"});
+        assert_eq!(
+            to_rig_tool_call(&native_tool_call(object.clone()))
+                .function
+                .arguments,
+            object,
+            "object arguments must pass through unchanged"
+        );
+
+        assert_eq!(
+            to_rig_tool_call(&native_tool_call(json!([])))
+                .function
+                .arguments,
+            json!({}),
+            "a persisted [] must egress as {{}}"
+        );
+        assert_eq!(
+            to_rig_tool_call(&native_tool_call(Value::Null))
+                .function
+                .arguments,
+            json!({}),
+            "persisted null args must egress as {{}}"
+        );
+
+        // Amy's actual poisoned row: a Value::String of corrupt bytes.
+        let healed = to_rig_tool_call(&native_tool_call(Value::String(
+            crate::test_support::CORRUPT_TOOL_ARGS_589.into(),
+        )))
+        .function
+        .arguments;
+        assert!(
+            healed.is_object(),
+            "the persisted #589 poison must egress object-shaped"
+        );
+        assert_eq!(healed["tool_name"], "list_hosts");
     }
 
     #[test]

--- a/crates/defra-agent/src/llm/tool.rs
+++ b/crates/defra-agent/src/llm/tool.rs
@@ -202,12 +202,23 @@ fn unparseable_args_error(error: &serde_json::Error) -> ToolError {
 
 /// Conservatively repair a tool-call `arguments` string the model emitted in a
 /// shape Rust's `serde_json` rejects, returning the repaired string only if a
-/// repair was applied. The single corruption handled is **lone backslashes**: the
-/// model writes a single backslash that is not a legal JSON escape (`\d`,
-/// `C:\temp`, a bare `\` before a normal char). We walk the string and double any
-/// backslash that does not introduce a valid JSON escape
-/// (`\" \\ \/ \b \f \n \r \t \uXXXX`), turning the raw output into the escaped
-/// form the model should have emitted.
+/// repair was applied. Two corruptions are handled, both escapes:
+///
+/// 1. **Lone backslashes**: the model writes a single backslash that is not a
+///    legal JSON escape (`\d`, `C:\temp`, a bare `\` before a normal char). We
+///    walk the string and double any backslash that does not introduce a valid
+///    JSON escape (`\" \\ \/ \b \f \n \r \t \uXXXX`), turning the raw output
+///    into the escaped form the model should have emitted.
+/// 2. **Literal control characters inside string literals** (#589): the
+///    model's reasoning channel bleeds raw newlines (and other `0x00-0x1f`
+///    bytes) into the middle of a JSON string, which `serde_json` rejects as
+///    "control character found while parsing a string". We escape them
+///    (`\n`, `\r`, `\t`, … `\uXXXX`), preserving the model's intent — a
+///    literal control character inside a string is never legal JSON, so the
+///    transform is identity on valid payloads. Control characters BETWEEN
+///    tokens are legal whitespace and are left untouched. This pass runs
+///    after backslash-doubling so every backslash begins a well-formed escape
+///    and in-string tracking is unambiguous.
 ///
 /// The repair is **escape-only by design**: it never closes a truncated value
 /// (dangling string / unbalanced brackets). Closing a truncation can produce JSON
@@ -216,11 +227,12 @@ fn unparseable_args_error(error: &serde_json::Error) -> ToolError {
 /// By refusing to close, a `finish_reason == "length"` payload simply stays
 /// unparseable and is surfaced as [`ToolError::UnparseableArgs`] instead of run.
 ///
-/// Returns `None` when no lone backslash was found (the caller has already tried
-/// a clean parse, so there is nothing to gain from re-parsing an identical
-/// string).
+/// Returns `None` when neither corruption was found (the caller has already
+/// tried a clean parse, so there is nothing to gain from re-parsing an
+/// identical string).
 pub fn repair_tool_arguments(raw: &str) -> Option<String> {
     let escaped = escape_lone_backslashes(raw);
+    let escaped = escape_control_characters_in_strings(&escaped);
     if escaped == raw {
         None
     } else {
@@ -273,6 +285,126 @@ fn is_valid_unicode_escape(bytes: &[u8], backslash_idx: usize) -> bool {
     bytes
         .get(hex_start..hex_start + 4)
         .is_some_and(|hex| hex.iter().all(u8::is_ascii_hexdigit))
+}
+
+/// Escape literal control characters (`0x00-0x1f`) that appear INSIDE string
+/// literals, leaving inter-token whitespace untouched (#589). Expects its
+/// input to have well-formed backslash escapes (run [`escape_lone_backslashes`]
+/// first), so `\"` inside a string never toggles the in-string state. An
+/// unterminated (truncated) string stays unterminated — this never closes
+/// anything.
+fn escape_control_characters_in_strings(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 8);
+    let mut in_string = false;
+    let mut chars = raw.chars();
+    while let Some(ch) = chars.next() {
+        if !in_string {
+            if ch == '"' {
+                in_string = true;
+            }
+            out.push(ch);
+            continue;
+        }
+        match ch {
+            // A well-formed escape pair: emit verbatim, consume the escaped
+            // char so an escaped quote does not toggle the string state.
+            '\\' => {
+                out.push(ch);
+                if let Some(next) = chars.next() {
+                    out.push(next);
+                }
+            }
+            '"' => {
+                in_string = false;
+                out.push(ch);
+            }
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{0008}' => out.push_str("\\b"),
+            '\u{000c}' => out.push_str("\\f"),
+            control if (control as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", control as u32));
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Normalize a tool-call `arguments` value to the provider-valid **object**
+/// shape (Lean `PromptAssembly.normalizeArgs`, issues #589/#590). Providers
+/// render history through templates that iterate `arguments.items()`, so a
+/// non-object value — a raw `Value::String` (the #589 poison), an array, a
+/// scalar, or `null` — deterministically jams every subsequent render of the
+/// session (#590). Applied at both rig-converter seams
+/// ([`crate::llm::rig_compat::from_rig_tool_call`], ingest — nothing
+/// non-object is ever accumulated into durable history — and
+/// [`crate::llm::rig_compat::to_rig_tool_call`], egress — already-poisoned
+/// durable history self-heals at request build).
+///
+/// The policy (each case fenced by conformance vectors mirroring the Lean
+/// theorems N1–N4):
+/// - an object passes through **unchanged** (N2);
+/// - `null` and an empty/whitespace string become `{}` silently (the
+///   absent-args shape providers accept);
+/// - a string that parses — after the tolerant escape-only
+///   [`repair_tool_arguments`] pass — to an object becomes **that object**
+///   (N4: the intended call survives, e.g. the #589 corrupt payload);
+/// - anything else (non-object JSON, unparseable string, array, scalar)
+///   becomes `{}` with a bounded warning so production occurrences are
+///   countable without dumping unbounded payloads.
+///
+/// `seam` labels the boundary ("ingest"/"egress") in the warning so healing
+/// of old poison is distinguishable from newly ingested poison.
+pub fn normalize_tool_call_arguments(
+    seam: &'static str,
+    tool_name: &str,
+    arguments: &serde_json::Value,
+) -> serde_json::Value {
+    use serde_json::Value;
+    match arguments {
+        Value::Object(_) => arguments.clone(),
+        Value::Null => Value::Object(serde_json::Map::new()),
+        Value::String(raw) if raw.trim().is_empty() => Value::Object(serde_json::Map::new()),
+        Value::String(raw) => {
+            let parsed = serde_json::from_str::<Value>(raw).ok().or_else(|| {
+                repair_tool_arguments(raw)
+                    .and_then(|repaired| serde_json::from_str::<Value>(&repaired).ok())
+            });
+            match parsed {
+                Some(Value::Object(map)) => Value::Object(map),
+                _ => {
+                    warn_nonobject_arguments_coerced(seam, tool_name, arguments);
+                    Value::Object(serde_json::Map::new())
+                }
+            }
+        }
+        _ => {
+            warn_nonobject_arguments_coerced(seam, tool_name, arguments);
+            Value::Object(serde_json::Map::new())
+        }
+    }
+}
+
+/// The truncation cap for the coercion warning's payload snippet: enough to
+/// identify the corruption class and build a fixture from real bytes, without
+/// dumping an unbounded model payload into the log stream.
+const COERCION_WARN_SNIPPET_CHARS: usize = 256;
+
+/// One bounded, counted warning per non-object coercion, so production
+/// occurrences of the #589/#590 class are observable (the original incident
+/// left zero log evidence of the offending bytes).
+fn warn_nonobject_arguments_coerced(seam: &str, tool_name: &str, arguments: &serde_json::Value) {
+    let rendered = arguments.to_string();
+    let truncated: String = rendered.chars().take(COERCION_WARN_SNIPPET_CHARS).collect();
+    tracing::warn!(
+        seam,
+        tool = tool_name,
+        payload_bytes = rendered.len(),
+        payload = %truncated,
+        "non-object tool-call arguments coerced to an empty object at the provider boundary"
+    );
 }
 
 #[cfg(test)]
@@ -438,6 +570,152 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    // ===== #589/#590: control-char salvage + object-shape normalization =====
+
+    #[test]
+    fn repair_escapes_control_characters_inside_strings() {
+        // The #589 production class: literal newlines (control characters)
+        // inside JSON strings, from reasoning-channel bleed. Escaping them is
+        // semantics-preserving (the model meant a newline) and lets the
+        // intended object parse; duplicate keys resolve last-wins.
+        let raw = crate::test_support::CORRUPT_TOOL_ARGS_589;
+        let repaired =
+            repair_tool_arguments(raw).expect("control characters in strings must be repaired");
+        let value: serde_json::Value =
+            serde_json::from_str(&repaired).expect("repaired #589 payload must parse");
+        assert!(value.is_object(), "salvage must recover an object");
+        assert_eq!(
+            value["tool_name"], "list_hosts",
+            "the intended call must survive the salvage"
+        );
+    }
+
+    #[test]
+    fn repair_leaves_inter_token_whitespace_untouched() {
+        // Newlines BETWEEN tokens are legal JSON whitespace; a payload that is
+        // already valid must not be "repaired" (None = nothing to re-parse).
+        let raw = "{\n  \"a\": 1\n}";
+        assert!(repair_tool_arguments(raw).is_none());
+    }
+
+    #[test]
+    fn repair_control_chars_still_does_not_close_truncation() {
+        // A payload with an in-string control char AND a truncated tail: the
+        // control char is escaped, but the truncation is never closed — the
+        // reparse still fails Eof and is reported Truncated, never run (#512
+        // guarantee preserved).
+        let raw = "{\"note\":\"line one\nline two that got cut";
+        let error = parse_tool_args::<SingleField>(raw)
+            .expect_err("truncated payload must not run even after control-char repair");
+        assert!(matches!(
+            error,
+            ToolError::UnparseableArgs {
+                kind: UnparseableArgsKind::Truncated,
+                ..
+            }
+        ));
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct DescribeToolArgs {
+        tool_name: String,
+    }
+
+    #[test]
+    fn parse_tool_args_salvages_589_contamination_to_typed_args() {
+        // Dispatch-level salvage: the corrupt payload deserializes into the
+        // tool's typed Args after repair, so the intended call runs instead of
+        // wasting a turn on "re-call the tool with valid JSON".
+        let parsed: DescribeToolArgs = parse_tool_args(crate::test_support::CORRUPT_TOOL_ARGS_589)
+            .expect("the #589 payload must salvage into typed args");
+        assert_eq!(parsed.tool_name, "list_hosts");
+    }
+
+    fn normalize(value: &serde_json::Value) -> serde_json::Value {
+        normalize_tool_call_arguments("test", "echo", value)
+    }
+
+    #[test]
+    fn normalize_passes_object_through_unchanged() {
+        // N2 (object fixpoint): the healthy flow has no regression.
+        let object = serde_json::json!({"city": "NYC", "nested": {"a": [1, 2]}});
+        assert_eq!(normalize(&object), object);
+    }
+
+    #[test]
+    fn normalize_coerces_null_and_empty_string_to_empty_object() {
+        // Empty/absent arguments egress as {} (the 200-control shape).
+        assert_eq!(normalize(&serde_json::Value::Null), serde_json::json!({}));
+        assert_eq!(normalize(&serde_json::json!("")), serde_json::json!({}));
+        assert_eq!(
+            normalize(&serde_json::json!("  \n ")),
+            serde_json::json!({})
+        );
+    }
+
+    #[test]
+    fn normalize_parses_stringified_object() {
+        // N4 (salvage): a JSON string holding an object becomes that object.
+        assert_eq!(
+            normalize(&serde_json::json!("{\"city\":\"NYC\"}")),
+            serde_json::json!({"city": "NYC"})
+        );
+    }
+
+    #[test]
+    fn normalize_salvages_589_corrupt_string_payload() {
+        // N4 on the production poison: the persisted Value::String of corrupt
+        // bytes normalizes to the intended object, so a poisoned session
+        // self-heals on next egress.
+        let poison = serde_json::Value::String(crate::test_support::CORRUPT_TOOL_ARGS_589.into());
+        let normalized = normalize(&poison);
+        assert!(normalized.is_object());
+        assert_eq!(normalized["tool_name"], "list_hosts");
+    }
+
+    #[test]
+    fn normalize_coerces_non_object_shapes_to_empty_object() {
+        // N1 (soundness): every non-object, non-salvageable shape becomes {}.
+        // Covers the full #590 reproduction matrix: "[]" (the repro), a JSON
+        // string literal (the production case), scalars, arrays.
+        for poison in [
+            serde_json::json!("[]"),
+            serde_json::json!("[1,2]"),
+            serde_json::json!("123"),
+            serde_json::json!("true"),
+            serde_json::json!("null"),
+            serde_json::json!("\"any string\""),
+            serde_json::json!("not json at all"),
+            serde_json::json!("{\"a\":"), // truncated
+            serde_json::json!([]),
+            serde_json::json!([1, 2]),
+            serde_json::json!(123),
+            serde_json::json!(true),
+        ] {
+            assert_eq!(
+                normalize(&poison),
+                serde_json::json!({}),
+                "non-object arguments {poison:?} must coerce to {{}}"
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_is_idempotent() {
+        // N3: ingest-then-egress normalization composes without drift.
+        for value in [
+            serde_json::json!({"city": "NYC"}),
+            serde_json::json!("[]"),
+            serde_json::json!("{\"a\": 1}"),
+            serde_json::Value::Null,
+            serde_json::json!([1]),
+            serde_json::Value::String(crate::test_support::CORRUPT_TOOL_ARGS_589.into()),
+        ] {
+            let once = normalize(&value);
+            assert_eq!(normalize(&once), once, "normalize must be idempotent");
+        }
     }
 
     #[test]

--- a/crates/defra-agent/tests/conformance/prompt_assembly.rs
+++ b/crates/defra-agent/tests/conformance/prompt_assembly.rs
@@ -272,3 +272,139 @@ fn pairing_identity_uses_call_id_over_item_id() {
     assert_eq!(out, history);
     assert_provider_valid(&out);
 }
+
+// ===== ToolArgs (issues #589/#590): value-granular argument-shape contract =====
+//
+// Mirrors `Proofs/PromptAssembly/ToolArgs.lean` against the Rust normalizer
+// `llm::tool::normalize_tool_call_arguments` (applied at both rig-converter
+// seams). The Lean model is below row granularity — normalization is pointwise
+// per tool call and never changes row shape — so these vectors fence the value
+// contract the row-granular sanitize theorems cannot see.
+
+use defra_agent::llm::tool::normalize_tool_call_arguments;
+
+/// The #589 production poison (Amy's persisted row `Rrt-HmhWfFSmkh1HSUmHt`):
+/// out-of-channel contamination with LITERAL newlines inside strings,
+/// duplicated keys, and the intended call surviving as the final `tool_name`.
+const CORRUPT_TOOL_ARGS_589: &str = "{\"raw_schema\": false, \
+     \"service_id\": \"observability-mcp\", \"tool房\n</think\": \"\n<tool_call>\n\
+     <function=describe_tool>\", \"raw_schema\": false, \
+     \"service_id\": \"observability-mcp\", \"tool_name\": \"list_hosts\"}";
+
+fn normalize_args(value: &serde_json::Value) -> serde_json::Value {
+    normalize_tool_call_arguments("conformance", "echo", value)
+}
+
+/// All non-object shapes a `serde_json::Value` can carry into the seam:
+/// the #590 reproduction matrix (string-encoded and native forms) plus the
+/// #589 corrupt raw string.
+fn nonobject_vectors() -> Vec<serde_json::Value> {
+    vec![
+        serde_json::Value::Null,
+        serde_json::json!(""),
+        serde_json::json!("[]"),
+        serde_json::json!("[1,2]"),
+        serde_json::json!("123"),
+        serde_json::json!("true"),
+        serde_json::json!("null"),
+        serde_json::json!("\"any string\""),
+        serde_json::json!("not json at all"),
+        serde_json::json!([]),
+        serde_json::json!([1, 2]),
+        serde_json::json!(123),
+        serde_json::json!(true),
+        serde_json::Value::String(CORRUPT_TOOL_ARGS_589.to_string()),
+        serde_json::json!("{\"city\":\"NYC\"}"),
+        serde_json::json!({"city": "NYC"}),
+    ]
+}
+
+/// Lean `normalize_isObject` (N1, soundness): normalization always yields an
+/// object, whatever shape came in — no egress path can hand the provider a
+/// non-object `arguments` value.
+#[test]
+fn tool_args_n1_normalize_always_yields_object() {
+    for vector in nonobject_vectors() {
+        let normalized = normalize_args(&vector);
+        assert!(
+            normalized.is_object(),
+            "N1 violated: {vector:?} normalized to non-object {normalized:?}"
+        );
+    }
+}
+
+/// Lean `normalize_fixpoint_of_isObject` (N2, object fixpoint): a well-formed
+/// object passes through byte-identical — the healthy flow has no regression.
+#[test]
+fn tool_args_n2_object_passes_through_unchanged() {
+    let objects = [
+        serde_json::json!({}),
+        serde_json::json!({"city": "NYC"}),
+        serde_json::json!({"nested": {"deep": [1, 2, {"x": null}]}}),
+    ];
+    for object in objects {
+        assert_eq!(
+            normalize_args(&object),
+            object,
+            "N2 violated: object arguments must be unchanged"
+        );
+    }
+}
+
+/// Lean `normalize_idempotent` (N3): the ingest and egress seams compose —
+/// a value persisted normalized re-egresses identical.
+#[test]
+fn tool_args_n3_normalize_is_idempotent() {
+    for vector in nonobject_vectors() {
+        let once = normalize_args(&vector);
+        assert_eq!(
+            normalize_args(&once),
+            once,
+            "N3 violated: double normalization drifted for {vector:?}"
+        );
+    }
+}
+
+/// Lean `normalize_salvages_str` (N4, salvage): a string that (post-repair)
+/// parses to an object recovers THAT object — the intended call survives
+/// rather than collapsing to the empty fallback. Includes the #589 corrupt
+/// production payload.
+#[test]
+fn tool_args_n4_stringified_object_recovers_its_payload() {
+    assert_eq!(
+        normalize_args(&serde_json::json!("{\"city\":\"NYC\"}")),
+        serde_json::json!({"city": "NYC"})
+    );
+
+    let salvaged = normalize_args(&serde_json::Value::String(
+        CORRUPT_TOOL_ARGS_589.to_string(),
+    ));
+    assert!(salvaged.is_object(), "N4: the #589 payload must salvage");
+    assert_eq!(
+        salvaged["tool_name"], "list_hosts",
+        "N4: the intended call must survive the salvage"
+    );
+}
+
+/// Lean `normalize_nonobject_to_empty`: the non-salvageable shapes collapse to
+/// exactly the EMPTY object, pinning the entire coercion table.
+#[test]
+fn tool_args_nonobject_collapses_to_empty_object() {
+    for vector in [
+        serde_json::Value::Null,
+        serde_json::json!(""),
+        serde_json::json!("[]"),
+        serde_json::json!("123"),
+        serde_json::json!("\"any string\""),
+        serde_json::json!("not json at all"),
+        serde_json::json!([]),
+        serde_json::json!(123),
+        serde_json::json!(true),
+    ] {
+        assert_eq!(
+            normalize_args(&vector),
+            serde_json::json!({}),
+            "non-salvageable {vector:?} must collapse to {{}}"
+        );
+    }
+}


### PR DESCRIPTION
## What

One shared normalization policy for `ToolFunction.arguments`, applied at both rig-converter seams, so a non-object arguments value can neither be persisted into durable history nor re-emitted to a provider. This closes both halves of the Amy/studio-1 incident: the ingest poison (#589) and the deterministic render jam (#590).

Lean-first per the foundation flow: `Proofs/PromptAssembly/ToolArgs.lean` models the argument-shape contract below the row-granular sanitize model — `normalizeArgs` with **N1** soundness (output is always object-shaped), **N2** object fixpoint (healthy calls pass through unchanged), **N3** idempotence (the two seams compose without drift), **N4** salvage (a string that parses to an object recovers *that* object, not the empty fallback), plus a coercion-table lemma pinning everything else to `{}`. Zero `sorry`s. Conformance vectors in `tests/conformance/prompt_assembly.rs` fence each theorem against the real Rust normalizer.

## The policy (`llm::tool::normalize_tool_call_arguments`)

| input | result |
|---|---|
| object | unchanged (byte-identical) |
| `null`, empty/whitespace string | `{}`, silent |
| string parsing (post-repair) to an object | that object (the #589 payload salvages to its intended call) |
| anything else (`"[]"`, scalar, array, unparseable string) | `{}` + one bounded (256-char), seam-labeled `warn` |

## How newly ingested poison is blocked

`from_rig_tool_call` normalizes at the accumulate/persist seam, so nothing non-object is ever written into an `AgentMessage` assistant turn — the exact write that poisoned session `9f61196d`. Dispatch deliberately still reads the **raw** wire value: an unsalvageable payload fails `parse_tool_args` and terminalizes `failed(ArgumentInvalid)` via the existing #512 marker path, with the model notified — never a live completed call carrying poison. The raw bytes remain on the failed `AgentToolCall` row for forensics, and the new warn logs a truncated snippet (the original incident left zero log evidence of the offending bytes).

## How already-poisoned sessions recover

`to_rig_tool_call` normalizes at request build, so a session whose durable history already holds poison (Amy's `Value::String` of corrupt bytes, or a `"[]"`-class value) egresses object-shaped on its **next turn** — no DB edit, no new session. Amy's specific payload actually salvages to its intended `{ tool_name: "list_hosts", … }` object rather than `{}`, because of the repair extension below.

## Salvage for the #589 corruption class

`repair_tool_arguments` gains a second **escape-only** pass: literal control characters inside JSON string literals are escaped (`\n`, `\r`, … `\uXXXX`). That is exactly the `serde_json` "control character at line 2 column 0" failure from the reasoning-channel bleed; escaping is identity on valid JSON and semantics-preserving on the corrupt class, and duplicate keys resolve last-wins. The pass **never closes a truncation** — all #512 guarantees are preserved and re-fenced (`repair_control_chars_still_does_not_close_truncation`). The `defra.*` meta-tool seam inherits the salvage automatically via `parse_stringified_object`; its strict reject-non-object dispatch behavior is unchanged.

## Tests

- Unit: full coercion table at the policy level, control-char repair, truncation preservation, typed-args salvage of the byte-faithful #589 fixture (`test_support::CORRUPT_TOOL_ARGS_589`).
- Seams: `from_rig_tool_call` / `to_rig_tool_call` ingest+egress vectors.
- Conformance: N1–N4 mirrored vectors (PromptAssembly home).
- StreamProcessor: corrupt streamed call persists object-shaped into `AgentMessage`.
- Loop-level incident regressions: the salvageable production payload runs the intended call and the next request is object-shaped; the `"[]"` class terminalizes `failed/argumentInvalid`, notifies the model, and never re-egresses.

Gate: `lake build` green (zero sorrys), `cargo test -p defra-agent` fully green (889 lib, 263 conformance, all integration binaries), `cargo test -p defra-agent-cli` green, `cargo fmt --all --check` clean.

Closes #589. Closes #590.

🤖 Generated with [Claude Code](https://claude.com/claude-code)