### PR TITLE
polish(desktop): onboarding hero, sticky fleet actions, quieter chat chrome

### DIFF
--- a/apps/desktop-tauri/src/components/chat/ChatComposer.tsx
+++ b/apps/desktop-tauri/src/components/chat/ChatComposer.tsx
@@ -59,12 +59,14 @@ export function ChatComposer({
       data-testid="composer-form"
       onSubmit={onSend}
     >
-      <div className="composer-toolbar">
+      <div
+        className="composer-toolbar"
+        // Store internals stay discoverable on hover without leaking
+        // "42 rows / 21.0 KB" into the primary chat surface.
+        title={`Local store: ${rowCount} rows / ${formatBytes(approxSerializedBytes)}`}
+      >
         <div className="muted small">
           Selected behavior: {behaviorLabel ?? "default"}
-        </div>
-        <div className="muted small">
-          {rowCount} rows / {formatBytes(approxSerializedBytes)}
         </div>
       </div>
 

--- a/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
@@ -87,9 +87,9 @@ export function FleetDashboard({
         <div className="fleet-empty-card panel">
           <BrandLockup />
           <div className="fleet-empty-copy">
-            <h2>Add Agent Connection</h2>
+            <h2>Connect your agent</h2>
             <p className="muted">
-              Connect the desktop to an agent before opening chat or config.
+              Start with the agent on this machine — one click, no configuration.
             </p>
           </div>
           <LocalRuntimeConnect
@@ -98,15 +98,23 @@ export function FleetDashboard({
             error={localRuntimeError}
             onConnect={connectLocalRuntime}
           />
-          <AddPeerForm
-            addingPeer={addingPeer}
-            disabled={starting || loading}
-            localError={peerFormError}
-            peerForm={peerForm}
-            onPeerFormChange={setPeerForm}
-            onFetchPeerStatus={onFetchPeerStatus}
-            onSubmit={submitPeer}
-          />
+          {/* Remote connection needs DIDs/multiaddrs — keep it behind a
+              disclosure so first-run isn't a wall of connection JSON. */}
+          <details
+            className="fleet-remote-disclosure"
+            data-testid="fleet-remote-disclosure"
+          >
+            <summary>Connect a remote agent instead…</summary>
+            <AddPeerForm
+              addingPeer={addingPeer}
+              disabled={starting || loading}
+              localError={peerFormError}
+              peerForm={peerForm}
+              onPeerFormChange={setPeerForm}
+              onFetchPeerStatus={onFetchPeerStatus}
+              onSubmit={submitPeer}
+            />
+          </details>
         </div>
       </section>
     );

--- a/apps/desktop-tauri/src/components/operations/OperationsRail.tsx
+++ b/apps/desktop-tauri/src/components/operations/OperationsRail.tsx
@@ -78,7 +78,7 @@ export function OperationsRail({
           onClick={() => onOpenChange?.(true)}
         >
           <span aria-hidden="true">‹</span>
-          <span>Ops</span>
+          <span>Operations</span>
         </button>
       </aside>
     );

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -28,6 +28,8 @@
     display: grid;
     grid-template-rows: auto auto minmax(0, 1fr);
     overflow: hidden;
+    /* Fully opaque: the transcript must not ghost through the open drawer. */
+    background: rgb(2 8 6);
     box-shadow:
       0 20px 80px rgb(0 0 0 / 0.5),
       inset 0 1px 0 rgb(255 255 255 / 0.025),
@@ -37,7 +39,8 @@
   .operations-rail.is-collapsed {
     top: 50%;
     width: 38px;
-    height: 92px;
+    height: auto;
+    min-height: 92px;
     display: flex;
     align-items: stretch;
     justify-content: center;

--- a/apps/desktop-tauri/src/styles/fleet/layout.css
+++ b/apps/desktop-tauri/src/styles/fleet/layout.css
@@ -94,6 +94,22 @@
     font-size: 12px;
   }
 
+  .fleet-remote-disclosure > summary {
+    cursor: pointer;
+    color: var(--color-text-muted);
+    font-size: 13px;
+    padding: var(--space-2) 0;
+    width: fit-content;
+  }
+
+  .fleet-remote-disclosure > summary:hover {
+    color: var(--color-accent);
+  }
+
+  .fleet-remote-disclosure[open] > summary {
+    margin-bottom: var(--space-4);
+  }
+
   .fleet-add-panel {
     display: grid;
     gap: var(--space-5);

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -178,23 +178,30 @@
     z-index: 1;
   }
 
+  /* Pinned cells must be opaque: the translucent surfaces are layered over
+     the page background so scrolled data columns can't ghost through. */
   .fleet-actions-header {
     width: 128px;
-    background: rgb(0 0 0 / 0.88);
+    background: linear-gradient(rgb(0 0 0 / 0.88), rgb(0 0 0 / 0.88)) var(--color-bg);
   }
 
   .fleet-actions-cell {
     min-width: 128px;
-    background-color: var(--color-surface-row);
+    background-color: var(--color-bg);
+    background-image: linear-gradient(
+      var(--color-surface-row),
+      var(--color-surface-row)
+    );
     box-shadow: -10px 0 10px -10px rgb(0 0 0 / 0.7);
   }
 
   .fleet-table tbody tr:hover td.fleet-actions-cell {
-    background-color: var(--color-surface-row);
-    background-image: linear-gradient(
-      rgb(var(--source-green-rgb) / 0.07),
-      rgb(var(--source-green-rgb) / 0.07)
-    );
+    background-image:
+      linear-gradient(
+        rgb(var(--source-green-rgb) / 0.07),
+        rgb(var(--source-green-rgb) / 0.07)
+      ),
+      linear-gradient(var(--color-surface-row), var(--color-surface-row));
   }
 
   .fleet-row-actions {

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -146,8 +146,7 @@
     color: var(--color-warning);
   }
 
-  .fleet-tool-icon svg,
-  .fleet-table-action svg {
+  .fleet-tool-icon svg {
     width: 13px;
     height: 13px;
     display: block;
@@ -158,27 +157,65 @@
     stroke-linejoin: round;
   }
 
+  .fleet-table-action svg {
+    width: 16px;
+    height: 16px;
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  /* The actions column stays pinned while the table scrolls horizontally at
+     narrow widths, so chat/config/repair are always visible — the wrap's
+     overflow:auto remains the reachability mechanism for the other columns. */
+  .fleet-actions-header,
+  .fleet-actions-cell {
+    position: sticky;
+    right: 0;
+    z-index: 1;
+  }
+
   .fleet-actions-header {
-    width: 102px;
+    width: 128px;
+    background: rgb(0 0 0 / 0.88);
   }
 
   .fleet-actions-cell {
-    min-width: 102px;
+    min-width: 128px;
+    background-color: var(--color-surface-row);
+    box-shadow: -10px 0 10px -10px rgb(0 0 0 / 0.7);
+  }
+
+  .fleet-table tbody tr:hover td.fleet-actions-cell {
+    background-color: var(--color-surface-row);
+    background-image: linear-gradient(
+      rgb(var(--source-green-rgb) / 0.07),
+      rgb(var(--source-green-rgb) / 0.07)
+    );
   }
 
   .fleet-row-actions {
     justify-content: flex-start;
-    gap: var(--space-2);
+    gap: var(--space-3);
   }
 
   .fleet-table-action {
-    width: 24px;
-    height: 24px;
-    min-height: 24px;
+    width: 32px;
+    height: 32px;
+    min-height: 32px;
     display: inline-grid;
     place-items: center;
     padding: 0;
-    border-radius: 0;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgb(var(--source-green-rgb) / 0.35);
+  }
+
+  .fleet-table-action:hover:not(:disabled) {
+    border-color: rgb(var(--source-green-rgb) / 0.75);
+    background: rgb(var(--source-green-rgb) / 0.12);
   }
 
   .fleet-table-action:disabled {


### PR DESCRIPTION
Stacks on #599. Home-screen and chat polish from the desktop-perfection visual audit (P1 items).

- **Onboarding hero** — the empty state leads with one-click "Connect Local Agent"; the remote form (connection JSON, DIDs, multiaddrs) moves behind a "Connect a remote agent instead…" disclosure, so first-run isn't a wall of operator plumbing.
- **Fleet row actions** — chat/config/repair buttons grow 24→32px with visible borders and hover states; the actions column is now **sticky**, so at narrow widths the buttons stay pinned and visible instead of scrolling off-screen (the previously-locked scroll-reachability contract is preserved — `.fleet-table-wrap` still owns overflow for the data columns).
- **Quieter chat chrome** — the composer's "42 rows / 21.0 KB" store internals demote to a hover tooltip; the cryptic collapsed "‹Ops" rail handle now reads "‹Operations".
- **Operations drawer** — fully opaque when open (transcript no longer ghosts through the top edge).

CSS/copy-level changes only; no behavior or testid changes. Verified: build + 144 unit + 99 e2e green; screenshots reviewed across desktop/laptop/narrow (all three action buttons visible at 390px).
