### PR TITLE
fix(p2p): back off relay open_path failures (#588)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6222,12 +6222,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-lock",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-trait",
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "anyhow",
  "document",
@@ -6780,6 +6780,7 @@ dependencies = [
  "futures-util",
  "hostname",
  "identity",
+ "iroh",
  "jsonschema",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -6809,6 +6810,7 @@ version = "0.6.2"
 dependencies = [
  "anyhow",
  "clap",
+ "defra-agent",
  "defra-agent-desktop-core",
  "serde_json",
  "tokio",
@@ -6907,7 +6909,7 @@ version = "0.6.2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "cid",
@@ -6931,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-stream",
@@ -6973,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "anyhow",
@@ -7006,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-trait",
@@ -7040,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "serde",
 ]
@@ -7458,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7636,11 +7638,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -7916,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11035,7 +11037,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -11477,9 +11479,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+checksum = "1a2e38557969901f8b356d1ebd882253bab98cc81500d53e7bcbf33f56082303"
 dependencies = [
  "backon",
  "blake3",
@@ -11488,7 +11490,7 @@ dependencies = [
  "ctutils 0.4.2",
  "data-encoding",
  "derive_more 2.1.1",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-util",
  "getrandom 0.4.2",
  "hickory-resolver 0.26.1",
@@ -11514,7 +11516,6 @@ dependencies = [
  "rustc-hash 2.1.2",
  "rustls 0.23.37",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
  "serde",
  "smallvec",
  "strum 0.28.0",
@@ -11525,29 +11526,25 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
+checksum = "61cdf012298adc13f5c2c821ad87214fecc9ac54c751301d45bf62b229a85da1"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more 2.1.1",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
@@ -11589,16 +11586,16 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.101.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e351f5c1db08dcfb456e6299bda0881e1ba95a360f0913a5e57344c1538fb2"
+checksum = "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126"
 dependencies = [
  "arrayvec",
  "bao-tree",
  "bytes",
  "cfg_aliases 0.2.1",
  "chrono",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.1.5",
  "data-encoding",
  "derive_more 2.1.1",
  "genawaiter",
@@ -11630,9 +11627,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+checksum = "4c24b83aae5ed4eced1c3724204c083c28c84c5d225a88e277eceeccce3dc3bd"
 dependencies = [
  "arc-swap",
  "cfg_aliases 0.2.1",
@@ -11642,8 +11639,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.2",
  "rustls 0.23.37",
  "simple-dns",
  "strum 0.28.0",
@@ -11654,19 +11651,15 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.99.0"
+version = "0.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48eaefd27751bc5dabda1f1b318c38a8b624fa137a1aaf429dfdd4d66b452ba9"
+checksum = "4e1dc4b05f73e7a1b9e83b531eb63c3fd671b0af3aeb13b59c546dd7ca747515"
 dependencies = [
  "blake3",
  "bytes",
- "constant_time_eq 0.3.1",
  "data-encoding",
  "derive_more 2.1.1",
- "ed25519-dalek 3.0.0-pre.7",
  "futures-concurrency",
- "futures-lite",
- "futures-util",
  "hex",
  "indexmap 2.13.1",
  "iroh",
@@ -11698,9 +11691,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -11713,9 +11706,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -11725,9 +11718,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+checksum = "9f16a5505939f9250297ff2f1210b5142d13618f496eab03ce3f964fc47e2e2b"
 dependencies = [
  "blake3",
  "bytes",
@@ -11771,9 +11764,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4b7fbfa10582f6b4f6b013eef1d21987d3df5fd42c0f7707d5de6abd34f8e9"
+checksum = "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54"
 dependencies = [
  "data-encoding",
  "derive_more 2.1.1",
@@ -11785,9 +11778,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7705450a124b2b05f7caad505620ab5ac3bf4eb6b85018e6b9bca36329fd031"
+checksum = "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00"
 dependencies = [
  "derive_more 2.1.1",
  "iroh",
@@ -11799,9 +11792,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d38567eed2ed120e1040386930eb3b9ce6ca8a94b13c20a1b3b6535f253b00c"
+checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
  "futures-buffered",
  "futures-util",
@@ -11821,9 +11814,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8030c02dce4c9a8aecfb6e0870ee13ba3060096d88f6c1309919af8f197793"
+checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12277,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-lock",
@@ -12425,7 +12418,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -13790,9 +13783,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "anyhow",
  "n0-error-macros",
@@ -13801,9 +13794,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13833,9 +13826,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more 2.1.1",
  "n0-error",
@@ -13944,19 +13937,22 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route 0.31.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -13989,21 +13985,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -14040,14 +14024,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases 0.2.1",
  "derive_more 2.1.1",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -14055,7 +14040,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -14183,9 +14168,9 @@ checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -14205,9 +14190,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -14234,9 +14219,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
@@ -14495,7 +14480,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15167,7 +15152,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "anyhow",
@@ -15992,9 +15977,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec2a8809e3f7dba624776bb223da9fed49c413c60b3bef21aadcb67a5e35944"
+checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -16457,7 +16442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16470,7 +16455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16585,7 +16570,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16621,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16638,7 +16623,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "async-lock",
@@ -16670,7 +16655,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17623,7 +17608,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "p2p",
  "query",
@@ -18422,7 +18407,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "cid",
  "defra-core",
@@ -19624,7 +19609,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20051,7 +20036,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24490,7 +24475,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?tag=v0.15.1#98aead3ef3ce390440fc13545b7ec99f451c4d00"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -24669,18 +24654,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,25 +50,30 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
+# defradb.rs rev = main just after #1084 (iroh 1.0 stable: production relays +
+# open_path backoff, see #588). Move to the next upstream tag when one is cut.
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+# Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
+# the CLI uses it to inspect the default relay set at startup (#588).
+iroh = "1"
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde", "unstable_machinery"] }
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", tag = "v0.15.1" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/apps/desktop-tauri/src-tauri/src/bridge/logging.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/logging.rs
@@ -1,8 +1,15 @@
 use std::fs::OpenOptions;
 use std::path::Path;
 
+use defra_agent::log_rate::{RateLimitConfig, RateLimitFilter};
 use defra_agent_desktop_core::client::DesktopPaths;
 use tracing_subscriber::{prelude::*, EnvFilter};
+
+/// Per-callsite log-rate ceiling: no code path may flood the desktop log
+/// file or the host journal, however hot its failure loop (#588).
+fn log_rate_ceiling() -> RateLimitFilter {
+    RateLimitFilter::new(RateLimitConfig::default())
+}
 
 pub(crate) fn init_tracing() {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
@@ -27,11 +34,13 @@ pub(crate) fn init_tracing() {
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
             .with_target(true)
-            .with_writer(move || open_log_writer(&file_writer_path));
+            .with_writer(move || open_log_writer(&file_writer_path))
+            .with_filter(log_rate_ceiling());
         let stderr_layer = tracing_subscriber::fmt::layer()
             .with_target(false)
             .compact()
-            .without_time();
+            .without_time()
+            .with_filter(log_rate_ceiling());
         let _ = tracing_subscriber::registry()
             .with(env_filter)
             .with(stderr_layer)
@@ -41,7 +50,8 @@ pub(crate) fn init_tracing() {
         let file_layer = tracing_subscriber::fmt::layer()
             .with_ansi(false)
             .with_target(true)
-            .with_writer(move || open_log_writer(&writer_path));
+            .with_writer(move || open_log_writer(&writer_path))
+            .with_filter(log_rate_ceiling());
         let _ = tracing_subscriber::registry()
             .with(env_filter)
             .with(file_layer)

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -35,6 +35,7 @@ defra-agent-protocol.workspace = true
 defra-node.workspace = true
 defra-p2p-adapter.workspace = true
 futures-util = "0.3"
+iroh.workspace = true
 query.workspace = true
 hostname.workspace = true
 opentelemetry.workspace = true

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -107,6 +107,9 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
     }
 
     let p2p_config = resolve_server_p2p_config(&home_dir, &args)?;
+    if p2p_config.is_some() {
+        crate::p2p_relay::log_relay_mode_diagnostics(args.p2p_relay_mode);
+    }
     // The MCP `defra_query` endpoint is opt-in (unauthenticated read surface).
     let mcp_query_scope = if !args.enable_mcp {
         None

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -19,6 +19,7 @@ mod desired_state;
 mod graphql_access;
 mod home_state;
 mod http;
+mod p2p_relay;
 mod request_helpers;
 mod resolve_helpers;
 mod shared;

--- a/crates/defra-agent-cli/src/p2p_relay.rs
+++ b/crates/defra-agent-cli/src/p2p_relay.rs
@@ -1,0 +1,117 @@
+//! Startup diagnostics for the embedded node's iroh relay configuration.
+//!
+//! The default relay set is whatever the pinned iroh crate ships. Pre-release
+//! iroh versions point `RelayMode::Default` at n0's *canary* infrastructure,
+//! which is expected to be unstable — exactly the trigger for the relay
+//! `open_path` retry flood that self-DoS'd a host in #588. These helpers make
+//! the resolved relay set visible at startup and flag non-production
+//! endpoints loudly.
+
+use crate::cli::args::P2pRelayModeArg;
+
+/// Returns the relay URLs that `--p2p-relay-mode default` resolves to under
+/// the pinned iroh version.
+pub(crate) fn default_relay_urls() -> Vec<String> {
+    iroh::RelayMode::Default
+        .relay_map()
+        .urls::<Vec<_>>()
+        .iter()
+        .map(|url| url.to_string())
+        .collect()
+}
+
+/// Filters `urls` down to endpoints that are not n0 production relays
+/// (canary or staging infrastructure).
+pub(crate) fn non_production_relay_urls<'a>(
+    urls: impl IntoIterator<Item = &'a String>,
+) -> Vec<String> {
+    urls.into_iter()
+        .filter(|url| {
+            let url = url.to_ascii_lowercase();
+            url.contains("canary") || url.contains("staging")
+        })
+        .cloned()
+        .collect()
+}
+
+/// Logs the relay configuration the server will run with, and warns loudly
+/// if the default relay set includes non-production endpoints.
+pub(crate) fn log_relay_mode_diagnostics(mode: P2pRelayModeArg) {
+    match mode {
+        P2pRelayModeArg::Disabled => {
+            tracing::info!(p2p_relay_mode = "disabled", "P2P relay disabled");
+        }
+        P2pRelayModeArg::Default => {
+            let relay_urls = default_relay_urls();
+            let non_production = non_production_relay_urls(&relay_urls);
+            tracing::info!(
+                ?relay_urls,
+                p2p_relay_mode = "default",
+                "P2P relay configuration"
+            );
+            if !non_production.is_empty() {
+                tracing::warn!(
+                    ?non_production,
+                    "default iroh relay set includes non-production (canary/staging) endpoints; \
+                     these are expected to be unstable and can trigger relay connect churn — \
+                     the pinned iroh version likely needs updating (see #588)"
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_production_relay_urls_flags_canary_and_staging() {
+        let urls = vec![
+            "https://use1-1.relay.n0.iroh.link./".to_string(),
+            "https://usw1-1.relay.n0.iroh-canary.iroh.link./".to_string(),
+            "https://euc1-1.staging-relay.n0.iroh.link./".to_string(),
+        ];
+
+        let flagged = non_production_relay_urls(&urls);
+
+        assert_eq!(
+            flagged,
+            vec![
+                "https://usw1-1.relay.n0.iroh-canary.iroh.link./".to_string(),
+                "https://euc1-1.staging-relay.n0.iroh.link./".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn non_production_relay_urls_passes_production_set() {
+        let urls = vec![
+            "https://use1-1.relay.n0.iroh.link./".to_string(),
+            "https://euc1-1.relay.n0.iroh.link./".to_string(),
+        ];
+
+        assert!(non_production_relay_urls(&urls).is_empty());
+    }
+
+    /// Tripwire: the iroh version pinned in Cargo.lock must resolve
+    /// `RelayMode::Default` to n0 *production* relays. Pre-release iroh
+    /// versions ship canary endpoints as the default relay set, which is the
+    /// #588 incident trigger. If this fails, the iroh pin regressed to a
+    /// pre-release default relay set.
+    #[test]
+    fn pinned_iroh_default_relay_set_is_production() {
+        let relay_urls = default_relay_urls();
+
+        assert!(
+            !relay_urls.is_empty(),
+            "default relay map should not be empty"
+        );
+        assert_eq!(
+            non_production_relay_urls(&relay_urls),
+            Vec::<String>::new(),
+            "pinned iroh RelayMode::Default points at non-production relays; \
+             bump the iroh pin (via sourcenetwork/defradb.rs) to a stable release"
+        );
+    }
+}

--- a/crates/defra-agent-cli/src/telemetry.rs
+++ b/crates/defra-agent-cli/src/telemetry.rs
@@ -53,6 +53,16 @@ impl TelemetryGuard {
     }
 }
 
+/// Per-callsite log-rate ceiling on everything the agent writes to stderr.
+///
+/// Guardrail for #588: one hot code path (an iroh relay retry loop) flooded
+/// journald at ~350k WARN lines/sec and wedged the host. Whatever the source,
+/// no single callsite may emit unbounded output; suppression is reported via
+/// bounded summary events, so failures stay visible.
+fn log_rate_ceiling() -> defra_agent::log_rate::RateLimitFilter {
+    defra_agent::log_rate::RateLimitFilter::new(defra_agent::log_rate::RateLimitConfig::default())
+}
+
 pub(crate) fn init(default_log_filter: &str) -> Result<TelemetryGuard> {
     install_trace_context_propagator();
 
@@ -63,7 +73,11 @@ pub(crate) fn init(default_log_filter: &str) -> Result<TelemetryGuard> {
     if !otlp_enabled_from_env() {
         tracing_subscriber::registry()
             .with(env_filter)
-            .with(fmt::layer().with_writer(std::io::stderr))
+            .with(
+                fmt::layer()
+                    .with_writer(std::io::stderr)
+                    .with_filter(log_rate_ceiling()),
+            )
             .try_init()
             .context("initializing tracing subscriber")?;
         return Ok(TelemetryGuard {
@@ -81,7 +95,11 @@ pub(crate) fn init(default_log_filter: &str) -> Result<TelemetryGuard> {
 
     tracing_subscriber::registry()
         .with(env_filter)
-        .with(fmt::layer().with_writer(std::io::stderr))
+        .with(
+            fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_filter(log_rate_ceiling()),
+        )
         .with(tracing_opentelemetry::layer().with_tracer(tracer))
         .try_init()
         .context("initializing tracing subscriber")?;

--- a/crates/defra-agent-desktop/Cargo.toml
+++ b/crates/defra-agent-desktop/Cargo.toml
@@ -9,6 +9,7 @@ description = "Compatibility launcher for the Tauri defra-agent desktop"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+defra-agent = { path = "../defra-agent" }
 defra-agent-desktop-core.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/crates/defra-agent-desktop/src/main.rs
+++ b/crates/defra-agent-desktop/src/main.rs
@@ -232,7 +232,12 @@ fn init_tracing() {
                 .with_writer(std::io::stderr)
                 .with_target(false)
                 .compact()
-                .without_time(),
+                .without_time()
+                // Per-callsite log-rate ceiling: no code path may flood the
+                // host journal, however hot its failure loop (#588).
+                .with_filter(defra_agent::log_rate::RateLimitFilter::new(
+                    defra_agent::log_rate::RateLimitConfig::default(),
+                )),
         )
         .try_init();
 

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -45,6 +45,7 @@ tokio.workspace = true
 toml.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true
+tracing-subscriber.workspace = true
 uuid.workspace = true
 rig-core.workspace = true
 reqwest.workspace = true
@@ -72,4 +73,3 @@ proptest = "1"
 agent-tool-call-lifecycle-v1-to-v2-lens = { path = "../defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2", default-features = false }
 defra-agent-lean-contract.workspace = true
 jsonschema = { version = "0.46.5", default-features = false }
-tracing-subscriber.workspace = true

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -45,6 +45,7 @@ pub(crate) mod test_support {
 }
 pub mod lifecycle;
 pub mod llm;
+pub mod log_rate;
 pub(crate) mod managed_exec;
 pub mod mcp_pool;
 pub mod meta_tools;

--- a/crates/defra-agent/src/log_rate.rs
+++ b/crates/defra-agent/src/log_rate.rs
@@ -1,0 +1,398 @@
+//! Process-wide log-rate ceiling.
+//!
+//! Guardrail for the incident class in #588: a single hot code path emitted
+//! unthrottled `WARN` events at ~350k lines/sec, saturating journald, CPU,
+//! and IO until the host wedged. No individual callsite should be able to
+//! flood the host journal, whatever its cause.
+//!
+//! [`CallsiteRateLimiter`] is the pure, deterministic core: a per-callsite
+//! fixed-window counter that admits up to `max_per_window` events per window
+//! and reports how many were suppressed when a new window opens.
+//! [`RateLimitFilter`] adapts it as a `tracing_subscriber` per-layer filter:
+//! suppression is never silent — when the next event from a suppressed
+//! callsite is admitted in a later window, a summary event reports the
+//! suppressed count. A callsite that goes permanently quiet after a
+//! suppressed stretch never flushes its final tail count; that is deliberate
+//! — its first `max_per_window` events of the window were already logged,
+//! and a quiet callsite is no longer a threat to the host.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use tracing_subscriber::layer::{Context, Filter};
+
+/// Target used for suppression summary events. Exempt from rate limiting so
+/// the summaries themselves can never recurse into suppression.
+pub const SUMMARY_TARGET: &str = "defra_agent::log_rate";
+
+/// Configuration for the per-callsite log-rate ceiling.
+#[derive(Debug, Clone, Copy)]
+pub struct RateLimitConfig {
+    /// Maximum events admitted per callsite within one window.
+    pub max_per_window: u32,
+    /// Length of the fixed window.
+    pub window: Duration,
+}
+
+impl Default for RateLimitConfig {
+    /// 100 events per second per callsite: far above any legitimate logging
+    /// pattern, three orders of magnitude below the #588 flood.
+    fn default() -> Self {
+        Self {
+            max_per_window: 100,
+            window: Duration::from_secs(1),
+        }
+    }
+}
+
+/// Outcome of admitting one event through the limiter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Decision {
+    /// Admit the event.
+    Allow,
+    /// Admit the event, and report that `suppressed` events were dropped at
+    /// this callsite since the last admitted one.
+    AllowWithSummary { suppressed: u64 },
+    /// Drop the event.
+    Suppress,
+}
+
+/// Deterministic fixed-window rate limiter keyed by callsite.
+#[derive(Debug)]
+pub struct CallsiteRateLimiter<K> {
+    config: RateLimitConfig,
+    states: HashMap<K, CallsiteState>,
+}
+
+#[derive(Debug)]
+struct CallsiteState {
+    window_start: Instant,
+    admitted_in_window: u32,
+    suppressed: u64,
+}
+
+impl<K: Eq + Hash> CallsiteRateLimiter<K> {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self {
+            config,
+            states: HashMap::new(),
+        }
+    }
+
+    /// Records one event at `key` observed at `now` and decides its fate.
+    pub fn check(&mut self, key: K, now: Instant) -> Decision {
+        let state = self.states.entry(key).or_insert(CallsiteState {
+            window_start: now,
+            admitted_in_window: 0,
+            suppressed: 0,
+        });
+
+        if now.saturating_duration_since(state.window_start) >= self.config.window {
+            let suppressed = state.suppressed;
+            state.window_start = now;
+            state.admitted_in_window = 1;
+            state.suppressed = 0;
+            return if suppressed > 0 {
+                Decision::AllowWithSummary { suppressed }
+            } else {
+                Decision::Allow
+            };
+        }
+
+        if state.admitted_in_window < self.config.max_per_window {
+            state.admitted_in_window += 1;
+            Decision::Allow
+        } else {
+            state.suppressed += 1;
+            Decision::Suppress
+        }
+    }
+}
+
+/// `tracing_subscriber` per-layer filter enforcing the ceiling on events.
+///
+/// Spans always pass; only events are rate-limited. When a suppressed
+/// stretch ends, a `WARN` summary event on [`SUMMARY_TARGET`] reports the
+/// suppressed count and the affected target, so suppression is observable.
+///
+/// Summaries cannot be emitted inline: `tracing` drops events dispatched
+/// while another dispatch is in progress on the same thread (the dispatcher
+/// thread-local is re-entrancy guarded), so a summary emitted from within
+/// `Filter::enabled` would vanish. A dedicated summariser thread emits them
+/// through the process-global dispatcher instead. Consequence: summaries are
+/// only visible on the global subscriber — which is how every production
+/// binary initializes telemetry — not on thread-scoped test subscribers.
+pub struct RateLimitFilter {
+    limiter: Mutex<CallsiteRateLimiter<tracing::callsite::Identifier>>,
+    now: fn() -> Instant,
+    summaries: std::sync::mpsc::Sender<SuppressionSummary>,
+}
+
+struct SuppressionSummary {
+    suppressed: u64,
+    original_target: String,
+}
+
+impl RateLimitFilter {
+    pub fn new(config: RateLimitConfig) -> Self {
+        Self::with_clock(config, Instant::now)
+    }
+
+    /// Test seam: inject a controllable clock.
+    pub fn with_clock(config: RateLimitConfig, now: fn() -> Instant) -> Self {
+        let (summaries, rx) = std::sync::mpsc::channel::<SuppressionSummary>();
+        std::thread::Builder::new()
+            .name("log-rate-summaries".into())
+            .spawn(move || {
+                // Exits when the owning filter (the sender) is dropped. This
+                // thread never has a scoped dispatcher, so the event goes to
+                // the global default.
+                for summary in rx {
+                    tracing::warn!(
+                        target: SUMMARY_TARGET,
+                        suppressed = summary.suppressed,
+                        original_target = %summary.original_target,
+                        "rate limiter suppressed repeated log events from one callsite"
+                    );
+                }
+            })
+            .expect("spawning log-rate summariser thread");
+        Self {
+            limiter: Mutex::new(CallsiteRateLimiter::new(config)),
+            now,
+            summaries,
+        }
+    }
+
+    fn check(&self, meta: &tracing::Metadata<'_>) -> Decision {
+        self.limiter
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .check(meta.callsite(), (self.now)())
+    }
+}
+
+impl<S: tracing::Subscriber> Filter<S> for RateLimitFilter {
+    fn enabled(&self, meta: &tracing::Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+        // Spans always pass: only event volume floods the journal, and span
+        // metadata is what makes the admitted events diagnosable.
+        if !meta.is_event() || meta.target() == SUMMARY_TARGET {
+            return true;
+        }
+
+        match self.check(meta) {
+            Decision::Allow => true,
+            Decision::AllowWithSummary { suppressed } => {
+                // A dead summariser thread only costs the summary, never the
+                // event.
+                let _ = self.summaries.send(SuppressionSummary {
+                    suppressed,
+                    original_target: meta.target().to_string(),
+                });
+                true
+            }
+            Decision::Suppress => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(max_per_window: u32, window_secs: u64) -> RateLimitConfig {
+        RateLimitConfig {
+            max_per_window,
+            window: Duration::from_secs(window_secs),
+        }
+    }
+
+    #[test]
+    fn admits_events_under_the_window_limit() {
+        let mut limiter = CallsiteRateLimiter::new(config(3, 10));
+        let start = Instant::now();
+
+        for i in 0..3 {
+            assert_eq!(
+                limiter.check("site-a", start + Duration::from_millis(i)),
+                Decision::Allow,
+                "event {i} should be admitted"
+            );
+        }
+    }
+
+    #[test]
+    fn suppresses_events_over_the_window_limit() {
+        let mut limiter = CallsiteRateLimiter::new(config(2, 10));
+        let start = Instant::now();
+
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+    }
+
+    #[test]
+    fn reports_suppressed_count_when_a_new_window_opens() {
+        let mut limiter = CallsiteRateLimiter::new(config(1, 10));
+        let start = Instant::now();
+
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+
+        assert_eq!(
+            limiter.check("site-a", start + Duration::from_secs(11)),
+            Decision::AllowWithSummary { suppressed: 2 }
+        );
+    }
+
+    #[test]
+    fn rollover_without_suppression_is_a_plain_allow() {
+        let mut limiter = CallsiteRateLimiter::new(config(2, 10));
+        let start = Instant::now();
+
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(
+            limiter.check("site-a", start + Duration::from_secs(11)),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn suppressed_count_resets_after_being_reported() {
+        let mut limiter = CallsiteRateLimiter::new(config(1, 10));
+        let start = Instant::now();
+
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+        assert_eq!(
+            limiter.check("site-a", start + Duration::from_secs(11)),
+            Decision::AllowWithSummary { suppressed: 1 }
+        );
+
+        // Next rollover with no interim suppression reports nothing.
+        assert_eq!(
+            limiter.check("site-a", start + Duration::from_secs(22)),
+            Decision::Allow
+        );
+    }
+
+    #[test]
+    fn callsites_are_limited_independently() {
+        let mut limiter = CallsiteRateLimiter::new(config(1, 10));
+        let start = Instant::now();
+
+        assert_eq!(limiter.check("site-a", start), Decision::Allow);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+        assert_eq!(limiter.check("site-b", start), Decision::Allow);
+        assert_eq!(limiter.check("site-b", start), Decision::Suppress);
+        assert_eq!(limiter.check("site-a", start), Decision::Suppress);
+    }
+
+    #[test]
+    fn flood_within_one_window_admits_exactly_the_limit() {
+        let mut limiter = CallsiteRateLimiter::new(config(100, 1));
+        let start = Instant::now();
+
+        let admitted = (0..350_000)
+            .filter(|_| limiter.check("hot-loop", start) != Decision::Suppress)
+            .count();
+
+        assert_eq!(admitted, 100);
+    }
+
+    mod filter {
+        use std::io;
+        use std::sync::atomic::{AtomicU64, Ordering};
+        use std::sync::{Arc, Mutex, OnceLock};
+
+        use tracing_subscriber::fmt::MakeWriter;
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::Layer;
+
+        use super::*;
+
+        /// Controllable clock for [`RateLimitFilter::with_clock`]: a fixed
+        /// base instant plus a test-adjustable millisecond offset.
+        static CLOCK_BASE: OnceLock<Instant> = OnceLock::new();
+        static CLOCK_OFFSET_MS: AtomicU64 = AtomicU64::new(0);
+
+        fn test_clock() -> Instant {
+            *CLOCK_BASE.get_or_init(Instant::now)
+                + Duration::from_millis(CLOCK_OFFSET_MS.load(Ordering::SeqCst))
+        }
+
+        #[derive(Clone, Default)]
+        struct CapturedOutput(Arc<Mutex<Vec<u8>>>);
+
+        impl CapturedOutput {
+            fn lines(&self) -> Vec<String> {
+                String::from_utf8(self.0.lock().expect("capture lock").clone())
+                    .expect("utf8 log output")
+                    .lines()
+                    .map(str::to_string)
+                    .collect()
+            }
+        }
+
+        impl io::Write for CapturedOutput {
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.0.lock().expect("capture lock").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        impl<'a> MakeWriter<'a> for CapturedOutput {
+            type Writer = CapturedOutput;
+
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        // The flood-cap + suppression-summary end-to-end test lives in
+        // `tests/log_rate_filter.rs`: summaries are emitted through the
+        // process-global dispatcher, which a `--lib` test cannot install
+        // without leaking into every other test in the binary.
+
+        #[test]
+        fn filter_passes_spans_through_untouched() {
+            let output = CapturedOutput::default();
+            let filter = RateLimitFilter::with_clock(
+                RateLimitConfig {
+                    max_per_window: 1,
+                    window: Duration::from_secs(60),
+                },
+                test_clock,
+            );
+            let subscriber = tracing_subscriber::registry().with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(output.clone())
+                    .with_ansi(false)
+                    .with_filter(filter),
+            );
+
+            tracing::subscriber::with_default(subscriber, || {
+                for i in 0..10 {
+                    let span = tracing::info_span!("loop_span", i);
+                    let _guard = span.enter();
+                    tracing::info!(i, "span-scoped event");
+                }
+            });
+
+            let lines = output.lines();
+            let event_lines = lines
+                .iter()
+                .filter(|l| l.contains("span-scoped event"))
+                .count();
+            assert_eq!(event_lines, 1, "events are rate limited even inside spans");
+        }
+    }
+}

--- a/crates/defra-agent/tests/log_rate_filter.rs
+++ b/crates/defra-agent/tests/log_rate_filter.rs
@@ -1,0 +1,122 @@
+//! End-to-end test for the log-rate ceiling (#588): a flooding callsite is
+//! capped and the suppressed count is reported via a summary event.
+//!
+//! This lives in its own integration binary because suppression summaries
+//! are emitted through the process-global dispatcher (see
+//! `defra_agent::log_rate`), so the test must own `set_global_default` —
+//! which cannot be done inside the shared `--lib` test binary.
+
+use std::io;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use defra_agent::log_rate::{RateLimitConfig, RateLimitFilter, SUMMARY_TARGET};
+use tracing_subscriber::fmt::MakeWriter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Layer;
+
+/// Controllable clock: a fixed base instant plus a test-adjustable offset.
+static CLOCK_BASE: OnceLock<Instant> = OnceLock::new();
+static CLOCK_OFFSET_MS: AtomicU64 = AtomicU64::new(0);
+
+fn test_clock() -> Instant {
+    *CLOCK_BASE.get_or_init(Instant::now)
+        + Duration::from_millis(CLOCK_OFFSET_MS.load(Ordering::SeqCst))
+}
+
+#[derive(Clone, Default)]
+struct CapturedOutput(Arc<Mutex<Vec<u8>>>);
+
+impl CapturedOutput {
+    fn lines(&self) -> Vec<String> {
+        String::from_utf8(self.0.lock().expect("capture lock").clone())
+            .expect("utf8 log output")
+            .lines()
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+impl io::Write for CapturedOutput {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CapturedOutput {
+    type Writer = CapturedOutput;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+#[test]
+fn filter_caps_a_flood_and_reports_suppression_on_rollover() {
+    let output = CapturedOutput::default();
+    let filter = RateLimitFilter::with_clock(
+        RateLimitConfig {
+            max_per_window: 5,
+            window: Duration::from_secs(60),
+        },
+        test_clock,
+    );
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_writer(output.clone())
+            .with_ansi(false)
+            .with_filter(filter),
+    );
+    tracing::subscriber::set_global_default(subscriber).expect("sole global subscriber");
+
+    // 1000 events in one window, then one more from the same callsite in a
+    // fresh window: that first admitted event triggers the suppression
+    // summary (emitted asynchronously from the summariser thread).
+    for i in 0..=1_000 {
+        if i == 1_000 {
+            CLOCK_OFFSET_MS.fetch_add(61_000, Ordering::SeqCst);
+        }
+        tracing::warn!(i, "hot loop event");
+    }
+
+    let lines = output.lines();
+    let hot_lines = lines
+        .iter()
+        .filter(|l| l.contains("hot loop event"))
+        .count();
+    assert_eq!(
+        hot_lines, 6,
+        "the window limit plus the one post-rollover event"
+    );
+    assert!(
+        lines.iter().any(|l| l.contains("i=1000")),
+        "post-rollover event should be admitted"
+    );
+
+    // The summary arrives asynchronously; wait for it, bounded.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let summary_seen = loop {
+        if output
+            .lines()
+            .iter()
+            .any(|l| l.contains(SUMMARY_TARGET) && l.contains("suppressed=995"))
+        {
+            break true;
+        }
+        if Instant::now() > deadline {
+            break false;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    };
+    assert!(
+        summary_seen,
+        "suppression summary missing or wrong: {:#?}",
+        output.lines()
+    );
+}


### PR DESCRIPTION
## Incident

A `defra-agent server` steward busy-looped in iroh's relay `open_path` connect path against an unreachable relay, emitting **unthrottled WARN lines at ~350k/sec** — journald + CPU/IO saturation starved every co-located service and wedged `workstation-1` for ~9h (physical power cycle to recover). See #588.

## Root cause

Upstream **iroh 1.0.0-rc.0**, pinned transitively via defradb.rs v0.15.1:

1. `RelayMode::Default` in the rc resolves to n0 **canary** relay infrastructure (`*.relay.n0.iroh-canary.iroh.link`) — expected-unstable, exactly the trigger. Fixed in iroh 1.0.0 (n0-computer/iroh#4341).
2. The `open_path` retry path logs a WARN per attempt with **no backoff** once path-opening fails (`MaxPathIdReached` fell through to an unthrottled `warn!`), re-triggered per path event per connection — n0-computer/iroh#4124, with a WARN-level `#[instrument]` span compounding it. Fixed in iroh 1.0.1 (backoff branch + spans capped at info, n0-computer/iroh#4375).

## Fix (three layers)

**1. The hot loop itself — repin to iroh 1.0.1 (where the fix lives).**
defradb.rs main just merged the iroh 1.0 stable bump (sourcenetwork/defradb.rs#1084); this PR repins the workspace from the v0.15.1 tag to that rev (`84fa8008`), picking up production relay defaults, rescheduled-with-backoff `MaxPathIdReached`, and info-capped spans. A pure lockfile bump was impossible from here: iroh-blobs 0.101.0 exact-pins `iroh = "=1.0.0-rc.0"`, so the companion crates had to move together upstream. Comment in `Cargo.toml` says to move to the next upstream tag when cut. (sourcenetwork/defradb.rs#1082 adds a relay-set startup log at the endpoint seam upstream.)

**2. The trigger class — relay-default validation fence (`defra-agent-cli/src/p2p_relay.rs`).**
`serve` now logs the resolved relay URL set at startup and WARNs if it contains canary/staging endpoints. A **tripwire test** (`pinned_iroh_default_relay_set_is_production`) fails the suite if the iroh pin ever regresses to a pre-release default relay set — the canary default was invisible until it took a host down. (The tripwire was verified against the incident's exact canary hostname in the classifier unit test; the composed test now passes on the 1.0.1 pin.)

**3. The damage class — process-wide log-rate ceiling (`defra-agent/src/log_rate.rs`).**
Per-callsite fixed-window rate limiter (default **100 events/sec/callsite**) applied as a `tracing_subscriber` per-layer filter to every fmt output layer: CLI server telemetry, desktop launcher, and Tauri desktop (stderr + log file). Properties:
- Suppression is never silent: when a suppressed callsite's next event is admitted in a later window, a WARN summary on `defra_agent::log_rate` reports the suppressed count (995 of 1000 in the e2e test). Failures stay visible as state transitions + bounded summaries, per the acceptance criteria.
- Spans always pass — only event volume floods a journal, and span context is what makes admitted events diagnosable.
- Summaries are emitted from a dedicated thread via the global dispatcher, because tracing drops events dispatched from inside a filter pass (re-entrancy guard) — discovered by the failing test, documented in the module.
- The deterministic core (`CallsiteRateLimiter`) is pure with an injected clock; 7 unit tests + a spans passthrough test + an end-to-end flood test in its own integration binary (it must own `set_global_default`).

At the incident's 350k WARN/sec, the ceiling caps output at ~101 lines/sec/callsite — three orders of magnitude below journald pressure, while iroh 1.0.1 removes the loop itself.

## Verification

- `cargo test -p defra-agent` — 882 lib + all integration binaries green at the new pin (exit 0)
- `cargo test -p defra-agent-cli` — 405 bin tests + all integration targets green (exit 0)
- `cargo check --all-targets` on desktop launcher + Tauri app green; clippy + fmt clean on all touched crates
- Upstream defradb.rs#1084 merged with their CI green; #1082 (relay startup log) slimmed and rebased on top

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)