### PR TITLE
fix(desktop): external links open in OS browser; in-app delete confirmation

### DIFF
--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { ChatWorkspace } from "./components/ChatWorkspace";
 import { CodeContextHeader } from "./components/code/CodeContextHeader";
@@ -6,10 +6,15 @@ import { ConfigWorkspace } from "./components/ConfigWorkspace";
 import { FleetDashboard } from "./components/fleet/FleetDashboard";
 import { Sidebar } from "./components/Sidebar";
 import { useDesktopShell } from "./hooks/useDesktopShell";
+import { installExternalLinkGuard } from "./lib/externalLinks";
 import "./App.css";
 
 function App() {
   const shell = useDesktopShell();
+
+  // External links (e.g. markdown links in the transcript) must open in the
+  // OS browser — an unguarded anchor click navigates the whole webview away.
+  useEffect(() => installExternalLinkGuard(document), []);
   const [workspaceView, setWorkspaceView] = useState<
     "fleet" | "chat" | "config" | "code"
   >("fleet");

--- a/apps/desktop-tauri/src/components/ConfirmDialog.tsx
+++ b/apps/desktop-tauri/src/components/ConfirmDialog.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+/// In-app confirmation dialog. Native `window.confirm`/`alert` are dead in
+/// the packaged app (wry's WKWebView has no JS-dialog delegate and resolves
+/// confirm() to false without showing anything) — always use this instead.
+export type ConfirmDialogProps = {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  danger?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  danger = false,
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (open) cancelRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="dialog-backdrop open"
+      role="presentation"
+      onClick={onCancel}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          onCancel();
+        }
+      }}
+    >
+      <div
+        className="dialog confirm-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-dialog-title"
+        data-testid="confirm-dialog"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header>
+          <h3 id="confirm-dialog-title">{title}</h3>
+        </header>
+        <div className="body">
+          <p>{message}</p>
+        </div>
+        <footer className="confirm-dialog-actions">
+          <button
+            className="btn btn-ghost"
+            data-testid="confirm-dialog-cancel"
+            ref={cancelRef}
+            type="button"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            className={danger ? "btn btn-danger" : "btn"}
+            data-testid="confirm-dialog-confirm"
+            type="button"
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop-tauri/src/components/ConfirmDialog.tsx
+++ b/apps/desktop-tauri/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type KeyboardEvent } from "react";
 
 /// In-app confirmation dialog. Native `window.confirm`/`alert` are dead in
 /// the packaged app (wry's WKWebView has no JS-dialog delegate and resolves
@@ -25,32 +25,58 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   const cancelRef = useRef<HTMLButtonElement | null>(null);
+  const dialogRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (open) cancelRef.current?.focus();
   }, [open]);
 
+  // ESC handler — document-level while open, so it works no matter where
+  // focus has landed (same pattern as CascadeCancelDialog).
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onCancel]);
+
   if (!open) return null;
 
+  // Tab trap: aria-modal promises inertness, so keep focus cycling inside
+  // the dialog instead of escaping into the (visually hidden) page.
+  function onDialogKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Tab" || !dialogRef.current) return;
+    const focusables = Array.from(
+      dialogRef.current.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), a[href], select, input:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      ),
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const active = document.activeElement;
+    if (event.shiftKey && active === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  }
+
   return (
-    <div
-      className="dialog-backdrop open"
-      role="presentation"
-      onClick={onCancel}
-      onKeyDown={(event) => {
-        if (event.key === "Escape") {
-          event.stopPropagation();
-          onCancel();
-        }
-      }}
-    >
+    <div className="dialog-backdrop open" role="presentation" onClick={onCancel}>
       <div
         className="dialog confirm-dialog"
         role="dialog"
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"
         data-testid="confirm-dialog"
+        ref={dialogRef}
         onClick={(event) => event.stopPropagation()}
+        onKeyDown={onDialogKeyDown}
       >
         <header>
           <h3 id="confirm-dialog-title">{title}</h3>

--- a/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
@@ -7,6 +7,7 @@ import type {
   SkillSaveRequest,
   SkillView,
 } from "../../lib/types";
+import { ConfirmDialog } from "../ConfirmDialog";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import { ignoreHandledActionError, linesToArray, optionalString } from "./formUtils";
 
@@ -108,6 +109,7 @@ export function SkillConfigEditor({
   const [toolRefs, setToolRefs] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [enabled, setEnabled] = useState(true);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   useEffect(() => {
     setSkillId(skill?.skillId ?? "");
@@ -141,15 +143,18 @@ export function SkillConfigEditor({
     }
   }
 
-  async function deleteSkill() {
+  function requestDeleteSkill() {
     const nextId = skill?.skillId ?? skillId.trim();
     if (!skill || !nextId) {
       return;
     }
-    const confirmed = window.confirm(
-      `Delete skill "${nextId}" and remove it from behavior bindings?`,
-    );
-    if (!confirmed) {
+    setConfirmingDelete(true);
+  }
+
+  async function deleteSkill() {
+    const nextId = skill?.skillId ?? skillId.trim();
+    setConfirmingDelete(false);
+    if (!skill || !nextId) {
       return;
     }
     try {
@@ -256,12 +261,23 @@ export function SkillConfigEditor({
             className="ghost-button danger-button"
             data-testid="skill-delete"
             disabled={saving}
-            onClick={deleteSkill}
+            onClick={requestDeleteSkill}
             type="button"
           >
             Delete Skill
           </button>
         ) : null}
+        <ConfirmDialog
+          open={confirmingDelete}
+          title="Delete skill"
+          message={`Delete skill "${skill?.skillId ?? skillId.trim()}" and remove it from behavior bindings?`}
+          confirmLabel="Delete Skill"
+          danger
+          onConfirm={() => {
+            void deleteSkill();
+          }}
+          onCancel={() => setConfirmingDelete(false)}
+        />
         <button
           className="primary-button"
           data-testid="skill-save"

--- a/apps/desktop-tauri/src/lib/externalLinks.ts
+++ b/apps/desktop-tauri/src/lib/externalLinks.ts
@@ -1,0 +1,51 @@
+/// External-link handling for the desktop webview.
+///
+/// In Tauri 2's WKWebView a plain `<a href="https://...">` click performs an
+/// in-place navigation that replaces the entire app UI with no way back.
+/// A document-level guard intercepts anchor clicks and routes external URLs
+/// to the OS default browser (opener plugin under Tauri, window.open in
+/// plain browsers like the Playwright harness).
+
+const EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const ABSOLUTE_URL = /^[a-z][a-z0-9+.-]*:/i;
+
+export function isExternalUrl(href: string): boolean {
+  if (!ABSOLUTE_URL.test(href)) return false;
+  try {
+    return EXTERNAL_PROTOCOLS.has(new URL(href).protocol);
+  } catch {
+    return false;
+  }
+}
+
+export async function openExternalUrl(url: string): Promise<void> {
+  if (typeof window !== "undefined" && "__TAURI_INTERNALS__" in window) {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl(url);
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
+/// Document-level click guard. Anchors pointing at external URLs open in the
+/// OS browser; any other anchor navigation (relative hrefs, unknown schemes)
+/// is suppressed — in-place navigation replaces the entire app UI. Pure hash
+/// anchors and already-handled clicks are left alone.
+export function handleExternalLinkClick(event: MouseEvent): void {
+  if (event.defaultPrevented) return;
+  const target = event.target as Element | null;
+  const anchor = target?.closest?.("a[href]");
+  if (!anchor) return;
+  const href = anchor.getAttribute("href");
+  if (!href || href.startsWith("#")) return;
+  event.preventDefault();
+  if (isExternalUrl(href)) {
+    void openExternalUrl(href);
+  }
+}
+
+export function installExternalLinkGuard(doc: Document): () => void {
+  const listener = (event: MouseEvent) => handleExternalLinkClick(event);
+  doc.addEventListener("click", listener);
+  return () => doc.removeEventListener("click", listener);
+}

--- a/apps/desktop-tauri/src/lib/externalLinks.ts
+++ b/apps/desktop-tauri/src/lib/externalLinks.ts
@@ -37,7 +37,10 @@ export function handleExternalLinkClick(event: MouseEvent): void {
   const anchor = target?.closest?.("a[href]");
   if (!anchor) return;
   const href = anchor.getAttribute("href");
-  if (!href || href.startsWith("#")) return;
+  if (href === null || href.startsWith("#")) return;
+  // Empty hrefs are suppressed too: markdown sanitizers rewrite hostile
+  // schemes (javascript:, data:) to href="", whose default click action
+  // reloads the whole document.
   event.preventDefault();
   if (isExternalUrl(href)) {
     void openExternalUrl(href);
@@ -46,6 +49,8 @@ export function handleExternalLinkClick(event: MouseEvent): void {
 
 export function installExternalLinkGuard(doc: Document): () => void {
   const listener = (event: MouseEvent) => handleExternalLinkClick(event);
-  doc.addEventListener("click", listener);
-  return () => doc.removeEventListener("click", listener);
+  // Capture phase: a component-level stopPropagation() must not be able to
+  // switch this guard off — it is the navigation boundary for agent output.
+  doc.addEventListener("click", listener, { capture: true });
+  return () => doc.removeEventListener("click", listener, { capture: true });
 }

--- a/apps/desktop-tauri/tests/external-links.test.ts
+++ b/apps/desktop-tauri/tests/external-links.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  handleExternalLinkClick,
+  installExternalLinkGuard,
+  isExternalUrl,
+} from "../src/lib/externalLinks";
+
+function clickAnchor(href: string): MouseEvent {
+  const anchor = document.createElement("a");
+  anchor.setAttribute("href", href);
+  anchor.textContent = "link";
+  document.body.appendChild(anchor);
+  const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+  anchor.dispatchEvent(event);
+  return event;
+}
+
+describe("external link guard", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("classifies URLs", () => {
+    expect(isExternalUrl("https://example.com")).toBe(true);
+    expect(isExternalUrl("http://example.com")).toBe(true);
+    expect(isExternalUrl("mailto:a@b.c")).toBe(true);
+    expect(isExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(isExternalUrl("docs/relative")).toBe(false);
+  });
+
+  it("suppresses navigation for relative and unknown-scheme anchors", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const uninstall = installExternalLinkGuard(document);
+
+    const event = clickAnchor("docs/relative");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openSpy).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it("prevents webview navigation and opens external links in the browser", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const uninstall = installExternalLinkGuard(document);
+
+    const event = clickAnchor("https://example.com/docs");
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/docs",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    uninstall();
+  });
+
+  it("leaves hash anchors and already-handled clicks alone", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const hashEvent = clickAnchor("#section");
+    handleExternalLinkClick(hashEvent as unknown as MouseEvent);
+    expect(hashEvent.defaultPrevented).toBe(false);
+
+    const handled = clickAnchor("https://example.com");
+    handled.preventDefault();
+    handleExternalLinkClick(handled as unknown as MouseEvent);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop-tauri/tests/external-links.test.ts
+++ b/apps/desktop-tauri/tests/external-links.test.ts
@@ -68,4 +68,57 @@ describe("external link guard", () => {
     handleExternalLinkClick(handled as unknown as MouseEvent);
     expect(openSpy).not.toHaveBeenCalled();
   });
+
+  it("suppresses hostile schemes and scheme-relative URLs without opening them", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const uninstall = installExternalLinkGuard(document);
+
+    for (const href of [
+      "javascript:alert(1)",
+      "data:text/html,<script>1</script>",
+      "file:///etc/passwd",
+      "//evil.example.com/x",
+    ]) {
+      const event = clickAnchor(href);
+      expect(event.defaultPrevented, href).toBe(true);
+    }
+    expect(openSpy).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it('suppresses empty hrefs (markdown sanitizers rewrite hostile links to href="")', () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const uninstall = installExternalLinkGuard(document);
+
+    const event = clickAnchor("");
+
+    // Default action of <a href=""> is a full document reload — must not run.
+    expect(event.defaultPrevented).toBe(true);
+    expect(openSpy).not.toHaveBeenCalled();
+    uninstall();
+  });
+
+  it("is not bypassed by a component-level stopPropagation", () => {
+    const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+    const uninstall = installExternalLinkGuard(document);
+
+    const wrapper = document.createElement("div");
+    // Bubble-phase swallow, as React components do (e.g. dialog click guards).
+    wrapper.addEventListener("click", (event) => event.stopPropagation());
+    const anchor = document.createElement("a");
+    anchor.setAttribute("href", "https://example.com/docs");
+    wrapper.appendChild(anchor);
+    document.body.appendChild(wrapper);
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    anchor.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/docs",
+      "_blank",
+      "noopener,noreferrer",
+    );
+    uninstall();
+  });
 });

--- a/apps/desktop-tauri/tests/skill-config-delete.test.tsx
+++ b/apps/desktop-tauri/tests/skill-config-delete.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SkillConfigPanel } from "../src/components/config";
+import type { DeploymentView } from "../src/lib/types";
+
+const deployment: DeploymentView = {
+  deploymentId: "dep-1",
+  agentDid: "did:test:operator",
+  displayName: "test",
+  defaultBehaviorId: "default",
+  behaviors: [{ behaviorId: "default", displayName: "default" }],
+  conversations: [],
+  process: null,
+  runtime: null,
+  inbox: { hasUnread: false, count: 0 },
+  skills: [
+    {
+      skillId: "review-skill",
+      name: "Review",
+      instructions: "review things",
+      toolRefs: [],
+      scope: "behavior",
+      enabled: true,
+    },
+  ],
+};
+
+function renderPanel(overrides: { onDeleteSkillConfig?: ReturnType<typeof vi.fn> }) {
+  const onDeleteSkillConfig = overrides.onDeleteSkillConfig ?? vi.fn();
+  const onDeletedSkill = vi.fn();
+  render(
+    <SkillConfigPanel
+      deployment={deployment}
+      selectedSkillId="review-skill"
+      saving={false}
+      savedStatus={null}
+      onSelectSkill={vi.fn()}
+      onCreateSkill={vi.fn()}
+      onDeletedSkill={onDeletedSkill}
+      onSavedStatusChange={vi.fn()}
+      onDeleteSkillConfig={onDeleteSkillConfig}
+      onSaveSkillConfig={vi.fn()}
+    />,
+  );
+  return { onDeleteSkillConfig, onDeletedSkill };
+}
+
+describe("SkillConfigPanel delete confirmation", () => {
+  it("opens the in-app confirm dialog instead of window.confirm and deletes on confirm", async () => {
+    const onDeleteSkillConfig = vi.fn().mockResolvedValue(undefined);
+    const confirmSpy = vi.spyOn(window, "confirm");
+    const { onDeletedSkill } = renderPanel({ onDeleteSkillConfig });
+
+    fireEvent.click(screen.getByTestId("skill-delete"));
+
+    expect(screen.getByTestId("confirm-dialog")).toBeInTheDocument();
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByTestId("confirm-dialog-confirm"));
+
+    await waitFor(() =>
+      expect(onDeleteSkillConfig).toHaveBeenCalledWith({
+        skillId: "review-skill",
+        agentDid: "did:test:operator",
+      }),
+    );
+    await waitFor(() => expect(onDeletedSkill).toHaveBeenCalled());
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+
+  it("does not delete when the dialog is cancelled", () => {
+    const onDeleteSkillConfig = vi.fn();
+    renderPanel({ onDeleteSkillConfig });
+
+    fireEvent.click(screen.getByTestId("skill-delete"));
+    fireEvent.click(screen.getByTestId("confirm-dialog-cancel"));
+
+    expect(onDeleteSkillConfig).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("confirm-dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Second WS1 slice of #608:

- **External links**: a document-level guard routes absolute http(s)/mailto anchor clicks to the OS browser (opener plugin under Tauri, `window.open` in plain browsers) and suppresses any other anchor navigation — a bare markdown link click previously replaced the whole webview UI with no way back.
- **Delete Skill**: replaced `window.confirm` (always returns false under wry's WKWebView — the button silently no-oped in the packaged app) with a reusable in-app `ConfirmDialog` built on the existing dialog styles.

Fences: `external-links.test.ts` (guard policy incl. relative/unknown schemes), `skill-config-delete.test.tsx` (dialog flow, confirms `window.confirm` is never called). Unit 164 passed, e2e 120 passed, visual 3×3 passed.

Stacked on #609.