### PR TITLE
fix(desktop): preserve in-progress config edits across snapshot refreshes

### DIFF
--- a/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
@@ -68,7 +68,8 @@ export function AgentConfigEditor({
   useEffect(() => {
     setDisplayName(agent.displayName ?? "");
     setEditingDisplayName(false);
-  }, [agent]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [agent.agentDid]);
 
   const defaultBehaviorId =
     agent.defaultBehaviorId ??

--- a/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
@@ -82,7 +82,9 @@ export function AgentConfigEditor({
     try {
       await onSaveAgentConfig({
         agentDid: agent.agentDid,
-        displayName,
+        // Only an in-progress rename may override the live document value —
+        // a save without one must not resurrect a stale hydration.
+        displayName: editingDisplayName ? displayName : (agent.displayName ?? ""),
         defaultBehaviorId,
         enabled: agent.enabled ?? true,
       });
@@ -107,14 +109,19 @@ export function AgentConfigEditor({
                 value={displayName}
               />
             ) : (
-              <h3>{displayName || "Agent"}</h3>
+              // Live document value: remote renames stay visible while no
+              // edit is in progress.
+              <h3>{agent.displayName || "Agent"}</h3>
             )}
             {!editingDisplayName ? (
               <button
                 aria-label="Edit agent display name"
                 className="ghost-button config-icon-button"
                 data-testid="agent-edit-display-name"
-                onClick={() => setEditingDisplayName(true)}
+                onClick={() => {
+                  setDisplayName(agent.displayName ?? "");
+                  setEditingDisplayName(true);
+                }}
                 title="Edit display name"
                 type="button"
               >

--- a/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
@@ -120,7 +120,8 @@ export function BackendConfigEditor({
       backend?.maxQueueDepth != null ? String(backend.maxQueueDepth) : "",
     );
     setEnabled(backend?.enabled ?? true);
-  }, [backend]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [backend?.backendId]);
 
   const maxConcurrentValid = isOptionalInt(maxConcurrent, { min: 1 });
   const maxQueueDepthValid = isOptionalInt(maxQueueDepth, { min: 1 });

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -155,19 +155,17 @@ export function BehaviorConfigEditor({
   const [skillRefs, setSkillRefs] = useState<string[]>([]);
   const [skillExcludes, setSkillExcludes] = useState<string[]>([]);
 
+  // Sorted like toolServiceIdKey: the joined key must not depend on row order.
+  const profileIdKey = inferenceProfiles
+    .map((p) => p.profileId)
+    .sort()
+    .join("|");
+
   useEffect(() => {
-    const selectedProfileId = behavior?.inferenceProfileId ?? null;
-    let nextProfileId = inferenceProfiles[0]?.profileId ?? "";
-    if (
-      selectedProfileId &&
-      inferenceProfiles.some((profile) => profile.profileId === selectedProfileId)
-    ) {
-      nextProfileId = selectedProfileId;
-    }
     setBehaviorId(behavior?.behaviorId ?? "");
     setSystemPrompt(behavior?.systemPrompt ?? "");
     setBackendId(behavior?.backendId ?? "");
-    setProfileId(nextProfileId);
+    setProfileId(behavior?.inferenceProfileId ?? "");
     setToolSelectionId(behavior?.toolSelectionId ?? "");
     setCompactionStrategy(behavior?.compactionStrategy ?? DEFAULT_COMPACTION_STRATEGY);
     setCompactionThreshold(
@@ -179,9 +177,25 @@ export function BehaviorConfigEditor({
     setDefaultForAgent(behavior?.isDefault ?? false);
     setSkillRefs(behavior?.skillRefs ?? []);
     setSkillExcludes(behavior?.skillExcludes ?? []);
-    // Id-keyed (plus the profile id set for the default-profile fallback):
-    // background snapshot refreshes must not wipe in-progress edits.
-  }, [behavior?.behaviorId, inferenceProfiles.map((p) => p.profileId).join("|")]);
+    // Id-keyed only: background snapshot refreshes (including profile-list
+    // churn) must not wipe in-progress edits.
+  }, [behavior?.behaviorId]);
+
+  // Default-profile fallback in its own effect so profile-set churn never
+  // resets the rest of the form: keep the current pick while it exists,
+  // otherwise fall back to the document's selection, then the first profile.
+  useEffect(() => {
+    setProfileId((current) => {
+      if (current && inferenceProfiles.some((p) => p.profileId === current)) {
+        return current;
+      }
+      const selected = behavior?.inferenceProfileId;
+      if (selected && inferenceProfiles.some((p) => p.profileId === selected)) {
+        return selected;
+      }
+      return inferenceProfiles[0]?.profileId ?? "";
+    });
+  }, [behavior?.behaviorId, profileIdKey]);
 
   const behaviorScopedSkills = skills.filter((skill) => skill.scope === "behavior");
   const principalScopedSkills = skills.filter((skill) => skill.scope === "principal");

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -179,7 +179,9 @@ export function BehaviorConfigEditor({
     setDefaultForAgent(behavior?.isDefault ?? false);
     setSkillRefs(behavior?.skillRefs ?? []);
     setSkillExcludes(behavior?.skillExcludes ?? []);
-  }, [behavior, inferenceProfiles]);
+    // Id-keyed (plus the profile id set for the default-profile fallback):
+    // background snapshot refreshes must not wipe in-progress edits.
+  }, [behavior?.behaviorId, inferenceProfiles.map((p) => p.profileId).join("|")]);
 
   const behaviorScopedSkills = skills.filter((skill) => skill.scope === "behavior");
   const principalScopedSkills = skills.filter((skill) => skill.scope === "principal");

--- a/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
@@ -112,7 +112,8 @@ export function EventTriggerConfigEditor({
     setFilter(eventTrigger?.filter ?? "");
     setEnabled(eventTrigger?.enabled ?? true);
     setConcurrency(eventTrigger?.concurrency ?? "serial");
-  }, [eventTrigger, selectedTask?.taskId]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [eventTrigger?.triggerId, selectedTask?.taskId]);
 
   async function submitEventTrigger(event: FormEvent) {
     event.preventDefault();

--- a/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
@@ -128,7 +128,8 @@ export function InferenceProfileConfigEditor({
     setDeadlineSecs(
       profile?.deadlineDurationSecs != null ? String(profile.deadlineDurationSecs) : "",
     );
-  }, [profile]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [profile?.profileId]);
 
   const contextWindowValid = isOptionalInt(contextWindow, { min: 1 });
   const maxOutputTokensValid = isOptionalInt(maxOutputTokens, { min: 1 });

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -122,7 +122,8 @@ export function ScheduleConfigEditor({
     );
     setEnabled(schedule?.enabled ?? true);
     setConcurrency(schedule?.concurrency ?? "serial");
-  }, [schedule, selectedTask?.taskId]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [schedule?.scheduleId, selectedTask?.taskId]);
 
   useEffect(() => {
     setRunStatus(null);

--- a/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
@@ -120,7 +120,8 @@ export function SkillConfigEditor({
     setToolRefs((skill?.toolRefs ?? []).join("\n"));
     setDisplayName(skill?.displayName ?? "");
     setEnabled(skill?.enabled ?? true);
-  }, [skill]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [skill?.skillId]);
 
   async function submitSkill(event: FormEvent) {
     event.preventDefault();

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -121,7 +121,8 @@ export function TaskConfigEditor({
     setPromptTemplate(task?.promptTemplate ?? "");
     setOutputSchemaRef(task?.outputSchemaRef ?? "");
     setEnabled(task?.enabled ?? true);
-  }, [selectedBehavior?.behaviorId, task]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [selectedBehavior?.behaviorId, task?.taskId]);
 
   useEffect(() => {
     setRunStatus(null);

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -220,7 +220,8 @@ export function ToolSelectionConfigEditor({
         : "",
     );
     setDefraQueryCollections((toolSelection?.defraQueryCollections ?? []).join("\n"));
-  }, [toolSelection, toolServiceIdKey]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [toolSelection?.selectionId, toolServiceIdKey]);
 
   function toggleAllowedMcpService(serviceId: string, checked: boolean) {
     const values = new Set(linesToArray(allowedMcpServiceIds));

--- a/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
@@ -129,7 +129,8 @@ export function ToolServiceConfigEditor({
     setStatus(toolService?.status ?? "online");
     setTestResult(null);
     setTestError(null);
-  }, [toolService]);
+    // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+  }, [toolService?.serviceId]);
 
   const mcpPortValid = isOptionalInt(mcpPort, { min: 1, max: 65535 });
   const serviceAddressPresent = Boolean(

--- a/apps/desktop-tauri/tests/config-edit-preservation.test.tsx
+++ b/apps/desktop-tauri/tests/config-edit-preservation.test.tsx
@@ -1,8 +1,16 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { BackendConfigPanel, SkillConfigPanel } from "../src/components/config";
-import type { DeploymentView } from "../src/lib/types";
+import {
+  BackendConfigPanel,
+  BehaviorConfigEditor,
+  SkillConfigPanel,
+} from "../src/components/config";
+import type {
+  BehaviorView,
+  DeploymentView,
+  InferenceProfileView,
+} from "../src/lib/types";
 
 // Fence for the background-refresh edit wipe: the Tauri bridge emits
 // client-updated on every store/health change, which re-fetches the snapshot
@@ -119,5 +127,58 @@ describe("config editors preserve in-progress edits across snapshot refreshes", 
 
     rerender(<SkillConfigPanel deployment={makeDeployment()} {...props} />);
     expect(screen.getByTestId("skill-name")).toHaveValue("Edited Name");
+  });
+
+  it("behavior editor keeps typed values when the inference-profile set changes", () => {
+    const behavior = (): BehaviorView => ({
+      behaviorId: "default",
+      displayName: "default",
+      systemPrompt: "original prompt",
+      inferenceProfileId: "profile-a",
+      enabled: true,
+      isDefault: true,
+      skillRefs: [],
+      skillExcludes: [],
+    });
+    const profile = (id: string): InferenceProfileView => ({ profileId: id });
+    const editorProps = {
+      agentDisplayName: "test",
+      agentDid: "did:test:operator",
+      agentEnabled: true,
+      currentDefaultBehaviorId: "default",
+      inferenceBackends: [],
+      skills: [],
+      toolSelections: [],
+      saving: false,
+      savedStatus: null,
+      onCreateBackend: vi.fn(),
+      onCreateProfile: vi.fn(),
+      onCreateToolSelection: vi.fn(),
+      onSaved: vi.fn(),
+      onSaveAgentConfig: vi.fn(),
+      onSaveBehaviorConfig: vi.fn(),
+    };
+    const { rerender } = render(
+      <BehaviorConfigEditor
+        {...editorProps}
+        behavior={behavior()}
+        inferenceProfiles={[profile("profile-a")]}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId("behavior-system-prompt"), {
+      target: { value: "edited prompt" },
+    });
+
+    // A remote profile registration must not wipe the in-progress edit; the
+    // valid current profile pick must survive too.
+    rerender(
+      <BehaviorConfigEditor
+        {...editorProps}
+        behavior={behavior()}
+        inferenceProfiles={[profile("profile-a"), profile("profile-b")]}
+      />,
+    );
+    expect(screen.getByTestId("behavior-system-prompt")).toHaveValue("edited prompt");
   });
 });

--- a/apps/desktop-tauri/tests/config-edit-preservation.test.tsx
+++ b/apps/desktop-tauri/tests/config-edit-preservation.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackendConfigPanel, SkillConfigPanel } from "../src/components/config";
+import type { DeploymentView } from "../src/lib/types";
+
+// Fence for the background-refresh edit wipe: the Tauri bridge emits
+// client-updated on every store/health change, which re-fetches the snapshot
+// and produces a fresh object tree. Editors must key their reset effects on
+// the document id, not object identity, or every background event discards
+// in-progress operator edits.
+
+function makeDeployment(): DeploymentView {
+  return {
+    deploymentId: "dep-1",
+    agentDid: "did:test:operator",
+    displayName: "test",
+    defaultBehaviorId: "default",
+    behaviors: [{ behaviorId: "default", displayName: "default" }],
+    conversations: [],
+    process: null,
+    runtime: null,
+    inbox: { hasUnread: false, count: 0 },
+    inferenceBackends: [
+      {
+        backendId: "backend-a",
+        name: "Backend A",
+        providerKind: "openai",
+        endpoint: "http://localhost:1234/v1",
+        models: ["m-1"],
+        enabled: true,
+      },
+      {
+        backendId: "backend-b",
+        name: "Backend B",
+        providerKind: "openai",
+        endpoint: "http://localhost:5678/v1",
+        models: ["m-2"],
+        enabled: true,
+      },
+    ],
+    skills: [
+      {
+        skillId: "review-skill",
+        name: "Review",
+        instructions: "review things",
+        toolRefs: [],
+        scope: "behavior",
+        enabled: true,
+      },
+    ],
+  };
+}
+
+const noopHandlers = {
+  saving: false,
+  savedStatus: null,
+  onSelectBackend: vi.fn(),
+  onCreateBackend: vi.fn(),
+  onSavedStatusChange: vi.fn(),
+  onSaveBackendConfig: vi.fn(),
+};
+
+describe("config editors preserve in-progress edits across snapshot refreshes", () => {
+  it("backend editor keeps typed values when the snapshot object tree is replaced", () => {
+    const { rerender } = render(
+      <BackendConfigPanel
+        deployment={makeDeployment()}
+        selectedBackendId="backend-a"
+        {...noopHandlers}
+      />,
+    );
+
+    const endpoint = screen.getByTestId("backend-endpoint");
+    fireEvent.change(endpoint, { target: { value: "http://edited:9999/v1" } });
+
+    // Background refresh: same data, fresh object identities.
+    rerender(
+      <BackendConfigPanel
+        deployment={makeDeployment()}
+        selectedBackendId="backend-a"
+        {...noopHandlers}
+      />,
+    );
+    expect(screen.getByTestId("backend-endpoint")).toHaveValue("http://edited:9999/v1");
+
+    // Selecting a different document still resets the form.
+    rerender(
+      <BackendConfigPanel
+        deployment={makeDeployment()}
+        selectedBackendId="backend-b"
+        {...noopHandlers}
+      />,
+    );
+    expect(screen.getByTestId("backend-endpoint")).toHaveValue(
+      "http://localhost:5678/v1",
+    );
+  });
+
+  it("skill editor keeps typed values when the snapshot object tree is replaced", () => {
+    const props = {
+      selectedSkillId: "review-skill",
+      saving: false,
+      savedStatus: null,
+      onSelectSkill: vi.fn(),
+      onCreateSkill: vi.fn(),
+      onDeletedSkill: vi.fn(),
+      onSavedStatusChange: vi.fn(),
+      onDeleteSkillConfig: vi.fn(),
+      onSaveSkillConfig: vi.fn(),
+    };
+    const { rerender } = render(
+      <SkillConfigPanel deployment={makeDeployment()} {...props} />,
+    );
+
+    fireEvent.change(screen.getByTestId("skill-name"), {
+      target: { value: "Edited Name" },
+    });
+
+    rerender(<SkillConfigPanel deployment={makeDeployment()} {...props} />);
+    expect(screen.getByTestId("skill-name")).toHaveValue("Edited Name");
+  });
+});


### PR DESCRIPTION
Third WS1 slice of #608. The bridge emits `client-updated` on every store/P2P-health change; the shell re-fetches the snapshot, every config view object gets a fresh identity, and each editor's reset effect re-fired — discarding whatever the operator had typed (any schedule fire, streaming response, or gossip event destroyed mid-edit form state).

All ten config editors now key their reset effects on the document **id** (plus real secondary keys like the selected task id / profile-id set), so forms rehydrate on selection change but survive background refreshes.

Fence: `config-edit-preservation.test.tsx` — typed values survive a full object-tree replacement; switching documents still resets. Unit 166, e2e 120, visual 3×3 green.

Stacked on #610.