### PR TITLE
fix(desktop): honest per-agent facts in fleet rows

### DIFF
--- a/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
@@ -55,6 +55,16 @@ export function FleetDashboard({
   const [peerFormError, setPeerFormError] = useState<string | null>(null);
   const [localRuntimeError, setLocalRuntimeError] = useState<string | null>(null);
   const hasDeployments = deployments.length > 0;
+  // The repair command re-dials the desktop client's P2P connections as a
+  // whole, so it lives here at fleet level — a per-row placement would lie
+  // about its scope. Shown only when something actually needs repairing.
+  const needsP2PRepair =
+    deployments.some(
+      (deployment) => !deployment.dialSucceeded || Boolean(deployment.lastError),
+    ) ||
+    (p2pHealth
+      ? p2pHealth.consecutiveFailures > 0 || Boolean(p2pHealth.lastError)
+      : false);
 
   async function submitPeer(request: PeerAddRequest) {
     setPeerFormError(null);
@@ -125,6 +135,18 @@ export function FleetDashboard({
       <header className="fleet-header">
         <BrandLockup />
         <div className="fleet-header-actions">
+          {needsP2PRepair ? (
+            <button
+              className="ghost-button"
+              data-testid="fleet-repair-p2p"
+              disabled={repairingP2P}
+              onClick={() => void onRepairP2P()}
+              title="Re-dial saved peers and refresh the desktop client's P2P connections"
+              type="button"
+            >
+              {repairingP2P ? "Reconnecting…" : "Reconnect P2P"}
+            </button>
+          ) : null}
           <button
             className="primary-button"
             onClick={() => setShowAddPeer((value) => !value)}
@@ -175,11 +197,8 @@ export function FleetDashboard({
                 bootstrap={bootstrap}
                 deployment={deployment}
                 key={deployment.peerId}
-                p2pHealth={p2pHealth}
-                repairingP2P={repairingP2P}
                 onOpenChat={onOpenChat}
                 onOpenConfig={onOpenConfig}
-                onRepairP2P={onRepairP2P}
               />
             ))}
           </tbody>

--- a/apps/desktop-tauri/src/components/fleet/FleetIcons.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetIcons.tsx
@@ -21,17 +21,6 @@ export function ConfigIcon() {
   );
 }
 
-export function RepairIcon() {
-  return (
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <path d="M20 7h-6v6" />
-      <path d="M20 7l-7 7" />
-      <path d="M4 17h6v-6" />
-      <path d="M4 17l7-7" />
-    </svg>
-  );
-}
-
 export function ToolIconGlyph({ kind }: { kind: ToolIconKind }) {
   if (kind === "file") {
     return (

--- a/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
@@ -111,7 +111,7 @@ export function FleetRow({
       <td>
         <Metric title="Processing conversations" value={openWorkCount} />
       </td>
-      <td title="Last runtime update reported by this agent">
+      <td title="Last runtime state change reported by this agent (agents write this on change, not on a timer — an idle agent ages here without being dead)">
         {formatRelativeTime(runtimeLastUpdate)}
       </td>
       <td className="fleet-actions-cell">

--- a/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
@@ -1,15 +1,16 @@
 import { isTerminalTurnState } from "../../lib/chat-shell";
-import type { BootstrapSummary, DeploymentView, P2PHealth } from "../../lib/types";
+import type { BootstrapSummary, DeploymentView } from "../../lib/types";
 import {
   displayAgentIdentity,
   displayBehaviorLabel,
   displayGraphqlEndpoint,
 } from "../../lib/types";
-import { ChatIcon, ConfigIcon, RepairIcon, ToolIconGlyph } from "./FleetIcons";
+import { ChatIcon, ConfigIcon, ToolIconGlyph } from "./FleetIcons";
 import {
   deploymentStatus,
   formatRelativeTime,
   inferenceBackendTitle,
+  isLocalRuntimeSource,
   toolCeilingIcons,
   type ToolIcon,
 } from "./fleetMetrics";
@@ -17,21 +18,15 @@ import {
 export type FleetRowProps = {
   bootstrap: BootstrapSummary | null;
   deployment: DeploymentView;
-  p2pHealth: P2PHealth | null;
-  repairingP2P: boolean;
   onOpenChat: (agentDid: string) => void;
   onOpenConfig: (agentDid: string) => void;
-  onRepairP2P: () => Promise<unknown>;
 };
 
 export function FleetRow({
   bootstrap,
   deployment,
-  p2pHealth,
-  repairingP2P,
   onOpenChat,
   onOpenConfig,
-  onRepairP2P,
 }: FleetRowProps) {
   const status = deploymentStatus(deployment);
   const enabledTaskCount = deployment.tasks.filter(
@@ -52,15 +47,16 @@ export function FleetRow({
   const toolIcons = toolCeilingIcons(
     deployment.toolSelections,
     defaultBehavior?.toolSelectionId,
-    bootstrap?.initToolCeiling,
+    isLocalRuntimeSource(deployment.source) ? bootstrap?.initToolCeiling : null,
   );
   const agentIdentity = displayAgentIdentity(deployment.agentDid);
   const graphqlEndpoint = displayGraphqlEndpoint(deployment.graphql);
   const defaultBehaviorLabel = displayBehaviorLabel(
     deployment.defaultBehaviorId ?? deployment.agentPrincipal.defaultBehaviorId,
   );
-  const p2pLastUpdate = p2pHealth?.lastOkAt ?? p2pHealth?.lastFailureAt ?? null;
-  const canRepairP2P = !deployment.dialSucceeded || Boolean(deployment.lastError);
+  // Per-deployment reconciler heartbeat — NOT the desktop client's global
+  // P2P probe, which is identical for every row and lies about dead peers.
+  const runtimeLastUpdate = deployment.runtime?.updatedAt ?? null;
 
   return (
     <tr data-testid={`fleet-row-${deployment.peerId}`}>
@@ -115,7 +111,9 @@ export function FleetRow({
       <td>
         <Metric title="Processing conversations" value={openWorkCount} />
       </td>
-      <td title="Last desktop P2P health probe">{formatRelativeTime(p2pLastUpdate)}</td>
+      <td title="Last runtime update reported by this agent">
+        {formatRelativeTime(runtimeLastUpdate)}
+      </td>
       <td className="fleet-actions-cell">
         <div className="fleet-row-actions">
           <button
@@ -137,21 +135,6 @@ export function FleetRow({
             type="button"
           >
             <ConfigIcon />
-          </button>
-          <button
-            aria-label={
-              canRepairP2P
-                ? `Repair ${deployment.label} P2P`
-                : `${deployment.label} P2P healthy`
-            }
-            className="ghost-button fleet-table-action"
-            data-testid={`fleet-repair-${deployment.peerId}`}
-            disabled={!canRepairP2P || repairingP2P}
-            onClick={() => void onRepairP2P()}
-            title={canRepairP2P ? "Repair P2P" : "P2P healthy"}
-            type="button"
-          >
-            <RepairIcon />
           </button>
         </div>
       </td>

--- a/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
+++ b/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
@@ -61,7 +61,11 @@ export function toolCeilingIcons(
         );
   const source = activeSelections.length ? activeSelections : selections;
   const icons: ToolIcon[] = [];
-  const ceilingLabel = displayToolCeiling(serverCeiling);
+  // Only claim a server ceiling when the caller could actually know it —
+  // init.json is a fact about the local machine, not remote peers.
+  const ceilingSuffix = serverCeiling
+    ? ` Server ceiling: ${displayToolCeiling(serverCeiling)}.`
+    : "";
   const bestFileMode = strongestMode(
     source
       .filter((selection) => selection.enableFileTools)
@@ -89,7 +93,7 @@ export function toolCeilingIcons(
       tone: bestFileMode === "readwrite" ? "readwrite" : "readonly",
       title: `Files (${modeTitle(bestFileMode)}): inspect${
         bestFileMode === "readwrite" ? " and edit" : ""
-      } workspace files. Server ceiling: ${ceilingLabel}.`,
+      } workspace files.${ceilingSuffix}`,
     });
   }
   if (bestBashMode) {
@@ -98,7 +102,7 @@ export function toolCeilingIcons(
       tone: bestBashMode === "readwrite" ? "readwrite" : "readonly",
       title: `Shell (${modeTitle(bestBashMode)}): run terminal commands for diagnostics${
         bestBashMode === "readwrite" ? " and changes" : ""
-      }. Server ceiling: ${ceilingLabel}.`,
+      }.${ceilingSuffix}`,
     });
   }
   if (allowedMetaServices.length || unrestrictedMetaServices) {
@@ -163,6 +167,14 @@ function uniqueValues(values: string[]) {
   return Array.from(
     new Set(values.map((value) => value.trim()).filter(Boolean)),
   ).sort();
+}
+
+/**
+ * The init.json tool ceiling describes THIS machine's runtime — only
+ * deployments sourced from the local runtime may claim it in their tooltip.
+ */
+export function isLocalRuntimeSource(source?: string | null): boolean {
+  return source === "local-standard" || source === "server-status";
 }
 
 export function formatRelativeTime(value?: string | null) {

--- a/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
+++ b/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
@@ -172,9 +172,11 @@ function uniqueValues(values: string[]) {
 /**
  * The init.json tool ceiling describes THIS machine's runtime — only
  * deployments sourced from the local runtime may claim it in their tooltip.
+ * "server-status" is NOT local: the peer directory stamps any graphql-bearing
+ * peer with it, including remote agents added by endpoint.
  */
 export function isLocalRuntimeSource(source?: string | null): boolean {
-  return source === "local-standard" || source === "server-status";
+  return source === "local-standard";
 }
 
 export function formatRelativeTime(value?: string | null) {

--- a/apps/desktop-tauri/tests/fleet-dashboard.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-dashboard.test.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { FleetDashboard } from "../src/components/fleet/FleetDashboard";
-import type { BootstrapSummary } from "../src/lib/types";
+import type { BootstrapSummary, DeploymentView } from "../src/lib/types";
+import { deployment } from "./config-panel-wiring/fixtures";
 
 const bootstrap: BootstrapSummary = {
   defaultAgentHome: "/Users/test/.defra-agent",
@@ -182,5 +183,40 @@ describe("FleetDashboard add connection flow", () => {
         graphql: "http://100.73.235.38:9181/api/v0/graphql",
       });
     });
+  });
+});
+
+describe("FleetDashboard fleet-level P2P repair", () => {
+  function renderFleet(deployments: DeploymentView[], onRepairP2P = vi.fn()) {
+    render(
+      <FleetDashboard
+        addingPeer={false}
+        bootstrap={bootstrap}
+        deployments={deployments}
+        loading={false}
+        p2pHealth={null}
+        repairingP2P={false}
+        starting={false}
+        onAddPeer={vi.fn()}
+        onFetchPeerStatus={vi.fn()}
+        onInitLocalRuntime={vi.fn()}
+        onOpenChat={vi.fn()}
+        onOpenConfig={vi.fn()}
+        onRepairP2P={onRepairP2P}
+      />,
+    );
+    return onRepairP2P;
+  }
+
+  it("hides the reconnect control while every connection is healthy", () => {
+    renderFleet([{ ...deployment, dialSucceeded: true, lastError: null }]);
+    expect(screen.queryByTestId("fleet-repair-p2p")).not.toBeInTheDocument();
+  });
+
+  it("shows the reconnect control and fires the repair when a peer is unhealthy", () => {
+    const onRepairP2P = renderFleet([{ ...deployment, dialSucceeded: false }]);
+    const repair = screen.getByTestId("fleet-repair-p2p");
+    fireEvent.click(repair);
+    expect(onRepairP2P).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop-tauri/tests/fleet-row.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-row.test.tsx
@@ -12,11 +12,8 @@ function renderRow(
   const props: FleetRowProps = {
     bootstrap: null,
     deployment: dep,
-    p2pHealth: null,
-    repairingP2P: false,
     onOpenChat: vi.fn(),
     onOpenConfig: vi.fn(),
-    onRepairP2P: vi.fn(async () => undefined),
     ...overrides,
   };
   render(
@@ -30,11 +27,13 @@ function renderRow(
 }
 
 describe("FleetRow", () => {
-  it("renders the three action buttons keyed by peerId", () => {
+  it("renders the chat and config action buttons keyed by peerId", () => {
     renderRow();
     expect(screen.getByTestId("fleet-chat-peer-1")).toBeInTheDocument();
     expect(screen.getByTestId("fleet-config-peer-1")).toBeInTheDocument();
-    expect(screen.getByTestId("fleet-repair-peer-1")).toBeInTheDocument();
+    // P2P repair is a desktop-client-wide action; it must not masquerade as a
+    // per-agent row action (it lives in the fleet header instead).
+    expect(screen.queryByTestId("fleet-repair-peer-1")).not.toBeInTheDocument();
   });
 
   it("calls onOpenChat with the agent DID when the chat button is clicked", () => {
@@ -49,23 +48,41 @@ describe("FleetRow", () => {
     expect(props.onOpenConfig).toHaveBeenCalledWith(deployment.agentDid);
   });
 
-  it("disables repair when the peer dialed successfully with no error", () => {
-    renderRow({}, { ...deployment, dialSucceeded: true, lastError: null });
-    expect(screen.getByTestId("fleet-repair-peer-1")).toBeDisabled();
+  it("shows the deployment's own runtime heartbeat as Last update", () => {
+    renderRow(
+      {},
+      {
+        ...deployment,
+        runtime: { updatedAt: new Date(Date.now() - 5_000).toISOString() },
+      },
+    );
+    expect(
+      screen.getByTitle("Last runtime update reported by this agent"),
+    ).toHaveTextContent(/s ago/);
   });
 
-  it("enables repair and fires onRepairP2P (no args) when the peer has not dialed", () => {
-    const props = renderRow({}, { ...deployment, dialSucceeded: false });
-    const repair = screen.getByTestId("fleet-repair-peer-1");
-    expect(repair).toBeEnabled();
-    fireEvent.click(repair);
-    expect(props.onRepairP2P).toHaveBeenCalledTimes(1);
-    // Repair is fired with NO args (unlike chat/config which pass the DID).
-    expect(props.onRepairP2P).toHaveBeenCalledWith();
+  it("shows unknown when the deployment has no runtime heartbeat", () => {
+    renderRow({}, { ...deployment, runtime: null });
+    expect(
+      screen.getByTitle("Last runtime update reported by this agent"),
+    ).toHaveTextContent("unknown");
   });
 
-  it("enables repair when the peer dialed but reported a last error", () => {
-    renderRow({}, { ...deployment, dialSucceeded: true, lastError: "dial timeout" });
-    expect(screen.getByTestId("fleet-repair-peer-1")).toBeEnabled();
+  it("claims the local init.json tool ceiling only for local-runtime rows", () => {
+    const bootstrap = { initToolCeiling: "readonly" };
+    renderRow(
+      { bootstrap: bootstrap as FleetRowProps["bootstrap"] },
+      { ...deployment, source: "local-standard" },
+    );
+    expect(document.querySelector('[title*="Server ceiling"]')).not.toBeNull();
+  });
+
+  it("omits the local tool ceiling from remote rows", () => {
+    const bootstrap = { initToolCeiling: "readonly" };
+    renderRow(
+      { bootstrap: bootstrap as FleetRowProps["bootstrap"] },
+      { ...deployment, source: "manual" },
+    );
+    expect(document.querySelector('[title*="Server ceiling"]')).toBeNull();
   });
 });

--- a/apps/desktop-tauri/tests/fleet-row.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-row.test.tsx
@@ -56,16 +56,12 @@ describe("FleetRow", () => {
         runtime: { updatedAt: new Date(Date.now() - 5_000).toISOString() },
       },
     );
-    expect(
-      screen.getByTitle("Last runtime update reported by this agent"),
-    ).toHaveTextContent(/s ago/);
+    expect(screen.getByTitle(/Last runtime state change/)).toHaveTextContent(/s ago/);
   });
 
   it("shows unknown when the deployment has no runtime heartbeat", () => {
     renderRow({}, { ...deployment, runtime: null });
-    expect(
-      screen.getByTitle("Last runtime update reported by this agent"),
-    ).toHaveTextContent("unknown");
+    expect(screen.getByTitle(/Last runtime state change/)).toHaveTextContent("unknown");
   });
 
   it("claims the local init.json tool ceiling only for local-runtime rows", () => {
@@ -81,7 +77,7 @@ describe("FleetRow", () => {
     const bootstrap = { initToolCeiling: "readonly" };
     renderRow(
       { bootstrap: bootstrap as FleetRowProps["bootstrap"] },
-      { ...deployment, source: "manual" },
+      { ...deployment, source: "server-status" },
     );
     expect(document.querySelector('[title*="Server ceiling"]')).toBeNull();
   });

--- a/apps/desktop-tauri/tests/playwright/desktop-fleet-actions.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-fleet-actions.spec.ts
@@ -1,7 +1,7 @@
 import { expect, gotoHarness, PEER_ID, test } from "./desktopTest";
 
 // The fleet-row navigation is exercised elsewhere via the agent NAME
-// (`fleet-chat-name-*`). These tests click the three per-row ACTION buttons
+// (`fleet-chat-name-*`). These tests click the per-row ACTION buttons
 // directly, so a regression that breaks the buttons (but not the name) cannot
 // ship silently — the class of defect behind "the row buttons do nothing".
 test.describe("fleet row action buttons", () => {
@@ -27,16 +27,17 @@ test.describe("fleet row action buttons", () => {
     await expect(page.locator(".config-workspace")).toBeVisible();
   });
 
-  test("repair action button is present and disabled while P2P is healthy", async ({
+  test("P2P repair is fleet-level and hidden while healthy, never a row action", async ({
     page,
   }) => {
     await gotoHarness(page, "default");
     await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
 
-    const repairAction = page.getByTestId(`fleet-repair-${PEER_ID}`);
-    await expect(repairAction).toBeVisible();
-    // The default fixture dials successfully with no last error, so repairing
-    // P2P is intentionally unavailable — the button is disabled, not broken.
-    await expect(repairAction).toBeDisabled();
+    // Repair re-dials the desktop client's connections as a whole, so it must
+    // not masquerade as a per-agent row action.
+    await expect(page.getByTestId(`fleet-repair-${PEER_ID}`)).toHaveCount(0);
+    // The default fixture dials successfully with no last error, so the
+    // fleet-level reconnect control is intentionally absent.
+    await expect(page.getByTestId("fleet-repair-p2p")).toHaveCount(0);
   });
 });

--- a/apps/desktop-tauri/tests/playwright/desktop-layout.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-layout.spec.ts
@@ -70,12 +70,10 @@ test.describe("desktop responsive layout guardrails", () => {
 
     const chatButton = page.getByTestId(`fleet-chat-${PEER_ID}`);
     const configButton = page.getByTestId(`fleet-config-${PEER_ID}`);
-    const repairButton = page.getByTestId(`fleet-repair-${PEER_ID}`);
 
-    // All three action buttons exist even when scrolled off-screen at 390px.
+    // Both action buttons exist even when scrolled off-screen at 390px.
     await expect(chatButton).toBeAttached();
     await expect(configButton).toBeAttached();
-    await expect(repairButton).toBeAttached();
 
     // Reachability mechanism: the actions cell lives inside a horizontally
     // scrollable container (.fleet-table-wrap { overflow: auto }) — NOT an
@@ -100,10 +98,6 @@ test.describe("desktop responsive layout guardrails", () => {
       await expect(button).toBeVisible();
       await button.click({ trial: true });
     }
-    // Repair is disabled in the default scenario (dialSucceeded=true, no error).
-    await repairButton.scrollIntoViewIfNeeded();
-    await expect(repairButton).toBeVisible();
-    await expect(repairButton).toBeDisabled();
 
     // Reaching the actions must never introduce page-level horizontal overflow.
     await expectNoPageHorizontalOverflow(page);


### PR DESCRIPTION
Fifth WS1 slice of #608. Three fleet-row elements showed desktop-global state as per-agent facts:

- **Last update** rendered the desktop client's single global P2P probe timestamp — identical in every row, so a dead remote agent could show "12s ago". Now driven by the deployment's own `runtime.updatedAt` reconciler heartbeat ("unknown" when absent).
- **Tool-ceiling tooltips** claimed "Server ceiling: X" from the local machine's init.json on every row. The claim now appears only on rows sourced from the local runtime (`local-standard`/`server-status`); remote rows omit it.
- **Repair** was labeled "Repair {agent} P2P" per row but invoked the client-wide repair (and disabled every row's button at once). It is now a single fleet-level "Reconnect P2P" control in the header, shown only when a peer or the P2P probe is actually unhealthy.

Fences: fleet-row tests (per-agent heartbeat, ceiling scoping, no row repair), fleet-dashboard tests (header control visibility + fire), updated Playwright fleet-actions and narrow-reachability specs. Visual baselines regenerated. Unit 171, e2e 120, visual 3×3 green.

Stacked on #612.