### PR TITLE
polish(desktop): spacing token sweep + raw-literal ratchets

### DIFF
--- a/apps/desktop-tauri/src/styles/backend-health/backend-health.css
+++ b/apps/desktop-tauri/src/styles/backend-health/backend-health.css
@@ -471,7 +471,7 @@
   }
 
   .backend-health__empty-body code {
-    padding: 1px 6px;
+    padding: 1px var(--space-2);
     background: var(--color-surface-strong);
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-subtle);

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -19,18 +19,18 @@
   .background-tools-panel .chip-row {
     display: flex;
     flex-wrap: wrap;
-    gap: 6px;
+    gap: var(--space-2);
     align-items: center;
   }
 
   .background-tools-panel .chip-row + .chip-row {
-    margin-top: 8px;
+    margin-top: var(--space-3);
   }
 
   .background-tools-panel .chip-label {
     font-size: var(--text-sm);
     color: var(--color-text-muted);
-    margin-right: 4px;
+    margin-right: var(--space-1);
     min-width: 64px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
@@ -39,8 +39,8 @@
   .background-tools-panel .chip {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
+    gap: var(--space-2);
+    padding: var(--space-1) var(--space-4);
     border-radius: var(--radius-pill);
     border: 1px solid var(--border-default);
     background: var(--color-surface-muted);
@@ -86,7 +86,7 @@
   .background-tools-panel .toggle {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
+    gap: var(--space-2);
     color: var(--color-text-soft);
     font-size: var(--text-sm);
     cursor: pointer;
@@ -103,8 +103,8 @@
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    gap: 12px;
-    margin-bottom: 8px;
+    gap: var(--space-5);
+    margin-bottom: var(--space-3);
   }
 
   .background-tools-panel .panel-summary .live-count {
@@ -144,7 +144,7 @@
 
   .background-tools-panel table.tools thead th {
     text-align: left;
-    padding: 10px 12px;
+    padding: var(--space-4) var(--space-5);
     background: var(--color-surface-deep);
     color: var(--color-text-muted);
     font-weight: 500;
@@ -197,7 +197,7 @@
   }
 
   .background-tools-panel table.tools td {
-    padding: 10px 12px;
+    padding: var(--space-4) var(--space-5);
     vertical-align: top;
     color: var(--color-text-soft);
   }
@@ -232,7 +232,7 @@
   .background-tools-panel .pill {
     display: inline-flex;
     align-items: center;
-    padding: 1px 8px;
+    padding: 1px var(--space-3);
     border-radius: var(--radius-pill);
     font-size: var(--text-xs);
     font-family: var(--font-body);
@@ -259,7 +259,7 @@
   }
 
   .background-tools-panel .pill.pill-status {
-    gap: 4px;
+    gap: var(--space-1);
   }
 
   .background-tools-panel .pill.pill-status[data-state="running"] {
@@ -289,7 +289,7 @@
 
   .background-tools-panel .row-actions {
     display: flex;
-    gap: 6px;
+    gap: var(--space-2);
     justify-content: flex-end;
   }
 
@@ -322,7 +322,7 @@
   /* ── Empty state ─────────────────────────────────────────────────────────── */
 
   .background-tools-panel .empty-state {
-    padding: 28px 12px;
+    padding: 28px var(--space-5);
     text-align: center;
     color: var(--color-text-muted);
     font-size: var(--text-md);
@@ -333,6 +333,6 @@
     color: var(--color-accent);
     opacity: 0.6;
     display: block;
-    margin-bottom: 6px;
+    margin-bottom: var(--space-2);
   }
 }

--- a/apps/desktop-tauri/src/styles/cancel-ux.css
+++ b/apps/desktop-tauri/src/styles/cancel-ux.css
@@ -3,8 +3,8 @@
   .cause-badge {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 3px 10px;
+    gap: var(--space-2);
+    padding: 3px var(--space-4);
     border-radius: var(--radius-pill);
     font-size: var(--text-xs);
     font-weight: 600;
@@ -49,7 +49,7 @@
   .cause-details {
     display: grid;
     grid-template-columns: 130px 1fr;
-    gap: 4px 12px;
+    gap: var(--space-1) var(--space-5);
     margin: 0;
     font-size: var(--text-sm);
     color: var(--color-text-muted);
@@ -81,7 +81,7 @@
     align-items: flex-start;
     justify-content: center;
     z-index: 50;
-    padding: 64px 16px;
+    padding: 64px var(--space-7);
     animation: fade-in 120ms ease-out;
   }
 
@@ -109,7 +109,7 @@
   }
 
   .dialog header {
-    padding: 16px 20px 8px;
+    padding: var(--space-7) var(--space-9) var(--space-3);
     border-bottom: 1px solid var(--border-subtle);
   }
 
@@ -121,11 +121,11 @@
   }
 
   .dialog header .sub {
-    margin-top: 4px;
+    margin-top: var(--space-1);
     font-size: var(--text-sm);
     color: var(--color-text-muted);
     display: flex;
-    gap: 8px;
+    gap: var(--space-3);
     align-items: center;
     flex-wrap: wrap;
   }
@@ -133,7 +133,7 @@
   .dialog header .sub code {
     font-family: var(--font-mono);
     background: var(--color-surface-strong);
-    padding: 1px 6px;
+    padding: 1px var(--space-2);
     border-radius: 4px;
     color: var(--color-text-warm);
   }
@@ -142,32 +142,32 @@
     background: rgb(var(--source-orange-rgb) / 0.14);
     color: var(--color-warning);
     border: 1px solid rgb(var(--source-orange-rgb) / 0.4);
-    padding: 2px 8px;
+    padding: 2px var(--space-3);
     border-radius: var(--radius-pill);
     font-size: var(--text-xs);
     font-weight: 600;
   }
 
   .dialog .body {
-    padding: 12px 20px;
+    padding: var(--space-5) var(--space-9);
   }
 
   .dialog footer {
-    padding: 12px 20px 16px;
+    padding: var(--space-5) var(--space-9) var(--space-7);
     display: flex;
     justify-content: flex-end;
-    gap: 8px;
+    gap: var(--space-3);
     border-top: 1px solid var(--border-subtle);
     background: var(--color-surface-strong);
   }
 
   /* ---------- Group layout (will-interrupt, will-detach, etc) ---------- */
   .group {
-    margin: 12px 0;
+    margin: var(--space-5) 0;
   }
 
   .group h4 {
-    margin: 0 0 6px;
+    margin: 0 0 var(--space-2);
     font-size: var(--text-xs);
     font-weight: 600;
     text-transform: uppercase;
@@ -175,14 +175,14 @@
     color: var(--color-text-muted);
     display: flex;
     align-items: center;
-    gap: 6px;
+    gap: var(--space-2);
   }
 
   .group h4 .count {
     background: var(--color-surface-strong);
     color: var(--color-text);
     border-radius: var(--radius-pill);
-    padding: 1px 8px;
+    padding: 1px var(--space-3);
     font-size: var(--text-2xs);
     font-weight: 700;
   }
@@ -213,12 +213,12 @@
   }
 
   .group ul li {
-    padding: 8px 12px;
+    padding: var(--space-3) var(--space-5);
     font-size: var(--text-sm);
     border-bottom: 1px solid var(--border-subtle);
     display: grid;
     grid-template-columns: 100px 1fr auto;
-    gap: 10px;
+    gap: var(--space-4);
     align-items: center;
   }
 
@@ -253,7 +253,7 @@
     grid-column: 1 / -1;
     color: var(--color-warning);
     font-size: var(--text-xs);
-    padding-top: 4px;
+    padding-top: var(--space-1);
   }
 
   /* ---------- Button variants for cancel-ux components ---------- */
@@ -261,7 +261,7 @@
     border: 1px solid var(--border-default);
     background: var(--color-surface-strong);
     color: var(--color-text);
-    padding: 7px 14px;
+    padding: 7px var(--space-6);
     border-radius: var(--radius-md);
     font-size: var(--text-md);
     font-weight: 500;
@@ -313,12 +313,12 @@
 
   /* ---------- Notice strip (success, info, warn) ---------- */
   .notice {
-    margin-top: 14px;
-    padding: 10px 14px;
+    margin-top: var(--space-6);
+    padding: var(--space-4) var(--space-6);
     border-radius: var(--radius-md);
     font-size: var(--text-sm);
     display: flex;
-    gap: 10px;
+    gap: var(--space-4);
     align-items: flex-start;
   }
 

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -173,7 +173,7 @@
     display: grid;
     align-content: start;
     scroll-behavior: smooth;
-    scroll-padding-bottom: 24px;
+    scroll-padding-bottom: var(--space-10);
     background:
       linear-gradient(180deg, rgb(var(--source-green-rgb) / 0.035), transparent 42%),
       var(--color-surface-strong);

--- a/apps/desktop-tauri/src/styles/config/documents.css
+++ b/apps/desktop-tauri/src/styles/config/documents.css
@@ -13,7 +13,7 @@
     border-bottom: 1px solid var(--border-subtle);
     border-radius: 0;
     background: transparent;
-    padding: 11px 10px;
+    padding: 11px var(--space-4);
   }
 
   .config-document-list-body .list-item:last-of-type {

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -16,7 +16,7 @@
   .fleet-table th,
   .fleet-table td {
     border-bottom: 1px solid var(--border-default);
-    padding: 11px 10px;
+    padding: 11px var(--space-4);
     text-align: left;
     vertical-align: middle;
   }

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -182,7 +182,8 @@
      the page background so scrolled data columns can't ghost through. */
   .fleet-actions-header {
     width: 128px;
-    background: linear-gradient(rgb(0 0 0 / 0.88), rgb(0 0 0 / 0.88)) var(--color-bg);
+    /* 0.88 black over the black page bg composites to the page bg exactly. */
+    background: var(--color-bg);
   }
 
   .fleet-actions-cell {

--- a/apps/desktop-tauri/src/styles/mcp-health.css
+++ b/apps/desktop-tauri/src/styles/mcp-health.css
@@ -27,7 +27,7 @@
   }
 
   .mcp-health-refresh {
-    padding: 6px 12px;
+    padding: var(--space-2) var(--space-5);
     background: transparent;
     color: var(--color-text-soft);
     border: 1px solid var(--border-default);
@@ -69,7 +69,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-3);
-    padding: 6px 10px 6px 8px;
+    padding: var(--space-2) var(--space-4) var(--space-2) var(--space-3);
     border: 1px solid var(--border-subtle);
     background: rgb(0 0 0 / 0.45);
     border-radius: var(--radius-pill);
@@ -115,7 +115,7 @@
     display: inline-flex;
     align-items: center;
     gap: var(--space-2);
-    padding: 6px 12px;
+    padding: var(--space-2) var(--space-5);
     border: 1px solid var(--border-default);
     background: var(--color-surface-row);
     color: var(--color-text-soft);
@@ -182,7 +182,7 @@
   .mcp-health-table th,
   .mcp-health-table td {
     border-bottom: 1px solid var(--border-default);
-    padding: 11px 12px;
+    padding: 11px var(--space-5);
     text-align: left;
     vertical-align: middle;
   }
@@ -333,7 +333,7 @@
   .mcp-health-k-badge {
     display: inline-flex;
     align-items: center;
-    padding: 2px 6px;
+    padding: 2px var(--space-2);
     border-radius: var(--radius-sm);
     font-size: var(--text-2xs);
     letter-spacing: 0.04em;
@@ -413,7 +413,7 @@
   }
 
   .mcp-health-probe-btn {
-    padding: 6px 12px;
+    padding: var(--space-2) var(--space-5);
     background: transparent;
     color: var(--color-text-soft);
     border: 1px solid var(--border-default);
@@ -440,7 +440,7 @@
 
   .mcp-health-kv {
     display: grid;
-    gap: 4px;
+    gap: var(--space-1);
     margin: 0;
     font-size: var(--text-sm);
   }

--- a/apps/desktop-tauri/src/styles/sidebar/lists.css
+++ b/apps/desktop-tauri/src/styles/sidebar/lists.css
@@ -14,7 +14,7 @@
     border-bottom: 1px solid var(--border-subtle);
     border-radius: 0;
     background: transparent;
-    padding: 12px 12px;
+    padding: var(--space-5) var(--space-5);
   }
 
   .sidebar .list-item:last-of-type {

--- a/apps/desktop-tauri/src/styles/subagent-lineage.css
+++ b/apps/desktop-tauri/src/styles/subagent-lineage.css
@@ -50,7 +50,7 @@
     border: 1px solid var(--border-default);
     color: var(--color-text-soft);
     border-radius: var(--radius-pill);
-    padding: 2px 10px;
+    padding: 2px var(--space-4);
     font: inherit;
     font-size: var(--text-xs);
     cursor: pointer;
@@ -128,7 +128,7 @@
   }
   .subagent-lineage-children {
     list-style: none;
-    padding-left: 18px;
+    padding-left: var(--space-8);
     margin: 0;
     position: relative;
   }
@@ -207,7 +207,7 @@
   .subagent-lineage-kind {
     display: inline-flex;
     align-items: center;
-    padding: 1px 8px;
+    padding: 1px var(--space-3);
     border-radius: var(--radius-pill);
     font-size: var(--text-2xs);
     letter-spacing: 0.06em;
@@ -240,8 +240,8 @@
   .subagent-lineage-state {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 1px 8px;
+    gap: var(--space-1);
+    padding: 1px var(--space-3);
     border-radius: var(--radius-pill);
     font-size: var(--text-2xs);
     font-family: var(--font-heading);

--- a/apps/desktop-tauri/src/styles/transcript/messages.css
+++ b/apps/desktop-tauri/src/styles/transcript/messages.css
@@ -76,7 +76,7 @@
 
   .markdown-content ul,
   .markdown-content ol {
-    padding-left: 20px;
+    padding-left: var(--space-9);
   }
 
   .markdown-content li + li {

--- a/apps/desktop-tauri/src/styles/transcript/tools.css
+++ b/apps/desktop-tauri/src/styles/transcript/tools.css
@@ -213,7 +213,7 @@
     font-family: ui-monospace, "JetBrains Mono", "SF Mono", Menlo, monospace;
     font-size: var(--text-2xs);
     letter-spacing: 0.04em;
-    padding: 2px 8px;
+    padding: 2px var(--space-3);
     border-radius: var(--radius-pill);
     background: rgb(var(--source-orange-rgb) / 0.16);
     border: 1px solid rgb(var(--source-orange-rgb) / 0.32);
@@ -251,7 +251,7 @@
   .denial-attempt .denied-token {
     background: rgb(var(--source-orange-rgb) / 0.22);
     color: var(--color-warning-soft, #ffd089);
-    padding: 0 4px;
+    padding: 0 var(--space-1);
     border-radius: 4px;
   }
 
@@ -318,7 +318,7 @@
   .code-exit {
     font-size: var(--text-xs);
     letter-spacing: 0.03em;
-    padding: 1px 8px;
+    padding: 1px var(--space-3);
     border-radius: var(--radius-pill, 999px);
   }
 

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -106,7 +106,9 @@ describe("token ratchets", () => {
     let count = 0;
     for (const css of sources.values()) {
       for (const match of css.matchAll(
-        /\b(?:padding|margin|gap|row-gap|column-gap)(?:-(?:top|right|bottom|left|inline|block))?\s*:\s*([^;{}]+)/g,
+        // (?<![\w-]) keeps scroll-padding-* out; -start/-end covers the
+        // logical longhands so raw px can't smuggle through them.
+        /(?<![\w-])(?:padding|margin|gap|row-gap|column-gap)(?:-(?:top|right|bottom|left|inline|block))?(?:-(?:start|end))?\s*:\s*([^;{}]+)/g,
       )) {
         count += (match[1].match(/\d+px\b/g) ?? []).length;
       }
@@ -119,7 +121,11 @@ describe("token ratchets", () => {
   });
 
   it("bespoke box-shadows do not grow (ceiling 38)", () => {
-    expect(countMatches(/box-shadow:/g)).toBeLessThanOrEqual(38);
+    // 'none' and pure --shadow-* token values are conformant, not bespoke:
+    // tokenizing shadows must lower this pressure, not preserve it.
+    expect(
+      countMatches(/box-shadow:\s*(?!none[;}\s]|var\(--shadow-)[^;{}]+/gi),
+    ).toBeLessThanOrEqual(38);
   });
 });
 

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -90,6 +90,39 @@ describe("type scale", () => {
   });
 });
 
+describe("token ratchets", () => {
+  // These counts may only go DOWN. They hold the line on raw values the
+  // per-screen polish passes are still sweeping onto tokens — a new raw
+  // literal fails here; when you tokenize some, lower the ceiling.
+  function countMatches(pattern: RegExp): number {
+    let count = 0;
+    for (const css of sources.values()) {
+      count += [...css.matchAll(pattern)].length;
+    }
+    return count;
+  }
+
+  it("raw px inside spacing declarations does not grow (ceiling 40)", () => {
+    let count = 0;
+    for (const css of sources.values()) {
+      for (const match of css.matchAll(
+        /\b(?:padding|margin|gap|row-gap|column-gap)(?:-(?:top|right|bottom|left|inline|block))?\s*:\s*([^;{}]+)/g,
+      )) {
+        count += (match[1].match(/\d+px\b/g) ?? []).length;
+      }
+    }
+    expect(count).toBeLessThanOrEqual(40);
+  });
+
+  it("raw rgb() literals do not grow (ceiling 90)", () => {
+    expect(countMatches(/rgb\(\d+ \d+ \d+/g)).toBeLessThanOrEqual(90);
+  });
+
+  it("bespoke box-shadows do not grow (ceiling 38)", () => {
+    expect(countMatches(/box-shadow:/g)).toBeLessThanOrEqual(38);
+  });
+});
+
 describe("cascade layers", () => {
   const appCss = sources.get(APP_CSS) ?? "";
   const orderMatch = appCss.match(/@layer\s+([\w\s,-]+);/);


### PR DESCRIPTION
Third WS2 slice of #608, deliberately value-preserving:

- Sweeps every exact-match px value inside spacing declarations (`padding`/`margin`/`gap` and variants) onto the `--space-*` scale — 71+ raw values down to 40, all remaining being hairline nudges (1–3px) and one-offs owned by the per-screen passes. Pixel-identical by construction: visual verification passes against the unchanged baselines.
- Adds **ratchet fences** to `design-system-conformance.test.ts`: raw spacing px (ceiling 40), raw `rgb()` literals (90), bespoke `box-shadow`s (38) may only go down — new raw literals fail CI, and each polish pass lowers the ceilings.

Shadow/color tokenization proper is left for the per-screen passes where the visual decisions belong; the ratchets stop the bleeding now.

Unit 179, e2e 120, visual 3×3 green (no baseline changes).

Stacked on #615.