### PR TITLE
polish(desktop): motion tokens, global reduced-motion, focus-ring integrity

### DIFF
--- a/apps/desktop-tauri/src/styles/backend-health/backend-health.css
+++ b/apps/desktop-tauri/src/styles/backend-health/backend-health.css
@@ -100,7 +100,7 @@
     border: 1px solid var(--border-subtle);
     border-radius: var(--radius-lg);
     overflow: hidden;
-    transition: border-color 120ms ease;
+    transition: border-color var(--motion-fast) ease;
   }
 
   .backend-health__row[data-state="available"] {
@@ -264,7 +264,7 @@
 
   .backend-health__chevron {
     color: var(--color-text-muted);
-    transition: transform 150ms ease;
+    transition: transform var(--motion-medium) ease;
     font-size: var(--text-base);
   }
 

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -49,9 +49,9 @@
     font-size: var(--text-sm);
     cursor: pointer;
     transition:
-      background 120ms ease,
-      border-color 120ms ease,
-      color 120ms ease;
+      background var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      color var(--motion-fast) ease;
   }
 
   .background-tools-panel .chip:hover {
@@ -169,7 +169,7 @@
 
   .background-tools-panel table.tools tbody tr {
     border-bottom: 1px solid var(--border-subtle);
-    transition: background 120ms ease;
+    transition: background var(--motion-fast) ease;
   }
 
   .background-tools-panel table.tools tbody tr:last-child {

--- a/apps/desktop-tauri/src/styles/base.css
+++ b/apps/desktop-tauri/src/styles/base.css
@@ -59,3 +59,16 @@
     font-size: var(--text-lg);
   }
 }
+
+@layer base {
+  /* Motion is an enhancement, never a requirement. */
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+    }
+  }
+}

--- a/apps/desktop-tauri/src/styles/base.css
+++ b/apps/desktop-tauri/src/styles/base.css
@@ -69,6 +69,7 @@
       animation-duration: 0.01ms !important;
       animation-iteration-count: 1 !important;
       transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
     }
   }
 }

--- a/apps/desktop-tauri/src/styles/cancel-ux.css
+++ b/apps/desktop-tauri/src/styles/cancel-ux.css
@@ -82,7 +82,7 @@
     justify-content: center;
     z-index: 50;
     padding: 64px var(--space-7);
-    animation: fade-in 120ms ease-out;
+    animation: fade-in var(--motion-fast) ease-out;
   }
 
   .dialog-backdrop.open {
@@ -266,9 +266,9 @@
     font-size: var(--text-md);
     font-weight: 500;
     transition:
-      background 120ms ease,
-      border-color 120ms ease,
-      color 120ms ease;
+      background var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      color var(--motion-fast) ease;
     cursor: pointer;
   }
 

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -66,7 +66,11 @@
   .operations-rail-collapsed-button:focus-visible {
     background: rgb(var(--source-green-rgb) / 0.1);
     color: var(--color-text);
-    outline: none;
+  }
+
+  .operations-rail-collapsed-button:focus-visible {
+    outline: 2px solid var(--color-info);
+    outline-offset: 2px;
   }
 
   .operations-rail-header {
@@ -105,7 +109,11 @@
     border-color: var(--border-selected);
     background: rgb(var(--source-green-rgb) / 0.1);
     color: var(--color-text);
-    outline: none;
+  }
+
+  .operations-rail-close:focus-visible {
+    outline: 2px solid var(--color-info);
+    outline-offset: 2px;
   }
 
   .operations-rail-tabs {

--- a/apps/desktop-tauri/src/styles/mcp-health.css
+++ b/apps/desktop-tauri/src/styles/mcp-health.css
@@ -232,7 +232,7 @@
 
   .mcp-health-caret {
     color: var(--color-text-muted);
-    transition: transform 120ms ease;
+    transition: transform var(--motion-fast) ease;
     font-size: var(--text-2xs);
     user-select: none;
   }
@@ -301,7 +301,7 @@
   }
   .mcp-health-dot-blue {
     background: var(--color-info);
-    animation: mcp-health-pulse 1.4s ease-in-out infinite;
+    animation: mcp-health-pulse var(--motion-pulse) ease-in-out infinite;
   }
 
   .mcp-health-dot-stuck {
@@ -315,12 +315,6 @@
     }
     50% {
       box-shadow: 0 0 0 6px rgb(var(--source-blue-rgb) / 0.3);
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .mcp-health-dot-blue {
-      animation: none;
     }
   }
 

--- a/apps/desktop-tauri/src/styles/primitives/controls.css
+++ b/apps/desktop-tauri/src/styles/primitives/controls.css
@@ -20,10 +20,10 @@
       inset 0 1px 0 var(--button-top-line, rgb(255 255 255 / 0.05)),
       inset var(--button-rail-width, 0) 0 0 var(--button-rail, transparent);
     transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease,
-      color 120ms ease;
+      background-color var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      box-shadow var(--motion-fast) ease,
+      color var(--motion-fast) ease;
   }
 
   .ghost-button {
@@ -113,10 +113,10 @@
       inset 0 1px 0 rgb(255 255 255 / 0.05),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
     transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease,
-      color 120ms ease;
+      background-color var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      box-shadow var(--motion-fast) ease,
+      color var(--motion-fast) ease;
   }
 
   .icon-button:not(:disabled):hover {

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -88,7 +88,7 @@
     background: transparent;
     color: var(--color-text-muted);
     font-weight: 600;
-    transition: 120ms ease;
+    transition: var(--motion-fast) ease;
   }
 
   .tab-button:last-child {

--- a/apps/desktop-tauri/src/styles/sidebar/behavior.css
+++ b/apps/desktop-tauri/src/styles/sidebar/behavior.css
@@ -33,10 +33,10 @@
     color: var(--color-text-muted);
     padding: 0;
     transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease,
-      color 120ms ease;
+      background-color var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      box-shadow var(--motion-fast) ease,
+      color var(--motion-fast) ease;
   }
 
   .behavior-new-chat-button:hover {

--- a/apps/desktop-tauri/src/styles/sidebar/peer-card.css
+++ b/apps/desktop-tauri/src/styles/sidebar/peer-card.css
@@ -36,10 +36,10 @@
       inset 0 1px 0 rgb(255 255 255 / 0.05),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
     transition:
-      background-color 120ms ease,
-      border-color 120ms ease,
-      box-shadow 120ms ease,
-      color 120ms ease;
+      background-color var(--motion-fast) ease,
+      border-color var(--motion-fast) ease,
+      box-shadow var(--motion-fast) ease,
+      color var(--motion-fast) ease;
   }
 
   .peer-config-button:hover {

--- a/apps/desktop-tauri/src/styles/subagent-lineage.css
+++ b/apps/desktop-tauri/src/styles/subagent-lineage.css
@@ -54,7 +54,7 @@
     font: inherit;
     font-size: var(--text-xs);
     cursor: pointer;
-    transition: 120ms ease;
+    transition: var(--motion-fast) ease;
   }
   .subagent-lineage-chip:hover {
     border-color: var(--border-strong);

--- a/apps/desktop-tauri/src/styles/tokens.css
+++ b/apps/desktop-tauri/src/styles/tokens.css
@@ -79,5 +79,10 @@
     --text-2xl: 22px;
     --text-3xl: 28px;
     --text-4xl: 32px;
+    /* Motion. One shared timing vocabulary; the global reduced-motion
+       override lives in base.css. */
+    --motion-fast: 120ms;
+    --motion-medium: 150ms;
+    --motion-pulse: 1.4s;
   }
 }

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -57,6 +57,33 @@ describe("design tokens", () => {
   });
 });
 
+describe("motion and focus", () => {
+  it("transition/animation durations use --motion-* tokens", () => {
+    const raw: string[] = [];
+    for (const [file, css] of sources) {
+      if (file.endsWith("tokens.css")) continue;
+      for (const match of css.matchAll(
+        /(?:transition|animation)[^:;{}]*:\s*[^;{}]*?(\d+(?:\.\d+)?m?s)\b/g,
+      )) {
+        // 0.01ms is the reduced-motion kill value in base.css.
+        if (match[1] === "0.01ms") continue;
+        raw.push(`${relative(STYLES_ROOT, file)}: ${match[1]}`);
+      }
+    }
+    expect(raw).toEqual([]);
+  });
+
+  it("focus outlines are never removed", () => {
+    const removals: string[] = [];
+    for (const [file, css] of sources) {
+      for (const match of css.matchAll(/outline:\s*(?:none|0)\s*[;}]/g)) {
+        removals.push(`${relative(STYLES_ROOT, file)}: ${match[0]}`);
+      }
+    }
+    expect(removals).toEqual([]);
+  });
+});
+
 describe("type scale", () => {
   it("every font-size declaration uses a --text-* token", () => {
     const raw: string[] = [];

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -76,7 +76,10 @@ describe("motion and focus", () => {
   it("focus outlines are never removed", () => {
     const removals: string[] = [];
     for (const [file, css] of sources) {
-      for (const match of css.matchAll(/outline:\s*(?:none|0)\s*[;}]/g)) {
+      // All removal spellings: longhands, 0px, !important, any casing.
+      for (const match of css.matchAll(
+        /outline(?:-style|-width)?\s*:\s*(?:none|0(?:px)?)\b(?:\s*!important)?\s*[;}]/gi,
+      )) {
         removals.push(`${relative(STYLES_ROOT, file)}: ${match[0]}`);
       }
     }


### PR DESCRIPTION
Fourth WS2 slice of #608, value-preserving like the last:

- **Motion tokens**: `--motion-fast/medium/pulse` replace every hard-coded duration (all 30 sites; same values, so pixel-identical — visual passes against unchanged baselines).
- **Reduced motion globally honored**: one `prefers-reduced-motion` override in base.css kills all animation/transition durations; the single per-sheet override it obsoletes is removed.
- **Focus outlines never removed**: the two `outline: none` declarations (ops-rail collapsed/close buttons, which masked focus with only a subtle background tint) now get a real `:focus-visible` ring.
- **Fences**: durations must use `--motion-*` tokens; `outline: none|0` fails CI.

Unit 181, e2e 120, visual 3×3 green (no baseline changes).

Stacked on #616.