### PR TITLE
fix(desktop): app-level error boundary

### DIFF
--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import { ChatWorkspace } from "./components/ChatWorkspace";
 import { CodeContextHeader } from "./components/code/CodeContextHeader";
 import { ConfigWorkspace } from "./components/ConfigWorkspace";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FleetDashboard } from "./components/fleet/FleetDashboard";
 import { Sidebar } from "./components/Sidebar";
 import { useDesktopShell } from "./hooks/useDesktopShell";
@@ -10,6 +11,14 @@ import { installExternalLinkGuard } from "./lib/externalLinks";
 import "./App.css";
 
 function App() {
+  return (
+    <ErrorBoundary>
+      <AppShell />
+    </ErrorBoundary>
+  );
+}
+
+function AppShell() {
   const shell = useDesktopShell();
 
   // External links (e.g. markdown links in the transcript) must open in the

--- a/apps/desktop-tauri/src/components/ErrorBoundary.tsx
+++ b/apps/desktop-tauri/src/components/ErrorBoundary.tsx
@@ -4,17 +4,20 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 /// white-screen the whole desktop app. Class component by necessity —
 /// React only exposes error boundaries via lifecycle methods.
 type ErrorBoundaryProps = { children: ReactNode };
-type ErrorBoundaryState = { error: Error | null };
+type ErrorBoundaryState = { error: Error | null; componentStack: string | null };
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null };
+  state: ErrorBoundaryState = { error: null, componentStack: null };
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error("desktop render error", error, info.componentStack);
+    // The packaged app has no visible console — the details panel is the
+    // only route these diagnostics have into a bug report.
+    this.setState({ componentStack: info.componentStack ?? null });
   }
 
   render() {
@@ -27,6 +30,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         <article
           className="panel centered-panel error-boundary"
           data-testid="error-boundary"
+          role="alert"
         >
           <p className="eyebrow">Desktop</p>
           <h2>Something went wrong</h2>
@@ -36,9 +40,15 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           </p>
           <details className="error-boundary-details">
             <summary>Error details</summary>
-            <pre>{message}</pre>
+            <pre>
+              {this.state.error.stack || message}
+              {this.state.componentStack
+                ? `\n\nComponent stack:${this.state.componentStack}`
+                : null}
+            </pre>
           </details>
           <button
+            autoFocus
             className="primary-button"
             data-testid="error-boundary-reload"
             type="button"

--- a/apps/desktop-tauri/src/components/ErrorBoundary.tsx
+++ b/apps/desktop-tauri/src/components/ErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/// Last-resort boundary: a render exception anywhere below used to
+/// white-screen the whole desktop app. Class component by necessity —
+/// React only exposes error boundaries via lifecycle methods.
+type ErrorBoundaryProps = { children: ReactNode };
+type ErrorBoundaryState = { error: Error | null };
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("desktop render error", error, info.componentStack);
+  }
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+    const message = this.state.error.message || String(this.state.error);
+    return (
+      <main className="app-shell">
+        <article
+          className="panel centered-panel error-boundary"
+          data-testid="error-boundary"
+        >
+          <p className="eyebrow">Desktop</p>
+          <h2>Something went wrong</h2>
+          <p className="muted">
+            The view hit an unexpected error. Reloading usually recovers; your agents
+            and data are unaffected.
+          </p>
+          <details className="error-boundary-details">
+            <summary>Error details</summary>
+            <pre>{message}</pre>
+          </details>
+          <button
+            className="primary-button"
+            data-testid="error-boundary-reload"
+            type="button"
+            onClick={() => window.location.reload()}
+          >
+            Reload
+          </button>
+        </article>
+      </main>
+    );
+  }
+}

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -187,6 +187,8 @@
     display: grid;
     gap: var(--space-5);
     justify-items: start;
+    /* .centered-panel centers text; wrapped error output must stay left. */
+    text-align: left;
   }
 
   .error-boundary-details {

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -180,3 +180,30 @@
     }
   }
 }
+
+@layer shell {
+  .error-boundary {
+    max-width: 60ch;
+    display: grid;
+    gap: var(--space-5);
+    justify-items: start;
+  }
+
+  .error-boundary-details {
+    justify-self: stretch;
+    color: var(--color-text-soft);
+    font-size: var(--text-sm);
+  }
+
+  .error-boundary-details pre {
+    margin: var(--space-3) 0 0;
+    padding: var(--space-5);
+    overflow: auto;
+    font-family: var(--font-mono);
+    background: var(--color-surface-deep);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius-md);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+}

--- a/apps/desktop-tauri/tests/error-boundary.test.tsx
+++ b/apps/desktop-tauri/tests/error-boundary.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorBoundary } from "../src/components/ErrorBoundary";
+
+function Thrower(): never {
+  throw new Error("boom from render");
+}
+
+describe("ErrorBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when nothing throws", () => {
+    render(
+      <ErrorBoundary>
+        <span data-testid="happy">ok</span>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId("happy")).toBeInTheDocument();
+  });
+
+  it("catches render errors and offers reload instead of white-screening", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const reload = vi.fn();
+    const original = window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...original, reload },
+    });
+
+    render(
+      <ErrorBoundary>
+        <Thrower />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
+    expect(screen.getByText("boom from render")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("error-boundary-reload"));
+    expect(reload).toHaveBeenCalled();
+
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: original,
+    });
+  });
+});

--- a/apps/desktop-tauri/tests/error-boundary.test.tsx
+++ b/apps/desktop-tauri/tests/error-boundary.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import App from "../src/App";
 import { ErrorBoundary } from "../src/components/ErrorBoundary";
 
 function Thrower(): never {
@@ -30,21 +31,34 @@ describe("ErrorBoundary", () => {
       value: { ...original, reload },
     });
 
-    render(
-      <ErrorBoundary>
-        <Thrower />
-      </ErrorBoundary>,
-    );
+    try {
+      render(
+        <ErrorBoundary>
+          <Thrower />
+        </ErrorBoundary>,
+      );
 
-    expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
-    expect(screen.getByText("boom from render")).toBeInTheDocument();
+      expect(screen.getByTestId("error-boundary")).toBeInTheDocument();
+      // The details carry the real diagnostics: stack + component stack —
+      // the packaged app has no console for a bug report to quote.
+      const details = screen.getByTestId("error-boundary").querySelector("pre");
+      expect(details?.textContent).toContain("boom from render");
+      expect(details?.textContent).toContain("Component stack:");
+      expect(details?.textContent).toContain("Thrower");
 
-    fireEvent.click(screen.getByTestId("error-boundary-reload"));
-    expect(reload).toHaveBeenCalled();
+      fireEvent.click(screen.getByTestId("error-boundary-reload"));
+      expect(reload).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "location", {
+        configurable: true,
+        value: original,
+      });
+    }
+  });
 
-    Object.defineProperty(window, "location", {
-      configurable: true,
-      value: original,
-    });
+  it("App wraps the shell in the boundary (the actual white-screen fix)", () => {
+    // App's outer function is hook-free, so its element tree can be
+    // inspected without mounting the shell.
+    expect(App({}).type).toBe(ErrorBoundary);
   });
 });


### PR DESCRIPTION
WS2 item 12 of #608. Any render exception previously white-screened the entire desktop app — no message, no recovery.

`ErrorBoundary` now wraps the app shell (inside `App`'s default export, so the app entry, the UI-test harness, and any future mount all get it). The fallback is a styled panel: plain-language message, collapsible error details, and a Reload action. Hook errors in `useDesktopShell` are covered too since the boundary sits above the shell component.

Fence: `error-boundary.test.tsx` (happy path renders children; a throwing child renders the fallback with details and a working Reload). Unit 183, e2e 120, visual 3×3 green (no baseline changes).

Stacked on #617.