### PR TITLE
fix(demo): pair waits for the conversation data-plane filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.11.0",
+ "itertools 0.13.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-lock",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-trait",
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "anyhow",
  "document",
@@ -6909,7 +6909,7 @@ version = "0.6.2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "cid",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-stream",
@@ -6975,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "anyhow",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-trait",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "serde",
 ]
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10811,7 +10811,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -11037,7 +11037,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -11595,7 +11595,7 @@ dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
  "chrono",
- "constant_time_eq 0.1.5",
+ "constant_time_eq 0.3.1",
  "data-encoding",
  "derive_more 2.1.1",
  "genawaiter",
@@ -12270,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-lock",
@@ -12418,7 +12418,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -14480,7 +14480,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15152,7 +15152,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "anyhow",
@@ -16442,7 +16442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16455,7 +16455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16570,7 +16570,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16606,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16623,7 +16623,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "async-lock",
@@ -16655,7 +16655,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17608,7 +17608,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "p2p",
  "query",
@@ -18407,7 +18407,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "cid",
  "defra-core",
@@ -19609,7 +19609,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20036,7 +20036,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24475,7 +24475,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=84fa80087f0fccd9e045ac30f0a7f83ace1426c6#84fa80087f0fccd9e045ac30f0a7f83ace1426c6"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,21 +50,22 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs rev = main just after #1084 (iroh 1.0 stable: production relays +
-# open_path backoff, see #588). Move to the next upstream tag when one is cut.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+# defradb.rs rev = main just after #1085 (Linux P2P connection refcount fix;
+# #1084 also included iroh 1.0 stable relays + open_path backoff, see #588).
+# Move to the next upstream tag when one is cut.
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -72,8 +73,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "84fa80087f0fccd9e045ac30f0a7f83ace1426c6" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent-cli/src/commands/demo/fleet.rs
+++ b/crates/defra-agent-cli/src/commands/demo/fleet.rs
@@ -200,9 +200,9 @@ pub(super) async fn pair(fleet: &mut Fleet) -> Result<()> {
     .await?;
     upsert_data_plane(&graphql_b, &peer_a, &did_b, &addr_a, "conversation").await?;
 
-    println!("  waiting for replicators…");
-    wait_replicator(&graphql_b, &peer_a).await?;
-    wait_replicator(&fleet.graphql_a, &peer_b).await?;
+    println!("  waiting for conversation data-plane replicators…");
+    wait_conversation_replicator(&graphql_b, &peer_a, &did_b).await?;
+    wait_conversation_replicator(&fleet.graphql_a, &peer_b, &fleet.did_a).await?;
 
     fleet.node_b = Some(NodeB {
         home: home_b,
@@ -269,25 +269,59 @@ fn data_plane_collections_literal(template: &str) -> Result<String> {
     Ok(format!("[{collections}]"))
 }
 
-async fn wait_replicator(graphql: &str, peer_id: &str) -> Result<()> {
+async fn wait_conversation_replicator(graphql: &str, peer_id: &str, local_did: &str) -> Result<()> {
     let query = format!(
-        r#"{{ PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{}" }} }}, limit: 1) {{ replicator_addresses replicator_filter }} }}"#,
+        r#"{{
+            PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                peer_id
+                collections
+                replicator_addresses
+                replicator_filter
+            }}
+            DataPlanePairingDesired(filter: {{ peer_id: {{ _eq: "{}" }} }}, limit: 1) {{
+                peer_id
+                agent_did
+                template
+                replicator_addresses
+            }}
+        }}"#,
+        escape_graphql_string(peer_id),
         escape_graphql_string(peer_id)
     );
+    let mut last = Value::Null;
     for _ in 0..240 {
         if let Ok(resp) = post_graphql(graphql, &query).await {
+            last = resp.get("data").cloned().unwrap_or(Value::Null);
             let armed = resp
                 .pointer("/data/PeerPairingApplied/0/replicator_addresses")
                 .and_then(Value::as_array)
                 .map(|addresses| !addresses.is_empty())
                 .unwrap_or(false);
-            if armed {
+            let filtered = resp
+                .pointer("/data/PeerPairingApplied/0/replicator_filter")
+                .and_then(Value::as_str)
+                .is_some_and(|filter| filter_mentions_agent_request(filter, local_did));
+            if armed && filtered {
                 return Ok(());
             }
         }
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
-    bail!("timed out waiting for the replicator for peer {peer_id}")
+    bail!(
+        "timed out waiting for the conversation data-plane replicator for peer {peer_id}; \
+         last pairing rows: {last}"
+    )
+}
+
+fn filter_mentions_agent_request(filter: &str, local_did: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(filter) else {
+        return false;
+    };
+    value
+        .get("AgentRequest")
+        .and_then(|entry| entry.get("value"))
+        .and_then(Value::as_str)
+        == Some(local_did)
 }
 
 async fn wait_replicator_filter(graphql: &str, peer_id: &str, needles: &[String]) -> Result<()> {


### PR DESCRIPTION
Follow-up to #587. `pair` declared victory when the applied replicator had addresses, without checking what it replicates — a stale or partially-applied pairing could pass the gate and the demo would fail later at chat time.

`wait_conversation_replicator` now also requires the applied `replicator_filter` to scope `AgentRequest` to the local DID (parsed, not substring-matched), and the timeout message dumps the last `PeerPairingApplied` / `DataPlanePairingDesired` rows so a stuck pair is diagnosable from the demo output alone.

`cargo test -p defra-agent-cli` green (40 suites).