### PR TITLE
fix(p2p): demo pair step-8 hang — skip redundant redial; collection set joins replicator identity

### DIFF
--- a/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
+++ b/crates/defra-agent-desktop-core/src/client/core/supervisor.rs
@@ -733,6 +733,7 @@ mod pairing_reconcile_tests {
                 .into_iter()
                 .filter_map(|replicator| replicator.address)
                 .collect(),
+            ..Default::default()
         }
     }
 

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -36,6 +36,7 @@ identity.workspace = true
 libc = "0.2"
 minijinja.workspace = true
 opentelemetry.workspace = true
+p2p.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -68,7 +69,6 @@ windows-sys = { version = "0.61.2", features = [
 [dev-dependencies]
 acp.workspace = true
 axum = "0.8"
-p2p.workspace = true
 proptest = "1"
 agent-tool-call-lifecycle-v1-to-v2-lens = { path = "../defra-agent-lenses/agent_tool_call_lifecycle_v1_to_v2", default-features = false }
 defra-agent-lean-contract.workspace = true

--- a/crates/defra-agent/proofs/Proofs/PairingReconcile/Convergence.lean
+++ b/crates/defra-agent/proofs/Proofs/PairingReconcile/Convergence.lean
@@ -100,8 +100,8 @@ theorem reconcile_idempotent_on_converged
       refine ⟨?_, ?_, ?_, ?_, h_connected⟩
       · exact fun c hc => h_desired_collections hc
       · exact fun c _hc_actual hc_applied => h_applied_collections hc_applied
-      · exact fun r f hr => h_desired_replicators hr
-      · exact fun r f _hr_actual hr_applied => h_applied_replicators hr_applied
+      · exact fun r f cs hr => h_desired_replicators hr
+      · exact fun r f cs _hr_actual hr_applied => h_applied_replicators hr_applied
 
 /-- A one-step transition from a converged state cannot flap managed wiring. -/
 theorem no_flap_on_converged_step
@@ -155,42 +155,68 @@ theorem no_flap_on_converged_step
       subst h_post
       simp [managedWiringUnchanged]
 
-/-! ## Filter change forces reinstall
+/-! ## Identity change forces reinstall
 
-A replicator's filter is part of its identity (`(address, filter)`), so changing
-the filter on an existing address is NOT an in-place mutate: it is a teardown of
-the old `(a, f1)` identity and an install of the new `(a, f2)` identity. We prove
-that from a state where desired carries `(a, f2)` but actual still carries the
-old `(a, f1)`:
+A replicator's filter AND its carried collection set are part of its identity
+(`(address, filter, collections)`), so changing either on an existing address is
+NOT an in-place mutate: it is a teardown of the old identity and an install of
+the new one. We prove that from a state where desired carries the new identity
+but actual still carries the old one:
 
   - the diff is genuinely non-empty (`disagreementCount > 0`), so the state is
     not falsely converged;
-  - both `reconcileTeardownReplicator (a, f1)` and `reconcileInstallReplicator
-    (a, f2)` are ENABLED transitions out of the state (their real guards hold);
-  - applying teardown-then-install drives that address's actual replicator from
-    `(a, f1)` to `(a, f2)`.
+  - both the teardown of the old identity and the install of the new one are
+    ENABLED transitions out of the state (their real guards hold);
+  - applying teardown-then-install drives that address's actual replicator to
+    the new identity.
 
-The hypothesis `f1 ≠ f2` is satisfiable (e.g. `∅` vs a singleton
-per-collection filter, or two distinct filter maps), and is what makes
-`(a, f1) ≠ (a, f2)` — the two identities distinct. -/
+The distinctness hypotheses (`f1 ≠ f2`, `cs1 ≠ cs2`) are satisfiable (witnesses
+below), and are what make the two identities distinct. -/
 
-/-- `f1 ≠ f2` makes the two replicator identities on the same address distinct.
-Sanity that the central hypothesis has teeth. -/
+/-- `f1 ≠ f2` makes the two replicator identities on the same address and
+collection set distinct. Sanity that the central hypothesis has teeth. -/
 theorem filter_change_distinct_identity
-    {a : String} {f1 f2 : ReplicatorFilter} (hf : f1 ≠ f2) :
-    ((a, f1) : ReplicatorId) ≠ (a, f2) := by
+    {a : String} {cs : ReplicatorCollections} {f1 f2 : ReplicatorFilter} (hf : f1 ≠ f2) :
+    ((a, f1, cs) : ReplicatorId) ≠ (a, f2, cs) := by
   intro h
-  exact hf (by injection h)
+  have h_rest : (f1, cs) = (f2, cs) := by injection h
+  have h_f : f1 = f2 := by injection h_rest
+  exact hf h_f
+
+/-- `cs1 ≠ cs2` makes the two replicator identities on the same address and
+filter distinct. This is the live demo bug's identity component: a replicator
+that carried only the data-plane collection set is NOT the replicator that
+carries the merged data-plane + control-plane set. -/
+theorem collections_change_distinct_identity
+    {a : String} {f : ReplicatorFilter} {cs1 cs2 : ReplicatorCollections} (hcs : cs1 ≠ cs2) :
+    ((a, f, cs1) : ReplicatorId) ≠ (a, f, cs2) := by
+  intro h
+  have h_rest : (f, cs1) = (f, cs2) := by injection h
+  have h_cs : cs1 = cs2 := by injection h_rest
+  exact hcs h_cs
 
 /-- A concrete witness that the `f1 ≠ f2` hypothesis is satisfiable: an
 unfiltered replicator and a filtered one on the same address are distinct. -/
 theorem filter_change_hypothesis_satisfiable (a : String) (k : CollectionFilterKey) :
-    ((a, (∅ : ReplicatorFilter)) : ReplicatorId) ≠ (a, ({k} : ReplicatorFilter)) := by
+    ((a, (∅ : ReplicatorFilter), (∅ : ReplicatorCollections)) : ReplicatorId)
+      ≠ (a, ({k} : ReplicatorFilter), (∅ : ReplicatorCollections)) := by
   apply filter_change_distinct_identity
   intro h
   have hk : k ∈ ({k} : ReplicatorFilter) := Finset.mem_singleton_self k
   rw [← h] at hk
   exact Finset.not_mem_empty k hk
+
+/-- A concrete witness that the `cs1 ≠ cs2` hypothesis is satisfiable: the
+data-plane-only collection set and the merged set differing by one
+control-plane collection are distinct. -/
+theorem collections_change_hypothesis_satisfiable (a : String) (c : String) :
+    ((a, (∅ : ReplicatorFilter), (∅ : ReplicatorCollections)) : ReplicatorId)
+      ≠ (a, (∅ : ReplicatorFilter), ({c} : ReplicatorCollections)) := by
+  apply collections_change_distinct_identity
+  intro h
+  have hc : c ∈ ({c} : ReplicatorCollections) := Finset.mem_singleton_self c
+  rw [← h] at hc
+  exact Finset.not_mem_empty c hc
 
 /-- **Filter change forces reinstall.** When desired carries `(a, f2)` and actual
 still carries the managed old identity `(a, f1)` with `f1 ≠ f2`, the diff is
@@ -202,47 +228,97 @@ Every conjunct is quantified over the real transition relation: the two
 guards from the hypotheses, so this is not a vacuous restatement of the goal. -/
 theorem filter_change_forces_reinstall
     {s : ReconcileState} {desired : PairingDesired}
-    {a : String} {f1 f2 : ReplicatorFilter}
+    {a : String} {cs : ReplicatorCollections} {f1 f2 : ReplicatorFilter}
     (h_desired : s.desired = some desired)
     (hf : f1 ≠ f2)
-    (h_new_desired : ((a, f2) : ReplicatorId) ∈ desired.replicators)
-    (h_old_not_desired : ((a, f1) : ReplicatorId) ∉ desired.replicators)
-    (h_old_actual : ((a, f1) : ReplicatorId) ∈ s.actual.replicators)
-    (h_old_applied : ((a, f1) : ReplicatorId) ∈ s.applied.replicators)
-    (h_new_not_actual : ((a, f2) : ReplicatorId) ∉ s.actual.replicators)
+    (h_new_desired : ((a, f2, cs) : ReplicatorId) ∈ desired.replicators)
+    (h_old_not_desired : ((a, f1, cs) : ReplicatorId) ∉ desired.replicators)
+    (h_old_actual : ((a, f1, cs) : ReplicatorId) ∈ s.actual.replicators)
+    (h_old_applied : ((a, f1, cs) : ReplicatorId) ∈ s.applied.replicators)
+    (h_new_not_actual : ((a, f2, cs) : ReplicatorId) ∉ s.actual.replicators)
     (h_connected : s.actual.connected = true) :
     -- (1) the state is genuinely diverged
     0 < disagreementCount s ∧
     -- (2) tearing down the OLD identity is an enabled transition
-    Transition s (teardownReplicatorState s (a, f1)) ∧
+    Transition s (teardownReplicatorState s (a, f1, cs)) ∧
     -- (3) installing the NEW identity is an enabled transition
-    Transition s (installReplicatorState s (a, f2)) ∧
+    Transition s (installReplicatorState s (a, f2, cs)) ∧
     -- (4) teardown-then-install lands the address on the new identity
-    ( ((a, f2) : ReplicatorId) ∈
-        (installReplicatorState (teardownReplicatorState s (a, f1)) (a, f2)).actual.replicators ∧
-      ((a, f1) : ReplicatorId) ∉
-        (installReplicatorState (teardownReplicatorState s (a, f1)) (a, f2)).actual.replicators ) := by
+    ( ((a, f2, cs) : ReplicatorId) ∈
+        (installReplicatorState (teardownReplicatorState s (a, f1, cs)) (a, f2, cs)).actual.replicators ∧
+      ((a, f1, cs) : ReplicatorId) ∉
+        (installReplicatorState (teardownReplicatorState s (a, f1, cs)) (a, f2, cs)).actual.replicators ) := by
   refine ⟨?_, ?_, ?_, ?_, ?_⟩
-  · -- non-empty diff: (a, f2) is desired but not actual, so it sits in the
+  · -- non-empty diff: (a, f2, cs) is desired but not actual, so it sits in the
     -- desired \ actual symmetric-difference summand.
-    have h_mem : ((a, f2) : ReplicatorId) ∈ desired.replicators \ s.actual.replicators :=
+    have h_mem : ((a, f2, cs) : ReplicatorId) ∈ desired.replicators \ s.actual.replicators :=
       Finset.mem_sdiff.mpr ⟨h_new_desired, h_new_not_actual⟩
     have h_card_pos : 0 < (desired.replicators \ s.actual.replicators).card :=
       Finset.card_pos.mpr ⟨_, h_mem⟩
     simp only [disagreementCount, h_desired]
     omega
-  · exact Transition.reconcileTeardownReplicator desired (a, f1)
+  · exact Transition.reconcileTeardownReplicator desired (a, f1, cs)
       h_desired h_old_actual h_old_not_desired h_old_applied rfl
-  · exact Transition.reconcileInstallReplicator desired (a, f2)
+  · exact Transition.reconcileInstallReplicator desired (a, f2, cs)
       h_desired h_new_desired h_new_not_actual h_connected rfl
-  · -- install inserts (a, f2)
+  · -- install inserts (a, f2, cs)
     exact Finset.mem_insert_self _ _
-  · -- after teardown of (a, f1) then install of (a, f2), (a, f1) is gone:
-    -- it is not (a, f2) (distinct identities) and was erased.
+  · -- after teardown of (a, f1, cs) then install of (a, f2, cs), the old
+    -- identity is gone: it is not (a, f2, cs) (distinct) and was erased.
     simp only [installReplicatorState, teardownReplicatorState]
     rw [Finset.mem_insert]
     push_neg
     exact ⟨filter_change_distinct_identity hf, Finset.not_mem_erase _ _⟩
+
+/-- **Collection-set change forces reinstall.** The live demo bug, as a theorem.
+A replicator installed while only the data-plane layer was visible carries only
+that layer's collection set `cs1`; when the control-plane layer merges in,
+desired carries the SAME address and filter but the larger merged set `cs2`.
+The collection set is part of the identity, so this is a teardown of the old
+identity and an install of the new one — NOT a silent no-op. (The pre-fix Rust
+diff keyed replicators on address alone, converged falsely, and never pushed
+the control-plane collections to the peer — the demo `pair` step-8 hang.)
+
+Same conjunct structure as `filter_change_forces_reinstall`; every conjunct is
+quantified over the real transition relation. -/
+theorem collections_change_forces_reinstall
+    {s : ReconcileState} {desired : PairingDesired}
+    {a : String} {f : ReplicatorFilter} {cs1 cs2 : ReplicatorCollections}
+    (h_desired : s.desired = some desired)
+    (hcs : cs1 ≠ cs2)
+    (h_new_desired : ((a, f, cs2) : ReplicatorId) ∈ desired.replicators)
+    (h_old_not_desired : ((a, f, cs1) : ReplicatorId) ∉ desired.replicators)
+    (h_old_actual : ((a, f, cs1) : ReplicatorId) ∈ s.actual.replicators)
+    (h_old_applied : ((a, f, cs1) : ReplicatorId) ∈ s.applied.replicators)
+    (h_new_not_actual : ((a, f, cs2) : ReplicatorId) ∉ s.actual.replicators)
+    (h_connected : s.actual.connected = true) :
+    -- (1) the state is genuinely diverged
+    0 < disagreementCount s ∧
+    -- (2) tearing down the OLD identity is an enabled transition
+    Transition s (teardownReplicatorState s (a, f, cs1)) ∧
+    -- (3) installing the NEW identity is an enabled transition
+    Transition s (installReplicatorState s (a, f, cs2)) ∧
+    -- (4) teardown-then-install lands the address on the new identity
+    ( ((a, f, cs2) : ReplicatorId) ∈
+        (installReplicatorState (teardownReplicatorState s (a, f, cs1)) (a, f, cs2)).actual.replicators ∧
+      ((a, f, cs1) : ReplicatorId) ∉
+        (installReplicatorState (teardownReplicatorState s (a, f, cs1)) (a, f, cs2)).actual.replicators ) := by
+  refine ⟨?_, ?_, ?_, ?_, ?_⟩
+  · have h_mem : ((a, f, cs2) : ReplicatorId) ∈ desired.replicators \ s.actual.replicators :=
+      Finset.mem_sdiff.mpr ⟨h_new_desired, h_new_not_actual⟩
+    have h_card_pos : 0 < (desired.replicators \ s.actual.replicators).card :=
+      Finset.card_pos.mpr ⟨_, h_mem⟩
+    simp only [disagreementCount, h_desired]
+    omega
+  · exact Transition.reconcileTeardownReplicator desired (a, f, cs1)
+      h_desired h_old_actual h_old_not_desired h_old_applied rfl
+  · exact Transition.reconcileInstallReplicator desired (a, f, cs2)
+      h_desired h_new_desired h_new_not_actual h_connected rfl
+  · exact Finset.mem_insert_self _ _
+  · simp only [installReplicatorState, teardownReplicatorState]
+    rw [Finset.mem_insert]
+    push_neg
+    exact ⟨collections_change_distinct_identity hcs, Finset.not_mem_erase _ _⟩
 
 /-- Stable converged desired state cannot flap managed wiring. -/
 theorem no_flap_on_converged_stable_desired

--- a/crates/defra-agent/proofs/Proofs/PairingReconcile/State.lean
+++ b/crates/defra-agent/proofs/Proofs/PairingReconcile/State.lean
@@ -35,14 +35,23 @@ replicator; collections absent from the set are unfiltered control-plane
 collections. -/
 abbrev ReplicatorFilter := Finset CollectionFilterKey
 
-/-- A managed replicator's identity: its address plus its filter map identity.
+/-- The collection set a managed replicator carries (collection-name space). -/
+abbrev ReplicatorCollections := Finset String
 
-This is the deliverable of Part A generalized for per-collection filters:
-`(address, filters)` makes "same address, different filter map" two DISTINCT
-replicators, so a filter change is a teardown of the old identity and an install
-of the new one (no in-place mutate). `∅` means an unfiltered replicator
-(`Replicate` delivery). -/
-abbrev ReplicatorId := String × ReplicatorFilter
+/-- A managed replicator's identity: its address, its filter map identity, and
+the collection set it carries.
+
+This is the deliverable of Part A generalized for per-collection filters and
+then for the carried collection set: `(address, filters, collections)` makes
+"same address, different filter map" AND "same address, same filter, different
+collection set" distinct replicators, so either change is a teardown of the old
+identity and an install of the new one (no in-place mutate). The collections
+component fences the live demo bug where a replicator installed from the
+data-plane layer alone silently kept its narrow collection set after the
+control-plane layer merged in — an address-keyed diff converged falsely and the
+network collections were never pushed. `∅` filters means an unfiltered
+replicator (`Replicate` delivery). -/
+abbrev ReplicatorId := String × ReplicatorFilter × ReplicatorCollections
 
 namespace ReplicatorId
 
@@ -50,7 +59,10 @@ namespace ReplicatorId
 def address (r : ReplicatorId) : String := r.1
 
 /-- The replicator's per-collection filter identity (`∅` = unfiltered). -/
-def filter (r : ReplicatorId) : ReplicatorFilter := r.2
+def filter (r : ReplicatorId) : ReplicatorFilter := r.2.1
+
+/-- The collection set the replicator carries. -/
+def collections (r : ReplicatorId) : ReplicatorCollections := r.2.2
 
 end ReplicatorId
 
@@ -79,14 +91,15 @@ end PairingDesired
 /-- Remote-observed actual pairing for one peer.
 
 RUST BOUNDARY: the model keys actual replicators on the full `ReplicatorId =
-(address, ReplicatorFilter)` so the convergence proofs can reason about the
-filter identity uniformly. The Rust `PairingActual` (`p2p_reconcile/diff.rs`)
-observes the transport *address only* — the installed filter map is not
-recoverable from the peer — and recovers the `(address, filters)` identity from
-the reconciler-owned `PairingApplied.replicator_filter` instead. The two are
-equivalent for the diff's safety obligations because a managed replicator's
-filter map is always known on the applied side; this abstraction gap is the
-intended boundary, not a hole. -/
+(address, ReplicatorFilter, ReplicatorCollections)` so the convergence proofs
+can reason about the identity uniformly. The Rust `PairingActual`
+(`p2p_reconcile/diff.rs`) observes the transport *address* and the *collection
+set* each replicator carries (`list_replicators` returns both) — the installed
+filter map is not recoverable from the peer, so the filter component is
+recovered from the reconciler-owned `PairingApplied.replicator_filter` instead.
+The composition is equivalent for the diff's safety obligations because a
+managed replicator's filter map is always known on the applied side; this
+abstraction gap is the intended boundary, not a hole. -/
 structure PairingActual where
   collections : Finset String
   replicators : Finset ReplicatorId

--- a/crates/defra-agent/src/agent/p2p_reconcile/diff.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/diff.rs
@@ -1,6 +1,6 @@
 //! Pure desired-vs-actual diff for pairing reconcile.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +38,18 @@ impl PairingDesired {
         !self.collections.is_empty() || !self.replicator_addresses.is_empty()
     }
 
+    /// The collection set this pairing's replicators carry. Explicit
+    /// `replicator_collections` wins; legacy rows with no explicit set fall
+    /// back to the subscription collections (the same convention `apply_op`
+    /// uses when installing).
+    pub fn effective_replicator_collections(&self) -> &BTreeSet<String> {
+        if self.replicator_collections.is_empty() {
+            &self.collections
+        } else {
+            &self.replicator_collections
+        }
+    }
+
     pub fn uses_subagent_template(&self) -> bool {
         self.template_ids
             .iter()
@@ -48,19 +60,30 @@ impl PairingDesired {
 /// Actual pairing state read from the remote.
 ///
 /// BOUNDARY (Lean `PairingReconcile.PairingActual`): the model keys actual
-/// replicators on the full `ReplicatorId = (address, ReplicatorFilter)`, but
-/// the remote read here observes the transport *address only* — the installed
-/// scope filters are not recoverable from the peer. The `(address, filters)`
-/// identity is therefore fenced on the reconciler-owned side:
+/// replicators on the full `ReplicatorId = (address, ReplicatorFilter,
+/// ReplicatorCollections)`. The remote read here observes the transport
+/// *address* and the *collection set* each replicator carries
+/// (`list_replicators` returns both) — the installed scope filters are not
+/// recoverable from the peer. The filter component of the identity is
+/// therefore fenced on the reconciler-owned side:
 /// `PairingApplied.replicator_filter` records the filter map last installed,
 /// and `compute_owned_pairing_diff` compares desired-vs-applied filters to
-/// force a reinstall on change (Lean `filter_change_forces_reinstall`). Actual
-/// carries no `replicator_filter` by design; do not add one expecting to read it
-/// back from the remote.
+/// force a reinstall on change (Lean `filter_change_forces_reinstall`), while
+/// the collections component compares desired against `replicator_collections`
+/// read back from the remote (Lean `collections_change_forces_reinstall`).
+/// Actual carries no `replicator_filter` by design; do not add one expecting
+/// to read it back from the remote.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PairingActual {
     pub collections: BTreeSet<String>,
     pub replicator_addresses: BTreeSet<String>,
+    /// Collection set each remote replicator carries, keyed by address, in
+    /// collection-*name* space (reverse-resolved at the read boundary like the
+    /// subscription set). An absent address means the collection set could not
+    /// be observed; the diff then skips the collections-identity comparison
+    /// for that address rather than churn.
+    #[serde(default)]
+    pub replicator_collections: BTreeMap<String, BTreeSet<String>>,
 }
 
 /// Reconciler-owned pairing state persisted after successful operations.
@@ -134,25 +157,36 @@ pub fn compute_owned_pairing_diff(
     {
         ops.push(DiffOp::TeardownCollection(c.clone()));
     }
-    // Replicator identity is (address, filter). A managed replicator whose
-    // desired filter differs from the applied filter is a *distinct* identity
-    // (Lean `filter_change_distinct_identity`): tear down the old identity and
-    // install the new one, even though the address is unchanged.
+    // Replicator identity is (address, filter, collections). A managed
+    // replicator whose desired filter differs from the applied filter, or
+    // whose remotely-observed collection set differs from the desired set, is
+    // a *distinct* identity (Lean `filter_change_distinct_identity`,
+    // `collections_change_distinct_identity`): tear down the old identity and
+    // install the new one, even though the address is unchanged. The
+    // collections comparison fences the layer-order race where a replicator
+    // installed from the data-plane layer alone silently kept its narrow
+    // collection set after the control-plane layer merged in.
     let filter_changed = desired.replicator_filter != applied.replicator_filter;
+    let desired_replicator_collections = desired.effective_replicator_collections();
     for r in desired
         .replicator_addresses
         .difference(&actual.replicator_addresses)
     {
         ops.push(DiffOp::InstallReplicator(r.clone()));
     }
-    if filter_changed {
-        // Reinstall every managed address that survives into the desired set:
-        // its identity changed, so the old filtered replicator must be replaced.
-        for r in actual
-            .replicator_addresses
-            .intersection(&applied.replicator_addresses)
-            .filter(|r| desired.replicator_addresses.contains(*r))
-        {
+    // Reinstall every managed address that survives into the desired set with
+    // a changed identity: the old replicator must be replaced (Lean
+    // `filter_change_forces_reinstall` / `collections_change_forces_reinstall`).
+    for r in actual
+        .replicator_addresses
+        .intersection(&applied.replicator_addresses)
+        .filter(|r| desired.replicator_addresses.contains(*r))
+    {
+        let collections_changed = actual
+            .replicator_collections
+            .get(r)
+            .is_some_and(|carried| carried != desired_replicator_collections);
+        if filter_changed || collections_changed {
             ops.push(DiffOp::TeardownReplicator(r.clone()));
             ops.push(DiffOp::InstallReplicator(r.clone()));
         }
@@ -217,6 +251,7 @@ mod tests {
         let actual = PairingActual {
             collections: s(&["c1"]),
             replicator_addresses: s(&["/ip4/1/p2p/p"]),
+            ..Default::default()
         };
         assert!(compute_pairing_diff(&desired, &actual).is_empty());
     }
@@ -241,6 +276,7 @@ mod tests {
         let actual = PairingActual {
             collections: s(&["manual"]),
             replicator_addresses: s(&["/ip4/manual/p2p/p"]),
+            ..Default::default()
         };
         let applied = PairingApplied::default();
         assert!(compute_owned_pairing_diff(&desired, &actual, &applied).is_empty());
@@ -272,6 +308,7 @@ mod tests {
         let actual = PairingActual {
             collections: BTreeSet::new(),
             replicator_addresses: s(&["addr1"]),
+            ..Default::default()
         };
         let applied = PairingApplied {
             collections: BTreeSet::new(),
@@ -301,11 +338,89 @@ mod tests {
         let actual = PairingActual {
             collections: BTreeSet::new(),
             replicator_addresses: s(&["addr1"]),
+            ..Default::default()
         };
         let applied = PairingApplied {
             collections: BTreeSet::new(),
             replicator_addresses: s(&["addr1"]),
             replicator_filter: f,
+            ..Default::default()
+        };
+        assert!(compute_owned_pairing_diff(&desired, &actual, &applied).is_empty());
+    }
+
+    /// Mirrors Lean `collections_change_forces_reinstall`: a replicator on
+    /// the same address with the same filter whose remotely-observed carried
+    /// collection set differs from the desired effective set is a distinct
+    /// identity, so the diff tears it down and reinstalls it. This is the
+    /// demo layer-order race: the replicator was installed from the
+    /// data-plane layer alone and kept its narrow set after the
+    /// control-plane layer merged in.
+    #[test]
+    fn changed_replicator_collections_reinstall_replicator() {
+        let desired = PairingDesired {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            replicator_collections: s(&["AgentNetwork", "AgentRequest"]),
+            ..Default::default()
+        };
+        let actual = PairingActual {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            replicator_collections: BTreeMap::from([("addr1".to_string(), s(&["AgentRequest"]))]),
+        };
+        let applied = PairingApplied {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            ..Default::default()
+        };
+        assert_eq!(
+            compute_owned_pairing_diff(&desired, &actual, &applied),
+            vec![
+                DiffOp::TeardownReplicator("addr1".into()),
+                DiffOp::InstallReplicator("addr1".into()),
+            ]
+        );
+    }
+
+    /// A carried set that matches the desired effective set yields no churn.
+    #[test]
+    fn matching_replicator_collections_do_not_reinstall() {
+        let desired = PairingDesired {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            ..Default::default()
+        };
+        let actual = PairingActual {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            replicator_collections: BTreeMap::from([("addr1".to_string(), s(&["AgentNetwork"]))]),
+        };
+        let applied = PairingApplied {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            ..Default::default()
+        };
+        assert!(compute_owned_pairing_diff(&desired, &actual, &applied).is_empty());
+    }
+
+    /// An unobservable carried set (no map entry for the address) must not
+    /// churn: absence means "could not be observed", not "empty".
+    #[test]
+    fn unobservable_replicator_collections_do_not_reinstall() {
+        let desired = PairingDesired {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            ..Default::default()
+        };
+        let actual = PairingActual {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
+            ..Default::default()
+        };
+        let applied = PairingApplied {
+            collections: s(&["AgentNetwork"]),
+            replicator_addresses: s(&["addr1"]),
             ..Default::default()
         };
         assert!(compute_owned_pairing_diff(&desired, &actual, &applied).is_empty());
@@ -317,6 +432,7 @@ mod tests {
         let actual = PairingActual {
             collections: s(&["manual", "managed"]),
             replicator_addresses: s(&["/ip4/manual/p2p/p", "/ip4/managed/p2p/p"]),
+            ..Default::default()
         };
         let applied = PairingApplied {
             collections: s(&["managed"]),

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -290,10 +290,42 @@ async fn read_actual(admin: &dyn RemoteP2pAdmin) -> Result<ActualSnapshot> {
         .filter_map(|replicator| Some((replicator.address?, replicator.collections)))
         .collect::<BTreeMap<_, _>>();
 
+    // The diff compares the replicator's carried collection set in *name*
+    // space (part of the replicator identity, Lean
+    // `collections_change_forces_reinstall`), but the transport reports it in
+    // id space — reverse-resolve like the subscription set above. An
+    // unresolvable token is kept raw at debug (unlike subscriptions, some
+    // adapters report names here already, so raw is not necessarily wrong).
+    let mut replicator_collections = BTreeMap::new();
+    for (address, ids) in &replicator_collections_by_addr {
+        let mut names = BTreeSet::new();
+        for id in ids {
+            match admin
+                .resolve_collection_name(id)
+                .await
+                .with_context(|| format!("resolve replicator collection name for id {id}"))?
+            {
+                Some(name) => {
+                    names.insert(name);
+                }
+                None => {
+                    tracing::debug!(
+                        collection = %id,
+                        address = %address,
+                        "replicator collection token has no local name; keeping it raw"
+                    );
+                    names.insert(id.clone());
+                }
+            }
+        }
+        replicator_collections.insert(address.clone(), names);
+    }
+
     Ok(ActualSnapshot {
         state: PairingActual {
             collections,
             replicator_addresses,
+            replicator_collections,
         },
         replicator_ids_by_addr,
         replicator_collections_by_addr,
@@ -324,16 +356,13 @@ async fn apply_op(
             // independent of the subscription set (`collections`): a `Push`
             // template subscribes to nothing but still replicates the full set.
             // Legacy rows with no explicit replicator set fall back to the
-            // subscription collections.
-            let collections = if desired.replicator_collections.is_empty() {
-                desired.collections.iter().cloned().collect::<Vec<_>>()
-            } else {
-                desired
-                    .replicator_collections
-                    .iter()
-                    .cloned()
-                    .collect::<Vec<_>>()
-            };
+            // subscription collections (the same effective set the diff keys
+            // the replicator identity on).
+            let collections = desired
+                .effective_replicator_collections()
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
             admin
                 .add_replicator(&addresses, &collections, &desired.replicator_filter)
                 .await
@@ -1282,11 +1311,14 @@ mod tests {
                 .unwrap()
                 .push((addresses.to_vec(), filters.clone()));
             for address in addresses {
+                // Like the real adapter, the transport records the carried
+                // collection set in *id* space; `read_actual` reverse-resolves
+                // it to names for the identity comparison.
                 self.replicators.lock().unwrap().insert(
                     address.clone(),
                     RemoteReplicator {
                         id: Some(format!("id-{address}")),
-                        collections: collections.to_vec(),
+                        collections: collections.iter().map(|c| mock_collection_id(c)).collect(),
                         address: Some(address.clone()),
                     },
                 );
@@ -1525,6 +1557,82 @@ mod tests {
         let recorded = admin.recorded_filters.lock().unwrap();
         assert_eq!(recorded.len(), 1);
         assert_eq!(recorded[0].1, conversation_filter);
+    }
+
+    /// Regression for the demo layer-order race: the data-plane desired lands
+    /// before the control-plane layer, so the first tick installs the
+    /// replicator carrying only the conversation collections. When the merged
+    /// desired arrives — same address, same filter, LARGER collection set —
+    /// the replicator must be reinstalled with the merged set: the carried
+    /// collection set is part of the replicator identity (Lean
+    /// `collections_change_forces_reinstall`). Pre-fix the diff keyed
+    /// replicators on address alone and converged falsely, so the
+    /// control-plane collections were never pushed to the peer (demo `pair`
+    /// step-8 hang even with a healthy connection).
+    #[tokio::test]
+    async fn grown_replicator_collection_set_reinstalls_replicator() {
+        let conversation_filter = one_filter("AgentRequest", "agent_did", "did:key:host");
+        // Tick 1: only the data-plane layer is visible (Push template shape:
+        // nothing subscribed, the filtered replicator carries the set).
+        let store = MockStore::with_desired(Some(PairingDesired {
+            collections: BTreeSet::new(),
+            replicator_addresses: set(&["addr1"]),
+            replicator_collections: set(&["AgentRequest"]),
+            replicator_filter: conversation_filter.clone(),
+            ..Default::default()
+        }));
+        let admin = MockAdmin {
+            active: Mutex::new(vec!["peer-a".into()]),
+            ..Default::default()
+        };
+
+        let first = reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("first tick");
+        assert_eq!(
+            first.ops_applied,
+            vec![DiffOp::InstallReplicator("addr1".into())]
+        );
+
+        // The control-plane layer merges in: same address, same filter,
+        // larger replicator collection set plus the control subscription.
+        *store.desired.lock().unwrap() = Ok(Some(PairingDesired {
+            collections: set(&["AgentNetwork"]),
+            replicator_addresses: set(&["addr1"]),
+            replicator_collections: set(&["AgentNetwork", "AgentRequest"]),
+            replicator_filter: conversation_filter,
+            ..Default::default()
+        }));
+
+        let second = reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("second tick");
+        assert_eq!(
+            second.ops_applied,
+            vec![
+                DiffOp::InstallCollection("AgentNetwork".into()),
+                DiffOp::TeardownReplicator("addr1".into()),
+                DiffOp::InstallReplicator("addr1".into()),
+            ]
+        );
+        // The reinstalled replicator carries the merged collection set.
+        assert_eq!(
+            admin.replicators.lock().unwrap()["addr1"].collections,
+            vec![
+                mock_collection_id("AgentNetwork"),
+                mock_collection_id("AgentRequest")
+            ]
+        );
+
+        // Tick 3: converged — the collections identity must not churn.
+        let third = reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("third tick");
+        assert!(
+            third.ops_applied.is_empty(),
+            "converged, got: {:?}",
+            third.ops_applied
+        );
     }
 
     /// The active-peer gate must fail open: a broken `active_peers` read means

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use p2p::iroh::parse_public_peer_addr;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
 
@@ -74,15 +75,28 @@ pub async fn reconcile_peer_tick(
     };
     let desired_state = desired.clone().unwrap_or_default();
     if desired_state.has_wiring() && !desired_state.replicator_addresses.is_empty() {
-        let addresses = desired_state
-            .replicator_addresses
-            .iter()
-            .cloned()
-            .collect::<Vec<_>>();
-        admin
-            .connect(&addresses)
-            .await
-            .context("connect pairing peer")?;
+        // Dial only when the peer is not already connected — the Lean
+        // `PairingReconcile.Transition.dial`/`dialFailed` premises both require
+        // `connected = false`; a connected peer proceeds straight to the
+        // reconcile ops. A redundant redial is not merely wasted work: on Linux
+        // it can time out even though the connection is healthy, and a dial
+        // failure aborts this tick before the diff below runs — leaving an
+        // already-paired peer permanently unable to pick up new desired state
+        // (e.g. the filtered conversation data-plane replicator on top of an
+        // applied control-plane pairing).
+        if peer_already_active(admin, peer_id).await {
+            tracing::debug!(peer_id, "pairing peer already connected; skipping redial");
+        } else {
+            let addresses = desired_state
+                .replicator_addresses
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>();
+            admin
+                .connect(&addresses)
+                .await
+                .context("connect pairing peer")?;
+        }
     }
     let mut applied = store.load_applied(peer_id).await?;
     let actual = read_actual(admin).await?;
@@ -110,6 +124,32 @@ pub async fn reconcile_peer_tick(
         peer_id: peer_id.to_string(),
         ops_applied,
         desired_read_failed: false,
+    })
+}
+
+/// True when `peer_id` already has a live connection according to
+/// `active_peers`. Entries are either bare peer ids or the dial address
+/// recorded for the peer (the embedded adapter returns whichever it has), so
+/// extract the peer id from each entry rather than comparing verbatim —
+/// mirroring the desktop supervisor's `is_connected_peer`. A failed read
+/// degrades to "not connected": the tick dials exactly as it did before this
+/// check existed.
+async fn peer_already_active(admin: &dyn RemoteP2pAdmin, peer_id: &str) -> bool {
+    let peers = match admin.active_peers().await {
+        Ok(peers) => peers,
+        Err(error) => {
+            tracing::debug!(
+                peer_id,
+                error = %error,
+                "active-peer read failed; assuming peer is not connected"
+            );
+            return false;
+        }
+    };
+    peers.iter().any(|entry| {
+        parse_public_peer_addr(entry)
+            .map(|(parsed, _)| parsed.as_str() == peer_id)
+            .unwrap_or_else(|_| entry.contains(peer_id))
     })
 }
 
@@ -920,7 +960,9 @@ mod tests {
     use anyhow::anyhow;
 
     use super::*;
-    use crate::agent::p2p_reconcile::{RemoteP2pAdminResult, RemoteReplicator};
+    use crate::agent::p2p_reconcile::{
+        RemoteP2pAdminError, RemoteP2pAdminResult, RemoteReplicator,
+    };
 
     fn set(values: &[&str]) -> BTreeSet<String> {
         values.iter().map(|value| value.to_string()).collect()
@@ -1194,6 +1236,14 @@ mod tests {
         connects: Mutex<Vec<Vec<String>>>,
         /// Filters recorded per `add_replicator` call: (addresses, filters).
         recorded_filters: Mutex<Vec<(Vec<String>, PairingFilters)>>,
+        /// Entries returned by `active_peers` (bare peer ids or dial addresses,
+        /// like the real adapters).
+        active: Mutex<Vec<String>>,
+        /// When set, `active_peers` fails, exercising the degraded-read path.
+        fail_active_peers: bool,
+        /// When set, `connect` fails after recording the call — modeling the
+        /// Linux redial-timeout that motivated the active-peer gate.
+        fail_connect: bool,
     }
 
     #[async_trait]
@@ -1203,11 +1253,17 @@ mod tests {
         }
 
         async fn active_peers(&self) -> RemoteP2pAdminResult<Vec<String>> {
-            Ok(Vec::new())
+            if self.fail_active_peers {
+                return Err(RemoteP2pAdminError::RpcError("active_peers down".into()));
+            }
+            Ok(self.active.lock().unwrap().clone())
         }
 
         async fn connect(&self, addresses: &[String]) -> RemoteP2pAdminResult<()> {
             self.connects.lock().unwrap().push(addresses.to_vec());
+            if self.fail_connect {
+                return Err(RemoteP2pAdminError::RpcTimeout);
+            }
             Ok(())
         }
 
@@ -1403,6 +1459,114 @@ mod tests {
                 ..Default::default()
             }
         );
+    }
+
+    /// Regression for the Linux demo `pair` hang at "waiting for conversation
+    /// data-plane replicators": the tick used to dial the desired replicator
+    /// addresses unconditionally, so a redial of an ALREADY-connected peer that
+    /// timed out aborted the tick before the diff ran — the applied
+    /// control-plane pairing never got upgraded with the filtered conversation
+    /// data-plane replicator (`PeerPairingApplied.replicator_filter` stayed
+    /// null forever). An active peer must skip the redial and still reconcile.
+    #[tokio::test]
+    async fn active_peer_skips_redial_and_upgrades_data_plane_replicator() {
+        let conversation_filter = one_filter("AgentRequest", "agent_did", "did:key:host");
+        // Desired now includes the conversation data plane: same address, new
+        // collection, and a scoped filter (identity change ⇒ reinstall).
+        let store = MockStore::with_desired(Some(PairingDesired {
+            collections: set(&["AgentNetwork", "AgentRequest"]),
+            replicator_addresses: set(&["addr1"]),
+            replicator_filter: conversation_filter.clone(),
+            ..Default::default()
+        }));
+        // Control-plane pairing already applied: unfiltered replicator on addr1.
+        *store.applied.lock().unwrap() = PairingApplied {
+            collections: set(&["AgentNetwork"]),
+            replicator_addresses: set(&["addr1"]),
+            replicator_filter: PairingFilters::new(),
+        };
+        let admin = MockAdmin {
+            active: Mutex::new(vec!["peer-a".into()]),
+            fail_connect: true,
+            ..Default::default()
+        };
+        *admin.collections.lock().unwrap() = set(&[&mock_collection_id("AgentNetwork")]);
+        admin.replicators.lock().unwrap().insert(
+            "addr1".into(),
+            RemoteReplicator {
+                id: Some("id-addr1".into()),
+                collections: vec!["AgentNetwork".into()],
+                address: Some("addr1".into()),
+            },
+        );
+
+        let outcome = reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("tick must reconcile without dialing");
+
+        assert!(
+            admin.connects.lock().unwrap().is_empty(),
+            "already-active peer must not be redialed"
+        );
+        assert_eq!(
+            outcome.ops_applied,
+            vec![
+                DiffOp::InstallCollection("AgentRequest".into()),
+                DiffOp::TeardownReplicator("addr1".into()),
+                DiffOp::InstallReplicator("addr1".into()),
+            ]
+        );
+        // Applied records the conversation filter — this is what surfaces as
+        // `PeerPairingApplied.replicator_filter` and what the demo waits on.
+        assert_eq!(
+            store.applied.lock().unwrap().replicator_filter,
+            conversation_filter
+        );
+        let recorded = admin.recorded_filters.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert_eq!(recorded[0].1, conversation_filter);
+    }
+
+    /// The active-peer gate must fail open: a broken `active_peers` read means
+    /// "assume not connected" and dial as before, never a wedged pairing.
+    #[tokio::test]
+    async fn active_peer_read_failure_still_dials() {
+        let store = MockStore::with_desired(Some(PairingDesired {
+            collections: set(&["c1"]),
+            replicator_addresses: set(&["addr1"]),
+            ..Default::default()
+        }));
+        let admin = MockAdmin {
+            fail_active_peers: true,
+            ..Default::default()
+        };
+
+        reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("tick result");
+
+        assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr1"]]);
+    }
+
+    /// A different peer being active is not this peer being active: the tick
+    /// must still dial.
+    #[tokio::test]
+    async fn other_active_peer_does_not_suppress_dial() {
+        let store = MockStore::with_desired(Some(PairingDesired {
+            collections: set(&["c1"]),
+            replicator_addresses: set(&["addr1"]),
+            ..Default::default()
+        }));
+        let admin = MockAdmin {
+            active: Mutex::new(vec!["peer-b".into()]),
+            ..Default::default()
+        };
+
+        reconcile_peer_tick(&admin, &store, "peer-a")
+            .await
+            .expect("tick result");
+
+        assert_eq!(*admin.connects.lock().unwrap(), vec![vec!["addr1"]]);
     }
 
     /// Review Finding #1: the remote subscription set is tracked in *id*-space by

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -241,6 +241,7 @@ fn pairing_replicator_teardown_diff_converges() -> bool {
     let actual = PairingActual {
         collections: BTreeSet::new(),
         replicator_addresses: BTreeSet::from(["addr1".to_string()]),
+        ..Default::default()
     };
     let applied = PairingApplied {
         collections: BTreeSet::new(),
@@ -264,6 +265,7 @@ fn operator_delete_yields_teardown_diff() -> bool {
     let actual = PairingActual {
         collections: BTreeSet::new(),
         replicator_addresses: BTreeSet::from(["addr1".to_string()]),
+        ..Default::default()
     };
     let applied = PairingApplied {
         collections: BTreeSet::new(),

--- a/crates/defra-agent/tests/support/pairing_conformance/invariants.rs
+++ b/crates/defra-agent/tests/support/pairing_conformance/invariants.rs
@@ -112,6 +112,7 @@ fn pending_owned_ops(
         &RuntimePairingActual {
             collections: snapshot.actual.collections.clone(),
             replicator_addresses: snapshot.actual.replicator_addresses.clone(),
+            ..Default::default()
         },
         &snapshot.applied,
     )

--- a/crates/defra-agent/tests/support/pairing_conformance/runner.rs
+++ b/crates/defra-agent/tests/support/pairing_conformance/runner.rs
@@ -310,9 +310,14 @@ async fn apply_desired_state(
         peer.actual_connected = true;
     }
 
+    // The harness does not model which collections each installed replicator
+    // carries; leaving the map empty means "unobservable", which the diff
+    // treats as no collections-identity divergence (matching the documented
+    // `PairingActual.replicator_collections` semantics).
     let actual = RuntimePairingActual {
         collections: peer.actual_collections.clone(),
         replicator_addresses: peer.actual_replicator_addresses.clone(),
+        ..Default::default()
     };
     let mut applied = PairingApplied {
         collections: reconciler.applied_collections.clone(),


### PR DESCRIPTION
Fixes the demo `pair` step-8 hang ("waiting for conversation data-plane replicators") end-to-end. Two stacked defects, one per commit:

## 1. Redundant redial aborts the tick (`dfdf2fc`)

`reconcile_peer_tick` dialed the desired replicator addresses on every tick before reading applied/actual state. A redial of an already-connected peer can time out (observed on Linux), and the dial failure aborted the tick before the diff ran — an applied control-plane pairing could never pick up new desired state.

Fix: gate the dial on `active_peers()` (fail open to dialing when the read errors). This also brings the code into conformance with the Lean model — `dial`/`dialFailed` both require `connected = false`, so the unconditional redial was a transition the spec cannot express. Promotes `p2p` from dev-dependency to dependency (address parser; already transitive).

## 2. Replicator collection set was not part of the replicator identity (`99d1e5c`)

The owned diff keyed replicators on `(address, filter)`. When the data-plane desired lands before the control-plane layer (a race the demo loses on node A), the replicator installs carrying only the conversation collections; the later merge grows the desired set but neither address nor filter changes, so the diff converges falsely. The network collections (`NetworkMembership`, `PeerEndpoint`, …) are then never pushed to the peer, the peer's Layer-2 membership gate never opens, and it never installs its filtered conversation replicator — `PeerPairingApplied.replicator_filter` stays null forever, which is exactly what step 8 waits on. Reproduced on macOS with a healthy connection; verified by injecting the two missing signed rows into node B mid-run, which immediately unblocked pairing.

Fix, foundation-flow order:
- **Lean**: `ReplicatorId` becomes `(address, filter, collections)`; `collections_change_distinct_identity` + `collections_change_forces_reinstall` proven (zero sorries), mirroring the existing filter-identity theorems.
- **Rust**: `read_actual` reverse-resolves each remote replicator's carried collection set to names (the transport reports it — same boundary treatment as the subscription set); `compute_owned_pairing_diff` reinstalls a managed replicator whose observed set differs from the desired effective set. An unobservable set (absent map entry) never churns.

## Tests

- New: layer-order-race regression at the engine level (data-plane first, merge second → reinstall with merged set, then converge); pure-diff tests mirroring the Lean theorem (changed / matching / unobservable carried set); skip-redial regressions (active peer, failed read fails open, other-peer still dials).
- `lake build`: all proofs green, zero sorries. `cargo test -p defra-agent`: full suite passes (928 lib + integration).
- Live: demo `pair` **and** `delegate` complete end-to-end from a fresh home (previously: 120s timeout at step 8 on macOS and Linux).