### PR TITLE
Bump defradb.rs to main after #1087

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6545,7 +6545,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-lock",
@@ -6584,7 +6584,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-trait",
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "anyhow",
  "document",
@@ -6909,7 +6909,7 @@ version = "0.6.2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "cid",
@@ -6933,7 +6933,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-stream",
@@ -6975,7 +6975,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "anyhow",
@@ -7008,7 +7008,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-trait",
@@ -7042,7 +7042,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "serde",
 ]
@@ -7460,7 +7460,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7918,7 +7918,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11037,7 +11037,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12270,7 +12270,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-lock",
@@ -12418,7 +12418,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15152,7 +15152,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "anyhow",
@@ -16570,7 +16570,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16606,7 +16606,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16623,7 +16623,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "async-lock",
@@ -16655,7 +16655,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17608,7 +17608,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "p2p",
  "query",
@@ -18407,7 +18407,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "cid",
  "defra-core",
@@ -19609,7 +19609,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20036,7 +20036,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24475,7 +24475,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=08c14cb40783b0e6fdde6b3167f5fc0cc219323f#08c14cb40783b0e6fdde6b3167f5fc0cc219323f"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=def0e7ec25b32c9db2963e2d55a390030937520b#def0e7ec25b32c9db2963e2d55a390030937520b"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,22 +50,22 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs rev = main just after #1085 (Linux P2P connection refcount fix;
-# #1084 also included iroh 1.0 stable relays + open_path backoff, see #588).
-# Move to the next upstream tag when one is cut.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+# defradb.rs rev = main just after #1087 (idempotent connect_peer/add_replicator:
+# no redial of already-connected peers — Linux demo pair fix; on top of #1085's
+# connection refcount fix). Move to the next upstream tag when one is cut.
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -73,8 +73,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "08c14cb40783b0e6fdde6b3167f5fc0cc219323f" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "def0e7ec25b32c9db2963e2d55a390030937520b" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"


### PR DESCRIPTION
Moves the defradb.rs pin from `08c14cb4` to `def0e7ec` (main after sourcenetwork/defradb.rs#1087).

That change makes `connect_peer` and `add_replicator` skip the dial when the peer is already connected, which was the remaining cause of the demo `pair` step-8 hang on Linux: redundant redials of healthy connections timed out and aborted the pairing reconcile before the data-plane replicator could install.

Verified on this pin: full `cargo test -p defra-agent` green (931 lib + integration suites), and demo `pair` + `delegate` complete end-to-end from a fresh home.