### PR TITLE
fix(mcp): bound and unwedge the MCP pool; gate + parallelize discover_tools

### DIFF
--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -22,6 +22,17 @@ use tracing::Instrument;
 
 pub const AGENT_DID_HEADER: &str = "x-agent-did";
 
+/// Bound on establishing an MCP connection (TCP connect + MCP handshake).
+/// A blackholed endpoint — e.g. the tailscale address of a powered-off host —
+/// drops packets silently, so without this bound the connect future never
+/// resolves (#622). rmcp's transport carries no timeout of its own.
+const MCP_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Bound on one tools/list round-trip. list_tools is a safe read on
+/// interactive paths (discover / describe / argument preflight) and the pool
+/// retries it once after eviction, so a caller waits at most two of these.
+const MCP_LIST_TOOLS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Wrapper that stores list_tools / call_tool closures over a concrete
 /// `RunningService` so that the pool doesn't need to name the transport
 /// generic parameter (which includes rmcp's internal reqwest 0.13 Client).
@@ -407,11 +418,24 @@ impl McpPool {
     }
 
     async fn list_tools_once(&self, service_id: &str) -> Result<ListToolsResult> {
-        let guard = self.inner.read().await;
-        let conn = guard
-            .get(service_id)
-            .context("connection disappeared after get_or_connect")?;
-        (conn.list_tools_fn)().await
+        // The closure's future owns an Arc of the client, so it can be
+        // awaited after the guard drops — a slow list call must not hold the
+        // pool lock and block unrelated services (#622).
+        let list_tools = {
+            let guard = self.inner.read().await;
+            let conn = guard
+                .get(service_id)
+                .context("connection disappeared after get_or_connect")?;
+            (conn.list_tools_fn)()
+        };
+        tokio::time::timeout(MCP_LIST_TOOLS_TIMEOUT, list_tools)
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "MCP list_tools on '{service_id}' timed out after {}s",
+                    MCP_LIST_TOOLS_TIMEOUT.as_secs()
+                )
+            })?
     }
 
     async fn call_tool_once(
@@ -419,11 +443,17 @@ impl McpPool {
         service_id: &str,
         params: CallToolRequestParams,
     ) -> Result<CallToolResult> {
-        let guard = self.inner.read().await;
-        let conn = guard
-            .get(service_id)
-            .context("connection disappeared after get_or_connect")?;
-        (conn.call_tool_fn)(params).await
+        // No pool-level timeout here — tool calls are bounded by the caller's
+        // health-keyed budget (meta_tools/call.rs). The guard still must not
+        // be held across the await (#622).
+        let call_tool = {
+            let guard = self.inner.read().await;
+            let conn = guard
+                .get(service_id)
+                .context("connection disappeared after get_or_connect")?;
+            (conn.call_tool_fn)(params)
+        };
+        call_tool.await
     }
 
     // -----------------------------------------------------------------------
@@ -432,9 +462,9 @@ impl McpPool {
 
     /// Ensure a valid connection for `service_id` exists in the pool.
     ///
-    /// Uses a double-checked locking pattern:
     /// 1. Read-lock: check if a connection exists and the endpoint matches.
-    /// 2. If not, take write-lock and re-check before actually connecting.
+    /// 2. If not, re-check under the write lock, then connect with no lock
+    ///    held and insert the result. Duplicate racing connects are benign.
     async fn get_or_connect(
         &self,
         service_id: &str,
@@ -458,37 +488,56 @@ impl McpPool {
             }
         }
 
-        // Slow path — write lock, re-check
-        let mut guard = self.inner.write().await;
-        if let Some(conn) = guard.get(service_id) {
-            let endpoint_changed = conn.endpoint != endpoint;
-            let agent_did_changed = conn.agent_did_header != agent_did_header;
-            let trace_context_changed = conn.trace_context_headers != trace_context_headers;
-            if conn.endpoint == endpoint
-                && conn.agent_did_header == agent_did_header
-                && conn.trace_context_headers == trace_context_headers
-            {
-                return Ok(());
+        // Slow path — re-check under the lock, but connect OUTSIDE it: a hung
+        // or slow connect (blackholed endpoint, #622) must not wedge every
+        // other service in the pool.
+        {
+            let guard = self.inner.write().await;
+            if let Some(conn) = guard.get(service_id) {
+                let endpoint_changed = conn.endpoint != endpoint;
+                let agent_did_changed = conn.agent_did_header != agent_did_header;
+                let trace_context_changed = conn.trace_context_headers != trace_context_headers;
+                if conn.endpoint == endpoint
+                    && conn.agent_did_header == agent_did_header
+                    && conn.trace_context_headers == trace_context_headers
+                {
+                    return Ok(());
+                }
+                tracing::info!(
+                    service_id,
+                    old_endpoint = %conn.endpoint,
+                    new_endpoint = %endpoint,
+                    endpoint_changed,
+                    agent_did_changed,
+                    trace_context_changed,
+                    "MCP connection context changed, reconnecting"
+                );
             }
-            tracing::info!(
-                service_id,
-                old_endpoint = %conn.endpoint,
-                new_endpoint = %endpoint,
-                endpoint_changed,
-                agent_did_changed,
-                trace_context_changed,
-                "MCP connection context changed, reconnecting"
-            );
         }
 
         tracing::info!(service_id, endpoint, "connecting MCP client");
-        let connection = (self.connect_fn)(
-            service_id.to_string(),
-            endpoint.to_string(),
-            agent_did_header,
-            trace_context_headers,
+        let connection = tokio::time::timeout(
+            MCP_CONNECT_TIMEOUT,
+            (self.connect_fn)(
+                service_id.to_string(),
+                endpoint.to_string(),
+                agent_did_header,
+                trace_context_headers,
+            ),
         )
-        .await?;
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "MCP connect to '{service_id}' ({endpoint}) timed out after {}s",
+                MCP_CONNECT_TIMEOUT.as_secs()
+            )
+        })??;
+
+        // Concurrent callers for the same service may both reach here; the
+        // last insert wins and the loser's connection is dropped. The
+        // handshake is idempotent and the cache is lazy, so this is benign —
+        // strictly better than serializing every connect behind one lock.
+        let mut guard = self.inner.write().await;
         guard.insert(service_id.to_string(), connection);
         Ok(())
     }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -489,3 +489,101 @@ fn mcp_http_response(method: &str, id: Option<serde_json::Value>) -> String {
         body
     )
 }
+
+// --- #622: a blackholed endpoint must never wedge the pool -------------------
+//
+// The hf-data incident: a ToolServiceRegistry row pointed at a host whose
+// tailscale peer silently dropped packets (no RST). rmcp's transport has no
+// timeout of its own, so the connect future never resolved — and because
+// `get_or_connect` awaited it, callers hung. These tests fence the pool-seam
+// bounds under `tokio::time` paused clocks: if no internal timer exists the
+// paused runtime auto-advances straight to the outer guard and the test fails.
+
+fn pending_connect_pool() -> McpPool {
+    McpPool::new_with_connector(|_service_id, _endpoint, _agent_did, _trace_headers| async {
+        std::future::pending::<anyhow::Result<McpConnection>>().await
+    })
+}
+
+#[tokio::test(start_paused = true)]
+async fn hung_connect_is_internally_bounded() {
+    let pool = pending_connect_pool();
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(3600),
+        pool.list_tools("hf-data", "http://strangenas:9200/mcp"),
+    )
+    .await
+    .expect("list_tools must internally bound a hung MCP connect");
+    let error = result.expect_err("hung connect must surface an error");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("timed out"),
+        "expected a timeout error, got: {message}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn hung_list_call_is_internally_bounded() {
+    let pool = McpPool::new_with_list_tools_handler(|_service_id, _endpoint| async {
+        std::future::pending::<anyhow::Result<ListToolsResult>>().await
+    });
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(3600),
+        pool.list_tools("hf-data", "http://strangenas:9200/mcp"),
+    )
+    .await
+    .expect("list_tools must internally bound a hung tools/list call");
+    let error = result.expect_err("hung list call must surface an error");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("timed out"),
+        "expected a timeout error, got: {message}"
+    );
+}
+
+#[tokio::test(start_paused = true)]
+async fn hung_connect_does_not_wedge_other_services() {
+    let pool = McpPool::new_with_connector(
+        |service_id, endpoint, agent_did, trace_headers| async move {
+            if service_id == "hf-data" {
+                std::future::pending::<()>().await;
+            }
+            Ok(McpConnection {
+                endpoint,
+                agent_did_header: agent_did,
+                trace_context_headers: trace_headers,
+                list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
+                call_tool_fn: Box::new(|_params| {
+                    Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                }),
+            })
+        },
+    );
+
+    let hung_pool = pool.clone();
+    let hung = tokio::spawn(async move {
+        let _ = hung_pool
+            .list_tools("hf-data", "http://strangenas:9200/mcp")
+            .await;
+    });
+    // Let the hung connect start (and, under the defective locking, take the
+    // pool write lock) before the healthy service is queried.
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+
+    let started = tokio::time::Instant::now();
+    let healthy = tokio::time::timeout(
+        std::time::Duration::from_secs(3600),
+        pool.list_tools("x-data", "http://studio-1:9198/mcp"),
+    )
+    .await
+    .expect("a hung connect for one service must not block other services");
+    assert!(healthy.is_ok(), "healthy service must list tools");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "healthy service waited {:?} behind the hung connect — connect must \
+         not hold the pool lock",
+        started.elapsed()
+    );
+
+    hung.abort();
+}

--- a/crates/defra-agent/src/meta_tools/discover.rs
+++ b/crates/defra-agent/src/meta_tools/discover.rs
@@ -3,6 +3,7 @@ use crate::llm::tool::ToolDefinition;
 use anyhow::anyhow;
 use serde::Deserialize;
 
+use crate::health_checker::HealthStatus;
 use crate::mcp_pool::resolve_mcp_url;
 
 use super::shared::{format_health_status, MetaToolContext, MetaToolError};
@@ -115,24 +116,21 @@ impl Tool for DiscoverToolsTool {
 
         let query_lower = args.query.as_deref().map(|q| q.to_lowercase());
 
-        let mut out = String::new();
-        let mut matched = 0usize;
-
-        for svc in &services {
+        // Contact services concurrently — one dead or slow endpoint must not
+        // serialize the rest (#622). Unreachable services are not contacted
+        // at all: the same preflight decision `call_tool` enforces (Lean
+        // MCPHealth coupling C1/C2); their registry row still renders below
+        // so the model can see them and why they list no tools.
+        let fetches = services.iter().map(|svc| async {
             let sid = svc
                 .get("service_id")
                 .and_then(|v| v.as_str())
                 .unwrap_or("?");
-            let name = svc
-                .get("display_name")
-                .and_then(|v| v.as_str())
-                .unwrap_or(sid);
-            let desc = svc
-                .get("description")
-                .and_then(|v| v.as_str())
-                .unwrap_or("");
-            let hostname = svc.get("hostname").and_then(|v| v.as_str()).unwrap_or("");
             let health = self.ctx.health.get(sid).await;
+            let unreachable = matches!(
+                health.as_ref().map(|h| h.status),
+                Some(HealthStatus::Unreachable)
+            );
 
             let svc_hostname = svc.get("hostname").and_then(|v| v.as_str()).unwrap_or("");
             let svc_tsip = svc
@@ -162,7 +160,9 @@ impl Tool for DiscoverToolsTool {
             } else {
                 Err(anyhow!("no mcp_port"))
             };
-            let tool_names: Vec<(String, String)> = if let Ok(ep) = &endpoint {
+            let tool_names: Vec<(String, String)> = if unreachable {
+                Vec::new()
+            } else if let Ok(ep) = &endpoint {
                 match self
                     .ctx
                     .mcp_pool
@@ -188,6 +188,27 @@ impl Tool for DiscoverToolsTool {
             } else {
                 Vec::new()
             };
+            (health, unreachable, tool_names)
+        });
+        let contacted = futures::future::join_all(fetches).await;
+
+        let mut out = String::new();
+        let mut matched = 0usize;
+
+        for (svc, (health, unreachable, tool_names)) in services.iter().zip(contacted) {
+            let sid = svc
+                .get("service_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let name = svc
+                .get("display_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or(sid);
+            let desc = svc
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let hostname = svc.get("hostname").and_then(|v| v.as_str()).unwrap_or("");
 
             if let Some(ref q) = query_lower {
                 let tool_text = tool_names
@@ -227,6 +248,9 @@ impl Tool for DiscoverToolsTool {
             }
             out.push_str("\nTools:\n");
 
+            if unreachable {
+                out.push_str("  (not contacted — service is unreachable)\n");
+            }
             for (tn, td) in &tool_names {
                 out.push_str(&format!("  - {tn}: {td}\n"));
             }
@@ -304,5 +328,201 @@ mod tests {
             "No allowed data services are currently online. Allowed services: x-data."
         );
         assert!(!output.contains("observability-mcp"));
+    }
+
+    // --- #622: discover must stay bounded and honor the health gate ---------
+
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use chrono::Utc;
+    use rmcp::model::{ListToolsResult, Tool as McpTool};
+
+    use crate::health_checker::{HealthStatus, ServiceHealth};
+    use crate::lean_vocab_test::lean_tool_preflight_cases;
+
+    async fn seed_registry_service(
+        node: &defra_node::EmbeddedNode,
+        service_id: &str,
+        hostname: &str,
+        port: u16,
+    ) {
+        let mutation = format!(
+            r#"mutation {{
+            upsert_ToolServiceRegistry(
+                filter: {{ service_id: {{ _eq: "{service_id}" }} }},
+                add: {{
+                    service_id: "{service_id}",
+                    display_name: "{service_id}",
+                    description: "test service {service_id}",
+                    hostname: "{hostname}",
+                    tailscale_ip: "",
+                    lan_ip: "",
+                    mcp_port: {port},
+                    mcp_path: "/mcp",
+                    status: "online"
+                }},
+                update: {{ status: "online" }}
+            ) {{ _docID }}
+        }}"#
+        );
+        let response = node.execute(&mutation).await;
+        assert!(
+            !response.has_errors(),
+            "registry insert failed: {:?}",
+            response.errors
+        );
+    }
+
+    fn stub_tool(name: &str) -> McpTool {
+        let schema = serde_json::json!({ "type": "object", "properties": {} })
+            .as_object()
+            .expect("object schema")
+            .clone();
+        McpTool::new(name.to_string(), format!("{name} tool"), Arc::new(schema))
+    }
+
+    fn test_context(
+        node: Arc<defra_node::EmbeddedNode>,
+        mcp_pool: McpPool,
+        health: ServiceHealthMap,
+    ) -> MetaToolContext {
+        MetaToolContext {
+            node,
+            mcp_pool,
+            health,
+            local_hostname: "studio-1".to_string(),
+            local_subnet: None,
+            agent_did: "did:key:z-test-agent".to_string(),
+            allowed_mcp_service_ids: Vec::new(),
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discover_stays_bounded_when_a_service_endpoint_blackholes() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        seed_registry_service(&node, "x-data", "elsewhere", 9198).await;
+        seed_registry_service(&node, "hf-data", "strangenas", 9200).await;
+
+        let pool = McpPool::new_with_list_tools_handler(|service_id, _endpoint| async move {
+            if service_id == "hf-data" {
+                std::future::pending::<()>().await;
+            }
+            Ok(ListToolsResult::with_all_items(vec![stub_tool(
+                "search_posts",
+            )]))
+        });
+
+        let tool = DiscoverToolsTool::new(test_context(node, pool, ServiceHealthMap::new()));
+
+        let output = tokio::time::timeout(
+            Duration::from_secs(3600),
+            tool.call(DiscoverToolsArgs { query: None }),
+        )
+        .await
+        .expect("discover_tools must stay bounded when a service endpoint blackholes")
+        .expect("discover returns model-readable text");
+
+        assert!(
+            output.contains("search_posts"),
+            "healthy service tools must still be listed: {output}"
+        );
+        assert!(
+            output.contains("hf-data"),
+            "the unreachable service must still appear in the index: {output}"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_contact_decisions_match_lean_preflight_health_gate() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        seed_registry_service(&node, "x-data", "elsewhere", 9198).await;
+
+        for case in lean_tool_preflight_cases()
+            .iter()
+            .filter(|case| case.schema_status == "unchecked")
+        {
+            let contacted = Arc::new(AtomicBool::new(false));
+            let contacted_in_handler = Arc::clone(&contacted);
+            let pool = McpPool::new_with_list_tools_handler(move |_service_id, _endpoint| {
+                let contacted = Arc::clone(&contacted_in_handler);
+                async move {
+                    contacted.store(true, Ordering::SeqCst);
+                    Ok(ListToolsResult::with_all_items(vec![stub_tool(
+                        "search_posts",
+                    )]))
+                }
+            });
+
+            let health = ServiceHealthMap::new();
+            health
+                .set_for_test(
+                    "x-data",
+                    ServiceHealth {
+                        status: match case.health.as_str() {
+                            "healthy" => HealthStatus::Healthy,
+                            "stale" => HealthStatus::Stale,
+                            "unreachable" => HealthStatus::Unreachable,
+                            other => panic!("unknown Lean health status {other:?}"),
+                        },
+                        last_seen: Utc::now(),
+                        last_error: (case.health == "unreachable")
+                            .then(|| "probe timed out".to_string()),
+                    },
+                )
+                .await;
+
+            let tool = DiscoverToolsTool::new(test_context(Arc::clone(&node), pool, health));
+            let output = tool
+                .call(DiscoverToolsArgs { query: None })
+                .await
+                .expect("discover returns model-readable text");
+
+            let expected_contact = case.decision == "dispatch";
+            assert_eq!(
+                contacted.load(Ordering::SeqCst),
+                expected_contact,
+                "Lean ToolExecution preflight case {} must gate discover's \
+                 list_tools contact (output: {output})",
+                case.name
+            );
+            assert!(
+                output.contains("x-data"),
+                "service must appear in the index regardless of health: {output}"
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn discover_fans_out_to_services_concurrently() {
+        let node = Arc::new(defra_node::EmbeddedNode::builder().build().await.unwrap());
+        crate::ensure_runtime_schemas(node.as_ref()).await.unwrap();
+        seed_registry_service(&node, "x-data", "elsewhere", 9198).await;
+        seed_registry_service(&node, "web-research-mcp", "studio-2", 9213).await;
+
+        let pool = McpPool::new_with_list_tools_handler(|_service_id, _endpoint| async move {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            Ok(ListToolsResult::with_all_items(vec![stub_tool(
+                "search_posts",
+            )]))
+        });
+
+        let tool = DiscoverToolsTool::new(test_context(node, pool, ServiceHealthMap::new()));
+
+        let started = tokio::time::Instant::now();
+        let output = tool
+            .call(DiscoverToolsArgs { query: None })
+            .await
+            .expect("discover returns model-readable text");
+        let elapsed = started.elapsed();
+
+        assert!(output.contains("x-data") && output.contains("web-research-mcp"));
+        assert!(
+            elapsed < Duration::from_secs(9),
+            "per-service list_tools must fan out concurrently; two 5s services \
+             took {elapsed:?} (serial would be ~10s)"
+        );
     }
 }


### PR DESCRIPTION
Closes #622.

## What happened

Amy (studio-1) hung indefinitely on `discover_tools`. The registry row for `hf-data` points at strangenas, which has been offline for 4 days — its tailscale address blackholes packets (silent drop, no RST). Three defects compounded:

1. **No timeouts anywhere in `mcp_pool`** — rmcp's `StreamableHttpClientTransport` carries none of its own, so the connect future never resolved.
2. **`get_or_connect` awaited the connect while holding the pool write lock** — one blackholed peer wedged *every* MCP operation in the process, not just its own service. (`list_tools_once`/`call_tool_once` had the same lock-across-await shape on the read side.)
3. **`discover_tools` contacted every `status: "online"` registry row serially, ungated and unbounded**, applying the user's query only afterwards — while fetching the health map for display only.

## The fix

- **Pool seam** (protects every caller — discover, describe, call_tool's argument preflight, tool_surface reconcile): connect bounded at 15s, tools/list at 30s. `call_tool` stays caller-timed (the health-keyed 120/300s budget in `meta_tools/call.rs`).
- **No await holds a pool lock**: connect runs outside the write lock (racing duplicate connects are benign — last insert wins); list/call futures are created under the read guard and awaited after it drops.
- **`discover_tools`**: concurrent fan-out (`join_all`), and `Unreachable` services are not contacted at all — the same preflight decision `call_tool` already enforces. Their rows still render with health status so the model sees them and why they list no tools.

## Spec status (Lean-first check)

No new states or transitions: `Proofs.MCPHealth` (healthy/degraded/evicted/reconnecting, `probeFail` folds error+timeout) coupled to `ToolExecution.preflight` via C1–C4 already defines exactly this — evicted/reconnecting block dispatch as ServiceUnavailable, stale dispatches with an adjusted budget. This PR is the Rust catching up to the proven gate at the one call site that bypassed it, fenced by a conformance test that keys discover's contact decision to the Lean-generated `lean_tool_preflight_cases()` (same mechanism `call.rs` uses).

## Tests (TDD; all six failed red before the fix)

Paused-clock (`start_paused`) fences — no internal timer means auto-advance hits the outer guard deterministically:
- `hung_connect_is_internally_bounded`, `hung_list_call_is_internally_bounded`
- `hung_connect_does_not_wedge_other_services` (empirically confirmed the lock defect: healthy service waited behind the hung connect before the fix)
- `discover_stays_bounded_when_a_service_endpoint_blackholes`
- `discover_fans_out_to_services_concurrently` (two 5s services: 10s serial before, 5s after)
- `discover_contact_decisions_match_lean_preflight_health_gate`

Gate: full `cargo test -p defra-agent` green (937 lib + all integration binaries, 0 failures). fmt clean; clippy warnings verified pre-existing (none in touched files).

## Coordination note

`fix/mcp-pool-session-leak` (../defra-agent-mcp-pool-leak worktree) is concurrently touching `mcp_pool.rs`; whichever lands second should rebase — the `get_or_connect` region moved here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)