### PR TITLE
fix(mcp-pool): bound idle connection lifetime with a 15m TTL

### DIFF
--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -51,6 +51,21 @@ struct McpConnection {
     trace_context_headers: HashMap<String, String>,
     list_tools_fn: Box<ListToolsFn>,
     call_tool_fn: Box<CallToolFn>,
+    last_used: std::sync::Mutex<std::time::Instant>,
+}
+
+impl McpConnection {
+    fn touch(&self) {
+        *self.last_used.lock().expect("last_used lock") = std::time::Instant::now();
+    }
+
+    fn idle_longer_than(&self, ttl: std::time::Duration) -> bool {
+        self.last_used.lock().expect("last_used lock").elapsed() > ttl
+    }
+}
+
+fn fresh_last_used() -> std::sync::Mutex<std::time::Instant> {
+    std::sync::Mutex::new(std::time::Instant::now())
 }
 
 fn wrap_connection<S>(
@@ -68,6 +83,7 @@ where
         endpoint,
         agent_did_header: None,
         trace_context_headers: HashMap::new(),
+        last_used: fresh_last_used(),
         list_tools_fn: Box::new(move || {
             let c = Arc::clone(&c1);
             Box::pin(async move {
@@ -234,7 +250,15 @@ pub struct McpPool {
     inner: Arc<RwLock<HashMap<String, McpConnection>>>,
     connect_fn: Arc<ConnectFn>,
     trace_context_headers_fn: Arc<TraceContextHeadersFn>,
+    idle_ttl: Option<std::time::Duration>,
 }
+
+/// Default idle TTL for pooled MCP connections.
+///
+/// A connection idle past this is replaced (and its session terminated) on
+/// next use. Bounds how long a wedged transport — e.g. one stuck in the rmcp
+/// dead-session SSE resume loop — can live unattended.
+pub const DEFAULT_MCP_IDLE_TTL: std::time::Duration = std::time::Duration::from_secs(15 * 60);
 
 impl McpPool {
     pub fn new() -> Self {
@@ -242,7 +266,15 @@ impl McpPool {
             inner: Arc::new(RwLock::new(HashMap::new())),
             connect_fn: default_connect_fn(),
             trace_context_headers_fn: Arc::new(crate::runtime_trace::current_trace_context_headers),
+            idle_ttl: Some(DEFAULT_MCP_IDLE_TTL),
         }
+    }
+
+    /// Replace connections idle longer than `ttl` on their next use (the old
+    /// session is terminated). Bounds how long a wedged transport can live.
+    pub fn with_idle_ttl(mut self, ttl: std::time::Duration) -> Self {
+        self.idle_ttl = Some(ttl);
+        self
     }
 
     #[cfg(test)]
@@ -267,6 +299,7 @@ impl McpPool {
                 },
             ),
             trace_context_headers_fn: Arc::new(crate::runtime_trace::current_trace_context_headers),
+            idle_ttl: None,
         }
     }
 
@@ -296,6 +329,7 @@ impl McpPool {
                         endpoint,
                         agent_did_header,
                         trace_context_headers: trace_headers,
+                        last_used: fresh_last_used(),
                         list_tools_fn: Box::new(move || {
                             let handler = Arc::clone(&handler);
                             let service_id = service_id_for_list.clone();
@@ -482,7 +516,9 @@ impl McpPool {
                 if conn.endpoint == endpoint
                     && conn.agent_did_header == agent_did_header
                     && conn.trace_context_headers == trace_context_headers
+                    && !self.idle_ttl.is_some_and(|ttl| conn.idle_longer_than(ttl))
                 {
+                    conn.touch();
                     return Ok(());
                 }
             }
@@ -497,10 +533,13 @@ impl McpPool {
                 let endpoint_changed = conn.endpoint != endpoint;
                 let agent_did_changed = conn.agent_did_header != agent_did_header;
                 let trace_context_changed = conn.trace_context_headers != trace_context_headers;
+                let idle_ttl_expired = self.idle_ttl.is_some_and(|ttl| conn.idle_longer_than(ttl));
                 if conn.endpoint == endpoint
                     && conn.agent_did_header == agent_did_header
                     && conn.trace_context_headers == trace_context_headers
+                    && !idle_ttl_expired
                 {
+                    conn.touch();
                     return Ok(());
                 }
                 tracing::info!(
@@ -510,6 +549,7 @@ impl McpPool {
                     endpoint_changed,
                     agent_did_changed,
                     trace_context_changed,
+                    idle_ttl_expired,
                     "MCP connection context changed, reconnecting"
                 );
             }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -169,6 +169,7 @@ async fn list_tools_transport_failure_retries_generated_safe_read_case() {
                     endpoint,
                     agent_did_header,
                     trace_context_headers: trace_headers,
+                    last_used: super::fresh_last_used(),
                     list_tools_fn: Box::new(move || {
                         let list_calls = Arc::clone(&list_calls);
                         Box::pin(async move {
@@ -224,6 +225,7 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
                 endpoint: endpoint.to_string(),
                 agent_did_header: None,
                 trace_context_headers: HashMap::new(),
+                last_used: super::fresh_last_used(),
                 list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
                 call_tool_fn: Box::new(move |_params| {
                     let calls = Arc::clone(&calls_for_fn);
@@ -345,6 +347,152 @@ async fn mcp_pool_reconnects_when_trace_context_changes() {
     );
 }
 
+/// Replacing a pooled connection (trace-context churn happens every task run)
+/// must terminate the old streamable-HTTP session on the server — otherwise
+/// every run leaks a zombie session server-side. Zombie accumulation is what
+/// fed the 2026-07-01 fleet-wide resume storm against observability-mcp.
+#[tokio::test]
+async fn replacing_connection_terminates_old_streamable_http_session() {
+    let sequence = Arc::new(AtomicUsize::new(0));
+    let sequence_for_headers = Arc::clone(&sequence);
+    let (endpoint, http_log) = spawn_session_tracking_mcp_server().await;
+    let pool = McpPool::new().with_trace_context_headers(move || {
+        let sequence = sequence_for_headers.fetch_add(1, Ordering::SeqCst) + 1;
+        HashMap::from([(
+            "traceparent".to_string(),
+            format!("00-{sequence:032x}-00f067aa0ba902b7-01"),
+        )])
+    });
+
+    pool.list_tools("session-service", &endpoint)
+        .await
+        .expect("first mock MCP list_tools should succeed");
+    // Trace context changed → pool replaces the cached connection.
+    pool.list_tools("session-service", &endpoint)
+        .await
+        .expect("second mock MCP list_tools should succeed");
+
+    // The replaced connection's worker sends the session DELETE asynchronously;
+    // poll briefly instead of asserting instantly.
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let log = http_log.lock().expect("http log lock");
+            let deleted_sessions: Vec<&str> = log
+                .iter()
+                .filter(|entry| entry.http_method == "DELETE")
+                .filter_map(|entry| entry.session_id.as_deref())
+                .collect();
+            if deleted_sessions.contains(&"session-1") {
+                return;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "expected a DELETE for the replaced connection's session-1; \
+                     without it every reconnect leaks a server-side session. log: {log:?}"
+                );
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+/// Evicting a dead connection (the list_tools transport-failure retry path)
+/// must also terminate the old session rather than orphan it.
+#[tokio::test]
+async fn evicting_connection_terminates_streamable_http_session() {
+    let (endpoint, http_log) = spawn_session_tracking_mcp_server().await;
+    let pool = McpPool::new();
+
+    pool.list_tools("evict-service", &endpoint)
+        .await
+        .expect("mock MCP list_tools should succeed");
+    pool.remove("evict-service").await;
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let log = http_log.lock().expect("http log lock");
+            if log.iter().any(|entry| entry.http_method == "DELETE") {
+                return;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "expected a session DELETE after McpPool::remove; \
+                     evicted connections must not orphan server-side sessions. log: {log:?}"
+                );
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+/// A pooled connection idle past the TTL must be replaced (and its session
+/// terminated) on next use instead of reused forever. Long-lived idle
+/// connections are the ones that got stuck in the rmcp dead-session resume
+/// loop during the 2026-07-01 fleet incident.
+#[tokio::test]
+async fn idle_connection_past_ttl_is_replaced_on_next_use() {
+    let (endpoint, http_log) = spawn_session_tracking_mcp_server().await;
+    let pool = McpPool::new().with_idle_ttl(std::time::Duration::from_millis(50));
+
+    pool.list_tools("ttl-service", &endpoint)
+        .await
+        .expect("first mock MCP list_tools should succeed");
+    tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+    pool.list_tools("ttl-service", &endpoint)
+        .await
+        .expect("second mock MCP list_tools should succeed");
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let log = http_log.lock().expect("http log lock");
+            let sessions_created = log
+                .iter()
+                .filter(|entry| entry.rpc_method.as_deref() == Some("initialize"))
+                .count();
+            let deleted = log.iter().any(|entry| {
+                entry.http_method == "DELETE" && entry.session_id.as_deref() == Some("session-1")
+            });
+            if sessions_created >= 2 && deleted {
+                return;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "expected the idle connection to be replaced (2 initializes) and its \
+                     session-1 deleted after the idle TTL elapsed. log: {log:?}"
+                );
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+}
+
+/// A connection used again within the TTL must be reused, not churned.
+#[tokio::test]
+async fn connection_within_idle_ttl_is_reused() {
+    let (endpoint, http_log) = spawn_session_tracking_mcp_server().await;
+    let pool = McpPool::new().with_idle_ttl(std::time::Duration::from_secs(600));
+
+    pool.list_tools("fresh-service", &endpoint)
+        .await
+        .expect("first mock MCP list_tools should succeed");
+    pool.list_tools("fresh-service", &endpoint)
+        .await
+        .expect("second mock MCP list_tools should succeed");
+
+    let log = http_log.lock().expect("http log lock");
+    let sessions_created = log
+        .iter()
+        .filter(|entry| entry.rpc_method.as_deref() == Some("initialize"))
+        .count();
+    assert_eq!(
+        sessions_created, 1,
+        "a connection inside its idle TTL must be reused, got {log:?}"
+    );
+}
+
 #[derive(Debug)]
 struct CapturedMcpHttpRequest {
     method: String,
@@ -387,11 +535,96 @@ async fn spawn_header_capture_mcp_server() -> (String, Arc<Mutex<Vec<CapturedMcp
     (format!("http://{addr}/mcp"), requests)
 }
 
+#[derive(Debug)]
+struct SessionHttpLogEntry {
+    http_method: String,
+    session_id: Option<String>,
+    rpc_method: Option<String>,
+}
+
+/// Mock MCP server that issues `Mcp-Session-Id: session-<n>` on each
+/// `initialize` and logs the HTTP method + session header of every request,
+/// so tests can observe session lifecycle (creation, use, DELETE).
+async fn spawn_session_tracking_mcp_server() -> (String, Arc<Mutex<Vec<SessionHttpLogEntry>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock MCP server");
+    let addr = listener.local_addr().expect("mock MCP server address");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let log_for_server = Arc::clone(&log);
+    let session_counter = Arc::new(AtomicUsize::new(0));
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let log = Arc::clone(&log_for_server);
+            let session_counter = Arc::clone(&session_counter);
+            tokio::spawn(async move {
+                let Ok(request) = read_mcp_http_request(&mut stream).await else {
+                    return;
+                };
+                log.lock()
+                    .expect("http log lock")
+                    .push(SessionHttpLogEntry {
+                        http_method: request.http_method.clone(),
+                        session_id: request.session_id_header.clone(),
+                        rpc_method: (!request.method.is_empty()).then(|| request.method.clone()),
+                    });
+                let response = match request.http_method.as_str() {
+                    "DELETE" => "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        .to_string(),
+                    "GET" => {
+                        // No standalone SSE stream in this mock.
+                        "HTTP/1.1 405 Method Not Allowed\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                            .to_string()
+                    }
+                    _ => {
+                        let session_header = if request.method == "initialize" {
+                            let n = session_counter.fetch_add(1, Ordering::SeqCst) + 1;
+                            Some(format!("session-{n}"))
+                        } else {
+                            None
+                        };
+                        mcp_http_response_with_session(
+                            &request.method,
+                            request.id,
+                            session_header.as_deref(),
+                        )
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    (format!("http://{addr}/mcp"), log)
+}
+
+fn mcp_http_response_with_session(
+    method: &str,
+    id: Option<serde_json::Value>,
+    session_id: Option<&str>,
+) -> String {
+    let base = mcp_http_response(method, id);
+    match session_id {
+        Some(session_id) => base.replacen(
+            "\r\nContent-Type:",
+            &format!("\r\nMcp-Session-Id: {session_id}\r\nContent-Type:"),
+            1,
+        ),
+        None => base,
+    }
+}
+
 struct ParsedMcpHttpRequest {
     method: String,
     id: Option<serde_json::Value>,
     agent_did_header: Option<String>,
     traceparent_header: Option<String>,
+    http_method: String,
+    session_id_header: Option<String>,
 }
 
 async fn read_mcp_http_request(stream: &mut TcpStream) -> std::io::Result<ParsedMcpHttpRequest> {
@@ -409,6 +642,17 @@ async fn read_mcp_http_request(stream: &mut TcpStream) -> std::io::Result<Parsed
     };
 
     let headers = String::from_utf8_lossy(&buf[..header_end]);
+    let http_method = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().next())
+        .unwrap_or_default()
+        .to_string();
+    let session_id_header = headers.lines().find_map(|line| {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("mcp-session-id")
+            .then(|| value.trim().to_string())
+    });
     let content_length = headers
         .lines()
         .find_map(|line| {
@@ -452,6 +696,8 @@ async fn read_mcp_http_request(stream: &mut TcpStream) -> std::io::Result<Parsed
         id,
         agent_did_header,
         traceparent_header,
+        http_method,
+        session_id_header,
     })
 }
 
@@ -556,6 +802,7 @@ async fn hung_connect_does_not_wedge_other_services() {
                 call_tool_fn: Box::new(|_params| {
                     Box::pin(async { anyhow::bail!("call_tool was not expected") })
                 }),
+                last_used: super::fresh_last_used(),
             })
         },
     );


### PR DESCRIPTION
## Incident

During the 2026-07-06 fleet incident, long-lived idle MCP connections (Amy's hub runtime) got stuck in the rmcp streamable-HTTP dead-session resume loop: the server answers a GET-resume of a closed session with **200 + empty stream** (deliberate — avoids browser EventSource retry loops), while rmcp's own Rust client **reconnects on stream end and resets its backoff on any successful connection**. The two halves chase each other indefinitely. In production this ran for ~4.7 days: 14.8M server WARN lines (2.9GB stdout log on observability-mcp), ~64h accumulated CPU, and degraded MCP responsiveness fleet-wide.

## What this PR does

- **`McpPool` idle TTL (default 15m, `DEFAULT_MCP_IDLE_TTL`)** — a pooled connection idle past the TTL is replaced on next use, and its old session is terminated through the existing drop → cancellation → worker-cleanup DELETE path. This bounds any wedged transport's unattended lifetime to minutes instead of days, regardless of where the wedge comes from. `with_idle_ttl` overrides the default.
- **Session-termination regression tests** — `replacing_connection_terminates_old_streamable_http_session` and `evicting_connection_terminates_streamable_http_session`. These pass on main today (the pool already DELETEs sessions on replace/evict); they exist to pin that behavior, since losing it would silently re-create server-side zombie sessions on every trace-context reconnect (one per task run).
- **Session-tracking mock MCP server** in the test harness — issues `Mcp-Session-Id` on initialize and logs HTTP method + session per request, making session lifecycle (create / use / DELETE) observable in unit tests for the first time.
- `idle_connection_past_ttl_is_replaced_on_next_use` / `connection_within_idle_ttl_is_reused` cover the new TTL behavior (written failing-first).

## What this PR does not do

The root cause lives in rmcp (present in 0.15.0 through 1.8.0): the server should return 404 for terminated sessions per the MCP spec so clients re-initialize, and the client should treat an immediately-EOF stream as a failed attempt for backoff purposes. Upstream issue to be filed; this change bounds the blast radius either way.

## Testing

- `cargo test -p defra-agent --lib` — 935 passed, 0 failed.
- TTL test verified RED (session reused, no DELETE) before implementation, GREEN after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)