### PR TITLE
fix(cli): scope runtime liveness and metrics to the local agent DID

### DIFF
--- a/crates/defra-agent-cli/src/commands/background.rs
+++ b/crates/defra-agent-cli/src/commands/background.rs
@@ -29,7 +29,7 @@ async fn background_list(args: BackgroundListArgs) -> Result<()> {
     let tool_calls = load_background_tool_calls(&access, &args, age_cutoff).await?;
     let liveness = match &access {
         ConfigAccess::Graphql(graphql) => {
-            crate::commands::status::load_liveness_value(graphql).await
+            crate::commands::status::load_liveness_value(graphql, "").await
         }
         ConfigAccess::Local(_) => Value::Null,
     };

--- a/crates/defra-agent-cli/src/commands/request.rs
+++ b/crates/defra-agent-cli/src/commands/request.rs
@@ -267,7 +267,8 @@ async fn load_request_show_snapshot(
         .with_context(|| format!("loading child AgentRequest rows for {request_id}"))?;
     let child_rows = value_array(&child_response, "/data/AgentRequest");
 
-    let liveness = crate::commands::status::load_liveness_value(graphql).await;
+    let request_agent_did = string_field(&request_row, "agent_did").unwrap_or_default();
+    let liveness = crate::commands::status::load_liveness_value(graphql, &request_agent_did).await;
     let active_tool_calls = active_tool_call_keys(&liveness);
     let native_executors_available = liveness
         .get("active_native_executors_available")

--- a/crates/defra-agent-cli/src/commands/status.rs
+++ b/crates/defra-agent-cli/src/commands/status.rs
@@ -59,7 +59,7 @@ pub(crate) async fn load_runtime_status_output(
         .and_then(|rows| rows.first())
         .cloned()
         .unwrap_or(Value::Null);
-    let liveness_value = crate::commands::status::load_liveness_value(graphql).await;
+    let liveness_value = crate::commands::status::load_liveness_value(graphql, agent_did).await;
     let home_dir = resolve_home_dir(home);
     let runtime_state = read_runtime_state(&home_dir)?;
     let p2p_status = crate::commands::p2p::load_live_http_p2p_status(home, graphql).await;
@@ -106,11 +106,11 @@ pub(crate) async fn load_runtime_status_output(
     Ok(output)
 }
 
-pub(crate) async fn load_liveness_value(graphql: &str) -> Value {
+pub(crate) async fn load_liveness_value(graphql: &str, agent_did: &str) -> Value {
     if let Some(liveness) = load_live_http_liveness_value(graphql).await {
         return liveness;
     }
-    match crate::http::prometheus::load_metrics_query_data(graphql).await {
+    match crate::http::prometheus::load_metrics_query_data(graphql, agent_did).await {
         Ok(data) => serde_json::to_value(&data.liveness).unwrap_or(Value::Null),
         Err(_) => Value::Null,
     }

--- a/crates/defra-agent-cli/src/http/healthz.rs
+++ b/crates/defra-agent-cli/src/http/healthz.rs
@@ -81,6 +81,8 @@ pub(crate) fn render_healthz_payload(
                         "active_native_executors_available": data.liveness.active_native_executors_available,
                         "active_native_executor_count": data.liveness.active_native_executors.len(),
                         "expired_processing_count": data.liveness.expired_processing_count,
+                        "ignored_foreign_processing_count": data.liveness.ignored_foreign_processing_count,
+                        "ignored_foreign_tool_call_count": data.liveness.ignored_foreign_tool_call_count,
                     },
                 },
                 "runtimes": data.agent_runtimes,
@@ -173,6 +175,7 @@ mod tests {
             liveness: RuntimeLivenessSnapshot {
                 active_request_ids: vec!["req-stuck".to_string()],
                 expired_processing_count: 1,
+                ignored_foreign_processing_count: 0,
                 requests: vec![ActiveRequest {
                     request_id: "req-stuck".to_string(),
                     claimed_at: Some("2026-05-13T11:55:00Z".to_string()),
@@ -194,6 +197,7 @@ mod tests {
                     running_age_ms: 270_000,
                     deadline_expired: true,
                 }],
+                ignored_foreign_tool_call_count: 0,
                 active_native_executors_available: true,
                 active_native_executors: Vec::new(),
             },

--- a/crates/defra-agent-cli/src/http/liveness.rs
+++ b/crates/defra-agent-cli/src/http/liveness.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 pub(crate) struct LivenessRequestRow {
     pub(crate) request_id: String,
     #[serde(default)]
+    pub(crate) agent_did: String,
+    #[serde(default)]
     pub(crate) claimed_at: Option<String>,
     #[serde(default)]
     pub(crate) deadline: Option<String>,
@@ -19,6 +21,8 @@ pub(crate) struct LivenessRequestRow {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct LivenessToolCallRow {
     pub(crate) request_id: String,
+    #[serde(default)]
+    pub(crate) agent_did: String,
     pub(crate) tool_call_id: String,
     pub(crate) tool_name: String,
     #[serde(default)]
@@ -33,8 +37,10 @@ pub(crate) struct LivenessToolCallRow {
 pub(crate) struct RuntimeLivenessSnapshot {
     pub(crate) active_request_ids: Vec<String>,
     pub(crate) expired_processing_count: i64,
+    pub(crate) ignored_foreign_processing_count: i64,
     pub(crate) requests: Vec<ActiveRequest>,
     pub(crate) active_tool_calls: Vec<ActiveToolCall>,
+    pub(crate) ignored_foreign_tool_call_count: i64,
     pub(crate) active_native_executors_available: bool,
     pub(crate) active_native_executors: Vec<defra_agent::NativeExecutorStatus>,
 }
@@ -66,11 +72,25 @@ pub(crate) struct ActiveToolCall {
 
 pub(crate) fn compute_request_liveness_summary(
     now: DateTime<Utc>,
+    local_agent_did: &str,
     requests: Vec<LivenessRequestRow>,
     tool_calls: Vec<LivenessToolCallRow>,
 ) -> RuntimeLivenessSnapshot {
+    let local_agent_did = local_agent_did.trim();
+    let local_request_count = requests
+        .iter()
+        .filter(|row| owns_liveness_row(local_agent_did, &row.agent_did))
+        .count();
+    let ignored_foreign_processing_count =
+        requests.len().saturating_sub(local_request_count) as i64;
+    let ignored_foreign_tool_call_count = tool_calls
+        .iter()
+        .filter(|row| !owns_liveness_row(local_agent_did, &row.agent_did))
+        .count() as i64;
+
     let active_tool_calls: Vec<ActiveToolCall> = tool_calls
         .iter()
+        .filter(|row| owns_liveness_row(local_agent_did, &row.agent_did))
         .map(|row| {
             let started_at = parse_optional_rfc3339(row.started_at.as_deref());
             let deadline_at = parse_optional_rfc3339(row.deadline_at.as_deref());
@@ -91,11 +111,14 @@ pub(crate) fn compute_request_liveness_summary(
         })
         .collect();
 
-    let mut active_request_ids = Vec::with_capacity(requests.len());
-    let mut request_views = Vec::with_capacity(requests.len());
+    let mut active_request_ids = Vec::with_capacity(local_request_count);
+    let mut request_views = Vec::with_capacity(local_request_count);
     let mut expired_processing_count = 0i64;
 
-    for row in &requests {
+    for row in requests
+        .iter()
+        .filter(|row| owns_liveness_row(local_agent_did, &row.agent_did))
+    {
         active_request_ids.push(row.request_id.clone());
         let claimed_at = parse_optional_rfc3339(row.claimed_at.as_deref());
         let deadline = parse_optional_rfc3339(row.deadline.as_deref());
@@ -136,8 +159,10 @@ pub(crate) fn compute_request_liveness_summary(
     RuntimeLivenessSnapshot {
         active_request_ids,
         expired_processing_count,
+        ignored_foreign_processing_count,
         requests: request_views,
         active_tool_calls,
+        ignored_foreign_tool_call_count,
         active_native_executors_available: false,
         active_native_executors: Vec::new(),
     }
@@ -160,6 +185,10 @@ fn parse_optional_rfc3339(value: Option<&str>) -> Option<DateTime<Utc>> {
     DateTime::parse_from_rfc3339(trimmed)
         .ok()
         .map(|dt| dt.with_timezone(&Utc))
+}
+
+fn owns_liveness_row(local_agent_did: &str, row_agent_did: &str) -> bool {
+    local_agent_did.is_empty() || row_agent_did.trim() == local_agent_did
 }
 
 fn millis_between(earlier: DateTime<Utc>, later: DateTime<Utc>) -> i64 {
@@ -186,6 +215,7 @@ mod tests {
     ) -> LivenessRequestRow {
         LivenessRequestRow {
             request_id: request_id.to_string(),
+            agent_did: "did:defra-agent:local".to_string(),
             claimed_at: Some(iso(claimed_offset_secs)),
             deadline: Some(iso(deadline_offset_secs)),
             subagent_depth: None,
@@ -204,6 +234,7 @@ mod tests {
     ) -> LivenessToolCallRow {
         LivenessToolCallRow {
             request_id: request_id.to_string(),
+            agent_did: "did:defra-agent:local".to_string(),
             tool_call_id: tool_call_id.to_string(),
             tool_name: tool_name.to_string(),
             started_at: Some(iso(started_offset_secs)),
@@ -218,7 +249,8 @@ mod tests {
             request("req-expired", -120, -30), // claimed 2m ago, deadline 30s ago
             request("req-fresh", -10, 60),     // claimed 10s ago, deadline 60s in future
         ];
-        let snapshot = compute_request_liveness_summary(now(), requests, Vec::new());
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, Vec::new());
 
         assert_eq!(snapshot.expired_processing_count, 1);
         assert!(snapshot
@@ -249,7 +281,8 @@ mod tests {
     fn active_tool_calls_carry_tool_name_and_running_age() {
         let requests = vec![request("req-1", -45, 60)];
         let tools = vec![tool_call("req-1", "tc-1", "glob", -30, Some(60), None)];
-        let snapshot = compute_request_liveness_summary(now(), requests, tools);
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, tools);
 
         assert_eq!(snapshot.active_tool_calls.len(), 1);
         let tc = &snapshot.active_tool_calls[0];
@@ -274,7 +307,8 @@ mod tests {
             None,
             Some("bridge"),
         )];
-        let snapshot = compute_request_liveness_summary(now(), requests, tools);
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, tools);
 
         let tc = &snapshot.active_tool_calls[0];
         assert_eq!(tc.await_mode.as_deref(), Some("bridge"));
@@ -284,7 +318,8 @@ mod tests {
     fn last_progress_age_ms_uses_most_recent_tool_activity_over_claimed_at() {
         let requests = vec![request("req-1", -300, 60)];
         let tools = vec![tool_call("req-1", "tc-1", "bash", -10, Some(60), None)];
-        let snapshot = compute_request_liveness_summary(now(), requests, tools);
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, tools);
 
         let req = snapshot
             .requests
@@ -306,7 +341,8 @@ mod tests {
     #[test]
     fn last_progress_age_ms_falls_back_to_claimed_at_when_no_tool_calls() {
         let requests = vec![request("req-1", -45, 60)];
-        let snapshot = compute_request_liveness_summary(now(), requests, Vec::new());
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, Vec::new());
 
         let req = &snapshot.requests[0];
         assert!(
@@ -314,5 +350,39 @@ mod tests {
             "claimed 45s ago, got {}",
             req.last_progress_age_ms
         );
+    }
+
+    #[test]
+    fn foreign_processing_requests_do_not_count_as_active_or_expired() {
+        let mut foreign = request("req-foreign", -120, -30);
+        foreign.agent_did = "did:defra-agent:foreign".to_string();
+        let requests = vec![request("req-local", -120, -30), foreign];
+
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, Vec::new());
+
+        assert_eq!(snapshot.expired_processing_count, 1);
+        assert_eq!(snapshot.ignored_foreign_processing_count, 1);
+        assert_eq!(snapshot.active_request_ids, vec!["req-local".to_string()]);
+        assert_eq!(snapshot.requests.len(), 1);
+        assert_eq!(snapshot.requests[0].request_id, "req-local");
+    }
+
+    #[test]
+    fn foreign_running_tool_calls_are_ignored() {
+        let requests = vec![request("req-local", -45, 60)];
+        let mut foreign_tool = tool_call("req-foreign", "tc-foreign", "bash", -30, None, None);
+        foreign_tool.agent_did = "did:defra-agent:foreign".to_string();
+        let tools = vec![
+            tool_call("req-local", "tc-local", "glob", -30, None, None),
+            foreign_tool,
+        ];
+
+        let snapshot =
+            compute_request_liveness_summary(now(), "did:defra-agent:local", requests, tools);
+
+        assert_eq!(snapshot.active_tool_calls.len(), 1);
+        assert_eq!(snapshot.active_tool_calls[0].tool_call_id, "tc-local");
+        assert_eq!(snapshot.ignored_foreign_tool_call_count, 1);
     }
 }

--- a/crates/defra-agent-cli/src/http/prometheus.rs
+++ b/crates/defra-agent-cli/src/http/prometheus.rs
@@ -157,8 +157,11 @@ where
     Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_else(|| "unknown".to_string()))
 }
 
-pub(crate) async fn render_prometheus_metrics(graphql: &str) -> Result<String> {
-    let data = load_metrics_query_data(graphql).await?;
+pub(crate) async fn render_prometheus_metrics(
+    graphql: &str,
+    local_agent_did: &str,
+) -> Result<String> {
+    let data = load_metrics_query_data(graphql, local_agent_did).await?;
     let data = with_local_native_executors(data);
     let inference_metrics = load_inference_metrics_query_data(graphql).await?;
 
@@ -386,6 +389,28 @@ pub(crate) async fn render_prometheus_metrics(graphql: &str) -> Result<String> {
         "defra_agent_expired_processing_count",
         &[],
         data.liveness.expired_processing_count,
+    );
+    push_metric_prelude(
+        &mut lines,
+        "defra_agent_ignored_foreign_processing_requests",
+        "Number of processing AgentRequest rows ignored because they belong to a different agent DID.",
+    );
+    push_metric_sample(
+        &mut lines,
+        "defra_agent_ignored_foreign_processing_requests",
+        &[],
+        data.liveness.ignored_foreign_processing_count,
+    );
+    push_metric_prelude(
+        &mut lines,
+        "defra_agent_ignored_foreign_running_tool_calls",
+        "Number of running AgentToolCall rows ignored because they belong to a different agent DID.",
+    );
+    push_metric_sample(
+        &mut lines,
+        "defra_agent_ignored_foreign_running_tool_calls",
+        &[],
+        data.liveness.ignored_foreign_tool_call_count,
     );
     push_metric_prelude(
         &mut lines,
@@ -694,7 +719,10 @@ fn nonnegative_metric_value(value: Option<i64>) -> Option<i64> {
     value.map(|value| value.max(0))
 }
 
-pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQueryData> {
+pub(crate) async fn load_metrics_query_data(
+    graphql: &str,
+    local_agent_did: &str,
+) -> Result<MetricsQueryData> {
     let response = post_graphql(
         graphql,
         r#"{
@@ -722,6 +750,7 @@ pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQuer
                 lifecycle_state: { _eq: "processing" }
             }) {
                 request_id
+                agent_did
                 claimed_at
                 deadline
                 subagent_depth
@@ -732,6 +761,7 @@ pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQuer
                 lifecycle_state: { _eq: "running" }
             }) {
                 request_id
+                agent_did
                 tool_call_id
                 tool_name
                 started_at
@@ -747,8 +777,12 @@ pub(crate) async fn load_metrics_query_data(graphql: &str) -> Result<MetricsQuer
         .unwrap_or_else(|| Value::Object(Default::default()));
     let envelope: MetricsQueryEnvelope =
         serde_json::from_value(data).context("decoding runtime HTTP query response")?;
-    let liveness =
-        compute_request_liveness_summary(Utc::now(), envelope.requests, envelope.tool_calls);
+    let liveness = compute_request_liveness_summary(
+        Utc::now(),
+        local_agent_did,
+        envelope.requests,
+        envelope.tool_calls,
+    );
     Ok(MetricsQueryData {
         agent_runtimes: envelope.agent_runtimes,
         inference_backends: envelope.inference_backends,

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -85,7 +85,7 @@ pub(crate) fn runtime_contract_router(
 }
 
 async fn metrics_handler(State(state): State<RuntimeHttpState>) -> Response {
-    match render_prometheus_metrics(&state.graphql).await {
+    match render_prometheus_metrics(&state.graphql, &state.agent_did).await {
         Ok(body) => ([(header::CONTENT_TYPE, PROMETHEUS_CONTENT_TYPE)], body).into_response(),
         Err(error) => (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -101,7 +101,7 @@ async fn version_handler() -> impl IntoResponse {
 }
 
 async fn healthz_handler(State(state): State<RuntimeHttpState>) -> Response {
-    match load_metrics_query_data(&state.graphql).await {
+    match load_metrics_query_data(&state.graphql, &state.agent_did).await {
         Ok(data) => {
             let data = with_local_native_executors(data);
             let health = render_healthz_payload(&state, Some(&data), None);
@@ -121,7 +121,7 @@ async fn healthz_handler(State(state): State<RuntimeHttpState>) -> Response {
 
 async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
     let p2p = crate::commands::p2p::load_live_http_p2p_status(None, &state.graphql).await;
-    let mut body = match load_metrics_query_data(&state.graphql).await {
+    let mut body = match load_metrics_query_data(&state.graphql, &state.agent_did).await {
         Ok(data) => {
             let data = with_local_native_executors(data);
             let health = render_healthz_payload(&state, Some(&data), None);
@@ -187,28 +187,29 @@ async fn status_handler(State(state): State<RuntimeHttpState>) -> Response {
 }
 
 async fn self_handler(State(state): State<RuntimeHttpState>) -> Response {
-    let (health, runtime, status_code) = match load_metrics_query_data(&state.graphql).await {
-        Ok(data) => {
-            let data = with_local_native_executors(data);
-            let health = render_healthz_payload(&state, Some(&data), None);
-            let status_code = if health.get("ok") == Some(&Value::Bool(true)) {
-                StatusCode::OK
-            } else {
-                StatusCode::SERVICE_UNAVAILABLE
-            };
-            let runtime = data
-                .agent_runtimes
-                .iter()
-                .find(|runtime| runtime.agent_did == state.agent_did)
-                .or_else(|| data.agent_runtimes.first())
-                .cloned();
-            (health, runtime, status_code)
-        }
-        Err(error) => {
-            let health = render_healthz_payload(&state, None, Some(error.to_string()));
-            (health, None, StatusCode::SERVICE_UNAVAILABLE)
-        }
-    };
+    let (health, runtime, status_code) =
+        match load_metrics_query_data(&state.graphql, &state.agent_did).await {
+            Ok(data) => {
+                let data = with_local_native_executors(data);
+                let health = render_healthz_payload(&state, Some(&data), None);
+                let status_code = if health.get("ok") == Some(&Value::Bool(true)) {
+                    StatusCode::OK
+                } else {
+                    StatusCode::SERVICE_UNAVAILABLE
+                };
+                let runtime = data
+                    .agent_runtimes
+                    .iter()
+                    .find(|runtime| runtime.agent_did == state.agent_did)
+                    .or_else(|| data.agent_runtimes.first())
+                    .cloned();
+                (health, runtime, status_code)
+            }
+            Err(error) => {
+                let health = render_healthz_payload(&state, None, Some(error.to_string()));
+                (health, None, StatusCode::SERVICE_UNAVAILABLE)
+            }
+        };
 
     match load_self_view(&state.graphql, &state.agent_did).await {
         // `/self` already returns the full `context_budget`; the compact context

--- a/crates/defra-agent-cli/tests/cli_request.rs
+++ b/crates/defra-agent-cli/tests/cli_request.rs
@@ -528,6 +528,7 @@ async fn request_show_expanded_view_surfaces_background_tools_and_child_lineage(
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{tool_call_key}",
+                    agent_did: "{agent_did}",
                     request_id: "{parent_request_id}",
                     session_id: "{session_id}",
                     message_sequence: 1,

--- a/crates/defra-agent-cli/tests/cli_status.rs
+++ b/crates/defra-agent-cli/tests/cli_status.rs
@@ -211,6 +211,7 @@ async fn status_liveness_surfaces_expired_processing_request_and_running_tool() 
             r#"mutation {{
                 create_AgentToolCall(input: {{
                     tool_call_key: "{key}",
+                    agent_did: "{agent_did}",
                     request_id: "{request_id}",
                     session_id: "{session_id}",
                     message_sequence: 1,


### PR DESCRIPTION
## Problem

On a P2P-replicated fleet, `AgentRequest` and `AgentToolCall` rows from other agents replicate into every node's store. The runtime liveness surface — `/healthz`, `/metrics`, `/status`, `/self`, and the `status` / `request show` CLI paths — counted those foreign rows as local activity:

- foreign stuck `processing` requests inflated `expired_processing_count` (a node looked wedged because *some other* node's request expired),
- foreign `running` tool calls showed up as local `active_tool_calls`.

Same defect class as #605 (replicated foreign rows polluting a local view); that issue covers the trigger-engine serial guard, this PR covers the observability surface only.

## What changed

- `compute_request_liveness_summary` now takes the local agent DID and counts only rows it owns. The metrics GraphQL query selects `agent_did` on both processing-request and running-tool-call rows.
- Foreign rows are not silently dropped — they surface as `ignored_foreign_processing_count` / `ignored_foreign_tool_call_count` in `/healthz` and as `defra_agent_ignored_foreign_processing_requests` / `defra_agent_ignored_foreign_running_tool_calls` Prometheus metrics, so fleet-wide replication pressure stays observable.
- `request show` scopes liveness by the request's own `agent_did`; `status` by the runtime's DID; an empty DID (no local runtime context, e.g. `background list`) keeps today's unscoped behavior.
- Test fixtures that seed `running` AgentToolCall rows now stamp `agent_did`, matching what every production creation path writes (`ToolCallLifecycle` stamps it at create in all three transition paths, plus session-fork).

## Testing

- New unit fences: `foreign_processing_requests_do_not_count_as_active_or_expired`, `foreign_running_tool_calls_are_ignored`.
- `cargo fmt --check -p defra-agent-cli` clean; full `cargo test -p defra-agent-cli` green (407 lib + all integration binaries, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)