### PR TITLE
feat(tools): agent-config query preset; demo agent reads its own config

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -431,6 +431,13 @@ pub(crate) struct InitArgs {
     )]
     pub(crate) disable_defra_query: bool,
     #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with = "disable_defra_query",
+        help = "Enable the read-only defra_query tool regardless of the tool package (pair with --defra-query-collection to scope it, e.g. the \"agent-config\" preset)"
+    )]
+    pub(crate) enable_defra_query: bool,
+    #[arg(
         long = "defra-query-collection",
         help = "Restrict the defra_query tool to these collections when a package enables it (repeatable); omit for all collections"
     )]

--- a/crates/defra-agent-cli/src/commands/demo/fleet.rs
+++ b/crates/defra-agent-cli/src/commands/demo/fleet.rs
@@ -400,7 +400,9 @@ pub(super) async fn delegate(fleet: &Fleet) -> Result<()> {
         &worker.did,
         &[
             "--enable-defra-query",
-            "false",
+            "true",
+            "--defra-query-collection",
+            "agent-config",
             "--subagent-allow-cross-deployment",
             "true",
         ],
@@ -421,7 +423,9 @@ pub(super) async fn delegate(fleet: &Fleet) -> Result<()> {
         &fleet.did_a,
         &[
             "--enable-defra-query",
-            "false",
+            "true",
+            "--defra-query-collection",
+            "agent-config",
             "--subagent-spawn-enabled",
             "true",
             "--subagent-background-enabled",

--- a/crates/defra-agent-cli/src/commands/demo/setup.rs
+++ b/crates/defra-agent-cli/src/commands/demo/setup.rs
@@ -1,5 +1,6 @@
 //! First-run setup and resume: locate the persistent demo home, read the saved
-//! agent DID, initialize a curated agent (read-only tools, `defra_query` off),
+//! agent DID, initialize a curated agent (read-only tools, `defra_query`
+//! scoped to the agent-config preset),
 //! and seed the demo skills.
 
 use std::path::{Path, PathBuf};
@@ -45,7 +46,12 @@ pub(super) async fn init_agent(
         agent_name.into(),
         "--tool-root".into(),
         path_arg(work),
-        "--disable-defra-query".into(),
+        // The demo agent is a learning environment: it can read (never
+        // write) its own configuration surface, so "how am I configured?"
+        // and "why doesn't X work?" are answerable in chat.
+        "--enable-defra-query".into(),
+        "--defra-query-collection".into(),
+        "agent-config".into(),
     ];
     init_args.extend(backend.init_args.iter().cloned());
     let init = run_cli_json(bin, &init_args).await?;
@@ -70,7 +76,11 @@ pub(super) async fn seed_demo_skills(bin: &Path, graphql: &str, agent_did: &str)
             "Explain this defra-agent demo and suggest what to try next.",
             "You are running inside `defra-agent demo`, an agent whose state lives in a DefraDB \
              control plane. Explain P2P pairing and cross-node subagent delegation in plain \
-             terms, and suggest the user try `pair` then `delegate` in the demo shell.",
+             terms, and suggest the user try `pair` then `delegate` in the demo shell. You can \
+             read your own configuration with the defra_query tool (behaviors, tool selections, \
+             backends, schedules, pairings) — use it to answer questions like \"how am I \
+             configured?\" or to diagnose why something is not working, and to teach the user \
+             what each piece does.",
         ),
     ];
     for (id, name, description, instructions) in skills {

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -498,7 +498,8 @@ async fn initialize_runtime_home(
     };
     write_inference_backend_document(access, &backend_doc).await?;
 
-    let enable_defra_query = init_enable_defra_query(tool_package, args.disable_defra_query);
+    let enable_defra_query =
+        init_enable_defra_query(tool_package, args.enable_defra_query, args.disable_defra_query);
     let tool_selection = tool_selection_for_package(
         agent_did,
         &tool_selection_id,
@@ -726,17 +727,24 @@ fn validate_init_tool_flags(args: &InitArgs, tool_package: ToolPackageArg) -> Re
     }
     if !args.defra_query_collections.is_empty() {
         let profile = tool_package_profile(tool_package);
-        if args.disable_defra_query || !profile.enable_defra_query {
+        if args.disable_defra_query
+            || !(profile.enable_defra_query || args.enable_defra_query)
+        {
             anyhow::bail!(
-                "--defra-query-collection requires a tool package with defra_query enabled and cannot be combined with --disable-defra-query"
+                "--defra-query-collection requires defra_query to be enabled — pass --enable-defra-query or a tool package that enables it, and do not combine with --disable-defra-query"
             );
         }
     }
     Ok(())
 }
 
-fn init_enable_defra_query(tool_package: ToolPackageArg, disable_defra_query: bool) -> bool {
-    tool_package_profile(tool_package).enable_defra_query && !disable_defra_query
+fn init_enable_defra_query(
+    tool_package: ToolPackageArg,
+    enable_defra_query: bool,
+    disable_defra_query: bool,
+) -> bool {
+    (tool_package_profile(tool_package).enable_defra_query || enable_defra_query)
+        && !disable_defra_query
 }
 
 fn tool_ceiling_for_package(tool_package: ToolPackageArg) -> ToolCeilingArg {
@@ -893,6 +901,7 @@ mod tests {
             tool_root: None,
             enable_memory: false,
             disable_defra_query: false,
+            enable_defra_query: false,
             defra_query_collections: Vec::new(),
         }
     }
@@ -993,7 +1002,7 @@ mod tests {
                 "default-tools",
                 case.package,
                 false,
-                init_enable_defra_query(case.package, false),
+                init_enable_defra_query(case.package, false, false),
                 Vec::new(),
             );
 
@@ -1029,7 +1038,7 @@ mod tests {
             "default-tools",
             ToolPackageArg::Write,
             false,
-            init_enable_defra_query(ToolPackageArg::Write, true),
+            init_enable_defra_query(ToolPackageArg::Write, false, true),
             Vec::new(),
         );
 
@@ -1087,7 +1096,7 @@ mod tests {
             "default-tools",
             ToolPackageArg::Introspection,
             true,
-            init_enable_defra_query(ToolPackageArg::Introspection, false),
+            init_enable_defra_query(ToolPackageArg::Introspection, false, false),
             scoped_introspection.defra_query_collections.clone(),
         );
         assert_eq!(selection.enable_memory, Some(true));
@@ -1105,7 +1114,7 @@ mod tests {
             "default-tools",
             ToolPackageArg::Yolo,
             false,
-            init_enable_defra_query(ToolPackageArg::Yolo, false),
+            init_enable_defra_query(ToolPackageArg::Yolo, false, false),
             Vec::new(),
         );
         assert_eq!(selection.enable_file_tools, Some(true));

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -721,11 +721,12 @@ fn resolve_init_tool_package(
 fn validate_init_tool_flags(args: &InitArgs, tool_package: ToolPackageArg) -> Result<()> {
     if args.identity_only
         && (args.enable_memory
+            || args.enable_defra_query
             || args.disable_defra_query
             || !args.defra_query_collections.is_empty())
     {
         anyhow::bail!(
-            "--enable-memory, --disable-defra-query, and --defra-query-collection cannot be used with --identity-only because no ToolSelection document is written"
+            "--enable-memory, --enable-defra-query, --disable-defra-query, and --defra-query-collection cannot be used with --identity-only because no ToolSelection document is written"
         );
     }
     if !args.defra_query_collections.is_empty() {
@@ -1157,6 +1158,16 @@ mod tests {
         identity_only.enable_memory = true;
         assert!(
             validate_init_tool_flags(&identity_only, ToolPackageArg::Readonly)
+                .unwrap_err()
+                .to_string()
+                .contains("--identity-only")
+        );
+
+        let mut identity_only_query = init_args();
+        identity_only_query.identity_only = true;
+        identity_only_query.enable_defra_query = true;
+        assert!(
+            validate_init_tool_flags(&identity_only_query, ToolPackageArg::Readonly)
                 .unwrap_err()
                 .to_string()
                 .contains("--identity-only")

--- a/crates/defra-agent-cli/src/commands/init.rs
+++ b/crates/defra-agent-cli/src/commands/init.rs
@@ -498,8 +498,11 @@ async fn initialize_runtime_home(
     };
     write_inference_backend_document(access, &backend_doc).await?;
 
-    let enable_defra_query =
-        init_enable_defra_query(tool_package, args.enable_defra_query, args.disable_defra_query);
+    let enable_defra_query = init_enable_defra_query(
+        tool_package,
+        args.enable_defra_query,
+        args.disable_defra_query,
+    );
     let tool_selection = tool_selection_for_package(
         agent_did,
         &tool_selection_id,
@@ -727,9 +730,7 @@ fn validate_init_tool_flags(args: &InitArgs, tool_package: ToolPackageArg) -> Re
     }
     if !args.defra_query_collections.is_empty() {
         let profile = tool_package_profile(tool_package);
-        if args.disable_defra_query
-            || !(profile.enable_defra_query || args.enable_defra_query)
-        {
+        if args.disable_defra_query || !(profile.enable_defra_query || args.enable_defra_query) {
             anyhow::bail!(
                 "--defra-query-collection requires defra_query to be enabled — pass --enable-defra-query or a tool package that enables it, and do not combine with --disable-defra-query"
             );

--- a/crates/defra-agent/src/defra_query/mod.rs
+++ b/crates/defra-agent/src/defra_query/mod.rs
@@ -78,7 +78,10 @@ pub(crate) mod query;
 pub(crate) mod render;
 pub(crate) mod schema;
 
-pub use query::{build_query, CollectionScope, DefraQueryParams, DEFAULT_LIMIT, MAX_LIMIT};
+pub use query::{
+    build_query, expand_collection_scope_aliases, CollectionScope, DefraQueryParams,
+    AGENT_CONFIG_QUERY_COLLECTIONS, AGENT_CONFIG_SCOPE_ALIAS, DEFAULT_LIMIT, MAX_LIMIT,
+};
 pub use schema::{
     diagnose_failed_query, discovery_payload, introspection_query, parse_collection_schema,
     unknown_collection_message, CollectionSchema, SchemaField,

--- a/crates/defra-agent/src/defra_query/query.rs
+++ b/crates/defra-agent/src/defra_query/query.rs
@@ -331,7 +331,12 @@ mod tests {
                 .collect::<Vec<_>>()
         );
         // The preset is config-only: no conversation content, no secrets.
-        for excluded in ["AgentRequest", "AgentResponse", "AgentMessage", "OAuthCredential"] {
+        for excluded in [
+            "AgentRequest",
+            "AgentResponse",
+            "AgentMessage",
+            "OAuthCredential",
+        ] {
             assert!(!expanded.contains(&excluded.to_string()), "{excluded}");
         }
     }
@@ -342,7 +347,10 @@ mod tests {
             expand_collection_scope_aliases(["AgentRequest", " agent-config ", "", "Custom"]);
         assert!(expanded.contains(&"AgentRequest".to_string()));
         assert!(expanded.contains(&"Custom".to_string()));
-        assert!(expanded.contains(&"AgentBehavior".to_string()), "alias expanded");
+        assert!(
+            expanded.contains(&"AgentBehavior".to_string()),
+            "alias expanded"
+        );
         assert!(!expanded.contains(&String::new()), "empties dropped");
         assert!(
             !expanded.contains(&"agent-config".to_string()),

--- a/crates/defra-agent/src/defra_query/query.rs
+++ b/crates/defra-agent/src/defra_query/query.rs
@@ -76,6 +76,73 @@ impl DefraQueryParams {
     }
 }
 
+/// Alias accepted in `ToolSelection.defra_query_collections` that expands to
+/// [`AGENT_CONFIG_QUERY_COLLECTIONS`]. Lets an operator (or a preset) grant
+/// the configuration read surface without enumerating collection names.
+pub const AGENT_CONFIG_SCOPE_ALIAS: &str = "agent-config";
+
+/// The configuration read surface: every collection an agent needs to explain
+/// its own setup and help diagnose config issues ("how am I configured?",
+/// "why doesn't X fire?", "which peers am I paired with?").
+///
+/// Deliberately excludes conversation content (`AgentRequest`/`AgentResponse`/
+/// `AgentMessage`/…), memory, telemetry (`InferenceCall`), and secret-bearing
+/// collections (`OAuthCredential`) — this is the agent's operating manual,
+/// not its mailbox. `InferenceBackend` rows are included but their key fields
+/// are already redacted by the schema's visible-field projection.
+pub const AGENT_CONFIG_QUERY_COLLECTIONS: &[&str] = &[
+    // Identity + behavior/tool configuration.
+    "AgentPrincipal",
+    "AgentBehavior",
+    "ToolSelection",
+    "Skill",
+    // Inference configuration (api_key fields are redacted at the schema
+    // projection; the raw column never reaches the model).
+    "InferenceBackend",
+    "InferenceProfile",
+    // Tool services + their health, for "why is my MCP tool failing?".
+    "ToolServiceRegistry",
+    "ToolServiceHealthState",
+    // Automation configuration.
+    "Task",
+    "Schedule",
+    "EventTrigger",
+    // Runtime reconcile state — the diagnosis anchor (generation, phase).
+    "AgentRuntime",
+    // Operator-visible P2P control plane, for pairing diagnosis. Addresses
+    // here are shareable multiaddrs by design; no key material.
+    "AgentNetwork",
+    "NetworkMembership",
+    "PeerEndpoint",
+    "PeerRegistry",
+    "PeerPairingDesired",
+    "PeerPairingApplied",
+    "DataPlanePairingDesired",
+];
+
+/// Expand scope aliases in a raw `defra_query_collections` list: each
+/// [`AGENT_CONFIG_SCOPE_ALIAS`] entry becomes the full
+/// [`AGENT_CONFIG_QUERY_COLLECTIONS`] set; literal collection names pass
+/// through unchanged. Callers dedupe via their scope-set types.
+pub fn expand_collection_scope_aliases<'a>(
+    collections: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    let mut expanded = Vec::new();
+    for entry in collections {
+        let entry = entry.trim();
+        if entry == AGENT_CONFIG_SCOPE_ALIAS {
+            expanded.extend(
+                AGENT_CONFIG_QUERY_COLLECTIONS
+                    .iter()
+                    .map(|collection| collection.to_string()),
+            );
+        } else if !entry.is_empty() {
+            expanded.push(entry.to_string());
+        }
+    }
+    expanded
+}
+
 /// Which collections a query surface is permitted to read.
 ///
 /// An explicit tristate so the deny-all case cannot be confused with allow-all
@@ -251,6 +318,36 @@ mod tests {
             fields: fields.iter().map(|f| f.to_string()).collect(),
             limit: None,
         }
+    }
+
+    #[test]
+    fn agent_config_alias_expands_to_the_preset() {
+        let expanded = expand_collection_scope_aliases(["agent-config"]);
+        assert_eq!(
+            expanded,
+            AGENT_CONFIG_QUERY_COLLECTIONS
+                .iter()
+                .map(|c| c.to_string())
+                .collect::<Vec<_>>()
+        );
+        // The preset is config-only: no conversation content, no secrets.
+        for excluded in ["AgentRequest", "AgentResponse", "AgentMessage", "OAuthCredential"] {
+            assert!(!expanded.contains(&excluded.to_string()), "{excluded}");
+        }
+    }
+
+    #[test]
+    fn literal_collections_pass_through_alias_expansion() {
+        let expanded =
+            expand_collection_scope_aliases(["AgentRequest", " agent-config ", "", "Custom"]);
+        assert!(expanded.contains(&"AgentRequest".to_string()));
+        assert!(expanded.contains(&"Custom".to_string()));
+        assert!(expanded.contains(&"AgentBehavior".to_string()), "alias expanded");
+        assert!(!expanded.contains(&String::new()), "empties dropped");
+        assert!(
+            !expanded.contains(&"agent-config".to_string()),
+            "the alias itself never survives as a literal"
+        );
     }
 
     #[test]

--- a/crates/defra-agent/src/tool_surface/policy.rs
+++ b/crates/defra-agent/src/tool_surface/policy.rs
@@ -339,11 +339,16 @@ impl ToolPolicySurface {
         } else if selection.defra_query_collections.is_empty() {
             EndpointScope::all()
         } else {
+            // Scope aliases (e.g. "agent-config") expand here so both the
+            // document path and the builder path resolve identically, and the
+            // runtime/explain projections see the literal collection set.
             EndpointScope::<String, ()>::only_units(
-                selection
-                    .defra_query_collections
-                    .iter()
-                    .map(|collection| collection.trim().to_string()),
+                crate::defra_query::expand_collection_scope_aliases(
+                    selection
+                        .defra_query_collections
+                        .iter()
+                        .map(String::as_str),
+                ),
             )
         };
 

--- a/crates/defra-agent/src/tool_surface/policy.rs
+++ b/crates/defra-agent/src/tool_surface/policy.rs
@@ -344,10 +344,7 @@ impl ToolPolicySurface {
             // runtime/explain projections see the literal collection set.
             EndpointScope::<String, ()>::only_units(
                 crate::defra_query::expand_collection_scope_aliases(
-                    selection
-                        .defra_query_collections
-                        .iter()
-                        .map(String::as_str),
+                    selection.defra_query_collections.iter().map(String::as_str),
                 ),
             )
         };

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -1503,7 +1503,12 @@ async fn agent_config_alias_expands_to_config_scope() {
             "{allowed} must be readable under the agent-config preset"
         );
     }
-    for denied in ["AgentRequest", "AgentMessage", "OAuthCredential", "agent-config"] {
+    for denied in [
+        "AgentRequest",
+        "AgentMessage",
+        "OAuthCredential",
+        "agent-config",
+    ] {
         assert!(
             surface.defra_query_scope.ensure_allowed(denied).is_err(),
             "{denied} must stay outside the agent-config preset"

--- a/crates/defra-agent/src/tool_surface/tests.rs
+++ b/crates/defra-agent/src/tool_surface/tests.rs
@@ -1471,3 +1471,42 @@ async fn defra_query_is_off_by_default() {
         meta_only.tool_names()
     );
 }
+
+/// The `agent-config` alias in `defra_query_collections` expands to the
+/// configuration read surface: config collections are allowed, conversation
+/// content stays denied, and the alias itself is never treated as a literal
+/// collection name.
+#[tokio::test]
+async fn agent_config_alias_expands_to_config_scope() {
+    let node = defra_node::EmbeddedNode::builder().build().await.unwrap();
+    crate::ensure_runtime_schemas(&node).await.unwrap();
+
+    let surface = BehaviorToolConfig::from_selection(
+        "ops",
+        ToolSelection {
+            enable_defra_query: true,
+            defra_query_collections: vec!["agent-config".to_string()],
+            ..Default::default()
+        },
+        &ToolCeiling::meta_only(),
+        Vec::new(),
+    )
+    .unwrap()
+    .resolve(&node)
+    .await
+    .unwrap();
+
+    assert!(surface.tool_names().contains(&"defra_query".to_string()));
+    for allowed in ["AgentBehavior", "ToolSelection", "Schedule", "AgentRuntime"] {
+        assert!(
+            surface.defra_query_scope.ensure_allowed(allowed).is_ok(),
+            "{allowed} must be readable under the agent-config preset"
+        );
+    }
+    for denied in ["AgentRequest", "AgentMessage", "OAuthCredential", "agent-config"] {
+        assert!(
+            surface.defra_query_scope.ensure_allowed(denied).is_err(),
+            "{denied} must stay outside the agent-config preset"
+        );
+    }
+}


### PR DESCRIPTION
The demo agent couldn't answer "how am I configured?" — `defra_query` (which already has schema discovery, failure diagnosis, and hard-coded secret redaction) is opt-in since #592 and the demo disabled it; scoping it to configuration meant hand-enumerating collection names.

- `agent-config` scope alias: expands to the configuration read surface (identity, behaviors, tool selections, skills, inference config, MCP services + health, tasks/schedules/triggers, runtime reconcile state, pairing control plane). Excludes conversation content, memory, telemetry, and `OAuthCredential`. Expansion happens at the policy seam so document and builder paths resolve identically and the deny-all traps are preserved.
- `init --enable-defra-query`: the flag could previously only disable; packages gated enabling. Validation updated accordingly.
- Demo: `init` grants config-scoped defra_query, `delegate` keeps it on for both agents, and the fleet-guide skill tells the agent to use it for config questions and diagnosis — the demo becomes a learning environment ("can you do this? how do I configure that?").

The #592 off-by-default posture is unchanged — only the demo and explicit flags opt in. Fences: alias-expansion tests, surface-scope test (config collections readable, `AgentRequest`/`OAuthCredential`/literal alias denied), #592 fences untouched. `cargo test -p defra-agent --lib` 951 and `-p defra-agent-cli` 561 green. Follow-ups deliberately out: write-path (`write_tools` grants for creating agents), default-on for regular init packages, system-prompt context injection.

Stacked on #632.
