### PR TITLE
fix(mcp-pool): make dead-session resume terminal; bound re-init with parking (#639)

### DIFF
--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -291,26 +291,31 @@ pub struct McpPool {
     park: Arc<std::sync::Mutex<HashMap<ParkKey, ParkState>>>,
 }
 
-/// Parking is scoped by service and endpoint. A service can move between
-/// LAN/Tailscale/registry endpoints; a bad endpoint must not park a later
-/// healthy endpoint for the same logical service.
+/// Parking is scoped by service, endpoint, and bound agent DID. A service can
+/// move between LAN/Tailscale/registry endpoints; a bad endpoint must not park
+/// a later healthy endpoint for the same logical service. Agent DID is included
+/// because MCP services may authorize per principal. Trace headers are
+/// intentionally excluded: they are per-call correlation context, not a useful
+/// failure partition.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct ParkKey {
     service_id: String,
     endpoint: String,
+    agent_did_header: Option<String>,
 }
 
 impl ParkKey {
-    fn new(service_id: &str, endpoint: &str) -> Self {
+    fn new(service_id: &str, endpoint: &str, agent_did_header: Option<&str>) -> Self {
         Self {
             service_id: service_id.to_string(),
             endpoint: endpoint.to_string(),
+            agent_did_header: agent_did_header.map(ToOwned::to_owned),
         }
     }
 }
 
-/// Per-service-endpoint connect-parking state (#639). Strikes are connect
-/// failures and poisoned-session detections; the park horizon grows
+/// Per-service-endpoint-principal connect-parking state (#639). Strikes are
+/// connect failures and poisoned-session detections; the park horizon grows
 /// exponentially so a flapping server ends up parked with a long retry
 /// horizon instead of converting the resume hot-loop into an init hot-loop.
 #[derive(Debug, Clone, Copy)]
@@ -656,11 +661,12 @@ impl McpPool {
         // Slow path — re-check under the lock, but connect OUTSIDE it: a hung
         // or slow connect (blackholed endpoint, #622) must not wedge every
         // other service in the pool.
-        let mut poison_detected_for_endpoint = None;
+        let mut poison_detected_for_key = None;
         {
             let mut guard = self.inner.write().await;
             if let Some(conn) = guard.get(service_id) {
                 let old_endpoint = conn.endpoint.clone();
+                let old_agent_did_header = conn.agent_did_header.clone();
                 let endpoint_changed = conn.endpoint != endpoint;
                 let agent_did_changed = conn.agent_did_header != agent_did_header;
                 let trace_context_changed = conn.trace_context_headers != trace_context_headers;
@@ -696,7 +702,7 @@ impl McpPool {
                         .session_reinits
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     guard.remove(service_id);
-                    poison_detected_for_endpoint = Some(old_endpoint);
+                    poison_detected_for_key = Some((old_endpoint, old_agent_did_header));
                 }
             }
         }
@@ -707,12 +713,18 @@ impl McpPool {
         // an expired horizon so concurrent callers do not stampede. Services
         // with no strike history keep the existing benign duplicate cold-start
         // connects.
-        let _dial_reservation =
-            self.reserve_dial_if_struck(service_id, endpoint, park_admission)?;
-        if let Some(poisoned_endpoint) = poison_detected_for_endpoint {
+        let park_agent_did_header = agent_did_header.clone();
+        let _dial_reservation = self.reserve_dial_if_struck(
+            service_id,
+            endpoint,
+            park_agent_did_header.as_deref(),
+            park_admission,
+        )?;
+        if let Some((poisoned_endpoint, poisoned_agent_did_header)) = poison_detected_for_key {
             self.record_strike(
                 service_id,
                 &poisoned_endpoint,
+                poisoned_agent_did_header.as_deref(),
                 "session poisoned (resume terminal)",
                 true,
             );
@@ -731,14 +743,14 @@ impl McpPool {
         .await
         {
             Err(_elapsed) => {
-                self.record_connect_failure(service_id, endpoint);
+                self.record_connect_failure(service_id, endpoint, park_agent_did_header.as_deref());
                 anyhow::bail!(
                     "MCP connect to '{service_id}' ({endpoint}) timed out after {}s",
                     MCP_CONNECT_TIMEOUT.as_secs()
                 );
             }
             Ok(Err(error)) => {
-                self.record_connect_failure(service_id, endpoint);
+                self.record_connect_failure(service_id, endpoint, park_agent_did_header.as_deref());
                 return Err(error);
             }
             Ok(Ok(connection)) => connection,
@@ -761,10 +773,11 @@ impl McpPool {
         &self,
         service_id: &str,
         endpoint: &str,
+        agent_did_header: Option<&str>,
         admission: ParkAdmission,
     ) -> Result<DialReservation> {
         let mut park = self.park.lock().expect("park lock");
-        let key = ParkKey::new(service_id, endpoint);
+        let key = ParkKey::new(service_id, endpoint, agent_did_header);
         if let Some(state) = park.get_mut(&key) {
             let now = tokio::time::Instant::now();
             if now < state.parked_until {
@@ -802,12 +815,23 @@ impl McpPool {
         Ok(DialReservation::Unreserved)
     }
 
-    fn record_connect_failure(&self, service_id: &str, endpoint: &str) {
+    fn record_connect_failure(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        agent_did_header: Option<&str>,
+    ) {
         self.resume_stats
             .stats_for(service_id)
             .connect_failures
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.record_strike(service_id, endpoint, "connect failed", false);
+        self.record_strike(
+            service_id,
+            endpoint,
+            agent_did_header,
+            "connect failed",
+            false,
+        );
     }
 
     /// Record a strike (a failed connect or a poisoned session) and extend
@@ -818,13 +842,14 @@ impl McpPool {
         &self,
         service_id: &str,
         endpoint: &str,
+        agent_did_header: Option<&str>,
         reason: &'static str,
         safe_read_retry_credit: bool,
     ) {
         let mut park = self.park.lock().expect("park lock");
         let now = tokio::time::Instant::now();
         let state = park
-            .entry(ParkKey::new(service_id, endpoint))
+            .entry(ParkKey::new(service_id, endpoint, agent_did_header))
             .or_insert_with(|| ParkState {
                 strikes: 0,
                 last_strike: now,
@@ -849,6 +874,7 @@ impl McpPool {
         tracing::warn!(
             service_id,
             endpoint,
+            agent_did_bound = agent_did_header.is_some(),
             reason,
             strikes = state.strikes,
             park_seconds = horizon.as_secs(),

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -20,6 +20,11 @@ use rmcp::{
 use tokio::sync::RwLock;
 use tracing::Instrument;
 
+mod resume;
+
+pub use resume::McpResumeStats;
+use resume::SessionResumePolicy;
+
 pub const AGENT_DID_HEADER: &str = "x-agent-did";
 
 /// Bound on establishing an MCP connection (TCP connect + MCP handshake).
@@ -52,6 +57,9 @@ struct McpConnection {
     list_tools_fn: Box<ListToolsFn>,
     call_tool_fn: Box<CallToolFn>,
     last_used: std::sync::Mutex<std::time::Instant>,
+    /// The transport's SSE retry policy (#639). Once it reports poisoned,
+    /// this connection must be replaced, never reused.
+    resume_policy: Arc<SessionResumePolicy>,
 }
 
 impl McpConnection {
@@ -62,6 +70,10 @@ impl McpConnection {
     fn idle_longer_than(&self, ttl: std::time::Duration) -> bool {
         self.last_used.lock().expect("last_used lock").elapsed() > ttl
     }
+
+    fn resume_poisoned(&self) -> bool {
+        self.resume_policy.is_poisoned()
+    }
 }
 
 fn fresh_last_used() -> std::sync::Mutex<std::time::Instant> {
@@ -71,6 +83,7 @@ fn fresh_last_used() -> std::sync::Mutex<std::time::Instant> {
 fn wrap_connection<S>(
     endpoint: String,
     client: rmcp::service::RunningService<RoleClient, S>,
+    resume_policy: Arc<SessionResumePolicy>,
 ) -> McpConnection
 where
     S: rmcp::service::Service<RoleClient> + Send + Sync + 'static,
@@ -84,6 +97,7 @@ where
         agent_did_header: None,
         trace_context_headers: HashMap::new(),
         last_used: fresh_last_used(),
+        resume_policy,
         list_tools_fn: Box::new(move || {
             let c = Arc::clone(&c1);
             Box::pin(async move {
@@ -145,37 +159,59 @@ async fn connect_mcp_service(
     endpoint: &str,
     agent_did_header: Option<&str>,
     trace_context_headers: HashMap<String, String>,
+    resume_stats: Arc<McpResumeStats>,
 ) -> Result<McpConnection> {
-    let config =
+    let mut config =
         streamable_http_transport_config(endpoint, agent_did_header, &trace_context_headers)?;
+    let resume_policy = Arc::new(SessionResumePolicy::new(service_id, resume_stats));
+    // Bounded SSE resume (#639): without this, rmcp's default policy resumes
+    // a dead session forever (a graceful stream close resets its counter).
+    config.retry_config = Arc::clone(&resume_policy)
+        as Arc<dyn rmcp::transport::common::client_side_sse::SseRetryPolicy>;
     let transport = rmcp::transport::StreamableHttpClientTransport::from_config(config);
     let client = ()
         .serve(transport)
         .await
         .map_err(|e| anyhow::anyhow!("MCP handshake failed for {service_id} ({endpoint}): {e}"))?;
-    let mut connection = wrap_connection(endpoint.to_string(), client);
+    let mut connection = wrap_connection(endpoint.to_string(), client, resume_policy);
     connection.agent_did_header = agent_did_header.map(ToOwned::to_owned);
     connection.trace_context_headers = trace_context_headers;
     Ok(connection)
 }
 
-fn default_connect_fn() -> Arc<ConnectFn> {
+fn default_connect_fn(stats: ResumeStatsRegistry) -> Arc<ConnectFn> {
     Arc::new(
-        |service_id: String,
-         endpoint: String,
-         agent_did_header: Option<String>,
-         trace_context_headers: HashMap<String, String>| {
+        move |service_id: String,
+              endpoint: String,
+              agent_did_header: Option<String>,
+              trace_context_headers: HashMap<String, String>| {
+            let resume_stats = stats.stats_for(&service_id);
             Box::pin(async move {
                 connect_mcp_service(
                     &service_id,
                     &endpoint,
                     agent_did_header.as_deref(),
                     trace_context_headers,
+                    resume_stats,
                 )
                 .await
             })
         },
     )
+}
+
+/// Per-service [`McpResumeStats`] registry, shared between the pool and the
+/// connections it creates.
+#[derive(Clone, Default)]
+struct ResumeStatsRegistry {
+    inner: Arc<std::sync::Mutex<HashMap<String, Arc<McpResumeStats>>>>,
+}
+
+impl ResumeStatsRegistry {
+    fn stats_for(&self, service_id: &str) -> Arc<McpResumeStats> {
+        let mut guard = self.inner.lock().expect("resume stats lock");
+        Arc::clone(guard.entry(service_id.to_string()).or_default())
+    }
 }
 
 #[cfg(test)]
@@ -251,7 +287,28 @@ pub struct McpPool {
     connect_fn: Arc<ConnectFn>,
     trace_context_headers_fn: Arc<TraceContextHeadersFn>,
     idle_ttl: Option<std::time::Duration>,
+    resume_stats: ResumeStatsRegistry,
+    park: Arc<std::sync::Mutex<HashMap<String, ParkState>>>,
 }
+
+/// Per-service connect-parking state (#639). Strikes are connect failures
+/// and poisoned-session detections; the park horizon grows exponentially so
+/// a flapping server ends up parked with a long retry horizon instead of
+/// converting the resume hot-loop into an init hot-loop.
+#[derive(Debug, Clone, Copy)]
+struct ParkState {
+    strikes: u32,
+    last_strike: tokio::time::Instant,
+    parked_until: tokio::time::Instant,
+}
+
+/// First park horizon; doubles per strike up to [`MCP_PARK_MAX`].
+const MCP_PARK_BASE: std::time::Duration = std::time::Duration::from_secs(1);
+/// Ceiling on the park horizon for a persistently failing service.
+const MCP_PARK_MAX: std::time::Duration = std::time::Duration::from_secs(15 * 60);
+/// A strike this long after the previous one resets the strike count: a
+/// service that stayed clean for this window earned a fresh horizon.
+const MCP_STRIKE_DECAY: std::time::Duration = std::time::Duration::from_secs(30 * 60);
 
 /// Default idle TTL for pooled MCP connections.
 ///
@@ -262,11 +319,14 @@ pub const DEFAULT_MCP_IDLE_TTL: std::time::Duration = std::time::Duration::from_
 
 impl McpPool {
     pub fn new() -> Self {
+        let resume_stats = ResumeStatsRegistry::default();
         Self {
             inner: Arc::new(RwLock::new(HashMap::new())),
-            connect_fn: default_connect_fn(),
+            connect_fn: default_connect_fn(resume_stats.clone()),
             trace_context_headers_fn: Arc::new(crate::runtime_trace::current_trace_context_headers),
             idle_ttl: Some(DEFAULT_MCP_IDLE_TTL),
+            resume_stats,
+            park: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -275,6 +335,12 @@ impl McpPool {
     pub fn with_idle_ttl(mut self, ttl: std::time::Duration) -> Self {
         self.idle_ttl = Some(ttl);
         self
+    }
+
+    /// Resume/re-init counters for `service_id` (#639). Created on first
+    /// access; shared with the connections the pool creates for the service.
+    pub fn resume_stats(&self, service_id: &str) -> Arc<McpResumeStats> {
+        self.resume_stats.stats_for(service_id)
     }
 
     #[cfg(test)]
@@ -300,6 +366,8 @@ impl McpPool {
             ),
             trace_context_headers_fn: Arc::new(crate::runtime_trace::current_trace_context_headers),
             idle_ttl: None,
+            resume_stats: ResumeStatsRegistry::default(),
+            park: Arc::new(std::sync::Mutex::new(HashMap::new())),
         }
     }
 
@@ -330,6 +398,7 @@ impl McpPool {
                         agent_did_header,
                         trace_context_headers: trace_headers,
                         last_used: fresh_last_used(),
+                        resume_policy: SessionResumePolicy::detached(&service_id),
                         list_tools_fn: Box::new(move || {
                             let handler = Arc::clone(&handler);
                             let service_id = service_id_for_list.clone();
@@ -517,6 +586,7 @@ impl McpPool {
                     && conn.agent_did_header == agent_did_header
                     && conn.trace_context_headers == trace_context_headers
                     && !self.idle_ttl.is_some_and(|ttl| conn.idle_longer_than(ttl))
+                    && !conn.resume_poisoned()
                 {
                     conn.touch();
                     return Ok(());
@@ -527,17 +597,20 @@ impl McpPool {
         // Slow path — re-check under the lock, but connect OUTSIDE it: a hung
         // or slow connect (blackholed endpoint, #622) must not wedge every
         // other service in the pool.
+        let mut poison_detected = false;
         {
-            let guard = self.inner.write().await;
+            let mut guard = self.inner.write().await;
             if let Some(conn) = guard.get(service_id) {
                 let endpoint_changed = conn.endpoint != endpoint;
                 let agent_did_changed = conn.agent_did_header != agent_did_header;
                 let trace_context_changed = conn.trace_context_headers != trace_context_headers;
                 let idle_ttl_expired = self.idle_ttl.is_some_and(|ttl| conn.idle_longer_than(ttl));
-                if conn.endpoint == endpoint
-                    && conn.agent_did_header == agent_did_header
-                    && conn.trace_context_headers == trace_context_headers
+                let resume_poisoned = conn.resume_poisoned();
+                if !endpoint_changed
+                    && !agent_did_changed
+                    && !trace_context_changed
                     && !idle_ttl_expired
+                    && !resume_poisoned
                 {
                     conn.touch();
                     return Ok(());
@@ -550,13 +623,35 @@ impl McpPool {
                     agent_did_changed,
                     trace_context_changed,
                     idle_ttl_expired,
+                    resume_poisoned,
                     "MCP connection context changed, reconnecting"
                 );
+                if resume_poisoned {
+                    // Terminal resume (#639): drop the dead session now —
+                    // through the #626 drop → cancellation → worker-cleanup
+                    // DELETE path — whether or not the fresh connect below
+                    // succeeds.
+                    self.resume_stats
+                        .stats_for(service_id)
+                        .session_reinits
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    guard.remove(service_id);
+                    poison_detected = true;
+                }
             }
         }
 
+        // Park gate (#639): while a service is parked after repeated connect
+        // failures or poisoned sessions, fail fast instead of dialing. The
+        // check uses the horizon from *previous* strikes, so the first
+        // detection after a healthy stretch still reconnects seamlessly.
+        self.check_parked(service_id)?;
+        if poison_detected {
+            self.record_strike(service_id, "session poisoned (resume terminal)");
+        }
+
         tracing::info!(service_id, endpoint, "connecting MCP client");
-        let connection = tokio::time::timeout(
+        let connection = match tokio::time::timeout(
             MCP_CONNECT_TIMEOUT,
             (self.connect_fn)(
                 service_id.to_string(),
@@ -566,12 +661,20 @@ impl McpPool {
             ),
         )
         .await
-        .map_err(|_| {
-            anyhow::anyhow!(
-                "MCP connect to '{service_id}' ({endpoint}) timed out after {}s",
-                MCP_CONNECT_TIMEOUT.as_secs()
-            )
-        })??;
+        {
+            Err(_elapsed) => {
+                self.record_connect_failure(service_id);
+                anyhow::bail!(
+                    "MCP connect to '{service_id}' ({endpoint}) timed out after {}s",
+                    MCP_CONNECT_TIMEOUT.as_secs()
+                );
+            }
+            Ok(Err(error)) => {
+                self.record_connect_failure(service_id);
+                return Err(error);
+            }
+            Ok(Ok(connection)) => connection,
+        };
 
         // Concurrent callers for the same service may both reach here; the
         // last insert wins and the loser's connection is dropped. The
@@ -580,6 +683,66 @@ impl McpPool {
         let mut guard = self.inner.write().await;
         guard.insert(service_id.to_string(), connection);
         Ok(())
+    }
+
+    /// Fail fast while `service_id` is inside its park horizon (#639).
+    fn check_parked(&self, service_id: &str) -> Result<()> {
+        let park = self.park.lock().expect("park lock");
+        if let Some(state) = park.get(service_id) {
+            let now = tokio::time::Instant::now();
+            if now < state.parked_until {
+                anyhow::bail!(
+                    "MCP service '{service_id}' is parked for {:?} after {} consecutive \
+                     connection/session failures (#639)",
+                    state.parked_until - now,
+                    state.strikes
+                );
+            }
+        }
+        Ok(())
+    }
+
+    fn record_connect_failure(&self, service_id: &str) {
+        self.resume_stats
+            .stats_for(service_id)
+            .connect_failures
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.record_strike(service_id, "connect failed");
+    }
+
+    /// Record a strike (a failed connect or a poisoned session) and extend
+    /// the park horizon. Strikes are only recorded for actual attempts —
+    /// calls blocked by the park gate never strike — so the horizon reflects
+    /// how the service behaves, not how often callers knock.
+    fn record_strike(&self, service_id: &str, reason: &'static str) {
+        let mut park = self.park.lock().expect("park lock");
+        let now = tokio::time::Instant::now();
+        let state = park
+            .entry(service_id.to_string())
+            .or_insert_with(|| ParkState {
+                strikes: 0,
+                last_strike: now,
+                parked_until: now,
+            });
+        if now.saturating_duration_since(state.last_strike) > MCP_STRIKE_DECAY {
+            state.strikes = 0;
+        }
+        state.strikes = state.strikes.saturating_add(1);
+        state.last_strike = now;
+        let horizon = MCP_PARK_BASE
+            .saturating_mul(2u32.saturating_pow(state.strikes.saturating_sub(1).min(30)))
+            .min(MCP_PARK_MAX);
+        state.parked_until = now + horizon;
+        // Bounded by construction: at most one strike per attempt, and
+        // attempts are park-gated — a flapping service converges to one warn
+        // per park horizon (≤ one per 15 minutes at the ceiling).
+        tracing::warn!(
+            service_id,
+            reason,
+            strikes = state.strikes,
+            park_seconds = horizon.as_secs(),
+            "MCP service struck; new connects parked (#639)"
+        );
     }
 }
 

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -300,6 +300,7 @@ struct ParkState {
     strikes: u32,
     last_strike: tokio::time::Instant,
     parked_until: tokio::time::Instant,
+    connect_in_flight: bool,
 }
 
 /// First park horizon; doubles per strike up to [`MCP_PARK_MAX`].
@@ -309,6 +310,28 @@ const MCP_PARK_MAX: std::time::Duration = std::time::Duration::from_secs(15 * 60
 /// A strike this long after the previous one resets the strike count: a
 /// service that stayed clean for this window earned a fresh horizon.
 const MCP_STRIKE_DECAY: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+
+enum DialReservation {
+    Unreserved,
+    Reserved {
+        park: Arc<std::sync::Mutex<HashMap<String, ParkState>>>,
+        service_id: String,
+    },
+}
+
+impl Drop for DialReservation {
+    fn drop(&mut self) {
+        let Self::Reserved { park, service_id } = self else {
+            return;
+        };
+        let Ok(mut park) = park.lock() else {
+            return;
+        };
+        if let Some(state) = park.get_mut(service_id) {
+            state.connect_in_flight = false;
+        }
+    }
+}
 
 /// Default idle TTL for pooled MCP connections.
 ///
@@ -642,10 +665,12 @@ impl McpPool {
         }
 
         // Park gate (#639): while a service is parked after repeated connect
-        // failures or poisoned sessions, fail fast instead of dialing. The
-        // check uses the horizon from *previous* strikes, so the first
-        // detection after a healthy stretch still reconnects seamlessly.
-        self.check_parked(service_id)?;
+        // failures or poisoned sessions, fail fast instead of dialing. Once a
+        // service has strike history, reserve the single dial allowed through
+        // an expired horizon so concurrent callers do not stampede. Services
+        // with no strike history keep the existing benign duplicate cold-start
+        // connects.
+        let _dial_reservation = self.reserve_dial_if_struck(service_id)?;
         if poison_detected {
             self.record_strike(service_id, "session poisoned (resume terminal)");
         }
@@ -676,19 +701,22 @@ impl McpPool {
             Ok(Ok(connection)) => connection,
         };
 
-        // Concurrent callers for the same service may both reach here; the
-        // last insert wins and the loser's connection is dropped. The
-        // handshake is idempotent and the cache is lazy, so this is benign —
-        // strictly better than serializing every connect behind one lock.
+        // Concurrent cold-start callers for a service with no strike history
+        // may both reach here; the last insert wins and the loser's connection
+        // is dropped. Once a service has strike history,
+        // `reserve_dial_if_struck` above admits only one in-flight dial per
+        // expired park horizon.
         let mut guard = self.inner.write().await;
         guard.insert(service_id.to_string(), connection);
         Ok(())
     }
 
-    /// Fail fast while `service_id` is inside its park horizon (#639).
-    fn check_parked(&self, service_id: &str) -> Result<()> {
-        let park = self.park.lock().expect("park lock");
-        if let Some(state) = park.get(service_id) {
+    /// Fail fast while `service_id` is inside its park horizon, and reserve
+    /// the single dial admitted for a struck service once the horizon expires
+    /// (#639).
+    fn reserve_dial_if_struck(&self, service_id: &str) -> Result<DialReservation> {
+        let mut park = self.park.lock().expect("park lock");
+        if let Some(state) = park.get_mut(service_id) {
             let now = tokio::time::Instant::now();
             if now < state.parked_until {
                 anyhow::bail!(
@@ -698,8 +726,20 @@ impl McpPool {
                     state.strikes
                 );
             }
+            if state.connect_in_flight {
+                anyhow::bail!(
+                    "MCP service '{service_id}' connect already in flight after {} consecutive \
+                     connection/session failures (#639)",
+                    state.strikes
+                );
+            }
+            state.connect_in_flight = true;
+            return Ok(DialReservation::Reserved {
+                park: Arc::clone(&self.park),
+                service_id: service_id.to_string(),
+            });
         }
-        Ok(())
+        Ok(DialReservation::Unreserved)
     }
 
     fn record_connect_failure(&self, service_id: &str) {
@@ -723,6 +763,7 @@ impl McpPool {
                 strikes: 0,
                 last_strike: now,
                 parked_until: now,
+                connect_in_flight: false,
             });
         if now.saturating_duration_since(state.last_strike) > MCP_STRIKE_DECAY {
             state.strikes = 0;

--- a/crates/defra-agent/src/mcp_pool.rs
+++ b/crates/defra-agent/src/mcp_pool.rs
@@ -288,19 +288,40 @@ pub struct McpPool {
     trace_context_headers_fn: Arc<TraceContextHeadersFn>,
     idle_ttl: Option<std::time::Duration>,
     resume_stats: ResumeStatsRegistry,
-    park: Arc<std::sync::Mutex<HashMap<String, ParkState>>>,
+    park: Arc<std::sync::Mutex<HashMap<ParkKey, ParkState>>>,
 }
 
-/// Per-service connect-parking state (#639). Strikes are connect failures
-/// and poisoned-session detections; the park horizon grows exponentially so
-/// a flapping server ends up parked with a long retry horizon instead of
-/// converting the resume hot-loop into an init hot-loop.
+/// Parking is scoped by service and endpoint. A service can move between
+/// LAN/Tailscale/registry endpoints; a bad endpoint must not park a later
+/// healthy endpoint for the same logical service.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ParkKey {
+    service_id: String,
+    endpoint: String,
+}
+
+impl ParkKey {
+    fn new(service_id: &str, endpoint: &str) -> Self {
+        Self {
+            service_id: service_id.to_string(),
+            endpoint: endpoint.to_string(),
+        }
+    }
+}
+
+/// Per-service-endpoint connect-parking state (#639). Strikes are connect
+/// failures and poisoned-session detections; the park horizon grows
+/// exponentially so a flapping server ends up parked with a long retry
+/// horizon instead of converting the resume hot-loop into an init hot-loop.
 #[derive(Debug, Clone, Copy)]
 struct ParkState {
     strikes: u32,
     last_strike: tokio::time::Instant,
     parked_until: tokio::time::Instant,
     connect_in_flight: bool,
+    /// One-shot escape hatch for the existing safe-read retry after a poison
+    /// recovery reconnect. It is not granted for plain connect failures.
+    safe_read_retry_credit: bool,
 }
 
 /// First park horizon; doubles per strike up to [`MCP_PARK_MAX`].
@@ -314,23 +335,29 @@ const MCP_STRIKE_DECAY: std::time::Duration = std::time::Duration::from_secs(30 
 enum DialReservation {
     Unreserved,
     Reserved {
-        park: Arc<std::sync::Mutex<HashMap<String, ParkState>>>,
-        service_id: String,
+        park: Arc<std::sync::Mutex<HashMap<ParkKey, ParkState>>>,
+        key: ParkKey,
     },
 }
 
 impl Drop for DialReservation {
     fn drop(&mut self) {
-        let Self::Reserved { park, service_id } = self else {
+        let Self::Reserved { park, key } = self else {
             return;
         };
         let Ok(mut park) = park.lock() else {
             return;
         };
-        if let Some(state) = park.get_mut(service_id) {
+        if let Some(state) = park.get_mut(key) {
             state.connect_in_flight = false;
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParkAdmission {
+    Normal,
+    SafeReadRetry,
 }
 
 /// Default idle TTL for pooled MCP connections.
@@ -454,7 +481,8 @@ impl McpPool {
         agent_did: Option<&str>,
     ) -> Result<ListToolsResult> {
         async {
-            self.get_or_connect(service_id, endpoint, agent_did).await?;
+            self.get_or_connect(service_id, endpoint, agent_did, ParkAdmission::Normal)
+                .await?;
             match self.list_tools_once(service_id).await {
                 Ok(result) => {
                     tracing::Span::current().record("tool_count", result.tools.len() as i64);
@@ -468,7 +496,13 @@ impl McpPool {
                         "MCP list_tools failed, evicting connection and retrying"
                     );
                     self.remove(service_id).await;
-                    self.get_or_connect(service_id, endpoint, agent_did).await?;
+                    self.get_or_connect(
+                        service_id,
+                        endpoint,
+                        agent_did,
+                        ParkAdmission::SafeReadRetry,
+                    )
+                    .await?;
                     let result = self.list_tools_once(service_id).await?;
                     tracing::Span::current().record("tool_count", result.tools.len() as i64);
                     Ok(result)
@@ -516,7 +550,8 @@ impl McpPool {
     ) -> Result<CallToolResult> {
         let argument_count = argument_count(&arguments);
         async {
-            self.get_or_connect(service_id, endpoint, agent_did).await?;
+            self.get_or_connect(service_id, endpoint, agent_did, ParkAdmission::Normal)
+                .await?;
             let result = self
                 .call_tool_once(service_id, build_call_tool_params(tool_name, arguments))
                 .await;
@@ -596,6 +631,7 @@ impl McpPool {
         service_id: &str,
         endpoint: &str,
         agent_did: Option<&str>,
+        park_admission: ParkAdmission,
     ) -> Result<()> {
         let agent_did_header = agent_did.map(ToOwned::to_owned);
         // rmcp's streamable HTTP worker keeps custom headers in its transport
@@ -620,10 +656,11 @@ impl McpPool {
         // Slow path — re-check under the lock, but connect OUTSIDE it: a hung
         // or slow connect (blackholed endpoint, #622) must not wedge every
         // other service in the pool.
-        let mut poison_detected = false;
+        let mut poison_detected_for_endpoint = None;
         {
             let mut guard = self.inner.write().await;
             if let Some(conn) = guard.get(service_id) {
+                let old_endpoint = conn.endpoint.clone();
                 let endpoint_changed = conn.endpoint != endpoint;
                 let agent_did_changed = conn.agent_did_header != agent_did_header;
                 let trace_context_changed = conn.trace_context_headers != trace_context_headers;
@@ -659,7 +696,7 @@ impl McpPool {
                         .session_reinits
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                     guard.remove(service_id);
-                    poison_detected = true;
+                    poison_detected_for_endpoint = Some(old_endpoint);
                 }
             }
         }
@@ -670,9 +707,15 @@ impl McpPool {
         // an expired horizon so concurrent callers do not stampede. Services
         // with no strike history keep the existing benign duplicate cold-start
         // connects.
-        let _dial_reservation = self.reserve_dial_if_struck(service_id)?;
-        if poison_detected {
-            self.record_strike(service_id, "session poisoned (resume terminal)");
+        let _dial_reservation =
+            self.reserve_dial_if_struck(service_id, endpoint, park_admission)?;
+        if let Some(poisoned_endpoint) = poison_detected_for_endpoint {
+            self.record_strike(
+                service_id,
+                &poisoned_endpoint,
+                "session poisoned (resume terminal)",
+                true,
+            );
         }
 
         tracing::info!(service_id, endpoint, "connecting MCP client");
@@ -688,14 +731,14 @@ impl McpPool {
         .await
         {
             Err(_elapsed) => {
-                self.record_connect_failure(service_id);
+                self.record_connect_failure(service_id, endpoint);
                 anyhow::bail!(
                     "MCP connect to '{service_id}' ({endpoint}) timed out after {}s",
                     MCP_CONNECT_TIMEOUT.as_secs()
                 );
             }
             Ok(Err(error)) => {
-                self.record_connect_failure(service_id);
+                self.record_connect_failure(service_id, endpoint);
                 return Err(error);
             }
             Ok(Ok(connection)) => connection,
@@ -714,62 +757,88 @@ impl McpPool {
     /// Fail fast while `service_id` is inside its park horizon, and reserve
     /// the single dial admitted for a struck service once the horizon expires
     /// (#639).
-    fn reserve_dial_if_struck(&self, service_id: &str) -> Result<DialReservation> {
+    fn reserve_dial_if_struck(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        admission: ParkAdmission,
+    ) -> Result<DialReservation> {
         let mut park = self.park.lock().expect("park lock");
-        if let Some(state) = park.get_mut(service_id) {
+        let key = ParkKey::new(service_id, endpoint);
+        if let Some(state) = park.get_mut(&key) {
             let now = tokio::time::Instant::now();
             if now < state.parked_until {
+                if admission == ParkAdmission::SafeReadRetry
+                    && state.safe_read_retry_credit
+                    && !state.connect_in_flight
+                {
+                    state.safe_read_retry_credit = false;
+                    state.connect_in_flight = true;
+                    return Ok(DialReservation::Reserved {
+                        park: Arc::clone(&self.park),
+                        key,
+                    });
+                }
                 anyhow::bail!(
-                    "MCP service '{service_id}' is parked for {:?} after {} consecutive \
-                     connection/session failures (#639)",
+                    "MCP service '{service_id}' endpoint '{endpoint}' is parked for {:?} after \
+                     {} consecutive connection/session failures (#639)",
                     state.parked_until - now,
                     state.strikes
                 );
             }
             if state.connect_in_flight {
                 anyhow::bail!(
-                    "MCP service '{service_id}' connect already in flight after {} consecutive \
-                     connection/session failures (#639)",
+                    "MCP service '{service_id}' endpoint '{endpoint}' connect already in flight \
+                     after {} consecutive connection/session failures (#639)",
                     state.strikes
                 );
             }
             state.connect_in_flight = true;
             return Ok(DialReservation::Reserved {
                 park: Arc::clone(&self.park),
-                service_id: service_id.to_string(),
+                key,
             });
         }
         Ok(DialReservation::Unreserved)
     }
 
-    fn record_connect_failure(&self, service_id: &str) {
+    fn record_connect_failure(&self, service_id: &str, endpoint: &str) {
         self.resume_stats
             .stats_for(service_id)
             .connect_failures
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        self.record_strike(service_id, "connect failed");
+        self.record_strike(service_id, endpoint, "connect failed", false);
     }
 
     /// Record a strike (a failed connect or a poisoned session) and extend
     /// the park horizon. Strikes are only recorded for actual attempts —
     /// calls blocked by the park gate never strike — so the horizon reflects
     /// how the service behaves, not how often callers knock.
-    fn record_strike(&self, service_id: &str, reason: &'static str) {
+    fn record_strike(
+        &self,
+        service_id: &str,
+        endpoint: &str,
+        reason: &'static str,
+        safe_read_retry_credit: bool,
+    ) {
         let mut park = self.park.lock().expect("park lock");
         let now = tokio::time::Instant::now();
         let state = park
-            .entry(service_id.to_string())
+            .entry(ParkKey::new(service_id, endpoint))
             .or_insert_with(|| ParkState {
                 strikes: 0,
                 last_strike: now,
                 parked_until: now,
                 connect_in_flight: false,
+                safe_read_retry_credit: false,
             });
         if now.saturating_duration_since(state.last_strike) > MCP_STRIKE_DECAY {
             state.strikes = 0;
+            state.safe_read_retry_credit = false;
         }
         state.strikes = state.strikes.saturating_add(1);
         state.last_strike = now;
+        state.safe_read_retry_credit = safe_read_retry_credit;
         let horizon = MCP_PARK_BASE
             .saturating_mul(2u32.saturating_pow(state.strikes.saturating_sub(1).min(30)))
             .min(MCP_PARK_MAX);
@@ -779,6 +848,7 @@ impl McpPool {
         // per park horizon (≤ one per 15 minutes at the ceiling).
         tracing::warn!(
             service_id,
+            endpoint,
             reason,
             strikes = state.strikes,
             park_seconds = horizon.as_secs(),

--- a/crates/defra-agent/src/mcp_pool/resume.rs
+++ b/crates/defra-agent/src/mcp_pool/resume.rs
@@ -29,6 +29,13 @@
 //! closes from different streams can in rare cases be misread as a rapid
 //! death. The consequence is one extra session re-initialization — accepted
 //! for the simplicity of keeping the policy stateless per-stream.
+//!
+//! Scope note: rmcp bypasses `retry_config.retry(0)` when an SSE stream
+//! supplies a `retry:` field, because the server-provided interval takes
+//! precedence. The production pathology this module bounds was a 200 + empty
+//! stream with no `retry:` field; bounding a server that repeatedly sends only
+//! `retry:` control frames and then closes requires an upstream rmcp seam or a
+//! custom transport wrapper.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};

--- a/crates/defra-agent/src/mcp_pool/resume.rs
+++ b/crates/defra-agent/src/mcp_pool/resume.rs
@@ -1,0 +1,276 @@
+//! Bounded client-side resume policy for rmcp streamable-HTTP sessions (#639).
+//!
+//! rmcp's `SseAutoReconnectStream` resumes a closed SSE stream forever: a
+//! graceful close consults the retry policy with `current_times == 0` every
+//! time, so `max_times`-style caps can never fire. Against a server that
+//! answers resume-of-a-dead-session with 200 + empty stream (the rmcp
+//! streamable-HTTP server does exactly this), the client re-resumes in a hot
+//! loop — ~5/s sustained in the 2026-07-06/07 incidents — and the #626 idle
+//! TTL cannot break it because an actively-failing session is never idle.
+//!
+//! [`SessionResumePolicy`] is installed as the transport's `retry_config` and
+//! closes both holes from our side:
+//!
+//! - A granted resume whose stream dies within
+//!   [`RAPID_STREAM_DEATH_THRESHOLD`] is the dead-session empty-stream
+//!   signature: the session is poisoned after that one attempt and no resume
+//!   is ever granted again.
+//! - Consecutive resume *errors* are capped at
+//!   [`MAX_CONSECUTIVE_RESUME_FAILURES`], then the session is poisoned —
+//!   defense in depth so no future resume path can hot-loop either.
+//!
+//! Poisoning is terminal for the session only: the pool observes it via
+//! [`SessionResumePolicy::is_poisoned`] on next use, drops the connection
+//! (which terminates the server-side session through the #626 drop →
+//! cancellation → worker-cleanup DELETE path) and connects fresh.
+//!
+//! One policy instance is shared by every SSE stream of one transport (the
+//! standalone GET stream and any POST-response streams), so interleaved
+//! closes from different streams can in rare cases be misread as a rapid
+//! death. The consequence is one extra session re-initialization — accepted
+//! for the simplicity of keeping the policy stateless per-stream.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use rmcp::transport::common::client_side_sse::SseRetryPolicy;
+use tokio::time::Instant;
+
+/// Delay before reconnecting after a graceful SSE stream close (mirrors
+/// rmcp's default base backoff).
+pub(crate) const RESUME_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+
+/// A granted resume whose stream lives shorter than this is treated as the
+/// dead-session empty-stream signature and poisons the session. Healthy
+/// streams live minutes-to-forever; the pathological empty stream closes
+/// within one round-trip.
+pub(crate) const RAPID_STREAM_DEATH_THRESHOLD: Duration = Duration::from_secs(10);
+
+/// Consecutive resume *errors* tolerated for one stream before the session
+/// is poisoned.
+pub(crate) const MAX_CONSECUTIVE_RESUME_FAILURES: usize = 3;
+
+/// Per-service counters for the resume/re-init lifecycle, so a flapping MCP
+/// server is visible without log archaeology. Shared between the pool (which
+/// counts re-inits and connect failures) and each connection's
+/// [`SessionResumePolicy`] (which counts resume attempts and failures).
+#[derive(Debug, Default)]
+pub struct McpResumeStats {
+    /// SSE reconnects granted by the policy (resume attempts).
+    pub resume_attempts: AtomicU64,
+    /// Resume attempts that errored (consulted on the transport error path).
+    pub resume_failures: AtomicU64,
+    /// Sessions declared terminal (empty-stream signature or failure cap).
+    pub sessions_poisoned: AtomicU64,
+    /// Poisoned connections replaced by the pool with a fresh session.
+    pub session_reinits: AtomicU64,
+    /// Failed attempts to establish a fresh connection.
+    pub connect_failures: AtomicU64,
+}
+
+/// `SseRetryPolicy` for one pooled MCP connection. See the module docs.
+#[derive(Debug)]
+pub(crate) struct SessionResumePolicy {
+    service_id: String,
+    stats: Arc<McpResumeStats>,
+    poisoned: AtomicBool,
+    last_grant: Mutex<Option<Grant>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Grant {
+    at: Instant,
+    delay: Duration,
+}
+
+impl SessionResumePolicy {
+    pub(crate) fn new(service_id: impl Into<String>, stats: Arc<McpResumeStats>) -> Self {
+        Self {
+            service_id: service_id.into(),
+            stats,
+            poisoned: AtomicBool::new(false),
+            last_grant: Mutex::new(None),
+        }
+    }
+
+    /// Policy with its own private stats — for connections whose stats are
+    /// not registered with a pool (test connectors).
+    #[cfg(test)]
+    pub(crate) fn detached(service_id: &str) -> Arc<Self> {
+        Arc::new(Self::new(service_id, Arc::new(McpResumeStats::default())))
+    }
+
+    /// True once resume has been declared terminal for this session. The
+    /// pool must drop the connection and connect fresh instead of reusing it.
+    pub(crate) fn is_poisoned(&self) -> bool {
+        self.poisoned.load(Ordering::Acquire)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn poison_for_test(&self) {
+        self.poison("test");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn stats(&self) -> &McpResumeStats {
+        &self.stats
+    }
+
+    fn poison(&self, reason: &str) {
+        if !self.poisoned.swap(true, Ordering::AcqRel) {
+            self.stats.sessions_poisoned.fetch_add(1, Ordering::Relaxed);
+            // At most one warn per session generation — the pathology being
+            // fixed is log flood, so the failure path must not add to it.
+            tracing::warn!(
+                service_id = %self.service_id,
+                reason,
+                resume_attempts = self.stats.resume_attempts.load(Ordering::Relaxed),
+                resume_failures = self.stats.resume_failures.load(Ordering::Relaxed),
+                "MCP SSE resume is terminal for this session; the pool will \
+                 re-initialize a fresh session on next use (#639)"
+            );
+        }
+    }
+
+    fn grant(&self, delay: Duration) -> Duration {
+        self.stats.resume_attempts.fetch_add(1, Ordering::Relaxed);
+        *self.last_grant.lock().expect("last_grant lock") = Some(Grant {
+            at: Instant::now(),
+            delay,
+        });
+        delay
+    }
+}
+
+impl SseRetryPolicy for SessionResumePolicy {
+    fn retry(&self, current_times: usize) -> Option<Duration> {
+        if self.is_poisoned() {
+            return None;
+        }
+
+        // rmcp's error path passes the count of consecutive reconnect
+        // failures for one stream (1-based); cap it.
+        if current_times >= 1 {
+            self.stats.resume_failures.fetch_add(1, Ordering::Relaxed);
+            if current_times >= MAX_CONSECUTIVE_RESUME_FAILURES {
+                self.poison("resume attempts kept erroring");
+                return None;
+            }
+            return Some(self.grant(RESUME_RECONNECT_DELAY));
+        }
+
+        // Graceful-close path: rmcp always passes 0 here, so the previous
+        // grant's stream lifetime is the only signal that distinguishes a
+        // healthy long-lived stream from a resume that came back dead.
+        let previous_grant = *self.last_grant.lock().expect("last_grant lock");
+        if let Some(grant) = previous_grant {
+            let stream_lifetime = Instant::now()
+                .saturating_duration_since(grant.at)
+                .saturating_sub(grant.delay);
+            if stream_lifetime < RAPID_STREAM_DEATH_THRESHOLD {
+                self.poison("resume returned an immediately-dead (empty) stream");
+                return None;
+            }
+        }
+        Some(self.grant(RESUME_RECONNECT_DELAY))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering::SeqCst;
+
+    #[tokio::test(start_paused = true)]
+    async fn resume_after_long_lived_stream_stays_granted() {
+        let policy = SessionResumePolicy::detached("healthy-service");
+
+        let delay = policy
+            .retry(0)
+            .expect("first resume after a stream close must be granted");
+        // The granted stream lives well past the rapid-death threshold.
+        tokio::time::advance(delay + Duration::from_secs(300)).await;
+        let delay = policy
+            .retry(0)
+            .expect("resume after a long-lived stream must stay granted");
+        tokio::time::advance(delay + Duration::from_secs(300)).await;
+        assert!(
+            policy.retry(0).is_some(),
+            "healthy reconnect cadence must never poison the session"
+        );
+        assert!(!policy.is_poisoned());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn empty_stream_resume_is_terminal_after_one_attempt() {
+        let policy = SessionResumePolicy::detached("dead-session-service");
+
+        let delay = policy
+            .retry(0)
+            .expect("first resume after a stream close must be granted");
+        // The granted resume comes back as a 200 + empty stream: it closes
+        // essentially immediately after the reconnect delay elapses.
+        tokio::time::advance(delay + Duration::from_millis(50)).await;
+        assert_eq!(
+            policy.retry(0),
+            None,
+            "a resume that yielded an immediately-dead stream must be terminal"
+        );
+        assert!(policy.is_poisoned());
+        assert_eq!(policy.stats().resume_attempts.load(SeqCst), 1);
+        assert_eq!(policy.stats().sessions_poisoned.load(SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn consecutive_resume_errors_hit_cap_and_poison() {
+        let policy = SessionResumePolicy::detached("erroring-service");
+
+        assert!(policy.retry(1).is_some(), "first resume error retries");
+        assert!(policy.retry(2).is_some(), "second resume error retries");
+        assert_eq!(
+            policy.retry(MAX_CONSECUTIVE_RESUME_FAILURES),
+            None,
+            "the failure cap must poison the session"
+        );
+        assert!(policy.is_poisoned());
+        assert_eq!(policy.stats().resume_failures.load(SeqCst), 3);
+        assert_eq!(policy.stats().sessions_poisoned.load(SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn poisoned_policy_never_grants_again() {
+        let policy = SessionResumePolicy::detached("poisoned-service");
+        policy.poison_for_test();
+
+        assert_eq!(policy.retry(0), None, "graceful-close path must stay shut");
+        assert_eq!(policy.retry(1), None, "error path must stay shut");
+        tokio::time::advance(Duration::from_secs(3600)).await;
+        assert_eq!(
+            policy.retry(0),
+            None,
+            "poisoning is permanent for the session"
+        );
+        assert_eq!(
+            policy.stats().sessions_poisoned.load(SeqCst),
+            1,
+            "poisoning must be counted once"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn error_path_success_followed_by_immediate_death_is_terminal() {
+        let policy = SessionResumePolicy::detached("flapping-service");
+
+        // One resume error, then the retried connect "succeeds"…
+        let delay = policy.retry(1).expect("first resume error retries");
+        // …but the stream it produced dies immediately (empty stream).
+        tokio::time::advance(delay + Duration::from_millis(50)).await;
+        assert_eq!(
+            policy.retry(0),
+            None,
+            "an error-path resume that produced a dead stream must be terminal"
+        );
+        assert!(policy.is_poisoned());
+    }
+}

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -990,6 +990,114 @@ async fn server_that_kills_every_fresh_session_gets_parked() {
     );
 }
 
+/// The park bound must hold under concurrency, not just sequentially: once a
+/// service has strike history, callers racing past an expired horizon must
+/// share ONE dial (a per-service in-flight reservation), not stampede — a
+/// stampede of N dials records N strikes and N warns before the first
+/// failure re-parks, breaking the ≤2-connects-per-horizon property.
+#[tokio::test(start_paused = true)]
+async fn concurrent_callers_to_struck_service_share_one_dial() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |_service_id, _endpoint, _agent_did, _trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                // Slow failing dial: concurrent callers arrive while this is
+                // in flight.
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                anyhow::bail!("connection refused")
+            }
+        });
+
+    // Establish strike history (strike 1, park 1s), then let the horizon
+    // expire.
+    let _ = pool
+        .list_tools("struck-service", "http://mcp.test/mcp")
+        .await;
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 1);
+    tokio::time::advance(std::time::Duration::from_secs(2)).await;
+
+    // Eight callers race in while the leader's dial is in flight.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            pool.list_tools("struck-service", "http://mcp.test/mcp")
+                .await
+        }));
+    }
+    let mut fast_failures = 0usize;
+    for handle in handles {
+        let error = handle
+            .await
+            .expect("task join")
+            .expect_err("dials to a dead service must fail");
+        let message = format!("{error:#}");
+        if message.contains("parked") || message.contains("already in flight") {
+            fast_failures += 1;
+        }
+    }
+
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        2,
+        "concurrent callers past an expired horizon must share one dial"
+    );
+    assert_eq!(
+        fast_failures, 7,
+        "the seven followers must fail fast without dialing"
+    );
+}
+
+/// Services with NO strike history keep the documented benign concurrent
+/// connects (racing duplicate handshakes, last insert wins) — the in-flight
+/// reservation must not serialize or fail healthy cold starts.
+#[tokio::test(start_paused = true)]
+async fn healthy_service_concurrent_cold_connects_stay_benign() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |service_id, endpoint, agent_did, trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                Ok(McpConnection {
+                    endpoint,
+                    agent_did_header: agent_did,
+                    trace_context_headers: trace_headers,
+                    last_used: super::fresh_last_used(),
+                    resume_policy: SessionResumePolicy::detached(&service_id),
+                    list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
+                    call_tool_fn: Box::new(|_params| {
+                        Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                    }),
+                })
+            }
+        });
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            pool.list_tools("cold-service", "http://mcp.test/mcp").await
+        }));
+    }
+    for handle in handles {
+        handle
+            .await
+            .expect("task join")
+            .expect("concurrent cold connects to a healthy service must all succeed");
+    }
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        4,
+        "healthy cold starts keep benign duplicate connects (no reservation)"
+    );
+}
+
 /// Strikes decay after a quiet period: a service that flapped long ago must
 /// not inherit a huge park horizon for its next transient failure.
 #[tokio::test(start_paused = true)]

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -1192,6 +1192,51 @@ async fn parked_endpoint_does_not_block_different_endpoint_for_same_service() {
     );
 }
 
+/// Parking is also principal-scoped: a shared pool may legitimately connect to
+/// the same service and endpoint with different bound agent DIDs, and a failure
+/// for one principal must not park the other.
+#[tokio::test(start_paused = true)]
+async fn parked_agent_did_does_not_block_different_agent_did_for_same_service_endpoint() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |_service_id, _endpoint, _agent_did, _trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                anyhow::bail!("connection refused")
+            }
+        });
+
+    let _ = pool
+        .list_tools_with_agent_did(
+            "multi-principal-service",
+            "http://mcp.test/mcp",
+            Some("did:key:agent-a"),
+        )
+        .await;
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 1);
+
+    let error = pool
+        .list_tools_with_agent_did(
+            "multi-principal-service",
+            "http://mcp.test/mcp",
+            Some("did:key:agent-b"),
+        )
+        .await
+        .expect_err("second principal still fails in this test connector");
+
+    assert!(
+        format!("{error:#}").contains("connection refused"),
+        "different agent DID should dial and surface connector error, not inherit principal-a park: {error:#}"
+    );
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        2,
+        "parking one bound agent DID must not block a different bound agent DID"
+    );
+}
+
 /// Strikes decay after a quiet period: a service that flapped long ago must
 /// not inherit a huge park horizon for its next transient failure.
 #[tokio::test(start_paused = true)]

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -170,6 +170,7 @@ async fn list_tools_transport_failure_retries_generated_safe_read_case() {
                     agent_did_header,
                     trace_context_headers: trace_headers,
                     last_used: super::fresh_last_used(),
+                    resume_policy: SessionResumePolicy::detached("read-service"),
                     list_tools_fn: Box::new(move || {
                         let list_calls = Arc::clone(&list_calls);
                         Box::pin(async move {
@@ -226,6 +227,7 @@ async fn assert_call_tool_transport_no_retry(case: &LeanToolRetryCase) {
                 agent_did_header: None,
                 trace_context_headers: HashMap::new(),
                 last_used: super::fresh_last_used(),
+                resume_policy: SessionResumePolicy::detached(&service_id),
                 list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
                 call_tool_fn: Box::new(move |_params| {
                     let calls = Arc::clone(&calls_for_fn);
@@ -803,6 +805,7 @@ async fn hung_connect_does_not_wedge_other_services() {
                     Box::pin(async { anyhow::bail!("call_tool was not expected") })
                 }),
                 last_used: super::fresh_last_used(),
+                resume_policy: SessionResumePolicy::detached(&service_id),
             })
         },
     );
@@ -833,4 +836,336 @@ async fn hung_connect_does_not_wedge_other_services() {
     );
 
     hung.abort();
+}
+
+// --- #639: dead-session resume must be terminal, re-init must be bounded ----
+
+/// Builds a pool whose connector counts connect attempts and records every
+/// created connection's resume policy, so tests can poison sessions and
+/// observe replacement.
+fn counting_pool(
+    connect_attempts: Arc<AtomicUsize>,
+    policies: Arc<Mutex<Vec<Arc<SessionResumePolicy>>>>,
+    poison_at_creation: bool,
+) -> McpPool {
+    McpPool::new_with_connector(move |service_id, endpoint, agent_did, trace_headers| {
+        let connect_attempts = Arc::clone(&connect_attempts);
+        let policies = Arc::clone(&policies);
+        async move {
+            connect_attempts.fetch_add(1, Ordering::SeqCst);
+            let resume_policy = SessionResumePolicy::detached(&service_id);
+            if poison_at_creation {
+                resume_policy.poison_for_test();
+            }
+            policies
+                .lock()
+                .expect("policies lock")
+                .push(Arc::clone(&resume_policy));
+            Ok(McpConnection {
+                endpoint,
+                agent_did_header: agent_did,
+                trace_context_headers: trace_headers,
+                last_used: super::fresh_last_used(),
+                resume_policy,
+                list_tools_fn: Box::new(|| Box::pin(async { Ok(ListToolsResult::default()) })),
+                call_tool_fn: Box::new(|_params| {
+                    Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                }),
+            })
+        }
+    })
+}
+
+/// Required behavior 1: a session whose resume went terminal (poisoned) must
+/// be dropped and re-initialized fresh on next use — never reused.
+#[tokio::test]
+async fn poisoned_session_is_replaced_on_next_use() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let policies = Arc::new(Mutex::new(Vec::new()));
+    let pool = counting_pool(Arc::clone(&connect_attempts), Arc::clone(&policies), false);
+
+    pool.list_tools("resume-service", "http://mcp.test/mcp")
+        .await
+        .expect("first list_tools should succeed");
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 1);
+
+    policies.lock().expect("policies lock")[0].poison_for_test();
+
+    pool.list_tools("resume-service", "http://mcp.test/mcp")
+        .await
+        .expect("list_tools after poisoning should succeed on a fresh session");
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        2,
+        "a poisoned session must be replaced, not reused"
+    );
+
+    pool.list_tools("resume-service", "http://mcp.test/mcp")
+        .await
+        .expect("healthy fresh session should be reused");
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        2,
+        "the healthy replacement must be reused, not churned"
+    );
+
+    assert_eq!(
+        pool.resume_stats("resume-service")
+            .session_reinits
+            .load(Ordering::SeqCst),
+        1,
+        "the poison-triggered replacement must be counted"
+    );
+}
+
+/// Required behavior 3 (test c): re-init failures park the service with an
+/// escalating horizon — bounded connect attempts over simulated time instead
+/// of one attempt per call.
+#[tokio::test(start_paused = true)]
+async fn repeated_connect_failures_park_the_service() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |_service_id, _endpoint, _agent_did, _trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                anyhow::bail!("connection refused")
+            }
+        });
+
+    let mut parked_failures = 0usize;
+    // Two simulated hours of a caller retrying every 30 seconds.
+    for _ in 0..240 {
+        let error = pool
+            .list_tools("down-service", "http://mcp.test/mcp")
+            .await
+            .expect_err("connects to a dead service must fail");
+        if format!("{error:#}").contains("parked") {
+            parked_failures += 1;
+        }
+        tokio::time::advance(std::time::Duration::from_secs(30)).await;
+    }
+
+    let attempts = connect_attempts.load(Ordering::SeqCst);
+    assert!(
+        attempts <= 30,
+        "connect attempts must be park-bounded over simulated time, got {attempts} in 240 calls"
+    );
+    assert!(
+        parked_failures >= 200,
+        "most calls to a parked service must fail fast without a connect \
+         attempt, got {parked_failures} parked failures"
+    );
+}
+
+/// Required behavior 3: a server that accepts the handshake but kills every
+/// fresh session (each new session poisons immediately) must also converge
+/// to parked — a resume hot-loop must not become an init hot-loop.
+#[tokio::test(start_paused = true)]
+async fn server_that_kills_every_fresh_session_gets_parked() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let policies = Arc::new(Mutex::new(Vec::new()));
+    let pool = counting_pool(Arc::clone(&connect_attempts), policies, true);
+
+    // 100 simulated minutes of a caller retrying every 10 seconds against a
+    // server that poisons every session it hands out.
+    for _ in 0..600 {
+        let _ = pool
+            .list_tools("flapping-service", "http://mcp.test/mcp")
+            .await;
+        tokio::time::advance(std::time::Duration::from_secs(10)).await;
+    }
+
+    // Steady state is two connects per park horizon: the call that detects a
+    // poisoned session strikes *and* reconnects (the park gate deliberately
+    // uses the pre-strike horizon so a one-off server restart recovers
+    // seamlessly), then the horizon blocks everything until it expires.
+    // Ramp (~11 doubling strikes) ≈ 22, plus ~4 capped horizons ≈ 8.
+    let attempts = connect_attempts.load(Ordering::SeqCst);
+    assert!(
+        attempts <= 35,
+        "session re-inits against a flapping server must be park-bounded, \
+         got {attempts} connects in 600 calls"
+    );
+}
+
+/// Strikes decay after a quiet period: a service that flapped long ago must
+/// not inherit a huge park horizon for its next transient failure.
+#[tokio::test(start_paused = true)]
+async fn park_strikes_decay_after_quiet_period() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |_service_id, _endpoint, _agent_did, _trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                anyhow::bail!("connection refused")
+            }
+        });
+
+    // Five failures far enough apart that none is blocked by the park
+    // horizon, close enough that strikes accumulate (park grows to 16s).
+    for _ in 0..5 {
+        let _ = pool
+            .list_tools("blippy-service", "http://mcp.test/mcp")
+            .await;
+        tokio::time::advance(std::time::Duration::from_secs(1000)).await;
+    }
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 5);
+
+    // A quiet period longer than the decay window resets the strike count…
+    tokio::time::advance(std::time::Duration::from_secs(31 * 60)).await;
+    let _ = pool
+        .list_tools("blippy-service", "http://mcp.test/mcp")
+        .await;
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 6);
+
+    // …so the follow-up failure parks with a fresh (tiny) horizon instead of
+    // the escalated pre-quiet one (32s would still be parked 3s later).
+    tokio::time::advance(std::time::Duration::from_secs(3)).await;
+    let _ = pool
+        .list_tools("blippy-service", "http://mcp.test/mcp")
+        .await;
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        7,
+        "decayed strikes must not inherit the pre-quiet park horizon"
+    );
+}
+
+/// End-to-end against a real rmcp transport (required test a): a server that
+/// answers SSE GETs with 200 + an immediately-closed empty stream — the
+/// dead-session signature from the 2026-07-06/07 incidents — must get exactly
+/// one resume attempt, then the session is poisoned, and the next pool use
+/// re-initializes a fresh session (DELETE-ing the old one, #626).
+#[tokio::test]
+async fn empty_stream_resume_is_terminal_and_reinitializes() {
+    let (endpoint, http_log) = spawn_empty_sse_stream_mcp_server().await;
+    let pool = McpPool::new();
+
+    pool.list_tools("resume-storm-service", &endpoint)
+        .await
+        .expect("first mock MCP list_tools should succeed");
+
+    // The transport's standalone GET stream comes back empty, closes, and is
+    // resumed once; that resume also comes back empty → session poisoned.
+    let stats = pool.resume_stats("resume-storm-service");
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
+    while stats.sessions_poisoned.load(Ordering::SeqCst) == 0 {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "session should have been poisoned after the empty-stream resume; log: {:?}",
+            http_log.lock().expect("http log lock")
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    // Quiet period: with the hot loop, GETs arrive ~1/s; after poisoning
+    // there must be no further resume traffic at all.
+    tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
+    {
+        let log = http_log.lock().expect("http log lock");
+        let gets = log.iter().filter(|e| e.http_method == "GET").count();
+        assert_eq!(
+            gets, 2,
+            "expected exactly the initial GET plus one resume attempt, got {gets}: {log:?}"
+        );
+    }
+
+    // Next use replaces the poisoned session: fresh initialize + DELETE of
+    // the dead session.
+    pool.list_tools("resume-storm-service", &endpoint)
+        .await
+        .expect("list_tools after poisoning should succeed on a fresh session");
+
+    let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    loop {
+        {
+            let log = http_log.lock().expect("http log lock");
+            let initializes = log
+                .iter()
+                .filter(|e| e.rpc_method.as_deref() == Some("initialize"))
+                .count();
+            let deleted = log
+                .iter()
+                .any(|e| e.http_method == "DELETE" && e.session_id.as_deref() == Some("session-1"));
+            if initializes >= 2 && deleted {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!(
+                    "expected a second initialize and a DELETE for session-1 after \
+                     the poisoned session was replaced. log: {log:?}"
+                );
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+    assert_eq!(
+        stats.session_reinits.load(Ordering::SeqCst),
+        1,
+        "the poison-triggered re-initialization must be counted"
+    );
+}
+
+/// Mock MCP server whose SSE GET endpoint always answers 200 +
+/// `text/event-stream` and immediately closes the connection — an empty
+/// stream, the rmcp dead-session resume signature. POSTs keep working so the
+/// test isolates the resume path.
+async fn spawn_empty_sse_stream_mcp_server() -> (String, Arc<Mutex<Vec<SessionHttpLogEntry>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind mock MCP server");
+    let addr = listener.local_addr().expect("mock MCP server address");
+    let log = Arc::new(Mutex::new(Vec::new()));
+    let log_for_server = Arc::clone(&log);
+    let session_counter = Arc::new(AtomicUsize::new(0));
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                break;
+            };
+            let log = Arc::clone(&log_for_server);
+            let session_counter = Arc::clone(&session_counter);
+            tokio::spawn(async move {
+                let Ok(request) = read_mcp_http_request(&mut stream).await else {
+                    return;
+                };
+                log.lock()
+                    .expect("http log lock")
+                    .push(SessionHttpLogEntry {
+                        http_method: request.http_method.clone(),
+                        session_id: request.session_id_header.clone(),
+                        rpc_method: (!request.method.is_empty()).then(|| request.method.clone()),
+                    });
+                let response = match request.http_method.as_str() {
+                    "DELETE" => "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                        .to_string(),
+                    // 200 + empty SSE stream, closed immediately: the
+                    // dead-session resume answer this issue is about.
+                    "GET" => "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n"
+                        .to_string(),
+                    _ => {
+                        let session_header = if request.method == "initialize" {
+                            let n = session_counter.fetch_add(1, Ordering::SeqCst) + 1;
+                            Some(format!("session-{n}"))
+                        } else {
+                            None
+                        };
+                        mcp_http_response_with_session(
+                            &request.method,
+                            request.id,
+                            session_header.as_deref(),
+                        )
+                    }
+                };
+                let _ = stream.write_all(response.as_bytes()).await;
+            });
+        }
+    });
+
+    (format!("http://{addr}/mcp"), log)
 }

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -1098,6 +1098,100 @@ async fn healthy_service_concurrent_cold_connects_stay_benign() {
     );
 }
 
+/// A poison-driven reconnect happens before the safe-read `list_tools` call.
+/// If that first call fails, the existing one-shot safe-read retry must still
+/// be allowed through the just-recorded poison park horizon.
+#[tokio::test(start_paused = true)]
+async fn poison_recovery_preserves_list_tools_safe_read_retry() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let policies = Arc::new(Mutex::new(Vec::new()));
+    let policies_for_fn = Arc::clone(&policies);
+    let pool =
+        McpPool::new_with_connector(move |service_id, endpoint, agent_did, trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            let policies = Arc::clone(&policies_for_fn);
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                let resume_policy = SessionResumePolicy::detached(&service_id);
+                policies
+                    .lock()
+                    .expect("policies lock")
+                    .push(Arc::clone(&resume_policy));
+                Ok(McpConnection {
+                    endpoint,
+                    agent_did_header: agent_did,
+                    trace_context_headers: trace_headers,
+                    last_used: super::fresh_last_used(),
+                    resume_policy,
+                    list_tools_fn: Box::new(move || {
+                        Box::pin(async move {
+                            if attempt == 2 {
+                                anyhow::bail!("transport dropped after poison recovery")
+                            }
+                            Ok(ListToolsResult::default())
+                        })
+                    }),
+                    call_tool_fn: Box::new(|_params| {
+                        Box::pin(async { anyhow::bail!("call_tool was not expected") })
+                    }),
+                })
+            }
+        });
+
+    pool.list_tools("retry-service", "http://mcp.test/mcp")
+        .await
+        .expect("first list_tools should succeed");
+    policies.lock().expect("policies lock")[0].poison_for_test();
+
+    pool.list_tools("retry-service", "http://mcp.test/mcp")
+        .await
+        .expect("safe-read retry after poison recovery must not be blocked by parking");
+
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        3,
+        "poison recovery should connect once, then safe-read retry once"
+    );
+}
+
+/// Parking is endpoint-scoped: a dynamic endpoint change for the same
+/// service id must be allowed through instead of inheriting the previous
+/// endpoint's park horizon.
+#[tokio::test(start_paused = true)]
+async fn parked_endpoint_does_not_block_different_endpoint_for_same_service() {
+    let connect_attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_fn = Arc::clone(&connect_attempts);
+    let pool =
+        McpPool::new_with_connector(move |_service_id, _endpoint, _agent_did, _trace_headers| {
+            let attempts = Arc::clone(&attempts_for_fn);
+            async move {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                anyhow::bail!("connection refused")
+            }
+        });
+
+    let _ = pool
+        .list_tools("dynamic-service", "http://old-endpoint.test/mcp")
+        .await;
+    assert_eq!(connect_attempts.load(Ordering::SeqCst), 1);
+
+    let error = pool
+        .list_tools("dynamic-service", "http://new-endpoint.test/mcp")
+        .await
+        .expect_err("new endpoint still fails in this test connector");
+
+    assert!(
+        format!("{error:#}").contains("connection refused"),
+        "new endpoint should dial and surface connector error, not inherit old endpoint park: {error:#}"
+    );
+    assert_eq!(
+        connect_attempts.load(Ordering::SeqCst),
+        2,
+        "parking one endpoint must not block a different endpoint"
+    );
+}
+
 /// Strikes decay after a quiet period: a service that flapped long ago must
 /// not inherit a huge park horizon for its next transient failure.
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Incident

When an MCP server loses a session, the runtime's client resumes it **in a hot loop, forever** (#639): the rmcp streamable-HTTP server answers resume-of-a-dead-session with **200 + empty stream**, and rmcp's client `SseAutoReconnectStream` treats every graceful stream close as reconnectable — it consults its retry policy with `current_times == 0` each time, so no `max_times`-style cap can ever fire. ~5/s sustained in production: 278k warns/15h on observability-mcp, a 117→1,415 dead-session set on hf-data, and a 5h telemetry blackout on strangenas from the warn flood's second-order journald damage. The #626 idle TTL structurally cannot break this — an actively-failing session is never idle.

## Where the loop lives, and the seam

The loop is entirely inside rmcp's client transport (`common/client_side_sse.rs`), applied to the standalone GET stream and every POST-response SSE stream. The one injection point rmcp exposes is `StreamableHttpClientTransportConfig::retry_config: Arc<dyn SseRetryPolicy>` — consulted on every resume decision. That's where this fix lives.

## What this PR does

- **`SessionResumePolicy`** (new `mcp_pool/resume.rs`, installed as `retry_config` on every pooled connection): a granted resume whose stream dies within 10s is the dead-session empty-stream signature → the session is **poisoned after exactly one resume attempt** and never resumed again. Consecutive resume *errors* are capped at 3 (defense in depth — no future resume path can hot-loop either). Poisoned streams terminate quietly instead of looping.
- **Pool replaces poisoned sessions on next use** (same lazy style as the #626 TTL): drop the connection — terminating the server-side session through the existing drop → cancellation → worker-cleanup **DELETE** path — and connect fresh.
- **Re-init is bounded by per-service parking**: connect failures and poisoned-session detections are strikes; the park horizon doubles 1s → 15m ceiling, decaying after 30m clean. A server that kills every fresh session converges to ≤2 connects per horizon (parked, not spinning); a one-off server restart still recovers seamlessly because the park gate uses the pre-strike horizon. While parked, calls fail fast without dialing.
- **Observability**: per-service `McpResumeStats` counters (resume attempts/failures, poisonings, re-inits, connect failures) via `McpPool::resume_stats`, and structurally bounded `warn!`s — ≤1 per session generation / per park horizon, with the #588 global log-rate ceiling as backstop. The failure path cannot itself flood.

The #622/#625 no-await-under-lock discipline is preserved: park/stats use `std::sync::Mutex` never held across an await; connects still happen outside the pool lock.

## Testing (TDD, red first)

- The red run of the new end-to-end test — real rmcp transport against a mock server speaking the 200+empty-SSE pathology — **reproduced the production hot loop live** (~1 GET/s, unbounded). Green asserts exactly one resume attempt, zero traffic after poisoning, then re-init with a fresh `initialize` and a DELETE of the dead session.
- Policy unit tests under paused clocks: empty-stream terminal after one attempt, error cap, permanence of poisoning, healthy long-lived reconnect cadence never poisons.
- Pool tests: poison-driven replacement (and reuse of the healthy replacement), park bounding over simulated hours (≤~30 connects where 600 calls were made), flapping-server convergence, strike decay after a quiet period.
- Idle-TTL + session-DELETE regressions remain covered by the #625/#626 tests (all green).
- Full gate: `cargo test -p defra-agent` — 13/13 binaries, 0 failures (957 lib tests + integration suites). Clippy at baseline.

## What this PR does not do

The server-side bug (200+empty for a dead session instead of a 4xx per spec) is the upstream rust-sdk issue filed 2026-07-06. This PR is the client's behavior given such a server, which will keep existing in the wild regardless. No Lean scope: client retry policy only, no lifecycle-state change (the ToolExecution retry-disposition vocabulary is untouched and its conformance tests pass).

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)