### PR TITLE
feat(cli): backend onboarding flow — shared core + onboard command (#647)

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -158,6 +158,41 @@ pub(crate) enum Command {
     },
     #[command(about = "Interactive, self-contained fleet demo (single node -> paired fleet)")]
     Demo(DemoArgs),
+    #[command(
+        about = "Configure and connect an inference backend for an initialized agent (#647)"
+    )]
+    Onboard(OnboardArgs),
+}
+
+#[derive(clap::Args)]
+pub(crate) struct OnboardArgs {
+    #[arg(long, help = "Agent home directory (defaults to the standard home)")]
+    pub(crate) home: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "GraphQL endpoint of a running server. Defaults to auto-detecting a live server for this home, else operating on the home offline"
+    )]
+    pub(crate) graphql: Option<String>,
+    #[arg(
+        long,
+        help = "Non-interactive: configure this backend preset (openai, openrouter, ollama, llama-cpp, vllm)"
+    )]
+    pub(crate) backend_preset: Option<BackendPresetArg>,
+    #[arg(
+        long,
+        help = "Non-interactive: configure this backend base URL, e.g. http://127.0.0.1:8080/v1"
+    )]
+    pub(crate) inference_url: Option<String>,
+    #[arg(
+        long,
+        help = "Model name to bind (defaults to the detected/preset model)"
+    )]
+    pub(crate) model: Option<String>,
+    #[arg(
+        long,
+        help = "API key stored in the backend document. Prefer an env-var backend for secrets"
+    )]
+    pub(crate) api_key: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -158,9 +158,7 @@ pub(crate) enum Command {
     },
     #[command(about = "Interactive, self-contained fleet demo (single node -> paired fleet)")]
     Demo(DemoArgs),
-    #[command(
-        about = "Configure and connect an inference backend for an initialized agent (#647)"
-    )]
+    #[command(about = "Configure and connect an inference backend for an initialized agent")]
     Onboard(OnboardArgs),
 }
 

--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -183,14 +183,19 @@ pub(crate) struct OnboardArgs {
     pub(crate) inference_url: Option<String>,
     #[arg(
         long,
-        help = "Model name to bind (defaults to the detected/preset model)"
+        help = "Model to bind. With --backend-preset/--inference-url: required unless the preset has a safe default (same rule as init). On the detect path: an optional override of the server's advertised model. Ignored when rebinding an already-stored backend"
     )]
     pub(crate) model: Option<String>,
     #[arg(
         long,
-        help = "API key stored in the backend document. Prefer an env-var backend for secrets"
+        help = "API key stored in the backend document. Prefer --api-key-env-var for secrets"
     )]
     pub(crate) api_key: Option<String>,
+    #[arg(
+        long,
+        help = "Environment variable name the runtime reads the API key from (kept out of the stored document; mirrors init)"
+    )]
+    pub(crate) api_key_env_var: Option<String>,
 }
 
 #[derive(clap::Args)]

--- a/crates/defra-agent-cli/src/commands/demo/backend.rs
+++ b/crates/defra-agent-cli/src/commands/demo/backend.rs
@@ -6,10 +6,8 @@
 //! paired node B reuse the same backend. No mock is ever offered.
 
 use std::path::Path;
-use std::time::Duration;
 
 use anyhow::{bail, Result};
-use serde_json::Value;
 
 use crate::cli::args::DemoArgs;
 
@@ -87,7 +85,9 @@ pub(super) async fn pick_backend(
                     let url = non_empty(&url)
                         .unwrap_or("http://127.0.0.1:11434/v1")
                         .to_string();
-                    let detected = probe_models(&url).await.unwrap_or_default();
+                    let detected = crate::onboarding::probe_models(&url)
+                        .await
+                        .unwrap_or_default();
                     (url, detected)
                 }
             };
@@ -110,12 +110,11 @@ pub(super) async fn pick_backend(
 }
 
 async fn detect_local() -> Option<(String, String)> {
-    for url in ["http://127.0.0.1:8080/v1", "http://127.0.0.1:11434/v1"] {
-        if let Some(model) = probe_models(url).await {
-            return Some((url.to_string(), model));
-        }
-    }
-    None
+    // Shared detection so the demo and the first-class `onboard` flow probe the
+    // same local endpoints and agree on what "a local server" means (#647).
+    crate::onboarding::detect_local_backend()
+        .await
+        .map(|backend| (backend.url, backend.model))
 }
 
 fn openai_backend(model: Option<&str>, api_key: Option<&str>) -> BackendChoice {
@@ -170,23 +169,6 @@ fn custom_url_backend(url: &str, model: Option<&str>, api_key: Option<&str>) -> 
         init_args,
         label: format!("{url} · {model}"),
     }
-}
-
-/// GET `{base}/models`; return the first advertised model id if reachable.
-async fn probe_models(base: &str) -> Option<String> {
-    let response = reqwest::Client::new()
-        .get(format!("{base}/models"))
-        .timeout(Duration::from_millis(700))
-        .send()
-        .await
-        .ok()?;
-    if !response.status().is_success() {
-        return None;
-    }
-    let body: Value = response.json().await.ok()?;
-    body.pointer("/data/0/id")
-        .and_then(Value::as_str)
-        .map(ToString::to_string)
 }
 
 pub(super) fn write_backend_args(path: &Path, args: &[String]) {

--- a/crates/defra-agent-cli/src/commands/demo/mod.rs
+++ b/crates/defra-agent-cli/src/commands/demo/mod.rs
@@ -19,7 +19,6 @@ mod shell;
 mod util;
 
 use anyhow::{Context, Result};
-use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::cli::args::DemoArgs;
 
@@ -41,7 +40,7 @@ pub(crate) async fn demo(args: DemoArgs) -> Result<()> {
     let backend_file = home.join("demo-backend.json");
 
     // One owned stdin reader drives the picker, the shell, and reconfigure.
-    let mut reader = BufReader::new(tokio::io::stdin()).lines();
+    let mut reader = crate::prompt::stdin_lines();
 
     // First run sets up; later runs resume the saved agent. The backend args are
     // persisted so a resumed session (and a paired node B) reuse the same backend.

--- a/crates/defra-agent-cli/src/commands/demo/util.rs
+++ b/crates/defra-agent-cli/src/commands/demo/util.rs
@@ -1,58 +1,16 @@
-//! Shared plumbing for the demo command: subprocess invocation, terminal
-//! prompts, and small string/path helpers.
-//!
-//! Every stdin read in the demo goes through one owned [`StdinLines`] so the
-//! first-run backend picker, the interactive shell, and `reconfigure` never
-//! fight over the terminal — mixing a blocking `std::io::stdin` read with an
-//! async tokio reader loses buffered input on piped stdin.
+//! Shared plumbing for the demo command: subprocess invocation and small
+//! string/path helpers. Terminal prompts live in [`crate::prompt`] and are
+//! re-exported here so demo call sites keep using `super::util::…`.
 
-use std::io::Write as _;
 use std::path::Path;
 
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
 use tokio::process::Command;
 
-/// The single owned stdin line reader threaded through the whole demo session.
-pub(super) type StdinLines = tokio::io::Lines<tokio::io::BufReader<tokio::io::Stdin>>;
-
-/// Print a prompt without a trailing newline and flush it.
-pub(super) fn prompt(text: &str) {
-    print!("{text}");
-    let _ = std::io::stdout().flush();
-}
-
-/// Print `text`, then read one line from the shared reader.
-pub(super) async fn prompt_line(reader: &mut StdinLines, text: &str) -> Result<String> {
-    prompt(text);
-    Ok(reader.next_line().await?.unwrap_or_default())
-}
-
-/// Read one line without echoing it (best-effort via `stty`; a non-terminal
-/// stdin, e.g. piped input, just reads normally since there is nothing to echo).
-pub(super) async fn prompt_secret(reader: &mut StdinLines, text: &str) -> Result<String> {
-    prompt(text);
-    let hidden = set_terminal_echo(false);
-    let line = reader.next_line().await;
-    if hidden {
-        set_terminal_echo(true);
-        println!();
-    }
-    Ok(line?.unwrap_or_default())
-}
-
-fn set_terminal_echo(on: bool) -> bool {
-    std::process::Command::new("stty")
-        .arg(if on { "echo" } else { "-echo" })
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-pub(super) fn non_empty(value: &str) -> Option<&str> {
-    let trimmed = value.trim();
-    (!trimmed.is_empty()).then_some(trimmed)
-}
+// One stdin reader and prompt implementation, shared with `onboard`, so stty
+// secret handling and buffered-input behavior never drift between the two.
+pub(super) use crate::prompt::{non_empty, prompt, prompt_line, prompt_secret, StdinLines};
 
 pub(super) fn short(did: &str) -> String {
     if did.len() > 16 {

--- a/crates/defra-agent-cli/src/commands/mod.rs
+++ b/crates/defra-agent-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod fleet;
 pub(crate) mod init;
 pub(crate) mod mcp;
 pub(crate) mod native_fs_runner;
+pub(crate) mod onboard;
 pub(crate) mod p2p;
 pub(crate) mod provision;
 pub(crate) mod query;

--- a/crates/defra-agent-cli/src/commands/onboard.rs
+++ b/crates/defra-agent-cli/src/commands/onboard.rs
@@ -36,6 +36,12 @@ use crate::{
 
 const DEFAULT_MODEL: &str = "gpt-4.1-mini";
 const DEFAULT_MAX_CONCURRENT: i64 = 8;
+/// A backend onboarding just probed successfully (detected-local path): safe to
+/// mark runnable now instead of waiting for the server's startup re-probe.
+const HEALTHY_PROBE_STATUS: &str = "healthy";
+/// A backend onboarding did not measure (remote / preset / scripted): the
+/// startup probe (#640) decides its health.
+const UNKNOWN_PROBE_STATUS: &str = "unknown";
 
 pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
     let home_dir = resolve_home_dir(args.home.as_deref());
@@ -79,7 +85,8 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
             .model
             .clone()
             .unwrap_or_else(|| DEFAULT_MODEL.to_string());
-        let backend_id = persist_backend(&access, &agent_did, &resolved, &model).await?;
+        let backend_id =
+            persist_backend(&access, &agent_did, &resolved, &model, UNKNOWN_PROBE_STATUS).await?;
         bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
         return report(&backend_id, "configured", &default_behavior_id);
     }
@@ -103,7 +110,12 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
                 None,
                 BackendResolutionMode::Init,
             )?;
-            let backend_id = persist_backend(&access, &agent_did, &resolved, &model).await?;
+            // detect_local_backend already probed this endpoint's /models, so
+            // record it healthy now — the behavior is runnable without waiting
+            // for the server to re-probe the same live server on next startup.
+            let backend_id =
+                persist_backend(&access, &agent_did, &resolved, &model, HEALTHY_PROBE_STATUS)
+                    .await?;
             bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
             println!(
                 "Detected a local inference server at {} — connected.",
@@ -124,8 +136,14 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
                 // bound — the user re-runs `onboard` once the server is up.
                 None => Ok(()),
                 Some((resolved, model)) => {
-                    let backend_id =
-                        persist_backend(&access, &agent_did, &resolved, &model).await?;
+                    let backend_id = persist_backend(
+                        &access,
+                        &agent_did,
+                        &resolved,
+                        &model,
+                        UNKNOWN_PROBE_STATUS,
+                    )
+                    .await?;
                     bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model))
                         .await?;
                     report(&backend_id, "configured", &default_behavior_id)
@@ -164,11 +182,17 @@ async fn query_configured_backends(access: &ConfigAccess) -> Result<Vec<Configur
 
 /// Persist a backend under the agent's canonical backend id (updating in place
 /// so onboarding is idempotent) and return that id.
+///
+/// `probe_status` is `HEALTHY_PROBE_STATUS` only when onboarding just made a
+/// successful live probe of this exact endpoint (the detected-local path);
+/// otherwise `UNKNOWN_PROBE_STATUS`, so the honest-probe subsystem (#640) — not
+/// this write — owns promoting an unmeasured endpoint to healthy.
 async fn persist_backend(
     access: &ConfigAccess,
     agent_did: &str,
     resolved: &ResolvedBackendConfig,
     model: &str,
+    probe_status: &str,
 ) -> Result<String> {
     let backend_id = format!("{agent_did}:backend");
     let doc = InferenceBackendUpsertDocument {
@@ -184,10 +208,7 @@ async fn persist_backend(
         enabled: true,
         models_on_add: vec![model.to_string()],
         models_on_update: Some(vec![model.to_string()]),
-        // Onboarding does not measure remote health; leave this as the catalog
-        // default so the honest-probe fix (#640) stays the single owner of the
-        // health signal rather than stamping "healthy" here.
-        probe_status: "unknown".to_string(),
+        probe_status: probe_status.to_string(),
     };
     write_inference_backend_document(access, &doc).await?;
     Ok(backend_id)

--- a/crates/defra-agent-cli/src/commands/onboard.rs
+++ b/crates/defra-agent-cli/src/commands/onboard.rs
@@ -1,0 +1,350 @@
+//! `onboard` — the interactive first-launch inference-backend flow (#647).
+//!
+//! Queries the stored inference backends, probes for a live local server, and
+//! applies the #647 decision tree ([`crate::onboarding::plan_backend_onboarding`])
+//! — a single stored backend (or a detected local one) connects with no
+//! prompt; multiple stored backends prompt for a pick; nothing stored and
+//! nothing detected offers to start a local server (printing instructions to
+//! re-run) or configure a remote one. The chosen backend AND its model are
+//! bound to the agent's default behavior.
+//!
+//! Config writes go through [`resolve_config_access`], so onboard works both
+//! against a running server (its GraphQL endpoint) and offline (an embedded
+//! node) — it never opens a second node on a data dir the server already holds.
+//! `serve` stays non-interactive and points here when the default behavior is
+//! not runnable.
+
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+
+use defra_agent::default_behavior_id_for_agent;
+use defra_agent::graphql::escape_graphql_string;
+
+use crate::cli::args::OnboardArgs;
+use crate::config_writes::{
+    write_inference_backend_document, ConfigAccess, InferenceBackendUpsertDocument,
+};
+use crate::onboarding::{
+    detect_local_backend, plan_backend_onboarding, BackendPlan, ConfiguredBackend,
+};
+use crate::prompt::{non_empty, prompt_line, prompt_secret, stdin_lines, StdinLines};
+use crate::resolve_helpers::{default_backend_max_queue_depth, resolve_backend_config_with_preset};
+use crate::shared::ResolvedBackendConfig;
+use crate::{
+    print_json, read_init_config, resolve_config_access, resolve_home_dir, BackendResolutionMode,
+};
+
+const DEFAULT_MODEL: &str = "gpt-4.1-mini";
+const DEFAULT_MAX_CONCURRENT: i64 = 8;
+
+pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
+    let home_dir = resolve_home_dir(args.home.as_deref());
+    let init_config = read_init_config(&home_dir)?.ok_or_else(|| {
+        anyhow!(
+            "no initialized agent in {}; run `defra-agent init` first",
+            home_dir.display()
+        )
+    })?;
+    let agent_did = init_config.agent_did.trim().to_string();
+    if agent_did.is_empty() {
+        anyhow::bail!("initialized home {} has no agent DID", home_dir.display());
+    }
+    let default_behavior_id = default_behavior_id_for_agent(&agent_did);
+
+    // `--api-key` alone cannot define a backend; require an endpoint or preset
+    // so the key is never silently dropped.
+    let has_backend_spec = args.backend_preset.is_some() || args.inference_url.is_some();
+    if args.api_key.is_some() && !has_backend_spec {
+        anyhow::bail!("--api-key requires --backend-preset or --inference-url");
+    }
+
+    // Route through the running server when one is up, else an offline node —
+    // never a second node on the server's locked data dir.
+    let (access, _home) =
+        resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
+
+    // Non-interactive escape hatch: explicit backend flags configure that
+    // backend and bind it with no prompts (headless / CI / scripted onboarding).
+    if has_backend_spec {
+        let resolved = resolve_backend_config_with_preset(
+            args.backend_preset,
+            args.inference_url.as_deref(),
+            None,
+            None,
+            args.api_key.as_deref(),
+            None,
+            BackendResolutionMode::Init,
+        )?;
+        let model = args
+            .model
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let backend_id = persist_backend(&access, &agent_did, &resolved, &model).await?;
+        bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
+        return report(&backend_id, "configured", &default_behavior_id);
+    }
+
+    let configured = query_configured_backends(&access).await?;
+    let detected = detect_local_backend().await;
+    match plan_backend_onboarding(&configured, detected) {
+        // Reusing an existing configured backend: keep its behavior model_name.
+        BackendPlan::AutoConnect { backend_id } => {
+            bind_default_behavior(&access, &default_behavior_id, &backend_id, None).await?;
+            report(&backend_id, "connected", &default_behavior_id)
+        }
+        BackendPlan::AdoptDetected { detected } => {
+            let model = args.model.clone().unwrap_or_else(|| detected.model.clone());
+            let resolved = resolve_backend_config_with_preset(
+                None,
+                Some(&detected.url),
+                None,
+                None,
+                None,
+                None,
+                BackendResolutionMode::Init,
+            )?;
+            let backend_id = persist_backend(&access, &agent_did, &resolved, &model).await?;
+            bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
+            println!(
+                "Detected a local inference server at {} — connected.",
+                detected.url
+            );
+            report(&backend_id, "connected", &default_behavior_id)
+        }
+        BackendPlan::Select { backend_ids } => {
+            let mut reader = stdin_lines();
+            let backend_id = prompt_select_backend(&mut reader, &backend_ids).await?;
+            bind_default_behavior(&access, &default_behavior_id, &backend_id, None).await?;
+            report(&backend_id, "connected", &default_behavior_id)
+        }
+        BackendPlan::OfferLaunchOrRemote => {
+            let mut reader = stdin_lines();
+            match offer_launch_or_remote(&mut reader).await? {
+                // "Launch a local server": instructions were printed; nothing is
+                // bound — the user re-runs `onboard` once the server is up.
+                None => Ok(()),
+                Some((resolved, model)) => {
+                    let backend_id =
+                        persist_backend(&access, &agent_did, &resolved, &model).await?;
+                    bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model))
+                        .await?;
+                    report(&backend_id, "configured", &default_behavior_id)
+                }
+            }
+        }
+    }
+}
+
+/// Every configured backend (global, not per-agent) as `(backend_id, enabled)`.
+async fn query_configured_backends(access: &ConfigAccess) -> Result<Vec<ConfiguredBackend>> {
+    let response = access
+        .execute("{ InferenceBackend { backend_id enabled } }")
+        .await?;
+    let rows = response
+        .get("data")
+        .and_then(|data| data.get("InferenceBackend"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let backend_id = row.get("backend_id").and_then(Value::as_str)?;
+            if backend_id.trim().is_empty() {
+                return None;
+            }
+            Some(ConfiguredBackend {
+                backend_id: backend_id.to_string(),
+                // A backend with no explicit `enabled` counts as enabled.
+                enabled: row.get("enabled").and_then(Value::as_bool).unwrap_or(true),
+            })
+        })
+        .collect())
+}
+
+/// Persist a backend under the agent's canonical backend id (updating in place
+/// so onboarding is idempotent) and return that id.
+async fn persist_backend(
+    access: &ConfigAccess,
+    agent_did: &str,
+    resolved: &ResolvedBackendConfig,
+    model: &str,
+) -> Result<String> {
+    let backend_id = format!("{agent_did}:backend");
+    let doc = InferenceBackendUpsertDocument {
+        backend_id: backend_id.clone(),
+        name: "Onboarded backend".to_string(),
+        provider_kind: resolved.provider_kind,
+        openai_wire_api: resolved.openai_wire_api,
+        endpoint: resolved.endpoint.clone(),
+        api_key: resolved.api_key.clone(),
+        api_key_env_var: resolved.api_key_env_var.clone(),
+        max_concurrent: DEFAULT_MAX_CONCURRENT,
+        max_queue_depth: default_backend_max_queue_depth(),
+        enabled: true,
+        models_on_add: vec![model.to_string()],
+        models_on_update: Some(vec![model.to_string()]),
+        // Onboarding does not measure remote health; leave this as the catalog
+        // default so the honest-probe fix (#640) stays the single owner of the
+        // health signal rather than stamping "healthy" here.
+        probe_status: "unknown".to_string(),
+    };
+    write_inference_backend_document(access, &doc).await?;
+    Ok(backend_id)
+}
+
+/// The `update_AgentBehavior` input body for binding a backend (and optionally
+/// overriding the model). Both values are GraphQL-escaped. `model` is set only
+/// when a newly-configured/detected backend serves a different model than the
+/// behavior currently names — the runtime sends `behavior.model_name` to the
+/// provider, so binding the backend without the model would request a model the
+/// endpoint does not serve.
+fn behavior_bind_input(backend_id: &str, model: Option<&str>) -> String {
+    let mut input = format!(r#"backend_id: "{}""#, escape_graphql_string(backend_id));
+    if let Some(model) = model {
+        input.push_str(&format!(
+            r#", model_name: "{}""#,
+            escape_graphql_string(model)
+        ));
+    }
+    input
+}
+
+/// Point the agent's default behavior at `backend_id` (and `model` when given).
+/// Errors if the behavior does not exist (the home was never initialized past
+/// identity).
+async fn bind_default_behavior(
+    access: &ConfigAccess,
+    behavior_id: &str,
+    backend_id: &str,
+    model: Option<&str>,
+) -> Result<()> {
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentBehavior(
+                filter: {{ behavior_id: {{ _eq: "{behavior}" }} }},
+                input: {{ {input} }}
+            ) {{ _docID }}
+        }}"#,
+        behavior = escape_graphql_string(behavior_id),
+        input = behavior_bind_input(backend_id, model),
+    );
+    let response = access.execute(&mutation).await?;
+    let updated = response
+        .get("data")
+        .and_then(|data| data.get("update_AgentBehavior"))
+        .and_then(Value::as_array)
+        .map(|rows| !rows.is_empty())
+        .unwrap_or(false);
+    if !updated {
+        anyhow::bail!(
+            "default behavior {behavior_id} not found; run `defra-agent init` before onboarding"
+        );
+    }
+    Ok(())
+}
+
+/// Prompt the operator to pick one of several stored backends.
+async fn prompt_select_backend(reader: &mut StdinLines, backend_ids: &[String]) -> Result<String> {
+    println!("\nMultiple inference backends are configured. Which should the agent use?");
+    for (index, id) in backend_ids.iter().enumerate() {
+        println!("  {}) {id}", index + 1);
+    }
+    let choice = prompt_line(reader, "> ").await?;
+    let choice = choice.trim();
+    let selection = choice
+        .parse::<usize>()
+        .ok()
+        .filter(|n| *n >= 1 && *n <= backend_ids.len());
+    match selection {
+        Some(n) => Ok(backend_ids[n - 1].clone()),
+        None => anyhow::bail!("unrecognized choice: {choice:?}"),
+    }
+}
+
+/// No stored backend and none detected: offer to launch a local server (print
+/// instructions and re-run) or configure a remote one now. Returns the remote
+/// backend config + model when the operator configures one, or `None` when they
+/// choose to launch a local server.
+async fn offer_launch_or_remote(
+    reader: &mut StdinLines,
+) -> Result<Option<(ResolvedBackendConfig, String)>> {
+    println!("\nNo inference backend is configured and no local server was detected.");
+    println!("  1) start a local server   (e.g. ollama / llama-server, then re-run `onboard`)");
+    println!("  2) configure a remote backend now");
+    let choice = prompt_line(reader, "> ").await?;
+    match choice.trim() {
+        "1" | "" => {
+            println!("\nStart a local OpenAI-compatible inference server, for example:");
+            println!("  ollama serve            # then: ollama pull <model>");
+            println!("  llama-server -m <model.gguf> --port 8080");
+            println!(
+                "onboard probes http://127.0.0.1:{{8080,11434,8000}}/v1 — once one is up, re-run `defra-agent onboard`."
+            );
+            Ok(None)
+        }
+        "2" => {
+            let url = prompt_line(reader, "Backend base URL (incl. /v1): ").await?;
+            let url = url.trim();
+            if url.is_empty() {
+                anyhow::bail!("no URL entered");
+            }
+            let model = prompt_line(reader, "Model name: ").await?;
+            let model = non_empty(&model).unwrap_or(DEFAULT_MODEL).to_string();
+            let key = prompt_secret(reader, "API key (optional, hidden): ").await?;
+            let resolved = resolve_backend_config_with_preset(
+                None,
+                Some(url),
+                None,
+                None,
+                non_empty(&key),
+                None,
+                BackendResolutionMode::Init,
+            )?;
+            Ok(Some((resolved, model)))
+        }
+        other => anyhow::bail!("unrecognized choice: {other:?}"),
+    }
+}
+
+fn report(backend_id: &str, action: &str, behavior_id: &str) -> Result<()> {
+    print_json(&json!({
+        "status": "ok",
+        "action": action,
+        "backend_id": backend_id,
+        "bound_behavior_id": behavior_id,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bind_input_sets_only_backend_when_no_model() {
+        assert_eq!(
+            behavior_bind_input("did:key:z:backend", None),
+            r#"backend_id: "did:key:z:backend""#
+        );
+    }
+
+    #[test]
+    fn bind_input_sets_model_when_given() {
+        let input = behavior_bind_input("did:key:z:backend", Some("llama3"));
+        assert!(
+            input.contains(r#"backend_id: "did:key:z:backend""#),
+            "{input}"
+        );
+        assert!(input.contains(r#"model_name: "llama3""#), "{input}");
+    }
+
+    #[test]
+    fn bind_input_escapes_injection_in_both_fields() {
+        // A quote in either value must be escaped, never break out of the string.
+        let input = behavior_bind_input(r#"b"x"#, Some(r#"m"y"#));
+        assert!(input.contains(r#"backend_id: "b\"x""#), "{input}");
+        assert!(input.contains(r#"model_name: "m\"y""#), "{input}");
+        // No unescaped quote sequence that would close the field early.
+        assert!(!input.contains(r#"b"x"#), "{input}");
+    }
+}

--- a/crates/defra-agent-cli/src/commands/onboard.rs
+++ b/crates/defra-agent-cli/src/commands/onboard.rs
@@ -1,18 +1,21 @@
 //! `onboard` — the interactive first-launch inference-backend flow (#647).
 //!
 //! Queries the stored inference backends, probes for a live local server, and
-//! applies the #647 decision tree ([`crate::onboarding::plan_backend_onboarding`])
-//! — a single stored backend (or a detected local one) connects with no
-//! prompt; multiple stored backends prompt for a pick; nothing stored and
-//! nothing detected offers to start a local server (printing instructions to
-//! re-run) or configure a remote one. The chosen backend AND its model are
-//! bound to the agent's default behavior.
+//! applies the #647 decision tree ([`crate::onboarding::plan_backend_onboarding`]):
+//! a single stored backend is bound (and best-effort probed — see
+//! [`connect_stored_backend`]); a detected local one is adopted; multiple
+//! stored backends prompt for a pick; nothing usable offers to start a local
+//! server (printing instructions to re-run) or configure a remote one. The
+//! chosen backend AND its model are bound to the agent's default behavior.
 //!
 //! Config writes go through [`resolve_config_access`], so onboard works both
 //! against a running server (its GraphQL endpoint) and offline (an embedded
 //! node) — it never opens a second node on a data dir the server already holds.
-//! `serve` stays non-interactive and points here when the default behavior is
-//! not runnable.
+//!
+//! Model resolution mirrors `init`'s `resolve_init_model_name` so the two
+//! commands never disagree on what model a preset/URL binds. Only `print_json`
+//! writes to stdout; every human message goes to stderr, so scripted consumers
+//! see a single JSON document.
 
 use anyhow::{anyhow, Result};
 use serde_json::{json, Value};
@@ -20,24 +23,28 @@ use serde_json::{json, Value};
 use defra_agent::default_behavior_id_for_agent;
 use defra_agent::graphql::escape_graphql_string;
 
-use crate::cli::args::OnboardArgs;
+use crate::cli::args::{BackendPresetArg, OnboardArgs};
 use crate::config_writes::{
     write_inference_backend_document, ConfigAccess, InferenceBackendUpsertDocument,
 };
 use crate::onboarding::{
-    detect_local_backend, plan_backend_onboarding, BackendPlan, ConfiguredBackend,
+    detect_local_backend, plan_backend_onboarding, probe_models, BackendPlan, ConfiguredBackend,
+    DetectedBackend,
 };
 use crate::prompt::{non_empty, prompt_line, prompt_secret, stdin_lines, StdinLines};
 use crate::resolve_helpers::{default_backend_max_queue_depth, resolve_backend_config_with_preset};
 use crate::shared::ResolvedBackendConfig;
 use crate::{
     print_json, read_init_config, resolve_config_access, resolve_home_dir, BackendResolutionMode,
+    DEFAULT_INIT_MODEL_NAME,
 };
 
-const DEFAULT_MODEL: &str = "gpt-4.1-mini";
-const DEFAULT_MAX_CONCURRENT: i64 = 8;
-/// A backend onboarding just probed successfully (detected-local path): safe to
-/// mark runnable now instead of waiting for the server's startup re-probe.
+/// Matches init's `--max-concurrent` default so an onboard-configured backend
+/// behaves like an init-configured one under the same canonical id.
+const DEFAULT_MAX_CONCURRENT: i64 = 2;
+/// A backend onboarding just probed successfully (detected-local / reachable
+/// AutoConnect): safe to mark runnable now instead of waiting for the server's
+/// startup re-probe.
 const HEALTHY_PROBE_STATUS: &str = "healthy";
 /// A backend onboarding did not measure (remote / preset / scripted): the
 /// startup probe (#640) decides its health.
@@ -57,11 +64,11 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
     }
     let default_behavior_id = default_behavior_id_for_agent(&agent_did);
 
-    // `--api-key` alone cannot define a backend; require an endpoint or preset
-    // so the key is never silently dropped.
+    // `--api-key`/`--api-key-env-var` alone cannot define a backend; require an
+    // endpoint or preset so the key is never silently dropped.
     let has_backend_spec = args.backend_preset.is_some() || args.inference_url.is_some();
-    if args.api_key.is_some() && !has_backend_spec {
-        anyhow::bail!("--api-key requires --backend-preset or --inference-url");
+    if (args.api_key.is_some() || args.api_key_env_var.is_some()) && !has_backend_spec {
+        anyhow::bail!("--api-key / --api-key-env-var require --backend-preset or --inference-url");
     }
 
     // Route through the running server when one is up, else an offline node —
@@ -78,13 +85,10 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
             None,
             None,
             args.api_key.as_deref(),
-            None,
+            args.api_key_env_var.as_deref(),
             BackendResolutionMode::Init,
         )?;
-        let model = args
-            .model
-            .clone()
-            .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+        let model = resolve_onboard_model(args.backend_preset, args.model.as_deref())?;
         let backend_id =
             persist_backend(&access, &agent_did, &resolved, &model, UNKNOWN_PROBE_STATUS).await?;
         bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
@@ -93,41 +97,26 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
 
     let configured = query_configured_backends(&access).await?;
     let detected = detect_local_backend().await;
+    let model_override = validated_model_override(args.model.as_deref())?;
+
     match plan_backend_onboarding(&configured, detected) {
-        // Reusing an existing configured backend: keep its behavior model_name.
         BackendPlan::AutoConnect { backend_id } => {
-            bind_default_behavior(&access, &default_behavior_id, &backend_id, None).await?;
-            report(&backend_id, "connected", &default_behavior_id)
+            connect_stored_backend(&access, &configured, &default_behavior_id, &backend_id).await
         }
         BackendPlan::AdoptDetected { detected } => {
-            let model = args.model.clone().unwrap_or_else(|| detected.model.clone());
-            let resolved = resolve_backend_config_with_preset(
-                None,
-                Some(&detected.url),
-                None,
-                None,
-                None,
-                None,
-                BackendResolutionMode::Init,
-            )?;
-            // detect_local_backend already probed this endpoint's /models, so
-            // record it healthy now — the behavior is runnable without waiting
-            // for the server to re-probe the same live server on next startup.
-            let backend_id =
-                persist_backend(&access, &agent_did, &resolved, &model, HEALTHY_PROBE_STATUS)
-                    .await?;
-            bind_default_behavior(&access, &default_behavior_id, &backend_id, Some(&model)).await?;
-            println!(
-                "Detected a local inference server at {} — connected.",
-                detected.url
-            );
-            report(&backend_id, "connected", &default_behavior_id)
+            adopt_detected(
+                &access,
+                &agent_did,
+                &default_behavior_id,
+                &detected,
+                model_override,
+            )
+            .await
         }
         BackendPlan::Select { backend_ids } => {
             let mut reader = stdin_lines();
             let backend_id = prompt_select_backend(&mut reader, &backend_ids).await?;
-            bind_default_behavior(&access, &default_behavior_id, &backend_id, None).await?;
-            report(&backend_id, "connected", &default_behavior_id)
+            connect_stored_backend(&access, &configured, &default_behavior_id, &backend_id).await
         }
         BackendPlan::OfferLaunchOrRemote => {
             let mut reader = stdin_lines();
@@ -153,10 +142,110 @@ pub(crate) async fn onboard(args: OnboardArgs) -> Result<()> {
     }
 }
 
-/// Every configured backend (global, not per-agent) as `(backend_id, enabled)`.
+/// Bind an already-stored backend as the default behavior's backend (used by
+/// AutoConnect and Select). Best-effort, NON-destructive: a successful
+/// unauthenticated `/models` probe records the backend healthy so it is
+/// immediately runnable; a failed probe (an authenticated remote returns 401,
+/// or a slow/down endpoint) does NOT tear down the operator's configuration —
+/// it binds the chosen backend anyway and explains how to reconfigure. The
+/// runtime's own startup probe (which authenticates) still owns health for
+/// endpoints this probe cannot reach.
+async fn connect_stored_backend(
+    access: &ConfigAccess,
+    configured: &[ConfiguredBackend],
+    behavior_id: &str,
+    backend_id: &str,
+) -> Result<()> {
+    let endpoint = endpoint_for(configured, backend_id).map(str::to_string);
+    let verified = match endpoint.as_deref() {
+        Some(url) => probe_models(url).await.is_some(),
+        None => false,
+    };
+    if verified {
+        mark_backend_probe_status(access, backend_id, HEALTHY_PROBE_STATUS).await?;
+    } else {
+        let at = endpoint.map(|url| format!(" ({url})")).unwrap_or_default();
+        eprintln!(
+            "Bound {backend_id}{at}, but could not verify it with an unauthenticated probe \
+             (an authenticated or slow remote is expected to fail this check). If it is the \
+             wrong backend, reconfigure with --backend-preset/--inference-url, or disable it \
+             and re-run onboard."
+        );
+    }
+    // Keep the behavior's existing model_name — this is the configured backend.
+    bind_default_behavior(access, behavior_id, backend_id, None).await?;
+    report(backend_id, "connected", behavior_id)
+}
+
+/// Adopt a live local server detected by [`detect_local_backend`]: persist it
+/// healthy (its `/models` was just probed) and bind it (with the operator's
+/// `--model` override, else the model the server advertised).
+async fn adopt_detected(
+    access: &ConfigAccess,
+    agent_did: &str,
+    behavior_id: &str,
+    detected: &DetectedBackend,
+    model_override: Option<String>,
+) -> Result<()> {
+    let model = model_override.unwrap_or_else(|| detected.model.clone());
+    let resolved = resolve_backend_config_with_preset(
+        None,
+        Some(&detected.url),
+        None,
+        None,
+        None,
+        None,
+        BackendResolutionMode::Init,
+    )?;
+    let backend_id =
+        persist_backend(access, agent_did, &resolved, &model, HEALTHY_PROBE_STATUS).await?;
+    bind_default_behavior(access, behavior_id, &backend_id, Some(&model)).await?;
+    eprintln!(
+        "Detected a local inference server at {} — connected.",
+        detected.url
+    );
+    report(&backend_id, "connected", behavior_id)
+}
+
+/// Resolve the model to bind for a flag-configured backend, mirroring init's
+/// `resolve_init_model_name`: an explicit `--model` wins (rejected when empty),
+/// else the preset's safe default, else an error for presets/URLs with no safe
+/// default, else the init default for a bare `--inference-url`.
+fn resolve_onboard_model(preset: Option<BackendPresetArg>, model: Option<&str>) -> Result<String> {
+    if let Some(explicit) = model {
+        let trimmed = explicit.trim();
+        if trimmed.is_empty() {
+            anyhow::bail!("--model must not be empty");
+        }
+        return Ok(trimmed.to_string());
+    }
+    if let Some(default) = preset.and_then(BackendPresetArg::default_model_name) {
+        return Ok(default.to_string());
+    }
+    if let Some(preset) = preset {
+        anyhow::bail!(
+            "--model is required for --backend-preset {} because that preset has no safe default model",
+            preset.as_str()
+        );
+    }
+    Ok(DEFAULT_INIT_MODEL_NAME.to_string())
+}
+
+/// Validate an optional `--model` override for the detect path: reject a
+/// whitespace-only value (consistent with init), pass through a trimmed value.
+fn validated_model_override(model: Option<&str>) -> Result<Option<String>> {
+    match model {
+        Some(value) if value.trim().is_empty() => anyhow::bail!("--model must not be empty"),
+        Some(value) => Ok(Some(value.trim().to_string())),
+        None => Ok(None),
+    }
+}
+
+/// Every configured backend (global, not per-agent): id, enabled, and endpoint
+/// (used to probe an AutoConnect candidate for reachability).
 async fn query_configured_backends(access: &ConfigAccess) -> Result<Vec<ConfiguredBackend>> {
     let response = access
-        .execute("{ InferenceBackend { backend_id enabled } }")
+        .execute("{ InferenceBackend { backend_id enabled endpoint } }")
         .await?;
     let rows = response
         .get("data")
@@ -175,18 +264,29 @@ async fn query_configured_backends(access: &ConfigAccess) -> Result<Vec<Configur
                 backend_id: backend_id.to_string(),
                 // A backend with no explicit `enabled` counts as enabled.
                 enabled: row.get("enabled").and_then(Value::as_bool).unwrap_or(true),
+                endpoint: row
+                    .get("endpoint")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
             })
         })
         .collect())
+}
+
+fn endpoint_for<'a>(configured: &'a [ConfiguredBackend], backend_id: &str) -> Option<&'a str> {
+    configured
+        .iter()
+        .find(|backend| backend.backend_id == backend_id)
+        .and_then(|backend| backend.endpoint.as_deref())
 }
 
 /// Persist a backend under the agent's canonical backend id (updating in place
 /// so onboarding is idempotent) and return that id.
 ///
 /// `probe_status` is `HEALTHY_PROBE_STATUS` only when onboarding just made a
-/// successful live probe of this exact endpoint (the detected-local path);
-/// otherwise `UNKNOWN_PROBE_STATUS`, so the honest-probe subsystem (#640) — not
-/// this write — owns promoting an unmeasured endpoint to healthy.
+/// successful live probe of this exact endpoint; otherwise
+/// `UNKNOWN_PROBE_STATUS`, so the honest-probe subsystem (#640) — not this
+/// write — owns promoting an unmeasured endpoint to healthy.
 async fn persist_backend(
     access: &ConfigAccess,
     agent_did: &str,
@@ -212,6 +312,27 @@ async fn persist_backend(
     };
     write_inference_backend_document(access, &doc).await?;
     Ok(backend_id)
+}
+
+/// Set an existing backend's `probe_status` (used to record a reachable
+/// AutoConnect candidate healthy after a successful probe).
+async fn mark_backend_probe_status(
+    access: &ConfigAccess,
+    backend_id: &str,
+    status: &str,
+) -> Result<()> {
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{id}" }} }},
+                input: {{ probe_status: "{status}" }}
+            ) {{ _docID }}
+        }}"#,
+        id = escape_graphql_string(backend_id),
+        status = escape_graphql_string(status),
+    );
+    access.execute(&mutation).await?;
+    Ok(())
 }
 
 /// The `update_AgentBehavior` input body for binding a backend (and optionally
@@ -267,9 +388,9 @@ async fn bind_default_behavior(
 
 /// Prompt the operator to pick one of several stored backends.
 async fn prompt_select_backend(reader: &mut StdinLines, backend_ids: &[String]) -> Result<String> {
-    println!("\nMultiple inference backends are configured. Which should the agent use?");
+    eprintln!("\nMultiple inference backends are configured. Which should the agent use?");
     for (index, id) in backend_ids.iter().enumerate() {
-        println!("  {}) {id}", index + 1);
+        eprintln!("  {}) {id}", index + 1);
     }
     let choice = prompt_line(reader, "> ").await?;
     let choice = choice.trim();
@@ -283,23 +404,23 @@ async fn prompt_select_backend(reader: &mut StdinLines, backend_ids: &[String]) 
     }
 }
 
-/// No stored backend and none detected: offer to launch a local server (print
+/// No usable backend and none detected: offer to launch a local server (print
 /// instructions and re-run) or configure a remote one now. Returns the remote
 /// backend config + model when the operator configures one, or `None` when they
 /// choose to launch a local server.
 async fn offer_launch_or_remote(
     reader: &mut StdinLines,
 ) -> Result<Option<(ResolvedBackendConfig, String)>> {
-    println!("\nNo inference backend is configured and no local server was detected.");
-    println!("  1) start a local server   (e.g. ollama / llama-server, then re-run `onboard`)");
-    println!("  2) configure a remote backend now");
+    eprintln!("\nNo usable inference backend is configured and no local server was detected.");
+    eprintln!("  1) start a local server   (e.g. ollama / llama-server, then re-run `onboard`)");
+    eprintln!("  2) configure a remote backend now");
     let choice = prompt_line(reader, "> ").await?;
     match choice.trim() {
         "1" | "" => {
-            println!("\nStart a local OpenAI-compatible inference server, for example:");
-            println!("  ollama serve            # then: ollama pull <model>");
-            println!("  llama-server -m <model.gguf> --port 8080");
-            println!(
+            eprintln!("\nStart a local OpenAI-compatible inference server, for example:");
+            eprintln!("  ollama serve            # then: ollama pull <model>");
+            eprintln!("  llama-server -m <model.gguf> --port 8080");
+            eprintln!(
                 "onboard probes http://127.0.0.1:{{8080,11434,8000}}/v1 — once one is up, re-run `defra-agent onboard`."
             );
             Ok(None)
@@ -311,7 +432,11 @@ async fn offer_launch_or_remote(
                 anyhow::bail!("no URL entered");
             }
             let model = prompt_line(reader, "Model name: ").await?;
-            let model = non_empty(&model).unwrap_or(DEFAULT_MODEL).to_string();
+            // A bare URL has no preset default; fall back to the init default,
+            // matching `init`'s `--inference-url` handling.
+            let model = non_empty(&model)
+                .unwrap_or(DEFAULT_INIT_MODEL_NAME)
+                .to_string();
             let key = prompt_secret(reader, "API key (optional, hidden): ").await?;
             let resolved = resolve_backend_config_with_preset(
                 None,
@@ -367,5 +492,55 @@ mod tests {
         assert!(input.contains(r#"model_name: "m\"y""#), "{input}");
         // No unescaped quote sequence that would close the field early.
         assert!(!input.contains(r#"b"x"#), "{input}");
+    }
+
+    #[test]
+    fn model_explicit_wins_and_is_trimmed() {
+        assert_eq!(
+            resolve_onboard_model(Some(BackendPresetArg::Ollama), Some("  my-model  ")).unwrap(),
+            "my-model"
+        );
+    }
+
+    #[test]
+    fn model_empty_is_rejected() {
+        assert!(resolve_onboard_model(Some(BackendPresetArg::Ollama), Some("   ")).is_err());
+        assert!(validated_model_override(Some("  ")).is_err());
+        assert_eq!(
+            validated_model_override(Some(" x ")).unwrap(),
+            Some("x".to_string())
+        );
+        assert_eq!(validated_model_override(None).unwrap(), None);
+    }
+
+    #[test]
+    fn model_uses_preset_default_when_available() {
+        // Ollama has a safe default; onboard must not substitute an OpenAI model.
+        let ollama = resolve_onboard_model(Some(BackendPresetArg::Ollama), None).unwrap();
+        assert_eq!(ollama, crate::DEFAULT_OLLAMA_MODEL_NAME);
+    }
+
+    #[test]
+    fn model_errors_for_preset_without_a_safe_default() {
+        // OpenRouter/vLLM/OpenAI/generic have no safe default — require --model.
+        for preset in [
+            BackendPresetArg::OpenRouter,
+            BackendPresetArg::Vllm,
+            BackendPresetArg::OpenAi,
+        ] {
+            assert!(
+                resolve_onboard_model(Some(preset), None).is_err(),
+                "{preset:?} must require an explicit model"
+            );
+        }
+    }
+
+    #[test]
+    fn model_defaults_to_init_default_for_bare_url() {
+        // No preset (a bare --inference-url) mirrors init's URL default.
+        assert_eq!(
+            resolve_onboard_model(None, None).unwrap(),
+            DEFAULT_INIT_MODEL_NAME
+        );
     }
 }

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -343,6 +343,16 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
     } else {
         eprintln!("defra-agent server is running local-only. Press Ctrl-C to stop.");
     }
+    // The runtime keeps serving even when the default behavior can't run; make
+    // that visible up front rather than leaving a silent "degraded" that fails
+    // only at chat time. Point at the backend flow (#647) without asserting the
+    // cause is a backend — the reason string carries the actual diagnosis.
+    if let Some(reason) = unavailable_behaviors.get(&default_behavior_id) {
+        eprintln!("The default behavior ({default_behavior_id}) is not runnable: {reason}");
+        eprintln!(
+            "If it needs an inference backend, configure one with `defra-agent onboard`, then restart."
+        );
+    }
 
     if let Some(handle) = codex_shim_handle.as_mut() {
         tokio::select! {

--- a/crates/defra-agent-cli/src/commands/serve.rs
+++ b/crates/defra-agent-cli/src/commands/serve.rs
@@ -349,8 +349,12 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
     // cause is a backend — the reason string carries the actual diagnosis.
     if let Some(reason) = unavailable_behaviors.get(&default_behavior_id) {
         eprintln!("The default behavior ({default_behavior_id}) is not runnable: {reason}");
+        // onboard writes through this running server's GraphQL and the runtime
+        // reconciles the change live, so a restart is usually unnecessary — only
+        // needed if the behavior stays unavailable (e.g. to re-run startup
+        // probes for a backend that just came online).
         eprintln!(
-            "If it needs an inference backend, configure one with `defra-agent onboard`, then restart."
+            "Configure a backend with `defra-agent onboard` (it writes to this running server); if the behavior stays unavailable, restart to re-run startup probes."
         );
     }
 

--- a/crates/defra-agent-cli/src/main.rs
+++ b/crates/defra-agent-cli/src/main.rs
@@ -19,7 +19,9 @@ mod desired_state;
 mod graphql_access;
 mod home_state;
 mod http;
+mod onboarding;
 mod p2p_relay;
+mod prompt;
 mod request_helpers;
 mod resolve_helpers;
 mod shared;
@@ -457,6 +459,7 @@ async fn async_main() -> Result<()> {
         Command::Session { command } => commands::session::dispatch(command).await,
         Command::Subagent { command } => commands::subagent::dispatch(command).await,
         Command::Demo(args) => commands::demo::demo(args).await,
+        Command::Onboard(args) => commands::onboard::onboard(args).await,
         Command::NativeFsRunner(_) => unreachable!("handled before telemetry initialization"),
     };
     telemetry.shutdown();

--- a/crates/defra-agent-cli/src/onboarding.rs
+++ b/crates/defra-agent-cli/src/onboarding.rs
@@ -1,10 +1,12 @@
 //! Shared inference-backend onboarding: local-server detection, live health
 //! probing, and the first-launch decision tree from #647.
 //!
-//! Consumed by the interactive `onboard` command, the `demo` setup, and the
-//! `serve` no-backend hint, so all three surfaces agree on what "configure and
-//! connect a backend" means. The decision tree itself ([`plan_backend_onboarding`])
-//! is pure and total — unit-tested without a node or network.
+//! Consumed by the interactive `onboard` command and the `demo` setup, so both
+//! agree on what "a local server" and "configure and connect a backend" mean.
+//! (`serve` does not call this module; it only prints a string pointing the
+//! operator at `onboard` when the default behavior is not runnable.) The
+//! decision tree itself ([`plan_backend_onboarding`]) is pure and total —
+//! unit-tested without a node or network.
 
 use std::time::Duration;
 
@@ -26,10 +28,13 @@ pub(crate) struct DetectedBackend {
 }
 
 /// A backend already stored in the node, as seen by the onboarding decision.
+/// `endpoint` is carried for the caller's reachability probe; the pure decision
+/// tree ignores it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ConfiguredBackend {
     pub(crate) backend_id: String,
     pub(crate) enabled: bool,
+    pub(crate) endpoint: Option<String>,
 }
 
 /// What first-launch onboarding should do, given the currently-stored backends
@@ -123,6 +128,7 @@ mod tests {
             .map(|(id, enabled)| ConfiguredBackend {
                 backend_id: (*id).to_string(),
                 enabled: *enabled,
+                endpoint: None,
             })
             .collect()
     }

--- a/crates/defra-agent-cli/src/onboarding.rs
+++ b/crates/defra-agent-cli/src/onboarding.rs
@@ -1,0 +1,195 @@
+//! Shared inference-backend onboarding: local-server detection, live health
+//! probing, and the first-launch decision tree from #647.
+//!
+//! Consumed by the interactive `onboard` command, the `demo` setup, and the
+//! `serve` no-backend hint, so all three surfaces agree on what "configure and
+//! connect a backend" means. The decision tree itself ([`plan_backend_onboarding`])
+//! is pure and total — unit-tested without a node or network.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+/// Common local inference endpoints, probed in priority order:
+/// llama-server / LM Studio (8080), Ollama (11434), vLLM (8000).
+const LOCAL_BACKEND_CANDIDATES: &[&str] = &[
+    "http://127.0.0.1:8080/v1",
+    "http://127.0.0.1:11434/v1",
+    "http://127.0.0.1:8000/v1",
+];
+
+/// A reachable local backend: its base URL and first advertised model id.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DetectedBackend {
+    pub(crate) url: String,
+    pub(crate) model: String,
+}
+
+/// A backend already stored in the node, as seen by the onboarding decision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfiguredBackend {
+    pub(crate) backend_id: String,
+    pub(crate) enabled: bool,
+}
+
+/// What first-launch onboarding should do, given the currently-stored backends
+/// and whether a local server is live. Encodes #647's tree exactly:
+/// stored-single → auto; stored-many → select; none+detected → adopt;
+/// none+nothing → offer to launch a local server or configure a remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum BackendPlan {
+    /// Exactly one usable stored backend — connect to it, no prompt.
+    AutoConnect { backend_id: String },
+    /// Multiple usable stored backends — the caller must let the user pick.
+    Select { backend_ids: Vec<String> },
+    /// No usable stored backend, but a local server answered — adopt it.
+    AdoptDetected { detected: DetectedBackend },
+    /// No usable stored backend and nothing detected — the caller must offer
+    /// to launch a local server or configure a remote one.
+    OfferLaunchOrRemote,
+}
+
+/// The pure #647 decision. `configured` is the stored backend set; a backend
+/// only counts when `enabled` (a disabled row is not a connectable choice).
+///
+/// Health is deliberately NOT consulted here: the stored `probe_status` is not
+/// yet trustworthy (#640 — dead endpoints report healthy), so gating on it
+/// would hide real backends. Once probes measure truthfully, an
+/// `enabled && healthy` filter belongs here.
+pub(crate) fn plan_backend_onboarding(
+    configured: &[ConfiguredBackend],
+    detected: Option<DetectedBackend>,
+) -> BackendPlan {
+    let usable: Vec<String> = configured
+        .iter()
+        .filter(|backend| backend.enabled)
+        .map(|backend| backend.backend_id.clone())
+        .collect();
+    match usable.len() {
+        0 => match detected {
+            Some(detected) => BackendPlan::AdoptDetected { detected },
+            None => BackendPlan::OfferLaunchOrRemote,
+        },
+        1 => BackendPlan::AutoConnect {
+            backend_id: usable.into_iter().next().expect("len checked"),
+        },
+        _ => BackendPlan::Select {
+            backend_ids: usable,
+        },
+    }
+}
+
+/// GET `{base}/models`; return the first advertised model id iff the endpoint
+/// answers 2xx within the timeout. A real reachability+liveness probe — a dead
+/// endpoint yields `None` — unlike a stored `probe_status` flag (#640).
+pub(crate) async fn probe_models(base: &str) -> Option<String> {
+    let base = base.trim_end_matches('/');
+    let response = reqwest::Client::new()
+        .get(format!("{base}/models"))
+        .timeout(Duration::from_millis(700))
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body: Value = response.json().await.ok()?;
+    body.pointer("/data/0/id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+/// Probe the common local endpoints in priority order; return the first live
+/// one, or `None` when no local inference server is reachable.
+pub(crate) async fn detect_local_backend() -> Option<DetectedBackend> {
+    for url in LOCAL_BACKEND_CANDIDATES {
+        if let Some(model) = probe_models(url).await {
+            return Some(DetectedBackend {
+                url: (*url).to_string(),
+                model,
+            });
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured(entries: &[(&str, bool)]) -> Vec<ConfiguredBackend> {
+        entries
+            .iter()
+            .map(|(id, enabled)| ConfiguredBackend {
+                backend_id: (*id).to_string(),
+                enabled: *enabled,
+            })
+            .collect()
+    }
+
+    fn detected() -> DetectedBackend {
+        DetectedBackend {
+            url: "http://127.0.0.1:11434/v1".to_string(),
+            model: "llama3".to_string(),
+        }
+    }
+
+    #[test]
+    fn single_stored_backend_auto_connects() {
+        assert_eq!(
+            plan_backend_onboarding(&configured(&[("openai", true)]), None),
+            BackendPlan::AutoConnect {
+                backend_id: "openai".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn multiple_stored_backends_require_selection() {
+        assert_eq!(
+            plan_backend_onboarding(&configured(&[("openai", true), ("ollama", true)]), None),
+            BackendPlan::Select {
+                backend_ids: vec!["openai".to_string(), "ollama".to_string()]
+            }
+        );
+    }
+
+    #[test]
+    fn disabled_backends_do_not_count_as_usable() {
+        // One enabled among disabled rows still auto-connects to the enabled one.
+        assert_eq!(
+            plan_backend_onboarding(
+                &configured(&[("old", false), ("live", true), ("stale", false)]),
+                None
+            ),
+            BackendPlan::AutoConnect {
+                backend_id: "live".to_string()
+            }
+        );
+        // All-disabled behaves as no usable backend: fall through to detection.
+        assert_eq!(
+            plan_backend_onboarding(&configured(&[("old", false)]), Some(detected())),
+            BackendPlan::AdoptDetected {
+                detected: detected()
+            }
+        );
+    }
+
+    #[test]
+    fn no_stored_backend_adopts_a_detected_local_server() {
+        assert_eq!(
+            plan_backend_onboarding(&[], Some(detected())),
+            BackendPlan::AdoptDetected {
+                detected: detected()
+            }
+        );
+    }
+
+    #[test]
+    fn no_stored_backend_and_nothing_detected_offers_launch_or_remote() {
+        assert_eq!(
+            plan_backend_onboarding(&[], None),
+            BackendPlan::OfferLaunchOrRemote
+        );
+    }
+}

--- a/crates/defra-agent-cli/src/prompt.rs
+++ b/crates/defra-agent-cli/src/prompt.rs
@@ -1,0 +1,57 @@
+//! Terminal prompt plumbing shared by the interactive `onboard` command and the
+//! `demo` session. One owned [`StdinLines`] reader is threaded through a whole
+//! interactive flow so successive prompts never fight over buffered stdin —
+//! mixing a blocking `std::io::stdin` read with an async tokio reader loses
+//! buffered input on piped stdin.
+
+use std::io::Write as _;
+
+use anyhow::Result;
+use tokio::io::AsyncBufReadExt as _;
+
+/// The single owned stdin line reader threaded through an interactive session.
+pub(crate) type StdinLines = tokio::io::Lines<tokio::io::BufReader<tokio::io::Stdin>>;
+
+/// Build the owned stdin line reader for an interactive session.
+pub(crate) fn stdin_lines() -> StdinLines {
+    tokio::io::BufReader::new(tokio::io::stdin()).lines()
+}
+
+/// Print `text` and flush, without a trailing newline (for inline prompts).
+pub(crate) fn prompt(text: &str) {
+    print!("{text}");
+    let _ = std::io::stdout().flush();
+}
+
+/// Print `text`, then read one line from the shared reader.
+pub(crate) async fn prompt_line(reader: &mut StdinLines, text: &str) -> Result<String> {
+    prompt(text);
+    Ok(reader.next_line().await?.unwrap_or_default())
+}
+
+/// Read one line without echoing it (best-effort via `stty`; a non-terminal
+/// stdin, e.g. piped input, just reads normally since there is nothing to echo).
+pub(crate) async fn prompt_secret(reader: &mut StdinLines, text: &str) -> Result<String> {
+    prompt(text);
+    let hidden = set_terminal_echo(false);
+    let line = reader.next_line().await;
+    if hidden {
+        set_terminal_echo(true);
+        println!();
+    }
+    Ok(line?.unwrap_or_default())
+}
+
+fn set_terminal_echo(on: bool) -> bool {
+    std::process::Command::new("stty")
+        .arg(if on { "echo" } else { "-echo" })
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Trimmed value, or `None` when empty/whitespace.
+pub(crate) fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}

--- a/crates/defra-agent-cli/src/prompt.rs
+++ b/crates/defra-agent-cli/src/prompt.rs
@@ -17,10 +17,12 @@ pub(crate) fn stdin_lines() -> StdinLines {
     tokio::io::BufReader::new(tokio::io::stdin()).lines()
 }
 
-/// Print `text` and flush, without a trailing newline (for inline prompts).
+/// Write an inline prompt (no trailing newline) to STDERR and flush. Prompts
+/// are interactive UI, not data — keeping them off stdout lets a caller pipe a
+/// command's stdout as a clean payload (e.g. onboard's single JSON report).
 pub(crate) fn prompt(text: &str) {
-    print!("{text}");
-    let _ = std::io::stdout().flush();
+    eprint!("{text}");
+    let _ = std::io::stderr().flush();
 }
 
 /// Print `text`, then read one line from the shared reader.
@@ -37,7 +39,8 @@ pub(crate) async fn prompt_secret(reader: &mut StdinLines, text: &str) -> Result
     let line = reader.next_line().await;
     if hidden {
         set_terminal_echo(true);
-        println!();
+        // The echoed newline is UI, not data — keep stdout clean.
+        eprintln!();
     }
     Ok(line?.unwrap_or_default())
 }


### PR DESCRIPTION
First slice of the #647 server flow.

Promotes the demo's ad-hoc backend detection into a first-class, tested `onboarding` module and adds an interactive `defra-agent onboard` command.

- `onboarding.rs`: a live `/models` health probe, local-server detection, and the #647 decision tree as a pure, unit-tested function — one stored backend (or a detected local one) auto-connects, multiple prompt for a pick, none-plus-detected adopts, none-plus-nothing offers to start a local server (prints instructions to re-run) or configure a remote one.
- `onboard` command: applies that tree and binds the chosen backend and its model to the default behavior. Writes go through `resolve_config_access`, so it works against a running server or offline and never opens a second node on the server's data dir. Non-interactive escape via `--backend-preset` / `--inference-url` / `--api-key` / `--model` for headless and CI.
- `serve`: when the default behavior is not runnable, it now points at `onboard` instead of leaving a silent "degraded".
- The demo's probe/detect is deduped onto the shared module.

Verified: `cargo check --workspace --all-targets` clean, fmt clean, 8 new unit tests (decision tree + the behavior-bind input builder, including GraphQL-escaping of interpolated values).

Deferred to follow-ups: the desktop backend menu (647b), starting a default agent on server startup, and honest backend probes (#640) so a required backend can be enforced as actually working.

Stacked on #635 (which carries the pre-existing main compile repairs); retarget to main once that lands.
