### PR TITLE
Improve sub-agent target config user experience

### DIFF
--- a/crates/defra-agent-cli/src/cli/args.rs
+++ b/crates/defra-agent-cli/src/cli/args.rs
@@ -1159,6 +1159,30 @@ pub(crate) enum ToolSelectionCommand {
         alias = "remove"
     )]
     Rm(ConfigShowArgs),
+    #[command(
+        name = "subagent-target-entry",
+        about = "Build a single --subagent-target JSON entry from its parts",
+        after_help = "Example:\n  defra-agent config tools set --graphql <url> --agent-did <did> \\\n    --selection-id main --subagent-target \"$(defra-agent config tools \\\n    subagent-target-entry --name researcher --agent-did did:key:z... \\\n    --behavior-id did:key:z...:default)\""
+    )]
+    SubagentTargetEntry(SubagentTargetEntryArgs),
+}
+
+#[derive(Debug, clap::Args)]
+pub(crate) struct SubagentTargetEntryArgs {
+    #[arg(long, help = "Model-facing name used by spawn_subagent")]
+    pub(crate) name: String,
+    #[arg(
+        long,
+        help = "DID of the agent that owns the target behavior (local or remote)"
+    )]
+    pub(crate) agent_did: String,
+    #[arg(long, help = "Behavior id on the owning agent")]
+    pub(crate) behavior_id: String,
+    #[arg(
+        long,
+        help = "Optional human-readable description surfaced to the model"
+    )]
+    pub(crate) description: Option<String>,
 }
 
 #[derive(Subcommand)]
@@ -1467,7 +1491,11 @@ pub(crate) struct ToolSelectionUpsertArgs {
     pub(crate) clear_defra_query_collections: bool,
     #[arg(
         long = "subagent-target",
-        help = "SubagentTarget JSON entry allowed for spawn_subagent (repeatable); omit to preserve existing targets"
+        help = "SubagentTarget JSON entry allowed for spawn_subagent, e.g. \
+                {\"name\":\"researcher\",\"agent_did\":\"did:key:...\",\"behavior_id\":\"did:key:...:default\",\"description\":\"...\"} \
+                (repeatable); or @path/@- to read one entry or a JSON array of entries from a \
+                file/stdin; omit to preserve existing targets. See `config tools \
+                subagent-target-entry --help` to build a single entry from its parts."
     )]
     pub(crate) subagent_targets: Vec<String>,
     #[arg(

--- a/crates/defra-agent-cli/src/commands/config/mod.rs
+++ b/crates/defra-agent-cli/src/commands/config/mod.rs
@@ -45,6 +45,9 @@ pub(crate) async fn dispatch(command: ConfigCommand) -> Result<()> {
             ToolSelectionCommand::Rm(args) => {
                 crud::config_rm(crud::TOOL_SELECTION_SPEC, args).await
             }
+            ToolSelectionCommand::SubagentTargetEntry(args) => {
+                tools::subagent_target_entry_command(args)
+            }
         },
         ConfigCommand::Profile { command } => match command {
             InferenceProfileCommand::Set(args) => profile::inference_profile_set(args).await,

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -707,7 +707,9 @@ mod tests {
         let entries = expand_subagent_target_value(&raw).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(
-            defra_agent::SubagentTarget::parse(&entries[0]).unwrap().name,
+            defra_agent::SubagentTarget::parse(&entries[0])
+                .unwrap()
+                .name,
             "worker"
         );
     }

--- a/crates/defra-agent-cli/src/commands/config/tools.rs
+++ b/crates/defra-agent-cli/src/commands/config/tools.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use defra_agent::{CommandExecutionMode, CommandNetworkMode, ToolSelectionDocument};
 use serde_json::json;
 
@@ -6,6 +6,20 @@ use crate::cli::*;
 use crate::config_writes::{write_tool_selection_document_with_clear_fields, ConfigAccess};
 use crate::normalize_optional_string;
 use crate::print_json;
+
+/// Builds a single `--subagent-target` JSON entry from its parts and prints
+/// it to stdout, so it composes as `--subagent-target "$(... subagent-target-entry ...)"`
+/// with real flag validation instead of a hand-typed JSON parse error.
+pub(super) fn subagent_target_entry_command(args: SubagentTargetEntryArgs) -> Result<()> {
+    let entry = defra_agent::subagent_target_entry(
+        args.name,
+        args.agent_did,
+        args.behavior_id,
+        args.description,
+    );
+    println!("{entry}");
+    Ok(())
+}
 
 pub(super) async fn tool_selection_set(args: ToolSelectionUpsertArgs) -> Result<()> {
     let plan = tool_selection_command_plan(&args)?;
@@ -341,8 +355,53 @@ fn subagent_targets_update(args: &ToolSelectionUpsertArgs) -> Result<Option<Vec<
     } else if args.subagent_targets.is_empty() {
         Ok(None)
     } else {
-        Ok(Some(args.subagent_targets.clone()))
+        let mut entries = Vec::new();
+        for raw in &args.subagent_targets {
+            entries.extend(expand_subagent_target_value(raw)?);
+        }
+        Ok(Some(entries))
     }
+}
+
+/// Expands one `--subagent-target` value. A plain value is passed through
+/// unchanged (the existing inline-JSON behavior). A `@path`/`@-` value reads
+/// the file (or stdin, for `-`) and accepts either a single JSON object or a
+/// JSON array of objects, expanding an array into multiple entries.
+fn expand_subagent_target_value(raw: &str) -> Result<Vec<String>> {
+    let Some(source) = raw.strip_prefix('@') else {
+        return Ok(vec![raw.to_string()]);
+    };
+    let contents = if source == "-" {
+        let mut buf = String::new();
+        std::io::Read::read_to_string(&mut std::io::stdin(), &mut buf)
+            .context("reading --subagent-target entries from stdin")?;
+        buf
+    } else {
+        std::fs::read_to_string(source)
+            .with_context(|| format!("reading --subagent-target entries from {source}"))?
+    };
+    parse_subagent_target_contents(&contents, raw)
+}
+
+/// Parses the contents of a `@path`/`@-` `--subagent-target` source: either a
+/// single JSON object or a JSON array of objects. Split out from
+/// [`expand_subagent_target_value`] so the parsing/expansion logic is
+/// testable without touching the filesystem or stdin.
+fn parse_subagent_target_contents(contents: &str, raw_for_error: &str) -> Result<Vec<String>> {
+    let value: serde_json::Value = serde_json::from_str(contents)
+        .with_context(|| format!("parsing --subagent-target JSON from {raw_for_error}"))?;
+    let items = match value {
+        serde_json::Value::Array(items) => items,
+        other => vec![other],
+    };
+    items
+        .into_iter()
+        .map(|item| {
+            serde_json::to_string(&item).with_context(|| {
+                format!("re-serializing --subagent-target entry from {raw_for_error}")
+            })
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -570,5 +629,128 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("--clear-allowed-mcp-service-ids"));
+    }
+
+    #[test]
+    fn subagent_target_entry_command_prints_valid_json() {
+        let args = SubagentTargetEntryArgs {
+            name: "researcher".to_string(),
+            agent_did: "did:key:z-test".to_string(),
+            behavior_id: "did:key:z-test:default".to_string(),
+            description: Some("A helper instance for delegated sub-tasks".to_string()),
+        };
+        // subagent_target_entry_command only prints; exercise the same
+        // construction it delegates to and confirm it round-trips through
+        // SubagentTarget::parse (the same parser used at write time).
+        let entry = defra_agent::subagent_target_entry(
+            args.name.clone(),
+            args.agent_did.clone(),
+            args.behavior_id.clone(),
+            args.description.clone(),
+        );
+        let parsed = defra_agent::SubagentTarget::parse(&entry).unwrap();
+        assert_eq!(parsed.name, "researcher");
+        assert_eq!(parsed.agent_did, "did:key:z-test");
+        assert_eq!(parsed.behavior_id, "did:key:z-test:default");
+        assert!(parsed.is_structurally_valid());
+    }
+
+    #[test]
+    fn expand_subagent_target_value_passes_through_inline_json() {
+        let inline = r#"{"name":"worker","agent_did":"did:key:z-test","behavior_id":"worker"}"#;
+        assert_eq!(
+            expand_subagent_target_value(inline).unwrap(),
+            vec![inline.to_string()]
+        );
+    }
+
+    #[test]
+    fn parse_subagent_target_contents_expands_single_object() {
+        let contents = r#"{"name":"worker","agent_did":"did:key:z-test","behavior_id":"worker"}"#;
+        let entries = parse_subagent_target_contents(contents, "@irrelevant").unwrap();
+        assert_eq!(entries.len(), 1);
+        let parsed = defra_agent::SubagentTarget::parse(&entries[0]).unwrap();
+        assert_eq!(parsed.name, "worker");
+    }
+
+    #[test]
+    fn parse_subagent_target_contents_expands_array() {
+        let contents = r#"[
+            {"name":"worker-a","agent_did":"did:key:z-test","behavior_id":"a"},
+            {"name":"worker-b","agent_did":"did:key:z-test","behavior_id":"b"}
+        ]"#;
+        let entries = parse_subagent_target_contents(contents, "@irrelevant").unwrap();
+        assert_eq!(entries.len(), 2);
+        let names: Vec<String> = entries
+            .iter()
+            .map(|entry| defra_agent::SubagentTarget::parse(entry).unwrap().name)
+            .collect();
+        assert_eq!(names, vec!["worker-a".to_string(), "worker-b".to_string()]);
+    }
+
+    #[test]
+    fn parse_subagent_target_contents_rejects_malformed_json() {
+        let error = parse_subagent_target_contents("not json", "@bad.json").unwrap_err();
+        assert!(error.to_string().contains("@bad.json"));
+    }
+
+    #[test]
+    fn expand_subagent_target_value_reads_single_object_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("target.json");
+        std::fs::write(
+            &path,
+            r#"{"name":"worker","agent_did":"did:key:z-test","behavior_id":"worker"}"#,
+        )
+        .unwrap();
+        let raw = format!("@{}", path.display());
+        let entries = expand_subagent_target_value(&raw).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            defra_agent::SubagentTarget::parse(&entries[0]).unwrap().name,
+            "worker"
+        );
+    }
+
+    #[test]
+    fn expand_subagent_target_value_reads_array_from_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("targets.json");
+        std::fs::write(
+            &path,
+            r#"[
+                {"name":"worker-a","agent_did":"did:key:z-test","behavior_id":"a"},
+                {"name":"worker-b","agent_did":"did:key:z-test","behavior_id":"b"}
+            ]"#,
+        )
+        .unwrap();
+        let raw = format!("@{}", path.display());
+        let entries = expand_subagent_target_value(&raw).unwrap();
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn expand_subagent_target_value_reports_missing_file() {
+        let raw = "@/nonexistent/path/targets.json";
+        let error = expand_subagent_target_value(raw).unwrap_err();
+        assert!(error.to_string().contains("targets.json"));
+    }
+
+    #[test]
+    fn subagent_targets_update_expands_file_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("targets.json");
+        std::fs::write(
+            &path,
+            r#"[
+                {"name":"worker-a","agent_did":"did:key:z-test","behavior_id":"a"},
+                {"name":"worker-b","agent_did":"did:key:z-test","behavior_id":"b"}
+            ]"#,
+        )
+        .unwrap();
+        let mut args = default_args();
+        args.subagent_targets = vec![format!("@{}", path.display())];
+        let updated = subagent_targets_update(&args).unwrap().unwrap();
+        assert_eq!(updated.len(), 2);
     }
 }


### PR DESCRIPTION
This PR makes some changes to improve user experience regarding the setting of config tools using subagent-target. Specifically, there are the following changes:

1. Previously, `--subagent-target` only accepted inline JSON. There are now several options available. Firstly, inline JSON still works, so it is backwards compatible. However, the user can now also prefix their input with `@` to signify a source to read from, rather than literal JSON. For examplee, `@some/path.json` would read in from a file, while `@-` would read from stdin. The contents of the source can be a singuularr JSON object, or an array of them.

2. A builder command has also been introduced. See `subagent-target-entry`. This subcommand takes `--name`, `--agent-did`, `--behavior-id`, and `--description` and formats/prints a valid JSON object to stdout. This is intended to provide users a way to easily prepare the input for the aforementioned command. **I would like to discuss how we feel about this idea as a team.**

3. The help text for `--subagent-target` has been updated to document the available forms of input, and point out the existence off the builder subcommand.

4. This PR contains unit tests for the new functionality where possible...

...and a more holistic set of tests were performed manually, by running the following script locally:

```
#!/usr/bin/env bash
# Exercises every --subagent-target input path: inline JSON, @file (single
# object), @file (array), and @- (stdin). Requires a running
# `defra-agent server --home /tmp/subagent-test` (or update the vars below
# to match your home / node).
set -euo pipefail

AGENT_DID=did:key:z6Mkv3ESeh7qdiibpsEVs7WRBQwfgRrgZYwq1ZGkSFy2AfFR
BEHAVIOR_ID=did:key:z6Mkv3ESeh7qdiibpsEVs7WRBQwfgRrgZYwq1ZGkSFy2AfFR:default
SELECTION_ID=did:key:z6Mkv3ESeh7qdiibpsEVs7WRBQwfgRrgZYwq1ZGkSFy2AfFR:default-tools
GRAPHQL=http://127.0.0.1:9191/api/v0/graphql

BIN=./target/debug/defra-agent
WORKDIR=$(mktemp -d)
trap 'rm -rf "$WORKDIR"' EXIT

show() {
  "$BIN" config tools show --graphql "$GRAPHQL" "$SELECTION_ID"
}

# check_names STEP NAME [NAME...]
# Fails unless `show` output contains exactly the given set of names (no
# extras, none missing) -- proves each path both wrote and fully replaced.
check_names() {
  local step="$1"; shift
  local output found
  output=$(show)
  # subagent_targets entries are stored as JSON-encoded strings, so quotes
  # inside them show up escaped (\"name\":\"...\"); strip the escaping
  # before matching so this works regardless of nesting depth.
  found=$(tr -d '\\' <<<"$output" | grep -oE '"name"[[:space:]]*:[[:space:]]*"[^"]*"' \
    | sed -E 's/.*"([^"]*)"$/\1/' | sort | tr '\n' ' '; true)
  local expected
  expected=$(printf '%s\n' "$@" | sort | tr '\n' ' ')
  if [[ "$found" != "$expected" ]]; then
    echo "FAIL [$step]: expected names [$expected] got [$found]"
    echo "$output"
    exit 1
  fi
  echo "PASS [$step]: subagent_targets == [$found]"
}

echo "== path 1: inline JSON via subagent-target-entry =="
ENTRY=$("$BIN" config tools subagent-target-entry \
  --name self-inline \
  --agent-did "$AGENT_DID" \
  --behavior-id "$BEHAVIOR_ID" \
  --description "inline path")
"$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target "$ENTRY" >/dev/null
check_names inline self-inline

echo "== path 2: @file with a single JSON object =="
SINGLE_FILE="$WORKDIR/single.json"
"$BIN" config tools subagent-target-entry \
  --name self-file \
  --agent-did "$AGENT_DID" \
  --behavior-id "$BEHAVIOR_ID" \
  --description "single object from file" >"$SINGLE_FILE"
"$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target "@$SINGLE_FILE" >/dev/null
check_names "file-single" self-file

echo "== path 3: @file with a JSON array of objects =="
ARRAY_FILE="$WORKDIR/array.json"
cat >"$ARRAY_FILE" <<EOF
[
  {"name":"self-array-a","agent_did":"$AGENT_DID","behavior_id":"$BEHAVIOR_ID","description":"array entry a"},
  {"name":"self-array-b","agent_did":"$AGENT_DID","behavior_id":"$BEHAVIOR_ID","description":"array entry b"}
]
EOF
"$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target "@$ARRAY_FILE" >/dev/null
check_names "file-array" self-array-a self-array-b

echo "== path 4: @- reading the same array from stdin =="
"$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target @- <"$ARRAY_FILE" >/dev/null
check_names stdin self-array-a self-array-b

echo "== error path: missing file =="
if "$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target "@$WORKDIR/does-not-exist.json" 2>"$WORKDIR/err.txt"; then
  echo "FAIL [missing-file]: expected a non-zero exit"
  exit 1
fi
grep -q "does-not-exist.json" "$WORKDIR/err.txt" && echo "PASS [missing-file]: error names the missing path"

echo "== error path: malformed JSON =="
echo "not json" >"$WORKDIR/bad.json"
if "$BIN" config tools set --graphql "$GRAPHQL" --agent-did "$AGENT_DID" --selection-id "$SELECTION_ID" \
  --subagent-target "@$WORKDIR/bad.json" 2>"$WORKDIR/err.txt"; then
  echo "FAIL [malformed-json]: expected a non-zero exit"
  exit 1
fi
grep -q "bad.json" "$WORKDIR/err.txt" && echo "PASS [malformed-json]: error names the bad source"

echo
echo "All --subagent-target paths verified."
```