### PR TITLE
docs+proofs: close Lean review follow-ups #556–#558 (#551)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Basic.lean
+++ b/crates/defra-agent/proofs/Proofs/Basic.lean
@@ -3,15 +3,38 @@
 
 Shared types and utilities used across all three layers of the
 ideal agent state machine.
+
+## Modeling boundary: `Nat`-typed IDs and `Time` (#558)
+
+`Time`, `SessionId`, `RequestId`, `BehaviorId`, and the other `abbrev … := Nat`
+aliases throughout the proofs are **deliberate abstractions**. The models need
+decidable equality and ordering for lifecycle/ordering arguments; they do not
+model:
+
+- wall-clock skew or non-monotonic host clocks
+- UUID/string parse or serialize failures
+- ID-namespace collisions (two real identifiers collapsed to the same `Nat`)
+- cross-node identity mismatches (`AgentDid` / `PeerId` / `RequestId` across
+  deployments)
+
+Cross-node identity uniqueness and collision-freedom are **not** claimed here.
+Distributed identity/membership obligations live at the TLA+ boundary
+(`tla/`, e.g. reverse-pairing / transport) and in Rust integration tests, not
+in these per-node lifecycle machines. Recorded as
+`boundary.model.nat-typed-ids-time` in `Proofs/Conformance/Boundaries.lean`.
 -/
 
-/-- Abstract time as natural numbers. We only need ordering, not real clocks. -/
+/-- Abstract time as natural numbers. We only need ordering, not real clocks.
+    See module docstring: wall-clock skew is outside the model (#558). -/
 abbrev Time := Nat
 
-/-- A session identifier. Opaque — we only need equality. -/
+/-- A session identifier. Opaque — we only need equality.
+    Real session keys may be strings/UUIDs; collision-freedom is a substrate
+    assumption, not proven here (#558). -/
 abbrev SessionId := Nat
 
-/-- A request identifier within a session. -/
+/-- A request identifier within a session.
+    Cross-node request-id uniqueness is not modeled (#558). -/
 abbrev RequestId := Nat
 
 /-- A behavior identifier bound to a session. -/

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -267,6 +267,9 @@ def boundaryStreamingResponseIdleTimeoutDeadlineId : String :=
 def boundaryPromptAssemblyProviderInputSanitizationId : String :=
   "boundary.prompt-assembly.provider-input-sanitization"
 
+def boundaryModelNatTypedIdsTimeId : String :=
+  "boundary.model.nat-typed-ids-time"
+
 def boundaries : List Boundary :=
   [ { id := boundaryRequestInputRequiredReservedId
     , domain := "RequestLifecycle"
@@ -407,6 +410,16 @@ def boundaries : List Boundary :=
     , subject := "provider input sanitization"
     , statement :=
         "Durable transcripts may contain unpaired assistant tool-call rows while tool execution is interrupted, failed, or in flight; provider sends must narrow loaded history through sanitize_history_for_provider so no dangling tool call reaches the backend."
+    }
+  , { id := boundaryModelNatTypedIdsTimeId
+    , domain := "ModelBoundary"
+    , subject := "Nat-typed IDs and Time"
+    , statement :=
+        "Core identifiers and Time are Nat abbreviations (Proofs/Basic and friends). Lifecycle and ordering proofs only need decidable equality and ordering. The abstraction deliberately omits wall-clock skew, UUID/string parse/serialize failures, ID-namespace collisions, and cross-node identity mismatches (AgentDid/PeerId/RequestId across deployments)."
+    , acceptedFailureMode :=
+        some "Collapsing distinct real identities to the same Nat equality could mask a cross-node identity bug class the distributed system can hit."
+    , acceptedFollowUp :=
+        some "Cross-node identity uniqueness is not claimed in Lean; load-bearing distributed identity/membership obligations live in tla/ (pairing/transport) and Rust integration tests. Targeted models only if a load-bearing collision class appears outside those fences (#558)."
     }
   ]
 

--- a/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Boundaries.lean
@@ -412,7 +412,7 @@ def boundaries : List Boundary :=
         "Durable transcripts may contain unpaired assistant tool-call rows while tool execution is interrupted, failed, or in flight; provider sends must narrow loaded history through sanitize_history_for_provider so no dangling tool call reaches the backend."
     }
   , { id := boundaryModelNatTypedIdsTimeId
-    , domain := "ModelBoundary"
+    , domain := "CoreTypes"
     , subject := "Nat-typed IDs and Time"
     , statement :=
         "Core identifiers and Time are Nat abbreviations (Proofs/Basic and friends). Lifecycle and ordering proofs only need decidable equality and ordering. The abstraction deliberately omits wall-clock skew, UUID/string parse/serialize failures, ID-namespace collisions, and cross-node identity mismatches (AgentDid/PeerId/RequestId across deployments)."

--- a/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
@@ -5,7 +5,24 @@ open RequestState RequestContext ComposedState
 /-!
 # Liveness Properties L1-L3
 
-Liveness modeled as constructive reachability to terminal states.
+## Liveness taxonomy (tier 1 — #557)
+
+Theorems in this file (and the wider suite's `*_eventually_*` /
+`*_convergence` names) are **tier-1 existential reachability**:
+
+> there exists a finite legal trace from the pre-state to a good post-state.
+
+They are **not**:
+- **tier 2** fair-scheduler liveness (progress under weak/strong fairness), or
+- **tier 3** bounded-latency guarantees (progress within N ticks/steps), or
+- **tier 4** operational watchdog guarantees (runtime-enforced timeouts).
+
+Tier-2/3 load for distributed delivery and pairing lives in `tla/`. Tier-4 is
+enforced by the Rust runtime (deadlines, idle timeouts, recovery sweeps).
+
+Naming note: historical `*_eventually_*` names are kept for continuity; new
+work should prefer `*_reachable` when the theorem is purely existential.
+See `crates/defra-agent/proofs/README.md` § Liveness taxonomy.
 -/
 
 /-- Termination measure: maximum remaining steps to terminal state. -/

--- a/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
@@ -5,20 +5,26 @@ open RequestState RequestContext ComposedState
 /-!
 # Liveness Properties L1-L3
 
-## Liveness taxonomy (tier 1 — #557)
+## Liveness taxonomy (#557)
 
-Theorems in this file (and the wider suite's `*_eventually_*` /
-`*_convergence` names) are **tier-1 existential reachability**:
+This file mixes two tiers — do not read every theorem as the same strength:
 
-> there exists a finite legal trace from the pre-state to a good post-state.
+| ID | Theorem | Tier | Shape |
+|----|---------|------|--------|
+| **L1** | `phase_change_decreases_measure` | **3** (bounded phase progress) | Conditional termination-measure decrease on real phase changes — not an existential trace. Closest cousin is a progress/safety-style ranking argument: each current-product phase change moves strictly closer to a terminal measure. |
+| **L2** | `claimed_eventually_terminal` | **1** (existential reachability) | `∃ post, Trace …` — a finite legal path exists. |
+| **L3** | `recovery_convergence` | **1** (existential reachability) | Finite stuck set can be driven to terminal outcomes in finite steps (constructive path, not fair scheduling). |
+
+The wider suite's `*_eventually_*` / `*_convergence` names are almost always
+**tier 1**, not fair-scheduler or wall-clock guarantees:
 
 They are **not**:
 - **tier 2** fair-scheduler liveness (progress under weak/strong fairness), or
-- **tier 3** bounded-latency guarantees (progress within N ticks/steps), or
 - **tier 4** operational watchdog guarantees (runtime-enforced timeouts).
 
-Tier-2/3 load for distributed delivery and pairing lives in `tla/`. Tier-4 is
-enforced by the Rust runtime (deadlines, idle timeouts, recovery sweeps).
+**Tier 3** in Lean is rare and local (measures/`Nat` bounds on a step), not
+distributed latency. Tier-2 load for delivery/pairing lives in `tla/`. Tier-4
+is enforced by the Rust runtime (deadlines, idle timeouts, recovery sweeps).
 
 Naming note: historical `*_eventually_*` names are kept for continuity; new
 work should prefer `*_reachable` when the theorem is purely existential.
@@ -38,6 +44,9 @@ def terminationMeasure (r : RequestContext) : Nat :=
   | .processing => (r.maxRetries - r.retryCount) + 2
   | .inputRequired => (r.maxRetries - r.retryCount) + 2
 
+/-- **L1 (tier 3):** a real current-product phase change strictly decreases the
+    termination measure. This is a ranking/measure argument, not an existential
+    reachability witness — contrast L2/L3 below. -/
 theorem phase_change_decreases_measure
     {pre post : RequestContext}
     (h_trans : RequestContext.Transition pre post)

--- a/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
+++ b/crates/defra-agent/proofs/Proofs/Properties/Liveness.lean
@@ -12,8 +12,8 @@ This file mixes two tiers — do not read every theorem as the same strength:
 | ID | Theorem | Tier | Shape |
 |----|---------|------|--------|
 | **L1** | `phase_change_decreases_measure` | **3** (bounded phase progress) | Conditional termination-measure decrease on real phase changes — not an existential trace. Closest cousin is a progress/safety-style ranking argument: each current-product phase change moves strictly closer to a terminal measure. |
-| **L2** | `claimed_eventually_terminal` | **1** (existential reachability) | `∃ post, Trace …` — a finite legal path exists. |
-| **L3** | `recovery_convergence` | **1** (existential reachability) | Finite stuck set can be driven to terminal outcomes in finite steps (constructive path, not fair scheduling). |
+| **L2** | `claimed_eventually_terminal` | **1** (existential reachability) | `∃ post, Trace …` — a finite legal composed path exists. |
+| **L3** | `recovery_convergence` | **1′** (existential *list* witness, not a Trace) | `∃ results, results.length = stuck.length ∧ ∀ r ∈ results, isTerminal` — a same-length list of terminal contexts exists. Does **not** prove a `Transition`/`Trace` from each stuck input to its result (the stuck-state hypothesis is unused in the proof). Weaker than L2; do not cite as recovery path existence. |
 
 The wider suite's `*_eventually_*` / `*_convergence` names are almost always
 **tier 1**, not fair-scheduler or wall-clock guarantees:
@@ -127,6 +127,11 @@ theorem claimed_eventually_terminal
           simp [post, postRequest] at h_proc
   refine ⟨post, ComposedState.Trace.step h_step ComposedState.Trace.refl, failed_is_terminal⟩
 
+/-- **L3 (tier 1′):** for any list of contexts, a same-length list of
+    *terminal* contexts exists. This is an existential list witness only —
+    it does **not** construct a `Transition`/`Trace` linking each stuck input
+    to its output, and the stuck-state hypothesis is unused. Stronger
+    recovery-path claims need a separate theorem; do not over-read this one. -/
 theorem recovery_convergence
     (stuck : List RequestContext)
     (_h_all_stuck : ∀ r, r ∈ stuck → r.state = .processing ∨ r.state = .claimed) :

--- a/crates/defra-agent/proofs/Proofs/Request/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/Request/Properties.lean
@@ -43,39 +43,41 @@ theorem terminal_implies_released_local
             cases admission <;> simp [coherent, coherentStateAdmission] at h_coherent
             rfl
 
+/-- Fields that no `RequestContext.Transition` constructor rewrites.
+
+Every constructor is a pure `{ pre with ... }` update that only touches
+lifecycle/admission/clock/persistence progress fields. Identity-bearing and
+submitter-owned fields are therefore preserved uniformly. Proving them once
+avoids 11-arm `cases h_trans` copies whenever a constructor is added (#556). -/
+theorem identity_fields_preserved
+    {pre post : RequestContext}
+    (h_trans : Transition pre post) :
+    post.origin = pre.origin ∧
+    post.backend = pre.backend ∧
+    post.maxRetries = pre.maxRetries ∧
+    post.messageSeq = pre.messageSeq ∧
+    post.isLatest = pre.isLatest ∧
+    post.interruptRequestedAt = pre.interruptRequestedAt ∧
+    post.validUntil = pre.validUntil ∧
+    post.subagentDepth = pre.subagentDepth ∧
+    post.causedByParentRequestId = pre.causedByParentRequestId ∧
+    post.causedByParentToolCallId = pre.causedByParentToolCallId ∧
+    post.requestDeadline = pre.requestDeadline ∧
+    post.retryCount = pre.retryCount ∧
+    post.currentTime = pre.currentTime := by
+  cases h_trans <;> simp_all
+
 theorem backend_binding_preserved
     {pre post : RequestContext}
     (h_trans : Transition pre post) :
-    post.backend = pre.backend := by
-  cases h_trans with
-  | claim _ _ _ h_post => rw [h_post]
-  | dedup_lose _ _ h_post => rw [h_post]
-  | begin_inference _ _ h_post => rw [h_post]
-  | advance _ _ h_post => rw [h_post]
-  | finish _ _ h_post => rw [h_post]
-  | fail _ _ h_post => rw [h_post]
-  | fail_before_stream _ _ h_post => rw [h_post]
-  | expire _ _ _ _ h_post => rw [h_post]
-  | interrupt_before_claim _ _ _ h_post => rw [h_post]
-  | interrupt_claimed _ _ _ h_post => rw [h_post]
-  | interrupt_processing _ _ _ h_post => rw [h_post]
+    post.backend = pre.backend :=
+  (identity_fields_preserved h_trans).2.1
 
 theorem origin_preserved
     {pre post : RequestContext}
     (h_trans : Transition pre post) :
-    post.origin = pre.origin := by
-  cases h_trans with
-  | claim _ _ _ h_post => rw [h_post]
-  | dedup_lose _ _ h_post => rw [h_post]
-  | begin_inference _ _ h_post => rw [h_post]
-  | advance _ _ h_post => rw [h_post]
-  | finish _ _ h_post => rw [h_post]
-  | fail _ _ h_post => rw [h_post]
-  | fail_before_stream _ _ h_post => rw [h_post]
-  | expire _ _ _ _ h_post => rw [h_post]
-  | interrupt_before_claim _ _ _ h_post => rw [h_post]
-  | interrupt_claimed _ _ _ h_post => rw [h_post]
-  | interrupt_processing _ _ _ h_post => rw [h_post]
+    post.origin = pre.origin :=
+  (identity_fields_preserved h_trans).1
 
 theorem transition_produces_coherent
     {pre post : RequestContext}

--- a/crates/defra-agent/proofs/Proofs/RuntimeReconcile/Transition.lean
+++ b/crates/defra-agent/proofs/Proofs/RuntimeReconcile/Transition.lean
@@ -90,47 +90,18 @@ inductive Transition : RuntimeState → RuntimeState → Prop where
         } →
       Transition pre post
 
+/-- Active generation is non-decreasing under every transition.
+
+Most constructors leave `active` untouched. Only `publish` advances generation;
+that arm is the sole non-uniform case. Discharged with a single `cases` +
+`simp_all` so adding a constructor that preserves `active` does not require a
+new proof arm (#556). -/
 theorem transition_generation_monotone
     {pre post : RuntimeState}
     (h_trans : Transition pre post) :
     pre.active.generation ≤ post.active.generation := by
-  cases h_trans with
-  | ack_write _ h_post =>
-      cases h_post
-      simp
-  | observe_doc _ _ _ h_post =>
-      cases h_post
-      simp
-  | start_resolve _ h_post =>
-      cases h_post
-      simp
-  | resolve_visible _ _ _ _ h_post =>
-      cases h_post
-      simp
-  | diff_noop _ _ _ _ h_post =>
-      cases h_post
-      simp
-  | begin_apply _ _ _ _ h_post =>
-      cases h_post
-      simp
-  | publish _ _ _ _ h_post =>
-      cases h_post
-      simp [ResolvedSnapshot.activate, Nat.le_succ pre.active.generation]
-  | apply_failed _ h_post =>
-      cases h_post
-      simp
-  | router_observe _ h_post =>
-      cases h_post
-      simp
-  | accept_request _ _ _ h_post =>
-      cases h_post
-      simp
-  | finish_request _ _ h_post =>
-      cases h_post
-      simp
-  | retire_generation _ _ _ _ _ h_post =>
-      cases h_post
-      simp
+  cases h_trans <;>
+    simp_all [ResolvedSnapshot.activate, Nat.le_succ]
 
 theorem coherent_preserved
     {pre post : RuntimeState}

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -439,7 +439,7 @@ fair-scheduler or wall-clock progress is a misread (#557).
 |------|---------|----------------|
 | **1. Existential reachability** | There exists a finite legal path from pre to a good post (`∃ post, Trace …` / `∃ actions, …`) | Lean (default): `claimed_eventually_terminal`, `recovery_convergence`, `accepted_work_eventually_releases`, `D1_delivery_convergence`, `streamIdle_eventually_terminal`, … |
 | **2. Fair-scheduler liveness** | Under weak/strong fairness, enabled progress steps fire | Primarily `tla/` (WF/SF annotations); Lean does not assume a fair scheduler |
-| **3. Bounded latency** | Progress within N steps/ticks | Rare; only when a concrete measure/`Nat` bound is part of the theorem statement |
+| **3. Bounded phase / measure progress** | Each relevant step decreases a `Nat` measure (or is otherwise step-bounded) — not wall-clock latency | Rare in Lean; example: L1 `phase_change_decreases_measure` (termination measure on phase change). Not distributed N-tick latency. |
 | **4. Operational watchdog** | Runtime-enforced deadline/timeout/recovery | Rust (request deadlines, stream idle timeouts, recovery sweeps) — not Lean |
 
 Naming convention going forward: prefer `*_reachable` for pure tier-1 results;

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -118,7 +118,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, and cancellation properties |
 | `Proofs/Persistence.lean` | Persistence lifecycle model plus executable `Action`, `step?`, and `replay?` |
 | `Proofs/StorageObservation.lean` | Daemon-visible storage observation model and persistence bridge |
-| `Proofs/CrossMachineComposed.lean` | Cross-machine composition and guards; global `WellFormed` (list-level coherence, unique call ids, no early tools, invFG) established at `initial` and preserved by every transition (#555) |
+| `Proofs/CrossMachineComposed.lean` | Cross-machine composition and guards; global `WellFormed` (list-level coherence, detached persistence/linkage, unique call ids, no early tools, invFG) established at `initial` and preserved by every transition (#555) |
 | `Proofs/Scheduling.lean` | Scheduler/backend slot state |
 | `Proofs/Fleet.lean` | Barrel for fleet state, transitions, executable semantics, and slot accounting |
 | `Proofs/SessionRecovery.lean` | Retry/reissue model for session-linked requests |
@@ -452,16 +452,19 @@ per-node Lean machines.
 | ID | Property | Tier | Why it matters | Theorem |
 |----|----------|------|----------------|---------|
 | L1 | Real current-product phase changes decrease a termination measure | 3 (bounded phase progress) | The model rules out endless phase churn that never gets closer to terminal state | `phase_change_decreases_measure` |
-| L2 | Claimed work has a constructive path to terminal state | 1 | A claimed request is not modeled as stuck forever before inference begins | `claimed_eventually_terminal` |
-| L3 | Recovery converges | 1 | A finite set of stuck requests can be driven to terminal outcomes in finite steps | `recovery_convergence` |
+| L2 | Claimed work has a constructive path to terminal state | 1 (`∃ post, Trace`) | A claimed request is not modeled as stuck forever before inference begins | `claimed_eventually_terminal` |
+| L3 | Recovery has a same-length terminal-result list | 1′ (list witness, **not** a Trace) | For any stuck list there exists a same-length list of terminal contexts; does *not* prove a transition path from each stuck input to its result | `recovery_convergence` |
 
 ### Scheduler Safety and Liveness
 
+Numeric tiers (1–4) apply to **liveness** rows only. Safety invariants are marked
+`— (safety)` rather than assigned a liveness tier.
+
 | ID | Property | Tier | Why it matters | Theorem |
 |----|----------|------|----------------|---------|
-| S7 | Capacity invariants are preserved | safety | Running-slot counts stay within backend limits | `capacity_invariant_preserved`, `reconstructedSlotCount_bounded_by_max_concurrent` |
-| S8 | Slot accounting is preserved | safety | Scheduler running counts stay aligned with per-request admission state and persisted running call rows | `slot_accounting_preserved`, `scheduler_running_reconstructed_from_inference_calls` |
-| S9 | Terminal work releases capacity; unavailable backends cannot acquire | safety | Slots are not leaked and unrunnable backends do not accept new work | `terminal_implies_released`, `permitDrop_terminalization_not_counted`, `unavailable_blocks_acquire` |
+| S7 | Capacity invariants are preserved | — (safety) | Running-slot counts stay within backend limits | `capacity_invariant_preserved`, `reconstructedSlotCount_bounded_by_max_concurrent` |
+| S8 | Slot accounting is preserved | — (safety) | Scheduler running counts stay aligned with per-request admission state and persisted running call rows | `slot_accounting_preserved`, `scheduler_running_reconstructed_from_inference_calls` |
+| S9 | Terminal work releases capacity; unavailable backends cannot acquire | — (safety) | Slots are not leaked and unrunnable backends do not accept new work | `terminal_implies_released`, `permitDrop_terminalization_not_counted`, `unavailable_blocks_acquire` |
 | L | Capacity-available work can acquire | 1 | A waiting request is not artificially blocked when slots exist | `acquire_when_capacity_available` |
 | L | Accepted work eventually releases | 1 | The model has a constructive path from accepted work to released capacity | `accepted_work_eventually_releases` |
 

--- a/crates/defra-agent/proofs/README.md
+++ b/crates/defra-agent/proofs/README.md
@@ -118,7 +118,7 @@ and either tested at the Rust boundary or treated as an external assumption.
 | `Proofs/InferenceCall.lean` | Barrel for inference-call state, transitions, slot accounting, and cancellation properties |
 | `Proofs/Persistence.lean` | Persistence lifecycle model plus executable `Action`, `step?`, and `replay?` |
 | `Proofs/StorageObservation.lean` | Daemon-visible storage observation model and persistence bridge |
-| `Proofs/CrossMachineComposed.lean` | Cross-machine composition and guards |
+| `Proofs/CrossMachineComposed.lean` | Cross-machine composition and guards; global `WellFormed` (list-level coherence, unique call ids, no early tools, invFG) established at `initial` and preserved by every transition (#555) |
 | `Proofs/Scheduling.lean` | Scheduler/backend slot state |
 | `Proofs/Fleet.lean` | Barrel for fleet state, transitions, executable semantics, and slot accounting |
 | `Proofs/SessionRecovery.lean` | Retry/reissue model for session-linked requests |
@@ -429,23 +429,41 @@ Local observation theorems also record the daemon assumptions Rust relies on:
 `failClosed_failed_mutation_retry_path`, `failOpen_failed_mutation_lost_path`,
 `staleRead_eventual_visibility_path`, and `staleEvent_eventual_visibility_path`.
 
+### Liveness taxonomy
+
+"Liveness" theorems in this suite fall into four tiers. **Almost all Lean
+results are tier 1.** Reading an `*_eventually_*` or `*_convergence` name as
+fair-scheduler or wall-clock progress is a misread (#557).
+
+| Tier | Meaning | Where it lives |
+|------|---------|----------------|
+| **1. Existential reachability** | There exists a finite legal path from pre to a good post (`∃ post, Trace …` / `∃ actions, …`) | Lean (default): `claimed_eventually_terminal`, `recovery_convergence`, `accepted_work_eventually_releases`, `D1_delivery_convergence`, `streamIdle_eventually_terminal`, … |
+| **2. Fair-scheduler liveness** | Under weak/strong fairness, enabled progress steps fire | Primarily `tla/` (WF/SF annotations); Lean does not assume a fair scheduler |
+| **3. Bounded latency** | Progress within N steps/ticks | Rare; only when a concrete measure/`Nat` bound is part of the theorem statement |
+| **4. Operational watchdog** | Runtime-enforced deadline/timeout/recovery | Rust (request deadlines, stream idle timeouts, recovery sweeps) — not Lean |
+
+Naming convention going forward: prefer `*_reachable` for pure tier-1 results;
+keep historical `*_eventually_*` names for continuity. Cross-node temporal
+load (pairing, transport, reverse-pairing) is carried by `tla/`, not by
+per-node Lean machines.
+
 ### Request/Process Liveness
 
-| ID | Property | Why it matters | Theorem |
-|----|----------|----------------|---------|
-| L1 | Real current-product phase changes decrease a termination measure | The model rules out endless phase churn that never gets closer to terminal state | `phase_change_decreases_measure` |
-| L2 | Claimed work has a constructive path to terminal state | A claimed request is not modeled as stuck forever before inference begins | `claimed_eventually_terminal` |
-| L3 | Recovery converges | A finite set of stuck requests can be driven to terminal outcomes in finite steps | `recovery_convergence` |
+| ID | Property | Tier | Why it matters | Theorem |
+|----|----------|------|----------------|---------|
+| L1 | Real current-product phase changes decrease a termination measure | 3 (bounded phase progress) | The model rules out endless phase churn that never gets closer to terminal state | `phase_change_decreases_measure` |
+| L2 | Claimed work has a constructive path to terminal state | 1 | A claimed request is not modeled as stuck forever before inference begins | `claimed_eventually_terminal` |
+| L3 | Recovery converges | 1 | A finite set of stuck requests can be driven to terminal outcomes in finite steps | `recovery_convergence` |
 
 ### Scheduler Safety and Liveness
 
-| ID | Property | Why it matters | Theorem |
-|----|----------|----------------|---------|
-| S7 | Capacity invariants are preserved | Running-slot counts stay within backend limits | `capacity_invariant_preserved`, `reconstructedSlotCount_bounded_by_max_concurrent` |
-| S8 | Slot accounting is preserved | Scheduler running counts stay aligned with per-request admission state and persisted running call rows | `slot_accounting_preserved`, `scheduler_running_reconstructed_from_inference_calls` |
-| S9 | Terminal work releases capacity; unavailable backends cannot acquire | Slots are not leaked and unrunnable backends do not accept new work | `terminal_implies_released`, `permitDrop_terminalization_not_counted`, `unavailable_blocks_acquire` |
-| L | Capacity-available work can acquire | A waiting request is not artificially blocked when slots exist | `acquire_when_capacity_available` |
-| L | Accepted work eventually releases | The model has a constructive path from accepted work to released capacity | `accepted_work_eventually_releases` |
+| ID | Property | Tier | Why it matters | Theorem |
+|----|----------|------|----------------|---------|
+| S7 | Capacity invariants are preserved | safety | Running-slot counts stay within backend limits | `capacity_invariant_preserved`, `reconstructedSlotCount_bounded_by_max_concurrent` |
+| S8 | Slot accounting is preserved | safety | Scheduler running counts stay aligned with per-request admission state and persisted running call rows | `slot_accounting_preserved`, `scheduler_running_reconstructed_from_inference_calls` |
+| S9 | Terminal work releases capacity; unavailable backends cannot acquire | safety | Slots are not leaked and unrunnable backends do not accept new work | `terminal_implies_released`, `permitDrop_terminalization_not_counted`, `unavailable_blocks_acquire` |
+| L | Capacity-available work can acquire | 1 | A waiting request is not artificially blocked when slots exist | `acquire_when_capacity_available` |
+| L | Accepted work eventually releases | 1 | The model has a constructive path from accepted work to released capacity | `accepted_work_eventually_releases` |
 
 The scheduling-liveness theorem was intentionally renamed to
 `accepted_work_eventually_releases`; the old name used the previous acceptance
@@ -779,6 +797,12 @@ These proofs do not establish:
 - MCP or external tool availability
 - desktop rendering correctness
 - OS sandbox behavior
+- wall-clock skew / real-time monotonicity (`Time := Nat` is abstract; #558)
+- ID-namespace collision freedom or cross-node identity uniqueness for
+  `RequestId` / `PeerId` / `AgentDid` collapsed to `Nat` (#558;
+  `boundary.model.nat-typed-ids-time`)
+- fair-scheduler or bounded-latency temporal liveness for distributed
+  delivery (tier 2/3; see § Liveness taxonomy and `tla/`)
 
 Those are handled through explicit assumptions, Rust integration tests,
-operational diagnostics, or platform-specific tests.
+operational diagnostics, TLA+ specs, or platform-specific tests.

--- a/crates/defra-agent/tests/conformance/coverage.rs
+++ b/crates/defra-agent/tests/conformance/coverage.rs
@@ -281,6 +281,7 @@ fn lean_boundary_metadata_is_typed_and_reviewable() {
         "boundary.event-delivery.rescan-doc-cap",
         "boundary.streaming-response.idle-timeout-deadline",
         "boundary.prompt-assembly.provider-input-sanitization",
+        "boundary.model.nat-typed-ids-time",
     ]
     .into_iter()
     .map(str::to_string)


### PR DESCRIPTION
## Summary

Closes the remaining documentation / maintainability items on the Lean-model review umbrella [#551](https://github.com/sourcenetwork/defra-agent/issues/551):

- **#557** — Document the four-tier liveness taxonomy (existential reachability / fair-scheduler / bounded latency / operational watchdog). Tag property tables and `Liveness.lean` so `*_eventually_*` names are not misread as fair-scheduler guarantees.
- **#558** — Record `Nat`-typed IDs/`Time` as an explicit model boundary (`boundary.model.nat-typed-ids-time`), with the decision that cross-node identity uniqueness stays in `tla/` + Rust integration tests.
- **#556** — Collapse Request identity-field preservation onto one shared discharge (`identity_fields_preserved`) and simplify RuntimeReconcile `transition_generation_monotone` to a uniform `cases <;> simp_all`.
- **#555** — Already landed in [#563](https://github.com/sourcenetwork/defra-agent/pull/563); this PR only documents global `WellFormed` in the proofs README.

## Test plan

- [x] `cd crates/defra-agent/proofs && lake build` (full suite green)
- [x] `cargo test -p defra-agent --test conformance coverage::` (6/6, includes `lean_boundary_metadata_is_typed_and_reviewable` pin for the new boundary id)
- [x] `cargo test -p defra-agent --test conformance lean_executable_contracts_cover_initial_domains`
- [x] `cargo test -p defra-agent --test conformance request_lifecycle` (14/14)
- [x] `cargo test -p defra-agent --test conformance composed_invariant` (WellFormed / C-theorem path)
- [ ] Full `cargo test -p defra-agent --test conformance` (not run locally — CI `rust-and-cli` / lean gate)

Closes #556
Closes #557
Closes #558