### PR TITLE
P2P: replicate an app-defined collection over a pairing (#657)

### DIFF
--- a/crates/defra-agent-cli/src/commands/demo/fleet.rs
+++ b/crates/defra-agent-cli/src/commands/demo/fleet.rs
@@ -258,8 +258,15 @@ async fn upsert_data_plane(
 }
 
 fn data_plane_collections_literal(template: &str) -> Result<String> {
+    use defra_agent::agent::p2p_reconcile::templates::APP_COLLECTIONS_TEMPLATE;
     let template = resolve_template(template)
         .with_context(|| format!("unknown data-plane template {template:?}"))?;
+    if template.id == APP_COLLECTIONS_TEMPLATE {
+        anyhow::bail!(
+            "app-collections requires an explicit collection set; fleet upsert_data_plane \
+             cannot expand it from the template (see #607 for config-apply ownership)"
+        );
+    }
     let collections = template
         .collections
         .iter()

--- a/crates/defra-agent-cli/src/commands/p2p/pairings.rs
+++ b/crates/defra-agent-cli/src/commands/p2p/pairings.rs
@@ -171,10 +171,19 @@ pub(super) async fn p2p_pairings_remove(args: P2pPairingRefArgs) -> Result<()> {
 /// the normalized id. An unknown template is a hard error (with the catalog
 /// listed) rather than a silent fallback, since the operator named it explicitly.
 pub(super) fn resolve_pairing_template(template: &str) -> Result<String> {
-    use defra_agent::agent::p2p_reconcile::templates::{builtin_templates, resolve_template};
+    use defra_agent::agent::p2p_reconcile::templates::{
+        builtin_templates, resolve_template, APP_COLLECTIONS_TEMPLATE,
+    };
     let template = template.trim();
     if template.is_empty() {
         return Ok("conversation".to_string());
+    }
+    if template == APP_COLLECTIONS_TEMPLATE {
+        anyhow::bail!(
+            "the app-collections template is for DataPlanePairingDesired rows only; \
+             it supplies no collections on the control-plane pairing path — write a \
+             data-plane pairing with an explicit collection set instead"
+        );
     }
     if resolve_template(template).is_some() {
         return Ok(template.to_string());
@@ -910,6 +919,17 @@ mod tests {
         let error = resolve_pairing_template("nope").unwrap_err().to_string();
         assert!(error.contains("unknown scope template"));
         assert!(error.contains("conversation"));
+    }
+
+    #[test]
+    fn app_collections_rejected_on_generic_pairing_path() {
+        let err = resolve_pairing_template("app-collections")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("app-collections"),
+            "error must name the offending template: {err}"
+        );
     }
 
     #[test]

--- a/crates/defra-agent/proofs/Proofs/PairingReconcile.lean
+++ b/crates/defra-agent/proofs/Proofs/PairingReconcile.lean
@@ -2,10 +2,12 @@ import Proofs.PairingReconcile.State
 import Proofs.PairingReconcile.Transition
 import Proofs.PairingReconcile.Executable
 import Proofs.PairingReconcile.Convergence
+import Proofs.PairingReconcile.Layering
 
 /-!
 # Pairing Reconcile Model
 
 Barrel import for the consumer-side pairing reconcile state model, transition
-relation, executable contract, and convergence witness.
+relation, executable contract, convergence witness, and layered-merge
+subscription rule (`Layering`).
 -/

--- a/crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean
+++ b/crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean
@@ -1,0 +1,102 @@
+import Proofs.Basic
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Pairing Reconcile — Layered merge (subscription rule)
+
+A pure derivation beside the reconcile machine (the ScopeTemplates pattern: a
+derivation below the machine, not a new machine). Models Rust
+`merge_layered_desired`: a control-plane base desired layer is merged with an
+optional data-plane layer. A data-plane layer's *subscriptions* are dropped
+UNLESS it is the app-collections (whole-collection Replicate) policy — push
+data-plane layers must not extend the subscription set, so conversation data
+never gossips unfiltered; app-collections is Unscoped Replicate and must
+subscribe on both sides for the merged doc to be observable. Replicator
+collection sets always union (the machine keys replicator identity on them).
+-/
+
+namespace PairingReconcile.Layering
+
+/-- The fields of Rust `PairingDesired` that the merge rule reads. -/
+structure Layer where
+  subscriptions : Finset String
+  replicatorCollections : Finset String
+  /-- `template_ids.contains "app-collections"` in Rust. -/
+  isAppCollections : Bool
+  deriving DecidableEq
+
+/-- Drop a data-plane layer's subscriptions unless it is app-collections. -/
+def clampDataPlane (l : Layer) : Layer :=
+  if l.isAppCollections then l else { l with subscriptions := (∅ : Finset String) }
+
+/-- Merge a control-plane base with an optional data-plane layer. Mirrors Rust
+`merge_layered_desired`: clamp the data-plane layer, then union. -/
+def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer :=
+  match base, dataPlane.map clampDataPlane with
+  | none, none => none
+  | some b, none => some b
+  | none, some d => some d
+  | some b, some d =>
+      some { subscriptions := b.subscriptions ∪ d.subscriptions
+           , replicatorCollections := b.replicatorCollections ∪ d.replicatorCollections
+           -- OR so a later re-use of the result as a data-plane input still
+           -- remembers that an app-collections layer contributed.
+           , isAppCollections := b.isAppCollections || d.isAppCollections }
+
+/-- An app-collections data-plane layer's subscriptions survive the merge, so an
+`InstallCollection` op can reach the diff. -/
+theorem appCollections_subscription_survives
+    (base : Option Layer) (d : Layer) (h : d.isAppCollections = true)
+    (m : Layer) (hm : mergeLayered base (some d) = some m) :
+    d.subscriptions ⊆ m.subscriptions := by
+  cases base with
+  | none =>
+      simp [mergeLayered, clampDataPlane, h] at hm
+      subst hm
+      exact Finset.Subset.refl _
+  | some b =>
+      simp [mergeLayered, clampDataPlane, h] at hm
+      subst hm
+      exact Finset.subset_union_right
+
+/-- A non-app-collections data-plane layer contributes NO subscriptions: with an
+empty base the merged subscription set is empty (push data never gossips
+unfiltered). -/
+theorem nonApp_none_base_no_subscription
+    (d : Layer) (h : d.isAppCollections = false) :
+    mergeLayered none (some d) = some { d with subscriptions := (∅ : Finset String) } := by
+  simp [mergeLayered, clampDataPlane, h]
+
+/-- A non-app-collections data-plane layer does not add to a base's subscriptions:
+the merged subscription set equals the base's. -/
+theorem nonApp_subscription_eq_base
+    (b d : Layer) (h : d.isAppCollections = false)
+    (m : Layer) (hm : mergeLayered (some b) (some d) = some m) :
+    m.subscriptions = b.subscriptions := by
+  simp [mergeLayered, clampDataPlane, h] at hm
+  subst hm
+  simp
+
+/-- The control-plane base is always preserved (subscriptions and replicator
+collections are supersets of the base's), regardless of the data-plane layer. -/
+theorem base_preserved
+    (b : Layer) (dp : Option Layer) (m : Layer)
+    (hm : mergeLayered (some b) dp = some m) :
+    b.subscriptions ⊆ m.subscriptions ∧ b.replicatorCollections ⊆ m.replicatorCollections := by
+  cases dp with
+  | none =>
+      simp [mergeLayered] at hm
+      subst hm
+      exact ⟨Finset.Subset.refl _, Finset.Subset.refl _⟩
+  | some d =>
+      cases h : d.isAppCollections with
+      | false =>
+          simp [mergeLayered, clampDataPlane, h] at hm
+          subst hm
+          exact ⟨by simp, by simp [Finset.subset_union_left]⟩
+      | true =>
+          simp [mergeLayered, clampDataPlane, h] at hm
+          subst hm
+          exact ⟨Finset.subset_union_left, Finset.subset_union_left⟩
+
+end PairingReconcile.Layering

--- a/crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
+++ b/crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
@@ -187,6 +187,23 @@ theorem subagentHost_in_catalog :
     resolveTemplate builtinCatalog "subagent-host" = some subagentHostTemplate := by
   decide
 
+/-- Concrete catalog membership: the app-collections (bring-your-own) template
+resolves from the built-in catalog. Its collection set is empty by contract —
+the DataPlanePairingDesired row supplies the collections. -/
+theorem appCollections_in_catalog :
+    resolveTemplate builtinCatalog "app-collections" = some appCollectionsTemplate := by
+  decide
+
+/-- The app-collections template carries no fixed collections: its set is
+row-supplied, not catalog-fixed. -/
+theorem appCollections_collections_empty :
+    appCollectionsTemplate.collections = (∅ : Finset String) := rfl
+
+/-- The app-collections template is whole-collection replicate (no per-peer
+filter): Unscoped scope yields no filters for any collection list. -/
+theorem appCollections_unscoped_no_filter (collections : List String) (peerDid localDid : Did) :
+    scopeFilter appCollectionsTemplate.scope collections peerDid localDid = [] := rfl
+
 /-- Supporting no-third-party corollary: every per-collection filter value is one
 of the local/peer DIDs. The exact-equality theorems above are the load-bearing
 crossing proof; this only backs the no-third-party value statement. -/

--- a/crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean
+++ b/crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean
@@ -154,6 +154,14 @@ def subagentHostTemplate : Template :=
   , scope := .perCollection subagentHostRules
   , delivery := .push }
 
+/-- Bring-your-own collection set: policy only (Unscoped Replicate); the
+`DataPlanePairingDesired` row supplies the collections. -/
+def appCollectionsTemplate : Template :=
+  { id := "app-collections"
+  , collections := (∅ : Finset String)
+  , scope := .unscoped
+  , delivery := .replicate }
+
 /-- Concrete catalog mirroring Rust `BUILTIN_TEMPLATES`. -/
 def builtinCatalog : Catalog :=
   [ conversationTemplate
@@ -162,6 +170,7 @@ def builtinCatalog : Catalog :=
   , discoveryTemplate
   , networkControlTemplate
   , subagentCoordinatorTemplate
-  , subagentHostTemplate ]
+  , subagentHostTemplate
+  , appCollectionsTemplate ]
 
 end ScopeTemplates

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -17,6 +17,7 @@ use crate::identity::AgentIdentity;
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::templates::{
     resolve_template, scope_filter, Delivery, DidSource, PairingFilters, Scope,
+    APP_COLLECTIONS_TEMPLATE,
 };
 use super::{
     compute_owned_pairing_diff, DiffOp, EmbeddedRemoteP2pAdmin, PairingActual, PairingApplied,
@@ -496,6 +497,7 @@ impl PairingStateStore for GraphqlPairingStateStore {
                 }}
                 DataPlanePairingDesired(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{
                     agent_did
+                    collections
                     replicator_addresses
                     template
                 }}
@@ -505,7 +507,8 @@ impl PairingStateStore for GraphqlPairingStateStore {
         ensure_no_errors(&response, "query pairing desired state")?;
         let base = first_row::<PairingStateRow>(&response, "PeerPairingDesired")?
             .map(|row| desired_from_pairing_row(row, self.identity.did()))
-            .transpose()?;
+            .transpose()?
+            .flatten();
         let materialized_entry = self
             .data_plane_materialized_entry(&raw_peer_id)
             .await
@@ -514,11 +517,9 @@ impl PairingStateStore for GraphqlPairingStateStore {
             materialized_entry,
             first_row::<PairingStateRow>(&response, "DataPlanePairingDesired")?,
         ) {
-            (Some(entry), Some(row)) => Some(data_plane_desired_from_pairing_row(
-                row,
-                &entry,
-                self.identity.did(),
-            )?),
+            (Some(entry), Some(row)) => {
+                data_plane_desired_from_pairing_row(row, &entry, self.identity.did())?
+            }
             _ => None,
         };
         Ok(merge_layered_desired(base, data_plane))
@@ -668,7 +669,10 @@ struct PeerIdRow {
     peer_id: String,
 }
 
-fn desired_from_pairing_row(row: PairingStateRow, local_did: &str) -> Result<PairingDesired> {
+fn desired_from_pairing_row(
+    row: PairingStateRow,
+    local_did: &str,
+) -> Result<Option<PairingDesired>> {
     let replicator_addresses = row
         .replicator_addresses
         .unwrap_or_default()
@@ -695,6 +699,19 @@ fn desired_from_pairing_row(row: PairingStateRow, local_did: &str) -> Result<Pai
         resolve_template(DEFAULT_PAIRING_TEMPLATE)
             .expect("default pairing template is in the catalog")
     });
+
+    // app-collections is a data-plane-only (bring-your-own) policy: a
+    // control-plane / PeerPairingDesired row cannot supply row collections, so
+    // it would resolve to empty wiring yet has_wiring() would be true (addresses
+    // present). Refuse to wire it. Soft-skip (Ok(None) + warn) so a raw-GraphQL
+    // row cannot install an empty-collection replicator.
+    if template.id == APP_COLLECTIONS_TEMPLATE {
+        tracing::warn!(
+            "PeerPairingDesired names the app-collections template, which is \
+             data-plane-only and supplies no collections here; skipping (no wiring)"
+        );
+        return Ok(None);
+    }
 
     // The scope filter value is the row's agent DID. For network-control rows
     // this is the remote member DID; for data-plane rows the loader first
@@ -726,20 +743,20 @@ fn desired_from_pairing_row(row: PairingStateRow, local_did: &str) -> Result<Pai
         Delivery::Replicate => replicator_collections.clone(),
     };
 
-    Ok(PairingDesired {
+    Ok(Some(PairingDesired {
         collections: subscription_collections,
         replicator_addresses,
         replicator_collections,
         replicator_filter,
         template_ids: BTreeSet::from([template.id.to_string()]),
-    })
+    }))
 }
 
 fn data_plane_desired_from_pairing_row(
     mut row: PairingStateRow,
     signed_endpoint: &NetworkEndpointEntry,
     self_did: &str,
-) -> Result<PairingDesired> {
+) -> Result<Option<PairingDesired>> {
     let row_addresses = row
         .replicator_addresses
         .as_ref()
@@ -810,21 +827,56 @@ fn data_plane_desired_from_pairing_row(
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
         .collect::<BTreeSet<_>>();
-    let replicator_collections = template
-        .collections
-        .iter()
-        .map(|&c| c.to_string())
-        .collect::<BTreeSet<_>>();
-    let replicator_filter =
-        data_plane_scope_filter(&template.scope, template.collections, peer_did, self_did);
 
-    Ok(PairingDesired {
-        collections: BTreeSet::new(),
+    // app-collections (bring-your-own): the row supplies the collection set; the
+    // template supplies only scope (Unscoped) + delivery (Replicate). A blank set
+    // is malformed input — SOFT-SKIP this layer (Ok(None) + warn) rather than
+    // bail, so a bad app row never fails the whole peer's desired load and stalls
+    // a co-existing control pairing (reconcile_peer_tick desired_read_failed).
+    let (replicator_collections, subscription_collections): (BTreeSet<String>, BTreeSet<String>) =
+        if template.id == APP_COLLECTIONS_TEMPLATE {
+            let row_cols = row
+                .collections
+                .unwrap_or_default()
+                .into_iter()
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .collect::<BTreeSet<_>>();
+            if row_cols.is_empty() {
+                tracing::warn!(
+                    peer_id = %signed_endpoint.peer_id,
+                    "app-collections DataPlanePairingDesired has no non-blank collections; \
+                     skipping this data-plane layer (control pairing unaffected)"
+                );
+                return Ok(None);
+            }
+            // Replicate: subscribe to the same set so the merged doc is observable.
+            (row_cols.clone(), row_cols)
+        } else {
+            // Legacy / template-driven data-plane rows: unchanged. Template
+            // collections drive the replicator; no subscription (push channel).
+            let cols = template
+                .collections
+                .iter()
+                .map(|&c| c.to_string())
+                .collect::<BTreeSet<_>>();
+            (cols, BTreeSet::new())
+        };
+
+    let filter_collections = replicator_collections
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let replicator_filter =
+        data_plane_scope_filter(&template.scope, &filter_collections, peer_did, self_did);
+
+    Ok(Some(PairingDesired {
+        collections: subscription_collections,
         replicator_addresses,
         replicator_collections,
         replicator_filter,
         template_ids: BTreeSet::from([template.id.to_string()]),
-    })
+    }))
 }
 
 fn scope_requires_peer_did(scope: &Scope) -> bool {
@@ -888,19 +940,25 @@ fn data_plane_scope_filter(
 /// Merge Layer-1 control-plane desired state with optional Layer-2 data-plane
 /// desired state for the same peer.
 ///
-/// Data-plane templates are delivered by filtered push replicators, so their
-/// collections extend only the per-peer replicator set. They must not extend the
-/// subscription set, otherwise conversation documents could gossip unfiltered.
+/// Most data-plane templates are delivered by filtered push replicators, so
+/// their collections extend only the per-peer replicator set — the subscription
+/// set is cleared so conversation data never gossips unfiltered. Exception:
+/// the `app-collections` (bring-your-own Unscoped/Replicate) policy preserves
+/// its subscription set so the merged doc is observable on both sides.
 pub fn merge_layered_desired(
     base: Option<PairingDesired>,
     data_plane: Option<PairingDesired>,
 ) -> Option<PairingDesired> {
     // Layer-2 desired rows add data-plane collections to the per-peer
-    // replicator, not to the subscription set. The subscription side must stay
-    // the Layer-1 network-control set so conversation data never gossips
+    // replicator, not to the subscription set — EXCEPT the app-collections
+    // (bring-your-own) policy, which is a whole-collection Replicate that must
+    // subscribe on both sides for the merged doc to be observable. All other
+    // data-plane layers keep the clear so conversation data never gossips
     // unfiltered.
     let data_plane = data_plane.map(|mut desired| {
-        desired.collections.clear();
+        if !desired.template_ids.contains(APP_COLLECTIONS_TEMPLATE) {
+            desired.collections.clear();
+        }
         desired
     });
     match (base, data_plane) {
@@ -1087,7 +1145,8 @@ mod tests {
             &signed_endpoint,
             "did:key:self",
         )
-        .expect("data-plane desired");
+        .expect("data-plane desired")
+        .expect("some data-plane layer");
 
         assert_eq!(
             desired.replicator_addresses,
@@ -1120,7 +1179,8 @@ mod tests {
             &signed_endpoint,
             "did:key:coord",
         )
-        .expect("data-plane coordinator desired");
+        .expect("data-plane coordinator desired")
+        .expect("some data-plane layer");
 
         assert_eq!(
             desired
@@ -1156,7 +1216,8 @@ mod tests {
             &signed_endpoint,
             "did:key:host",
         )
-        .expect("data-plane host desired");
+        .expect("data-plane host desired")
+        .expect("some data-plane layer");
 
         assert_eq!(desired.replicator_filter.len(), 8);
         for predicate in desired.replicator_filter.values() {
@@ -1844,7 +1905,8 @@ mod tests {
             desired_row(Some("conversation"), Some("did:key:bob")),
             "did:key:self",
         )
-        .expect("template resolves");
+        .expect("template resolves")
+        .expect("some desired layer");
 
         assert!(
             desired.collections.is_empty(),
@@ -1867,7 +1929,8 @@ mod tests {
             desired_row(Some("agent-config"), Some("did:key:bob")),
             "did:key:self",
         )
-        .expect("template resolves");
+        .expect("template resolves")
+        .expect("some desired layer");
 
         assert!(desired.collections.contains("AgentBehavior"));
         assert_eq!(desired.collections, desired.replicator_collections);
@@ -1883,7 +1946,8 @@ mod tests {
     fn missing_and_unknown_template_default_to_conversation() {
         let missing =
             desired_from_pairing_row(desired_row(None, Some("did:key:bob")), "did:key:self")
-                .expect("default resolves");
+                .expect("default resolves")
+                .expect("some desired layer");
         assert!(missing.collections.is_empty());
         assert!(missing.replicator_filter.contains_key("AgentRequest"));
 
@@ -1891,7 +1955,8 @@ mod tests {
             desired_row(Some("not-a-template"), Some("did:key:bob")),
             "did:key:self",
         )
-        .expect("default resolves");
+        .expect("default resolves")
+        .expect("some desired layer");
         assert_eq!(
             unknown.replicator_collections,
             missing.replicator_collections
@@ -1905,7 +1970,8 @@ mod tests {
             desired_row(Some("subagent-coordinator"), Some("did:key:host")),
             "did:key:coord",
         )
-        .expect("subagent coordinator template resolves");
+        .expect("subagent coordinator template resolves")
+        .expect("some desired layer");
 
         assert!(desired.collections.is_empty());
         assert_eq!(
@@ -1934,7 +2000,8 @@ mod tests {
             desired_row(Some("subagent-host"), Some("did:key:coord")),
             "did:key:host",
         )
-        .expect("subagent host template resolves");
+        .expect("subagent host template resolves")
+        .expect("some desired layer");
 
         assert!(desired.collections.is_empty());
         assert!(desired.replicator_collections.contains("AgentToolCall"));
@@ -1943,6 +2010,105 @@ mod tests {
             assert_eq!(predicate.field, "agent_did");
             assert_eq!(predicate.value, "did:key:host");
         }
+    }
+
+    #[test]
+    fn app_collections_on_control_plane_path_soft_skips() {
+        // A base/PeerPairingDesired row naming app-collections has no way to
+        // supply row collections; it must resolve to no wiring (soft-skip),
+        // never an empty-collection replicator.
+        let out = desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:peer".to_string()),
+                collections: None,
+                replicator_addresses: Some(vec!["addr-b".to_string()]),
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            "did:key:self",
+        )
+        .expect("resolve ok");
+        assert!(out.is_none(), "app-collections is invalid for a control-plane row");
+    }
+
+    #[test]
+    fn app_collections_row_resolves_row_collections_as_subscription_and_replicator() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let layer = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:self".to_string()),
+                collections: Some(vec!["ChangeProposed".to_string()]),
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect("resolve ok")
+        .expect("some layer");
+        assert!(layer.replicator_collections.contains("ChangeProposed"));
+        assert!(
+            layer.collections.contains("ChangeProposed"),
+            "app-collections must subscribe (Replicate)"
+        );
+        assert!(layer.replicator_filter.is_empty(), "unscoped => no filter");
+        assert!(layer.template_ids.contains("app-collections"));
+    }
+
+    #[test]
+    fn app_collections_empty_collections_soft_skips() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let out = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:self".to_string()),
+                collections: Some(vec!["   ".to_string()]),
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect("resolve ok (soft-skip is Ok(None), not Err)");
+        assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
+    }
+
+    /// Residual (documented, not softened in #657): a foreign `agent_did` on a
+    /// data-plane row still hard-fails the whole peer load (`desired_read_failed`),
+    /// including a co-existing control pairing. Security refusal, not soft-skip.
+    #[test]
+    fn foreign_agent_did_still_hard_fails_whole_peer_load() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let err = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:someone-else".to_string()),
+                collections: Some(vec!["ChangeProposed".to_string()]),
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect_err("foreign agent_did must hard-fail, not soft-skip");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("foreign") || msg.contains("someone-else") || msg.contains("refusing"),
+            "error should name the refusal: {msg}"
+        );
     }
 
     /// End-to-end reconcile of a `Push` (conversation) template: a filtered
@@ -1954,7 +2120,8 @@ mod tests {
                 desired_row(Some("conversation"), Some("did:key:bob")),
                 "did:key:self",
             )
-            .expect("template resolves"),
+            .expect("template resolves")
+            .expect("some desired layer"),
         ));
         let admin = MockAdmin::default();
 
@@ -1996,7 +2163,8 @@ mod tests {
                 desired_row(Some("agent-config"), Some("did:key:bob")),
                 "did:key:self",
             )
-            .expect("template resolves"),
+            .expect("template resolves")
+            .expect("some desired layer"),
         ));
         let admin = MockAdmin::default();
 
@@ -2038,7 +2206,8 @@ mod tests {
                 desired_row(Some("conversation"), Some("did:key:bob")),
                 "did:key:self",
             )
-            .expect("template resolves"),
+            .expect("template resolves")
+            .expect("some desired layer"),
         ));
         // Applied state: addr1 already installed under a DIFFERENT (alice) filter.
         let mut alice_filter = PairingFilters::default();

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -2028,7 +2028,10 @@ mod tests {
             "did:key:self",
         )
         .expect("resolve ok");
-        assert!(out.is_none(), "app-collections is invalid for a control-plane row");
+        assert!(
+            out.is_none(),
+            "app-collections is invalid for a control-plane row"
+        );
     }
 
     #[test]
@@ -2079,7 +2082,10 @@ mod tests {
             "did:key:self",
         )
         .expect("resolve ok (soft-skip is Ok(None), not Err)");
-        assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
+        assert!(
+            out.is_none(),
+            "empty/blank app-collections set must soft-skip to None"
+        );
     }
 
     /// Residual (documented, not softened in #657): a foreign `agent_did` on a

--- a/crates/defra-agent/src/agent/p2p_reconcile/templates.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/templates.rs
@@ -220,6 +220,7 @@ const SUBAGENT_HOST_RULES: &[CollectionRule] = &[
 pub const NETWORK_CONTROL_TEMPLATE: &str = "network-control";
 pub const SUBAGENT_COORDINATOR_TEMPLATE: &str = "subagent-coordinator";
 pub const SUBAGENT_HOST_TEMPLATE: &str = "subagent-host";
+pub const APP_COLLECTIONS_TEMPLATE: &str = "app-collections";
 
 static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
     ScopeTemplate {
@@ -263,6 +264,13 @@ static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
         collections: CONVERSATION_COLLECTIONS,
         scope: Scope::PerCollection(SUBAGENT_HOST_RULES),
         delivery: Delivery::Push,
+    },
+    ScopeTemplate {
+        id: APP_COLLECTIONS_TEMPLATE,
+        // Bring-your-own: the DataPlanePairingDesired row supplies the set.
+        collections: &[],
+        scope: Scope::Unscoped,
+        delivery: Delivery::Replicate,
     },
 ];
 
@@ -385,6 +393,15 @@ mod tests {
     #[test]
     fn all_builtin_templates_have_nonempty_collections() {
         for t in builtin_templates() {
+            // app-collections is the one bring-your-own template: its collection
+            // set is supplied by the DataPlanePairingDesired row, not the catalog.
+            if t.id == APP_COLLECTIONS_TEMPLATE {
+                assert!(
+                    t.collections.is_empty(),
+                    "app-collections must carry no fixed collections"
+                );
+                continue;
+            }
             assert!(
                 !t.collections.is_empty(),
                 "template {} has no collections",
@@ -394,8 +411,16 @@ mod tests {
     }
 
     #[test]
-    fn builtin_template_count_is_seven() {
-        assert_eq!(builtin_templates().len(), 7);
+    fn builtin_template_count_is_eight() {
+        assert_eq!(builtin_templates().len(), 8);
+    }
+
+    #[test]
+    fn app_collections_is_byo_unscoped_replicate() {
+        let t = resolve_template(APP_COLLECTIONS_TEMPLATE).unwrap();
+        assert_eq!(t.delivery, Delivery::Replicate);
+        assert!(matches!(t.scope, Scope::Unscoped));
+        assert!(t.collections.is_empty());
     }
 
     #[test]

--- a/crates/defra-agent/tests/conformance/pairing_reconcile.rs
+++ b/crates/defra-agent/tests/conformance/pairing_reconcile.rs
@@ -199,3 +199,75 @@ fn layered_desired_merge_absent_data_plane_preserves_control_only() {
 
     assert_eq!(merged, control);
 }
+
+/// Mirrors Lean `PairingReconcile.Layering.appCollections_subscription_survives`
+/// / `nonApp_none_base_no_subscription`: an `app-collections` data-plane layer's
+/// subscription set survives `merge_layered_desired`, so an `InstallCollection`
+/// op can reach the diff; a network-control-only data-plane layer's subscription
+/// is still cleared (conversation data must never gossip unfiltered).
+#[test]
+fn merge_preserves_app_collections_subscription_only() {
+    // app-collections data-plane layer: subscription set must survive.
+    let app_layer = PairingDesired {
+        collections: set(&["ChangeProposed"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["ChangeProposed"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["app-collections"]),
+    };
+    let merged = merge_layered_desired(None, Some(app_layer)).expect("merged");
+    assert!(
+        merged.collections.contains("ChangeProposed"),
+        "app-collections subscription must survive the merge: {merged:?}"
+    );
+
+    // network-control data-plane layer: subscription still cleared.
+    let nc_layer = PairingDesired {
+        collections: set(&["AgentRequest"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["AgentRequest"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["network-control"]),
+    };
+    let merged_nc = merge_layered_desired(None, Some(nc_layer)).expect("merged nc");
+    assert!(
+        merged_nc.collections.is_empty(),
+        "non-app-collections data-plane subscription must be cleared: {merged_nc:?}"
+    );
+}
+
+/// Spec conformance case (iii); mirrors Lean `PairingReconcile.Layering.base_preserved`:
+/// an app-collections data-plane layer merges with a co-existing control
+/// (network-control) base pairing without cross-contaminating their subscriptions
+/// or replicator filters — the control pairing is undisturbed.
+#[test]
+fn app_collections_coexists_with_control_pairing() {
+    let base = PairingDesired {
+        collections: set(&["AgentNetwork", "NetworkMembership"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["AgentNetwork", "NetworkMembership"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["network-control"]),
+    };
+    let app_layer = PairingDesired {
+        collections: set(&["ChangeProposed"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["ChangeProposed"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["app-collections"]),
+    };
+    let merged = merge_layered_desired(Some(base), Some(app_layer)).expect("merged");
+    // Control-plane subscriptions preserved AND the app-collections subscription added.
+    assert!(merged.collections.contains("AgentNetwork"));
+    assert!(merged.collections.contains("NetworkMembership"));
+    assert!(merged.collections.contains("ChangeProposed"));
+    // Both replicator collection sets present; no filter cross-contamination.
+    assert!(merged.replicator_collections.contains("AgentNetwork"));
+    assert!(merged.replicator_collections.contains("ChangeProposed"));
+    assert!(
+        merged.replicator_filter.is_empty(),
+        "both layers unscoped => no filter"
+    );
+    assert!(merged.template_ids.contains("network-control"));
+    assert!(merged.template_ids.contains("app-collections"));
+}

--- a/crates/defra-agent/tests/conformance/scope_templates.rs
+++ b/crates/defra-agent/tests/conformance/scope_templates.rs
@@ -143,6 +143,11 @@ fn app_collections_template_is_unscoped_replicate_byo() {
         "app-collections carries no fixed collections; the row supplies them"
     );
     // Unscoped yields no filters even over a supplied collection list.
-    let f = scope_filter(&t.scope, &["ChangeProposed"], "did:key:bob", "did:key:alice");
+    let f = scope_filter(
+        &t.scope,
+        &["ChangeProposed"],
+        "did:key:bob",
+        "did:key:alice",
+    );
     assert!(f.is_empty(), "unscoped app-collections must not filter");
 }

--- a/crates/defra-agent/tests/conformance/scope_templates.rs
+++ b/crates/defra-agent/tests/conformance/scope_templates.rs
@@ -127,3 +127,22 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
         );
     }
 }
+
+/// Mirrors Lean `appCollections_in_catalog` / `appCollections_collections_empty`
+/// / `appCollections_unscoped_no_filter`: the app-collections "bring-your-own"
+/// template resolves, is Unscoped + Replicate, and carries no fixed collections
+/// (the DataPlanePairingDesired row supplies them).
+#[test]
+fn app_collections_template_is_unscoped_replicate_byo() {
+    let t = resolve_template("app-collections").expect("app-collections in catalog");
+    assert_eq!(t.id, "app-collections");
+    assert!(matches!(t.delivery, Delivery::Replicate));
+    assert!(matches!(t.scope, Scope::Unscoped));
+    assert!(
+        t.collections.is_empty(),
+        "app-collections carries no fixed collections; the row supplies them"
+    );
+    // Unscoped yields no filters even over a supplied collection list.
+    let f = scope_filter(&t.scope, &["ChangeProposed"], "did:key:bob", "did:key:alice");
+    assert!(f.is_empty(), "unscoped app-collections must not filter");
+}

--- a/crates/defra-agent/tests/e2e_triggers.rs
+++ b/crates/defra-agent/tests/e2e_triggers.rs
@@ -5,12 +5,12 @@
 
 mod support;
 
+#[path = "e2e_triggers/app_collection_pairing_p2p_e2e.rs"]
+mod app_collection_pairing_p2p_e2e;
 #[path = "e2e_triggers/event_trigger_e2e.rs"]
 mod event_trigger_e2e;
 #[path = "e2e_triggers/event_trigger_p2p_e2e.rs"]
 mod event_trigger_p2p_e2e;
-#[path = "e2e_triggers/app_collection_pairing_p2p_e2e.rs"]
-mod app_collection_pairing_p2p_e2e;
 #[path = "e2e_triggers/trigger_engine_e2e.rs"]
 mod trigger_engine_e2e;
 #[path = "e2e_triggers/write_tool_trigger_e2e.rs"]

--- a/crates/defra-agent/tests/e2e_triggers.rs
+++ b/crates/defra-agent/tests/e2e_triggers.rs
@@ -9,6 +9,8 @@ mod support;
 mod event_trigger_e2e;
 #[path = "e2e_triggers/event_trigger_p2p_e2e.rs"]
 mod event_trigger_p2p_e2e;
+#[path = "e2e_triggers/app_collection_pairing_p2p_e2e.rs"]
+mod app_collection_pairing_p2p_e2e;
 #[path = "e2e_triggers/trigger_engine_e2e.rs"]
 mod trigger_engine_e2e;
 #[path = "e2e_triggers/write_tool_trigger_e2e.rs"]

--- a/crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
+++ b/crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
@@ -757,18 +757,12 @@ async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
     // Co-existing control pairing: network reconciler materializes PeerPairingDesired
     // (source=network, template=network-control) from the seeded membership docs.
     // Do NOT create_PeerPairingDesired ourselves — peer_id is unique and would conflict.
-    let control_a = wait_for_control_pairing_applied(
-        db_a.node.as_ref(),
-        &peer_b,
-        Duration::from_secs(60),
-    )
-    .await;
-    let control_b = wait_for_control_pairing_applied(
-        db_b.node.as_ref(),
-        &peer_a,
-        Duration::from_secs(60),
-    )
-    .await;
+    let control_a =
+        wait_for_control_pairing_applied(db_a.node.as_ref(), &peer_b, Duration::from_secs(60))
+            .await;
+    let control_b =
+        wait_for_control_pairing_applied(db_b.node.as_ref(), &peer_a, Duration::from_secs(60))
+            .await;
 
     // App-collections data-plane rows on both sides.
     write_app_collection_pairing(
@@ -822,8 +816,7 @@ async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
         );
     }
 
-    let source_doc_id =
-        write_change_proposed(db_a.node.as_ref(), EXTERNAL_ID, "signup").await;
+    let source_doc_id = write_change_proposed(db_a.node.as_ref(), EXTERNAL_ID, "signup").await;
 
     let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
     let requests = loop {
@@ -978,12 +971,9 @@ async fn empty_app_collection_row_does_not_stall_control_pairing() {
     .await;
 
     // Network reconciler installs control pairing from seeded membership.
-    let control = wait_for_control_pairing_applied(
-        db_a.node.as_ref(),
-        &peer_b,
-        Duration::from_secs(60),
-    )
-    .await;
+    let control =
+        wait_for_control_pairing_applied(db_a.node.as_ref(), &peer_b, Duration::from_secs(60))
+            .await;
     let before = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
         .await
         .expect("control applied");

--- a/crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
+++ b/crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
@@ -1,0 +1,1037 @@
+//! #657 — reconcile-driven app-collection replication fires an EventTrigger.
+//!
+//! Unlike `event_trigger_p2p_e2e` (manual `install_one_way_replicator`), this
+//! drives replication through `DataPlanePairingDesired` + the pairing
+//! reconciler. Both nodes run `DefraAgent::run`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use defra_agent::agent::p2p_reconcile::{GraphqlNetworkStore, NetworkStore};
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{AgentIdentity, DefraAgent, DocumentRuntimeOptions, ToolCeiling};
+use defra_agent_protocol::network_token::{
+    derive_membership_key, EndpointRecord, MembershipRecord, NetworkRecord,
+};
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::support::fixtures::{bind_default_behavior_backend, test_identity};
+use crate::support::mock_endpoint::MockModelEndpoint;
+use crate::support::snapshots::{fetch_runtime_snapshot, RuntimeSnapshot};
+use crate::support::test_p2p_db;
+
+const TRIGGER_ID: &str = "trigger-app-collection-pairing";
+const TASK_ID: &str = "task-app-collection-pairing";
+const EXTERNAL_ID: &str = "change-app-1";
+const PROMPT_TEMPLATE: &str = "fired for {{ doc.external_id }}";
+const NETWORK_ID: &str = "net-app-collection-pairing";
+const NETWORK_NAME: &str = "App Collection Pairing Net";
+
+fn bs58_sig(sig: &[u8]) -> String {
+    bs58::encode(sig).into_string()
+}
+
+async fn register_change_proposed_schema(node: &EmbeddedNode) {
+    // @branchable is REQUIRED — DefraDB only P2P-syncs branchable collections.
+    let sdl = r#"
+        type ChangeProposed @branchable {
+            external_id: String
+            payload: String
+            kind: String @index
+        }
+    "#;
+    node.add_schema(sdl)
+        .await
+        .expect("add_schema ChangeProposed");
+}
+
+/// Write the signed AgentNetwork + active NetworkMembership + fresh PeerEndpoint
+/// documents on `node` so `GraphqlNetworkStore::load_materializable_entries`
+/// materializes `member_identity`'s endpoint.
+async fn seed_materializable_peer(
+    node: &EmbeddedNode,
+    network_id: &str,
+    admin_identity: &dyn AgentIdentity,
+    member_identity: &dyn AgentIdentity,
+    member_node_id: &str,
+    member_address: &str,
+) {
+    let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+
+    let mut network = NetworkRecord {
+        network_id: network_id.to_string(),
+        admin_did: admin_identity.did().to_string(),
+        display_name: NETWORK_NAME.to_string(),
+        default_template: "network-control".to_string(),
+        created_at: now.clone(),
+        sig: Vec::new(),
+    };
+    network.sig = admin_identity
+        .sign(&network.signing_payload())
+        .await
+        .expect("sign AgentNetwork");
+
+    let mut membership = MembershipRecord {
+        network_id: network_id.to_string(),
+        member_did: member_identity.did().to_string(),
+        status: "active".to_string(),
+        granted_at: now.clone(),
+        revoked_at: String::new(),
+        sig: Vec::new(),
+    };
+    membership.sig = admin_identity
+        .sign(&membership.signing_payload())
+        .await
+        .expect("sign NetworkMembership");
+
+    let mut endpoint = EndpointRecord {
+        did: member_identity.did().to_string(),
+        node_id: member_node_id.to_string(),
+        address: member_address.to_string(),
+        updated_at: now.clone(),
+        sig: Vec::new(),
+    };
+    endpoint.sig = member_identity
+        .sign(&endpoint.signing_payload())
+        .await
+        .expect("sign PeerEndpoint");
+
+    let network_id_g = escape_graphql_string(&network.network_id);
+    let admin_did = escape_graphql_string(&network.admin_did);
+    let display_name = escape_graphql_string(&network.display_name);
+    let default_template = escape_graphql_string(&network.default_template);
+    let created_at = escape_graphql_string(&network.created_at);
+    let admin_sig = escape_graphql_string(&bs58_sig(&network.sig));
+    let network_mutation = format!(
+        r#"mutation {{
+            upsert_AgentNetwork(
+                filter: {{ network_id: {{ _eq: "{network_id_g}" }} }},
+                add: {{
+                    network_id: "{network_id_g}",
+                    admin_did: "{admin_did}",
+                    display_name: "{display_name}",
+                    default_template: "{default_template}",
+                    created_at: "{created_at}",
+                    admin_sig: "{admin_sig}"
+                }},
+                update: {{
+                    admin_did: "{admin_did}",
+                    display_name: "{display_name}",
+                    default_template: "{default_template}",
+                    created_at: "{created_at}",
+                    admin_sig: "{admin_sig}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&network_mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "upsert AgentNetwork failed: {:?}",
+        resp.errors
+    );
+
+    let membership_key = escape_graphql_string(&derive_membership_key(
+        &membership.network_id,
+        &membership.member_did,
+    ));
+    let member_did = escape_graphql_string(&membership.member_did);
+    let status = escape_graphql_string(&membership.status);
+    let granted_at = escape_graphql_string(&membership.granted_at);
+    let revoked_at = escape_graphql_string(&membership.revoked_at);
+    let mem_sig = escape_graphql_string(&bs58_sig(&membership.sig));
+    let mem_mutation = format!(
+        r#"mutation {{
+            upsert_NetworkMembership(
+                filter: {{ membership_key: {{ _eq: "{membership_key}" }} }},
+                add: {{
+                    membership_key: "{membership_key}",
+                    network_id: "{network_id_g}",
+                    member_did: "{member_did}",
+                    status: "{status}",
+                    granted_at: "{granted_at}",
+                    revoked_at: "{revoked_at}",
+                    admin_sig: "{mem_sig}"
+                }},
+                update: {{
+                    network_id: "{network_id_g}",
+                    member_did: "{member_did}",
+                    status: "{status}",
+                    granted_at: "{granted_at}",
+                    revoked_at: "{revoked_at}",
+                    admin_sig: "{mem_sig}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mem_mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "upsert NetworkMembership failed: {:?}",
+        resp.errors
+    );
+
+    let did = escape_graphql_string(&endpoint.did);
+    let node_id = escape_graphql_string(&endpoint.node_id);
+    let address = escape_graphql_string(&endpoint.address);
+    let updated_at = escape_graphql_string(&endpoint.updated_at);
+    let binding_sig = escape_graphql_string(&bs58_sig(&endpoint.sig));
+    let ep_mutation = format!(
+        r#"mutation {{
+            upsert_PeerEndpoint(
+                filter: {{ did: {{ _eq: "{did}" }} }},
+                add: {{
+                    did: "{did}",
+                    node_id: "{node_id}",
+                    address: "{address}",
+                    updated_at: "{updated_at}",
+                    binding_sig: "{binding_sig}"
+                }},
+                update: {{
+                    node_id: "{node_id}",
+                    address: "{address}",
+                    updated_at: "{updated_at}",
+                    binding_sig: "{binding_sig}"
+                }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&ep_mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "upsert PeerEndpoint failed: {:?}",
+        resp.errors
+    );
+}
+
+async fn wait_for_peer_identity(node: &EmbeddedNode) -> (String, String) {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let p2p = node.p2p().expect("p2p enabled");
+        let peer_id = p2p.local_peer_id().await.ok();
+        let shareable = p2p.shareable_address().await.ok().flatten();
+        if let (Some(peer_id), Some(address)) = (peer_id, shareable) {
+            if !peer_id.trim().is_empty() && !address.trim().is_empty() {
+                return (peer_id, address);
+            }
+        }
+        // Fallback: listen address + parse peer id from the multiaddr tail.
+        if let Ok(addrs) = p2p.listen_addresses().await {
+            if let Some(addr) = addrs.first() {
+                if let Some(peer_id) = addr.rsplit("/p2p/").nth(1) {
+                    if !peer_id.is_empty() {
+                        return (peer_id.to_string(), addr.clone());
+                    }
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!("node never exposed a P2P peer identity");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn create_task(node: &EmbeddedNode, task_id: &str, behavior_id: &str, prompt_template: &str) {
+    let escaped_task_id = escape_graphql_string(task_id);
+    let escaped_behavior_id = escape_graphql_string(behavior_id);
+    let escaped_prompt_template = escape_graphql_string(prompt_template);
+    let mutation = format!(
+        r#"mutation {{
+            create_Task(input: {{
+                task_id: "{escaped_task_id}",
+                name: "{escaped_task_id}",
+                behavior_id: "{escaped_behavior_id}",
+                prompt_template: "{escaped_prompt_template}",
+                enabled: true
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create Task failed: {:?}",
+        response.errors
+    );
+}
+
+async fn create_event_trigger_with_filter(
+    node: &EmbeddedNode,
+    trigger_id: &str,
+    task_id: &str,
+    source_collection: &str,
+    event_kind: &str,
+    filter: &str,
+) {
+    let escaped_trigger_id = escape_graphql_string(trigger_id);
+    let escaped_task_id = escape_graphql_string(task_id);
+    let escaped_source_collection = escape_graphql_string(source_collection);
+    let escaped_event_kind = escape_graphql_string(event_kind);
+    let escaped_filter = escape_graphql_string(filter);
+    let mutation = format!(
+        r#"mutation {{
+            create_EventTrigger(input: {{
+                trigger_id: "{escaped_trigger_id}",
+                task_id: "{escaped_task_id}",
+                source_collection: "{escaped_source_collection}",
+                event_kind: "{escaped_event_kind}",
+                filter: "{escaped_filter}",
+                enabled: true,
+                concurrency: "serial",
+                fire_count: 0
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create EventTrigger failed: {:?}",
+        response.errors
+    );
+}
+
+async fn wait_for_runtime_snapshot<F>(
+    node: &EmbeddedNode,
+    agent_did: &str,
+    predicate: F,
+) -> RuntimeSnapshot
+where
+    F: Fn(&RuntimeSnapshot) -> bool,
+{
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Some(snapshot) = fetch_runtime_snapshot(node, agent_did).await {
+            if predicate(&snapshot) {
+                return snapshot;
+            }
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for runtime snapshot for {agent_did}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+/// Write a DataPlanePairingDesired row via desired-state config (NOT add_replicator).
+async fn write_app_collection_pairing(
+    node: &EmbeddedNode,
+    peer_id: &str,
+    self_did: &str,
+    address: &str,
+    collections: &[&str],
+) {
+    assert!(
+        collections.iter().any(|c| !c.trim().is_empty()),
+        "write_app_collection_pairing is happy-path only; pass a non-empty collection set"
+    );
+    let peer = escape_graphql_string(peer_id);
+    let did = escape_graphql_string(self_did);
+    let addr = escape_graphql_string(address);
+    let cols = collections
+        .iter()
+        .map(|c| format!(r#""{}""#, escape_graphql_string(c)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            create_DataPlanePairingDesired(input: {{
+                peer_id: "{peer}", agent_did: "{did}",
+                collections: [{cols}], replicator_addresses: ["{addr}"],
+                template: "app-collections", created_at: "{now}", updated_at: "{now}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create DataPlanePairingDesired: {:?}",
+        resp.errors
+    );
+}
+
+async fn fetch_pairing_applied(
+    node: &EmbeddedNode,
+    peer_id: &str,
+) -> Option<(Vec<String>, Vec<String>)> {
+    let escaped = escape_graphql_string(peer_id);
+    let query = format!(
+        r#"{{
+            PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{
+                peer_id
+                collections
+                replicator_addresses
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    if response.has_errors() {
+        return None;
+    }
+    let row = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("PeerPairingApplied"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()?;
+    let collections = row
+        .get("collections")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    let addresses = row
+        .get("replicator_addresses")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    Some((collections, addresses))
+}
+
+async fn wait_for_app_collections_pairing_applied(
+    node: &EmbeddedNode,
+    peer_id: &str,
+    expected_collection: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    let mut last = String::from("<none>");
+    loop {
+        if let Some((collections, addresses)) = fetch_pairing_applied(node, peer_id).await {
+            last = format!("collections={collections:?} addresses={addresses:?}");
+            let has_addr = addresses.iter().any(|a| !a.trim().is_empty());
+            let has_col = collections.iter().any(|c| c == expected_collection);
+            if has_addr && has_col {
+                return;
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for PeerPairingApplied({peer_id}) to install \
+                 {expected_collection}; last={last}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+async fn wait_for_control_pairing_applied(
+    node: &EmbeddedNode,
+    peer_id: &str,
+    timeout: Duration,
+) -> Vec<String> {
+    let deadline = Instant::now() + timeout;
+    let mut last = String::from("<none>");
+    loop {
+        if let Some((collections, addresses)) = fetch_pairing_applied(node, peer_id).await {
+            last = format!("collections={collections:?} addresses={addresses:?}");
+            let has_addr = addresses.iter().any(|a| !a.trim().is_empty());
+            let has_control = collections.iter().any(|c| c == "AgentNetwork");
+            if has_addr && has_control {
+                return collections;
+            }
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "timed out waiting for network-control PeerPairingApplied({peer_id}); last={last}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AgentRequestRow {
+    #[serde(rename = "_docID")]
+    _doc_id: String,
+    request_id: String,
+    content: String,
+    caused_by_trigger_id: Option<String>,
+    caused_by_trigger_kind: Option<String>,
+    execution_origin: Option<String>,
+}
+
+async fn query_agent_requests_for_trigger(
+    node: &EmbeddedNode,
+    trigger_id: &str,
+) -> Vec<AgentRequestRow> {
+    let escaped_trigger_id = escape_graphql_string(trigger_id);
+    let query = format!(
+        r#"{{
+            AgentRequest(
+                filter: {{ caused_by_trigger_id: {{ _eq: "{escaped_trigger_id}" }} }}
+            ) {{
+                _docID
+                request_id
+                content
+                caused_by_trigger_id
+                caused_by_trigger_kind
+                execution_origin
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "AgentRequest query failed: {:?}",
+        response.errors
+    );
+    let rows = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRequest"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    rows.into_iter()
+        .map(|row| serde_json::from_value(row).expect("decode AgentRequest row"))
+        .collect()
+}
+
+#[derive(Debug, Deserialize)]
+struct EventTriggerRow {
+    fire_count: Option<i64>,
+    last_status: Option<String>,
+    last_fired_source_doc_id: Option<String>,
+    last_error: Option<String>,
+    task_id: Option<String>,
+    source_collection: Option<String>,
+    event_kind: Option<String>,
+    enabled: Option<bool>,
+    concurrency: Option<String>,
+}
+
+async fn fetch_event_trigger(node: &EmbeddedNode, trigger_id: &str) -> EventTriggerRow {
+    let escaped_trigger_id = escape_graphql_string(trigger_id);
+    let query = format!(
+        r#"{{
+            EventTrigger(
+                filter: {{ trigger_id: {{ _eq: "{escaped_trigger_id}" }} }},
+                limit: 1
+            ) {{
+                fire_count
+                last_status
+                last_fired_source_doc_id
+                last_error
+                task_id
+                source_collection
+                event_kind
+                enabled
+                concurrency
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "EventTrigger query failed: {:?}",
+        response.errors
+    );
+    let row = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("EventTrigger"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("EventTrigger row missing");
+    serde_json::from_value(row).expect("decode EventTrigger row")
+}
+
+async fn write_change_proposed(node: &EmbeddedNode, external_id: &str, kind: &str) -> String {
+    let escaped_external_id = escape_graphql_string(external_id);
+    let escaped_kind = escape_graphql_string(kind);
+    let mutation = format!(
+        r#"mutation {{
+            add_ChangeProposed(input: {{
+                external_id: "{escaped_external_id}",
+                payload: "{{}}",
+                kind: "{escaped_kind}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "add_ChangeProposed failed: {:?}",
+        response.errors
+    );
+    let data = response
+        .data
+        .as_ref()
+        .expect("add_ChangeProposed response missing data");
+    let field = data
+        .get("add_ChangeProposed")
+        .or_else(|| data.get("create_ChangeProposed"))
+        .unwrap_or_else(|| panic!("add_/create_ChangeProposed key missing; data={data:?}"));
+    field
+        .get("_docID")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            field
+                .as_array()
+                .and_then(|rows| rows.first())
+                .and_then(|row| row.get("_docID"))
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned)
+        })
+        .unwrap_or_else(|| panic!("ChangeProposed mutation returned no _docID: {field}"))
+}
+
+async fn query_change_proposed(node: &EmbeddedNode) -> Vec<Value> {
+    let response = node
+        .execute(r#"{ ChangeProposed { external_id kind } }"#)
+        .await;
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("ChangeProposed"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn seed_makes_peer_materializable() {
+    let db = test_p2p_db("app-collection-seed").await;
+    let admin = test_identity("app-collection-seed-admin");
+    let member = test_identity("app-collection-seed-member");
+    seed_materializable_peer(
+        db.node.as_ref(),
+        "net-test",
+        &admin,
+        &member,
+        "peer-node",
+        "/ip4/127.0.0.1/tcp/9/p2p/peer-node",
+    )
+    .await;
+    let store = GraphqlNetworkStore::new(db.node.clone(), Arc::new(admin));
+    let entries = store
+        .load_materializable_entries()
+        .await
+        .expect("load materializable");
+    assert!(
+        entries.iter().any(|e| e.peer_id == "peer-node"),
+        "seeded peer must be materializable: {entries:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
+    // Compress pairing sweeps for this process (read once at daemon start).
+    std::env::set_var("DEFRA_AGENT_PAIRING_SWEEP_MS", "1000");
+
+    let db_a = test_p2p_db("app-collection-pairing-a").await;
+    let db_b = test_p2p_db("app-collection-pairing-b").await;
+    register_change_proposed_schema(db_a.node.as_ref()).await;
+    register_change_proposed_schema(db_b.node.as_ref()).await;
+
+    let identity_a: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-agent-a"));
+    let identity_b: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-agent-b"));
+    let admin: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-admin"));
+    let did_a = identity_a.did().to_string();
+    let did_b = identity_b.did().to_string();
+
+    let mock_a = MockModelEndpoint::start("default").unwrap();
+    let mock_b = MockModelEndpoint::start("default").unwrap();
+    bind_default_behavior_backend(
+        db_a.node.as_ref(),
+        &did_a,
+        "backend-app-collection-a",
+        mock_a.endpoint(),
+    )
+    .await;
+    bind_default_behavior_backend(
+        db_b.node.as_ref(),
+        &did_b,
+        "backend-app-collection-b",
+        mock_b.endpoint(),
+    )
+    .await;
+
+    let agent_a = DefraAgent::from_default_behavior_documents(
+        db_a.node.clone(),
+        identity_a.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let agent_b = DefraAgent::from_default_behavior_documents(
+        db_b.node.clone(),
+        identity_b.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let default_behavior_b = agent_b.default_behavior_id().to_string();
+    let (shutdown_a_tx, shutdown_a_rx) = tokio::sync::watch::channel(false);
+    let (shutdown_b_tx, shutdown_b_rx) = tokio::sync::watch::channel(false);
+    let handle_a = tokio::spawn(agent_a.run(shutdown_a_rx));
+    let handle_b = tokio::spawn(agent_b.run(shutdown_b_rx));
+
+    let (peer_a, addr_a) = wait_for_peer_identity(db_a.node.as_ref()).await;
+    let (peer_b, addr_b) = wait_for_peer_identity(db_b.node.as_ref()).await;
+
+    // Seed membership docs locally on both nodes (no chicken-and-egg with P2P).
+    seed_materializable_peer(
+        db_a.node.as_ref(),
+        NETWORK_ID,
+        admin.as_ref(),
+        identity_b.as_ref(),
+        &peer_b,
+        &addr_b,
+    )
+    .await;
+    seed_materializable_peer(
+        db_b.node.as_ref(),
+        NETWORK_ID,
+        admin.as_ref(),
+        identity_a.as_ref(),
+        &peer_a,
+        &addr_a,
+    )
+    .await;
+
+    let store_a = GraphqlNetworkStore::new(db_a.node.clone(), admin.clone());
+    let store_b = GraphqlNetworkStore::new(db_b.node.clone(), admin.clone());
+    let entries_a = store_a.load_materializable_entries().await.unwrap();
+    let entries_b = store_b.load_materializable_entries().await.unwrap();
+    assert!(
+        entries_a.iter().any(|e| e.peer_id == peer_b),
+        "A must materialize B: {entries_a:?}"
+    );
+    assert!(
+        entries_b.iter().any(|e| e.peer_id == peer_a),
+        "B must materialize A: {entries_b:?}"
+    );
+
+    // B: document reconcile for Task + EventTrigger (ordering invariant).
+    let startup = wait_for_runtime_snapshot(db_b.node.as_ref(), &did_b, |s| {
+        s.process_state == "ready" && s.reconcile_phase == "idle" && s.active_generation >= 1
+    })
+    .await;
+    let initial_generation = startup.active_generation;
+
+    create_task(
+        db_b.node.as_ref(),
+        TASK_ID,
+        &default_behavior_b,
+        PROMPT_TEMPLATE,
+    )
+    .await;
+    create_event_trigger_with_filter(
+        db_b.node.as_ref(),
+        TRIGGER_ID,
+        TASK_ID,
+        "ChangeProposed",
+        "created",
+        r#"{ kind: { _eq: "signup" } }"#,
+    )
+    .await;
+    wait_for_runtime_snapshot(db_b.node.as_ref(), &did_b, |s| {
+        s.process_state == "ready"
+            && s.reconcile_phase == "idle"
+            && s.active_generation > initial_generation
+            && s.last_reconcile_result == "applied"
+    })
+    .await;
+
+    // Co-existing control pairing: network reconciler materializes PeerPairingDesired
+    // (source=network, template=network-control) from the seeded membership docs.
+    // Do NOT create_PeerPairingDesired ourselves — peer_id is unique and would conflict.
+    let control_a = wait_for_control_pairing_applied(
+        db_a.node.as_ref(),
+        &peer_b,
+        Duration::from_secs(60),
+    )
+    .await;
+    let control_b = wait_for_control_pairing_applied(
+        db_b.node.as_ref(),
+        &peer_a,
+        Duration::from_secs(60),
+    )
+    .await;
+
+    // App-collections data-plane rows on both sides.
+    write_app_collection_pairing(
+        db_a.node.as_ref(),
+        &peer_b,
+        &did_a,
+        &addr_b,
+        &["ChangeProposed"],
+    )
+    .await;
+    write_app_collection_pairing(
+        db_b.node.as_ref(),
+        &peer_a,
+        &did_b,
+        &addr_a,
+        &["ChangeProposed"],
+    )
+    .await;
+    wait_for_app_collections_pairing_applied(
+        db_a.node.as_ref(),
+        &peer_b,
+        "ChangeProposed",
+        Duration::from_secs(45),
+    )
+    .await;
+    wait_for_app_collections_pairing_applied(
+        db_b.node.as_ref(),
+        &peer_a,
+        "ChangeProposed",
+        Duration::from_secs(45),
+    )
+    .await;
+
+    // Control collections still present after app-collections merge.
+    let (applied_a, _) = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
+        .await
+        .expect("applied on A");
+    for col in &control_a {
+        assert!(
+            applied_a.contains(col),
+            "control collection {col} missing after app-collections merge: {applied_a:?}"
+        );
+    }
+    let (applied_b, _) = fetch_pairing_applied(db_b.node.as_ref(), &peer_a)
+        .await
+        .expect("applied on B");
+    for col in &control_b {
+        assert!(
+            applied_b.contains(col),
+            "control collection {col} missing after app-collections merge: {applied_b:?}"
+        );
+    }
+
+    let source_doc_id =
+        write_change_proposed(db_a.node.as_ref(), EXTERNAL_ID, "signup").await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+    let requests = loop {
+        let rows = query_agent_requests_for_trigger(db_b.node.as_ref(), TRIGGER_ID).await;
+        if !rows.is_empty() {
+            break rows;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let on_b = query_change_proposed(db_b.node.as_ref()).await;
+            let on_a = query_change_proposed(db_a.node.as_ref()).await;
+            panic!(
+                "timed out: P2P-replicated ChangeProposed did not fire B's trigger \
+                 (source_doc_id={source_doc_id}).\n\
+                 DIAGNOSTIC: ChangeProposed on A={on_a:?}\n\
+                 DIAGNOSTIC: ChangeProposed on B={on_b:?}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    };
+    assert_eq!(
+        requests.len(),
+        1,
+        "expected exactly one AgentRequest, got {}: {:?}",
+        requests.len(),
+        requests
+    );
+    let request = &requests[0];
+    assert_eq!(request.caused_by_trigger_id.as_deref(), Some(TRIGGER_ID));
+    assert_eq!(request.caused_by_trigger_kind.as_deref(), Some("event"));
+    assert_eq!(request.execution_origin.as_deref(), Some("scheduled"));
+    assert_eq!(request.content, format!("fired for {EXTERNAL_ID}"));
+    assert!(!request.request_id.is_empty());
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    let fired = loop {
+        let row = fetch_event_trigger(db_b.node.as_ref(), TRIGGER_ID).await;
+        if row.last_status.as_deref() == Some("fired") {
+            break row;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for EventTrigger.last_status=\"fired\" (last row: {row:?})"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    assert_eq!(fired.fire_count, Some(1));
+    assert_eq!(
+        fired.last_fired_source_doc_id.as_deref(),
+        Some(source_doc_id.as_str())
+    );
+    assert!(fired.last_error.as_deref().unwrap_or("").is_empty());
+    assert_eq!(fired.task_id.as_deref(), Some(TASK_ID));
+    assert_eq!(fired.source_collection.as_deref(), Some("ChangeProposed"));
+    assert_eq!(fired.event_kind.as_deref(), Some("created"));
+    assert_eq!(fired.enabled, Some(true));
+    assert_eq!(fired.concurrency.as_deref(), Some("serial"));
+
+    // Idempotence: applied state stable across another sweep window.
+    let post = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
+        .await
+        .expect("post applied");
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let post2 = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
+        .await
+        .expect("post2 applied");
+    assert_eq!(post, post2, "pairing applied should be stable (idempotent)");
+    for col in &control_a {
+        assert!(post2.0.contains(col), "control still present: {post2:?}");
+    }
+
+    let _ = shutdown_a_tx.send(true);
+    let _ = shutdown_b_tx.send(true);
+    handle_a.await.unwrap().unwrap();
+    handle_b.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_app_collection_row_does_not_stall_control_pairing() {
+    std::env::set_var("DEFRA_AGENT_PAIRING_SWEEP_MS", "1000");
+
+    let db_a = test_p2p_db("app-collection-soft-skip-a").await;
+    let db_b = test_p2p_db("app-collection-soft-skip-b").await;
+
+    let identity_a: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-soft-a"));
+    let identity_b: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-soft-b"));
+    let admin: Arc<dyn AgentIdentity> = Arc::new(test_identity("app-collection-soft-admin"));
+    let did_a = identity_a.did().to_string();
+    let did_b = identity_b.did().to_string();
+
+    let mock_a = MockModelEndpoint::start("default").unwrap();
+    let mock_b = MockModelEndpoint::start("default").unwrap();
+    bind_default_behavior_backend(
+        db_a.node.as_ref(),
+        &did_a,
+        "backend-soft-a",
+        mock_a.endpoint(),
+    )
+    .await;
+    bind_default_behavior_backend(
+        db_b.node.as_ref(),
+        &did_b,
+        "backend-soft-b",
+        mock_b.endpoint(),
+    )
+    .await;
+
+    let agent_a = DefraAgent::from_default_behavior_documents(
+        db_a.node.clone(),
+        identity_a.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let agent_b = DefraAgent::from_default_behavior_documents(
+        db_b.node.clone(),
+        identity_b.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let (shutdown_a_tx, shutdown_a_rx) = tokio::sync::watch::channel(false);
+    let (shutdown_b_tx, shutdown_b_rx) = tokio::sync::watch::channel(false);
+    let handle_a = tokio::spawn(agent_a.run(shutdown_a_rx));
+    let handle_b = tokio::spawn(agent_b.run(shutdown_b_rx));
+
+    let (peer_a, addr_a) = wait_for_peer_identity(db_a.node.as_ref()).await;
+    let (peer_b, addr_b) = wait_for_peer_identity(db_b.node.as_ref()).await;
+
+    seed_materializable_peer(
+        db_a.node.as_ref(),
+        "net-soft-skip",
+        admin.as_ref(),
+        identity_b.as_ref(),
+        &peer_b,
+        &addr_b,
+    )
+    .await;
+    seed_materializable_peer(
+        db_b.node.as_ref(),
+        "net-soft-skip",
+        admin.as_ref(),
+        identity_a.as_ref(),
+        &peer_a,
+        &addr_a,
+    )
+    .await;
+
+    // Network reconciler installs control pairing from seeded membership.
+    let control = wait_for_control_pairing_applied(
+        db_a.node.as_ref(),
+        &peer_b,
+        Duration::from_secs(60),
+    )
+    .await;
+    let before = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
+        .await
+        .expect("control applied");
+
+    // Blank-only collections: schema allows [String!]!, resolver soft-skips.
+    let peer = escape_graphql_string(&peer_b);
+    let did = escape_graphql_string(&did_a);
+    let addr = escape_graphql_string(&addr_b);
+    let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    let mutation = format!(
+        r#"mutation {{
+            create_DataPlanePairingDesired(input: {{
+                peer_id: "{peer}", agent_did: "{did}",
+                collections: ["   "], replicator_addresses: ["{addr}"],
+                template: "app-collections", created_at: "{now}", updated_at: "{now}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let resp = db_a.node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create blank DataPlanePairingDesired: {:?}",
+        resp.errors
+    );
+
+    // Wait at least one sweep for the soft-skip path to run.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
+    let after = fetch_pairing_applied(db_a.node.as_ref(), &peer_b)
+        .await
+        .expect("control applied after soft-skip");
+    for col in &control {
+        assert!(
+            after.0.contains(col),
+            "control collection {col} lost after blank app-collections row: before={before:?} after={after:?}"
+        );
+    }
+    assert!(
+        !after.0.iter().any(|c| c == "ChangeProposed"),
+        "blank app-collections must not install ChangeProposed: {after:?}"
+    );
+    assert_eq!(
+        before.1, after.1,
+        "control replicator addresses should be unchanged"
+    );
+
+    let _ = shutdown_a_tx.send(true);
+    let _ = shutdown_b_tx.send(true);
+    handle_a.await.unwrap().unwrap();
+    handle_b.await.unwrap().unwrap();
+}

--- a/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
+++ b/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
@@ -36,8 +36,9 @@
 - `crates/defra-agent/src/agent/p2p_reconcile/engine.rs` — `load_desired` query; `data_plane_desired_from_pairing_row` (honor row collections, soft-skip, `Result<Option<..>>`); `desired_from_pairing_row` (reject app-collections, `Result<Option<..>>`); `merge_layered_desired` conditional subscription preservation; **plus its in-crate `#[cfg(test)] mod tests`** — new app-collections resolver/soft-skip/reject tests AND updates to the existing resolver call sites that the signature change breaks (Tasks 4–7).
 - `crates/defra-agent/tests/conformance/pairing_reconcile.rs` — merge subscription-preservation conformance only (Task 5, via the public `merge_layered_desired`). Resolution / soft-skip / reject tests are in-crate in engine.rs (Tasks 6–7), not here.
 - `crates/defra-agent-cli/src/commands/p2p/pairings.rs` — reject `app-collections` on generic pairing path (Task 8).
+- `crates/defra-agent-cli/src/commands/demo/fleet.rs` — reject `app-collections` in `data_plane_collections_literal` so fleet never expands to `[]` / silent soft-skip (Task 8b).
 - `crates/defra-agent/tests/e2e_triggers.rs` — the harness root (a file, not `mod.rs`); add `mod app_collection_pairing_p2p_e2e;` next to `mod event_trigger_p2p_e2e;` (line ~11) (Task 9).
-- `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs` — membership-materialization harness + acceptance e2e (Tasks 9–10).
+- `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs` — membership-materialization harness + acceptance e2e (Tasks 9–10). Wait pairing readiness on `PeerPairingApplied`, not RuntimeSnapshot.
 
 ---
 
@@ -163,7 +164,9 @@ def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer
   | some b, some d =>
       some { subscriptions := b.subscriptions ∪ d.subscriptions
            , replicatorCollections := b.replicatorCollections ∪ d.replicatorCollections
-           , isAppCollections := b.isAppCollections }
+           -- OR so a later re-use of the result as a data-plane input still
+           -- remembers that an app-collections layer contributed.
+           , isAppCollections := b.isAppCollections || d.isAppCollections }
 
 /-- An app-collections data-plane layer's subscriptions survive the merge, so an
 `InstallCollection` op can reach the diff. -/
@@ -201,6 +204,8 @@ theorem base_preserved
   cases dp with
   | none => simp [mergeLayered] at hm; subst hm; exact ⟨subset_rfl, subset_rfl⟩
   | some d =>
+      -- After clampDataPlane the merged record still supersets the base,
+      -- regardless of d.isAppCollections (and regardless of the OR on the flag).
       simp [mergeLayered, clampDataPlane] at hm
       subst hm
       exact ⟨Finset.subset_union_left, Finset.subset_union_left⟩
@@ -499,9 +504,25 @@ If `merge_layered_desired` or `PairingDesired` are not already `pub` at those pa
 Run: `cargo test -p defra-agent --test conformance merge_preserves_app_collections_subscription_only`
 Expected: FAIL — the current blanket `desired.collections.clear()` empties the app-collections subscription, so `merged.collections.contains("ChangeProposed")` is false.
 
-- [ ] **Step 3: Make the clear conditional**
+- [ ] **Step 3: Make the clear conditional + rewrite the function doc comment**
 
-Replace the unconditional clear (lines 902-905) with:
+First, rewrite the doc comment above `merge_layered_desired` (currently lines
+888-893: "Data-plane templates are delivered by filtered push… must not extend
+the subscription set"). That blanket claim becomes wrong once app-collections
+is allowed to subscribe. Replace it with:
+
+```rust
+/// Merge Layer-1 control-plane desired state with optional Layer-2 data-plane
+/// desired state for the same peer.
+///
+/// Most data-plane templates are delivered by filtered push replicators, so
+/// their collections extend only the per-peer replicator set — the subscription
+/// set is cleared so conversation data never gossips unfiltered. Exception:
+/// the `app-collections` (bring-your-own Unscoped/Replicate) policy preserves
+/// its subscription set so the merged doc is observable on both sides.
+```
+
+Then replace the unconditional clear (lines 902-905) with:
 
 ```rust
     // Layer-2 desired rows add data-plane collections to the per-peer
@@ -604,12 +625,42 @@ git commit -m "feat(p2p): preserve app-collections subscription through merge_la
         .expect("resolve ok (soft-skip is Ok(None), not Err)");
         assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
     }
+
+    /// Residual (documented, not softened in #657): a foreign `agent_did` on a
+    /// data-plane row still hard-fails the whole peer load (`desired_read_failed`),
+    /// including a co-existing control pairing. Security refusal, not soft-skip.
+    /// Keep this test so a future co-existence hardening change is deliberate.
+    #[test]
+    fn foreign_agent_did_still_hard_fails_whole_peer_load() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let err = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:someone-else".to_string()), // != self_did
+                collections: Some(vec!["ChangeProposed".to_string()]),
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect_err("foreign agent_did must hard-fail, not soft-skip");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("foreign") || msg.contains("someone-else") || msg.contains("refusing"),
+            "error should name the refusal: {msg}"
+        );
+    }
 ```
 
 - [ ] **Step 2: Run to verify they fail**
 
 Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections`
-Expected: FAIL to COMPILE — the resolver currently returns `Result<PairingDesired>`, so `.expect("resolve ok").expect("some layer")` (a double unwrap through `Option`) does not type-check. This compile failure is the red state; Step 3 changes the signature to `Result<Option<..>>`.
+Expected: FAIL to COMPILE — the resolver currently returns `Result<PairingDesired>`, so `.expect("resolve ok").expect("some layer")` (a double unwrap through `Option`) does not type-check. This compile failure is the red state; Step 3 changes the signature to `Result<Option<..>>`. The foreign-DID test should still type-check as `Err` either before or after the signature change (it stays `Err`).
 
 - [ ] **Step 3: Change the signature to `Result<Option<PairingDesired>>` and honor row collections**
 
@@ -894,15 +945,36 @@ In `resolve_pairing_template`, after the empty check and before the `resolve_tem
     }
 ```
 
+- [ ] **Step 3b (cheap defense-in-depth): reject `app-collections` in fleet `data_plane_collections_literal`**
+
+`demo/fleet.rs:data_plane_collections_literal` expands `template.collections`, which
+is `[]` for app-collections — and Global Constraints forbid emitting `[]` in
+mutations; even a non-empty blank workaround would soft-skip silently. Reject
+early so a mis-invoked fleet helper fails loud rather than writing a no-op row:
+
+```rust
+// in data_plane_collections_literal, after resolve_template:
+if template.id == defra_agent::agent::p2p_reconcile::templates::APP_COLLECTIONS_TEMPLATE {
+    anyhow::bail!(
+        "app-collections requires an explicit collection set; fleet upsert_data_plane \
+         cannot expand it from the template (see #607 for config-apply ownership)"
+    );
+}
+```
+
+Full `--collections` / `config apply` ownership remains #607. This only closes
+the silent-skip footgun for the one built-in writer that would expand to `[]`.
+
 - [ ] **Step 4: Run to verify it passes**
 
 Run: `cargo test -p defra-agent-cli app_collections_rejected_on_generic_pairing_path`
 Expected: PASS.
+(If Step 3b added a unit test for the fleet reject, run that too.)
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add crates/defra-agent-cli/src/commands/p2p/pairings.rs
+git add crates/defra-agent-cli/src/commands/p2p/pairings.rs crates/defra-agent-cli/src/commands/demo/fleet.rs
 git commit -m "feat(cli): reject app-collections on the generic pairing path (#657)"
 ```
 
@@ -919,6 +991,15 @@ The integration-test binary is named `e2e_triggers` (from `e2e_triggers.rs`), so
 **Interfaces:**
 - Consumes: `defra_agent_protocol::network_token::{NetworkRecord, MembershipRecord, EndpointRecord}` (each has `signing_payload()`); `AgentIdentity::sign`; `bs58` (sig encoding — see `network.rs:690 decode_sig` uses `bs58::decode`, so write with `bs58::encode(sig).into_string()`); `graphql::escape_graphql_string`.
 - Produces: `async fn seed_materializable_peer(node, network_id, admin_identity, member_identity, member_node_id, member_address)` that writes admin-signed `AgentNetwork` + admin-signed active `NetworkMembership` + member-signed fresh `PeerEndpoint` so `GraphqlNetworkStore::load_materializable_entries` returns the member. Verified against that function.
+
+**Peer identity contract (load-bearing for Task 10):**
+- `PeerEndpoint.node_id` becomes `NetworkEndpointEntry.peer_id` (`network.rs:141`).
+- `materializable_entry_for_peer` matches on `peer_id` **and** `agent_did != self_did`.
+- `DataPlanePairingDesired.peer_id` must equal that remote `node_id`.
+- The signed endpoint **address** is authoritative (row addresses are overridden).
+- Task 9's unit gate may use synthetic `"peer-node"` / `"addr"`; Task 10 **must**
+  derive real listen addresses and peer node ids from each `EmbeddedNode`'s P2P
+  transport (same source as `install_one_way_replicator` / `wait_for_listen_addr`).
 
 **NOTE — spike first.** This task front-loads investigation: the exact mutation field names + sig encoding must match the decoders `network_record` / `membership_record` / `endpoint_record` (`network.rs:638-690`) and the writers `write_agent_network` / `write_membership` (`crates/defra-agent-cli/src/commands/p2p/network_admin.rs:275+`) and `endpoint.rs:112 upsert_PeerEndpoint`. Read those four before writing the helper; mirror their field/encoding shapes exactly. The verification gate (Step 3) is objective, so a wrong encoding fails fast.
 
@@ -1002,11 +1083,46 @@ git commit -m "test(e2e): in-process membership-materialization harness for app-
 - Modify: `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs`
 
 **Interfaces:**
-- Consumes: `seed_materializable_peer` (Task 9); the harness helpers copied from `event_trigger_p2p_e2e.rs` (`wait_for_runtime_snapshot`, `create_task`, `create_event_trigger_with_filter`, `query_agent_requests_for_trigger`, `fetch_event_trigger`, `test_p2p_db`, `MockModelEndpoint`, `bind_default_behavior_backend`).
+- Consumes: `seed_materializable_peer` (Task 9); harness helpers copied from
+  `event_trigger_p2p_e2e.rs` (`wait_for_runtime_snapshot`, `create_task`,
+  `create_event_trigger_with_filter`, `query_agent_requests_for_trigger`,
+  `fetch_event_trigger`, `test_p2p_db`, `MockModelEndpoint`,
+  `bind_default_behavior_backend`, `wait_for_listen_addr`).
+- Pairing-ready wait helper (new): poll **`PeerPairingApplied`**, not the
+  document-reconcile RuntimeSnapshot. Mirror
+  `cancel_propagation::wait_for_replicator_installed` and
+  `demo/fleet.rs::wait_conversation_replicator`.
 
-- [ ] **Step 1: Write the failing acceptance test**
+**Observation channels (do not conflate):**
 
-Model on `p2p_replicated_doc_fires_event_trigger` (event_trigger_p2p_e2e.rs:401-576). Key deltas — the source collection is app-defined `@branchable`, and replication is established by **config rows + reconcile**, not `install_one_way_replicator`:
+| Signal | What it means | Use for |
+|--------|---------------|---------|
+| `RuntimeSnapshot.active_generation` + `last_reconcile_result == "applied"` | Document reconciler (Task / EventTrigger) | Ordering: trigger live **before** data-plane rows |
+| `PeerPairingApplied.replicator_addresses` non-empty + `collections` contains `ChangeProposed` | Pairing reconciler applied app-collections | Pairing readiness after writing data-plane rows |
+| `PeerPairingApplied` control collections unchanged | Soft-skip / co-existence | Malformed row + idempotence |
+
+`desired_read_failed` is **internal** to `PairingTickOutcome` — it is **not** on
+RuntimeSnapshot. Soft-skip is observed only via applied-state stability.
+
+**Dual-agent requirement:** Unlike `event_trigger_p2p_e2e` (bare writer + one
+agent + manual `install_one_way_replicator`), both nodes must run
+`DefraAgent::run` so **both** start `run_pairing_reconciler`. That means two
+identities, two default behaviors, two mock model endpoints (A may never
+complete; still needs a backend bind). Allow generous timeouts (pairing + P2P
+is heavier than the one-way admin path).
+
+**Co-existing control pairing:** use **`network-control`** on `PeerPairingDesired`
+(Unscoped Replicate of `AgentNetwork` / `NetworkMembership` / `PeerEndpoint`) —
+not subagent. Subagent adds complement templates and PeerDid scoping noise
+without testing anything app-collections-specific. Capture applied control
+collections before the data-plane write; assert they remain after.
+
+- [ ] **Step 1: Write helpers + acceptance test**
+
+Model trigger assertions on `p2p_replicated_doc_fires_event_trigger`
+(event_trigger_p2p_e2e.rs:401-576). Key deltas — app-defined `@branchable`
+collection; replication via **config rows + reconcile**, not
+`install_one_way_replicator`:
 
 ```rust
 async fn register_change_proposed_schema(node: &EmbeddedNode) {
@@ -1027,6 +1143,10 @@ async fn register_change_proposed_schema(node: &EmbeddedNode) {
 /// mutation, NOT through this helper — because `collections` is `[String!]!`
 /// (non-null), the only valid "empty" vector is a blank-only list `["   "]`, and
 /// this helper must never be asked to emit `[]` (Global Constraints).
+///
+/// `peer_id` = remote peer's P2P node_id (must match PeerEndpoint.node_id seeded
+/// for that peer). `self_did` = THIS node's agent DID (foreign DID hard-fails).
+/// `address` = remote listen address (signed endpoint address still wins at load).
 async fn write_app_collection_pairing(
     node: &EmbeddedNode, peer_id: &str, self_did: &str, address: &str, collections: &[&str],
 ) {
@@ -1052,51 +1172,123 @@ async fn write_app_collection_pairing(
     assert!(!resp.has_errors(), "create DataPlanePairingDesired: {:?}", resp.errors);
 }
 
+/// Poll PeerPairingApplied until the app-collections subscription + replicator
+/// are installed. Do NOT use RuntimeSnapshot for pairing readiness.
+async fn wait_for_app_collections_pairing_applied(
+    node: &EmbeddedNode,
+    peer_id: &str,
+    expected_collection: &str,
+    timeout: Duration,
+) {
+    let deadline = Instant::now() + timeout;
+    let escaped = escape_graphql_string(peer_id);
+    let mut last = String::from("<none>");
+    loop {
+        let query = format!(
+            r#"{{
+                PeerPairingApplied(filter: {{ peer_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{
+                    peer_id collections replicator_addresses replicator_filter
+                }}
+            }}"#
+        );
+        let response = node.execute(&query).await;
+        // parse first row; require:
+        //   - replicator_addresses has at least one non-empty entry
+        //   - collections contains expected_collection (Replicate path)
+        // on success return; else sleep 250ms until deadline then panic with last
+        let _ = (response, expected_collection, &mut last, deadline);
+        todo!("implement per cancel_propagation::wait_for_replicator_installed");
+    }
+}
+
+/// Write PeerPairingDesired with template network-control for co-existence.
+async fn write_network_control_pairing(
+    node: &EmbeddedNode, peer_id: &str, agent_did: &str, address: &str,
+) { /* create_PeerPairingDesired template: "network-control", addresses, agent_did */ }
+
+async fn fetch_pairing_applied_collections(
+    node: &EmbeddedNode, peer_id: &str,
+) -> Vec<String> { /* query PeerPairingApplied.collections */ }
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
-    // Node A (sender/writer) + Node B (agent). Both run DefraAgent::run.
+    // BOTH nodes run DefraAgent::run (pairing reconciler on each side).
+    //
+    // 0. Boot A + B with P2P, distinct identities, mock backends, DefraAgent::run.
+    //    Derive real peer ids + listen addresses (wait_for_listen_addr / peer_info).
     // 1. Both register ChangeProposed (@branchable).
-    // 2. seed_materializable_peer on BOTH nodes: A knows B, B knows A
-    //    (signed network/membership/endpoint), so data_plane_materialized_entry
-    //    returns Some on both.
-    // 3. On B: Task + EventTrigger watching ChangeProposed/created; WAIT for the
-    //    trigger to reconcile into the active snapshot (ordering invariant).
-    // 4. Co-existing control pairing: establish a subagent (control) pairing on
-    //    A<->B (write the PeerPairingDesired rows) and capture its applied state.
+    // 2. seed_materializable_peer on BOTH nodes with REAL node_id + address:
+    //    - on A: seed B's endpoint (member = B's identity, node_id = B's peer id)
+    //    - on B: seed A's endpoint (member = A's identity, node_id = A's peer id)
+    //    Use a shared admin identity to sign AgentNetwork + NetworkMembership on
+    //    both nodes (same signed docs, written locally — no chicken-and-egg with
+    //    network-control replication). Confirm data_plane_materialized_entry would
+    //    return Some for the remote peer on each side.
+    // 3. On B only: Task + EventTrigger watching ChangeProposed/created.
+    //    WAIT via RuntimeSnapshot (document reconciler) until trigger is live
+    //    (ordering invariant — seed_seen_docs runs on empty collection).
+    // 4. Co-existing control: write_network_control_pairing on A and B.
+    //    wait_for_replicator-style poll until PeerPairingApplied has control
+    //    collections; CAPTURE that applied collections snapshot.
     // 5. Write DataPlanePairingDesired (template app-collections, collections
-    //    ["ChangeProposed"]) on BOTH nodes (A->B and B->A) via config. Wait for
-    //    each node's reconcile generation to advance and last_reconcile_result
-    //    == "applied".
+    //    ["ChangeProposed"]) on BOTH nodes (A→B and B→A). agent_did = local self
+    //    DID; peer_id = remote node_id; address = remote listen addr.
+    //    WAIT via wait_for_app_collections_pairing_applied on BOTH nodes
+    //    (PeerPairingApplied contains ChangeProposed + non-empty replicator_addresses).
+    //    Also assert control collections from step 4 are still present (union).
     // 6. Write a ChangeProposed doc on A; poll B for exactly one AgentRequest
     //    caused_by_trigger_id, rendered content, execution_origin "scheduled";
     //    then EventTrigger last_status "fired", fire_count 1,
     //    last_fired_source_doc_id == the doc id.
-    // 7. Idempotence: capture generation, force/await another sweep, assert no new
-    //    ops and the control pairing's applied state is unchanged.
+    //    On timeout: diagnostic — query ChangeProposed on A and B (replicate vs fire).
+    // 7. Idempotence: re-read PeerPairingApplied on both nodes after another
+    //    pairing sweep interval (or force by writing a no-op touch and waiting);
+    //    assert collections + replicator_addresses unchanged from post-step-5
+    //    snapshot; control collections still equal the captured union.
 }
 ```
 
-Fill the body by copying the assertion blocks from `event_trigger_p2p_e2e.rs:436-573` verbatim (they already assert exactly one request, lineage, `execution_origin`, rendered content, `last_status`/`fire_count`/`last_fired_source_doc_id`/`last_error`, and the apply-owned fields), swapping `ReplicatedEvent`→`ChangeProposed` and the trigger/task ids.
+Fill trigger assertion blocks from `event_trigger_p2p_e2e.rs:436-573` (exactly
+one request, lineage, `execution_origin`, rendered content, fire bookkeeping),
+swapping `ReplicatedEvent`→`ChangeProposed` and the trigger/task ids.
 
-- [ ] **Step 2: Run to verify it fails for the RIGHT reason**
+- [ ] **Step 2: Run as the acceptance gate (after Tasks 3–7)**
 
 Run: `cargo test -p defra-agent --test e2e_triggers app_collection_pairing_fires_event_trigger_via_reconcile -- --nocapture`
-Expected at this point in the branch: it should **PASS** if Tasks 3-7 are already merged (the reconcile path is implemented). To honor TDD, run this test on a checkout WITHOUT Tasks 5-6 (e.g. `git stash` the engine.rs resolver/merge changes) and confirm it FAILS with the diagnostic ("doc replicated but trigger did not fire" or "no replicator established"). Document the observed failure, then restore.
+
+Expected: **PASS** once Tasks 3–7 are on the branch. This e2e is the final
+acceptance gate, not a red-first unit. If it fails, use the diagnostic panics:
+
+- `PeerPairingApplied` never gains `ChangeProposed` → resolver/merge/membership
+  gate (Tasks 5–6 / 9).
+- Doc on B but no trigger fire → product/trigger gap (not pairing).
+- Empty `ChangeProposed` on B → P2P/replicator path (addresses, both-sides rows).
+
+Do **not** block on a `git stash` red ritual; optional offline check only.
 
 - [ ] **Step 3: Add the malformed-path assertion (guards the soft-skip)**
 
-Append a second `#[tokio::test]` (or extend the first after the happy-path asserts):
+Append a second `#[tokio::test]`:
 
 ```rust
-// Malformed app-collections row (empty collections) must NOT stall the
-// co-existing control pairing: the data-plane layer soft-skips, base survives.
+// Malformed app-collections row (blank-only collections) must NOT stall the
+// co-existing control pairing: data-plane layer soft-skips, base survives.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_app_collection_row_does_not_stall_control_pairing() {
-    // Boot one agent node with a control pairing already applied; write a
-    // DataPlanePairingDesired with collections: ["   "] (blank-only) + template
-    // app-collections; assert the next reconcile tick is NOT desired_read_failed
-    // (fetch_runtime_snapshot / last_reconcile_result stays "applied") and the
-    // control pairing's applied collections are unchanged.
+    // 1. Boot one (or two) agent node(s) with P2P + DefraAgent::run.
+    // 2. Seed materializable peer + write_network_control_pairing; wait until
+    //    PeerPairingApplied has control collections (e.g. AgentNetwork).
+    //    CAPTURE applied collections + replicator_addresses.
+    // 3. Write DataPlanePairingDesired with collections: ["   "] (blank-only)
+    //    + template app-collections + valid peer_id / self agent_did.
+    // 4. Wait at least one pairing sweep interval (and/or trigger a store update).
+    // 5. Assert PeerPairingApplied control collections + addresses are UNCHANGED
+    //    (still present; not deleted; not desired_read_failed starvation).
+    // 6. Assert ChangeProposed is NOT in applied.collections (layer skipped).
+    //
+    // Do NOT assert via RuntimeSnapshot.last_reconcile_result — that is the
+    // document reconciler. Do NOT assert desired_read_failed (not externally
+    // readable). Soft-skip success = control applied state stable.
 }
 ```
 
@@ -1155,12 +1347,17 @@ Closes #657. Follow-up epic: #660 (document-defined scope templates).
 Adds an `app-collections` (Unscoped/Replicate, bring-your-own) scope template and
 honors the previously-dropped `DataPlanePairingDesired.collections` field, gated on
 `template == "app-collections"`. Subscription is preserved for that policy at both
-the resolver and `merge_layered_desired`. Malformed rows soft-skip (never stall a
-co-existing control pairing); the template is rejected on the control-plane path
-(reconciler + CLI). Lean-first: catalog totality extended; behavior fenced by
-conformance calling the real resolver/merge. Acceptance e2e drives replication
-through reconcile (not `add_replicator`) and fires B's EventTrigger on the merged
-app-defined doc.
+the resolver and `merge_layered_desired`. Malformed (blank-only) rows soft-skip so
+they never stall a co-existing control pairing; the template is rejected on the
+control-plane path (reconciler + CLI) and in fleet `data_plane_collections_literal`.
+Lean-first: catalog entry + pure `mergeLayered` subscription rule; resolution /
+soft-skip fenced by in-crate unit tests + merge conformance. Acceptance e2e drives
+replication through reconcile (not `add_replicator`) and fires B's EventTrigger on
+the merged app-defined doc.
+
+Known residual: a foreign `agent_did` on a data-plane row still hard-fails the
+whole peer load (`desired_read_failed`), including control — security refusal,
+unchanged. Full `config apply` / `--collections` for app-collections is #607.
 
 Spec: docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
 
@@ -1173,9 +1370,12 @@ EOF
 
 ## Notes for the executor
 
-- **Resolver tests live in-crate (Tasks 6-7).** `data_plane_desired_from_pairing_row` / `desired_from_pairing_row` are private; test them from the existing `#[cfg(test)] mod tests` in `engine.rs` (which already calls the former directly), NOT from `tests/conformance/*` — integration tests compile `defra-agent` as a normal dependency and cannot see private items or `#[cfg(test)]`/unfeatured-`pub` seams. Do not add a `conformance-seams` feature. Merge-rule conformance (Task 5) is different: it uses the already-`pub` `merge_layered_desired`, so it can (and does) live in `tests/conformance/pairing_reconcile.rs`.
+- **Resolver tests live in-crate (Tasks 6-7).** `data_plane_desired_from_pairing_row` / `desired_from_pairing_row` are private; test them from the existing `#[cfg(test)] mod tests` in `engine.rs` (which already calls the former directly), NOT from `tests/conformance/*` — integration tests compile `defra-agent` as a normal dependency and cannot see private items or `#[cfg(test)]`/unfeatured-`pub` seams. Do not add a `conformance-seams` feature. Merge-rule conformance (Task 5) is different: it uses the already-`pub` `merge_layered_desired`, so it can (and does) live in `tests/conformance/pairing_reconcile.rs`. Design-doc items (i)/(iv)/(v) map to those in-crate tests; (ii)/(iii) map to conformance.
 - **e2e target name:** integration tests under `tests/e2e_triggers/` compile as one binary; find its harness entry (`grep -rn "mod event_trigger_p2p_e2e" crates/defra-agent/tests/`) and use that `--test e2e_triggers` for the run commands above.
 - **`data_plane_scope_filter` for app-collections** returns `{}` (Unscoped), so the replicator is unfiltered — correct for whole-collection sync. Confirm `apply_op`'s `InstallReplicator` passes an empty `PairingFilters` (it reads `desired.replicator_filter`).
-- **Ordering invariant** is enforced by test sequencing (trigger reconciled before the data-plane rows are written), matching `event_trigger_p2p_e2e.rs`.
+- **Ordering invariant** is enforced by test sequencing (document-reconcile trigger live **before** the data-plane rows are written), matching `event_trigger_p2p_e2e.rs`. Pairing readiness is a **separate** wait on `PeerPairingApplied`.
+- **Pairing vs document reconcile:** never use `RuntimeSnapshot.last_reconcile_result` as a proxy for pairing apply or soft-skip. Soft-skip is not externally readable as `desired_read_failed`; observe control `PeerPairingApplied` stability.
+- **Foreign `agent_did` residual:** still hard-`bail!`s the whole peer (control + data plane). Soft-skip covers empty/blank collections only. Unit test in Task 6 documents this deliberately.
 - **Optional (spec §4, reviewer-optional):** a diagnostic test that an unknown/non-`@branchable` collection name surfaces an error string naming the offending collection. This exercises the `apply_op` → `add_p2p_collections` error path, which needs a live node; only add it if it can be written without excessive harness cost. No runtime branchable gate either way. Not a blocking deliverable.
-- **CLI writer (`upsert_data_plane`, `demo/fleet.rs`):** unchanged by this plan. It is only unsafe if invoked with `template == "app-collections"` (its `data_plane_collections_literal` expands to `[]`), which the demo never does. Full `config apply` ownership of `DataPlanePairingDesired.collections` — including a proper `--collections` writer for `app-collections` — is #607, out of scope here.
+- **Optional follow-ups (not blocking):** teardown when the app-collections row is deleted; multi-collection row; idempotent second sweep with empty ops list.
+- **CLI / fleet writers:** Task 8 rejects control-plane `app-collections` and rejects fleet `data_plane_collections_literal` expansion (would be `[]`). Full `config apply` ownership of `DataPlanePairingDesired.collections` — including a proper `--collections` writer for `app-collections` — remains #607. Do not invoke fleet upsert with `app-collections` until then.

--- a/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
+++ b/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
@@ -27,8 +27,10 @@
 
 ## File Structure
 
-- `crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean` — add `appCollectionsTemplate` + extend `builtinCatalog` (Task 1).
-- `crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean` — add catalog-membership theorem (Task 1).
+- `crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean` — add `appCollectionsTemplate` + extend `builtinCatalog` (Task 1a).
+- `crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean` — add catalog-membership theorem (Task 1a).
+- `crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean` — **new**: model `mergeLayered` + the delivery-aware subscription rule; prove app-collections subscription survives, push data-plane subscription is cleared (no unfiltered gossip), control-plane base preserved (Task 1b).
+- `crates/defra-agent/proofs/Proofs/PairingReconcile.lean` — add `import Proofs.PairingReconcile.Layering` to the barrel (Task 1b).
 - `crates/defra-agent/tests/conformance/scope_templates.rs` — conformance: app-collections resolves as Unscoped/Replicate/empty template set (Task 2).
 - `crates/defra-agent/src/agent/p2p_reconcile/templates.rs` — new template + const + fix two unit tests (Task 3).
 - `crates/defra-agent/src/agent/p2p_reconcile/engine.rs` — `load_desired` query; `data_plane_desired_from_pairing_row` (honor row collections, soft-skip, `Result<Option<..>>`); `desired_from_pairing_row` (reject app-collections, `Result<Option<..>>`); `merge_layered_desired` conditional subscription preservation (Tasks 4–7).
@@ -39,14 +41,32 @@
 
 ---
 
-## Task 1: Lean — add `app-collections` to the template catalog
+## Task 1: Lean — catalog entry + layered-merge subscription model
+
+Two Lean model changes proven together under one `lake build`: **1a** adds the
+`app-collections` template to the catalog; **1b** models `mergeLayered` and proves
+the delivery-aware subscription rule that the Rust `merge_layered_desired` change
+(Task 5) implements. 1b exists because the "data-plane push layers do not extend
+the subscription set, so conversation data never gossips unfiltered" property is
+safety-relevant, and this change makes an app-collections exception to it — that
+is exactly a "what invariants hold" change, which starts in Lean (CLAUDE.md).
+
+**Scope boundary (stated deliberately):** the *source* of a data-plane layer's
+collection set (row vs template) and the *soft-skip* of a malformed row are
+input-validation plumbing below the machine boundary — the reconcile machine
+consumes an abstract desired state and proves nothing about where its Finsets
+originate, and "malformed input → no layer" is not a safety property. Those are
+fenced by Rust unit/conformance (Tasks 6–7), not Lean. Only the subscription
+rule — which governs what may gossip — is modeled here.
 
 **Files:**
 - Modify: `crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean:157-165` (builtinCatalog) + add a def near line 155
 - Modify: `crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean` (add theorem near line 188)
+- Create: `crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean`
+- Modify: `crates/defra-agent/proofs/Proofs/PairingReconcile.lean` (barrel import)
 
 **Interfaces:**
-- Produces: `ScopeTemplates.appCollectionsTemplate : Template`; `builtinCatalog` now has 8 entries; theorem `appCollections_in_catalog`.
+- Produces: `ScopeTemplates.appCollectionsTemplate : Template`; `builtinCatalog` now has 8 entries; theorem `appCollections_in_catalog`. `PairingReconcile.Layering.{Layer, clampDataPlane, mergeLayered}` + subscription-rule theorems mirrored by Rust conformance in Task 5.
 
 - [ ] **Step 1: Add the template def and catalog entry**
 
@@ -97,16 +117,111 @@ theorem appCollections_unscoped_no_filter (collections : List String) (peerDid l
     scopeFilter appCollectionsTemplate.scope collections peerDid localDid = [] := rfl
 ```
 
-- [ ] **Step 3: Build the proofs and verify zero sorries**
+- [ ] **Step 3 (1b): Create the layered-merge model**
+
+Create `crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean`:
+
+```lean
+import Proofs.Basic
+import Mathlib.Data.Finset.Basic
+
+/-!
+# Pairing Reconcile — Layered merge (subscription rule)
+
+A pure derivation beside the reconcile machine (the ScopeTemplates pattern: a
+derivation below the machine, not a new machine). Models Rust
+`merge_layered_desired`: a control-plane base desired layer is merged with an
+optional data-plane layer. A data-plane layer's *subscriptions* are dropped
+UNLESS it is the app-collections (whole-collection Replicate) policy — push
+data-plane layers must not extend the subscription set, so conversation data
+never gossips unfiltered; app-collections is Unscoped Replicate and must
+subscribe on both sides for the merged doc to be observable. Replicator
+collection sets always union (the machine keys replicator identity on them).
+-/
+
+namespace PairingReconcile.Layering
+
+/-- The fields of Rust `PairingDesired` that the merge rule reads. -/
+structure Layer where
+  subscriptions : Finset String
+  replicatorCollections : Finset String
+  /-- `template_ids.contains "app-collections"` in Rust. -/
+  isAppCollections : Bool
+  deriving DecidableEq, Repr
+
+/-- Drop a data-plane layer's subscriptions unless it is app-collections. -/
+def clampDataPlane (l : Layer) : Layer :=
+  if l.isAppCollections then l else { l with subscriptions := (∅ : Finset String) }
+
+/-- Merge a control-plane base with an optional data-plane layer. Mirrors Rust
+`merge_layered_desired`: clamp the data-plane layer, then union. -/
+def mergeLayered (base : Option Layer) (dataPlane : Option Layer) : Option Layer :=
+  match base, dataPlane.map clampDataPlane with
+  | none, none => none
+  | some b, none => some b
+  | none, some d => some d
+  | some b, some d =>
+      some { subscriptions := b.subscriptions ∪ d.subscriptions
+           , replicatorCollections := b.replicatorCollections ∪ d.replicatorCollections
+           , isAppCollections := b.isAppCollections }
+
+/-- An app-collections data-plane layer's subscriptions survive the merge, so an
+`InstallCollection` op can reach the diff. -/
+theorem appCollections_subscription_survives
+    (base : Option Layer) (d : Layer) (h : d.isAppCollections = true)
+    (m : Layer) (hm : mergeLayered base (some d) = some m) :
+    d.subscriptions ⊆ m.subscriptions := by
+  cases base with
+  | none => simp [mergeLayered, clampDataPlane, h] at hm; subst hm; exact subset_rfl
+  | some b =>
+      simp [mergeLayered, clampDataPlane, h] at hm; subst hm; exact Finset.subset_union_right
+
+/-- A non-app-collections data-plane layer contributes NO subscriptions: with an
+empty base the merged subscription set is empty (push data never gossips
+unfiltered). -/
+theorem nonApp_none_base_no_subscription
+    (d : Layer) (h : d.isAppCollections = false) :
+    mergeLayered none (some d) = some { d with subscriptions := (∅ : Finset String) } := by
+  simp [mergeLayered, clampDataPlane, h]
+
+/-- A non-app-collections data-plane layer does not add to a base's subscriptions:
+the merged subscription set equals the base's. -/
+theorem nonApp_subscription_eq_base
+    (b d : Layer) (h : d.isAppCollections = false)
+    (m : Layer) (hm : mergeLayered (some b) (some d) = some m) :
+    m.subscriptions = b.subscriptions := by
+  simp [mergeLayered, clampDataPlane, h] at hm; subst hm; simp
+
+/-- The control-plane base is always preserved (subscriptions and replicator
+collections are supersets of the base's), regardless of the data-plane layer. -/
+theorem base_preserved
+    (b : Layer) (dp : Option Layer) (m : Layer)
+    (hm : mergeLayered (some b) dp = some m) :
+    b.subscriptions ⊆ m.subscriptions ∧ b.replicatorCollections ⊆ m.replicatorCollections := by
+  cases dp with
+  | none => simp [mergeLayered] at hm; subst hm; exact ⟨subset_rfl, subset_rfl⟩
+  | some d =>
+      simp [mergeLayered, clampDataPlane] at hm
+      subst hm
+      exact ⟨Finset.subset_union_left, Finset.subset_union_left⟩
+```
+
+Add to the barrel `crates/defra-agent/proofs/Proofs/PairingReconcile.lean`:
+
+```lean
+import Proofs.PairingReconcile.Layering
+```
+
+- [ ] **Step 4: Build the proofs and verify zero sorries**
 
 Run: `cd crates/defra-agent/proofs && lake build`
-Expected: builds clean, no errors, no `sorry` warnings. (If a fresh worktree, first symlink the parent's mathlib `.lake/build` per the reference note, then `lake build`.)
+Expected: builds clean, no errors, no `sorry` warnings. (If a fresh worktree, first symlink the parent's mathlib `.lake/build` per the reference note, then `lake build`.) If a `simp`/`subst` tactic above does not close a goal, adjust it (e.g. add the relevant `Finset.subset_union_left`/`Finset.mem_union` lemma or `cases`/`rfl`) until the goal is discharged — the statements are exact; only the proof term may need tuning. Zero `sorry` is the gate.
 
-- [ ] **Step 4: Commit**
+- [ ] **Step 5: Commit**
 
 ```bash
-git add crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
-git commit -m "proof(scope-templates): add app-collections to builtin catalog (#657)"
+git add crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean crates/defra-agent/proofs/Proofs/PairingReconcile/Layering.lean crates/defra-agent/proofs/Proofs/PairingReconcile.lean
+git commit -m "proof: app-collections catalog + layered-merge subscription rule (#657)"
 ```
 
 ---
@@ -301,10 +416,11 @@ git commit -m "feat(p2p): read DataPlanePairingDesired.collections in load_desir
 Append to `pairing_reconcile.rs` (uses the existing `set(&[...])` helper in that file):
 
 ```rust
-/// An `app-collections` data-plane layer's subscription set survives
-/// `merge_layered_desired`, so an `InstallCollection` op can reach the diff.
-/// A network-control-only data-plane layer's subscription is still cleared
-/// (conversation data must never gossip unfiltered).
+/// Mirrors Lean `PairingReconcile.Layering.appCollections_subscription_survives`
+/// / `nonApp_none_base_no_subscription`: an `app-collections` data-plane layer's
+/// subscription set survives `merge_layered_desired`, so an `InstallCollection`
+/// op can reach the diff; a network-control-only data-plane layer's subscription
+/// is still cleared (conversation data must never gossip unfiltered).
 #[test]
 fn merge_preserves_app_collections_subscription_only() {
     use defra_agent::agent::p2p_reconcile::diff::PairingDesired;
@@ -339,9 +455,10 @@ fn merge_preserves_app_collections_subscription_only() {
     );
 }
 
-/// Spec conformance case (iii): an app-collections data-plane layer merges with a
-/// co-existing control (network-control) base pairing without cross-contaminating
-/// their subscriptions or replicator filters — the control pairing is undisturbed.
+/// Spec conformance case (iii); mirrors Lean `PairingReconcile.Layering.base_preserved`:
+/// an app-collections data-plane layer merges with a co-existing control
+/// (network-control) base pairing without cross-contaminating their subscriptions
+/// or replicator filters — the control pairing is undisturbed.
 #[test]
 fn app_collections_coexists_with_control_pairing() {
     use defra_agent::agent::p2p_reconcile::diff::PairingDesired;
@@ -432,83 +549,67 @@ git commit -m "feat(p2p): preserve app-collections subscription through merge_la
 - Consumes: `templates::APP_COLLECTIONS_TEMPLATE`, `PairingStateRow.collections` (Task 4).
 - Produces: signature changes to `fn data_plane_desired_from_pairing_row(row, signed_endpoint, self_did) -> Result<Option<PairingDesired>>`. For `template == "app-collections"`: `replicator_collections` and `collections` (subscription) both = trimmed row collections, filter Unscoped (`{}`); empty trimmed set → `Ok(None)` (soft-skip). For other templates → `Ok(Some(..))` unchanged. Foreign `agent_did` still `Err`.
 
-- [ ] **Step 1: Write the failing conformance tests**
+- [ ] **Step 1: Write the failing unit tests (in-crate, no feature seam)**
 
-Append to `pairing_reconcile.rs`. These call the real resolver via a thin store or the function directly — expose it. First, ensure `data_plane_desired_from_pairing_row` is reachable: it is currently private. Add `pub(crate)` and re-export via a test-visible path, or test through `GraphqlPairingStateStore::load_desired` with a seeded node. **Chosen approach:** make `data_plane_desired_from_pairing_row` `pub` and its input `PairingStateRow` constructor reachable by adding a `#[doc(hidden)] pub fn new_for_test(...)`. To avoid widening the API, instead test the two behaviors through the existing `merge_layered_desired` + a small pure helper. **Simplest that matches repo style:** promote `data_plane_desired_from_pairing_row` to `pub(crate)` and add a conformance test in an in-crate test module.
-
-Given the repo tests the resolver via conformance calling public seams, expose a focused public wrapper in `engine.rs`:
+`data_plane_desired_from_pairing_row` is private; the repo already tests it directly from the in-crate `#[cfg(test)] mod tests` in `engine.rs` (see `data_plane_desired_uses_signed_endpoint_address_and_self_did` at ~engine.rs:1073, which constructs `PairingStateRow` + `NetworkEndpointEntry` inline). Add the two new tests to **that same module** — do NOT invent a `conformance-seams` feature: integration tests compile `defra-agent` as a normal dependency, so a `#[cfg(any(test, feature=...))]` `pub` seam is invisible to `tests/conformance/*` unless the feature is declared in `Cargo.toml` AND the test run enables it. In-crate `#[cfg(test)]` is the idiomatic home here. Append inside the `#[cfg(test)] mod tests` block:
 
 ```rust
-/// Test/conformance seam: resolve a data-plane desired layer from explicit
-/// inputs (mirrors what `load_desired` does per row). Keeps the row struct
-/// private while letting conformance exercise the app-collections resolution.
-#[cfg(any(test, feature = "conformance-seams"))]
-pub fn resolve_data_plane_layer_for_test(
-    agent_did: Option<&str>,
-    collections: &[&str],
-    template: &str,
-    signed_address: &str,
-    signed_peer_did: &str,
-    signed_peer_id: &str,
-    self_did: &str,
-) -> anyhow::Result<Option<PairingDesired>> {
-    let row = PairingStateRow {
-        agent_did: agent_did.map(str::to_string),
-        collections: Some(collections.iter().map(|s| s.to_string()).collect()),
-        replicator_addresses: None,
-        template: Some(template.to_string()),
-        replicator_filter: None,
-    };
-    let entry = NetworkEndpointEntry {
-        peer_id: signed_peer_id.to_string(),
-        agent_did: signed_peer_did.to_string(),
-        address: signed_address.to_string(),
-    };
-    data_plane_desired_from_pairing_row(row, &entry, self_did)
-}
-```
+    #[test]
+    fn app_collections_row_resolves_row_collections_as_subscription_and_replicator() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let layer = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:self".to_string()), // == self_did (allowed)
+                collections: Some(vec!["ChangeProposed".to_string()]),
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect("resolve ok")
+        .expect("some layer");
+        assert!(layer.replicator_collections.contains("ChangeProposed"));
+        assert!(
+            layer.collections.contains("ChangeProposed"),
+            "app-collections must subscribe (Replicate)"
+        );
+        assert!(layer.replicator_filter.is_empty(), "unscoped => no filter");
+        assert!(layer.template_ids.contains("app-collections"));
+    }
 
-If the `conformance-seams` feature does not exist, use `#[cfg(test)]` plus an in-crate `#[cfg(test)] mod` conformance instead; confirm how sibling resolvers are exercised (grep `resolve.*_for_test` / existing `pub(crate)` seams in `engine.rs`) and match that convention rather than inventing a feature. Then the conformance test:
-
-```rust
-#[test]
-fn app_collections_row_resolves_row_collections_as_subscription_and_replicator() {
-    use defra_agent::agent::p2p_reconcile::engine::resolve_data_plane_layer_for_test;
-    let layer = resolve_data_plane_layer_for_test(
-        Some("did:key:self"),           // agent_did == self (allowed)
-        &["ChangeProposed"],
-        "app-collections",
-        "addr-b", "did:key:peer", "peer-b",
-        "did:key:self",
-    )
-    .expect("resolve ok")
-    .expect("some layer");
-    assert!(layer.replicator_collections.contains("ChangeProposed"));
-    assert!(layer.collections.contains("ChangeProposed"),
-        "app-collections must subscribe (Replicate)");
-    assert!(layer.replicator_filter.is_empty(), "unscoped => no filter");
-    assert!(layer.template_ids.contains("app-collections"));
-}
-
-#[test]
-fn app_collections_empty_collections_soft_skips() {
-    use defra_agent::agent::p2p_reconcile::engine::resolve_data_plane_layer_for_test;
-    let out = resolve_data_plane_layer_for_test(
-        Some("did:key:self"),
-        &["   "],                        // blank-only after trim
-        "app-collections",
-        "addr-b", "did:key:peer", "peer-b",
-        "did:key:self",
-    )
-    .expect("resolve ok (soft-skip is Ok(None), not Err)");
-    assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
-}
+    #[test]
+    fn app_collections_empty_collections_soft_skips() {
+        let signed_endpoint = NetworkEndpointEntry {
+            peer_id: "peer-b".to_string(),
+            agent_did: "did:key:peer-b".to_string(),
+            address: "/ip4/127.0.0.1/tcp/4001/p2p/peer-b".to_string(),
+        };
+        let out = data_plane_desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:self".to_string()),
+                collections: Some(vec!["   ".to_string()]), // blank-only after trim
+                replicator_addresses: None,
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            &signed_endpoint,
+            "did:key:self",
+        )
+        .expect("resolve ok (soft-skip is Ok(None), not Err)");
+        assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
+    }
 ```
 
 - [ ] **Step 2: Run to verify they fail**
 
-Run: `cargo test -p defra-agent --test conformance app_collections_row_resolves`
-Expected: FAIL — the resolver currently ignores `row.collections` and returns `Result<PairingDesired>` (won't compile against `.expect("some layer")` on an `Option`).
+Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections`
+Expected: FAIL to COMPILE — the resolver currently returns `Result<PairingDesired>`, so `.expect("resolve ok").expect("some layer")` (a double unwrap through `Option`) does not type-check. This compile failure is the red state; Step 3 changes the signature to `Result<Option<..>>`.
 
 - [ ] **Step 3: Change the signature to `Result<Option<PairingDesired>>` and honor row collections**
 
@@ -618,17 +719,17 @@ At lines 513-523, the match arm already unwraps with `?`. Because the function n
 
 (The soft-skip `Ok(None)` now flows through as `data_plane = None`, leaving `base` intact in `merge_layered_desired`.)
 
-- [ ] **Step 5: Run the conformance tests + full engine tests**
+- [ ] **Step 5: Run the in-crate tests + full engine tests**
 
-Run: `cargo test -p defra-agent --test conformance app_collections_row`
+Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections`
 Expected: PASS (both resolution + soft-skip).
 Run: `cargo test -p defra-agent --lib p2p_reconcile`
-Expected: PASS.
+Expected: PASS (existing resolver/merge unit tests unaffected).
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs crates/defra-agent/tests/conformance/pairing_reconcile.rs
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs
 git commit -m "feat(p2p): honor app-collections row collections + soft-skip malformed rows (#657)"
 ```
 
@@ -638,60 +739,44 @@ git commit -m "feat(p2p): honor app-collections row collections + soft-skip malf
 
 **Files:**
 - Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:671-736` (`desired_from_pairing_row`) + its `load_desired` call site (lines 506-508)
-- Test: `crates/defra-agent/tests/conformance/pairing_reconcile.rs`
+- Test: in-crate `#[cfg(test)] mod tests` in `engine.rs`
 
 **Interfaces:**
 - Produces: `fn desired_from_pairing_row(row, local_did) -> Result<Option<PairingDesired>>`. A `PeerPairingDesired`/base row whose resolved template is `app-collections` → `Ok(None)` + warn (no wiring). All other templates unchanged.
 
-- [ ] **Step 1: Write the failing conformance test**
+- [ ] **Step 1: Write the failing in-crate unit test**
 
-Append to `pairing_reconcile.rs` (mirror the seam approach from Task 6; add a base-path wrapper if needed):
-
-```rust
-/// A base/PeerPairingDesired row that names the app-collections template has no
-/// way to supply row collections; it must resolve to no wiring (soft-skip),
-/// never an empty-collection replicator.
-#[test]
-fn app_collections_on_control_plane_path_soft_skips() {
-    use defra_agent::agent::p2p_reconcile::engine::resolve_control_plane_desired_for_test;
-    let out = resolve_control_plane_desired_for_test(
-        Some("did:key:peer"),
-        &["addr-b"],
-        "app-collections",
-        "did:key:self",
-    )
-    .expect("resolve ok");
-    assert!(out.is_none(), "app-collections is invalid for a control-plane row");
-}
-```
-
-Add the seam wrapper in `engine.rs` beside the Task 6 one:
+Append to the same in-crate `#[cfg(test)] mod tests` in `engine.rs`, calling the private `desired_from_pairing_row` directly (as the Task 6 tests do):
 
 ```rust
-#[cfg(any(test, feature = "conformance-seams"))]
-pub fn resolve_control_plane_desired_for_test(
-    agent_did: Option<&str>,
-    replicator_addresses: &[&str],
-    template: &str,
-    local_did: &str,
-) -> anyhow::Result<Option<PairingDesired>> {
-    let row = PairingStateRow {
-        agent_did: agent_did.map(str::to_string),
-        collections: None,
-        replicator_addresses: Some(replicator_addresses.iter().map(|s| s.to_string()).collect()),
-        template: Some(template.to_string()),
-        replicator_filter: None,
-    };
-    desired_from_pairing_row(row, local_did)
-}
+    #[test]
+    fn app_collections_on_control_plane_path_soft_skips() {
+        // A base/PeerPairingDesired row naming app-collections has no way to
+        // supply row collections; it must resolve to no wiring (soft-skip),
+        // never an empty-collection replicator.
+        let out = desired_from_pairing_row(
+            PairingStateRow {
+                agent_did: Some("did:key:peer".to_string()),
+                collections: None,
+                replicator_addresses: Some(vec!["addr-b".to_string()]),
+                template: Some("app-collections".to_string()),
+                replicator_filter: None,
+            },
+            "did:key:self",
+        )
+        .expect("resolve ok");
+        assert!(out.is_none(), "app-collections is invalid for a control-plane row");
+    }
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
-Run: `cargo test -p defra-agent --test conformance app_collections_on_control_plane_path_soft_skips`
-Expected: FAIL — `desired_from_pairing_row` returns `Result<PairingDesired>` (won't compile against `.is_none()`), and today resolves app-collections to empty-collection wiring.
+Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections_on_control_plane_path_soft_skips`
+Expected: FAIL to COMPILE — `desired_from_pairing_row` returns `Result<PairingDesired>`, so `.expect("resolve ok")` then `.is_none()` does not type-check; today it also resolves app-collections to empty-collection wiring.
 
 - [ ] **Step 3: Change signature + add the reject**
+
+First, make `APP_COLLECTIONS_TEMPLATE` usable unqualified in `engine.rs`: add it to the existing `use super::templates::{ resolve_template, scope_filter, Delivery, DidSource, PairingFilters, Scope };` import (engine.rs:18) — i.e. append `APP_COLLECTIONS_TEMPLATE`. (Task 5's `merge_layered_desired` edit may reference it as `super::templates::APP_COLLECTIONS_TEMPLATE`; either form is fine, but with the import both Tasks 5-7 can use the bare name consistently.)
 
 In `desired_from_pairing_row` (line 671), change the return type to `Result<Option<PairingDesired>>`. After the template is resolved (around line 697), add:
 
@@ -723,9 +808,9 @@ At lines 506-508, the base currently does `.map(|row| desired_from_pairing_row(r
             .flatten();
 ```
 
-- [ ] **Step 5: Run conformance + full lib tests**
+- [ ] **Step 5: Run the in-crate test + full lib tests**
 
-Run: `cargo test -p defra-agent --test conformance app_collections_on_control_plane_path_soft_skips`
+Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections_on_control_plane_path_soft_skips`
 Expected: PASS.
 Run: `cargo test -p defra-agent --lib p2p_reconcile`
 Expected: PASS.
@@ -733,7 +818,7 @@ Expected: PASS.
 - [ ] **Step 6: Commit**
 
 ```bash
-git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs crates/defra-agent/tests/conformance/pairing_reconcile.rs
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs
 git commit -m "feat(p2p): reject app-collections template on the control-plane path (#657)"
 ```
 
@@ -863,7 +948,9 @@ async fn seed_makes_peer_materializable() {
         db.node.clone(), Arc::new(admin_clone),
     );
     let entries = store.load_materializable_entries().await.unwrap();
-    assert!(entries.iter().any(|e| e.node_id == "peer-node"),
+    // NetworkEndpointEntry exposes { peer_id, agent_did, address } (network.rs:28);
+    // the endpoint doc's node_id becomes the entry's peer_id (network.rs:141).
+    assert!(entries.iter().any(|e| e.peer_id == "peer-node"),
         "seeded peer must be materializable: {entries:?}");
 }
 ```
@@ -969,14 +1056,17 @@ Append a second `#[tokio::test]` (or extend the first after the happy-path asser
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn empty_app_collection_row_does_not_stall_control_pairing() {
     // Boot one agent node with a control pairing already applied; write a
-    // DataPlanePairingDesired with collections: null (empty) + template
+    // DataPlanePairingDesired with collections: ["   "] (blank-only) + template
     // app-collections; assert the next reconcile tick is NOT desired_read_failed
     // (fetch_runtime_snapshot / last_reconcile_result stays "applied") and the
     // control pairing's applied collections are unchanged.
 }
 ```
 
-To write an empty-collections row, emit `collections: null` (never `[]` — Global Constraints).
+`DataPlanePairingDesired.collections` is declared `[String!]!` (non-null) in the
+SDL, so the malformed vector must be a valid **blank-only list** `["   "]` — which
+the resolver trims to empty and soft-skips. Do NOT use `collections: null` (schema
+rejects it) nor `[]` (Global Constraints: corrupts nillable array columns).
 
 - [ ] **Step 4: Run the full e2e module**
 
@@ -1046,7 +1136,7 @@ EOF
 
 ## Notes for the executor
 
-- **Test-visibility seam (Tasks 6-7):** the plan exposes `resolve_data_plane_layer_for_test` / `resolve_control_plane_desired_for_test` behind `#[cfg(any(test, feature = "conformance-seams"))]`. Before adopting a new cargo feature, grep `engine.rs` for how sibling resolvers are already exercised by conformance (`pub(crate)`, existing seams). Match the repo's convention; do not invent a feature if one isn't already the pattern.
+- **Resolver tests live in-crate (Tasks 6-7).** `data_plane_desired_from_pairing_row` / `desired_from_pairing_row` are private; test them from the existing `#[cfg(test)] mod tests` in `engine.rs` (which already calls the former directly), NOT from `tests/conformance/*` — integration tests compile `defra-agent` as a normal dependency and cannot see private items or `#[cfg(test)]`/unfeatured-`pub` seams. Do not add a `conformance-seams` feature. Merge-rule conformance (Task 5) is different: it uses the already-`pub` `merge_layered_desired`, so it can (and does) live in `tests/conformance/pairing_reconcile.rs`.
 - **e2e target name:** integration tests under `tests/e2e_triggers/` compile as one binary; find its harness entry (`grep -rn "mod event_trigger_p2p_e2e" crates/defra-agent/tests/`) and use that `--test <name>` for the run commands above.
 - **`data_plane_scope_filter` for app-collections** returns `{}` (Unscoped), so the replicator is unfiltered — correct for whole-collection sync. Confirm `apply_op`'s `InstallReplicator` passes an empty `PairingFilters` (it reads `desired.replicator_filter`).
 - **Ordering invariant** is enforced by test sequencing (trigger reconciled before the data-plane rows are written), matching `event_trigger_p2p_e2e.rs`.

--- a/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
+++ b/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
@@ -33,11 +33,11 @@
 - `crates/defra-agent/proofs/Proofs/PairingReconcile.lean` — add `import Proofs.PairingReconcile.Layering` to the barrel (Task 1b).
 - `crates/defra-agent/tests/conformance/scope_templates.rs` — conformance: app-collections resolves as Unscoped/Replicate/empty template set (Task 2).
 - `crates/defra-agent/src/agent/p2p_reconcile/templates.rs` — new template + const + fix two unit tests (Task 3).
-- `crates/defra-agent/src/agent/p2p_reconcile/engine.rs` — `load_desired` query; `data_plane_desired_from_pairing_row` (honor row collections, soft-skip, `Result<Option<..>>`); `desired_from_pairing_row` (reject app-collections, `Result<Option<..>>`); `merge_layered_desired` conditional subscription preservation (Tasks 4–7).
-- `crates/defra-agent/tests/conformance/pairing_reconcile.rs` — merge subscription-preservation + resolution + soft-skip + reject conformance (Tasks 5–7).
+- `crates/defra-agent/src/agent/p2p_reconcile/engine.rs` — `load_desired` query; `data_plane_desired_from_pairing_row` (honor row collections, soft-skip, `Result<Option<..>>`); `desired_from_pairing_row` (reject app-collections, `Result<Option<..>>`); `merge_layered_desired` conditional subscription preservation; **plus its in-crate `#[cfg(test)] mod tests`** — new app-collections resolver/soft-skip/reject tests AND updates to the existing resolver call sites that the signature change breaks (Tasks 4–7).
+- `crates/defra-agent/tests/conformance/pairing_reconcile.rs` — merge subscription-preservation conformance only (Task 5, via the public `merge_layered_desired`). Resolution / soft-skip / reject tests are in-crate in engine.rs (Tasks 6–7), not here.
 - `crates/defra-agent-cli/src/commands/p2p/pairings.rs` — reject `app-collections` on generic pairing path (Task 8).
+- `crates/defra-agent/tests/e2e_triggers.rs` — the harness root (a file, not `mod.rs`); add `mod app_collection_pairing_p2p_e2e;` next to `mod event_trigger_p2p_e2e;` (line ~11) (Task 9).
 - `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs` — membership-materialization harness + acceptance e2e (Tasks 9–10).
-- `crates/defra-agent/tests/e2e_triggers/mod.rs` (or the harness's mod root) — register the new test module (Task 9).
 
 ---
 
@@ -543,7 +543,7 @@ git commit -m "feat(p2p): preserve app-collections subscription through merge_la
 
 **Files:**
 - Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:738-828` (`data_plane_desired_from_pairing_row`) and its call site in `load_desired` (lines 513-523)
-- Test: `crates/defra-agent/tests/conformance/pairing_reconcile.rs`
+- Test: in-crate `#[cfg(test)] mod tests` in `engine.rs` (new tests + updates to existing call sites the signature change breaks)
 
 **Interfaces:**
 - Consumes: `templates::APP_COLLECTIONS_TEMPLATE`, `PairingStateRow.collections` (Task 4).
@@ -719,12 +719,25 @@ At lines 513-523, the match arm already unwraps with `?`. Because the function n
 
 (The soft-skip `Ok(None)` now flows through as `data_plane = None`, leaving `base` intact in `merge_layered_desired`.)
 
+- [ ] **Step 4b: Update the existing in-crate test call sites the signature change breaks**
+
+The signature is now `Result<Option<PairingDesired>>`, so every existing test that did `data_plane_desired_from_pairing_row(..).expect("..")` and then read a field now has an `Option` and won't compile. Update these call sites in the `#[cfg(test)] mod tests` — they are `.expect(..)`-then-use-field sites at approximately engine.rs **1079, 1112, 1148** (add a second unwrap):
+
+```rust
+        // before: .expect("data-plane desired")
+        // after:
+        .expect("data-plane desired")
+        .expect("some data-plane layer")
+```
+
+The **error-expecting** site at ~engine.rs **1175** (`let error = data_plane_desired_from_pairing_row(..)` used to assert a `bail!`) is UNAFFECTED — the foreign-`agent_did` path still returns `Err`, so its `.unwrap_err()`/error assertion still holds. Do not add a second unwrap there. Let the compiler enumerate the exact sites: fix each until `cargo test -p defra-agent --lib p2p_reconcile` compiles.
+
 - [ ] **Step 5: Run the in-crate tests + full engine tests**
 
 Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections`
 Expected: PASS (both resolution + soft-skip).
 Run: `cargo test -p defra-agent --lib p2p_reconcile`
-Expected: PASS (existing resolver/merge unit tests unaffected).
+Expected: PASS (existing resolver/merge unit tests updated in Step 4b, all green).
 
 - [ ] **Step 6: Commit**
 
@@ -808,12 +821,26 @@ At lines 506-508, the base currently does `.map(|row| desired_from_pairing_row(r
             .flatten();
 ```
 
+- [ ] **Step 4b: Update the existing in-crate test call sites the signature change breaks**
+
+`desired_from_pairing_row` now returns `Result<Option<PairingDesired>>`. The existing in-crate tests call it at approximately engine.rs **1843, 1866, 1885, 1890, 1904, 1933, 1953, 1995, 2037**. Each `.expect("..")`-then-use-field site (including the **1890 "unknown template"** case — an unknown id falls back to `conversation`, which is now `Ok(Some(..))`, so it needs the second unwrap too) gets a second unwrap:
+
+```rust
+        // before: desired_from_pairing_row(row, "did:key:self").expect("desired")
+        // after:
+        desired_from_pairing_row(row, "did:key:self")
+            .expect("desired")
+            .expect("some desired layer")
+```
+
+The only sites that must NOT get a second unwrap are any that assert an `Err` (the blank-DID `bail!` at engine.rs:708 is unchanged). Let the compiler enumerate: fix each until `cargo test -p defra-agent --lib p2p_reconcile` compiles.
+
 - [ ] **Step 5: Run the in-crate test + full lib tests**
 
 Run: `cargo test -p defra-agent --lib p2p_reconcile::engine::tests::app_collections_on_control_plane_path_soft_skips`
 Expected: PASS.
 Run: `cargo test -p defra-agent --lib p2p_reconcile`
-Expected: PASS.
+Expected: PASS (existing resolver tests updated in Step 4b).
 
 - [ ] **Step 6: Commit**
 
@@ -885,7 +912,9 @@ git commit -m "feat(cli): reject app-collections on the generic pairing path (#6
 
 **Files:**
 - Create: `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs`
-- Modify: the `e2e_triggers` module root to register it (grep for where `event_trigger_p2p_e2e` is declared: `mod event_trigger_p2p_e2e;` and add `mod app_collection_pairing_p2p_e2e;`).
+- Modify: `crates/defra-agent/tests/e2e_triggers.rs` (the harness root is this FILE, not `e2e_triggers/mod.rs`) — add `mod app_collection_pairing_p2p_e2e;` next to the existing `mod event_trigger_p2p_e2e;` (line ~11).
+
+The integration-test binary is named `e2e_triggers` (from `e2e_triggers.rs`), so all `cargo test` runs below use `--test e2e_triggers`.
 
 **Interfaces:**
 - Consumes: `defra_agent_protocol::network_token::{NetworkRecord, MembershipRecord, EndpointRecord}` (each has `signing_payload()`); `AgentIdentity::sign`; `bs58` (sig encoding — see `network.rs:690 decode_sig` uses `bs58::decode`, so write with `bs58::encode(sig).into_string()`); `graphql::escape_graphql_string`.
@@ -955,13 +984,13 @@ async fn seed_makes_peer_materializable() {
 }
 ```
 
-Run: `cargo test -p defra-agent --test <e2e_triggers-target> seed_makes_peer_materializable`
+Run: `cargo test -p defra-agent --test e2e_triggers seed_makes_peer_materializable`
 Expected: PASS. If FAIL, the sig encoding or a field name is wrong — compare against Step 1 decoders (this is the fast feedback loop; do not proceed until green).
 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs crates/defra-agent/tests/e2e_triggers/mod.rs
+git add crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs crates/defra-agent/tests/e2e_triggers.rs
 git commit -m "test(e2e): in-process membership-materialization harness for app-collection pairing (#657)"
 ```
 
@@ -993,9 +1022,18 @@ async fn register_change_proposed_schema(node: &EmbeddedNode) {
 }
 
 /// Write a DataPlanePairingDesired row via desired-state config (NOT add_replicator).
+/// HAPPY-PATH ONLY: this helper requires a non-empty collection set. The malformed
+/// (blank-only) soft-skip row in Task 10 Step 3 is written by its own inline
+/// mutation, NOT through this helper — because `collections` is `[String!]!`
+/// (non-null), the only valid "empty" vector is a blank-only list `["   "]`, and
+/// this helper must never be asked to emit `[]` (Global Constraints).
 async fn write_app_collection_pairing(
     node: &EmbeddedNode, peer_id: &str, self_did: &str, address: &str, collections: &[&str],
 ) {
+    assert!(
+        collections.iter().any(|c| !c.trim().is_empty()),
+        "write_app_collection_pairing is happy-path only; pass a non-empty collection set"
+    );
     let peer = escape_graphql_string(peer_id);
     let did = escape_graphql_string(self_did);
     let addr = escape_graphql_string(address);
@@ -1003,7 +1041,6 @@ async fn write_app_collection_pairing(
         .map(|c| format!(r#""{}""#, escape_graphql_string(c)))
         .collect::<Vec<_>>().join(",");
     let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
-    // collections is a non-empty literal here; if it were empty we would emit null.
     let mutation = format!(r#"mutation {{
         create_DataPlanePairingDesired(input: {{
             peer_id: "{peer}", agent_did: "{did}",
@@ -1043,7 +1080,7 @@ Fill the body by copying the assertion blocks from `event_trigger_p2p_e2e.rs:436
 
 - [ ] **Step 2: Run to verify it fails for the RIGHT reason**
 
-Run: `cargo test -p defra-agent --test <e2e_triggers-target> app_collection_pairing_fires_event_trigger_via_reconcile -- --nocapture`
+Run: `cargo test -p defra-agent --test e2e_triggers app_collection_pairing_fires_event_trigger_via_reconcile -- --nocapture`
 Expected at this point in the branch: it should **PASS** if Tasks 3-7 are already merged (the reconcile path is implemented). To honor TDD, run this test on a checkout WITHOUT Tasks 5-6 (e.g. `git stash` the engine.rs resolver/merge changes) and confirm it FAILS with the diagnostic ("doc replicated but trigger did not fire" or "no replicator established"). Document the observed failure, then restore.
 
 - [ ] **Step 3: Add the malformed-path assertion (guards the soft-skip)**
@@ -1070,7 +1107,7 @@ rejects it) nor `[]` (Global Constraints: corrupts nillable array columns).
 
 - [ ] **Step 4: Run the full e2e module**
 
-Run: `cargo test -p defra-agent --test <e2e_triggers-target> app_collection_pairing`
+Run: `cargo test -p defra-agent --test e2e_triggers app_collection_pairing`
 Expected: PASS (both the happy path and the malformed-path guard).
 
 - [ ] **Step 5: Commit**
@@ -1137,7 +1174,7 @@ EOF
 ## Notes for the executor
 
 - **Resolver tests live in-crate (Tasks 6-7).** `data_plane_desired_from_pairing_row` / `desired_from_pairing_row` are private; test them from the existing `#[cfg(test)] mod tests` in `engine.rs` (which already calls the former directly), NOT from `tests/conformance/*` — integration tests compile `defra-agent` as a normal dependency and cannot see private items or `#[cfg(test)]`/unfeatured-`pub` seams. Do not add a `conformance-seams` feature. Merge-rule conformance (Task 5) is different: it uses the already-`pub` `merge_layered_desired`, so it can (and does) live in `tests/conformance/pairing_reconcile.rs`.
-- **e2e target name:** integration tests under `tests/e2e_triggers/` compile as one binary; find its harness entry (`grep -rn "mod event_trigger_p2p_e2e" crates/defra-agent/tests/`) and use that `--test <name>` for the run commands above.
+- **e2e target name:** integration tests under `tests/e2e_triggers/` compile as one binary; find its harness entry (`grep -rn "mod event_trigger_p2p_e2e" crates/defra-agent/tests/`) and use that `--test e2e_triggers` for the run commands above.
 - **`data_plane_scope_filter` for app-collections** returns `{}` (Unscoped), so the replicator is unfiltered — correct for whole-collection sync. Confirm `apply_op`'s `InstallReplicator` passes an empty `PairingFilters` (it reads `desired.replicator_filter`).
 - **Ordering invariant** is enforced by test sequencing (trigger reconciled before the data-plane rows are written), matching `event_trigger_p2p_e2e.rs`.
 - **Optional (spec §4, reviewer-optional):** a diagnostic test that an unknown/non-`@branchable` collection name surfaces an error string naming the offending collection. This exercises the `apply_op` → `add_p2p_collections` error path, which needs a live node; only add it if it can be written without excessive harness cost. No runtime branchable gate either way. Not a blocking deliverable.

--- a/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
+++ b/docs/superpowers/plans/2026-07-08-app-defined-collection-pairing.md
@@ -1,0 +1,1054 @@
+# App-Defined Collection Pairing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let one agent replicate an app-defined `@branchable` collection (e.g. `ChangeProposed`) to a paired peer as desired-state config, so a merged document fires the peer's `EventTrigger` through the reconcile path — no hand-wired `add_replicator`.
+
+**Architecture:** Add one `app-collections` policy template (`Unscoped` + `Replicate`, bring-your-own collections). Honor the already-existing-but-dropped `DataPlanePairingDesired.collections` field, gated on `template == "app-collections"`. Populate the subscription set at both the resolver and `merge_layered_desired`. Soft-skip malformed rows so a bad data-plane row never stalls a co-existing control pairing; reject `app-collections` on the control-plane path.
+
+**Tech Stack:** Rust (`defra-agent`, `defra-agent-cli`, `defra-agent-schemas`), Lean 4 + Mathlib (`crates/defra-agent/proofs`), DefraDB P2P (embedded), tokio integration tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md`. Issue #657. Follow-up epic #660.
+
+## Global Constraints
+
+- **Lean-first foundation flow:** Lean model → conformance tests → Rust. Zero `sorry`s. (CLAUDE.md)
+- **`graphql::escape_graphql_string()`** for every value interpolated into a GraphQL string.
+- **Never emit `[]`** in a DefraDB mutation — an empty list literal corrupts nillable array columns; emit `null`.
+- **Gate with the full package suite** `cargo test -p defra-agent` (not `--lib`; integration tests are separate compile units).
+- **Compile the whole workspace before pushing:** `cargo check --workspace --all-targets`.
+- **`tracing`, never `println`.**
+- **Clippy clean:** `cargo clippy --workspace --all-targets -- -D warnings`.
+- **New template id string is exactly `app-collections`;** the Rust const is `APP_COLLECTIONS_TEMPLATE`; the Lean def is `appCollectionsTemplate`. Use these verbatim everywhere.
+- **Replicated app collections must be `@branchable`** (operator/schema responsibility; the e2e schema carries it).
+- **PR to `sourcenetwork/defra-agent` off `origin/main`, referencing #657. Do not merge.**
+
+---
+
+## File Structure
+
+- `crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean` — add `appCollectionsTemplate` + extend `builtinCatalog` (Task 1).
+- `crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean` — add catalog-membership theorem (Task 1).
+- `crates/defra-agent/tests/conformance/scope_templates.rs` — conformance: app-collections resolves as Unscoped/Replicate/empty template set (Task 2).
+- `crates/defra-agent/src/agent/p2p_reconcile/templates.rs` — new template + const + fix two unit tests (Task 3).
+- `crates/defra-agent/src/agent/p2p_reconcile/engine.rs` — `load_desired` query; `data_plane_desired_from_pairing_row` (honor row collections, soft-skip, `Result<Option<..>>`); `desired_from_pairing_row` (reject app-collections, `Result<Option<..>>`); `merge_layered_desired` conditional subscription preservation (Tasks 4–7).
+- `crates/defra-agent/tests/conformance/pairing_reconcile.rs` — merge subscription-preservation + resolution + soft-skip + reject conformance (Tasks 5–7).
+- `crates/defra-agent-cli/src/commands/p2p/pairings.rs` — reject `app-collections` on generic pairing path (Task 8).
+- `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs` — membership-materialization harness + acceptance e2e (Tasks 9–10).
+- `crates/defra-agent/tests/e2e_triggers/mod.rs` (or the harness's mod root) — register the new test module (Task 9).
+
+---
+
+## Task 1: Lean — add `app-collections` to the template catalog
+
+**Files:**
+- Modify: `crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean:157-165` (builtinCatalog) + add a def near line 155
+- Modify: `crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean` (add theorem near line 188)
+
+**Interfaces:**
+- Produces: `ScopeTemplates.appCollectionsTemplate : Template`; `builtinCatalog` now has 8 entries; theorem `appCollections_in_catalog`.
+
+- [ ] **Step 1: Add the template def and catalog entry**
+
+In `State.lean`, add after `subagentHostTemplate` (line 155):
+
+```lean
+def appCollectionsTemplate : Template :=
+  { id := "app-collections"
+  , collections := (∅ : Finset String)
+  , scope := .unscoped
+  , delivery := .replicate }
+```
+
+Then extend `builtinCatalog` (line 158) to include it as the final entry:
+
+```lean
+def builtinCatalog : Catalog :=
+  [ conversationTemplate
+  , agentConfigTemplate
+  , backupTemplate
+  , discoveryTemplate
+  , networkControlTemplate
+  , subagentCoordinatorTemplate
+  , subagentHostTemplate
+  , appCollectionsTemplate ]
+```
+
+- [ ] **Step 2: Add the catalog-membership theorem**
+
+In `Derivation.lean`, after `subagentHost_in_catalog` (line 188):
+
+```lean
+/-- Concrete catalog membership: the app-collections (bring-your-own) template
+resolves from the built-in catalog. Its collection set is empty by contract —
+the DataPlanePairingDesired row supplies the collections. -/
+theorem appCollections_in_catalog :
+    resolveTemplate builtinCatalog "app-collections" = some appCollectionsTemplate := by
+  decide
+
+/-- The app-collections template carries no fixed collections: its set is
+row-supplied, not catalog-fixed. -/
+theorem appCollections_collections_empty :
+    appCollectionsTemplate.collections = (∅ : Finset String) := rfl
+
+/-- The app-collections template is whole-collection replicate (no per-peer
+filter): Unscoped scope yields no filters for any collection list. -/
+theorem appCollections_unscoped_no_filter (collections : List String) (peerDid localDid : Did) :
+    scopeFilter appCollectionsTemplate.scope collections peerDid localDid = [] := rfl
+```
+
+- [ ] **Step 3: Build the proofs and verify zero sorries**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: builds clean, no errors, no `sorry` warnings. (If a fresh worktree, first symlink the parent's mathlib `.lake/build` per the reference note, then `lake build`.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
+git commit -m "proof(scope-templates): add app-collections to builtin catalog (#657)"
+```
+
+---
+
+## Task 2: Conformance — `app-collections` resolution mirror
+
+**Files:**
+- Modify: `crates/defra-agent/tests/conformance/scope_templates.rs`
+
+**Interfaces:**
+- Consumes: real `defra_agent::agent::p2p_reconcile::templates::{resolve_template, Delivery, Scope}` (Task 3 must make `resolve_template("app-collections")` return `Some`; this test is written first and fails until then).
+
+- [ ] **Step 1: Write the failing conformance test**
+
+Append to `scope_templates.rs`:
+
+```rust
+/// Mirrors Lean `appCollections_in_catalog` / `appCollections_collections_empty`
+/// / `appCollections_unscoped_no_filter`: the app-collections "bring-your-own"
+/// template resolves, is Unscoped + Replicate, and carries no fixed collections
+/// (the DataPlanePairingDesired row supplies them).
+#[test]
+fn app_collections_template_is_unscoped_replicate_byo() {
+    let t = resolve_template("app-collections").expect("app-collections in catalog");
+    assert_eq!(t.id, "app-collections");
+    assert!(matches!(t.delivery, Delivery::Replicate));
+    assert!(matches!(t.scope, Scope::Unscoped));
+    assert!(
+        t.collections.is_empty(),
+        "app-collections carries no fixed collections; the row supplies them"
+    );
+    // Unscoped yields no filters even over a supplied collection list.
+    let f = scope_filter(&t.scope, &["ChangeProposed"], "did:key:bob", "did:key:alice");
+    assert!(f.is_empty(), "unscoped app-collections must not filter");
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p defra-agent --test conformance app_collections_template_is_unscoped_replicate_byo`
+Expected: FAIL — `resolve_template("app-collections")` returns `None` (panics on `.expect`).
+
+- [ ] **Step 3: Commit the failing test**
+
+```bash
+git add crates/defra-agent/tests/conformance/scope_templates.rs
+git commit -m "test(conformance): app-collections template resolution (failing) (#657)"
+```
+
+---
+
+## Task 3: Rust — add the `app-collections` template
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/p2p_reconcile/templates.rs`
+
+**Interfaces:**
+- Produces: `pub const APP_COLLECTIONS_TEMPLATE: &str = "app-collections";`; a new `ScopeTemplate` in `BUILTIN_TEMPLATES` with `collections: &[]`, `scope: Scope::Unscoped`, `delivery: Delivery::Replicate`. `resolve_template("app-collections")` returns `Some`.
+
+- [ ] **Step 1: Add the constant**
+
+In `templates.rs`, next to the other template-id consts (after line 222):
+
+```rust
+pub const APP_COLLECTIONS_TEMPLATE: &str = "app-collections";
+```
+
+- [ ] **Step 2: Add the catalog entry**
+
+Append to `BUILTIN_TEMPLATES` (before the closing `]` at line 267):
+
+```rust
+    ScopeTemplate {
+        id: APP_COLLECTIONS_TEMPLATE,
+        // Bring-your-own: the DataPlanePairingDesired row supplies the set.
+        collections: &[],
+        scope: Scope::Unscoped,
+        delivery: Delivery::Replicate,
+    },
+```
+
+- [ ] **Step 3: Fix the two unit tests the new entry breaks**
+
+Update `all_builtin_templates_have_nonempty_collections` (line 386) to exempt the bring-your-own template:
+
+```rust
+    #[test]
+    fn all_builtin_templates_have_nonempty_collections() {
+        for t in builtin_templates() {
+            // app-collections is the one bring-your-own template: its collection
+            // set is supplied by the DataPlanePairingDesired row, not the catalog.
+            if t.id == APP_COLLECTIONS_TEMPLATE {
+                assert!(
+                    t.collections.is_empty(),
+                    "app-collections must carry no fixed collections"
+                );
+                continue;
+            }
+            assert!(
+                !t.collections.is_empty(),
+                "template {} has no collections",
+                t.id
+            );
+        }
+    }
+```
+
+Update `builtin_template_count_is_seven` (line 397) to eight and rename:
+
+```rust
+    #[test]
+    fn builtin_template_count_is_eight() {
+        assert_eq!(builtin_templates().len(), 8);
+    }
+```
+
+- [ ] **Step 4: Add a focused unit test for the new template**
+
+```rust
+    #[test]
+    fn app_collections_is_byo_unscoped_replicate() {
+        let t = resolve_template(APP_COLLECTIONS_TEMPLATE).unwrap();
+        assert_eq!(t.delivery, Delivery::Replicate);
+        assert!(matches!(t.scope, Scope::Unscoped));
+        assert!(t.collections.is_empty());
+    }
+```
+
+- [ ] **Step 5: Run templates unit tests + the Task 2 conformance test**
+
+Run: `cargo test -p defra-agent --lib p2p_reconcile::templates`
+Expected: PASS (including the count/nonempty/byo tests).
+Run: `cargo test -p defra-agent --test conformance app_collections_template_is_unscoped_replicate_byo`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/p2p_reconcile/templates.rs
+git commit -m "feat(p2p): add app-collections bring-your-own scope template (#657)"
+```
+
+---
+
+## Task 4: Rust — select `collections` in `load_desired`
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:497-502` (the `DataPlanePairingDesired` sub-query)
+
+**Interfaces:**
+- Produces: `PairingStateRow.collections` is populated for data-plane rows (already deserialized; only the query field was missing).
+
+- [ ] **Step 1: Add `collections` to the sub-query**
+
+In `load_desired` (the query around line 497), change the `DataPlanePairingDesired` selection to include `collections`:
+
+```rust
+                DataPlanePairingDesired(filter: {{ peer_id: {{ _eq: "{peer_id}" }} }}) {{
+                    agent_did
+                    collections
+                    replicator_addresses
+                    template
+                }}
+```
+
+- [ ] **Step 2: Compile check (no behavior change yet)**
+
+Run: `cargo check -p defra-agent`
+Expected: compiles clean (the field flows into `PairingStateRow.collections`, still unused by the resolver until Task 6).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+git commit -m "feat(p2p): read DataPlanePairingDesired.collections in load_desired (#657)"
+```
+
+---
+
+## Task 5: Rust — `merge_layered_desired` preserves the app-collections subscription
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:894-919` (`merge_layered_desired`)
+- Test: `crates/defra-agent/tests/conformance/pairing_reconcile.rs`
+
+**Interfaces:**
+- Consumes: `PairingDesired.template_ids: BTreeSet<String>` (already exists), `templates::APP_COLLECTIONS_TEMPLATE` (Task 3).
+- Produces: `merge_layered_desired` keeps the data-plane layer's `collections` when `template_ids` contains `app-collections`; clears it otherwise (unchanged for every existing template).
+
+- [ ] **Step 1: Write the failing conformance test**
+
+Append to `pairing_reconcile.rs` (uses the existing `set(&[...])` helper in that file):
+
+```rust
+/// An `app-collections` data-plane layer's subscription set survives
+/// `merge_layered_desired`, so an `InstallCollection` op can reach the diff.
+/// A network-control-only data-plane layer's subscription is still cleared
+/// (conversation data must never gossip unfiltered).
+#[test]
+fn merge_preserves_app_collections_subscription_only() {
+    use defra_agent::agent::p2p_reconcile::diff::PairingDesired;
+    use defra_agent::agent::p2p_reconcile::engine::merge_layered_desired;
+
+    // app-collections data-plane layer: subscription set must survive.
+    let app_layer = PairingDesired {
+        collections: set(&["ChangeProposed"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["ChangeProposed"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["app-collections"]),
+    };
+    let merged = merge_layered_desired(None, Some(app_layer)).expect("merged");
+    assert!(
+        merged.collections.contains("ChangeProposed"),
+        "app-collections subscription must survive the merge: {merged:?}"
+    );
+
+    // network-control data-plane layer: subscription still cleared.
+    let nc_layer = PairingDesired {
+        collections: set(&["AgentRequest"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["AgentRequest"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["network-control"]),
+    };
+    let merged_nc = merge_layered_desired(None, Some(nc_layer)).expect("merged nc");
+    assert!(
+        merged_nc.collections.is_empty(),
+        "non-app-collections data-plane subscription must be cleared: {merged_nc:?}"
+    );
+}
+
+/// Spec conformance case (iii): an app-collections data-plane layer merges with a
+/// co-existing control (network-control) base pairing without cross-contaminating
+/// their subscriptions or replicator filters — the control pairing is undisturbed.
+#[test]
+fn app_collections_coexists_with_control_pairing() {
+    use defra_agent::agent::p2p_reconcile::diff::PairingDesired;
+    use defra_agent::agent::p2p_reconcile::engine::merge_layered_desired;
+
+    let base = PairingDesired {
+        collections: set(&["AgentNetwork", "NetworkMembership"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["AgentNetwork", "NetworkMembership"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["network-control"]),
+    };
+    let app_layer = PairingDesired {
+        collections: set(&["ChangeProposed"]),
+        replicator_addresses: set(&["addr-b"]),
+        replicator_collections: set(&["ChangeProposed"]),
+        replicator_filter: Default::default(),
+        template_ids: set(&["app-collections"]),
+    };
+    let merged = merge_layered_desired(Some(base), Some(app_layer)).expect("merged");
+    // Control-plane subscriptions preserved AND the app-collections subscription added.
+    assert!(merged.collections.contains("AgentNetwork"));
+    assert!(merged.collections.contains("NetworkMembership"));
+    assert!(merged.collections.contains("ChangeProposed"));
+    // Both replicator collection sets present; no filter cross-contamination.
+    assert!(merged.replicator_collections.contains("AgentNetwork"));
+    assert!(merged.replicator_collections.contains("ChangeProposed"));
+    assert!(merged.replicator_filter.is_empty(), "both layers unscoped => no filter");
+    assert!(merged.template_ids.contains("network-control"));
+    assert!(merged.template_ids.contains("app-collections"));
+}
+```
+
+If `merge_layered_desired` or `PairingDesired` are not already `pub` at those paths, note it — Step 3 makes them reachable. (`PairingDesired` is `pub` in `diff.rs`; confirm `merge_layered_desired` is `pub` in `engine.rs` — it is, per `pub fn merge_layered_desired`.)
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cargo test -p defra-agent --test conformance merge_preserves_app_collections_subscription_only`
+Expected: FAIL — the current blanket `desired.collections.clear()` empties the app-collections subscription, so `merged.collections.contains("ChangeProposed")` is false.
+
+- [ ] **Step 3: Make the clear conditional**
+
+Replace the unconditional clear (lines 902-905) with:
+
+```rust
+    // Layer-2 desired rows add data-plane collections to the per-peer
+    // replicator, not to the subscription set — EXCEPT the app-collections
+    // (bring-your-own) policy, which is a whole-collection Replicate that must
+    // subscribe on both sides for the merged doc to be observable. All other
+    // data-plane layers keep the clear so conversation data never gossips
+    // unfiltered.
+    let data_plane = data_plane.map(|mut desired| {
+        if !desired
+            .template_ids
+            .contains(super::templates::APP_COLLECTIONS_TEMPLATE)
+        {
+            desired.collections.clear();
+        }
+        desired
+    });
+```
+
+(`super::templates::APP_COLLECTIONS_TEMPLATE` — confirm the `use`/path resolves in `engine.rs`; it already references `super::templates::*` elsewhere.)
+
+- [ ] **Step 4: Run it to verify it passes + run existing merge tests**
+
+Run: `cargo test -p defra-agent --test conformance merge_preserves_app_collections_subscription_only`
+Expected: PASS.
+Run: `cargo test -p defra-agent --lib p2p_reconcile::engine`
+Expected: PASS (existing `merge_layered_*` unit tests at engine.rs:1017+ unaffected — they use network-control/AgentRequest layers that still clear).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs crates/defra-agent/tests/conformance/pairing_reconcile.rs
+git commit -m "feat(p2p): preserve app-collections subscription through merge_layered_desired (#657)"
+```
+
+---
+
+## Task 6: Rust — honor row collections + soft-skip in `data_plane_desired_from_pairing_row`
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:738-828` (`data_plane_desired_from_pairing_row`) and its call site in `load_desired` (lines 513-523)
+- Test: `crates/defra-agent/tests/conformance/pairing_reconcile.rs`
+
+**Interfaces:**
+- Consumes: `templates::APP_COLLECTIONS_TEMPLATE`, `PairingStateRow.collections` (Task 4).
+- Produces: signature changes to `fn data_plane_desired_from_pairing_row(row, signed_endpoint, self_did) -> Result<Option<PairingDesired>>`. For `template == "app-collections"`: `replicator_collections` and `collections` (subscription) both = trimmed row collections, filter Unscoped (`{}`); empty trimmed set → `Ok(None)` (soft-skip). For other templates → `Ok(Some(..))` unchanged. Foreign `agent_did` still `Err`.
+
+- [ ] **Step 1: Write the failing conformance tests**
+
+Append to `pairing_reconcile.rs`. These call the real resolver via a thin store or the function directly — expose it. First, ensure `data_plane_desired_from_pairing_row` is reachable: it is currently private. Add `pub(crate)` and re-export via a test-visible path, or test through `GraphqlPairingStateStore::load_desired` with a seeded node. **Chosen approach:** make `data_plane_desired_from_pairing_row` `pub` and its input `PairingStateRow` constructor reachable by adding a `#[doc(hidden)] pub fn new_for_test(...)`. To avoid widening the API, instead test the two behaviors through the existing `merge_layered_desired` + a small pure helper. **Simplest that matches repo style:** promote `data_plane_desired_from_pairing_row` to `pub(crate)` and add a conformance test in an in-crate test module.
+
+Given the repo tests the resolver via conformance calling public seams, expose a focused public wrapper in `engine.rs`:
+
+```rust
+/// Test/conformance seam: resolve a data-plane desired layer from explicit
+/// inputs (mirrors what `load_desired` does per row). Keeps the row struct
+/// private while letting conformance exercise the app-collections resolution.
+#[cfg(any(test, feature = "conformance-seams"))]
+pub fn resolve_data_plane_layer_for_test(
+    agent_did: Option<&str>,
+    collections: &[&str],
+    template: &str,
+    signed_address: &str,
+    signed_peer_did: &str,
+    signed_peer_id: &str,
+    self_did: &str,
+) -> anyhow::Result<Option<PairingDesired>> {
+    let row = PairingStateRow {
+        agent_did: agent_did.map(str::to_string),
+        collections: Some(collections.iter().map(|s| s.to_string()).collect()),
+        replicator_addresses: None,
+        template: Some(template.to_string()),
+        replicator_filter: None,
+    };
+    let entry = NetworkEndpointEntry {
+        peer_id: signed_peer_id.to_string(),
+        agent_did: signed_peer_did.to_string(),
+        address: signed_address.to_string(),
+    };
+    data_plane_desired_from_pairing_row(row, &entry, self_did)
+}
+```
+
+If the `conformance-seams` feature does not exist, use `#[cfg(test)]` plus an in-crate `#[cfg(test)] mod` conformance instead; confirm how sibling resolvers are exercised (grep `resolve.*_for_test` / existing `pub(crate)` seams in `engine.rs`) and match that convention rather than inventing a feature. Then the conformance test:
+
+```rust
+#[test]
+fn app_collections_row_resolves_row_collections_as_subscription_and_replicator() {
+    use defra_agent::agent::p2p_reconcile::engine::resolve_data_plane_layer_for_test;
+    let layer = resolve_data_plane_layer_for_test(
+        Some("did:key:self"),           // agent_did == self (allowed)
+        &["ChangeProposed"],
+        "app-collections",
+        "addr-b", "did:key:peer", "peer-b",
+        "did:key:self",
+    )
+    .expect("resolve ok")
+    .expect("some layer");
+    assert!(layer.replicator_collections.contains("ChangeProposed"));
+    assert!(layer.collections.contains("ChangeProposed"),
+        "app-collections must subscribe (Replicate)");
+    assert!(layer.replicator_filter.is_empty(), "unscoped => no filter");
+    assert!(layer.template_ids.contains("app-collections"));
+}
+
+#[test]
+fn app_collections_empty_collections_soft_skips() {
+    use defra_agent::agent::p2p_reconcile::engine::resolve_data_plane_layer_for_test;
+    let out = resolve_data_plane_layer_for_test(
+        Some("did:key:self"),
+        &["   "],                        // blank-only after trim
+        "app-collections",
+        "addr-b", "did:key:peer", "peer-b",
+        "did:key:self",
+    )
+    .expect("resolve ok (soft-skip is Ok(None), not Err)");
+    assert!(out.is_none(), "empty/blank app-collections set must soft-skip to None");
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo test -p defra-agent --test conformance app_collections_row_resolves`
+Expected: FAIL — the resolver currently ignores `row.collections` and returns `Result<PairingDesired>` (won't compile against `.expect("some layer")` on an `Option`).
+
+- [ ] **Step 3: Change the signature to `Result<Option<PairingDesired>>` and honor row collections**
+
+Rewrite `data_plane_desired_from_pairing_row` (lines 738-828). Keep the address-mismatch warn and the foreign-`agent_did` hard `bail!` (lines 754-780) exactly. Replace the collection/subscription construction (lines 782-827) with:
+
+```rust
+    let template_id = row
+        .template
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .unwrap_or(DEFAULT_PAIRING_TEMPLATE);
+    let template = resolve_template(template_id).unwrap_or_else(|| {
+        tracing::warn!(
+            template = template_id,
+            "unknown data-plane pairing scope template; falling back to default \"{DEFAULT_PAIRING_TEMPLATE}\""
+        );
+        resolve_template(DEFAULT_PAIRING_TEMPLATE)
+            .expect("default pairing template is in the catalog")
+    });
+    let peer_did = signed_endpoint.agent_did.trim();
+    if data_plane_scope_requires_signed_peer_did(&template.scope) && peer_did.is_empty() {
+        anyhow::bail!(
+            "DataPlanePairingDesired for peer {} uses template {template_id:?} but the signed \
+             PeerEndpoint has a blank agent_did",
+            signed_endpoint.peer_id
+        );
+    }
+
+    row.replicator_addresses = Some(vec![signed_endpoint.address.clone()]);
+    let replicator_addresses = row
+        .replicator_addresses
+        .unwrap_or_default()
+        .into_iter()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>();
+
+    // app-collections (bring-your-own): the row supplies the collection set; the
+    // template supplies only scope (Unscoped) + delivery (Replicate). A blank set
+    // is malformed input — SOFT-SKIP this layer (Ok(None) + warn) rather than
+    // bail, so a bad app row never fails the whole peer's desired load and stalls
+    // a co-existing control pairing (reconcile_peer_tick desired_read_failed).
+    let (replicator_collections, subscription_collections): (BTreeSet<String>, BTreeSet<String>) =
+        if template.id == super::templates::APP_COLLECTIONS_TEMPLATE {
+            let row_cols = row
+                .collections
+                .unwrap_or_default()
+                .into_iter()
+                .map(|c| c.trim().to_string())
+                .filter(|c| !c.is_empty())
+                .collect::<BTreeSet<_>>();
+            if row_cols.is_empty() {
+                tracing::warn!(
+                    peer_id = %signed_endpoint.peer_id,
+                    "app-collections DataPlanePairingDesired has no non-blank collections; \
+                     skipping this data-plane layer (control pairing unaffected)"
+                );
+                return Ok(None);
+            }
+            // Replicate: subscribe to the same set so the merged doc is observable.
+            (row_cols.clone(), row_cols)
+        } else {
+            // Legacy / template-driven data-plane rows: unchanged. Template
+            // collections drive the replicator; no subscription (push channel).
+            let cols = template
+                .collections
+                .iter()
+                .map(|&c| c.to_string())
+                .collect::<BTreeSet<_>>();
+            (cols, BTreeSet::new())
+        };
+
+    let filter_collections = replicator_collections
+        .iter()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    let replicator_filter =
+        data_plane_scope_filter(&template.scope, &filter_collections, peer_did, self_did);
+
+    Ok(Some(PairingDesired {
+        collections: subscription_collections,
+        replicator_addresses,
+        replicator_collections,
+        replicator_filter,
+        template_ids: BTreeSet::from([template.id.to_string()]),
+    }))
+```
+
+Note: `data_plane_scope_filter` takes `&[&str]`; the previous call passed `template.collections` (a `&[&str]`). We now pass the row-derived set, so build `filter_collections` as shown. For non-app-collections templates this is the template's own collection names (identical set), preserving prior filter behavior.
+
+- [ ] **Step 4: Update the `load_desired` call site**
+
+At lines 513-523, the match arm already unwraps with `?`. Because the function now returns `Result<Option<PairingDesired>>`, the `?` yields `Option<PairingDesired>` directly — which is exactly the type of `data_plane`. Change the arm from `Some(data_plane_desired_from_pairing_row(row, &entry, ...)?)` to just the flattened value:
+
+```rust
+        let data_plane = match (
+            materialized_entry,
+            first_row::<PairingStateRow>(&response, "DataPlanePairingDesired")?,
+        ) {
+            (Some(entry), Some(row)) => {
+                data_plane_desired_from_pairing_row(row, &entry, self.identity.did())?
+            }
+            _ => None,
+        };
+```
+
+(The soft-skip `Ok(None)` now flows through as `data_plane = None`, leaving `base` intact in `merge_layered_desired`.)
+
+- [ ] **Step 5: Run the conformance tests + full engine tests**
+
+Run: `cargo test -p defra-agent --test conformance app_collections_row`
+Expected: PASS (both resolution + soft-skip).
+Run: `cargo test -p defra-agent --lib p2p_reconcile`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs crates/defra-agent/tests/conformance/pairing_reconcile.rs
+git commit -m "feat(p2p): honor app-collections row collections + soft-skip malformed rows (#657)"
+```
+
+---
+
+## Task 7: Rust — reject `app-collections` on the control-plane path
+
+**Files:**
+- Modify: `crates/defra-agent/src/agent/p2p_reconcile/engine.rs:671-736` (`desired_from_pairing_row`) + its `load_desired` call site (lines 506-508)
+- Test: `crates/defra-agent/tests/conformance/pairing_reconcile.rs`
+
+**Interfaces:**
+- Produces: `fn desired_from_pairing_row(row, local_did) -> Result<Option<PairingDesired>>`. A `PeerPairingDesired`/base row whose resolved template is `app-collections` → `Ok(None)` + warn (no wiring). All other templates unchanged.
+
+- [ ] **Step 1: Write the failing conformance test**
+
+Append to `pairing_reconcile.rs` (mirror the seam approach from Task 6; add a base-path wrapper if needed):
+
+```rust
+/// A base/PeerPairingDesired row that names the app-collections template has no
+/// way to supply row collections; it must resolve to no wiring (soft-skip),
+/// never an empty-collection replicator.
+#[test]
+fn app_collections_on_control_plane_path_soft_skips() {
+    use defra_agent::agent::p2p_reconcile::engine::resolve_control_plane_desired_for_test;
+    let out = resolve_control_plane_desired_for_test(
+        Some("did:key:peer"),
+        &["addr-b"],
+        "app-collections",
+        "did:key:self",
+    )
+    .expect("resolve ok");
+    assert!(out.is_none(), "app-collections is invalid for a control-plane row");
+}
+```
+
+Add the seam wrapper in `engine.rs` beside the Task 6 one:
+
+```rust
+#[cfg(any(test, feature = "conformance-seams"))]
+pub fn resolve_control_plane_desired_for_test(
+    agent_did: Option<&str>,
+    replicator_addresses: &[&str],
+    template: &str,
+    local_did: &str,
+) -> anyhow::Result<Option<PairingDesired>> {
+    let row = PairingStateRow {
+        agent_did: agent_did.map(str::to_string),
+        collections: None,
+        replicator_addresses: Some(replicator_addresses.iter().map(|s| s.to_string()).collect()),
+        template: Some(template.to_string()),
+        replicator_filter: None,
+    };
+    desired_from_pairing_row(row, local_did)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p defra-agent --test conformance app_collections_on_control_plane_path_soft_skips`
+Expected: FAIL — `desired_from_pairing_row` returns `Result<PairingDesired>` (won't compile against `.is_none()`), and today resolves app-collections to empty-collection wiring.
+
+- [ ] **Step 3: Change signature + add the reject**
+
+In `desired_from_pairing_row` (line 671), change the return type to `Result<Option<PairingDesired>>`. After the template is resolved (around line 697), add:
+
+```rust
+    // app-collections is a data-plane-only (bring-your-own) policy: a
+    // control-plane / PeerPairingDesired row cannot supply row collections, so
+    // it would resolve to empty wiring yet has_wiring() would be true (addresses
+    // present). Refuse to wire it. Soft-skip (Ok(None) + warn) so a raw-GraphQL
+    // row cannot install an empty-collection replicator.
+    if template.id == APP_COLLECTIONS_TEMPLATE {
+        tracing::warn!(
+            "PeerPairingDesired names the app-collections template, which is \
+             data-plane-only and supplies no collections here; skipping (no wiring)"
+        );
+        return Ok(None);
+    }
+```
+
+Wrap the final `Ok(PairingDesired { .. })` (line 729) as `Ok(Some(PairingDesired { .. }))`, and the existing `bail!` (line 708) stays a hard `Err`.
+
+- [ ] **Step 4: Update the `load_desired` base call site**
+
+At lines 506-508, the base currently does `.map(|row| desired_from_pairing_row(row, self.identity.did())).transpose()?` yielding `Option<PairingDesired>`. Now the closure returns `Result<Option<..>>`, so after `.transpose()?` you get `Option<Option<PairingDesired>>`; flatten it:
+
+```rust
+        let base = first_row::<PairingStateRow>(&response, "PeerPairingDesired")?
+            .map(|row| desired_from_pairing_row(row, self.identity.did()))
+            .transpose()?
+            .flatten();
+```
+
+- [ ] **Step 5: Run conformance + full lib tests**
+
+Run: `cargo test -p defra-agent --test conformance app_collections_on_control_plane_path_soft_skips`
+Expected: PASS.
+Run: `cargo test -p defra-agent --lib p2p_reconcile`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/defra-agent/src/agent/p2p_reconcile/engine.rs crates/defra-agent/tests/conformance/pairing_reconcile.rs
+git commit -m "feat(p2p): reject app-collections template on the control-plane path (#657)"
+```
+
+---
+
+## Task 8: CLI — reject `app-collections` on the generic pairing path
+
+**Files:**
+- Modify: `crates/defra-agent-cli/src/commands/p2p/pairings.rs:173-188` (`resolve_pairing_template`)
+
+**Interfaces:**
+- Consumes: `defra_agent::agent::p2p_reconcile::templates::APP_COLLECTIONS_TEMPLATE`.
+- Produces: `resolve_pairing_template("app-collections")` returns `Err` with a clear message; all other ids unchanged.
+
+- [ ] **Step 1: Write the failing unit test**
+
+In `pairings.rs` tests (or the crate's CLI tests), add:
+
+```rust
+    #[test]
+    fn app_collections_rejected_on_generic_pairing_path() {
+        let err = resolve_pairing_template("app-collections").unwrap_err().to_string();
+        assert!(
+            err.contains("app-collections"),
+            "error must name the offending template: {err}"
+        );
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p defra-agent-cli app_collections_rejected_on_generic_pairing_path`
+Expected: FAIL — `app-collections` currently resolves successfully (it is a valid builtin).
+
+- [ ] **Step 3: Add the guard**
+
+In `resolve_pairing_template`, after the empty check and before the `resolve_template(template).is_some()` acceptance:
+
+```rust
+    if template == defra_agent::agent::p2p_reconcile::templates::APP_COLLECTIONS_TEMPLATE {
+        anyhow::bail!(
+            "the app-collections template is for DataPlanePairingDesired rows only; \
+             it supplies no collections on the control-plane pairing path — write a \
+             data-plane pairing with an explicit collection set instead"
+        );
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cargo test -p defra-agent-cli app_collections_rejected_on_generic_pairing_path`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent-cli/src/commands/p2p/pairings.rs
+git commit -m "feat(cli): reject app-collections on the generic pairing path (#657)"
+```
+
+---
+
+## Task 9: E2E harness — in-process membership materialization helper
+
+**Files:**
+- Create: `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs`
+- Modify: the `e2e_triggers` module root to register it (grep for where `event_trigger_p2p_e2e` is declared: `mod event_trigger_p2p_e2e;` and add `mod app_collection_pairing_p2p_e2e;`).
+
+**Interfaces:**
+- Consumes: `defra_agent_protocol::network_token::{NetworkRecord, MembershipRecord, EndpointRecord}` (each has `signing_payload()`); `AgentIdentity::sign`; `bs58` (sig encoding — see `network.rs:690 decode_sig` uses `bs58::decode`, so write with `bs58::encode(sig).into_string()`); `graphql::escape_graphql_string`.
+- Produces: `async fn seed_materializable_peer(node, network_id, admin_identity, member_identity, member_node_id, member_address)` that writes admin-signed `AgentNetwork` + admin-signed active `NetworkMembership` + member-signed fresh `PeerEndpoint` so `GraphqlNetworkStore::load_materializable_entries` returns the member. Verified against that function.
+
+**NOTE — spike first.** This task front-loads investigation: the exact mutation field names + sig encoding must match the decoders `network_record` / `membership_record` / `endpoint_record` (`network.rs:638-690`) and the writers `write_agent_network` / `write_membership` (`crates/defra-agent-cli/src/commands/p2p/network_admin.rs:275+`) and `endpoint.rs:112 upsert_PeerEndpoint`. Read those four before writing the helper; mirror their field/encoding shapes exactly. The verification gate (Step 3) is objective, so a wrong encoding fails fast.
+
+- [ ] **Step 1: Read the four reference writers/decoders and the record structs**
+
+Run (read, do not edit):
+```bash
+sed -n '638,700p' crates/defra-agent/src/agent/p2p_reconcile/network.rs        # decoders + decode_sig (bs58)
+sed -n '275,430p' crates/defra-agent-cli/src/commands/p2p/network_admin.rs      # write_agent_network / write_membership mutation shapes
+sed -n '80,130p'  crates/defra-agent/src/agent/p2p_reconcile/endpoint.rs        # upsert_PeerEndpoint mutation shape
+grep -n "signing_payload\|struct NetworkRecord\|struct MembershipRecord\|struct EndpointRecord" $(rg -l network_token crates/*/src | head)
+```
+Record the exact field names (`network_id`, `admin_did`, `admin_sig`, `member_did`, `status`, `granted_at`, `did`, `node_id`, `address`, `updated_at`, `binding_sig`, …) and that signatures are **bs58-encoded**.
+
+- [ ] **Step 2: Write the helper (mirror the signing pattern from `peer_registry_discovery.rs:362-410`)**
+
+Skeleton — fill field names/encoding from Step 1; the signing shape is known-good from the conformance test:
+
+```rust
+use defra_agent_protocol::network_token::{EndpointRecord, MembershipRecord, NetworkRecord};
+
+fn bs58_sig(sig: &[u8]) -> String { bs58::encode(sig).into_string() }
+
+/// Write the signed AgentNetwork + active NetworkMembership + fresh PeerEndpoint
+/// documents on `node` so `GraphqlNetworkStore::load_materializable_entries`
+/// materializes `member_identity`'s endpoint. `admin_identity` signs the network
+/// + membership; `member_identity` signs its own endpoint binding.
+async fn seed_materializable_peer(
+    node: &EmbeddedNode,
+    network_id: &str,
+    admin_identity: &dyn AgentIdentity,
+    member_identity: &dyn AgentIdentity,
+    member_node_id: &str,
+    member_address: &str,
+) {
+    // 1. AgentNetwork (admin-signed) — construct NetworkRecord, sign
+    //    signing_payload(), write via add_/create_AgentNetwork with admin_sig=bs58.
+    // 2. NetworkMembership (admin-signed, status="active", granted_at=now).
+    // 3. PeerEndpoint (member-signed, updated_at=now so it is fresh) for the member.
+    //    Mirror endpoint.rs:112 upsert_PeerEndpoint field names.
+    // Escape every interpolated string with escape_graphql_string; never emit [].
+}
+```
+
+- [ ] **Step 3: Verify the gate materializes the peer (the objective fence)**
+
+Add a `#[tokio::test]` that boots one node, calls `seed_materializable_peer`, then constructs `GraphqlNetworkStore::new(node, admin_identity)` and asserts `load_materializable_entries()` contains an entry with the member's `node_id`/`address`:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn seed_makes_peer_materializable() {
+    let db = test_p2p_db("app-collection-seed").await;
+    // ... register schemas / identities ...
+    seed_materializable_peer(db.node.as_ref(), "net-test", &admin, &member, "peer-node", "addr").await;
+    let store = defra_agent::agent::p2p_reconcile::network::GraphqlNetworkStore::new(
+        db.node.clone(), Arc::new(admin_clone),
+    );
+    let entries = store.load_materializable_entries().await.unwrap();
+    assert!(entries.iter().any(|e| e.node_id == "peer-node"),
+        "seeded peer must be materializable: {entries:?}");
+}
+```
+
+Run: `cargo test -p defra-agent --test <e2e_triggers-target> seed_makes_peer_materializable`
+Expected: PASS. If FAIL, the sig encoding or a field name is wrong — compare against Step 1 decoders (this is the fast feedback loop; do not proceed until green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs crates/defra-agent/tests/e2e_triggers/mod.rs
+git commit -m "test(e2e): in-process membership-materialization harness for app-collection pairing (#657)"
+```
+
+---
+
+## Task 10: E2E — reconcile-driven app-collection replication fires the trigger
+
+**Files:**
+- Modify: `crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs`
+
+**Interfaces:**
+- Consumes: `seed_materializable_peer` (Task 9); the harness helpers copied from `event_trigger_p2p_e2e.rs` (`wait_for_runtime_snapshot`, `create_task`, `create_event_trigger_with_filter`, `query_agent_requests_for_trigger`, `fetch_event_trigger`, `test_p2p_db`, `MockModelEndpoint`, `bind_default_behavior_backend`).
+
+- [ ] **Step 1: Write the failing acceptance test**
+
+Model on `p2p_replicated_doc_fires_event_trigger` (event_trigger_p2p_e2e.rs:401-576). Key deltas — the source collection is app-defined `@branchable`, and replication is established by **config rows + reconcile**, not `install_one_way_replicator`:
+
+```rust
+async fn register_change_proposed_schema(node: &EmbeddedNode) {
+    // @branchable is REQUIRED — DefraDB only P2P-syncs branchable collections.
+    let sdl = r#"
+        type ChangeProposed @branchable {
+            external_id: String
+            payload: String
+            kind: String @index
+        }
+    "#;
+    node.add_schema(sdl).await.expect("add_schema ChangeProposed");
+}
+
+/// Write a DataPlanePairingDesired row via desired-state config (NOT add_replicator).
+async fn write_app_collection_pairing(
+    node: &EmbeddedNode, peer_id: &str, self_did: &str, address: &str, collections: &[&str],
+) {
+    let peer = escape_graphql_string(peer_id);
+    let did = escape_graphql_string(self_did);
+    let addr = escape_graphql_string(address);
+    let cols = collections.iter()
+        .map(|c| format!(r#""{}""#, escape_graphql_string(c)))
+        .collect::<Vec<_>>().join(",");
+    let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
+    // collections is a non-empty literal here; if it were empty we would emit null.
+    let mutation = format!(r#"mutation {{
+        create_DataPlanePairingDesired(input: {{
+            peer_id: "{peer}", agent_did: "{did}",
+            collections: [{cols}], replicator_addresses: ["{addr}"],
+            template: "app-collections", created_at: "{now}", updated_at: "{now}"
+        }}) {{ _docID }}
+    }}"#);
+    let resp = node.execute(&mutation).await;
+    assert!(!resp.has_errors(), "create DataPlanePairingDesired: {:?}", resp.errors);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn app_collection_pairing_fires_event_trigger_via_reconcile() {
+    // Node A (sender/writer) + Node B (agent). Both run DefraAgent::run.
+    // 1. Both register ChangeProposed (@branchable).
+    // 2. seed_materializable_peer on BOTH nodes: A knows B, B knows A
+    //    (signed network/membership/endpoint), so data_plane_materialized_entry
+    //    returns Some on both.
+    // 3. On B: Task + EventTrigger watching ChangeProposed/created; WAIT for the
+    //    trigger to reconcile into the active snapshot (ordering invariant).
+    // 4. Co-existing control pairing: establish a subagent (control) pairing on
+    //    A<->B (write the PeerPairingDesired rows) and capture its applied state.
+    // 5. Write DataPlanePairingDesired (template app-collections, collections
+    //    ["ChangeProposed"]) on BOTH nodes (A->B and B->A) via config. Wait for
+    //    each node's reconcile generation to advance and last_reconcile_result
+    //    == "applied".
+    // 6. Write a ChangeProposed doc on A; poll B for exactly one AgentRequest
+    //    caused_by_trigger_id, rendered content, execution_origin "scheduled";
+    //    then EventTrigger last_status "fired", fire_count 1,
+    //    last_fired_source_doc_id == the doc id.
+    // 7. Idempotence: capture generation, force/await another sweep, assert no new
+    //    ops and the control pairing's applied state is unchanged.
+}
+```
+
+Fill the body by copying the assertion blocks from `event_trigger_p2p_e2e.rs:436-573` verbatim (they already assert exactly one request, lineage, `execution_origin`, rendered content, `last_status`/`fire_count`/`last_fired_source_doc_id`/`last_error`, and the apply-owned fields), swapping `ReplicatedEvent`→`ChangeProposed` and the trigger/task ids.
+
+- [ ] **Step 2: Run to verify it fails for the RIGHT reason**
+
+Run: `cargo test -p defra-agent --test <e2e_triggers-target> app_collection_pairing_fires_event_trigger_via_reconcile -- --nocapture`
+Expected at this point in the branch: it should **PASS** if Tasks 3-7 are already merged (the reconcile path is implemented). To honor TDD, run this test on a checkout WITHOUT Tasks 5-6 (e.g. `git stash` the engine.rs resolver/merge changes) and confirm it FAILS with the diagnostic ("doc replicated but trigger did not fire" or "no replicator established"). Document the observed failure, then restore.
+
+- [ ] **Step 3: Add the malformed-path assertion (guards the soft-skip)**
+
+Append a second `#[tokio::test]` (or extend the first after the happy-path asserts):
+
+```rust
+// Malformed app-collections row (empty collections) must NOT stall the
+// co-existing control pairing: the data-plane layer soft-skips, base survives.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn empty_app_collection_row_does_not_stall_control_pairing() {
+    // Boot one agent node with a control pairing already applied; write a
+    // DataPlanePairingDesired with collections: null (empty) + template
+    // app-collections; assert the next reconcile tick is NOT desired_read_failed
+    // (fetch_runtime_snapshot / last_reconcile_result stays "applied") and the
+    // control pairing's applied collections are unchanged.
+}
+```
+
+To write an empty-collections row, emit `collections: null` (never `[]` — Global Constraints).
+
+- [ ] **Step 4: Run the full e2e module**
+
+Run: `cargo test -p defra-agent --test <e2e_triggers-target> app_collection_pairing`
+Expected: PASS (both the happy path and the malformed-path guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/defra-agent/tests/e2e_triggers/app_collection_pairing_p2p_e2e.rs
+git commit -m "test(e2e): reconcile-driven app-collection replication fires EventTrigger (#657)"
+```
+
+---
+
+## Task 11: Whole-workspace gate + PR
+
+**Files:** none (verification + PR).
+
+- [ ] **Step 1: Full package suite**
+
+Run: `cargo test -p defra-agent`
+Expected: PASS (lib + conformance + e2e_triggers all compile and pass).
+
+- [ ] **Step 2: Workspace compile (examples/desktop/all targets)**
+
+Run: `cargo check --workspace --all-targets`
+Expected: clean. (Two resolver signatures changed to `Result<Option<..>>`; confirm no other caller broke.)
+
+- [ ] **Step 3: Clippy**
+
+Run: `cargo clippy --workspace --all-targets -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4: Lean proofs**
+
+Run: `cd crates/defra-agent/proofs && lake build`
+Expected: clean, zero sorries.
+
+- [ ] **Step 5: Open the PR (do not merge)**
+
+```bash
+git push -u origin feat/app-collection-pairing-657
+gh pr create --repo sourcenetwork/defra-agent --base main \
+  --title "P2P: replicate an app-defined collection over a pairing (#657)" \
+  --body "$(cat <<'EOF'
+Closes #657. Follow-up epic: #660 (document-defined scope templates).
+
+Adds an `app-collections` (Unscoped/Replicate, bring-your-own) scope template and
+honors the previously-dropped `DataPlanePairingDesired.collections` field, gated on
+`template == "app-collections"`. Subscription is preserved for that policy at both
+the resolver and `merge_layered_desired`. Malformed rows soft-skip (never stall a
+co-existing control pairing); the template is rejected on the control-plane path
+(reconciler + CLI). Lean-first: catalog totality extended; behavior fenced by
+conformance calling the real resolver/merge. Acceptance e2e drives replication
+through reconcile (not `add_replicator`) and fires B's EventTrigger on the merged
+app-defined doc.
+
+Spec: docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Notes for the executor
+
+- **Test-visibility seam (Tasks 6-7):** the plan exposes `resolve_data_plane_layer_for_test` / `resolve_control_plane_desired_for_test` behind `#[cfg(any(test, feature = "conformance-seams"))]`. Before adopting a new cargo feature, grep `engine.rs` for how sibling resolvers are already exercised by conformance (`pub(crate)`, existing seams). Match the repo's convention; do not invent a feature if one isn't already the pattern.
+- **e2e target name:** integration tests under `tests/e2e_triggers/` compile as one binary; find its harness entry (`grep -rn "mod event_trigger_p2p_e2e" crates/defra-agent/tests/`) and use that `--test <name>` for the run commands above.
+- **`data_plane_scope_filter` for app-collections** returns `{}` (Unscoped), so the replicator is unfiltered — correct for whole-collection sync. Confirm `apply_op`'s `InstallReplicator` passes an empty `PairingFilters` (it reads `desired.replicator_filter`).
+- **Ordering invariant** is enforced by test sequencing (trigger reconciled before the data-plane rows are written), matching `event_trigger_p2p_e2e.rs`.
+- **Optional (spec §4, reviewer-optional):** a diagnostic test that an unknown/non-`@branchable` collection name surfaces an error string naming the offending collection. This exercises the `apply_op` → `add_p2p_collections` error path, which needs a live node; only add it if it can be written without excessive harness cost. No runtime branchable gate either way. Not a blocking deliverable.
+- **CLI writer (`upsert_data_plane`, `demo/fleet.rs`):** unchanged by this plan. It is only unsafe if invoked with `template == "app-collections"` (its `data_plane_collections_literal` expands to `[]`), which the demo never does. Full `config apply` ownership of `DataPlanePairingDesired.collections` — including a proper `--collections` writer for `app-collections` — is #607, out of scope here.

--- a/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
+++ b/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
@@ -20,6 +20,9 @@ with the whole edge declared in config.
 
 ## Verified current behavior
 
+(All `p2p_reconcile/*` and `templates.rs` paths below are under
+`crates/defra-agent/src/agent/`; CLI paths under `crates/defra-agent-cli/src/`.)
+
 - The reconciler derives `replicator_collections` from `template.collections`
   (`p2p_reconcile/engine.rs:713` for network-control rows, `:813` for data-plane
   rows), keyed off the row's `template`.
@@ -39,7 +42,21 @@ with the whole edge declared in config.
 - Data-plane rows currently produce `collections: BTreeSet::new()` (no gossip
   subscription) — a replicator-only channel. The subscription set for a
   `Delivery::Replicate` template comes from `replicator_collections`
-  (`engine.rs:721–727`), but the data-plane path hardcodes the empty set.
+  (`engine.rs:721–727`), but the data-plane path hardcodes the empty set —
+  **and `merge_layered_desired` (`engine.rs:902–905`) then unconditionally
+  `.collections.clear()`s the data-plane layer** so no data-plane subscription
+  ever survives to the diff. Any subscription for a data-plane pairing must
+  therefore be re-enabled at *both* the resolver and the merge.
+- **Existing writers already populate `DataPlanePairingDesired.collections` with
+  template expansion**, not with an app-defined set: `demo/fleet.rs:260`
+  (`data_plane_collections_literal` expands `template.collections`) and
+  `cli_fleet_delegation_live.rs:2126` (`CONVERSATION_COLLECTIONS`). So a
+  *non-empty* `collections` is **not** a reliable signal of an explicit custom
+  set — legacy rows are non-empty. The new behavior must be gated on the
+  **template id** (`data-plane`), not on non-emptiness.
+- `resolve_pairing_template` (`p2p/pairings.rs:173`) accepts any built-in
+  template for the generic `PeerPairingDesired` path, which has no way to supply
+  row collections. A `data-plane` template must be rejected there.
 
 ## Chosen approach: (b) honor the existing `collections` field
 
@@ -91,30 +108,70 @@ ScopeTemplate {
 A `pub const DATA_PLANE_TEMPLATE: &str = "data-plane";` mirrors the existing
 `NETWORK_CONTROL_TEMPLATE` / `SUBAGENT_*_TEMPLATE` constants.
 
+Two `templates.rs` unit tests must move with the new entry:
+`all_builtin_templates_have_nonempty_collections` (exempt `data-plane`) and
+`builtin_template_count_is_seven` (now eight).
+
 ### 2. Read `collections` in `load_desired`
 
 Add `collections` to the `DataPlanePairingDesired` sub-query in
 `GraphqlPairingStateStore::load_desired` (`engine.rs:497`) so the row's explicit
 set reaches `data_plane_desired_from_pairing_row`.
 
-### 3. Honor `row.collections` in `data_plane_desired_from_pairing_row`
+### 3. Honor `row.collections` in `data_plane_desired_from_pairing_row` — gated on `template == "data-plane"`
 
-When `row.collections` is **non-empty** (the explicit app-defined set):
+The new behavior is gated on the **template id**, not on `collections` being
+non-empty (legacy rows are non-empty — see Verified current behavior).
 
-- Use it as `replicator_collections` and as the collection list the scope filter
-  is built over — instead of `template.collections`.
-- For `Delivery::Replicate`, populate the subscription `collections` set from it
-  as well (so both nodes `add_collections` + `add_replicator`, mirroring the
-  manual `install_one_way_replicator`). For `Delivery::Push`, keep the empty
-  subscription set (unchanged).
+When `template_id == "data-plane"`:
 
-When `row.collections` is **empty**: current behavior exactly
-(`template.collections`, empty subscription set). Fully backward compatible — the
-existing network-control / subagent data-plane pairings are provably undisturbed.
+- Require `row.collections`, after trim/dedupe of blanks, to contain **at least
+  one** collection. An empty set is a hard error for this template (the template
+  supplies none), so we never install an empty-collection replicator. Mirror the
+  existing blank-`agent_did` `anyhow::bail!` skip in this function (`engine.rs:797`),
+  so the peer is skipped per-sweep rather than mis-wired.
+- Use the trimmed `row.collections` as `replicator_collections` and as the
+  collection list the scope filter is built over — instead of
+  `template.collections` (which is `&[]`).
+- Because `data-plane` is `Delivery::Replicate`, populate the subscription
+  `collections` set from the same trimmed set, so both nodes `add_collections` +
+  `add_replicator` (mirroring the manual `install_one_way_replicator`).
+
+For every **other** template id: current behavior exactly — `template.collections`
+drives, subscription set stays empty. Fully backward compatible; the existing
+network-control / subagent / any template-expanded data-plane rows are provably
+undisturbed because none of them use the `data-plane` template.
 
 The template continues to supply scope + delivery; a blank `template` still
-defaults to `conversation` for backward compatibility, but the intended pairing
-carries `template: "data-plane"`.
+defaults to `conversation` for backward compatibility. The custom pairing carries
+`template: "data-plane"` explicitly.
+
+### 3b. Preserve the data-plane subscription through `merge_layered_desired`
+
+`merge_layered_desired` (`engine.rs:894–919`) currently clears the entire
+data-plane subscription set (`desired.collections.clear()`) so conversation docs
+never gossip unfiltered. That blanket clear must become conditional: **preserve
+the data-plane layer's subscription set only when the layer is a `data-plane`
+pairing** (detected via `template_ids.contains("data-plane")`). All other
+data-plane layers keep the existing clear. This is the single point that lets an
+`InstallCollection("ChangeProposed")` op reach the diff; without it, step 3's
+resolver change is inert. A conformance test fences exactly this: a `data-plane`
+layer's subscription survives the merge, a network-control-only data-plane layer's
+does not.
+
+### 3c. Guard the generic pairing CLI against the `data-plane` template
+
+`resolve_pairing_template` (`p2p/pairings.rs:173`) feeds the generic
+`PeerPairingDesired` path, which cannot supply row collections. Reject
+`data-plane` there with a clear "data-plane-only template; use the data-plane
+pairing path with an explicit `--collections`" error, so a `data-plane`
+`PeerPairingDesired` (which would resolve to no collections) is impossible to
+write. The data-plane writer path (`demo/fleet.rs:234 upsert_data_plane`) must,
+for the `data-plane` template, take the collection set from an explicit argument
+rather than `data_plane_collections_literal` (whose template expansion is `[]`
+for `data-plane`). #657's e2e writes rows directly and does not exercise these CLI
+paths; the guards exist so the new template cannot be misused. Full
+`config apply` ownership of `DataPlanePairingDesired.collections` is #607.
 
 ### 4. `@branchable` is the operator's responsibility
 
@@ -140,19 +197,25 @@ model concern. Per the foundation flow (CLAUDE.md), start in the Lean spec:
 
 - `PairingReconcile` already models `ReplicatorId = (address, ReplicatorFilter,
   ReplicatorCollections)` and the merge boundary. Extend the data-plane
-  resolution so the effective `ReplicatorCollections` is the explicit per-pairing
-  set when present, else the template set. Prove the existing safety/liveness
+  resolution so that for the `data-plane` policy the effective
+  `ReplicatorCollections` **and** the subscription set are the row-supplied set,
+  while every other template resolves exactly as today (template set,
+  subscription cleared at the merge). Prove the existing safety/liveness
   properties (idempotence, filter-change-forces-reinstall,
-  co-existing-pairing-non-interference) still hold under a row-supplied set.
-- Mirror into `tests/conformance/pairing_reconcile.rs`: a data-plane row with an
-  explicit `collections` set resolves to that set as `replicator_collections`
-  (and, for `Replicate`, as the subscription set), and merges with a co-existing
-  control pairing without cross-contaminating filters.
+  co-existing-pairing-non-interference) still hold, and prove the new merge
+  property: a `data-plane` layer's subscription survives, a non-`data-plane`
+  data-plane layer's does not.
+- Mirror into `tests/conformance/pairing_reconcile.rs`: (i) a `data-plane` row
+  resolves its row `collections` as both `replicator_collections` and the
+  subscription set; (ii) that subscription survives `merge_layered_desired`
+  while a network-control-only data-plane layer's subscription is still cleared;
+  (iii) the `data-plane` layer merges with a co-existing control pairing without
+  cross-contaminating filters or subscriptions.
 - Zero `sorry`s.
 
-If the resolution is a pure function over already-modeled quantities (explicit
-set vs template set), the proof obligation is light; if it is not, that is
-information (CLAUDE.md) and we stop to reconsider.
+If the resolution is a pure function over already-modeled quantities
+(template-id-gated row set vs template set), the proof obligation is light; if it
+is not, that is information (CLAUDE.md) and we stop to reconsider.
 
 ## Acceptance e2e (TDD — written first, must fail first)
 
@@ -199,7 +262,10 @@ a signal to reconsider harness shape (e.g. CLI-subprocess like
 
 ## Reversibility
 
-The change is additive: one new template entry, one query field, one branch in
-`data_plane_desired_from_pairing_row` guarded on `row.collections` non-empty.
-Reverting restores exact prior behavior; empty-`collections` rows already behave
-as today.
+The change is additive and gated on the `data-plane` template id: one new
+template entry, one query field, one `template == "data-plane"` branch in
+`data_plane_desired_from_pairing_row`, one conditional in `merge_layered_desired`,
+and two CLI guards. Reverting restores exact prior behavior. Because every branch
+keys on `template_ids`/`template == "data-plane"` — a template no existing row
+uses — rows on all other templates behave byte-for-byte as today, regardless of
+whether their `collections` field is populated.

--- a/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
+++ b/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
@@ -1,0 +1,205 @@
+# Replicate an app-defined collection over a pairing (data-plane replication for custom collections)
+
+Issue: sourcenetwork/defra-agent#657
+Follow-up epic: #660 (document-defined scope templates)
+Date: 2026-07-08
+
+## Problem
+
+The P2P pairing reconciler replicates the collections fixed by a pairing's scope
+**template**, not an arbitrary app-defined collection. There is no supported,
+reconcile-driven way for one agent to replicate a *custom* `@branchable`
+collection (e.g. `ChangeProposed`) to a paired peer as desired-state config. The
+only working path is the manual admin path in
+`tests/e2e_triggers/event_trigger_p2p_e2e.rs` (`add_collections` +
+`add_replicator`), which is not desired-state / manifest-managed.
+
+The driving use case: an event-driven multi-agent flow where a host agent writes
+an app-defined document that must fire an `EventTrigger` on a **paired** agent,
+with the whole edge declared in config.
+
+## Verified current behavior
+
+- The reconciler derives `replicator_collections` from `template.collections`
+  (`p2p_reconcile/engine.rs:713` for network-control rows, `:813` for data-plane
+  rows), keyed off the row's `template`.
+- Built-in templates carry no app-defined collection
+  (`p2p_reconcile/templates.rs`): `conversation`, `agent-config`, `backup`,
+  `discovery`, `network-control`, `subagent-coordinator`, `subagent-host`.
+- **`DataPlanePairingDesired` already declares `collections: [String!]!`** in its
+  SDL (`crates/defra-agent-schemas/schemas/agent/data_plane_pairing_desired.graphql`)
+  and it is already read into `PairingStateRow.collections: Option<Vec<String>>`.
+  But `load_desired`'s query (`engine.rs:497`) does **not select it**, and
+  `data_plane_desired_from_pairing_row` (`engine.rs:782–827`) **ignores it**,
+  deriving the collection set from `template.collections` instead.
+- Data-plane rows are gated behind `data_plane_materialized_entry`
+  (`engine.rs:509`): the peer must be materializable through the
+  network-membership gate (signed `AgentNetwork` + active `NetworkMembership` +
+  fresh member-signed `PeerEndpoint`, per `select_materializable_entries`).
+- Data-plane rows currently produce `collections: BTreeSet::new()` (no gossip
+  subscription) — a replicator-only channel. The subscription set for a
+  `Delivery::Replicate` template comes from `replicator_collections`
+  (`engine.rs:721–727`), but the data-plane path hardcodes the empty set.
+
+## Chosen approach: (b) honor the existing `collections` field
+
+Honor the `DataPlanePairingDesired.collections` field that already exists but is
+silently dropped. This is the smallest, most reversible change and the most
+direct expression of "replicate these collections to this peer." The app-defined
+collection *name* lives in a **document** (the row) — not in the runtime's
+compiled catalog — which is correct for app-owned schema (#435) and consistent
+with "the database is the control plane."
+
+Rejected alternatives:
+
+- **(a) app-defined scope template** — would put an app's collection name into
+  defra-agent's static `BUILTIN_TEMPLATES`, forcing a recompile per custom
+  collection set. Wrong ownership boundary.
+- **(c) raw-admin affordance** — bypasses the membership gate; a
+  desired-state/security regression. Not the durable answer.
+
+The template catalog remains the extension point for **policy** (scope +
+delivery); the **row** supplies the app-specific **collection set**. A fuller
+future move — templates themselves loaded from documents — is filed as #660 and
+this design is forward-compatible with it (`resolve_template` simply grows a
+document source later; the same row keeps working).
+
+## Design
+
+### 1. New `data-plane` policy template
+
+Add one built-in template to `templates.rs`:
+
+```
+ScopeTemplate {
+    id: "data-plane",
+    collections: &[],            // bring-your-own: supplied by the row
+    scope: Scope::Unscoped,      // replicate the whole custom collection
+    delivery: Delivery::Replicate,
+}
+```
+
+- `Unscoped` — an app-defined event document (e.g. `ChangeProposed`) is not keyed
+  by the peer's DID, so the whole collection syncs (no per-peer filter).
+- `Replicate` — the receiver must **observe** the merged doc for its
+  `EventTrigger` to fire `created`; `Push` deliberately never subscribes.
+- `collections: &[]` — the template carries no fixed set; the row supplies it.
+  This relaxes the `all_builtin_templates_have_nonempty_collections` unit
+  invariant, which is updated to exempt the `data-plane` "bring-your-own"
+  template (its collection set is row-supplied by contract).
+
+A `pub const DATA_PLANE_TEMPLATE: &str = "data-plane";` mirrors the existing
+`NETWORK_CONTROL_TEMPLATE` / `SUBAGENT_*_TEMPLATE` constants.
+
+### 2. Read `collections` in `load_desired`
+
+Add `collections` to the `DataPlanePairingDesired` sub-query in
+`GraphqlPairingStateStore::load_desired` (`engine.rs:497`) so the row's explicit
+set reaches `data_plane_desired_from_pairing_row`.
+
+### 3. Honor `row.collections` in `data_plane_desired_from_pairing_row`
+
+When `row.collections` is **non-empty** (the explicit app-defined set):
+
+- Use it as `replicator_collections` and as the collection list the scope filter
+  is built over — instead of `template.collections`.
+- For `Delivery::Replicate`, populate the subscription `collections` set from it
+  as well (so both nodes `add_collections` + `add_replicator`, mirroring the
+  manual `install_one_way_replicator`). For `Delivery::Push`, keep the empty
+  subscription set (unchanged).
+
+When `row.collections` is **empty**: current behavior exactly
+(`template.collections`, empty subscription set). Fully backward compatible — the
+existing network-control / subagent data-plane pairings are provably undisturbed.
+
+The template continues to supply scope + delivery; a blank `template` still
+defaults to `conversation` for backward compatibility, but the intended pairing
+carries `template: "data-plane"`.
+
+### 4. `@branchable` is the operator's responsibility
+
+DefraDB only P2P-syncs `@branchable` collections. This is enforced at schema
+registration time by the app (#435), not by the reconciler. Documented here; the
+e2e uses a `@branchable` schema. No runtime gate (keeps the change minimal).
+
+### 5. Membership gate is a precondition, not a bypass
+
+The data-plane row is only honored once the peer is materializable
+(`data_plane_materialized_entry`). This is intentional (per the issue): the
+pairing requires network membership first. The design does not weaken the gate.
+The ordering invariant (subscriber reconciles its `EventTrigger` **before** the
+replicator is established, so `seed_seen_docs_for_collection` runs on an empty
+collection and the merged doc is a genuine first-observation) is preserved by
+establishing membership + trigger reconcile before writing the data-plane row on
+the sender.
+
+## Lean / conformance
+
+The change alters *what collection set a data-plane pairing resolves to* — a
+model concern. Per the foundation flow (CLAUDE.md), start in the Lean spec:
+
+- `PairingReconcile` already models `ReplicatorId = (address, ReplicatorFilter,
+  ReplicatorCollections)` and the merge boundary. Extend the data-plane
+  resolution so the effective `ReplicatorCollections` is the explicit per-pairing
+  set when present, else the template set. Prove the existing safety/liveness
+  properties (idempotence, filter-change-forces-reinstall,
+  co-existing-pairing-non-interference) still hold under a row-supplied set.
+- Mirror into `tests/conformance/pairing_reconcile.rs`: a data-plane row with an
+  explicit `collections` set resolves to that set as `replicator_collections`
+  (and, for `Replicate`, as the subscription set), and merges with a co-existing
+  control pairing without cross-contaminating filters.
+- Zero `sorry`s.
+
+If the resolution is a pure function over already-modeled quantities (explicit
+set vs template set), the proof obligation is light; if it is not, that is
+information (CLAUDE.md) and we stop to reconsider.
+
+## Acceptance e2e (TDD — written first, must fail first)
+
+New test in `tests/e2e_triggers/` (sibling of `event_trigger_p2p_e2e.rs`),
+modeled on `p2p_replicated_doc_fires_event_trigger` but driving replication
+through **reconcile**, not manual admin:
+
+1. Two agent nodes A and B, P2P enabled, each running `DefraAgent::run`.
+2. Register an app-defined `@branchable` `ChangeProposed` schema on both.
+3. Materialize the peers through the real membership gate (signed
+   `AgentNetwork` + active `NetworkMembership` + fresh `PeerEndpoint`), so
+   `data_plane_materialized_entry` returns `Some` on both — B-on-A and A-on-B.
+   (Implementation task: locate/build the in-process materialization path the
+   CLI `p2p network create` / `invite` / `join` flow uses.)
+4. On B: create a `Task` + `EventTrigger` watching `ChangeProposed` for
+   `created`; wait for it to reconcile into the active snapshot (ordering
+   invariant — trigger before replicator).
+5. **Co-existing control pairing**: establish a subagent (control) pairing on the
+   same A↔B peer and assert it stays intact across the data-plane reconcile.
+6. Via **desired-state config**, write a `DataPlanePairingDesired` row
+   (`template: "data-plane"`, `collections: ["ChangeProposed"]`) on the sender
+   (and the reverse authorization row on the receiver); let the reconciler
+   establish the replicator. No `add_replicator` call in the test.
+7. Write a `ChangeProposed` doc on A; assert it replicates to B and fires B's
+   `EventTrigger` as `created` — exactly one `AgentRequest` with the rendered
+   prompt and matching trigger lineage, `last_status="fired"`, `fire_count=1`,
+   `last_fired_source_doc_id` = the replicated doc id.
+8. Assert reconcile idempotence (a second sweep installs nothing new) and the
+   control pairing is untouched.
+
+The membership-materialization step is the heavy part of the harness; TDD forces
+it out. If an in-process materialization path proves prohibitively large, that is
+a signal to reconsider harness shape (e.g. CLI-subprocess like
+`cli_p2p_network.rs`) — but the product change (b) is unaffected.
+
+## Scope / non-goals
+
+- **In:** honor `DataPlanePairingDesired.collections`; `data-plane` template;
+  Lean + conformance; the reconcile-path e2e.
+- **Out (#660):** document-defined scope templates.
+- **Out:** `config apply` ownership of `DataPlanePairingDesired` (#607 territory);
+  the e2e writes rows directly.
+- **Out:** any weakening of the membership gate or a raw-admin bypass (c).
+
+## Reversibility
+
+The change is additive: one new template entry, one query field, one branch in
+`data_plane_desired_from_pairing_row` guarded on `row.collections` non-empty.
+Reverting restores exact prior behavior; empty-`collections` rows already behave
+as today.

--- a/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
+++ b/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
@@ -151,8 +151,10 @@ hard-fail: an empty/blank-only `app-collections` collection set yields `Ok(None)
 (warn + skip this layer only), honoring "must not disturb a co-existing control
 pairing." The pre-existing hard-`Err` for a **foreign `agent_did`**
 (`engine.rs:772`) is kept as-is — it is a security refusal, not a malformed-input
-case — and is documented as the one condition that still fails the whole peer
-load (unchanged behavior).
+case — and is the documented residual that still fails the whole peer load
+(unchanged behavior; unit-tested so any future softening is deliberate). Note:
+`desired_read_failed` is not exposed on RuntimeSnapshot; e2e observes soft-skip
+success only via co-existing `PeerPairingApplied` stability.
 
 For every **other** template id: current behavior exactly — `template.collections`
 drives, subscription set stays empty. Fully backward compatible; the existing
@@ -196,12 +198,12 @@ CLI is not the only writer:
   DataPlanePairingDesired rows only; supply an explicit `--collections` set"
   error, so the operator gets an immediate message instead of a silent skip.
 
-The data-plane writer path (`demo/fleet.rs:234 upsert_data_plane`) must, for the
-`app-collections` template, take the collection set from an explicit argument rather
-than `data_plane_collections_literal` (whose template expansion is `[]` for
-`app-collections`). #657's e2e writes rows directly and does not exercise these CLI
-paths; the guards exist so the new template cannot be misused. Full
-`config apply` ownership of `DataPlanePairingDesired.collections` is #607.
+The data-plane writer path (`demo/fleet.rs:234 upsert_data_plane`) currently
+expands collections via `data_plane_collections_literal` (template set → `[]` for
+`app-collections`). #657 rejects `app-collections` there so a mis-invocation fails
+loud rather than writing a blank set that soft-skips. Full `config apply` /
+explicit-collections ownership of `DataPlanePairingDesired.collections` is #607;
+the e2e writes rows directly and does not exercise fleet upsert.
 
 ### 4. `@branchable` is the operator's responsibility
 
@@ -230,88 +232,86 @@ the sender.
 
 ## Lean / conformance
 
-The change alters *what collection set a data-plane pairing resolves to* — a
-model concern. Per the foundation flow (CLAUDE.md), start in the Lean spec:
+The change introduces a **safety-relevant exception** to the data-plane
+subscription rule ("data-plane layers must not extend the subscription set").
+Per the foundation flow (CLAUDE.md), that rule change starts in Lean. Scope is
+deliberately narrow:
 
-- **`ScopeTemplates` catalog.** The Lean `ScopeTemplates.builtinCatalog`
-  currently mirrors the seven Rust builtins. Add `dataPlaneTemplate` (empty
-  collections, `Unscoped`, `Replicate`) so catalog membership / totality proofs
-  track the eighth entry, plus a resolution theorem
-  (`resolveTemplate "app-collections" = some dataPlaneTemplate`). Row-supplied
-  collections do **not** belong in the static template's collection set — they
-  enter as a derivation in `PairingReconcile` (below), keeping the template a
-  pure policy.
-- `PairingReconcile` already models `ReplicatorId = (address, ReplicatorFilter,
-  ReplicatorCollections)` and the merge boundary. Extend the data-plane
-  resolution so that for the `app-collections` policy the effective
-  `ReplicatorCollections` **and** the subscription set are the row-supplied set,
-  while every other template resolves exactly as today (template set,
-  subscription cleared at the merge). Prove the existing safety/liveness
-  properties (idempotence, filter-change-forces-reinstall,
-  co-existing-pairing-non-interference) still hold, and prove the new merge
-  property: an `app-collections` layer's subscription survives, a non-`app-collections`
-  data-plane layer's does not.
-- Mirror into `tests/conformance/pairing_reconcile.rs`: (i) an `app-collections` row
-  resolves its row `collections` as both `replicator_collections` and the
-  subscription set; (ii) that subscription survives `merge_layered_desired`
-  while a network-control-only data-plane layer's subscription is still cleared;
-  (iii) the `app-collections` layer merges with a co-existing control pairing without
-  cross-contaminating filters or subscriptions; (iv) an empty/blank-only
-  `app-collections` row soft-skips (layer → `None`, base preserved); (v) a
-  `app-collections` template on the `PeerPairingDesired`/base path soft-skips to no
-  wiring.
+- **`ScopeTemplates` catalog.** Add `appCollectionsTemplate` (empty collections,
+  `Unscoped`, `Replicate`) as the eighth `builtinCatalog` entry, plus
+  `appCollections_in_catalog` / empty-collections / unscoped-no-filter theorems.
+  Row-supplied collections do **not** belong in the static template — the
+  template stays pure policy.
+- **`PairingReconcile.Layering` (new pure derivation, not a new machine).** Model
+  `clampDataPlane` + `mergeLayered`: drop a data-plane layer's subscriptions
+  unless `isAppCollections`; always union replicator collections; prove
+  (a) app-collections subscriptions survive, (b) non-app data-plane
+  subscriptions clear, (c) control-plane base is preserved. Existing
+  PairingReconcile machine proofs (idempotence, filter-change-forces-reinstall,
+  …) are untouched — the layering change is additive beside the machine.
+- **Not modeled in Lean** (input-validation plumbing below the machine boundary;
+  fenced by Rust unit/conformance instead): the *source* of a data-plane
+  collection set (row vs template), soft-skip of malformed rows, and control-plane
+  rejection of `app-collections`. Those do not change what the reconcile machine
+  may do once it has a desired state.
+- **Rust fencing:**
+  - Conformance (`tests/conformance/pairing_reconcile.rs`): (ii) app-collections
+    subscription survives `merge_layered_desired` while network-control data-plane
+    still clears; (iii) co-existence with a control base (no filter/subscription
+    cross-contamination).
+  - In-crate unit tests (`engine.rs` `#[cfg(test)]`): (i) row collections resolve
+    as both replicator + subscription sets; (iv) empty/blank-only soft-skips;
+    (v) control-plane path soft-skips `app-collections`; plus a documented residual
+    that foreign `agent_did` still hard-fails the whole peer load.
 - Zero `sorry`s.
 
-If the resolution is a pure function over already-modeled quantities
-(template-id-gated row set vs template set), the proof obligation is light; if it
-is not, that is information (CLAUDE.md) and we stop to reconsider.
-
-## Acceptance e2e (TDD — written first, must fail first)
+## Acceptance e2e (final gate; after engine tasks)
 
 New test in `tests/e2e_triggers/` (sibling of `event_trigger_p2p_e2e.rs`),
 modeled on `p2p_replicated_doc_fires_event_trigger` but driving replication
 through **reconcile**, not manual admin:
 
-1. Two agent nodes A and B, P2P enabled, each running `DefraAgent::run`.
+1. Two agent nodes A and B, P2P enabled, **each running `DefraAgent::run`** (both
+   need the pairing reconciler — unlike the bare-writer existing P2P trigger e2e).
 2. Register an app-defined `@branchable` `ChangeProposed` schema on both.
 3. Materialize the peers through the real membership gate (signed
-   `AgentNetwork` + active `NetworkMembership` + fresh `PeerEndpoint`), so
+   `AgentNetwork` + active `NetworkMembership` + fresh `PeerEndpoint` written
+   **locally on each node** with real P2P `node_id` + listen address), so
    `data_plane_materialized_entry` returns `Some` on both — B-on-A and A-on-B.
-   (Implementation task: locate/build the in-process materialization path the
-   CLI `p2p network create` / `invite` / `join` flow uses.)
 4. On B: create a `Task` + `EventTrigger` watching `ChangeProposed` for
-   `created`; wait for it to reconcile into the active snapshot (ordering
-   invariant — trigger before replicator).
-5. **Co-existing control pairing**: establish a subagent (control) pairing on the
-   same A↔B peer and assert it stays intact across the data-plane reconcile.
+   `created`; wait for **document** reconcile into the active snapshot
+   (`RuntimeSnapshot.last_reconcile_result == "applied"`) — ordering invariant
+   (trigger before replicator).
+5. **Co-existing control pairing**: write `PeerPairingDesired` with template
+   **`network-control`** (not subagent) on the same A↔B peer; wait until
+   `PeerPairingApplied` shows control collections; capture that snapshot.
 6. Via **desired-state config**, write a `DataPlanePairingDesired` row on **both**
    nodes — mirroring the manual `install_one_way_replicator`, which does
-   `add_collections` + `add_replicator` on both sides (sender pushes; receiver
-   authorizes). Both rows carry the **same** `template: "app-collections"` and the
-   **same** `collections: ["ChangeProposed"]`:
-   - A's row targets peer B; B's row targets peer A.
-   - Both peers are already materializable (step 3), so both `load_desired`s
-     honor their rows.
-   - Both rows are written **after** B's trigger reconciles (step 4), preserving
-     the ordering invariant (`seed_seen_docs_for_collection` runs on an empty
-     collection → the merged doc is a genuine first-observation).
-   The reconciler — not the test — establishes both replicators + subscriptions.
+   `add_collections` + `add_replicator` on both sides. Both rows carry the
+   **same** `template: "app-collections"` and the **same**
+   `collections: ["ChangeProposed"]`; `agent_did` = local self DID; `peer_id` =
+   remote node_id:
+   - Both rows are written **after** B's trigger reconciles (step 4).
+   - Wait for pairing readiness via **`PeerPairingApplied`** (non-empty
+     `replicator_addresses` + `collections` contains `ChangeProposed`) — **not**
+     RuntimeSnapshot. Assert control collections from step 5 still present.
    No `add_replicator` / `add_collections` call in the test.
 7. Write a `ChangeProposed` doc on A; assert it replicates to B and fires B's
    `EventTrigger` as `created` — exactly one `AgentRequest` with the rendered
    prompt and matching trigger lineage, `last_status="fired"`, `fire_count=1`,
    `last_fired_source_doc_id` = the replicated doc id.
-8. Assert reconcile idempotence (a second sweep installs nothing new) and the
-   control pairing is untouched.
+8. Assert pairing idempotence (`PeerPairingApplied` stable across another sweep)
+   and the control pairing collections are untouched.
 9. **Malformed path** (guards the soft-skip fix): write a `DataPlanePairingDesired`
-   row with an empty/blank-only `collections` set and assert the co-existing
-   control pairing still reconciles (data-plane layer skipped, `base` intact) —
-   the tick is *not* marked `desired_read_failed`.
+   row with a blank-only `collections` set `["   "]` and assert the co-existing
+   control `PeerPairingApplied` is unchanged (data-plane layer skipped, `base`
+   intact). Soft-skip is **not** observable as `desired_read_failed` on
+   RuntimeSnapshot — observe applied-state stability only.
 
-The membership-materialization step is the heavy part of the harness; TDD forces
-it out. If an in-process materialization path proves prohibitively large, that is
-a signal to reconsider harness shape (e.g. CLI-subprocess like
-`cli_p2p_network.rs`) — but the product change (b) is unaffected.
+The membership-materialization step is the heavy part of the harness. If an
+in-process materialization path proves prohibitively large, that is a signal to
+reconsider harness shape (e.g. CLI-subprocess like `cli_p2p_network.rs`) — but
+the product change (b) is unaffected.
 
 ## Scope / non-goals
 

--- a/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
+++ b/docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md
@@ -53,10 +53,10 @@ with the whole edge declared in config.
   `cli_fleet_delegation_live.rs:2126` (`CONVERSATION_COLLECTIONS`). So a
   *non-empty* `collections` is **not** a reliable signal of an explicit custom
   set — legacy rows are non-empty. The new behavior must be gated on the
-  **template id** (`data-plane`), not on non-emptiness.
+  **template id** (`app-collections`), not on non-emptiness.
 - `resolve_pairing_template` (`p2p/pairings.rs:173`) accepts any built-in
   template for the generic `PeerPairingDesired` path, which has no way to supply
-  row collections. A `data-plane` template must be rejected there.
+  row collections. An `app-collections` template must be rejected there.
 
 ## Chosen approach: (b) honor the existing `collections` field
 
@@ -83,13 +83,13 @@ document source later; the same row keeps working).
 
 ## Design
 
-### 1. New `data-plane` policy template
+### 1. New `app-collections` policy template
 
 Add one built-in template to `templates.rs`:
 
 ```
 ScopeTemplate {
-    id: "data-plane",
+    id: "app-collections",
     collections: &[],            // bring-your-own: supplied by the row
     scope: Scope::Unscoped,      // replicate the whole custom collection
     delivery: Delivery::Replicate,
@@ -98,18 +98,25 @@ ScopeTemplate {
 
 - `Unscoped` — an app-defined event document (e.g. `ChangeProposed`) is not keyed
   by the peer's DID, so the whole collection syncs (no per-peer filter).
+  **Blast-radius note:** `Unscoped` means every data-plane edge for a collection
+  replicates *all* of its documents to the peer — in a multi-peer fleet, each
+  paired peer gets the whole collection, and `Replicate` also adds a
+  node-global subscription. The network-membership gate is the only boundary;
+  there is no per-peer document filtering here. Operators wanting peer-scoped
+  slices need a future `PeerDid`-scoped data-plane policy (a new template —
+  the catalog is the extension point), not this one.
 - `Replicate` — the receiver must **observe** the merged doc for its
   `EventTrigger` to fire `created`; `Push` deliberately never subscribes.
 - `collections: &[]` — the template carries no fixed set; the row supplies it.
   This relaxes the `all_builtin_templates_have_nonempty_collections` unit
-  invariant, which is updated to exempt the `data-plane` "bring-your-own"
+  invariant, which is updated to exempt the `app-collections` "bring-your-own"
   template (its collection set is row-supplied by contract).
 
-A `pub const DATA_PLANE_TEMPLATE: &str = "data-plane";` mirrors the existing
-`NETWORK_CONTROL_TEMPLATE` / `SUBAGENT_*_TEMPLATE` constants.
+A `pub const APP_COLLECTIONS_TEMPLATE: &str = "app-collections";` mirrors the
+existing `NETWORK_CONTROL_TEMPLATE` / `SUBAGENT_*_TEMPLATE` constants.
 
 Two `templates.rs` unit tests must move with the new entry:
-`all_builtin_templates_have_nonempty_collections` (exempt `data-plane`) and
+`all_builtin_templates_have_nonempty_collections` (exempt `app-collections`) and
 `builtin_template_count_is_seven` (now eight).
 
 ### 2. Read `collections` in `load_desired`
@@ -118,58 +125,81 @@ Add `collections` to the `DataPlanePairingDesired` sub-query in
 `GraphqlPairingStateStore::load_desired` (`engine.rs:497`) so the row's explicit
 set reaches `data_plane_desired_from_pairing_row`.
 
-### 3. Honor `row.collections` in `data_plane_desired_from_pairing_row` — gated on `template == "data-plane"`
+### 3. Honor `row.collections` in `data_plane_desired_from_pairing_row` — gated on `template == "app-collections"`
 
 The new behavior is gated on the **template id**, not on `collections` being
 non-empty (legacy rows are non-empty — see Verified current behavior).
 
-When `template_id == "data-plane"`:
+When `template_id == "app-collections"`:
 
-- Require `row.collections`, after trim/dedupe of blanks, to contain **at least
-  one** collection. An empty set is a hard error for this template (the template
-  supplies none), so we never install an empty-collection replicator. Mirror the
-  existing blank-`agent_did` `anyhow::bail!` skip in this function (`engine.rs:797`),
-  so the peer is skipped per-sweep rather than mis-wired.
-- Use the trimmed `row.collections` as `replicator_collections` and as the
-  collection list the scope filter is built over — instead of
+- Use `row.collections`, after trim/dedupe of blanks, as `replicator_collections`
+  and as the collection list the scope filter is built over — instead of
   `template.collections` (which is `&[]`).
-- Because `data-plane` is `Delivery::Replicate`, populate the subscription
+- Because `app-collections` is `Delivery::Replicate`, populate the subscription
   `collections` set from the same trimmed set, so both nodes `add_collections` +
   `add_replicator` (mirroring the manual `install_one_way_replicator`).
+- If the trimmed set is **empty**, **soft-skip the data-plane layer** — log a
+  warn and treat the layer as `None`, leaving `base` (the control pairing)
+  intact. It is **not** an `anyhow::bail!`. See "Soft-skip" below.
+
+**Soft-skip vs hard-fail (bug fix).** `data_plane_desired_from_pairing_row`
+returns `Result<Option<PairingDesired>>`. `load_desired` propagates a hard `Err`
+out to `reconcile_peer_tick`, which then returns `desired_read_failed: true` and
+**skips every op for the peer — including a co-existing Layer-1 control pairing
+that loaded fine** (`engine.rs:61–75`). So a malformed *app* row must never
+hard-fail: an empty/blank-only `app-collections` collection set yields `Ok(None)`
+(warn + skip this layer only), honoring "must not disturb a co-existing control
+pairing." The pre-existing hard-`Err` for a **foreign `agent_did`**
+(`engine.rs:772`) is kept as-is — it is a security refusal, not a malformed-input
+case — and is documented as the one condition that still fails the whole peer
+load (unchanged behavior).
 
 For every **other** template id: current behavior exactly — `template.collections`
 drives, subscription set stays empty. Fully backward compatible; the existing
 network-control / subagent / any template-expanded data-plane rows are provably
-undisturbed because none of them use the `data-plane` template.
+undisturbed because none of them use the `app-collections` template.
 
 The template continues to supply scope + delivery; a blank `template` still
 defaults to `conversation` for backward compatibility. The custom pairing carries
-`template: "data-plane"` explicitly.
+`template: "app-collections"` explicitly.
 
 ### 3b. Preserve the data-plane subscription through `merge_layered_desired`
 
 `merge_layered_desired` (`engine.rs:894–919`) currently clears the entire
 data-plane subscription set (`desired.collections.clear()`) so conversation docs
 never gossip unfiltered. That blanket clear must become conditional: **preserve
-the data-plane layer's subscription set only when the layer is a `data-plane`
-pairing** (detected via `template_ids.contains("data-plane")`). All other
+the data-plane layer's subscription set only when the layer is an `app-collections`
+pairing** (detected via `template_ids.contains("app-collections")`). All other
 data-plane layers keep the existing clear. This is the single point that lets an
 `InstallCollection("ChangeProposed")` op reach the diff; without it, step 3's
-resolver change is inert. A conformance test fences exactly this: a `data-plane`
+resolver change is inert. A conformance test fences exactly this: an `app-collections`
 layer's subscription survives the merge, a network-control-only data-plane layer's
 does not.
 
-### 3c. Guard the generic pairing CLI against the `data-plane` template
+### 3c. Reject the `app-collections` template on the control-plane path — reconciler AND CLI
 
-`resolve_pairing_template` (`p2p/pairings.rs:173`) feeds the generic
-`PeerPairingDesired` path, which cannot supply row collections. Reject
-`data-plane` there with a clear "data-plane-only template; use the data-plane
-pairing path with an explicit `--collections`" error, so a `data-plane`
-`PeerPairingDesired` (which would resolve to no collections) is impossible to
-write. The data-plane writer path (`demo/fleet.rs:234 upsert_data_plane`) must,
-for the `data-plane` template, take the collection set from an explicit argument
-rather than `data_plane_collections_literal` (whose template expansion is `[]`
-for `data-plane`). #657's e2e writes rows directly and does not exercise these CLI
+The `app-collections` template is meaningless for a `PeerPairingDesired` (control-plane)
+row, which has no way to supply row collections. Two layers of guard, because the
+CLI is not the only writer:
+
+- **Reconciler (authoritative).** `desired_from_pairing_row` (the base /
+  `PeerPairingDesired` path, `engine.rs:671`) also returns
+  `Result<Option<PairingDesired>>` and **soft-skips** (warn + `Ok(None)`) when the
+  resolved template is `app-collections`. Without this, a raw-GraphQL
+  `PeerPairingDesired { template: "app-collections", replicator_addresses: [...] }`
+  resolves to empty `replicator_collections` yet `has_wiring()` is true (addresses
+  present), so `reconcile_peer_tick` would `connect` and install an
+  empty-collection replicator (`engine.rs:77`, `diff.rs:36`). The soft-skip makes
+  that row produce no wiring.
+- **CLI (defense-in-depth + good error).** `resolve_pairing_template`
+  (`p2p/pairings.rs:173`) rejects `app-collections` with a clear "the app-collections template is for
+  DataPlanePairingDesired rows only; supply an explicit `--collections` set"
+  error, so the operator gets an immediate message instead of a silent skip.
+
+The data-plane writer path (`demo/fleet.rs:234 upsert_data_plane`) must, for the
+`app-collections` template, take the collection set from an explicit argument rather
+than `data_plane_collections_literal` (whose template expansion is `[]` for
+`app-collections`). #657's e2e writes rows directly and does not exercise these CLI
 paths; the guards exist so the new template cannot be misused. Full
 `config apply` ownership of `DataPlanePairingDesired.collections` is #607.
 
@@ -178,6 +208,14 @@ paths; the guards exist so the new template cannot be misused. Full
 DefraDB only P2P-syncs `@branchable` collections. This is enforced at schema
 registration time by the app (#435), not by the reconciler. Documented here; the
 e2e uses a `@branchable` schema. No runtime gate (keeps the change minimal).
+
+**Failure mode for an invalid / non-`@branchable` collection name.** The reconciler
+does not pre-validate the name. An unknown or non-branchable collection surfaces as
+an `add_p2p_collections` / `add_replicator` error inside `apply_op`, which fails
+the tick (`engine.rs:113`) and retries next sweep — a sticky, self-repeating warn
+until the operator fixes the schema or the row. Acceptable for minimality; a unit
+test asserts the error string names the offending collection so the sticky log is
+diagnosable. No runtime branchable gate.
 
 ### 5. Membership gate is a precondition, not a bypass
 
@@ -195,22 +233,33 @@ the sender.
 The change alters *what collection set a data-plane pairing resolves to* — a
 model concern. Per the foundation flow (CLAUDE.md), start in the Lean spec:
 
+- **`ScopeTemplates` catalog.** The Lean `ScopeTemplates.builtinCatalog`
+  currently mirrors the seven Rust builtins. Add `dataPlaneTemplate` (empty
+  collections, `Unscoped`, `Replicate`) so catalog membership / totality proofs
+  track the eighth entry, plus a resolution theorem
+  (`resolveTemplate "app-collections" = some dataPlaneTemplate`). Row-supplied
+  collections do **not** belong in the static template's collection set — they
+  enter as a derivation in `PairingReconcile` (below), keeping the template a
+  pure policy.
 - `PairingReconcile` already models `ReplicatorId = (address, ReplicatorFilter,
   ReplicatorCollections)` and the merge boundary. Extend the data-plane
-  resolution so that for the `data-plane` policy the effective
+  resolution so that for the `app-collections` policy the effective
   `ReplicatorCollections` **and** the subscription set are the row-supplied set,
   while every other template resolves exactly as today (template set,
   subscription cleared at the merge). Prove the existing safety/liveness
   properties (idempotence, filter-change-forces-reinstall,
   co-existing-pairing-non-interference) still hold, and prove the new merge
-  property: a `data-plane` layer's subscription survives, a non-`data-plane`
+  property: an `app-collections` layer's subscription survives, a non-`app-collections`
   data-plane layer's does not.
-- Mirror into `tests/conformance/pairing_reconcile.rs`: (i) a `data-plane` row
+- Mirror into `tests/conformance/pairing_reconcile.rs`: (i) an `app-collections` row
   resolves its row `collections` as both `replicator_collections` and the
   subscription set; (ii) that subscription survives `merge_layered_desired`
   while a network-control-only data-plane layer's subscription is still cleared;
-  (iii) the `data-plane` layer merges with a co-existing control pairing without
-  cross-contaminating filters or subscriptions.
+  (iii) the `app-collections` layer merges with a co-existing control pairing without
+  cross-contaminating filters or subscriptions; (iv) an empty/blank-only
+  `app-collections` row soft-skips (layer → `None`, base preserved); (v) a
+  `app-collections` template on the `PeerPairingDesired`/base path soft-skips to no
+  wiring.
 - Zero `sorry`s.
 
 If the resolution is a pure function over already-modeled quantities
@@ -235,16 +284,29 @@ through **reconcile**, not manual admin:
    invariant — trigger before replicator).
 5. **Co-existing control pairing**: establish a subagent (control) pairing on the
    same A↔B peer and assert it stays intact across the data-plane reconcile.
-6. Via **desired-state config**, write a `DataPlanePairingDesired` row
-   (`template: "data-plane"`, `collections: ["ChangeProposed"]`) on the sender
-   (and the reverse authorization row on the receiver); let the reconciler
-   establish the replicator. No `add_replicator` call in the test.
+6. Via **desired-state config**, write a `DataPlanePairingDesired` row on **both**
+   nodes — mirroring the manual `install_one_way_replicator`, which does
+   `add_collections` + `add_replicator` on both sides (sender pushes; receiver
+   authorizes). Both rows carry the **same** `template: "app-collections"` and the
+   **same** `collections: ["ChangeProposed"]`:
+   - A's row targets peer B; B's row targets peer A.
+   - Both peers are already materializable (step 3), so both `load_desired`s
+     honor their rows.
+   - Both rows are written **after** B's trigger reconciles (step 4), preserving
+     the ordering invariant (`seed_seen_docs_for_collection` runs on an empty
+     collection → the merged doc is a genuine first-observation).
+   The reconciler — not the test — establishes both replicators + subscriptions.
+   No `add_replicator` / `add_collections` call in the test.
 7. Write a `ChangeProposed` doc on A; assert it replicates to B and fires B's
    `EventTrigger` as `created` — exactly one `AgentRequest` with the rendered
    prompt and matching trigger lineage, `last_status="fired"`, `fire_count=1`,
    `last_fired_source_doc_id` = the replicated doc id.
 8. Assert reconcile idempotence (a second sweep installs nothing new) and the
    control pairing is untouched.
+9. **Malformed path** (guards the soft-skip fix): write a `DataPlanePairingDesired`
+   row with an empty/blank-only `collections` set and assert the co-existing
+   control pairing still reconciles (data-plane layer skipped, `base` intact) —
+   the tick is *not* marked `desired_read_failed`.
 
 The membership-materialization step is the heavy part of the harness; TDD forces
 it out. If an in-process materialization path proves prohibitively large, that is
@@ -253,7 +315,7 @@ a signal to reconsider harness shape (e.g. CLI-subprocess like
 
 ## Scope / non-goals
 
-- **In:** honor `DataPlanePairingDesired.collections`; `data-plane` template;
+- **In:** honor `DataPlanePairingDesired.collections`; `app-collections` template;
   Lean + conformance; the reconcile-path e2e.
 - **Out (#660):** document-defined scope templates.
 - **Out:** `config apply` ownership of `DataPlanePairingDesired` (#607 territory);
@@ -262,10 +324,14 @@ a signal to reconsider harness shape (e.g. CLI-subprocess like
 
 ## Reversibility
 
-The change is additive and gated on the `data-plane` template id: one new
-template entry, one query field, one `template == "data-plane"` branch in
-`data_plane_desired_from_pairing_row`, one conditional in `merge_layered_desired`,
-and two CLI guards. Reverting restores exact prior behavior. Because every branch
-keys on `template_ids`/`template == "data-plane"` — a template no existing row
-uses — rows on all other templates behave byte-for-byte as today, regardless of
-whether their `collections` field is populated.
+The change is additive and gated on the `app-collections` template id: one new
+template entry, one query field, a `template == "app-collections"` branch in
+`data_plane_desired_from_pairing_row` (which now returns `Result<Option<..>>` to
+support soft-skip), an `app-collections` soft-skip in `desired_from_pairing_row`, one
+conditional in `merge_layered_desired`, and one CLI guard. Reverting restores
+exact prior behavior. Because every branch keys on
+`template_ids`/`template == "app-collections"` — a template no existing row uses —
+rows on all other templates behave byte-for-byte as today, regardless of whether
+their `collections` field is populated. (The two resolver functions' signatures
+change to `Result<Option<PairingDesired>>`; `load_desired`'s two call sites
+flatten accordingly.)


### PR DESCRIPTION
Closes #657. Follow-up epic: #660 (document-defined scope templates).

Adds an `app-collections` (Unscoped/Replicate, bring-your-own) scope template and
honors the previously-dropped `DataPlanePairingDesired.collections` field, gated on
`template == "app-collections"`. Subscription is preserved for that policy at both
the resolver and `merge_layered_desired`. Malformed (blank-only) rows soft-skip so
they never stall a co-existing control pairing; the template is rejected on the
control-plane path (reconciler + CLI) and in fleet `data_plane_collections_literal`.
Lean-first: catalog entry + pure `mergeLayered` subscription rule; resolution /
soft-skip fenced by in-crate unit tests + merge conformance. Acceptance e2e drives
replication through reconcile (not `add_replicator`) and fires B's EventTrigger on
the merged app-defined doc.

Known residual: a foreign `agent_did` on a data-plane row still hard-fails the
whole peer load (`desired_read_failed`), including control — security refusal,
unchanged. Full `config apply` / `--collections` for app-collections is #607.

Spec: docs/superpowers/specs/2026-07-08-app-defined-collection-pairing-design.md

## Verification
- `cargo test -p defra-agent --lib p2p_reconcile` (94 passed)
- `cargo test -p defra-agent --test conformance app_collections` (3 passed)
- `cargo test -p defra-agent --test e2e_triggers app_collection_pairing` (3 passed)
- `cargo test -p defra-agent-cli --bin defra-agent app_collections` (1 passed)
- `cargo check --workspace --all-targets`
- `lake build` (zero sorries)