### PR TITLE
fix(noq): discard stale abandoned-path packets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,11 +136,12 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev 
 # `reasoning` vs `reasoning_content` mismatch on Chat Completions). Without the
 # fork our Responses-API reasoning capture is silently empty.
 rig-core = { git = "https://github.com/sourcenetwork/rig", rev = "81c34131627e1331f02d36bd12742155d1fa9865" }
-# noq 1.0.1 crash-fixes until n0-computer/noq ships a release with #743 + #723:
+# noq 1.0.1 crash-fixes until n0-computer/noq ships a release with #732 + #743 + #723:
+# - proto: discard late packets for paths whose state has already been abandoned
 # - proto: edge-trigger Draining on terminal state (duplicate stateless reset)
 # - endpoint: don't panic in EndpointDriver::Drop on a poisoned mutex
 # - endpoint: fence active_connections underflow on duplicate Draining
-# See third_party/README.md and defra-agent#634.
+# See third_party/README.md, defradb.rs#1090, and defra-agent#634.
 noq = { path = "third_party/noq" }
 noq-proto = { path = "third_party/noq-proto" }
 

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -7,8 +7,14 @@ releases a fix past crates.io `1.0.1`. These packages are listed under
 `workspace.exclude` (each has an empty `[workspace]` table) so they are not
 fmt/test targets of the main workspace.
 
+Source provenance: both directories are the crates.io `1.0.1` sources. The
+table below lists every downstream code deviation. The #732 change is copied
+from upstream merge commit
+[`52a50004`](https://github.com/n0-computer/noq/commit/52a500044d47ade2ebba07e0bb59c7b224104df5).
+
 | Upstream | Symptom | Patch |
 | --- | --- | --- |
+| [n0-computer/noq#732](https://github.com/n0-computer/noq/pull/732) | A stale coalesced datagram routed after its path state is discarded reaches `path_data_mut(path_id).expect("known path")` and panics | `noq-proto`: early-discard packets absent from `paths` but present in `abandoned_paths`; includes the upstream regression test |
 | [n0-computer/noq#743](https://github.com/n0-computer/noq/issues/743) | Duplicate `Draining` endpoint events from a second stateless reset underflows `active_connections` (panic with overflow checks; silent hang on `wait_all_draining` without them) | `noq-proto`: edge-trigger `Draining` on `!was_drained` for the Reset/AEAD arm |
 | [n0-computer/noq#723](https://github.com/n0-computer/noq/issues/723) | `EndpointDriver::drop` `unwrap()`s a poisoned mutex → process abort | `noq`: recover with `PoisonError::into_inner` |
 | (defense) | Same underflow site if another path reintroduces duplicate Draining | `noq`: per-connection `draining_reported` (kept past `Drained`); ignore Draining when handle not in `senders` |
@@ -17,15 +23,22 @@ fmt/test targets of the main workspace.
 ### Why this is in defra-agent
 
 - Production: fleet builds set `overflow-checks = true`, so the underflow kills steward nodes (defradb.rs#1091 / defra-agent#634).
+- Production: stale packets for a recently abandoned path panic hub nodes during
+  multipath churn (defradb.rs#1090).
 - Conformance: `generated_r5_cross_deployment_cases_drive_production_dispatch` tears down P2P endpoints; a poisoned Drop aborts the whole binary rather than one test.
 
 ### Remove when
 
-Upstream cuts a release including #743 (and ideally #723), and `iroh`/`defradb.rs` bump to it. Then delete these crates and the `[patch.crates-io]` entries.
+Upstream cuts a release including #732 and #743 (and ideally #723), and
+`iroh`/`defradb.rs` bump to it. Then delete these crates and the
+`[patch.crates-io]` entries. If a release omits #723, retain or rebase the two
+poison-recovery deviations explicitly rather than dropping them silently.
 
 ### Regression
 
 ```sh
+cargo test --manifest-path third_party/noq-proto/Cargo.toml \
+  stale_coalesced_datagram_after_path_discard_is_ignored
 cargo test --manifest-path third_party/noq-proto/Cargo.toml \
   regression_double_stateless_reset_single_draining
 ```

--- a/third_party/noq-proto/src/connection/mod.rs
+++ b/third_party/noq-proto/src/connection/mod.rs
@@ -2286,6 +2286,11 @@ impl Connection {
             return true;
         }
 
+        if !self.paths.contains_key(&path_id) && self.abandoned_paths.contains(&path_id) {
+            trace!(%path_id, "discarding packet for discarded path");
+            return true;
+        }
+
         let peer_may_probe = self.peer_may_probe();
         let local_ip_may_migrate = self.local_ip_may_migrate();
 

--- a/third_party/noq-proto/src/tests/mod.rs
+++ b/third_party/noq-proto/src/tests/mod.rs
@@ -22,16 +22,18 @@ use tracing::info;
 
 use crate::{
     AckFrequencyConfig, ApplicationClose, ClientConfig, Connection, ConnectionClose,
-    ConnectionError, ConnectionHandle, DEFAULT_SUPPORTED_VERSIONS, Datagram, DatagramEvent, Dir,
-    Duration, Endpoint, EndpointConfig, Event, FinishError, FourTuple, HashedConnectionIdGenerator,
-    Instant, MIN_INITIAL_SIZE, PathEvent, PathId, ReadError, ReadableError, RecvStream,
-    SendDatagramError, ServerConfig,
+    ConnectionError, ConnectionEvent, ConnectionHandle, DEFAULT_SUPPORTED_VERSIONS, Datagram,
+    DatagramEvent, Dir, Duration, Endpoint, EndpointConfig, Event, FinishError, FourTuple,
+    HashedConnectionIdGenerator, Instant, MIN_INITIAL_SIZE, PathEvent, PathId, PathStatus,
+    ReadError, ReadableError, RecvStream, SendDatagramError, ServerConfig,
     Side::*,
     StreamEvent, Transmit, TransportConfig, TransportErrorCode, VarInt, WriteError,
     cid_generator::{ConnectionIdGenerator, RandomConnectionIdGenerator},
     coding::{Decodable, Encodable},
     crypto::rustls::{QuicServerConfig, configured_provider},
     frame::{self, Frame, FrameStruct},
+    packet::{FixedLengthConnectionIdParser, PartialDecode},
+    shared::{ConnectionEventInner, DatagramConnectionEvent},
     transport_parameters::TransportParameters,
 };
 
@@ -1349,6 +1351,81 @@ fn initial_retransmit() {
         pair.client_conn_mut(client_ch).poll(),
         Some(Event::Connected)
     );
+}
+
+#[test]
+fn stale_coalesced_datagram_after_path_discard_is_ignored() {
+    let _guard = subscribe();
+    let (mut pair, client_cfg) = ConnPair::builder().enable_multipath().build_pair();
+
+    let client_ch = pair.begin_connect(client_cfg);
+    pair.drive_client();
+    pair.drive_server();
+
+    let cid_parser =
+        FixedLengthConnectionIdParser::new(RandomConnectionIdGenerator::default().cid_len());
+    let (first_decode, remaining, ecn, remote, dst_ip) = pair
+        .client
+        .inbound
+        .iter()
+        .find_map(|inbound| {
+            let Ok((first_decode, remaining)) = PartialDecode::new(
+                inbound.packet.clone(),
+                &cid_parser,
+                DEFAULT_SUPPORTED_VERSIONS,
+                pair.client.config().grease_quic_bit,
+            ) else {
+                return None;
+            };
+
+            remaining.is_some().then_some((
+                first_decode,
+                remaining,
+                inbound.ecn,
+                inbound.remote,
+                inbound.dst_ip,
+            ))
+        })
+        .expect("server should have queued a coalesced handshake datagram for client");
+
+    pair.drive();
+    let server_ch = pair.server.assert_accept();
+    pair.finish_connect(client_ch, server_ch);
+
+    let mut pair = ConnPair::new(pair, client_ch, server_ch);
+    let path_id = pair
+        .open_path(
+            Client,
+            FourTuple::from_remote(pair.routes.public_server_addr()),
+            PathStatus::Available,
+        )
+        .expect("path should open");
+    pair.drive();
+    assert_ne!(path_id, PathId::ZERO);
+
+    pair.close_path(Client, PathId::ZERO, 0u8.into())
+        .expect("path 0 should close once path 1 exists");
+    pair.drive();
+    assert!(
+        !pair.paths(Client).contains(&PathId::ZERO),
+        "path 0 should have been discarded"
+    );
+
+    let now = pair.time;
+    pair.conn_mut(Client)
+        .handle_event(ConnectionEvent(ConnectionEventInner::Datagram(
+            DatagramConnectionEvent {
+                now,
+                network_path: FourTuple {
+                    remote,
+                    local_ip: dst_ip,
+                },
+                path_id: PathId::ZERO,
+                ecn,
+                first_decode,
+                remaining,
+            },
+        )));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- backport [n0-computer/noq#732](https://github.com/n0-computer/noq/pull/732) into the vendored `noq-proto` 1.0.1 source
- discard packets for paths that are absent from `paths` but present in `abandoned_paths` before coalesced-packet handling assumes the path still exists
- include the upstream regression test and document all vendor deviations and release removal conditions

## Root cause

A stale coalesced datagram can be routed to a connection after its path state has been discarded. The receive path continued into coalesced-packet handling, which calls `path_data_mut(path_id).expect("known path")` and panics. This is the crash reported in [defradb.rs#1090](https://github.com/sourcenetwork/defradb.rs/issues/1090).

## Impact

Late packets for abandoned paths are now ignored instead of crashing the process during multipath churn. The existing duplicate-`Draining`, underflow, and poisoned-`Drop` defenses remain unchanged.

## Validation

The new regression was first run without the implementation change and reproduced the `known path` panic. After the backport, the following passed:

- `cargo test --manifest-path third_party/noq-proto/Cargo.toml tests::stale_coalesced_datagram_after_path_discard_is_ignored -- --exact`
- `cargo test --manifest-path third_party/noq-proto/Cargo.toml tests::regression_double_stateless_reset_single_draining -- --exact`
- `cargo test -p defra-agent --test conformance generated_r5_cross_deployment_cases_drive_production_dispatch -- --exact`
- `cargo test -p defra-agent`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
