### PR TITLE
Add declarative peer pairing ownership

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6758,6 +6758,7 @@ version = "0.6.6"
 dependencies = [
  "acp",
  "anyhow",
+ "async-trait",
  "axum",
  "bs58",
  "chrono",

--- a/crates/defra-agent-cli/Cargo.toml
+++ b/crates/defra-agent-cli/Cargo.toml
@@ -64,6 +64,7 @@ uuid.workspace = true
 
 [dev-dependencies]
 acp.workspace = true
+async-trait = "0.1"
 defra-agent-lean-contract.workspace = true
 identity.workspace = true
 jsonschema = { version = "0.46.5", default-features = false }

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -147,7 +147,9 @@ fn split_apply_counts(
 fn prune_counts_from_plan(planned: &desired_state::DesiredStateDiffReport) -> ConfigApplyCounts {
     let mut counts = ConfigApplyCounts::default();
     for collection in Collection::ALL {
-        counts.set(collection, planned.collections.get(collection).delete.len());
+        if !collection.manifest_authoritative() {
+            counts.set(collection, planned.collections.get(collection).delete.len());
+        }
     }
     counts
 }

--- a/crates/defra-agent-cli/src/commands/config/apply.rs
+++ b/crates/defra-agent-cli/src/commands/config/apply.rs
@@ -43,9 +43,10 @@ pub(crate) async fn apply_bound_desired_manifest(
     let desired_manifest = &bound.manifest;
 
     // Apply-time live validation complements the static desired-state
-    // validation. It probes the live node's GraphQL schema for EventTrigger
-    // filter syntax and `doc.*` field resolution. We only run it from the
-    // apply path, where we already hold a live `ConfigAccess`.
+    // validation. It checks pairing ownership and probes the live node's
+    // GraphQL schema for EventTrigger filter syntax and `doc.*` field
+    // resolution. Apply rejects every error before opening a transaction;
+    // config diff reports only pairing ownership collisions alongside drift.
     let live_errs =
         desired_state::validate::validate_manifest_against_live(desired_manifest, &access).await?;
     if !live_errs.is_empty() {

--- a/crates/defra-agent-cli/src/commands/config/binding.rs
+++ b/crates/defra-agent-cli/src/commands/config/binding.rs
@@ -204,6 +204,7 @@ fn counts_for_manifest(manifest: &DesiredStateManifest) -> DesiredStateCounts {
         inference_profiles: manifest.inference_profiles.len(),
         tool_service_registries: manifest.tool_service_registries.len(),
         projection_acp_bindings: manifest.projection_acp_bindings.len(),
+        peer_pairings: manifest.peer_pairings.len(),
         tasks: manifest.tasks.len(),
         schedules: manifest.schedules.len(),
         event_triggers: manifest.event_triggers.len(),

--- a/crates/defra-agent-cli/src/commands/config/crud.rs
+++ b/crates/defra-agent-cli/src/commands/config/crud.rs
@@ -254,6 +254,7 @@ fn empty_bundle(access_mode: &str, agent_did: &str) -> ConfigExportBundle {
         inference_profiles: Vec::new(),
         tool_service_registries: Vec::new(),
         projection_acp_bindings: Vec::new(),
+        peer_pairings: Vec::new(),
         tasks: Vec::new(),
         schedules: Vec::new(),
         event_triggers: Vec::new(),
@@ -278,6 +279,7 @@ fn push_doc(bundle: &mut ConfigExportBundle, collection: Collection, doc: Value)
         Collection::InferenceProfile => bundle.inference_profiles.push(doc),
         Collection::ToolServiceRegistry => bundle.tool_service_registries.push(doc),
         Collection::ProjectionAcpBinding => bundle.projection_acp_bindings.push(doc),
+        Collection::PeerPairingDesired => bundle.peer_pairings.push(doc),
         Collection::Task => bundle.tasks.push(doc),
         Collection::Schedule => bundle.schedules.push(doc),
         Collection::EventTrigger => bundle.event_triggers.push(doc),
@@ -332,6 +334,9 @@ fn remove_target(
         Collection::ProjectionAcpBinding => manifest
             .projection_acp_bindings
             .retain(|row| row.binding_id != id),
+        Collection::PeerPairingDesired => manifest
+            .peer_pairings
+            .retain(|row| row.resolved_peer_id().as_deref() != Some(id)),
         Collection::Task => manifest.tasks.retain(|row| row.task_id != id),
         Collection::Schedule => manifest.schedules.retain(|row| row.schedule_id != id),
         Collection::EventTrigger => manifest.event_triggers.retain(|row| row.trigger_id != id),

--- a/crates/defra-agent-cli/src/commands/config/diff.rs
+++ b/crates/defra-agent-cli/src/commands/config/diff.rs
@@ -31,24 +31,31 @@ pub(crate) async fn diff_bound_desired_manifest(
     bound: &super::binding::BoundDesiredManifest,
 ) -> Result<desired_state::DesiredStateDiffReport> {
     let desired_manifest = &bound.manifest;
-    let live_errors =
-        desired_state::validate::validate_manifest_against_live(desired_manifest, access).await?;
-    if !live_errors.is_empty() {
-        anyhow::bail!(
-            "{} live validation error(s): {}",
-            live_errors.len(),
-            live_errors.join("; ")
-        );
-    }
+    // Diff remains an observability command even when the desired state cannot
+    // currently be applied. Pairing ownership collisions are included in the
+    // structured report; apply still rejects them before opening a transaction.
+    // Other live validation (such as EventTrigger schema probes) remains an
+    // apply-time concern and must not hide the diff that helps diagnose it.
+    let live_validation_errors =
+        desired_state::validate::validate_peer_pairing_ownership_against_live(
+            desired_manifest,
+            access,
+        )
+        .await?;
     let live_bundle = build_desired_state_live_bundle(&access, desired_manifest).await?;
     let (live_principal, live_manifest) =
         live_manifest_from_bundle(desired_manifest, &live_bundle)?;
-    Ok(desired_state::diff_manifests(
+    let mut report = desired_state::diff_manifests(
         root,
         access.mode(),
         desired_manifest,
         live_principal.as_ref(),
         &live_manifest,
         false,
-    ))
+    );
+    if !live_validation_errors.is_empty() {
+        report.ok = false;
+        report.live_validation_errors = live_validation_errors;
+    }
+    Ok(report)
 }

--- a/crates/defra-agent-cli/src/commands/config/diff.rs
+++ b/crates/defra-agent-cli/src/commands/config/diff.rs
@@ -31,6 +31,15 @@ pub(crate) async fn diff_bound_desired_manifest(
     bound: &super::binding::BoundDesiredManifest,
 ) -> Result<desired_state::DesiredStateDiffReport> {
     let desired_manifest = &bound.manifest;
+    let live_errors =
+        desired_state::validate::validate_manifest_against_live(desired_manifest, access).await?;
+    if !live_errors.is_empty() {
+        anyhow::bail!(
+            "{} live validation error(s): {}",
+            live_errors.len(),
+            live_errors.join("; ")
+        );
+    }
     let live_bundle = build_desired_state_live_bundle(&access, desired_manifest).await?;
     let (live_principal, live_manifest) =
         live_manifest_from_bundle(desired_manifest, &live_bundle)?;

--- a/crates/defra-agent-cli/src/commands/diagnose/mod.rs
+++ b/crates/defra-agent-cli/src/commands/diagnose/mod.rs
@@ -49,6 +49,7 @@ pub(crate) async fn diagnose(args: DiagnoseArgs) -> Result<()> {
         inference_profiles: Vec::new(),
         tool_service_registries: Vec::new(),
         projection_acp_bindings: Vec::new(),
+        peer_pairings: Vec::new(),
         tasks: Vec::new(),
         schedules: Vec::new(),
         event_triggers: Vec::new(),

--- a/crates/defra-agent-cli/src/commands/status.rs
+++ b/crates/defra-agent-cli/src/commands/status.rs
@@ -278,6 +278,7 @@ mod tests {
             inference_profiles,
             tool_service_registries: Vec::new(),
             projection_acp_bindings: Vec::new(),
+            peer_pairings: Vec::new(),
             tasks: Vec::new(),
             schedules: Vec::new(),
             event_triggers: Vec::new(),

--- a/crates/defra-agent-cli/src/config_bundle.rs
+++ b/crates/defra-agent-cli/src/config_bundle.rs
@@ -230,6 +230,7 @@ pub(crate) async fn build_config_export_bundle(
     )
     .await?;
     sort_document_rows(&mut projection_acp_binding_rows, "binding_id");
+    let peer_pairing_rows = load_manifest_owned_peer_pairings(access, agent_did).await?;
 
     Ok(ConfigExportBundle {
         format: CONFIG_EXPORT_FORMAT.to_string(),
@@ -244,6 +245,7 @@ pub(crate) async fn build_config_export_bundle(
         inference_profiles: profile_rows,
         tool_service_registries: tool_service_registry_rows,
         projection_acp_bindings: projection_acp_binding_rows,
+        peer_pairings: peer_pairing_rows,
         tasks: task_rows,
         schedules: schedule_rows,
         event_triggers: event_trigger_rows,
@@ -516,6 +518,7 @@ pub(crate) async fn build_desired_state_live_bundle(
                 .is_some_and(|binding_id| desired_binding_ids.contains(binding_id))
     });
     sort_document_rows(&mut projection_acp_binding_rows, "binding_id");
+    let peer_pairing_rows = load_manifest_owned_peer_pairings(access, agent_did).await?;
 
     Ok(ConfigExportBundle {
         format: CONFIG_EXPORT_FORMAT.to_string(),
@@ -530,6 +533,7 @@ pub(crate) async fn build_desired_state_live_bundle(
         inference_profiles: profile_rows,
         tool_service_registries: tool_service_registry_rows,
         projection_acp_bindings: projection_acp_binding_rows,
+        peer_pairings: peer_pairing_rows,
         tasks: task_rows,
         schedules: schedule_rows,
         event_triggers: event_trigger_rows,
@@ -558,12 +562,39 @@ pub(crate) fn live_manifest_from_bundle(
                 inference_profiles: Vec::new(),
                 tool_service_registries: Vec::new(),
                 projection_acp_bindings: Vec::new(),
+                peer_pairings: Vec::new(),
                 tasks: Vec::new(),
                 schedules: Vec::new(),
                 event_triggers: Vec::new(),
             },
         ))
     }
+}
+
+async fn load_manifest_owned_peer_pairings(
+    access: &ConfigAccess,
+    owner_agent_did: &str,
+) -> Result<Vec<Value>> {
+    let source = desired_state::peer_pairing_manifest_source(owner_agent_did);
+    let source = escape_graphql_string(&source);
+    let mut rows = graphql_rows_or_empty_if_collection_missing(
+        access,
+        "PeerPairingDesired",
+        &format!(
+            r#"{{
+                PeerPairingDesired(filter: {{ source: {{ _eq: "{source}" }} }}) {{
+                    peer_id
+                    agent_did
+                    replicator_addresses
+                    template
+                    source
+                }}
+            }}"#
+        ),
+    )
+    .await?;
+    sort_document_rows(&mut rows, "peer_id");
+    Ok(rows)
 }
 
 /// Scope globally-fetched `Task`, `Schedule`, and `EventTrigger` rows to

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -2142,6 +2142,7 @@ mod lean_apply_write_boundary_tests {
             root: format!("lean://{}", case.name),
             access_mode: "graphql".to_string(),
             agent_did: agent_did_for_case(case),
+            live_validation_errors: Vec::new(),
             counts,
             collections,
         }

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -33,7 +33,8 @@ const CONFIG_IMPORT_BATCH_SIZE: usize = 50;
 // realizes the Lean retry model by rebuilding the live diff at the start of
 // each `config apply` attempt, then applying selected documents with
 // unique-field upserts or equivalent override writers.
-const CONFIG_APPLY_ORDER: [Collection; 11] = [
+const CONFIG_APPLY_ORDER: [Collection; 12] = [
+    Collection::PeerPairingDesired,
     Collection::InferenceBackend,
     Collection::InferenceProfile,
     Collection::ToolServiceRegistry,
@@ -47,7 +48,7 @@ const CONFIG_APPLY_ORDER: [Collection; 11] = [
     Collection::AgentPrincipal,
 ];
 
-const CONFIG_PRUNE_ORDER: [Collection; 11] = [
+const CONFIG_PRUNE_ORDER: [Collection; 12] = [
     Collection::AgentPrincipal,
     Collection::EventTrigger,
     Collection::Schedule,
@@ -59,6 +60,7 @@ const CONFIG_PRUNE_ORDER: [Collection; 11] = [
     Collection::ToolServiceRegistry,
     Collection::InferenceProfile,
     Collection::InferenceBackend,
+    Collection::PeerPairingDesired,
 ];
 
 #[cfg(test)]
@@ -140,7 +142,9 @@ pub(crate) async fn apply_import_collection(
         return Ok(0);
     }
 
-    if override_existing && uses_custom_apply_writer(collection_name) {
+    if override_existing && collection_name == "PeerPairingDesired" {
+        apply_manifest_pairing_documents(txn, &prepared).await?;
+    } else if override_existing && uses_custom_apply_writer(collection_name) {
         apply_custom_override_collection_batched(txn, collection_name, unique_field, &prepared)
             .await?;
     } else {
@@ -155,6 +159,91 @@ pub(crate) async fn apply_import_collection(
     }
 
     Ok(docs.len())
+}
+
+async fn apply_manifest_pairing_documents(
+    txn: &ConfigApplyTxn<'_>,
+    docs: &[PreparedImportDocument],
+) -> Result<()> {
+    let fields = docs
+        .iter()
+        .enumerate()
+        .map(|(index, doc)| {
+            let source = doc
+                .add_doc
+                .get("source")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|source| {
+                    source.starts_with(desired_state::PEER_PAIRING_MANIFEST_SOURCE_PREFIX)
+                })
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "manifest PeerPairingDesired {} is missing manifest source provenance",
+                        doc.unique_value
+                    )
+                })?;
+            let add_literal = graphql_input_literal(&doc.add_doc)?;
+            let update_literal =
+                graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
+                    anyhow::anyhow!("missing update document for PeerPairingDesired")
+                })?)?;
+            Ok(AliasedMutationField {
+                alias: format!("doc_{index}"),
+                field: format!(
+                    r#"doc_{index}: upsert_PeerPairingDesired(
+                        filter: {{
+                            peer_id: {{ _eq: "{peer_id}" }},
+                            source: {{ _eq: "{source}" }}
+                        }},
+                        add: {add_literal},
+                        update: {update_literal}
+                    ) {{ _docID }}"#,
+                    peer_id = escape_graphql_string(&doc.unique_value),
+                    source = escape_graphql_string(source),
+                ),
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    execute_aliased_mutation_batches(txn, "PeerPairingDesired", &fields).await
+}
+
+async fn apply_delete_manifest_pairings(
+    txn: &ConfigApplyTxn<'_>,
+    ids: &[String],
+    owner_agent_did: &str,
+) -> Result<usize> {
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    let source = desired_state::peer_pairing_manifest_source(owner_agent_did);
+    let fields = ids
+        .iter()
+        .enumerate()
+        .map(|(index, peer_id)| manifest_pairing_delete_mutation_field(index, peer_id, &source))
+        .collect::<Vec<_>>();
+    execute_aliased_mutation_batches(txn, "PeerPairingDesired", &fields).await?;
+    Ok(ids.len())
+}
+
+fn manifest_pairing_delete_mutation_field(
+    index: usize,
+    peer_id: &str,
+    source: &str,
+) -> AliasedMutationField {
+    AliasedMutationField {
+        alias: format!("doc_{index}"),
+        field: format!(
+            r#"doc_{index}: delete_PeerPairingDesired(
+                filter: {{
+                    peer_id: {{ _eq: "{peer_id}" }},
+                    source: {{ _eq: "{source}" }}
+                }}
+            ) {{ _docID }}"#,
+            peer_id = escape_graphql_string(peer_id),
+            source = escape_graphql_string(source),
+        ),
+    }
 }
 
 pub(crate) async fn apply_delete_collection(
@@ -692,13 +781,17 @@ pub(crate) async fn apply_desired_state_changes(
 
     for collection in CONFIG_PRUNE_ORDER {
         let diff = planned.collections.get(collection);
-        let deleted = apply_delete_collection(
-            txn,
-            collection.graphql_type(),
-            collection.unique_field(),
-            &diff.delete,
-        )
-        .await?;
+        let deleted = if collection == Collection::PeerPairingDesired {
+            apply_delete_manifest_pairings(txn, &diff.delete, &planned.agent_did).await?
+        } else {
+            apply_delete_collection(
+                txn,
+                collection.graphql_type(),
+                collection.unique_field(),
+                &diff.delete,
+            )
+            .await?
+        };
         counts.add(collection, deleted);
 
         if let Some(sleep) = per_collection_sleep {
@@ -829,6 +922,23 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
             filter: { task_id: { _eq: "task\"with\\chars" } }
         ) { _docID }"#
         );
+    }
+
+    #[test]
+    fn manifest_pairing_delete_is_owner_scoped_and_escaped() {
+        let field = manifest_pairing_delete_mutation_field(
+            3,
+            r#"peer"with\chars"#,
+            r#"manifest:did:key:owner"with\chars"#,
+        );
+
+        assert_eq!(field.alias, "doc_3");
+        assert!(field
+            .field
+            .contains(r#"peer_id: { _eq: "peer\"with\\chars" }"#));
+        assert!(field
+            .field
+            .contains(r#"source: { _eq: "manifest:did:key:owner\"with\\chars" }"#));
     }
 
     #[test]
@@ -1774,6 +1884,10 @@ mod lean_apply_write_boundary_tests {
                 .into_iter()
                 .map(|doc| desired_projection_acp_binding(doc, &agent_did))
                 .collect(),
+            peer_pairings: docs_for_collection(case, Collection::PeerPairingDesired)
+                .into_iter()
+                .map(desired_peer_pairing)
+                .collect(),
             tasks: docs_for_collection(case, Collection::Task)
                 .into_iter()
                 .map(desired_task)
@@ -1968,6 +2082,16 @@ mod lean_apply_write_boundary_tests {
         }
     }
 
+    fn desired_peer_pairing(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredPeerPairing {
+        desired_state::DesiredPeerPairing {
+            peer_did: format!("did:key:{}", doc.content),
+            addresses: vec![format!("{}@127.0.0.1:4100", doc.id)],
+            template: "conversation".to_string(),
+            enabled: true,
+            peer_id: doc.id.clone(),
+        }
+    }
+
     fn desired_schedule(doc: &LeanApplyDesiredDoc) -> desired_state::DesiredSchedule {
         desired_state::DesiredSchedule {
             schedule_id: doc.id.clone(),
@@ -2005,6 +2129,7 @@ mod lean_apply_write_boundary_tests {
             inference_profiles: diff_for_collection(case, Collection::InferenceProfile),
             tool_service_registries: diff_for_collection(case, Collection::ToolServiceRegistry),
             projection_acp_bindings: diff_for_collection(case, Collection::ProjectionAcpBinding),
+            peer_pairings: diff_for_collection(case, Collection::PeerPairingDesired),
             tasks: diff_for_collection(case, Collection::Task),
             schedules: diff_for_collection(case, Collection::Schedule),
             event_triggers: diff_for_collection(case, Collection::EventTrigger),
@@ -2138,6 +2263,7 @@ mod lean_apply_write_boundary_tests {
             Collection::InferenceProfile => counts.inference_profiles,
             Collection::ToolServiceRegistry => counts.tool_service_registries,
             Collection::ProjectionAcpBinding => counts.projection_acp_bindings,
+            Collection::PeerPairingDesired => counts.peer_pairings,
             Collection::Task => counts.tasks,
             Collection::Schedule => counts.schedules,
             Collection::EventTrigger => counts.event_triggers,
@@ -2149,6 +2275,7 @@ mod lean_apply_write_boundary_tests {
             Collection::InferenceBackend => &["probe_status"],
             Collection::ToolServiceRegistry => &["tools", "version"],
             Collection::ProjectionAcpBinding => &[],
+            Collection::PeerPairingDesired => &[],
             Collection::Schedule => &[
                 "next_run_at",
                 "last_attempt_at",

--- a/crates/defra-agent-cli/src/desired_state/convert.rs
+++ b/crates/defra-agent-cli/src/desired_state/convert.rs
@@ -7,7 +7,10 @@ use super::validate::{
     normalize_tool_service_mcp_path, normalize_tool_service_string, optional_i64_from_value,
     optional_string_from_value,
 };
-use super::{DesiredStateManifest, DesiredToolServiceRegistry, TOOL_SERVICE_ADDRESS_FIELDS};
+use super::{
+    peer_pairing_manifest_source, DesiredPeerPairing, DesiredStateManifest,
+    DesiredToolServiceRegistry, TOOL_SERVICE_ADDRESS_FIELDS,
+};
 
 pub(crate) fn tool_service_registry_from_live_value(
     value: &Value,
@@ -239,6 +242,11 @@ pub(crate) fn manifest_from_export_bundle(
                 )
             })
             .collect::<Result<Vec<_>>>()?,
+        peer_pairings: bundle
+            .peer_pairings
+            .iter()
+            .map(peer_pairing_from_live_value)
+            .collect::<Result<Vec<_>>>()?,
         tasks: bundle
             .tasks
             .iter()
@@ -344,6 +352,12 @@ pub(crate) fn export_bundle_from_manifest(
             .iter()
             .map(serde_json::to_value)
             .collect::<serde_json::Result<Vec<_>>>()?,
+        peer_pairings: manifest
+            .peer_pairings
+            .iter()
+            .filter(|pairing| pairing.enabled)
+            .map(|pairing| peer_pairing_apply_value(pairing, manifest))
+            .collect::<Result<Vec<_>>>()?,
         tasks: manifest
             .tasks
             .iter()
@@ -361,6 +375,78 @@ pub(crate) fn export_bundle_from_manifest(
             .collect::<serde_json::Result<Vec<_>>>()?,
     };
     Ok(super::DesiredApplyBundle::from_trusted_bundle(bundle))
+}
+
+fn peer_pairing_from_live_value(value: &Value) -> Result<DesiredPeerPairing> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow!("expected PeerPairingDesired live row to be an object"))?;
+    let peer_id = object
+        .get("peer_id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow!("PeerPairingDesired live row is missing peer_id"))?;
+    let peer_did = object
+        .get("agent_did")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .unwrap_or_default();
+    let addresses = object
+        .get("replicator_addresses")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let template = object
+        .get("template")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(defra_agent::agent::p2p_reconcile::engine::DEFAULT_PAIRING_TEMPLATE);
+
+    Ok(DesiredPeerPairing {
+        peer_did: peer_did.to_string(),
+        addresses,
+        template: template.to_string(),
+        enabled: true,
+        peer_id: peer_id.to_string(),
+    })
+}
+
+fn peer_pairing_apply_value(
+    pairing: &DesiredPeerPairing,
+    manifest: &DesiredStateManifest,
+) -> Result<Value> {
+    let peer_id = pairing.resolved_peer_id().ok_or_else(|| {
+        anyhow!(
+            "enabled peer pairing {:?} has no derivable peer_id",
+            pairing.peer_did
+        )
+    })?;
+    let template = defra_agent::agent::p2p_reconcile::resolve_template(&pairing.template)
+        .ok_or_else(|| anyhow!("unknown peer pairing template {:?}", pairing.template))?;
+    let collections = template
+        .collections
+        .iter()
+        .map(|collection| Value::String((*collection).to_string()))
+        .collect::<Vec<_>>();
+    Ok(serde_json::json!({
+        "peer_id": peer_id,
+        "agent_did": pairing.peer_did,
+        "collections": collections,
+        "replicator_addresses": pairing.addresses,
+        "profiles": Value::Null,
+        "template": pairing.template,
+        "source": peer_pairing_manifest_source(&manifest.agent_principal.agent_did),
+    }))
 }
 
 pub(crate) fn desired_from_value<T>(value: &Value, allowed_fields: &[&str]) -> Result<T>

--- a/crates/defra-agent-cli/src/desired_state/diff.rs
+++ b/crates/defra-agent-cli/src/desired_state/diff.rs
@@ -2,8 +2,8 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use super::{
-    DesiredAgentPrincipal, DesiredStateCollectionDiff, DesiredStateDiffCollections,
-    DesiredStateDiffReport, DesiredStateManifest, HasUniqueId,
+    DesiredAgentPrincipal, DesiredPeerPairing, DesiredStateCollectionDiff,
+    DesiredStateDiffCollections, DesiredStateDiffReport, DesiredStateManifest, HasUniqueId,
 };
 
 pub(crate) fn diff_manifests(
@@ -40,6 +40,11 @@ pub(crate) fn diff_manifests(
             &desired.projection_acp_bindings,
             &live.projection_acp_bindings,
         ),
+        // Pairing manifests are authoritative for rows carrying this root's
+        // provenance marker. Managed live rows absent from the root (or named
+        // by an `enabled: false` entry) are always removals; unrelated sources
+        // are excluded from `live` before this boundary.
+        peer_pairings: diff_peer_pairings(&desired.peer_pairings, &live.peer_pairings),
         tasks: diff_manifest_collection(&desired.tasks, &live.tasks),
         schedules: diff_manifest_collection(&desired.schedules, &live.schedules),
         event_triggers: diff_manifest_collection(&desired.event_triggers, &live.event_triggers),
@@ -61,6 +66,80 @@ pub(crate) fn diff_manifests(
         agent_did: desired.agent_principal.agent_did.clone(),
         counts,
         collections,
+    }
+}
+
+fn diff_peer_pairings(
+    desired: &[DesiredPeerPairing],
+    live: &[DesiredPeerPairing],
+) -> DesiredStateCollectionDiff {
+    let mut remaining_live = live.iter().collect::<Vec<_>>();
+    remaining_live.sort_by_key(|pairing| pairing.resolved_peer_id());
+
+    let mut create = BTreeSet::new();
+    let mut update = BTreeSet::new();
+    let mut delete = BTreeSet::new();
+    let mut unchanged = BTreeSet::new();
+
+    // Claim active rows by their unique database key before considering
+    // disabled entries. This permits safe peer-DID corrections (and even DID
+    // swaps) as updates instead of create/delete conflicts on `peer_id`.
+    for pairing in desired.iter().filter(|pairing| pairing.enabled) {
+        let desired_peer_id = pairing
+            .resolved_peer_id()
+            .unwrap_or_else(|| pairing.peer_did.trim().to_string());
+        let matching_index = remaining_live
+            .iter()
+            .position(|row| row.resolved_peer_id().as_deref() == Some(desired_peer_id.as_str()));
+        if let Some(index) = matching_index {
+            let row = remaining_live.remove(index);
+            if pairing == row {
+                unchanged.insert(desired_peer_id.clone());
+            } else {
+                update.insert(desired_peer_id.clone());
+            }
+        } else {
+            create.insert(desired_peer_id);
+        }
+    }
+
+    for pairing in desired.iter().filter(|pairing| !pairing.enabled) {
+        let peer_did = pairing.peer_did.trim();
+        let desired_peer_id = pairing.resolved_peer_id();
+        let mut matching = Vec::new();
+        remaining_live.retain(|row| {
+            let matches = row.peer_did.trim() == peer_did
+                || desired_peer_id
+                    .as_deref()
+                    .is_some_and(|peer_id| row.resolved_peer_id().as_deref() == Some(peer_id));
+            if matches {
+                matching.push(*row);
+            }
+            !matches
+        });
+        if matching.is_empty() {
+            unchanged.insert(desired_peer_id.unwrap_or_else(|| peer_did.to_string()));
+        } else {
+            for row in matching {
+                if let Some(peer_id) = row.resolved_peer_id() {
+                    delete.insert(peer_id);
+                }
+            }
+        }
+    }
+
+    for row in remaining_live {
+        if let Some(peer_id) = row.resolved_peer_id() {
+            delete.insert(peer_id);
+        }
+    }
+
+    DesiredStateCollectionDiff {
+        create: create.into_iter().collect(),
+        update: update.into_iter().collect(),
+        delete: delete.into_iter().collect(),
+        unchanged: unchanged.into_iter().collect(),
+        live_only: Vec::new(),
     }
 }
 

--- a/crates/defra-agent-cli/src/desired_state/diff.rs
+++ b/crates/defra-agent-cli/src/desired_state/diff.rs
@@ -64,6 +64,7 @@ pub(crate) fn diff_manifests(
         root: root.display().to_string(),
         access_mode: access_mode.to_string(),
         agent_did: desired.agent_principal.agent_did.clone(),
+        live_validation_errors: Vec::new(),
         counts,
         collections,
     }

--- a/crates/defra-agent-cli/src/desired_state/load.rs
+++ b/crates/defra-agent-cli/src/desired_state/load.rs
@@ -7,9 +7,9 @@ use super::normalize::normalize_manifest;
 use super::validate::validate_manifest;
 use super::{
     DesiredAgentBehavior, DesiredAgentPrincipal, DesiredEventTrigger, DesiredInferenceBackend,
-    DesiredInferenceProfile, DesiredProjectionAcpBinding, DesiredSchedule, DesiredSkill,
-    DesiredStateCounts, DesiredStateManifest, DesiredStateValidationReport, DesiredTask,
-    DesiredToolSelection, DesiredToolServiceRegistry, HasUniqueId,
+    DesiredInferenceProfile, DesiredPeerPairing, DesiredProjectionAcpBinding, DesiredSchedule,
+    DesiredSkill, DesiredStateCounts, DesiredStateManifest, DesiredStateValidationReport,
+    DesiredTask, DesiredToolSelection, DesiredToolServiceRegistry, HasUniqueId,
 };
 use defra_agent::Collection;
 
@@ -43,6 +43,7 @@ pub(crate) fn load_manifest_root(
         load_per_doc_collection(root, Collection::ToolServiceRegistry, &mut errors);
     let projection_acp_bindings: Vec<DesiredProjectionAcpBinding> =
         load_per_doc_collection(root, Collection::ProjectionAcpBinding, &mut errors);
+    let peer_pairings = load_peer_pairings(root, &mut errors);
     let mut tasks: Vec<DesiredTask> = load_per_doc_collection(root, Collection::Task, &mut errors);
     let schedules: Vec<DesiredSchedule> =
         load_per_doc_collection(root, Collection::Schedule, &mut errors);
@@ -77,6 +78,7 @@ pub(crate) fn load_manifest_root(
         inference_profiles: inference_profiles.len(),
         tool_service_registries: tool_service_registries.len(),
         projection_acp_bindings: projection_acp_bindings.len(),
+        peer_pairings: peer_pairings.len(),
         tasks: tasks.len(),
         schedules: schedules.len(),
         event_triggers: event_triggers.len(),
@@ -94,6 +96,7 @@ pub(crate) fn load_manifest_root(
             inference_profiles,
             tool_service_registries,
             projection_acp_bindings,
+            peer_pairings,
             tasks,
             schedules,
             event_triggers,
@@ -118,6 +121,92 @@ pub(crate) fn load_manifest_root(
             errors,
         },
     )
+}
+
+/// Load `peer-pairings/<handle>/object.json` documents.
+///
+/// Pairing handles are intentionally human-readable labels (for example
+/// `coding-steward`), while the stable document identity is `peer_did`; unlike
+/// the other per-document collections, the directory name therefore does not
+/// have to equal a field inside `object.json`.
+fn load_peer_pairings(root: &Path, errors: &mut Vec<String>) -> Vec<DesiredPeerPairing> {
+    let collection_path = root.join(
+        Collection::PeerPairingDesired
+            .dir_name()
+            .expect("PeerPairingDesired uses a directory manifest form"),
+    );
+    if !collection_path.exists() {
+        return Vec::new();
+    }
+    if !collection_path.is_dir() {
+        errors.push(format!(
+            "manifest collection path is not a directory: {}",
+            collection_path.display()
+        ));
+        return Vec::new();
+    }
+
+    let entries = match fs::read_dir(&collection_path) {
+        Ok(entries) => entries,
+        Err(error) => {
+            errors.push(format!(
+                "reading {} failed: {error}",
+                collection_path.display()
+            ));
+            return Vec::new();
+        }
+    };
+    let mut subdirs = entries
+        .filter_map(|entry| match entry {
+            Ok(entry) if entry.path().is_dir() => entry
+                .file_name()
+                .to_str()
+                .filter(|name| !name.starts_with('.'))
+                .map(|name| (name.to_string(), entry.path())),
+            Ok(_) => None,
+            Err(error) => {
+                errors.push(format!(
+                    "reading {} failed: {error}",
+                    collection_path.display()
+                ));
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    subdirs.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut pairings = Vec::with_capacity(subdirs.len());
+    let mut did_to_handle = std::collections::BTreeMap::<String, String>::new();
+    for (handle, path) in subdirs {
+        let object_path = path.join("object.json");
+        let bytes = match fs::read(&object_path) {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                errors.push(if error.kind() == std::io::ErrorKind::NotFound {
+                    format!("per-doc dir is missing object.json: {}", path.display())
+                } else {
+                    format!("reading {} failed: {error}", object_path.display())
+                });
+                continue;
+            }
+        };
+        let pairing: DesiredPeerPairing = match serde_json::from_slice(&bytes) {
+            Ok(pairing) => pairing,
+            Err(error) => {
+                errors.push(format!("invalid {}: {error}", object_path.display()));
+                continue;
+            }
+        };
+        let peer_did = pairing.peer_did.trim().to_string();
+        if let Some(previous) = did_to_handle.insert(peer_did.clone(), handle.clone()) {
+            errors.push(format!(
+                "duplicate peer_did in peer-pairings manifest: {peer_did} ({previous}/ and {handle}/)"
+            ));
+            continue;
+        }
+        pairings.push(pairing);
+    }
+    pairings
 }
 
 fn empty_report(root_display: String, errors: Vec<String>) -> DesiredStateValidationReport {

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -26,6 +26,15 @@ use defra_agent::{BackendProviderKind, Collection};
 
 pub(crate) const DEFAULT_TOOL_SERVICE_MCP_PATH: &str = "/mcp";
 pub(crate) const TOOL_SERVICE_ADDRESS_FIELDS: &[&str] = &["hostname", "tailscale_ip", "lan_ip"];
+pub(crate) const PEER_PAIRING_MANIFEST_SOURCE_PREFIX: &str =
+    defra_agent::agent::p2p_reconcile::SOURCE_MANIFEST_PREFIX;
+
+pub(crate) fn peer_pairing_manifest_source(owner_agent_did: &str) -> String {
+    format!(
+        "{PEER_PAIRING_MANIFEST_SOURCE_PREFIX}{}",
+        owner_agent_did.trim()
+    )
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -421,6 +430,68 @@ pub(crate) struct DesiredProjectionAcpBinding {
     pub(crate) enabled: bool,
 }
 
+/// Manifest-authoring shape for one declaratively owned control-plane pairing.
+///
+/// `peer_id` is derived from `addresses` during validation and is not part of
+/// the checked-in document. Live rows populate it directly so removals remain
+/// possible even if a stale row has malformed or empty addresses.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct DesiredPeerPairing {
+    pub(crate) peer_did: String,
+    pub(crate) addresses: Vec<String>,
+    pub(crate) template: String,
+    pub(crate) enabled: bool,
+    #[serde(skip)]
+    pub(crate) peer_id: String,
+}
+
+impl DesiredPeerPairing {
+    pub(crate) fn resolved_peer_id(&self) -> Option<String> {
+        let stored = self.peer_id.trim();
+        if !stored.is_empty() {
+            return Some(stored.to_string());
+        }
+        self.addresses.iter().find_map(|address| {
+            p2p::iroh::parse_public_peer_addr(address.trim())
+                .ok()
+                .map(|(peer_id, _)| peer_id.to_string())
+        })
+    }
+
+    fn normalized_addresses(&self) -> Vec<(String, Vec<String>)> {
+        let mut normalized = self
+            .addresses
+            .iter()
+            .map(|address| {
+                p2p::iroh::parse_public_peer_addr(address.trim())
+                    .map(|(peer_id, addresses)| {
+                        let mut addresses = addresses
+                            .iter()
+                            .map(|address| address.as_str().to_string())
+                            .collect::<Vec<_>>();
+                        addresses.sort();
+                        (peer_id.to_string(), addresses)
+                    })
+                    .unwrap_or_else(|_| (address.trim().to_string(), Vec::new()))
+            })
+            .collect::<Vec<_>>();
+        normalized.sort();
+        normalized.dedup();
+        normalized
+    }
+}
+
+impl PartialEq for DesiredPeerPairing {
+    fn eq(&self, other: &Self) -> bool {
+        self.peer_did.trim() == other.peer_did.trim()
+            && self.template.trim() == other.template.trim()
+            && self.enabled == other.enabled
+            && self.resolved_peer_id() == other.resolved_peer_id()
+            && self.normalized_addresses() == other.normalized_addresses()
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct DesiredStateManifest {
     pub(crate) agent_principal: DesiredAgentPrincipal,
@@ -431,6 +502,7 @@ pub(crate) struct DesiredStateManifest {
     pub(crate) inference_profiles: Vec<DesiredInferenceProfile>,
     pub(crate) tool_service_registries: Vec<DesiredToolServiceRegistry>,
     pub(crate) projection_acp_bindings: Vec<DesiredProjectionAcpBinding>,
+    pub(crate) peer_pairings: Vec<DesiredPeerPairing>,
     pub(crate) tasks: Vec<DesiredTask>,
     pub(crate) schedules: Vec<DesiredSchedule>,
     pub(crate) event_triggers: Vec<DesiredEventTrigger>,
@@ -476,6 +548,7 @@ pub(crate) struct DesiredStateDiffCollections {
     pub(crate) inference_profiles: DesiredStateCollectionDiff,
     pub(crate) tool_service_registries: DesiredStateCollectionDiff,
     pub(crate) projection_acp_bindings: DesiredStateCollectionDiff,
+    pub(crate) peer_pairings: DesiredStateCollectionDiff,
     pub(crate) tasks: DesiredStateCollectionDiff,
     pub(crate) schedules: DesiredStateCollectionDiff,
     pub(crate) event_triggers: DesiredStateCollectionDiff,
@@ -492,6 +565,7 @@ impl DesiredStateDiffCollections {
             Collection::InferenceProfile => &self.inference_profiles,
             Collection::ToolServiceRegistry => &self.tool_service_registries,
             Collection::ProjectionAcpBinding => &self.projection_acp_bindings,
+            Collection::PeerPairingDesired => &self.peer_pairings,
             Collection::Task => &self.tasks,
             Collection::Schedule => &self.schedules,
             Collection::EventTrigger => &self.event_triggers,
@@ -508,6 +582,7 @@ impl DesiredStateDiffCollections {
             Collection::InferenceProfile => &mut self.inference_profiles,
             Collection::ToolServiceRegistry => &mut self.tool_service_registries,
             Collection::ProjectionAcpBinding => &mut self.projection_acp_bindings,
+            Collection::PeerPairingDesired => &mut self.peer_pairings,
             Collection::Task => &mut self.tasks,
             Collection::Schedule => &mut self.schedules,
             Collection::EventTrigger => &mut self.event_triggers,
@@ -537,6 +612,7 @@ impl DesiredStateDiffCollections {
             inference_profiles: self.inference_profiles.counts(),
             tool_service_registries: self.tool_service_registries.counts(),
             projection_acp_bindings: self.projection_acp_bindings.counts(),
+            peer_pairings: self.peer_pairings.counts(),
             tasks: self.tasks.counts(),
             schedules: self.schedules.counts(),
             event_triggers: self.event_triggers.counts(),
@@ -554,6 +630,7 @@ pub(crate) struct DesiredStateDiffCollectionsCounts {
     pub(crate) inference_profiles: DesiredStateDiffCounts,
     pub(crate) tool_service_registries: DesiredStateDiffCounts,
     pub(crate) projection_acp_bindings: DesiredStateDiffCounts,
+    pub(crate) peer_pairings: DesiredStateDiffCounts,
     pub(crate) tasks: DesiredStateDiffCounts,
     pub(crate) schedules: DesiredStateDiffCounts,
     pub(crate) event_triggers: DesiredStateDiffCounts,
@@ -577,6 +654,7 @@ impl DesiredStateDiffCollectionsCounts {
             Collection::InferenceProfile => &self.inference_profiles,
             Collection::ToolServiceRegistry => &self.tool_service_registries,
             Collection::ProjectionAcpBinding => &self.projection_acp_bindings,
+            Collection::PeerPairingDesired => &self.peer_pairings,
             Collection::Task => &self.tasks,
             Collection::Schedule => &self.schedules,
             Collection::EventTrigger => &self.event_triggers,
@@ -616,6 +694,7 @@ pub(crate) struct DesiredStateCounts {
     pub(crate) inference_profiles: usize,
     pub(crate) tool_service_registries: usize,
     pub(crate) projection_acp_bindings: usize,
+    pub(crate) peer_pairings: usize,
     pub(crate) tasks: usize,
     pub(crate) schedules: usize,
     pub(crate) event_triggers: usize,
@@ -632,6 +711,7 @@ impl DesiredStateCounts {
             inference_profiles: 0,
             tool_service_registries: 0,
             projection_acp_bindings: 0,
+            peer_pairings: 0,
             tasks: 0,
             schedules: 0,
             event_triggers: 0,
@@ -697,6 +777,11 @@ impl DesiredFields for DesiredProjectionAcpBinding {
         "projection_acp_bindings"
     }
 }
+impl DesiredFields for DesiredPeerPairing {
+    fn collection_tag(&self) -> &'static str {
+        "peer_pairings"
+    }
+}
 impl DesiredFields for DesiredTask {
     fn collection_tag(&self) -> &'static str {
         "tasks"
@@ -756,6 +841,11 @@ impl HasUniqueId for DesiredToolServiceRegistry {
 impl HasUniqueId for DesiredProjectionAcpBinding {
     fn unique_id(&self) -> &str {
         &self.binding_id
+    }
+}
+impl HasUniqueId for DesiredPeerPairing {
+    fn unique_id(&self) -> &str {
+        &self.peer_did
     }
 }
 impl HasUniqueId for DesiredTask {

--- a/crates/defra-agent-cli/src/desired_state/mod.rs
+++ b/crates/defra-agent-cli/src/desired_state/mod.rs
@@ -680,6 +680,8 @@ pub(crate) struct DesiredStateDiffReport {
     pub(crate) root: String,
     pub(crate) access_mode: String,
     pub(crate) agent_did: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) live_validation_errors: Vec<String>,
     pub(crate) counts: DesiredStateDiffCollectionsCounts,
     pub(crate) collections: DesiredStateDiffCollections,
 }

--- a/crates/defra-agent-cli/src/desired_state/normalize.rs
+++ b/crates/defra-agent-cli/src/desired_state/normalize.rs
@@ -25,6 +25,9 @@ pub(crate) fn normalize_manifest(manifest: &mut DesiredStateManifest) {
         .projection_acp_bindings
         .sort_by(|left, right| left.binding_id.cmp(&right.binding_id));
     manifest
+        .peer_pairings
+        .sort_by(|left, right| left.peer_did.cmp(&right.peer_did));
+    manifest
         .tasks
         .sort_by(|left, right| left.task_id.cmp(&right.task_id));
     manifest
@@ -89,6 +92,22 @@ pub(crate) fn normalize_manifest(manifest: &mut DesiredStateManifest) {
         normalize_optional_string(&mut binding.resource_map_json);
         normalize_optional_string(&mut binding.publication_status);
         normalize_optional_string(&mut binding.published_at);
+    }
+    for pairing in &mut manifest.peer_pairings {
+        pairing.peer_did = pairing.peer_did.trim().to_string();
+        pairing.template = pairing.template.trim().to_string();
+        pairing.addresses = pairing
+            .addresses
+            .iter()
+            .map(|address| address.trim())
+            .filter(|address| !address.is_empty())
+            .map(ToOwned::to_owned)
+            .collect();
+        pairing.addresses.sort();
+        pairing.addresses.dedup();
+        if pairing.peer_id.trim().is_empty() {
+            pairing.peer_id = pairing.resolved_peer_id().unwrap_or_default();
+        }
     }
 }
 

--- a/crates/defra-agent-cli/src/desired_state/tests.rs
+++ b/crates/defra-agent-cli/src/desired_state/tests.rs
@@ -25,6 +25,7 @@ fn empty_manifest(agent_did: &str) -> DesiredStateManifest {
         inference_profiles: Vec::new(),
         tool_service_registries: Vec::new(),
         projection_acp_bindings: Vec::new(),
+        peer_pairings: Vec::new(),
         tasks: Vec::new(),
         schedules: Vec::new(),
         event_triggers: Vec::new(),
@@ -109,6 +110,208 @@ fn profile(id: &str) -> DesiredInferenceProfile {
         retry_allow_repair: None,
         retry_interactive_max: None,
     }
+}
+
+fn peer_pairing(
+    peer_did: &str,
+    peer_id: &str,
+    template: &str,
+    enabled: bool,
+) -> DesiredPeerPairing {
+    DesiredPeerPairing {
+        peer_did: peer_did.to_string(),
+        addresses: vec![format!("{peer_id}@127.0.0.1:4100")],
+        template: template.to_string(),
+        enabled,
+        peer_id: peer_id.to_string(),
+    }
+}
+
+fn pairing_diff(
+    desired: &DesiredStateManifest,
+    live: &DesiredStateManifest,
+) -> DesiredStateCollectionDiff {
+    diff_manifests(
+        &PathBuf::from("/tmp/fake-root"),
+        "local",
+        desired,
+        Some(&live.agent_principal),
+        live,
+        false,
+    )
+    .collections
+    .peer_pairings
+}
+
+#[test]
+fn peer_pairing_diff_covers_create_update_unchanged_and_remove() {
+    let peer_a = "11".repeat(32);
+    let peer_b = "22".repeat(32);
+    let mut desired = empty_manifest("did:key:owner");
+    desired.peer_pairings.push(peer_pairing(
+        "did:key:peer-a",
+        &peer_a,
+        "conversation",
+        true,
+    ));
+    desired.peer_pairings.push(peer_pairing(
+        "did:key:peer-b",
+        &peer_b,
+        "agent-config",
+        true,
+    ));
+
+    let mut live = empty_manifest("did:key:owner");
+    live.peer_pairings.push(peer_pairing(
+        "did:key:peer-b",
+        &peer_b,
+        "conversation",
+        true,
+    ));
+    let stale_id = "33".repeat(32);
+    live.peer_pairings.push(peer_pairing(
+        "did:key:stale",
+        &stale_id,
+        "conversation",
+        true,
+    ));
+
+    let diff = pairing_diff(&desired, &live);
+    assert_eq!(diff.create, vec![peer_a]);
+    assert_eq!(diff.update, vec![peer_b]);
+    assert_eq!(diff.delete, vec![stale_id]);
+    assert!(diff.unchanged.is_empty());
+
+    live.peer_pairings = desired.peer_pairings.clone();
+    let diff = pairing_diff(&desired, &live);
+    assert_eq!(diff.unchanged, vec!["11".repeat(32), "22".repeat(32)]);
+    assert!(diff.create.is_empty());
+    assert!(diff.update.is_empty());
+    assert!(diff.delete.is_empty());
+}
+
+#[test]
+fn disabled_or_absent_manifest_pairing_removes_stale_enabled_owned_row() {
+    let peer_id = "44".repeat(32);
+    let mut live = empty_manifest("did:key:owner");
+    live.peer_pairings
+        .push(peer_pairing("did:key:peer", &peer_id, "conversation", true));
+
+    let absent = empty_manifest("did:key:owner");
+    assert_eq!(pairing_diff(&absent, &live).delete, vec![peer_id.clone()]);
+
+    let mut disabled = empty_manifest("did:key:owner");
+    disabled.peer_pairings.push(peer_pairing(
+        "did:key:peer",
+        &peer_id,
+        "conversation",
+        false,
+    ));
+    let diff = pairing_diff(&disabled, &live);
+    assert_eq!(diff.delete, vec![peer_id]);
+    assert!(diff.update.is_empty(), "disabled is absence, not an update");
+}
+
+#[test]
+fn pairing_address_surface_forms_compare_semantically() {
+    let peer_id = "55".repeat(32);
+    let mut desired = empty_manifest("did:key:owner");
+    desired
+        .peer_pairings
+        .push(peer_pairing("did:key:peer", &peer_id, "conversation", true));
+    let mut live = desired.clone();
+    live.peer_pairings[0].addresses = vec![format!("127.0.0.1:4100/p2p/{peer_id}")];
+
+    assert_eq!(pairing_diff(&desired, &live).unchanged, vec![peer_id]);
+}
+
+#[test]
+fn pairing_did_correction_updates_the_existing_peer_id() {
+    let peer_id = "5a".repeat(32);
+    let mut desired = empty_manifest("did:key:owner");
+    desired.peer_pairings.push(peer_pairing(
+        "did:key:corrected",
+        &peer_id,
+        "conversation",
+        true,
+    ));
+    let mut live = empty_manifest("did:key:owner");
+    live.peer_pairings.push(peer_pairing(
+        "did:key:stale",
+        &peer_id,
+        "conversation",
+        true,
+    ));
+
+    let diff = pairing_diff(&desired, &live);
+    assert_eq!(diff.update, vec![peer_id]);
+    assert!(diff.create.is_empty());
+    assert!(diff.delete.is_empty());
+}
+
+#[test]
+fn peer_pairing_validation_rejects_unsafe_shapes() {
+    let peer_a = "66".repeat(32);
+    let peer_b = "77".repeat(32);
+    let mut manifest = empty_manifest("did:key:owner");
+    manifest.peer_pairings.push(DesiredPeerPairing {
+        peer_did: "did:key:owner".to_string(),
+        addresses: vec![
+            format!("{peer_a}@127.0.0.1:4100"),
+            format!("{peer_b}@127.0.0.1:4200"),
+        ],
+        template: "app-collections".to_string(),
+        enabled: true,
+        peer_id: String::new(),
+    });
+    let mut errors = Vec::new();
+    validate_manifest(&manifest, &mut errors);
+    assert!(errors.iter().any(|error| error.contains("own agent_did")));
+    assert!(errors.iter().any(|error| error.contains("data-plane-only")));
+    assert!(errors.iter().any(|error| error.contains("mixes addresses")));
+
+    manifest.peer_pairings[0].peer_did = "did:key:peer".to_string();
+    manifest.peer_pairings[0].addresses.clear();
+    manifest.peer_pairings[0].template = "conversation".to_string();
+    errors.clear();
+    validate_manifest(&manifest, &mut errors);
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("must contain at least one address")));
+
+    manifest.peer_pairings[0].addresses = vec!["not-a-peer@127.0.0.1:4100".to_string()];
+    errors.clear();
+    validate_manifest(&manifest, &mut errors);
+    assert!(errors
+        .iter()
+        .any(|error| error.contains("invalid iroh peer id")));
+}
+
+#[test]
+fn pairing_apply_bundle_stamps_owner_provenance_and_omits_disabled_rows() {
+    let peer_id = "88".repeat(32);
+    let mut manifest = empty_manifest("did:key:owner");
+    manifest.peer_pairings.push(peer_pairing(
+        "did:key:enabled",
+        &peer_id,
+        "conversation",
+        true,
+    ));
+    manifest.peer_pairings.push(DesiredPeerPairing {
+        peer_did: "did:key:disabled".to_string(),
+        addresses: Vec::new(),
+        template: "conversation".to_string(),
+        enabled: false,
+        peer_id: String::new(),
+    });
+
+    let bundle = export_bundle_from_manifest(&manifest, "local").unwrap();
+    assert_eq!(bundle.as_bundle().peer_pairings.len(), 1);
+    let row = &bundle.as_bundle().peer_pairings[0];
+    assert_eq!(row["peer_id"], peer_id);
+    assert_eq!(row["agent_did"], "did:key:enabled");
+    assert_eq!(row["source"], "manifest:did:key:owner");
+    assert!(row["profiles"].is_null());
 }
 
 fn deletes_contain(
@@ -596,6 +799,7 @@ fn round_trip_load_write_load_is_identity() {
         loaded.tool_service_registries,
         original.tool_service_registries
     );
+    assert_eq!(loaded.peer_pairings, original.peer_pairings);
     assert_eq!(loaded.tasks, original.tasks);
     assert_eq!(loaded.schedules, original.schedules);
 }
@@ -645,6 +849,32 @@ mod load_manifest_root {
         assert_eq!(manifest.agent_principal.agent_did, "did:key:example");
         assert_eq!(manifest.agent_behaviors.len(), 1);
         assert!(manifest.tasks.is_empty());
+    }
+
+    #[test]
+    fn loads_peer_pairing_from_human_readable_handle() {
+        let tmp = tempdir().unwrap();
+        write_minimal_root(tmp.path());
+        let peer_id = "bb".repeat(32);
+        let pairing_dir = tmp.path().join("peer-pairings").join("coding-steward");
+        fs::create_dir_all(&pairing_dir).unwrap();
+        fs::write(
+            pairing_dir.join("object.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "peer_did": "did:key:remote",
+                "addresses": [format!("{peer_id}@127.0.0.1:4100")],
+                "template": "subagent-coordinator",
+                "enabled": true
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+
+        let (manifest, report) = load_manifest_root(tmp.path());
+        assert!(report.ok, "errors: {:?}", report.errors);
+        let pairing = &manifest.unwrap().peer_pairings[0];
+        assert_eq!(pairing.peer_did, "did:key:remote");
+        assert_eq!(pairing.peer_id, peer_id);
     }
 
     #[test]
@@ -2441,6 +2671,7 @@ pub(super) mod write_manifest_root {
             inference_profiles: Vec::new(),
             tool_service_registries: Vec::new(),
             projection_acp_bindings: Vec::new(),
+            peer_pairings: Vec::new(),
             tasks: vec![DesiredTask {
                 task_id: "seed-health".to_string(),
                 name: "Seed fleet health".to_string(),

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -966,9 +966,11 @@ fn validate_schedule_cadence(schedule: &super::DesiredSchedule, errors: &mut Vec
 
 /// Live-DB validation that complements the pure `validate_manifest`.
 ///
-/// Unlike `validate_manifest`, this probes the live database schema and
-/// filter syntax for every `EventTrigger`. It is only invoked from code
-/// paths that already hold a live `ConfigAccess` (i.e. `config apply`).
+/// Unlike `validate_manifest`, this checks pairing ownership and probes the
+/// live database schema and filter syntax for every `EventTrigger`. The full
+/// validator is an apply-time gate. `config diff` invokes only the narrower
+/// pairing ownership check so it can report an unsafe plan without hiding the
+/// rest of the diff.
 ///
 /// Two checks per trigger:
 ///
@@ -988,8 +990,7 @@ pub(crate) async fn validate_manifest_against_live(
     manifest: &DesiredStateManifest,
     access: &ConfigAccess,
 ) -> Result<Vec<String>> {
-    let mut errors = Vec::new();
-    validate_peer_pairing_ownership_against_live(manifest, access, &mut errors).await?;
+    let mut errors = validate_peer_pairing_ownership_against_live(manifest, access).await?;
     for trig in &manifest.event_triggers {
         // Skip triggers that failed basic structural validation; the pure
         // validator already reported those and live probes on empty
@@ -1113,13 +1114,13 @@ pub(crate) async fn validate_manifest_against_live(
     Ok(errors)
 }
 
-async fn validate_peer_pairing_ownership_against_live(
+pub(crate) async fn validate_peer_pairing_ownership_against_live(
     manifest: &DesiredStateManifest,
     access: &ConfigAccess,
-    errors: &mut Vec<String>,
-) -> Result<()> {
+) -> Result<Vec<String>> {
+    let mut errors = Vec::new();
     if manifest.peer_pairings.is_empty() {
-        return Ok(());
+        return Ok(errors);
     }
 
     let rows = crate::graphql_rows(
@@ -1172,7 +1173,7 @@ async fn validate_peer_pairing_ownership_against_live(
             ));
         }
     }
-    Ok(())
+    Ok(errors)
 }
 
 fn format_variable_ref(var: &VariableRef) -> String {
@@ -1704,8 +1705,12 @@ mod live_tests {
     }
 
     #[tokio::test]
-    async fn live_validate_rejects_non_manifest_pairing_collision() -> Result<()> {
+    async fn live_validate_rejects_non_manifest_pairing_collision_and_diff_reports_it() -> Result<()>
+    {
         use super::super::DesiredPeerPairing;
+        use crate::commands::config::binding::{
+            BoundDesiredManifest, ManifestBindMode, ManifestBindingContext,
+        };
         use crate::config_bundle::{build_desired_state_live_bundle, live_manifest_from_bundle};
         use crate::config_import::apply_desired_state_changes;
         use crate::desired_state::{diff_manifests, export_bundle_from_manifest};
@@ -1748,6 +1753,31 @@ mod live_tests {
         });
         let errors = validate_manifest_against_live(&manifest, &access).await?;
         assert!(errors.iter().any(|error| {
+            error.contains("source \"operator\"")
+                && error.contains("refusing to overwrite or delete")
+        }));
+
+        // Diff remains available as an observability command. The collision
+        // marks the report non-OK and is carried next to the planned drift
+        // instead of replacing the entire report with an error.
+        let owner_did = manifest.agent_principal.agent_did.clone();
+        let bound = BoundDesiredManifest {
+            context: ManifestBindingContext {
+                bind_mode: ManifestBindMode::Manifest,
+                target_agent_did: owner_did.clone(),
+                source_manifest_dids: std::collections::BTreeSet::from([owner_did]),
+            },
+            manifest: manifest.clone(),
+        };
+        let report = crate::commands::config::diff::diff_bound_desired_manifest(
+            std::path::Path::new("/ownership-collision"),
+            &access,
+            &bound,
+        )
+        .await?;
+        assert_eq!(report.status, "diffed");
+        assert!(!report.ok);
+        assert!(report.live_validation_errors.iter().any(|error| {
             error.contains("source \"operator\"")
                 && error.contains("refusing to overwrite or delete")
         }));

--- a/crates/defra-agent-cli/src/desired_state/validate.rs
+++ b/crates/defra-agent-cli/src/desired_state/validate.rs
@@ -37,6 +37,90 @@ pub(crate) fn validate_manifest(manifest: &DesiredStateManifest, errors: &mut Ve
         errors.push("agent-principal.json must contain a non-empty agent_did".to_string());
     }
 
+    let mut pairing_dids = BTreeSet::new();
+    let mut pairing_peer_ids = BTreeSet::new();
+    for pairing in &manifest.peer_pairings {
+        let peer_did = pairing.peer_did.trim();
+        if peer_did.is_empty() {
+            errors.push("peer-pairings manifest contains an empty peer_did".to_string());
+        } else {
+            if !pairing_dids.insert(peer_did.to_string()) {
+                errors.push(format!(
+                    "duplicate peer_did in peer-pairings manifest: {peer_did}"
+                ));
+            }
+            if !principal_agent_did.is_empty() && peer_did == principal_agent_did {
+                errors.push(format!(
+                    "peer pairing {peer_did} points at this manifest's own agent_did"
+                ));
+            }
+        }
+
+        let template = pairing.template.trim();
+        if template.is_empty() {
+            errors.push(format!(
+                "peer pairing {peer_did:?} must contain a non-empty template"
+            ));
+        } else {
+            use defra_agent::agent::p2p_reconcile::templates::{
+                builtin_templates, resolve_template, APP_COLLECTIONS_TEMPLATE,
+            };
+            if template == APP_COLLECTIONS_TEMPLATE {
+                errors.push(format!(
+                    "peer pairing {peer_did:?} uses data-plane-only template {template:?}"
+                ));
+            } else if resolve_template(template).is_none() {
+                let known = builtin_templates()
+                    .iter()
+                    .map(|template| template.id)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                errors.push(format!(
+                    "peer pairing {peer_did:?} has unknown template {template:?}; known templates: {known}"
+                ));
+            }
+        }
+
+        if pairing.enabled && pairing.addresses.is_empty() {
+            errors.push(format!(
+                "enabled peer pairing {peer_did:?} must contain at least one address"
+            ));
+        }
+        let mut row_peer_id = None::<String>;
+        for address in &pairing.addresses {
+            match p2p::iroh::parse_public_peer_addr(address.trim()) {
+                Ok((peer_id, _)) => {
+                    let peer_id = peer_id.to_string();
+                    if let Err(error) = peer_id.parse::<iroh::EndpointId>() {
+                        errors.push(format!(
+                            "peer pairing {peer_did:?} address {address:?} has invalid iroh peer id {peer_id:?}: {error}"
+                        ));
+                        continue;
+                    }
+                    if let Some(expected) = row_peer_id.as_deref() {
+                        if expected != peer_id {
+                            errors.push(format!(
+                                "peer pairing {peer_did:?} mixes addresses for peer ids {expected:?} and {peer_id:?}"
+                            ));
+                        }
+                    } else {
+                        row_peer_id = Some(peer_id);
+                    }
+                }
+                Err(error) => errors.push(format!(
+                    "peer pairing {peer_did:?} has invalid address {address:?}: {error}"
+                )),
+            }
+        }
+        if let Some(peer_id) = row_peer_id {
+            if !pairing_peer_ids.insert(peer_id.clone()) {
+                errors.push(format!(
+                    "duplicate peer_id {peer_id:?} derived by peer-pairings manifest"
+                ));
+            }
+        }
+    }
+
     let mut behavior_ids = BTreeSet::new();
     let mut backend_ids = BTreeSet::new();
     let mut tool_selection_ids = BTreeSet::new();
@@ -905,6 +989,7 @@ pub(crate) async fn validate_manifest_against_live(
     access: &ConfigAccess,
 ) -> Result<Vec<String>> {
     let mut errors = Vec::new();
+    validate_peer_pairing_ownership_against_live(manifest, access, &mut errors).await?;
     for trig in &manifest.event_triggers {
         // Skip triggers that failed basic structural validation; the pure
         // validator already reported those and live probes on empty
@@ -1026,6 +1111,68 @@ pub(crate) async fn validate_manifest_against_live(
     // resolution is handled out-of-band via P2P at runtime.
 
     Ok(errors)
+}
+
+async fn validate_peer_pairing_ownership_against_live(
+    manifest: &DesiredStateManifest,
+    access: &ConfigAccess,
+    errors: &mut Vec<String>,
+) -> Result<()> {
+    if manifest.peer_pairings.is_empty() {
+        return Ok(());
+    }
+
+    let rows = crate::graphql_rows(
+        access,
+        "PeerPairingDesired",
+        r#"query {
+            PeerPairingDesired {
+                peer_id
+                agent_did
+                source
+            }
+        }"#,
+    )
+    .await?;
+    let desired_dids = manifest
+        .peer_pairings
+        .iter()
+        .map(|pairing| pairing.peer_did.trim())
+        .filter(|peer_did| !peer_did.is_empty())
+        .collect::<BTreeSet<_>>();
+    let desired_peer_ids = manifest
+        .peer_pairings
+        .iter()
+        .filter_map(|pairing| pairing.resolved_peer_id())
+        .collect::<BTreeSet<_>>();
+    let expected_source = super::peer_pairing_manifest_source(&manifest.agent_principal.agent_did);
+
+    for row in rows {
+        let peer_id = row
+            .get("peer_id")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .unwrap_or_default();
+        let peer_did = row
+            .get("agent_did")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .unwrap_or_default();
+        if !desired_dids.contains(peer_did) && !desired_peer_ids.contains(peer_id) {
+            continue;
+        }
+        let source = row
+            .get("source")
+            .and_then(serde_json::Value::as_str)
+            .map(str::trim)
+            .unwrap_or("operator");
+        if source != expected_source {
+            errors.push(format!(
+                "peer pairing {peer_did:?} (peer_id {peer_id:?}) is owned by source {source:?}, not this manifest; refusing to overwrite or delete it"
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn format_variable_ref(var: &VariableRef) -> String {
@@ -1284,6 +1431,7 @@ mod tests {
             inference_profiles: Vec::new(),
             tool_service_registries: Vec::new(),
             projection_acp_bindings: Vec::new(),
+            peer_pairings: Vec::new(),
             tasks: task_prompt
                 .map(|prompt| {
                     vec![DesiredTask {
@@ -1480,6 +1628,7 @@ mod live_tests {
             inference_profiles: Vec::new(),
             tool_service_registries: Vec::new(),
             projection_acp_bindings: Vec::new(),
+            peer_pairings: Vec::new(),
             tasks: Vec::new(),
             schedules: Vec::new(),
             event_triggers: Vec::new(),
@@ -1551,6 +1700,353 @@ mod live_tests {
                 .any(|msg| msg.contains("amy-research") || msg.contains("live-test-sel")),
             "expected no subagent errors for known target, got {errors:?}"
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn live_validate_rejects_non_manifest_pairing_collision() -> Result<()> {
+        use super::super::DesiredPeerPairing;
+        use crate::config_bundle::{build_desired_state_live_bundle, live_manifest_from_bundle};
+        use crate::config_import::apply_desired_state_changes;
+        use crate::desired_state::{diff_manifests, export_bundle_from_manifest};
+        use defra_agent::graphql::escape_graphql_string;
+
+        let tempdir = tempfile::tempdir()?;
+        let node = EmbeddedNode::builder()
+            .data_path(tempdir.path().join("data"))
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node);
+        let peer_id = "aa".repeat(32);
+        let peer_did = "did:key:remote";
+        let address = format!("{peer_id}@127.0.0.1:4100");
+        access
+            .execute(&format!(
+                r#"mutation {{ create_PeerPairingDesired(input: {{
+                    peer_id: "{}",
+                    agent_did: "{}",
+                    collections: ["AgentRequest"],
+                    replicator_addresses: ["{}"],
+                    template: "conversation",
+                    source: "operator"
+                }}) {{ _docID }} }}"#,
+                escape_graphql_string(&peer_id),
+                escape_graphql_string(peer_did),
+                escape_graphql_string(&address),
+            ))
+            .await?;
+
+        let mut manifest = manifest_with_subagent_targets(Vec::new());
+        manifest.peer_pairings.push(DesiredPeerPairing {
+            peer_did: peer_did.to_string(),
+            addresses: vec![address],
+            template: "conversation".to_string(),
+            enabled: false,
+            peer_id,
+        });
+        let errors = validate_manifest_against_live(&manifest, &access).await?;
+        assert!(errors.iter().any(|error| {
+            error.contains("source \"operator\"")
+                && error.contains("refusing to overwrite or delete")
+        }));
+
+        // Removing the manifest entry entirely does not make the operator row
+        // managed: the live projection only includes this root's provenance,
+        // so apply plans no pairing deletion and leaves the row intact.
+        manifest.peer_pairings.clear();
+        manifest.tool_selections.clear();
+        let live_bundle = build_desired_state_live_bundle(&access, &manifest).await?;
+        let (live_principal, live_manifest) = live_manifest_from_bundle(&manifest, &live_bundle)?;
+        let planned = diff_manifests(
+            std::path::Path::new("/ownership-safe"),
+            access.mode(),
+            &manifest,
+            live_principal.as_ref(),
+            &live_manifest,
+            false,
+        );
+        assert!(planned.collections.peer_pairings.delete.is_empty());
+        let bundle = export_bundle_from_manifest(&manifest, access.mode())?;
+        let txn = access.begin_apply_txn().await?;
+        apply_desired_state_changes(&txn, &bundle, &planned).await?;
+        txn.commit().await?;
+        let rows = crate::graphql_rows(
+            &access,
+            "PeerPairingDesired",
+            "{ PeerPairingDesired { peer_id source } }",
+        )
+        .await?;
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["source"], "operator");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn preboot_pairing_apply_is_idempotent_and_restart_loader_consumes_seed() -> Result<()> {
+        use std::sync::Arc;
+
+        use crate::config_bundle::{build_desired_state_live_bundle, live_manifest_from_bundle};
+        use crate::config_import::apply_desired_state_changes;
+        use crate::desired_state::{diff_manifests, export_bundle_from_manifest};
+        use defra_agent::agent::p2p_reconcile::{
+            reconcile_peer_tick, GraphqlPairingStateStore, PairingFilters, PairingStateStore,
+            RemoteP2pAdmin, RemoteP2pAdminResult, RemoteReplicator,
+        };
+        use defra_agent::KeyIdentity;
+
+        let tempdir = tempfile::tempdir()?;
+        let data_path = tempdir.path().join("data");
+        let node = EmbeddedNode::builder()
+            .data_path(&data_path)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node);
+        let peer_id = "bb".repeat(32);
+        let address = format!("{peer_id}@127.0.0.1:4100");
+        let mut manifest = manifest_with_subagent_targets(Vec::new());
+        manifest.tool_selections.clear();
+        manifest
+            .peer_pairings
+            .push(super::super::DesiredPeerPairing {
+                peer_did: "did:key:remote".to_string(),
+                addresses: vec![address.clone()],
+                template: "conversation".to_string(),
+                enabled: true,
+                peer_id: peer_id.clone(),
+            });
+
+        let live_bundle = build_desired_state_live_bundle(&access, &manifest).await?;
+        let (live_principal, live_manifest) = live_manifest_from_bundle(&manifest, &live_bundle)?;
+        let planned = diff_manifests(
+            std::path::Path::new("/preboot"),
+            access.mode(),
+            &manifest,
+            live_principal.as_ref(),
+            &live_manifest,
+            false,
+        );
+        assert_eq!(
+            planned.collections.peer_pairings.create,
+            vec![peer_id.clone()]
+        );
+        let bundle = export_bundle_from_manifest(&manifest, access.mode())?;
+        let txn = access.begin_apply_txn().await?;
+        let counts = apply_desired_state_changes(&txn, &bundle, &planned).await?;
+        txn.commit().await?;
+        assert_eq!(counts.peer_pairings, 1);
+
+        let live_bundle = build_desired_state_live_bundle(&access, &manifest).await?;
+        let (live_principal, live_manifest) = live_manifest_from_bundle(&manifest, &live_bundle)?;
+        let noop = diff_manifests(
+            std::path::Path::new("/preboot"),
+            access.mode(),
+            &manifest,
+            live_principal.as_ref(),
+            &live_manifest,
+            false,
+        );
+        assert_eq!(
+            noop.collections.peer_pairings.unchanged,
+            vec![peer_id.clone()]
+        );
+        assert!(!noop.counts.has_pending_apply());
+        let txn = access.begin_apply_txn().await?;
+        let repeated = apply_desired_state_changes(&txn, &bundle, &noop).await?;
+        txn.commit().await?;
+        assert_eq!(repeated.peer_pairings, 0);
+        drop(access);
+
+        // A freshly-created reconciler store (the restart boundary) reads the
+        // exact desired document seeded before any runtime was started.
+        let identity = Arc::new(KeyIdentity::load_or_create(
+            tempdir.path().join("restart-identity.key"),
+            None,
+        )?);
+        let restarted_node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(&data_path)
+                .with_storage_backend(StorageBackend::RocksDb)
+                .build()
+                .await?,
+        );
+        let restarted_store =
+            GraphqlPairingStateStore::new(restarted_node.clone(), identity.clone());
+        let loaded = restarted_store
+            .load_desired(&peer_id)
+            .await?
+            .expect("seeded pairing is visible to restarted reconciler");
+        assert!(loaded.replicator_addresses.contains(&address));
+
+        #[derive(Default)]
+        struct RestartAdmin {
+            added_replicators: std::sync::Mutex<Vec<String>>,
+        }
+
+        #[async_trait::async_trait]
+        impl RemoteP2pAdmin for RestartAdmin {
+            async fn peer_info(&self) -> RemoteP2pAdminResult<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn active_peers(&self) -> RemoteP2pAdminResult<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn connect(&self, _addresses: &[String]) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn list_replicators(&self) -> RemoteP2pAdminResult<Vec<RemoteReplicator>> {
+                Ok(self
+                    .added_replicators
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .map(|address| RemoteReplicator {
+                        id: Some(address.clone()),
+                        collections: Vec::new(),
+                        address: Some(address.clone()),
+                    })
+                    .collect())
+            }
+            async fn add_replicator(
+                &self,
+                addresses: &[String],
+                _collections: &[String],
+                _filters: &PairingFilters,
+            ) -> RemoteP2pAdminResult<()> {
+                self.added_replicators
+                    .lock()
+                    .unwrap()
+                    .extend_from_slice(addresses);
+                Ok(())
+            }
+            async fn delete_replicator(
+                &self,
+                id: &str,
+                _collections: &[String],
+            ) -> RemoteP2pAdminResult<()> {
+                self.added_replicators
+                    .lock()
+                    .unwrap()
+                    .retain(|address| address != id);
+                Ok(())
+            }
+            async fn list_p2p_collections(&self) -> RemoteP2pAdminResult<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn resolve_collection_id(
+                &self,
+                name: &str,
+            ) -> RemoteP2pAdminResult<Option<String>> {
+                Ok(Some(name.to_string()))
+            }
+            async fn resolve_collection_name(
+                &self,
+                id: &str,
+            ) -> RemoteP2pAdminResult<Option<String>> {
+                Ok(Some(id.to_string()))
+            }
+            async fn add_p2p_collections(
+                &self,
+                _collections: &[String],
+            ) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn delete_p2p_collections(
+                &self,
+                _collections: &[String],
+            ) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn list_p2p_documents(&self) -> RemoteP2pAdminResult<Vec<String>> {
+                Ok(Vec::new())
+            }
+            async fn add_p2p_documents(&self, _doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn delete_p2p_documents(&self, _doc_ids: &[String]) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn sync_documents(
+                &self,
+                _collection_name: &str,
+                _doc_ids: &[String],
+                _timeout: Option<std::time::Duration>,
+            ) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn sync_collection_versions(
+                &self,
+                _version_ids: &[String],
+                _timeout: Option<std::time::Duration>,
+            ) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+            async fn sync_branchable_collection(
+                &self,
+                _collection_id: &str,
+                _timeout: Option<std::time::Duration>,
+            ) -> RemoteP2pAdminResult<()> {
+                Ok(())
+            }
+        }
+
+        let admin = RestartAdmin::default();
+        let outcome = reconcile_peer_tick(&admin, &restarted_store, &peer_id).await?;
+        assert!(!outcome.ops_applied.is_empty());
+        assert_eq!(
+            admin.added_replicators.lock().unwrap().as_slice(),
+            &[address.clone()]
+        );
+        drop(restarted_store);
+        drop(restarted_node);
+
+        manifest.peer_pairings[0].enabled = false;
+        let node = EmbeddedNode::builder()
+            .data_path(&data_path)
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        let access = ConfigAccess::Local(node);
+        let live_bundle = build_desired_state_live_bundle(&access, &manifest).await?;
+        let (live_principal, live_manifest) = live_manifest_from_bundle(&manifest, &live_bundle)?;
+        let removal = diff_manifests(
+            std::path::Path::new("/preboot"),
+            access.mode(),
+            &manifest,
+            live_principal.as_ref(),
+            &live_manifest,
+            false,
+        );
+        assert_eq!(
+            removal.collections.peer_pairings.delete,
+            vec![peer_id.clone()]
+        );
+        let bundle = export_bundle_from_manifest(&manifest, access.mode())?;
+        let txn = access.begin_apply_txn().await?;
+        apply_desired_state_changes(&txn, &bundle, &removal).await?;
+        txn.commit().await?;
+        let rows = crate::graphql_rows(
+            &access,
+            "PeerPairingDesired",
+            "{ PeerPairingDesired { peer_id } }",
+        )
+        .await?;
+        assert!(rows.is_empty());
+        drop(access);
+        let removal_node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(&data_path)
+                .with_storage_backend(StorageBackend::RocksDb)
+                .build()
+                .await?,
+        );
+        let removal_store = GraphqlPairingStateStore::new(removal_node, identity);
+        let outcome = reconcile_peer_tick(&admin, &removal_store, &peer_id).await?;
+        assert!(!outcome.ops_applied.is_empty());
+        assert!(admin.added_replicators.lock().unwrap().is_empty());
         Ok(())
     }
 
@@ -1651,6 +2147,7 @@ mod live_tests {
                 inference_profiles: Vec::new(),
                 tool_service_registries: Vec::new(),
                 projection_acp_bindings: Vec::new(),
+                peer_pairings: Vec::new(),
                 tasks: Vec::new(),
                 schedules: Vec::new(),
                 event_triggers: Vec::new(),
@@ -1836,6 +2333,7 @@ mod live_tests {
                 inference_profiles: Vec::new(),
                 tool_service_registries: Vec::new(),
                 projection_acp_bindings: Vec::new(),
+                peer_pairings: Vec::new(),
                 tasks: Vec::new(),
                 schedules: Vec::new(),
                 event_triggers: Vec::new(),

--- a/crates/defra-agent-cli/src/desired_state/write.rs
+++ b/crates/defra-agent-cli/src/desired_state/write.rs
@@ -64,6 +64,7 @@ fn validate_handles(manifest: &DesiredStateManifest) -> Result<(), String> {
     validate_vec(&manifest.inference_profiles, "profile_id")?;
     validate_vec(&manifest.tool_service_registries, "service_id")?;
     validate_vec(&manifest.projection_acp_bindings, "binding_id")?;
+    validate_vec(&manifest.peer_pairings, "peer_did")?;
     validate_vec(&manifest.tasks, "task_id")?;
     validate_vec(&manifest.schedules, "schedule_id")?;
     validate_vec(&manifest.event_triggers, "trigger_id")?;
@@ -130,6 +131,12 @@ pub(crate) fn write_manifest_root(
         root,
         Collection::ProjectionAcpBinding,
         &manifest.projection_acp_bindings,
+        no_sidecar,
+    )?;
+    write_per_doc_collection(
+        root,
+        Collection::PeerPairingDesired,
+        &manifest.peer_pairings,
         no_sidecar,
     )?;
     write_per_doc_collection(root, Collection::Task, &manifest.tasks, spill_task_sidecar)?;

--- a/crates/defra-agent-cli/src/shared.rs
+++ b/crates/defra-agent-cli/src/shared.rs
@@ -229,6 +229,8 @@ pub(crate) struct ConfigExportBundle {
     #[serde(default)]
     pub(crate) projection_acp_bindings: Vec<Value>,
     #[serde(default)]
+    pub(crate) peer_pairings: Vec<Value>,
+    #[serde(default)]
     pub(crate) tasks: Vec<Value>,
     #[serde(default)]
     pub(crate) schedules: Vec<Value>,
@@ -247,6 +249,7 @@ impl ConfigExportBundle {
             Collection::InferenceProfile => Some(&self.inference_profiles),
             Collection::ToolServiceRegistry => Some(&self.tool_service_registries),
             Collection::ProjectionAcpBinding => Some(&self.projection_acp_bindings),
+            Collection::PeerPairingDesired => Some(&self.peer_pairings),
             Collection::Task => Some(&self.tasks),
             Collection::Schedule => Some(&self.schedules),
             Collection::EventTrigger => Some(&self.event_triggers),
@@ -264,6 +267,7 @@ pub(crate) struct ConfigApplyCounts {
     pub(crate) inference_profiles: usize,
     pub(crate) tool_service_registries: usize,
     pub(crate) projection_acp_bindings: usize,
+    pub(crate) peer_pairings: usize,
     pub(crate) tasks: usize,
     pub(crate) schedules: usize,
     pub(crate) event_triggers: usize,
@@ -280,6 +284,7 @@ impl ConfigApplyCounts {
             Collection::InferenceProfile => self.inference_profiles,
             Collection::ToolServiceRegistry => self.tool_service_registries,
             Collection::ProjectionAcpBinding => self.projection_acp_bindings,
+            Collection::PeerPairingDesired => self.peer_pairings,
             Collection::Task => self.tasks,
             Collection::Schedule => self.schedules,
             Collection::EventTrigger => self.event_triggers,
@@ -296,6 +301,7 @@ impl ConfigApplyCounts {
             Collection::InferenceProfile => self.inference_profiles = count,
             Collection::ToolServiceRegistry => self.tool_service_registries = count,
             Collection::ProjectionAcpBinding => self.projection_acp_bindings = count,
+            Collection::PeerPairingDesired => self.peer_pairings = count,
             Collection::Task => self.tasks = count,
             Collection::Schedule => self.schedules = count,
             Collection::EventTrigger => self.event_triggers = count,
@@ -312,6 +318,7 @@ impl ConfigApplyCounts {
             Collection::InferenceProfile => self.inference_profiles += count,
             Collection::ToolServiceRegistry => self.tool_service_registries += count,
             Collection::ProjectionAcpBinding => self.projection_acp_bindings += count,
+            Collection::PeerPairingDesired => self.peer_pairings += count,
             Collection::Task => self.tasks += count,
             Collection::Schedule => self.schedules += count,
             Collection::EventTrigger => self.event_triggers += count,

--- a/crates/defra-agent-cli/tests/cli_server.rs
+++ b/crates/defra-agent-cli/tests/cli_server.rs
@@ -634,31 +634,56 @@ async fn server_exposes_fleet_slot_snapshot_endpoint() -> Result<()> {
     )
     .await?;
     wait_for_inference_call_state(&graphql, &request_id, "running").await?;
-    let active_calls = active_inference_calls_for_backend(&graphql, &backend_id).await?;
-    let expected_backend_running = count_inference_calls(&active_calls, None, "running");
-    let expected_backend_queued = count_inference_calls(&active_calls, None, "queued");
-    let expected_behavior_running =
-        count_inference_calls(&active_calls, Some(&default_behavior_id), "running");
-    let expected_behavior_queued =
-        count_inference_calls(&active_calls, Some(&default_behavior_id), "queued");
+
+    let client = reqwest::Client::new();
+    let stable_deadline = Instant::now() + Duration::from_secs(5);
+    let (
+        snapshot,
+        active_calls,
+        expected_backend_running,
+        expected_backend_queued,
+        expected_behavior_running,
+        expected_behavior_queued,
+    ) = loop {
+        let response = client
+            .get(format!("http://127.0.0.1:{port}/fleet/slots"))
+            .send()
+            .await
+            .context("fetching /fleet/slots")?;
+        assert!(
+            response.status().is_success(),
+            "unexpected /fleet/slots response: {response:?}"
+        );
+        let snapshot: Value = response.json().await.context("reading /fleet/slots body")?;
+        let active_calls = active_inference_calls_for_backend(&graphql, &backend_id).await?;
+        let backend_running = count_inference_calls(&active_calls, None, "running");
+        let backend_queued = count_inference_calls(&active_calls, None, "queued");
+        let snapshot_running = snapshot.pointer("/totals/assigned").and_then(Value::as_i64);
+        let snapshot_queued = snapshot.pointer("/totals/queued").and_then(Value::as_i64);
+        if snapshot_running == Some(backend_running) && snapshot_queued == Some(backend_queued) {
+            break (
+                snapshot,
+                active_calls.clone(),
+                backend_running,
+                backend_queued,
+                count_inference_calls(&active_calls, Some(&default_behavior_id), "running"),
+                count_inference_calls(&active_calls, Some(&default_behavior_id), "queued"),
+            );
+        }
+        if Instant::now() >= stable_deadline {
+            return Err(anyhow!(
+                "fleet slot snapshot did not stabilize with active inference calls; snapshot={snapshot}; active_calls={}",
+                Value::Array(active_calls)
+            ));
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
     let expected_available = 1_i64.saturating_sub(expected_backend_running);
     assert!(
         expected_backend_running >= 1,
         "test setup should hold at least one running call; active calls={}",
-        Value::Array(active_calls.clone())
+        Value::Array(active_calls)
     );
-
-    let client = reqwest::Client::new();
-    let response = client
-        .get(format!("http://127.0.0.1:{port}/fleet/slots"))
-        .send()
-        .await
-        .context("fetching /fleet/slots")?;
-    assert!(
-        response.status().is_success(),
-        "unexpected /fleet/slots response: {response:?}"
-    );
-    let snapshot: Value = response.json().await.context("reading /fleet/slots body")?;
 
     assert_eq!(
         snapshot.pointer("/source").and_then(Value::as_str),

--- a/crates/defra-agent-cli/tests/cli_trace_export.rs
+++ b/crates/defra-agent-cli/tests/cli_trace_export.rs
@@ -1474,6 +1474,8 @@ async fn projection_graphql_mock(
         json!({ "data": { "AgentSession": [projection_mock_session()] } })
     } else if query.contains("AgentConversation(") {
         json!({ "data": { "AgentConversation": [projection_mock_conversation()] } })
+    } else if query.contains("InferenceCall(") {
+        json!({ "data": { "InferenceCall": [] } })
     } else {
         json!({
             "errors": [{

--- a/crates/defra-agent-cli/tests/support/waits.rs
+++ b/crates/defra-agent-cli/tests/support/waits.rs
@@ -26,11 +26,17 @@ pub async fn wait_for_runtime_ready(
                 escape_graphql_string(agent_did),
             ),
         )
-        .await?;
-        if let Ok(row) = first_graphql_row(&response, "AgentRuntime") {
-            if row.get("process_state").and_then(Value::as_str) == Some("ready") {
-                return Ok(());
+        .await;
+        match response {
+            Ok(response) => {
+                if let Ok(row) = first_graphql_row(&response, "AgentRuntime") {
+                    if row.get("process_state").and_then(Value::as_str) == Some("ready") {
+                        return Ok(());
+                    }
+                }
             }
+            Err(error) if agent_runtime_schema_is_starting(&error) => {}
+            Err(error) => return Err(error),
         }
 
         if Instant::now() >= deadline {
@@ -178,17 +184,28 @@ pub async fn wait_for_runtime_doc_id(graphql: &str, agent_did: &str) -> Result<S
                 escape_graphql_string(agent_did),
             ),
         )
-        .await?;
-        if let Ok(row) = first_graphql_row(&response, "AgentRuntime") {
-            if let Some(doc_id) = row.get("_docID").and_then(Value::as_str) {
-                return Ok(doc_id.to_string());
+        .await;
+        match response {
+            Ok(response) => {
+                if let Ok(row) = first_graphql_row(&response, "AgentRuntime") {
+                    if let Some(doc_id) = row.get("_docID").and_then(Value::as_str) {
+                        return Ok(doc_id.to_string());
+                    }
+                }
             }
+            Err(error) if agent_runtime_schema_is_starting(&error) => {}
+            Err(error) => return Err(error),
         }
         if Instant::now() >= deadline {
             bail!("timed out waiting for AgentRuntime _docID for {agent_did}");
         }
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
+}
+
+fn agent_runtime_schema_is_starting(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("Cannot query field") && message.contains("AgentRuntime")
 }
 
 pub async fn wait_for_request(

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/Collections.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/Collections.lean
@@ -23,6 +23,7 @@ inductive Collection where
   | inferenceProfile
   | toolServiceRegistry
   | projectionAcpBinding
+  | peerPairingDesired
   | task
   | schedule
   | eventTrigger
@@ -36,12 +37,20 @@ def Collection.applyOrder : Collection → Nat
   | .inferenceProfile      => 0
   | .toolServiceRegistry   => 0
   | .skill                 => 0
+  | .peerPairingDesired    => 0
   | .agentBehavior         => 1
   | .projectionAcpBinding  => 2
   | .task                  => 2
   | .schedule              => 2
   | .agentPrincipal        => 3
   | .eventTrigger          => 3
+
+/-- Collections whose live projection is already provenance-scoped to the
+    current manifest owner. Absence is therefore authoritative retraction,
+    independent of the opt-in generic prune mode. -/
+def Collection.manifestAuthoritative : Collection → Bool
+  | .peerPairingDesired => true
+  | _ => false
 
 /-- Comparison on Collection: by `applyOrder` rank. -/
 instance : LT Collection where
@@ -93,6 +102,7 @@ example (c : Collection) : Nat :=
   | .inferenceProfile     => 0
   | .toolServiceRegistry  => 0
   | .projectionAcpBinding => 2
+  | .peerPairingDesired   => 0
   | .task                 => 2
   | .schedule             => 2
   | .eventTrigger         => 3
@@ -109,6 +119,7 @@ theorem applyOrder_matches_parity_contract : ∀ c : Collection,
        | .inferenceProfile     => 0
        | .toolServiceRegistry  => 0
        | .projectionAcpBinding => 2
+       | .peerPairingDesired   => 0
        | .task                 => 2
        | .schedule             => 2
        | .eventTrigger         => 3) := by

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Diff.lean
@@ -57,18 +57,16 @@ def noDesiredDocReferencesTarget (desired : List ContractDoc) (target : DocRef) 
   !(desired.any fun doc => docReferencesTarget doc target)
 
 def diffDelete (scenario : ApplyReconcileScenario) : List DocRef :=
-  if scenario.pruneMode then
-    productionPruneOrder.flatMap fun collection =>
-      (sortedDocRefs <|
-        scenario.preDesired.filterMap fun doc =>
-          if collectionBEq doc.ref.collection collection &&
-              !(containsDoc scenario.manifest doc.ref) &&
-              noDesiredDocReferencesTarget scenario.preDesired doc.ref then
-            some doc.ref
-          else
-            none)
-  else
-    []
+  productionPruneOrder.flatMap fun collection =>
+    (sortedDocRefs <|
+      scenario.preDesired.filterMap fun doc =>
+        if (scenario.pruneMode || collection.manifestAuthoritative) &&
+            collectionBEq doc.ref.collection collection &&
+            !(containsDoc scenario.manifest doc.ref) &&
+            noDesiredDocReferencesTarget scenario.preDesired doc.ref then
+          some doc.ref
+        else
+          none)
 
 def diffDeleteSteps (scenario : ApplyReconcileScenario) : List ContractStep :=
   (diffDelete scenario).map deleteStep

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Fixtures.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Fixtures.lean
@@ -28,6 +28,7 @@ def serviceA : DocRef := doc .toolServiceRegistry "service-a"
 def skillA : DocRef := doc .skill "skill-a"
 def behaviorA : DocRef := doc .agentBehavior "behavior-a"
 def projectionBindingA : DocRef := doc .projectionAcpBinding "projection-binding-a"
+def pairingA : DocRef := doc .peerPairingDesired "1111111111111111111111111111111111111111111111111111111111111111"
 def taskA : DocRef := doc .task "task-a"
 def scheduleA : DocRef := doc .schedule "schedule-a"
 def eventTriggerA : DocRef := doc .eventTrigger "trigger-a"
@@ -64,6 +65,14 @@ def applyReconcileScenarios : List ApplyReconcileScenario :=
     , preLive := [live .inferenceBackend "backend-b" "orphan-runtime"]
     , pruneMode := false
     , prefixLen := 0
+    }
+  , { name := "managed_pairing_absent_retracts_without_prune"
+    , manifest := []
+    , preDesired :=
+        [ desired .peerPairingDesired pairingA.id "manifest-owned-pairing" ]
+    , preLive := [live .peerPairingDesired pairingA.id "runtime-pairing-state"]
+    , pruneMode := false
+    , prefixLen := 1
     }
   , { name := "prune_live_only_unreferenced_backend"
     , manifest := []
@@ -110,7 +119,10 @@ def applyReconcileScenarios : List ApplyReconcileScenario :=
     }
   , { name := "production_write_boundary_all_collections"
     , manifest :=
-        [ desired .inferenceBackend "backend-a" "backend-desired"
+        [ desired .peerPairingDesired
+            "1111111111111111111111111111111111111111111111111111111111111111"
+            "pairing-desired"
+        , desired .inferenceBackend "backend-a" "backend-desired"
         , desired .inferenceProfile "profile-a" "profile-desired"
         , desired .toolServiceRegistry "service-a" "service-desired"
         , desired .toolSelection "selection-a" "selection-desired"

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/ContractCases/Types.lean
@@ -93,6 +93,7 @@ def collectionName : Collection → String
   | .inferenceProfile => "InferenceProfile"
   | .toolServiceRegistry => "ToolServiceRegistry"
   | .projectionAcpBinding => "ProjectionAcpBinding"
+  | .peerPairingDesired => "PeerPairingDesired"
   | .task => "Task"
   | .schedule => "Schedule"
   | .eventTrigger => "EventTrigger"
@@ -106,12 +107,14 @@ def collectionUniqueField : Collection → String
   | .inferenceProfile => "profile_id"
   | .toolServiceRegistry => "service_id"
   | .projectionAcpBinding => "binding_id"
+  | .peerPairingDesired => "peer_id"
   | .task => "task_id"
   | .schedule => "schedule_id"
   | .eventTrigger => "trigger_id"
 
 def productionWriteOrder : List Collection :=
-  [ .inferenceBackend
+  [ .peerPairingDesired
+  , .inferenceBackend
   , .inferenceProfile
   , .toolServiceRegistry
   , .toolSelection

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/Diff.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/Diff.lean
@@ -145,22 +145,44 @@ lemma noLiveReferencesIn_deleteSafe
   rw [htrue] at hfalse
   cases hfalse
 
+/-- Deletes for live-only rows whose collection is provenance-scoped to the
+    current manifest owner. These rows converge on manifest absence without
+    enabling generic prune mode. -/
+noncomputable def managedDeletes
+    (M : Manifest) (L : LiveState) (support : LiveSupport) : List ApplyStep :=
+  (support.toList.filterMap (fun d =>
+    if d.collection.manifestAuthoritative then
+      if M.contains d then none
+      else if L.contains d then
+        if noLiveReferencesIn L support d then some (ApplyStep.delete d) else none
+      else none
+    else none)).mergeSort ApplyStep.deleteLe
+
 /-- Prune-mode delete steps for live-only desired rows. The default `diff`
     above remains byte-for-byte create/update only; callers opt into these
-    deletes explicitly and must supply the finite live desired support. -/
+    deletes explicitly and must supply the finite live desired support.
+    Manifest-authoritative rows are excluded because `managedDeletes` owns
+    their retraction in every mode. -/
 noncomputable def pruneDeletes
     (M : Manifest) (L : LiveState) (support : LiveSupport) : List ApplyStep :=
   (support.toList.filterMap (fun d =>
-    if M.contains d then none
+    if d.collection.manifestAuthoritative then none
+    else if M.contains d then none
     else if L.contains d then
       if noLiveReferencesIn L support d then some (ApplyStep.delete d) else none
     else none)).mergeSort ApplyStep.deleteLe
 
+/-- Default config convergence: create/update writes followed by retractions
+    from manifest-authoritative, provenance-scoped collections. -/
+noncomputable def diffManaged
+    (M : Manifest) (L : LiveState) (support : LiveSupport) : List ApplyStep :=
+  diff M L ++ managedDeletes M L support
+
 /-- Prune-mode apply diff: write desired create/update steps first, then the
-    opt-in delete sequence over live-only rows. -/
+    always-on managed retractions and opt-in generic delete sequence. -/
 noncomputable def diffPrune
     (M : Manifest) (L : LiveState) (support : LiveSupport) : List ApplyStep :=
-  diff M L ++ pruneDeletes M L support
+  diffManaged M L support ++ pruneDeletes M L support
 
 /-- Extract rank and id-level obligations from a true `DocRef.le`. -/
 private lemma DocRef.le_elim {a b : DocRef} (h : DocRef.le a b = true) :
@@ -282,6 +304,36 @@ theorem delete_order_referrers_before_dependencies
   unfold ApplyStep.deleteLe ApplyStep.target
   exact DocRef.le_intro (Or.inl hrank)
 
+/-- Every automatic manifest-authoritative delete is globally safe, provided
+    the owner-scoped live support is complete. -/
+theorem managedDeletes_emits_only_safe_deletes
+    {M : Manifest} {L : LiveState} {support : LiveSupport} {s : ApplyStep}
+    (hcomplete : LiveSupportComplete L support)
+    (hmem : s ∈ managedDeletes M L support) :
+    ∃ d, s = ApplyStep.delete d ∧ deleteSafe L d := by
+  unfold managedDeletes at hmem
+  rw [List.mem_mergeSort, List.mem_filterMap] at hmem
+  rcases hmem with ⟨d, _hd, hprod⟩
+  by_cases hOwned : d.collection.manifestAuthoritative = true
+  · by_cases hM : M.contains d = true
+    · simp [hOwned, hM] at hprod
+    · have hMfalse : M.contains d = false := by
+        cases h : M.contains d <;> simp [h] at hM ⊢
+      by_cases hL : L.contains d = true
+      · by_cases hcheck : noLiveReferencesIn L support d = true
+        · simp [hOwned, hMfalse, hL, hcheck] at hprod
+          subst hprod
+          exact ⟨d, rfl, noLiveReferencesIn_deleteSafe hcomplete hcheck⟩
+        · have hcheckFalse : noLiveReferencesIn L support d = false := by
+            cases h : noLiveReferencesIn L support d <;> simp [h] at hcheck ⊢
+          simp [hOwned, hMfalse, hL, hcheckFalse] at hprod
+      · have hLfalse : L.contains d = false := by
+          cases h : L.contains d <;> simp [h] at hL ⊢
+        simp [hOwned, hMfalse, hLfalse] at hprod
+  · have hOwnedFalse : d.collection.manifestAuthoritative = false := by
+      cases h : d.collection.manifestAuthoritative <;> simp [h] at hOwned ⊢
+    simp [hOwnedFalse] at hprod
+
 /-- Every emitted prune-delete is globally delete-safe, provided the finite
     support supplied to prune generation covers every live desired row. -/
 theorem pruneDeletes_emits_only_safe_deletes
@@ -292,21 +344,25 @@ theorem pruneDeletes_emits_only_safe_deletes
   unfold pruneDeletes at hmem
   rw [List.mem_mergeSort, List.mem_filterMap] at hmem
   rcases hmem with ⟨d, _hd, hprod⟩
-  by_cases hM : M.contains d = true
-  · simp [hM] at hprod
-  · have hMfalse : M.contains d = false := by
-      cases h : M.contains d <;> simp [h] at hM ⊢
-    by_cases hL : L.contains d = true
-    · by_cases hcheck : noLiveReferencesIn L support d = true
-      · simp [hMfalse, hL, hcheck] at hprod
-        subst hprod
-        exact ⟨d, rfl, noLiveReferencesIn_deleteSafe hcomplete hcheck⟩
-      · have hcheckFalse : noLiveReferencesIn L support d = false := by
-          cases h : noLiveReferencesIn L support d <;> simp [h] at hcheck ⊢
-        simp [hMfalse, hL, hcheckFalse] at hprod
-    · have hLfalse : L.contains d = false := by
-        cases h : L.contains d <;> simp [h] at hL ⊢
-      simp [hMfalse, hLfalse] at hprod
+  by_cases hOwned : d.collection.manifestAuthoritative = true
+  · simp [hOwned] at hprod
+  · have hOwnedFalse : d.collection.manifestAuthoritative = false := by
+      cases h : d.collection.manifestAuthoritative <;> simp [h] at hOwned ⊢
+    by_cases hM : M.contains d = true
+    · simp [hOwnedFalse, hM] at hprod
+    · have hMfalse : M.contains d = false := by
+        cases h : M.contains d <;> simp [h] at hM ⊢
+      by_cases hL : L.contains d = true
+      · by_cases hcheck : noLiveReferencesIn L support d = true
+        · simp [hOwnedFalse, hMfalse, hL, hcheck] at hprod
+          subst hprod
+          exact ⟨d, rfl, noLiveReferencesIn_deleteSafe hcomplete hcheck⟩
+        · have hcheckFalse : noLiveReferencesIn L support d = false := by
+            cases h : noLiveReferencesIn L support d <;> simp [h] at hcheck ⊢
+          simp [hOwnedFalse, hMfalse, hL, hcheckFalse] at hprod
+      · have hLfalse : L.contains d = false := by
+          cases h : L.contains d <;> simp [h] at hL ⊢
+        simp [hOwnedFalse, hMfalse, hLfalse] at hprod
 
 theorem pruneDeletes_deleteSafe
     {M : Manifest} {L : LiveState} {support : LiveSupport} {d : DocRef}
@@ -317,6 +373,27 @@ theorem pruneDeletes_deleteSafe
   cases hstep
   exact hsafe
 
+theorem managedDeletes_deleteSafe
+    {M : Manifest} {L : LiveState} {support : LiveSupport} {d : DocRef}
+    (hcomplete : LiveSupportComplete L support)
+    (hmem : ApplyStep.delete d ∈ managedDeletes M L support) :
+    deleteSafe L d := by
+  rcases managedDeletes_emits_only_safe_deletes hcomplete hmem with ⟨d', hstep, hsafe⟩
+  cases hstep
+  exact hsafe
+
+theorem diffManaged_deleteSafe
+    {M : Manifest} {L : LiveState} {support : LiveSupport} {d : DocRef}
+    (hcomplete : LiveSupportComplete L support)
+    (hmem : ApplyStep.delete d ∈ diffManaged M L support) :
+    deleteSafe L d := by
+  unfold diffManaged at hmem
+  rw [List.mem_append] at hmem
+  rcases hmem with hdiff | hmanaged
+  · have hpayload := diff_step_payload_isSome hdiff
+    simp [ApplyStep.payload?] at hpayload
+  · exact managedDeletes_deleteSafe hcomplete hmanaged
+
 theorem diffPrune_deleteSafe
     {M : Manifest} {L : LiveState} {support : LiveSupport} {d : DocRef}
     (hcomplete : LiveSupportComplete L support)
@@ -324,10 +401,18 @@ theorem diffPrune_deleteSafe
     deleteSafe L d := by
   unfold diffPrune at hmem
   rw [List.mem_append] at hmem
-  rcases hmem with hdiff | hprune
-  · have hpayload := diff_step_payload_isSome hdiff
-    simp [ApplyStep.payload?] at hpayload
+  rcases hmem with hmanaged | hprune
+  · exact diffManaged_deleteSafe hcomplete hmanaged
   · exact pruneDeletes_deleteSafe hcomplete hprune
+
+/-- T-Managed-delete-safety: default-mode retraction of a provenance-scoped
+    manifest-authoritative row never removes a structurally referenced row. -/
+theorem t_managed_delete_safety
+    {M : Manifest} {L : LiveState} {support : LiveSupport} {d : DocRef}
+    (hcomplete : LiveSupportComplete L support)
+    (hmem : ApplyStep.delete d ∈ diffManaged M L support) :
+    ∀ referrer : DocRef, ¬ liveReferences L referrer d :=
+  diffManaged_deleteSafe hcomplete hmem
 
 /-- T-Delete-safety: any delete emitted by prune-mode diff has no structural
     live referrer at the state where the diff is computed, assuming the finite

--- a/crates/defra-agent/proofs/Proofs/ApplyReconcile/Manifest.lean
+++ b/crates/defra-agent/proofs/Proofs/ApplyReconcile/Manifest.lean
@@ -43,8 +43,9 @@ end Manifest
 
 /-- DB state observable to both apply and runtime, exposing the desired-
     and live-projection per document. `liveOnly` documents are those with
-    no manifest entry but nonzero live state — the current CLI reports
-    these diagnostically but does not delete them. -/
+    no manifest entry but nonzero live state. The CLI reports generic rows
+    diagnostically unless prune is enabled; provenance-scoped,
+    manifest-authoritative rows are retracted automatically. -/
 structure LiveState where
   desired : DocRef → Option DesiredFields
   live    : DocRef → Option LiveFields

--- a/crates/defra-agent/src/agent/p2p_reconcile/discovery.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/discovery.rs
@@ -13,6 +13,9 @@
 //! `"manifest:<owner-did>"`; registry rows use `"registry"`. Registry writes
 //! and deletes are still queried as an exact partition
 //! (`filter: { source: { _eq: "registry" } }`).
+//! The manifest owner DID is a stable part of that partition key: rotating a
+//! principal DID does not transfer existing manifest rows. Such rows remain in
+//! the old owner's partition and require explicit migration or deletion.
 //!
 //! Mirrored Lean properties:
 //! - `deriveRegistryDesired(self, registry)` = live, non-self registry entries

--- a/crates/defra-agent/src/agent/p2p_reconcile/discovery.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/discovery.rs
@@ -8,8 +8,11 @@
 //! **operator-owned** and **registry-owned** rows, and the discovery step only
 //! ever writes or deletes registry-owned rows — it never reads, writes, or
 //! deletes operator-owned rows. We carry that partition as a `source`
-//! discriminator field on `PeerPairingDesired` (`"operator"` | `"registry"`),
-//! *queried as a partition* (`filter: { source: { _eq: "registry" } }`).
+//! discriminator field on `PeerPairingDesired`. Direct operator rows use
+//! `"operator"`; config-managed rows use the operator subpartition
+//! `"manifest:<owner-did>"`; registry rows use `"registry"`. Registry writes
+//! and deletes are still queried as an exact partition
+//! (`filter: { source: { _eq: "registry" } }`).
 //!
 //! Mirrored Lean properties:
 //! - `deriveRegistryDesired(self, registry)` = live, non-self registry entries
@@ -45,6 +48,10 @@ pub const PREFERRED_DISCOVERY_TEMPLATE: &str = "conversation";
 
 /// The `source` discriminator value for operator-authored desired rows.
 pub const SOURCE_OPERATOR: &str = "operator";
+/// Config-manifest rows are an explicitly-provenanced subpartition of
+/// operator intent. Discovery treats them as operator-owned for exclusion, but
+/// the suffix lets `config apply` remove only rows owned by its manifest root.
+pub const SOURCE_MANIFEST_PREFIX: &str = "manifest:";
 /// The `source` discriminator value for registry-derived (discovery-owned)
 /// desired rows.
 pub const SOURCE_REGISTRY: &str = "registry";
@@ -595,7 +602,22 @@ impl DiscoveryStore for GraphqlDiscoveryStore {
     }
 
     async fn list_operator_owned_peers(&self) -> Result<BTreeSet<String>> {
-        self.list_peers_by_source(SOURCE_OPERATOR).await
+        let query = r#"{
+            PeerPairingDesired {
+                peer_id
+                source
+            }
+        }"#;
+        let response = self.node.execute(query).await;
+        ensure_no_errors(&response, "query operator-owned PeerPairingDesired rows")?;
+        Ok(rows::<PeerSourceRow>(&response, "PeerPairingDesired")?
+            .into_iter()
+            .filter(|row| source_is_operator_owned(row.source.as_deref()))
+            .filter_map(|row| {
+                let peer_id = row.peer_id.trim().to_string();
+                (!peer_id.is_empty()).then_some(peer_id)
+            })
+            .collect())
     }
 
     async fn list_network_owned_peers(&self) -> Result<BTreeSet<String>> {
@@ -624,6 +646,11 @@ impl DiscoveryStore for GraphqlDiscoveryStore {
         let response = self.node.execute(&mutation).await;
         ensure_no_errors(&response, "delete registry-owned PeerPairingDesired")
     }
+}
+
+fn source_is_operator_owned(source: Option<&str>) -> bool {
+    let source = source.map(str::trim).unwrap_or(SOURCE_OPERATOR);
+    source == SOURCE_OPERATOR || source.starts_with(SOURCE_MANIFEST_PREFIX)
 }
 
 /// Upsert a registry-owned `PeerPairingDesired` row, populated from the registry
@@ -776,6 +803,12 @@ struct PeerIdRow {
     peer_id: String,
 }
 
+#[derive(Deserialize)]
+struct PeerSourceRow {
+    peer_id: String,
+    source: Option<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Mutex;
@@ -793,6 +826,19 @@ mod tests {
     }
 
     // ---- pure derivation (mirrors Lean deriveRegistryDesired) ----
+
+    #[test]
+    fn manifest_provenance_is_an_operator_owned_subpartition() {
+        assert!(source_is_operator_owned(None));
+        assert!(source_is_operator_owned(Some(SOURCE_OPERATOR)));
+        assert!(source_is_operator_owned(Some(
+            "manifest:did:key:local-owner"
+        )));
+        assert!(!source_is_operator_owned(Some(SOURCE_REGISTRY)));
+        assert!(!source_is_operator_owned(Some(
+            super::super::network::SOURCE_NETWORK
+        )));
+    }
 
     #[test]
     fn derive_skips_self_and_offline() {

--- a/crates/defra-agent/src/agent/p2p_reconcile/mod.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/mod.rs
@@ -20,8 +20,8 @@ pub use diff::{
 pub use discovery::{
     decide_join_admission, derive_registry_desired, heartbeat_is_fresh, reconcile_discovery_tick,
     run_discovery_reconciler, DiscoveredEntry, DiscoveryStore, DiscoveryTickOutcome,
-    GraphqlDiscoveryStore, JoinAdmission, RegistryMemberRow, REGISTRY_STALE_AFTER, SOURCE_OPERATOR,
-    SOURCE_REGISTRY,
+    GraphqlDiscoveryStore, JoinAdmission, RegistryMemberRow, REGISTRY_STALE_AFTER,
+    SOURCE_MANIFEST_PREFIX, SOURCE_OPERATOR, SOURCE_REGISTRY,
 };
 pub use embedded_impl::EmbeddedRemoteP2pAdmin;
 pub use endpoint::{peer_endpoint_upsert_mutation, run_endpoint_heartbeat};

--- a/crates/defra-agent/src/apply_model.rs
+++ b/crates/defra-agent/src/apply_model.rs
@@ -109,10 +109,14 @@ pub fn references_of(payload: &DesiredFields) -> Vec<DocRef> {
     payload.refs.clone()
 }
 
+/// Default convergence diff. Mirrors Lean `diffManaged`: writes manifest rows
+/// and retracts absent rows only for manifest-authoritative collections.
 pub fn diff(m: &Manifest, l: &LiveState) -> DiffReport {
     diff_inner(m, l, false)
 }
 
+/// Prune convergence diff. Adds safe generic live-only deletions to the
+/// always-on manifest-authoritative retractions.
 pub fn diff_prune(m: &Manifest, l: &LiveState) -> DiffReport {
     diff_inner(m, l, true)
 }
@@ -142,7 +146,7 @@ fn diff_inner(m: &Manifest, l: &LiveState, prune: bool) -> DiffReport {
             }
             (None, Some(_)) => {
                 live_only.push((*d).clone());
-                if prune && delete_safe(l, d) {
+                if (prune || d.collection.manifest_authoritative()) && delete_safe(l, d) {
                     delete.push((*d).clone());
                 }
             }
@@ -152,9 +156,7 @@ fn diff_inner(m: &Manifest, l: &LiveState, prune: bool) -> DiffReport {
 
     steps.sort_by_key(|s| (s.target().collection.apply_order(), s.target().id.clone()));
     delete.sort_by_key(|d| (std::cmp::Reverse(d.collection.apply_order()), d.id.clone()));
-    if prune {
-        steps.extend(delete.iter().cloned().map(ApplyStep::Delete));
-    }
+    steps.extend(delete.iter().cloned().map(ApplyStep::Delete));
 
     DiffReport {
         create,
@@ -339,6 +341,25 @@ mod tests {
         let after = apply_all(&l, prune_report.steps());
         assert!(!after.desired.contains_key(&backend));
         assert_eq!(after.live, l.live);
+    }
+
+    #[test]
+    fn default_diff_retracts_manifest_authoritative_pairing() {
+        let pairing = DocRef {
+            collection: Collection::PeerPairingDesired,
+            id: "peer".into(),
+        };
+        let m = Manifest {
+            docs: BTreeMap::new(),
+        };
+        let l = LiveState {
+            desired: BTreeMap::from([(pairing.clone(), DesiredFields::opaque("owned"))]),
+            live: BTreeMap::new(),
+        };
+
+        let report = diff(&m, &l);
+        assert_eq!(report.delete, vec![pairing.clone()]);
+        assert_eq!(report.steps(), &[ApplyStep::Delete(pairing)]);
     }
 
     #[test]

--- a/crates/defra-agent/src/collection.rs
+++ b/crates/defra-agent/src/collection.rs
@@ -19,6 +19,7 @@ pub enum Collection {
     InferenceProfile,
     ToolServiceRegistry,
     ProjectionAcpBinding,
+    PeerPairingDesired,
     Task,
     Schedule,
     EventTrigger,
@@ -27,7 +28,7 @@ pub enum Collection {
 impl Collection {
     /// All variants in declaration order. Not sorted by `apply_order()` —
     /// callers that need apply-ordered iteration must sort explicitly.
-    pub const ALL: [Collection; 11] = [
+    pub const ALL: [Collection; 12] = [
         Collection::AgentPrincipal,
         Collection::AgentBehavior,
         Collection::Skill,
@@ -36,6 +37,7 @@ impl Collection {
         Collection::InferenceProfile,
         Collection::ToolServiceRegistry,
         Collection::ProjectionAcpBinding,
+        Collection::PeerPairingDesired,
         Collection::Task,
         Collection::Schedule,
         Collection::EventTrigger,
@@ -60,6 +62,7 @@ impl Collection {
             Collection::InferenceProfile => Some("inference-profiles"),
             Collection::ToolServiceRegistry => Some("tool-services"),
             Collection::ProjectionAcpBinding => Some("projection-acp-bindings"),
+            Collection::PeerPairingDesired => Some("peer-pairings"),
             Collection::Task => Some("tasks"),
             Collection::Schedule => Some("schedules"),
             // EventTrigger uses underscore (not hyphen) to match the schema
@@ -80,6 +83,7 @@ impl Collection {
             Collection::InferenceProfile => "InferenceProfile",
             Collection::ToolServiceRegistry => "ToolServiceRegistry",
             Collection::ProjectionAcpBinding => "ProjectionAcpBinding",
+            Collection::PeerPairingDesired => "PeerPairingDesired",
             Collection::Task => "Task",
             Collection::Schedule => "Schedule",
             Collection::EventTrigger => "EventTrigger",
@@ -97,6 +101,7 @@ impl Collection {
             Collection::InferenceProfile => "profile_id",
             Collection::ToolServiceRegistry => "service_id",
             Collection::ProjectionAcpBinding => "binding_id",
+            Collection::PeerPairingDesired => "peer_id",
             Collection::Task => "task_id",
             Collection::Schedule => "schedule_id",
             Collection::EventTrigger => "trigger_id",
@@ -112,7 +117,8 @@ impl Collection {
             | Collection::ToolSelection
             | Collection::InferenceProfile
             | Collection::ToolServiceRegistry
-            | Collection::Skill => 0,
+            | Collection::Skill
+            | Collection::PeerPairingDesired => 0,
             Collection::AgentBehavior => 1,
             Collection::ProjectionAcpBinding => 2,
             Collection::Task => 2,
@@ -120,6 +126,13 @@ impl Collection {
             Collection::AgentPrincipal => 3,
             Collection::EventTrigger => 3,
         }
+    }
+
+    /// Whether this collection's live config projection is provenance-scoped
+    /// to the current manifest owner. Such rows converge on manifest absence
+    /// without requiring generic `--prune`.
+    pub fn manifest_authoritative(self) -> bool {
+        matches!(self, Collection::PeerPairingDesired)
     }
 }
 
@@ -138,6 +151,7 @@ impl fmt::Display for Collection {
             Collection::InferenceProfile => "inference_profiles",
             Collection::ToolServiceRegistry => "tool_service_registries",
             Collection::ProjectionAcpBinding => "projection_acp_bindings",
+            Collection::PeerPairingDesired => "peer_pairings",
             Collection::Task => "tasks",
             Collection::Schedule => "schedules",
             Collection::EventTrigger => "event_triggers",
@@ -177,6 +191,15 @@ mod tests {
     }
 
     #[test]
+    fn peer_pairings_are_the_only_manifest_authoritative_collection() {
+        let authoritative = Collection::ALL
+            .into_iter()
+            .filter(|collection| collection.manifest_authoritative())
+            .collect::<Vec<_>>();
+        assert_eq!(authoritative, vec![Collection::PeerPairingDesired]);
+    }
+
+    #[test]
     fn canonical_variants_and_ranks() {
         // This list is the Rust side of the parity contract. The Lean
         // inductive `ApplyReconcile.Collection` and the
@@ -200,6 +223,7 @@ mod tests {
             (Collection::InferenceProfile, 0, "InferenceProfile"),
             (Collection::ToolServiceRegistry, 0, "ToolServiceRegistry"),
             (Collection::ProjectionAcpBinding, 2, "ProjectionAcpBinding"),
+            (Collection::PeerPairingDesired, 0, "PeerPairingDesired"),
             (Collection::Task, 2, "Task"),
             (Collection::Schedule, 2, "Schedule"),
             (Collection::EventTrigger, 3, "EventTrigger"),

--- a/crates/defra-agent/tests/apply_property.rs
+++ b/crates/defra-agent/tests/apply_property.rs
@@ -17,6 +17,7 @@ fn collection_strategy() -> impl Strategy<Value = Collection> {
         Just(Collection::InferenceProfile),
         Just(Collection::ToolServiceRegistry),
         Just(Collection::ProjectionAcpBinding),
+        Just(Collection::PeerPairingDesired),
         Just(Collection::Task),
         Just(Collection::Schedule),
         Just(Collection::EventTrigger),
@@ -32,6 +33,7 @@ const LEAF_COLLECTIONS: &[Collection] = &[
     Collection::ToolSelection,
     Collection::InferenceProfile,
     Collection::ToolServiceRegistry,
+    Collection::PeerPairingDesired,
 ];
 
 fn leaf_docref_strategy() -> impl Strategy<Value = DocRef> {
@@ -41,6 +43,7 @@ fn leaf_docref_strategy() -> impl Strategy<Value = DocRef> {
             Just(Collection::ToolSelection),
             Just(Collection::InferenceProfile),
             Just(Collection::ToolServiceRegistry),
+            Just(Collection::PeerPairingDesired),
         ],
         "[a-z]{1,4}",
     )

--- a/crates/defra-agent/tests/conformance/apply_reconcile.rs
+++ b/crates/defra-agent/tests/conformance/apply_reconcile.rs
@@ -214,6 +214,7 @@ fn generated_apply_reconcile_cases_drive_apply_model_and_production_ordering() {
         "backend_before_behavior_ordering",
         "update_existing_backend",
         "live_only_no_op",
+        "managed_pairing_absent_retracts_without_prune",
         "prune_live_only_unreferenced_backend",
         "prune_blocks_referenced_dependency",
         "prefix_retry_convergence_idempotence",

--- a/crates/defra-agent/tests/conformance/coverage.rs
+++ b/crates/defra-agent/tests/conformance/coverage.rs
@@ -119,7 +119,7 @@ pub(super) fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().runtime_reconcile_cases.len(), 6);
     assert_eq!(lean_contract_snapshot().request_transition_cases.len(), 81);
     assert_eq!(lean_contract_snapshot().process_transition_cases.len(), 25);
-    assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 9);
+    assert_eq!(lean_contract_snapshot().apply_reconcile_cases.len(), 10);
     assert_eq!(lean_contract_snapshot().session_recovery_cases.len(), 18);
     assert_eq!(
         lean_contract_snapshot()


### PR DESCRIPTION
## Summary

- add `PeerPairingDesired` to the Lean apply/reconcile model and prove manifest-authoritative removals remain delete-safe
- support `peer-pairings/<handle>/object.json` across config loading, normalization, validation, diff, export, and apply
- stamp pairing rows with the exact manifest owner and scope mutations/deletes to that owner so declarative config cannot take over operator-managed rows
- seed pairings before runtime boot, reconcile enabled/disabled/removed pairings idempotently, and cover restart plus live replicator install/teardown
- stabilize asynchronous CLI/runtime tests exposed by the required full-package gates

## Why

Pairings were previously discovered and reconciled at runtime, but were not part of the declarative config ownership model. Operators could not safely declare the desired pairing set, validate peer identity collisions before apply, or retract a manifest-owned pairing simply by removing it from configuration.

This adds a narrow, pairing-specific manifest-authoritative boundary while preserving existing operator-, registry-, and network-owned rows.

Closes #607.

## Impact

Operators can now manage peer pairings through `peer-pairings/<human-handle>/object.json`. Enabled entries are created or updated before runtime boot; disabled or removed manifest-owned entries are retracted without requiring global prune. Foreign-owned rows are rejected during validation and remain protected at the mutation boundary.

## Validation

- `lake build Proofs.ApplyReconcile Proofs.ApplyReconcile.ContractCases`
- `lake build Proofs.Conformance.Contracts:olean`
- `lake env lean --run Proofs/Conformance/Contracts.lean`
- `cargo test -p defra-agent-cli --bin defra-agent pairing -- --nocapture`
- generated apply write-boundary CLI test
- `cargo test -p defra-agent`
- `cargo test -p defra-agent-cli`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
