### PR TITLE
Fix active version migration bug

### DIFF
--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -802,6 +802,7 @@ pub async fn ensure_subagent_extensions_migrations(node: Arc<EmbeddedNode>) -> R
                 v10 = %v10.version_id,
                 "ToolSelection patched with context budget flag"
             );
+            active_version = v10;
         }
     } else {
         tracing::debug!("ToolSelection collection absent; subagent patch no-op");


### PR DESCRIPTION
In the `ensure_subagent_extensions_migrations` function inside `migration.rs` see that v3 through v9 blocks all concluude by setting the `active_version` value to the new version ID. However, this line was missing for v10. This PR simply adds the missing line.

Note: A previous version of this PR was much larger in scope, but the issues it addressed have been separately, and independently resolved.