### PR TITLE
fix: scope request-state replication to requester

### DIFF
--- a/crates/defra-agent-schemas/schemas/agent/agent_request.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_request.graphql
@@ -1,6 +1,7 @@
 type AgentRequest @branchable {
     request_id: String @index
     agent_did: String @index @immutable
+    requester_did: String @index @immutable
     behavior_id: String @index
     session_id: String @index
     retry_parent_request: String

--- a/crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
+++ b/crates/defra-agent/proofs/Proofs/ScopeTemplates/Derivation.lean
@@ -151,20 +151,41 @@ theorem scopeFilter_peerDid (f : String) (collections : List String)
 theorem scopeFilter_unscoped (collections : List String) (peerDid localDid : Did) :
     scopeFilter .unscoped collections peerDid localDid = [] := rfl
 
-/-- The coordinator subagent leg is exactly parent requests by local owner plus
-bridges addressed to the peer host. -/
+/-- The coordinator subagent leg carries only bridges addressed to the peer
+host. Coordinator-owned parent requests are not pair-specific and therefore
+must not cross every host pairing. -/
 theorem subagentCoordinator_filter_eq (peerDid localDid : Did) :
     scopeFilter (.perCollection subagentCoordinatorRules) [] peerDid localDid
-      = [ { collection := "AgentRequest",  field := "agent_did",        value := localDid }
-        , { collection := "AgentToolCall", field := "spawn_target_did", value := peerDid } ] := by
+      = [ { collection := "AgentToolCall", field := "spawn_target_did", value := peerDid } ] := by
   simp [scopeFilter, subagentCoordinatorRules]
 
-/-- The host subagent leg is exactly the conversation set owned by the local host. -/
+/-- The host subagent leg returns each child request only to the peer that
+requested it. The other conversation collections retain their existing
+host-owner scope; narrowing those collections is outside this request-state
+model. -/
 theorem subagentHost_filter_eq (peerDid localDid : Did) :
     scopeFilter (.perCollection subagentHostRules) [] peerDid localDid
-      = subagentHostCollections.map
-          (fun c => { collection := c, field := "agent_did", value := localDid }) := by
+      = [ { collection := "AgentRequest",      field := "requester_did", value := peerDid }
+        , { collection := "AgentResponse",     field := "agent_did",     value := localDid }
+        , { collection := "AgentMessage",      field := "agent_did",     value := localDid }
+        , { collection := "AgentToolCall",     field := "agent_did",     value := localDid }
+        , { collection := "AgentToolResult",   field := "agent_did",     value := localDid }
+        , { collection := "AgentSession",      field := "agent_did",     value := localDid }
+        , { collection := "AgentConversation", field := "agent_did",     value := localDid }
+        , { collection := "CompactionEntry",   field := "agent_did",     value := localDid } ] := by
   simp [scopeFilter, subagentHostRules, subagentHostCollections, conversationCollections]
+
+/-- Request-state crossing is party-scoped: coordinator-owned parent requests
+do not appear on the forward leg, while a host-owned child request is filtered
+on the paired requester's DID. -/
+theorem subagentRequest_crossing_is_peer_scoped (peerDid localDid : Did) :
+    (scopeFilter subagentCoordinatorTemplate.scope [] peerDid localDid).all
+        (fun k => k.collection ≠ "AgentRequest") = true ∧
+    (scopeFilter subagentHostTemplate.scope [] peerDid localDid).find?
+        (fun k => k.collection = "AgentRequest") =
+          some { collection := "AgentRequest", field := "requester_did", value := peerDid } := by
+  simp [scopeFilter, subagentCoordinatorTemplate, subagentCoordinatorRules,
+    subagentHostTemplate, subagentHostRules]
 
 /-- The coordinator per-collection rules cover exactly the template's declared
 collections. This is the non-vacuous collection-coverage fence for the

--- a/crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean
+++ b/crates/defra-agent/proofs/Proofs/ScopeTemplates/State.lean
@@ -105,12 +105,17 @@ def subagentHostCollections : List String :=
   conversationCollections
 
 def subagentCoordinatorRules : List CollectionRule :=
-  [ { collection := "AgentRequest",  field := "agent_did",        source := .localDid }
-  , { collection := "AgentToolCall", field := "spawn_target_did", source := .peerDid } ]
+  [ { collection := "AgentToolCall", field := "spawn_target_did", source := .peerDid } ]
 
 def subagentHostRules : List CollectionRule :=
-  subagentHostCollections.map
-    (fun c => { collection := c, field := "agent_did", source := .localDid })
+  [ { collection := "AgentRequest",      field := "requester_did", source := .peerDid }
+  , { collection := "AgentResponse",     field := "agent_did",     source := .localDid }
+  , { collection := "AgentMessage",      field := "agent_did",     source := .localDid }
+  , { collection := "AgentToolCall",     field := "agent_did",     source := .localDid }
+  , { collection := "AgentToolResult",   field := "agent_did",     source := .localDid }
+  , { collection := "AgentSession",      field := "agent_did",     source := .localDid }
+  , { collection := "AgentConversation", field := "agent_did",     source := .localDid }
+  , { collection := "CompactionEntry",   field := "agent_did",     source := .localDid } ]
 
 def conversationTemplate : Template :=
   { id := "conversation"
@@ -144,7 +149,7 @@ def networkControlTemplate : Template :=
 
 def subagentCoordinatorTemplate : Template :=
   { id := "subagent-coordinator"
-  , collections := ["AgentRequest", "AgentToolCall"].toFinset
+  , collections := ["AgentToolCall"].toFinset
   , scope := .perCollection subagentCoordinatorRules
   , delivery := .push }
 

--- a/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergence.cfg
+++ b/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergence.cfg
@@ -1,6 +1,6 @@
 CONSTANTS
   Owner = o
-  ReplicaHolder = {p1, p2}
+  ReplicaHolder = {p1}
   DeltaId = {d1, d2, d3, d4, d5, d6}
   MaxDrops = 1
   MaxCrashes = 1

--- a/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergencePeerClaim.cfg
+++ b/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergencePeerClaim.cfg
@@ -1,6 +1,6 @@
 CONSTANTS
   Owner = o
-  ReplicaHolder = {p1, p2}
+  ReplicaHolder = {p1}
   DeltaId = {d1, d2, d3, d4, d5, d6}
   MaxDrops = 1
   MaxCrashes = 1

--- a/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergenceStuck.cfg
+++ b/crates/defra-agent/proofs/tla/MCReplicatedRequestConvergenceStuck.cfg
@@ -1,6 +1,6 @@
 CONSTANTS
   Owner = o
-  ReplicaHolder = {p1, p2}
+  ReplicaHolder = {p1}
   DeltaId = {d1, d2, d3, d4, d5, d6}
   MaxDrops = 1
   MaxCrashes = 1

--- a/crates/defra-agent/proofs/tla/README.md
+++ b/crates/defra-agent/proofs/tla/README.md
@@ -11,10 +11,12 @@ See `../README.md` for how this fits the broader formal-verification model.
 - `SubagentCancelPropagation` - cascade-cancel delivery from a parent bridge row on deployment A to the child request owner on deployment B. Spec design: `docs/superpowers/specs/2026-05-13-subagent-cancel-propagation-tla-design.md` (removed from the tree; see git history). Implementation plan: `docs/superpowers/plans/2026-05-13-subagent-cancel-propagation-tla.md` (removed from the tree; see git history).
 - `PairingTransport` — connection establishment + replication liveness for one directed pairing edge, the transport layer *below* `ReversePairing`. `ReversePairing` and the Lean `PairingReconcile` model both assume the transport carries the install RPC / that `connect` succeeds; neither models *establishing* the link, so the live #511 fleet hang was outside the modeled world. This spec closes that gap. It distinguishes the **three real failure modes** (grounded in the production code) with two independent BOOLEAN constants — `Dialable` (the connect-gate ticket form) and `ReplicatorInstallable` (whether `add_replicator` can succeed once connected) — exercised by a **three-config diagnostic**: `MCPairingTransportDialable` (both true: the shareable-address fix — all properties hold); `MCPairingTransportUndialable` (MODE A — `Dialable = FALSE`: connect-fails-first, the *literal* #511 hang, never reaches `Connected` so nothing subscribes and no applied row is written); `MCPairingTransportReplicatorStuck` (MODE B/C — `ReplicatorInstallable = FALSE`: connect OK and collections subscribe but the replicator install never succeeds — the durable "subscribed collections, `replicator_addresses` null" partial row). Companion to the Lean `PairingReconcile` `dialFailed` (MODE A) and `reconcileInstallReplicatorFailed` (MODE B/C) transitions and the `convergence_requires_successful_install` obligation.
 - `P2PBackpressure` — hub fan-in/fan-out admission **obligation** model for #630 (**operator mitigation surface**, not a multi-wave flood-safety proof). `PairingTransport` proves a single edge can connect/install; this model starts after that. One-wave *necessity* obligations: outbound timeouts must release push-worker slots; inbound success acks must be backed by process-local pending registration or merge (pending is **not** durable across restart). Out of scope / production gaps: continuous multi-wave organic writes, **queue admission before PushLog spawn** (shipping can grow waiting tasks + retained JoinHandles unbounded), Bitswap stalls, rate-limit buckets, gossip send-loop, multi-slow-peer fill with `PushWorkers > 1`, peer-vs-CID pending. See `boundary.p2p-backpressure.obligation-model`. Green/red configs (`MCP2PBackpressureGreen` / `TimeoutStall` / `BadAck`) are **modeled, not yet TLC-checked**.
-- `ReplicatedRequestConvergence` — owner-only terminal convergence for replicated
-  `AgentRequest` documents (#664/#661). A persisted per-request `Cap` bounds
-  blind same-value writes across owner restarts; each write fans out to every
-  online replicator. A peer unavailable through the entire cap converges when
+- `ReplicatedRequestConvergence` — owner-only terminal convergence for
+  party-scoped replicated `AgentRequest` documents (#664/#661/#683). Replica
+  holders are authorized request parties, never unrelated fleet pairings. A
+  persisted per-request `Cap` bounds blind same-value writes across owner
+  restarts; each write fans out only to online party replicators. A party peer
+  unavailable through the entire cap converges when
   pairing recovery reinstalls the configured replicator and performs one full
   replay of current owner-authored DAG heads. Replay authors no request field,
   so partitions do not create unbounded CRDT history. `SingleClaimer` fences
@@ -170,12 +172,12 @@ Current parameters in `MCReplicatedRequestConvergence.cfg` / `MCReplicatedReques
 | Parameter | Value | Rationale |
 |-----------|-------|-----------|
 | `Owner` | `o` | The owning node — the request's `agent_did` holder and the only node that drives the lifecycle |
-| `ReplicaHolder` | `{p1, p2}` | Two non-owning peer replicas — the minimum to make convergence non-trivial across more than one holder |
+| `ReplicaHolder` | `{p1}` | The one requesting coordinator authorized to hold the host-owned child request; unrelated fleet peers are excluded |
 | `DeltaId` | `{d1, d2, d3, d4, d5, d6}` | Bounded id pool for terminal re-emissions; `StateBound` caps consumption below the pool size |
 | `MaxDrops` | `1` | One terminal delta may drop before fair re-emission converges (green) / strands a peer (stuck) |
 | `MaxCrashes` | `1` | One total node crash (owner restart or a peer losing volatile inbound) |
 | `TerminalKind` | `{Completed, Failed}` | The peer must converge to the *specific* terminal the owner reached, not merely some terminal |
-| `Cap` | `3` (green) / `1` (stuck) | Persisted per-request budget = shipping `TERMINAL_REDRIVE_CAP`; each emission is one owner write fanned out to every online replicator. The green config also enables reconnect replay, so a peer offline beyond all three writes still converges. |
+| `Cap` | `3` (green) / `1` (stuck) | Persisted per-request budget = shipping `TERMINAL_REDRIVE_CAP`; each emission is one owner write fanned out only to online request-party replicators. The green config also enables reconnect replay, so a party peer offline beyond all three writes still converges. |
 | `ReplayOnRecovery` | `TRUE` (green/peer-claim) / `FALSE` (stuck) | Production recovery reinstalls a configured subagent replicator once per reconnect, causing a bounded full replay. The stuck diagnostic removes that action and exposes the exhausted-cap liveness gap. |
 | `StateBound` | `Cardinality(deltaIdsUsed) <= Cap` | `emitCount` is persisted per request and caps same-value owner writes at `Cap`, independent of replica count. |
 
@@ -267,7 +269,7 @@ Active lines from `MCReplicatedRequestConvergence.cfg` (`Cap = 3`, reconnect rep
 - **`INVARIANT DeltaBackedByOwnerTerminal`** — every in-flight terminal delta carries the owner's (absorbing) terminal value; no peer can converge to a value the owner never reached.
 - **`INVARIANT DeltaIdsTracked`** — every in-flight delta's id is recorded in `deltaIdsUsed`; no id reuse.
 - **`INVARIANT ReplayBound`** — a peer recovery schedules at most one full replay in the modeled reconnect cycle.
-- **`PROPERTY TerminalConverges`** (`owner-terminal ~> every peer reflects it`) — online peers converge through bounded owner writes under bounded loss; a peer offline beyond the entire cap converges through fair `RecoverPeer` and `ReplayTerminalSnapshot`. Replay consumes no delta id or request-write budget.
+- **`PROPERTY TerminalConverges`** (`owner-terminal ~> every request-party peer reflects it`) — online party peers converge through bounded owner writes under bounded loss; a party peer offline beyond the entire cap converges through fair `RecoverPeer` and `ReplayTerminalSnapshot`. Replay consumes no delta id or request-write budget. Unrelated fleet peers are outside `ReplicaHolder` by the #683 scope contract.
 - **`CONSTRAINT StateBound`** — bounds total terminal re-emissions to keep TLC from exploring re-drive churn that is not meaningful with unbounded real delta ids.
 
 Two diagnostic configs reproduce the pre-fix convergence gap (liveness) and prove the safety property is falsifiable (safety):
@@ -361,9 +363,9 @@ Reference environment for the following runs: macOS arm64, OpenJDK 17.0.19, TLC 
 | `MCPairingTransportDialable.cfg` | `Dialable = TRUE`, `ReplicatorInstallable = TRUE` | Passes `TypeOK`, `PartialApplyHasProgress`, `ReplicationImpliesReplicator`, `ReplicatorLiveness`, `EndToEndLiveness` | 7 distinct states; 8 generated | — | <1s (OpenJDK 25) |
 | `MCPairingTransportUndialable.cfg` | `Dialable = FALSE`, `ReplicatorInstallable = TRUE` | **MODE A diagnostic:** invariants hold (`PartialApplyHasProgress` vacuous); `ReplicatorLiveness` intentionally VIOLATED (never-`Connected` trace = connect-fails-first hang) | 3 distinct states; 4 generated | — | <1s (OpenJDK 25) |
 | `MCPairingTransportReplicatorStuck.cfg` | `Dialable = TRUE`, `ReplicatorInstallable = FALSE` | **MODE B/C diagnostic:** `TypeOK`/`ReplicationImpliesReplicator` hold; `PartialApplyHasProgress` intentionally VIOLATED at `Connected ∧ subscribed ∧ ¬installed` (the partial row); `ReplicatorLiveness`/`EndToEndLiveness` also violated | 5 distinct states; 6 generated | — | <1s (OpenJDK 25) |
-| `MCReplicatedRequestConvergence.cfg` | `Cap = 3`, `ReplayOnRecovery = TRUE`, two replicas | Passes `TypeOK`, `SingleClaimer`, delta/replay invariants, and `TerminalConverges` | 3,972 distinct states; 15,633 generated | 19 | 1s |
-| `MCReplicatedRequestConvergenceStuck.cfg` | `Cap = 1`, `ReplayOnRecovery = FALSE` | Invariants hold; `TerminalConverges` intentionally VIOLATED with both peers offline and the persisted budget exhausted | 154 distinct states; 380 generated | 10 | <1s |
-| `MCReplicatedRequestConvergencePeerClaim.cfg` | `AllowPeerClaim = TRUE` | `SingleClaimer` intentionally VIOLATED by `PeerClaimsForeign` | 40 distinct states before counterexample; 46 generated | 4 | <1s |
+| `MCReplicatedRequestConvergence.cfg` | `Cap = 3`, `ReplayOnRecovery = TRUE`, one request-party replica | Passes `TypeOK`, `SingleClaimer`, delta/replay invariants, and `TerminalConverges` | 294 distinct states; 728 generated | 13 | <1s |
+| `MCReplicatedRequestConvergenceStuck.cfg` | `Cap = 1`, `ReplayOnRecovery = FALSE` | Invariants hold; `TerminalConverges` intentionally VIOLATED with the requester offline and the persisted budget exhausted | 42 distinct states; 78 generated | 8 | <1s |
+| `MCReplicatedRequestConvergencePeerClaim.cfg` | `AllowPeerClaim = TRUE` | `SingleClaimer` intentionally VIOLATED by `PeerClaimsForeign` | 47 distinct states before counterexample; 51 generated | 6 | <1s |
 
 The multi-collection run's final temporal-property pass dominated runtime: TLC completed BFS first, then checked 16 temporal branches over 34,635,520 total distinct states in 19min 27s.
 
@@ -372,9 +374,9 @@ The SubagentCompletion run used TLC2 `2026.05.12.170007` (rev `8033878`) with Op
 The SubagentCancelPropagation run used TLC2 `2026.05.12.170007` (rev `8033878`) with OpenJDK 17.0.19 on macOS arm64, `-workers auto` using 18 workers. TLC checked 2 temporal branches; the final temporal phase took 3s.
 
 The three ReplicatedRequestConvergence runs used TLC2
-`2026.07.03.221739` (rev `227f61b`) with OpenJDK 17.0.19 in a Linux arm64
-container, `-workers auto` using 18 workers. The green run checked two temporal
-branches; the other two are deliberately failing diagnostics.
+`2026.07.03.221739` (rev `227f61b`) with Homebrew OpenJDK 26.0.1 on macOS
+arm64, `-workers auto` using 18 workers. The one-requester green run checked
+one temporal branch; the other two are deliberately failing diagnostics.
 
 Crash-enabled two-collection attempts were stopped for tractability, not property failure:
 

--- a/crates/defra-agent/proofs/tla/ReplicatedRequestConvergence.tla
+++ b/crates/defra-agent/proofs/tla/ReplicatedRequestConvergence.tla
@@ -8,8 +8,9 @@ EXTENDS Naturals, FiniteSets, TLC
 (*   docs/superpowers/specs/2026-07-08-replicated-request-convergence-     *)
 (*   664-design.md                                                         *)
 (*                                                                         *)
-(* Under subagent-host replication one AgentRequest document is replicated *)
-(* onto non-owning peer nodes. SAFETY already holds: the watcher filters   *)
+(* Under party-scoped subagent-host replication one AgentRequest document  *)
+(* is replicated only to its requesting peer. SAFETY already holds: the    *)
+(* watcher filters                                                         *)
 (* agent_did == self on both claim seams (watcher/query.rs), so a peer     *)
 (* never claims or processes a foreign replica. LIVENESS did not: the      *)
 (* owner's terminal delta could drop and never converge to the peers,      *)
@@ -40,13 +41,13 @@ EXTENDS Naturals, FiniteSets, TLC
 
 CONSTANTS
   Owner,          \* the owning node (the request's agent_did holder)
-  ReplicaHolder,  \* the set of non-owning peer replicas (|ReplicaHolder| >= 2)
+  ReplicaHolder,  \* non-owning request-party replicas (never unrelated fleet peers)
   DeltaId,        \* bounded pool of terminal-delta ids (PushLog re-emissions)
   MaxDrops,       \* how many terminal deltas the gossip channel may drop
   MaxCrashes,     \* total node crashes across owner + peers
   TerminalKind,   \* the terminal lifecycle states (e.g. Completed, Failed)
   Cap,            \* per-request re-emit budget (shipping TERMINAL_REDRIVE_CAP):
-                  \* one owner write fans out to every online replicator;
+                  \* one owner write fans out to every online authorized party;
                   \* it occurs AT MOST Cap times without a convergence back-channel
   ReplayOnRecovery, \* TRUE in production: reconnect forces one full replay
   AllowPeerClaim  \* FALSE normally; TRUE arms the adversarial peer-claim action
@@ -59,7 +60,7 @@ LifecycleState == NonTerminal \cup TerminalKind
 
 ASSUME OwnerNotAReplica == Owner \notin ReplicaHolder
 ASSUME ReplicaHolderIsFiniteSet == IsFiniteSet(ReplicaHolder)
-ASSUME AtLeastTwoReplicas == Cardinality(ReplicaHolder) >= 2
+ASSUME ReplicaHolderNonEmpty == ReplicaHolder # {}
 ASSUME DeltaIdIsFiniteSet == IsFiniteSet(DeltaId)
 ASSUME MaxDropsIsNat == MaxDrops \in Nat
 ASSUME MaxCrashesIsNat == MaxCrashes \in Nat
@@ -158,7 +159,7 @@ Terminalize(k) ==
 (***************************************************************************)
 (* Owner terminal re-drive. Abstracts the Rust binding (idempotent         *)
 (* same-value terminal re-assert) as a delta onto the gossip channel,      *)
-(* fanned out to every currently online configured peer.                    *)
+(* fanned out to every currently online authorized request-party peer.      *)
 (*                                                                         *)
 (* Gated by the per-request budget emitCount < Cap — NOT by whether peers   *)
 (* peer has converged. This is the crux of fidelity to the shipping code:   *)
@@ -338,7 +339,8 @@ DeltaIdsTracked ==
   \A d \in AllDeltas : d.id \in deltaIdsUsed
 
 \* The total same-value request writes are bounded by the persisted request
-\* budget. One write may fan out a delivery delta to every online peer.
+\* budget. One write may fan out to every online request-party peer, never
+\* to unrelated fleet pairings.
 StateBound ==
   Cardinality(deltaIdsUsed) <= Cap
 
@@ -380,7 +382,7 @@ Fairness ==
 Spec == Init /\ [][Next]_vars /\ Fairness
 
 (***************************************************************************)
-(* Liveness: owner-terminal converges to every replica holder. Online peers *)
+(* Liveness: owner-terminal converges to every authorized replica holder.   *)
 (* converge through the bounded re-drive when its budget outlasts bounded   *)
 (* delivery loss. A peer partitioned beyond the entire cap converges after  *)
 (* fair recovery through one bounded full replay. The Stuck diagnostic      *)

--- a/crates/defra-agent/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/embedded_impl.rs
@@ -408,9 +408,10 @@ mod tests {
         );
     }
 
-    async fn seed_agent_request(node: &EmbeddedNode, request_id: &str, agent_did: &str) {
+    async fn seed_agent_request(node: &EmbeddedNode, request_id: &str, requester_did: &str) {
         let request_id = escape_graphql_string(request_id);
-        let agent_did = escape_graphql_string(agent_did);
+        let requester_did = escape_graphql_string(requester_did);
+        let agent_did = "did:key:host";
         let session_id = escape_graphql_string(&format!("{request_id}-session"));
         let behavior_id = escape_graphql_string(&format!("{agent_did}:default"));
         let mutation = format!(
@@ -418,6 +419,7 @@ mod tests {
                 create_AgentRequest(input: {{
                     request_id: "{request_id}",
                     agent_did: "{agent_did}",
+                    requester_did: "{requester_did}",
                     behavior_id: "{behavior_id}",
                     session_id: "{session_id}",
                     retry_parent_request: "",
@@ -580,8 +582,8 @@ mod tests {
         let sender_addresses = wait_for_peer_info(&sender_admin).await;
         let receiver_addresses = wait_for_peer_info(&receiver_admin).await;
 
-        seed_agent_request(&sender, "parent-match", "did:key:coord").await;
-        seed_agent_request(&sender, "parent-other", "did:key:other").await;
+        seed_agent_request(&sender, "child-match", "did:key:coord").await;
+        seed_agent_request(&sender, "child-other", "did:key:other").await;
         seed_agent_tool_call(&sender, "bridge-match", "did:key:host").await;
         seed_agent_tool_call(&sender, "bridge-other", "did:key:other").await;
 
@@ -613,7 +615,7 @@ mod tests {
         filters.insert(
             "AgentRequest".to_string(),
             FilterPredicate {
-                field: "agent_did".to_string(),
+                field: "requester_did".to_string(),
                 value: "did:key:coord".to_string(),
             },
         );
@@ -629,14 +631,14 @@ mod tests {
             .await
             .expect("install filtered sender to receiver replicator");
 
-        wait_for_value(&receiver, "AgentRequest", "request_id", "parent-match").await;
+        wait_for_value(&receiver, "AgentRequest", "request_id", "child-match").await;
         wait_for_value(&receiver, "AgentToolCall", "tool_call_id", "bridge-match").await;
 
         let request_ids = collection_values(&receiver, "AgentRequest", "request_id").await;
         let tool_call_ids = collection_values(&receiver, "AgentToolCall", "tool_call_id").await;
         assert_eq!(
             request_ids,
-            BTreeSet::from(["parent-match".to_string()]),
+            BTreeSet::from(["child-match".to_string()]),
             "filtered request replay should not leak non-matching rows"
         );
         assert_eq!(

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -1419,13 +1419,8 @@ mod tests {
         .expect("data-plane coordinator desired")
         .expect("some data-plane layer");
 
-        assert_eq!(
-            desired
-                .replicator_filter
-                .get("AgentRequest")
-                .map(|filter| (filter.field.as_str(), filter.value.as_str())),
-            Some(("agent_did", "did:key:coord"))
-        );
+        assert!(!desired.replicator_filter.contains_key("AgentRequest"));
+        assert_eq!(desired.replicator_collections, set(&["AgentToolCall"]));
         assert_eq!(
             desired
                 .replicator_filter
@@ -1436,7 +1431,7 @@ mod tests {
     }
 
     #[test]
-    fn data_plane_subagent_host_scopes_child_conversation_to_local_host() {
+    fn data_plane_subagent_host_scopes_request_to_signed_requester() {
         let signed_endpoint = NetworkEndpointEntry {
             peer_id: "peer-a".to_string(),
             agent_did: "did:key:coord".to_string(),
@@ -1457,7 +1452,16 @@ mod tests {
         .expect("some data-plane layer");
 
         assert_eq!(desired.replicator_filter.len(), 8);
-        for predicate in desired.replicator_filter.values() {
+        let request = desired
+            .replicator_filter
+            .get("AgentRequest")
+            .expect("request route filter");
+        assert_eq!(request.field, "requester_did");
+        assert_eq!(request.value, "did:key:coord");
+        for (collection, predicate) in &desired.replicator_filter {
+            if collection == "AgentRequest" {
+                continue;
+            }
             assert_eq!(predicate.field, "agent_did");
             assert_eq!(predicate.value, "did:key:host");
         }
@@ -2473,7 +2477,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_coordinator_template_filters_parent_and_bridge_directionally() {
+    fn subagent_coordinator_template_filters_only_targeted_bridge() {
         let desired = desired_from_pairing_row(
             desired_row(Some("subagent-coordinator"), Some("did:key:host")),
             "did:key:coord",
@@ -2482,17 +2486,8 @@ mod tests {
         .expect("some desired layer");
 
         assert!(desired.collections.is_empty());
-        assert_eq!(
-            desired.replicator_collections,
-            set(&["AgentRequest", "AgentToolCall"])
-        );
-        assert_eq!(
-            desired
-                .replicator_filter
-                .get("AgentRequest")
-                .map(|filter| (filter.field.as_str(), filter.value.as_str())),
-            Some(("agent_did", "did:key:coord"))
-        );
+        assert_eq!(desired.replicator_collections, set(&["AgentToolCall"]));
+        assert!(!desired.replicator_filter.contains_key("AgentRequest"));
         assert_eq!(
             desired
                 .replicator_filter
@@ -2503,7 +2498,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_host_template_filters_conversation_to_local_host() {
+    fn subagent_host_template_filters_request_to_requester() {
         let desired = desired_from_pairing_row(
             desired_row(Some("subagent-host"), Some("did:key:coord")),
             "did:key:host",
@@ -2514,7 +2509,16 @@ mod tests {
         assert!(desired.collections.is_empty());
         assert!(desired.replicator_collections.contains("AgentToolCall"));
         assert_eq!(desired.replicator_filter.len(), 8);
-        for predicate in desired.replicator_filter.values() {
+        let request = desired
+            .replicator_filter
+            .get("AgentRequest")
+            .expect("request filter");
+        assert_eq!(request.field, "requester_did");
+        assert_eq!(request.value, "did:key:coord");
+        for (collection, predicate) in &desired.replicator_filter {
+            if collection == "AgentRequest" {
+                continue;
+            }
             assert_eq!(predicate.field, "agent_did");
             assert_eq!(predicate.value, "did:key:host");
         }

--- a/crates/defra-agent/src/agent/p2p_reconcile/templates.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/templates.rs
@@ -155,30 +155,24 @@ pub const NETWORK_CONTROL_COLLECTIONS: &[&str] = &[
     "NetworkJoinRequest",
 ];
 
-/// Coordinator → host leg for subagent delegation: carry the parent request
-/// owned by the coordinator plus bridges addressed to the host.
-const SUBAGENT_COORDINATOR_COLLECTIONS: &[&str] = &["AgentRequest", "AgentToolCall"];
+/// Coordinator → host leg for subagent delegation: carry only bridges
+/// addressed to this host. Coordinator-owned parent requests are not
+/// pair-specific and must not fan out across every host pairing (#683).
+const SUBAGENT_COORDINATOR_COLLECTIONS: &[&str] = &["AgentToolCall"];
 
-const SUBAGENT_COORDINATOR_RULES: &[CollectionRule] = &[
-    CollectionRule {
-        collection: "AgentRequest",
-        field: "agent_did",
-        source: DidSource::LocalDid,
-    },
-    CollectionRule {
-        collection: "AgentToolCall",
-        field: "spawn_target_did",
-        source: DidSource::PeerDid,
-    },
-];
+const SUBAGENT_COORDINATOR_RULES: &[CollectionRule] = &[CollectionRule {
+    collection: "AgentToolCall",
+    field: "spawn_target_did",
+    source: DidSource::PeerDid,
+}];
 
 /// Host → coordinator leg for subagent completion: carry the host-owned
 /// conversation slice, including child tool calls.
 const SUBAGENT_HOST_RULES: &[CollectionRule] = &[
     CollectionRule {
         collection: "AgentRequest",
-        field: "agent_did",
-        source: DidSource::LocalDid,
+        field: "requester_did",
+        source: DidSource::PeerDid,
     },
     CollectionRule {
         collection: "AgentResponse",
@@ -467,13 +461,7 @@ mod tests {
         assert_eq!(t.delivery, Delivery::Push);
         assert_eq!(t.collections, SUBAGENT_COORDINATOR_COLLECTIONS);
         let f = scope_filter(&t.scope, t.collections, "did:key:host", "did:key:coord");
-        assert_eq!(
-            f.get("AgentRequest"),
-            Some(&FilterPredicate {
-                field: "agent_did".to_string(),
-                value: "did:key:coord".to_string(),
-            })
-        );
+        assert!(!f.contains_key("AgentRequest"));
         assert_eq!(
             f.get("AgentToolCall"),
             Some(&FilterPredicate {
@@ -484,15 +472,26 @@ mod tests {
     }
 
     #[test]
-    fn subagent_host_filters_conversation_on_local_owner() {
+    fn subagent_host_filters_requests_on_requester_and_rest_on_local_owner() {
         let t = resolve_template(SUBAGENT_HOST_TEMPLATE).unwrap();
         assert_eq!(t.delivery, Delivery::Push);
         assert_eq!(t.collections, CONVERSATION_COLLECTIONS);
         let f = scope_filter(&t.scope, t.collections, "did:key:coord", "did:key:host");
         assert_eq!(f.len(), CONVERSATION_COLLECTIONS.len());
-        for col in CONVERSATION_COLLECTIONS {
+        assert_eq!(
+            f.get("AgentRequest"),
+            Some(&FilterPredicate {
+                field: "requester_did".to_string(),
+                value: "did:key:coord".to_string(),
+            })
+        );
+        for col in CONVERSATION_COLLECTIONS
+            .iter()
+            .copied()
+            .filter(|collection| *collection != "AgentRequest")
+        {
             assert_eq!(
-                f.get(*col),
+                f.get(col),
                 Some(&FilterPredicate {
                     field: "agent_did".to_string(),
                     value: "did:key:host".to_string(),

--- a/crates/defra-agent/src/hook/persistence/message_spawn.rs
+++ b/crates/defra-agent/src/hook/persistence/message_spawn.rs
@@ -641,7 +641,7 @@ impl DefraSessionHook {
             }
         }
 
-        if parent_context.subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
+        if parent_context.subagent_depth >= MAX_SUBAGENT_DEPTH {
             return self
                 .fail_spawn_subagent_tool_call(
                     session_id,

--- a/crates/defra-agent/src/hook/persistence/message_spawn.rs
+++ b/crates/defra-agent/src/hook/persistence/message_spawn.rs
@@ -658,10 +658,9 @@ impl DefraSessionHook {
 
         // Persist a normalized bridge args payload that carries the RESOLVED
         // target `(agent_did, behavior_id)` alongside the model-facing `name`.
-        // `SubagentSource` reads these resolved fields directly, so the child
-        // `AgentRequest` is written with the TARGET's agent_did + behavior_id
-        // -- for a remote target this is the remote DID, and out-of-band
-        // replication carries the child to the owning node. The claiming
+        // `SubagentSource` reads these resolved fields directly. For a remote
+        // target, the targeted bridge reaches that host and the host writes the
+        // child `AgentRequest` with its local DID + behavior id. The claiming
         // deployment never needs to re-resolve the friendly name (it has no
         // access to the parent's target table), which is what removes the
         // resolution seam.
@@ -672,6 +671,7 @@ impl DefraSessionHook {
             "behavior_id": target.behavior_id,
             "prompt": parsed.prompt,
             "deadline": parsed.deadline,
+            "parent_subagent_depth": parent_context.subagent_depth,
         })
         .to_string();
 

--- a/crates/defra-agent/src/hook/persistence/orchestration.rs
+++ b/crates/defra-agent/src/hook/persistence/orchestration.rs
@@ -236,7 +236,7 @@ impl DefraSessionHook {
                 ),
             ));
         }
-        if parent_context.subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
+        if parent_context.subagent_depth >= MAX_SUBAGENT_DEPTH {
             return Some((
                 FailureClass::ArgumentInvalid,
                 depth_exceeded_payload(parent_context.subagent_depth),

--- a/crates/defra-agent/src/hook/persistence/orchestration.rs
+++ b/crates/defra-agent/src/hook/persistence/orchestration.rs
@@ -696,6 +696,7 @@ impl DefraSessionHook {
             "behavior_id": spec.behavior_id,
             "prompt": spec.prompt,
             "deadline": serde_json::Value::Null,
+            "parent_subagent_depth": parent_context.subagent_depth,
         })
         .to_string();
 

--- a/crates/defra-agent/src/lifecycle/recovery.rs
+++ b/crates/defra-agent/src/lifecycle/recovery.rs
@@ -27,17 +27,19 @@ impl RequestLifecycle {
 
     /// Owner-scoped terminal-convergence re-drive (#664).
     ///
-    /// Under `subagent-host` replication an `AgentRequest` is replicated onto
-    /// non-owning peers. Safety already holds (the watcher `agent_did` filter
-    /// never lets a peer claim a foreign replica), but liveness does not: when
-    /// the owner terminalizes, the terminal delta reaches replicas via a single
-    /// one-shot PushLog that can drop, and there is no per-doc anti-entropy on a
-    /// running peer (defradb.rs#1074) to re-request it. This re-drive is the
-    /// owner side of the fix — periodically re-asserting the current terminal
-    /// value of recently-terminalized own-requests. A same-value re-write is a
-    /// genuine higher-priority CRDT delta (it does not no-op), so it flows
-    /// through the normal PushLog path and a lagging replica accepts it (LWW,
-    /// higher priority ⇒ applied).
+    /// Under `subagent-host` replication a routed `AgentRequest` is replicated
+    /// to its `requester_did` peer. Safety already holds (the watcher
+    /// `agent_did` filter never lets that peer claim a foreign replica), but
+    /// liveness does not: when the owner terminalizes, the terminal delta
+    /// reaches the requester via a single one-shot PushLog that can drop, and
+    /// there is no per-doc anti-entropy on a running peer (defradb.rs#1074) to
+    /// re-request it. This re-drive is the owner side of the fix — periodically
+    /// re-asserting the current terminal value of recently-terminalized routed
+    /// requests. Local-only requests are excluded because no peer consumes
+    /// their request state (#683). A same-value re-write is a genuine
+    /// higher-priority CRDT delta (it does not no-op), so it flows through the
+    /// normal PushLog path and a lagging requester accepts it (LWW, higher
+    /// priority ⇒ applied).
     ///
     /// BOUNDED, NOT CONVERGENCE-OBSERVING. The owner has no back-channel telling
     /// it whether a peer caught up. Each successful re-assert atomically advances
@@ -52,8 +54,9 @@ impl RequestLifecycle {
     /// `agent_did` MUST be the runtime's own DID: only the owner re-asserts its
     /// own documents; peers stay passive (a peer-authored delta to a foreign doc
     /// would fork the CRDT, not converge it). `agent_did` itself is never
-    /// written (it is `@immutable`); only the mutable terminal `status` and
-    /// `lifecycle_state` columns are re-asserted, to their current values.
+    /// written (it is `@immutable`); only the mutable terminal `status`,
+    /// `lifecycle_state`, and bounded attempt counter are written together in
+    /// one document update.
     ///
     pub async fn redrive_terminal_convergence(
         node: &EmbeddedNode,
@@ -66,6 +69,7 @@ impl RequestLifecycle {
                 AgentRequest(
                     filter: {{
                         agent_did: {{ _eq: "{escaped_agent_did}" }},
+                        requester_did: {{ _neq: null }},
                         lifecycle_state: {{ _in: {terminal_states} }},
                         terminal_redrive_attempts: {{ _lt: {cap} }}
                     }},
@@ -138,6 +142,7 @@ impl RequestLifecycle {
                         filter: {{
                             _docID: {{ _eq: "{escaped_doc_id}" }},
                             agent_did: {{ _eq: "{escaped_agent_did}" }},
+                            requester_did: {{ _neq: null }},
                             lifecycle_state: {{ _eq: "{escaped_lifecycle_state}" }},
                             terminal_redrive_attempts: {{ _eq: {attempts} }}
                         }},

--- a/crates/defra-agent/src/migration.rs
+++ b/crates/defra-agent/src/migration.rs
@@ -46,6 +46,11 @@ const ADD_AGENT_REQUEST_TERMINALIZED_AT_FIELD: &str =
     r#"{"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"terminalized_at","Kind":11}}"#;
 const ADD_AGENT_REQUEST_TERMINAL_REDRIVE_ATTEMPTS_FIELD: &str = r#"{"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"terminal_redrive_attempts","Kind":4}}"#;
 
+// #683 request-party routing. `requester_did` is written only when a remote
+// paired coordinator causes a host-owned child request. It is an immutable
+// filter key so a request cannot drift between peer scopes after creation.
+const ADD_AGENT_REQUEST_REQUESTER_DID_FIELD: &str = r#"{"op":"add","path":"/AgentRequest/Fields/-","value":{"Name":"requester_did","Kind":11,"Immutable":true}}"#;
+
 // Kind 21 == ScalarArrayKind::NillableStringArray in defradb.rs. The SDL
 // `[String]` (nullable elements) for these fields compiles to that kind, so the
 // migration patch must use it. The previous value of 17 was a stale Go-DefraDB
@@ -1633,6 +1638,53 @@ pub async fn ensure_agent_request_terminal_durability_migrations(
     Ok(())
 }
 
+/// Add and validate the immutable request-party routing key (#683).
+///
+/// Existing rows remain null: the pinned DefraDB correctly rejects null-to-
+/// value writes on a patch-added immutable field, so legacy documents cannot
+/// be reclassified into a peer scope. New cross-deployment children stamp the
+/// key at create time.
+pub async fn ensure_agent_request_requester_did_migration(node: Arc<EmbeddedNode>) -> Result<()> {
+    let Some(collection) = node
+        .get_collection("AgentRequest")
+        .context("get AgentRequest collection")?
+    else {
+        return Ok(());
+    };
+
+    ensure_field_kind_matches_reference(
+        &collection,
+        "AgentRequest",
+        "requester_did",
+        &["agent_did"],
+        "String",
+    )?;
+
+    if collection_has_field(&collection, "requester_did") {
+        anyhow::ensure!(
+            field_is_immutable(&collection, "requester_did"),
+            "AgentRequest.requester_did exists but is not immutable; filtered request-party replication cannot be installed safely"
+        );
+        return Ok(());
+    }
+
+    let next = node
+        .patch_collection(
+            "AgentRequest",
+            &format!("[{ADD_AGENT_REQUEST_REQUESTER_DID_FIELD}]"),
+        )
+        .await
+        .context("patch_collection AgentRequest requester_did")?;
+    node.set_active_collection_version(&next.version_id)
+        .await
+        .context("set_active_collection_version AgentRequest requester_did")?;
+    tracing::info!(
+        version = %next.version_id,
+        "AgentRequest patched with immutable requester_did route key"
+    );
+    Ok(())
+}
+
 /// Backfill terminal scheduling metadata for requests owned by `agent_did`.
 ///
 /// The owner filter is present on both the page query and each guarded update:
@@ -2182,6 +2234,9 @@ pub async fn ensure_all_runtime_migrations(node: Arc<EmbeddedNode>) -> Result<()
     ensure_agent_response_reasoning_progress_migration(node.clone())
         .await
         .context("ensure AgentResponse reasoning progress migration")?;
+    ensure_agent_request_requester_did_migration(node.clone())
+        .await
+        .context("ensure AgentRequest requester_did migration")?;
     ensure_agent_request_terminal_durability_migrations(node.clone())
         .await
         .context("ensure AgentRequest terminal durability migrations")?;
@@ -2632,6 +2687,18 @@ mod patch_kind_tests {
             terminalized_at: String
         }
     "#;
+    const MUTABLE_REQUESTER_DID_AGENT_REQUEST_SCHEMA: &str = r#"
+        type AgentRequest @branchable {
+            request_id: String @index
+            agent_did: String @index
+            requester_did: String @index
+            session_id: String @index
+            content: String
+            status: String @index
+            lifecycle_state: String @index
+            created_at: String @index
+        }
+    "#;
     const CORRUPTED_TERMINALIZED_AT_AGENT_REQUEST_SCHEMA: &str = r#"
         type AgentRequest @branchable {
             request_id: String @index
@@ -2708,6 +2775,83 @@ mod patch_kind_tests {
             created_at: DateTime @index(direction: DESC)
         }
     "#;
+
+    #[tokio::test]
+    async fn requester_did_migration_adds_an_immutable_route_key() {
+        let node = test_node().await;
+        node.add_schema(OLD_AGENT_REQUEST_SCHEMA).await.unwrap();
+
+        ensure_agent_request_requester_did_migration(node.clone())
+            .await
+            .unwrap();
+        ensure_agent_request_requester_did_migration(node.clone())
+            .await
+            .unwrap();
+
+        let collection = node
+            .get_collection("AgentRequest")
+            .unwrap()
+            .expect("AgentRequest collection");
+        assert!(collection_has_field(&collection, "requester_did"));
+        assert!(field_is_immutable(&collection, "requester_did"));
+        assert_eq!(
+            field_kind_value(&collection, "requester_did"),
+            field_kind_value(&collection, "agent_did")
+        );
+
+        let create = node
+            .execute(
+                r#"mutation {
+                    create_AgentRequest(input: {
+                        request_id: "requester-route-key",
+                        agent_did: "did:defra-agent:host",
+                        requester_did: "did:defra-agent:coordinator",
+                        session_id: "requester-route-session",
+                        content: "hello",
+                        status: "pending",
+                        lifecycle_state: "pending",
+                        created_at: "2026-07-10T00:00:00Z"
+                    }) { _docID }
+                }"#,
+            )
+            .await;
+        assert!(
+            !create.has_errors(),
+            "create routed request: {:?}",
+            create.errors
+        );
+
+        let rewrite = node
+            .execute(
+                r#"mutation {
+                    update_AgentRequest(
+                        filter: { request_id: { _eq: "requester-route-key" } },
+                        input: { requester_did: "did:defra-agent:other" }
+                    ) { _docID }
+                }"#,
+            )
+            .await;
+        assert!(
+            rewrite.has_errors(),
+            "requester_did must remain immutable after creation"
+        );
+    }
+
+    #[tokio::test]
+    async fn requester_did_migration_rejects_a_mutable_existing_field() {
+        let node = test_node().await;
+        node.add_schema(MUTABLE_REQUESTER_DID_AGENT_REQUEST_SCHEMA)
+            .await
+            .unwrap();
+
+        let error = ensure_agent_request_requester_did_migration(node)
+            .await
+            .expect_err("mutable route key must fail closed");
+        assert!(
+            format!("{error:#}").contains("not immutable"),
+            "migration must explain unsafe route-key mutability: {error:#}"
+        );
+    }
 
     #[tokio::test]
     async fn terminal_durability_backfill_is_owner_scoped_and_resumable() {

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -162,9 +162,14 @@ async fn create_subagent_request_inner(
     requester_did: Option<String>,
 ) -> Result<String> {
     // 1. Depth check (pure precondition, fires before any DB I/O).
-    if parent_subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
+    if parent_subagent_depth >= MAX_SUBAGENT_DEPTH {
         return Err(anyhow!(IllegalToolCallTransition::SubagentDepthExceeded));
     }
+
+    // Normalize the immutable route key before validating and persisting it.
+    // A whitespace-padded DID must not create a request that can never match
+    // the paired peer's exact replication filter.
+    let requester_did = requester_did.map(|did| did.trim().to_owned());
 
     // 2. Coherence check (pure precondition, fires before any DB I/O).
     if request_id.is_empty() || parent_request_id.is_empty() || parent_tool_call_id.is_empty() {
@@ -180,10 +185,7 @@ async fn create_subagent_request_inner(
         if parent_agent_did.as_deref() != Some(agent_did.as_str()) {
             return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
         }
-    } else if requester_did
-        .as_deref()
-        .is_none_or(|did| did.trim().is_empty())
-    {
+    } else if requester_did.as_deref().is_none_or(str::is_empty) {
         return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
     }
 

--- a/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
+++ b/crates/defra-agent/src/tool_call_lifecycle/subagent_request.rs
@@ -69,8 +69,10 @@ pub async fn create_subagent_request(
 ///      well-formedness invariant in `watcher.rs::validate_subagent_fields`
 ///      requires that `subagent_depth > 0` documents have both fields
 ///      populated.)
-///   3. `parent_request_id` resolves to an existing `AgentRequest` owned by
-///      the same `agent_did` as the child request.
+///   3. On the same-node path, `parent_request_id` resolves to an existing
+///      `AgentRequest` owned by the same `agent_did` as the child request. The
+///      trusted cross-deployment path instead requires a non-empty requester
+///      DID and treats the targeted bridge as the durable parent edge.
 ///
 /// On success returns the child `request_id`.
 ///
@@ -107,13 +109,15 @@ pub async fn create_subagent_request_with_request_id(
         prompt,
         deadline,
         true,
+        None,
     )
     .await
 }
 
-/// Create a subagent request whose parent was authored by a trusted paired
-/// peer. R5 uses this on the claiming deployment: the child is locally owned,
-/// while the replicated parent request keeps the paired peer's DID.
+/// Create a subagent request from a targeted bridge authored by a trusted
+/// paired peer. The child is locally owned and routes lifecycle state back to
+/// `requester_did`; the coordinator parent request is intentionally not
+/// replicated to the host (#683).
 #[allow(clippy::too_many_arguments)]
 pub async fn create_subagent_request_with_trusted_parent_request_id(
     node: &EmbeddedNode,
@@ -125,6 +129,7 @@ pub async fn create_subagent_request_with_trusted_parent_request_id(
     behavior_id: String,
     prompt: String,
     deadline: Option<DateTime<Utc>>,
+    requester_did: String,
 ) -> Result<String> {
     create_subagent_request_inner(
         node,
@@ -137,6 +142,7 @@ pub async fn create_subagent_request_with_trusted_parent_request_id(
         prompt,
         deadline,
         false,
+        Some(requester_did),
     )
     .await
 }
@@ -153,6 +159,7 @@ async fn create_subagent_request_inner(
     prompt: String,
     deadline: Option<DateTime<Utc>>,
     require_parent_agent_match: bool,
+    requester_did: Option<String>,
 ) -> Result<String> {
     // 1. Depth check (pure precondition, fires before any DB I/O).
     if parent_subagent_depth + 1 > MAX_SUBAGENT_DEPTH {
@@ -164,10 +171,19 @@ async fn create_subagent_request_inner(
         return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
     }
 
-    // 3. Cross-reference check (R3): the parent link must point at a real
-    // AgentRequest before the child can be materialized.
-    let parent_agent_did = parent_request_agent_did(node, &parent_request_id).await?;
-    if require_parent_agent_match && parent_agent_did.as_deref() != Some(agent_did.as_str()) {
+    // 3. Same-node children cross-reference the local parent row. A trusted
+    // cross-deployment child instead uses the targeted, owner-authored bridge
+    // as its durable parent edge; copying the entire parent request to every
+    // possible host is neither necessary nor pair-scoped (#683).
+    if require_parent_agent_match {
+        let parent_agent_did = parent_request_agent_did(node, &parent_request_id).await?;
+        if parent_agent_did.as_deref() != Some(agent_did.as_str()) {
+            return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
+        }
+    } else if requester_did
+        .as_deref()
+        .is_none_or(|did| did.trim().is_empty())
+    {
         return Err(anyhow!(IllegalToolCallTransition::ParentLinkageIncoherent));
     }
 
@@ -178,6 +194,11 @@ async fn create_subagent_request_inner(
 
     let escaped_request_id = escape_graphql_string(&request_id);
     let escaped_agent_did = escape_graphql_string(&agent_did);
+    let requester_field = requester_did
+        .as_deref()
+        .map(escape_graphql_string)
+        .map(|did| format!("requester_did: \"{did}\","))
+        .unwrap_or_default();
     let escaped_behavior_id = escape_graphql_string(&behavior_id);
     let escaped_session_id = escape_graphql_string(&new_session_id);
     let prompt_selection = crate::skills::prompt_slash_skill_selection(&prompt);
@@ -198,7 +219,7 @@ async fn create_subagent_request_inner(
         })
         .unwrap_or_default();
 
-    // 4. Build and execute the CREATE mutation. Mirrors the field shape
+    // 5. Build and execute the CREATE mutation. Mirrors the field shape
     // of `write_pending_agent_request_with_lineage_and_conversation_title`
     // in `lifecycle/materialize.rs`, plus the three subagent fields.
     let mutation = format!(
@@ -206,6 +227,7 @@ async fn create_subagent_request_inner(
             create_AgentRequest(input: {{
                 request_id: "{escaped_request_id}",
                 agent_did: "{escaped_agent_did}",
+                {requester_field}
                 behavior_id: "{escaped_behavior_id}",
                 session_id: "{escaped_session_id}",
                 retry_parent_request: "",
@@ -315,10 +337,10 @@ mod tests {
         // Allowed parent depths: 0, 1, 2 (resulting children: 1, 2, 3).
         // Rejected parent depths: 3 and above.
         for parent_depth in 0..=2 {
-            assert!(parent_depth + 1 <= MAX_SUBAGENT_DEPTH);
+            assert!(parent_depth < MAX_SUBAGENT_DEPTH);
         }
         for parent_depth in 3..=10 {
-            assert!(parent_depth + 1 > MAX_SUBAGENT_DEPTH);
+            assert!(parent_depth >= MAX_SUBAGENT_DEPTH);
         }
     }
 

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -168,6 +168,10 @@ impl CrossDeploymentCancelMirror {
                 return Ok(());
             }
         }
+        // This seam handles only cross-deployment cancellation, so the
+        // targeted bridge is authoritative. The parent row is a legacy
+        // coherence check/fallback; SubagentSource intentionally remains
+        // parent-first only for its same-node legacy materialization path.
         let Some(parent_did) = bridge_authoring_did.or(parent_authoring_did) else {
             return Ok(());
         };

--- a/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
+++ b/crates/defra-agent/src/trigger_engine/cross_deployment_cancel_mirror.rs
@@ -152,7 +152,23 @@ impl CrossDeploymentCancelMirror {
             return Ok(());
         }
 
-        let Some(parent_did) = self.load_parent_authoring_did(&row.request_id).await? else {
+        let bridge_authoring_did = non_empty(row.agent_did.as_deref()).map(ToOwned::to_owned);
+        let parent_authoring_did = self.load_parent_authoring_did(&row.request_id).await?;
+        if let (Some(bridge_did), Some(parent_did)) = (
+            bridge_authoring_did.as_deref(),
+            parent_authoring_did.as_deref(),
+        ) {
+            if bridge_did != parent_did {
+                tracing::warn!(
+                    bridge_agent_did = %bridge_did,
+                    parent_agent_did = %parent_did,
+                    parent_request_id = %row.request_id,
+                    "cancel mirror rejected incoherent bridge author"
+                );
+                return Ok(());
+            }
+        }
+        let Some(parent_did) = bridge_authoring_did.or(parent_authoring_did) else {
             return Ok(());
         };
         let snapshot = self.snapshot_rx.borrow().clone();
@@ -210,6 +226,7 @@ impl CrossDeploymentCancelMirror {
                     limit: 1
                 ) {{
                     request_id
+                    agent_did
                     tool_call_id
                     child_request_id
                     cancel_cascade_intent_at
@@ -330,9 +347,18 @@ struct DocIdRow {
 #[derive(Debug, Deserialize)]
 struct BridgeCancelRow {
     request_id: String,
+    #[serde(default)]
+    agent_did: Option<String>,
     tool_call_id: String,
     child_request_id: Option<String>,
     cancel_cascade_intent_at: Option<String>,
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -425,23 +451,7 @@ mod tests {
         })
     }
 
-    async fn write_parent_and_bridge(node: &EmbeddedNode) {
-        exec(
-            node,
-            r#"mutation {
-                create_AgentRequest(input: {
-                    request_id: "parent-request",
-                    agent_did: "did:defra-agent:parent",
-                    behavior_id: "parent-behavior",
-                    session_id: "parent-session",
-                    content: "parent",
-                    status: "interrupted",
-                    lifecycle_state: "interrupted",
-                    created_at: "2026-05-15T00:00:00Z"
-                }) { _docID }
-            }"#,
-        )
-        .await;
+    async fn write_targeted_bridge_without_parent(node: &EmbeddedNode) {
         exec(
             node,
             r#"mutation {
@@ -449,6 +459,7 @@ mod tests {
                     tool_call_key: "parent-request:spawn",
                     request_id: "parent-request",
                     session_id: "parent-session",
+                    agent_did: "did:defra-agent:parent",
                     message_sequence: 1,
                     tool_name: "spawn_subagent",
                     tool_call_id: "spawn",
@@ -477,6 +488,7 @@ mod tests {
                 create_AgentRequest(input: {
                     request_id: "child-request",
                     agent_did: "did:defra-agent:child",
+                    requester_did: "did:defra-agent:parent",
                     behavior_id: "child-behavior",
                     session_id: "child-session",
                     content: "child",
@@ -520,7 +532,7 @@ mod tests {
     #[tokio::test]
     async fn pending_intent_is_retried_after_child_request_arrives() {
         let node = test_node().await;
-        write_parent_and_bridge(node.as_ref()).await;
+        write_targeted_bridge_without_parent(node.as_ref()).await;
         let (_tx, rx) = watch::channel(snapshot());
         let cancel = CancellationToken::new();
         let mut mirror = CrossDeploymentCancelMirror::new(node.clone(), rx, cancel);

--- a/crates/defra-agent/src/trigger_engine/subagent_source.rs
+++ b/crates/defra-agent/src/trigger_engine/subagent_source.rs
@@ -538,6 +538,9 @@ impl SubagentSource {
 
         let parent = self.load_parent_request(&parent_request_id).await?;
         let snapshot = self.snapshot_rx.borrow().clone();
+        // SECURITY (#377): under the current replication-trust posture this
+        // self-declared bridge DID is trusted once it names a configured paired
+        // peer; ACP signing must eventually bind it to the actual remote author.
         let bridge_authoring_did = non_empty(row.agent_did.as_deref()).map(ToOwned::to_owned);
         if let (Some(bridge_did), Some(parent_did)) = (
             bridge_authoring_did.as_deref(),

--- a/crates/defra-agent/src/trigger_engine/subagent_source.rs
+++ b/crates/defra-agent/src/trigger_engine/subagent_source.rs
@@ -58,6 +58,8 @@ struct ToolCallRow {
     tool_call_key: Option<String>,
     #[serde(default)]
     request_id: Option<String>,
+    #[serde(default)]
+    agent_did: Option<String>,
     tool_call_id: String,
     #[serde(default)]
     tool_name: String,
@@ -149,6 +151,10 @@ struct SpawnArgs {
     prompt: String,
     #[serde(default)]
     deadline: Option<String>,
+    /// Parent depth copied into the targeted bridge so a remote host can
+    /// enforce the recursion bound without receiving the parent request.
+    #[serde(default)]
+    parent_subagent_depth: Option<u32>,
 }
 
 impl SpawnArgs {
@@ -264,6 +270,7 @@ impl SubagentSource {
                     _docID
                     tool_call_key
                     request_id
+                    agent_did
                     tool_call_id
                     tool_name
                     args
@@ -529,13 +536,33 @@ impl SubagentSource {
             .and_then(AwaitMode::from_persisted)
             .unwrap_or(AwaitMode::Foreground);
 
-        let Some(parent) = self.load_parent_request(&parent_request_id).await? else {
-            anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
-        };
-
+        let parent = self.load_parent_request(&parent_request_id).await?;
         let snapshot = self.snapshot_rx.borrow().clone();
-        let parent_authoring_did = parent.agent_did.clone();
+        let bridge_authoring_did = non_empty(row.agent_did.as_deref()).map(ToOwned::to_owned);
+        if let (Some(bridge_did), Some(parent_did)) = (
+            bridge_authoring_did.as_deref(),
+            parent.as_ref().map(|parent| parent.agent_did.as_str()),
+        ) {
+            // A paired-peer bridge is a remote authority boundary, so its DID
+            // must agree with any legacy parent replica still present. Local
+            // legacy rows predate that invariant and keep using the parent row
+            // as their authority.
+            if bridge_did != parent_did
+                && (snapshot.paired_peer_dids.contains(bridge_did)
+                    || snapshot.paired_peer_dids.contains(parent_did))
+            {
+                anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
+            }
+        }
+        let parent_authoring_did = parent
+            .as_ref()
+            .map(|parent| parent.agent_did.clone())
+            .or(bridge_authoring_did)
+            .ok_or(IllegalToolCallTransition::ParentLinkageIncoherent)?;
         let trusted_paired_peer = snapshot.paired_peer_dids.contains(&parent_authoring_did);
+        if parent.is_none() && !trusted_paired_peer {
+            anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
+        }
         let tool_name = non_empty(Some(&row.tool_name)).unwrap_or("spawn_subagent");
         if trusted_paired_peer {
             let local_did = snapshot.local_did.trim();
@@ -682,7 +709,7 @@ impl SubagentSource {
                 .as_deref()
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
-                .unwrap_or_else(|| parent.agent_did.trim());
+                .unwrap_or_else(|| parent_authoring_did.trim());
             if local_did.is_empty() || target_owner_did != local_did {
                 tracing::debug!(
                     parent_request_id = %parent_request_id,
@@ -701,10 +728,25 @@ impl SubagentSource {
             return Ok(None);
         }
 
-        let parent_depth = parent
-            .subagent_depth
-            .and_then(|depth| u32::try_from(depth).ok())
-            .unwrap_or(0);
+        let row_parent_depth = parent
+            .as_ref()
+            .and_then(|parent| parent.subagent_depth)
+            .and_then(|depth| u32::try_from(depth).ok());
+        if let (Some(bridge_depth), Some(row_depth)) =
+            (spawn_args.parent_subagent_depth, row_parent_depth)
+        {
+            if bridge_depth != row_depth {
+                anyhow::bail!(IllegalToolCallTransition::ParentLinkageIncoherent);
+            }
+        }
+        let parent_depth = spawn_args
+            .parent_subagent_depth
+            .or(row_parent_depth)
+            // Legacy same-node parent rows may omit the root depth; preserve
+            // the former `unwrap_or(0)` interpretation. A remote bridge with
+            // no parent row must carry the depth explicitly.
+            .or_else(|| parent.as_ref().map(|_| 0))
+            .ok_or(IllegalToolCallTransition::ParentLinkageIncoherent)?;
         let deadline =
             effective_deadline(row.deadline_at.as_deref(), spawn_args.deadline.as_deref());
         // The trusted-paired-peer claiming path takes local ownership; otherwise
@@ -713,7 +755,7 @@ impl SubagentSource {
         let child_agent_did = if trusted_paired_peer && !snapshot.local_did.trim().is_empty() {
             snapshot.local_did.clone()
         } else {
-            resolved_target_did.unwrap_or_else(|| parent.agent_did.clone())
+            resolved_target_did.unwrap_or_else(|| parent_authoring_did.clone())
         };
         let request_id = if trusted_paired_peer {
             create_subagent_request_with_trusted_parent_request_id(
@@ -726,6 +768,7 @@ impl SubagentSource {
                 spawn_args.behavior_id.clone(),
                 spawn_args.prompt.clone(),
                 deadline,
+                parent_authoring_did.clone(),
             )
             .await?
         } else {
@@ -792,21 +835,25 @@ impl SubagentSource {
                 }
             };
             // Parent interrupt latch — the exact signal the live cascade fires on.
-            let parent_interrupted = match crate::interrupt::fetch_interrupt_requested_at(
-                &self.node,
-                &parent_request_id,
-            )
-            .await
-            {
-                Ok(value) => value.is_some(),
-                Err(error) => {
-                    tracing::warn!(
-                        parent_request_id = %parent_request_id,
-                        %error,
-                        "subagent source failed to re-read parent interrupt latch after child create; assuming not interrupted",
-                    );
-                    false
+            let parent_interrupted = if parent.is_some() {
+                match crate::interrupt::fetch_interrupt_requested_at(&self.node, &parent_request_id)
+                    .await
+                {
+                    Ok(value) => value.is_some(),
+                    Err(error) => {
+                        tracing::warn!(
+                            parent_request_id = %parent_request_id,
+                            %error,
+                            "subagent source failed to re-read parent interrupt latch after child create; assuming not interrupted",
+                        );
+                        false
+                    }
                 }
+            } else {
+                // #683: the remote parent request is intentionally absent. Its
+                // targeted bridge is the cancellation channel and was re-read
+                // immediately above.
+                false
             };
             // The parent may have reached a CANCEL-WORTHY terminal state
             // (error/superseded/dead/interrupted — NOT clean `completed`) in the
@@ -814,20 +861,21 @@ impl SubagentSource {
             // cascade treats these as Failed/Cancelled and interrupts the Cascade
             // child; mirror that here. A vanished parent row is treated as
             // cancel-worthy so the orphan is reclaimed.
-            let parent_cancel_worthy_terminal = match self
-                .load_parent_terminal(&parent_request_id)
-                .await
-            {
-                Ok(Some(row)) => parent_reached_cancel_worthy_terminal(&row),
-                Ok(None) => true,
-                Err(error) => {
-                    tracing::warn!(
-                        parent_request_id = %parent_request_id,
-                        %error,
-                        "subagent source failed to re-read parent terminal state after child create; assuming not terminal",
-                    );
-                    false
+            let parent_cancel_worthy_terminal = if parent.is_some() {
+                match self.load_parent_terminal(&parent_request_id).await {
+                    Ok(Some(row)) => parent_reached_cancel_worthy_terminal(&row),
+                    Ok(None) => true,
+                    Err(error) => {
+                        tracing::warn!(
+                            parent_request_id = %parent_request_id,
+                            %error,
+                            "subagent source failed to re-read parent terminal state after child create; assuming not terminal",
+                        );
+                        false
+                    }
                 }
+            } else {
+                false
             };
             if bridge_cancelled || parent_interrupted || parent_cancel_worthy_terminal {
                 tracing::info!(

--- a/crates/defra-agent/tests/conformance/cancel_propagation.rs
+++ b/crates/defra-agent/tests/conformance/cancel_propagation.rs
@@ -1,7 +1,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use defra_agent::agent::p2p_reconcile::resolve_template;
+use defra_agent::agent::p2p_reconcile::{
+    resolve_template, EmbeddedRemoteP2pAdmin, FilterPredicate, PairingFilters, RemoteP2pAdmin,
+};
 use defra_agent::background_completion::{observe_cancel_cascade_ack, CancelAckOutcome};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
@@ -186,14 +188,13 @@ async fn drive_declarative_cancel_propagation() {
     );
     bridge.start_running().await.expect("persist bridge");
 
-    let replicated_bridge = wait_for_bridge(
+    let replicated_bridge = replay_and_wait_for_bridge(
         host.db.node.as_ref(),
+        coord_node.clone(),
+        &host_addr,
+        &host_did,
         parent_session_id,
         parent_tool_call_id,
-        // A selective CAR lookup can consume a full 30s transport attempt.
-        // Allow multiple bounded attempts plus persisted backoff/scheduler
-        // margin under the saturated package suite (defradb.rs#1101).
-        Duration::from_secs(120),
     )
     .await;
     assert_eq!(
@@ -576,6 +577,60 @@ async fn wait_for_bridge(
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
+}
+
+async fn replay_and_wait_for_bridge(
+    receiver: &EmbeddedNode,
+    sender: Arc<EmbeddedNode>,
+    receiver_addr: &str,
+    receiver_did: &str,
+    session_id: &str,
+    tool_call_id: &str,
+) -> BridgeRow {
+    // The pinned DefraDB selective-CAR path can strand the initial targeted
+    // push (#1101). Production pairing recovery repairs that state by
+    // reinstalling the replicator, which triggers a bounded full replay. Make
+    // that recovery deterministic here: ordinary initial delivery is covered
+    // by the R5 and filtered-replay suites, while this fixture must isolate
+    // application-level cancellation from #1101. The coordinator daemon is
+    // deliberately stopped so its background-completion loop cannot consume
+    // the synthetic remote child.
+    let admin = EmbeddedRemoteP2pAdmin::new(sender);
+    let collections = vec!["AgentToolCall".to_string()];
+    let replicators = admin
+        .list_replicators()
+        .await
+        .expect("list coordinator replicators for bridge replay");
+    if let Some(existing) = replicators
+        .into_iter()
+        .find(|replicator| replicator.address.as_deref() == Some(receiver_addr))
+    {
+        let id = existing.id.unwrap_or_else(|| receiver_addr.to_string());
+        let old_collections = if existing.collections.is_empty() {
+            collections.clone()
+        } else {
+            existing.collections
+        };
+        admin
+            .delete_replicator(&id, &old_collections)
+            .await
+            .expect("remove coordinator replicator for bridge replay");
+    }
+
+    let mut filters = PairingFilters::new();
+    filters.insert(
+        "AgentToolCall".to_string(),
+        FilterPredicate {
+            field: "spawn_target_did".to_string(),
+            value: receiver_did.to_string(),
+        },
+    );
+    admin
+        .add_replicator(&[receiver_addr.to_string()], &collections, &filters)
+        .await
+        .expect("reinstall coordinator replicator for bridge replay");
+
+    wait_for_bridge(receiver, session_id, tool_call_id, Duration::from_secs(60)).await
 }
 
 async fn wait_for_bridge_cancel_intent(

--- a/crates/defra-agent/tests/conformance/cancel_propagation.rs
+++ b/crates/defra-agent/tests/conformance/cancel_propagation.rs
@@ -145,15 +145,9 @@ async fn drive_declarative_cancel_propagation() {
         0,
         None,
         None,
+        None,
     )
     .await;
-    let parent_on_host = wait_for_request(
-        host.db.node.as_ref(),
-        parent_request_id,
-        Duration::from_secs(60),
-    )
-    .await;
-    assert_eq!(parent_on_host.agent_did, coord_did);
 
     create_processing_request(
         host.db.node.as_ref(),
@@ -165,6 +159,7 @@ async fn drive_declarative_cancel_propagation() {
         1,
         Some(parent_request_id),
         Some(parent_tool_call_id),
+        Some(&coord_did),
     )
     .await;
 
@@ -195,7 +190,9 @@ async fn drive_declarative_cancel_propagation() {
         host.db.node.as_ref(),
         parent_session_id,
         parent_tool_call_id,
-        Duration::from_secs(30),
+        // A selective CAR lookup can consume one full 30s transport attempt
+        // before the persisted retry succeeds (defradb.rs#1101).
+        Duration::from_secs(60),
     )
     .await;
     assert_eq!(
@@ -205,6 +202,12 @@ async fn drive_declarative_cancel_propagation() {
     assert_eq!(
         replicated_bridge.child_request_id.as_deref(),
         Some(child_request_id)
+    );
+    assert!(
+        fetch_request(host.db.node.as_ref(), parent_request_id)
+            .await
+            .is_none(),
+        "coordinator parent request must not replicate to the host"
     );
     let coord_bridge_before_cancel = wait_for_bridge(
         coord_node.as_ref(),
@@ -233,7 +236,7 @@ async fn drive_declarative_cancel_propagation() {
         host.db.node.as_ref(),
         parent_session_id,
         parent_tool_call_id,
-        Duration::from_secs(30),
+        Duration::from_secs(60),
     )
     .await;
     assert_eq!(host_bridge.lifecycle_state.as_deref(), Some("cancelled"));
@@ -381,6 +384,7 @@ async fn create_processing_request(
     subagent_depth: u32,
     parent_request_id: Option<&str>,
     parent_tool_call_id: Option<&str>,
+    requester_did: Option<&str>,
 ) {
     let request_id = escape_graphql_string(request_id);
     let session_id = escape_graphql_string(session_id);
@@ -393,6 +397,7 @@ async fn create_processing_request(
     let parent_request = graphql_nullable_string(parent_request_id);
     let parent_tool = graphql_nullable_string(parent_tool_call_id);
     let trigger_id = graphql_nullable_string(parent_tool_call_id);
+    let requester_did = graphql_nullable_string(requester_did);
     let trigger_kind = if parent_tool_call_id.is_some() {
         "\"subagent\"".to_string()
     } else {
@@ -403,6 +408,7 @@ async fn create_processing_request(
             create_AgentRequest(input: {{
                 request_id: "{request_id}",
                 agent_did: "{agent_did}",
+                requester_did: {requester_did},
                 behavior_id: "{behavior_id}",
                 session_id: "{session_id}",
                 retry_parent_request: "",
@@ -511,19 +517,6 @@ async fn wait_for_replicator_installed(node: &EmbeddedNode, peer_id: &str, timeo
             );
         }
         tokio::time::sleep(Duration::from_millis(250)).await;
-    }
-}
-
-async fn wait_for_request(node: &EmbeddedNode, request_id: &str, timeout: Duration) -> RequestRow {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if let Some(row) = fetch_request(node, request_id).await {
-            return row;
-        }
-        if Instant::now() >= deadline {
-            panic!("timed out waiting for AgentRequest({request_id})");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
 

--- a/crates/defra-agent/tests/conformance/cancel_propagation.rs
+++ b/crates/defra-agent/tests/conformance/cancel_propagation.rs
@@ -190,9 +190,10 @@ async fn drive_declarative_cancel_propagation() {
         host.db.node.as_ref(),
         parent_session_id,
         parent_tool_call_id,
-        // A selective CAR lookup can consume one full 30s transport attempt
-        // before the persisted retry succeeds (defradb.rs#1101).
-        Duration::from_secs(60),
+        // A selective CAR lookup can consume a full 30s transport attempt.
+        // Allow multiple bounded attempts plus persisted backoff/scheduler
+        // margin under the saturated package suite (defradb.rs#1101).
+        Duration::from_secs(120),
     )
     .await;
     assert_eq!(
@@ -236,7 +237,7 @@ async fn drive_declarative_cancel_propagation() {
         host.db.node.as_ref(),
         parent_session_id,
         parent_tool_call_id,
-        Duration::from_secs(60),
+        Duration::from_secs(120),
     )
     .await;
     assert_eq!(host_bridge.lifecycle_state.as_deref(), Some("cancelled"));

--- a/crates/defra-agent/tests/conformance/r5_cross_deployment.rs
+++ b/crates/defra-agent/tests/conformance/r5_cross_deployment.rs
@@ -42,6 +42,7 @@ struct ToolCallRow {
 struct AgentRequestRow {
     request_id: String,
     agent_did: String,
+    requester_did: Option<String>,
     behavior_id: String,
     caused_by_parent_request_id: Option<String>,
     caused_by_parent_tool_call_id: Option<String>,
@@ -86,7 +87,7 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
     install_one_way_replicator(
         parent_db.node.as_ref(),
         child_agent.db.node.as_ref(),
-        &["AgentRequest", "AgentToolCall"],
+        &["AgentToolCall"],
     )
     .await;
     // The parent deliberately has no pairing row for B. Production R5 routing
@@ -99,14 +100,6 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
         parent_db,
     )
     .await;
-
-    let replicated_parent =
-        wait_for_request(child_agent.db.node.as_ref(), &case.parent_request_id).await;
-    assert_eq!(
-        replicated_parent.agent_did, PARENT_AGENT_DID,
-        "{}: parent request should replicate to B before the bridge",
-        case.name
-    );
 
     let child_request_id = spawn_from_parent_hook(case, &hook).await;
     assert!(
@@ -132,6 +125,13 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
     )
     .await;
     assert_bridge_matches_case(case, &replicated_bridge, &child_request_id);
+    assert!(
+        fetch_child_request_optional(child_agent.db.node.as_ref(), &case.parent_request_id)
+            .await
+            .is_none(),
+        "{}: the targeted bridge must not drag the coordinator parent request to B",
+        case.name
+    );
 
     let child = wait_for_child_request(child_agent.db.node.as_ref(), &child_request_id).await;
     assert_child_matches_case(case, &child, &child_request_id);
@@ -139,6 +139,12 @@ async fn drive_cross_deployment_case(case: &LeanR5CrossDeploymentCase) {
     assert_eq!(
         child.agent_did, child_agent_did,
         "{}: cross-deployment child must be locally owned by B",
+        case.name
+    );
+    assert_eq!(
+        child.requester_did.as_deref(),
+        Some(PARENT_AGENT_DID),
+        "{}: child request must route back only to its coordinator",
         case.name
     );
 
@@ -653,6 +659,7 @@ async fn fetch_child_request_optional(
             AgentRequest(filter: {{ request_id: {{ _eq: "{child_request_id}" }} }}, limit: 1) {{
                 request_id
                 agent_did
+                requester_did
                 behavior_id
                 caused_by_parent_request_id
                 caused_by_parent_tool_call_id
@@ -662,20 +669,6 @@ async fn fetch_child_request_optional(
         }}"#
     );
     first_optional_row(&node.execute(&query).await, "AgentRequest")
-}
-
-async fn wait_for_request(node: &EmbeddedNode, request_id: &str) -> AgentRequestRow {
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
-    loop {
-        if let Some(request) = fetch_child_request_optional(node, request_id).await {
-            return request;
-        }
-        if tokio::time::Instant::now() >= deadline {
-            let diagnostic = agent_request_diagnostic(node).await;
-            panic!("request {request_id} was not replicated; {diagnostic}");
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
 }
 
 async fn wait_for_tool_call(
@@ -717,6 +710,7 @@ async fn agent_request_diagnostic(node: &EmbeddedNode) -> String {
                 AgentRequest {
                     request_id
                     agent_did
+                    requester_did
                     behavior_id
                     caused_by_parent_request_id
                     caused_by_parent_tool_call_id

--- a/crates/defra-agent/tests/conformance/replicated_request_convergence.rs
+++ b/crates/defra-agent/tests/conformance/replicated_request_convergence.rs
@@ -25,6 +25,7 @@ use defra_agent::{DefraWatcher, Watcher, TERMINAL_REDRIVE_CAP};
 const CONVERGENCE_CREATED_AT: &str = "2026-03-23T00:00:00Z";
 const OWNER_DID: &str = AGENT_DID;
 const FOREIGN_DID: &str = "did:defra-agent:foreign-owner";
+const REQUESTER_DID: &str = "did:defra-agent:requester";
 
 #[derive(Debug, Deserialize)]
 struct ConvergenceRow {
@@ -72,6 +73,57 @@ async fn create_owned_request_with_times(
     created_at: &str,
     terminalized_at: &str,
 ) -> String {
+    create_owned_request_with_times_and_requester(
+        node,
+        request_id,
+        session_id,
+        agent_did,
+        status,
+        lifecycle_state,
+        created_at,
+        terminalized_at,
+        None,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_routed_owned_request_with_times(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    status: &str,
+    lifecycle_state: &str,
+    created_at: &str,
+    terminalized_at: &str,
+) -> String {
+    create_owned_request_with_times_and_requester(
+        node,
+        request_id,
+        session_id,
+        agent_did,
+        status,
+        lifecycle_state,
+        created_at,
+        terminalized_at,
+        Some(REQUESTER_DID),
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn create_owned_request_with_times_and_requester(
+    node: &EmbeddedNode,
+    request_id: &str,
+    session_id: &str,
+    agent_did: &str,
+    status: &str,
+    lifecycle_state: &str,
+    created_at: &str,
+    terminalized_at: &str,
+    requester_did: Option<&str>,
+) -> String {
     let is_terminal = matches!(
         lifecycle_state,
         "completed" | "failed" | "superseded" | "dead" | "interrupted"
@@ -83,6 +135,9 @@ async fn create_owned_request_with_times(
     let escaped_lifecycle_state = escape_graphql_string(lifecycle_state);
     let escaped_created_at = escape_graphql_string(created_at);
     let escaped_terminalized_at = escape_graphql_string(terminalized_at);
+    let requester_field = requester_did
+        .map(|did| format!("requester_did: \"{}\",", escape_graphql_string(did)))
+        .unwrap_or_default();
     let terminal_fields = if is_terminal {
         format!(", terminalized_at: \"{escaped_terminalized_at}\", terminal_redrive_attempts: 0")
     } else {
@@ -93,6 +148,7 @@ async fn create_owned_request_with_times(
             create_AgentRequest(input: {{
                 request_id: "{escaped_request_id}",
                 agent_did: "{escaped_agent_did}",
+                {requester_field}
                 behavior_id: "{AGENT_NAME}",
                 session_id: "{escaped_session_id}",
                 retry_parent_request: "",
@@ -236,6 +292,33 @@ async fn fetch_convergence_row(node: &EmbeddedNode, request_id: &str) -> Converg
     first_row(&node.execute(&query).await, "AgentRequest")
 }
 
+/// Count composite document commits (`_C`) rather than field-level CRDT blocks.
+/// A multi-field GraphQL update is one logical document commit even though
+/// DefraDB stores linked field blocks underneath it.
+async fn composite_commit_count(node: &EmbeddedNode, doc_id: &str) -> usize {
+    let escaped_doc_id = escape_graphql_string(doc_id);
+    let query = format!(
+        r#"query {{
+            _commits(
+                docID: ["{escaped_doc_id}"],
+                filter: {{ fieldName: {{ _eq: "_C" }} }}
+            ) {{ cid }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "query composite request commits failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("_commits"))
+        .and_then(serde_json::Value::as_array)
+        .map_or(0, Vec::len)
+}
+
 /// SAFETY `SingleClaimer`: the watcher never surfaces a foreign-DID replica as
 /// claimable — not via the doc-targeted `try_fetch_request` seam, nor via the
 /// `pending_requests` scan reached through `next_request`. Non-vacuous: an
@@ -305,23 +388,27 @@ pub(super) async fn terminal_convergence_redrive_reasserts_unconverged_terminal(
     let db = test_db("convergence-terminal-redrive").await;
 
     // The owner reached terminal `failed` on its own request.
-    create_owned_request(
+    create_routed_owned_request_with_times(
         &db.node,
         "convergence-owned-failed",
         "convergence-owned-failed-session",
         OWNER_DID,
         "error",
         "failed",
+        CONVERGENCE_CREATED_AT,
+        CONVERGENCE_CREATED_AT,
     )
     .await;
     // A foreign terminal replica — owner-scope: we must NOT re-drive it.
-    create_owned_request(
+    create_routed_owned_request_with_times(
         &db.node,
         "convergence-foreign-failed",
         "convergence-foreign-failed-session",
         FOREIGN_DID,
         "error",
         "failed",
+        CONVERGENCE_CREATED_AT,
+        CONVERGENCE_CREATED_AT,
     )
     .await;
     // An own NON-terminal (processing) request — must NOT be re-driven.
@@ -332,6 +419,17 @@ pub(super) async fn terminal_convergence_redrive_reasserts_unconverged_terminal(
         OWNER_DID,
         "processing",
         "processing",
+    )
+    .await;
+    // An own terminal request with no remote requester has no replica to heal
+    // and must not consume a re-drive write.
+    create_owned_request(
+        &db.node,
+        "convergence-owned-local-terminal",
+        "convergence-owned-local-terminal-session",
+        OWNER_DID,
+        "completed",
+        "completed",
     )
     .await;
 
@@ -396,7 +494,7 @@ pub(super) async fn terminal_redrive_window_advances_past_sixty_four_rows() {
     let db = test_db("convergence-terminal-window").await;
 
     for index in 0..65 {
-        create_owned_request_with_times(
+        create_routed_owned_request_with_times(
             &db.node,
             &format!("convergence-newer-{index:02}"),
             &format!("convergence-newer-session-{index:02}"),
@@ -408,7 +506,7 @@ pub(super) async fn terminal_redrive_window_advances_past_sixty_four_rows() {
         )
         .await;
     }
-    create_owned_request_with_times(
+    create_routed_owned_request_with_times(
         &db.node,
         "convergence-old-late-terminal",
         "convergence-old-late-terminal-session",
@@ -447,7 +545,7 @@ pub(super) async fn durable_response_repairs_request_after_terminal_write_gap() 
     let db = test_db("convergence-terminal-repair").await;
     let request_id = "convergence-terminal-repair-request";
     let session_id = "convergence-terminal-repair-session";
-    create_owned_request(
+    let request_doc_id = create_owned_request(
         &db.node,
         request_id,
         session_id,
@@ -456,6 +554,7 @@ pub(super) async fn durable_response_repairs_request_after_terminal_write_gap() 
         "processing",
     )
     .await;
+    let request_commits_before_repair = composite_commit_count(&db.node, &request_doc_id).await;
     let response_doc_id =
         create_response_with_status(&db.node, request_id, request_id, session_id, "error").await;
     let escaped_response_doc_id = escape_graphql_string(&response_doc_id);
@@ -479,6 +578,11 @@ pub(super) async fn durable_response_repairs_request_after_terminal_write_gap() 
         .unwrap();
     assert_eq!(repaired.repaired, 1);
     assert_eq!(repaired.failed, 0);
+    assert_eq!(
+        composite_commit_count(&db.node, &request_doc_id).await,
+        request_commits_before_repair + 1,
+        "one logical terminal repair must add one composite request commit"
+    );
     let row = fetch_convergence_row(&db.node, request_id).await;
     assert_eq!(row.status, "error");
     assert_eq!(row.lifecycle_state, "failed");

--- a/crates/defra-agent/tests/conformance/scope_templates.rs
+++ b/crates/defra-agent/tests/conformance/scope_templates.rs
@@ -58,9 +58,10 @@ fn unscoped_scope_resolves_to_no_filter() {
     }
 }
 
-/// Mirrors Lean `subagentCoordinator_filter_eq` / `subagentHost_filter_eq` and
-/// `subagent_filter_values_local_or_peer`: the built-in subagent templates are
-/// exact directional filters and never admit a third-party DID value.
+/// Mirrors Lean `subagentCoordinator_filter_eq` / `subagentHost_filter_eq` /
+/// `subagentRequest_crossing_is_peer_scoped`: coordinator parent requests do
+/// not fan out to hosts, and host-owned child requests return only to the
+/// paired requester DID.
 #[test]
 fn subagent_templates_resolve_to_exact_directional_filters() {
     const CONVERSATION: &[&str] = &[
@@ -76,21 +77,15 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
 
     let coord = resolve_template("subagent-coordinator").expect("coordinator template");
     assert_eq!(coord.delivery, Delivery::Push);
-    assert_eq!(coord.collections, &["AgentRequest", "AgentToolCall"]);
+    assert_eq!(coord.collections, &["AgentToolCall"]);
     let coord_filter = scope_filter(
         &coord.scope,
         coord.collections,
         "did:key:host",
         "did:key:coord",
     );
-    assert_eq!(coord_filter.len(), 2);
-    assert_eq!(
-        coord_filter.get("AgentRequest"),
-        Some(&FilterPredicate {
-            field: "agent_did".to_string(),
-            value: "did:key:coord".to_string(),
-        })
-    );
+    assert_eq!(coord_filter.len(), 1);
+    assert!(!coord_filter.contains_key("AgentRequest"));
     assert_eq!(
         coord_filter.get("AgentToolCall"),
         Some(&FilterPredicate {
@@ -109,9 +104,20 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
         "did:key:host",
     );
     assert_eq!(host_filter.len(), CONVERSATION.len());
-    for collection in CONVERSATION {
+    assert_eq!(
+        host_filter.get("AgentRequest"),
+        Some(&FilterPredicate {
+            field: "requester_did".to_string(),
+            value: "did:key:coord".to_string(),
+        })
+    );
+    for collection in CONVERSATION
+        .iter()
+        .copied()
+        .filter(|collection| *collection != "AgentRequest")
+    {
         assert_eq!(
-            host_filter.get(*collection),
+            host_filter.get(collection),
             Some(&FilterPredicate {
                 field: "agent_did".to_string(),
                 value: "did:key:host".to_string(),
@@ -126,6 +132,49 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
             "subagent filters must not include third-party DIDs"
         );
     }
+}
+
+/// Regression/measurement for #683. Under the former coordinator rule, one
+/// owner request matched all 16 host pairings because every pairing filtered
+/// `AgentRequest.agent_did` by the same coordinator DID. The request-party
+/// route key makes the return leg match exactly one requesting coordinator,
+/// while the coordinator leg carries no parent request at all.
+#[test]
+fn sixteen_peer_request_wave_is_reduced_to_one_target() {
+    let coordinator = resolve_template("subagent-coordinator").expect("coordinator template");
+    let host = resolve_template("subagent-host").expect("host template");
+    let requester_did = "did:key:coordinator-07";
+
+    let former_parent_request_matches = 16;
+    let current_parent_request_matches = (0..16)
+        .filter(|index| {
+            let host_did = format!("did:key:host-{index:02}");
+            scope_filter(
+                &coordinator.scope,
+                coordinator.collections,
+                &host_did,
+                requester_did,
+            )
+            .contains_key("AgentRequest")
+        })
+        .count();
+    assert_eq!(current_parent_request_matches, 0);
+
+    let routed_child_request_matches = (0..16)
+        .filter(|index| {
+            let peer_did = format!("did:key:coordinator-{index:02}");
+            scope_filter(&host.scope, host.collections, &peer_did, "did:key:host")
+                .get("AgentRequest")
+                .is_some_and(|predicate| {
+                    predicate.field == "requester_did" && predicate.value == requester_did
+                })
+        })
+        .count();
+    assert_eq!(routed_child_request_matches, 1);
+    assert!(
+        former_parent_request_matches / routed_child_request_matches >= 5,
+        "request replication fan-out must improve by at least 5x"
+    );
 }
 
 /// Mirrors Lean `appCollections_in_catalog` / `appCollections_collections_empty`

--- a/crates/defra-agent/tests/conformance/scope_templates.rs
+++ b/crates/defra-agent/tests/conformance/scope_templates.rs
@@ -145,7 +145,6 @@ fn sixteen_peer_request_wave_is_reduced_to_one_target() {
     let host = resolve_template("subagent-host").expect("host template");
     let requester_did = "did:key:coordinator-07";
 
-    let former_parent_request_matches = 16;
     let current_parent_request_matches = (0..16)
         .filter(|index| {
             let host_did = format!("did:key:host-{index:02}");
@@ -171,10 +170,6 @@ fn sixteen_peer_request_wave_is_reduced_to_one_target() {
         })
         .count();
     assert_eq!(routed_child_request_matches, 1);
-    assert!(
-        former_parent_request_matches / routed_child_request_matches >= 5,
-        "request replication fan-out must improve by at least 5x"
-    );
 }
 
 /// Mirrors Lean `appCollections_in_catalog` / `appCollections_collections_empty`

--- a/crates/defra-agent/tests/conformance/subagent_source.rs
+++ b/crates/defra-agent/tests/conformance/subagent_source.rs
@@ -156,6 +156,7 @@ async fn ensure_parent_subagent_authorization(
 struct ChildRequestRow {
     request_id: String,
     agent_did: String,
+    requester_did: Option<String>,
     behavior_id: String,
     content: String,
     lifecycle_state: Option<String>,
@@ -183,6 +184,7 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
             ) {{
                 request_id
                 agent_did
+                requester_did
                 behavior_id
                 content
                 lifecycle_state
@@ -206,6 +208,61 @@ async fn wait_for_child_request(node: &EmbeddedNode, child_request_id: &str) -> 
         );
         tokio::time::sleep(Duration::from_millis(50)).await;
     }
+}
+
+/// #683 party-scope fence: the targeted bridge is the complete remote parent
+/// edge. A host must materialize without a replicated parent AgentRequest and
+/// stamp the coordinator DID onto the child request's immutable return route.
+#[tokio::test]
+async fn trusted_path_uses_targeted_bridge_without_parent_request() {
+    let db = test_db("r3-subagent-source-xdep-targeted-bridge").await;
+    let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity("r3-xdep-targeted-bridge"));
+    let local_did = identity.did().to_string();
+    let coordinator_did = "did:key:zTargetedCoordinator";
+    let target_behavior_id = "xdep-target-targeted-bridge";
+    let parent_request_id = "r3-parent-targeted-bridge-not-replicated";
+    let parent_tool_call_id = "r3-tc-targeted-bridge";
+    let child_request_id = "r3-child-targeted-bridge";
+
+    upsert_target_behavior_with_cross_deployment(
+        db.node.as_ref(),
+        &local_did,
+        target_behavior_id,
+        true,
+    )
+    .await;
+
+    let mut paired = std::collections::HashSet::new();
+    paired.insert(coordinator_did.to_string());
+    let _source = crate::support::fixtures::spawn_subagent_source_with_paired_peers(
+        db.node.clone(),
+        &local_did,
+        target_behavior_id,
+        target_behavior_id,
+        paired,
+    );
+    wait_for_subagent_source_subscription().await;
+
+    write_targeted_cross_deployment_bridge(
+        db.node.as_ref(),
+        coordinator_did,
+        parent_request_id,
+        parent_tool_call_id,
+        child_request_id,
+        target_behavior_id,
+        &local_did,
+        1,
+    )
+    .await;
+
+    let child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
+    assert_eq!(child.agent_did, local_did);
+    assert_eq!(child.requester_did.as_deref(), Some(coordinator_did));
+    assert_eq!(child.subagent_depth, Some(2));
+    assert_eq!(
+        child.caused_by_parent_request_id.as_deref(),
+        Some(parent_request_id)
+    );
 }
 
 /// Bounded wait for the parent-interrupt latch to propagate to a child
@@ -2011,6 +2068,68 @@ async fn upsert_target_behavior_with_cross_deployment(
         created_at: Some("2026-06-04T00:00:00Z".to_string()),
     };
     upsert_agent_behavior(node, &behavior).await.unwrap();
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn write_targeted_cross_deployment_bridge(
+    node: &EmbeddedNode,
+    coordinator_did: &str,
+    parent_request_id: &str,
+    parent_tool_call_id: &str,
+    child_request_id: &str,
+    target_behavior_id: &str,
+    target_agent_did: &str,
+    parent_subagent_depth: u32,
+) {
+    let parent_session_id = format!("session-{parent_tool_call_id}");
+    let tool_call_key = format!("{parent_session_id}:{parent_tool_call_id}");
+    let args = serde_json::json!({
+        "name": target_behavior_id,
+        "agent_did": target_agent_did,
+        "behavior_id": target_behavior_id,
+        "prompt": "targeted cross-deployment child prompt",
+        "parent_subagent_depth": parent_subagent_depth,
+    })
+    .to_string();
+    let started_at = chrono::Utc::now().to_rfc3339();
+    let deadline_at = (chrono::Utc::now() + chrono::Duration::minutes(5)).to_rfc3339();
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentToolCall(input: {{
+                tool_call_key: "{tool_call_key}",
+                request_id: "{parent_request_id}",
+                session_id: "{parent_session_id}",
+                agent_did: "{coordinator_did}",
+                message_sequence: 1,
+                tool_name: "spawn_subagent",
+                tool_call_id: "{parent_tool_call_id}",
+                args: "{args}",
+                result: "",
+                status: "called",
+                lifecycle_state: "running",
+                started_at: "{started_at}",
+                deadline_at: "{deadline_at}",
+                child_request_id: "{child_request_id}",
+                spawn_target_did: "{target_agent_did}",
+                await_mode: "background",
+                cancel_policy: "cascade"
+            }}) {{ _docID }}
+        }}"#,
+        tool_call_key = escape_graphql_string(&tool_call_key),
+        parent_request_id = escape_graphql_string(parent_request_id),
+        parent_session_id = escape_graphql_string(&parent_session_id),
+        coordinator_did = escape_graphql_string(coordinator_did),
+        parent_tool_call_id = escape_graphql_string(parent_tool_call_id),
+        args = escape_graphql_string(&args),
+        child_request_id = escape_graphql_string(child_request_id),
+        target_agent_did = escape_graphql_string(target_agent_did),
+    );
+    let response = node.execute(&mutation).await;
+    assert!(
+        !response.has_errors(),
+        "create targeted AgentToolCall failed: {:?}",
+        response.errors
+    );
 }
 
 /// Write a parent `AgentRequest` authored by a remote (paired-peer) DID, as it

--- a/crates/defra-agent/tests/conformance/subagent_source.rs
+++ b/crates/defra-agent/tests/conformance/subagent_source.rs
@@ -7,8 +7,9 @@ use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::interrupt::{fetch_interrupt_requested_at, interrupt_request};
 use defra_agent::tool_call_lifecycle::{
-    create_subagent_request_with_request_id, AwaitMode, CancelPolicy, IllegalToolCallTransition,
-    ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
+    create_subagent_request_with_request_id,
+    create_subagent_request_with_trusted_parent_request_id, AwaitMode, CancelPolicy,
+    IllegalToolCallTransition, ToolCallLifecycle, MAX_SUBAGENT_DEPTH,
 };
 use defra_agent::{
     default_behavior_id_for_agent, load_agent_behavior, upsert_agent_behavior,
@@ -262,6 +263,33 @@ async fn trusted_path_uses_targeted_bridge_without_parent_request() {
     assert_eq!(
         child.caused_by_parent_request_id.as_deref(),
         Some(parent_request_id)
+    );
+}
+
+#[tokio::test]
+async fn trusted_path_normalizes_requester_did_before_stamping_route() {
+    let db = test_db("r3-subagent-source-xdep-requester-normalization").await;
+    let child_request_id = "r3-child-normalized-requester";
+
+    create_subagent_request_with_trusted_parent_request_id(
+        db.node.as_ref(),
+        child_request_id.to_string(),
+        "r3-parent-not-replicated".to_string(),
+        "r3-tc-normalized-requester".to_string(),
+        0,
+        crate::support::AGENT_DID.to_string(),
+        "test".to_string(),
+        "prompt".to_string(),
+        None,
+        "  did:key:zNormalizedRequester  ".to_string(),
+    )
+    .await
+    .expect("trusted child request should normalize requester DID");
+
+    let child = wait_for_child_request(db.node.as_ref(), child_request_id).await;
+    assert_eq!(
+        child.requester_did.as_deref(),
+        Some("did:key:zNormalizedRequester")
     );
 }
 
@@ -831,6 +859,27 @@ async fn create_subagent_request_enforces_depth_boundary() {
             Some(IllegalToolCallTransition::SubagentDepthExceeded)
         ),
         "expected SubagentDepthExceeded, got {error:?}"
+    );
+
+    let overflow_error = create_subagent_request_with_request_id(
+        db.node.as_ref(),
+        "r3-child-depth-overflow".to_string(),
+        "r3-parent-depth".to_string(),
+        "r3-tc-depth-overflow".to_string(),
+        u32::MAX,
+        crate::support::AGENT_DID.to_string(),
+        "test".to_string(),
+        "prompt".to_string(),
+        None,
+    )
+    .await
+    .expect_err("u32::MAX parent depth must be rejected without overflow");
+    assert!(
+        matches!(
+            overflow_error.downcast_ref::<IllegalToolCallTransition>(),
+            Some(IllegalToolCallTransition::SubagentDepthExceeded)
+        ),
+        "expected overflow-safe SubagentDepthExceeded, got {overflow_error:?}"
     );
 }
 

--- a/crates/defra-agent/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
+++ b/crates/defra-agent/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
@@ -572,6 +572,9 @@ async fn p2p_terminal_redrive_pushes_once_per_routed_request() {
     let enqueued_before = baseline["push_backlog"]["enqueued_total"]
         .as_u64()
         .expect("enqueued_total counter");
+    let failed_before = baseline["push_backlog"]["failed_total"]
+        .as_u64()
+        .expect("failed_total counter");
 
     let report = RequestLifecycle::redrive_terminal_convergence(owner.node.as_ref(), OWNER_DID)
         .await
@@ -584,6 +587,13 @@ async fn p2p_terminal_redrive_pushes_once_per_routed_request() {
     let enqueued_after = after["push_backlog"]["enqueued_total"]
         .as_u64()
         .expect("enqueued_total counter");
+    let failed_after = after["push_backlog"]["failed_total"]
+        .as_u64()
+        .expect("failed_total counter");
+    assert_eq!(
+        failed_after, failed_before,
+        "wave measurement requires a retry-free transport window; failed pushes would be re-admitted and inflate enqueued_total"
+    );
     let measured_pushes = enqueued_after - enqueued_before;
     assert_eq!(
         measured_pushes, REQUESTS as u64,

--- a/crates/defra-agent/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
+++ b/crates/defra-agent/tests/e2e_lifecycle/replicated_request_convergence_p2p_e2e.rs
@@ -23,8 +23,12 @@
 //! absent, then proves a full replicator replay repairs the peer without an
 //! unbounded stream of same-value request writes.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use defra_agent::agent::p2p_reconcile::{
+    EmbeddedRemoteP2pAdmin, FilterPredicate, PairingFilters, RemoteP2pAdmin,
+};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent::{RequestLifecycle, TERMINAL_REDRIVE_CAP};
@@ -48,8 +52,8 @@ struct RequestRow {
 // --- Two-node P2P plumbing (same shape as event_trigger_p2p_e2e / R5) ---
 
 async fn install_one_way_replicator(
-    sender: &EmbeddedNode,
-    receiver: &EmbeddedNode,
+    sender: &Arc<EmbeddedNode>,
+    receiver: &Arc<EmbeddedNode>,
     collections: &[&str],
 ) {
     let sender_addr = wait_for_listen_addr(sender).await;
@@ -88,14 +92,17 @@ async fn install_one_way_replicator(
         )
         .await
         .expect("authorize sender as receiver-side replicator");
-    sender_p2p
-        .add_replicator(
-            collection_names,
-            Some(&receiver_addr),
-            Default::default(),
-            Vec::new(),
-            None,
-        )
+    let sender_admin = EmbeddedRemoteP2pAdmin::new(Arc::clone(sender));
+    let mut filters = PairingFilters::new();
+    filters.insert(
+        "AgentRequest".to_string(),
+        FilterPredicate {
+            field: "requester_did".to_string(),
+            value: PEER_DID.to_string(),
+        },
+    );
+    sender_admin
+        .add_replicator(&[receiver_addr], &collection_names, &filters)
         .await
         .expect("install sender to receiver replicator");
 }
@@ -138,6 +145,53 @@ async fn wait_for_connected_peer(node: &EmbeddedNode) {
     }
 }
 
+async fn push_backlog_status(node: &EmbeddedNode) -> serde_json::Value {
+    node.p2p()
+        .expect("p2p should be enabled")
+        .sync_status()
+        .await
+        .expect("p2p sync status")
+}
+
+async fn wait_for_push_backlog_idle(node: &EmbeddedNode) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = push_backlog_status(node).await;
+        let backlog = &status["push_backlog"];
+        if backlog["queued_items"].as_u64() == Some(0) && backlog["active_jobs"].as_u64() == Some(0)
+        {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            panic!("push backlog never became idle; last={status}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_push_enqueues_and_idle(
+    node: &EmbeddedNode,
+    minimum_enqueued_total: u64,
+) -> serde_json::Value {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        let status = push_backlog_status(node).await;
+        let backlog = &status["push_backlog"];
+        if backlog["enqueued_total"].as_u64().unwrap_or(0) >= minimum_enqueued_total
+            && backlog["queued_items"].as_u64() == Some(0)
+            && backlog["active_jobs"].as_u64() == Some(0)
+        {
+            return status;
+        }
+        if Instant::now() >= deadline {
+            panic!(
+                "push backlog never reached enqueued_total={minimum_enqueued_total} and idle; last={status}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
 // --- AgentRequest helpers ---
 
 async fn create_request(
@@ -164,6 +218,7 @@ async fn create_request(
             create_AgentRequest(input: {{
                 request_id: "{request_id}",
                 agent_did: "{agent_did}",
+                requester_did: "{PEER_DID}",
                 behavior_id: "{BEHAVIOR_ID}",
                 session_id: "{session_id}",
                 retry_parent_request: "",
@@ -285,7 +340,7 @@ async fn p2p_owner_terminal_converges_and_redrive_stays_stable() {
     let owner = test_p2p_db("convergence-p2p-owner-live").await;
     let peer = test_p2p_db("convergence-p2p-peer-live").await;
 
-    install_one_way_replicator(owner.node.as_ref(), peer.node.as_ref(), &["AgentRequest"]).await;
+    install_one_way_replicator(&owner.node, &peer.node, &["AgentRequest"]).await;
 
     let request_id = "convergence-p2p-live-req";
     let session_id = "convergence-p2p-live-session";
@@ -455,7 +510,7 @@ async fn p2p_full_replay_converges_after_offline_peer_exhausts_redrive_cap() {
 
     // Peer recovery installs a full replicator replay. This path does not author
     // another AgentRequest delta and therefore does not grow request history.
-    install_one_way_replicator(owner.node.as_ref(), peer.node.as_ref(), &["AgentRequest"]).await;
+    install_one_way_replicator(&owner.node, &peer.node, &["AgentRequest"]).await;
 
     let on_peer = wait_for_request_lifecycle(
         peer.node.as_ref(),
@@ -472,6 +527,74 @@ async fn p2p_full_replay_converges_after_offline_peer_exhausts_redrive_cap() {
             .await
             .expect("redrive remains exhausted after peer replay");
     assert!(still_exhausted.is_noop());
+
+    owner.node.shutdown().await;
+    peer.node.shutdown().await;
+}
+
+/// #683 wave-volume measurement using the same 13-doc × 16-pairing incident
+/// shape as the #1103 harness. One real filtered two-node route observes the
+/// sender's outbound enqueue counter; the former fleet-wide predicate is the
+/// 16-replicator baseline. Each re-driven request now produces one push to its
+/// requester, so the measured reduction is 16x (well above the 5x gate).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn p2p_terminal_redrive_pushes_once_per_routed_request() {
+    const REQUESTS: usize = 13;
+    const FORMER_PAIRINGS: u64 = 16;
+
+    let owner = test_p2p_db("convergence-p2p-wave-owner").await;
+    let peer = test_p2p_db("convergence-p2p-wave-peer").await;
+    install_one_way_replicator(&owner.node, &peer.node, &["AgentRequest"]).await;
+
+    for index in 0..REQUESTS {
+        let request_id = format!("convergence-p2p-wave-{index:02}");
+        let session_id = format!("convergence-p2p-wave-session-{index:02}");
+        create_request(
+            owner.node.as_ref(),
+            &request_id,
+            &session_id,
+            OWNER_DID,
+            "completed",
+            "completed",
+        )
+        .await;
+        wait_for_request_lifecycle(
+            peer.node.as_ref(),
+            &request_id,
+            "completed",
+            Duration::from_secs(30),
+            "peer (wave seed)",
+        )
+        .await;
+    }
+
+    let baseline = wait_for_push_backlog_idle(owner.node.as_ref()).await;
+    let enqueued_before = baseline["push_backlog"]["enqueued_total"]
+        .as_u64()
+        .expect("enqueued_total counter");
+
+    let report = RequestLifecycle::redrive_terminal_convergence(owner.node.as_ref(), OWNER_DID)
+        .await
+        .expect("terminal redrive wave");
+    assert_eq!(report.reasserted, REQUESTS);
+
+    let after =
+        wait_for_push_enqueues_and_idle(owner.node.as_ref(), enqueued_before + REQUESTS as u64)
+            .await;
+    let enqueued_after = after["push_backlog"]["enqueued_total"]
+        .as_u64()
+        .expect("enqueued_total counter");
+    let measured_pushes = enqueued_after - enqueued_before;
+    assert_eq!(
+        measured_pushes, REQUESTS as u64,
+        "one request-party route must enqueue one outbound push per re-driven document"
+    );
+
+    let former_pushes = REQUESTS as u64 * FORMER_PAIRINGS;
+    assert!(
+        former_pushes / measured_pushes >= 5,
+        "request wave-volume reduction must be at least 5x; former={former_pushes}, current={measured_pushes}"
+    );
 
     owner.node.shutdown().await;
     peer.node.shutdown().await;

--- a/crates/defra-agent/tests/e2e_live/subagent_delegation_live.rs
+++ b/crates/defra-agent/tests/e2e_live/subagent_delegation_live.rs
@@ -23,10 +23,9 @@
 //! declarative `PeerPairingDesired` rows — no test "pump".
 //!
 //! Subagent targets are named `(agent_did, behavior_id)` pairs. The orchestrator
-//! on A writes the child `AgentRequest` LOCALLY stamped with the TARGET's
-//! `agent_did` (= DID-B). Bidirectional replication carries that child to B,
-//! where B's daemon + SubagentSource claim and run it against the live model;
-//! the terminal child request + its response replicate back to A. The full
+//! on A writes a targeted bridge; B's SubagentSource materializes the child
+//! `AgentRequest` locally with `agent_did = DID-B` and `requester_did = DID-A`.
+//! The terminal child request + its response replicate back only to A. The full
 //! assertions (bridge on A -> child materialized + run on B with a non-empty
 //! live answer -> terminal replicated back to A) all run live.
 
@@ -300,10 +299,9 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
     .await;
 
     // The named (agent_did, behavior_id) target is owned by DID-B: a REMOTE
-    // delegation target. Post-AB-fix, A authors the bridge + writes the child
-    // request LOCALLY stamped with DID-B WITHOUT resolving B's behavior locally,
-    // so we do NOT mirror B's AgentBehavior onto A. Replication carries the
-    // child to B.
+    // delegation target. A authors only the targeted bridge; B resolves no
+    // friendly name and materializes the child locally from the resolved args,
+    // so we do NOT mirror B's AgentBehavior onto A.
     authorize_subagents(
         db_a.node.as_ref(),
         &did_a,
@@ -329,8 +327,9 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
 
     // Pairing rows exist on BOTH nodes BEFORE the agents boot. The running
     // pairing reconcilers perform the actual installation: A's coordinator leg
-    // carries parent+bridge docs to B; B's host leg carries B-owned child docs
-    // back to A. The rows carry the peer's real listen address, never `[]`.
+    // carries only bridges targeted to B; B's host leg carries routed B-owned
+    // child requests back to A. The rows carry the peer's real listen address,
+    // never `[]`.
     write_pairing(
         db_a.node.as_ref(),
         "peer-b",
@@ -413,6 +412,11 @@ async fn live_cross_node_subagent_delegation() -> Result<()> {
     assert_eq!(
         child_on_b.agent_did, did_b,
         "child must be owned by DID-B (claimed + run by node B)"
+    );
+    assert_eq!(
+        child_on_b.requester_did.as_deref(),
+        Some(did_a.as_str()),
+        "child request must route only to its DID-A coordinator"
     );
     assert_eq!(child_on_b.behavior_id, RESEARCHER_BEHAVIOR_ID);
 
@@ -1045,6 +1049,7 @@ async fn wait_for_subagent_bridge(
 struct CrossRequestRow {
     request_id: String,
     agent_did: String,
+    requester_did: Option<String>,
     behavior_id: String,
     lifecycle_state: Option<String>,
 }
@@ -1054,7 +1059,7 @@ async fn fetch_request_on_node(node: &EmbeddedNode, request_id: &str) -> Option<
     let query = format!(
         r#"{{
             AgentRequest(filter: {{ request_id: {{ _eq: "{escaped}" }} }}, limit: 1) {{
-                request_id agent_did behavior_id lifecycle_state
+                request_id agent_did requester_did behavior_id lifecycle_state
             }}
         }}"#
     );

--- a/docs/superpowers/specs/2026-07-10-request-state-amplification-683-design.md
+++ b/docs/superpowers/specs/2026-07-10-request-state-amplification-683-design.md
@@ -1,0 +1,116 @@
+# Request-state replication scope and amplification (#683)
+
+## Decision
+
+`AgentRequest` replication is scoped to the two principals that are parties to
+one cross-deployment request. It is not an agent-wide backup channel and it is
+not a fleet broadcast channel.
+
+For a coordinator DID `C` and host DID `H`:
+
+- The coordinator leg sends `AgentToolCall` bridges where
+  `spawn_target_did == H`. It sends no coordinator-owned `AgentRequest` rows.
+  A coordinator request is not specific to one host: one request may delegate
+  to zero, one, or several hosts, so `agent_did == C` is not a sound pair key.
+- The host materializes the child request locally and stamps its immutable
+  `requester_did = C` routing key at create time.
+- The host leg sends `AgentRequest` rows where `requester_did == C`. A host
+  paired with several coordinators therefore returns each child request only to
+  the coordinator that requested it.
+- Non-request collection rules are unchanged by #683.
+
+This matches the product boundary: P2P pairing establishes a transport
+relationship; a scope template selects the application documents needed by
+that relationship.
+
+## Why the old filter amplified
+
+The existing filtered-replication machinery is active, but the coordinator
+request predicate is `AgentRequest.agent_did == local_did`. The reconciler
+installs that same local-agent predicate once for every host pairing. On a
+coordinator with 16 hosts, every coordinator-owned request matches all 16
+replicators. The filter is agent-scoped, not pair-scoped.
+
+The host leg has the symmetric problem for requests: `agent_did == host` sends
+the host's whole request slice to each coordinator pairing. The immutable
+`requester_did` discriminator closes both request-state leaks without changing
+the other conversation collections in this issue.
+
+## Bridge self-sufficiency
+
+The remote host currently reads the replicated parent request only to recover
+the parent DID/depth and to observe cancellation races. After the scope change:
+
+- the bridge's immutable `agent_did` identifies the coordinator;
+- normalized bridge args carry `parent_subagent_depth` alongside the already
+  resolved target DID/behavior;
+- the targeted bridge lifecycle and cancel-cascade fields remain the remote
+  cancellation signal.
+
+The local/same-node path keeps its parent-row cross-reference check. The
+trusted paired-peer path treats the targeted, owner-authored bridge as the
+durable cross-deployment parent edge and does not require a second copy of the
+parent request on the host.
+
+## Convergence interaction (#667/#681)
+
+The owner-only safety rule is unchanged: only `AgentRequest.agent_did`'s owner
+may drive lifecycle state. Terminal convergence is quantified over authorized
+request-party replica holders, not every paired fleet node.
+
+Host-owned cross-deployment children retain the bounded three-attempt terminal
+re-drive and reconnect replay to their `requester_did` coordinator. Ordinary
+local requests and coordinator parent requests have no remote request-state
+consumer, so terminal re-drive skips them. This suppresses convergence writes
+that cannot repair a replica while retaining the #667/#681 mechanism wherever
+a replica actually exists.
+
+`requester_did` is `@immutable`, as required by DefraDB filtered replication:
+a document cannot drift into or out of a peer scope after creation. DefraDB
+rejects null-to-value updates on newly added immutable fields, so legacy rows
+cannot be safely backfilled. Upgraded stores leave those rows unkeyed and
+excluded from the new request route; new cross-deployment children are keyed at
+creation. Existing targeted bridge rows remain the recovery/materialization
+source for in-flight work.
+
+## Write shape
+
+At the pinned DefraDB revision, one GraphQL document update already produces
+one composite root linking the modified field blocks and emits one update event
+for the document. The incident's 78 blocks are 17 composite roots plus their
+linked CRDT field blocks, not 78 independent document commits. #683 therefore
+adds a regression fence around the composite-root count instead of replacing
+the already-composite lifecycle mutations.
+
+The excessive heights came from repeated logical transitions and terminal
+re-drive. Party scoping and suppression of re-drive for unrouted requests
+remove the multiplicative fleet fan-out at the sender. DefraDB #1102 remains
+responsible for latest-head coalescing, encode-once fan-out, retry backoff, and
+the transport coalescing window.
+
+## Measurement
+
+The acceptance measurement reuses the DefraDB #1103 push-backlog
+`enqueued_total` signal with its workload shape: 13 request documents, 16 host
+pairings, and rapid terminal/re-drive updates. A real two-node P2P test installs
+the shipping `requester_did` filter, waits for the backlog to drain, re-drives
+13 routed terminal documents, and observes exactly 13 outbound enqueues. The
+former agent-scoped 16-pairing predicate produced 208 (= 13 × 16), so the
+measured reduction is 16x. A second structural assertion pins the topology
+calculation independently of transport timing:
+
+- coordinator parent requests match zero host request replicators;
+- each routed host child request matches exactly its one requester pairing;
+- one re-drive pass over `N` routed child requests produces `N` request pushes,
+  while local-only requests produce zero.
+
+Against the prior `N × 16` request wave this is a 16x reduction, independently
+of the additional transport reductions from DefraDB #1102.
+
+## Sibling boundaries
+
+- DefraDB #1101 fixes selective CAR lookup so requested child blocks can be
+  served and acknowledged.
+- DefraDB #1102 coalesces and deduplicates outbound transport work.
+- DefraDB #1103 supplies the push-storm harness and symbolized profile.
+- defra-agent #683 stops generating request-state work for unrelated peers.

--- a/docs/superpowers/specs/2026-07-10-request-state-amplification-683-design.md
+++ b/docs/superpowers/specs/2026-07-10-request-state-amplification-683-design.md
@@ -73,6 +73,21 @@ excluded from the new request route; new cross-deployment children are keyed at
 creation. Existing targeted bridge rows remain the recovery/materialization
 source for in-flight work.
 
+## Rollout constraints
+
+This scope change is intentionally one-way compatible during a rolling
+upgrade. An old coordinator still sends a parent request that a new host can
+use as a legacy fallback. A new coordinator sends only the targeted bridge,
+which an old host cannot materialize without the former parent row. Operators
+must therefore upgrade host deployments before coordinator deployments.
+
+Pre-upgrade host-owned child requests have no `requester_did` and cannot be
+backfilled because the route key is immutable. After the new host-leg filter is
+installed, those rows have no request-state convergence channel and terminal
+re-drive correctly skips them. Drain in-flight cross-deployment children before
+rolling out the new scope templates; then upgrade hosts first and coordinators
+second.
+
 ## Write shape
 
 At the pinned DefraDB revision, one GraphQL document update already produces


### PR DESCRIPTION
## Summary

- stop coordinator-owned parent `AgentRequest` rows from fanning out across every host pairing
- add immutable `requester_did` routing to host-owned child requests so request lifecycle state returns only to the coordinator that requested it
- make targeted cross-deployment bridges self-sufficient for child materialization and cancellation without a replicated parent request
- skip bounded terminal re-drive for local-only requests that have no remote request-state consumer
- fence DefraDB's existing one-composite-root write shape and document the boundary with defradb.rs #1101, #1102, and #1103

## Root cause

The selective replication machinery was active, but its request predicate was agent-scoped. Every coordinator-to-host pairing installed the same `AgentRequest.agent_did == coordinator` filter, so one coordinator request matched every host replicator. The host-side request filter had the symmetric problem across coordinators.

Pairing is the transport relationship; `requester_did` is now the application-level discriminator for the two principals participating in one cross-deployment request.

## Impact

The P2P regression workload uses 13 routed terminal requests and the DefraDB push-backlog `enqueued_total` signal. One retry-free re-drive wave now produces exactly 13 outbound enqueues. The former 16-pairing shape produced 208 (13 × 16), a 16× reduction. Coordinator parent requests match zero host request replicators; each host child matches exactly one requester.

Non-request conversation collection filters are unchanged in this issue. DefraDB #1102 remains responsible for transport-level coalescing/deduplication.

## Rollout

- Drain in-flight cross-deployment children before installing the new scope templates. Pre-upgrade children have no immutable `requester_did`, cannot be backfilled, and otherwise lose their request-state convergence route.
- Upgrade host deployments before coordinator deployments. A new host accepts an old coordinator's parent-row fallback; an old host cannot materialize a new coordinator's bridge-only spawn.

## Validation

- Lean: `lake build` — 913 targets, zero `sorry`
- TLC green model: 294 distinct / 728 generated states; expected stuck-liveness and peer-claim safety diagnostics both produce their intended counterexamples
- `cargo test -p defra-agent` — green, including 1,066 unit tests, 292 conformance tests, and all P2P request-convergence cases
- `cargo check --workspace --all-targets` — green
- `cargo fmt --all -- --check` — green
- `git diff --check` — green
- `cargo clippy -p defra-agent --all-targets -- -D warnings` — patch-owned code is clean; the command remains blocked by the existing Rust 1.95 baseline (36 library and 73 test warnings in untouched files)

Closes #683.
