### PR TITLE
Fix v0.6.9 release gates

### DIFF
--- a/.github/scripts/prepare-macos-release-dsym.sh
+++ b/.github/scripts/prepare-macos-release-dsym.sh
@@ -30,7 +30,17 @@ if ! grep -Eq 'defra_agent(_cli)?' "${symbols_file}"; then
   echo "::error::${binary_path} has no defra-agent Rust symbols; build with CARGO_PROFILE_RELEASE_STRIP=false before running dsymutil" >&2
   exit 1
 fi
-probe_address="$(awk '/defra_agent(_cli)?/ { print $1; exit }' "${symbols_file}")"
+probe_addresses="$(awk '
+  /defra_agent(_cli)?/ && $2 ~ /^[tT]$/ {
+    print $1
+    count++
+    if (count == 64) exit
+  }
+' "${symbols_file}")"
+if [[ -z "${probe_addresses}" ]]; then
+  echo "::error::${binary_path} has no defra-agent text symbols suitable for a symbolication probe" >&2
+  exit 1
+fi
 
 rm -rf "${dsym_path}"
 if ! xcrun dsymutil --verify-dwarf=output "${binary_path}" -o "${dsym_path}" 2> "${dsymutil_log}"; then
@@ -69,9 +79,23 @@ if [[ -z "${binary_uuid}" || "${binary_uuid}" != "${dsym_uuid}" ]]; then
   exit 1
 fi
 binary_arch="$(awk '{ value=$2; gsub(/[()]/, "", value); print value }' <<< "${binary_uuid}")"
-resolved_symbol="$(xcrun atos -o "${dwarf_path}" -arch "${binary_arch}" "${probe_address}")"
-if [[ "${resolved_symbol}" != *defra_agent* ]]; then
-  echo "::error::dSYM failed to resolve ${probe_address}: ${resolved_symbol}" >&2
+probe_address=""
+resolved_symbol=""
+# Linker deduplication can make a valid Rust text symbol resolve only as
+# `<deduplicated_symbol>`. Probe a bounded candidate set for a real frame.
+while IFS= read -r candidate_address; do
+  [[ -n "${candidate_address}" ]] || continue
+  candidate_symbol="$(
+    xcrun atos -o "${dwarf_path}" -arch "${binary_arch}" "${candidate_address}" 2>&1 || true
+  )"
+  if [[ "${candidate_symbol}" == *defra_agent* && "${candidate_symbol}" != *"<deduplicated_symbol>"* ]]; then
+    probe_address="${candidate_address}"
+    resolved_symbol="${candidate_symbol}"
+    break
+  fi
+done <<< "${probe_addresses}"
+if [[ -z "${probe_address}" ]]; then
+  echo "::error::dSYM failed to resolve a defra-agent frame from the first 64 text-symbol candidates" >&2
   exit 1
 fi
 

--- a/crates/defra-agent-cli/src/http/prometheus.rs
+++ b/crates/defra-agent-cli/src/http/prometheus.rs
@@ -608,6 +608,11 @@ fn render_p2p_sync_metrics(
             backlog.per_peer_active_cap,
         ),
         (
+            "defra_agent_p2p_push_encode_cache_entries",
+            "Encoded DAG payloads currently retained by DefraDB push coalescing.",
+            status.encode_cache_entries,
+        ),
+        (
             "defra_agent_p2p_pending_dags",
             "Live in-memory pending DAG registrations.",
             status.pending_dags,
@@ -681,6 +686,26 @@ fn render_p2p_sync_metrics(
             backlog.failed_total,
         ),
         (
+            "defra_agent_p2p_push_stale_head_retirements_total",
+            "Stale outbound CID heads retired by DefraDB push coalescing.",
+            backlog.stale_head_retirements_total,
+        ),
+        (
+            "defra_agent_p2p_push_encode_cache_hits_total",
+            "Outbound pushes that reused a cached encoded DAG payload.",
+            status.encode_cache_hits_total,
+        ),
+        (
+            "defra_agent_p2p_broadcast_coalesced_total",
+            "Redundant DefraDB broadcast updates coalesced before outbound push.",
+            status.broadcast_coalesced_total,
+        ),
+        (
+            "defra_agent_p2p_push_updates_coalesced_total",
+            "Outbound push updates retired in favor of a newer CID head.",
+            status.push_updates_coalesced_total,
+        ),
+        (
             "defra_agent_p2p_missing_link_retries_total",
             "Missing-link retry attempts recorded by DefraDB sync.",
             status.missing_link_retries,
@@ -698,6 +723,20 @@ fn render_p2p_sync_metrics(
     ] {
         push_metric_prelude_with_type(lines, name, help, "counter");
         push_metric_sample(lines, name, &[], value);
+    }
+
+    push_metric_prelude(
+        lines,
+        "defra_agent_p2p_push_cid_retry_count",
+        "Current outbound retry count retained for one CID.",
+    );
+    for retry in &backlog.per_cid_retry_counts {
+        push_metric_sample(
+            lines,
+            "defra_agent_p2p_push_cid_retry_count",
+            &[("cid", retry.cid.clone())],
+            retry.retry_count,
+        );
     }
 
     for (name, help) in [
@@ -1373,6 +1412,11 @@ mod tests {
                         rejected_bytes_total: 2,
                         completed_total: 79,
                         failed_total: 4,
+                        stale_head_retirements_total: 17,
+                        per_cid_retry_counts: vec![defra_agent::P2pCidRetrySnapshot {
+                            cid: "bafy-retry".to_string(),
+                            retry_count: 19,
+                        }],
                         per_peer: vec![defra_agent::P2pPeerBacklogSnapshot {
                             peer_id: "peer-a".to_string(),
                             queued_items: 4,
@@ -1382,6 +1426,10 @@ mod tests {
                             cooldown_remaining_ms: 750,
                         }],
                     },
+                    encode_cache_hits_total: 37,
+                    encode_cache_entries: 5,
+                    broadcast_coalesced_total: 41,
+                    push_updates_coalesced_total: 43,
                     pending_dags: 13,
                     pending_dag_capacity: 1_000,
                     persisted_pending_dags: 17,
@@ -1409,10 +1457,16 @@ mod tests {
         assert!(rendered.contains("defra_agent_p2p_push_queue_items 7"));
         assert!(rendered.contains("defra_agent_p2p_push_queue_bytes 4096"));
         assert!(rendered.contains("defra_agent_p2p_push_active_jobs 3"));
+        assert!(rendered.contains("defra_agent_p2p_push_encode_cache_entries 5"));
         assert!(rendered.contains("defra_agent_p2p_pending_dags 13"));
         assert!(rendered.contains("defra_agent_p2p_persisted_pending_dags 17"));
         assert!(rendered.contains("defra_agent_p2p_push_rejected_items_total 5"));
+        assert!(rendered.contains("defra_agent_p2p_push_stale_head_retirements_total 17"));
+        assert!(rendered.contains("defra_agent_p2p_push_encode_cache_hits_total 37"));
+        assert!(rendered.contains("defra_agent_p2p_broadcast_coalesced_total 41"));
+        assert!(rendered.contains("defra_agent_p2p_push_updates_coalesced_total 43"));
         assert!(rendered.contains("defra_agent_p2p_missing_link_retries_total 23"));
+        assert!(rendered.contains(r#"defra_agent_p2p_push_cid_retry_count{cid="bafy-retry"} 19"#));
         assert!(
             rendered.contains(r#"defra_agent_p2p_peer_consecutive_failures{peer_id="peer-a"} 3"#)
         );

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -573,6 +573,11 @@ mod tests {
                         "rejected_bytes_total": 2,
                         "completed_total": 79,
                         "failed_total": 4,
+                        "stale_head_retirements_total": 17,
+                        "per_cid_retry_counts": [{
+                            "cid": "bafy-retry",
+                            "retry_count": 19
+                        }],
                         "per_peer": [{
                             "peer_id": "peer-a",
                             "queued_items": 4,
@@ -582,6 +587,10 @@ mod tests {
                             "cooldown_remaining_ms": 750
                         }]
                     },
+                    "encode_cache_hits_total": 37,
+                    "encode_cache_entries": 5,
+                    "broadcast_coalesced_total": 41,
+                    "push_updates_coalesced_total": 43,
                     "pending_dags": 13,
                     "pending_dag_capacity": 1000,
                     "persisted_pending_dags": 17,
@@ -600,7 +609,11 @@ mod tests {
         assert_eq!(snapshot.replicators, 2);
         let sync = snapshot.sync_status.expect("valid pinned sync status");
         assert_eq!(sync.push_backlog.queued_items, 7);
+        assert_eq!(sync.push_backlog.stale_head_retirements_total, 17);
+        assert_eq!(sync.push_backlog.per_cid_retry_counts[0].retry_count, 19);
         assert_eq!(sync.push_backlog.per_peer[0].consecutive_failures, 3);
+        assert_eq!(sync.encode_cache_hits_total, 37);
+        assert_eq!(sync.push_updates_coalesced_total, 43);
         assert_eq!(sync.persisted_pending_dags, 17);
         assert_eq!(sync.missing_link_retries, 23);
     }

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -162,8 +162,8 @@ pub use native_executor_status::{active_native_executors, NativeExecutorStatus};
 pub use oneshot::{run_openai_oneshot, run_openai_oneshot_with_tools, OneshotRunResult};
 pub use openai_wire::OpenAiWireApi;
 pub use p2p_observability::{
-    JsonP2pSyncStatusAdapter, P2pPeerBacklogSnapshot, P2pPushBacklogSnapshot, P2pSyncStatusAdapter,
-    P2pSyncStatusSnapshot,
+    JsonP2pSyncStatusAdapter, P2pCidRetrySnapshot, P2pPeerBacklogSnapshot, P2pPushBacklogSnapshot,
+    P2pSyncStatusAdapter, P2pSyncStatusSnapshot,
 };
 pub use periodic_recovery::{
     periodic_recovery_sweep_metadata, run_periodic_recovery_sweeps, PeriodicRecoverySweepMetadata,

--- a/crates/defra-agent/src/p2p_observability.rs
+++ b/crates/defra-agent/src/p2p_observability.rs
@@ -10,13 +10,16 @@ use serde_json::Value;
 
 /// Typed view of the pinned DefraDB `p2p::sync::SyncStatus` JSON contract.
 ///
-/// Fields added by defradb.rs#1101/#1102 belong here only after their upstream
-/// names land. The pinned-struct conformance test then forces this adapter to
-/// be reviewed on the same change as the dependency revision.
+/// The pinned-struct conformance test forces this adapter to be reviewed on the
+/// same change as each DefraDB diagnostics contract revision.
 #[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct P2pSyncStatusSnapshot {
     pub push_backlog: P2pPushBacklogSnapshot,
+    pub encode_cache_hits_total: u64,
+    pub encode_cache_entries: usize,
+    pub broadcast_coalesced_total: u64,
+    pub push_updates_coalesced_total: u64,
     pub pending_dags: usize,
     pub pending_dag_capacity: usize,
     pub persisted_pending_dags: usize,
@@ -45,7 +48,17 @@ pub struct P2pPushBacklogSnapshot {
     pub rejected_bytes_total: u64,
     pub completed_total: u64,
     pub failed_total: u64,
+    pub stale_head_retirements_total: u64,
+    pub per_cid_retry_counts: Vec<P2pCidRetrySnapshot>,
     pub per_peer: Vec<P2pPeerBacklogSnapshot>,
+}
+
+/// Current retry count retained for one outbound CID.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct P2pCidRetrySnapshot {
+    pub cid: String,
+    pub retry_count: u64,
 }
 
 /// Per-peer occupancy and cooldown state from the outbound push backlog.
@@ -62,8 +75,8 @@ pub struct P2pPeerBacklogSnapshot {
 
 /// Converts the upstream diagnostics representation into the agent contract.
 ///
-/// The trait keeps the eventual #1101/#1102 pin update to one thin mapping and
-/// lets conformance tests drive the same boundary as production metrics.
+/// The trait keeps DefraDB diagnostics revisions at one thin mapping and lets
+/// conformance tests drive the same boundary as production metrics.
 pub trait P2pSyncStatusAdapter {
     type Error;
 

--- a/crates/defra-agent/tests/conformance/p2p_observability.rs
+++ b/crates/defra-agent/tests/conformance/p2p_observability.rs
@@ -1,5 +1,5 @@
 use defra_agent::{JsonP2pSyncStatusAdapter, P2pSyncStatusAdapter};
-use p2p::sync::{PeerBacklogSnapshot, PushBacklogSnapshot, SyncStatus};
+use p2p::sync::{CidRetrySnapshot, PeerBacklogSnapshot, PushBacklogSnapshot, SyncStatus};
 
 /// Compile-time + wire-shape fence for the pinned DefraDB diagnostics API.
 ///
@@ -23,6 +23,11 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
             rejected_bytes_total: 2,
             completed_total: 79,
             failed_total: 4,
+            stale_head_retirements_total: 17,
+            per_cid_retry_counts: vec![CidRetrySnapshot {
+                cid: "bafy-retry".to_string(),
+                retry_count: 19,
+            }],
             per_peer: vec![PeerBacklogSnapshot {
                 peer_id: "peer-a".to_string(),
                 queued_items: 4,
@@ -32,6 +37,10 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
                 cooldown_remaining_ms: 750,
             }],
         },
+        encode_cache_hits_total: 37,
+        encode_cache_entries: 5,
+        broadcast_coalesced_total: 41,
+        push_updates_coalesced_total: 43,
         pending_dags: 13,
         pending_dag_capacity: 1_000,
         persisted_pending_dags: 17,
@@ -54,8 +63,18 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
     assert_eq!(adapted.push_backlog.active_jobs, 3);
     assert_eq!(adapted.push_backlog.rejected_items_total, 5);
     assert_eq!(adapted.push_backlog.rejected_bytes_total, 2);
+    assert_eq!(adapted.push_backlog.stale_head_retirements_total, 17);
+    assert_eq!(
+        adapted.push_backlog.per_cid_retry_counts[0].cid,
+        "bafy-retry"
+    );
+    assert_eq!(adapted.push_backlog.per_cid_retry_counts[0].retry_count, 19);
     assert_eq!(adapted.push_backlog.per_peer[0].peer_id, "peer-a");
     assert_eq!(adapted.push_backlog.per_peer[0].consecutive_failures, 3);
+    assert_eq!(adapted.encode_cache_hits_total, 37);
+    assert_eq!(adapted.encode_cache_entries, 5);
+    assert_eq!(adapted.broadcast_coalesced_total, 41);
+    assert_eq!(adapted.push_updates_coalesced_total, 43);
     assert_eq!(adapted.pending_dags, 13);
     assert_eq!(adapted.persisted_pending_dags, 17);
     assert!(adapted.pending_resync_in_flight);


### PR DESCRIPTION
## Summary

- make the macOS dSYM gate inspect up to 64 defra-agent text-symbol candidates
- skip linker-deduplicated addresses that resolve only as `<deduplicated_symbol>`
- accept the first candidate that resolves to a real `defra_agent` frame
- adapt every outbound coalescing diagnostic shipped by the pinned DefraDB `99a4626d`
- expose stale-head retirement, encode-cache, broadcast/update coalescing, and per-CID retry metrics
- extend the exhaustive pinned-struct fence and JSON/Prometheus tests

## Root causes

The v0.6.9 macOS release run selected the first `nm` match as its sole symbolication probe. That address was valid but linker-deduplicated, so `atos` returned `<deduplicated_symbol>` and the workflow stopped before signing or publishing any macOS assets.

The v0.6.9 DefraDB pin also added #1110 diagnostic fields without updating the agent's exhaustive `SyncStatus` conformance literal. PR CI correctly caught the missing fields. Because the production adapter rejects unknown fields, the published v0.6.9 binary cannot decode that expanded status payload or expose the acceptance counters.

## Impact

The dSYM gate remains fail-closed: DWARF verification, CLI compilation-unit presence, UUID equality, stripping, and symbolication are still required. It now tolerates a deduplicated candidate without rejecting an otherwise valid dSYM.

The agent diagnostics surface now exactly matches the pinned DefraDB contract and publishes the counters required to evaluate outbound push coalescing during the acceptance canary.

## Validation

- `bash -n .github/scripts/prepare-macos-release-dsym.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p defra-agent --test conformance p2p_observability::pinned_defradb_sync_status_satisfies_agent_observability_contract -- --exact`
- `cargo test -p defra-agent-cli p2p_metrics_ -- --nocapture`
- full dSYM script run against the preserved unstripped v0.6.9 release executable on the failed macOS runner
- regenerated 808 MiB dSYM and matched binary/dSYM UUID `89B412E5-8F1E-3C05-BB89-3A85ECD47C49`
- skipped candidate `000000010000407c` (`<deduplicated_symbol>`)
- resolved candidate `00000001000041b8` to a `defra_agent` Rust frame at `lib.rs:135`
- stripped release binary remained a valid arm64 Mach-O

Follow-up to #689 and failed release run 29130455349.
