### PR TITLE
Fix canonical Kind schema CLI fixtures

### DIFF
--- a/crates/defra-agent-cli/src/commands/schema.rs
+++ b/crates/defra-agent-cli/src/commands/schema.rs
@@ -553,7 +553,7 @@ mod tests {
     #[test]
     fn collection_name_from_patch_uses_first_path_segment() {
         let patch = json!([
-            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": 11}}
+            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": "String"}}
         ]);
 
         assert_eq!(collection_name_from_patch(&patch).unwrap(), "ActionRequest");
@@ -563,7 +563,7 @@ mod tests {
     fn normalize_patch_value_accepts_wrapped_patch() {
         let wrapped = json!({
             "Patch": [
-                {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": 11}}
+                {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": "String"}}
             ]
         });
 
@@ -573,8 +573,8 @@ mod tests {
     #[test]
     fn filters_already_existing_additive_field_ops() {
         let patch = json!([
-            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": 11}},
-            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "reviewed_at", "Kind": 10}}
+            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "status", "Kind": "String"}},
+            {"op": "add", "path": "/ActionRequest/Fields/-", "value": {"Name": "reviewed_at", "Kind": "DateTime"}}
         ]);
         let field_adds = additive_field_ops("ActionRequest", &patch).unwrap();
         let existing_fields = BTreeSet::from(["status".to_string()]);

--- a/crates/defra-agent-cli/tests/cli_schema.rs
+++ b/crates/defra-agent-cli/tests/cli_schema.rs
@@ -24,7 +24,7 @@ type ActionRequest {
     fs::write(
         schema_dir.join("action_request.patch.json"),
         r#"[
-  {"op":"add","path":"/ActionRequest/Fields/-","value":{"Name":"status","Kind":11}}
+  {"op":"add","path":"/ActionRequest/Fields/-","value":{"Name":"status","Kind":"String"}}
 ]"#,
     )?;
 


### PR DESCRIPTION
## Summary

- use canonical `String` and `DateTime` Kind values in schema CLI test patches
- repair the full-main CLI regression exposed after #691

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p defra-agent-cli --test cli_schema`
- `cargo test -p defra-agent-cli commands::schema::tests`

Follow-up to #691 and failed main CI run 29139374095. This is test/example alignment with DefraDB #1106; runtime migration behavior is unchanged.
