### PR TITLE
Fix startup recovery on duplicate-session stores; count only real recoveries (#693)

### DIFF
--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -601,6 +601,17 @@ async fn log_recovery(node: &defra_node::EmbeddedNode, agent_did: &str, default_
                     "recovered stuck conversations"
                 );
             }
+            if report.conversations_failed > 0 {
+                // Failed attempts found stuck documents, so the pass was not
+                // a no-op — but they are the opposite of a recovery and must
+                // never inflate the recovered count (#693).
+                recovered_any = true;
+                tracing::warn!(
+                    agent_did = %agent_did,
+                    count = report.conversations_failed,
+                    "startup conversation recovery attempts failed"
+                );
+            }
         }
         Err(error) => {
             tracing::warn!(agent_did = %agent_did, error = %error, "startup recovery failed");

--- a/crates/defra-agent/src/lifecycle.rs
+++ b/crates/defra-agent/src/lifecycle.rs
@@ -243,6 +243,9 @@ pub struct RecoveryReport {
     pub requests_recovered: usize,
     pub responses_recovered: usize,
     pub conversations_recovered: usize,
+    /// Conversations whose recovery attempt failed. Failures are the opposite
+    /// of a recovery and must never fold into the recovered count (#693).
+    pub conversations_failed: usize,
 }
 
 /// Outcome of one durable request-terminal repair pass. A terminal response

--- a/crates/defra-agent/src/lifecycle/recovery.rs
+++ b/crates/defra-agent/src/lifecycle/recovery.rs
@@ -16,12 +16,14 @@ impl RequestLifecycle {
         let requests_recovered = Self::repair_terminal_requests(node, agent_did)
             .await?
             .repaired;
-        let conversations_recovered = recover_stuck_conversations(node, agent_did).await?;
+        let (conversations_recovered, conversations_failed) =
+            recover_stuck_conversations(node, agent_did).await?;
 
         Ok(RecoveryReport {
             responses_recovered,
             requests_recovered,
             conversations_recovered,
+            conversations_failed,
         })
     }
 
@@ -546,7 +548,13 @@ async fn recover_missing_response_documents(node: &EmbeddedNode, agent_did: &str
     Ok(recovered)
 }
 
-async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
+/// Returns `(recovered, failed)`. The recovered count reflects only writes
+/// that actually succeeded — a failed attempt is the opposite of a recovery
+/// and gets its own WARN instead (#693).
+async fn recover_stuck_conversations(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<(usize, usize)> {
     let escaped_agent_did = escape_graphql_string(agent_did);
     let query = format!(
         r#"{{
@@ -557,6 +565,7 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
                 }}
             ) {{
                 _docID
+                updated_at
                 agent_name
                 behavior_id
                 session_id
@@ -571,7 +580,7 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
         anyhow::bail!("querying stuck conversations: {:?}", resp.errors);
     }
 
-    let rows: Vec<serde_json::Value> = resp
+    let mut rows: Vec<serde_json::Value> = resp
         .data
         .as_ref()
         .and_then(|d| d.get("AgentConversation"))
@@ -579,8 +588,23 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
         .cloned()
         .unwrap_or_default();
 
-    let count = rows.len();
+    // A duplicate-carrying store (#693) yields one stuck row per twin.
+    // Recover each session once, driving the canonical stuck row (latest
+    // updated_at, docID tie-break — ascending sort, later insert wins), so a
+    // duplicated session can neither double-count nor double-write.
+    rows.sort_by(|left, right| {
+        stuck_conversation_recency(left).cmp(&stuck_conversation_recency(right))
+    });
+    let mut canonical_rows: std::collections::BTreeMap<String, &serde_json::Value> =
+        std::collections::BTreeMap::new();
     for row in &rows {
+        let session_id = row.get("session_id").and_then(|v| v.as_str()).unwrap_or("");
+        canonical_rows.insert(session_id.to_string(), row);
+    }
+
+    let mut recovered = 0usize;
+    let mut failed = 0usize;
+    for row in canonical_rows.into_values() {
         let doc_id = row.get("_docID").and_then(|v| v.as_str()).unwrap_or("");
         let agent_name = row.get("agent_name").and_then(|v| v.as_str()).unwrap_or("");
         let behavior_id = row
@@ -611,6 +635,7 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
         )
         .await
         {
+            failed += 1;
             tracing::warn!(
                 doc_id = %doc_id,
                 agent_name = %agent_name,
@@ -621,6 +646,7 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
                 "failed to recover stuck conversation"
             );
         } else {
+            recovered += 1;
             tracing::info!(
                 doc_id = %doc_id,
                 agent_name = %agent_name,
@@ -633,5 +659,22 @@ async fn recover_stuck_conversations(node: &EmbeddedNode, agent_did: &str) -> Re
         }
     }
 
-    Ok(count)
+    Ok((recovered, failed))
+}
+
+/// Canonical ordering key for stuck conversation rows sharing a session_id:
+/// latest `updated_at` wins, `_docID` breaks ties. An unparseable timestamp
+/// sorts oldest, so a malformed twin never outranks a well-formed one.
+fn stuck_conversation_recency(row: &serde_json::Value) -> (chrono::DateTime<chrono::Utc>, &str) {
+    let updated_at = row
+        .get("updated_at")
+        .and_then(|value| value.as_str())
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
+    let doc_id = row
+        .get("_docID")
+        .and_then(|value| value.as_str())
+        .unwrap_or("");
+    (updated_at, doc_id)
 }

--- a/crates/defra-agent/src/session/conversation.rs
+++ b/crates/defra-agent/src/session/conversation.rs
@@ -65,14 +65,8 @@ pub(crate) async fn upsert_conversation_from_request_with_identity_and_title(
     let escaped_title_source = escape_graphql_string(&title_source);
     let escaped_created_at = escape_graphql_string(&created_at);
 
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentConversation(
-                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
-                add: {{
-                    session_id: "{escaped_session_id}",
-                    agent_name: "{escaped_agent_name}",
-                    agent_did: "{escaped_agent_did}",
+    let assignments = format!(
+        r#"agent_name: "{escaped_agent_name}",
                     behavior_id: "{escaped_behavior_id}",
                     title: "{escaped_title}",
                     title_source: "{escaped_title_source}",
@@ -80,22 +74,39 @@ pub(crate) async fn upsert_conversation_from_request_with_identity_and_title(
                     status: "{escaped_status}",
                     created_at: "{escaped_created_at}",
                     updated_at: "{now}",
-                    latest_request_id: "{escaped_request_id}"
-                }},
-                update: {{
-                    agent_name: "{escaped_agent_name}",
-                    behavior_id: "{escaped_behavior_id}",
-                    title: "{escaped_title}",
-                    title_source: "{escaped_title_source}",
-                    preview_text: "{escaped_preview}",
-                    status: "{escaped_status}",
-                    created_at: "{escaped_created_at}",
-                    updated_at: "{now}",
-                    latest_request_id: "{escaped_request_id}"
-                }}
-            ) {{ _docID }}
-        }}"#
+                    latest_request_id: "{escaped_request_id}""#
     );
+    // Query-first (#693): a store can carry duplicate documents for one
+    // session_id, and an upsert whose filter matches more than one document
+    // is refused by DefraDB. Once the canonical document is known, address it
+    // by _docID; upsert remains only for the not-yet-created case, where its
+    // atomicity still closes the concurrent-create race.
+    let mutation = match existing.as_ref() {
+        Some(existing) => {
+            let escaped_doc_id = escape_graphql_string(&existing.doc_id);
+            format!(
+                r#"mutation {{
+                    update_AgentConversation(
+                        filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                        input: {{ {assignments} }}
+                    ) {{ _docID }}
+                }}"#
+            )
+        }
+        None => format!(
+            r#"mutation {{
+                upsert_AgentConversation(
+                    filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
+                    add: {{
+                        session_id: "{escaped_session_id}",
+                        agent_did: "{escaped_agent_did}",
+                        {assignments}
+                    }},
+                    update: {{ {assignments} }}
+                ) {{ _docID }}
+            }}"#
+        ),
+    };
 
     execute_mutation_with_retry(node, &mutation, "upsert_conversation_from_request").await?;
     Ok(())
@@ -144,14 +155,8 @@ pub(crate) async fn update_conversation_status_with_identity(
     let escaped_latest_request_id = escape_graphql_string(&latest_request_id);
     let escaped_created_at = escape_graphql_string(&created_at);
 
-    let mutation = format!(
-        r#"mutation {{
-            upsert_AgentConversation(
-                filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
-                add: {{
-                    session_id: "{escaped_session_id}",
-                    agent_name: "{escaped_agent_name}",
-                    agent_did: "{escaped_agent_did}",
+    let assignments = format!(
+        r#"agent_name: "{escaped_agent_name}",
                     behavior_id: "{escaped_behavior_id}",
                     title: "{escaped_title}",
                     title_source: "{escaped_title_source}",
@@ -159,22 +164,38 @@ pub(crate) async fn update_conversation_status_with_identity(
                     status: "{escaped_status}",
                     created_at: "{escaped_created_at}",
                     updated_at: "{now}",
-                    latest_request_id: "{escaped_latest_request_id}"
-                }},
-                update: {{
-                    agent_name: "{escaped_agent_name}",
-                    behavior_id: "{escaped_behavior_id}",
-                    title: "{escaped_title}",
-                    title_source: "{escaped_title_source}",
-                    preview_text: "{escaped_preview_text}",
-                    status: "{escaped_status}",
-                    created_at: "{escaped_created_at}",
-                    updated_at: "{now}",
-                    latest_request_id: "{escaped_latest_request_id}"
-                }}
-            ) {{ _docID }}
-        }}"#
+                    latest_request_id: "{escaped_latest_request_id}""#
     );
+    // Query-first (#693): address the canonical document by _docID so a
+    // duplicated session_id (which makes an upsert filter multi-match, and
+    // DefraDB refuse it) cannot fail the write — startup recovery routes
+    // through here and must survive duplicate-carrying stores.
+    let mutation = match existing.as_ref() {
+        Some(existing) => {
+            let escaped_doc_id = escape_graphql_string(&existing.doc_id);
+            format!(
+                r#"mutation {{
+                    update_AgentConversation(
+                        filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                        input: {{ {assignments} }}
+                    ) {{ _docID }}
+                }}"#
+            )
+        }
+        None => format!(
+            r#"mutation {{
+                upsert_AgentConversation(
+                    filter: {{ session_id: {{ _eq: "{escaped_session_id}" }} }},
+                    add: {{
+                        session_id: "{escaped_session_id}",
+                        agent_did: "{escaped_agent_did}",
+                        {assignments}
+                    }},
+                    update: {{ {assignments} }}
+                ) {{ _docID }}
+            }}"#
+        ),
+    };
 
     execute_mutation_with_retry(node, &mutation, "update_conversation_status").await?;
     Ok(())

--- a/crates/defra-agent/src/session/query.rs
+++ b/crates/defra-agent/src/session/query.rs
@@ -66,6 +66,15 @@ pub(crate) async fn load_session_behavior_id(
         }))
 }
 
+/// Load the canonical conversation document for a session.
+///
+/// A store can carry more than one `AgentConversation` document per
+/// `session_id` (#693): P2P merge enforces no unique index, and stores from
+/// the schema-broken era minted such twins. This loader reads every match
+/// and deterministically picks the canonical document — latest `updated_at`,
+/// `_docID` as tie-break — warning per duplicated session. Duplicates are
+/// flagged, never deleted; writers key their mutations on the returned
+/// document's `_docID` so a duplicate can never fail a write.
 pub(super) async fn load_conversation_document(
     node: &EmbeddedNode,
     session_id: &str,
@@ -76,10 +85,10 @@ pub(super) async fn load_conversation_document(
             AgentConversation(
                 filter: {{
                     session_id: {{ _eq: "{escaped_session_id}" }}
-                }},
-                limit: 1
+                }}
             ) {{
                 _docID
+                updated_at
                 title
                 title_source
                 preview_text
@@ -114,7 +123,28 @@ pub(super) async fn load_conversation_document(
         None => Vec::new(),
     };
 
+    rows.sort_by(|left, right| conversation_recency(left).cmp(&conversation_recency(right)));
+    if rows.len() > 1 {
+        tracing::warn!(
+            session_id = %session_id,
+            duplicate_count = rows.len(),
+            canonical_doc_id = %rows.last().map(|row| row.doc_id.as_str()).unwrap_or(""),
+            "duplicate AgentConversation documents share one session_id; \
+             using the canonical document (latest updated_at, docID tie-break) — \
+             duplicates are flagged, not deleted"
+        );
+    }
     Ok(rows.pop())
+}
+
+/// Canonical ordering key for duplicated conversation documents: latest
+/// `updated_at` wins, `_docID` breaks ties. An unparseable timestamp sorts
+/// oldest, so a malformed twin never outranks a well-formed one.
+fn conversation_recency(document: &ConversationDocument) -> (chrono::DateTime<chrono::Utc>, &str) {
+    let updated_at = chrono::DateTime::parse_from_rfc3339(&document.updated_at)
+        .map(|value| value.with_timezone(&chrono::Utc))
+        .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
+    (updated_at, document.doc_id.as_str())
 }
 
 pub(super) async fn load_recent_conversation_titles(

--- a/crates/defra-agent/src/session/rows.rs
+++ b/crates/defra-agent/src/session/rows.rs
@@ -30,9 +30,10 @@ pub(super) struct SessionDocument {
 #[derive(Debug, Clone, Deserialize)]
 pub(super) struct ConversationDocument {
     #[serde(rename = "_docID")]
-    #[allow(dead_code)]
     #[serde(default)]
     pub(super) doc_id: String,
+    #[serde(default)]
+    pub(super) updated_at: String,
     #[serde(default)]
     pub(super) title: String,
     #[serde(default)]

--- a/crates/defra-agent/tests/e2e_lifecycle/lifecycle_recovery.rs
+++ b/crates/defra-agent/tests/e2e_lifecycle/lifecycle_recovery.rs
@@ -7,13 +7,69 @@ use serde::Deserialize;
 
 use crate::support::snapshots::fetch_tool_call_snapshots_for_session;
 use crate::support::{
-    create_request, create_response_with_content_and_status, create_response_with_status,
-    first_row, test_db, upsert_conversation, AGENT_DID,
+    create_conversation_document, create_request, create_response_with_content_and_status,
+    create_response_with_status, first_row, test_db, test_db_with_duplicate_capable_conversations,
+    upsert_conversation, AGENT_DID, AGENT_NAME,
 };
 
 #[derive(Debug, Clone, Deserialize)]
 struct StatusRow {
     status: String,
+}
+
+/// Thread-scoped tracing capture so a test can assert on the WARN a recovery
+/// pass emits, without touching the process-global subscriber.
+#[derive(Clone, Default)]
+struct LogCapture(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+impl LogCapture {
+    fn contents(&self) -> String {
+        String::from_utf8_lossy(&self.0.lock().expect("capture lock")).into_owned()
+    }
+}
+
+impl std::io::Write for LogCapture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().expect("capture lock").extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for LogCapture {
+    type Writer = LogCapture;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn capture_subscriber(capture: &LogCapture) -> impl tracing::Subscriber {
+    use tracing_subscriber::layer::SubscriberExt;
+    tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(capture.clone()),
+    )
+}
+
+async fn conversation_status_by_doc_id(
+    node: &defra_agent::defra_node::EmbeddedNode,
+    doc_id: &str,
+) -> String {
+    let query = format!(
+        r#"{{
+            AgentConversation(
+                filter: {{ _docID: {{ _eq: "{doc_id}" }} }},
+                limit: 1
+            ) {{ status }}
+        }}"#
+    );
+    let resp = node.execute(&query).await;
+    first_row::<ConversationRow>(&resp, "AgentConversation").status
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -256,6 +312,113 @@ async fn recover_all_creates_error_response_when_response_doc_is_missing() {
     assert!(response
         .content
         .contains("daemon restarted before response could be generated"));
+}
+
+/// #693 defect 1: a store carrying two `AgentConversation` docs with one
+/// `session_id` must still recover — the canonical doc (latest `updated_at`,
+/// `_docID` tie-break) is repaired, the duplicate is flagged by a WARN naming
+/// the session_id and duplicate count, and is otherwise left untouched.
+#[tokio::test]
+async fn recover_all_recovers_canonical_conversation_when_session_id_is_duplicated() {
+    let db = test_db_with_duplicate_capable_conversations("lifecycle-recover-dupe").await;
+    let stale_doc = create_conversation_document(
+        &db.node,
+        "session-dupe",
+        AGENT_NAME,
+        "Stale title",
+        "processing",
+        "req-dupe",
+        "2026-01-01T00:00:00Z",
+    )
+    .await;
+    let canonical_doc = create_conversation_document(
+        &db.node,
+        "session-dupe",
+        AGENT_NAME,
+        "Rich title",
+        "processing",
+        "req-dupe",
+        "2026-06-01T00:00:00Z",
+    )
+    .await;
+    assert_ne!(stale_doc, canonical_doc, "seeding must mint two documents");
+
+    let capture = LogCapture::default();
+    let report = {
+        let _guard = tracing::subscriber::set_default(capture_subscriber(&capture));
+        RequestLifecycle::recover_all(&db.node, AGENT_DID)
+            .await
+            .unwrap()
+    };
+
+    // One duplicated session = one recovery, and the count reflects only
+    // recoveries that actually happened (#693 defect 2).
+    assert_eq!(report.conversations_recovered, 1);
+    assert_eq!(report.conversations_failed, 0);
+
+    // The canonical (newest) doc is recovered; latest_request_id has no
+    // matching request, so it re-activates.
+    assert_eq!(
+        conversation_status_by_doc_id(&db.node, &canonical_doc).await,
+        "active"
+    );
+    // The duplicate is flagged, not reaped or mutated (v1: operators sweep).
+    assert_eq!(
+        conversation_status_by_doc_id(&db.node, &stale_doc).await,
+        "processing"
+    );
+
+    let logs = capture.contents();
+    assert!(
+        logs.contains("duplicate AgentConversation"),
+        "expected duplicate WARN, got logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("session-dupe"),
+        "duplicate WARN must name the session_id, got logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("duplicate_count=2"),
+        "duplicate WARN must carry the duplicate count, got logs:\n{logs}"
+    );
+}
+
+/// #693 defect 2: a conversation recovery attempt that fails must be counted
+/// as a failure, never as a recovery. Failure injected via a behavior_id
+/// conflict between the stuck doc and its newer duplicate twin.
+#[tokio::test]
+async fn recover_all_counts_only_successful_conversation_recoveries() {
+    let db = test_db_with_duplicate_capable_conversations("lifecycle-recover-dupe-fail").await;
+    create_conversation_document(
+        &db.node,
+        "session-mismatch",
+        "behavior-alpha",
+        "Stale title",
+        "processing",
+        "req-mismatch",
+        "2026-01-01T00:00:00Z",
+    )
+    .await;
+    create_conversation_document(
+        &db.node,
+        "session-mismatch",
+        "behavior-beta",
+        "Rich title",
+        "active",
+        "req-mismatch",
+        "2026-06-01T00:00:00Z",
+    )
+    .await;
+
+    let report = RequestLifecycle::recover_all(&db.node, AGENT_DID)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        report.conversations_recovered, 0,
+        "a failed recovery attempt must not be counted as recovered"
+    );
+    assert_eq!(report.conversations_failed, 1);
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/support/mod.rs
+++ b/crates/defra-agent/tests/support/mod.rs
@@ -52,6 +52,47 @@ pub async fn test_db(name: &str) -> TestDb {
     }
 }
 
+/// A store that can carry duplicate `AgentConversation` session_ids (#693).
+///
+/// Production stores minted duplicates during the schema-broken era (the
+/// merge path enforces no unique index, and era stores predate it). The
+/// mutation path in a fresh test store DOES enforce `@index(unique: true)`,
+/// so to seed the wound we create the collection first from an era-faithful
+/// SDL whose `session_id` index is non-unique; `ensure_runtime_schemas`
+/// then treats the collection as already existing (indexes are immutable —
+/// they cannot be patched in later, exactly like the live stores).
+pub async fn test_db_with_duplicate_capable_conversations(name: &str) -> TestDb {
+    let tempdir = tempfile::Builder::new()
+        .prefix(&format!("defra-agent-{name}-"))
+        .tempdir()
+        .expect("tempdir");
+    let node = Arc::new(
+        EmbeddedNode::builder()
+            .data_path(tempdir.path())
+            .build()
+            .await
+            .expect("embedded node"),
+    );
+    let canonical = defra_agent_protocol::schemas::AGENT_CONVERSATION;
+    let unique_marker = "session_id: String @index(unique: true)";
+    assert!(
+        canonical.contains(unique_marker),
+        "AgentConversation SDL no longer declares the unique session_id index; \
+         update this helper alongside the schema"
+    );
+    let era_sdl = canonical.replace(unique_marker, "session_id: String @index");
+    node.add_schema(&era_sdl)
+        .await
+        .expect("era AgentConversation schema");
+    ensure_runtime_schemas(&node)
+        .await
+        .expect("runtime schemas");
+    TestDb {
+        node,
+        _tempdir: tempdir,
+    }
+}
+
 /// P2P admission overrides for multi-node tests that exercise hub backpressure
 /// bounds (#630). Defaults match `p2p::sync::DEFAULT_*`.
 #[derive(Debug, Clone)]
@@ -358,6 +399,63 @@ pub async fn upsert_conversation(
         "upsert conversation failed: {:?}",
         resp.errors
     );
+}
+
+/// Raw `create_AgentConversation` (no upsert): lets a test seed the #693
+/// wound — two conversation documents sharing one `session_id`, as minted on
+/// production stores during the schema-broken era.
+pub async fn create_conversation_document(
+    node: &EmbeddedNode,
+    session_id: &str,
+    behavior_id: &str,
+    title: &str,
+    status: &str,
+    latest_request_id: &str,
+    updated_at: &str,
+) -> String {
+    let session_id = escape_graphql_string(session_id);
+    let behavior_id = escape_graphql_string(behavior_id);
+    let title = escape_graphql_string(title);
+    let status = escape_graphql_string(status);
+    let latest_request_id = escape_graphql_string(latest_request_id);
+    let updated_at = escape_graphql_string(updated_at);
+    let mutation = format!(
+        r#"mutation {{
+            create_AgentConversation(input: {{
+                session_id: "{session_id}",
+                agent_name: "{AGENT_NAME}",
+                agent_did: "{AGENT_DID}",
+                behavior_id: "{behavior_id}",
+                title: "{title}",
+                preview_text: "seeded",
+                status: "{status}",
+                created_at: "{updated_at}",
+                updated_at: "{updated_at}",
+                latest_request_id: "{latest_request_id}"
+            }}) {{ _docID }}
+        }}"#
+    );
+    let resp = node.execute(&mutation).await;
+    assert!(
+        !resp.has_errors(),
+        "create conversation document failed: {:?}",
+        resp.errors
+    );
+
+    // Duplicated session_ids are the point of this helper, so requery by the
+    // (session_id, title) pair — callers give each seeded twin a unique title.
+    let query = format!(
+        r#"{{
+            AgentConversation(filter: {{
+                session_id: {{ _eq: "{session_id}" }},
+                title: {{ _eq: "{title}" }}
+            }}) {{
+                _docID
+            }}
+        }}"#
+    );
+    let resp = node.execute(&query).await;
+    first_row::<DocIdRow>(&resp, "AgentConversation").doc_id
 }
 
 pub async fn set_interrupt_requested_at(node: &EmbeddedNode, doc_id: &str, at: &str) {


### PR DESCRIPTION
Fixes #693 — both defects observed on the v0.6.11 rollout (strangenas, studio-1 web-research/inference, amygdalabook):

1. **Duplicate `session_id` docs bricked conversation recovery.** `upsert_AgentConversation(filter: {session_id: …})` multi-matches on a duplicate-carrying store and DefraDB refuses it (`cannot upsert multiple matching documents`), so the conversation was never recovered.
2. **Failed attempts were logged as successes.** `recovered stuck conversations … count=` tallied attempts (`rows.len()`), so a fully-failed pass reported healthy.

## Fix (query-first, per the issue's preferred option)

- **`session/query.rs::load_conversation_document`** — reads every doc matching the session and deterministically picks the canonical one: **latest `updated_at`, `_docID` tie-break** (an unparseable timestamp sorts oldest, so a malformed twin never outranks a well-formed one). When duplicates exist it WARNs with the `session_id`, `duplicate_count`, and `canonical_doc_id`. Duplicates are **flagged, never deleted** (v1: operators wipe or a later sweep reconciles).
- **`session/conversation.rs`** — the two upsert helpers now address an existing document by `_docID` (`update_AgentConversation`), making multi-match structurally impossible. The upsert survives only for the doc-doesn't-exist case, where its atomicity still closes the concurrent-create race. This also heals the **live request path** on a duped store, which routed through the same upsert and would have failed on every turn of the wounded session.
- **`lifecycle/recovery.rs::recover_stuck_conversations`** — a duplicate-carrying store yields one stuck row per twin, so the pass now drives **one attempt per session_id** (canonical stuck row by the same recency rule) and returns `(recovered, failed)`: the recovered count reflects only writes that succeeded.
- **`startup.rs`** — `conversations_failed > 0` gets its own distinct WARN (`startup conversation recovery attempts failed`); the count in the INFO line is successes only.

**Sibling audit** (issue ask 2 / prompt step 3): request, response, tool-call, and inference-call recovery counters already increment only on success with per-failure WARNs — conversations was the lone `rows.len()` offender. No change needed there.

## Regression tests (TDD — both watched red on the exact production failure first)

Seeding a duplicate through the mutation path is impossible on a fresh store (the unique `session_id` index rejects it — production twins arrived via P2P merge, which enforces no index; indexes are also immutable to patches). The new `test_db_with_duplicate_capable_conversations` support therefore creates the collection from an **era-faithful SDL** (non-unique `session_id` index) before normal bootstrap — the same shape the affected stores actually lived through — and the recovery semantics under test (upsert multi-match refusal, `_docID`-keyed update) are index-independent.

- `recover_all_recovers_canonical_conversation_when_session_id_is_duplicated` — two twins, one session: canonical (newest) doc recovered to `active`, stale twin untouched, `conversations_recovered == 1`, WARN names the session_id and `duplicate_count=2` (asserted via a thread-scoped tracing capture). **Red before fix: count=2 with zero successful writes.**
- `recover_all_counts_only_successful_conversation_recoveries` — failure injected via a behavior_id conflict between the stuck doc and its newer twin: `conversations_recovered == 0`, `conversations_failed == 1`. **Red before fix: count=1.**

No Lean change: the Recovery model doesn't cover conversation-status repair, and this changes no legal transitions — it's write-path robustness plus counter honesty.

## Gates

- `cargo test -p defra-agent --lib --tests` — green (exit 0, full suite)
- `cargo check --workspace --all-targets` — green
- `cargo fmt --all --check` — green
- clippy: all changed files clean under local clippy 1.95; remaining findings are pre-existing new-lint noise in untouched crates (CI runs no clippy step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)