### PR TITLE
Bound startup build failures: demote instead of wedging the readiness barrier (#559)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Runtime.lean
@@ -123,4 +123,120 @@ def queueDeadlineConformanceCaseJson
       ++ boolString witness.explicitDeadlinePreserved
     ++ "}"
 
+
+/-- Startup-readiness vectors for the bounded build-failure barrier
+(defra-agent#559).
+
+`outcomes` is the build-attempt sequence the slot observes; `post_standing` is
+the behavior's standing with the barrier afterwards. `blocks_ready` pins the
+liveness claim: a released standing never holds `Ready` hostage, and the only
+standing that may is `pending`. `requires_restart` is pinned `false` everywhere
+— release follows from the budget, never from restarting the process. -/
+structure StartupReadinessCase where
+  witness : String
+  leanTheorems : List String
+  budget : Nat
+  outcomes : List String
+  /-- Reconcile retires the slot after the outcomes are observed. -/
+  retiredAfter : Bool
+  postStanding : String
+  blocksReady : Bool
+  requiresRestart : Bool
+
+def startupReadinessCaseJson (witness : StartupReadinessCase) : String :=
+  "{"
+    ++ "\"witness\":" ++ jsonString witness.witness ++ ","
+    ++ "\"lean_theorems\":" ++ jsonStringArray witness.leanTheorems ++ ","
+    ++ "\"budget\":" ++ toString witness.budget ++ ","
+    ++ "\"outcomes\":" ++ jsonStringArray witness.outcomes ++ ","
+    ++ "\"retired_after\":" ++ boolString witness.retiredAfter ++ ","
+    ++ "\"post_standing\":" ++ jsonString witness.postStanding ++ ","
+    ++ "\"blocks_ready\":" ++ boolString witness.blocksReady ++ ","
+    ++ "\"requires_restart\":" ++ boolString witness.requiresRestart
+    ++ "}"
+
+def startupReadinessCases : List StartupReadinessCase :=
+  [ -- #559 itself: every build fails; the budget demotes instead of wedging.
+    { witness := "startup_readiness.persistent_build_failure_demotes"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.budgeted_attempts_release"
+        , "RuntimeReconcile.StartupReadiness.seeded_release"
+        , "RuntimeReconcile.StartupReadiness.demoted_consumed_the_budget"
+        ]
+    , budget := 3
+    , outcomes := ["failed", "failed", "failed"]
+    , retiredAfter := false
+    , postStanding := "demoted"
+    , blocksReady := false
+    , requiresRestart := false
+    }
+    -- A transient failure within the budget still reaches ready.
+  , { witness := "startup_readiness.transient_failure_then_start_is_ready"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.start_within_budget_is_ready"
+        , "RuntimeReconcile.StartupReadiness.ready_requires_a_start"
+        ]
+    , budget := 3
+    , outcomes := ["failed", "started"]
+    , retiredAfter := false
+    , postStanding := "ready"
+    , blocksReady := false
+    , requiresRestart := false
+    }
+    -- Demotion never claims health: a spent budget is not a start.
+  , { witness := "startup_readiness.demotion_is_not_readiness"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.ready_requires_a_start"
+        ]
+    , budget := 1
+    , outcomes := ["failed"]
+    , retiredAfter := false
+    , postStanding := "demoted"
+    , blocksReady := false
+    , requiresRestart := false
+    }
+    -- Under budget with no success yet: still pending, still blocking Ready.
+  , { witness := "startup_readiness.within_budget_still_pending"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.budgeted_attempts_release"
+        ]
+    , budget := 3
+    , outcomes := ["failed"]
+    , retiredAfter := false
+    , postStanding := "pending"
+    , blocksReady := true
+    , requiresRestart := false
+    }
+    -- Ready is absorbing: post-start outcomes never re-enter the barrier.
+  , { witness := "startup_readiness.ready_is_absorbing"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.released_absorbing"
+        ]
+    , budget := 3
+    , outcomes := ["started", "failed", "failed", "failed", "failed"]
+    , retiredAfter := false
+    , postStanding := "ready"
+    , blocksReady := false
+    , requiresRestart := false
+    }
+    -- Reconcile retires a never-started slot mid-startup: released without a
+    -- health claim, instead of orphaning the pending entry (the second #559
+    -- hang path).
+  , { witness := "startup_readiness.retirement_releases_a_pending_behavior"
+    , leanTheorems :=
+        [ "RuntimeReconcile.StartupReadiness.retire_releases"
+        , "RuntimeReconcile.StartupReadiness.retire_never_claims_ready"
+        ]
+    , budget := 3
+    , outcomes := ["failed"]
+    , retiredAfter := true
+    , postStanding := "superseded"
+    , blocksReady := false
+    , requiresRestart := false
+    }
+  ]
+
+def startupReadinessCasesJson : String :=
+  jsonArray (startupReadinessCases.map startupReadinessCaseJson)
+
 end Conformance.Contracts

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -53,6 +53,8 @@ def snapshotJson : String :=
       ++ Conformance.ClientShellContracts.desktopClientShellCasesJson ++ ","
     ++ "\"request_lifecycle_operator_ui_cases\":"
       ++ Conformance.ClientShellContracts.requestLifecycleOperatorUiCasesJson ++ ","
+    ++ "\"startup_readiness_cases\":"
+      ++ startupReadinessCasesJson ++ ","
     ++ "\"runtime_reconcile_cases\":"
       ++ jsonArray (runtimeReconcileCases.map runtimeReconcileCaseJson) ++ ","
     ++ "\"apply_reconcile_cases\":"

--- a/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/CoverageLedger.lean
@@ -452,6 +452,11 @@ def caseCoverage : List CoverageEntry :=
       "runtime_status::tests::runtime_status_generation_updates_match_lean_runtime_reconcile_cases")
       "runtime-reconcile" [Surface.runtimeInternal]
   , tagged (consumerCoverage
+      "startup_readiness_cases"
+      "StartupReadinessCases"
+      "conformance::generated_startup_readiness_cases_pin_bounded_barrier_release")
+      "runtime-reconcile" [Surface.runtimeInternal]
+  , tagged (consumerCoverage
       "apply_reconcile_cases"
       "ApplyReconcileCases"
       "config_import::lean_apply_write_boundary_tests::generated_apply_reconcile_cases_fence_production_apply_write_boundary")

--- a/crates/defra-agent/proofs/Proofs/RuntimeReconcile.lean
+++ b/crates/defra-agent/proofs/Proofs/RuntimeReconcile.lean
@@ -1,3 +1,4 @@
+import Proofs.RuntimeReconcile.StartupReadiness
 import Proofs.RuntimeReconcile.State
 import Proofs.RuntimeReconcile.Transition
 import Proofs.RuntimeReconcile.Executable

--- a/crates/defra-agent/proofs/Proofs/RuntimeReconcile/StartupReadiness.lean
+++ b/crates/defra-agent/proofs/Proofs/RuntimeReconcile/StartupReadiness.lean
@@ -1,0 +1,285 @@
+import Proofs.Basic
+
+/-!
+# Startup readiness under bounded build failures
+
+The startup barrier seeds every snapshot-runnable behavior as *pending* and the
+process reports `Ready` only when no behavior is pending. A behavior leaves
+pending today in exactly one way: its daemon starts (`mark_behavior_ready`),
+which happens only **after** its completion client builds. A behavior that is
+runnable at snapshot time but persistently fails to *build* therefore never
+leaves pending — the slot hot-restarts forever, `wait_ready()` never returns,
+and the process never reports `Ready` (defra-agent#559). The blast radius is
+worse than a wrong status: the trigger engine is also gated on the barrier, so
+one un-buildable behavior silently disables all schedules and event triggers.
+
+The fix modeled here: build attempts consume a **budget**. Each failed build of
+a still-pending behavior counts against it; at the budget the behavior is
+**demoted** — released from the barrier *without being claimed healthy*. Ready
+and demoted are both absorbing for the barrier, so the barrier's pending set
+only shrinks and `wait_ready` terminates after boundedly many attempts.
+
+Two facts of the Rust runtime this model pins:
+
+* Demotion is *not* readiness. `demoted` is a distinct terminal standing; the
+  theorems forbid any path from a failed budget to `ready`.
+* Slot keep/recreate across reconcile generations carries the standing: an
+  **unchanged** behavior keeps its slot (and so its demotion — nothing changed,
+  the build will still fail), while a **changed** behavior gets a fresh slot
+  with a fresh budget (the operator's fix earns a fresh chance).
+
+There is a third way to leave the barrier, with no build outcome at all:
+reconcile can **retire** a behavior's slot (config change or removal) before it
+ever starts. The barrier previously had no retirement path, so a behavior
+retired mid-startup orphaned its pending entry — the same hang with no failure
+anywhere. `retire` supersedes the standing: released, unclaimed, accounted.
+
+Model boundary: the outcome list is the sequence of build attempts the slot
+actually observes (across all of its executor workers — the runtime counts them
+on one shared counter). A build that *hangs* is surfaced back into this machine
+by the runtime's per-attempt build timeout, which converts it into a `failed`
+outcome — so the termination theorem covers hangs too, and `Ready` never has to
+be force-flipped by a deadline that would weaken what it claims.
+-/
+
+namespace RuntimeReconcile.StartupReadiness
+
+/-- One build attempt's outcome, as the slot loop observes it. -/
+inductive BuildOutcome
+  /-- The daemon began `run()`: the behavior is serving. -/
+  | started
+  /-- The build returned an error before the daemon started. -/
+  | failed
+  deriving DecidableEq, Repr
+
+/-- A behavior's standing with the startup barrier. -/
+inductive BehaviorStanding
+  /-- Seeded runnable, not yet started; carries consecutive build failures. -/
+  | pending (failures : Nat)
+  /-- Started successfully. The only standing that claims health. -/
+  | ready
+  /-- Released from the barrier after exhausting the build budget — accounted
+      for, observable, and *never* claimed healthy. -/
+  | demoted
+  /-- Released because reconcile retired the slot before it started (config
+      change or removal). Released, unclaimed, accounted. -/
+  | superseded
+  deriving DecidableEq, Repr
+
+namespace BehaviorStanding
+
+/-- The barrier no longer waits on this behavior. -/
+def released : BehaviorStanding → Bool
+  | .pending _ => false
+  | .ready => true
+  | .demoted => true
+  | .superseded => true
+
+end BehaviorStanding
+
+/-- How one behavior's standing responds to one build outcome, under `budget`
+tolerated failures. Ready and demoted are absorbing: post-start crashes restart
+the daemon but never re-enter the barrier. -/
+def step (budget : Nat) : BehaviorStanding → BuildOutcome → BehaviorStanding
+  | .pending _, .started => .ready
+  | .pending failures, .failed =>
+      if failures + 1 < budget then .pending (failures + 1) else .demoted
+  | standing, _ => standing
+
+/-- A behavior's standing after a sequence of build attempts. -/
+def run (budget : Nat) (standing : BehaviorStanding) (outcomes : List BuildOutcome) :
+    BehaviorStanding :=
+  outcomes.foldl (step budget) standing
+
+/-- Reconcile retires the slot: a still-pending behavior is superseded; a
+standing that already left the barrier keeps its verdict. -/
+def retire : BehaviorStanding → BehaviorStanding
+  | .pending _ => .superseded
+  | standing => standing
+
+/-- The fresh standing every snapshot-runnable behavior is seeded with. -/
+def seeded : BehaviorStanding := .pending 0
+
+/-- `Ready` fires exactly when no seeded behavior is still pending. -/
+def processReady (standings : List BehaviorStanding) : Bool :=
+  standings.all BehaviorStanding.released
+
+/-! ## Absorption: leaving the barrier is permanent -/
+
+theorem ready_absorbing (budget : Nat) (outcome : BuildOutcome) :
+    step budget .ready outcome = .ready := by
+  cases outcome <;> rfl
+
+theorem demoted_absorbing (budget : Nat) (outcome : BuildOutcome) :
+    step budget .demoted outcome = .demoted := by
+  cases outcome <;> rfl
+
+theorem released_absorbing (budget : Nat) (standing : BehaviorStanding)
+    (outcomes : List BuildOutcome) (hReleased : standing.released = true) :
+    run budget standing outcomes = standing := by
+  induction outcomes with
+  | nil => rfl
+  | cons outcome rest ih =>
+      cases standing with
+      | pending _ => simp [BehaviorStanding.released] at hReleased
+      | ready => simp [run, List.foldl_cons, step] at ih ⊢; cases outcome <;> simpa [step] using ih
+      | demoted => simp [run, List.foldl_cons, step] at ih ⊢; cases outcome <;> simpa [step] using ih
+      | superseded =>
+          simp [run, List.foldl_cons, step] at ih ⊢; cases outcome <;> simpa [step] using ih
+
+/-! ## Soundness: demotion never claims health -/
+
+/-- A behavior is `ready` only if some attempt actually `started`. Exhausting a
+budget cannot manufacture health. -/
+theorem ready_requires_a_start (budget : Nat) (failures : Nat)
+    (outcomes : List BuildOutcome)
+    (hReady : run budget (.pending failures) outcomes = .ready) :
+    .started ∈ outcomes := by
+  induction outcomes generalizing failures with
+  | nil => simp [run] at hReady
+  | cons outcome rest ih =>
+      cases outcome with
+      | started => exact List.mem_cons_self ..
+      | failed =>
+          simp only [run, List.foldl_cons, step] at hReady
+          by_cases hBudget : failures + 1 < budget
+          · simp only [hBudget, if_true] at hReady
+            exact List.mem_cons_of_mem _ (ih _ hReady)
+          · simp only [hBudget, if_false] at hReady
+            rw [show List.foldl (step budget) BehaviorStanding.demoted rest
+                  = run budget .demoted rest from rfl,
+                released_absorbing budget .demoted rest rfl] at hReady
+            exact absurd hReady (by simp)
+
+/-! ## Termination: the barrier cannot hang past the budget -/
+
+/-- **The #559 theorem.** After `budget` build attempts — whatever their
+outcomes — a seeded behavior has left the barrier. With every behavior's
+attempts bounded, `wait_ready` terminates; a persistently un-buildable behavior
+is demoted instead of wedging the process.
+
+The `failures < budget` hypothesis is the reachability invariant: `step` demotes
+the moment the budget is consumed, so a still-pending behavior always has spent
+strictly less than the budget. `seeded` satisfies it whenever `0 < budget`
+(which the runtime enforces). -/
+theorem budgeted_attempts_release (budget : Nat) (failures : Nat)
+    (outcomes : List BuildOutcome)
+    (hInv : failures < budget)
+    (hEnough : budget ≤ failures + outcomes.length) :
+    (run budget (.pending failures) outcomes).released = true := by
+  induction outcomes generalizing failures with
+  | nil =>
+      simp only [List.length_nil, Nat.add_zero] at hEnough
+      omega
+  | cons outcome rest ih =>
+      cases outcome with
+      | started =>
+          simp only [run, List.foldl_cons, step]
+          rw [show List.foldl (step budget) BehaviorStanding.ready rest
+                = run budget .ready rest from rfl,
+              released_absorbing budget .ready rest rfl]
+          rfl
+      | failed =>
+          simp only [run, List.foldl_cons, step]
+          by_cases hBudget : failures + 1 < budget
+          · simp only [hBudget, if_true]
+            exact ih (failures + 1) hBudget (by
+              simp only [List.length_cons] at hEnough
+              omega)
+          · simp only [hBudget, if_false]
+            rw [show List.foldl (step budget) BehaviorStanding.demoted rest
+                  = run budget .demoted rest from rfl,
+                released_absorbing budget .demoted rest rfl]
+            rfl
+
+/-- The seeded corollary in the form the runtime actually uses: with a positive
+budget and at least `budget` attempts, a freshly seeded behavior is released. -/
+theorem seeded_release (budget : Nat) (outcomes : List BuildOutcome)
+    (hPos : 0 < budget) (hEnough : budget ≤ outcomes.length) :
+    (run budget seeded outcomes).released = true :=
+  budgeted_attempts_release budget 0 outcomes hPos (by simpa using hEnough)
+
+/-! ## No premature demotion: success within budget wins -/
+
+/-- A behavior whose build succeeds before the budget is exhausted becomes
+`ready` — demotion never races a viable build. -/
+theorem start_within_budget_is_ready (budget : Nat) (failures : Nat)
+    (rest : List BuildOutcome) :
+    run budget (.pending failures) (.started :: rest) = .ready := by
+  simp only [run, List.foldl_cons, step]
+  rw [show List.foldl (step budget) BehaviorStanding.ready rest
+        = run budget .ready rest from rfl,
+      released_absorbing budget .ready rest rfl]
+
+/-- Demotion requires the whole budget: a demoted behavior really did fail
+`budget` builds with no success interleaved. -/
+theorem demoted_consumed_the_budget (budget : Nat) (failures : Nat)
+    (outcomes : List BuildOutcome)
+    (hDemoted : run budget (.pending failures) outcomes = .demoted) :
+    budget ≤ failures + outcomes.length := by
+  induction outcomes generalizing failures with
+  | nil =>
+      simp [run] at hDemoted
+  | cons outcome rest ih =>
+      cases outcome with
+      | started =>
+          rw [start_within_budget_is_ready budget failures rest] at hDemoted
+          exact absurd hDemoted (by simp)
+      | failed =>
+          simp only [run, List.foldl_cons, step] at hDemoted
+          by_cases hBudget : failures + 1 < budget
+          · simp only [hBudget, if_true] at hDemoted
+            have := ih (failures + 1) hDemoted
+            simpa [List.length_cons, Nat.add_comm, Nat.add_left_comm] using this
+          · simp only [List.length_cons]
+            omega
+
+/-! ## Process accounting -/
+
+/-- `Ready` accounts for every behavior: each is genuinely serving, demoted
+with its budget consumed, or superseded by reconcile — never silently dropped. -/
+theorem process_ready_accounts (standings : List BehaviorStanding)
+    (hReady : processReady standings = true) :
+    ∀ standing ∈ standings,
+      standing = .ready ∨ standing = .demoted ∨ standing = .superseded := by
+  intro standing hMem
+  have := List.all_eq_true.mp hReady standing hMem
+  cases standing with
+  | pending _ => simp [BehaviorStanding.released] at this
+  | ready => exact Or.inl rfl
+  | demoted => exact Or.inr (Or.inl rfl)
+  | superseded => exact Or.inr (Or.inr rfl)
+
+/-- Retirement always releases: reconcile retiring a slot mid-startup cannot
+orphan a pending entry — the second hang path of #559. -/
+theorem retire_releases (standing : BehaviorStanding) :
+    (retire standing).released = true := by
+  cases standing <;> rfl
+
+/-- Retirement never claims health: only a real start produces `ready`. -/
+theorem retire_never_claims_ready (standing : BehaviorStanding)
+    (hNotReady : standing ≠ .ready) :
+    retire standing ≠ .ready := by
+  cases standing with
+  | pending _ => simp [retire]
+  | ready => exact absurd rfl hNotReady
+  | demoted => simp [retire]
+  | superseded => simp [retire]
+
+/-! ## Generations: keep carries the standing, recreate resets it -/
+
+/-- Reconcile's slot diffing, restricted to what matters here: an unchanged
+behavior keeps its slot; a changed behavior gets a fresh one. -/
+def acrossGeneration (changed : Bool) (standing : BehaviorStanding) : BehaviorStanding :=
+  if changed then seeded else standing
+
+/-- A no-op republish never resurrects a known-bad build. -/
+theorem demotion_persists_when_unchanged (standing : BehaviorStanding) :
+    acrossGeneration false standing = standing := rfl
+
+/-- A config change earns a fresh budget: the operator's fix gets a real
+chance instead of inheriting a spent counter. -/
+theorem change_restores_the_budget (standing : BehaviorStanding) :
+    acrossGeneration true standing = seeded := rfl
+
+end RuntimeReconcile.StartupReadiness

--- a/crates/defra-agent/src/agent.rs
+++ b/crates/defra-agent/src/agent.rs
@@ -84,6 +84,10 @@ pub struct DocumentRuntimeOptions {
     /// the runtime create its own.
     pub backend_health: Option<BackendHealthMap>,
     pub process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
+    /// Startup readiness knobs (#559): the build-failure budget that demotes a
+    /// persistently un-buildable behavior instead of wedging `Ready`, and the
+    /// per-attempt build timeout that turns a hanging build into a failure.
+    pub startup_readiness: crate::startup_readiness::StartupReadinessOptions,
 }
 
 #[derive(Clone)]
@@ -112,6 +116,7 @@ pub struct DefraAgent {
     backend_prober_options: BackendProberOptions,
     backend_health: BackendHealthMap,
     process_state_observer: Option<Arc<dyn ProcessLifecycleObserver>>,
+    startup_readiness: crate::startup_readiness::StartupReadinessOptions,
     rendered_request_capture_factory:
         Option<crate::rendered_request::RenderedRequestCaptureFactory>,
     /// Populated once the runtime's `TriggerEngine` has constructed the
@@ -195,6 +200,7 @@ impl DefraAgent {
             backend_prober_options: options.backend_prober_options,
             backend_health,
             process_state_observer: options.process_state_observer,
+            startup_readiness: options.startup_readiness,
             rendered_request_capture_factory: None,
             manual_trigger_handle: Arc::new(OnceCell::new()),
         })

--- a/crates/defra-agent/src/agent/builder.rs
+++ b/crates/defra-agent/src/agent/builder.rs
@@ -229,6 +229,7 @@ impl DefraAgentBuilder {
             backend_prober_options: crate::backend_health::BackendProberOptions::default(),
             backend_health: crate::backend_health::BackendHealthMap::new(),
             process_state_observer: self.process_state_observer,
+            startup_readiness: Default::default(),
             rendered_request_capture_factory: self.rendered_request_capture_factory,
             manual_trigger_handle: Arc::new(tokio::sync::OnceCell::new()),
         })

--- a/crates/defra-agent/src/agent/daemon.rs
+++ b/crates/defra-agent/src/agent/daemon.rs
@@ -63,6 +63,7 @@ pub(super) struct BehaviorDaemon<M: CompletionModel> {
     background_tool_registry: crate::hook::BackgroundToolRegistry,
     background_execution_registry: crate::hook::BackgroundExecutionRegistry,
     startup_barrier: Arc<StartupBarrier>,
+    startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
 }
 
 enum HandleRequestOutcome {
@@ -86,6 +87,7 @@ impl<M: CompletionModel + 'static> BehaviorDaemon<M> {
         background_tool_registry: crate::hook::BackgroundToolRegistry,
         background_execution_registry: crate::hook::BackgroundExecutionRegistry,
         startup_barrier: Arc<StartupBarrier>,
+        startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
     ) -> Self {
         let stream_writer = DefraStreamWriter::new(
             node.clone(),
@@ -118,6 +120,7 @@ impl<M: CompletionModel + 'static> BehaviorDaemon<M> {
             background_tool_registry,
             background_execution_registry,
             startup_barrier,
+            startup_demotions,
         }
     }
 
@@ -137,6 +140,10 @@ impl<M: CompletionModel + 'static> BehaviorDaemon<M> {
         self.startup_barrier
             .mark_behavior_ready(&self.behavior.behavior_id)
             .await;
+        // A successful start supersedes any demotion that raced it: the
+        // behavior is serving, so the ledger entry (which would make the
+        // router reject its requests) must not survive.
+        self.startup_demotions.clear(&self.behavior.behavior_id);
         tracing::info!(
             behavior_id = %self.behavior.behavior_id,
             did = %self.behavior.agent_did(),

--- a/crates/defra-agent/src/agent/reconcile.rs
+++ b/crates/defra-agent/src/agent/reconcile.rs
@@ -20,6 +20,7 @@ mod slot;
 use diff::diff_counts;
 #[cfg(test)]
 use slot::spawn_slot;
+pub(in crate::agent) use slot::SlotFailurePolicy;
 use slot::{
     behavior_executor_capacity, retire_slot, spawn_slot_with_capacity, spawn_slots, BehaviorSlot,
     BehaviorSlotState,
@@ -32,6 +33,7 @@ pub(super) struct GenerationSupervisor<F> {
     retry_policy: RetryPolicy,
     runner: F,
     runtime_status: RuntimeStatusHandle,
+    slot_failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
 }
 
 impl<F, Fut> GenerationSupervisor<F>
@@ -55,6 +57,7 @@ where
         runner: F,
         runtime_status: RuntimeStatusHandle,
         shutdown: watch::Receiver<bool>,
+        slot_failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
     ) -> Result<Self> {
         admission_registry.reconcile(1, &resolved_snapshot.backend_admission_configs);
         let active_slots = spawn_slots(
@@ -62,6 +65,7 @@ where
             retry_policy.clone(),
             runner.clone(),
             shutdown,
+            slot_failure_policy.clone(),
         );
         let dispatchers = active_slots
             .iter()
@@ -89,6 +93,7 @@ where
             retry_policy,
             runner,
             runtime_status,
+            slot_failure_policy,
         })
     }
 
@@ -210,6 +215,10 @@ where
     ) -> Result<()> {
         let mut next_slots = HashMap::new();
         let mut retired_slots = Vec::new();
+        // (behavior_id, recreated): retirement must release a never-started
+        // behavior from the startup barrier (superseded), and a recreated slot
+        // earns a fresh build budget (#559).
+        let mut retired_behaviors: Vec<(String, bool)> = Vec::new();
 
         for (behavior_id, behavior) in &resolved_snapshot.behaviors {
             let tool_surface = resolved_snapshot
@@ -226,6 +235,7 @@ where
                 }
                 Some(existing) => {
                     retired_slots.push(existing);
+                    retired_behaviors.push((behavior_id.clone(), true));
                     next_slots.insert(
                         behavior_id.clone(),
                         spawn_slot_with_capacity(
@@ -235,6 +245,7 @@ where
                             self.retry_policy.clone(),
                             self.runner.clone(),
                             shutdown.clone(),
+                            self.slot_failure_policy.clone(),
                         ),
                     );
                 }
@@ -248,12 +259,18 @@ where
                             self.retry_policy.clone(),
                             self.runner.clone(),
                             shutdown.clone(),
+                            self.slot_failure_policy.clone(),
                         ),
                     );
                 }
             }
         }
 
+        retired_behaviors.extend(
+            self.active_slots
+                .keys()
+                .map(|behavior_id| (behavior_id.clone(), false)),
+        );
         retired_slots.extend(self.active_slots.drain().map(|(_, slot)| slot));
 
         let dispatchers = next_slots
@@ -285,6 +302,13 @@ where
 
         for slot in retired_slots {
             retire_slot(slot);
+        }
+        if let Some(policy) = self.slot_failure_policy.clone() {
+            tokio::spawn(async move {
+                for (behavior_id, recreated) in retired_behaviors {
+                    policy.on_slot_retired(&behavior_id, recreated).await;
+                }
+            });
         }
 
         Ok(())

--- a/crates/defra-agent/src/agent/reconcile/slot.rs
+++ b/crates/defra-agent/src/agent/reconcile/slot.rs
@@ -10,6 +10,7 @@ use crate::admission::BackendAdmissionConfig;
 use crate::config::AgentBehavior;
 use crate::retry::RetryPolicy;
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
+use crate::startup_readiness::{BuildOutcome, BuildStanding};
 use crate::tool_surface::ToolSurface;
 use crate::watcher::AgentRequest;
 
@@ -46,11 +47,134 @@ impl BehaviorSlot {
     }
 }
 
+/// Decides what a slot does about repeated failures before its behavior ever
+/// started (#559).
+///
+/// The slot loop counts consecutive pre-start failures on one shared standing
+/// per slot (mirroring `RuntimeReconcile.StartupReadiness`); when the budget is
+/// spent it asks the policy to demote. The policy re-checks the startup barrier
+/// at that moment: a behavior that already started once (this worker or a
+/// sibling) is a post-start crash and keeps today's unbounded restart behavior.
+/// Behaviors spawned by post-startup generations never enter the barrier, so
+/// `try_demote` declines them and they also keep today's behavior.
+#[async_trait::async_trait]
+pub(crate) trait SlotFailurePolicy: Send + Sync {
+    /// Consecutive pre-start build failures tolerated before demotion.
+    fn build_failure_budget(&self) -> u32;
+    /// Demote the behavior if it is still startup-pending: release it from the
+    /// barrier without claiming health, record the reason, surface it. Returns
+    /// whether the demotion was actually taken.
+    async fn try_demote(&self, behavior_id: &str, error: &str) -> bool;
+    /// Reconcile retired this behavior's slot. A still-pending behavior must be
+    /// released as superseded so mid-startup retirement cannot orphan its
+    /// barrier entry; a recreated slot starts with a fresh budget.
+    async fn on_slot_retired(&self, behavior_id: &str, recreated: bool);
+}
+
+/// Count a worker failure against the slot's build budget and demote at the
+/// budget. Returns `true` when this worker should stop (parked after a
+/// demotion) instead of taking the classic restart path.
+///
+/// The stepping mirrors `RuntimeReconcile.StartupReadiness.step`; the policy's
+/// `try_demote` re-checks the startup barrier at the demotion moment, so a
+/// behavior that started on a sibling worker (post-start crash) or that never
+/// entered the barrier (post-startup generations) declines demotion and keeps
+/// today's restart behavior.
+async fn handle_slot_failure(
+    behavior_id: &str,
+    error: &str,
+    failure_policy: Option<&dyn SlotFailurePolicy>,
+    standing: &Arc<std::sync::Mutex<BuildStanding>>,
+    shutdown: &mut watch::Receiver<bool>,
+    state_rx: &mut watch::Receiver<BehaviorSlotState>,
+) -> bool {
+    let Some(policy) = failure_policy else {
+        return false;
+    };
+    enum Verdict {
+        /// Ready (post-start crash) or lock poisoned: classic restarts.
+        Restart,
+        /// A sibling already spent the budget; this worker parks too.
+        AlreadyDemoted,
+        /// This failure consumed the last of the budget.
+        Transitioned,
+        /// Budget remains: classic restart, keep counting.
+        StillPending,
+    }
+    let verdict = match standing.lock() {
+        Err(_) => Verdict::Restart,
+        Ok(mut standing) => {
+            if standing.released() {
+                if *standing == BuildStanding::Demoted {
+                    Verdict::AlreadyDemoted
+                } else {
+                    Verdict::Restart
+                }
+            } else {
+                let next = standing.step(policy.build_failure_budget(), BuildOutcome::Failed);
+                *standing = next;
+                if next == BuildStanding::Demoted {
+                    Verdict::Transitioned
+                } else {
+                    Verdict::StillPending
+                }
+            }
+        }
+    };
+    match verdict {
+        Verdict::Restart | Verdict::StillPending => return false,
+        Verdict::AlreadyDemoted => {
+            park_until_retired(shutdown, state_rx).await;
+            return true;
+        }
+        Verdict::Transitioned => {}
+    }
+    if policy.try_demote(behavior_id, error).await {
+        park_until_retired(shutdown, state_rx).await;
+        true
+    } else {
+        // The barrier had already released this behavior (it started once, or
+        // never entered the barrier): not a startup demotion. Absorb to Ready
+        // so the budget machinery stays out of the way of classic restarts.
+        if let Ok(mut standing) = standing.lock() {
+            *standing = BuildStanding::Ready;
+        }
+        false
+    }
+}
+
+/// Park a demoted worker: the behavior cannot serve, so restarting the build
+/// would only burn CPU against a spent budget. Wakes only for shutdown or
+/// slot retirement.
+async fn park_until_retired(
+    shutdown: &mut watch::Receiver<bool>,
+    state_rx: &mut watch::Receiver<BehaviorSlotState>,
+) {
+    loop {
+        if *shutdown.borrow() || *state_rx.borrow() == BehaviorSlotState::Retiring {
+            return;
+        }
+        tokio::select! {
+            changed = shutdown.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+            changed = state_rx.changed() => {
+                if changed.is_err() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
 pub(super) fn spawn_slots<F, Fut>(
     resolved_snapshot: &ResolvedRuntimeSnapshot,
     retry_policy: RetryPolicy,
     runner: F,
     shutdown: watch::Receiver<bool>,
+    failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
 ) -> HashMap<String, BehaviorSlot>
 where
     F: Fn(
@@ -81,6 +205,7 @@ where
                 retry_policy.clone(),
                 runner.clone(),
                 shutdown.clone(),
+                failure_policy.clone(),
             ),
         );
     }
@@ -108,7 +233,15 @@ where
         + 'static,
     Fut: std::future::Future<Output = Result<()>> + Send + 'static,
 {
-    spawn_slot_with_capacity(behavior, tool_surface, 1, retry_policy, runner, shutdown)
+    spawn_slot_with_capacity(
+        behavior,
+        tool_surface,
+        1,
+        retry_policy,
+        runner,
+        shutdown,
+        None,
+    )
 }
 
 pub(super) fn spawn_slot_with_capacity<F, Fut>(
@@ -118,6 +251,7 @@ pub(super) fn spawn_slot_with_capacity<F, Fut>(
     retry_policy: RetryPolicy,
     runner: F,
     shutdown: watch::Receiver<bool>,
+    failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
 ) -> BehaviorSlot
 where
     F: Fn(
@@ -139,6 +273,10 @@ where
     let behavior_fingerprint = format!("{behavior:?}");
     let tool_surface_fingerprint = format!("{tool_surface:?}");
 
+    // One standing per slot, shared across its executor workers: the budget
+    // is a per-behavior property, and the interleaved worker outcomes are the
+    // model's single outcome list.
+    let standing = Arc::new(std::sync::Mutex::new(BuildStanding::seeded()));
     let handle = tokio::spawn(run_slot_workers(
         behavior,
         tool_surface,
@@ -148,6 +286,8 @@ where
         runner,
         shutdown,
         state_rx,
+        failure_policy,
+        standing,
     ));
 
     BehaviorSlot {
@@ -200,7 +340,9 @@ async fn run_slot_loop<F, Fut>(
     retry_policy: RetryPolicy,
     runner: F,
     mut shutdown: watch::Receiver<bool>,
-    state_rx: watch::Receiver<BehaviorSlotState>,
+    mut state_rx: watch::Receiver<BehaviorSlotState>,
+    failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
+    standing: Arc<std::sync::Mutex<BuildStanding>>,
 ) where
     F: Fn(
             Arc<AgentBehavior>,
@@ -217,6 +359,16 @@ async fn run_slot_loop<F, Fut>(
     let mut failure_count = 0u32;
     loop {
         if *shutdown.borrow() || *state_rx.borrow() == BehaviorSlotState::Retiring {
+            return;
+        }
+        // A sibling worker may have spent the budget already; a demoted slot
+        // must not keep rebuilding against a verdict that is already final.
+        if standing
+            .lock()
+            .map(|standing| *standing == BuildStanding::Demoted)
+            .unwrap_or(false)
+        {
+            park_until_retired(&mut shutdown, &mut state_rx).await;
             return;
         }
 
@@ -236,6 +388,12 @@ async fn run_slot_loop<F, Fut>(
         match outcome {
             Ok(Ok(())) if *state_rx.borrow() == BehaviorSlotState::Retiring => return,
             Ok(Ok(())) => {
+                // The daemon ran (it only returns Ok after starting), so the
+                // behavior started at least once: absorb the standing so later
+                // errors are the post-start crash class, not build failures.
+                if let Ok(mut standing) = standing.lock() {
+                    *standing = standing.step(u32::MAX, BuildOutcome::Started);
+                }
                 let delay = retry_policy.delay_for_attempt(failure_count);
                 failure_count += 1;
                 tracing::warn!(
@@ -248,6 +406,18 @@ async fn run_slot_loop<F, Fut>(
                 }
             }
             Ok(Err(error)) => {
+                if handle_slot_failure(
+                    &behavior.behavior_id,
+                    &format!("{error:#}"),
+                    failure_policy.as_deref(),
+                    &standing,
+                    &mut shutdown,
+                    &mut state_rx,
+                )
+                .await
+                {
+                    return;
+                }
                 let delay = retry_policy.delay_for_attempt(failure_count);
                 failure_count += 1;
                 tracing::error!(
@@ -261,6 +431,18 @@ async fn run_slot_loop<F, Fut>(
                 }
             }
             Err(_) => {
+                if handle_slot_failure(
+                    &behavior.behavior_id,
+                    "behavior runner panicked",
+                    failure_policy.as_deref(),
+                    &standing,
+                    &mut shutdown,
+                    &mut state_rx,
+                )
+                .await
+                {
+                    return;
+                }
                 let delay = retry_policy.delay_for_attempt(failure_count);
                 failure_count += 1;
                 tracing::error!(
@@ -285,6 +467,8 @@ async fn run_slot_workers<F, Fut>(
     runner: F,
     shutdown: watch::Receiver<bool>,
     state_rx: watch::Receiver<BehaviorSlotState>,
+    failure_policy: Option<Arc<dyn SlotFailurePolicy>>,
+    standing: Arc<std::sync::Mutex<BuildStanding>>,
 ) where
     F: Fn(
             Arc<AgentBehavior>,
@@ -314,6 +498,8 @@ async fn run_slot_workers<F, Fut>(
             runner.clone(),
             shutdown.clone(),
             state_rx.clone(),
+            failure_policy.clone(),
+            standing.clone(),
         ));
         tracing::debug!(
             behavior_id = %behavior.behavior_id,

--- a/crates/defra-agent/src/agent/reconcile/tests.rs
+++ b/crates/defra-agent/src/agent/reconcile/tests.rs
@@ -521,6 +521,7 @@ async fn behavior_slot_fans_out_background_children_to_backend_capacity() {
         },
         runner,
         shutdown_rx,
+        None,
     );
     let dispatcher = slots
         .get("general")
@@ -628,6 +629,7 @@ async fn generation_supervisor_rotates_dispatcher_on_backend_capacity_change() {
         runner,
         runtime_status,
         shutdown_rx.clone(),
+        None,
     )
     .unwrap();
     let active_snapshot = supervisor.current_snapshot();
@@ -780,6 +782,7 @@ async fn generation_supervisor_rotates_dispatcher_on_behavior_change() {
         runner,
         runtime_status.clone(),
         shutdown_rx.clone(),
+        None,
     )
     .unwrap();
     let active_snapshot = supervisor.current_snapshot();
@@ -923,6 +926,7 @@ async fn generation_supervisor_keeps_previous_generation_after_failed_apply() {
         runner,
         runtime_status.clone(),
         shutdown_rx.clone(),
+        None,
     )
     .unwrap();
     let initial_active = supervisor.current_snapshot();
@@ -1106,6 +1110,7 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
         runner,
         runtime_status.clone(),
         shutdown_rx.clone(),
+        None,
     )
     .unwrap();
     let active_snapshot = supervisor.current_snapshot();
@@ -1139,6 +1144,112 @@ async fn generation_supervisor_rotates_dispatcher_on_tool_surface_change() {
 
     let _ = shutdown_tx.send(true);
     tokio::time::timeout(Duration::from_secs(1), task)
+        .await
+        .expect("supervisor should stop on shutdown")
+        .unwrap()
+        .unwrap();
+}
+
+/// #559: a slot retired by a generation change must release its behavior from
+/// the startup barrier (superseded) instead of orphaning the pending entry —
+/// the policy's retirement hook is the only path that knowledge can take.
+#[tokio::test]
+async fn retiring_a_slot_notifies_the_failure_policy() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct RecordingPolicy {
+        retired: std::sync::Mutex<Vec<(String, bool)>>,
+        demote_calls: AtomicUsize,
+    }
+
+    #[async_trait::async_trait]
+    impl slot::SlotFailurePolicy for RecordingPolicy {
+        fn build_failure_budget(&self) -> u32 {
+            3
+        }
+        async fn try_demote(&self, _behavior_id: &str, _error: &str) -> bool {
+            self.demote_calls.fetch_add(1, Ordering::SeqCst);
+            false
+        }
+        async fn on_slot_retired(&self, behavior_id: &str, recreated: bool) {
+            self.retired
+                .lock()
+                .expect("retired mutex")
+                .push((behavior_id.to_string(), recreated));
+        }
+    }
+
+    let node = test_node().await;
+    ensure_runtime_schemas(node.as_ref()).await.unwrap();
+    let runtime_status =
+        crate::runtime_status::RuntimeStatusHandle::new(node.clone(), "did:test:policy");
+    let behavior = Arc::new(
+        PendingAgentBehavior::new("general")
+            .build_with_identity_for_test(test_identity("policy-retirement-559")),
+    );
+    let initial_snapshot =
+        snapshot_for_behaviors(node.as_ref(), "general", vec![behavior.clone()]).await;
+    // A runner that parks until shutdown: the behavior never "starts", exactly
+    // the mid-startup window the retirement release exists for.
+    let runner = |_behavior: Arc<AgentBehavior>,
+                  _tool_surface: Arc<ToolSurface>,
+                  _request_rx: Arc<Mutex<mpsc::Receiver<AgentRequest>>>,
+                  mut shutdown: watch::Receiver<bool>| async move {
+        let _ = shutdown.changed().await;
+        Ok(())
+    };
+
+    let policy = Arc::new(RecordingPolicy {
+        retired: std::sync::Mutex::new(Vec::new()),
+        demote_calls: AtomicUsize::new(0),
+    });
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let supervisor = GenerationSupervisor::bootstrap(
+        initial_snapshot,
+        crate::admission::AdmissionRegistry::new(node.clone()),
+        crate::retry::RetryPolicy {
+            max_retries: 1,
+            base_delay_ms: 1,
+            max_delay_ms: 2,
+        },
+        runner,
+        runtime_status,
+        shutdown_rx.clone(),
+        Some(policy.clone() as Arc<dyn slot::SlotFailurePolicy>),
+    )
+    .unwrap();
+    let (active_tx, mut active_rx) = watch::channel(supervisor.current_snapshot());
+    let (proposal_tx, proposal_rx) = mpsc::channel(4);
+    let task = tokio::spawn(supervisor.run(active_tx, proposal_rx, shutdown_rx));
+
+    // A generation without the behavior: its slot is retired outright.
+    let empty_snapshot = snapshot_for_behaviors(node.as_ref(), "general", vec![]).await;
+    proposal_tx.send(empty_snapshot).await.unwrap();
+    tokio::time::timeout(Duration::from_secs(1), active_rx.changed())
+        .await
+        .expect("removal generation should publish")
+        .unwrap();
+
+    // The retirement hook runs on a spawned task; give it a beat.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        if policy
+            .retired
+            .lock()
+            .expect("retired mutex")
+            .contains(&("general".to_string(), false))
+        {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "retirement must notify the policy so the barrier is released"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    let _ = shutdown_tx.send(true);
+    tokio::time::timeout(Duration::from_secs(2), task)
         .await
         .expect("supervisor should stop on shutdown")
         .unwrap()

--- a/crates/defra-agent/src/agent/runtime/context.rs
+++ b/crates/defra-agent/src/agent/runtime/context.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use crate::llm::tool::ToolDyn;
 use anyhow::{Context, Result};
 use rig::client::CompletionClient;
-use tokio::sync::{mpsc, watch, Mutex, Notify};
+use tokio::sync::{mpsc, watch, Mutex};
 
 use crate::admission::AdmissionRegistry;
 use crate::agent::daemon::BehaviorDaemon;
@@ -25,6 +25,12 @@ pub(super) struct RuntimeContext {
         Option<crate::rendered_request::RenderedRequestCaptureFactory>,
     pub(super) background_execution_registry: BackgroundExecutionRegistry,
     pub(super) startup_barrier: Arc<StartupBarrier>,
+    /// Startup readiness knobs (#559): the per-attempt build timeout below and
+    /// the failure budget consumed by the slot loop's demotion policy.
+    pub(super) startup_readiness: crate::startup_readiness::StartupReadinessOptions,
+    /// Demotion ledger, cleared by the daemon on a successful start so a
+    /// demotion racing a late success self-heals.
+    pub(super) startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
 }
 
 pub(super) struct BehaviorResolution {
@@ -34,40 +40,87 @@ pub(super) struct BehaviorResolution {
 
 pub struct StartupBarrier {
     pending_behaviors: Mutex<HashSet<String>>,
-    notify: Notify,
+    /// The pending count as a watch channel rather than a `Notify`: the old
+    /// check-then-`notified()` loop could miss a final `notify_waiters` fired
+    /// between the check and the registration, hanging `wait_ready` on an
+    /// empty set. A watch receiver observes the latest value by construction,
+    /// so the release can never be lost.
+    pending_count_tx: watch::Sender<usize>,
 }
 
 impl StartupBarrier {
     pub(super) fn new(behaviors: &[Arc<crate::config::AgentBehavior>]) -> Self {
+        let pending: HashSet<String> = behaviors
+            .iter()
+            .map(|behavior| behavior.behavior_id.clone())
+            .collect();
+        let (pending_count_tx, _) = watch::channel(pending.len());
         Self {
-            pending_behaviors: Mutex::new(
-                behaviors
-                    .iter()
-                    .map(|behavior| behavior.behavior_id.clone())
-                    .collect::<HashSet<_>>(),
-            ),
-            notify: Notify::new(),
+            pending_behaviors: Mutex::new(pending),
+            pending_count_tx,
+        }
+    }
+
+    async fn release(&self, behavior_id: &str) {
+        let mut pending = self.pending_behaviors.lock().await;
+        if pending.remove(behavior_id) {
+            // send_replace, not send: a release that lands before any waiter
+            // subscribes must still be stored, or the count freezes at its
+            // seeded value and wait_ready never observes zero.
+            let _ = self.pending_count_tx.send_replace(pending.len());
         }
     }
 
     pub async fn mark_behavior_ready(&self, behavior_id: &str) {
-        let mut pending = self.pending_behaviors.lock().await;
-        let removed = pending.remove(behavior_id);
-        let is_empty = pending.is_empty();
-        drop(pending);
+        self.release(behavior_id).await;
+    }
 
-        if removed && is_empty {
-            self.notify.notify_waiters();
-        }
+    /// Release a behavior from the barrier WITHOUT claiming it healthy (#559).
+    ///
+    /// The demotion accounting (reason, counts, router rejection) lives in
+    /// `StartupDemotions`; the barrier's only job is to stop waiting so one
+    /// persistently un-buildable behavior cannot wedge `Ready` and the trigger
+    /// engine forever. The distinction from readiness is carried by the
+    /// ledger, exactly as the Lean model separates `ready` from `demoted`
+    /// while `released` covers both.
+    pub async fn mark_behavior_demoted(&self, behavior_id: &str) {
+        self.release(behavior_id).await;
+    }
+
+    /// Release a behavior whose slot reconcile retired before it ever started
+    /// (config change or removal mid-startup). Without this, retirement
+    /// orphaned the pending entry — the second #559 hang path. Mirrors
+    /// `RuntimeReconcile.StartupReadiness.retire`.
+    pub async fn mark_behavior_superseded(&self, behavior_id: &str) {
+        self.release(behavior_id).await;
+    }
+
+    /// Whether the barrier is still waiting on this behavior — i.e. it has
+    /// neither started once, been demoted, nor been superseded. The slot
+    /// failure policy uses this to tell a build failure (pending) from a
+    /// post-start crash (released), which keeps today's restart behavior.
+    pub async fn is_pending(&self, behavior_id: &str) -> bool {
+        self.pending_behaviors.lock().await.contains(behavior_id)
+    }
+
+    /// The behaviors the barrier is still waiting on, for watchdog logging.
+    pub async fn pending_behaviors(&self) -> Vec<String> {
+        let mut pending: Vec<String> = self
+            .pending_behaviors
+            .lock()
+            .await
+            .iter()
+            .cloned()
+            .collect();
+        pending.sort();
+        pending
     }
 
     pub(super) async fn wait_ready(&self) {
-        loop {
-            if self.pending_behaviors.lock().await.is_empty() {
-                return;
-            }
-            self.notify.notified().await;
-        }
+        let mut rx = self.pending_count_tx.subscribe();
+        // `wait_for` inspects the current value first, so a barrier that is
+        // already (or was seeded) empty returns immediately.
+        let _ = rx.wait_for(|count| *count == 0).await;
     }
 }
 
@@ -205,12 +258,26 @@ impl RuntimeContext {
                 .await
             }
             BackendProviderKind::ChatGptCodex => {
-                let client = crate::chatgpt_codex::build_responses_client(
-                    self.node.clone(),
-                    behavior.agent_did(),
-                    &behavior.backend_endpoint,
+                // The only async client build (DB + network): a hang here would
+                // produce no outcome for the slot's build budget, so bound it —
+                // the timeout converts a hang into a failed attempt and the
+                // demotion machinery covers it (#559).
+                let client = tokio::time::timeout(
+                    self.startup_readiness.build_timeout,
+                    crate::chatgpt_codex::build_responses_client(
+                        self.node.clone(),
+                        behavior.agent_did(),
+                        &behavior.backend_endpoint,
+                    ),
                 )
                 .await
+                .map_err(|_| {
+                    anyhow::anyhow!(
+                        "timed out after {:?} building the ChatGPT Codex completion client",
+                        self.startup_readiness.build_timeout
+                    )
+                })
+                .and_then(|result| result)
                 .with_context(|| {
                     format!(
                         "building ChatGPT Codex completion client for behavior {} against {}",
@@ -265,7 +332,83 @@ impl RuntimeContext {
             background_tool_registry,
             self.background_execution_registry.clone(),
             self.startup_barrier.clone(),
+            self.startup_demotions.clone(),
         );
         daemon.run(request_rx, shutdown).await
+    }
+}
+
+#[cfg(test)]
+mod startup_barrier_tests {
+    use super::*;
+
+    fn behavior(behavior_id: &str) -> Arc<crate::config::AgentBehavior> {
+        Arc::new(
+            crate::agent::PendingAgentBehavior::new(behavior_id).build_with_identity_for_test(
+                crate::KeyIdentity::load_or_create(
+                    std::env::temp_dir().join(format!(
+                        "barrier-{behavior_id}-{}.key",
+                        uuid::Uuid::new_v4()
+                    )),
+                    None,
+                )
+                .unwrap(),
+            ),
+        )
+    }
+
+    #[tokio::test]
+    async fn empty_seed_is_immediately_ready() {
+        let barrier = StartupBarrier::new(&[]);
+        tokio::time::timeout(std::time::Duration::from_secs(1), barrier.wait_ready())
+            .await
+            .expect("an empty barrier must not wait");
+    }
+
+    /// The lost-wakeup regression (#559): the final release may land at any
+    /// point relative to the waiter. With the watch channel the waiter always
+    /// observes the current count, so release-before-wait, release-after-wait,
+    /// and anything between all complete.
+    #[tokio::test]
+    async fn release_before_and_after_wait_both_complete() {
+        let barrier = Arc::new(StartupBarrier::new(&[behavior("a"), behavior("b")]));
+
+        // Release one before any waiter exists.
+        barrier.mark_behavior_ready("a").await;
+
+        let waiter = {
+            let barrier = barrier.clone();
+            tokio::spawn(async move { barrier.wait_ready().await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        barrier.mark_behavior_ready("b").await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("waiter must observe the final release")
+            .unwrap();
+    }
+
+    /// Every release class frees the barrier: readiness, demotion (budget
+    /// spent), and supersession (retired mid-startup). Only readiness claims
+    /// health; the others carry their verdict in the demotion ledger.
+    #[tokio::test]
+    async fn demotion_and_supersession_release_without_readiness() {
+        let barrier = Arc::new(StartupBarrier::new(&[
+            behavior("healthy"),
+            behavior("unbuildable"),
+            behavior("retired"),
+        ]));
+
+        barrier.mark_behavior_ready("healthy").await;
+        barrier.mark_behavior_demoted("unbuildable").await;
+        assert!(barrier.is_pending("retired").await);
+        barrier.mark_behavior_superseded("retired").await;
+        assert!(!barrier.is_pending("retired").await);
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), barrier.wait_ready())
+            .await
+            .expect("all release classes together must free the barrier");
+        assert!(barrier.pending_behaviors().await.is_empty());
     }
 }

--- a/crates/defra-agent/src/agent/runtime/router.rs
+++ b/crates/defra-agent/src/agent/runtime/router.rs
@@ -17,9 +17,18 @@ pub(super) async fn run_router(
     agent_did: String,
     active_snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
     shutdown: watch::Receiver<bool>,
+    startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
 ) -> Result<()> {
     let watcher = DefraWatcher::new(node.clone(), &agent_did);
-    run_router_with_watcher(node, agent_did, watcher, active_snapshot_rx, shutdown).await
+    run_router_with_watcher(
+        node,
+        agent_did,
+        watcher,
+        active_snapshot_rx,
+        shutdown,
+        startup_demotions,
+    )
+    .await
 }
 
 async fn run_router_with_watcher<W>(
@@ -28,6 +37,7 @@ async fn run_router_with_watcher<W>(
     mut watcher: W,
     mut active_snapshot_rx: watch::Receiver<Arc<ActiveRuntimeSnapshot>>,
     mut shutdown: watch::Receiver<bool>,
+    startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
 ) -> Result<()>
 where
     W: Watcher,
@@ -67,6 +77,29 @@ where
                 request,
                 resolution.behavior_id.as_str(),
                 reason,
+            )
+            .await?;
+            continue;
+        }
+
+        // A behavior demoted for startup build failures still has a dispatcher
+        // (its slot is parked); dispatching would queue the request into a
+        // channel nobody drains. Fail it loudly with the build error instead
+        // (#559), mirroring the snapshot-unavailable rejection below.
+        if let Some(reason) = startup_demotions.reason(&resolution.behavior_id) {
+            tracing::warn!(
+                request_id = %request.request_id,
+                session_id = %request.session_id,
+                behavior_id = %resolution.behavior_id,
+                reason = %reason,
+                "behavior demoted at startup; rejecting request"
+            );
+            fail_routed_request(
+                node.clone(),
+                agent_did.as_str(),
+                request,
+                resolution.behavior_id.as_str(),
+                reason.as_str(),
             )
             .await?;
             continue;

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -41,6 +41,63 @@ enum BackgroundTaskResult {
     DiscoveryReconcile(Result<()>),
 }
 
+/// Startup demotion policy (#559): demote a behavior only while the startup
+/// barrier is still waiting on it, releasing the barrier without claiming
+/// health and surfacing the reason through the ledger, the status counts, and
+/// the log. `RuntimeReconcile.StartupReadiness` is the model; the conformance
+/// fence drives its emitted vectors through the same `BuildStanding` the slot
+/// loop steps.
+struct StartupSlotFailurePolicy {
+    barrier: Arc<StartupBarrier>,
+    demotions: Arc<crate::startup_readiness::StartupDemotions>,
+    runtime_status: RuntimeStatusHandle,
+    budget: u32,
+}
+
+#[async_trait::async_trait]
+impl crate::agent::reconcile::SlotFailurePolicy for StartupSlotFailurePolicy {
+    fn build_failure_budget(&self) -> u32 {
+        self.budget.max(1)
+    }
+
+    async fn try_demote(&self, behavior_id: &str, error: &str) -> bool {
+        // The authoritative pending check happens here, at the demotion
+        // moment: a behavior that started once (this or a sibling worker) or
+        // that never entered the barrier is not a startup demotion.
+        if !self.barrier.is_pending(behavior_id).await {
+            return false;
+        }
+        let reason = format!(
+            "demoted after {} consecutive startup build failures; last error: {error}",
+            self.build_failure_budget()
+        );
+        self.demotions.record(behavior_id, reason.clone());
+        self.barrier.mark_behavior_demoted(behavior_id).await;
+        self.runtime_status.record_startup_demotion().await;
+        tracing::error!(
+            behavior_id = %behavior_id,
+            budget = self.build_failure_budget(),
+            error = %error,
+            "behavior demoted: its completion client failed to build repeatedly; \
+             the process will report Ready without it. Fix the behavior/backend \
+             config — a config change re-admits it with a fresh budget."
+        );
+        true
+    }
+
+    async fn on_slot_retired(&self, behavior_id: &str, recreated: bool) {
+        // Retirement releases a never-started behavior (superseded) so a
+        // mid-startup generation change cannot orphan its barrier entry; a
+        // recreated slot earns a fresh budget, so its old demotion is lifted.
+        self.barrier.mark_behavior_superseded(behavior_id).await;
+        // Recreated: fresh budget lifts the old demotion. Removed: drop the
+        // stale reason so the router does not reject with a demotion message
+        // for a behavior that no longer exists. Either way the entry goes.
+        let _ = recreated;
+        self.demotions.clear(behavior_id);
+    }
+}
+
 pub(in crate::agent) async fn run_agent(
     agent: DefraAgent,
     mut shutdown: watch::Receiver<bool>,
@@ -147,8 +204,18 @@ pub(in crate::agent) async fn run_agent(
         rendered_request_capture_factory: agent.rendered_request_capture_factory.clone(),
         background_execution_registry: agent.background_execution_registry.clone(),
         startup_barrier: startup_barrier.clone(),
+        startup_readiness: agent.startup_readiness.clone(),
+        startup_demotions: runtime_status.startup_demotions(),
     };
     let runtime_for_runner = runtime.clone();
+    let startup_demotions = runtime_status.startup_demotions();
+    let slot_failure_policy: Arc<dyn crate::agent::reconcile::SlotFailurePolicy> =
+        Arc::new(StartupSlotFailurePolicy {
+            barrier: startup_barrier.clone(),
+            demotions: startup_demotions.clone(),
+            runtime_status: runtime_status.clone(),
+            budget: agent.startup_readiness.build_failure_budget,
+        });
     let generation_supervisor = GenerationSupervisor::bootstrap(
         resolved_snapshot,
         admission_registry.clone(),
@@ -163,6 +230,7 @@ pub(in crate::agent) async fn run_agent(
         },
         runtime_status.clone(),
         shutdown.clone(),
+        Some(slot_failure_policy),
     )?;
     let initial_active_snapshot = generation_supervisor.current_snapshot();
     runtime_status
@@ -248,10 +316,27 @@ pub(in crate::agent) async fn run_agent(
     let ready_runtime_status = runtime_status.clone();
     let ready_behavior_count = initial_active_snapshot.behaviors.len();
     let ready_unavailable_count = initial_active_snapshot.unavailable_behaviors.len();
+    let ready_demotions = startup_demotions.clone();
     let readiness_handle = tokio::spawn(async move {
-        tokio::select! {
-            _ = ready_cancel.cancelled() => return,
-            _ = ready_startup_barrier.wait_ready() => {}
+        // Watchdog, not a deadline: demotion (budget) and supersession
+        // (retirement) make the barrier terminate by construction, and the
+        // per-attempt build timeout converts hangs into failures — so nothing
+        // here force-flips Ready. This only makes an unforeseen wedge loud.
+        let mut watchdog = tokio::time::interval(std::time::Duration::from_secs(60));
+        watchdog.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        watchdog.tick().await;
+        loop {
+            tokio::select! {
+                _ = ready_cancel.cancelled() => return,
+                _ = ready_startup_barrier.wait_ready() => break,
+                _ = watchdog.tick() => {
+                    let pending = ready_startup_barrier.pending_behaviors().await;
+                    tracing::warn!(
+                        pending_behaviors = ?pending,
+                        "startup readiness barrier is still waiting; a build may be wedged"
+                    );
+                }
+            }
         }
         ready_runtime_status
             .set_process_state(ProcessLifecycleState::Ready)
@@ -259,11 +344,23 @@ pub(in crate::agent) async fn run_agent(
         if let Some(observer) = &ready_observer {
             observer.on_process_state_change(ProcessLifecycleState::Ready);
         }
-        tracing::info!(
-            runnable_behaviors = ready_behavior_count,
-            unavailable_behaviors = ready_unavailable_count,
-            "defra-agent ready"
-        );
+        let demoted = ready_demotions.snapshot();
+        if demoted.is_empty() {
+            tracing::info!(
+                runnable_behaviors = ready_behavior_count,
+                unavailable_behaviors = ready_unavailable_count,
+                "defra-agent ready"
+            );
+        } else {
+            let mut demoted_ids: Vec<&String> = demoted.keys().collect();
+            demoted_ids.sort();
+            tracing::warn!(
+                runnable_behaviors = ready_behavior_count.saturating_sub(demoted.len()),
+                unavailable_behaviors = ready_unavailable_count + demoted.len(),
+                demoted_behaviors = ?demoted_ids,
+                "defra-agent ready (degraded: startup build failures demoted behaviors)"
+            );
+        }
     });
 
     let mut background_tasks = JoinSet::new();
@@ -398,6 +495,7 @@ pub(in crate::agent) async fn run_agent(
     let router_agent_did = agent.agent_did().to_string();
     let router_active_snapshot_rx = active_snapshot_rx.clone();
     let router_shutdown = shutdown.clone();
+    let router_startup_demotions = startup_demotions.clone();
     background_tasks.spawn(async move {
         BackgroundTaskResult::Router(
             super::router::run_router(
@@ -405,6 +503,7 @@ pub(in crate::agent) async fn run_agent(
                 router_agent_did,
                 router_active_snapshot_rx,
                 router_shutdown,
+                router_startup_demotions,
             )
             .await,
         )

--- a/crates/defra-agent/src/lean_vocab_test.rs
+++ b/crates/defra-agent/src/lean_vocab_test.rs
@@ -38,6 +38,8 @@ pub(crate) struct LeanContractSnapshot {
     pub(crate) desktop_client_shell_cases: Vec<LeanClientShellCase>,
     pub(crate) request_lifecycle_operator_ui_cases: Vec<LeanClientShellCase>,
     pub(crate) runtime_reconcile_cases: Vec<LeanRuntimeReconcileCase>,
+    #[serde(default)]
+    pub(crate) startup_readiness_cases: Vec<LeanStartupReadinessCase>,
     pub(crate) apply_reconcile_cases: Vec<LeanApplyReconcileCase>,
     #[serde(default)]
     pub(crate) tool_policy_cases: Vec<LeanToolPolicyCase>,
@@ -321,6 +323,10 @@ pub(crate) fn lean_request_transition_cases() -> &'static [LeanLifecycleTransiti
 
 pub(crate) fn lean_process_transition_cases() -> &'static [LeanLifecycleTransitionCase] {
     &lean_contract_snapshot().process_transition_cases
+}
+
+pub(crate) fn lean_startup_readiness_cases() -> &'static [LeanStartupReadinessCase] {
+    &lean_contract_snapshot().startup_readiness_cases
 }
 
 pub(crate) fn lean_runtime_reconcile_cases() -> &'static [LeanRuntimeReconcileCase] {

--- a/crates/defra-agent/src/lean_vocab_test/triggers_runtime_apply.rs
+++ b/crates/defra-agent/src/lean_vocab_test/triggers_runtime_apply.rs
@@ -145,3 +145,16 @@ pub(crate) struct LeanApplyReconcileCase {
     #[serde(default)]
     pub(crate) delete_safety_holds: bool,
 }
+
+/// Startup-readiness vectors for the bounded build-failure barrier (#559).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub(crate) struct LeanStartupReadinessCase {
+    pub(crate) witness: String,
+    pub(crate) lean_theorems: Vec<String>,
+    pub(crate) budget: u64,
+    pub(crate) outcomes: Vec<String>,
+    pub(crate) retired_after: bool,
+    pub(crate) post_standing: String,
+    pub(crate) blocks_ready: bool,
+    pub(crate) requires_restart: bool,
+}

--- a/crates/defra-agent/src/lib.rs
+++ b/crates/defra-agent/src/lib.rs
@@ -35,6 +35,7 @@ pub mod interrupt;
 pub(crate) mod lean_vocab_test;
 pub mod openai_wire;
 pub mod p2p_observability;
+pub mod startup_readiness;
 
 /// Shared in-crate test utilities.
 #[cfg(test)]

--- a/crates/defra-agent/src/runtime_status.rs
+++ b/crates/defra-agent/src/runtime_status.rs
@@ -96,6 +96,10 @@ impl RuntimeStatusRow {
 pub(crate) struct RuntimeStatusHandle {
     node: Arc<defra_node::EmbeddedNode>,
     state: Arc<Mutex<RuntimeStatusRow>>,
+    /// Startup build-failure demotions (#559), folded into the runnable /
+    /// unavailable counts at every publish so a reconcile republish cannot
+    /// silently undo them — and `/healthz` degrades instead of reading green.
+    startup_demotions: Arc<crate::startup_readiness::StartupDemotions>,
 }
 
 impl RuntimeStatusHandle {
@@ -103,7 +107,25 @@ impl RuntimeStatusHandle {
         Self {
             node,
             state: Arc::new(Mutex::new(RuntimeStatusRow::new(agent_did.into()))),
+            startup_demotions: Arc::new(crate::startup_readiness::StartupDemotions::new()),
         }
+    }
+
+    pub(crate) fn startup_demotions(&self) -> Arc<crate::startup_readiness::StartupDemotions> {
+        self.startup_demotions.clone()
+    }
+
+    /// Re-publish counts after a startup demotion so the degradation is
+    /// visible immediately, not only at the next reconcile publish.
+    pub(crate) async fn record_startup_demotion(&self) {
+        self.update(|row| {
+            if row.runnable_behavior_count > 0 {
+                row.runnable_behavior_count -= 1;
+            }
+            row.unavailable_behavior_count += 1;
+            true
+        })
+        .await;
     }
 
     pub(crate) async fn set_process_state(&self, state: ProcessLifecycleState) {
@@ -190,13 +212,24 @@ impl RuntimeStatusHandle {
 
     async fn publish_snapshot(&self, snapshot: &ActiveRuntimeSnapshot, result: ReconcileResult) {
         let executor_status = executor_status_fields(snapshot);
+        // A behavior demoted for startup build failures is still in the
+        // snapshot's runnable set (the snapshot is document-derived); fold the
+        // ledger in so republishes report it unavailable, not healthy.
+        let demoted = self.startup_demotions.snapshot();
+        let demoted_runnable = snapshot
+            .behaviors
+            .keys()
+            .filter(|behavior_id| demoted.contains_key(*behavior_id))
+            .count();
         self.update(|row| {
             let mut changed = false;
             let generation = i64::try_from(snapshot.generation).unwrap_or(i64::MAX);
             let runnable_behavior_count =
-                i64::try_from(snapshot.behaviors.len()).unwrap_or(i64::MAX);
+                i64::try_from(snapshot.behaviors.len().saturating_sub(demoted_runnable))
+                    .unwrap_or(i64::MAX);
             let unavailable_behavior_count =
-                i64::try_from(snapshot.unavailable_behaviors.len()).unwrap_or(i64::MAX);
+                i64::try_from(snapshot.unavailable_behaviors.len() + demoted_runnable)
+                    .unwrap_or(i64::MAX);
             if row.reconcile_phase != ReconcilePhase::Idle.as_str() {
                 row.reconcile_phase = ReconcilePhase::Idle.as_str().to_string();
                 changed = true;

--- a/crates/defra-agent/src/startup_readiness.rs
+++ b/crates/defra-agent/src/startup_readiness.rs
@@ -1,0 +1,169 @@
+//! Startup readiness under bounded build failures (#559).
+//!
+//! The startup barrier seeds every snapshot-runnable behavior and the process
+//! reports `Ready` only when none is pending. A behavior used to leave pending
+//! in exactly one way — its daemon started — so a behavior that was runnable at
+//! snapshot time but persistently failed to *build* its completion client
+//! wedged the barrier forever: the slot hot-restarted, `wait_ready()` never
+//! returned, the process never reported `Ready`, and (because the trigger
+//! engine is gated on the same barrier) every schedule and event trigger was
+//! silently disabled.
+//!
+//! Build attempts now consume a budget. Exhausting it **demotes** the behavior:
+//! released from the barrier, never claimed healthy, its build error recorded
+//! in the [`StartupDemotions`] ledger where the router, runtime status, and
+//! `/healthz` can see it. The model is
+//! `proofs/Proofs/RuntimeReconcile/StartupReadiness.lean`; the emitted case
+//! table is fenced by
+//! `conformance::generated_startup_readiness_cases_pin_bounded_barrier_release`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Knobs for startup readiness (#559). The defaults are deliberate:
+///
+/// * `build_failure_budget = 3` — a genuinely transient build error (DNS blip,
+///   racing config write) gets real retries, while a deterministic failure
+///   demotes within seconds instead of wedging `Ready` forever.
+/// * `build_timeout = 60s` — a build that *hangs* (the ChatGptCodex client
+///   build does DB and network work) would produce no outcome and escape the
+///   budget entirely; the per-attempt timeout converts a hang into a `failed`
+///   outcome, so the model's termination theorem covers hangs too and `Ready`
+///   never has to be force-flipped by a deadline that would weaken its claim.
+#[derive(Debug, Clone)]
+pub struct StartupReadinessOptions {
+    pub build_failure_budget: u32,
+    pub build_timeout: Duration,
+}
+
+impl Default for StartupReadinessOptions {
+    fn default() -> Self {
+        Self {
+            build_failure_budget: 3,
+            build_timeout: Duration::from_secs(60),
+        }
+    }
+}
+
+/// One build attempt's outcome, as the slot loop observes it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildOutcome {
+    /// The daemon began running: the behavior is serving.
+    Started,
+    /// The build returned an error before the daemon started.
+    Failed,
+}
+
+/// A behavior's standing with the startup barrier.
+///
+/// Mirrors `RuntimeReconcile.StartupReadiness.BehaviorStanding`. `Ready` and
+/// `Demoted` are absorbing: post-start crashes restart the daemon but never
+/// re-enter the barrier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildStanding {
+    /// Seeded runnable, not yet started; counts consecutive build failures.
+    Pending { failures: u32 },
+    /// Started successfully. The only standing that claims health.
+    Ready,
+    /// Released from the barrier after exhausting the build budget — accounted
+    /// for, observable, and never claimed healthy.
+    Demoted,
+    /// Released because reconcile retired the slot before it started (config
+    /// change or removal). Released, unclaimed, accounted.
+    Superseded,
+}
+
+impl BuildStanding {
+    /// The fresh standing every snapshot-runnable behavior is seeded with.
+    pub fn seeded() -> Self {
+        Self::Pending { failures: 0 }
+    }
+
+    /// The barrier no longer waits on this behavior.
+    pub fn released(self) -> bool {
+        !matches!(self, Self::Pending { .. })
+    }
+
+    /// Mirrors `RuntimeReconcile.StartupReadiness.retire`: reconcile retires
+    /// the slot; a still-pending behavior is superseded, a settled verdict is
+    /// kept. Retirement always releases and never claims health — the second
+    /// #559 hang path (a slot retired mid-startup orphaned its pending entry).
+    pub fn retire(self) -> Self {
+        match self {
+            Self::Pending { .. } => Self::Superseded,
+            standing => standing,
+        }
+    }
+
+    /// Mirrors `RuntimeReconcile.StartupReadiness.step`: how the standing
+    /// responds to one build outcome under `budget` tolerated failures.
+    pub fn step(self, budget: u32, outcome: BuildOutcome) -> Self {
+        match (self, outcome) {
+            (Self::Pending { .. }, BuildOutcome::Started) => Self::Ready,
+            (Self::Pending { failures }, BuildOutcome::Failed) => {
+                if failures + 1 < budget {
+                    Self::Pending {
+                        failures: failures + 1,
+                    }
+                } else {
+                    Self::Demoted
+                }
+            }
+            (standing, _) => standing,
+        }
+    }
+}
+
+/// Startup build-failure demotions, keyed by behavior id.
+///
+/// Shared between the slot failure policy (writer), the request router (which
+/// fails requests to demoted behaviors loudly instead of queueing them into a
+/// parked slot), and runtime status (which folds demotions into the
+/// runnable/unavailable counts so `/healthz` degrades instead of reading green).
+#[derive(Debug, Default)]
+pub struct StartupDemotions {
+    inner: Mutex<HashMap<String, String>>,
+}
+
+impl StartupDemotions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record(&self, behavior_id: &str, reason: impl Into<String>) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.insert(behavior_id.to_string(), reason.into());
+        }
+    }
+
+    pub fn reason(&self, behavior_id: &str) -> Option<String> {
+        self.inner
+            .lock()
+            .ok()
+            .and_then(|inner| inner.get(behavior_id).cloned())
+    }
+
+    /// A changed behavior gets a fresh slot and a fresh budget
+    /// (`RuntimeReconcile.StartupReadiness.change_restores_the_budget`), so its
+    /// demotion is cleared when reconcile recreates the slot.
+    pub fn clear(&self, behavior_id: &str) {
+        if let Ok(mut inner) = self.inner.lock() {
+            inner.remove(behavior_id);
+        }
+    }
+
+    pub fn snapshot(&self) -> HashMap<String, String> {
+        self.inner
+            .lock()
+            .map(|inner| inner.clone())
+            .unwrap_or_default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner
+            .lock()
+            .map(|inner| inner.is_empty())
+            .unwrap_or(true)
+    }
+}

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -52,9 +52,10 @@ use lean_vocab_test::{
     lean_r6_backgrounding_case, lean_r6_backgrounding_cases, lean_recovery_equivalence_cases,
     lean_recovery_sweep_cases, lean_request_transition_cases, lean_response_interrupt_flow_cases,
     lean_response_transition_cases, lean_runtime_reconcile_case, lean_runtime_reconcile_cases,
-    lean_session_recovery_case, lean_state_machine_contract, lean_subagent_delegation_graph_cases,
-    lean_transcript_case, lean_transcript_cases, lean_vocabulary_values, LeanEventDeliveryAction,
-    LeanLifecycleTransitionCase, LeanR4cBackgroundWorkCase,
+    lean_session_recovery_case, lean_startup_readiness_cases, lean_state_machine_contract,
+    lean_subagent_delegation_graph_cases, lean_transcript_case, lean_transcript_cases,
+    lean_vocabulary_values, LeanEventDeliveryAction, LeanLifecycleTransitionCase,
+    LeanR4cBackgroundWorkCase,
 };
 use support::conformance_consumers::assert_registered_conformance_consumers_resolve;
 use support::snapshots::{
@@ -122,6 +123,8 @@ mod replicated_request_convergence;
 mod request_lifecycle;
 #[path = "conformance/session_recovery.rs"]
 mod session_recovery;
+#[path = "conformance/startup_readiness.rs"]
+mod startup_readiness;
 #[path = "conformance/streaming_compaction.rs"]
 mod streaming_compaction;
 #[path = "conformance/tool_call.rs"]
@@ -232,6 +235,11 @@ fn generated_r4c_background_work_cases_pin_observable_shapes() {
 #[test]
 fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     codex_shim::generated_codex_shim_projection_cases_pin_adapter_mapping();
+}
+
+#[test]
+fn generated_startup_readiness_cases_pin_bounded_barrier_release() {
+    startup_readiness::generated_startup_readiness_cases_pin_bounded_barrier_release();
 }
 
 #[tokio::test]

--- a/crates/defra-agent/tests/conformance/coverage.rs
+++ b/crates/defra-agent/tests/conformance/coverage.rs
@@ -746,6 +746,12 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
             "CodexShimProjectionCases".to_string(),
         ));
     }
+    if !lean_startup_readiness_cases().is_empty() {
+        emitted.insert((
+            "startup_readiness_cases".to_string(),
+            "StartupReadinessCases".to_string(),
+        ));
+    }
     if !lean_codex_shim_turn_lifecycle_cases().is_empty() {
         emitted.insert((
             "codex_shim_turn_lifecycle_cases".to_string(),
@@ -834,6 +840,7 @@ fn lean_contract_coverage_ledger_accounts_for_every_emitted_domain() {
         "identity_contracts",
         "r4c_background_work_cases",
         "codex_shim_projection_cases",
+        "startup_readiness_cases",
         "codex_shim_turn_lifecycle_cases",
         "r6_background_cases",
         "r5_cross_deployment_cases",

--- a/crates/defra-agent/tests/conformance/startup_readiness.rs
+++ b/crates/defra-agent/tests/conformance/startup_readiness.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+use defra_agent::startup_readiness::{BuildOutcome, BuildStanding};
+
+/// Fence for the bounded startup-readiness barrier (#559).
+///
+/// Drives the real `BuildStanding` — the same state machine the slot loop
+/// steps — through every vector the Lean model emits. The barrier used to hang
+/// forever on a behavior that was snapshot-runnable but persistently failed to
+/// build its client; these vectors pin that a spent budget (or a retirement)
+/// releases the barrier without ever claiming health, and that nothing anywhere
+/// requires a process restart.
+pub(super) fn generated_startup_readiness_cases_pin_bounded_barrier_release() {
+    let cases = lean_startup_readiness_cases();
+    assert_eq!(
+        cases.len(),
+        6,
+        "the Lean startup-readiness contract must stay fully consumed"
+    );
+
+    for case in cases {
+        assert!(
+            !case.requires_restart,
+            "{}: release must follow from the budget or retirement, never a restart",
+            case.witness
+        );
+        let budget = u32::try_from(case.budget).expect("budget fits u32");
+        assert!(
+            budget > 0,
+            "{}: the runtime enforces budget >= 1",
+            case.witness
+        );
+
+        let mut standing = BuildStanding::seeded();
+        for outcome in &case.outcomes {
+            let outcome = match outcome.as_str() {
+                "started" => BuildOutcome::Started,
+                "failed" => BuildOutcome::Failed,
+                other => panic!("{}: unmodeled outcome {other:?}", case.witness),
+            };
+            standing = standing.step(budget, outcome);
+        }
+        if case.retired_after {
+            standing = standing.retire();
+        }
+
+        let observed = match standing {
+            BuildStanding::Pending { .. } => "pending",
+            BuildStanding::Ready => "ready",
+            BuildStanding::Demoted => "demoted",
+            BuildStanding::Superseded => "superseded",
+        };
+        assert_eq!(
+            observed, case.post_standing,
+            "{}: the runtime's standing must land where the model says",
+            case.witness
+        );
+
+        // `blocks_ready` is the liveness claim: only a pending standing may
+        // hold the barrier, and every released standing lets Ready fire.
+        assert_eq!(
+            !standing.released(),
+            case.blocks_ready,
+            "{}: released() must agree with the model's Ready-blocking claim",
+            case.witness
+        );
+
+        // Health soundness: `ready` requires a genuine start
+        // (RuntimeReconcile.StartupReadiness.ready_requires_a_start).
+        if observed == "ready" {
+            assert!(
+                case.outcomes.iter().any(|outcome| outcome == "started"),
+                "{}: ready without a started outcome would fake health",
+                case.witness
+            );
+        }
+
+        // Absorption: further outcomes never move a released standing
+        // (released_absorbing), so a demotion can never flap back.
+        if standing.released() {
+            let after = standing
+                .step(budget, BuildOutcome::Failed)
+                .step(budget, BuildOutcome::Started);
+            assert_eq!(
+                after, standing,
+                "{}: released standings must be absorbing",
+                case.witness
+            );
+        }
+    }
+}

--- a/crates/defra-agent/tests/startup_readiness_barrier.rs
+++ b/crates/defra-agent/tests/startup_readiness_barrier.rs
@@ -1,0 +1,274 @@
+mod support;
+
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::startup_readiness::StartupReadinessOptions;
+use defra_agent::{
+    ensure_runtime_schemas, AgentIdentity, DefraAgent, DocumentRuntimeOptions,
+    ProcessLifecycleObserver, ProcessLifecycleState, ToolCeiling,
+};
+use serde_json::Value;
+use tokio::sync::watch;
+
+use support::fixtures::bind_default_behavior_backend;
+use support::fixtures::test_identity;
+use support::mock_endpoint::MockModelEndpoint;
+use support::waits::wait_for_runtime_process_state;
+
+#[derive(Default)]
+struct RecordingObserver {
+    states: Mutex<Vec<ProcessLifecycleState>>,
+}
+
+impl ProcessLifecycleObserver for RecordingObserver {
+    fn on_process_state_change(&self, state: ProcessLifecycleState) {
+        self.states
+            .lock()
+            .expect("recording observer mutex poisoned")
+            .push(state);
+    }
+}
+
+/// The #559 regression, end to end on the production startup path.
+///
+/// The behavior is snapshot-RUNNABLE (backend healthy, references resolve) but
+/// its build fails on every attempt: the backend's `api_key_env_var` names an
+/// environment variable that is not set, which snapshot classification never
+/// resolves and `completion_client_api_key()` bails on. On main this wedges the
+/// readiness barrier forever — the slot hot-restarts, `wait_ready()` never
+/// returns, the process never reports Ready, and the trigger engine never
+/// starts. With the bounded budget the behavior is demoted instead: the process
+/// reaches Ready without it, and the degradation is visible in the AgentRuntime
+/// counts (`/healthz` reads them as degraded).
+#[tokio::test]
+async fn persistent_build_failure_demotes_instead_of_wedging_ready() -> Result<()> {
+    let node = Arc::new(EmbeddedNode::builder().build().await?);
+    ensure_runtime_schemas(node.as_ref()).await?;
+    let identity = Arc::new(test_identity("startup-readiness-559"));
+    let mock_endpoint = MockModelEndpoint::start("default")?;
+    bind_default_behavior_backend(
+        node.as_ref(),
+        identity.did(),
+        "backend-559",
+        mock_endpoint.endpoint(),
+    )
+    .await;
+
+    // The build poison: an env var nothing sets. Unique to this test so no
+    // other test's environment can accidentally satisfy it.
+    let escaped_backend_id = escape_graphql_string("backend-559");
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{escaped_backend_id}" }} }},
+                input: {{ api_key_env_var: "DEFRA_AGENT_TEST_559_UNSET_KEY" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    assert!(
+        std::env::var_os("DEFRA_AGENT_TEST_559_UNSET_KEY").is_none(),
+        "the poison env var must not be set for this test to be honest"
+    );
+
+    let observer = Arc::new(RecordingObserver::default());
+    let agent = DefraAgent::from_default_behavior_documents(
+        node.clone(),
+        identity.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            process_state_observer: Some(observer.clone()),
+            retry_policy: defra_agent::retry::RetryPolicy {
+                max_retries: 3,
+                base_delay_ms: 1,
+                max_delay_ms: 5,
+            },
+            startup_readiness: StartupReadinessOptions {
+                build_failure_budget: 2,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await?;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let run_task = tokio::spawn(agent.run(shutdown_rx));
+
+    // On main this wait never completes: the barrier has no release path for a
+    // behavior that cannot build. The helper's internal deadline turns the
+    // #559 hang into a loud failure.
+    wait_for_runtime_process_state(node.as_ref(), identity.did(), "ready").await;
+
+    // The demotion is observable, not silent: the runnable count dropped and
+    // the unavailable count carries the demoted behavior — the exact fields
+    // /healthz derives `degraded` from.
+    let escaped_did = escape_graphql_string(identity.did());
+    let query = format!(
+        r#"{{
+            AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }}, limit: 1) {{
+                runnable_behavior_count
+                unavailable_behavior_count
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let row = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRuntime"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("AgentRuntime row");
+    assert_eq!(
+        row.get("runnable_behavior_count").and_then(Value::as_i64),
+        Some(0),
+        "the demoted behavior must not be counted runnable: {row}"
+    );
+    assert_eq!(
+        row.get("unavailable_behavior_count")
+            .and_then(Value::as_i64),
+        Some(1),
+        "the demotion must be visible as unavailable: {row}"
+    );
+
+    let _ = shutdown_tx.send(true);
+    run_task.await??;
+
+    // Ready was genuinely reached through the normal lifecycle.
+    let observed = observer
+        .states
+        .lock()
+        .expect("recording observer mutex poisoned")
+        .clone();
+    assert!(
+        observed.contains(&ProcessLifecycleState::Ready),
+        "process must reach Ready despite the un-buildable behavior; observed {observed:?}"
+    );
+
+    Ok(())
+}
+
+/// A build failure within the budget must not demote: the behavior that
+/// recovers on a later attempt reaches Ready as a healthy behavior. Here the
+/// env var appears after the first failure, so attempt two succeeds.
+#[tokio::test]
+async fn transient_build_failure_within_budget_still_reaches_ready_healthy() -> Result<()> {
+    use std::ffi::OsString;
+    use std::sync::LazyLock;
+
+    // Serialize env mutation with any other test touching process env.
+    static ENV_VAR_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+        LazyLock::new(|| tokio::sync::Mutex::new(()));
+    let _env_guard = ENV_VAR_LOCK.lock().await;
+
+    struct RestoreEnv(&'static str, Option<OsString>);
+    impl Drop for RestoreEnv {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.1 {
+                    Some(value) => std::env::set_var(self.0, value),
+                    None => std::env::remove_var(self.0),
+                }
+            }
+        }
+    }
+    const VAR: &str = "DEFRA_AGENT_TEST_559_LATE_KEY";
+    let _restore = RestoreEnv(VAR, std::env::var_os(VAR));
+    unsafe {
+        std::env::remove_var(VAR);
+    }
+
+    let node = Arc::new(EmbeddedNode::builder().build().await?);
+    ensure_runtime_schemas(node.as_ref()).await?;
+    let identity = Arc::new(test_identity("startup-readiness-559-transient"));
+    let mock_endpoint = MockModelEndpoint::start("default")?;
+    bind_default_behavior_backend(
+        node.as_ref(),
+        identity.did(),
+        "backend-559-late",
+        mock_endpoint.endpoint(),
+    )
+    .await;
+    let escaped_backend_id = escape_graphql_string("backend-559-late");
+    let mutation = format!(
+        r#"mutation {{
+            update_InferenceBackend(
+                filter: {{ backend_id: {{ _eq: "{escaped_backend_id}" }} }},
+                input: {{ api_key_env_var: "{VAR}" }}
+            ) {{ _docID }}
+        }}"#
+    );
+    let response = node.execute(&mutation).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+
+    let agent = DefraAgent::from_default_behavior_documents(
+        node.clone(),
+        identity.clone(),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::meta_only(),
+            retry_policy: defra_agent::retry::RetryPolicy {
+                max_retries: 3,
+                base_delay_ms: 50,
+                max_delay_ms: 100,
+            },
+            startup_readiness: StartupReadinessOptions {
+                // Generous budget: the point is that recovery within it wins.
+                build_failure_budget: 10,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+    .await?;
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let run_task = tokio::spawn(agent.run(shutdown_rx));
+
+    // Let at least one build attempt fail, then supply the key.
+    tokio::time::sleep(std::time::Duration::from_millis(75)).await;
+    unsafe {
+        std::env::set_var(VAR, "late-key");
+    }
+
+    wait_for_runtime_process_state(node.as_ref(), identity.did(), "ready").await;
+
+    let escaped_did = escape_graphql_string(identity.did());
+    let query = format!(
+        r#"{{
+            AgentRuntime(filter: {{ agent_did: {{ _eq: "{escaped_did}" }} }}, limit: 1) {{
+                runnable_behavior_count
+                unavailable_behavior_count
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(!response.has_errors(), "{:?}", response.errors);
+    let row = response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentRuntime"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+        .expect("AgentRuntime row");
+    assert_eq!(
+        row.get("runnable_behavior_count").and_then(Value::as_i64),
+        Some(1),
+        "a behavior that recovered within the budget must be healthy: {row}"
+    );
+    assert_eq!(
+        row.get("unavailable_behavior_count")
+            .and_then(Value::as_i64),
+        Some(0),
+        "no demotion may survive a successful start: {row}"
+    );
+
+    let _ = shutdown_tx.send(true);
+    run_task.await??;
+    Ok(())
+}

--- a/crates/defra-agent/tests/support/conformance_consumers.rs
+++ b/crates/defra-agent/tests/support/conformance_consumers.rs
@@ -483,6 +483,13 @@ pub fn registered_conformance_consumers() -> &'static [ConformanceConsumer] {
             function: "generated_codex_shim_projection_cases_pin_adapter_mapping",
         },
         ConformanceConsumer::RustTest {
+            id: "conformance::generated_startup_readiness_cases_pin_bounded_barrier_release",
+            package: "defra-agent",
+            source_path: "crates/defra-agent/tests/conformance.rs",
+            module_path: "conformance",
+            function: "generated_startup_readiness_cases_pin_bounded_barrier_release",
+        },
+        ConformanceConsumer::RustTest {
             id: "conformance::generated_transcript_cases_drive_agent_message_ordering_contract",
             package: "defra-agent",
             source_path: "crates/defra-agent/tests/conformance.rs",


### PR DESCRIPTION
Fixes #559.

## The bug class, precisely

The startup barrier seeds every snapshot-runnable behavior and the process reports `Ready` only when none is pending. The **only** drain was `mark_behavior_ready`, called after a successful client build. So a behavior that was runnable at snapshot time but persistently failed to *build* (unset `api_key_env_var`, malformed endpoint, transient DNS at the wrong moment) wedged the barrier forever: the slot hot-restarted on a ~30s cadence with no budget, `wait_ready()` never returned, `process_state` stayed `recovering`, and — because the **trigger engine is gated on the same barrier** — every schedule and event trigger was silently disabled. `/healthz` reported permanent `unhealthy` with no cause.

Mapping the machinery surfaced **two more defects in the same accounting hole**:

- **Orphaned retirement** (a second, independent never-Ready path): reconcile never touched the barrier, so a behavior retired by a generation change *before it ever started* left its pending entry behind forever — the identical hang with no failure anywhere.
- **A lost-wakeup race in the barrier itself**: `wait_ready` was a check-then-`Notify::notified()` loop, so a final `notify_waiters` firing between the check and the registration was dropped — a hang even with correct accounting.

## Spec first

`proofs/Proofs/RuntimeReconcile/StartupReadiness.lean` — new, zero `sorry`, 13 theorems. Build attempts consume a **budget**; exhausting it **demotes** the behavior: released from the barrier, never claimed healthy. Retirement **supersedes** a pending standing: released, unclaimed, accounted. Ready/demoted/superseded are absorbing.

The load-bearing theorems:
- `budgeted_attempts_release` / `seeded_release` — **the #559 theorem**: after `budget` attempts, whatever their outcomes, the behavior has left the barrier. Stated with the reachability invariant `failures < budget` (the naive statement is false at unreachable states).
- `ready_requires_a_start` — a spent budget cannot manufacture health.
- `start_within_budget_is_ready` / `demoted_consumed_the_budget` — demotion never races a viable build.
- `retire_releases` / `retire_never_claims_ready` — the orphaned-retirement path is closed, soundly.
- `process_ready_accounts` — `Ready` means every seeded behavior is serving, demoted, or superseded; never silently dropped.

Emitted as `startup_readiness_cases` (6 vectors) and consumed by `conformance::generated_startup_readiness_cases_pin_bounded_barrier_release`, which drives the runtime's real `BuildStanding` through every vector plus absorption probes. Registered in the coverage ledger.

## The fix

- **`startup_readiness` module**: `BuildStanding` (the Lean mirror the slot loop actually steps), `StartupDemotions` (the reason ledger), `StartupReadinessOptions` (`build_failure_budget: 3`, `build_timeout: 60s`).
- **Barrier**: rewritten on a `watch` counter (kills the lost-wakeup race; `send_replace` so a release landing before any waiter subscribes is still stored — the unit test caught exactly that). Three release classes: `mark_behavior_ready`, `mark_behavior_demoted`, `mark_behavior_superseded`.
- **Slot loop**: one shared standing per slot (the budget is per-behavior; executor workers interleave into the model's single outcome list). On the budget-spending failure the policy re-checks the barrier at the demotion moment — a behavior that started once (post-start crash) or never entered the barrier (post-startup generations) declines demotion and keeps today's restart behavior. A demoted slot **parks** (no more hot-restarts) until retirement.
- **Reconcile**: retiring a slot notifies the policy — a never-started behavior is superseded (closes the orphan path), and a **recreated** slot clears its demotion: a config change earns a fresh budget, mirroring `change_restores_the_budget`. Kept slots keep their verdict — a no-op republish cannot resurrect a known-bad build.
- **Build hangs stay inside the model**: the one async client build (ChatGptCodex — DB + network) gets a per-attempt timeout that converts a hang into a `failed` outcome, so the termination theorem covers hangs too. No deadline force-flips `Ready`; a 60s watchdog log covers the unforeseen.
- **Observability**: demotions fold into the AgentRuntime `runnable/unavailable` counts **at every publish** (so a reconcile republish cannot silently undo them) — `/healthz` degrades through its existing count path instead of reading green. The **router rejects requests to demoted behaviors** with the recorded build error (they previously queued into a channel nobody drained, and a full queue blocks dispatch for *all* behaviors). The daemon clears a demotion on successful start, so a demotion racing a late success self-heals. The ready log names demoted behaviors.

## Tests

- **End-to-end regression** (`tests/startup_readiness_barrier.rs`), on the production startup path: backend's `api_key_env_var` names an unset env var — snapshot-runnable, build fails every attempt. Asserts the process reaches `Ready` with the demotion visible in the counts. Neutering demotion reproduces the #559 hang (the wait helper's deadline fires). A second test proves recovery within the budget reaches `Ready` healthy with no demotion residue.
- **Supervisor test**: retiring a never-started slot notifies the policy (the superseded release).
- **Barrier tests**: empty-seed immediate readiness, release-before/after-wait (the lost-wakeup shape), and all three release classes freeing the barrier.
- **Conformance fence**: fails by witness name when the budget step is broken.

## Gates

`cargo fmt --all --check`, `lake build` (zero `sorry`), `cargo test -p defra-agent` (full package incl. conformance + coverage ledger), `cargo test -p defra-agent-cli` (single-threaded), `cargo check --workspace --all-targets` — all green.