### PR TITLE
Bump defradb.rs to the unique-index semantics fix and mint recreate identities over tombstones (#700)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6540,12 +6540,13 @@ dependencies = [
  "schema",
  "storage",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-lock",
@@ -6584,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-trait",
@@ -6599,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "anyhow",
  "document",
@@ -6911,7 +6912,7 @@ version = "0.6.12"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "cid",
@@ -6935,7 +6936,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-stream",
@@ -6977,7 +6978,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "anyhow",
@@ -7011,7 +7012,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-trait",
@@ -7045,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "serde",
 ]
@@ -7463,7 +7464,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7921,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11040,7 +11041,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12273,7 +12274,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-lock",
@@ -12421,7 +12422,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15151,7 +15152,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "anyhow",
@@ -16575,7 +16576,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16611,7 +16612,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16628,7 +16629,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "async-lock",
@@ -16660,7 +16661,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17613,7 +17614,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "p2p",
  "query",
@@ -18412,7 +18413,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "cid",
  "defra-core",
@@ -19614,7 +19615,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20041,7 +20042,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24480,7 +24481,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=f750e009325a59ad4000e5dc31979c713438cfdf#f750e009325a59ad4000e5dc31979c713438cfdf"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=67ca1c6c0a17bccb51eecde9834beecf97cd888a#67ca1c6c0a17bccb51eecde9834beecf97cd888a"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,24 +57,26 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs rev = main at #1125: empty-store genesis-storm convergence kernel
-# (#1117), gossip direction filter (#1118), receiver-pull ledger + peer-park
-# (#1119, incl. #1112/#1113), push-log ack honesty (#1121), and root-level
-# `__typename` introspection routing (#1124/#1125). Move to the next upstream
+# defradb.rs rev = defined unique-index semantics at the merge and tombstone
+# boundaries (#1126, fixes #1111 / defra-agent#700): stale unique entries
+# pointing at dead docs self-heal, merges onto tombstones skip indexing, and
+# live merge conflicts converge to a deterministic winner instead of wedging.
+# On top of main at #1125 (genesis-storm kernel #1117-#1121, `__typename`
+# introspection routing #1124/#1125). Move to the next upstream
 # tag when one is cut.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -82,8 +84,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "f750e009325a59ad4000e5dc31979c713438cfdf" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "67ca1c6c0a17bccb51eecde9834beecf97cd888a" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -183,7 +183,8 @@ async fn apply_manifest_pairing_documents(
                         doc.unique_value
                     )
                 })?;
-            let add_literal = graphql_input_literal(&doc.add_doc)?;
+            let add_doc = crate::config_writes::mint_recreate_identity(&doc.add_doc);
+            let add_literal = graphql_input_literal(&add_doc)?;
             let update_literal =
                 graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
                     anyhow::anyhow!("missing update document for PeerPairingDesired")
@@ -356,7 +357,12 @@ fn generic_import_mutation_field(
     override_existing: bool,
 ) -> Result<AliasedMutationField> {
     let alias = format!("doc_{index}");
-    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let add_doc = if override_existing {
+        crate::config_writes::mint_recreate_identity(&doc.add_doc)
+    } else {
+        doc.add_doc.clone()
+    };
+    let add_literal = graphql_input_literal(&add_doc)?;
     let field = if override_existing {
         // This is the generic production bridge for apply retry convergence:
         // after a partial prefix, rerunning `config apply` recomputes live diff
@@ -403,7 +409,12 @@ async fn apply_generic_import_document(
     doc: &PreparedImportDocument,
     override_existing: bool,
 ) -> Result<()> {
-    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let add_doc = if override_existing {
+        crate::config_writes::mint_recreate_identity(&doc.add_doc)
+    } else {
+        doc.add_doc.clone()
+    };
+    let add_literal = graphql_input_literal(&add_doc)?;
     let mutation = if override_existing {
         // Per-document fallback preserves the same retry property as the batch
         // path: the unique-field filter makes repeated successful writes land
@@ -862,6 +873,36 @@ mod tests {
     }
 
     #[test]
+    fn every_apply_collection_schema_has_a_recreate_identity_field() {
+        use defra_agent_protocol::schemas;
+
+        for collection in Collection::ALL {
+            let schema = match collection {
+                Collection::AgentPrincipal => schemas::AGENT_PRINCIPAL,
+                Collection::AgentBehavior => schemas::AGENT_BEHAVIOR,
+                Collection::Skill => schemas::SKILL,
+                Collection::ToolSelection => schemas::TOOL_SELECTION,
+                Collection::InferenceBackend => schemas::INFERENCE_BACKEND,
+                Collection::InferenceProfile => schemas::INFERENCE_PROFILE,
+                Collection::ToolServiceRegistry => schemas::TOOL_SERVICE_REGISTRY,
+                Collection::ProjectionAcpBinding => schemas::PROJECTION_ACP_BINDING,
+                Collection::PeerPairingDesired => schemas::PEER_PAIRING_DESIRED,
+                Collection::Task => schemas::TASK,
+                Collection::Schedule => schemas::SCHEDULE,
+                Collection::EventTrigger => schemas::EVENT_TRIGGER,
+            };
+
+            assert!(
+                schema
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("updated_at:")),
+                "{} must expose updated_at for tombstone-safe recreation",
+                collection.graphql_type()
+            );
+        }
+    }
+
+    #[test]
     fn config_apply_order_has_retry_safe_prefixes() {
         for prefix_len in 0..=CONFIG_APPLY_ORDER_FOR_TESTS.len() {
             let prefix = &CONFIG_APPLY_ORDER_FOR_TESTS[..prefix_len];
@@ -1002,6 +1043,95 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
         ];
 
         assert!(has_duplicate_unique_values(&docs));
+    }
+
+    #[test]
+    fn generic_override_stamps_only_the_add_branch() {
+        let doc = PreparedImportDocument {
+            unique_value: "tools-a".to_string(),
+            add_doc: json!({
+                "selection_id": "tools-a",
+                "agent_did": "did:example:agent"
+            }),
+            update_doc: Some(json!({ "agent_did": "did:example:agent" })),
+        };
+
+        let field =
+            generic_import_mutation_field(0, "ToolSelection", "selection_id", &doc, true).unwrap();
+
+        let (_, update) = field.field.split_once("update:").unwrap();
+        assert!(field.field.contains("updated_at:"));
+        assert!(!update.contains("updated_at:"));
+    }
+
+    #[tokio::test]
+    async fn generic_override_recreates_a_tombstoned_tool_selection() -> Result<()> {
+        use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+        use defra_agent::ensure_runtime_schemas;
+
+        let tempdir = tempfile::tempdir()?;
+        let node = EmbeddedNode::builder()
+            .data_path(tempdir.path().join("data"))
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node);
+        let doc = json!({
+            "selection_id": "tools-a",
+            "agent_did": "did:example:agent",
+            "display_name": "Tools A"
+        });
+
+        let txn = access.begin_apply_txn().await?;
+        apply_import_collection(
+            &txn,
+            "ToolSelection",
+            "selection_id",
+            std::slice::from_ref(&doc),
+            true,
+        )
+        .await?;
+        txn.commit().await?;
+        let first_doc_id = tool_selection_doc_id(&access).await?;
+
+        access
+            .execute(
+                r#"mutation {
+                    delete_ToolSelection(filter: { selection_id: { _eq: "tools-a" } }) { _docID }
+                }"#,
+            )
+            .await?;
+
+        let txn = access.begin_apply_txn().await?;
+        apply_import_collection(
+            &txn,
+            "ToolSelection",
+            "selection_id",
+            std::slice::from_ref(&doc),
+            true,
+        )
+        .await?;
+        txn.commit().await?;
+        let recreated_doc_id = tool_selection_doc_id(&access).await?;
+
+        assert_ne!(first_doc_id, recreated_doc_id);
+        Ok(())
+    }
+
+    async fn tool_selection_doc_id(access: &ConfigAccess) -> Result<String> {
+        let response = access
+            .execute(
+                r#"{
+                    ToolSelection(filter: { selection_id: { _eq: "tools-a" } }) { _docID }
+                }"#,
+            )
+            .await?;
+        response
+            .pointer("/data/ToolSelection/0/_docID")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("live ToolSelection missing after apply: {response}"))
     }
 
     #[test]

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -603,7 +603,15 @@ fn custom_override_mutation_field(
             doc_id = escape_graphql_string(doc_id),
         )
     } else {
-        let add_literal = graphql_input_literal(&doc.add_doc)?;
+        // A tombstone occupies this unique value: identical manifest content
+        // would regenerate the tombstoned docID and never produce a live row
+        // (#700) — mint a fresh identity for the new incarnation.
+        let add_doc = if existing.is_some() {
+            crate::config_writes::mint_recreate_identity(&doc.add_doc)
+        } else {
+            doc.add_doc.clone()
+        };
+        let add_literal = graphql_input_literal(&add_doc)?;
         format!(r#"{alias}: create_{collection_name}(input: {add_literal}) {{ _docID }}"#)
     };
 

--- a/crates/defra-agent-cli/src/config_writes/common.rs
+++ b/crates/defra-agent-cli/src/config_writes/common.rs
@@ -83,3 +83,24 @@ pub(super) fn select_existing_document(
 
     Ok(deleted_rows.first().map(|row| (*row).clone()))
 }
+
+/// Mint a fresh document identity for a recreate over a tombstone.
+///
+/// Deletion is terminal in DefraDB and docIDs are content-addressed, so
+/// recreating a row whose manifest content is IDENTICAL to the tombstoned one
+/// would regenerate the tombstoned docID — and a create onto a tombstoned
+/// docID does not produce a live row (#700). Stamping the apply time gives the
+/// new incarnation distinct content, and with it a new identity.
+pub(crate) fn mint_recreate_identity(add_doc: &serde_json::Value) -> serde_json::Value {
+    let mut doc = add_doc.clone();
+    if let Some(map) = doc.as_object_mut() {
+        let now = chrono::Utc::now().to_rfc3339();
+        map.insert(
+            "updated_at".to_string(),
+            serde_json::Value::String(now.clone()),
+        );
+        map.entry("created_at".to_string())
+            .or_insert(serde_json::Value::String(now));
+    }
+    doc
+}

--- a/crates/defra-agent-cli/src/config_writes/common.rs
+++ b/crates/defra-agent-cli/src/config_writes/common.rs
@@ -84,23 +84,41 @@ pub(super) fn select_existing_document(
     Ok(deleted_rows.first().map(|row| (*row).clone()))
 }
 
-/// Mint a fresh document identity for a recreate over a tombstone.
+/// Mint a fresh document identity for an apply-owned create.
 ///
 /// Deletion is terminal in DefraDB and docIDs are content-addressed, so
 /// recreating a row whose manifest content is IDENTICAL to the tombstoned one
-/// would regenerate the tombstoned docID — and a create onto a tombstoned
-/// docID does not produce a live row (#700). Stamping the apply time gives the
-/// new incarnation distinct content, and with it a new identity.
+/// would regenerate the tombstoned docID. Every apply-controlled collection
+/// carries `updated_at`, so stamping the add branch gives each incarnation a
+/// distinct identity without changing a live row's update payload.
 pub(crate) fn mint_recreate_identity(add_doc: &serde_json::Value) -> serde_json::Value {
     let mut doc = add_doc.clone();
     if let Some(map) = doc.as_object_mut() {
-        let now = chrono::Utc::now().to_rfc3339();
         map.insert(
             "updated_at".to_string(),
-            serde_json::Value::String(now.clone()),
+            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
         );
-        map.entry("created_at".to_string())
-            .or_insert(serde_json::Value::String(now));
     }
     doc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn recreate_identity_preserves_content_and_stamps_updated_at() {
+        let original = json!({
+            "selection_id": "tools-a",
+            "created_at": "2026-01-01T00:00:00Z"
+        });
+
+        let minted = mint_recreate_identity(&original);
+
+        assert_eq!(minted.get("selection_id"), original.get("selection_id"));
+        assert_eq!(minted.get("created_at"), original.get("created_at"));
+        assert!(minted.get("updated_at").and_then(Value::as_str).is_some());
+        assert!(original.get("updated_at").is_none());
+    }
 }

--- a/crates/defra-agent-cli/src/config_writes/event_trigger.rs
+++ b/crates/defra-agent-cli/src/config_writes/event_trigger.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `EventTrigger` collection.
 ///
@@ -38,7 +40,8 @@ pub(crate) async fn write_event_trigger_document(
         return create_event_trigger_document(txn, trigger_id, add_doc).await;
     };
     if existing.deleted {
-        return create_event_trigger_document(txn, trigger_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_event_trigger_document(txn, trigger_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -8,6 +8,7 @@ mod tool_selection;
 mod txn;
 
 pub(crate) use agent_behavior::write_agent_behavior_document;
+pub(crate) use common::mint_recreate_identity;
 pub(crate) use event_trigger::write_event_trigger_document;
 pub(crate) use inference_backend::{
     write_inference_backend_document, InferenceBackendUpsertDocument,

--- a/crates/defra-agent-cli/src/config_writes/schedule.rs
+++ b/crates/defra-agent-cli/src/config_writes/schedule.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `Schedule` collection.
 ///
@@ -37,7 +39,8 @@ pub(crate) async fn write_schedule_document(
         return create_schedule_document(txn, schedule_id, add_doc).await;
     };
     if existing.deleted {
-        return create_schedule_document(txn, schedule_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_schedule_document(txn, schedule_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent-cli/src/config_writes/task.rs
+++ b/crates/defra-agent-cli/src/config_writes/task.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use crate::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `Task` collection.
 ///
@@ -30,7 +32,8 @@ pub(crate) async fn write_task_document(
         return create_task_document(txn, task_id, add_doc).await;
     };
     if existing.deleted {
-        return create_task_document(txn, task_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_task_document(txn, task_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -574,6 +574,7 @@ mod tests {
                         "completed_total": 79,
                         "failed_total": 4,
                         "stale_head_retirements_total": 17,
+                        "peer_capacity_parks_total": 3,
                         "per_cid_retry_counts": [{
                             "cid": "bafy-retry",
                             "retry_count": 19
@@ -591,6 +592,7 @@ mod tests {
                     "encode_cache_entries": 5,
                     "broadcast_coalesced_total": 41,
                     "push_updates_coalesced_total": 43,
+                    "gossip_direction_filtered_total": 47,
                     "pending_dags": 13,
                     "pending_dag_capacity": 1000,
                     "persisted_pending_dags": 17,
@@ -599,7 +601,13 @@ mod tests {
                     "retained_background_tasks": 6,
                     "missing_link_retries": 23,
                     "pending_dag_resolved": 29,
-                    "pending_dag_expired": 31
+                    "pending_dag_expired": 31,
+                    "single_flight_suppressed": 53,
+                    "already_merged_fast_path": 59,
+                    "pending_dag_capacity_shed": 61,
+                    "pending_dag_retry_dispatched": 67,
+                    "pending_dag_retry_suppressed": 71,
+                    "next_pending_retry_in_ms": 250
                 }
             }),
             None,
@@ -616,6 +624,10 @@ mod tests {
         assert_eq!(sync.push_updates_coalesced_total, 43);
         assert_eq!(sync.persisted_pending_dags, 17);
         assert_eq!(sync.missing_link_retries, 23);
+        assert_eq!(sync.push_backlog.peer_capacity_parks_total, 3);
+        assert_eq!(sync.gossip_direction_filtered_total, 47);
+        assert_eq!(sync.pending_dag_retry_dispatched, 67);
+        assert_eq!(sync.next_pending_retry_in_ms, Some(250));
     }
 
     #[test]

--- a/crates/defra-agent-cli/tests/cli_config_apply_local.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_local.rs
@@ -595,3 +595,148 @@ async fn config_apply_rebinds_placeholder_manifest_to_home_identity_locally() ->
 
     Ok(())
 }
+
+/// #700 regression: a config row deleted by prune leaves a tombstone, and
+/// re-applying a manifest that wants the same unique id back must converge —
+/// the tombstone-aware writer issues `create_`, and the store must accept it
+/// (a tombstone never holds a unique slot; a stale index entry pointing at one
+/// is healed by the store, sourcenetwork/defradb.rs#1111).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reapply_recreates_a_pruned_unique_row() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir.path().join("infra").join("agents").join("default");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-recreate-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let agent_name = format!("cli-recreate-{}", Uuid::new_v4().simple());
+    run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
+    let principal = read_json_file(&root.join("agent-principal.json"))?;
+    let behavior_id = principal
+        .get("default_behavior_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing default_behavior_id after export"))?
+        .to_string();
+
+    let task_id = format!("recreate-task-{}", Uuid::new_v4().simple());
+    let task_dir = root.join("tasks").join(&task_id);
+    let task_object = serde_json::json!({
+        "task_id": task_id.clone(),
+        "name": "Recreate Me",
+        "description": "Tombstoned unique row recreate regression (#700).",
+        "behavior_id": behavior_id.clone(),
+        "prompt_template": "Check convergence.",
+        "enabled": false,
+    });
+    write_json_file(&task_dir.join("object.json"), &task_object)?;
+
+    let root_str = root
+        .to_str()
+        .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
+    let explicit_home = home_dir.join(".defra-agent");
+    let explicit_home_str = explicit_home
+        .to_str()
+        .ok_or_else(|| anyhow!("explicit home path is not UTF-8"))?;
+
+    // 1. Create the row.
+    let created = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        created.get("status").and_then(Value::as_str),
+        Some("applied")
+    );
+
+    // 2. Tombstone it: drop the task from the manifest and prune.
+    fs::remove_dir_all(&task_dir).with_context(|| format!("removing {}", task_dir.display()))?;
+    let pruned = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+            "--prune",
+        ],
+    )?;
+    assert_eq!(pruned.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        pruned.pointer("/pruned/tasks").and_then(Value::as_u64),
+        Some(1)
+    );
+
+    // 3. Want the SAME unique task_id back. The live bundle does not see the
+    //    tombstone, the diff says "create", and the create must succeed —
+    //    this is exactly the step #700's wounded store could never pass.
+    write_json_file(&task_dir.join("object.json"), &task_object)?;
+    let recreated = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        recreated.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "recreating a pruned unique row must converge: {recreated}"
+    );
+    assert_eq!(
+        recreated.pointer("/applied/tasks").and_then(Value::as_u64),
+        Some(1),
+        "the tombstoned task must be recreated: {recreated}"
+    );
+
+    // 4. And the store must be exactly converged afterwards.
+    let settled = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "diff",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        settled.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "diff must be exact after the recreate: {settled}"
+    );
+
+    Ok(())
+}

--- a/crates/defra-agent-protocol/schemas/inference/inference_backend.graphql
+++ b/crates/defra-agent-protocol/schemas/inference/inference_backend.graphql
@@ -17,4 +17,5 @@ type InferenceBackend {
     models: [String]
     last_probe: DateTime
     probe_status: String @index
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-protocol/schemas/inference/inference_profile.graphql
+++ b/crates/defra-agent-protocol/schemas/inference/inference_profile.graphql
@@ -13,4 +13,5 @@ type InferenceProfile {
     retry_max_resample: Int
     retry_allow_repair: Boolean
     retry_interactive_max: Int
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/agent_behavior.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_behavior.graphql
@@ -16,4 +16,5 @@ type AgentBehavior {
     skill_refs: [String!]
     skill_excludes: [String!]
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/agent_principal.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_principal.graphql
@@ -4,5 +4,6 @@ type AgentPrincipal {
     default_behavior_id: String @index
     enabled: Boolean @index
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
     created_by: String
 }

--- a/crates/defra-agent-schemas/schemas/agent/skill.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/skill.graphql
@@ -10,4 +10,5 @@ type Skill {
     interface_json: String
     enabled: Boolean @index
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/tool_selection.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/tool_selection.graphql
@@ -40,4 +40,5 @@ type ToolSelection {
     enable_defra_query: Boolean
     defra_query_collections: [String]
     write_tools: [String]
+    updated_at: DateTime @index(direction: DESC)
 }


### PR DESCRIPTION
Fixes #700 by bumping defradb.rs to the unique-index semantics fix (sourcenetwork/defradb.rs#1126) and making the tombstone-aware config writers mint a fresh document identity when recreating over a tombstone.

## The two halves of #700

**Upstream (the wound):** the unique check was a bare index-key probe with no occupant-liveness awareness. Two merge orderings stranded entries owned by tombstones (a replicated update merged after a delete re-mints the entry while the `/del/` marker stays; an out-of-order delete cleans nothing when the doc isn't materialized yet), and with index constraints unpatchable there was no repair — recreating the value failed forever with `can not index a doc's field(s) that violates unique index`. #1126 makes stale entries **self-heal**: a unique conflict whose holder is deleted or missing is reclaimed on the spot (deletion is terminal, so the old holder can never return). Era-wounded stores repair themselves lazily on the exact operation that used to fail — no migration, no hand repair. Merges onto tombstoned docs no longer touch indexes (Go parity), closing both minting orderings, and live merge conflicts now converge to a deterministic winner instead of wedging the doc's sync forever (#1111).

**Downstream (the loop):** even with a clean index, recreating a config row whose manifest content is **identical** to the tombstoned row regenerates the same content-addressed docID — and a create onto a tombstoned docID does not produce a live row (the create reports success while the `/del/` marker keeps the row invisible). Provision would report `applied` yet the post-apply diff kept demanding the same create: an eternal, invisible loop. Both apply paths now **mint a fresh identity** on a recreate-over-tombstone by stamping `updated_at`/`created_at` with the apply time — the batched mutation builder (`custom_override_mutation_field`, which handled tombstones as plain creates and is the path that actually runs for diff-creates) and the per-document Task/Schedule/EventTrigger writers share one `mint_recreate_identity`. Distinct content → new docID → a genuinely live row → exact convergence.

`ToolSelection` — #700's literal collection — has no timestamp field to mint with; that residual is #706. Its different-content recreates (the common case, and the field incident's shape once the stale entry heals) converge; identical-content recreates still silently fail to materialize until #706 gives the writer something to mint with.

## Regression test

`cli_config_apply_local::reapply_recreates_a_pruned_unique_row`: apply a manifest with a task → prune it (tombstone) → re-add the same `task_id` → re-apply must converge exactly (`ok: true`, diff exact). Without the identity minting the test fails exactly as #700 reported: the apply loops on a create that never materializes.

## Baseline repair

defra-agent main's CI is red independently of this PR: the #1125 pin bump landed without updating the pinned live sync-status JSON fixture in `http/router.rs`, so `p2p_metrics_snapshot_decodes_pinned_live_sync_status` fails on clean main (`deny_unknown_fields` + the new `gossip_direction_filtered_total` / single-flight / receiver-pull counters and `peer_capacity_parks_total`). Repaired here with the missing fields and assertions.

## Gates

`cargo fmt --all --check`, `cargo test -p defra-agent` (full package incl. conformance), `cargo test -p defra-agent-cli` (single-threaded), `cargo test -p defra-agent-desktop-core`, `cargo check --workspace --all-targets` — all green.

## Worth knowing

Validating this work surfaced that the pairing reconciler **depends on** delete-then-identical-recreate of `PeerPairingApplied` rows. A Go-parity "deletion is terminal" guard upstream broke it immediately, so that guard was reverted and left as a flagged decision on #1126 — this PR does not change local create-onto-tombstone semantics.
