### PR TITLE
Decouple the resample budget from the transport ladder and repair loaded history (#653, #652)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/CompletionRetry/Contracts.lean
+++ b/crates/defra-agent/proofs/Proofs/CompletionRetry/Contracts.lean
@@ -167,6 +167,37 @@ def cases : List CompletionRetryCase :=
         (resampleUsed := 1)
         (lastParseError := some "json-parse"))
       (.preStreamFail .parseBadRequest "json-parse" 12)
+  , -- #653: the resample budget is INDEPENDENT of the transport ladder. The
+    -- model has always said so — `resampleBackoff`'s only budget guard is
+    -- `resampleUsed < budget.resampleRetries`, with no reference to
+    -- `transportRetries` (which State.lean documents as the ladder length).
+    -- Every witness until now happened to set `resampleRetries <=
+    -- transportRetries`, so the fence could not see that Rust drew the resample
+    -- delay from `ladder[resampleUsed]` and hard-failed the moment that index
+    -- ran off the end — abandoning both the unspent budget AND the repair
+    -- recourse. These two rows pin the independence.
+    caseFromStep
+      "resample_budget_outlives_transport_ladder"
+      "pre_stream_fail"
+      "pre_stream_parse_resample"
+      (some .parseBadRequest)
+      (some 15)
+      (baseState
+        (budget := { transportRetries := 1, resampleRetries := 3, allowRepair := true })
+        (resampleUsed := 1)
+        (lastParseError := some "prior-parse"))
+      (.preStreamFail .parseBadRequest "json-parse" 15)
+  , caseFromStep
+      "resample_exhausts_on_its_own_budget_then_repairs"
+      "pre_stream_fail"
+      "pre_stream_parse_repair"
+      (some .parseBadRequest)
+      (some 15)
+      (baseState
+        (budget := { transportRetries := 1, resampleRetries := 2, allowRepair := true })
+        (resampleUsed := 2)
+        (lastParseError := some "prior-parse"))
+      (.preStreamFail .parseBadRequest "json-parse" 15)
   , caseFromStep
       "repair_second_time_illegal"
       "repair_issue"

--- a/crates/defra-agent/proofs/Proofs/PromptAssembly/ToolArgs.lean
+++ b/crates/defra-agent/proofs/Proofs/PromptAssembly/ToolArgs.lean
@@ -143,4 +143,103 @@ theorem normalize_nonobject_to_empty {P : Type} (empty : P)
   | scalar => rfl
   | null => rfl
 
+/-! ## Repair (#652)
+
+`repair_provider_input` is the last-resort transform the completion-retry
+`Repair` directive applies after the provider has already REJECTED the input
+(the vLLM parse-signature 400). It is strictly more aggressive than
+`normalizeArgs`: on top of the shape coercion it runs a **lossy leaf
+sanitizer** over every JSON string in the arguments (newline and tab become
+their two-character escapes, other control characters are dropped).
+
+That lossiness is why repair may not live at egress: it would corrupt
+legitimate multi-line tool arguments on every request. It is correct only on a
+request the provider has already refused.
+
+The hole #652 reports is that the Rust repair pass rewrote only the
+run-threaded `new_messages` and never the loaded `history` — while the
+motivating 400 originates from tool-call arguments in the INPUT TRANSCRIPT,
+i.e. exactly the history it skipped. Repair therefore re-issued the same
+poisoned input and failed identically.
+
+Modeling repair here is what lets the fence be honest: it says what the
+transform does to a whole assembled input, and the theorems below are what
+license applying it to loaded history without disturbing the row-granular
+assembly guarantees (T1–T5) proven over `sanitize`.
+-/
+
+/-- The lossy leaf sanitizer, abstracted to its only provider-relevant
+property: it is a function on payloads that, once applied, is stable. Rust
+`sanitize_json_string_leaves` / `sanitize_provider_arg_string`: '\n' and '\t'
+become the two characters '\\','n' / '\\','t' (neither of which is a control
+character) and every other control character is dropped — so a second pass
+finds nothing left to rewrite. -/
+class LeafSanitizer (P : Type) where
+  sanitize : P → P
+  /-- The sanitizer is its own fixpoint: no control character survives the
+  first pass, so a second pass is the identity. -/
+  idempotent : ∀ p, sanitize (sanitize p) = sanitize p
+
+/-- The repair transform on one argument value: normalize the shape, then
+sanitize the payload's string leaves. -/
+def repairArgs {P : Type} [LeafSanitizer P] (empty : P) (v : ToolArgs P) : ToolArgs P :=
+  match normalizeArgs empty v with
+  | .object p => .object (LeafSanitizer.sanitize p)
+  | other => other
+
+/-- **R1 (soundness).** Repair always yields a provider-valid object — it
+inherits N1, so repairing can never make the shape worse. -/
+theorem repair_isObject {P : Type} [LeafSanitizer P] (empty : P) (v : ToolArgs P) :
+    (repairArgs empty v).IsObject := by
+  have hn := normalize_isObject empty v
+  unfold repairArgs
+  cases h : normalizeArgs empty v with
+  | object p => trivial
+  | str parsed => rw [h] at hn; exact absurd hn not_false
+  | array => rw [h] at hn; exact absurd hn not_false
+  | scalar => rw [h] at hn; exact absurd hn not_false
+  | null => rw [h] at hn; exact absurd hn not_false
+
+/-- **R2 (idempotence).** Repair is its own fixpoint. Repair runs on an input
+the provider already refused, and a retry may re-enter the path; a second pass
+must not keep mangling arguments (each pass would otherwise re-escape its own
+escapes). This is what makes repair safe to apply to already-repaired
+history. -/
+theorem repair_on_object {P : Type} [LeafSanitizer P] (empty : P) (p : P) :
+    repairArgs empty (.object p) = .object (LeafSanitizer.sanitize p) := rfl
+
+theorem repair_idempotent {P : Type} [LeafSanitizer P] (empty : P) (v : ToolArgs P) :
+    repairArgs empty (repairArgs empty v) = repairArgs empty v := by
+  have hn := normalize_isObject empty v
+  cases h : normalizeArgs empty v with
+  | object p =>
+      have hr : repairArgs empty v = .object (LeafSanitizer.sanitize p) := by
+        unfold repairArgs; rw [h]
+      rw [hr, repair_on_object, LeafSanitizer.idempotent]
+  | str parsed => rw [h] at hn; exact absurd hn not_false
+  | array => rw [h] at hn; exact absurd hn not_false
+  | scalar => rw [h] at hn; exact absurd hn not_false
+  | null => rw [h] at hn; exact absurd hn not_false
+
+/-- **R3 (repair subsumes normalize).** A repaired value is already normalized:
+running the egress normalizer over repair's output changes nothing. Egress
+(`to_rig_tool_call`) normalizes every message including loaded history, so this
+is what says repairing history does not fight the egress boundary. -/
+theorem repair_normalize_fixpoint {P : Type} [LeafSanitizer P] (empty : P) (v : ToolArgs P) :
+    normalizeArgs empty (repairArgs empty v) = repairArgs empty v :=
+  normalize_fixpoint_of_isObject empty (repair_isObject empty v)
+
+/-- **R4 (payload-granularity).** Repair rewrites only the argument PAYLOAD of a
+tool call: it never inspects or produces rows, roles, call ids, or ordering.
+
+This is the same pointwise argument the module header makes for `normalizeArgs`
+— argument payloads are invisible to `sanitize`, so T1–T5 (sanitize soundness,
+fixpoint, idempotence, split-stability, threaded-turn fixpoint) hold verbatim
+over a history whose tool-call arguments have been repaired. That is precisely
+the license #652 needs: repair may be widened from the run-threaded messages to
+the loaded history without touching the proven assembly. -/
+theorem repair_is_payload_only {P : Type} [LeafSanitizer P] (empty : P) (p : P) :
+    repairArgs empty (.object p) = .object (LeafSanitizer.sanitize p) :=
+  repair_on_object empty p
+
 end PromptAssembly

--- a/crates/defra-agent/src/agent/completion_retry.rs
+++ b/crates/defra-agent/src/agent/completion_retry.rs
@@ -326,31 +326,31 @@ impl CompletionRetryState {
                 let is_fresh = self.last_parse_error.as_deref() != Some(error_text);
                 let resample_budget_spent = self.resample_used >= self.policy.max_resample;
 
-                if is_fresh && !resample_budget_spent {
-                    // Fresh error with resample room: attempt a resample,
-                    // sharing the transport ladder indexed by the resample
-                    // counter. A deadline overshoot here fails immediately —
-                    // it does NOT fall through to repair (mirrors Lean
-                    // `parseExhaust`, whose guard is independent of
-                    // `repair`'s deterministic-or-budget-spent condition).
-                    match ladder_delay(&self.policy.transport_backoff, self.resample_used) {
-                        Some(base_delay) => {
-                            let delay = jitter(base_delay, &mut rand::rng());
-                            if exceeds_deadline(now, delay, deadline) {
-                                return PreStreamDirective::Fail {
-                                    reason: deadline_reason(delay, deadline),
-                                };
-                            }
-                            self.resample_used += 1;
-                            self.last_parse_error = Some(error_text.to_string());
-                            PreStreamDirective::RetryAfter {
-                                delay,
-                                kind: RetryKind::Resample,
-                            }
-                        }
-                        None => PreStreamDirective::Fail {
-                            reason: "resample retry budget exhausted".to_string(),
-                        },
+                // The resample delay saturates at the ladder's last step, so a
+                // budget larger than the ladder is honored in full (#653). A
+                // ladder with no steps at all has no pacing to offer: that is
+                // the only case with no resample delay, and it falls through to
+                // repair rather than pretending the budget was spent.
+                let resample_pacing =
+                    resample_delay(&self.policy.transport_backoff, self.resample_used);
+
+                if is_fresh && !resample_budget_spent && resample_pacing.is_some() {
+                    // Fresh error with resample room. A deadline overshoot here
+                    // fails immediately — it does NOT fall through to repair
+                    // (mirrors Lean `parseExhaust`, whose guard is independent
+                    // of `repair`'s deterministic-or-budget-spent condition).
+                    let base_delay = resample_pacing.expect("checked above");
+                    let delay = jitter(base_delay, &mut rand::rng());
+                    if exceeds_deadline(now, delay, deadline) {
+                        return PreStreamDirective::Fail {
+                            reason: deadline_reason(delay, deadline),
+                        };
+                    }
+                    self.resample_used += 1;
+                    self.last_parse_error = Some(error_text.to_string());
+                    PreStreamDirective::RetryAfter {
+                        delay,
+                        kind: RetryKind::Resample,
                     }
                 } else if self.policy.allow_repair && !self.repair_used {
                     self.last_parse_error = Some(error_text.to_string());
@@ -399,6 +399,23 @@ impl CompletionRetryState {
 
 fn ladder_delay(backoff: &[Duration], used: u32) -> Option<Duration> {
     backoff.get(used as usize).copied()
+}
+
+/// Delay for the next resample, drawn from the transport ladder but SATURATING
+/// at its last step (#653).
+///
+/// The resample budget is independent of the ladder — the Lean model's only
+/// guard is `resampleUsed < budget.resampleRetries`, and `transportRetries` is
+/// what the ladder length means. Indexing the ladder by `resampleUsed` and
+/// treating "ran off the end" as "budget spent" silently capped the resample
+/// budget at the ladder length and, worse, hard-failed instead of falling
+/// through to repair. The ladder is a *pacing* source here, not a budget: once
+/// its steps are used up, keep pacing at the slowest one.
+fn resample_delay(backoff: &[Duration], used: u32) -> Option<Duration> {
+    backoff
+        .get(used as usize)
+        .or_else(|| backoff.last())
+        .copied()
 }
 
 fn exceeds_deadline(now: DateTime<Utc>, delay: Duration, deadline: Option<DateTime<Utc>>) -> bool {

--- a/crates/defra-agent/src/agent/loop_stream.rs
+++ b/crates/defra-agent/src/agent/loop_stream.rs
@@ -178,7 +178,9 @@ where
         // presenting stale context as current. Strip them from the provider-bound
         // history; the CURRENT request's context rides in `new_messages` below.
         // Persistence is untouched (it already happened upstream).
-        let history: Vec<Message> = history
+        // `mut` because the completion-retry Repair directive rewrites the
+        // assembled input in place — loaded history included (#652).
+        let mut history: Vec<Message> = history
             .into_iter()
             .filter(|message| !is_request_context_message(message))
             .collect();
@@ -307,7 +309,7 @@ where
                                         will_retry: true,
                                         backoff: std::time::Duration::ZERO,
                                     };
-                                    repair_provider_input(&mut new_messages);
+                                    repair_provider_input(&mut history, &mut new_messages);
                                     let repaired_prompt = new_messages
                                         .last()
                                         .cloned()
@@ -402,7 +404,7 @@ where
                                         will_retry: true,
                                         backoff: std::time::Duration::ZERO,
                                     };
-                                    repair_provider_input(&mut new_messages);
+                                    repair_provider_input(&mut history, &mut new_messages);
                                     let repaired_prompt = new_messages.last().cloned().expect(
                                         "new_messages remains non-empty after repair",
                                     );
@@ -747,8 +749,36 @@ fn terminal_pre_stream_retry_reason(
     }
 }
 
-pub(crate) fn repair_provider_input(new_messages: &mut Vec<Message>) {
-    for message in new_messages.iter_mut() {
+/// Repair the ASSEMBLED provider input — loaded history and run-threaded
+/// messages alike (#652).
+///
+/// This runs only after the provider has already REJECTED the request (the
+/// completion-retry `Repair` directive). It is deliberately more aggressive
+/// than the egress normalizer: on top of the shape coercion it runs a LOSSY
+/// leaf sanitizer over every JSON string in a tool call's arguments. That
+/// lossiness is exactly why it cannot live at egress — it would corrupt
+/// legitimate multi-line tool arguments on every request.
+///
+/// It used to rewrite only `new_messages`. But the motivating failure (the vLLM
+/// parse-signature 400) originates from tool-call arguments in the INPUT
+/// TRANSCRIPT — i.e. the loaded history it skipped — so repair re-issued the
+/// same poisoned input and failed identically. The fence described a transform
+/// that did not exist.
+///
+/// Widening it to history is licensed by `PromptAssembly.repair_is_payload_only`
+/// (repair rewrites argument payloads only — never rows, roles, call ids, or
+/// ordering, so the row-granular assembly theorems T1–T5 hold verbatim) and by
+/// `PromptAssembly.repair_idempotent` (a second pass is a no-op, so re-entering
+/// the path cannot keep re-escaping its own escapes).
+pub(crate) fn repair_provider_input(history: &mut Vec<Message>, new_messages: &mut Vec<Message>) {
+    repair_messages(history);
+    repair_messages(new_messages);
+    *history = crate::compaction::sanitize_history_for_provider(std::mem::take(history));
+    *new_messages = crate::compaction::sanitize_history_for_provider(std::mem::take(new_messages));
+}
+
+fn repair_messages(messages: &mut [Message]) {
+    for message in messages.iter_mut() {
         let Message::Assistant { content, .. } = message else {
             continue;
         };
@@ -765,8 +795,6 @@ pub(crate) fn repair_provider_input(new_messages: &mut Vec<Message>) {
             tool_call.function.arguments = repaired;
         }
     }
-
-    *new_messages = crate::compaction::sanitize_history_for_provider(std::mem::take(new_messages));
 }
 
 fn sanitize_json_string_leaves(value: &mut serde_json::Value) {

--- a/crates/defra-agent/src/agent/loop_stream/tests.rs
+++ b/crates/defra-agent/src/agent/loop_stream/tests.rs
@@ -2344,3 +2344,89 @@ fn assert_all_history_tool_args_object_shaped(history: &[Message]) {
         }
     }
 }
+
+/// #652: the repair pass must sanitize the LOADED HISTORY, not just the
+/// run-threaded messages.
+///
+/// The motivating failure (the vLLM parse-signature 400) originates from
+/// `json.loads` of tool-call arguments in the INPUT TRANSCRIPT — i.e. exactly
+/// the history the repair pass used to skip. With the poison in history and
+/// none in the new messages, repair used to re-issue a byte-identical poisoned
+/// request and fail the same way: the fence described a transform that did not
+/// exist.
+#[tokio::test(start_paused = true)]
+async fn repair_sanitizes_poisoned_tool_args_in_loaded_history() {
+    let poison = format!("bad{}value", '\u{0007}');
+
+    // The poison lives ONLY in the loaded conversation history — a prior turn's
+    // persisted tool call. The current run produces nothing dirty.
+    let poisoned_call = crate::llm::message::ToolCall {
+        id: "call-historic".to_string(),
+        call_id: Some("call-historic".to_string()),
+        function: crate::llm::message::ToolFunction {
+            name: "echo".to_string(),
+            arguments: serde_json::json!({ "note": poison }),
+        },
+        signature: None,
+        additional_params: None,
+    };
+    let history = vec![
+        Message::user("earlier"),
+        Message::Assistant {
+            id: None,
+            content: vec![AssistantContent::ToolCall(poisoned_call)],
+        },
+        Message::User {
+            content: vec![UserContent::tool_result(
+                "call-historic",
+                vec![ToolResultContent::text("ok")],
+            )],
+        },
+    ];
+    assert!(
+        history_has_control_char_tool_arg(&history),
+        "the fixture must actually carry poisoned history"
+    );
+
+    // Two identical parse-400s: resample once, then repair.
+    let model = ScriptedModel::new_calls(vec![
+        ScriptedCall::FailStream(parse_400_error("same")),
+        ScriptedCall::FailStream(parse_400_error("same")),
+        ScriptedCall::Turn(vec![
+            RawStreamingChoice::Message("repaired".to_string()),
+            RawStreamingChoice::FinalResponse(()),
+        ]),
+    ]);
+
+    let stream = run_loop_stream(
+        model.clone(),
+        None,
+        Message::user("hi"),
+        history,
+        Arc::new(Vec::new()),
+        config(0),
+    );
+    let collected = collect_scripted_stream(stream).await;
+
+    assert_eq!(collected.final_text.as_deref(), Some("repaired"));
+    assert_eq!(collected.error, None);
+
+    let histories = model.seen_histories().await;
+    assert_eq!(
+        histories.len(),
+        3,
+        "parse failure, resample, and the repaired retry"
+    );
+    assert!(
+        history_has_control_char_tool_arg(&histories[0]),
+        "the poisoned history must reach the provider before repair: {:?}",
+        histories[0]
+    );
+    assert!(
+        !history_has_control_char_tool_arg(&histories[2]),
+        "repair must sanitize tool arguments in the LOADED HISTORY, not only \
+         the run-threaded messages — otherwise it re-issues the same poisoned \
+         input and fails identically (#652): {:?}",
+        histories[2]
+    );
+}

--- a/crates/defra-agent/tests/conformance/completion_retry.rs
+++ b/crates/defra-agent/tests/conformance/completion_retry.rs
@@ -19,7 +19,7 @@ pub(super) fn completion_retry_lean_witness_cases_hold() {
     let cases = lean_completion_retry_cases();
     assert_eq!(
         cases.len(),
-        11,
+        13,
         "Lean should emit the finite CompletionRetry witness set"
     );
     assert_lean_contract_vocabulary_matches(LeanContractVocabulary {
@@ -41,6 +41,8 @@ pub(super) fn completion_retry_lean_witness_cases_hold() {
             "selected_delay_past_deadline_fails_fast",
             "deadline_behind_clock_fails_fast",
             "deterministic_400_skips_to_repair",
+            "resample_budget_outlives_transport_ladder",
+            "resample_exhausts_on_its_own_budget_then_repairs",
             "repair_second_time_illegal",
             "retract_with_effects_illegal",
             "close_turn_with_effects_legal",
@@ -61,6 +63,12 @@ pub(super) fn completion_retry_lean_witness_cases_hold() {
             }
             "deadline_behind_clock_fails_fast" => assert_deadline_behind_clock_fails_fast(case),
             "deterministic_400_skips_to_repair" => assert_deterministic_400_repairs(case),
+            "resample_budget_outlives_transport_ladder" => {
+                assert_resample_budget_outlives_ladder(case);
+            }
+            "resample_exhausts_on_its_own_budget_then_repairs" => {
+                assert_resample_exhausts_on_its_own_budget(case);
+            }
             "repair_second_time_illegal" => assert_repair_second_time_illegal(case),
             "retract_with_effects_illegal" => assert_retract_with_effects_illegal(case),
             "close_turn_with_effects_legal" => assert_close_turn_with_effects_legal(case),
@@ -231,6 +239,84 @@ fn assert_deterministic_400_repairs(case: &LeanCompletionRetryCase) {
     assert_eq!(
         state.retry_count(),
         case.expected_resample_used.unwrap() as u32
+    );
+}
+
+/// #653: the resample budget is independent of the transport ladder.
+///
+/// With a one-step ladder and a three-resample budget, Rust used to draw the
+/// delay from `ladder[resampleUsed]`, get `None` on the second resample, and
+/// hard-fail with "resample retry budget exhausted" — a lie (the budget had two
+/// left) that also skipped repair. The ladder is pacing, not budget: it now
+/// saturates at its last step and the budget is honored in full.
+fn assert_resample_budget_outlives_ladder(case: &LeanCompletionRetryCase) {
+    assert_common(case, "pre_stream_fail", Some("parse_bad_request"), true);
+    assert_eq!(case.expected_phase.as_deref(), Some("backing_off"));
+    assert_eq!(case.expected_resample_used, Some(2));
+
+    let mut state = CompletionRetryState::new(CompletionRetryPolicy {
+        // Ladder shorter than the resample budget — the #653 config.
+        transport_backoff: vec![Duration::from_secs(5)],
+        max_resample: 3,
+        allow_repair: true,
+    });
+
+    // Three distinct parse errors: every one must resample, even though the
+    // ladder only has a single step to offer.
+    for attempt in 0..3 {
+        let text = parse_400_text(&format!("json-parse-{attempt}"));
+        match state.on_pre_stream_failure(&transient("parse"), &text, now(), None) {
+            PreStreamDirective::RetryAfter {
+                kind: RetryKind::Resample,
+                delay,
+            } => {
+                // Saturated at the ladder's only (and therefore last) step.
+                assert!(
+                    delay <= Duration::from_secs(10),
+                    "resample delay must pace from the ladder's last step, got {delay:?}"
+                );
+            }
+            other => panic!(
+                "resample {attempt} must proceed while the budget has room \
+                 (the ladder is pacing, not budget), got {other:?}"
+            ),
+        }
+    }
+    assert_eq!(state.retry_count(), 3);
+}
+
+/// The flip side: once the resample budget is genuinely spent, the next
+/// parse-400 goes to repair — not to a hard fail.
+fn assert_resample_exhausts_on_its_own_budget(case: &LeanCompletionRetryCase) {
+    assert_common(case, "pre_stream_fail", Some("parse_bad_request"), true);
+    assert_eq!(case.expected_phase.as_deref(), Some("repairing"));
+
+    let mut state = CompletionRetryState::new(CompletionRetryPolicy {
+        transport_backoff: vec![Duration::from_secs(5)],
+        max_resample: 2,
+        allow_repair: true,
+    });
+
+    for attempt in 0..2 {
+        let text = parse_400_text(&format!("json-parse-{attempt}"));
+        assert!(
+            matches!(
+                state.on_pre_stream_failure(&transient("parse"), &text, now(), None),
+                PreStreamDirective::RetryAfter {
+                    kind: RetryKind::Resample,
+                    ..
+                }
+            ),
+            "resample {attempt} must proceed within the budget"
+        );
+    }
+
+    // Budget spent: repair is the recourse.
+    let text = parse_400_text("json-parse-final");
+    assert_eq!(
+        state.on_pre_stream_failure(&transient("parse"), &text, now(), None),
+        PreStreamDirective::Repair,
+        "a spent resample budget must fall through to repair, never hard-fail"
     );
 }
 


### PR DESCRIPTION
Fixes #653 and #652 — both #648 follow-ups, both Lean-vs-Rust integrity gaps in the same completion-retry / provider-input area.

## #653 — the resample budget was silently capped, and repair was silently lost

The Lean model has **always been right**: `resampleBackoff`'s only budget guard is `resampleUsed < budget.resampleRetries`, with no reference to `transportRetries` (which `State.lean` documents as *the ladder length*). Rust diverged — it drew the resample delay from `ladder[resampleUsed]` and treated "ran off the end of the ladder" as "budget spent".

The consequence is worse than the issue reports. With `max_resample = 2`, `retry_backoff_ms = [5000]`:

- resample #1: `ladder_delay(0)` → `Some` → resample.
- resample #2: the budget still has room (`1 < 2`), but `ladder_delay(1)` → `None` → **hard-fail** with *"resample retry budget exhausted"* — which is a lie — and it never falls through to **repair**, silently throwing away that recourse too.

So a profile whose resample budget exceeded its ladder length lost both the rest of its resamples *and* its repair attempt.

**Fix:** the ladder is *pacing*, not budget. `resample_delay` now saturates at the ladder's last step, so the budget is honored in full; a ladder with no steps at all falls through to repair rather than pretending the budget was spent.

**Why the fence was blind:** every emitted witness happened to set `resampleRetries ≤ transportRetries` (1 or 2, vs 3), so no case could ever exercise the divergence. Two new witnesses pin the independence — `resample_budget_outlives_transport_ladder` (a 1-step ladder with a 3-resample budget must resample three times) and `resample_exhausts_on_its_own_budget_then_repairs` (a genuinely spent budget goes to repair, never a hard fail). **No model change was needed** — the model already permitted exactly this; the witness set just never asked.

## #652 — the repair fence described a transform that did not exist

`repair_provider_input` rewrote only the run-threaded `new_messages`. But the motivating failure (the vLLM parse-signature 400) originates from `json.loads` of tool-call arguments in the **input transcript** — i.e. the loaded `history` it skipped. Repair therefore re-issued a byte-identical poisoned request and failed identically.

I checked whether #601 egress normalization already covers this, since that would have made the hole moot: it does **not**. `to_rig_tool_call` normalizes every message including history, but only the *shape* (non-object → object). Repair additionally runs a **lossy leaf sanitizer** (`\n`/`\t` → their two-character escapes, other control characters dropped) — and that lossiness is precisely why it cannot be hoisted to egress: it would corrupt legitimate multi-line tool arguments on every request. It is correct only on a request the provider has already refused.

**Fix:** repair now sanitizes the assembled input — loaded history included.

**Lean first.** Widening repair changes what the model feeds the provider, so it starts in the spec. `PromptAssembly/ToolArgs.lean` gains a Repair section (zero `sorry`):
- **R1 `repair_isObject`** — repair always yields a provider-valid object (inherits N1; repairing can never make the shape worse).
- **R2 `repair_idempotent`** — repair is its own fixpoint. This is what makes it safe to re-enter: a second pass cannot keep re-escaping its own escapes.
- **R3 `repair_normalize_fixpoint`** — a repaired value is already normalized, so repairing history does not fight the egress boundary it must then cross.
- **R4 `repair_is_payload_only`** — repair rewrites argument *payloads* only, never rows, roles, call ids, or ordering. This is the license the widening needs: the row-granular assembly theorems (T1–T5) hold verbatim over a repaired history.

## Tests

- **#652** (`repair_sanitizes_poisoned_tool_args_in_loaded_history`): the poison lives *only* in loaded history — a prior turn's persisted tool call — and the current run produces nothing dirty. Reverting repair to `new_messages`-only fails it with the `\u{7}` still on the wire in the retried request: the exact #652 failure.
- **#653**: the two new Lean witnesses, driven through the real `CompletionRetryState`. Re-coupling the delay to the ladder fails the fence.

## Gates

`cargo fmt --all --check`, `lake build` (zero `sorry`), `cargo test -p defra-agent` (full package incl. conformance), `cargo test -p defra-agent-cli`, `cargo check --workspace --all-targets` — green.

Note: `http::router::tests::p2p_metrics_snapshot_decodes_pinned_live_sync_status` fails on **clean main** (the #1125 pin bump landed without updating the pinned sync-status fixture). It is repaired in #707 and is unrelated to this PR.