### PR TITLE
Retract reciprocal pairings after membership revocation (#672)

### DIFF
--- a/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/ReciprocalConversation.lean
+++ b/crates/defra-agent/proofs/Proofs/PeerRegistryDiscovery/ReciprocalConversation.lean
@@ -9,8 +9,9 @@ import Mathlib.Data.Finset.Prod
 This model is the document-driven bridge for mobile `conversation` dapair
 pairings. A server-authored reciprocal intent plus a live, self-signed endpoint
 for the invited DID derives exactly one reciprocal data-plane desired row scoped
-to the server's own DID. The existing pairing reconciler consumes the derived
-row; this derivation owns only the reciprocal partition.
+to the server's own DID, unless a valid network revocation explicitly blocks
+that DID. The existing pairing reconciler consumes the derived row; this
+derivation owns only the reciprocal partition.
 -/
 
 namespace PeerRegistryDiscovery
@@ -74,8 +75,10 @@ def reciprocalDataPlaneDesired
 def deriveReciprocal
     (self : Did)
     (intents : Finset ReciprocalIntent)
-    (endpoints : Finset PeerEndpoint) : Finset DataPlaneRow :=
-  (((intents ×ˢ endpoints).filter (fun pair => materializable pair.1 pair.2))).image
+    (endpoints : Finset PeerEndpoint)
+    (revokedMembers : Finset Did) : Finset DataPlaneRow :=
+  (((intents ×ˢ endpoints).filter (fun pair =>
+      pair.1.memberDid ∉ revokedMembers ∧ materializable pair.1 pair.2))).image
     (fun pair => {
       peer := pair.2.peer,
       agentDid := self,
@@ -89,6 +92,7 @@ structure ReciprocalState where
   self : Did
   intents : Finset ReciprocalIntent
   endpoints : Finset PeerEndpoint
+  revokedMembers : Finset Did
   operatorDesired : Finset DataPlaneRow
   networkDesired : Finset DataPlaneRow
   registryDesired : Finset DataPlaneRow
@@ -98,7 +102,7 @@ structure ReciprocalState where
 namespace ReciprocalState
 
 def settled (s : ReciprocalState) : Prop :=
-  s.reciprocalDesired = deriveReciprocal s.self s.intents s.endpoints
+  s.reciprocalDesired = deriveReciprocal s.self s.intents s.endpoints s.revokedMembers
 
 instance (s : ReciprocalState) : Decidable s.settled := by
   unfold settled
@@ -106,7 +110,8 @@ instance (s : ReciprocalState) : Decidable s.settled := by
 
 /-- Canonical reciprocal sweep. -/
 def deriveStep (s : ReciprocalState) : ReciprocalState :=
-  { s with reciprocalDesired := deriveReciprocal s.self s.intents s.endpoints }
+  { s with reciprocalDesired :=
+      deriveReciprocal s.self s.intents s.endpoints s.revokedMembers }
 
 end ReciprocalState
 
@@ -118,10 +123,11 @@ materialized. -/
 theorem mem_deriveReciprocal {self : Did}
     {intents : Finset ReciprocalIntent}
     {endpoints : Finset PeerEndpoint}
+    {revokedMembers : Finset Did}
     {row : DataPlaneRow} :
-    row ∈ deriveReciprocal self intents endpoints ↔
+    row ∈ deriveReciprocal self intents endpoints revokedMembers ↔
       ∃ intent ∈ intents, ∃ endpoint ∈ endpoints,
-        materializable intent endpoint ∧
+        intent.memberDid ∉ revokedMembers ∧ materializable intent endpoint ∧
         row = {
           peer := endpoint.peer,
           agentDid := self,
@@ -131,10 +137,13 @@ theorem mem_deriveReciprocal {self : Did}
   unfold deriveReciprocal
   simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_product]
   constructor
-  · rintro ⟨pair, ⟨⟨h_intent, h_endpoint⟩, h_materializable⟩, h_row⟩
-    exact ⟨pair.1, h_intent, pair.2, h_endpoint, h_materializable, h_row.symm⟩
-  · rintro ⟨intent, h_intent, endpoint, h_endpoint, h_materializable, h_row⟩
-    exact ⟨(intent, endpoint), ⟨⟨h_intent, h_endpoint⟩, h_materializable⟩, h_row.symm⟩
+  · rintro ⟨pair, ⟨⟨h_intent, h_endpoint⟩, h_revoked, h_materializable⟩, h_row⟩
+    exact ⟨pair.1, h_intent, pair.2, h_endpoint,
+      h_revoked, h_materializable, h_row.symm⟩
+  · rintro ⟨intent, h_intent, endpoint, h_endpoint,
+      h_revoked, h_materializable, h_row⟩
+    exact ⟨(intent, endpoint),
+      ⟨⟨h_intent, h_endpoint⟩, h_revoked, h_materializable⟩, h_row.symm⟩
 
 /-! ## (1) Idempotence -/
 
@@ -181,11 +190,12 @@ still present in the input. -/
 theorem deriveReciprocal_retraction_sound_intent {self : Did}
     {intents : Finset ReciprocalIntent}
     {endpoints : Finset PeerEndpoint}
+    {revokedMembers : Finset Did}
     {removed : ReciprocalIntent}
     {row : DataPlaneRow} :
-    row ∈ deriveReciprocal self (intents.erase removed) endpoints ↔
+    row ∈ deriveReciprocal self (intents.erase removed) endpoints revokedMembers ↔
       ∃ intent ∈ intents, intent ≠ removed ∧ ∃ endpoint ∈ endpoints,
-        materializable intent endpoint ∧
+        intent.memberDid ∉ revokedMembers ∧ materializable intent endpoint ∧
         row = {
           peer := endpoint.peer,
           agentDid := self,
@@ -194,12 +204,15 @@ theorem deriveReciprocal_retraction_sound_intent {self : Did}
         } := by
   rw [mem_deriveReciprocal]
   constructor
-  · rintro ⟨intent, h_intent, endpoint, h_endpoint, h_materializable, h_row⟩
+  · rintro ⟨intent, h_intent, endpoint, h_endpoint,
+      h_revoked, h_materializable, h_row⟩
     exact ⟨intent, Finset.mem_of_mem_erase h_intent,
-      Finset.ne_of_mem_erase h_intent, endpoint, h_endpoint, h_materializable, h_row⟩
-  · rintro ⟨intent, h_intent, h_ne, endpoint, h_endpoint, h_materializable, h_row⟩
+      Finset.ne_of_mem_erase h_intent, endpoint, h_endpoint,
+      h_revoked, h_materializable, h_row⟩
+  · rintro ⟨intent, h_intent, h_ne, endpoint, h_endpoint,
+      h_revoked, h_materializable, h_row⟩
     exact ⟨intent, Finset.mem_erase.mpr ⟨h_ne, h_intent⟩,
-      endpoint, h_endpoint, h_materializable, h_row⟩
+      endpoint, h_endpoint, h_revoked, h_materializable, h_row⟩
 
 /-- Removing or staling an endpoint retracts exactly the rows whose only endpoint
 witness was that endpoint; all remaining rows are backed by a different live
@@ -207,10 +220,40 @@ endpoint still present in the input. -/
 theorem deriveReciprocal_retraction_sound_endpoint {self : Did}
     {intents : Finset ReciprocalIntent}
     {endpoints : Finset PeerEndpoint}
+    {revokedMembers : Finset Did}
     {removed : PeerEndpoint}
     {row : DataPlaneRow} :
-    row ∈ deriveReciprocal self intents (endpoints.erase removed) ↔
+    row ∈ deriveReciprocal self intents (endpoints.erase removed) revokedMembers ↔
       ∃ intent ∈ intents, ∃ endpoint ∈ endpoints, endpoint ≠ removed ∧
+        intent.memberDid ∉ revokedMembers ∧ materializable intent endpoint ∧
+        row = {
+          peer := endpoint.peer,
+          agentDid := self,
+          address := endpoint.address,
+          template := "conversation"
+        } := by
+  rw [mem_deriveReciprocal]
+  constructor
+  · rintro ⟨intent, h_intent, endpoint, h_endpoint,
+      h_revoked, h_materializable, h_row⟩
+    exact ⟨intent, h_intent, endpoint, Finset.mem_of_mem_erase h_endpoint,
+      Finset.ne_of_mem_erase h_endpoint, h_revoked, h_materializable, h_row⟩
+  · rintro ⟨intent, h_intent, endpoint, h_endpoint, h_ne,
+      h_revoked, h_materializable, h_row⟩
+    exact ⟨intent, h_intent, endpoint, Finset.mem_erase.mpr ⟨h_ne, h_endpoint⟩,
+      h_revoked, h_materializable, h_row⟩
+
+/-- Adding an explicit revocation retracts exactly the rows whose intent names
+that DID. Intents for every other non-revoked DID remain derivation witnesses. -/
+theorem deriveReciprocal_retraction_sound_revocation {self : Did}
+    {intents : Finset ReciprocalIntent}
+    {endpoints : Finset PeerEndpoint}
+    {revokedMembers : Finset Did}
+    {revokedDid : Did}
+    {row : DataPlaneRow} :
+    row ∈ deriveReciprocal self intents endpoints (insert revokedDid revokedMembers) ↔
+      ∃ intent ∈ intents, intent.memberDid ≠ revokedDid ∧
+        intent.memberDid ∉ revokedMembers ∧ ∃ endpoint ∈ endpoints,
         materializable intent endpoint ∧
         row = {
           peer := endpoint.peer,
@@ -220,12 +263,19 @@ theorem deriveReciprocal_retraction_sound_endpoint {self : Did}
         } := by
   rw [mem_deriveReciprocal]
   constructor
-  · rintro ⟨intent, h_intent, endpoint, h_endpoint, h_materializable, h_row⟩
-    exact ⟨intent, h_intent, endpoint, Finset.mem_of_mem_erase h_endpoint,
-      Finset.ne_of_mem_erase h_endpoint, h_materializable, h_row⟩
-  · rintro ⟨intent, h_intent, endpoint, h_endpoint, h_ne, h_materializable, h_row⟩
-    exact ⟨intent, h_intent, endpoint, Finset.mem_erase.mpr ⟨h_ne, h_endpoint⟩,
-      h_materializable, h_row⟩
+  · rintro ⟨intent, h_intent, endpoint, h_endpoint,
+      h_not_revoked, h_materializable, h_row⟩
+    have h_parts : intent.memberDid ≠ revokedDid ∧
+        intent.memberDid ∉ revokedMembers := by
+      simpa using h_not_revoked
+    exact ⟨intent, h_intent, h_parts.1, h_parts.2,
+      endpoint, h_endpoint, h_materializable, h_row⟩
+  · rintro ⟨intent, h_intent, h_ne, h_not_revoked,
+      endpoint, h_endpoint, h_materializable, h_row⟩
+    have h_not_insert : intent.memberDid ∉ insert revokedDid revokedMembers := by
+      simpa using And.intro h_ne h_not_revoked
+    exact ⟨intent, h_intent, endpoint, h_endpoint,
+      h_not_insert, h_materializable, h_row⟩
 
 /-- Staling an endpoint (setting `live = false`) makes that physical endpoint no
 longer materializable. -/

--- a/crates/defra-agent/src/agent/p2p_reconcile/network.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/network.rs
@@ -147,6 +147,62 @@ pub async fn select_materializable_entries(
     Ok(out)
 }
 
+/// Return DIDs carrying an explicit, valid admin-signed revocation.
+///
+/// Absence is deliberately not revocation: reciprocal conversation pairing
+/// does not require positive network membership. This negative gate only
+/// honors `status="revoked"` rows from the selected network after verifying
+/// both the network root and membership signature.
+pub async fn select_revoked_member_dids(
+    identity: &dyn AgentIdentity,
+    network: &NetworkRecord,
+    memberships: &[MembershipRecord],
+) -> Result<BTreeSet<String>> {
+    if !verify_record(
+        identity,
+        &network.admin_did,
+        &network.signing_payload(),
+        &network.sig,
+        "AgentNetwork",
+    )
+    .await?
+    {
+        tracing::warn!(
+            network_id = %network.network_id,
+            admin_did = %network.admin_did,
+            "reciprocal revocation gate ignored AgentNetwork with invalid admin signature"
+        );
+        return Ok(BTreeSet::new());
+    }
+
+    let mut revoked = BTreeSet::new();
+    for membership in memberships {
+        if membership.network_id != network.network_id || membership.status.trim() != "revoked" {
+            continue;
+        }
+        if !verify_record(
+            identity,
+            &network.admin_did,
+            &membership.signing_payload(),
+            &membership.sig,
+            "NetworkMembership",
+        )
+        .await?
+        {
+            tracing::warn!(
+                member_did = %membership.member_did,
+                "reciprocal revocation gate ignored membership with invalid admin signature"
+            );
+            continue;
+        }
+        let member_did = membership.member_did.trim();
+        if !member_did.is_empty() {
+            revoked.insert(member_did.to_string());
+        }
+    }
+    Ok(revoked)
+}
+
 /// Return the signed materialized endpoint for a Layer-2 data-plane peer. The
 /// endpoint set has already passed the network/membership/signature/freshness
 /// gate in [`select_materializable_entries`], so callers must use the returned
@@ -382,6 +438,48 @@ pub struct GraphqlNetworkStore {
 impl GraphqlNetworkStore {
     pub fn new(node: Arc<EmbeddedNode>, identity: Arc<dyn AgentIdentity>) -> Self {
         Self { node, identity }
+    }
+
+    pub(super) async fn load_revoked_member_dids(&self) -> Result<BTreeSet<String>> {
+        let query = r#"{
+            AgentNetwork {
+                network_id
+                admin_did
+                display_name
+                default_template
+                created_at
+                admin_sig
+            }
+            NetworkMembership {
+                network_id
+                member_did
+                status
+                granted_at
+                revoked_at
+                admin_sig
+            }
+        }"#;
+        let response = self.node.execute(query).await;
+        ensure_no_errors(&response, "query reciprocal revocation inputs")?;
+
+        let network_rows = rows::<NetworkRow>(&response, "AgentNetwork")?;
+        let network = match network_rows.as_slice() {
+            [] => return Ok(BTreeSet::new()),
+            [row] => network_record(row)?,
+            rows => network_record(select_local_network(rows, self.identity.did()))?,
+        };
+        let memberships = rows::<MembershipRow>(&response, "NetworkMembership")?
+            .into_iter()
+            .filter_map(|row| match membership_record(&row) {
+                Ok(record) => Some(record),
+                Err(error) => {
+                    tracing::warn!(error = %error, "reciprocal revocation gate skipped malformed NetworkMembership");
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        select_revoked_member_dids(self.identity.as_ref(), &network, &memberships).await
     }
 
     async fn list_peers_by_source(&self, source: &str) -> Result<BTreeSet<String>> {

--- a/crates/defra-agent/src/agent/p2p_reconcile/reciprocal.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/reciprocal.rs
@@ -27,11 +27,13 @@ pub const SOURCE_RECIPROCAL: &str = "reciprocal";
 /// without a dialable peer id/address.
 pub fn derive_reciprocal_desired<'a>(
     intent_dids: &BTreeSet<String>,
+    revoked_member_dids: &BTreeSet<String>,
     endpoints: &'a [NetworkEndpointEntry],
 ) -> Vec<&'a NetworkEndpointEntry> {
     endpoints
         .iter()
         .filter(|entry| intent_dids.contains(&entry.agent_did))
+        .filter(|entry| !revoked_member_dids.contains(&entry.agent_did))
         .filter(|entry| !entry.peer_id.trim().is_empty())
         .filter(|entry| !entry.address.trim().is_empty())
         .collect()
@@ -57,6 +59,7 @@ pub struct ReciprocalTickOutcome {
 #[async_trait]
 pub trait ReciprocalStore: Send + Sync {
     async fn load_intent_dids(&self) -> Result<BTreeSet<String>>;
+    async fn load_revoked_member_dids(&self) -> Result<BTreeSet<String>>;
     async fn load_endpoint_for_did(&self, did: &str) -> Result<Option<NetworkEndpointEntry>>;
     async fn upsert_reciprocal_data_plane(
         &self,
@@ -83,8 +86,15 @@ pub async fn reconcile_reciprocal_tick(
         .load_intent_dids()
         .await
         .context("load reciprocal conversation intents")?;
+    let revoked_member_dids = store
+        .load_revoked_member_dids()
+        .await
+        .context("load verified revoked network memberships")?;
     let mut endpoints = Vec::new();
     for did in &intent_dids {
+        if revoked_member_dids.contains(did) {
+            continue;
+        }
         if let Some(endpoint) = store
             .load_endpoint_for_did(did)
             .await
@@ -98,7 +108,7 @@ pub async fn reconcile_reciprocal_tick(
         .list_non_reciprocal_data_plane_peers()
         .await
         .context("list non-reciprocal data-plane desired peers")?;
-    let desired = derive_reciprocal_desired(&intent_dids, &endpoints)
+    let desired = derive_reciprocal_desired(&intent_dids, &revoked_member_dids, &endpoints)
         .into_iter()
         .filter(|entry| !blocked.contains(&entry.peer_id))
         .map(|entry| (entry.peer_id.clone(), entry))
@@ -213,8 +223,12 @@ impl GraphqlReciprocalStore {
 
     pub async fn load_materializable_entries(&self) -> Result<Vec<NetworkEndpointEntry>> {
         let intent_dids = <Self as ReciprocalStore>::load_intent_dids(self).await?;
+        let revoked_member_dids = <Self as ReciprocalStore>::load_revoked_member_dids(self).await?;
         let mut endpoints = Vec::new();
         for did in intent_dids {
+            if revoked_member_dids.contains(&did) {
+                continue;
+            }
             if let Some(endpoint) =
                 <Self as ReciprocalStore>::load_endpoint_for_did(self, &did).await?
             {
@@ -264,6 +278,12 @@ impl ReciprocalStore for GraphqlReciprocalStore {
                 .filter(|did| !did.is_empty())
                 .collect(),
         )
+    }
+
+    async fn load_revoked_member_dids(&self) -> Result<BTreeSet<String>> {
+        super::network::GraphqlNetworkStore::new(self.node.clone(), self.identity.clone())
+            .load_revoked_member_dids()
+            .await
     }
 
     async fn load_endpoint_for_did(&self, did: &str) -> Result<Option<NetworkEndpointEntry>> {
@@ -586,7 +606,10 @@ struct DataPlaneSourceRow {
 mod tests {
     use std::sync::Mutex;
 
+    use defra_agent_protocol::network_token::{MembershipRecord, NetworkRecord};
+
     use super::*;
+    use crate::identity::KeyIdentity;
 
     fn endpoint(did: &str, peer_id: &str, address: &str) -> NetworkEndpointEntry {
         NetworkEndpointEntry {
@@ -601,7 +624,7 @@ mod tests {
         let intents = BTreeSet::from(["did:key:phone".to_string()]);
         let endpoints = vec![endpoint("did:key:phone", "peer-phone", "/ticket/phone")];
 
-        let desired = derive_reciprocal_desired(&intents, &endpoints);
+        let desired = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints);
 
         assert_eq!(desired.len(), 1);
         assert_eq!(desired[0].peer_id, "peer-phone");
@@ -614,7 +637,7 @@ mod tests {
         let intents = BTreeSet::from(["did:key:phone".to_string()]);
         let endpoints = vec![endpoint("did:key:other", "peer-other", "/ticket/other")];
 
-        let desired = derive_reciprocal_desired(&intents, &endpoints);
+        let desired = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints);
 
         assert!(desired.is_empty());
     }
@@ -629,7 +652,7 @@ mod tests {
             endpoint("did:key:phone", "peer-phone", "   "),
         ];
 
-        let desired = derive_reciprocal_desired(&intents, &endpoints);
+        let desired = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints);
 
         assert!(desired.is_empty());
     }
@@ -637,6 +660,7 @@ mod tests {
     #[derive(Default)]
     struct MockReciprocalStore {
         intents: BTreeSet<String>,
+        revoked_members: BTreeSet<String>,
         endpoints: BTreeMap<String, NetworkEndpointEntry>,
         existing: BTreeMap<String, ReciprocalRowState>,
         blocked: BTreeSet<String>,
@@ -657,6 +681,10 @@ mod tests {
     impl ReciprocalStore for MockReciprocalStore {
         async fn load_intent_dids(&self) -> Result<BTreeSet<String>> {
             Ok(self.intents.clone())
+        }
+
+        async fn load_revoked_member_dids(&self) -> Result<BTreeSet<String>> {
+            Ok(self.revoked_members.clone())
         }
 
         async fn load_endpoint_for_did(&self, did: &str) -> Result<Option<NetworkEndpointEntry>> {
@@ -898,5 +926,107 @@ mod tests {
         assert!(mutation.contains("AgentRequest"));
         assert!(mutation.contains("AgentResponse"));
         assert!(!mutation.contains("[]"));
+    }
+
+    #[tokio::test]
+    async fn graphql_tick_retracts_for_signed_revoked_membership() -> Result<()> {
+        let tempdir = tempfile::tempdir()?;
+        let node = Arc::new(
+            EmbeddedNode::builder()
+                .data_path(tempdir.path().join("data"))
+                .build()
+                .await?,
+        );
+        crate::ensure_runtime_schemas(&node).await?;
+        let identity = Arc::new(KeyIdentity::load_or_create(
+            tempdir.path().join("admin.key"),
+            None,
+        )?);
+        let now = "2026-07-14T00:00:00Z";
+        let member_did = "did:key:revoked-member";
+
+        let mut network = NetworkRecord {
+            network_id: "network-a".to_string(),
+            admin_did: identity.did().to_string(),
+            display_name: "Network A".to_string(),
+            default_template: "network-control".to_string(),
+            created_at: now.to_string(),
+            sig: Vec::new(),
+        };
+        network.sig = identity.sign(&network.signing_payload()).await?;
+        let mut membership = MembershipRecord {
+            network_id: network.network_id.clone(),
+            member_did: member_did.to_string(),
+            status: "revoked".to_string(),
+            granted_at: now.to_string(),
+            revoked_at: now.to_string(),
+            sig: Vec::new(),
+        };
+        membership.sig = identity.sign(&membership.signing_payload()).await?;
+        let network_sig = bs58::encode(&network.sig).into_string();
+        let membership_sig = bs58::encode(&membership.sig).into_string();
+
+        let seed = format!(
+            r#"mutation {{
+                create_AgentNetwork(input: {{
+                    network_id: "network-a",
+                    admin_did: "{admin_did}",
+                    display_name: "Network A",
+                    default_template: "network-control",
+                    created_at: "{now}",
+                    admin_sig: "{network_sig}"
+                }}) {{ _docID }}
+                create_NetworkMembership(input: {{
+                    membership_key: "network-a:{member_did}",
+                    network_id: "network-a",
+                    member_did: "{member_did}",
+                    status: "revoked",
+                    granted_at: "{now}",
+                    revoked_at: "{now}",
+                    admin_sig: "{membership_sig}"
+                }}) {{ _docID }}
+                create_ReciprocalConversationIntent(input: {{
+                    member_did: "{member_did}",
+                    template: "conversation",
+                    created_at: "{now}",
+                    updated_at: "{now}"
+                }}) {{ _docID }}
+                create_DataPlanePairingDesired(input: {{
+                    peer_id: "peer-revoked",
+                    agent_did: "{admin_did}",
+                    collections: ["AgentRequest"],
+                    replicator_addresses: ["/ticket/revoked"],
+                    template: "conversation",
+                    source: "reciprocal",
+                    created_at: "{now}",
+                    updated_at: "{now}"
+                }}) {{ _docID }}
+            }}"#,
+            admin_did = escape_graphql_string(identity.did()),
+            network_sig = escape_graphql_string(&network_sig),
+            membership_sig = escape_graphql_string(&membership_sig),
+        );
+        let response = node.execute(&seed).await;
+        ensure_no_errors(&response, "seed reciprocal revocation regression")?;
+
+        let store = GraphqlReciprocalStore::new(node.clone(), identity);
+        let outcome = reconcile_reciprocal_tick(&store, "did:key:server").await?;
+
+        assert_eq!(
+            outcome.retracted,
+            BTreeSet::from(["peer-revoked".to_string()])
+        );
+        let response = node
+            .execute(
+                r#"{
+                    DataPlanePairingDesired(filter: { peer_id: { _eq: "peer-revoked" } }) {
+                        peer_id
+                    }
+                }"#,
+            )
+            .await;
+        ensure_no_errors(&response, "query reciprocal row after revocation")?;
+        assert!(rows::<DataPlaneRow>(&response, "DataPlanePairingDesired")?.is_empty());
+        Ok(())
     }
 }

--- a/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
+++ b/crates/defra-agent/tests/conformance/peer_registry_discovery.rs
@@ -19,8 +19,8 @@ use defra_agent::agent::p2p_reconcile::discovery::{
 };
 use defra_agent::agent::p2p_reconcile::network::{
     decide_v5_admission, derive_network_desired, peer_is_materializable, reconcile_network_tick,
-    select_materializable_entries, NetworkEndpointEntry, NetworkStore, V5AdmissionClaim,
-    V5Rejection,
+    select_materializable_entries, select_revoked_member_dids, NetworkEndpointEntry, NetworkStore,
+    V5AdmissionClaim, V5Rejection,
 };
 use defra_agent::identity::{AgentIdentity, KeyIdentity};
 use defra_agent_protocol::network_token::{EndpointRecord, MembershipRecord, NetworkRecord};
@@ -450,6 +450,29 @@ async fn gate_excludes_revoked_member() {
         out.is_empty(),
         "revoked membership must not materialize (Lean revoke_drops_member)"
     );
+}
+
+/// The reciprocal negative gate accepts only explicit revocations signed by
+/// the selected network's admin. Active and forged rows cannot suppress a
+/// standing conversation intent.
+#[tokio::test]
+async fn reciprocal_gate_selects_only_verified_revocations() {
+    let admin = gate_identity("reciprocal-revoke-admin");
+    let valid_member = gate_identity("reciprocal-revoke-valid");
+    let forged_member = gate_identity("reciprocal-revoke-forged");
+    let active_member = gate_identity("reciprocal-revoke-active");
+    let net = signed_network(&admin).await;
+    let valid = signed_membership(&admin, &net.network_id, valid_member.did(), "revoked").await;
+    let mut forged =
+        signed_membership(&admin, &net.network_id, forged_member.did(), "revoked").await;
+    forged.sig = vec![0u8; 64];
+    let active = signed_membership(&admin, &net.network_id, active_member.did(), "active").await;
+
+    let revoked = select_revoked_member_dids(&admin, &net, &[valid, forged, active])
+        .await
+        .expect("revocation gate");
+
+    assert_eq!(revoked, BTreeSet::from([valid_member.did().to_string()]));
 }
 
 /// Mirrors `unsigned_membership_not_materialized`: a membership whose admin

--- a/crates/defra-agent/tests/conformance/reciprocal_conversation.rs
+++ b/crates/defra-agent/tests/conformance/reciprocal_conversation.rs
@@ -36,7 +36,7 @@ fn reciprocal_derivation_matches_intent_endpoint_join() {
         endpoint("did:key:phone", "peer-blank-address", ""),
     ];
 
-    let derived = derive_reciprocal_desired(&intents, &endpoints);
+    let derived = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints);
 
     assert_eq!(derived.len(), 1);
     assert_eq!(derived[0].peer_id, "peer-phone");
@@ -51,11 +51,11 @@ fn reciprocal_derivation_is_idempotent_and_convergent() {
     let intents = BTreeSet::from(["did:key:phone".to_string()]);
     let endpoints = vec![endpoint("did:key:phone", "peer-phone", "/ticket/phone")];
 
-    let first = derive_reciprocal_desired(&intents, &endpoints)
+    let first = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints)
         .into_iter()
         .map(|entry| entry.peer_id.clone())
         .collect::<BTreeSet<_>>();
-    let second = derive_reciprocal_desired(&intents, &endpoints)
+    let second = derive_reciprocal_desired(&intents, &BTreeSet::new(), &endpoints)
         .into_iter()
         .map(|entry| entry.peer_id.clone())
         .collect::<BTreeSet<_>>();
@@ -66,6 +66,7 @@ fn reciprocal_derivation_is_idempotent_and_convergent() {
 
 struct ReciprocalPartitionStore {
     intents: BTreeSet<String>,
+    revoked_members: BTreeSet<String>,
     endpoints: BTreeMap<String, NetworkEndpointEntry>,
     reciprocal_owned: Mutex<BTreeMap<String, ReciprocalRowState>>,
     operator_owned: BTreeSet<String>,
@@ -82,6 +83,7 @@ impl ReciprocalPartitionStore {
     ) -> Self {
         Self {
             intents: intents.iter().map(|value| value.to_string()).collect(),
+            revoked_members: BTreeSet::new(),
             endpoints: endpoints
                 .into_iter()
                 .map(|entry| (entry.agent_did.clone(), entry))
@@ -113,6 +115,10 @@ impl ReciprocalPartitionStore {
 impl ReciprocalStore for ReciprocalPartitionStore {
     async fn load_intent_dids(&self) -> Result<BTreeSet<String>> {
         Ok(self.intents.clone())
+    }
+
+    async fn load_revoked_member_dids(&self) -> Result<BTreeSet<String>> {
+        Ok(self.revoked_members.clone())
     }
 
     async fn load_endpoint_for_did(&self, did: &str) -> Result<Option<NetworkEndpointEntry>> {
@@ -267,4 +273,32 @@ async fn reciprocal_retraction_removes_only_derived_rows() {
         .lock()
         .unwrap()
         .contains(&"peer-operator".to_string()));
+}
+
+/// Mirrors Lean `deriveReciprocal_retraction_sound_revocation`: a verified
+/// revocation retracts only rows derived for that member DID.
+#[tokio::test]
+async fn reciprocal_revocation_retracts_only_the_revoked_member() {
+    let mut store = ReciprocalPartitionStore::new(
+        &["did:key:phone-a", "did:key:phone-b"],
+        vec![
+            endpoint("did:key:phone-a", "peer-a", "/ticket/a"),
+            endpoint("did:key:phone-b", "peer-b", "/ticket/b"),
+        ],
+        &[("peer-a", "/ticket/a"), ("peer-b", "/ticket/b")],
+        &[],
+    );
+    store.revoked_members.insert("did:key:phone-a".to_string());
+
+    let outcome = reconcile_reciprocal_tick(&store, "did:key:server")
+        .await
+        .expect("tick");
+
+    assert_eq!(outcome.retracted, BTreeSet::from(["peer-a".to_string()]));
+    assert_eq!(*store.deletes.lock().unwrap(), vec!["peer-a".to_string()]);
+    assert!(store
+        .reciprocal_owned
+        .lock()
+        .unwrap()
+        .contains_key("peer-b"));
 }


### PR DESCRIPTION
## Summary

- stop deriving reciprocal conversation pairings for principals with a valid admin-signed revoked membership
- preserve invite-only pairing when no membership exists and ignore forged revocations
- add a Lean retraction theorem, generated conformance coverage, and a persisted GraphQL integration test

## Why

A standing reciprocal intent and endpoint could continue materializing a conversation data plane after network membership was revoked. The runtime now treats the newest verified revocation as an explicit negative gate while keeping absence of membership distinct from revocation.

## Validation

- `lake build`
- `cargo test -p defra-agent`
- `cargo check --workspace --all-targets`
- `cargo fmt --all --check`

Fixes #672