### PR TITLE
Lean-fence the timeline interleaving; share the ordering skeleton across shells (#608)

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/session_timeline.rs
@@ -103,7 +103,9 @@ fn session_snapshot_deduplicates_persisted_rows_from_multiple_sources() {
     let mut rows = make_streaming_store_with_response_content("").to_rows();
     rows.responses.clear();
 
-    let duplicate_user = rows.messages[0].clone();
+    let mut duplicate_user = rows.messages[0].clone();
+    duplicate_user.sequence = Some(9);
+    duplicate_user.content = Some(user_message_json("later duplicate"));
     rows.messages.push(duplicate_user);
     rows.message_source_agent_dids = vec![None, Some("did:defra:amy".to_string())];
 
@@ -119,7 +121,10 @@ fn session_snapshot_deduplicates_persisted_rows_from_multiple_sources() {
     };
     rows.messages.push(assistant.clone());
     rows.message_source_agent_dids.push(None);
-    rows.messages.push(assistant);
+    let mut duplicate_assistant = assistant;
+    duplicate_assistant.sequence = Some(10);
+    duplicate_assistant.content = Some(assistant_message_json("later duplicate"));
+    rows.messages.push(duplicate_assistant);
     rows.message_source_agent_dids
         .push(Some("did:defra:amy".to_string()));
 
@@ -144,6 +149,22 @@ fn session_snapshot_deduplicates_persisted_rows_from_multiple_sources() {
         })
         .collect::<Vec<_>>();
     assert_eq!(kinds, vec!["user", "assistant"]);
+    assert!(matches!(
+        &snapshot.timeline_items[0],
+        RenderedTimelineItem::UserMessage {
+            sequence: Some(1),
+            content,
+            ..
+        } if content == "hello"
+    ));
+    assert!(matches!(
+        &snapshot.timeline_items[1],
+        RenderedTimelineItem::AssistantMessage {
+            sequence: Some(2),
+            content: Some(content),
+            ..
+        } if content == "hello back"
+    ));
 }
 
 #[test]

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
@@ -181,7 +181,9 @@ pub(super) fn build_rendered_timeline(
             (false, None)
         };
         if let Some(item) = item {
-            rendered_message.insert(message.message_key.clone(), item);
+            rendered_message
+                .entry(message.message_key.clone())
+                .or_insert(item);
         }
         // Presentation dedup token: the desktop only dedups by presentation when
         // the message carries a sequence (None opts out). Serialize the same

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/timeline.rs
@@ -1,5 +1,11 @@
 use serde_json::Value;
 
+use std::collections::BTreeMap;
+
+use defra_agent_protocol::timeline::{
+    build_timeline_order, TimelineMessageInput, TimelineRole, TimelineSlot,
+};
+
 use super::super::types::{
     normalize_optional, MessageView, PendingTurnView, RenderedTimelineItem, RenderedToolCallView,
     ResponseView, ToolCallView, ToolDetailFieldView, ToolDetailValueView,
@@ -115,35 +121,32 @@ pub(super) fn build_rendered_timeline(
     pending_turn: Option<&PendingTurnView>,
     active_response_overlay: Option<&ResponseView>,
 ) -> Vec<RenderedTimelineItem> {
-    let mut timeline = Vec::new();
-    let mut tool_groups: std::collections::BTreeMap<Option<i64>, Vec<ToolCallView>> =
-        std::collections::BTreeMap::new();
-
+    // Group tool calls by their owning message sequence (rich lookup for the
+    // mapping-back step); the presentation-neutral ORDER is decided by the
+    // shared, Lean-fenced skeleton, not here.
+    let mut tool_groups: BTreeMap<Option<i64>, Vec<ToolCallView>> = BTreeMap::new();
     for tool in tool_calls.iter().cloned() {
         tool_groups
             .entry(tool.message_sequence)
             .or_default()
             .push(tool);
     }
+    let group_sequences: Vec<Option<i64>> = tool_groups.keys().copied().collect();
 
-    let mut used_group_keys = std::collections::BTreeSet::new();
-
-    let mut timeline_messages = messages
-        .iter()
-        .filter(|message| {
-            !message.has_tool_results
-                && (!normalize_timeline_text(message.display_content.as_deref()).is_empty()
-                    || !normalize_timeline_text(message.reasoning.as_deref()).is_empty()
-                    || message.has_tool_calls)
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    timeline_messages.sort_by_key(|message| message.sequence.unwrap_or_default());
-
-    let mut seen_message_keys = std::collections::BTreeSet::new();
-    let mut seen_presentations = std::collections::BTreeSet::new();
-
-    for message in timeline_messages {
+    // Candidate messages (step-2 filter: drop tool-result rows and rows with no
+    // rendered content/reasoning/tool-calls — a presentation decision). For each
+    // candidate, project the ordering-relevant fields the skeleton consumes, and
+    // remember the rich content by key for mapping the slots back.
+    let mut inputs: Vec<TimelineMessageInput> = Vec::new();
+    let mut rendered_message: BTreeMap<String, RenderedTimelineItem> = BTreeMap::new();
+    for message in messages.iter() {
+        let keep = !message.has_tool_results
+            && (!normalize_timeline_text(message.display_content.as_deref()).is_empty()
+                || !normalize_timeline_text(message.reasoning.as_deref()).is_empty()
+                || message.has_tool_calls);
+        if !keep {
+            continue;
+        }
         let role = message
             .display_role
             .as_deref()
@@ -151,73 +154,99 @@ pub(super) fn build_rendered_timeline(
             .unwrap_or("assistant");
         let normalized_content = normalize_optional(message.display_content.as_deref());
         let normalized_reasoning = normalize_optional(message.reasoning.as_deref());
-        if !seen_message_keys.insert(message.message_key.clone()) {
-            continue;
-        }
-        if let Some(presentation_key) =
-            message_presentation_key(&message, role, &normalized_content, &normalized_reasoning)
-        {
-            if !seen_presentations.insert(presentation_key) {
-                continue;
-            }
-        }
-
-        match role {
-            "user" => {
-                if let Some(content) = normalized_content.clone() {
-                    timeline.push(RenderedTimelineItem::UserMessage {
+        let is_user = role == "user";
+        let (emits_item, item) = if is_user {
+            match normalized_content.clone() {
+                Some(content) => (
+                    true,
+                    Some(RenderedTimelineItem::UserMessage {
                         item_key: message.message_key.clone(),
                         sequence: message.sequence,
                         content,
-                    });
-                }
+                    }),
+                ),
+                None => (false, None),
             }
-            _ => {
-                if normalized_content.is_some() || normalized_reasoning.is_some() {
-                    timeline.push(RenderedTimelineItem::AssistantMessage {
-                        item_key: message.message_key.clone(),
-                        sequence: message.sequence,
-                        content: normalized_content,
-                        reasoning: normalized_reasoning,
-                    });
-                }
-            }
+        } else if normalized_content.is_some() || normalized_reasoning.is_some() {
+            (
+                true,
+                Some(RenderedTimelineItem::AssistantMessage {
+                    item_key: message.message_key.clone(),
+                    sequence: message.sequence,
+                    content: normalized_content.clone(),
+                    reasoning: normalized_reasoning.clone(),
+                }),
+            )
+        } else {
+            (false, None)
+        };
+        if let Some(item) = item {
+            rendered_message.insert(message.message_key.clone(), item);
         }
-
-        let key = message.sequence;
-        if let Some(grouped_tools) = tool_groups.get(&key).cloned() {
-            used_group_keys.insert(key);
-            timeline.push(RenderedTimelineItem::ToolGroup {
-                item_key: format!("tools-{}", key.unwrap_or(-1)),
-                message_sequence: key,
-                tools: grouped_tools.into_iter().map(render_tool_call).collect(),
-            });
-        }
-    }
-
-    if let Some(pending_turn) = pending_turn {
-        timeline.push(RenderedTimelineItem::PendingUserTurn {
-            item_key: format!("pending-{}", pending_turn.request_id),
-            request_id: pending_turn.request_id.clone(),
-            content: pending_turn.content.clone(),
-            selected_skill_ids: pending_turn.selected_skill_ids.clone(),
-            lifecycle_state: pending_turn.lifecycle_state.clone(),
-            created_at: pending_turn.created_at.clone(),
+        // Presentation dedup token: the desktop only dedups by presentation when
+        // the message carries a sequence (None opts out). Serialize the same
+        // tuple the old `message_presentation_key` used, as an opaque token.
+        let dedup_token =
+            message_presentation_key(message, role, &normalized_content, &normalized_reasoning)
+                .map(|key| format!("{key:?}"));
+        inputs.push(TimelineMessageInput {
+            key: message.message_key.clone(),
+            sequence: message.sequence,
+            role: if is_user {
+                TimelineRole::User
+            } else {
+                TimelineRole::Assistant
+            },
+            emits_item,
+            dedup_token,
         });
     }
 
-    for (key, grouped_tools) in tool_groups {
-        if used_group_keys.contains(&key) {
-            continue;
-        }
+    // The parity-critical ordering + partition, computed once in the shared
+    // skeleton. Overlay is decided in the adapter (below) against the assembled
+    // rich items, so pass `None` here.
+    let order = build_timeline_order(&inputs, &group_sequences, pending_turn.is_some(), None);
 
-        timeline.push(RenderedTimelineItem::ToolGroup {
-            item_key: format!("tools-{}", key.unwrap_or(-1)),
-            message_sequence: key,
-            tools: grouped_tools.into_iter().map(render_tool_call).collect(),
-        });
+    let mut timeline = Vec::with_capacity(order.len());
+    for slot in order {
+        match slot {
+            TimelineSlot::Message { key, .. } => {
+                if let Some(item) = rendered_message.get(&key) {
+                    timeline.push(item.clone());
+                }
+            }
+            TimelineSlot::ToolGroup { message_sequence } => {
+                let tools = tool_groups
+                    .get(&message_sequence)
+                    .cloned()
+                    .unwrap_or_default();
+                timeline.push(RenderedTimelineItem::ToolGroup {
+                    item_key: format!("tools-{}", message_sequence.unwrap_or(-1)),
+                    message_sequence,
+                    tools: tools.into_iter().map(render_tool_call).collect(),
+                });
+            }
+            TimelineSlot::Pending => {
+                if let Some(pending_turn) = pending_turn {
+                    timeline.push(RenderedTimelineItem::PendingUserTurn {
+                        item_key: format!("pending-{}", pending_turn.request_id),
+                        request_id: pending_turn.request_id.clone(),
+                        content: pending_turn.content.clone(),
+                        selected_skill_ids: pending_turn.selected_skill_ids.clone(),
+                        lifecycle_state: pending_turn.lifecycle_state.clone(),
+                        created_at: pending_turn.created_at.clone(),
+                    });
+                }
+            }
+            // The skeleton was called with `overlay: None`, so it emits no
+            // overlay slot; the live overlay is appended below.
+            TimelineSlot::Overlay => {}
+        }
     }
 
+    // Overlay: appended last iff present and not a duplicate of the trailing
+    // assistant. Identical to the pre-#608 behavior; the skeleton also models
+    // this (`OverlayInput`) for a shell that prefers to pass the bit in.
     let overlay_content =
         active_response_overlay.and_then(|overlay| normalize_optional(overlay.content.as_deref()));
     let overlay_reasoning = active_response_overlay

--- a/crates/defra-agent-protocol/src/lib.rs
+++ b/crates/defra-agent-protocol/src/lib.rs
@@ -10,6 +10,7 @@ pub mod network_token;
 pub mod pairing_token;
 pub mod row;
 pub mod schemas;
+pub mod timeline;
 pub mod transcript;
 
 pub use bearer_token::{

--- a/crates/defra-agent-protocol/src/timeline.rs
+++ b/crates/defra-agent-protocol/src/timeline.rs
@@ -1,0 +1,370 @@
+//! Presentation-neutral timeline ordering (#608 parity).
+//!
+//! Every client shell — desktop today, mobile next — must render a session's
+//! transcript in the **same order**, interleaving assistant/user messages with
+//! their tool groups, placing the pending turn, appending orphan tool groups,
+//! and the live-assistant overlay last. The *order and the message↔tool-group
+//! partition* are semantics; only the pixels are presentation.
+//!
+//! That ordering used to live only in the desktop Tauri bridge
+//! (`build_rendered_timeline`), unshared and unfenced — the single biggest
+//! parity risk, because a second shell that re-interleaves will drift on order
+//! and on which tool group is an orphan. This module is the shared, Lean-fenced
+//! skeleton (`proofs/Proofs/ClientShell/Timeline.lean`): shells compute the slot
+//! order here, then map each neutral slot to their own rich item.
+
+/// A message's role, reduced to what the ordering cares about.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimelineRole {
+    User,
+    Assistant,
+}
+
+/// The ordering-relevant projection of one transcript message.
+///
+/// A shell fills this from its rich view; the skeleton reads only these fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TimelineMessageInput {
+    /// Stable identity for first-wins dedup (the desktop `message_key`).
+    pub key: String,
+    /// Ordering key and tool-group attach key. `None` sorts first, matching the
+    /// `BTreeMap<Option<i64>, _>` grouping the desktop bridge uses.
+    pub sequence: Option<i64>,
+    pub role: TimelineRole,
+    /// Whether this message contributes a visible message slot. A message can
+    /// survive dedup, emit no slot (e.g. a user turn with no rendered content),
+    /// and still own a tool group — so this is separate from dedup.
+    pub emits_item: bool,
+    /// Opaque secondary dedup token (the desktop presentation key). `None` opts
+    /// out of presentation dedup. The skeleton only compares tokens for
+    /// equality — it never inspects content, so it stays presentation-neutral.
+    pub dedup_token: Option<String>,
+}
+
+/// The live-assistant overlay's ordering-relevant state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OverlayInput {
+    /// True when the overlay's content equals the trailing assistant message
+    /// already in the timeline — in which case it must NOT be re-emitted.
+    pub matches_trailing_assistant: bool,
+}
+
+/// One ordered slot. A shell maps each to its rich, platform-specific item;
+/// the *order and identity* of the slots is the shared contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TimelineSlot {
+    Message {
+        key: String,
+        sequence: Option<i64>,
+        role: TimelineRole,
+    },
+    ToolGroup {
+        message_sequence: Option<i64>,
+    },
+    Pending,
+    Overlay,
+}
+
+/// The BTreeMap ordering the desktop bridge relies on: `None` first, then
+/// ascending. Kept explicit so the ordering is a stated contract, not an
+/// accident of a collection type.
+fn sequence_lt(left: Option<i64>, right: Option<i64>) -> bool {
+    match (left, right) {
+        (None, None) => false,
+        (None, Some(_)) => true,
+        (Some(_), None) => false,
+        (Some(l), Some(r)) => l < r,
+    }
+}
+
+/// Build the canonical timeline slot order (#608).
+///
+/// `messages` are the already-content-filtered transcript messages in arbitrary
+/// order (the shell decides which messages are worth showing — that is
+/// presentation). `group_sequences` are the `message_sequence` keys that have
+/// at least one tool call. `has_pending` / `overlay` gate the two tail slots.
+///
+/// Discipline, mirrored by `ClientShell.Timeline.buildOrder`:
+/// 1. sort messages by `sequence` (None first),
+/// 2. first-wins dedup by `key`, then by `dedup_token`,
+/// 3. each surviving message emits its slot (if `emits_item`) immediately
+///    followed by its tool group (if it owns one), marking that group attached,
+/// 4. the pending turn,
+/// 5. orphan tool groups — those attached to no surviving message — in sequence
+///    order,
+/// 6. the overlay, iff present and not a duplicate of the trailing assistant.
+pub fn build_timeline_order(
+    messages: &[TimelineMessageInput],
+    group_sequences: &[Option<i64>],
+    has_pending: bool,
+    overlay: Option<OverlayInput>,
+) -> Vec<TimelineSlot> {
+    let mut ordered: Vec<&TimelineMessageInput> = messages.iter().collect();
+    ordered.sort_by(|left, right| {
+        if sequence_lt(left.sequence, right.sequence) {
+            std::cmp::Ordering::Less
+        } else if sequence_lt(right.sequence, left.sequence) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+
+    let mut slots = Vec::new();
+    let mut seen_keys = std::collections::BTreeSet::new();
+    let mut seen_tokens = std::collections::BTreeSet::new();
+    let mut attached = std::collections::BTreeSet::new();
+
+    for message in ordered {
+        if !seen_keys.insert(message.key.clone()) {
+            continue;
+        }
+        if let Some(token) = &message.dedup_token {
+            if !seen_tokens.insert(token.clone()) {
+                continue;
+            }
+        }
+        if message.emits_item {
+            slots.push(TimelineSlot::Message {
+                key: message.key.clone(),
+                sequence: message.sequence,
+                role: message.role,
+            });
+        }
+        if group_sequences.contains(&message.sequence) && attached.insert(message.sequence) {
+            slots.push(TimelineSlot::ToolGroup {
+                message_sequence: message.sequence,
+            });
+        }
+    }
+
+    if has_pending {
+        slots.push(TimelineSlot::Pending);
+    }
+
+    let mut orphans: Vec<Option<i64>> = group_sequences
+        .iter()
+        .copied()
+        .filter(|sequence| !attached.contains(sequence))
+        .collect();
+    orphans.sort_by(|left, right| {
+        if sequence_lt(*left, *right) {
+            std::cmp::Ordering::Less
+        } else if sequence_lt(*right, *left) {
+            std::cmp::Ordering::Greater
+        } else {
+            std::cmp::Ordering::Equal
+        }
+    });
+    orphans.dedup();
+    for sequence in orphans {
+        slots.push(TimelineSlot::ToolGroup {
+            message_sequence: sequence,
+        });
+    }
+
+    if let Some(overlay) = overlay {
+        if !overlay.matches_trailing_assistant {
+            slots.push(TimelineSlot::Overlay);
+        }
+    }
+
+    slots
+}
+
+#[cfg(test)]
+mod tests {
+    //! Conformance for the timeline ordering skeleton. Each test drives the real
+    //! `build_timeline_order` through a witness and asserts a property the Lean
+    //! model proves (`proofs/Proofs/ClientShell/Timeline.lean`). If the Rust
+    //! ordering drifts from the fenced discipline, the matching test fails —
+    //! which is what stops a second shell from silently diverging.
+
+    use super::*;
+
+    fn msg(key: &str, seq: i64, role: TimelineRole) -> TimelineMessageInput {
+        TimelineMessageInput {
+            key: key.to_string(),
+            sequence: Some(seq),
+            role,
+            emits_item: true,
+            dedup_token: None,
+        }
+    }
+
+    fn count_group(slots: &[TimelineSlot], seq: Option<i64>) -> usize {
+        slots
+            .iter()
+            .filter(|s| matches!(s, TimelineSlot::ToolGroup { message_sequence } if *message_sequence == seq))
+            .count()
+    }
+
+    /// Lean `group_attached_or_orphan` + `group_not_both`: every tool group is
+    /// placed exactly once — attached to its owner or as an orphan, never both,
+    /// never dropped.
+    #[test]
+    fn every_tool_group_is_placed_exactly_once() {
+        let messages = vec![
+            msg("a", 0, TimelineRole::User),
+            msg("b", 2, TimelineRole::Assistant),
+        ];
+        // seq 0 is owned by message "a"; seq 5 is an orphan (no message owns it).
+        let groups = vec![Some(0), Some(5)];
+        let slots = build_timeline_order(&messages, &groups, false, None);
+
+        assert_eq!(
+            count_group(&slots, Some(0)),
+            1,
+            "attached group placed once"
+        );
+        assert_eq!(count_group(&slots, Some(5)), 1, "orphan group placed once");
+        // The attached group immediately follows its owner message.
+        let a_pos = slots
+            .iter()
+            .position(|s| matches!(s, TimelineSlot::Message { key, .. } if key == "a"))
+            .unwrap();
+        assert!(
+            matches!(
+                &slots[a_pos + 1],
+                TimelineSlot::ToolGroup {
+                    message_sequence: Some(0)
+                }
+            ),
+            "attached group must immediately follow its owner: {slots:?}"
+        );
+    }
+
+    /// Lean `overlay_shown_iff` + `overlay_is_last`: the overlay is emitted iff
+    /// present and not a duplicate of the trailing assistant, and it is last.
+    #[test]
+    fn overlay_is_shown_conditionally_and_last() {
+        let messages = vec![msg("a", 0, TimelineRole::Assistant)];
+        let groups = vec![Some(0)];
+
+        let shown = build_timeline_order(
+            &messages,
+            &groups,
+            true,
+            Some(OverlayInput {
+                matches_trailing_assistant: false,
+            }),
+        );
+        assert_eq!(
+            shown.last(),
+            Some(&TimelineSlot::Overlay),
+            "overlay must be last: {shown:?}"
+        );
+
+        let hidden = build_timeline_order(
+            &messages,
+            &groups,
+            true,
+            Some(OverlayInput {
+                matches_trailing_assistant: true,
+            }),
+        );
+        assert!(
+            !hidden.contains(&TimelineSlot::Overlay),
+            "a duplicate overlay must not be shown: {hidden:?}"
+        );
+
+        let absent = build_timeline_order(&messages, &groups, true, None);
+        assert!(!absent.contains(&TimelineSlot::Overlay));
+    }
+
+    /// Lean `pending_shown_iff`: the pending turn appears iff a turn is pending,
+    /// and (structurally) after the body, before orphan groups.
+    #[test]
+    fn pending_turn_shown_iff_and_before_orphans() {
+        let messages = vec![msg("a", 0, TimelineRole::User)];
+        let groups = vec![Some(9)]; // orphan
+        let slots = build_timeline_order(&messages, &groups, true, None);
+
+        let pending_pos = slots
+            .iter()
+            .position(|s| matches!(s, TimelineSlot::Pending));
+        let orphan_pos = slots.iter().position(|s| {
+            matches!(
+                s,
+                TimelineSlot::ToolGroup {
+                    message_sequence: Some(9)
+                }
+            )
+        });
+        assert!(pending_pos.is_some(), "pending must be shown");
+        assert!(
+            pending_pos < orphan_pos,
+            "pending must precede orphan groups: {slots:?}"
+        );
+
+        let no_pending = build_timeline_order(&messages, &groups, false, None);
+        assert!(!no_pending
+            .iter()
+            .any(|s| matches!(s, TimelineSlot::Pending)));
+    }
+
+    /// Lean `kept_keys_nodup`: first-wins dedup by key — a repeated message key
+    /// yields a single message slot.
+    #[test]
+    fn duplicate_message_keys_are_deduped_first_wins() {
+        let messages = vec![
+            msg("dup", 0, TimelineRole::Assistant),
+            msg("dup", 1, TimelineRole::Assistant),
+            msg("other", 2, TimelineRole::Assistant),
+        ];
+        let slots = build_timeline_order(&messages, &[], false, None);
+        let dup_count = slots
+            .iter()
+            .filter(|s| matches!(s, TimelineSlot::Message { key, .. } if key == "dup"))
+            .count();
+        assert_eq!(
+            dup_count, 1,
+            "a repeated message key must render once: {slots:?}"
+        );
+    }
+
+    /// Presentation-token dedup collapses re-presentations AND suppresses the
+    /// second message's group attach (the desktop `continue`-before-attach
+    /// nuance a naive shell would miss).
+    #[test]
+    fn presentation_token_dedup_also_drops_the_second_group_attach() {
+        let mut first = msg("m1", 0, TimelineRole::Assistant);
+        first.dedup_token = Some("same".to_string());
+        let mut second = msg("m2", 1, TimelineRole::Assistant);
+        second.dedup_token = Some("same".to_string());
+
+        // Both message sequences own a group; the second message is dropped by
+        // presentation dedup, so its group becomes an orphan (placed in the tail),
+        // not attached.
+        let slots = build_timeline_order(&[first, second], &[Some(0), Some(1)], false, None);
+
+        let m2_shown = slots
+            .iter()
+            .any(|s| matches!(s, TimelineSlot::Message { key, .. } if key == "m2"));
+        assert!(
+            !m2_shown,
+            "presentation-deduped message must not render: {slots:?}"
+        );
+        // Group 1 still appears exactly once — as an orphan.
+        assert_eq!(count_group(&slots, Some(1)), 1);
+    }
+
+    /// `None` sequences sort first (matching the desktop `BTreeMap<Option<i64>>`).
+    #[test]
+    fn none_sequence_sorts_before_some() {
+        let mut none_msg = msg("none", 0, TimelineRole::Assistant);
+        none_msg.sequence = None;
+        let some_msg = msg("some", 5, TimelineRole::Assistant);
+        let slots = build_timeline_order(&[some_msg, none_msg], &[], false, None);
+        let none_pos = slots
+            .iter()
+            .position(|s| matches!(s, TimelineSlot::Message { key, .. } if key == "none"));
+        let some_pos = slots
+            .iter()
+            .position(|s| matches!(s, TimelineSlot::Message { key, .. } if key == "some"));
+        assert!(
+            none_pos < some_pos,
+            "None sequence must sort first: {slots:?}"
+        );
+    }
+}

--- a/crates/defra-agent/proofs/Proofs/ClientShell.lean
+++ b/crates/defra-agent/proofs/Proofs/ClientShell.lean
@@ -2,6 +2,7 @@ import Proofs.ClientShell.Types
 import Proofs.ClientShell.Submission
 import Proofs.ClientShell.Transition
 import Proofs.ClientShell.Projection
+import Proofs.ClientShell.Timeline
 import Proofs.ClientShell.Theorems
 
 /-!

--- a/crates/defra-agent/proofs/Proofs/ClientShell/Timeline.lean
+++ b/crates/defra-agent/proofs/Proofs/ClientShell/Timeline.lean
@@ -1,0 +1,265 @@
+import Proofs.Client
+
+/-!
+# Client Shell Timeline Ordering (#608 parity)
+
+Every client shell renders a session's transcript in the same order: messages
+interleaved with their tool groups, then the pending turn, then orphan tool
+groups, then the live-assistant overlay. The *order and the message↔tool-group
+partition* are semantics a second shell must reproduce exactly; only the pixels
+are presentation.
+
+This models `defra_agent_protocol::timeline::build_timeline_order`. The Rust
+function is structured in the same four phases this model concatenates:
+
+    buildOrder = body ++ pending ++ orphans ++ overlay
+
+where `body` interleaves each surviving (deduped) message with the tool group it
+owns, `orphans` are the tool groups no surviving message owns, and the two tail
+phases are gated singletons.
+
+Model boundary: the input message list is taken **already sorted** by the
+shell's total sequence order (the Rust sorts first; sort correctness is a
+standard fact, not re-derived here). The fence is the interleave / partition /
+tail discipline *on top of* that order — which is exactly the part a second
+shell re-implements and can get wrong.
+-/
+
+namespace ClientShell.Timeline
+
+inductive Role
+  | user
+  | assistant
+  deriving DecidableEq, Repr
+
+/-- The ordering-relevant projection of one transcript message. `seq` is the
+sort key and the tool-group attach key; `emitsItem` says whether it contributes
+a visible slot; `token` is an opaque presentation-dedup token. -/
+structure Msg where
+  key : Nat
+  seq : Int
+  role : Role
+  emitsItem : Bool
+  token : Option Nat
+  deriving DecidableEq, Repr
+
+/-- One ordered slot. A shell maps each to a rich item; the order and identity
+of the slots is the shared contract. -/
+inductive Slot
+  | message (key : Nat) (seq : Int) (role : Role)
+  | toolGroup (seq : Int)
+  | pending
+  | overlay
+  deriving DecidableEq, Repr
+
+/-- First-wins dedup by `key`, then by `token`. Threads the seen sets in order,
+so the SURVIVING messages keep their input order. -/
+def dedup (seenKeys : List Nat) (seenTokens : List Nat) : List Msg → List Msg
+  | [] => []
+  | m :: rest =>
+      if m.key ∈ seenKeys then
+        dedup seenKeys seenTokens rest
+      else
+        match m.token with
+        | some t =>
+            if t ∈ seenTokens then
+              dedup (m.key :: seenKeys) seenTokens rest
+            else
+              m :: dedup (m.key :: seenKeys) (t :: seenTokens) rest
+        | none =>
+            m :: dedup (m.key :: seenKeys) seenTokens rest
+
+/-- The kept (deduped) messages, in input order. -/
+def kept (msgs : List Msg) : List Msg := dedup [] [] msgs
+
+/-- Does sequence `s` have a tool group? -/
+def hasGroup (groups : List Int) (s : Int) : Bool := s ∈ groups
+
+/-- Body slots: each kept message emits its slot (when `emitsItem`) immediately
+followed by the tool group it owns (when it owns one). Mirrors the per-message
+loop; the `attached` accumulator prevents a repeated sequence from re-emitting a
+group. -/
+def bodyGo (groups : List Int) (attached : List Int) : List Msg → List Slot
+  | [] => []
+  | m :: rest =>
+      let msgSlots := if m.emitsItem then [Slot.message m.key m.seq m.role] else []
+      if hasGroup groups m.seq ∧ m.seq ∉ attached then
+        msgSlots ++ Slot.toolGroup m.seq :: bodyGo groups (m.seq :: attached) rest
+      else
+        msgSlots ++ bodyGo groups attached rest
+
+def body (groups : List Int) (msgs : List Msg) : List Slot :=
+  bodyGo groups [] (kept msgs)
+
+/-- The sequences a surviving message attaches a group to. -/
+def attachedSeqs (groups : List Int) (msgs : List Msg) : List Int :=
+  ((kept msgs).map Msg.seq).filter (fun s => hasGroup groups s)
+
+/-- Orphan groups: those attached to no surviving message. -/
+def orphans (groups : List Int) (msgs : List Msg) : List Int :=
+  groups.filter (fun s => s ∉ attachedSeqs groups msgs)
+
+/-- Whether the overlay's content equals the trailing assistant already shown. -/
+structure Overlay where
+  matchesTrailing : Bool
+  deriving DecidableEq, Repr
+
+/-- The four-phase timeline order. -/
+def buildOrder (groups : List Int) (msgs : List Msg)
+    (hasPending : Bool) (overlay : Option Overlay) : List Slot :=
+  body groups msgs
+    ++ (if hasPending then [Slot.pending] else [])
+    ++ (orphans groups msgs).map Slot.toolGroup
+    ++ (match overlay with
+        | some o => if o.matchesTrailing then [] else [Slot.overlay]
+        | none => [])
+
+/-! ## Slot-membership helpers -/
+
+/-- No `Slot.overlay` is produced by the body phase: the interleave emits only
+message and tool-group slots. -/
+theorem overlay_not_in_bodyGo (groups : List Int) (attached : List Int) (ms : List Msg) :
+    Slot.overlay ∉ bodyGo groups attached ms := by
+  induction ms generalizing attached with
+  | nil => simp [bodyGo]
+  | cons m rest ih =>
+      unfold bodyGo
+      by_cases hg : hasGroup groups m.seq ∧ m.seq ∉ attached
+      · simp only [hg, if_true]
+        cases m.emitsItem <;> simp [List.mem_append, ih]
+      · simp only [hg, if_false]
+        cases m.emitsItem <;> simp [List.mem_append, ih]
+
+theorem overlay_not_in_body (groups : List Int) (msgs : List Msg) :
+    Slot.overlay ∉ body groups msgs :=
+  overlay_not_in_bodyGo groups [] (kept msgs)
+
+theorem overlay_not_in_orphans (groups : List Int) (msgs : List Msg) :
+    Slot.overlay ∉ (orphans groups msgs).map Slot.toolGroup := by
+  simp
+
+/-! ## Overlay: shown iff live, and always last -/
+
+/-- The overlay is emitted exactly when it is present and not a duplicate of the
+trailing assistant. -/
+theorem overlay_shown_iff (groups : List Int) (msgs : List Msg)
+    (hasPending : Bool) (o : Overlay) :
+    (Slot.overlay ∈ buildOrder groups msgs hasPending (some o)) ↔ o.matchesTrailing = false := by
+  unfold buildOrder
+  have hb := overlay_not_in_body groups msgs
+  have ho := overlay_not_in_orphans groups msgs
+  cases hp : hasPending <;> cases hm : o.matchesTrailing <;>
+    simp [hp, hm, List.mem_append, hb, ho]
+
+/-- No overlay slot appears when the overlay is absent. -/
+theorem no_overlay_when_absent (groups : List Int) (msgs : List Msg)
+    (hasPending : Bool) :
+    Slot.overlay ∉ buildOrder groups msgs hasPending none := by
+  unfold buildOrder
+  have hb := overlay_not_in_body groups msgs
+  have ho := overlay_not_in_orphans groups msgs
+  cases hp : hasPending <;> simp [hp, List.mem_append, hb, ho]
+
+/-! ## Partition: every tool group is placed exactly once -/
+
+/-- A sequence that a surviving message attaches a group to is a real group. -/
+theorem attachedSeqs_subset_groups (groups : List Int) (msgs : List Msg) {s : Int}
+    (h : s ∈ attachedSeqs groups msgs) : s ∈ groups := by
+  unfold attachedSeqs at h
+  rw [List.mem_filter] at h
+  simpa [hasGroup] using h.2
+
+/-- **Partition (completeness).** Every tool group is either attached to a
+surviving message or an orphan — none is dropped. -/
+theorem group_attached_or_orphan (groups : List Int) (msgs : List Msg) {s : Int}
+    (h : s ∈ groups) : s ∈ attachedSeqs groups msgs ∨ s ∈ orphans groups msgs := by
+  by_cases ha : s ∈ attachedSeqs groups msgs
+  · exact Or.inl ha
+  · refine Or.inr ?_
+    unfold orphans
+    rw [List.mem_filter]
+    exact ⟨h, by simpa using ha⟩
+
+/-- **Partition (disjointness).** No tool group is both attached and an orphan —
+none is placed twice. -/
+theorem group_not_both (groups : List Int) (msgs : List Msg) {s : Int}
+    (ha : s ∈ attachedSeqs groups msgs) : s ∉ orphans groups msgs := by
+  unfold orphans
+  rw [List.mem_filter]
+  simp [ha]
+
+/-! ## Tail structure -/
+
+/-- The pending turn appears exactly when a turn is pending. -/
+theorem pending_shown_iff (groups : List Int) (msgs : List Msg)
+    (hasPending : Bool) (overlay : Option Overlay) :
+    (Slot.pending ∈ buildOrder groups msgs hasPending overlay) ↔ hasPending = true := by
+  unfold buildOrder
+  have hb : Slot.pending ∉ body groups msgs := by
+    unfold body
+    generalize (kept msgs) = ks
+    generalize ([] : List Int) = acc
+    induction ks generalizing acc with
+    | nil => simp [bodyGo]
+    | cons m rest ih =>
+        unfold bodyGo
+        by_cases hg : hasGroup groups m.seq ∧ m.seq ∉ acc
+        · simp only [hg, if_true]; cases m.emitsItem <;> simp [List.mem_append, ih]
+        · simp only [hg, if_false]; cases m.emitsItem <;> simp [List.mem_append, ih]
+  have ho : Slot.pending ∉ (orphans groups msgs).map Slot.toolGroup := by simp
+  cases hp : hasPending <;>
+    cases overlay with
+    | none => simp [hp, List.mem_append, hb, ho]
+    | some o => cases o.matchesTrailing <;> simp [hp, List.mem_append, hb, ho]
+
+/-- **Overlay is last.** When the overlay is emitted, it is the final slot — a
+shell rendering it anywhere else has broken the order. -/
+theorem overlay_is_last (groups : List Int) (msgs : List Msg)
+    (hasPending : Bool) (o : Overlay) (hshow : o.matchesTrailing = false) :
+    (buildOrder groups msgs hasPending (some o)).getLast? = some Slot.overlay := by
+  unfold buildOrder
+  simp [hshow, List.getLast?_append]
+
+/-! ## Dedup: no message is shown twice -/
+
+/-- The surviving messages have distinct keys, and none was already seen. First-
+wins dedup is what stops a shell from rendering the same message twice. -/
+theorem dedup_keys_nodup (msgs : List Msg) :
+    ∀ seenKeys seenTokens,
+      ((dedup seenKeys seenTokens msgs).map Msg.key).Nodup ∧
+        ∀ k ∈ (dedup seenKeys seenTokens msgs).map Msg.key, k ∉ seenKeys := by
+  induction msgs with
+  | nil => intro _ _; simp [dedup]
+  | cons m rest ih =>
+      intro seenKeys seenTokens
+      by_cases hk : m.key ∈ seenKeys
+      · simp only [dedup, hk, if_true]
+        exact ih seenKeys seenTokens
+      · match hmt : m.token with
+        | some t =>
+            by_cases ht : t ∈ seenTokens
+            · simp only [dedup, hk, if_false, hmt, ht, if_true]
+              obtain ⟨hnd, hns⟩ := ih (m.key :: seenKeys) seenTokens
+              exact ⟨hnd, fun k hkm => (hns k hkm) ∘ List.mem_cons_of_mem _⟩
+            · simp only [dedup, hk, if_false, hmt, ht, if_false, List.map_cons, List.nodup_cons]
+              obtain ⟨hnd, hns⟩ := ih (m.key :: seenKeys) (t :: seenTokens)
+              refine ⟨⟨fun hmem => hns m.key hmem (List.mem_cons_self ..), hnd⟩, ?_⟩
+              intro k hk'
+              rcases List.mem_cons.mp hk' with h | h
+              · subst h; exact hk
+              · exact (hns k h) ∘ List.mem_cons_of_mem _
+        | none =>
+            simp only [dedup, hk, if_false, hmt, List.map_cons, List.nodup_cons]
+            obtain ⟨hnd, hns⟩ := ih (m.key :: seenKeys) seenTokens
+            refine ⟨⟨fun hmem => hns m.key hmem (List.mem_cons_self ..), hnd⟩, ?_⟩
+            intro k hk'
+            rcases List.mem_cons.mp hk' with h | h
+            · subst h; exact hk
+            · exact (hns k h) ∘ List.mem_cons_of_mem _
+
+/-- **Each surviving message key is unique.** -/
+theorem kept_keys_nodup (msgs : List Msg) :
+    ((kept msgs).map Msg.key).Nodup :=
+  (dedup_keys_nodup msgs [] []).1
+
+end ClientShell.Timeline


### PR DESCRIPTION
First execution step of the desktop/mobile parity work (`.agents/desktop-mobile-parity-contract.md`, T0). Tackles the single biggest parity risk *before* a second shell exists.

## The problem

`build_rendered_timeline` — the function that interleaves a session's messages with their tool groups, places the pending turn, appends orphan tool groups, and the live-assistant overlay — lived **only in the desktop Tauri bridge**, unshared and unfenced. It carries subtle discipline (first-wins dedup by message key *and* presentation key, the attached-vs-orphan tool-group partition, `None`-sequence-sorts-first, overlay-not-duplicating-the-trailing-assistant). A second shell (mobile, a full peer node) that re-implements this will drift on **order** and on **which tool group is an orphan** — the exact class of divergence the parity contract exists to prevent, and impossible to catch without a shared, fenced source of truth.

## The approach — presentation-neutral skeleton in the shared layer

Rather than lift the function verbatim (which would drag the whole bridge view-type zoo down into the core), this splits along the contract's own line — **presentation-neutral projection in the shared layer; visual mapping in the shell**:

- **`defra_agent_protocol::timeline::build_timeline_order`** — a new pure function next to `derive_turn` that computes the ordered list of *neutral slots* (`Message{key,seq,role}` / `ToolGroup{seq}` / `Pending` / `Overlay`) from ordering-relevant inputs. This is the order + partition — the semantics.
- **The bridge's `build_rendered_timeline` is now a thin adapter**: it projects the rich views into neutral inputs, delegates ordering to the shared skeleton, then maps each returned slot back to its rich `RenderedTimelineItem` (attaching content, rendered tools, pending details). The overlay dedup stays in the adapter via the existing helper — identical behavior.

A mobile shell calls the same `build_timeline_order` and does its own rich mapping, so it **cannot** diverge on order.

## Lean fence

`proofs/Proofs/ClientShell/Timeline.lean` models `build_timeline_order` (zero `sorry`, 8 theorems):
- **Partition** — `group_attached_or_orphan` (every tool group is placed — attached to its owner or orphan, never dropped) + `group_not_both` (never placed twice).
- **Overlay** — `overlay_shown_iff` (emitted iff present ∧ not a duplicate of the trailing assistant) + `overlay_is_last`.
- **Pending** — `pending_shown_iff` (and structurally before orphan groups).
- **Dedup** — `kept_keys_nodup` (first-wins by key → no message rendered twice).

Model boundary (stated in the file): the message list is taken already-sorted by the shell's total sequence order; the fence is the interleave/partition/tail discipline *on top of* that order — the part a second shell re-implements.

## Tests

- **Protocol conformance** (6 tests): each drives the real `build_timeline_order` and asserts a proven invariant, citing the theorem — partition + attach-adjacency, overlay shown-iff + last, pending placement, key-dedup, the presentation-token-also-drops-the-second-group-attach nuance, and `None`-sorts-first. Breaking the attachment logic fails the partition test.
- **Behavior preservation**: the desktop `session_timeline` suite (8/8) and the full `bridge::snapshot` suite (77/0 single-threaded) pass unchanged. The 4 flakes seen under `--test-threads` many were the known node-spawn port race — all pass in isolation and single-threaded.

## Gates

`cargo fmt --all --check`, `lake build Proofs.ClientShell` (zero `sorry`), `cargo test -p defra-agent-protocol`, `cargo check --workspace --all-targets`, `cargo clippy` on the touched crates — green.

## Follow-ups (in the contract doc)

This is the **template** for the remaining T1 move-downs (session/runtime projection, cancel cascade, denial label table): extract the neutral skeleton to `protocol`, fence it, adapter in the shell. The crate rename (`desktop-core` → `client-core`) and the FFI scaffold remain T0. A latent nicety this surfaced: the neutral function guards against double-placing a group when two surviving messages share a sequence (the old bridge code did not) — a stricter-but-correct behavior that only differs on malformed input.