### PR TITLE
edit_file: drift-tolerant match ladder, dry-run, regex mode, content-hash preconditions (#738, #724)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6734,6 +6734,7 @@ dependencies = [
  "proptest",
  "query",
  "rand 0.9.2",
+ "regex",
  "reqwest 0.12.28",
  "rig-core",
  "rmcp 1.3.0",

--- a/crates/defra-agent/Cargo.toml
+++ b/crates/defra-agent/Cargo.toml
@@ -40,6 +40,7 @@ query.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+regex = "1"
 sha2.workspace = true
 thiserror.workspace = true
 tokio.workspace = true

--- a/crates/defra-agent/proofs/Proofs.lean
+++ b/crates/defra-agent/proofs/Proofs.lean
@@ -48,5 +48,6 @@ import Proofs.SelfConfig
 import Proofs.ReversePairingHandlers
 import Proofs.Identity
 import Proofs.Skills
+import Proofs.EditMatch
 import Proofs.EventDelivery
 import Proofs.Conformance.EventDelivery

--- a/crates/defra-agent/proofs/Proofs/EditMatch.lean
+++ b/crates/defra-agent/proofs/Proofs/EditMatch.lean
@@ -1,0 +1,12 @@
+import Proofs.EditMatch.Model
+import Proofs.EditMatch.Properties
+
+/-!
+# EditMatch (#738, #724)
+
+The `edit_file` matcher: deterministic relaxation ladder (exact →
+trailing-whitespace → trim/indentation → unicode-normalized), ambiguity
+gating, convenience-operation desugaring, one pure decision shared by
+dry-run and apply, and the #724 optimistic-concurrency stale gate.
+Conformance home: `tests/conformance/edit_match.rs`.
+-/

--- a/crates/defra-agent/proofs/Proofs/EditMatch/Model.lean
+++ b/crates/defra-agent/proofs/Proofs/EditMatch/Model.lean
@@ -1,0 +1,175 @@
+/-!
+# EditMatch — model (#738, #724)
+
+The `edit_file` matcher: a deterministic relaxation ladder over lines
+(exact → trailing-whitespace-insensitive → trim/indentation-insensitive →
+unicode-normalized), an optimistic-concurrency precondition (expected
+content identity), uniqueness gating, and a single pure decision function
+shared by dry-run and apply.
+
+A line is abstracted as leading blanks, body, and trailing blanks; interior
+whitespace lives in `body`, so trim-level strategies never see it. The
+unicode fold is an arbitrary idempotent character map (the runtime's
+punctuation/space normalization is one instance). Content identity is
+modeled by the document itself: the runtime's cryptographic hash is the
+boundary that makes `expected = current` checkable without the bytes.
+-/
+
+namespace Proofs.EditMatch
+
+/-- A line: leading blank count, body characters, trailing blank count. -/
+structure Line where
+  lead  : Nat
+  body  : List Char
+  trail : Nat
+  deriving Repr, DecidableEq
+
+abbrev Doc := List Line
+
+/-- Ladder strategies, strictest first. -/
+inductive Strategy
+  | exact
+  | trailingWs
+  | trim
+  | unicode
+  deriving Repr, DecidableEq
+
+namespace Strategy
+
+/-- Ladder order: every strategy the matcher tries, strictest first. -/
+def ladder : List Strategy := [.exact, .trailingWs, .trim, .unicode]
+
+end Strategy
+
+/-- The comparison key a strategy sees for a line. Coarser strategies
+    project away more of the line. `fold` is the unicode normalization. -/
+def keyAt (fold : Char → Char) : Strategy → Line → Nat × List Char × Nat
+  | .exact,      l => (l.lead, l.body, l.trail)
+  | .trailingWs, l => (l.lead, l.body, 0)
+  | .trim,       l => (0, l.body, 0)
+  | .unicode,    l => (0, l.body.map fold, 0)
+
+/-- Two line windows match under a strategy iff their keys agree pointwise. -/
+def windowMatches (fold : Char → Char) (s : Strategy) (window pat : Doc) : Bool :=
+  window.length == pat.length
+    && (window.zip pat).all fun (a, b) => keyAt fold s a == keyAt fold s b
+
+/-- Does `pat` match `doc` at index `i` under strategy `s`? -/
+def matchesAt (fold : Char → Char) (s : Strategy) (doc pat : Doc) (i : Nat) : Bool :=
+  windowMatches fold s ((doc.drop i).take pat.length) pat
+
+/-- All match positions for `pat` in `doc` under `s`. -/
+def occurrences (fold : Char → Char) (s : Strategy) (doc pat : Doc) : List Nat :=
+  (List.range (doc.length + 1 - pat.length)).filter fun i =>
+    matchesAt fold s doc pat i
+
+/-- The ladder decision: the first strategy (strictest first) with at least
+    one occurrence, together with all its occurrences. -/
+def ladderMatch (fold : Char → Char) (doc pat : Doc) :
+    Option (Strategy × List Nat) :=
+  go Strategy.ladder
+where
+  go : List Strategy → Option (Strategy × List Nat)
+    | [] => none
+    | s :: rest =>
+      let occ := occurrences fold s doc pat
+      if occ.isEmpty then go rest else some (s, occ)
+
+/-- Splice `repl` over the `len`-line window at `i`. -/
+def splice (doc : Doc) (i len : Nat) (repl : Doc) : Doc :=
+  doc.take i ++ repl ++ doc.drop (i + len)
+
+/-- Re-indent the replacement to the matched site: shift every replacement
+    line's lead by the delta between the matched window's first line and the
+    pattern's first line. Only coarse strategies (which ignored `lead` when
+    matching) re-indent; exact and trailing-ws matched the lead literally. -/
+def reindent (s : Strategy) (doc pat repl : Doc) (i : Nat) : Doc :=
+  match s with
+  | .exact => repl
+  | .trailingWs => repl
+  | _ =>
+    match doc.drop i, pat with
+    | m :: _, p :: _ =>
+      repl.map fun l => { l with lead := l.lead + m.lead - p.lead }
+    | _, _ => repl
+
+/-- One edit request. `expected` is the optimistic-concurrency precondition:
+    the document version the model believes it is editing (#724). -/
+structure Request where
+  pattern     : Doc
+  replacement : Doc
+  replaceAll  : Bool
+  expected    : Option Doc
+  deriving Repr
+
+/-- Decision outcomes. `applied` carries the full result document: dry-run
+    and apply are projections of the same decision. -/
+inductive Outcome
+  | applied (result : Doc) (strategy : Strategy)
+  | rejectedStale
+  | notFound
+  | ambiguous (strategy : Strategy) (count : Nat)
+  | noop (strategy : Strategy)
+  deriving Repr
+
+/-- Replace every occurrence, right-to-left so indices stay valid. -/
+def spliceAll (s : Strategy) (doc pat repl : Doc)
+    (occ : List Nat) : Doc :=
+  occ.reverse.foldl
+    (fun acc i => splice acc i pat.length (reindent s doc pat repl i))
+    doc
+
+/-- The result document for an accepted match set. -/
+def chosenResult (s : Strategy) (doc : Doc) (req : Request)
+    (occ : List Nat) : Doc :=
+  if req.replaceAll then
+    spliceAll s doc req.pattern req.replacement occ
+  else
+    match occ with
+    | i :: _ =>
+      splice doc i req.pattern.length
+        (reindent s doc req.pattern req.replacement i)
+    | [] => doc
+
+def decideMatched (fold : Char → Char) (doc : Doc) (req : Request) : Outcome :=
+  match ladderMatch fold doc req.pattern with
+  | none => .notFound
+  | some (s, occ) =>
+    if occ.length = 1 ∨ req.replaceAll = true then
+      if chosenResult s doc req occ = doc then .noop s
+      else .applied (chosenResult s doc req occ) s
+    else
+      .ambiguous s occ.length
+
+/-- The single pure decision shared by dry-run and apply. Order of gates:
+    stale precondition, ladder match, uniqueness, no-op. -/
+def decide (fold : Char → Char) (doc : Doc) (req : Request) : Outcome :=
+  match req.expected with
+  | some expected =>
+    if expected = doc then decideMatched fold doc req else .rejectedStale
+  | none => decideMatched fold doc req
+
+/-- A trivial filesystem: the current document. Apply writes the decided
+    result; dry-run never writes. -/
+def applyFs (fold : Char → Char) (doc : Doc) (req : Request) : Doc :=
+  match decide fold doc req with
+  | .applied result _ => result
+  | _ => doc
+
+def dryRunFs (_fold : Char → Char) (doc : Doc) (_req : Request) : Doc := doc
+
+/-- Convenience operations desugar onto `Request`; there is exactly one
+    matcher (#738 insert_after / insert_before / delete). -/
+def insertAfter (pat text : Doc) (expected : Option Doc) : Request :=
+  { pattern := pat, replacement := pat ++ text, replaceAll := false
+  , expected := expected }
+
+def insertBefore (pat text : Doc) (expected : Option Doc) : Request :=
+  { pattern := pat, replacement := text ++ pat, replaceAll := false
+  , expected := expected }
+
+def deleteText (pat : Doc) (expected : Option Doc) : Request :=
+  { pattern := pat, replacement := [], replaceAll := false
+  , expected := expected }
+
+end Proofs.EditMatch

--- a/crates/defra-agent/proofs/Proofs/EditMatch/Model.lean
+++ b/crates/defra-agent/proofs/Proofs/EditMatch/Model.lean
@@ -75,6 +75,20 @@ where
       let occ := occurrences fold s doc pat
       if occ.isEmpty then go rest else some (s, occ)
 
+/-- Greedy non-overlapping selection from (ascending) match positions:
+    overlapping windows would invalidate each other's line ranges when
+    splicing. Mirrors the runtime's `window_occurrences` selection. Fuel
+    form (fuel = input length suffices: filtering never grows the list)
+    keeps the proofs structural. -/
+def selectDisjointGo (len : Nat) : Nat → List Nat → List Nat
+  | 0, _ => []
+  | _, [] => []
+  | fuel + 1, i :: rest =>
+    i :: selectDisjointGo len fuel (rest.filter (fun j => i + len ≤ j))
+
+def selectDisjoint (len : Nat) (occ : List Nat) : List Nat :=
+  selectDisjointGo len occ.length occ
+
 /-- Splice `repl` over the `len`-line window at `i`. -/
 def splice (doc : Doc) (i len : Nat) (repl : Doc) : Doc :=
   doc.take i ++ repl ++ doc.drop (i + len)
@@ -135,11 +149,13 @@ def decideMatched (fold : Char → Char) (doc : Doc) (req : Request) : Outcome :
   match ladderMatch fold doc req.pattern with
   | none => .notFound
   | some (s, occ) =>
-    if occ.length = 1 ∨ req.replaceAll = true then
-      if chosenResult s doc req occ = doc then .noop s
-      else .applied (chosenResult s doc req occ) s
+    if (selectDisjoint req.pattern.length occ).length = 1
+        ∨ req.replaceAll = true then
+      if chosenResult s doc req (selectDisjoint req.pattern.length occ) = doc
+      then .noop s
+      else .applied (chosenResult s doc req (selectDisjoint req.pattern.length occ)) s
     else
-      .ambiguous s occ.length
+      .ambiguous s (selectDisjoint req.pattern.length occ).length
 
 /-- The single pure decision shared by dry-run and apply. Order of gates:
     stale precondition, ladder match, uniqueness, no-op. -/

--- a/crates/defra-agent/proofs/Proofs/EditMatch/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/EditMatch/Properties.lean
@@ -1,0 +1,210 @@
+import Proofs.EditMatch.Model
+
+/-!
+# EditMatch — properties
+
+The obligations the runtime matcher is fenced against:
+
+- **E1 exact priority**: when an exact match exists, the ladder answers with
+  the exact strategy — relaxation can never shadow an exact hit.
+- **E2 soundness**: every position the ladder reports actually matches under
+  the reported strategy.
+- **E3 coarsening**: each ladder step's equivalence refines the next, so a
+  strategy fires only when every stricter strategy had no match anywhere.
+- **E4 ambiguity gate**: `ambiguous` is only produced for ≥ 2 occurrences
+  without `replaceAll`; a single edit is never applied at an ambiguous site.
+- **E5 dry-run/apply equivalence**: one decision function; apply writes the
+  decided result exactly when the outcome is `applied`, dry-run never writes.
+- **E6 stale gate (#724)**: a stale expected-content precondition rejects
+  before any match is attempted and the document is untouched.
+- **E7 exact windows are literal**: exact-strategy matches pin the window
+  byte-for-byte, so `insert_after` provably preserves the matched text.
+- **E8 no-op honesty**: `noop` and non-`applied` outcomes never change the
+  document, and `applied` always does.
+-/
+
+namespace Proofs.EditMatch
+
+variable (fold : Char → Char)
+
+/-! ## E3 — coarsening: stricter keys determine looser keys -/
+
+theorem keyAt_exact_inj {a b : Line} (h : keyAt fold .exact a = keyAt fold .exact b) :
+    a = b := by
+  cases a; cases b
+  simp [keyAt] at h
+  simp [h.1, h.2.1, h.2.2]
+
+theorem key_coarsen_trailingWs {a b : Line}
+    (h : keyAt fold .exact a = keyAt fold .exact b) :
+    keyAt fold .trailingWs a = keyAt fold .trailingWs b := by
+  simp [keyAt] at h ⊢
+  exact ⟨h.1, h.2.1⟩
+
+theorem key_coarsen_trim {a b : Line}
+    (h : keyAt fold .trailingWs a = keyAt fold .trailingWs b) :
+    keyAt fold .trim a = keyAt fold .trim b := by
+  simp [keyAt] at h ⊢
+  exact h.2
+
+theorem key_coarsen_unicode {a b : Line}
+    (h : keyAt fold .trim a = keyAt fold .trim b) :
+    keyAt fold .unicode a = keyAt fold .unicode b := by
+  simp [keyAt] at h ⊢
+  exact congrArg (List.map fold) h
+
+/-! ## E2 — reported positions really match -/
+
+theorem occurrences_sound {s : Strategy} {doc pat : Doc} {i : Nat}
+    (h : i ∈ occurrences fold s doc pat) :
+    matchesAt fold s doc pat i = true :=
+  (List.mem_filter.mp h).2
+
+theorem ladderMatch_sound {doc pat : Doc} {s : Strategy} {occ : List Nat}
+    (h : ladderMatch fold doc pat = some (s, occ)) :
+    ∀ i ∈ occ, matchesAt fold s doc pat i = true := by
+  intro i hi
+  have hocc : occ = occurrences fold s doc pat := by
+    have aux : ∀ ss : List Strategy,
+        ladderMatch.go fold doc pat ss = some (s, occ) →
+        occ = occurrences fold s doc pat := by
+      intro ss
+      induction ss with
+      | nil => intro h; simp [ladderMatch.go] at h
+      | cons head rest ih =>
+        intro h
+        by_cases hempty : (occurrences fold s doc pat).isEmpty
+        all_goals
+          simp only [ladderMatch.go] at h
+          split at h
+          · exact ih h
+          · simp at h; simp [← h.1, h.2]
+    exact aux Strategy.ladder h
+  subst hocc
+  exact occurrences_sound fold hi
+
+/-! ## E1 — exact matches are never shadowed -/
+
+theorem ladderMatch_exact_priority {doc pat : Doc}
+    (h : (occurrences fold .exact doc pat).isEmpty = false) :
+    ladderMatch fold doc pat = some (.exact, occurrences fold .exact doc pat) := by
+  simp [ladderMatch, ladderMatch.go, Strategy.ladder, h]
+
+/-! ## E6 — stale precondition rejects before matching (#724) -/
+
+theorem stale_rejects {doc expected : Doc} {req : Request}
+    (hexp : req.expected = some expected) (hne : expected ≠ doc) :
+    decide fold doc req = .rejectedStale := by
+  simp [decide, hexp, hne]
+
+theorem stale_never_writes {doc expected : Doc} {req : Request}
+    (hexp : req.expected = some expected) (hne : expected ≠ doc) :
+    applyFs fold doc req = doc := by
+  simp [applyFs, stale_rejects (fold := fold) hexp hne]
+
+/-! ## E4 — ambiguity gate -/
+
+theorem ambiguous_needs_multiple {doc : Doc} {req : Request} {s : Strategy}
+    {n : Nat} (h : decideMatched fold doc req = .ambiguous s n) :
+    2 ≤ n ∧ req.replaceAll = false := by
+  unfold decideMatched at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i sM occM heq
+    split at h
+    · split at h <;> exact absurd h (by simp)
+    · rename_i hcond
+      have hlen : occM.length ≠ 1 := fun h1 => hcond (Or.inl h1)
+      have hall : req.replaceAll ≠ true := fun ha => hcond (Or.inr ha)
+      simp only [Outcome.ambiguous.injEq] at h
+      obtain ⟨hs, hn⟩ := h
+      subst hn
+      refine ⟨?_, Bool.eq_false_iff.mpr hall⟩
+      -- occurrences from a successful ladder match are nonempty
+      have hne : occM ≠ [] := by
+        have aux : ∀ ss : List Strategy,
+            ladderMatch.go fold doc req.pattern ss = some (sM, occM) →
+            occM ≠ [] := by
+          intro ss
+          induction ss with
+          | nil => intro hgo; simp [ladderMatch.go] at hgo
+          | cons head rest ih =>
+            intro hgo
+            simp only [ladderMatch.go] at hgo
+            split at hgo
+            · exact ih hgo
+            · rename_i hnonempty
+              cases hgo
+              simpa [List.isEmpty_iff] using hnonempty
+        exact aux Strategy.ladder heq
+      have hpos : 0 < occM.length := List.length_pos_iff.mpr hne
+      omega
+
+/-! ## E5 + E8 — one decision, honest outcomes -/
+
+theorem apply_writes_decided {doc result : Doc} {req : Request} {s : Strategy}
+    (h : decide fold doc req = .applied result s) :
+    applyFs fold doc req = result := by
+  simp [applyFs, h]
+
+theorem non_applied_never_writes {doc : Doc} {req : Request}
+    (h : ∀ result s, decide fold doc req ≠ .applied result s) :
+    applyFs fold doc req = doc := by
+  unfold applyFs
+  split
+  · rename_i r s heq; exact absurd heq (h r s)
+  all_goals rfl
+
+theorem dry_run_never_writes (doc : Doc) (req : Request) :
+    dryRunFs fold doc req = doc := rfl
+
+theorem applied_changes {doc result : Doc} {req : Request} {s : Strategy}
+    (h : decideMatched fold doc req = .applied result s) :
+    result ≠ doc := by
+  unfold decideMatched at h
+  split at h
+  · exact absurd h (by simp)
+  · split at h
+    · split at h
+      · exact absurd h (by simp)
+      · rename_i hne
+        simp only [Outcome.applied.injEq] at h
+        exact h.1 ▸ hne
+    · exact absurd h (by simp)
+
+theorem noop_is_honest {doc : Doc} {req : Request} {s : Strategy}
+    {occ : List Nat}
+    (hl : ladderMatch fold doc req.pattern = some (s, occ))
+    (hg : occ.length = 1 ∨ req.replaceAll = true)
+    (h : decideMatched fold doc req = .noop s) :
+    chosenResult s doc req occ = doc := by
+  unfold decideMatched at h
+  rw [hl] at h
+  simp only [hg, if_true] at h
+  split at h
+  · assumption
+  · exact absurd h (by simp)
+
+/-! ## E7 — exact windows are literal, so insert_after preserves them -/
+
+theorem windowMatches_exact_eq {window pat : Doc}
+    (h : windowMatches fold .exact window pat = true) : window = pat := by
+  unfold windowMatches at h
+  simp only [Bool.and_eq_true, beq_iff_eq, List.all_eq_true] at h
+  obtain ⟨hlen, hall⟩ := h
+  apply List.ext_getElem hlen
+  intro i h1 h2
+  have hzip : i < (window.zip pat).length := by
+    simpa [List.length_zip, hlen] using h2
+  have hmem : (window[i], pat[i]) ∈ window.zip pat := by
+    have hget : (window.zip pat)[i] = (window[i], pat[i]) := by
+      simp [List.getElem_zip]
+    exact hget ▸ List.getElem_mem hzip
+  exact keyAt_exact_inj (fold := fold) (by simpa using hall _ hmem)
+
+theorem matchesAt_exact_window {doc pat : Doc} {i : Nat}
+    (h : matchesAt fold .exact doc pat i = true) :
+    (doc.drop i).take pat.length = pat :=
+  windowMatches_exact_eq (fold := fold) h
+
+end Proofs.EditMatch

--- a/crates/defra-agent/proofs/Proofs/EditMatch/Properties.lean
+++ b/crates/defra-agent/proofs/Proofs/EditMatch/Properties.lean
@@ -83,6 +83,48 @@ theorem ladderMatch_sound {doc pat : Doc} {s : Strategy} {occ : List Nat}
   subst hocc
   exact occurrences_sound fold hi
 
+/-! ## E9 — applied windows are pairwise disjoint (no splice overlap) -/
+
+theorem selectDisjointGo_subset {len : Nat} :
+    ∀ (fuel : Nat) (occ : List Nat) (i : Nat),
+      i ∈ selectDisjointGo len fuel occ → i ∈ occ := by
+  intro fuel
+  induction fuel with
+  | zero => intro occ i h; simp [selectDisjointGo] at h
+  | succ n ih =>
+    intro occ i h
+    cases occ with
+    | nil => simp [selectDisjointGo] at h
+    | cons head rest =>
+      simp only [selectDisjointGo, List.mem_cons] at h
+      rcases h with rfl | h
+      · exact List.mem_cons_self ..
+      · exact List.mem_cons_of_mem _ (List.mem_filter.mp (ih _ _ h)).1
+
+theorem selectDisjoint_subset {len : Nat} {occ : List Nat} {i : Nat}
+    (h : i ∈ selectDisjoint len occ) : i ∈ occ :=
+  selectDisjointGo_subset _ _ _ h
+
+/-- Selected positions are pairwise at least a full window apart: with
+    ascending inputs (which `occurrences` produces by construction), splice
+    ranges can never overlap — the runtime panic class the review found. -/
+theorem selectDisjoint_pairwise_gap {len : Nat} :
+    ∀ (fuel : Nat) (occ : List Nat),
+      (selectDisjointGo len fuel occ).Pairwise (fun a b => a + len ≤ b) := by
+  intro fuel
+  induction fuel with
+  | zero => intro occ; simp [selectDisjointGo]
+  | succ n ih =>
+    intro occ
+    cases occ with
+    | nil => simp [selectDisjointGo]
+    | cons head rest =>
+      simp only [selectDisjointGo]
+      refine List.Pairwise.cons ?_ (ih _)
+      intro b hb
+      have hmem := selectDisjointGo_subset (len := len) _ _ _ hb
+      simpa using (List.mem_filter.mp hmem).2
+
 /-! ## E1 — exact matches are never shadowed -/
 
 theorem ladderMatch_exact_priority {doc pat : Doc}
@@ -114,13 +156,15 @@ theorem ambiguous_needs_multiple {doc : Doc} {req : Request} {s : Strategy}
     split at h
     · split at h <;> exact absurd h (by simp)
     · rename_i hcond
-      have hlen : occM.length ≠ 1 := fun h1 => hcond (Or.inl h1)
+      have hlen : (selectDisjoint req.pattern.length occM).length ≠ 1 :=
+        fun h1 => hcond (Or.inl h1)
       have hall : req.replaceAll ≠ true := fun ha => hcond (Or.inr ha)
       simp only [Outcome.ambiguous.injEq] at h
       obtain ⟨hs, hn⟩ := h
       subst hn
       refine ⟨?_, Bool.eq_false_iff.mpr hall⟩
-      -- occurrences from a successful ladder match are nonempty
+      -- occurrences from a successful ladder match are nonempty, and the
+      -- disjoint selection always keeps the head
       have hne : occM ≠ [] := by
         have aux : ∀ ss : List Strategy,
             ladderMatch.go fold doc req.pattern ss = some (sM, occM) →
@@ -137,7 +181,12 @@ theorem ambiguous_needs_multiple {doc : Doc} {req : Request} {s : Strategy}
               cases hgo
               simpa [List.isEmpty_iff] using hnonempty
         exact aux Strategy.ladder heq
-      have hpos : 0 < occM.length := List.length_pos_iff.mpr hne
+      have hsel : selectDisjoint req.pattern.length occM ≠ [] := by
+        cases occM with
+        | nil => exact absurd rfl hne
+        | cons head rest => simp [selectDisjoint, selectDisjointGo]
+      have hpos : 0 < (selectDisjoint req.pattern.length occM).length :=
+        List.length_pos_iff.mpr hsel
       omega
 
 /-! ## E5 + E8 — one decision, honest outcomes -/
@@ -175,9 +224,10 @@ theorem applied_changes {doc result : Doc} {req : Request} {s : Strategy}
 theorem noop_is_honest {doc : Doc} {req : Request} {s : Strategy}
     {occ : List Nat}
     (hl : ladderMatch fold doc req.pattern = some (s, occ))
-    (hg : occ.length = 1 ∨ req.replaceAll = true)
+    (hg : (selectDisjoint req.pattern.length occ).length = 1
+      ∨ req.replaceAll = true)
     (h : decideMatched fold doc req = .noop s) :
-    chosenResult s doc req occ = doc := by
+    chosenResult s doc req (selectDisjoint req.pattern.length occ) = doc := by
   unfold decideMatched at h
   rw [hl] at h
   simp only [hg, if_true] at h

--- a/crates/defra-agent/src/toolset.rs
+++ b/crates/defra-agent/src/toolset.rs
@@ -11,6 +11,7 @@ mod cancellable;
 mod cli_tool;
 mod context_budget;
 mod denial;
+pub mod edit_match;
 mod file_tools;
 #[cfg(feature = "agent-memory")]
 mod memory;

--- a/crates/defra-agent/src/toolset/args.rs
+++ b/crates/defra-agent/src/toolset/args.rs
@@ -71,6 +71,19 @@ pub(super) struct EditFileArgs {
     pub replace_all: bool,
     #[serde(default)]
     pub raw_json: bool,
+    /// Preview only: return the diff without writing (#738).
+    #[serde(default)]
+    pub dry_run: bool,
+    /// "ladder" (default) or "regex" (#738).
+    #[serde(default)]
+    pub match_mode: Option<String>,
+    /// "replace" (default), "insert_after", "insert_before", or "delete".
+    #[serde(default)]
+    pub operation: Option<String>,
+    /// Optimistic-concurrency precondition: the content_hash from a prior
+    /// read of this file; a mismatch rejects before matching (#724).
+    #[serde(default)]
+    pub expected_content_hash: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/defra-agent/src/toolset/edit_match.rs
+++ b/crates/defra-agent/src/toolset/edit_match.rs
@@ -509,7 +509,7 @@ fn closest_match(content_lines: &[&str], pattern_lines: &[&str]) -> Option<Close
             .map(|(k, p)| similarity(content_lines[i + k].trim(), p.trim()))
             .sum::<f64>()
             / pattern_lines.len() as f64;
-        if best.map_or(true, |(_, b)| score > b) {
+        if best.is_none_or(|(_, b)| score > b) {
             best = Some((i, score));
         }
     }

--- a/crates/defra-agent/src/toolset/edit_match.rs
+++ b/crates/defra-agent/src/toolset/edit_match.rs
@@ -158,41 +158,50 @@ pub fn restore_content(text: &str, ending: LineEnding, had_bom: bool) -> String 
 /// `EditMatch.decideMatched` (the #724 stale gate runs in the caller,
 /// before this, on raw bytes).
 pub fn decide(content: &str, req: &EditRequest<'_>) -> EditOutcome {
-    let (pattern, replacement) = desugar(req);
-    if pattern.is_empty() {
+    if req.old_text.is_empty() {
         return EditOutcome::NotFound { closest: None };
     }
     match req.match_mode {
-        MatchMode::Regex => decide_regex(content, &pattern, &replacement, req.replace_all),
-        MatchMode::Ladder => decide_ladder(content, &pattern, &replacement, req.replace_all),
+        MatchMode::Regex => decide_regex(
+            content,
+            req.old_text,
+            req.new_text,
+            req.replace_all,
+            req.operation,
+        ),
+        MatchMode::Ladder => {
+            let (pattern, replacement) = desugar(req);
+            decide_ladder(content, &pattern, &replacement, req.replace_all)
+        }
     }
 }
 
+/// Ladder-mode desugaring only: regex-mode operations are composed inside
+/// the replacer closure (template composition cannot express "the matched
+/// text" without corrupting user templates that end in `$`).
 fn desugar(req: &EditRequest<'_>) -> (String, String) {
     let old = req.old_text.to_string();
     match req.operation {
         Operation::Replace => (old, req.new_text.to_string()),
-        // In regex mode the pattern SOURCE is not the matched text: inserts
-        // must preserve the actual match via whole-match substitution.
-        Operation::InsertAfter => match req.match_mode {
-            MatchMode::Regex => (old, format!("${{0}}{}", req.new_text)),
-            MatchMode::Ladder => {
-                let repl = format!("{}{}", req.old_text, req.new_text);
-                (old, repl)
-            }
-        },
-        Operation::InsertBefore => match req.match_mode {
-            MatchMode::Regex => (old, format!("{}${{0}}", req.new_text)),
-            MatchMode::Ladder => {
-                let repl = format!("{}{}", req.new_text, req.old_text);
-                (old, repl)
-            }
-        },
+        Operation::InsertAfter => {
+            let repl = format!("{}{}", req.old_text, req.new_text);
+            (old, repl)
+        }
+        Operation::InsertBefore => {
+            let repl = format!("{}{}", req.new_text, req.old_text);
+            (old, repl)
+        }
         Operation::Delete => (old, String::new()),
     }
 }
 
-fn decide_regex(content: &str, pattern: &str, replacement: &str, replace_all: bool) -> EditOutcome {
+fn decide_regex(
+    content: &str,
+    pattern: &str,
+    new_text: &str,
+    replace_all: bool,
+    operation: Operation,
+) -> EditOutcome {
     const REGEX_SIZE_LIMIT: usize = 10 * (1 << 20);
     let regex = match regex::RegexBuilder::new(pattern)
         .size_limit(REGEX_SIZE_LIMIT)
@@ -228,11 +237,21 @@ fn decide_regex(content: &str, pattern: &str, replacement: &str, replace_all: bo
             previews,
         };
     }
-    let result = if replace_all {
-        regex.replace_all(content, replacement).into_owned()
-    } else {
-        regex.replacen(content, 1, replacement).into_owned()
+    // One replacer for every operation: the user template expands with
+    // replace-mode semantics ($1, $$ for literal $), and inserts splice the
+    // ACTUAL matched text around the expansion.
+    let render = |caps: &regex::Captures<'_>| -> String {
+        let mut expanded = String::new();
+        caps.expand(new_text, &mut expanded);
+        match operation {
+            Operation::Replace => expanded,
+            Operation::InsertAfter => format!("{}{expanded}", &caps[0]),
+            Operation::InsertBefore => format!("{expanded}{}", &caps[0]),
+            Operation::Delete => String::new(),
+        }
     };
+    let limit = if replace_all { 0 } else { 1 };
+    let result = regex.replacen(content, limit, render).into_owned();
     finish(content, result, Strategy::Regex, count.max(1))
 }
 
@@ -271,14 +290,20 @@ fn decide_ladder(
 
     // Passes 2-4 — line-window matching with progressively coarser keys. A
     // pattern ending in a newline splits into a trailing empty line that
-    // would force the NEXT content line to be empty; drop it (and one
-    // trailing newline of the replacement to keep line structure).
+    // would force the NEXT content line to be empty; drop it. Replacement
+    // semantics must match the exact pass: the pattern's trailing newline is
+    // CONSUMED, so a replacement that does not end in a newline merges with
+    // the following line (drift must not decide newline preservation).
     let content_lines: Vec<&str> = content.split('\n').collect();
     let mut pattern_lines: Vec<&str> = pattern.split('\n').collect();
     let mut replacement = replacement;
+    let mut merge_tail = false;
     if pattern_lines.len() > 1 && pattern_lines.last() == Some(&"") {
         pattern_lines.pop();
-        replacement = replacement.strip_suffix('\n').unwrap_or(replacement);
+        match replacement.strip_suffix('\n') {
+            Some(stripped) => replacement = stripped,
+            None => merge_tail = !replacement.is_empty(),
+        }
     }
     for strategy in [Strategy::TrailingWs, Strategy::Trim, Strategy::Unicode] {
         let occ = window_occurrences(&content_lines, &pattern_lines, strategy);
@@ -300,7 +325,14 @@ fn decide_ladder(
                 previews,
             };
         }
-        let result = splice_windows(&content_lines, &pattern_lines, replacement, strategy, &occ);
+        let result = splice_windows(
+            &content_lines,
+            &pattern_lines,
+            replacement,
+            strategy,
+            &occ,
+            merge_tail,
+        );
         return finish(content, result, strategy, occ.len());
     }
 
@@ -375,16 +407,30 @@ fn splice_windows(
     replacement: &str,
     strategy: Strategy,
     occ: &[usize],
+    merge_tail: bool,
 ) -> String {
     let mut lines: Vec<String> = content_lines.iter().map(|l| l.to_string()).collect();
     for &i in occ.iter().rev() {
-        let repl_lines = reindent_replacement(
+        let mut repl_lines = reindent_replacement(
             replacement,
             strategy,
             content_lines[i],
             pattern_lines.first().copied().unwrap_or(""),
         );
-        lines.splice(i..i + pattern_lines.len(), repl_lines);
+        let end = i + pattern_lines.len();
+        // The pattern consumed a trailing newline the replacement does not
+        // supply: join the replacement's last line with the following line,
+        // exactly as the exact-substring pass would have.
+        if merge_tail && !repl_lines.is_empty() && end < lines.len() {
+            let following = lines[end].clone();
+            repl_lines
+                .last_mut()
+                .expect("non-empty replacement lines")
+                .push_str(&following);
+            lines.splice(i..end + 1, repl_lines);
+        } else {
+            lines.splice(i..end, repl_lines);
+        }
     }
     lines.join("\n")
 }
@@ -888,6 +934,113 @@ mod tests {
                 assert_eq!(strategy, Strategy::TrailingWs);
                 assert_eq!(result, "bar\nnext\n");
             }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Round-2 finding 2: regex replacement semantics (including literal $
+    // via $$ and capture refs) must be identical across replace and insert
+    // operations — inserts expand the user template, then splice the whole
+    // match around it.
+    #[test]
+    fn regex_insert_before_preserves_literal_dollar_replacement() {
+        let content = "timeout = 1800\n";
+        let mut request = req(r"timeout = (\d+)", "$$");
+        request.match_mode = MatchMode::Regex;
+        request.operation = Operation::InsertBefore;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, "$timeout = 1800\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn regex_insert_before_lone_dollar_matches_replace_semantics() {
+        // In replace mode a lone trailing $ renders as a literal $; insert
+        // modes must not let template composition eat the match.
+        let content = "timeout = 1800
+";
+        let mut request = req(r"timeout = (\d+)", "$");
+        request.match_mode = MatchMode::Regex;
+        request.operation = Operation::InsertBefore;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(
+                    result,
+                    "$timeout = 1800
+"
+                );
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn regex_insert_after_expands_capture_refs_like_replace() {
+        let content = "timeout = 1800\n";
+        let mut request = req(r"timeout = (\d+)", " # doubled from $1");
+        request.match_mode = MatchMode::Regex;
+        request.operation = Operation::InsertAfter;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, "timeout = 1800 # doubled from 1800\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Round-2 finding 3: whitespace drift must not change replacement
+    // semantics. Exact replacement of "foo\n" with "bar" consumes the
+    // newline; the drifted pattern must produce the same result.
+    #[test]
+    fn relaxed_trailing_newline_consumes_the_newline_like_exact() {
+        let exact = decide("foo\nnext\n", &req("foo\n", "bar"));
+        let relaxed = decide("foo\nnext\n", &req("foo   \n", "bar"));
+        let exact_result = match exact {
+            EditOutcome::Applied { result, .. } => result,
+            other => panic!("exact: {other:?}"),
+        };
+        assert_eq!(exact_result, "barnext\n");
+        match relaxed {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::TrailingWs);
+                assert_eq!(result, exact_result, "drift changed semantics");
+            }
+            other => panic!("relaxed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relaxed_trailing_newline_replace_all_matches_exact_semantics() {
+        // Adjacent windows: exact replace_all of "foo\n" -> "bar" on
+        // "foo\nfoo\nnext\n" yields "barbarnext\n"; drifted input must too.
+        let mut request = req("foo\n", "bar");
+        request.replace_all = true;
+        let exact = match decide("foo\nfoo\nnext\n", &request) {
+            EditOutcome::Applied { result, .. } => result,
+            other => panic!("exact: {other:?}"),
+        };
+        assert_eq!(exact, "barbarnext\n");
+        let mut request = req("foo  \n", "bar");
+        request.replace_all = true;
+        match decide("foo\nfoo\nnext\n", &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, exact, "drifted replace_all diverged");
+            }
+            other => panic!("relaxed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relaxed_trailing_newline_delete_matches_exact_semantics() {
+        let mut request = req("foo   \n", "");
+        request.operation = Operation::Delete;
+        match decide("foo\nnext\n", &request) {
+            EditOutcome::Applied { result, .. } => assert_eq!(result, "next\n"),
             other => panic!("expected applied, got {other:?}"),
         }
     }

--- a/crates/defra-agent/src/toolset/edit_match.rs
+++ b/crates/defra-agent/src/toolset/edit_match.rs
@@ -296,13 +296,18 @@ fn decide_ladder(
     // the following line (drift must not decide newline preservation).
     let content_lines: Vec<&str> = content.split('\n').collect();
     let mut pattern_lines: Vec<&str> = pattern.split('\n').collect();
-    let mut replacement = replacement;
+    // Replacement handled in LINE space: "" splits to one empty line (an
+    // emptied line, matching the exact pass), and popping the consumed
+    // trailing newline pops a LINE — a newline-only replacement keeps its
+    // blank line instead of degrading to deletion.
+    let mut replacement_lines: Vec<&str> = replacement.split('\n').collect();
     let mut merge_tail = false;
     if pattern_lines.len() > 1 && pattern_lines.last() == Some(&"") {
         pattern_lines.pop();
-        match replacement.strip_suffix('\n') {
-            Some(stripped) => replacement = stripped,
-            None => merge_tail = !replacement.is_empty(),
+        if replacement_lines.last() == Some(&"") {
+            replacement_lines.pop();
+        } else {
+            merge_tail = true;
         }
     }
     for strategy in [Strategy::TrailingWs, Strategy::Trim, Strategy::Unicode] {
@@ -328,7 +333,7 @@ fn decide_ladder(
         let result = splice_windows(
             &content_lines,
             &pattern_lines,
-            replacement,
+            &replacement_lines,
             strategy,
             &occ,
             merge_tail,
@@ -404,7 +409,7 @@ fn window_occurrences(
 fn splice_windows(
     content_lines: &[&str],
     pattern_lines: &[&str],
-    replacement: &str,
+    replacement_lines: &[&str],
     strategy: Strategy,
     occ: &[usize],
     merge_tail: bool,
@@ -412,7 +417,7 @@ fn splice_windows(
     let mut lines: Vec<String> = content_lines.iter().map(|l| l.to_string()).collect();
     for &i in occ.iter().rev() {
         let mut repl_lines = reindent_replacement(
-            replacement,
+            replacement_lines,
             strategy,
             content_lines[i],
             pattern_lines.first().copied().unwrap_or(""),
@@ -440,20 +445,17 @@ fn leading_whitespace(line: &str) -> &str {
 }
 
 fn reindent_replacement(
-    replacement: &str,
+    replacement_lines: &[&str],
     strategy: Strategy,
     matched_first: &str,
     pattern_first: &str,
 ) -> Vec<String> {
-    if replacement.is_empty() {
-        return Vec::new();
-    }
-    let lines = replacement.split('\n');
     match strategy {
         Strategy::Trim | Strategy::Unicode => {
             let matched_lead = leading_whitespace(matched_first);
             let pattern_lead = leading_whitespace(pattern_first);
-            lines
+            replacement_lines
+                .iter()
                 .map(|l| {
                     if let Some(rest) = l.strip_prefix(pattern_lead) {
                         format!("{matched_lead}{rest}")
@@ -463,7 +465,7 @@ fn reindent_replacement(
                 })
                 .collect()
         }
-        _ => lines.map(|l| l.to_string()).collect(),
+        _ => replacement_lines.iter().map(|l| l.to_string()).collect(),
     }
 }
 
@@ -869,10 +871,10 @@ mod tests {
         request.replace_all = true;
         match decide(content, &request) {
             EditOutcome::Applied { result, .. } => {
-                assert_eq!(
-                    result, "a ",
-                    "one non-overlapping window deleted: {result:?}"
-                );
+                // Deleting text WITHOUT its trailing newline empties the
+                // window's lines (exact-pass parity) rather than removing
+                // them: one disjoint window -> one blank line remains.
+                assert_eq!(result, "\na ", "one non-overlapping window: {result:?}");
             }
             other => panic!("expected applied, got {other:?}"),
         }
@@ -1042,6 +1044,62 @@ mod tests {
         match decide("foo\nnext\n", &request) {
             EditOutcome::Applied { result, .. } => assert_eq!(result, "next\n"),
             other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Round-3 finding 1: a newline-only replacement is NOT a deletion —
+    // relaxed results must stay byte-identical to the exact pass.
+    #[test]
+    fn relaxed_newline_only_replacement_matches_exact() {
+        let exact = match decide("foo\nnext\n", &req("foo\n", "\n")) {
+            EditOutcome::Applied { result, .. } => result,
+            other => panic!("exact: {other:?}"),
+        };
+        assert_eq!(exact, "\nnext\n");
+        match decide("foo\nnext\n", &req("foo   \n", "\n")) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, exact, "drift turned blank-line into deletion");
+            }
+            other => panic!("relaxed: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn relaxed_newline_only_replace_all_matches_exact() {
+        let mut request = req("foo\n", "\n");
+        request.replace_all = true;
+        let exact = match decide("foo\nfoo\nnext\n", &request) {
+            EditOutcome::Applied { result, .. } => result,
+            other => panic!("exact: {other:?}"),
+        };
+        assert_eq!(exact, "\n\nnext\n");
+        let mut request = req("foo  \n", "\n");
+        request.replace_all = true;
+        match decide("foo\nfoo\nnext\n", &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, exact, "replace_all collapsed blank lines");
+            }
+            other => panic!("relaxed: {other:?}"),
+        }
+    }
+
+    // Same divergence class from the other side: deleting text WITHOUT its
+    // newline leaves an empty line, exactly as the exact pass does.
+    #[test]
+    fn relaxed_no_newline_delete_leaves_empty_line_like_exact() {
+        let exact = match decide("foo\nnext\n", &req("foo", "")) {
+            EditOutcome::Applied { result, .. } => result,
+            other => panic!("exact: {other:?}"),
+        };
+        assert_eq!(exact, "\nnext\n");
+        match decide("foo\nnext\n", &req("foo   ", "")) {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::TrailingWs);
+                assert_eq!(result, exact, "drift dropped the emptied line");
+            }
+            other => panic!("relaxed: {other:?}"),
         }
     }
 

--- a/crates/defra-agent/src/toolset/edit_match.rs
+++ b/crates/defra-agent/src/toolset/edit_match.rs
@@ -172,14 +172,22 @@ fn desugar(req: &EditRequest<'_>) -> (String, String) {
     let old = req.old_text.to_string();
     match req.operation {
         Operation::Replace => (old, req.new_text.to_string()),
-        Operation::InsertAfter => {
-            let repl = format!("{}{}", req.old_text, req.new_text);
-            (old, repl)
-        }
-        Operation::InsertBefore => {
-            let repl = format!("{}{}", req.new_text, req.old_text);
-            (old, repl)
-        }
+        // In regex mode the pattern SOURCE is not the matched text: inserts
+        // must preserve the actual match via whole-match substitution.
+        Operation::InsertAfter => match req.match_mode {
+            MatchMode::Regex => (old, format!("${{0}}{}", req.new_text)),
+            MatchMode::Ladder => {
+                let repl = format!("{}{}", req.old_text, req.new_text);
+                (old, repl)
+            }
+        },
+        Operation::InsertBefore => match req.match_mode {
+            MatchMode::Regex => (old, format!("{}${{0}}", req.new_text)),
+            MatchMode::Ladder => {
+                let repl = format!("{}{}", req.new_text, req.old_text);
+                (old, repl)
+            }
+        },
         Operation::Delete => (old, String::new()),
     }
 }
@@ -207,9 +215,10 @@ fn decide_regex(content: &str, pattern: &str, replacement: &str, replace_all: bo
             .take(5)
             .map(|m| {
                 let line = 1 + content[..m.start()].matches('\n').count();
+                let end = floor_char_boundary(content, m.end().min(m.start() + 120));
                 OccurrencePreview {
                     line,
-                    text: content[m.start()..m.end().min(m.start() + 120)].to_string(),
+                    text: content[m.start()..end].to_string(),
                 }
             })
             .collect();
@@ -260,9 +269,17 @@ fn decide_ladder(
         return finish(content, result, Strategy::Exact, exact.len());
     }
 
-    // Passes 2-4 — line-window matching with progressively coarser keys.
+    // Passes 2-4 — line-window matching with progressively coarser keys. A
+    // pattern ending in a newline splits into a trailing empty line that
+    // would force the NEXT content line to be empty; drop it (and one
+    // trailing newline of the replacement to keep line structure).
     let content_lines: Vec<&str> = content.split('\n').collect();
-    let pattern_lines: Vec<&str> = pattern.split('\n').collect();
+    let mut pattern_lines: Vec<&str> = pattern.split('\n').collect();
+    let mut replacement = replacement;
+    if pattern_lines.len() > 1 && pattern_lines.last() == Some(&"") {
+        pattern_lines.pop();
+        replacement = replacement.strip_suffix('\n').unwrap_or(replacement);
+    }
     for strategy in [Strategy::TrailingWs, Strategy::Trim, Strategy::Unicode] {
         let occ = window_occurrences(&content_lines, &pattern_lines, strategy);
         if occ.is_empty() {
@@ -328,14 +345,25 @@ fn window_occurrences(
     if pattern_lines.is_empty() || pattern_lines.len() > content_lines.len() {
         return Vec::new();
     }
-    (0..=content_lines.len() - pattern_lines.len())
-        .filter(|&i| {
-            pattern_lines
-                .iter()
-                .enumerate()
-                .all(|(k, p)| line_matches(strategy, content_lines[i + k], p))
-        })
-        .collect()
+    // Greedy non-overlapping selection (matching str::match_indices for the
+    // exact pass): overlapping windows would invalidate each other's line
+    // ranges during right-to-left splicing.
+    let mut occurrences = Vec::new();
+    let mut next_free = 0;
+    for i in 0..=content_lines.len() - pattern_lines.len() {
+        if i < next_free {
+            continue;
+        }
+        let matched = pattern_lines
+            .iter()
+            .enumerate()
+            .all(|(k, p)| line_matches(strategy, content_lines[i + k], p));
+        if matched {
+            occurrences.push(i);
+            next_free = i + pattern_lines.len();
+        }
+    }
+    occurrences
 }
 
 /// Splice replacement lines over each matched window, re-indented to the
@@ -453,6 +481,14 @@ pub fn render_diff(original: &str, result: &str) -> String {
         let _ = writeln!(out, " {:>5} | {}", idx + 1, line);
     }
     out.trim_end().to_string()
+}
+
+/// Largest char boundary <= `index` (std's floor_char_boundary is unstable).
+fn floor_char_boundary(s: &str, mut index: usize) -> usize {
+    while index > 0 && !s.is_char_boundary(index) {
+        index -= 1;
+    }
+    index
 }
 
 fn line_at_offset(content: &str, offset: usize) -> &str {
@@ -772,6 +808,85 @@ mod tests {
                     restore_content(&result, norm.ending, norm.had_bom),
                     "\u{FEFF}key: 2\n"
                 );
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Review finding 3: overlapping relaxed windows must not panic (or
+    // double-apply) under replace_all — selection is non-overlapping.
+    #[test]
+    fn overlapping_relaxed_windows_do_not_panic_on_replace_all() {
+        let content = "a \na \na ";
+        let mut request = req("a\na", "");
+        request.operation = Operation::Delete;
+        request.replace_all = true;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(
+                    result, "a ",
+                    "one non-overlapping window deleted: {result:?}"
+                );
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Review finding 4: ambiguity previews truncate on char boundaries even
+    // when the 120-byte cap lands inside a multibyte character.
+    #[test]
+    fn regex_ambiguity_preview_truncates_on_char_boundary() {
+        let long_unicode = format!("needle {}", "\u{00e9}".repeat(80));
+        let content = format!("{long_unicode}\n{long_unicode}\n");
+        let mut request = req("needle.*", "x");
+        request.match_mode = MatchMode::Regex;
+        match decide(&content, &request) {
+            EditOutcome::Ambiguous { previews, .. } => assert_eq!(previews.len(), 2),
+            other => panic!("expected ambiguous, got {other:?}"),
+        }
+    }
+
+    // Review finding 5: regex-mode inserts preserve the MATCHED TEXT, not
+    // the pattern source.
+    #[test]
+    fn regex_insert_after_preserves_matched_text_not_pattern() {
+        let content = "timeout = 1800\n";
+        let mut request = req(r"timeout = (\d+)", " # bounded");
+        request.match_mode = MatchMode::Regex;
+        request.operation = Operation::InsertAfter;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, "timeout = 1800 # bounded\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn regex_delete_removes_matched_text() {
+        let content = "keep\ndrop_me = 7\n";
+        let mut request = req(r"drop_me = \d+\n", "");
+        request.match_mode = MatchMode::Regex;
+        request.operation = Operation::Delete;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => assert_eq!(result, "keep\n"),
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Review finding 6: a pattern ending in a newline must still match via
+    // the relaxed rungs (the trailing empty pattern line is dropped, from
+    // both pattern and replacement).
+    #[test]
+    fn trailing_newline_pattern_matches_via_relaxed_rungs() {
+        let content = "foo\nnext\n";
+        let out = decide(content, &req("foo   \n", "bar\n"));
+        match out {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::TrailingWs);
+                assert_eq!(result, "bar\nnext\n");
             }
             other => panic!("expected applied, got {other:?}"),
         }

--- a/crates/defra-agent/src/toolset/edit_match.rs
+++ b/crates/defra-agent/src/toolset/edit_match.rs
@@ -1,0 +1,798 @@
+//! The `edit_file` matcher — Rust half of the Lean `EditMatch` model
+//! (`proofs/Proofs/EditMatch/`, #738/#724).
+//!
+//! One pure decision function drives both dry-run and apply: a deterministic
+//! relaxation ladder over lines (exact → trailing-whitespace → trim with
+//! replacement re-indent → unicode-normalized), an ambiguity gate, and
+//! convenience-operation desugaring. Similarity scoring exists ONLY for
+//! diagnostics (closest-match error hints) — it never selects an edit site.
+//! The stale-content precondition (#724) is enforced by the caller against
+//! raw bytes before this module runs; gate ordering is fenced in
+//! `tests/conformance/edit_match.rs`.
+
+use std::fmt::Write as _;
+
+/// Ladder strategies, strictest first. Mirrors `EditMatch.Strategy`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Strategy {
+    Exact,
+    TrailingWs,
+    Trim,
+    Unicode,
+    /// Opt-in regex mode: not a ladder rung, reported for metadata parity.
+    Regex,
+}
+
+impl Strategy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Strategy::Exact => "exact",
+            Strategy::TrailingWs => "trailing_whitespace",
+            Strategy::Trim => "trim",
+            Strategy::Unicode => "unicode",
+            Strategy::Regex => "regex",
+        }
+    }
+}
+
+/// Convenience operations desugar onto replace before matching. Mirrors
+/// `EditMatch.insertAfter/insertBefore/deleteText`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operation {
+    Replace,
+    InsertAfter,
+    InsertBefore,
+    Delete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchMode {
+    Ladder,
+    Regex,
+}
+
+pub struct EditRequest<'a> {
+    pub old_text: &'a str,
+    pub new_text: &'a str,
+    pub replace_all: bool,
+    pub operation: Operation,
+    pub match_mode: MatchMode,
+}
+
+/// Diagnostics for a failed match: the closest window by similarity, used
+/// only in error text (never to apply).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ClosestMatch {
+    /// 1-based line of the closest window's first line.
+    pub line: usize,
+    /// 0..=100.
+    pub similarity_pct: u8,
+    /// First differing (pattern line, file line) pair.
+    pub first_diff: Option<(String, String)>,
+}
+
+/// Preview of one occurrence for ambiguity errors: 1-based line + the line's
+/// text, truncated by the renderer.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OccurrencePreview {
+    pub line: usize,
+    pub text: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum EditOutcome {
+    Applied {
+        result: String,
+        strategy: Strategy,
+        replacements: usize,
+        /// 1-based first changed line in the result.
+        first_changed_line: usize,
+        /// Numbered hunk diff for the model.
+        diff: String,
+    },
+    NotFound {
+        closest: Option<ClosestMatch>,
+    },
+    Ambiguous {
+        strategy: Strategy,
+        count: usize,
+        previews: Vec<OccurrencePreview>,
+    },
+    Noop {
+        strategy: Strategy,
+    },
+    InvalidRegex {
+        error: String,
+    },
+}
+
+/// Detected line-ending flavor; matching always runs in LF space and the
+/// original flavor is restored on write. Mirrors the normalization boundary
+/// assumption in the Lean model (`Line` abstracts an LF-split line).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LineEnding {
+    Lf,
+    CrLf,
+}
+
+pub struct NormalizedContent {
+    pub text: String,
+    pub ending: LineEnding,
+    pub had_bom: bool,
+}
+
+/// Strip BOM, detect dominant line ending, normalize to LF.
+pub fn normalize_content(raw: &str) -> NormalizedContent {
+    let (had_bom, rest) = match raw.strip_prefix('\u{FEFF}') {
+        Some(rest) => (true, rest),
+        None => (false, raw),
+    };
+    let crlf = rest.matches("\r\n").count();
+    let lf_total = rest.matches('\n').count();
+    let ending = if crlf > 0 && crlf * 2 >= lf_total {
+        LineEnding::CrLf
+    } else {
+        LineEnding::Lf
+    };
+    NormalizedContent {
+        text: rest.replace("\r\n", "\n"),
+        ending,
+        had_bom,
+    }
+}
+
+/// Restore the original BOM/line-ending flavor for writing.
+pub fn restore_content(text: &str, ending: LineEnding, had_bom: bool) -> String {
+    let body = match ending {
+        LineEnding::Lf => text.to_string(),
+        LineEnding::CrLf => text.replace('\n', "\r\n"),
+    };
+    if had_bom {
+        format!("\u{FEFF}{body}")
+    } else {
+        body
+    }
+}
+
+/// The single pure decision shared by dry-run and apply. Mirrors
+/// `EditMatch.decideMatched` (the #724 stale gate runs in the caller,
+/// before this, on raw bytes).
+pub fn decide(content: &str, req: &EditRequest<'_>) -> EditOutcome {
+    let (pattern, replacement) = desugar(req);
+    if pattern.is_empty() {
+        return EditOutcome::NotFound { closest: None };
+    }
+    match req.match_mode {
+        MatchMode::Regex => decide_regex(content, &pattern, &replacement, req.replace_all),
+        MatchMode::Ladder => decide_ladder(content, &pattern, &replacement, req.replace_all),
+    }
+}
+
+fn desugar(req: &EditRequest<'_>) -> (String, String) {
+    let old = req.old_text.to_string();
+    match req.operation {
+        Operation::Replace => (old, req.new_text.to_string()),
+        Operation::InsertAfter => {
+            let repl = format!("{}{}", req.old_text, req.new_text);
+            (old, repl)
+        }
+        Operation::InsertBefore => {
+            let repl = format!("{}{}", req.new_text, req.old_text);
+            (old, repl)
+        }
+        Operation::Delete => (old, String::new()),
+    }
+}
+
+fn decide_regex(content: &str, pattern: &str, replacement: &str, replace_all: bool) -> EditOutcome {
+    const REGEX_SIZE_LIMIT: usize = 10 * (1 << 20);
+    let regex = match regex::RegexBuilder::new(pattern)
+        .size_limit(REGEX_SIZE_LIMIT)
+        .build()
+    {
+        Ok(regex) => regex,
+        Err(error) => {
+            return EditOutcome::InvalidRegex {
+                error: error.to_string(),
+            }
+        }
+    };
+    let count = regex.find_iter(content).count();
+    if count == 0 {
+        return EditOutcome::NotFound { closest: None };
+    }
+    if count > 1 && !replace_all {
+        let previews = regex
+            .find_iter(content)
+            .take(5)
+            .map(|m| {
+                let line = 1 + content[..m.start()].matches('\n').count();
+                OccurrencePreview {
+                    line,
+                    text: content[m.start()..m.end().min(m.start() + 120)].to_string(),
+                }
+            })
+            .collect();
+        return EditOutcome::Ambiguous {
+            strategy: Strategy::Regex,
+            count,
+            previews,
+        };
+    }
+    let result = if replace_all {
+        regex.replace_all(content, replacement).into_owned()
+    } else {
+        regex.replacen(content, 1, replacement).into_owned()
+    };
+    finish(content, result, Strategy::Regex, count.max(1))
+}
+
+fn decide_ladder(
+    content: &str,
+    pattern: &str,
+    replacement: &str,
+    replace_all: bool,
+) -> EditOutcome {
+    // Pass 1 — exact substring anywhere (current tool semantics, including
+    // mid-line boundaries). An exact hit is never shadowed (E1).
+    let exact: Vec<usize> = content.match_indices(pattern).map(|(i, _)| i).collect();
+    if !exact.is_empty() {
+        if exact.len() > 1 && !replace_all {
+            let previews = exact
+                .iter()
+                .take(5)
+                .map(|&i| OccurrencePreview {
+                    line: 1 + content[..i].matches('\n').count(),
+                    text: line_at_offset(content, i).to_string(),
+                })
+                .collect();
+            return EditOutcome::Ambiguous {
+                strategy: Strategy::Exact,
+                count: exact.len(),
+                previews,
+            };
+        }
+        let result = if replace_all {
+            content.replace(pattern, replacement)
+        } else {
+            content.replacen(pattern, replacement, 1)
+        };
+        return finish(content, result, Strategy::Exact, exact.len());
+    }
+
+    // Passes 2-4 — line-window matching with progressively coarser keys.
+    let content_lines: Vec<&str> = content.split('\n').collect();
+    let pattern_lines: Vec<&str> = pattern.split('\n').collect();
+    for strategy in [Strategy::TrailingWs, Strategy::Trim, Strategy::Unicode] {
+        let occ = window_occurrences(&content_lines, &pattern_lines, strategy);
+        if occ.is_empty() {
+            continue;
+        }
+        if occ.len() > 1 && !replace_all {
+            let previews = occ
+                .iter()
+                .take(5)
+                .map(|&i| OccurrencePreview {
+                    line: i + 1,
+                    text: content_lines[i].to_string(),
+                })
+                .collect();
+            return EditOutcome::Ambiguous {
+                strategy,
+                count: occ.len(),
+                previews,
+            };
+        }
+        let result = splice_windows(&content_lines, &pattern_lines, replacement, strategy, &occ);
+        return finish(content, result, strategy, occ.len());
+    }
+
+    EditOutcome::NotFound {
+        closest: closest_match(&content_lines, &pattern_lines),
+    }
+}
+
+/// Per-line key equality for a ladder strategy. Mirrors `EditMatch.keyAt`:
+/// coarser strategies project away more of the line, and each key refines
+/// the next (E3), so a strategy fires only when all stricter ones missed.
+fn line_matches(strategy: Strategy, file_line: &str, pattern_line: &str) -> bool {
+    match strategy {
+        Strategy::Exact | Strategy::Regex => file_line == pattern_line,
+        Strategy::TrailingWs => file_line.trim_end() == pattern_line.trim_end(),
+        Strategy::Trim => file_line.trim() == pattern_line.trim(),
+        Strategy::Unicode => {
+            normalize_unicode(file_line.trim()) == normalize_unicode(pattern_line.trim())
+        }
+    }
+}
+
+/// Map common typographic code points to ASCII (the Codex `seek_sequence`
+/// normalization set: dashes, curly quotes, exotic spaces).
+fn normalize_unicode(line: &str) -> String {
+    line.chars()
+        .map(|c| match c {
+            '\u{2010}'..='\u{2015}' | '\u{2212}' => '-',
+            '\u{2018}'..='\u{201B}' => '\'',
+            '\u{201C}'..='\u{201F}' => '"',
+            '\u{00A0}' | '\u{2002}'..='\u{200A}' | '\u{202F}' | '\u{205F}' | '\u{3000}' => ' ',
+            other => other,
+        })
+        .collect()
+}
+
+fn window_occurrences(
+    content_lines: &[&str],
+    pattern_lines: &[&str],
+    strategy: Strategy,
+) -> Vec<usize> {
+    if pattern_lines.is_empty() || pattern_lines.len() > content_lines.len() {
+        return Vec::new();
+    }
+    (0..=content_lines.len() - pattern_lines.len())
+        .filter(|&i| {
+            pattern_lines
+                .iter()
+                .enumerate()
+                .all(|(k, p)| line_matches(strategy, content_lines[i + k], p))
+        })
+        .collect()
+}
+
+/// Splice replacement lines over each matched window, re-indented to the
+/// matched site for indentation-insensitive strategies (Trim/Unicode).
+/// Mirrors `EditMatch.reindent`/`spliceAll` (right-to-left application).
+fn splice_windows(
+    content_lines: &[&str],
+    pattern_lines: &[&str],
+    replacement: &str,
+    strategy: Strategy,
+    occ: &[usize],
+) -> String {
+    let mut lines: Vec<String> = content_lines.iter().map(|l| l.to_string()).collect();
+    for &i in occ.iter().rev() {
+        let repl_lines = reindent_replacement(
+            replacement,
+            strategy,
+            content_lines[i],
+            pattern_lines.first().copied().unwrap_or(""),
+        );
+        lines.splice(i..i + pattern_lines.len(), repl_lines);
+    }
+    lines.join("\n")
+}
+
+fn leading_whitespace(line: &str) -> &str {
+    &line[..line.len() - line.trim_start().len()]
+}
+
+fn reindent_replacement(
+    replacement: &str,
+    strategy: Strategy,
+    matched_first: &str,
+    pattern_first: &str,
+) -> Vec<String> {
+    if replacement.is_empty() {
+        return Vec::new();
+    }
+    let lines = replacement.split('\n');
+    match strategy {
+        Strategy::Trim | Strategy::Unicode => {
+            let matched_lead = leading_whitespace(matched_first);
+            let pattern_lead = leading_whitespace(pattern_first);
+            lines
+                .map(|l| {
+                    if let Some(rest) = l.strip_prefix(pattern_lead) {
+                        format!("{matched_lead}{rest}")
+                    } else {
+                        l.to_string()
+                    }
+                })
+                .collect()
+        }
+        _ => lines.map(|l| l.to_string()).collect(),
+    }
+}
+
+/// No-op honesty (E8) + diff/first-changed-line for the applied outcome.
+fn finish(original: &str, result: String, strategy: Strategy, replacements: usize) -> EditOutcome {
+    if result == original {
+        return EditOutcome::Noop { strategy };
+    }
+    let first_changed_line = original
+        .split('\n')
+        .zip(result.split('\n'))
+        .position(|(a, b)| a != b)
+        .map(|i| i + 1)
+        .unwrap_or_else(|| original.split('\n').count().min(result.split('\n').count()));
+    let diff = render_diff(original, &result);
+    EditOutcome::Applied {
+        result,
+        strategy,
+        replacements,
+        first_changed_line,
+        diff,
+    }
+}
+
+/// Numbered hunk diff: common prefix/suffix elided, ±2 lines of context,
+/// old lines numbered against the original, new against the result.
+pub fn render_diff(original: &str, result: &str) -> String {
+    const CONTEXT: usize = 2;
+    let old: Vec<&str> = original.split('\n').collect();
+    let new: Vec<&str> = result.split('\n').collect();
+    let mut prefix = 0;
+    while prefix < old.len() && prefix < new.len() && old[prefix] == new[prefix] {
+        prefix += 1;
+    }
+    let mut suffix = 0;
+    while suffix < old.len() - prefix
+        && suffix < new.len() - prefix
+        && old[old.len() - 1 - suffix] == new[new.len() - 1 - suffix]
+    {
+        suffix += 1;
+    }
+    let ctx_start = prefix.saturating_sub(CONTEXT);
+    let mut out = String::new();
+    let _ = writeln!(out, "@@ line {}", ctx_start + 1);
+    for (idx, line) in old.iter().enumerate().take(prefix).skip(ctx_start) {
+        let _ = writeln!(out, " {:>5} | {}", idx + 1, line);
+    }
+    for (idx, line) in old.iter().enumerate().take(old.len() - suffix).skip(prefix) {
+        let _ = writeln!(out, "-{:>5} | {}", idx + 1, line);
+    }
+    for (idx, line) in new.iter().enumerate().take(new.len() - suffix).skip(prefix) {
+        let _ = writeln!(out, "+{:>5} | {}", idx + 1, line);
+    }
+    let ctx_end = (old.len() - suffix + CONTEXT).min(old.len());
+    for (idx, line) in old
+        .iter()
+        .enumerate()
+        .take(ctx_end)
+        .skip(old.len() - suffix)
+    {
+        let _ = writeln!(out, " {:>5} | {}", idx + 1, line);
+    }
+    out.trim_end().to_string()
+}
+
+fn line_at_offset(content: &str, offset: usize) -> &str {
+    let start = content[..offset].rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let end = content[offset..]
+        .find('\n')
+        .map(|i| offset + i)
+        .unwrap_or(content.len());
+    &content[start..end]
+}
+
+/// Levenshtein distance, two-row DP. Diagnostics only.
+fn levenshtein(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut curr = vec![0usize; b.len() + 1];
+    for (i, ca) in a.iter().enumerate() {
+        curr[0] = i + 1;
+        for (j, cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
+        }
+        std::mem::swap(&mut prev, &mut curr);
+    }
+    prev[b.len()]
+}
+
+fn similarity(a: &str, b: &str) -> f64 {
+    let max = a.chars().count().max(b.chars().count());
+    if max == 0 {
+        return 1.0;
+    }
+    1.0 - levenshtein(a, b) as f64 / max as f64
+}
+
+/// Best window by average per-line similarity — DIAGNOSTICS ONLY. Bounded:
+/// scans at most `MAX_CLOSEST_WINDOWS` windows so a huge file cannot turn an
+/// error path into a walk.
+fn closest_match(content_lines: &[&str], pattern_lines: &[&str]) -> Option<ClosestMatch> {
+    const MAX_CLOSEST_WINDOWS: usize = 20_000;
+    if pattern_lines.is_empty() || content_lines.len() < pattern_lines.len() {
+        return None;
+    }
+    let windows = (content_lines.len() - pattern_lines.len() + 1).min(MAX_CLOSEST_WINDOWS);
+    let mut best: Option<(usize, f64)> = None;
+    for i in 0..windows {
+        let score: f64 = pattern_lines
+            .iter()
+            .enumerate()
+            .map(|(k, p)| similarity(content_lines[i + k].trim(), p.trim()))
+            .sum::<f64>()
+            / pattern_lines.len() as f64;
+        if best.map_or(true, |(_, b)| score > b) {
+            best = Some((i, score));
+        }
+    }
+    let (i, score) = best?;
+    let first_diff = pattern_lines.iter().enumerate().find_map(|(k, p)| {
+        let file_line = content_lines[i + k];
+        if file_line.trim() != p.trim() {
+            Some((p.to_string(), file_line.to_string()))
+        } else {
+            None
+        }
+    });
+    Some(ClosestMatch {
+        line: i + 1,
+        similarity_pct: (score * 100.0).round().clamp(0.0, 100.0) as u8,
+        first_diff,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req<'a>(old: &'a str, new: &'a str) -> EditRequest<'a> {
+        EditRequest {
+            old_text: old,
+            new_text: new,
+            replace_all: false,
+            operation: Operation::Replace,
+            match_mode: MatchMode::Ladder,
+        }
+    }
+
+    // E1 — exact matches are never shadowed by relaxation.
+    #[test]
+    fn exact_match_wins_even_when_relaxed_would_also_match() {
+        let content = "  a: 1\n  b: 2\n";
+        let out = decide(content, &req("  b: 2", "  b: 3"));
+        match out {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::Exact);
+                assert_eq!(result, "  a: 1\n  b: 3\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Amy failure #1: the pattern carries trailing whitespace the file lacks
+    // (the file-side-drift direction is already covered by exact substring).
+    #[test]
+    fn trailing_whitespace_drift_matches_via_ladder() {
+        let content = "{\n  \"max_turns\": 20,\n  \"model\": \"d4f\"\n}";
+        let out = decide(
+            content,
+            &req("  \"max_turns\": 20,   ", "  \"max_turns\": 250,"),
+        );
+        match out {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::TrailingWs);
+                assert!(result.contains("\"max_turns\": 250,"), "{result}");
+                // Unchanged parts stay byte-identical.
+                assert!(result.contains("\"model\": \"d4f\""));
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // A pattern that is a mid-line substring of a drifted line matches via
+    // the exact pass — relaxation is not needed and must not preempt it.
+    #[test]
+    fn file_side_trailing_whitespace_is_covered_by_exact_substring() {
+        let content = "{\n  \"max_turns\": 20,  \n}";
+        match decide(
+            content,
+            &req("  \"max_turns\": 20,", "  \"max_turns\": 250,"),
+        ) {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::Exact);
+                assert!(result.contains("\"max_turns\": 250,"), "{result}");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Amy failure class: the pattern is MORE indented than the file (the
+    // other direction hits the exact-substring pass). The replacement is
+    // re-indented to the matched site.
+    #[test]
+    fn indentation_drift_matches_and_reindents_replacement() {
+        let content = "fn main() {\n  let x = 1;\n}";
+        let out = decide(content, &req("        let x = 1;", "        let x = 2;"));
+        match out {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::Trim);
+                assert_eq!(result, "fn main() {\n  let x = 2;\n}");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unicode_punctuation_drift_matches() {
+        let content = "title: \u{201C}hello\u{201D} \u{2014} subtitle\n";
+        let out = decide(content, &req("title: \"hello\" - subtitle", "title: x"));
+        match out {
+            EditOutcome::Applied { strategy, .. } => assert_eq!(strategy, Strategy::Unicode),
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // E4 — ambiguity is an error carrying previews, never a guess.
+    #[test]
+    fn ambiguous_exact_match_reports_occurrences() {
+        let content = "x = 1\ny = 2\nx = 1\n";
+        let out = decide(content, &req("x = 1", "x = 9"));
+        match out {
+            EditOutcome::Ambiguous {
+                count, previews, ..
+            } => {
+                assert_eq!(count, 2);
+                assert_eq!(previews.len(), 2);
+                assert_eq!(previews[0].line, 1);
+                assert_eq!(previews[1].line, 3);
+            }
+            other => panic!("expected ambiguous, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn replace_all_applies_every_occurrence() {
+        let content = "x = 1\ny = 2\nx = 1\n";
+        let mut request = req("x = 1", "x = 9");
+        request.replace_all = true;
+        match decide(content, &request) {
+            EditOutcome::Applied {
+                result,
+                replacements,
+                ..
+            } => {
+                assert_eq!(replacements, 2);
+                assert_eq!(result, "x = 9\ny = 2\nx = 9\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // E8 — no-op honesty.
+    #[test]
+    fn identical_replacement_is_a_noop_not_a_success() {
+        let content = "a\nb\n";
+        match decide(content, &req("a", "a")) {
+            EditOutcome::Noop { strategy } => assert_eq!(strategy, Strategy::Exact),
+            other => panic!("expected noop, got {other:?}"),
+        }
+    }
+
+    // E2-adjacent diagnostics: not-found carries a closest match with the
+    // first differing line, similarity, and 1-based line number.
+    #[test]
+    fn not_found_reports_closest_match() {
+        let content = "{\n  \"max_turns\": 20\n}";
+        match decide(content, &req("  \"max_turns\": 21", "x")) {
+            EditOutcome::NotFound { closest: Some(c) } => {
+                assert_eq!(c.line, 2);
+                assert!(c.similarity_pct >= 80, "{}", c.similarity_pct);
+                let (pat, file) = c.first_diff.expect("first diff");
+                assert!(pat.contains("21"));
+                assert!(file.contains("20"));
+            }
+            other => panic!("expected closest match, got {other:?}"),
+        }
+    }
+
+    // Regex mode (opt-in): pattern is regex, capture groups substitute.
+    #[test]
+    fn regex_mode_replaces_with_capture_groups() {
+        let content = "timeout_secs: 1800\n";
+        let mut request = req(r"timeout_secs: (\d+)", "timeout_secs: 3600 # was $1");
+        request.match_mode = MatchMode::Regex;
+        match decide(content, &request) {
+            EditOutcome::Applied {
+                result, strategy, ..
+            } => {
+                assert_eq!(strategy, Strategy::Regex);
+                assert_eq!(result, "timeout_secs: 3600 # was 1800\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn regex_mode_invalid_pattern_is_reported_not_fallback() {
+        let content = "call foo(bar)\n";
+        let mut request = req("foo(", "baz(");
+        request.match_mode = MatchMode::Regex;
+        match decide(content, &request) {
+            EditOutcome::InvalidRegex { .. } => {}
+            other => panic!("expected invalid regex, got {other:?}"),
+        }
+    }
+
+    // Convenience operations desugar onto the same matcher (Lean T7 family).
+    #[test]
+    fn insert_after_preserves_matched_text() {
+        let content = "line one\nline two\n";
+        let mut request = req("line one", "\ninserted");
+        request.operation = Operation::InsertAfter;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, "line one\ninserted\nline two\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn delete_removes_matched_text() {
+        let content = "keep\ndrop me\nkeep too\n";
+        let mut request = req("drop me\n", "");
+        request.operation = Operation::Delete;
+        match decide(content, &request) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(result, "keep\nkeep too\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    // Normalization: CRLF files match LF-authored old_text and write back CRLF.
+    #[test]
+    fn crlf_content_normalizes_for_match_and_restores_on_write() {
+        let raw = "a\r\nmax_turns: 20\r\nz\r\n";
+        let norm = normalize_content(raw);
+        assert_eq!(norm.ending, LineEnding::CrLf);
+        match decide(&norm.text, &req("max_turns: 20", "max_turns: 250")) {
+            EditOutcome::Applied { result, .. } => {
+                let restored = restore_content(&result, norm.ending, norm.had_bom);
+                assert_eq!(restored, "a\r\nmax_turns: 250\r\nz\r\n");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bom_is_preserved_across_edit() {
+        let raw = "\u{FEFF}key: 1\n";
+        let norm = normalize_content(raw);
+        assert!(norm.had_bom);
+        match decide(&norm.text, &req("key: 1", "key: 2")) {
+            EditOutcome::Applied { result, .. } => {
+                assert_eq!(
+                    restore_content(&result, norm.ending, norm.had_bom),
+                    "\u{FEFF}key: 2\n"
+                );
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn diff_is_numbered_with_context() {
+        let content = "one\ntwo\nthree\nfour\nfive\n";
+        match decide(content, &req("three", "THREE")) {
+            EditOutcome::Applied {
+                diff,
+                first_changed_line,
+                ..
+            } => {
+                assert_eq!(first_changed_line, 3);
+                assert!(diff.contains("-    3 | three"), "{diff}");
+                assert!(diff.contains("+    3 | THREE"), "{diff}");
+                assert!(diff.contains("     2 | two"), "{diff}");
+                assert!(diff.contains("     4 | four"), "{diff}");
+            }
+            other => panic!("expected applied, got {other:?}"),
+        }
+    }
+}

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -26,20 +26,24 @@ fn content_hash(bytes: &[u8]) -> String {
     format!("sha256:{:x}", Sha256::digest(bytes))
 }
 
-/// Per-path serialization for edit_file's read → hash-check → match → write
-/// sequence: without it, two concurrent edits can both validate the same
-/// pre-edit hash and overwrite each other (lost update). Scope: WITHIN this
-/// process, keyed by canonical path. External writers are outside the lock —
-/// they are caught by the expected_content_hash check at entry and otherwise
+/// Per-path serialization for FILE MUTATORS — edit_file's read →
+/// hash-check → match → write sequence AND write_file's overwrite share it:
+/// without it, a concurrent mutation can land inside edit_file's validated
+/// window and be silently overwritten (lost update). Scope: WITHIN this
+/// process, keyed by canonical path (falling back to the resolved path for
+/// not-yet-existing files). External writers are outside the lock — they
+/// are caught by the expected_content_hash check at entry and otherwise
 /// race as ordinary last-writer-wins POSIX writes (#724 documents the
 /// optimistic-concurrency boundary; there is no OS-level file lock).
-static EDIT_LOCKS: std::sync::LazyLock<
+static FILE_MUTATION_LOCKS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<PathBuf, std::sync::Arc<tokio::sync::Mutex<()>>>>,
 > = std::sync::LazyLock::new(Default::default);
 
-fn edit_lock_for(path: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+fn file_mutation_lock_for(path: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
     let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-    let mut locks = EDIT_LOCKS.lock().expect("edit lock registry poisoned");
+    let mut locks = FILE_MUTATION_LOCKS
+        .lock()
+        .expect("file mutation lock registry poisoned");
     locks.entry(key).or_default().clone()
 }
 
@@ -432,6 +436,8 @@ impl Tool for WriteFileTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let path = self.context.resolve_path_allow_create(&args.path)?;
+        let lock = file_mutation_lock_for(&path);
+        let _guard = lock.lock().await;
         let created = !path.exists();
         if let Some(parent) = path.parent() {
             tokio::fs::create_dir_all(parent).await?;
@@ -611,7 +617,7 @@ impl Tool for EditFileTool {
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let path = self.context.resolve_existing_file(&args.path)?;
         let display = self.context.display_path(&path);
-        let lock = edit_lock_for(&path);
+        let lock = file_mutation_lock_for(&path);
         let _guard = lock.lock().await;
         let raw = tokio::fs::read(&path).await?;
         let pre_edit_hash = content_hash(&raw);

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -2,6 +2,8 @@
 // glob, grep) that share private helpers defined in the same file. Splitting
 // each tool into its own file would scatter the shared defaults and make
 // cross-tool consistency harder to verify.
+use std::fmt::Write as _;
+
 use crate::llm::tool::Tool;
 use crate::llm::tool::ToolDefinition;
 use anyhow::{anyhow, Context as _, Result};
@@ -12,8 +14,16 @@ use defra_native_fs_runner::protocol::{
 use serde::Serialize;
 
 use super::args::{EditFileArgs, GlobArgs, GrepArgs, ListFilesArgs, ReadFileArgs, WriteFileArgs};
+use super::edit_match::{self, EditOutcome, EditRequest, MatchMode, Operation};
 use super::native_runner::NativeFsRunner;
 use super::shared::{cap_output, render_file_contents, ToolContext, ToolError};
+
+/// Raw-byte content identity (#724): stable across line-ending or encoding
+/// drift precisely because nothing is normalized before hashing.
+fn content_hash(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    format!("sha256:{:x}", Sha256::digest(bytes))
+}
 
 const OUTPUT_META_PREFIX: &str = "defra_fs: ";
 
@@ -173,7 +183,7 @@ impl Tool for ReadFileTool {
         ToolDefinition {
             name: Self::NAME.to_string(),
             description: format!(
-                "Read a UTF-8 text file under the allowed root ({}). Relative paths resolve from the active request workspace when one is provided, otherwise from the root. Returns compact line-numbered text with stable defra_fs metadata. Set raw_json=true for structured JSON.",
+                "Read a UTF-8 text file under the allowed root ({}). Relative paths resolve from the active request workspace when one is provided, otherwise from the root. Returns compact line-numbered text with stable defra_fs metadata, including content_hash — the raw-byte identity of the whole file, usable as edit_file expected_content_hash to guard against concurrent changes. Set raw_json=true for structured JSON.",
                 self.context.root().display()
             ),
             parameters: serde_json::json!({
@@ -215,6 +225,7 @@ impl Tool for ReadFileTool {
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let path = self.context.resolve_existing_file(&args.path)?;
         let bytes = tokio::fs::read(&path).await?;
+        let content_hash = content_hash(&bytes);
         let text = String::from_utf8_lossy(&bytes).into_owned();
         let rendered = render_file_contents(&text, args.start_line, args.end_line);
         let max_chars = args.max_chars.min(self.default_max_chars).max(1);
@@ -231,6 +242,7 @@ impl Tool for ReadFileTool {
                 truncated,
                 start_line: rendered.start_line,
                 end_line: rendered.end_line,
+                content_hash,
             },
             content,
         };
@@ -419,6 +431,7 @@ impl Tool for WriteFileTool {
                 truncated: false,
                 bytes_written: args.content.len(),
                 created,
+                content_hash: content_hash(args.content.as_bytes()),
             },
         };
 
@@ -524,7 +537,7 @@ impl Tool for EditFileTool {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Replace text in an existing file under the configured root. Relative paths resolve from the active request workspace when one is provided, otherwise from the root. Returns compact success metadata by default. Set raw_json=true for structured JSON.".to_string(),
+            description: "Edit an existing file under the configured root by replacing old_text with new_text. Relative paths resolve from the active request workspace when one is provided, otherwise from the root. Matching tolerates trailing-whitespace, indentation, and unicode-punctuation drift (the result reports match_strategy; an exact match always wins), and files are matched with normalized line endings, so CRLF files edit cleanly. Use the smallest old_text that uniquely identifies the change; if it matches multiple places the call fails with the locations. On failure the error includes the closest near-match — re-read the file and build new old_text from CURRENT content instead of retrying the same call. Set dry_run=true to preview the diff without writing. Pass expected_content_hash (from read_file) to reject the edit if the file changed since you read it. Set raw_json=true for structured JSON.".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -534,16 +547,37 @@ impl Tool for EditFileTool {
                     },
                     "old_text": {
                         "type": "string",
-                        "description": "Exact text to replace. The call fails if this text is not found."
+                        "description": "Text to locate. Whitespace/indentation drift is tolerated; interior wording must match. With match_mode=\"regex\" this is a Rust regex instead."
                     },
                     "new_text": {
                         "type": "string",
-                        "description": "Replacement text."
+                        "description": "Replacement text. With match_mode=\"regex\", capture groups substitute ($1, $2, ...)."
                     },
                     "replace_all": {
                         "type": "boolean",
                         "default": false,
-                        "description": "When false, replace only the first occurrence. When true, replace every occurrence."
+                        "description": "When false, old_text must match exactly one location. When true, replace every match."
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "When true, return the diff that WOULD be applied without writing the file."
+                    },
+                    "match_mode": {
+                        "type": "string",
+                        "enum": ["ladder", "regex"],
+                        "default": "ladder",
+                        "description": "ladder = tolerant literal matching (default). regex = old_text is a Rust regex."
+                    },
+                    "operation": {
+                        "type": "string",
+                        "enum": ["replace", "insert_after", "insert_before", "delete"],
+                        "default": "replace",
+                        "description": "replace swaps old_text for new_text; insert_after/insert_before keep old_text and add new_text after/before it; delete removes old_text (new_text ignored)."
+                    },
+                    "expected_content_hash": {
+                        "type": "string",
+                        "description": "Optional content_hash from a prior read_file of this file. If the file's current bytes hash differently, the edit is rejected before matching."
                     },
                     "raw_json": {
                         "type": "boolean",
@@ -558,54 +592,160 @@ impl Tool for EditFileTool {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let path = self.context.resolve_existing_file(&args.path)?;
-        let original = tokio::fs::read_to_string(&path).await?;
-        let replacements = original.matches(&args.old_text).count();
-        if replacements == 0 {
-            return Err(anyhow!(
-                "text to replace was not found in {}",
-                self.context.display_path(&path)
-            )
-            .into());
+        let display = self.context.display_path(&path);
+        let raw = tokio::fs::read(&path).await?;
+        let pre_edit_hash = content_hash(&raw);
+
+        // #724 stale gate: fires BEFORE any matching (Lean E6), so a stale
+        // read never even reports ambiguity against content the model has
+        // not seen.
+        if let Some(expected) = &args.expected_content_hash {
+            if expected != &pre_edit_hash {
+                return Err(anyhow!(
+                    "{display} has changed since it was read: expected {expected}, but the current content hashes to {pre_edit_hash}. Re-read the file and rebuild the edit from current content."
+                )
+                .into());
+            }
         }
 
-        let updated = if args.replace_all {
-            original.replace(&args.old_text, &args.new_text)
-        } else {
-            original.replacen(&args.old_text, &args.new_text, 1)
+        let operation = match args.operation.as_deref() {
+            None | Some("replace") => Operation::Replace,
+            Some("insert_after") => Operation::InsertAfter,
+            Some("insert_before") => Operation::InsertBefore,
+            Some("delete") => Operation::Delete,
+            Some(other) => return Err(anyhow!(
+                "unknown operation {other:?}; valid: replace, insert_after, insert_before, delete"
+            )
+            .into()),
         };
-        tokio::fs::write(&path, updated.as_bytes()).await?;
-
-        let replacements_applied = if args.replace_all { replacements } else { 1 };
-        let output = EditFileOutput {
-            metadata: EditFileMetadata {
-                ok: true,
-                status: "success",
-                tool: Self::NAME,
-                path: self.context.display_path(&path),
-                returned_count: replacements_applied,
-                total_count: Some(replacements),
-                truncated: false,
-                replacements_applied,
-                replace_all: args.replace_all,
-                bytes_written: updated.len(),
-            },
+        let match_mode = match args.match_mode.as_deref() {
+            None | Some("ladder") => MatchMode::Ladder,
+            Some("regex") => MatchMode::Regex,
+            Some(other) => {
+                return Err(anyhow!("unknown match_mode {other:?}; valid: ladder, regex").into())
+            }
         };
 
-        Ok(render_tool_output(
-            &output.metadata,
-            format!(
-                "edit_file: edited {} ({} replacement{})",
-                output.metadata.path,
-                output.metadata.replacements_applied,
-                if output.metadata.replacements_applied != 1 {
-                    "s"
-                } else {
-                    ""
+        let raw_text = String::from_utf8_lossy(&raw).into_owned();
+        let normalized = edit_match::normalize_content(&raw_text);
+        let old_text = args.old_text.replace("\r\n", "\n");
+        let new_text = args.new_text.replace("\r\n", "\n");
+        let request = EditRequest {
+            old_text: &old_text,
+            new_text: &new_text,
+            replace_all: args.replace_all,
+            operation,
+            match_mode,
+        };
+
+        match edit_match::decide(&normalized.text, &request) {
+            EditOutcome::Applied {
+                result,
+                strategy,
+                replacements,
+                first_changed_line,
+                diff,
+            } => {
+                let post_text =
+                    edit_match::restore_content(&result, normalized.ending, normalized.had_bom);
+                let post_edit_hash = content_hash(post_text.as_bytes());
+                if !args.dry_run {
+                    tokio::fs::write(&path, post_text.as_bytes()).await?;
+                    // Post-write verification: some hosts report success
+                    // without persisting bytes; stat/mtime are not reliable.
+                    let verify = tokio::fs::read(&path).await?;
+                    if verify != post_text.as_bytes() {
+                        return Err(anyhow!(
+                            "post-write verification failed for {display}: the bytes on disk do not match the edited content"
+                        )
+                        .into());
+                    }
                 }
-            ),
-            &output,
-            args.raw_json,
-        )?)
+                let output = EditFileOutput {
+                    metadata: EditFileMetadata {
+                        ok: true,
+                        status: "success",
+                        tool: Self::NAME,
+                        path: display,
+                        returned_count: replacements,
+                        total_count: Some(replacements),
+                        truncated: false,
+                        replacements_applied: replacements,
+                        replace_all: args.replace_all,
+                        dry_run: args.dry_run,
+                        match_strategy: strategy.as_str(),
+                        first_changed_line,
+                        pre_edit_hash,
+                        post_edit_hash,
+                        bytes_written: if args.dry_run { 0 } else { post_text.len() },
+                    },
+                    diff,
+                };
+                let verb = if args.dry_run {
+                    "dry-run preview for"
+                } else {
+                    "edited"
+                };
+                Ok(render_tool_output(
+                    &output.metadata,
+                    format!(
+                        "edit_file: {verb} {} ({} replacement{}, strategy {})\n{}",
+                        output.metadata.path,
+                        replacements,
+                        if replacements != 1 { "s" } else { "" },
+                        output.metadata.match_strategy,
+                        output.diff,
+                    ),
+                    &output,
+                    args.raw_json,
+                )?)
+            }
+            EditOutcome::NotFound { closest } => {
+                let mut message = format!("old_text was not found in {display}.");
+                if let Some(c) = closest {
+                    let _ = write!(
+                        message,
+                        "\nClosest match ({}% similar) at line {}:",
+                        c.similarity_pct, c.line
+                    );
+                    if let Some((pattern_line, file_line)) = c.first_diff {
+                        let _ = write!(
+                            message,
+                            "\n  your text: {pattern_line}\n  file has:  {file_line}"
+                        );
+                    }
+                }
+                message.push_str(
+                    "\nRe-read the file and build old_text from its CURRENT content; do not retry the same call.",
+                );
+                Err(anyhow!(message).into())
+            }
+            EditOutcome::Ambiguous {
+                strategy,
+                count,
+                previews,
+            } => {
+                let mut message = format!(
+                    "old_text matches {count} locations in {display} (strategy {}):",
+                    strategy.as_str()
+                );
+                for preview in previews {
+                    let _ = write!(message, "\n  line {}: {}", preview.line, preview.text);
+                }
+                message.push_str(
+                    "\nAdd surrounding context to make it unique, or set replace_all=true.",
+                );
+                Err(anyhow!(message).into())
+            }
+            EditOutcome::Noop { .. } => Err(anyhow!(
+                "the edit would produce identical content in {display}; nothing was written. old_text and new_text are equivalent at the matched site."
+            )
+            .into()),
+            EditOutcome::InvalidRegex { error } => Err(anyhow!(
+                "match_mode=\"regex\": pattern failed to parse: {error}"
+            )
+            .into()),
+        }
     }
 }
 
@@ -620,6 +760,9 @@ struct ReadFileMetadata {
     truncated: bool,
     start_line: usize,
     end_line: usize,
+    /// Raw-byte identity of the COMPLETE file (even for ranged/truncated
+    /// reads) — pass to edit_file's expected_content_hash (#724).
+    content_hash: String,
 }
 
 #[derive(Serialize)]
@@ -640,6 +783,7 @@ struct WriteFileMetadata {
     truncated: bool,
     bytes_written: usize,
     created: bool,
+    content_hash: String,
 }
 
 #[derive(Serialize)]
@@ -659,6 +803,11 @@ struct EditFileMetadata {
     truncated: bool,
     replacements_applied: usize,
     replace_all: bool,
+    dry_run: bool,
+    match_strategy: &'static str,
+    first_changed_line: usize,
+    pre_edit_hash: String,
+    post_edit_hash: String,
     bytes_written: usize,
 }
 
@@ -666,6 +815,7 @@ struct EditFileMetadata {
 struct EditFileOutput {
     #[serde(flatten)]
     metadata: EditFileMetadata,
+    diff: String,
 }
 
 fn render_tool_output(

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -613,10 +613,12 @@ impl Tool for EditFileTool {
             Some("insert_after") => Operation::InsertAfter,
             Some("insert_before") => Operation::InsertBefore,
             Some("delete") => Operation::Delete,
-            Some(other) => return Err(anyhow!(
+            Some(other) => {
+                return Err(anyhow!(
                 "unknown operation {other:?}; valid: replace, insert_after, insert_before, delete"
             )
-            .into()),
+                .into())
+            }
         };
         let match_mode = match args.match_mode.as_deref() {
             None | Some("ladder") => MatchMode::Ladder,

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -39,8 +39,35 @@ static FILE_MUTATION_LOCKS: std::sync::LazyLock<
     std::sync::Mutex<std::collections::HashMap<PathBuf, std::sync::Arc<tokio::sync::Mutex<()>>>>,
 > = std::sync::LazyLock::new(Default::default);
 
-fn file_mutation_lock_for(path: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
-    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+/// Lock key that is stable across path aliases even when the leaf does not
+/// exist yet: canonicalize the deepest existing ancestor and append the
+/// missing suffix, so `alias/new.txt` and `real/new.txt` (alias -> real)
+/// serialize on one lock.
+fn canonical_lock_key(path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical;
+    }
+    let mut suffix: Vec<std::ffi::OsString> = Vec::new();
+    let mut current = path;
+    while let Some(parent) = current.parent() {
+        match current.file_name() {
+            Some(name) => suffix.push(name.to_os_string()),
+            None => break,
+        }
+        if let Ok(canonical) = std::fs::canonicalize(parent) {
+            let mut key = canonical;
+            for part in suffix.iter().rev() {
+                key.push(part);
+            }
+            return key;
+        }
+        current = parent;
+    }
+    path.to_path_buf()
+}
+
+pub(super) fn file_mutation_lock_for(path: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    let key = canonical_lock_key(path);
     let mut locks = FILE_MUTATION_LOCKS
         .lock()
         .expect("file mutation lock registry poisoned");

--- a/crates/defra-agent/src/toolset/file_tools.rs
+++ b/crates/defra-agent/src/toolset/file_tools.rs
@@ -3,6 +3,7 @@
 // each tool into its own file would scatter the shared defaults and make
 // cross-tool consistency harder to verify.
 use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
 
 use crate::llm::tool::Tool;
 use crate::llm::tool::ToolDefinition;
@@ -23,6 +24,23 @@ use super::shared::{cap_output, render_file_contents, ToolContext, ToolError};
 fn content_hash(bytes: &[u8]) -> String {
     use sha2::{Digest, Sha256};
     format!("sha256:{:x}", Sha256::digest(bytes))
+}
+
+/// Per-path serialization for edit_file's read → hash-check → match → write
+/// sequence: without it, two concurrent edits can both validate the same
+/// pre-edit hash and overwrite each other (lost update). Scope: WITHIN this
+/// process, keyed by canonical path. External writers are outside the lock —
+/// they are caught by the expected_content_hash check at entry and otherwise
+/// race as ordinary last-writer-wins POSIX writes (#724 documents the
+/// optimistic-concurrency boundary; there is no OS-level file lock).
+static EDIT_LOCKS: std::sync::LazyLock<
+    std::sync::Mutex<std::collections::HashMap<PathBuf, std::sync::Arc<tokio::sync::Mutex<()>>>>,
+> = std::sync::LazyLock::new(Default::default);
+
+fn edit_lock_for(path: &Path) -> std::sync::Arc<tokio::sync::Mutex<()>> {
+    let key = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut locks = EDIT_LOCKS.lock().expect("edit lock registry poisoned");
+    locks.entry(key).or_default().clone()
 }
 
 const OUTPUT_META_PREFIX: &str = "defra_fs: ";
@@ -593,6 +611,8 @@ impl Tool for EditFileTool {
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         let path = self.context.resolve_existing_file(&args.path)?;
         let display = self.context.display_path(&path);
+        let lock = edit_lock_for(&path);
+        let _guard = lock.lock().await;
         let raw = tokio::fs::read(&path).await?;
         let pre_edit_hash = content_hash(&raw);
 
@@ -628,7 +648,14 @@ impl Tool for EditFileTool {
             }
         };
 
-        let raw_text = String::from_utf8_lossy(&raw).into_owned();
+        // Strict UTF-8: a lossy conversion followed by a full-file rewrite
+        // would silently replace every invalid byte with U+FFFD.
+        let raw_text = String::from_utf8(raw).map_err(|error| {
+            anyhow!(
+                "{display} is not valid UTF-8 (first invalid byte at offset {}); edit_file only edits UTF-8 text files",
+                error.utf8_error().valid_up_to()
+            )
+        })?;
         let normalized = edit_match::normalize_content(&raw_text);
         let old_text = args.old_text.replace("\r\n", "\n");
         let new_text = args.new_text.replace("\r\n", "\n");

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -762,6 +762,10 @@ async fn write_and_edit_file_work_under_root() {
             new_text: "amy".to_string(),
             replace_all: false,
             raw_json: false,
+            dry_run: false,
+            match_mode: None,
+            operation: None,
+            expected_content_hash: None,
         },
     )
     .await
@@ -1775,4 +1779,192 @@ fn read_only_bash_rejects_mutating_host_diagnostics_commands() {
     )
     .is_err());
     assert!(validate_read_only_command("tailscale", &[String::from("up")], &allowlist).is_err());
+}
+
+// --- #738/#724: edit_file match ladder, dry-run, and content-hash wiring ---
+
+fn edit_args(path: &str, old: &str, new: &str) -> EditFileArgs {
+    EditFileArgs {
+        path: path.to_string(),
+        old_text: old.to_string(),
+        new_text: new.to_string(),
+        replace_all: false,
+        raw_json: true,
+        dry_run: false,
+        match_mode: None,
+        operation: None,
+        expected_content_hash: None,
+    }
+}
+
+#[tokio::test]
+async fn read_file_reports_raw_content_hash() {
+    let root = temp_root("defra-agent-read-hash");
+    std::fs::write(root.join("config.json"), "{\"max_turns\": 20}\n").unwrap();
+    let tool = ReadFileTool::new(
+        ToolContext::new(root, false).unwrap(),
+        DEFAULT_MAX_FILE_CHARS,
+    );
+    let output = crate::llm::tool::Tool::call(
+        &tool,
+        ReadFileArgs {
+            path: "config.json".to_string(),
+            start_line: None,
+            end_line: None,
+            max_chars: DEFAULT_MAX_FILE_CHARS,
+            raw_json: true,
+        },
+    )
+    .await
+    .unwrap();
+    let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+    let hash = value["content_hash"].as_str().unwrap();
+    assert!(hash.starts_with("sha256:"), "{hash}");
+    assert_eq!(hash.len(), "sha256:".len() + 64);
+}
+
+#[tokio::test]
+async fn edit_file_dry_run_previews_diff_without_writing() {
+    let root = temp_root("defra-agent-edit-dry-run");
+    let file = root.join("config.json");
+    std::fs::write(&file, "{\n  \"max_turns\": 20\n}\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let mut args = edit_args("config.json", "\"max_turns\": 20", "\"max_turns\": 250");
+    args.dry_run = true;
+    let output = crate::llm::tool::Tool::call(&tool, args).await.unwrap();
+    let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(value["dry_run"], true, "{value}");
+    assert!(
+        value["diff"].as_str().unwrap().contains("max_turns"),
+        "{value}"
+    );
+    // Nothing was written.
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "{\n  \"max_turns\": 20\n}\n"
+    );
+}
+
+#[tokio::test]
+async fn edit_file_stale_hash_rejects_before_matching_and_reports_current() {
+    let root = temp_root("defra-agent-edit-stale");
+    let file = root.join("a.txt");
+    // Pattern is ambiguous — but the stale gate must fire FIRST (Lean E6).
+    std::fs::write(&file, "dup\ndup\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let mut args = edit_args("a.txt", "dup", "x");
+    args.expected_content_hash =
+        Some("sha256:0000000000000000000000000000000000000000000000000000000000000000".to_string());
+    let err = crate::llm::tool::Tool::call(&tool, args)
+        .await
+        .expect_err("stale hash must reject");
+    let text = err.to_string();
+    assert!(text.contains("changed since"), "{text}");
+    assert!(text.contains("sha256:"), "{text}");
+    assert!(
+        text.contains("re-read") || text.contains("Re-read"),
+        "{text}"
+    );
+    assert_eq!(std::fs::read_to_string(&file).unwrap(), "dup\ndup\n");
+}
+
+#[tokio::test]
+async fn edit_file_success_reports_strategy_hashes_and_diff() {
+    let root = temp_root("defra-agent-edit-success");
+    let file = root.join("profile.json");
+    std::fs::write(&file, "{\n  \"max_turns\": 20\n}\n").unwrap();
+    let pre_hash = {
+        use sha2::{Digest, Sha256};
+        format!("sha256:{:x}", Sha256::digest(std::fs::read(&file).unwrap()))
+    };
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    // Pattern carries trailing whitespace the file lacks: ladder must apply.
+    let mut args = edit_args(
+        "profile.json",
+        "  \"max_turns\": 20   ",
+        "  \"max_turns\": 250",
+    );
+    args.expected_content_hash = Some(pre_hash.clone());
+    let output = crate::llm::tool::Tool::call(&tool, args).await.unwrap();
+    let value: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(value["match_strategy"], "trailing_whitespace", "{value}");
+    assert_eq!(value["pre_edit_hash"].as_str().unwrap(), pre_hash);
+    assert!(value["post_edit_hash"]
+        .as_str()
+        .unwrap()
+        .starts_with("sha256:"));
+    assert_ne!(value["post_edit_hash"], value["pre_edit_hash"]);
+    assert!(value["diff"].as_str().unwrap().contains("+"), "{value}");
+    assert!(std::fs::read_to_string(&file)
+        .unwrap()
+        .contains("\"max_turns\": 250"));
+}
+
+#[tokio::test]
+async fn edit_file_not_found_error_carries_closest_match() {
+    let root = temp_root("defra-agent-edit-closest");
+    std::fs::write(root.join("a.yaml"), "max_turns: 20\nmodel: d4f\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let err = crate::llm::tool::Tool::call(
+        &tool,
+        edit_args("a.yaml", "max_turns: 21", "max_turns: 250"),
+    )
+    .await
+    .expect_err("no match");
+    let text = err.to_string();
+    assert!(text.contains("Closest match"), "{text}");
+    assert!(text.contains("line 1"), "{text}");
+    assert!(text.contains("% similar"), "{text}");
+}
+
+#[tokio::test]
+async fn edit_file_ambiguous_error_lists_occurrences() {
+    let root = temp_root("defra-agent-edit-ambiguous");
+    std::fs::write(root.join("a.txt"), "x = 1\ny\nx = 1\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let err = crate::llm::tool::Tool::call(&tool, edit_args("a.txt", "x = 1", "x = 2"))
+        .await
+        .expect_err("ambiguous");
+    let text = err.to_string();
+    assert!(text.contains("2 "), "{text}");
+    assert!(text.contains("line 1"), "{text}");
+    assert!(text.contains("line 3"), "{text}");
+    assert!(text.contains("replace_all"), "{text}");
+}
+
+#[tokio::test]
+async fn edit_file_crlf_file_round_trips() {
+    let root = temp_root("defra-agent-edit-crlf");
+    let file = root.join("w.ini");
+    std::fs::write(&file, "a=1\r\nmax_turns=20\r\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let output =
+        crate::llm::tool::Tool::call(&tool, edit_args("w.ini", "max_turns=20", "max_turns=250"))
+            .await
+            .unwrap();
+    let _: serde_json::Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(std::fs::read(&file).unwrap(), b"a=1\r\nmax_turns=250\r\n");
+}
+
+#[tokio::test]
+async fn edit_file_regex_mode_and_insert_after_operation() {
+    let root = temp_root("defra-agent-edit-regex-ops");
+    let file = root.join("c.toml");
+    std::fs::write(&file, "timeout = 1800\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root.clone(), false).unwrap());
+    let mut args = edit_args("c.toml", r"timeout = (\d+)", "timeout = 3600 # was $1");
+    args.match_mode = Some("regex".to_string());
+    crate::llm::tool::Tool::call(&tool, args).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "timeout = 3600 # was 1800\n"
+    );
+
+    let mut args = edit_args("c.toml", "timeout = 3600 # was 1800", "\nretries = 3");
+    args.operation = Some("insert_after".to_string());
+    crate::llm::tool::Tool::call(&tool, args).await.unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&file).unwrap(),
+        "timeout = 3600 # was 1800\nretries = 3\n"
+    );
 }

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -1968,3 +1968,41 @@ async fn edit_file_regex_mode_and_insert_after_operation() {
         "timeout = 3600 # was 1800\nretries = 3\n"
     );
 }
+
+// Review finding 2: non-UTF-8 files are rejected, never lossy-rewritten.
+#[tokio::test]
+async fn edit_file_rejects_non_utf8_instead_of_corrupting() {
+    let root = temp_root("defra-agent-edit-non-utf8");
+    let file = root.join("latin1.txt");
+    std::fs::write(&file, b"caf\xe9 target\n").unwrap();
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    let err = crate::llm::tool::Tool::call(&tool, edit_args("latin1.txt", "target", "x"))
+        .await
+        .expect_err("non-UTF-8 must be rejected");
+    assert!(err.to_string().contains("UTF-8"), "{err}");
+    // The file is untouched — no U+FFFD rewrite.
+    assert_eq!(std::fs::read(&file).unwrap(), b"caf\xe9 target\n");
+}
+
+// Review finding 1: concurrent edits to the same file serialize — neither
+// lost-updates the other. (Without the per-path lock this interleaves:
+// both read, both write full content, one edit vanishes.)
+#[tokio::test(flavor = "multi_thread")]
+async fn edit_file_concurrent_edits_do_not_lose_updates() {
+    let root = temp_root("defra-agent-edit-concurrent");
+    let file = root.join("both.txt");
+    let tool = EditFileTool::new(ToolContext::new(root, false).unwrap());
+    for round in 0..20 {
+        std::fs::write(&file, "alpha: 0\nbeta: 0\n").unwrap();
+        let a = crate::llm::tool::Tool::call(&tool, edit_args("both.txt", "alpha: 0", "alpha: 1"));
+        let b = crate::llm::tool::Tool::call(&tool, edit_args("both.txt", "beta: 0", "beta: 1"));
+        let (ra, rb) = tokio::join!(a, b);
+        ra.unwrap();
+        rb.unwrap();
+        let text = std::fs::read_to_string(&file).unwrap();
+        assert_eq!(
+            text, "alpha: 1\nbeta: 1\n",
+            "round {round}: lost update, file is {text:?}"
+        );
+    }
+}

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -2006,3 +2006,36 @@ async fn edit_file_concurrent_edits_do_not_lose_updates() {
         );
     }
 }
+
+// Round-2 finding 1: write_file shares the mutation lock — a concurrent
+// edit_file + write_file pair serializes, so the final state is always one
+// of the two legal serial orders, never a torn third state (edit reads
+// before the write, lands after it, resurrecting overwritten content).
+#[tokio::test(flavor = "multi_thread")]
+async fn write_file_and_edit_file_serialize_on_the_same_lock() {
+    let root = temp_root("defra-agent-write-edit-serialize");
+    let file = root.join("both.txt");
+    let context = ToolContext::new(root, false).unwrap();
+    let editor = EditFileTool::new(context.clone());
+    let writer = WriteFileTool::new(context);
+    for round in 0..20 {
+        std::fs::write(&file, "alpha: 0\nbeta: 0\n").unwrap();
+        let edit =
+            crate::llm::tool::Tool::call(&editor, edit_args("both.txt", "alpha: 0", "alpha: 1"));
+        let write = crate::llm::tool::Tool::call(
+            &writer,
+            WriteFileArgs {
+                path: "both.txt".to_string(),
+                content: "alpha: 0\nbeta: 1\n".to_string(),
+                raw_json: false,
+            },
+        );
+        let (re, rw) = tokio::join!(edit, write);
+        rw.unwrap();
+        let _ = re; // edit may legitimately fail if it reads mid-transition
+        let text = std::fs::read_to_string(&file).unwrap();
+        let legal = text == "alpha: 1\nbeta: 1\n" // write then edit
+            || text == "alpha: 0\nbeta: 1\n"; // edit then write (write wins)
+        assert!(legal, "round {round}: torn interleaving produced {text:?}");
+    }
+}

--- a/crates/defra-agent/src/toolset/tests.rs
+++ b/crates/defra-agent/src/toolset/tests.rs
@@ -2039,3 +2039,19 @@ async fn write_file_and_edit_file_serialize_on_the_same_lock() {
         assert!(legal, "round {round}: torn interleaving produced {text:?}");
     }
 }
+
+// Round-3 finding 2: mutation-lock keys for not-yet-existing files resolve
+// symlinked directory aliases to one key — both spellings share one lock.
+#[cfg(unix)]
+#[test]
+fn mutation_lock_keys_resolve_symlinked_parents_for_new_files() {
+    let root = temp_root("defra-agent-lock-alias");
+    std::fs::create_dir_all(root.join("real")).unwrap();
+    std::os::unix::fs::symlink(root.join("real"), root.join("alias")).unwrap();
+    let via_alias = super::file_tools::file_mutation_lock_for(&root.join("alias/new.txt"));
+    let via_real = super::file_tools::file_mutation_lock_for(&root.join("real/new.txt"));
+    assert!(
+        std::sync::Arc::ptr_eq(&via_alias, &via_real),
+        "alias and real spellings of a new file must share one lock"
+    );
+}

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -321,6 +321,41 @@ fn generated_backend_health_cases_pin_threshold_and_veto_shape() {
 }
 
 #[test]
+fn edit_match_exact_priority_is_never_shadowed() {
+    edit_match::exact_priority_is_never_shadowed();
+}
+
+#[test]
+fn edit_match_ladder_fires_at_the_strictest_matching_rung() {
+    edit_match::ladder_fires_at_the_strictest_matching_rung();
+}
+
+#[test]
+fn edit_match_ambiguity_gate_requires_unique_or_replace_all() {
+    edit_match::ambiguity_gate_requires_unique_or_replace_all();
+}
+
+#[test]
+fn edit_match_decision_is_pure_and_deterministic() {
+    edit_match::decision_is_pure_and_deterministic();
+}
+
+#[test]
+fn edit_match_noop_is_reported_not_applied() {
+    edit_match::noop_is_reported_not_applied();
+}
+
+#[test]
+fn edit_match_operations_desugar_onto_the_single_matcher() {
+    edit_match::operations_desugar_onto_the_single_matcher();
+}
+
+#[test]
+fn edit_match_near_miss_is_diagnosed_never_applied() {
+    edit_match::near_miss_is_diagnosed_never_applied();
+}
+
+#[test]
 fn generated_process_transition_cases_cover_runtime_status_policy_shape() {
     process::generated_process_transition_cases_cover_runtime_status_policy_shape();
 }
@@ -386,6 +421,8 @@ async fn event_delivery_convergence_traces_match_runtime_or_deviation() {
 mod apply_reconcile;
 #[path = "conformance/docs.rs"]
 mod docs;
+#[path = "conformance/edit_match.rs"]
+mod edit_match;
 #[path = "conformance/identity.rs"]
 mod identity;
 #[path = "conformance/identity_proptest.rs"]

--- a/crates/defra-agent/tests/conformance.rs
+++ b/crates/defra-agent/tests/conformance.rs
@@ -356,6 +356,11 @@ fn edit_match_near_miss_is_diagnosed_never_applied() {
 }
 
 #[test]
+fn edit_match_overlapping_windows_apply_disjoint_selection() {
+    edit_match::overlapping_windows_apply_disjoint_selection();
+}
+
+#[test]
 fn generated_process_transition_cases_cover_runtime_status_policy_shape() {
     process::generated_process_transition_cases_cover_runtime_status_policy_shape();
 }

--- a/crates/defra-agent/tests/conformance/edit_match.rs
+++ b/crates/defra-agent/tests/conformance/edit_match.rs
@@ -1,0 +1,144 @@
+//! EditMatch conformance home (`proofs/Proofs/EditMatch/`, #738/#724).
+//!
+//! Fences the runtime matcher (`defra_agent::toolset::edit_match`) against
+//! the Lean obligations E1–E8. E6's write-side gate ordering (stale hash
+//! rejects before matching, file untouched) is additionally fenced against
+//! the real `edit_file` tool by
+//! `toolset::tests::edit_file_stale_hash_rejects_before_matching_and_reports_current`
+//! — the decision-level pieces live here.
+
+use defra_agent::toolset::edit_match::{
+    decide, EditOutcome, EditRequest, MatchMode, Operation, Strategy,
+};
+
+fn ladder_req<'a>(old: &'a str, new: &'a str, replace_all: bool) -> EditRequest<'a> {
+    EditRequest {
+        old_text: old,
+        new_text: new,
+        replace_all,
+        operation: Operation::Replace,
+        match_mode: MatchMode::Ladder,
+    }
+}
+
+/// E1 — an exact hit is never shadowed by relaxation, even when a coarser
+/// strategy would also match elsewhere.
+pub(super) fn exact_priority_is_never_shadowed() {
+    // The pattern (with trailing newline) exact-matches only line 1; the
+    // trim rung would ALSO match line 2. Exact must win and edit only its
+    // own unique site.
+    let content = "target: 1\n  target: 1  \nend\n";
+    match decide(content, &ladder_req("target: 1\n", "hit: 2\n", false)) {
+        EditOutcome::Applied {
+            strategy, result, ..
+        } => {
+            assert_eq!(strategy, Strategy::Exact);
+            assert_eq!(result, "hit: 2\n  target: 1  \nend\n");
+        }
+        other => panic!("E1 violated: {other:?}"),
+    }
+}
+
+/// E3 — ladder ordering: each drift class fires at its own rung, never a
+/// coarser one (coarsening means stricter rungs are checked first over the
+/// WHOLE document).
+pub(super) fn ladder_fires_at_the_strictest_matching_rung() {
+    let cases = [
+        ("let x = 1;\n", "let x = 1;", Strategy::Exact),
+        ("let x = 1;\n", "let x = 1;   ", Strategy::TrailingWs),
+        ("  let x = 1;\n", "        let x = 1;", Strategy::Trim),
+        ("say \u{201C}hi\u{201D}\n", "say \"hi\"", Strategy::Unicode),
+    ];
+    for (content, pattern, expected) in cases {
+        match decide(content, &ladder_req(pattern, "REPLACED", false)) {
+            EditOutcome::Applied { strategy, .. } => {
+                assert_eq!(
+                    strategy, expected,
+                    "content {content:?} pattern {pattern:?}"
+                )
+            }
+            other => panic!("expected applied for {pattern:?}, got {other:?}"),
+        }
+    }
+}
+
+/// E4 — ambiguity gate: >= 2 occurrences without replace_all is an error
+/// carrying the count; with replace_all every occurrence is applied.
+pub(super) fn ambiguity_gate_requires_unique_or_replace_all() {
+    let content = "dup\nmiddle\ndup\n";
+    match decide(content, &ladder_req("dup", "x", false)) {
+        EditOutcome::Ambiguous { count, .. } => assert_eq!(count, 2),
+        other => panic!("E4 violated: {other:?}"),
+    }
+    match decide(content, &ladder_req("dup", "x", true)) {
+        EditOutcome::Applied {
+            replacements,
+            result,
+            ..
+        } => {
+            assert_eq!(replacements, 2);
+            assert_eq!(result, "x\nmiddle\nx\n");
+        }
+        other => panic!("replace_all should apply: {other:?}"),
+    }
+}
+
+/// E5 — one pure decision: identical inputs decide identically, so dry-run
+/// (decide, no write) and apply (decide, write result) cannot diverge.
+pub(super) fn decision_is_pure_and_deterministic() {
+    let content = "a\nvalue = 1\nz\n";
+    let req = ladder_req("value = 1", "value = 2", false);
+    let first = decide(content, &req);
+    let second = decide(content, &req);
+    assert_eq!(first, second, "decide must be deterministic");
+    match first {
+        EditOutcome::Applied { result, .. } => {
+            assert_eq!(result, "a\nvalue = 2\nz\n");
+        }
+        other => panic!("expected applied, got {other:?}"),
+    }
+}
+
+/// E8 — no-op honesty: an edit producing identical content is reported as
+/// noop, never as applied.
+pub(super) fn noop_is_reported_not_applied() {
+    let content = "same\n";
+    match decide(content, &ladder_req("same", "same", false)) {
+        EditOutcome::Noop { strategy } => assert_eq!(strategy, Strategy::Exact),
+        other => panic!("E8 violated: {other:?}"),
+    }
+}
+
+/// E7 family — convenience operations desugar onto the one matcher: the
+/// matched text survives insert_after/insert_before and disappears on delete.
+pub(super) fn operations_desugar_onto_the_single_matcher() {
+    let content = "anchor\nrest\n";
+    let mut req = ladder_req("anchor", "\nadded", false);
+    req.operation = Operation::InsertAfter;
+    match decide(content, &req) {
+        EditOutcome::Applied { result, .. } => assert_eq!(result, "anchor\nadded\nrest\n"),
+        other => panic!("insert_after: {other:?}"),
+    }
+    let mut req = ladder_req("anchor\n", "", false);
+    req.operation = Operation::Delete;
+    match decide(content, &req) {
+        EditOutcome::Applied { result, .. } => assert_eq!(result, "rest\n"),
+        other => panic!("delete: {other:?}"),
+    }
+}
+
+/// Diagnostics discipline: similarity scoring may only ever surface in
+/// NotFound diagnostics — a below-ladder near-miss must not be applied.
+pub(super) fn near_miss_is_diagnosed_never_applied() {
+    let content = "max_turns: 20\n";
+    match decide(
+        content,
+        &ladder_req("max_turns: 21", "max_turns: 250", false),
+    ) {
+        EditOutcome::NotFound { closest: Some(c) } => {
+            assert_eq!(c.line, 1);
+            assert!(c.similarity_pct < 100);
+        }
+        other => panic!("near-miss must be NotFound with diagnostics: {other:?}"),
+    }
+}

--- a/crates/defra-agent/tests/conformance/edit_match.rs
+++ b/crates/defra-agent/tests/conformance/edit_match.rs
@@ -127,6 +127,25 @@ pub(super) fn operations_desugar_onto_the_single_matcher() {
     }
 }
 
+/// E9 — overlapping relaxed windows: the applied selection is pairwise
+/// disjoint (greedy), so replace_all splicing can never corrupt or panic.
+pub(super) fn overlapping_windows_apply_disjoint_selection() {
+    let content = "a \na \na ";
+    let mut req = ladder_req("a\na", "", true);
+    req.operation = Operation::Delete;
+    match decide(content, &req) {
+        EditOutcome::Applied {
+            result,
+            replacements,
+            ..
+        } => {
+            assert_eq!(replacements, 1);
+            assert_eq!(result, "a ");
+        }
+        other => panic!("E9 violated: {other:?}"),
+    }
+}
+
 /// Diagnostics discipline: similarity scoring may only ever surface in
 /// NotFound diagnostics — a below-ladder near-miss must not be applied.
 pub(super) fn near_miss_is_diagnosed_never_applied() {

--- a/crates/defra-agent/tests/conformance/edit_match.rs
+++ b/crates/defra-agent/tests/conformance/edit_match.rs
@@ -140,7 +140,9 @@ pub(super) fn overlapping_windows_apply_disjoint_selection() {
             ..
         } => {
             assert_eq!(replacements, 1);
-            assert_eq!(result, "a ");
+            // No-newline delete empties the window's lines (exact-pass
+            // parity); the disjointness property is the single application.
+            assert_eq!(result, "\na ");
         }
         other => panic!("E9 violated: {other:?}"),
     }

--- a/crates/defra-agent/tests/conformance/structure.rs
+++ b/crates/defra-agent/tests/conformance/structure.rs
@@ -51,6 +51,7 @@ fn model_homes() -> BTreeMap<&'static str, Home> {
             "CrossMachineComposed",
             Module("conformance/composed_invariants.rs"),
         ),
+        ("EditMatch", Module("conformance/edit_match.rs")),
         ("EventDelivery", Module("conformance/event_delivery.rs")),
         ("Fleet", Module("conformance/fleet.rs")),
         ("Identity", Module("conformance/identity.rs")),

--- a/crates/defra-agent/tests/e2e_live.rs
+++ b/crates/defra-agent/tests/e2e_live.rs
@@ -7,6 +7,8 @@ mod support;
 
 #[path = "e2e_live/backend_auth_live.rs"]
 mod backend_auth_live;
+#[path = "e2e_live/edit_file_live.rs"]
+mod edit_file_live;
 #[path = "e2e_live/interrupt_live.rs"]
 mod interrupt_live;
 #[path = "e2e_live/p2p_admission_concurrent_live.rs"]

--- a/crates/defra-agent/tests/e2e_live/edit_file_live.rs
+++ b/crates/defra-agent/tests/e2e_live/edit_file_live.rs
@@ -1,0 +1,208 @@
+//! #738/#724 LIVE qualification: a real model, faced with drifted file
+//! content, lands the edit through `edit_file` instead of falling back to
+//! `write_file` — the production failure pattern that motivated #738 (amy
+//! gave up on `edit_file` for 80% of her mutation work).
+//!
+//! What real inference exercises that the deterministic fences cannot:
+//! whether the MODEL, given the new tool description, diagnostics, and
+//! content-hash flow, actually completes the read → edit_file loop on a
+//! file whose bytes drift from what the read rendering suggests (CRLF +
+//! trailing whitespace). The matcher itself is Lean-fenced
+//! (`Proofs/EditMatch/`) and conformance-fenced; this pins the
+//! model-facing contract end to end.
+//!
+//! Gated on `DEFRA_AGENT_D4F_LIVE=1` (same gate and backend as
+//! `steward_loop_live.rs`). Run with:
+//!
+//! ```bash
+//! DEFRA_AGENT_D4F_LIVE=1 cargo test --test e2e_live \
+//!   -- --test-threads=1 edit_file_live --nocapture
+//! ```
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use defra_agent::defra_node::EmbeddedNode;
+use defra_agent::graphql::escape_graphql_string;
+use defra_agent::{
+    load_agent_behavior, upsert_agent_behavior, upsert_tool_selection, DefraAgent,
+    DocumentRuntimeOptions, ToolCeiling, ToolSelectionDocument,
+};
+use serde::Deserialize;
+
+use defra_agent::AgentIdentity;
+
+use crate::steward_loop_live::{bind_d4f_backend, wait_for_request_terminal};
+use crate::support::fixtures::test_identity;
+use crate::support::interrupt::{create_runtime_request, wait_for_runtime_ready, BootedAgent};
+use crate::support::test_db;
+
+fn d4f_enabled() -> bool {
+    std::env::var("DEFRA_AGENT_D4F_LIVE").as_deref() == Ok("1")
+}
+
+/// The drifted config the model must edit: CRLF line endings and trailing
+/// whitespace after the target value — the exact byte drift that made
+/// exact-match `edit_file` unusable in production.
+const SEED: &str = "{\r\n  \"max_turns\": 20,  \r\n  \"model_name\": \"d4f\"\r\n}\r\n";
+
+#[derive(Deserialize)]
+struct ToolCallRow {
+    tool_name: Option<String>,
+    status: Option<String>,
+    result: Option<String>,
+}
+
+async fn fetch_tool_calls(node: &EmbeddedNode, request_id: &str) -> Vec<ToolCallRow> {
+    let escaped = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentToolCall(filter: {{ request_id: {{ _eq: "{escaped}" }} }}) {{
+                tool_name
+                status
+                result
+            }}
+        }}"#
+    );
+    let resp = node.execute(&query).await;
+    assert!(
+        !resp.has_errors(),
+        "tool call query failed: {:?}",
+        resp.errors
+    );
+    resp.data
+        .as_ref()
+        .and_then(|data| data.get("AgentToolCall"))
+        .and_then(|rows| rows.as_array())
+        .map(|rows| {
+            rows.iter()
+                .cloned()
+                .map(|value| serde_json::from_value(value).expect("decode AgentToolCall row"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn edit_file_live_model_lands_drifted_edit_without_write_file() {
+    if !d4f_enabled() {
+        eprintln!("DEFRA_AGENT_D4F_LIVE is not 1; skipping edit_file live qualification");
+        return;
+    }
+
+    let db = test_db("edit-file-live").await;
+    let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity("edit-file-live"));
+
+    // Workspace with the drift-trap config file.
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+    std::fs::write(workspace.path().join("profile.json"), SEED).unwrap();
+
+    let (agent_did, behavior_id) = bind_d4f_backend(db.node.as_ref(), identity.as_ref()).await;
+
+    // File tools (ReadWrite) only — bash stays off so there is no scripting
+    // escape hatch: the model must succeed through edit_file or fail.
+    upsert_tool_selection(
+        db.node.as_ref(),
+        &ToolSelectionDocument {
+            selection_id: "edit-live-tools".to_string(),
+            agent_did: agent_did.clone(),
+            enable_file_tools: Some(true),
+            file_tools_mode: Some("ReadWrite".to_string()),
+            file_tool_root: Some(workspace.path().display().to_string()),
+            enable_bash: Some(false),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let mut behavior = load_agent_behavior(db.node.as_ref(), &behavior_id)
+        .await
+        .expect("load behavior")
+        .expect("behavior exists");
+    behavior.tool_selection_id = Some("edit-live-tools".to_string());
+    upsert_agent_behavior(db.node.as_ref(), &behavior)
+        .await
+        .expect("bind tool selection");
+
+    let agent = DefraAgent::from_default_behavior_documents(
+        db.node.clone(),
+        Arc::clone(&identity),
+        DocumentRuntimeOptions {
+            tool_ceiling: ToolCeiling::readwrite(workspace.path()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("boot agent");
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    let handle = tokio::spawn(agent.run(shutdown_rx));
+    wait_for_runtime_ready(db.node.as_ref(), &agent_did).await;
+    let booted = BootedAgent::new(shutdown_tx, handle, agent_did.clone());
+
+    let request_id = "edit-file-live-req-1";
+    create_runtime_request(
+        db.node.as_ref(),
+        &agent_did,
+        &behavior_id,
+        request_id,
+        "edit-file-live-session-1",
+        "In profile.json, change max_turns from 20 to 250. Use read_file first, \
+         then make the change with edit_file, passing the content_hash from the \
+         read as expected_content_hash. Do not use write_file. Reply DONE when \
+         the edit is applied.",
+    )
+    .await;
+
+    let terminal =
+        wait_for_request_terminal(db.node.as_ref(), request_id, Duration::from_secs(300)).await;
+    assert_eq!(terminal, "completed", "live edit run must complete");
+
+    // The file: value changed, CRLF endings preserved, untouched line intact.
+    let bytes = std::fs::read(workspace.path().join("profile.json")).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("\"max_turns\": 250"),
+        "edited content:\n{text}"
+    );
+    assert!(
+        !text.contains("\"max_turns\": 20"),
+        "old value gone:\n{text}"
+    );
+    assert!(
+        text.contains("\r\n"),
+        "CRLF endings must survive the edit:\n{text:?}"
+    );
+    assert!(
+        text.contains("  \"model_name\": \"d4f\""),
+        "unrelated line untouched:\n{text}"
+    );
+
+    // The tool trail: edit_file succeeded; write_file was never used (the
+    // production fallback this feature exists to eliminate).
+    let calls = fetch_tool_calls(db.node.as_ref(), request_id).await;
+    assert!(!calls.is_empty(), "tool calls must be persisted");
+    let edit_completed = calls.iter().any(|c| {
+        c.tool_name.as_deref() == Some("edit_file")
+            && c.status.as_deref() == Some("completed")
+            && c.result
+                .as_deref()
+                .is_some_and(|r| r.contains("match_strategy"))
+    });
+    assert!(
+        edit_completed,
+        "a completed edit_file call with match_strategy metadata is required; calls: {:?}",
+        calls
+            .iter()
+            .map(|c| (c.tool_name.clone(), c.status.clone()))
+            .collect::<Vec<_>>()
+    );
+    let used_write_file = calls
+        .iter()
+        .any(|c| c.tool_name.as_deref() == Some("write_file"));
+    assert!(
+        !used_write_file,
+        "model fell back to write_file — the #738 failure pattern"
+    );
+
+    booted.shutdown().await;
+}


### PR DESCRIPTION
Fixes #738. Fixes #724.

Production shape this fixes (amy's own filing, #738): exact byte-match `edit_file` failed on trailing whitespace / CRLF / indentation drift, so **80% of her mutation work bypassed the tool entirely** — falling back to whole-file `write_file` overwrites and Python scripts, with no preview and no concurrency protection.

## Design (prior art researched in local Codex + oh-my-pi checkouts)

Codex's `apply_patch` matcher is a deterministic relaxation ladder (exact → rstrip → trim → unicode-normalize) with no fuzzy scoring; oh-my-pi adds Levenshtein-fuzzy apply behind threshold+dominance guards, rich failure diagnostics, dry-run, and content-hash staleness protection. This PR takes the ladder (deterministic, provable), oh-my-pi's diagnostics/dry-run/hash ideas, and draws the line at **fuzzy-applies-edits: similarity scoring is diagnostics-only** — it ranks closest-match error hints but never selects an edit site.

## Lean first (`Proofs/EditMatch/`, zero sorries)

- **E1** exact-hit priority (relaxation never shadows an exact match)
- **E2** occurrence soundness; **E3** ladder keys provably coarsen (a rung fires only when every stricter rung missed everywhere)
- **E4** ambiguity gate: ≥2 occurrences without `replace_all` is an error, never a guess
- **E5** one pure decision shared by dry-run and apply; **E8** no-op honesty
- **E6** stale-precondition gate (#724): rejects before any matching, document untouched
- **E7** exact windows are literal (insert_after provably preserves the matched text)

Conformance home `tests/conformance/edit_match.rs` fences E1–E8 against the real matcher (structure-fence entry added).

## What the model gets

- **`edit_file`**: drift-tolerant ladder with the replacement re-indented to the matched site; `match_strategy` reported in metadata. `dry_run: true` returns the numbered diff without writing. `match_mode: "regex"` (opt-in, bounded compile, capture groups). `operation: insert_after | insert_before | delete`. `expected_content_hash` rejects stale edits before matching, with the current hash and a re-read instruction. Success echoes the numbered hunk diff, pre/post hashes, and `first_changed_line`; writes are byte-verified after the fact.
- **Failure UX**: not-found errors carry the closest match (% similarity, line, first-differing line pair) and explicit "re-read, don't retry" guidance; ambiguity errors list the occurrence locations.
- **`read_file` / `write_file`**: raw-byte `content_hash` (sha256, whole file even on ranged/truncated reads) — the #724 optimistic-concurrency handle.
- BOM and CRLF round-trip: matching runs in LF space, the original flavor is restored on write.

## Verification

- 16 unit tests (each of amy's documented failure modes has one), 7 conformance fences, 8 tool-wiring tests (stale-gate ordering, dry-run no-write, hash echo, CRLF round-trip, regex + operations end-to-end).
- **Live e2e against real inference** (`tests/e2e_live/edit_file_live.rs`, gated on `DEFRA_AGENT_D4F_LIVE=1`): seeds a CRLF + trailing-whitespace config, asks the model to change `max_turns` via read → `edit_file` with `expected_content_hash`, bash disabled so there is no scripting escape hatch. Asserts the request completes, the file is correctly edited with CRLF preserved, a completed `edit_file` call carries `match_strategy`, and **`write_file` was never used**. Ran against the fleet d4f (DeepSeek-V4-Flash): PASSED.
- Gates: full `cargo test -p defra-agent` ✅, `cargo check --workspace --all-targets` ✅, `lake build Proofs.EditMatch` ✅, zero clippy warnings in new code.

## Follow-ups (filed)

- #739 structural (JSON/YAML path) edit mode — deferred by design decision.
- Guarded-mode policy knob (require `expected_content_hash` per behavior/tool policy) — #724's remaining slice once clients and prompts carry the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
