### PR TITLE
Fix Codex terminal reasoning and subagent projection races

### DIFF
--- a/crates/defra-agent-cli/src/commands/codex_shim/command_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/command_projection.rs
@@ -33,24 +33,28 @@ impl ToolProjectionStatus {
 }
 
 pub(super) fn tool_projection_status(tool: &DefraToolCallProgress) -> ToolProjectionStatus {
-    tool_projection_status_with_settled(tool, false)
+    tool_projection_status_with_settled(tool, false, false)
 }
 
 pub(super) fn tool_projection_status_with_settled(
     tool: &DefraToolCallProgress,
     projection_settled: bool,
+    link_settle_expired: bool,
 ) -> ToolProjectionStatus {
     let status = defra_tool_call_status(tool);
     if is_subagent_control_tool(&tool.tool_name) {
         if let Some(projection) = collab_projection(tool) {
             ToolProjectionStatus::Collab(projection)
         } else if status == codex::McpToolCallStatus::Failed
-            || (projection_settled && status == codex::McpToolCallStatus::Completed)
+            || (projection_settled
+                && link_settle_expired
+                && status == codex::McpToolCallStatus::Completed)
         {
             // A rejected control call may never create a child edge. Likewise,
-            // once the enclosing projection is terminal, an unresolved but
-            // completed bridge has no remaining retry window. Preserve the
-            // durable tool result as MCP instead of hiding it forever.
+            // once the enclosing projection is terminal and its bounded link
+            // settle window has expired, an unresolved completed bridge has
+            // no remaining retry window. Preserve the durable tool result as
+            // MCP instead of hiding it forever.
             ToolProjectionStatus::Mcp(status)
         } else {
             // The child request and its reciprocal bridge may replicate just
@@ -449,7 +453,11 @@ mod tests {
             ToolProjectionStatus::DeferredCollab
         );
         assert_eq!(
-            tool_projection_status_with_settled(&tool, true),
+            tool_projection_status_with_settled(&tool, true, false),
+            ToolProjectionStatus::DeferredCollab
+        );
+        assert_eq!(
+            tool_projection_status_with_settled(&tool, true, true),
             ToolProjectionStatus::Mcp(codex::McpToolCallStatus::Completed)
         );
     }

--- a/crates/defra-agent-cli/src/commands/codex_shim/history_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/history_projection.rs
@@ -5,7 +5,7 @@ use codex_app_server_protocol as codex;
 use codex_protocol::models::MessagePhase;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent_protocol::transcript::present_persisted_message;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 use serde_json::{json, Value};
 
 use super::command_projection::{
@@ -30,32 +30,32 @@ use super::ShimState;
 #[derive(Debug, Clone, Deserialize)]
 struct RequestRow {
     request_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     content: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     status: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     lifecycle_state: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     failure_reason: String,
     #[serde(default)]
     created_at: Option<String>,
     #[serde(default)]
     terminalized_at: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     metadata: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     execution_origin: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 struct ResponseRow {
     request_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     content: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     reasoning: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     status: String,
     #[serde(default)]
     error_message: Option<String>,
@@ -81,7 +81,7 @@ struct ToolRow {
 struct CompactionRow {
     request_id: String,
     call_id: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     call_state: String,
     #[serde(default)]
     call_seq: i64,
@@ -90,12 +90,19 @@ struct CompactionRow {
 #[derive(Debug, Clone, Deserialize)]
 struct MessageRow {
     sequence: i64,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     role: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     content: String,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_string")]
     reasoning: String,
+}
+
+fn deserialize_nullable_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Ok(Option::<String>::deserialize(deserializer)?.unwrap_or_default())
 }
 
 pub(super) async fn load_thread_turns(
@@ -706,7 +713,7 @@ fn project_tool(
     tool: &DefraToolCallProgress,
     projection_settled: bool,
 ) -> Option<codex::ThreadItem> {
-    match tool_projection_status_with_settled(tool, projection_settled) {
+    match tool_projection_status_with_settled(tool, projection_settled, true) {
         ToolProjectionStatus::Mcp(status) => Some(defra_tool_item(tool, status)),
         ToolProjectionStatus::Command(status) => {
             Some(command_execution_item(&record.cwd, tool, status))
@@ -906,6 +913,43 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
+
+    #[test]
+    fn replicated_nullable_history_scalars_decode_as_empty_text() {
+        let response = json!({
+            "data": {
+                "AgentRequest": [{
+                    "request_id": "request-1",
+                    "content": null,
+                    "status": null,
+                    "lifecycle_state": null,
+                    "failure_reason": null,
+                    "metadata": null,
+                    "execution_origin": null
+                }],
+                "AgentResponse": [{
+                    "request_id": "request-1",
+                    "content": null,
+                    "reasoning": null,
+                    "status": null
+                }],
+                "AgentMessage": [{
+                    "sequence": 1,
+                    "role": null,
+                    "content": null,
+                    "reasoning": null
+                }]
+            }
+        });
+
+        let requests = decode_rows::<RequestRow>(&response, "AgentRequest").unwrap();
+        assert_eq!(requests[0].content, "");
+        assert_eq!(requests[0].failure_reason, "");
+        let responses = decode_rows::<ResponseRow>(&response, "AgentResponse").unwrap();
+        assert_eq!(responses[0].reasoning, "");
+        let messages = decode_rows::<MessageRow>(&response, "AgentMessage").unwrap();
+        assert_eq!(messages[0].role, "");
+    }
 
     #[test]
     fn completed_request_overrides_error_response_status() {

--- a/crates/defra-agent-cli/src/commands/codex_shim/subagent_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/subagent_projection.rs
@@ -763,10 +763,18 @@ fn tool_child_request_id(tool: &DefraToolCallProgress) -> Option<String> {
 pub(super) fn collab_projection(tool: &DefraToolCallProgress) -> Option<CollabProjection> {
     let collab_tool = collab_tool(&tool.tool_name)?;
     let link = tool.subagent_link.as_ref()?;
-    let status = match defra_tool_call_status(tool) {
-        codex::McpToolCallStatus::InProgress => codex::CollabAgentToolCallStatus::InProgress,
-        codex::McpToolCallStatus::Completed => codex::CollabAgentToolCallStatus::Completed,
-        codex::McpToolCallStatus::Failed => codex::CollabAgentToolCallStatus::Failed,
+    let runtime_status = defra_tool_call_status(tool);
+    let status = match (&collab_tool, runtime_status) {
+        (_, codex::McpToolCallStatus::Failed) => codex::CollabAgentToolCallStatus::Failed,
+        (codex::CollabAgentTool::SpawnAgent, _) => {
+            // The reciprocal edge proves the spawn operation succeeded. DEFRA
+            // deliberately keeps the bridge row running while a background
+            // child works; Codex represents that child lifecycle separately
+            // in agentsStates, so the collaboration operation is complete.
+            codex::CollabAgentToolCallStatus::Completed
+        }
+        (_, codex::McpToolCallStatus::InProgress) => codex::CollabAgentToolCallStatus::InProgress,
+        (_, codex::McpToolCallStatus::Completed) => codex::CollabAgentToolCallStatus::Completed,
     };
     Some(CollabProjection {
         status,
@@ -1097,6 +1105,11 @@ mod tests {
             created_at: None,
         });
         let projection = collab_projection(&tool).expect("authorized spawn projection");
+        assert_eq!(
+            projection.status,
+            codex::CollabAgentToolCallStatus::Completed,
+            "the linked spawn operation completes while agentsStates tracks the running child"
+        );
         let item = collab_tool_item("parent-thread", &tool, &projection);
         let value = serde_json::to_value(&item).expect("serialize collab item");
         serde_json::from_value::<codex::ThreadItem>(value.clone())
@@ -1104,6 +1117,7 @@ mod tests {
 
         assert_eq!(value["type"], "collabAgentToolCall");
         assert_eq!(value["tool"], "spawnAgent");
+        assert_eq!(value["status"], "completed");
         assert_eq!(value["senderThreadId"], "parent-thread");
         assert_eq!(value["receiverThreadIds"], json!([child_session_id]));
         assert_eq!(value["prompt"], "Inspect the patch");

--- a/crates/defra-agent-cli/src/commands/codex_shim/turn/stream.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/turn/stream.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::hash::{Hash, Hasher};
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use codex_app_server_protocol as codex;
@@ -34,6 +35,8 @@ use super::super::turn_projection::TurnProjection;
 use super::super::{ConnectionState, ShimState};
 use super::active::next_steering_request_after;
 use crate::{is_terminal_lifecycle_state, request_diagnostic_hint, SubmittedRequest};
+
+const SUBAGENT_LINK_SETTLE_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct ProgressMarker {
@@ -179,6 +182,7 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
     let subagent_update_filter = SubagentProjectionUpdateFilter::from_state(state);
     let mut subagent_links = Vec::new();
     let mut subagent_links_dirty = true;
+    let mut subagent_link_settle_started_at = None;
     let mut latest_content_cursor = ContentCursor::default();
     let mut latest_reasoning_cursor = ReasoningCursor::default();
     let mut latest_error_message: Option<String> = None;
@@ -330,6 +334,24 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
             subagent_links_dirty = false;
             subagent_links_refreshed = true;
         }
+        let unresolved_terminal_control = projection_settled
+            && tool_rows.iter().any(|row| {
+                let Some(mut tool) = decode_defra_tool_call_progress(row) else {
+                    return false;
+                };
+                attach_subagent_link(&mut tool, &subagent_links);
+                matches!(
+                    tool_projection_status_with_settled(&tool, false, false),
+                    ToolProjectionStatus::DeferredCollab
+                )
+            });
+        let link_settle_expired = observe_subagent_link_settle_window(
+            &mut subagent_link_settle_started_at,
+            unresolved_terminal_control,
+            tokio::time::Instant::now(),
+            SUBAGENT_LINK_SETTLE_TIMEOUT,
+        );
+        let waiting_for_subagent_links = unresolved_terminal_control && !link_settle_expired;
 
         if marker_changed && !projection_settled {
             if let Some(reasoning) = response_row
@@ -374,7 +396,8 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
             if has_subagent_control {
                 attach_subagent_link(&mut tool, &subagent_links);
             }
-            let projection_status = tool_projection_status_with_settled(&tool, projection_settled);
+            let projection_status =
+                tool_projection_status_with_settled(&tool, projection_settled, link_settle_expired);
             let previous_status = known_tool_calls.get(&tool.tool_call_key).cloned();
             update_running_background_tools(
                 &mut running_background_tools,
@@ -423,7 +446,7 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
         let terminal_by_request = is_terminal_lifecycle_state(lifecycle_state);
         let terminal_by_response = matches!(response_status, "complete" | "completed" | "error");
 
-        if terminal_by_request || terminal_by_response {
+        if (terminal_by_request || terminal_by_response) && !waiting_for_subagent_links {
             let mut terminal_response = response_row.cloned().unwrap_or_else(|| {
                 json!({
                     "request_id": current.request_id.clone(),
@@ -567,6 +590,7 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
                     known_compaction_states.clear();
                     known_inference_usage_call_id = None;
                     subagent_links_dirty = true;
+                    subagent_link_settle_started_at = None;
                     latest_content_cursor.reset();
                     latest_reasoning_cursor.reset();
                     projection.reset_response_timing();
@@ -662,6 +686,20 @@ pub(in crate::commands::codex_shim) async fn stream_defra_turn(
             }
         }
     }
+}
+
+fn observe_subagent_link_settle_window(
+    started_at: &mut Option<tokio::time::Instant>,
+    unresolved: bool,
+    now: tokio::time::Instant,
+    timeout: Duration,
+) -> bool {
+    if !unresolved {
+        *started_at = None;
+        return false;
+    }
+    let started_at = *started_at.get_or_insert(now);
+    now.duration_since(started_at) >= timeout
 }
 
 fn nonempty_timestamp_field<'a>(row: &'a Value, field: &str) -> Option<&'a str> {
@@ -1223,9 +1261,42 @@ mod tests {
     use codex_app_server_protocol as codex;
 
     use super::{
-        content_delta_from_cursor, resumable_reasoning_item, suffix_prefix_overlap, ContentCursor,
-        ReasoningCursor,
+        content_delta_from_cursor, observe_subagent_link_settle_window, resumable_reasoning_item,
+        suffix_prefix_overlap, ContentCursor, ReasoningCursor,
     };
+
+    #[test]
+    fn terminal_subagent_link_gets_a_bounded_replication_window() {
+        let start = tokio::time::Instant::now();
+        let timeout = std::time::Duration::from_secs(5);
+        let mut started_at = None;
+
+        assert!(!observe_subagent_link_settle_window(
+            &mut started_at,
+            true,
+            start,
+            timeout
+        ));
+        assert!(!observe_subagent_link_settle_window(
+            &mut started_at,
+            true,
+            start + std::time::Duration::from_secs(4),
+            timeout
+        ));
+        assert!(observe_subagent_link_settle_window(
+            &mut started_at,
+            true,
+            start + timeout,
+            timeout
+        ));
+        assert!(!observe_subagent_link_settle_window(
+            &mut started_at,
+            false,
+            start + timeout,
+            timeout
+        ));
+        assert!(started_at.is_none());
+    }
 
     #[test]
     fn content_cursor_emits_only_appended_suffix() {

--- a/crates/defra-agent-cli/src/commands/codex_shim/turn_projection.rs
+++ b/crates/defra-agent-cli/src/commands/codex_shim/turn_projection.rs
@@ -32,6 +32,10 @@ impl ReasoningCompletionTracker {
         self.item_ids.contains(item_id)
     }
 
+    fn is_empty(&self) -> bool {
+        self.item_ids.is_empty()
+    }
+
     fn record(&mut self, item_id: String) -> bool {
         self.item_ids.insert(item_id)
     }
@@ -90,9 +94,7 @@ impl<'a> TurnProjection<'a> {
         if self.response_started_at_ms.is_none() {
             self.response_started_at_ms = started_at_ms;
         }
-        if self.response_completed_at_ms.is_none() {
-            self.response_completed_at_ms = completed_at_ms;
-        }
+        observe_latest_response_completion(&mut self.response_completed_at_ms, completed_at_ms);
     }
 
     pub(super) fn reset_response_timing(&mut self) {
@@ -163,6 +165,14 @@ impl<'a> TurnProjection<'a> {
             return Ok(());
         }
         let durable_text = durable_text.filter(|text| !text.trim().is_empty());
+        if durable_text.is_some()
+            && !terminal_reasoning_backfill_allowed(
+                self.active_reasoning_item_id.is_some(),
+                !self.completed_reasoning_items.is_empty(),
+            )
+        {
+            return Ok(());
+        }
         if self.active_reasoning_item_id.is_none() {
             if let Some(text) = durable_text {
                 self.append_reasoning_delta(outbound, item_id, text).await?;
@@ -728,11 +738,24 @@ fn suppress_blank_agent_delta(active_agent_text: &str, delta: &str) -> bool {
     delta.trim().is_empty() && active_agent_text.trim().is_empty()
 }
 
+fn terminal_reasoning_backfill_allowed(item_open: bool, item_completed: bool) -> bool {
+    item_open || !item_completed
+}
+
+fn observe_latest_response_completion(current: &mut Option<i64>, observed: Option<i64>) {
+    if observed.is_some() {
+        *current = observed;
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use codex_app_server_protocol as codex;
 
-    use super::{reasoning_item, suppress_blank_agent_delta, ReasoningCompletionTracker};
+    use super::{
+        observe_latest_response_completion, reasoning_item, suppress_blank_agent_delta,
+        terminal_reasoning_backfill_allowed, ReasoningCompletionTracker,
+    };
 
     #[test]
     fn suppresses_blank_delta_that_would_open_phantom_agent_stream() {
@@ -757,6 +780,22 @@ mod tests {
         assert!(completed.record("reasoning-1".to_string()));
         assert!(completed.contains("reasoning-1"));
         assert!(!completed.record("reasoning-1".to_string()));
+    }
+
+    #[test]
+    fn reset_before_terminal_suppresses_durable_backfill() {
+        assert!(terminal_reasoning_backfill_allowed(false, false));
+        assert!(terminal_reasoning_backfill_allowed(true, true));
+        assert!(!terminal_reasoning_backfill_allowed(false, true));
+    }
+
+    #[test]
+    fn final_response_completion_overwrites_prior_materialization_time() {
+        let mut completed_at_ms = None;
+        observe_latest_response_completion(&mut completed_at_ms, Some(100));
+        observe_latest_response_completion(&mut completed_at_ms, None);
+        observe_latest_response_completion(&mut completed_at_ms, Some(250));
+        assert_eq!(completed_at_ms, Some(250));
     }
 
     #[test]

--- a/crates/defra-agent-cli/tests/cli_codex_shim.rs
+++ b/crates/defra-agent-cli/tests/cli_codex_shim.rs
@@ -2594,8 +2594,8 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
     .context("timed out waiting for appended child reasoning delta")??;
     assert_eq!(appended_reasoning, reasoning_tail);
 
-    let durable_reasoning = format!("{live_child_reasoning}{reasoning_tail}; durable message wins");
-    let child_completed_at_ms = complete_child_materialized_response(
+    let durable_reasoning = format!("{live_child_reasoning}{reasoning_tail}");
+    let child_materialized_at_ms = materialize_child_response_before_terminal(
         &graphql,
         &agent_did,
         &child_request_id,
@@ -2603,15 +2603,20 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         &durable_reasoning,
     )
     .await?;
-    let (
-        completed_reasoning,
-        durable_delta,
-        completed,
-        child_thread_status,
-        projected_completed_at_ms,
-    ) = tokio::time::timeout(
+    let (completed_reasoning, projected_materialized_at_ms) = tokio::time::timeout(
         Duration::from_secs(15),
-        read_reasoning_completion_and_collab_status(
+        read_child_reasoning_completion(&mut ws, &child_thread_id, &child_request_id),
+    )
+    .await
+    .context("timed out waiting for reasoning completion at the final reset-tail window")??;
+    assert_eq!(completed_reasoning, durable_reasoning);
+    assert_eq!(projected_materialized_at_ms, child_materialized_at_ms);
+
+    let child_completed_at_ms =
+        finalize_child_response_after_materialization(&graphql, &child_request_id).await?;
+    let (completed, child_thread_status, projected_completed_at_ms) = tokio::time::timeout(
+        Duration::from_secs(15),
+        read_terminal_child_without_reasoning_replay(
             &mut ws,
             &child_thread_id,
             &child_request_id,
@@ -2619,9 +2624,7 @@ async fn codex_shim_projects_authorized_subagent_and_enforces_read_only_child_th
         ),
     )
     .await
-    .context("timed out waiting for durable reasoning and refreshed subagent state")??;
-    assert_eq!(completed_reasoning, durable_reasoning);
-    assert_eq!(durable_delta, "; durable message wins");
+    .context("timed out waiting for terminal child state after final reset-tail window")??;
     assert_eq!(completed, codex::CollabAgentStatus::Completed);
     assert_eq!(child_thread_status, codex::ThreadStatus::Idle);
     assert_eq!(projected_completed_at_ms, child_completed_at_ms);
@@ -4794,7 +4797,7 @@ async fn update_streaming_response_reasoning(
     Ok(())
 }
 
-async fn complete_child_materialized_response(
+async fn materialize_child_response_before_terminal(
     graphql: &str,
     agent_did: &str,
     request_id: &str,
@@ -4802,7 +4805,7 @@ async fn complete_child_materialized_response(
     reasoning: &str,
 ) -> Result<i64> {
     let now = chrono::Utc::now().to_rfc3339();
-    let completed_at_ms = chrono::DateTime::parse_from_rfc3339(&now)?.timestamp_millis();
+    let materialized_at_ms = chrono::DateTime::parse_from_rfc3339(&now)?.timestamp_millis();
     let message_key = format!("{session_id}:2");
     let content = r#"{"role":"assistant","id":null,"content":[{"text":"durable child answer"}]}"#;
     let mutation = format!(
@@ -4823,9 +4826,36 @@ async fn complete_child_materialized_response(
                 input: {{
                     content: "",
                     reasoning: "",
-                    status: "complete",
+                    progress_seq: 2,
                     materialized_message_sequence: 2,
-                    materialized_at: "{now}",
+                    materialized_at: "{now}"
+                }}
+            ) {{ _docID }}
+        }}"#,
+        message_key = escape_graphql_string(&message_key),
+        session_id = escape_graphql_string(session_id),
+        agent_did = escape_graphql_string(agent_did),
+        request_id = escape_graphql_string(request_id),
+        content = escape_graphql_string(content),
+        reasoning = escape_graphql_string(reasoning),
+        now = escape_graphql_string(&now),
+    );
+    graphql_query(graphql, &mutation).await?;
+    Ok(materialized_at_ms)
+}
+
+async fn finalize_child_response_after_materialization(
+    graphql: &str,
+    request_id: &str,
+) -> Result<i64> {
+    let now = chrono::Utc::now().to_rfc3339();
+    let completed_at_ms = chrono::DateTime::parse_from_rfc3339(&now)?.timestamp_millis();
+    let mutation = format!(
+        r#"mutation {{
+            update_AgentResponse(
+                filter: {{ response_key: {{ _eq: "{request_id}" }} }},
+                input: {{
+                    status: "complete",
                     completed_at: "{now}"
                 }}
             ) {{ _docID }}
@@ -4838,12 +4868,7 @@ async fn complete_child_materialized_response(
                 }}
             ) {{ _docID }}
         }}"#,
-        message_key = escape_graphql_string(&message_key),
-        session_id = escape_graphql_string(session_id),
-        agent_did = escape_graphql_string(agent_did),
         request_id = escape_graphql_string(request_id),
-        content = escape_graphql_string(content),
-        reasoning = escape_graphql_string(reasoning),
         now = escape_graphql_string(&now),
     );
     graphql_query(graphql, &mutation).await?;
@@ -5542,23 +5567,49 @@ async fn read_child_reasoning_delta(
     }
 }
 
-async fn read_reasoning_completion_and_collab_status(
+async fn read_child_reasoning_completion(
+    ws: &mut ShimWebSocket,
+    child_thread_id: &str,
+    child_turn_id: &str,
+) -> Result<(String, i64)> {
+    loop {
+        match read_jsonrpc(ws).await? {
+            codex::JSONRPCMessage::Notification(notification) => {
+                if let codex::ServerNotification::ItemCompleted(completed) =
+                    server_notification_from_jsonrpc(notification)?
+                {
+                    if completed.thread_id == child_thread_id && completed.turn_id == child_turn_id
+                    {
+                        if let codex::ThreadItem::Reasoning {
+                            content, summary, ..
+                        } = completed.item
+                        {
+                            assert!(summary.is_empty());
+                            return Ok((content.concat(), completed.completed_at_ms));
+                        }
+                    }
+                }
+            }
+            codex::JSONRPCMessage::Error(error) => {
+                bail!("Codex shim emitted JSON-RPC error: {}", error.error.message);
+            }
+            codex::JSONRPCMessage::Request(request) => {
+                bail!("Codex shim sent unexpected server request: {request:?}");
+            }
+            codex::JSONRPCMessage::Response(_) => {}
+        }
+    }
+}
+
+async fn read_terminal_child_without_reasoning_replay(
     ws: &mut ShimWebSocket,
     child_thread_id: &str,
     child_turn_id: &str,
     expected_tool_call_key: &str,
-) -> Result<(
-    String,
-    String,
-    codex::CollabAgentStatus,
-    codex::ThreadStatus,
-    i64,
-)> {
-    let mut completed_reasoning = None;
-    let mut durable_delta = None;
+) -> Result<(codex::CollabAgentStatus, codex::ThreadStatus, i64)> {
     let mut child_status = None;
     let mut thread_status = None;
-    let mut completed_at_ms = None;
+    let mut agent_completed_at_ms = None;
     loop {
         match read_jsonrpc(ws).await? {
             codex::JSONRPCMessage::Notification(notification) => {
@@ -5566,17 +5617,34 @@ async fn read_reasoning_completion_and_collab_status(
                     codex::ServerNotification::ReasoningTextDelta(delta)
                         if delta.thread_id == child_thread_id && delta.turn_id == child_turn_id =>
                     {
-                        durable_delta = Some(delta.delta);
+                        bail!(
+                            "terminal durable reasoning replayed after reset-tail completion: {}",
+                            delta.delta
+                        );
+                    }
+                    codex::ServerNotification::ItemStarted(started)
+                        if started.thread_id == child_thread_id
+                            && started.turn_id == child_turn_id
+                            && matches!(started.item, codex::ThreadItem::Reasoning { .. }) =>
+                    {
+                        bail!(
+                            "terminal durable reasoning opened a duplicate item after reset-tail"
+                        );
                     }
                     codex::ServerNotification::ItemCompleted(completed) => match completed.item {
-                        codex::ThreadItem::Reasoning {
-                            content, summary, ..
-                        } if completed.thread_id == child_thread_id
-                            && completed.turn_id == child_turn_id =>
+                        codex::ThreadItem::Reasoning { .. }
+                            if completed.thread_id == child_thread_id
+                                && completed.turn_id == child_turn_id =>
                         {
-                            assert!(summary.is_empty());
-                            completed_reasoning = Some(content.concat());
-                            completed_at_ms = Some(completed.completed_at_ms);
+                            bail!(
+                                "terminal durable reasoning completed a duplicate item after reset-tail"
+                            );
+                        }
+                        codex::ThreadItem::AgentMessage { .. }
+                            if completed.thread_id == child_thread_id
+                                && completed.turn_id == child_turn_id =>
+                        {
+                            agent_completed_at_ms = Some(completed.completed_at_ms);
                         }
                         codex::ThreadItem::CollabAgentToolCall {
                             id, agents_states, ..
@@ -5604,20 +5672,13 @@ async fn read_reasoning_completion_and_collab_status(
             codex::JSONRPCMessage::Response(_) => {}
         }
 
-        if completed_reasoning.is_some()
-            && durable_delta.is_some()
-            && child_status.is_some()
-            && thread_status.is_some()
-            && completed_at_ms.is_some()
-        {
+        if child_status.is_some() && thread_status.is_some() && agent_completed_at_ms.is_some() {
             return Ok((
-                completed_reasoning.take().expect("checked reasoning"),
-                durable_delta.take().expect("checked durable delta"),
                 child_status.take().expect("checked child status"),
                 thread_status.take().expect("checked thread status"),
-                completed_at_ms
+                agent_completed_at_ms
                     .take()
-                    .expect("checked completion timestamp"),
+                    .expect("checked agent completion timestamp"),
             ));
         }
     }

--- a/crates/defra-agent-cli/tests/cli_fleet_delegation_live.rs
+++ b/crates/defra-agent-cli/tests/cli_fleet_delegation_live.rs
@@ -240,10 +240,19 @@ async fn five_process_filtered_conversation_delegation_live() -> Result<()> {
     // still producing real model output on a remote deployment. This is the
     // end-to-end fence between DEFRA's durable state machine and the native
     // Codex collaboration/thread protocol.
-    let (parent_capture, live_child) = tokio::try_join!(
+    let observation = tokio::try_join!(
         fleet_capture_parent_turn(&mut parent_ws),
         fleet_observe_live_child(shim_port, &parent_session_id),
-    )?;
+    );
+    let (parent_capture, live_child) = match observation {
+        Ok(observation) => observation,
+        Err(error) => {
+            dump_fleet_doc_state(&fleet).await;
+            persist_fleet_logs(&fleet, "delegation-fail");
+            dump_fleet_logs(&fleet);
+            return Err(error);
+        }
+    };
     assert_eq!(parent_capture.turn.status, codex::TurnStatus::Completed);
 
     let completed_children = wait_for_all_subagent_children_completed(
@@ -640,11 +649,15 @@ fn assert_fleet_parent_collab_projection(
             *status == codex::CollabAgentToolCallStatus::Completed,
             "spawn projection was not terminal-completed: {item:?}"
         );
+        // Cross-deployment conversation replication deliberately does not
+        // replicate AgentBehavior. Preserve an absent child model rather than
+        // inventing root metadata; when runtime metadata is locally available,
+        // it must still be meaningful.
         anyhow::ensure!(
             model
                 .as_deref()
-                .is_some_and(|value| !value.trim().is_empty()),
-            "spawn projection omitted the child model: {item:?}"
+                .is_none_or(|value| !value.trim().is_empty()),
+            "spawn projection exposed a blank child model: {item:?}"
         );
         for thread_id in receiver_thread_ids {
             anyhow::ensure!(

--- a/crates/defra-agent/proofs/Proofs/CodexShim/Projection.lean
+++ b/crates/defra-agent/proofs/Proofs/CodexShim/Projection.lean
@@ -92,10 +92,44 @@ theorem known_subagent_control_projects_collab
 theorem non_control_tool_stays_mcp :
     projectSubagentControl .other = none := rfl
 
+/-- Lifecycle of the Codex collaboration operation itself. This is distinct
+from the child agent state carried in `agentsStates`. -/
+inductive CollabToolCallPhase where
+  | inProgress
+  | completed
+  | failed
+  deriving DecidableEq, Repr
+
+/-- A linked spawn operation is complete once the child exists, even while the
+runtime bridge remains open to follow that child's background lifecycle. Tool
+failure remains authoritative; non-spawn controls retain their runtime phase. -/
+def projectCollabToolCallPhase
+    (tool : SubagentControlTool)
+    (hasReciprocalLink : Bool)
+    (runtimePhase : CollabToolCallPhase) : CollabToolCallPhase :=
+  match runtimePhase with
+  | .failed => .failed
+  | phase =>
+      if tool == .spawn && hasReciprocalLink then .completed else phase
+
+theorem linked_spawn_operation_completes_while_child_runs :
+    projectCollabToolCallPhase .spawn true .inProgress = .completed := rfl
+
+theorem failed_spawn_operation_stays_failed (hasReciprocalLink : Bool) :
+    projectCollabToolCallPhase .spawn hasReciprocalLink .failed = .failed := rfl
+
+theorem non_spawn_control_retains_runtime_phase
+    (tool : SubagentControlTool)
+    (phase : CollabToolCallPhase)
+    (h : tool ≠ .spawn) :
+    projectCollabToolCallPhase tool true phase = phase := by
+  cases phase <;> simp [projectCollabToolCallPhase, h]
+
 /-- Whether a subagent control row is ready to be shown to Codex. A reciprocal
 link authorizes the native collaboration item. While that link may still
-replicate, the item stays deferred; once the enclosing projection is settled,
-the durable MCP row is the visibility-preserving fallback. -/
+replicate, the item stays deferred, including for a bounded settle window after
+the enclosing request becomes terminal. Once that window expires, the durable
+MCP row is the visibility-preserving fallback. -/
 inductive SubagentItemProjection where
   | collab (tool : CollabTool)
   | mcp
@@ -104,33 +138,41 @@ inductive SubagentItemProjection where
 
 def projectSubagentItem
     (tool : SubagentControlTool)
-    (hasReciprocalLink projectionSettled : Bool) : SubagentItemProjection :=
+    (hasReciprocalLink projectionSettled linkSettleExpired : Bool) :
+    SubagentItemProjection :=
   match projectSubagentControl tool with
   | none => .mcp
   | some collab =>
       if hasReciprocalLink then .collab collab
-      else if projectionSettled then .mcp
+      else if projectionSettled && linkSettleExpired then .mcp
       else .deferred
 
 theorem linked_subagent_control_projects_native
     (tool : SubagentControlTool)
     (collab : CollabTool)
     (h : projectSubagentControl tool = some collab) :
-    projectSubagentItem tool true false = .collab collab := by
+    projectSubagentItem tool true false false = .collab collab := by
   simp [projectSubagentItem, h]
 
 theorem unresolved_subagent_control_defers_while_open
     (tool : SubagentControlTool)
     (collab : CollabTool)
     (h : projectSubagentControl tool = some collab) :
-    projectSubagentItem tool false false = .deferred := by
+    projectSubagentItem tool false false false = .deferred := by
   simp [projectSubagentItem, h]
 
-theorem settled_unresolved_subagent_control_stays_visible
+theorem settled_unresolved_subagent_control_defers_during_link_window
     (tool : SubagentControlTool)
     (collab : CollabTool)
     (h : projectSubagentControl tool = some collab) :
-    projectSubagentItem tool false true = .mcp := by
+    projectSubagentItem tool false true false = .deferred := by
+  simp [projectSubagentItem, h]
+
+theorem expired_unresolved_subagent_control_stays_visible
+    (tool : SubagentControlTool)
+    (collab : CollabTool)
+    (h : projectSubagentControl tool = some collab) :
+    projectSubagentItem tool false true true = .mcp := by
   simp [projectSubagentItem, h]
 
 /-- Codex's per-agent status vocabulary.  `shutdown` and `notFound` are local
@@ -339,6 +381,7 @@ inductive ReasoningProjectionEvent where
 /-- Facts available at one reasoning projection observation. -/
 structure ReasoningProjectionObservation where
   itemOpen : Bool
+  itemCompleted : Bool
   cursorPrimed : Bool
   streamedText : Option String
   liveDelta : Option String
@@ -362,7 +405,7 @@ def reasoningTextForObservation
   match nonemptyReasoningText obs.liveDelta with
   | some text => some text
   | none =>
-      if obs.terminal && !obs.itemOpen && !obs.cursorPrimed then
+      if obs.terminal && !obs.itemOpen && !obs.itemCompleted && !obs.cursorPrimed then
         nonemptyReasoningText obs.durableText
       else
         none
@@ -378,18 +421,22 @@ def reasoningProjectionEvents
     | none => []
   let openAfter := obs.itemOpen || text.isSome
   let completionEvents :=
-    if obs.terminal && openAfter then [.completed] else []
+    if obs.terminal && openAfter && !obs.itemCompleted then [.completed] else []
   startEvents ++ deltaEvents ++ completionEvents
 
 /-- Completed-item content comes from the durable materialized message, never
 from the bounded live preview, when that durable value exists. -/
 def completedReasoningText
     (obs : ReasoningProjectionObservation) : Option String :=
-  if obs.terminal then preferReasoningText obs.durableText obs.streamedText else none
+  if obs.terminal && !obs.itemCompleted then
+    preferReasoningText obs.durableText obs.streamedText
+  else
+    none
 
 theorem first_live_reasoning_projects_raw_lifecycle :
     reasoningProjectionEvents
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := some "inspect"
@@ -400,6 +447,7 @@ theorem first_live_reasoning_projects_raw_lifecycle :
 theorem appended_live_reasoning_projects_only_delta :
     reasoningProjectionEvents
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect"
       , liveDelta := some " then test"
@@ -410,6 +458,7 @@ theorem appended_live_reasoning_projects_only_delta :
 theorem primed_resume_without_new_reasoning_replays_nothing :
     reasoningProjectionEvents
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := true
       , streamedText := some "already visible"
       , liveDelta := none
@@ -419,6 +468,7 @@ theorem primed_resume_without_new_reasoning_replays_nothing :
 theorem terminal_open_reasoning_completes_without_replay :
     reasoningProjectionEvents
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect then test"
       , liveDelta := none
@@ -428,6 +478,7 @@ theorem terminal_open_reasoning_completes_without_replay :
 theorem terminal_durable_first_observation_projects_lifecycle :
     reasoningProjectionEvents
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := none
@@ -438,6 +489,7 @@ theorem terminal_durable_first_observation_projects_lifecycle :
 theorem absent_reasoning_projects_nothing :
     reasoningProjectionEvents
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := none
@@ -447,6 +499,7 @@ theorem absent_reasoning_projects_nothing :
 theorem terminal_completed_item_uses_durable_reasoning :
     completedReasoningText
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "bounded preview"
       , liveDelta := none
@@ -456,6 +509,7 @@ theorem terminal_completed_item_uses_durable_reasoning :
 theorem terminal_without_durable_reasoning_keeps_streamed_text :
     completedReasoningText
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "streamed reasoning"
       , liveDelta := none
@@ -465,12 +519,33 @@ theorem terminal_without_durable_reasoning_keeps_streamed_text :
 theorem terminal_durable_suffix_projects_before_completion :
     reasoningProjectionEvents
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect then test"
       , liveDelta := some "; durable suffix"
       , durableText := some "inspect then test; durable suffix"
       , terminal := true } =
       [.rawTextDelta "; durable suffix", .completed] := rfl
+
+theorem reset_before_terminal_suppresses_durable_replay :
+    reasoningProjectionEvents
+      { itemOpen := false
+      , itemCompleted := true
+      , cursorPrimed := false
+      , streamedText := none
+      , liveDelta := none
+      , durableText := some "already completed reasoning"
+      , terminal := true } = [] := rfl
+
+theorem reset_before_terminal_has_no_second_completed_text :
+    completedReasoningText
+      { itemOpen := false
+      , itemCompleted := true
+      , cursorPrimed := false
+      , streamedText := none
+      , liveDelta := none
+      , durableText := some "already completed reasoning"
+      , terminal := true } = none := rfl
 
 theorem nonterminal_without_live_reasoning_projects_nothing
     (obs : ReasoningProjectionObservation)

--- a/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/CodexShim.lean
+++ b/crates/defra-agent/proofs/Proofs/Conformance/Contracts/Json/CodexShim.lean
@@ -233,6 +233,9 @@ structure CodexShimSubagentToolCase where
   collabTool : Option String
   reciprocalLink : Bool
   projectionSettled : Bool
+  linkSettleExpired : Bool
+  runtimeToolStatus : Option String := none
+  projectedCollabStatus : Option String := none
 
 def codexShimSubagentToolCaseJson
     (witness : CodexShimSubagentToolCase) : String :=
@@ -243,17 +246,34 @@ def codexShimSubagentToolCaseJson
     ++ "\"projected_item_kind\":" ++ jsonString witness.projectedItemKind ++ ","
     ++ "\"collab_tool\":" ++ jsonOptionalString witness.collabTool ++ ","
     ++ "\"reciprocal_link\":" ++ boolString witness.reciprocalLink ++ ","
-    ++ "\"projection_settled\":" ++ boolString witness.projectionSettled
+    ++ "\"projection_settled\":" ++ boolString witness.projectionSettled ++ ","
+    ++ "\"link_settle_expired\":" ++ boolString witness.linkSettleExpired ++ ","
+    ++ "\"runtime_tool_status\":" ++ jsonOptionalString witness.runtimeToolStatus ++ ","
+    ++ "\"projected_collab_status\":"
+      ++ jsonOptionalString witness.projectedCollabStatus
     ++ "}"
+
+def collabToolCallPhaseString : CodexShim.CollabToolCallPhase → String
+  | .inProgress => "inProgress"
+  | .completed => "completed"
+  | .failed => "failed"
 
 def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
   [ { witness := "codex_shim.subagent_tool.spawn"
-    , leanTheorems := [ "CodexShim.known_subagent_control_projects_collab" ]
+    , leanTheorems :=
+        [ "CodexShim.known_subagent_control_projects_collab"
+        , "CodexShim.linked_spawn_operation_completes_while_child_runs"
+        ]
     , toolName := "spawn_subagent"
     , projectedItemKind := "collabAgentToolCall"
     , collabTool := some "spawnAgent"
     , reciprocalLink := true
     , projectionSettled := false
+    , linkSettleExpired := false
+    , runtimeToolStatus := some "inProgress"
+    , projectedCollabStatus := some (collabToolCallPhaseString
+        (CodexShim.projectCollabToolCallPhase
+          .spawn true .inProgress))
     }
   , { witness := "codex_shim.subagent_tool.wait"
     , leanTheorems := [ "CodexShim.known_subagent_control_projects_collab" ]
@@ -262,6 +282,7 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := some "wait"
     , reciprocalLink := true
     , projectionSettled := false
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.steer"
     , leanTheorems := [ "CodexShim.known_subagent_control_projects_collab" ]
@@ -270,6 +291,7 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := some "sendInput"
     , reciprocalLink := true
     , projectionSettled := false
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.cancel"
     , leanTheorems := [ "CodexShim.known_subagent_control_projects_collab" ]
@@ -278,6 +300,7 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := some "closeAgent"
     , reciprocalLink := true
     , projectionSettled := false
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.list"
     , leanTheorems := [ "CodexShim.non_control_tool_stays_mcp" ]
@@ -286,6 +309,7 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := none
     , reciprocalLink := false
     , projectionSettled := false
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.read"
     , leanTheorems := [ "CodexShim.non_control_tool_stays_mcp" ]
@@ -294,6 +318,7 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := none
     , reciprocalLink := false
     , projectionSettled := false
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.unresolved_open"
     , leanTheorems := [ "CodexShim.unresolved_subagent_control_defers_while_open" ]
@@ -302,15 +327,27 @@ def codexShimSubagentToolCases : List CodexShimSubagentToolCase :=
     , collabTool := none
     , reciprocalLink := false
     , projectionSettled := false
+    , linkSettleExpired := false
+    }
+  , { witness := "codex_shim.subagent_tool.unresolved_settling"
+    , leanTheorems :=
+        [ "CodexShim.settled_unresolved_subagent_control_defers_during_link_window" ]
+    , toolName := "spawn_subagent"
+    , projectedItemKind := "deferred"
+    , collabTool := none
+    , reciprocalLink := false
+    , projectionSettled := true
+    , linkSettleExpired := false
     }
   , { witness := "codex_shim.subagent_tool.unresolved_settled"
     , leanTheorems :=
-        [ "CodexShim.settled_unresolved_subagent_control_stays_visible" ]
+        [ "CodexShim.expired_unresolved_subagent_control_stays_visible" ]
     , toolName := "spawn_subagent"
     , projectedItemKind := "mcpToolCall"
     , collabTool := none
     , reciprocalLink := false
     , projectionSettled := true
+    , linkSettleExpired := true
     }
   ]
 
@@ -561,6 +598,7 @@ structure CodexShimReasoningProjectionCase where
   witness : String
   leanTheorems : List String
   itemOpen : Bool
+  itemCompleted : Bool
   cursorPrimed : Bool
   streamedText : Option String
   liveDelta : Option String
@@ -583,6 +621,7 @@ def codexShimReasoningProjectionCase
   { witness := witness
   , leanTheorems := leanTheorems
   , itemOpen := observation.itemOpen
+  , itemCompleted := observation.itemCompleted
   , cursorPrimed := observation.cursorPrimed
   , streamedText := observation.streamedText
   , liveDelta := observation.liveDelta
@@ -601,6 +640,7 @@ def codexShimReasoningProjectionCaseJson
     ++ "\"witness\":" ++ jsonString witness.witness ++ ","
     ++ "\"lean_theorems\":" ++ jsonStringArray witness.leanTheorems ++ ","
     ++ "\"item_open\":" ++ boolString witness.itemOpen ++ ","
+    ++ "\"item_completed\":" ++ boolString witness.itemCompleted ++ ","
     ++ "\"cursor_primed\":" ++ boolString witness.cursorPrimed ++ ","
     ++ "\"streamed_text\":" ++ jsonOptionalString witness.streamedText ++ ","
     ++ "\"live_delta\":" ++ jsonOptionalString witness.liveDelta ++ ","
@@ -616,6 +656,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       "codex_shim.reasoning.first_live"
       [ "CodexShim.first_live_reasoning_projects_raw_lifecycle" ]
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := some "inspect"
@@ -625,6 +666,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       "codex_shim.reasoning.append_live"
       [ "CodexShim.appended_live_reasoning_projects_only_delta" ]
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect"
       , liveDelta := some " then test"
@@ -634,6 +676,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       "codex_shim.reasoning.resumed_unchanged"
       [ "CodexShim.primed_resume_without_new_reasoning_replays_nothing" ]
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := true
       , streamedText := some "already visible"
       , liveDelta := none
@@ -645,6 +688,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       , "CodexShim.terminal_completed_item_uses_durable_reasoning"
       ]
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect then test"
       , liveDelta := none
@@ -656,6 +700,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       , "CodexShim.terminal_completed_item_uses_durable_reasoning"
       ]
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := none
@@ -665,6 +710,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       "codex_shim.reasoning.absent"
       [ "CodexShim.absent_reasoning_projects_nothing" ]
       { itemOpen := false
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := none
       , liveDelta := none
@@ -676,6 +722,7 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       , "CodexShim.terminal_completed_item_uses_durable_reasoning"
       ]
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "inspect then test"
       , liveDelta := some "; durable suffix"
@@ -685,10 +732,23 @@ def codexShimReasoningProjectionCases : List CodexShimReasoningProjectionCase :=
       "codex_shim.reasoning.terminal_streamed_fallback"
       [ "CodexShim.terminal_without_durable_reasoning_keeps_streamed_text" ]
       { itemOpen := true
+      , itemCompleted := false
       , cursorPrimed := false
       , streamedText := some "streamed reasoning"
       , liveDelta := none
       , durableText := none
+      , terminal := true }
+  , codexShimReasoningProjectionCase
+      "codex_shim.reasoning.reset_before_terminal"
+      [ "CodexShim.reset_before_terminal_suppresses_durable_replay"
+      , "CodexShim.reset_before_terminal_has_no_second_completed_text"
+      ]
+      { itemOpen := false
+      , itemCompleted := true
+      , cursorPrimed := false
+      , streamedText := none
+      , liveDelta := none
+      , durableText := some "already completed reasoning"
       , terminal := true }
   ]
 

--- a/crates/defra-agent/src/lean_vocab_test/codex_shim.rs
+++ b/crates/defra-agent/src/lean_vocab_test/codex_shim.rs
@@ -22,6 +22,9 @@ pub(crate) struct LeanCodexShimSubagentToolCase {
     pub(crate) collab_tool: Option<String>,
     pub(crate) reciprocal_link: bool,
     pub(crate) projection_settled: bool,
+    pub(crate) link_settle_expired: bool,
+    pub(crate) runtime_tool_status: Option<String>,
+    pub(crate) projected_collab_status: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -76,6 +79,7 @@ pub(crate) struct LeanCodexShimReasoningProjectionCase {
     pub(crate) witness: String,
     pub(crate) lean_theorems: Vec<String>,
     pub(crate) item_open: bool,
+    pub(crate) item_completed: bool,
     pub(crate) cursor_primed: bool,
     pub(crate) streamed_text: Option<String>,
     pub(crate) live_delta: Option<String>,

--- a/crates/defra-agent/tests/conformance/codex_shim.rs
+++ b/crates/defra-agent/tests/conformance/codex_shim.rs
@@ -169,7 +169,7 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
         .contains(&"CodexShim.interrupt_step_is_terminal".to_string()));
 
     let tool_cases = lean_codex_shim_subagent_tool_cases();
-    assert_eq!(tool_cases.len(), 8);
+    assert_eq!(tool_cases.len(), 9);
     for case in tool_cases {
         let expected = match case.witness.as_str() {
             "codex_shim.subagent_tool.spawn" => ("collabAgentToolCall", Some("spawnAgent")),
@@ -180,6 +180,7 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
                 ("mcpToolCall", None)
             }
             "codex_shim.subagent_tool.unresolved_open" => ("deferred", None),
+            "codex_shim.subagent_tool.unresolved_settling" => ("deferred", None),
             "codex_shim.subagent_tool.unresolved_settled" => ("mcpToolCall", None),
             other => panic!("unmodeled subagent tool witness {other:?}"),
         };
@@ -188,8 +189,20 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
         if case.projected_item_kind == "collabAgentToolCall" {
             assert!(case.reciprocal_link, "{}", case.witness);
         }
+        if case.witness == "codex_shim.subagent_tool.spawn" {
+            assert_eq!(case.runtime_tool_status.as_deref(), Some("inProgress"));
+            assert_eq!(case.projected_collab_status.as_deref(), Some("completed"));
+            assert!(case.lean_theorems.contains(
+                &"CodexShim.linked_spawn_operation_completes_while_child_runs".to_string()
+            ));
+        }
+        if case.witness == "codex_shim.subagent_tool.unresolved_settling" {
+            assert!(case.projection_settled, "{}", case.witness);
+            assert!(!case.link_settle_expired, "{}", case.witness);
+        }
         if case.witness == "codex_shim.subagent_tool.unresolved_settled" {
             assert!(case.projection_settled, "{}", case.witness);
+            assert!(case.link_settle_expired, "{}", case.witness);
         }
     }
 
@@ -264,7 +277,7 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
     assert_eq!(shape.replay_stages, ["user", "compaction", "modelItems"]);
 
     let reasoning_cases = lean_codex_shim_reasoning_projection_cases();
-    assert_eq!(reasoning_cases.len(), 8);
+    assert_eq!(reasoning_cases.len(), 9);
     for case in reasoning_cases {
         assert_eq!(
             case.projected_delta,
@@ -273,7 +286,10 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
                 .filter(|text| !text.is_empty())
                 .cloned()
                 .or_else(|| {
-                    (case.terminal && !case.item_open && !case.cursor_primed)
+                    (case.terminal
+                        && !case.item_open
+                        && !case.item_completed
+                        && !case.cursor_primed)
                         .then(|| case.durable_text.clone())
                         .flatten()
                         .filter(|text| !text.is_empty())
@@ -283,7 +299,7 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
         );
         assert_eq!(
             case.completed_text,
-            case.terminal
+            (case.terminal && !case.item_completed)
                 .then(|| {
                     case.durable_text
                         .clone()
@@ -334,6 +350,13 @@ pub(super) fn generated_codex_shim_projection_cases_pin_adapter_mapping() {
         durable_suffix.projected_delta.as_deref(),
         Some("; durable suffix")
     );
+    let reset_before_terminal = reasoning_cases
+        .iter()
+        .find(|case| case.witness == "codex_shim.reasoning.reset_before_terminal")
+        .expect("reset-before-terminal reasoning witness");
+    assert!(reset_before_terminal.projected_events.is_empty());
+    assert_eq!(reset_before_terminal.projected_delta, None);
+    assert_eq!(reset_before_terminal.completed_text, None);
 
     let thread_status_cases = lean_codex_shim_thread_status_cases();
     assert_eq!(thread_status_cases.len(), 11);


### PR DESCRIPTION
## What changed

- make terminal reasoning completion idempotent across the runtime's final `reset_tail` window, and use the final response timestamp for completion timing
- give unresolved terminal subagent edges a bounded replication-settle window before the visible MCP fallback
- decode nullable replicated history fields defensively and project a linked background spawn as a completed Codex operation while preserving the child's live lifecycle in `agentsStates`
- strengthen the comprehensive shim and real-inference fleet tests, including failure diagnostics for cross-node delegation

## Why

This is the focused follow-up to #744. A poll between the runtime's final reasoning-tail reset and lifecycle transition could complete one reasoning item and then replay the durable reasoning into a second item. The same terminal path also retained an earlier materialization timestamp in multi-model-turn requests. Real cross-node inference exposed two adjacent projection races: replicated nullable history fields and a spawn bridge whose runtime lifecycle intentionally remains running after the Codex spawn operation is complete.

The projection rules continue to treat `defra-agent` runtime documents as authoritative; the shim only translates that state into Codex protocol semantics.

## Verification

- `lake build Proofs.CodexShim.Projection Proofs.Conformance.Contracts`
- `cargo test -p defra-agent --test conformance codex_shim`
- `cargo test -p defra-agent-cli --test cli_codex_shim codex_shim_projects_authorized_subagent_and_enforces_read_only_child_thread -- --nocapture`
- `DEFRA_AGENT_LIVE_OPENAI=1 DEFRA_AGENT_LIVE_OPENAI_MODEL=d4f cargo test -p defra-agent-cli --test cli_fleet_delegation_live five_process_filtered_conversation_delegation_live -- --ignored --nocapture`
- `cargo test -p defra-agent`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

The full package suite encountered one unrelated DefraDB transaction-conflict flake on its first run; the exact test and the complete suite both passed on retry. It is tracked in #750.
