### PR TITLE
Pin DefraDB at #1135 and harden runtime compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-lock",
@@ -6585,7 +6585,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-trait",
@@ -6600,7 +6600,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "anyhow",
  "document",
@@ -6913,7 +6913,7 @@ version = "0.6.12"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "cid",
@@ -6937,7 +6937,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-stream",
@@ -6981,7 +6981,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "anyhow",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-trait",
@@ -7049,7 +7049,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "serde",
 ]
@@ -7467,7 +7467,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7925,7 +7925,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -10818,7 +10818,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -11044,7 +11044,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -11602,7 +11602,7 @@ dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
  "chrono",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.1.5",
  "data-encoding",
  "derive_more 2.1.1",
  "genawaiter",
@@ -12277,7 +12277,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-lock",
@@ -12425,7 +12425,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -14483,7 +14483,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15155,7 +15155,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "anyhow",
@@ -16445,7 +16445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16458,7 +16458,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16579,7 +16579,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16615,7 +16615,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16632,7 +16632,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "async-lock",
@@ -16664,7 +16664,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17617,7 +17617,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "p2p",
  "query",
@@ -18416,7 +18416,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "cid",
  "defra-core",
@@ -19618,7 +19618,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20045,7 +20045,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24484,7 +24484,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=89a4b46f05f6436afddaa5c200b68a37792cb773#89a4b46f05f6436afddaa5c200b68a37792cb773"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=e74733a6e54ebcca39a577420ac7af15090a5fb8#e74733a6e54ebcca39a577420ac7af15090a5fb8"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,27 +57,23 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs rev = main at #1126: adds unique-index merge/tombstone semantics
-# (#1126, deterministic smallest-docID-wins on merge conflict — no more
-# fail-and-wedge) and two-stream ACK response-token routing (#1127) on top of
-# the #1125 genesis-storm convergence kernel
-# (#1117), gossip direction filter (#1118), receiver-pull ledger + peer-park
-# (#1119, incl. #1112/#1113), push-log ack honesty (#1121), and root-level
-# `__typename` introspection routing (#1124/#1125). Move to the next upstream
-# tag when one is cut.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
+# defradb.rs rev = #1135: adds twin-unique merge-semantics coverage and
+# terminal pending-DAG merge-failure quarantine (#1133), on top of unique-index
+# tombstone healing (#1126) and the preceding fleet convergence fixes.
+# Move to the next upstream tag when one is cut.
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -85,8 +81,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "89a4b46f05f6436afddaa5c200b68a37792cb773" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "e74733a6e54ebcca39a577420ac7af15090a5fb8" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent-cli/src/http/prometheus.rs
+++ b/crates/defra-agent-cli/src/http/prometheus.rs
@@ -633,6 +633,11 @@ fn render_p2p_sync_metrics(
             status.persisted_pending_dag_capacity,
         ),
         (
+            "defra_agent_p2p_quarantined_pending_dags",
+            "Pending DAG roots quarantined after a terminal merge rejection.",
+            status.quarantined_pending_dags,
+        ),
+        (
             "defra_agent_p2p_retained_background_tasks",
             "DefraDB P2P background task handles retained for shutdown.",
             status.retained_background_tasks,
@@ -744,6 +749,11 @@ fn render_p2p_sync_metrics(
             "defra_agent_p2p_already_merged_fast_path_total",
             "Receives skipped because the announced CID was already merged.",
             status.already_merged_fast_path,
+        ),
+        (
+            "defra_agent_p2p_pending_dag_terminal_quarantined_total",
+            "Pending DAG roots quarantined after a deterministic terminal merge rejection.",
+            status.pending_dag_terminal_quarantined,
         ),
     ] {
         push_metric_prelude_with_type(lines, name, help, "counter");
@@ -1472,6 +1482,8 @@ mod tests {
                     pending_dag_retry_dispatched: 61,
                     pending_dag_retry_suppressed: 67,
                     next_pending_retry_in_ms: Some(71),
+                    pending_dag_terminal_quarantined: 73,
+                    quarantined_pending_dags: 79,
                 }),
                 stale: false,
             }),
@@ -1493,6 +1505,7 @@ mod tests {
         assert!(rendered.contains("defra_agent_p2p_push_encode_cache_entries 5"));
         assert!(rendered.contains("defra_agent_p2p_pending_dags 13"));
         assert!(rendered.contains("defra_agent_p2p_persisted_pending_dags 17"));
+        assert!(rendered.contains("defra_agent_p2p_quarantined_pending_dags 79"));
         assert!(rendered.contains("defra_agent_p2p_push_rejected_items_total 5"));
         assert!(rendered.contains("defra_agent_p2p_push_stale_head_retirements_total 17"));
         assert!(rendered.contains("defra_agent_p2p_push_peer_capacity_parks_total 13"));
@@ -1504,6 +1517,7 @@ mod tests {
         assert!(rendered.contains("defra_agent_p2p_pending_dag_capacity_shed_total 59"));
         assert!(rendered.contains("defra_agent_p2p_single_flight_suppressed_total 37"));
         assert!(rendered.contains("defra_agent_p2p_already_merged_fast_path_total 53"));
+        assert!(rendered.contains("defra_agent_p2p_pending_dag_terminal_quarantined_total 73"));
         assert!(rendered.contains(r#"defra_agent_p2p_push_cid_retry_count{cid="bafy-retry"} 19"#));
         assert!(
             rendered.contains(r#"defra_agent_p2p_peer_consecutive_failures{peer_id="peer-a"} 3"#)

--- a/crates/defra-agent-cli/src/http/router.rs
+++ b/crates/defra-agent-cli/src/http/router.rs
@@ -614,7 +614,9 @@ mod tests {
                     "pending_dag_capacity_shed": 59,
                     "pending_dag_retry_dispatched": 61,
                     "pending_dag_retry_suppressed": 67,
-                    "next_pending_retry_in_ms": 71
+                    "next_pending_retry_in_ms": 71,
+                    "pending_dag_terminal_quarantined": 73,
+                    "quarantined_pending_dags": 79
                 }
             }),
             None,
@@ -635,6 +637,8 @@ mod tests {
         assert_eq!(sync.gossip_direction_filtered_total, 47);
         assert_eq!(sync.pending_dag_capacity_shed, 59);
         assert_eq!(sync.next_pending_retry_in_ms, Some(71));
+        assert_eq!(sync.pending_dag_terminal_quarantined, 73);
+        assert_eq!(sync.quarantined_pending_dags, 79);
     }
 
     #[test]

--- a/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
+++ b/crates/defra-agent/src/agent/p2p_reconcile/engine.rs
@@ -749,9 +749,10 @@ impl PairingStateStore for GraphqlPairingStateStore {
         let collections = graphql_nullable_string_array(&applied.collections);
         let replicator_addresses = graphql_nullable_string_array(&applied.replicator_addresses);
         let replicator_filter = graphql_nullable_filter_literal(&applied.replicator_filter);
-        let now = escape_graphql_string(
-            &chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-        );
+        // Keep subsecond precision in the add payload. DefraDB derives document
+        // identity from genesis content, so an immediate delete/recreate with
+        // second-truncated timestamps can regenerate a tombstoned docID.
+        let now = escape_graphql_string(&chrono::Utc::now().to_rfc3339());
         let mutation = format!(
             r#"mutation {{
                 upsert_PeerPairingApplied(

--- a/crates/defra-agent/src/p2p_observability.rs
+++ b/crates/defra-agent/src/p2p_observability.rs
@@ -47,6 +47,11 @@ pub struct P2pSyncStatusSnapshot {
     /// Milliseconds until the earliest due incomplete pending-DAG retry;
     /// `None` when no incomplete entry is registered.
     pub next_pending_retry_in_ms: Option<u64>,
+    /// Pending-DAG roots quarantined after a deterministic merge rejection
+    /// (defradb #1133).
+    pub pending_dag_terminal_quarantined: u64,
+    /// Current gauge of quarantined pending-DAG roots (defradb #1133).
+    pub quarantined_pending_dags: usize,
 }
 
 /// Typed view of DefraDB's bounded outbound push backlog.

--- a/crates/defra-agent/src/watcher.rs
+++ b/crates/defra-agent/src/watcher.rs
@@ -133,6 +133,12 @@ impl EventDeliveryRuntimeContract for DefraWatcher {
     };
 }
 
+fn request_update_wakeup(message: &events::Message) -> Option<&events::Update> {
+    // Event origin is deliberately not an eligibility gate. The persisted
+    // AgentRequest query below owns scope and lifecycle validation.
+    message.as_update()
+}
+
 impl Watcher for DefraWatcher {
     async fn next_request(&mut self) -> Option<Result<AgentRequest>> {
         loop {
@@ -171,13 +177,17 @@ impl Watcher for DefraWatcher {
                     }
                 };
 
-            let update = match msg.as_update() {
-                Some(u) if u.is_relay => u,
-                _ => continue,
+            // Local writes and relayed writes are equally eligible wakeups.
+            // The subsequent document query is the authority for agent scope,
+            // lifecycle state, and lineage coherence. Ignoring local updates
+            // can strand a request until the 30-second fallback poll when it
+            // is created just after the loop's pending-request scan.
+            let Some(update) = request_update_wakeup(&msg) else {
+                continue;
             };
 
             let doc_id = &update.doc_id;
-            tracing::trace!(doc_id = %doc_id, "P2P update event received");
+            tracing::trace!(doc_id = %doc_id, is_relay = update.is_relay, "DefraDB update event received");
 
             let dropped = self.subscription.check_and_reset_dropped();
             if dropped > 0 {

--- a/crates/defra-agent/src/watcher/tests.rs
+++ b/crates/defra-agent/src/watcher/tests.rs
@@ -6,6 +6,28 @@ use std::time::Instant;
 use super::cooldown::{take_next_eligible_pending_request, PROCESSED_REQUEST_COOLDOWN};
 use super::*;
 
+#[test]
+fn local_and_relayed_updates_are_both_request_wakeups() {
+    fn update_message(is_relay: bool) -> events::Message {
+        let block = format!("request-update-{is_relay}").into_bytes();
+        let cid = defra_core::block::generate_cid_from_bytes(&block)
+            .expect("fixture bytes produce a CID");
+        events::Message::update(events::Update::new(
+            "request-doc".to_string(),
+            cid,
+            "request-collection".to_string(),
+            block,
+            false,
+            is_relay,
+        ))
+    }
+
+    let local = update_message(false);
+    let relayed = update_message(true);
+    assert!(!request_update_wakeup(&local).unwrap().is_relay);
+    assert!(request_update_wakeup(&relayed).unwrap().is_relay);
+}
+
 // ---------------------------------------------------------------------------
 // validate_agent_request_subagent_coherence
 // ---------------------------------------------------------------------------

--- a/crates/defra-agent/tests/conformance/p2p_observability.rs
+++ b/crates/defra-agent/tests/conformance/p2p_observability.rs
@@ -58,6 +58,8 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
         pending_dag_retry_dispatched: 61,
         pending_dag_retry_suppressed: 67,
         next_pending_retry_in_ms: Some(71),
+        pending_dag_terminal_quarantined: 73,
+        quarantined_pending_dags: 79,
     };
 
     let wire = serde_json::to_value(upstream).expect("serialize pinned DefraDB SyncStatus");
@@ -96,4 +98,6 @@ fn pinned_defradb_sync_status_satisfies_agent_observability_contract() {
     assert_eq!(adapted.pending_dag_retry_dispatched, 61);
     assert_eq!(adapted.pending_dag_retry_suppressed, 67);
     assert_eq!(adapted.next_pending_retry_in_ms, Some(71));
+    assert_eq!(adapted.pending_dag_terminal_quarantined, 73);
+    assert_eq!(adapted.quarantined_pending_dags, 79);
 }

--- a/crates/defra-agent/tests/support/pairing_conformance/runner.rs
+++ b/crates/defra-agent/tests/support/pairing_conformance/runner.rs
@@ -546,7 +546,10 @@ async fn write_peer_pairing_applied(
     } else {
         let collections = graphql_string_set_literal(&applied.collections);
         let replicator_addresses = graphql_string_set_literal(&applied.replicator_addresses);
-        let now = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+        // Mirror the production writer's recreate identity: preserving
+        // subsecond precision prevents an immediate reinstall from deriving
+        // the same docID as the row that was just tombstoned.
+        let now = chrono::Utc::now().to_rfc3339();
         let now = escape_graphql_string(&now);
         format!(
             r#"mutation {{


### PR DESCRIPTION
## Summary

- pin every DefraDB workspace dependency to `e74733a6` (#1135), including terminal pending-DAG quarantine from #1133 and the preceding fleet convergence / unique-index tombstone fixes
- expose the new pending-DAG quarantine gauge and terminal-quarantine counter through runtime status and Prometheus metrics
- give recreated `PeerPairingApplied` rows subsecond timestamps so delete/recreate cannot regenerate the same content-addressed document identity within one second
- treat both local and relayed DefraDB request updates as watcher wakeups; the authoritative persisted request query still enforces agent scope, lifecycle state, and lineage

## Why this pin

I first tested current DefraDB `main` at `5ddedab` (#1131). Under the parallel embedded lifecycle suite, successful local creates could subsequently disappear: the survivor `AgentRequest` was absent after a successful create/lookup, and a newly created `AgentResponse` vanished before the streaming write. The same 48-test lifecycle binary passes at `e74733a6`.

That makes `e74733a6` the latest release-safe pin currently available. The #1131 regression is tracked upstream as sourcenetwork/defradb.rs#1138 and should block moving the pin past this commit.

The watcher change is origin handling, not a lifecycle-policy change: the existing model is origin-agnostic at enqueue, and the wakeup is still narrowed by the persisted request read before claim.

## Validation

- `cargo test -p defra-agent`
- `cargo check --workspace --all-targets`
- `cargo test -p defra-agent-cli p2p_metrics` (3 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Additional A/B: `cargo test -p defra-agent --test e2e_lifecycle` passes 48/48 at `e74733a6`; the #1131 pin reproduced the missing-document failure.
