### PR TITLE
Fix config recreation over tombstones

### DIFF
--- a/crates/defra-agent-cli/src/commands/config/profile.rs
+++ b/crates/defra-agent-cli/src/commands/config/profile.rs
@@ -3,6 +3,7 @@ use defra_agent::graphql::escape_graphql_string;
 use serde_json::json;
 
 use crate::cli::*;
+use crate::config_writes::mint_recreate_identity_timestamp;
 use crate::extract_mutation_doc_id;
 use crate::optional_bool_field;
 use crate::optional_f64_field;
@@ -76,6 +77,10 @@ pub(super) async fn inference_profile_set(args: InferenceProfileUpsertArgs) -> R
         optional_i64_field("retry_max_resample", args.retry_max_resample),
         optional_bool_field("retry_allow_repair", args.retry_allow_repair),
         optional_i64_field("retry_interactive_max", args.retry_interactive_max),
+        Some(format!(
+            r#"updated_at: "{}""#,
+            escape_graphql_string(&mint_recreate_identity_timestamp())
+        )),
     ]
     .into_iter()
     .flatten()

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -183,7 +183,8 @@ async fn apply_manifest_pairing_documents(
                         doc.unique_value
                     )
                 })?;
-            let add_literal = graphql_input_literal(&doc.add_doc)?;
+            let add_doc = crate::config_writes::mint_recreate_identity(&doc.add_doc);
+            let add_literal = graphql_input_literal(&add_doc)?;
             let update_literal =
                 graphql_input_literal(doc.update_doc.as_ref().ok_or_else(|| {
                     anyhow::anyhow!("missing update document for PeerPairingDesired")
@@ -356,7 +357,12 @@ fn generic_import_mutation_field(
     override_existing: bool,
 ) -> Result<AliasedMutationField> {
     let alias = format!("doc_{index}");
-    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let add_doc = if override_existing {
+        crate::config_writes::mint_recreate_identity(&doc.add_doc)
+    } else {
+        doc.add_doc.clone()
+    };
+    let add_literal = graphql_input_literal(&add_doc)?;
     let field = if override_existing {
         // This is the generic production bridge for apply retry convergence:
         // after a partial prefix, rerunning `config apply` recomputes live diff
@@ -403,7 +409,12 @@ async fn apply_generic_import_document(
     doc: &PreparedImportDocument,
     override_existing: bool,
 ) -> Result<()> {
-    let add_literal = graphql_input_literal(&doc.add_doc)?;
+    let add_doc = if override_existing {
+        crate::config_writes::mint_recreate_identity(&doc.add_doc)
+    } else {
+        doc.add_doc.clone()
+    };
+    let add_literal = graphql_input_literal(&add_doc)?;
     let mutation = if override_existing {
         // Per-document fallback preserves the same retry property as the batch
         // path: the unique-field filter makes repeated successful writes land
@@ -603,7 +614,15 @@ fn custom_override_mutation_field(
             doc_id = escape_graphql_string(doc_id),
         )
     } else {
-        let add_literal = graphql_input_literal(&doc.add_doc)?;
+        // A tombstone occupies this unique value: identical manifest content
+        // would regenerate the tombstoned docID. Mint a fresh identity for the
+        // new incarnation while leaving a first-time create unchanged.
+        let add_doc = if existing.is_some() {
+            crate::config_writes::mint_recreate_identity(&doc.add_doc)
+        } else {
+            doc.add_doc.clone()
+        };
+        let add_literal = graphql_input_literal(&add_doc)?;
         format!(r#"{alias}: create_{collection_name}(input: {add_literal}) {{ _docID }}"#)
     };
 
@@ -854,6 +873,36 @@ mod tests {
     }
 
     #[test]
+    fn every_apply_collection_schema_has_a_recreate_identity_field() {
+        use defra_agent_protocol::schemas;
+
+        for collection in Collection::ALL {
+            let schema = match collection {
+                Collection::AgentPrincipal => schemas::AGENT_PRINCIPAL,
+                Collection::AgentBehavior => schemas::AGENT_BEHAVIOR,
+                Collection::Skill => schemas::SKILL,
+                Collection::ToolSelection => schemas::TOOL_SELECTION,
+                Collection::InferenceBackend => schemas::INFERENCE_BACKEND,
+                Collection::InferenceProfile => schemas::INFERENCE_PROFILE,
+                Collection::ToolServiceRegistry => schemas::TOOL_SERVICE_REGISTRY,
+                Collection::ProjectionAcpBinding => schemas::PROJECTION_ACP_BINDING,
+                Collection::PeerPairingDesired => schemas::PEER_PAIRING_DESIRED,
+                Collection::Task => schemas::TASK,
+                Collection::Schedule => schemas::SCHEDULE,
+                Collection::EventTrigger => schemas::EVENT_TRIGGER,
+            };
+
+            assert!(
+                schema
+                    .lines()
+                    .any(|line| line.trim_start().starts_with("updated_at:")),
+                "{} must expose updated_at for tombstone-safe recreation",
+                collection.graphql_type()
+            );
+        }
+    }
+
+    #[test]
     fn config_apply_order_has_retry_safe_prefixes() {
         for prefix_len in 0..=CONFIG_APPLY_ORDER_FOR_TESTS.len() {
             let prefix = &CONFIG_APPLY_ORDER_FOR_TESTS[..prefix_len];
@@ -997,6 +1046,95 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
     }
 
     #[test]
+    fn generic_override_stamps_only_the_add_branch() {
+        let doc = PreparedImportDocument {
+            unique_value: "tools-a".to_string(),
+            add_doc: json!({
+                "selection_id": "tools-a",
+                "agent_did": "did:example:agent"
+            }),
+            update_doc: Some(json!({ "agent_did": "did:example:agent" })),
+        };
+
+        let field =
+            generic_import_mutation_field(0, "ToolSelection", "selection_id", &doc, true).unwrap();
+
+        let (_, update) = field.field.split_once("update:").unwrap();
+        assert!(field.field.contains("updated_at:"));
+        assert!(!update.contains("updated_at:"));
+    }
+
+    #[tokio::test]
+    async fn generic_override_recreates_a_tombstoned_tool_selection() -> Result<()> {
+        use defra_agent::defra_node::{EmbeddedNode, StorageBackend};
+        use defra_agent::ensure_runtime_schemas;
+
+        let tempdir = tempfile::tempdir()?;
+        let node = EmbeddedNode::builder()
+            .data_path(tempdir.path().join("data"))
+            .with_storage_backend(StorageBackend::RocksDb)
+            .build()
+            .await?;
+        ensure_runtime_schemas(&node).await?;
+        let access = ConfigAccess::Local(node);
+        let doc = json!({
+            "selection_id": "tools-a",
+            "agent_did": "did:example:agent",
+            "display_name": "Tools A"
+        });
+
+        let txn = access.begin_apply_txn().await?;
+        apply_import_collection(
+            &txn,
+            "ToolSelection",
+            "selection_id",
+            std::slice::from_ref(&doc),
+            true,
+        )
+        .await?;
+        txn.commit().await?;
+        let first_doc_id = tool_selection_doc_id(&access).await?;
+
+        access
+            .execute(
+                r#"mutation {
+                    delete_ToolSelection(filter: { selection_id: { _eq: "tools-a" } }) { _docID }
+                }"#,
+            )
+            .await?;
+
+        let txn = access.begin_apply_txn().await?;
+        apply_import_collection(
+            &txn,
+            "ToolSelection",
+            "selection_id",
+            std::slice::from_ref(&doc),
+            true,
+        )
+        .await?;
+        txn.commit().await?;
+        let recreated_doc_id = tool_selection_doc_id(&access).await?;
+
+        assert_ne!(first_doc_id, recreated_doc_id);
+        Ok(())
+    }
+
+    async fn tool_selection_doc_id(access: &ConfigAccess) -> Result<String> {
+        let response = access
+            .execute(
+                r#"{
+                    ToolSelection(filter: { selection_id: { _eq: "tools-a" } }) { _docID }
+                }"#,
+            )
+            .await?;
+        response
+            .pointer("/data/ToolSelection/0/_docID")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("live ToolSelection missing after apply: {response}"))
+    }
+
+    #[test]
     fn custom_override_mutation_field_updates_live_doc_by_doc_id() {
         let doc = PreparedImportDocument {
             unique_value: "task-a".to_string(),
@@ -1041,6 +1179,7 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
             "expected create field, got {}",
             field.field
         );
+        assert!(field.field.contains("updated_at:"));
     }
 }
 

--- a/crates/defra-agent-cli/src/config_import.rs
+++ b/crates/defra-agent-cli/src/config_import.rs
@@ -512,8 +512,98 @@ async fn query_existing_documents_by_unique_values(
         .iter()
         .map(|doc| doc.unique_value.clone())
         .collect::<Vec<_>>();
-    query_document_refs_by_unique_values(txn, collection_name, unique_field, &unique_values, true)
-        .await
+    // Query live rows independently so an unbounded tombstone history can
+    // never consume the batch limit and make an existing document look
+    // absent. At two rows per requested key, either every valid live row fits
+    // or a duplicated key is represented at least twice and the selector
+    // below rejects it as corruption.
+    let mut by_unique = query_document_refs_by_unique_values(
+        txn,
+        collection_name,
+        unique_field,
+        &unique_values,
+        false,
+    )
+    .await?;
+
+    let without_live = unique_values
+        .into_iter()
+        .filter(|unique_value| !by_unique.contains_key(unique_value))
+        .collect::<Vec<_>>();
+    let tombstones = query_one_historical_document_per_unique_value(
+        txn,
+        collection_name,
+        unique_field,
+        &without_live,
+    )
+    .await?;
+    for (unique_value, rows) in tombstones {
+        by_unique.entry(unique_value).or_default().extend(rows);
+    }
+    Ok(by_unique)
+}
+
+/// Fetch at most one historical row per logical key.
+///
+/// A separate aliased field per key prevents one key's arbitrarily long
+/// tombstone history from starving later keys under a global query limit.
+async fn query_one_historical_document_per_unique_value(
+    txn: &ConfigApplyTxn<'_>,
+    collection_name: &str,
+    unique_field: &str,
+    unique_values: &[String],
+) -> Result<BTreeMap<String, Vec<ExistingDocumentRef>>> {
+    let mut by_unique = BTreeMap::new();
+    for chunk in unique_values.chunks(CONFIG_IMPORT_BATCH_SIZE) {
+        let fields = chunk
+            .iter()
+            .enumerate()
+            .map(|(index, unique_value)| {
+                format!(
+                    r#"lookup_{index}: {collection_name}(
+                        showDeleted: true,
+                        filter: {{ {unique_field}: {{ _eq: "{unique_value}" }} }},
+                        limit: 1
+                    ) {{
+                        _docID
+                        _deleted
+                    }}"#,
+                    unique_value = escape_graphql_string(unique_value),
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let response = txn.execute(&format!("{{\n{fields}\n}}")).await?;
+        for (index, unique_value) in chunk.iter().enumerate() {
+            let rows = response
+                .pointer(&format!("/data/lookup_{index}"))
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            for row in rows {
+                let doc_ref = ExistingDocumentRef {
+                    doc_id: row
+                        .get("_docID")
+                        .and_then(Value::as_str)
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "{collection_name} history row missing _docID for {unique_field}={unique_value}: {row}"
+                            )
+                        })?
+                        .to_string(),
+                    deleted: row
+                        .get("_deleted")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false),
+                };
+                by_unique
+                    .entry(unique_value.clone())
+                    .or_insert_with(Vec::new)
+                    .push(doc_ref);
+            }
+        }
+    }
+    Ok(by_unique)
 }
 
 async fn query_document_refs_by_unique_values(
@@ -533,7 +623,11 @@ async fn query_document_refs_by_unique_values(
         ""
     };
     let unique_values_literal = graphql_string_list_literal(unique_values);
-    let limit = unique_values.len().saturating_mul(16).max(16);
+    let limit = if show_deleted {
+        unique_values.len().saturating_mul(16).max(16)
+    } else {
+        unique_values.len().saturating_mul(2).max(2)
+    };
     let query = format!(
         r#"{{
             {collection_name}(
@@ -645,14 +739,7 @@ fn select_existing_import_document(
         return Ok(Some((*row).clone()));
     }
 
-    let deleted_rows = rows.iter().filter(|row| row.deleted).collect::<Vec<_>>();
-    if deleted_rows.len() > 1 {
-        anyhow::bail!(
-            "multiple deleted {collection_name} tombstones share {unique_field}={unique_value}"
-        );
-    }
-
-    Ok(deleted_rows.first().map(|row| (*row).clone()))
+    Ok(rows.iter().find(|row| row.deleted).cloned())
 }
 
 async fn apply_custom_override_documents_individually(
@@ -1180,6 +1267,58 @@ doc_1: create_Task(input: { task_id: "b" }) { _docID }
             field.field
         );
         assert!(field.field.contains("updated_at:"));
+    }
+
+    #[test]
+    fn custom_selector_accepts_arbitrary_tombstone_history() {
+        let rows = (0..32)
+            .map(|index| ExistingDocumentRef {
+                doc_id: format!("deleted-{index}"),
+                deleted: true,
+            })
+            .collect::<Vec<_>>();
+
+        let selected = select_existing_import_document("Task", "task_id", "task-a", &rows)
+            .unwrap()
+            .expect("tombstone history should select recreate");
+        assert!(selected.deleted);
+    }
+
+    #[test]
+    fn custom_selector_prefers_the_only_live_row_over_tombstones() {
+        let mut rows = (0..32)
+            .map(|index| ExistingDocumentRef {
+                doc_id: format!("deleted-{index}"),
+                deleted: true,
+            })
+            .collect::<Vec<_>>();
+        rows.push(ExistingDocumentRef {
+            doc_id: "live".to_string(),
+            deleted: false,
+        });
+
+        let selected = select_existing_import_document("Task", "task_id", "task-a", &rows)
+            .unwrap()
+            .expect("live row should be selected");
+        assert_eq!(selected.doc_id, "live");
+    }
+
+    #[test]
+    fn custom_selector_rejects_multiple_live_rows() {
+        let rows = vec![
+            ExistingDocumentRef {
+                doc_id: "live-a".to_string(),
+                deleted: false,
+            },
+            ExistingDocumentRef {
+                doc_id: "live-b".to_string(),
+                deleted: false,
+            },
+        ];
+
+        let error =
+            select_existing_import_document("Task", "task_id", "task-a", &rows).unwrap_err();
+        assert!(error.to_string().contains("multiple live Task documents"));
     }
 }
 

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -5,8 +5,8 @@
 //! tools and the CLI apply/imperative paths share one proven write path.
 
 pub(crate) use defra_agent::config_client::{
-    write_agent_behavior_document, write_event_trigger_document, write_inference_backend_document,
-    write_schedule_document, write_task_document, write_tool_selection_document,
-    write_tool_selection_document_with_clear_fields, ConfigAccess, ConfigApplyTxn,
-    ExistingDocumentRef, InferenceBackendUpsertDocument,
+    mint_recreate_identity, write_agent_behavior_document, write_event_trigger_document,
+    write_inference_backend_document, write_schedule_document, write_task_document,
+    write_tool_selection_document, write_tool_selection_document_with_clear_fields, ConfigAccess,
+    ConfigApplyTxn, ExistingDocumentRef, InferenceBackendUpsertDocument,
 };

--- a/crates/defra-agent-cli/src/config_writes/mod.rs
+++ b/crates/defra-agent-cli/src/config_writes/mod.rs
@@ -5,8 +5,9 @@
 //! tools and the CLI apply/imperative paths share one proven write path.
 
 pub(crate) use defra_agent::config_client::{
-    mint_recreate_identity, write_agent_behavior_document, write_event_trigger_document,
-    write_inference_backend_document, write_schedule_document, write_task_document,
-    write_tool_selection_document, write_tool_selection_document_with_clear_fields, ConfigAccess,
-    ConfigApplyTxn, ExistingDocumentRef, InferenceBackendUpsertDocument,
+    mint_recreate_identity, mint_recreate_identity_timestamp, write_agent_behavior_document,
+    write_event_trigger_document, write_inference_backend_document, write_schedule_document,
+    write_task_document, write_tool_selection_document,
+    write_tool_selection_document_with_clear_fields, ConfigAccess, ConfigApplyTxn,
+    ExistingDocumentRef, InferenceBackendUpsertDocument,
 };

--- a/crates/defra-agent-cli/tests/cli_config_apply_local.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_local.rs
@@ -729,5 +729,69 @@ async fn reapply_recreates_a_pruned_unique_row() -> Result<()> {
         "diff must be exact after the recreate: {settled}"
     );
 
+    // Repeat the full cycle. The second delete leaves two terminal documents
+    // with the same logical task_id; recreation must treat both as history,
+    // not as an ambiguous current row.
+    fs::remove_dir_all(&task_dir).with_context(|| format!("removing {}", task_dir.display()))?;
+    let pruned_again = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+            "--prune",
+        ],
+    )?;
+    assert_eq!(
+        pruned_again
+            .pointer("/pruned/tasks")
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    write_json_file(&task_dir.join("object.json"), &task_object)?;
+    let recreated_again = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        recreated_again.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "recreating over multiple tombstones must converge: {recreated_again}"
+    );
+    assert_eq!(
+        recreated_again
+            .pointer("/applied/tasks")
+            .and_then(Value::as_u64),
+        Some(1)
+    );
+
+    let settled_again = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "diff",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        settled_again.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "diff must remain exact after repeated recreation: {settled_again}"
+    );
+
     Ok(())
 }

--- a/crates/defra-agent-cli/tests/cli_config_apply_local.rs
+++ b/crates/defra-agent-cli/tests/cli_config_apply_local.rs
@@ -595,3 +595,139 @@ async fn config_apply_rebinds_placeholder_manifest_to_home_identity_locally() ->
 
     Ok(())
 }
+
+/// #706 regression: pruning leaves a terminal tombstone, so reapplying the
+/// same manifest content must mint a distinct document identity and converge.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reapply_recreates_a_pruned_unique_row() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    let root = tempdir.path().join("infra").join("agents").join("default");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("mock-recreate-model-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let agent_name = format!("cli-recreate-{}", Uuid::new_v4().simple());
+    run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    run_cli_text(
+        &home_dir,
+        &[
+            "config",
+            "export",
+            "--root",
+            root.to_str().expect("utf-8 root"),
+        ],
+    )?;
+    let principal = read_json_file(&root.join("agent-principal.json"))?;
+    let behavior_id = principal
+        .get("default_behavior_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("missing default_behavior_id after export"))?
+        .to_string();
+
+    let task_id = format!("recreate-task-{}", Uuid::new_v4().simple());
+    let task_dir = root.join("tasks").join(&task_id);
+    let task_object = serde_json::json!({
+        "task_id": task_id.clone(),
+        "name": "Recreate Me",
+        "description": "Tombstoned unique row recreate regression (#706).",
+        "behavior_id": behavior_id,
+        "prompt_template": "Check convergence.",
+        "enabled": false,
+    });
+    write_json_file(&task_dir.join("object.json"), &task_object)?;
+
+    let root_str = root
+        .to_str()
+        .ok_or_else(|| anyhow!("manifest root path is not UTF-8"))?;
+    let explicit_home = home_dir.join(".defra-agent");
+    let explicit_home_str = explicit_home
+        .to_str()
+        .ok_or_else(|| anyhow!("explicit home path is not UTF-8"))?;
+
+    let created = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        created.get("status").and_then(Value::as_str),
+        Some("applied")
+    );
+
+    fs::remove_dir_all(&task_dir).with_context(|| format!("removing {}", task_dir.display()))?;
+    let pruned = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+            "--prune",
+        ],
+    )?;
+    assert_eq!(pruned.get("ok").and_then(Value::as_bool), Some(true));
+    assert_eq!(
+        pruned.pointer("/pruned/tasks").and_then(Value::as_u64),
+        Some(1)
+    );
+
+    write_json_file(&task_dir.join("object.json"), &task_object)?;
+    let recreated = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "apply",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        recreated.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "recreating a pruned unique row must converge: {recreated}"
+    );
+    assert_eq!(
+        recreated.pointer("/applied/tasks").and_then(Value::as_u64),
+        Some(1),
+        "the tombstoned task must be recreated: {recreated}"
+    );
+
+    let settled = run_cli_json(
+        &home_dir,
+        &[
+            "config",
+            "diff",
+            "--root",
+            root_str,
+            "--home",
+            explicit_home_str,
+        ],
+    )?;
+    assert_eq!(
+        settled.get("ok").and_then(Value::as_bool),
+        Some(true),
+        "diff must be exact after the recreate: {settled}"
+    );
+
+    Ok(())
+}

--- a/crates/defra-agent-cli/tests/cli_config_backend.rs
+++ b/crates/defra-agent-cli/tests/cli_config_backend.rs
@@ -178,3 +178,146 @@ async fn config_backend_set_preset_and_discover_models_from_backend_id() -> Resu
 
     Ok(())
 }
+
+/// #706 regression for the imperative writers: rm leaves a terminal,
+/// content-addressed document, so an identical set must vary only the add
+/// branch's `updated_at` identity and create a new document.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn imperative_config_writers_recreate_after_remove() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+
+    let model_name = format!("imperative-recreate-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockModelEndpoint::start(&model_name)?;
+    let port = allocate_port()?;
+    let graphql = graphql_url(port);
+    let agent_name = format!("cli-imperative-recreate-{}", Uuid::new_v4().simple());
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            &agent_name,
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let mut serve = spawn_server(&home_dir, port)?;
+    wait_for_port(port, &mut serve)?;
+    wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    let selection_id = format!("recreate-tools-{}", Uuid::new_v4().simple());
+    let tool_args = [
+        "config",
+        "tools",
+        "set",
+        "--graphql",
+        &graphql,
+        "--agent-did",
+        &agent_did,
+        "--selection-id",
+        &selection_id,
+        "--display-name",
+        "Recreate tools",
+    ];
+    assert_remove_then_identical_set_recreates(
+        &home_dir,
+        &tool_args,
+        &[
+            "config",
+            "tools",
+            "rm",
+            "--graphql",
+            &graphql,
+            "--id",
+            &selection_id,
+        ],
+    )?;
+
+    let backend_id = format!("recreate-backend-{}", Uuid::new_v4().simple());
+    let backend_args = [
+        "config",
+        "backend",
+        "set",
+        "--graphql",
+        &graphql,
+        "--backend-id",
+        &backend_id,
+        "--name",
+        "Recreate backend",
+        "--backend-preset",
+        "openrouter",
+        "--endpoint",
+        mock_endpoint.endpoint(),
+        "--max-concurrent",
+        "1",
+    ];
+    assert_remove_then_identical_set_recreates(
+        &home_dir,
+        &backend_args,
+        &[
+            "config",
+            "backend",
+            "rm",
+            "--graphql",
+            &graphql,
+            "--id",
+            &backend_id,
+        ],
+    )?;
+
+    let profile_id = format!("recreate-profile-{}", Uuid::new_v4().simple());
+    let profile_args = [
+        "config",
+        "profile",
+        "set",
+        "--graphql",
+        &graphql,
+        "--profile-id",
+        &profile_id,
+        "--display-name",
+        "Recreate profile",
+    ];
+    assert_remove_then_identical_set_recreates(
+        &home_dir,
+        &profile_args,
+        &[
+            "config",
+            "profile",
+            "rm",
+            "--graphql",
+            &graphql,
+            "--id",
+            &profile_id,
+        ],
+    )?;
+
+    Ok(())
+}
+
+fn assert_remove_then_identical_set_recreates(
+    home_dir: &std::path::Path,
+    set_args: &[&str],
+    remove_args: &[&str],
+) -> Result<()> {
+    let first = run_cli_json(home_dir, set_args)?;
+    let first_doc_id = first
+        .get("doc_id")
+        .and_then(Value::as_str)
+        .context("first set output missing doc_id")?;
+
+    run_cli_json(home_dir, remove_args)?;
+
+    let second = run_cli_json(home_dir, set_args)?;
+    let second_doc_id = second
+        .get("doc_id")
+        .and_then(Value::as_str)
+        .context("second set output missing doc_id")?;
+    assert_ne!(
+        first_doc_id, second_doc_id,
+        "recreate must mint a distinct content-addressed document"
+    );
+    Ok(())
+}

--- a/crates/defra-agent-protocol/schemas/inference/inference_backend.graphql
+++ b/crates/defra-agent-protocol/schemas/inference/inference_backend.graphql
@@ -17,4 +17,5 @@ type InferenceBackend {
     models: [String]
     last_probe: DateTime
     probe_status: String @index
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-protocol/schemas/inference/inference_profile.graphql
+++ b/crates/defra-agent-protocol/schemas/inference/inference_profile.graphql
@@ -22,4 +22,5 @@ type InferenceProfile {
     retry_max_resample: Int
     retry_allow_repair: Boolean
     retry_interactive_max: Int
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/agent_behavior.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_behavior.graphql
@@ -16,4 +16,5 @@ type AgentBehavior {
     skill_refs: [String!]
     skill_excludes: [String!]
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/agent_principal.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/agent_principal.graphql
@@ -4,5 +4,6 @@ type AgentPrincipal {
     default_behavior_id: String @index
     enabled: Boolean @index
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
     created_by: String
 }

--- a/crates/defra-agent-schemas/schemas/agent/skill.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/skill.graphql
@@ -10,4 +10,5 @@ type Skill {
     interface_json: String
     enabled: Boolean @index
     created_at: String
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent-schemas/schemas/agent/tool_selection.graphql
+++ b/crates/defra-agent-schemas/schemas/agent/tool_selection.graphql
@@ -51,4 +51,5 @@ type ToolSelection {
     # Opt-in guardrail: get_my_config accepts a patch preview (diff without
     # committing).
     self_config_dry_run: Boolean
+    updated_at: DateTime @index(direction: DESC)
 }

--- a/crates/defra-agent/proofs/Proofs/SelfConfig/Types.lean
+++ b/crates/defra-agent/proofs/Proofs/SelfConfig/Types.lean
@@ -92,7 +92,7 @@ def allFields : Target → List FieldKey
       , "system_prompt", "request_context_template", "backend_id", "model_name"
       , "tool_selection_id", "inference_profile_id", "compaction_strategy"
       , "compaction_threshold", "enabled", "skill_refs", "skill_excludes"
-      , "created_at" ]
+      , "created_at", "updated_at" ]
   | .toolSelection =>
       [ "selection_id", "agent_did", "display_name", "tool_policy_version"
       , "enable_file_tools", "file_tools_mode", "file_tool_root", "enable_bash"
@@ -107,17 +107,17 @@ def allFields : Target → List FieldKey
       , "enable_session_history_tool", "enable_context_budget"
       , "enable_defra_query", "defra_query_collections", "write_tools"
       , "enable_self_config", "self_config_categories"
-      , "self_config_no_lockout", "self_config_dry_run" ]
+      , "self_config_no_lockout", "self_config_dry_run", "updated_at" ]
   | .inferenceProfile =>
       [ "profile_id", "display_name", "context_window", "max_output_tokens"
       , "max_turns", "temperature", "top_p", "top_k", "min_p", "frequency_penalty", "presence_penalty", "repetition_penalty", "stream_batch_ms"
       , "stream_liveness_timeout_secs", "deadline_duration_secs"
       , "retry_max_transport", "retry_backoff_ms", "retry_max_resample"
-      , "retry_allow_repair", "retry_interactive_max" ]
+      , "retry_allow_repair", "retry_interactive_max", "updated_at" ]
   | .inferenceBackend =>
       [ "backend_id", "name", "provider_kind", "openai_wire_api", "endpoint"
       , "api_key", "api_key_env_var", "max_concurrent", "max_queue_depth"
-      , "enabled", "models", "last_probe", "probe_status" ]
+      , "enabled", "models", "last_probe", "probe_status", "updated_at" ]
   | .toolServiceRegistry =>
       [ "service_id", "display_name", "description", "hostname", "tailscale_ip"
       , "lan_ip", "mcp_port", "mcp_path", "send_agent_did", "status", "version"
@@ -240,6 +240,12 @@ theorem automation_runtime_fields_protected :
       ∧ (["last_attempt_at", "last_fired_source_doc_id", "last_status",
           "last_error", "fire_count"]).all
           (fun k => decide (k ∈ protectedFields .eventTrigger)) := by
+  native_decide
+
+/-- Apply-stamped recreate identities are never writable through self-config. -/
+theorem recreate_identity_field_protected :
+    ∀ t ∈ allTargets,
+      "updated_at" ∈ allFields t → "updated_at" ∈ protectedFields t := by
   native_decide
 
 /-- Every target's gating category is part of the category vocabulary, and the

--- a/crates/defra-agent/src/config_client/common.rs
+++ b/crates/defra-agent/src/config_client/common.rs
@@ -83,3 +83,42 @@ pub(super) fn select_existing_document(
 
     Ok(deleted_rows.first().map(|row| (*row).clone()))
 }
+
+/// Mint a fresh document identity for an apply-owned create.
+///
+/// Deletion is terminal in DefraDB and docIDs are content-addressed, so
+/// recreating a row whose manifest content is IDENTICAL to the tombstoned one
+/// would regenerate the tombstoned docID. Every apply-controlled collection
+/// carries `updated_at`, so stamping the add branch gives each incarnation a
+/// distinct identity without changing a live row's update payload.
+pub fn mint_recreate_identity(add_doc: &serde_json::Value) -> serde_json::Value {
+    let mut doc = add_doc.clone();
+    if let Some(map) = doc.as_object_mut() {
+        map.insert(
+            "updated_at".to_string(),
+            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+        );
+    }
+    doc
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn recreate_identity_preserves_content_and_stamps_updated_at() {
+        let original = json!({
+            "selection_id": "tools-a",
+            "created_at": "2026-01-01T00:00:00Z"
+        });
+
+        let minted = mint_recreate_identity(&original);
+
+        assert_eq!(minted.get("selection_id"), original.get("selection_id"));
+        assert_eq!(minted.get("created_at"), original.get("created_at"));
+        assert!(minted.get("updated_at").and_then(Value::as_str).is_some());
+        assert!(original.get("updated_at").is_none());
+    }
+}

--- a/crates/defra-agent/src/config_client/common.rs
+++ b/crates/defra-agent/src/config_client/common.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde_json::Value;
+use std::sync::atomic::{AtomicI64, Ordering};
 
 use super::ExistingDocumentRef;
 
@@ -9,6 +10,48 @@ pub(super) async fn query_documents_by_unique_value(
     unique_field: &str,
     unique_value: &str,
     show_deleted: bool,
+) -> Result<Vec<ExistingDocumentRef>> {
+    if show_deleted {
+        // Never let a long tombstone history consume the query limit before a
+        // live row is observed. Live rows decide update-vs-create, so resolve
+        // them in a dedicated query first. Only when there is no live row do
+        // we need a single tombstone as evidence that the add branch must mint
+        // a new content-addressed identity.
+        let live = query_documents_by_unique_value_once(
+            txn,
+            collection_name,
+            unique_field,
+            unique_value,
+            false,
+            2,
+        )
+        .await?;
+        if !live.is_empty() {
+            return Ok(live);
+        }
+
+        return query_documents_by_unique_value_once(
+            txn,
+            collection_name,
+            unique_field,
+            unique_value,
+            true,
+            1,
+        )
+        .await;
+    }
+
+    query_documents_by_unique_value_once(txn, collection_name, unique_field, unique_value, false, 2)
+        .await
+}
+
+async fn query_documents_by_unique_value_once(
+    txn: &super::ConfigApplyTxn<'_>,
+    collection_name: &str,
+    unique_field: &str,
+    unique_value: &str,
+    show_deleted: bool,
+    limit: usize,
 ) -> Result<Vec<ExistingDocumentRef>> {
     use crate::graphql::escape_graphql_string;
 
@@ -21,7 +64,7 @@ pub(super) async fn query_documents_by_unique_value(
         r#"{{
             {collection_name}(
                 {show_deleted_arg}filter: {{ {unique_field}: {{ _eq: "{unique_value}" }} }},
-                limit: 16
+                limit: {limit}
             ) {{
                 _docID
                 _deleted
@@ -31,6 +74,7 @@ pub(super) async fn query_documents_by_unique_value(
         show_deleted_arg = show_deleted_arg,
         unique_field = unique_field,
         unique_value = escape_graphql_string(unique_value),
+        limit = limit,
     );
     let response = txn.execute(&query).await?;
     let rows = response
@@ -74,14 +118,41 @@ pub(super) fn select_existing_document(
         return Ok(Some((*row).clone()));
     }
 
-    let deleted_rows = rows.iter().filter(|row| row.deleted).collect::<Vec<_>>();
-    if deleted_rows.len() > 1 {
-        anyhow::bail!(
-            "multiple deleted {collection_name} tombstones share {unique_field}={unique_value}"
-        );
-    }
+    // Tombstones are history, not an ambiguity: every successful recreation
+    // deliberately adds another one. Any tombstone is sufficient to select a
+    // freshly-stamped create branch when no live row exists.
+    Ok(rows.iter().find(|row| row.deleted).cloned())
+}
 
-    Ok(deleted_rows.first().map(|row| (*row).clone()))
+// Process-local monotonicity closes the practical collision window for rapid
+// retries, concurrent apply workers, and wall-clock rollback while the process
+// is alive. A process restart cannot make a system clock globally monotonic;
+// DefraDB's unique/live checks still reject a collision safely, and a retry
+// later in that process mints from a new observation. The i64 nanosecond
+// representation reaches its chrono boundary in 2262.
+static LAST_RECREATE_IDENTITY_NANOS: AtomicI64 = AtomicI64::new(i64::MIN);
+
+/// Mint the timestamp carried only by document add/recreate branches.
+pub fn mint_recreate_identity_timestamp() -> String {
+    let now = chrono::Utc::now()
+        .timestamp_nanos_opt()
+        .expect("current time must fit chrono's nanosecond timestamp range");
+    let mut observed = LAST_RECREATE_IDENTITY_NANOS.load(Ordering::Relaxed);
+    loop {
+        let candidate = now.max(observed.saturating_add(1));
+        match LAST_RECREATE_IDENTITY_NANOS.compare_exchange_weak(
+            observed,
+            candidate,
+            Ordering::Relaxed,
+            Ordering::Relaxed,
+        ) {
+            Ok(_) => {
+                return chrono::DateTime::<chrono::Utc>::from_timestamp_nanos(candidate)
+                    .to_rfc3339_opts(chrono::SecondsFormat::Nanos, true);
+            }
+            Err(actual) => observed = actual,
+        }
+    }
 }
 
 /// Mint a fresh document identity for an apply-owned create.
@@ -96,7 +167,7 @@ pub fn mint_recreate_identity(add_doc: &serde_json::Value) -> serde_json::Value 
     if let Some(map) = doc.as_object_mut() {
         map.insert(
             "updated_at".to_string(),
-            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+            serde_json::Value::String(mint_recreate_identity_timestamp()),
         );
     }
     doc
@@ -120,5 +191,51 @@ mod tests {
         assert_eq!(minted.get("created_at"), original.get("created_at"));
         assert!(minted.get("updated_at").and_then(Value::as_str).is_some());
         assert!(original.get("updated_at").is_none());
+    }
+
+    #[test]
+    fn recreate_identity_timestamps_are_distinct_and_monotonic() {
+        let first = mint_recreate_identity_timestamp();
+        let second = mint_recreate_identity_timestamp();
+        let first = chrono::DateTime::parse_from_rfc3339(&first).unwrap();
+        let second = chrono::DateTime::parse_from_rfc3339(&second).unwrap();
+
+        assert!(second > first);
+    }
+
+    #[test]
+    fn multiple_tombstones_are_valid_recreate_history() {
+        let rows = vec![
+            ExistingDocumentRef {
+                doc_id: "old-a".to_string(),
+                deleted: true,
+            },
+            ExistingDocumentRef {
+                doc_id: "old-b".to_string(),
+                deleted: true,
+            },
+        ];
+
+        let selected = select_existing_document("Task", "task_id", "task-a", &rows)
+            .unwrap()
+            .expect("any tombstone should select recreate");
+        assert!(selected.deleted);
+    }
+
+    #[test]
+    fn multiple_live_rows_remain_a_hard_error() {
+        let rows = vec![
+            ExistingDocumentRef {
+                doc_id: "live-a".to_string(),
+                deleted: false,
+            },
+            ExistingDocumentRef {
+                doc_id: "live-b".to_string(),
+                deleted: false,
+            },
+        ];
+
+        let error = select_existing_document("Task", "task_id", "task-a", &rows).unwrap_err();
+        assert!(error.to_string().contains("multiple live Task documents"));
     }
 }

--- a/crates/defra-agent/src/config_client/event_trigger.rs
+++ b/crates/defra-agent/src/config_client/event_trigger.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use defra_agent_protocol::graphql::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `EventTrigger` collection.
 ///
@@ -38,7 +40,8 @@ pub async fn write_event_trigger_document(
         return create_event_trigger_document(txn, trigger_id, add_doc).await;
     };
     if existing.deleted {
-        return create_event_trigger_document(txn, trigger_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_event_trigger_document(txn, trigger_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent/src/config_client/inference_backend.rs
+++ b/crates/defra-agent/src/config_client/inference_backend.rs
@@ -2,7 +2,7 @@ use crate::graphql::escape_graphql_string;
 use crate::{BackendProviderKind, OpenAiWireApi};
 use anyhow::Result;
 
-use super::ConfigAccess;
+use super::{mint_recreate_identity_timestamp, ConfigAccess};
 use defra_agent_protocol::graphql::{
     graphql_bool_literal, nullable_string_field, string_list_field,
 };
@@ -28,6 +28,7 @@ pub async fn write_inference_backend_document(
     access: &ConfigAccess,
     backend: &InferenceBackendUpsertDocument,
 ) -> Result<String> {
+    let recreate_identity = escape_graphql_string(&mint_recreate_identity_timestamp());
     let models_add = string_list_field("models", &backend.models_on_add)
         .ok_or_else(|| anyhow::anyhow!("backend models field could not be rendered"))?;
     let models_update = backend
@@ -88,7 +89,8 @@ pub async fn write_inference_backend_document(
                     max_queue_depth: {max_queue_depth},
                     enabled: {enabled},
                     {models_add},
-                    probe_status: "{probe_status}"
+                    probe_status: "{probe_status}",
+                    updated_at: "{recreate_identity}"
                 }},
                 update: {{
                     {update_fields}
@@ -111,6 +113,7 @@ pub async fn write_inference_backend_document(
         enabled = graphql_bool_literal(backend.enabled),
         models_add = models_add,
         probe_status = escape_graphql_string(&backend.probe_status),
+        recreate_identity = recreate_identity,
         update_fields = update_fields,
     );
     let response = access.execute(&mutation).await?;

--- a/crates/defra-agent/src/config_client/mod.rs
+++ b/crates/defra-agent/src/config_client/mod.rs
@@ -31,6 +31,7 @@ mod txn;
 pub mod patch;
 
 pub use agent_behavior::write_agent_behavior_document;
+pub use common::mint_recreate_identity;
 pub use event_trigger::write_event_trigger_document;
 pub use inference_backend::{write_inference_backend_document, InferenceBackendUpsertDocument};
 pub use schedule::write_schedule_document;

--- a/crates/defra-agent/src/config_client/mod.rs
+++ b/crates/defra-agent/src/config_client/mod.rs
@@ -31,7 +31,7 @@ mod txn;
 pub mod patch;
 
 pub use agent_behavior::write_agent_behavior_document;
-pub use common::mint_recreate_identity;
+pub use common::{mint_recreate_identity, mint_recreate_identity_timestamp};
 pub use event_trigger::write_event_trigger_document;
 pub use inference_backend::{write_inference_backend_document, InferenceBackendUpsertDocument};
 pub use schedule::write_schedule_document;

--- a/crates/defra-agent/src/config_client/patch.rs
+++ b/crates/defra-agent/src/config_client/patch.rs
@@ -133,6 +133,7 @@ impl SelfConfigTarget {
                 "skill_refs",
                 "skill_excludes",
                 "created_at",
+                "updated_at",
             ],
             Self::ToolSelection => &[
                 "selection_id",
@@ -172,6 +173,7 @@ impl SelfConfigTarget {
                 "self_config_categories",
                 "self_config_no_lockout",
                 "self_config_dry_run",
+                "updated_at",
             ],
             Self::InferenceProfile => &[
                 "profile_id",
@@ -194,6 +196,7 @@ impl SelfConfigTarget {
                 "retry_max_resample",
                 "retry_allow_repair",
                 "retry_interactive_max",
+                "updated_at",
             ],
             Self::InferenceBackend => &[
                 "backend_id",
@@ -209,6 +212,7 @@ impl SelfConfigTarget {
                 "models",
                 "last_probe",
                 "probe_status",
+                "updated_at",
             ],
             Self::ToolServiceRegistry => &[
                 "service_id",

--- a/crates/defra-agent/src/config_client/schedule.rs
+++ b/crates/defra-agent/src/config_client/schedule.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use defra_agent_protocol::graphql::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `Schedule` collection.
 ///
@@ -37,7 +39,8 @@ pub async fn write_schedule_document(
         return create_schedule_document(txn, schedule_id, add_doc).await;
     };
     if existing.deleted {
-        return create_schedule_document(txn, schedule_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_schedule_document(txn, schedule_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent/src/config_client/task.rs
+++ b/crates/defra-agent/src/config_client/task.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use defra_agent_protocol::graphql::graphql_input_literal;
 
-use super::common::{query_documents_by_unique_value, select_existing_document};
+use super::common::{
+    mint_recreate_identity, query_documents_by_unique_value, select_existing_document,
+};
 
 /// Apply-path writer for the `Task` collection.
 ///
@@ -30,7 +32,8 @@ pub async fn write_task_document(
         return create_task_document(txn, task_id, add_doc).await;
     };
     if existing.deleted {
-        return create_task_document(txn, task_id, add_doc).await;
+        let add_doc = mint_recreate_identity(add_doc);
+        return create_task_document(txn, task_id, &add_doc).await;
     }
 
     let input_literal = graphql_input_literal(update_doc)?;

--- a/crates/defra-agent/src/config_client/tool_selection.rs
+++ b/crates/defra-agent/src/config_client/tool_selection.rs
@@ -2,7 +2,7 @@ use crate::graphql::escape_graphql_string;
 use crate::ToolSelectionDocument;
 use anyhow::Result;
 
-use super::ConfigAccess;
+use super::{mint_recreate_identity_timestamp, ConfigAccess};
 use defra_agent_protocol::graphql::{
     optional_bool_field, optional_string_field, string_list_field,
 };
@@ -19,7 +19,11 @@ pub async fn write_tool_selection_document_with_clear_fields(
     selection: &ToolSelectionDocument,
     clear_update_fields: &[&str],
 ) -> Result<String> {
-    let add_fields = tool_selection_fields(selection, true);
+    let add_fields = format!(
+        "{},\n                    updated_at: \"{}\"",
+        tool_selection_fields(selection, true),
+        escape_graphql_string(&mint_recreate_identity_timestamp()),
+    );
     let mut update_fields = tool_selection_fields(selection, false);
     if !clear_update_fields.is_empty() {
         if !update_fields.is_empty() {

--- a/crates/defra-agent/src/document_config/inference_profile.rs
+++ b/crates/defra-agent/src/document_config/inference_profile.rs
@@ -8,6 +8,7 @@ use crate::config::{
     DEFAULT_CONTEXT_WINDOW, DEFAULT_DEADLINE_DURATION_SECS, DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_MAX_TURNS, DEFAULT_STREAM_BATCH_MS, DEFAULT_STREAM_LIVENESS_TIMEOUT_SECS,
 };
+use crate::config_client::mint_recreate_identity_timestamp;
 use crate::graphql::escape_graphql_string;
 use crate::retry::execute_graphql_with_conflict_retry;
 
@@ -288,6 +289,10 @@ pub(crate) fn upsert_inference_profile_mutation(profile: &InferenceProfile) -> S
             "retry_interactive_max",
             profile.retry_interactive_max,
         ),
+        Some(format!(
+            r#"updated_at: "{}""#,
+            escape_graphql_string(&mint_recreate_identity_timestamp())
+        )),
     ]
     .into_iter()
     .flatten()

--- a/crates/defra-agent/src/document_config/tool_selection.rs
+++ b/crates/defra-agent/src/document_config/tool_selection.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::graphql_fields;
 use super::serde_helpers;
+use crate::config_client::mint_recreate_identity_timestamp;
 use crate::defra_query::DEFRA_QUERY_TOOL_NAME;
 use crate::document_config::SubagentTarget;
 use crate::graphql::escape_graphql_string;
@@ -933,6 +934,10 @@ pub async fn upsert_tool_selection(
             "self_config_dry_run",
             selection.self_config_dry_run,
         ),
+        Some(format!(
+            r#"updated_at: "{}""#,
+            escape_graphql_string(&mint_recreate_identity_timestamp())
+        )),
     ]
     .into_iter()
     .flatten()


### PR DESCRIPTION
Closes #706.

## What changed

- add an indexed `updated_at` recreation identity to the six apply-managed config schemas that previously had no mutable identity field
- stamp only add/recreate mutations, leaving update mutations stable
- share the recreation helper across CLI apply and runtime Task/Schedule/EventTrigger writers
- classify `updated_at` as protected in the Lean self-config contract and prove that every managed target exposing it protects it
- cover generic overrides, custom automation mutations, embedded DefraDB delete/recreate behavior, and the full CLI create → prune → identical re-add flow

This is a clean extraction of the #706 fix from the stale/conflicting #707 branch, rebased onto current `main`. It is independent of the DefraDB pin in #752.

## Validation

- `lake build`
- `cargo test -p defra-agent`
- `cargo check --workspace --all-targets`
- `cargo test -p defra-agent-cli recreate -- --nocapture`
- `cargo test -p defra-agent-cli generic_override_stamps_only_the_add_branch`
- `cargo fmt --all -- --check`
- `git diff --check`
