### PR TITLE
fix(llm): rig pin bump — Responses tools keep optional parameters (#542)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17790,7 +17790,7 @@ dependencies = [
 [[package]]
 name = "rig-core"
 version = "0.35.0"
-source = "git+https://github.com/sourcenetwork/rig?rev=81c34131627e1331f02d36bd12742155d1fa9865#81c34131627e1331f02d36bd12742155d1fa9865"
+source = "git+https://github.com/sourcenetwork/rig?rev=1ebeeaee3b569bb6e242e000c11df1ed2c0cca90#1ebeeaee3b569bb6e242e000c11df1ed2c0cca90"
 dependencies = [
  "as-any",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,7 @@ tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev 
 # as `response.reasoning_text.delta`, which rig has no variant for (also a
 # `reasoning` vs `reasoning_content` mismatch on Chat Completions). Without the
 # fork our Responses-API reasoning capture is silently empty.
-rig-core = { git = "https://github.com/sourcenetwork/rig", rev = "81c34131627e1331f02d36bd12742155d1fa9865" }
+rig-core = { git = "https://github.com/sourcenetwork/rig", rev = "1ebeeaee3b569bb6e242e000c11df1ed2c0cca90" }
 # noq 1.0.1 crash-fixes until n0-computer/noq ships a release with #732 + #743 + #723:
 # - proto: discard late packets for paths whose state has already been abandoned
 # - proto: edge-trigger Draining on terminal state (duplicate stateless reset)

--- a/crates/defra-agent/src/llm/rig_compat.rs
+++ b/crates/defra-agent/src/llm/rig_compat.rs
@@ -732,6 +732,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn responses_capture_preserves_optional_tool_parameters() {
+        let mut request = sample_request();
+        request.tools[0].parameters = json!({
+            "type": "object",
+            "properties": {
+                "path": { "type": "string" },
+                "limit": { "type": "integer" }
+            },
+            "required": ["path"]
+        });
+
+        let rendered = rendered_completion_request(&responses_context(false), 0, 0, &request)
+            .expect("render Responses request");
+        let tool = &rendered.tools_json[0];
+
+        assert_eq!(tool["parameters"]["required"], json!(["path"]));
+        assert_ne!(tool.get("strict"), Some(&Value::Bool(true)));
+    }
+
     // ===== #589/#590: argument-shape normalization at both converter seams =====
 
     fn native_tool_call(arguments: Value) -> message::ToolCall {


### PR DESCRIPTION
Bumps the `sourcenetwork/rig` fork to `1ebeeae`, which stops hardcoding `strict: true` on Responses-API tools and stops rewriting `required` to all properties — tools with optional parameters were silently broken on that path (#542).

Fence: `responses_capture_preserves_optional_tool_parameters` in `rig_compat.rs` asserts the rendered tool JSON keeps `required: ["path"]` and carries no `strict: true`.

Gates: full `cargo test -p defra-agent` green (all suites), `cargo check --workspace --all-targets` clean (two pre-existing `failing_peers` warnings, untouched), `cargo fmt --all --check` clean.

Closes #542.