### PR TITLE
polish(desktop): chat turn feedback — thinking indicator, load skeleton, reliable auto-follow

### DIFF
--- a/apps/desktop-tauri/src/components/chat/ChatTranscriptPanel.tsx
+++ b/apps/desktop-tauri/src/components/chat/ChatTranscriptPanel.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 
+import { isTerminalTurnState } from "../../lib/chat-shell";
 import type { DesktopSessionSnapshot } from "../../lib/types";
 import { MessageList } from "../Transcript";
 
@@ -56,6 +57,19 @@ export function ChatTranscriptPanel({
     setAutoFollowTranscript(true);
   }, [selectedSessionId]);
 
+  // The user's own send always re-engages following — matching every chat
+  // app's behavior — even if they had scrolled up to read history.
+  const lastItem = session?.timelineItems[session.timelineItems.length - 1];
+  const pendingSendKey =
+    lastItem?.kind === "pendingUserTurn"
+      ? `${session?.timelineItems.length}:${lastItem.content}`
+      : null;
+  useEffect(() => {
+    if (pendingSendKey) {
+      setAutoFollowTranscript(true);
+    }
+  }, [pendingSendKey]);
+
   useEffect(() => {
     if (!autoFollowTranscript) {
       return;
@@ -67,7 +81,11 @@ export function ChatTranscriptPanel({
     }
 
     const frame = window.requestAnimationFrame(() => {
-      scrollTarget.scrollIntoView({ block: "end" });
+      // Instant, not smooth: the panel's CSS smooth-scroll animates
+      // scrollIntoView, and a chunk landing mid-animation left the scroll
+      // short of the bottom — which the scroll handler then misread as the
+      // user scrolling away, silently disengaging follow.
+      scrollTarget.scrollIntoView({ block: "end", behavior: "instant" });
     });
 
     return () => window.cancelAnimationFrame(frame);
@@ -85,6 +103,19 @@ export function ChatTranscriptPanel({
 
   const responseError = session?.latestResponse?.errorMessage?.trim() ?? "";
   const showResponseError = Boolean(responseError);
+
+  // Animated placeholder between send and the assistant's first visible
+  // output — without it the transcript sits inert while the turn runs.
+  const turnActive = Boolean(
+    session?.turnState && !isTerminalTurnState(session.turnState),
+  );
+  const assistantSilent =
+    !lastItem ||
+    lastItem.kind === "userMessage" ||
+    lastItem.kind === "pendingUserTurn" ||
+    (lastItem.kind === "liveAssistant" &&
+      !(lastItem.content?.length || lastItem.reasoning?.length));
+  const showThinking = turnActive && assistantSilent && !showResponseError;
 
   return (
     <section
@@ -119,6 +150,23 @@ export function ChatTranscriptPanel({
               session.latestResponse?.materializedMessageSequence
             }
           />
+          {showThinking ? (
+            <div className="turn-block">
+              <article
+                className="message-card thinking-card"
+                data-testid="assistant-thinking"
+                role="status"
+                aria-label="Assistant is working"
+              >
+                <div className="message-role">assistant</div>
+                <div className="thinking-dots" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+              </article>
+            </div>
+          ) : null}
           {showResponseError ? (
             <div className="turn-block">
               <article
@@ -134,6 +182,17 @@ export function ChatTranscriptPanel({
             </div>
           ) : null}
           <div className="transcript-end-anchor" ref={transcriptEndRef} />
+        </div>
+      ) : selectedSessionId ? (
+        <div
+          className="transcript-loading"
+          data-testid="transcript-loading"
+          role="status"
+          aria-label="Loading conversation"
+        >
+          <div className="skeleton-row" />
+          <div className="skeleton-row" />
+          <div className="skeleton-row" />
         </div>
       ) : (
         <div className="empty-transcript compact-empty">

--- a/apps/desktop-tauri/src/components/chat/ChatTranscriptPanel.tsx
+++ b/apps/desktop-tauri/src/components/chat/ChatTranscriptPanel.tsx
@@ -57,18 +57,32 @@ export function ChatTranscriptPanel({
     setAutoFollowTranscript(true);
   }, [selectedSessionId]);
 
-  // The user's own send always re-engages following — matching every chat
-  // app's behavior — even if they had scrolled up to read history.
   const lastItem = session?.timelineItems[session.timelineItems.length - 1];
-  const pendingSendKey =
-    lastItem?.kind === "pendingUserTurn"
-      ? `${session?.timelineItems.length}:${lastItem.content}`
-      : null;
+  // A send may be observed as pending or already materialized. Prefer the
+  // request identity so that pending -> materialized does not look like a
+  // second send; fall back to the user row identity for partial snapshots.
+  const latestUserTurn = useMemo(() => {
+    const items = session?.timelineItems ?? [];
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index];
+      if (item.kind === "userMessage" || item.kind === "pendingUserTurn") {
+        return item;
+      }
+    }
+    return null;
+  }, [session?.timelineItems]);
+  const sendIdentity = session?.latestRequestId
+    ? `request:${session.latestRequestId}`
+    : latestUserTurn?.kind === "pendingUserTurn"
+      ? `request:${latestUserTurn.requestId}`
+      : latestUserTurn
+        ? `message:${latestUserTurn.itemKey}`
+        : null;
   useEffect(() => {
-    if (pendingSendKey) {
+    if (sendIdentity) {
       setAutoFollowTranscript(true);
     }
-  }, [pendingSendKey]);
+  }, [sendIdentity]);
 
   useEffect(() => {
     if (!autoFollowTranscript) {

--- a/apps/desktop-tauri/src/styles/transcript/messages.css
+++ b/apps/desktop-tauri/src/styles/transcript/messages.css
@@ -189,3 +189,73 @@
     margin-bottom: 0;
   }
 }
+
+@layer transcript {
+  .thinking-card .thinking-dots {
+    display: inline-flex;
+    gap: var(--space-2);
+    padding: var(--space-2) 0;
+  }
+
+  .thinking-dots span {
+    width: 7px;
+    height: 7px;
+    border-radius: var(--radius-pill);
+    background: var(--color-accent-muted);
+    animation: thinking-pulse var(--motion-pulse) ease-in-out infinite;
+  }
+
+  .thinking-dots span:nth-child(2) {
+    animation-delay: var(--motion-medium);
+  }
+
+  .thinking-dots span:nth-child(3) {
+    animation-delay: calc(var(--motion-medium) * 2);
+  }
+
+  @keyframes thinking-pulse {
+    0%,
+    100% {
+      opacity: 0.25;
+      transform: translateY(0);
+    }
+    30% {
+      opacity: 1;
+      transform: translateY(-2px);
+    }
+  }
+
+  .transcript-loading {
+    display: grid;
+    gap: var(--space-5);
+    padding: var(--space-7);
+    align-content: start;
+  }
+
+  .skeleton-row {
+    height: var(--space-10);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-muted);
+    animation: skeleton-pulse var(--motion-pulse) ease-in-out infinite;
+  }
+
+  .skeleton-row:nth-child(2) {
+    width: 72%;
+    animation-delay: var(--motion-medium);
+  }
+
+  .skeleton-row:nth-child(3) {
+    width: 48%;
+    animation-delay: calc(var(--motion-medium) * 2);
+  }
+
+  @keyframes skeleton-pulse {
+    0%,
+    100% {
+      opacity: 0.45;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+}

--- a/apps/desktop-tauri/tests/chat-transcript-states.test.tsx
+++ b/apps/desktop-tauri/tests/chat-transcript-states.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ChatTranscriptPanel } from "../src/components/chat";
+import type { DesktopSessionSnapshot, RenderedTimelineItem } from "../src/lib/types";
+
+function makeSession(
+  overrides: Partial<DesktopSessionSnapshot> = {},
+): DesktopSessionSnapshot {
+  return {
+    sessionId: "s1",
+    agentDid: "did:test:operator",
+    turnState: "streaming",
+    timelineItems: [],
+    ...overrides,
+  };
+}
+
+const pendingTurn: RenderedTimelineItem = {
+  kind: "pendingUserTurn",
+  itemKey: "p1",
+  requestId: "req_1",
+  content: "do the thing",
+  selectedSkillIds: [],
+};
+
+describe("ChatTranscriptPanel states", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("shows a loading skeleton (not the first-message empty state) while a selected conversation loads", () => {
+    render(<ChatTranscriptPanel selectedSessionId="s1" session={null} />);
+    expect(screen.getByTestId("transcript-loading")).toBeInTheDocument();
+    expect(screen.queryByText("Send the first message")).not.toBeInTheDocument();
+  });
+
+  it("reserves the first-message empty state for no selected session", () => {
+    render(<ChatTranscriptPanel selectedSessionId={null} session={null} />);
+    expect(screen.getByText("Send the first message")).toBeInTheDocument();
+    expect(screen.queryByTestId("transcript-loading")).not.toBeInTheDocument();
+  });
+
+  it("shows the thinking indicator while the turn runs and the assistant is silent", () => {
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({ timelineItems: [pendingTurn] })}
+      />,
+    );
+    expect(screen.getByTestId("assistant-thinking")).toBeInTheDocument();
+  });
+
+  it("hides the thinking indicator once live assistant content streams", () => {
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({
+          timelineItems: [
+            pendingTurn,
+            { kind: "liveAssistant", itemKey: "l1", content: "first tokens" },
+          ],
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("assistant-thinking")).not.toBeInTheDocument();
+  });
+
+  it("hides the thinking indicator on terminal turn states", () => {
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({
+          turnState: "completed",
+          timelineItems: [pendingTurn],
+        })}
+      />,
+    );
+    expect(screen.queryByTestId("assistant-thinking")).not.toBeInTheDocument();
+  });
+
+  it("follows the transcript with instant (not smooth) scrolling on a fresh send", async () => {
+    // tests/setup.ts installs a no-op on HTMLElement.prototype — spy there.
+    const scrollSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+
+    render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({ timelineItems: [pendingTurn] })}
+      />,
+    );
+
+    expect(scrollSpy).toHaveBeenCalledWith({
+      block: "end",
+      behavior: "instant",
+    });
+  });
+});

--- a/apps/desktop-tauri/tests/chat-transcript-states.test.tsx
+++ b/apps/desktop-tauri/tests/chat-transcript-states.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ChatTranscriptPanel } from "../src/components/chat";
@@ -102,5 +102,70 @@ describe("ChatTranscriptPanel states", () => {
       block: "end",
       behavior: "instant",
     });
+  });
+
+  it("re-engages follow when an identical retry is first observed as a materialized user message", async () => {
+    const scrollSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => {});
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+
+    const { rerender } = render(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({
+          turnState: "failed",
+          latestRequestId: "req_1",
+          timelineItems: [
+            {
+              kind: "userMessage",
+              itemKey: "user_1",
+              content: "do the thing",
+            },
+          ],
+        })}
+      />,
+    );
+
+    const panel = screen.getByTestId("transcript-panel");
+    Object.defineProperties(panel, {
+      scrollHeight: { configurable: true, value: 1000 },
+      scrollTop: { configurable: true, value: 100 },
+      clientHeight: { configurable: true, value: 400 },
+    });
+    fireEvent.scroll(panel);
+    scrollSpy.mockClear();
+
+    rerender(
+      <ChatTranscriptPanel
+        selectedSessionId="s1"
+        session={makeSession({
+          latestRequestId: "req_2",
+          timelineItems: [
+            {
+              kind: "userMessage",
+              itemKey: "user_1",
+              content: "do the thing",
+            },
+            {
+              kind: "userMessage",
+              itemKey: "user_2",
+              content: "do the thing",
+            },
+          ],
+        })}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(scrollSpy).toHaveBeenCalledWith({
+        block: "end",
+        behavior: "instant",
+      }),
+    );
   });
 });


### PR DESCRIPTION
First WS3 (chat) slice of #608 — the three feedback gaps that made the chat feel inert:

- **Thinking indicator**: an animated placeholder assistant turn renders whenever the turn is non-terminal and the assistant has produced no visible output yet (previously the transcript sat motionless between send and first token).
- **Conversation-switch loading skeleton**: opening an existing conversation showed the "Send the first message" empty state while the snapshot loaded — factually wrong copy. A selected-but-loading session now gets skeleton rows; the empty state is reserved for no-session.
- **Reliable auto-follow**: follow scrolling is now `behavior: "instant"` — the CSS smooth-scroll animated each programmatic scroll, and a chunk landing mid-animation left the panel short of bottom, which the position heuristic misread as the user scrolling away (silently disengaging follow mid-stream). A fresh user send also force-re-engages follow.

All animation uses the motion tokens; skeleton/dots use existing color tokens (ratchets unchanged). Fences: `chat-transcript-states.test.tsx` (6 tests incl. the instant-scroll call shape). Unit 200, e2e 120, visual 3×3 green.

Part of #608 (WS3).