### PR TITLE
polish(desktop): message differentiation + reading measure

### DIFF
--- a/apps/desktop-tauri/src/components/Transcript.tsx
+++ b/apps/desktop-tauri/src/components/Transcript.tsx
@@ -251,7 +251,7 @@ export function MessageList({
           case "userMessage":
             return (
               <div className="turn-block" key={timelineKey}>
-                <article className="message-card">
+                <article className="message-card user-card">
                   <div className="message-role">
                     user
                     <CopyButton

--- a/apps/desktop-tauri/src/styles/transcript/messages.css
+++ b/apps/desktop-tauri/src/styles/transcript/messages.css
@@ -393,3 +393,27 @@
     word-break: break-word;
   }
 }
+
+@layer transcript {
+  /* Reading measure: prose lines cap near 76ch; assistant text reads as an
+     open page while the user's asks sit in visually distinct cards. */
+  .transcript-panel .message-card {
+    max-width: 76ch;
+  }
+
+  .transcript-panel .user-card,
+  .transcript-panel .pending-card {
+    background: var(--color-surface-muted);
+    border-color: var(--border-default);
+    box-shadow: none;
+  }
+
+  .transcript-panel
+    .message-card:not(.user-card):not(.pending-card):not(.response-error-card):not(
+      .thinking-card
+    ) {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+}

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -153,8 +153,10 @@ describe("token ratchets", () => {
   it("bespoke box-shadows do not grow (ceiling 38)", () => {
     // 'none' and pure --shadow-* token values are conformant, not bespoke:
     // tokenizing shadows must lower this pressure, not preserve it.
+    // The lookahead sits before \s* — a backtrackable \s* ahead of the
+    // lookahead let "box-shadow: none" slip back into the count.
     expect(
-      countMatches(/box-shadow:\s*(?!none[;}\s]|var\(--shadow-)[^;{}]+/gi),
+      countMatches(/box-shadow:(?!\s*none\s*[;}]|\s*var\(--shadow-)[^;{}]+/gi),
     ).toBeLessThanOrEqual(38);
   });
 });


### PR DESCRIPTION
Fifth WS3 (chat) slice of #608. User and assistant messages were visually identical full-width cards.

- **Reading measure**: message cards cap at 76ch — long assistant prose no longer spans the full panel width.
- **Differentiation**: the user's asks sit in distinct tinted cards (`--color-surface-muted`); assistant turns read as open page text (transparent, borderless), matching the ask-vs-answer rhythm of every mature chat app. Error/pending/thinking cards keep their special treatments.
- **Fence repair**: the box-shadow ratchet's `\s*` sat before its `(?!none…)` lookahead, so backtracking let `box-shadow: none` slip back into the count — the lookahead now anchors directly after the property. (Found because this slice's two legitimate `none` declarations tripped it.)

Unit 212, e2e 120, visual baselines regenerated (chat states). Stacked on #758. Part of #608 (WS3).