### PR TITLE
polish(desktop): interrupt toast + tool-row chrome

### DIFF
--- a/apps/desktop-tauri/src/components/ChatWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ChatWorkspace.tsx
@@ -87,9 +87,10 @@ export function ActiveChatWorkspace({
     )?.displayName ?? displayBehaviorLabel(activeBehaviorId);
 
   const [cascade, setCascade] = useState<null | { rootRequestId: string }>(null);
-  const [interruptResultBanner, setInterruptResultBanner] = useState<string | null>(
-    null,
-  );
+  const [interruptResultBanner, setInterruptResultBanner] = useState<{
+    text: string;
+    tone: "info" | "error";
+  } | null>(null);
   const [operationsOpen, setOperationsOpen] = useState(false);
   // Set when a background-tools row asks to focus the lineage view on its
   // parent request; falls back to the session's latest request.
@@ -125,14 +126,18 @@ export function ActiveChatWorkspace({
             cause: "userCancelled",
             cascade: false,
           });
-          if (result.accepted) setInterruptResultBanner("Interrupt accepted");
+          if (result.accepted)
+            setInterruptResultBanner({ text: "Interrupted", tone: "info" });
           else if (result.alreadyInterrupted)
-            setInterruptResultBanner("Already interrupted by another caller");
+            setInterruptResultBanner({ text: "Already interrupted", tone: "info" });
           return;
         }
         setCascade({ rootRequestId: requestId });
       } catch (e) {
-        setInterruptResultBanner(`Interrupt preview failed: ${String(e)}`);
+        setInterruptResultBanner({
+          text: `Couldn't interrupt: ${String(e)}`,
+          tone: "error",
+        });
       }
     },
     [selectedDeployment.agentDid],
@@ -206,17 +211,6 @@ export function ActiveChatWorkspace({
             onRetryMessage={onRetryMessage}
           />
 
-          {interruptResultBanner ? (
-            <div
-              className="muted small"
-              role="status"
-              aria-live="polite"
-              style={{ padding: "4px 12px" }}
-            >
-              {interruptResultBanner}
-            </div>
-          ) : null}
-
           <ChatComposer
             activeRequestId={session?.latestRequestId ?? null}
             approxSerializedBytes={approxSerializedBytes}
@@ -235,6 +229,18 @@ export function ActiveChatWorkspace({
           />
         </div>
         <OperationsRail open={operationsOpen} onOpenChange={setOperationsOpen} />
+        {interruptResultBanner ? (
+          <div
+            className={`chat-toast${
+              interruptResultBanner.tone === "error" ? " is-error" : ""
+            }`}
+            data-testid="chat-toast"
+            role="status"
+            aria-live="polite"
+          >
+            {interruptResultBanner.text}
+          </div>
+        ) : null}
       </section>
 
       {cascade ? (
@@ -245,15 +251,19 @@ export function ActiveChatWorkspace({
           onClose={() => setCascade(null)}
           onAccepted={(at) => {
             setCascade(null);
-            setInterruptResultBanner(`Interrupt accepted at ${at ?? "(unknown)"}`);
+            void at;
+            setInterruptResultBanner({ text: "Interrupted", tone: "info" });
           }}
           onAlreadyInterrupted={() => {
             setCascade(null);
-            setInterruptResultBanner("Already interrupted by another caller");
+            setInterruptResultBanner({ text: "Already interrupted", tone: "info" });
           }}
           onError={(msg) => {
             setCascade(null);
-            setInterruptResultBanner(`Interrupt failed: ${msg}`);
+            setInterruptResultBanner({
+              text: `Couldn't interrupt: ${msg}`,
+              tone: "error",
+            });
           }}
         />
       ) : null}

--- a/apps/desktop-tauri/src/components/Transcript.tsx
+++ b/apps/desktop-tauri/src/components/Transcript.tsx
@@ -105,15 +105,22 @@ function ToolDetailSection({
   );
 }
 
+/** One-line digest of a call's arguments for the collapsed summary. */
+function toolArgsPreview(args?: ToolDetailValueView | null): string | null {
+  if (!args) {
+    return null;
+  }
+  const source = args.fields.find((field) => field.value.trim())?.value ?? args.rawText;
+  const flat = source.replace(/\s+/g, " ").trim();
+  if (!flat) {
+    return null;
+  }
+  return flat.length > 64 ? `${flat.slice(0, 64)}…` : flat;
+}
+
 function ToolGroups({ tools }: { tools: RenderedToolCallView[] }) {
   return (
     <section className="tool-group">
-      <div className="tool-group-meta">
-        <span className="tool-group-label">Tool Calls</span>
-        <span className="muted small">
-          {tools.length} tool {tools.length === 1 ? "call" : "calls"}
-        </span>
-      </div>
       {tools.map((tool) => {
         // Prefer structured DenialReason fields persisted on AgentToolCall.
         // The parser remains as a compatibility fallback for older rows.
@@ -145,6 +152,11 @@ function ToolGroups({ tools }: { tools: RenderedToolCallView[] }) {
               <span className="tool-item-summary-left">
                 <span aria-hidden="true" className={toolStatusClass(tool.statusKind)} />
                 <span className="tool-item-name">{tool.toolName}</span>
+                {toolArgsPreview(tool.args) ? (
+                  <span className="tool-item-preview">
+                    {toolArgsPreview(tool.args)}
+                  </span>
+                ) : null}
                 {tool.cancelCause ? (
                   <CancelCauseBadge
                     cause={tool.cancelCause}
@@ -152,7 +164,9 @@ function ToolGroups({ tools }: { tools: RenderedToolCallView[] }) {
                   />
                 ) : null}
               </span>
-              <span className="tool-item-action">View</span>
+              <span aria-hidden="true" className="tool-item-action">
+                ▸
+              </span>
             </summary>
             <div className="tool-item-body">
               {tool.cancelCause ? (

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -223,6 +223,27 @@
     border-color: var(--border-selected);
   }
 
+  .chat-toast {
+    position: absolute;
+    z-index: 4;
+    left: 50%;
+    bottom: var(--space-10);
+    transform: translateX(-50%);
+    max-width: min(60ch, 90%);
+    padding: var(--space-3) var(--space-7);
+    border: 1px solid var(--border-strong);
+    border-radius: var(--radius-pill);
+    background: var(--color-surface-deep);
+    color: var(--color-text-soft);
+    font-size: var(--text-sm);
+    animation: fade-in var(--motion-fast) ease-out;
+  }
+
+  .chat-toast.is-error {
+    border-color: var(--color-error-strong);
+    color: var(--color-error);
+  }
+
   .chat-title-row {
     display: flex;
     align-items: center;

--- a/apps/desktop-tauri/src/styles/transcript/tools.css
+++ b/apps/desktop-tauri/src/styles/transcript/tools.css
@@ -8,17 +8,6 @@
     background: var(--color-surface-deep);
   }
 
-  .tool-group-meta {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-    gap: var(--space-3);
-    min-width: 0;
-    padding: var(--space-4) var(--space-5);
-    border-bottom: 1px solid rgb(var(--source-green-rgb) / 0.1);
-  }
-
-  .tool-group-label,
   .tool-item-label,
   .tool-detail-key,
   .tool-detail-label {
@@ -99,6 +88,21 @@
     font-size: var(--text-sm);
     white-space: nowrap;
     opacity: 0.7;
+    transition: transform var(--motion-fast) ease;
+  }
+
+  .tool-item[open] .tool-item-action {
+    transform: rotate(90deg);
+  }
+
+  .tool-item-preview {
+    color: var(--color-text-muted);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
 
   .tool-item-body {

--- a/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
@@ -160,7 +160,7 @@ test.describe("desktop UI harness", () => {
     await gotoHarness(page, "active-turn");
     await openChat(page);
     await page.getByTestId("cancel-button").click();
-    await expect(page.getByRole("status")).toContainText("Interrupt accepted");
+    await expect(page.getByTestId("chat-toast")).toContainText("Interrupted");
 
     await gotoHarness(page, "cascade-turn");
     await openChat(page);
@@ -170,7 +170,7 @@ test.describe("desktop UI harness", () => {
     ).toBeVisible();
     await expect(page.getByText("Will request interrupt by cascade")).toBeVisible();
     await page.getByRole("button", { name: /interrupt parent and cascade/i }).click();
-    await expect(page.getByRole("status")).toContainText("Interrupt accepted");
+    await expect(page.getByTestId("chat-toast")).toContainText("Interrupted");
   });
 
   test("sad path scenarios surface empty, bridge, save, and backend-health errors", async ({


### PR DESCRIPTION
Sixth WS3 (chat) slice of #608:

- **Interrupt feedback is a toast**: results render as a pill overlaying the chat column (no layout reflow on appear/dismiss), errors styled as errors instead of muted small text, copy humanized ("Interrupted" / "Couldn't interrupt: …" — no raw timestamp). The two e2e assertions pinned to the old copy updated to the toast testid.
- **Tool rows tell you what they did**: collapsed summaries now carry a one-line args digest (query/path/first arg, 64-char cap, mono), so operators stop expanding every row. The redundant "Tool Calls — N tool calls" group header is gone, and the static "View" label is a chevron that rotates on open (motion token).

Unit 212, e2e 120, visual 3×3 green (unchanged baselines). Stacked on #759. Part of #608 (WS3).