### PR TITLE
polish(desktop): humanize cancel-cause + cascade dialog copy

### DIFF
--- a/apps/desktop-tauri/src/components/cancelUx/CancelCauseDetails.tsx
+++ b/apps/desktop-tauri/src/components/cancelUx/CancelCauseDetails.tsx
@@ -5,27 +5,56 @@ export type CancelCauseDetailsProps = {
   cause: DerivedCancelCauseView;
 };
 
+const CAUSE_LABELS: Record<DerivedCancelCauseView["cause"], string> = {
+  userCancelled: "Cancelled by you",
+  interrupted: "Interrupted",
+  deadline: "Hit its deadline",
+  unknown: "Stopped — cause unknown",
+};
+
+const SOURCE_LABELS: Record<DerivedCancelCauseView["source"], string> = {
+  requestInterrupt: "a direct interrupt on this request",
+  parentCascade: "a cascade from the parent request",
+  deadline: "the runtime deadline",
+  toolLifecycle: "the tool's lifecycle",
+  responseInterruptedAt: "the response's interrupt marker",
+  unresolved: "an unresolved source",
+};
+
+/// Operator-facing summary first; the raw derivation (enums, confidence,
+/// evidence rows) stays available behind a disclosure for bug reports.
 export function CancelCauseDetails({ cause }: CancelCauseDetailsProps): JSX.Element {
+  const at = cause.at ? new Date(cause.at) : null;
+  const atLabel = at && !Number.isNaN(at.getTime()) ? at.toLocaleTimeString() : null;
   return (
-    <dl className="cause-details">
-      <dt>cause</dt>
-      <dd>{cause.cause}</dd>
-      <dt>confidence</dt>
-      <dd>{cause.confidence}</dd>
-      <dt>source</dt>
-      <dd>{cause.source}</dd>
-      {cause.at ? (
-        <>
-          <dt>at</dt>
-          <dd>{cause.at}</dd>
-        </>
-      ) : null}
-      {cause.evidence.map((line, i) => (
-        <span key={i} style={{ display: "contents" }}>
-          <dt>evidence</dt>
-          <dd>{line}</dd>
-        </span>
-      ))}
-    </dl>
+    <div className="cause-details">
+      <p className="cause-headline">
+        {CAUSE_LABELS[cause.cause]} · via {SOURCE_LABELS[cause.source]}
+        {atLabel ? ` · ${atLabel}` : ""}
+      </p>
+      <details className="cause-evidence">
+        <summary>Technical details</summary>
+        <dl>
+          <dt>cause</dt>
+          <dd>{cause.cause}</dd>
+          <dt>confidence</dt>
+          <dd>{cause.confidence}</dd>
+          <dt>source</dt>
+          <dd>{cause.source}</dd>
+          {cause.at ? (
+            <>
+              <dt>at</dt>
+              <dd>{cause.at}</dd>
+            </>
+          ) : null}
+          {cause.evidence.map((line, i) => (
+            <span key={i} style={{ display: "contents" }}>
+              <dt>evidence</dt>
+              <dd>{line}</dd>
+            </span>
+          ))}
+        </dl>
+      </details>
+    </div>
   );
 }

--- a/apps/desktop-tauri/src/components/cancelUx/CascadeCancelDialog.tsx
+++ b/apps/desktop-tauri/src/components/cancelUx/CascadeCancelDialog.tsx
@@ -224,13 +224,17 @@ export function CascadeCancelDialog(
             <>
               {renderGroup(
                 "will-interrupt",
-                "Will request interrupt by cascade",
+                "Will be interrupted",
                 preview.willInterrupt,
               )}
-              {renderGroup("will-detach", "Will continue detached", preview.willDetach)}
+              {renderGroup(
+                "will-detach",
+                "Will keep running detached",
+                preview.willDetach,
+              )}
               {renderGroup(
                 "already-terminal",
-                "Already terminal",
+                "Already finished",
                 preview.alreadyTerminal,
               )}
               {renderUnknownPolicy(preview.unknownPolicy)}
@@ -254,7 +258,7 @@ export function CascadeCancelDialog(
             disabled={phase === "submitting" || !preview}
             onClick={onConfirm}
           >
-            {phase === "submitting" ? "Cancelling…" : "Interrupt parent and cascade"}
+            {phase === "submitting" ? "Interrupting…" : "Interrupt all"}
           </button>
         </footer>
       </div>
@@ -293,7 +297,7 @@ function renderUnknownPolicy(items: CascadeAffectedRequest[]) {
   return (
     <section className="group unknown-policy">
       <h4>
-        Policy unknown — will be left running{" "}
+        No cancellation policy — will be left running{" "}
         <span className="count">{items.length}</span>
       </h4>
       <ul>
@@ -307,8 +311,8 @@ function renderUnknownPolicy(items: CascadeAffectedRequest[]) {
           </li>
         ))}
         <li className="warning-row">
-          These descendants have no cancel_policy on their bridge row. Confirming will
-          NOT interrupt them.
+          These background tasks don&apos;t declare how they handle cancellation, so
+          confirming will leave them running.
         </li>
       </ul>
     </section>

--- a/apps/desktop-tauri/src/styles/cancel-ux.css
+++ b/apps/desktop-tauri/src/styles/cancel-ux.css
@@ -67,6 +67,20 @@
     color: var(--color-text-muted);
   }
 
+  .cause-headline {
+    margin: 0 0 var(--space-2);
+    color: var(--color-text-soft);
+    font-size: var(--text-md);
+  }
+
+  .cause-evidence summary {
+    cursor: pointer;
+    color: var(--color-text-muted);
+    font-size: var(--text-xs);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
   .cause-details code {
     font-family: var(--font-mono);
     color: var(--color-text-warm);

--- a/apps/desktop-tauri/tests/cascade-cancel-dialog.test.tsx
+++ b/apps/desktop-tauri/tests/cascade-cancel-dialog.test.tsx
@@ -92,10 +92,8 @@ describe("CascadeCancelDialog", () => {
       agentDid: "did:test:operator",
       includeTerminal: true,
     });
-    expect(
-      await screen.findByText(/will request interrupt by cascade/i),
-    ).toBeInTheDocument();
-    expect(await screen.findByText(/policy unknown/i)).toBeInTheDocument();
+    expect(await screen.findByText(/will be interrupted/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no cancellation policy/i)).toBeInTheDocument();
     expect(screen.getByText(/req_b91/)).toBeInTheDocument();
     expect(screen.getByText(/req_c02/)).toBeInTheDocument();
   });
@@ -113,7 +111,7 @@ describe("CascadeCancelDialog", () => {
 
     fireEvent.click(
       await screen.findByRole("button", {
-        name: /interrupt parent and cascade/i,
+        name: /interrupt all/i,
       }),
     );
 
@@ -142,7 +140,7 @@ describe("CascadeCancelDialog", () => {
       });
     render(<CascadeCancelDialog {...baseProps} />);
     const confirm = await screen.findByRole("button", {
-      name: /interrupt parent and cascade/i,
+      name: /interrupt all/i,
     });
 
     fireEvent.click(confirm);

--- a/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-ui.spec.ts
@@ -168,8 +168,8 @@ test.describe("desktop UI harness", () => {
     await expect(
       page.getByRole("dialog", { name: /interrupt parent request/i }),
     ).toBeVisible();
-    await expect(page.getByText("Will request interrupt by cascade")).toBeVisible();
-    await page.getByRole("button", { name: /interrupt parent and cascade/i }).click();
+    await expect(page.getByText("Will be interrupted")).toBeVisible();
+    await page.getByRole("button", { name: /interrupt all/i }).click();
     await expect(page.getByTestId("chat-toast")).toContainText("Interrupted");
   });
 


### PR DESCRIPTION
Seventh WS3 (chat) slice of #608. The cancel/interrupt surfaces spoke in raw protocol terms.

- **CancelCauseDetails**: leads with a plain-language headline (e.g. "Interrupted · via a cascade from the parent request · 3:14:07 PM") mapping the cause/source enums to operator language; the raw derivation (cause, confidence, source, evidence rows) moves behind a "Technical details" disclosure for bug reports.
- **CascadeCancelDialog**: group headings and the confirm button are now human ("Will be interrupted", "Will keep running detached", "Already finished", "Interrupt all"); the unknown-policy warning drops `cancel_policy`/bridge-row jargon.

Test copy assertions (2 unit, 1 e2e) updated to the new strings. Unit 212, e2e 120, visual 3×3 green. Stacked on #760. Part of #608 (WS3).