### PR TITLE
polish(desktop): terminal/diff block quality

### DIFF
--- a/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
+++ b/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
@@ -1,4 +1,11 @@
-import type { CodeToolView } from "./codeTools";
+import { CopyButton } from "../CopyButton";
+import { formatDuration, type CodeToolView, type DiffLine } from "./codeTools";
+
+function diffText(diff: DiffLine[]): string {
+  return diff
+    .map((line) => `${line.kind === "add" ? "+" : "-"}${line.text}`)
+    .join("\n");
+}
 
 // Renders a code tool call as a diff (file edits) or a terminal block (bash),
 // instead of the generic args/result disclosure. Foundation-aligned: the data
@@ -22,19 +29,25 @@ export function CodeToolItem({ view }: { view: CodeToolView }) {
           </span>
           <span className="tool-item-action">diff</span>
         </summary>
-        <pre className="code-diff" data-testid="code-diff">
-          {view.diff.map((line, index) => (
-            <div
-              className={`code-diff-line code-diff-${line.kind}`}
-              key={`${line.kind}-${index}`}
-            >
-              <span aria-hidden="true" className="code-diff-gutter">
-                {line.kind === "add" ? "+" : "-"}
-              </span>
-              <span className="code-diff-text">{line.text}</span>
-            </div>
-          ))}
-        </pre>
+        <div className="code-output">
+          <CopyButton
+            className="code-output-copy"
+            getText={() => diffText(view.diff)}
+          />
+          <pre className="code-diff" data-testid="code-diff">
+            {view.diff.map((line, index) => (
+              <div
+                className={`code-diff-line code-diff-${line.kind}`}
+                key={`${line.kind}-${index}`}
+              >
+                <span aria-hidden="true" className="code-diff-gutter">
+                  {line.kind === "add" ? "+" : "-"}
+                </span>
+                <span className="code-diff-text">{line.text}</span>
+              </div>
+            ))}
+          </pre>
+        </div>
       </details>
     );
   }
@@ -68,21 +81,38 @@ export function CodeToolItem({ view }: { view: CodeToolView }) {
         </span>
       </summary>
       <div className="tool-item-body">
-        {view.executionMode || view.networkMode ? (
+        {view.executionMode ||
+        view.networkMode ||
+        view.durationMs != null ||
+        view.cwd ? (
           <div className="code-command-meta muted small">
+            {view.durationMs != null ? (
+              <span data-testid="code-duration">{formatDuration(view.durationMs)}</span>
+            ) : null}
+            {view.cwd ? (
+              <span className="mono" data-testid="code-cwd">
+                {view.cwd}
+              </span>
+            ) : null}
             {view.executionMode ? <span>sandbox: {view.executionMode}</span> : null}
             {view.networkMode ? <span>network: {view.networkMode}</span> : null}
           </div>
         ) : null}
         {view.stdout ? (
-          <pre className="code-terminal" data-testid="code-terminal">
-            {view.stdout}
-          </pre>
+          <div className="code-output">
+            <CopyButton className="code-output-copy" getText={() => view.stdout} />
+            <pre className="code-terminal" data-testid="code-terminal">
+              {view.stdout}
+            </pre>
+          </div>
         ) : null}
         {view.stderr ? (
           <div className="code-stderr" data-testid="code-stderr">
             <div className="tool-detail-label">stderr</div>
-            <pre className="code-terminal">{view.stderr}</pre>
+            <div className="code-output">
+              <CopyButton className="code-output-copy" getText={() => view.stderr} />
+              <pre className="code-terminal">{view.stderr}</pre>
+            </div>
           </div>
         ) : null}
       </div>

--- a/apps/desktop-tauri/src/components/codeTools/codeTools.ts
+++ b/apps/desktop-tauri/src/components/codeTools/codeTools.ts
@@ -31,11 +31,36 @@ export type CommandRunView = {
   exitCode: number | null;
   executionMode: string | null;
   networkMode: string | null;
+  durationMs: number | null;
+  cwd: string | null;
   timedOut: boolean;
   failed: boolean;
   stdout: string;
   stderr: string;
 };
+
+/** Operator-facing duration: 480ms · 1.2s · 2m 14s. */
+export function formatDuration(ms: number): string {
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`;
+  }
+  if (ms < 60_000) {
+    return `${(ms / 1000).toFixed(1).replace(/\.0$/, "")}s`;
+  }
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return seconds > 0 ? `${minutes}m ${seconds}s` : `${minutes}m`;
+}
+
+// Terminal escapes the webview can't render: CSI (colors/cursor), OSC
+// (titles/hyperlink wrappers), and stray two-byte escape controls.
+const ANSI_PATTERN =
+  // eslint-disable-next-line no-control-regex
+  /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)|\x1b[@-Z\\-_]/g;
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_PATTERN, "");
+}
 
 export type CodeToolView = FileEditView | CommandRunView;
 
@@ -202,7 +227,7 @@ function splitAtMarker(
 }
 
 function normalizeStream(value: string): string {
-  const trimmed = value.replace(/\s+$/, "");
+  const trimmed = stripAnsi(value).replace(/\s+$/, "");
   return trimmed === "(empty)" ? "" : trimmed;
 }
 
@@ -299,12 +324,15 @@ function toCommandRunView(tool: RenderedToolCallView): CommandRunView | null {
     status === "exit_nonzero" ||
     (exitCode != null && exitCode !== 0);
   const { stdout, stderr } = streams;
+  const durationRaw = meta?.["duration_ms"];
   return {
     kind: "command",
     command,
     exitCode,
     executionMode: stringField(meta, "execution_mode"),
     networkMode: stringField(meta, "network_mode"),
+    durationMs: typeof durationRaw === "number" ? durationRaw : null,
+    cwd: stringField(meta, "cwd"),
     timedOut,
     failed,
     stdout,

--- a/apps/desktop-tauri/src/styles/transcript/tools.css
+++ b/apps/desktop-tauri/src/styles/transcript/tools.css
@@ -342,10 +342,28 @@
     padding: 0 var(--space-5) var(--space-2);
   }
 
+  .code-output {
+    position: relative;
+  }
+
+  .code-output-copy {
+    position: absolute;
+    top: var(--space-2);
+    right: var(--space-2);
+    opacity: 0;
+    background: var(--color-surface-deep);
+  }
+
+  .code-output:hover .code-output-copy,
+  .code-output-copy:focus-visible {
+    opacity: 1;
+  }
+
   .code-terminal {
     margin: 0;
     padding: var(--space-3) var(--space-5);
-    overflow-x: auto;
+    max-height: 320px;
+    overflow: auto;
     background: var(--color-surface-deep);
     border-radius: var(--radius-md, 8px);
     font-size: var(--text-md);

--- a/apps/desktop-tauri/tests/code-tools.test.tsx
+++ b/apps/desktop-tauri/tests/code-tools.test.tsx
@@ -123,6 +123,8 @@ describe("toCodeToolView", () => {
       exitCode: 0,
       executionMode: "read_only",
       networkMode: "disabled",
+      durationMs: null,
+      cwd: null,
       timedOut: false,
       failed: false,
       stdout: "test result: ok. 3 passed",

--- a/apps/desktop-tauri/tests/terminal-quality.test.tsx
+++ b/apps/desktop-tauri/tests/terminal-quality.test.tsx
@@ -1,0 +1,125 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodeToolItem } from "../src/components/codeTools/CodeToolItem";
+import {
+  formatDuration,
+  stripAnsi,
+  toCodeToolView,
+} from "../src/components/codeTools/codeTools";
+import type { RenderedToolCallView } from "../src/lib/types";
+
+describe("formatDuration", () => {
+  it("scales units for operator reading", () => {
+    expect(formatDuration(480)).toBe("480ms");
+    expect(formatDuration(1230)).toBe("1.2s");
+    expect(formatDuration(2000)).toBe("2s");
+    expect(formatDuration(134000)).toBe("2m 14s");
+    expect(formatDuration(120000)).toBe("2m");
+  });
+});
+
+describe("stripAnsi", () => {
+  it("removes color, cursor, and OSC sequences but keeps text", () => {
+    expect(stripAnsi("\x1b[31mred\x1b[0m plain")).toBe("red plain");
+    expect(stripAnsi("\x1b]8;;http://x\x07link\x1b]8;;\x07")).toBe("link");
+    expect(stripAnsi("no escapes [0m here")).toBe("no escapes [0m here");
+  });
+});
+
+function commandCall(
+  meta: Record<string, unknown>,
+  body: string,
+): RenderedToolCallView {
+  return {
+    itemKey: "t1",
+    toolName: "bash",
+    statusKind: "success",
+    args: { rawText: JSON.stringify({ command: "make build" }), fields: [] },
+    result: {
+      rawText: `defra_exec: ${JSON.stringify(meta)}\n${body}`,
+      fields: [],
+    },
+  } as unknown as RenderedToolCallView;
+}
+
+describe("command projection metadata", () => {
+  it("carries duration and cwd and strips ANSI from streams", () => {
+    const view = toCodeToolView(
+      commandCall(
+        {
+          ok: true,
+          status: "success",
+          command: "make build",
+          exit_code: 0,
+          timed_out: false,
+          duration_ms: 1230,
+          cwd: "/work/repo",
+        },
+        "stdout:\n\x1b[32mok\x1b[0m done\nstderr:\n(empty)",
+      ),
+    );
+    expect(view).toMatchObject({
+      kind: "command",
+      durationMs: 1230,
+      cwd: "/work/repo",
+      stdout: "ok done",
+    });
+  });
+});
+
+describe("CodeToolItem terminal chrome", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders duration + cwd and copies stdout", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <CodeToolItem
+        view={{
+          kind: "command",
+          command: "make build",
+          exitCode: 0,
+          executionMode: "read_only",
+          networkMode: "disabled",
+          durationMs: 134000,
+          cwd: "/work/repo",
+          timedOut: false,
+          failed: false,
+          stdout: "all green",
+          stderr: "",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("code-duration")).toHaveTextContent("2m 14s");
+    expect(screen.getByTestId("code-cwd")).toHaveTextContent("/work/repo");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("all green"));
+  });
+
+  it("offers diff copy with +/- prefixes", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <CodeToolItem
+        view={{
+          kind: "fileEdit",
+          path: "src/a.rs",
+          created: false,
+          replacementsApplied: 1,
+          diff: [
+            { kind: "del", text: "old line" },
+            { kind: "add", text: "new line" },
+          ],
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith("-old line\n+new line"));
+  });
+});


### PR DESCRIPTION
WS3 Code-mode slice of #608 — the terminal/diff rendering items that need no bridge changes:

- **Metadata the envelope already carried but the UI dropped**: command blocks now show duration (formatted: 480ms / 1.2s / 2m 14s) and cwd alongside sandbox/network modes.
- **ANSI stripping**: CSI color/cursor codes, OSC title/hyperlink wrappers, and stray two-byte escapes are removed from stdout/stderr (explicit \x1b escapes in source, not literal control bytes).
- **Height cap**: terminal blocks scroll internally at 320px instead of swamping the transcript with one large dump.
- **Copy actions** on terminal stdout, stderr, and diffs (diffs copy with +/- prefixes) — extending the transcript copy affordances into the code experience.

Fences: `terminal-quality.test.tsx` (duration formatting, ANSI cases incl. OSC hyperlinks, metadata projection, both copy paths). Unit 223, e2e 120, visual unchanged.

Stacked on #762. Part of #608 (WS3 code-mode).