### PR TITLE
polish(desktop): readable read-tool blocks

### DIFF
--- a/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
+++ b/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
@@ -7,6 +7,30 @@ function diffText(diff: DiffLine[]): string {
     .join("\n");
 }
 
+const READ_TOOL_LABELS: Record<string, { verb: string; noun: string }> = {
+  read_file: { verb: "read", noun: "lines" },
+  grep: { verb: "grep", noun: "matches" },
+  glob: { verb: "glob", noun: "files" },
+  list_files: { verb: "ls", noun: "entries" },
+};
+
+function readCountLabel(view: {
+  tool: string;
+  returnedCount: number | null;
+  totalCount: number | null;
+  truncated: boolean;
+}): string | null {
+  const noun = READ_TOOL_LABELS[view.tool]?.noun ?? "items";
+  if (view.returnedCount == null) {
+    return null;
+  }
+  const of =
+    view.totalCount != null && view.totalCount !== view.returnedCount
+      ? ` of ${view.totalCount}`
+      : "";
+  return `${view.returnedCount}${of} ${noun}${view.truncated ? " · truncated" : ""}`;
+}
+
 // Renders a code tool call as a diff (file edits) or a terminal block (bash),
 // instead of the generic args/result disclosure. Foundation-aligned: the data
 // is already on the persisted tool call; this is a projection, not new state.
@@ -47,6 +71,45 @@ export function CodeToolItem({ view }: { view: CodeToolView }) {
               </div>
             ))}
           </pre>
+        </div>
+      </details>
+    );
+  }
+
+  if (view.kind === "fileRead") {
+    const counts = readCountLabel(view);
+    return (
+      <details className="tool-item code-tool" data-testid="code-file-read">
+        <summary className="tool-item-summary">
+          <span className="tool-item-summary-left">
+            <span aria-hidden="true" className="tool-item-dot tool-item-dot-success" />
+            <span className="code-tool-kind">
+              {READ_TOOL_LABELS[view.tool]?.verb ?? view.tool}
+            </span>
+            {view.target ? (
+              <span className="code-tool-path mono">{view.target}</span>
+            ) : null}
+            {counts ? (
+              <span className="code-read-counts" data-testid="code-read-counts">
+                {counts}
+              </span>
+            ) : null}
+          </span>
+          <span aria-hidden="true" className="tool-item-action">
+            ▸
+          </span>
+        </summary>
+        <div className="tool-item-body">
+          {view.body ? (
+            <div className="code-output">
+              <CopyButton className="code-output-copy" getText={() => view.body} />
+              <pre className="code-terminal" data-testid="code-read-body">
+                {view.body}
+              </pre>
+            </div>
+          ) : (
+            <div className="muted small">No results.</div>
+          )}
         </div>
       </details>
     );

--- a/apps/desktop-tauri/src/components/codeTools/codeTools.ts
+++ b/apps/desktop-tauri/src/components/codeTools/codeTools.ts
@@ -62,10 +62,24 @@ export function stripAnsi(value: string): string {
   return value.replace(ANSI_PATTERN, "");
 }
 
-export type CodeToolView = FileEditView | CommandRunView;
+export type FileReadTool = "read_file" | "grep" | "glob" | "list_files";
+
+export type FileReadView = {
+  kind: "fileRead";
+  tool: FileReadTool;
+  /** The path or pattern the call targeted, when the args carry one. */
+  target: string | null;
+  returnedCount: number | null;
+  totalCount: number | null;
+  truncated: boolean;
+  body: string;
+};
+
+export type CodeToolView = FileEditView | CommandRunView | FileReadView;
 
 const FILE_EDIT_TOOLS = new Set(["write_file", "edit_file"]);
 const COMMAND_TOOLS = new Set(["bash", "bash_unrestricted"]);
+const FILE_READ_TOOLS = new Set<string>(["read_file", "grep", "glob", "list_files"]);
 
 function safeJsonObject(text?: string | null): Record<string, unknown> | null {
   if (!text) {
@@ -251,7 +265,45 @@ export function toCodeToolView(tool: RenderedToolCallView): CodeToolView | null 
   if (COMMAND_TOOLS.has(name)) {
     return toCommandRunView(tool);
   }
+  if (FILE_READ_TOOLS.has(name)) {
+    return toFileReadView(tool, name as FileReadTool);
+  }
   return null;
+}
+
+function numberField(
+  record: Record<string, unknown> | null,
+  key: string,
+): number | null {
+  const value = record?.[key];
+  return typeof value === "number" ? value : null;
+}
+
+function toFileReadView(
+  tool: RenderedToolCallView,
+  name: FileReadTool,
+): FileReadView | null {
+  const { meta, body } = splitEnvelope(tool.result?.rawText ?? "", "defra_fs: ");
+  // Same honesty rule as edits/commands: no parseable metadata → keep the
+  // generic disclosure instead of projecting a fabricated read result.
+  if (!meta) {
+    return null;
+  }
+  const args = safeJsonObject(tool.args?.rawText);
+  const target =
+    stringField(meta, "path") ??
+    stringField(args, "path") ??
+    stringField(args, "pattern") ??
+    null;
+  return {
+    kind: "fileRead",
+    tool: name,
+    target,
+    returnedCount: numberField(meta, "returned_count"),
+    totalCount: numberField(meta, "total_count"),
+    truncated: meta["truncated"] === true,
+    body: body.replace(/\s+$/, ""),
+  };
 }
 
 function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView | null {

--- a/apps/desktop-tauri/src/styles/transcript/tools.css
+++ b/apps/desktop-tauri/src/styles/transcript/tools.css
@@ -342,6 +342,12 @@
     padding: 0 var(--space-5) var(--space-2);
   }
 
+  .code-read-counts {
+    color: var(--color-text-muted);
+    font-size: var(--text-xs);
+    white-space: nowrap;
+  }
+
   .code-output {
     position: relative;
   }

--- a/apps/desktop-tauri/tests/read-tools.test.tsx
+++ b/apps/desktop-tauri/tests/read-tools.test.tsx
@@ -1,0 +1,111 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CodeToolItem } from "../src/components/codeTools/CodeToolItem";
+import { toCodeToolView } from "../src/components/codeTools/codeTools";
+import type { RenderedToolCallView } from "../src/lib/types";
+
+function readCall(
+  toolName: string,
+  argsJson: Record<string, unknown>,
+  meta: Record<string, unknown>,
+  body: string,
+): RenderedToolCallView {
+  return {
+    itemKey: "r1",
+    toolName,
+    statusKind: "success",
+    args: { rawText: JSON.stringify(argsJson), fields: [] },
+    result: { rawText: `defra_fs: ${JSON.stringify(meta)}\n${body}`, fields: [] },
+  } as unknown as RenderedToolCallView;
+}
+
+describe("file-read projection", () => {
+  it("projects read_file with counts and body, dropping the JSON head", () => {
+    const view = toCodeToolView(
+      readCall(
+        "read_file",
+        { path: "src/main.rs" },
+        {
+          ok: true,
+          status: "success",
+          tool: "read_file",
+          path: "src/main.rs",
+          returned_count: 120,
+          total_count: 400,
+          truncated: true,
+        },
+        "1: fn main() {}\n2: // done",
+      ),
+    );
+    expect(view).toMatchObject({
+      kind: "fileRead",
+      tool: "read_file",
+      target: "src/main.rs",
+      returnedCount: 120,
+      totalCount: 400,
+      truncated: true,
+      body: "1: fn main() {}\n2: // done",
+    });
+  });
+
+  it("falls back to the args pattern for glob and stays honest without metadata", () => {
+    const globView = toCodeToolView(
+      readCall(
+        "glob",
+        { pattern: "**/*.rs" },
+        {
+          ok: true,
+          status: "success",
+          tool: "glob",
+          returned_count: 8,
+          total_count: 8,
+          truncated: false,
+        },
+        "src/a.rs\nsrc/b.rs",
+      ),
+    );
+    expect(globView).toMatchObject({ kind: "fileRead", target: "**/*.rs" });
+
+    const noMeta = toCodeToolView({
+      itemKey: "r2",
+      toolName: "grep",
+      statusKind: "success",
+      args: { rawText: JSON.stringify({ pattern: "todo" }), fields: [] },
+      result: { rawText: "not an envelope", fields: [] },
+    } as unknown as RenderedToolCallView);
+    expect(noMeta).toBeNull();
+  });
+});
+
+describe("file-read rendering", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("renders collapsed with a count summary and copyable body", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <CodeToolItem
+        view={{
+          kind: "fileRead",
+          tool: "grep",
+          target: "todo",
+          returnedCount: 12,
+          totalCount: 12,
+          truncated: false,
+          body: "src/a.rs:L10: // TODO fix",
+        }}
+      />,
+    );
+
+    const details = screen.getByTestId("code-file-read");
+    expect(details).not.toHaveAttribute("open");
+    expect(screen.getByTestId("code-read-counts")).toHaveTextContent("12 matches");
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("src/a.rs:L10: // TODO fix"),
+    );
+  });
+});


### PR DESCRIPTION
WS3 Code-mode slice of #608. `read_file`/`grep`/`glob`/`list_files` results dumped the raw `defra_fs` envelope JSON at operators through the generic disclosure.

They now project into collapsed read blocks: a summary line with the tool verb, target path/pattern, and honest counts ("120 of 400 lines · truncated", "12 matches"), and a copyable mono body with the JSON head stripped. Collapsed by default — reads are bulky and secondary — with the same rotating-chevron affordance as other tool rows. The projection follows the established honesty rule: no parseable metadata → generic disclosure, never a fabricated result.

Fences: `read-tools.test.tsx` (projection per tool, args-pattern fallback, no-metadata honesty, collapsed default, count label, copy). Unit 226, e2e 120, visual unchanged.

Stacked on #763. Part of #608 (WS3 code-mode).