### PR TITLE
polish(desktop): honest write_file overwrite rendering

### DIFF
--- a/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
+++ b/apps/desktop-tauri/src/components/codeTools/CodeToolItem.tsx
@@ -42,7 +42,7 @@ export function CodeToolItem({ view }: { view: CodeToolView }) {
           <span className="tool-item-summary-left">
             <span aria-hidden="true" className="tool-item-dot tool-item-dot-success" />
             <span className="code-tool-kind">
-              {view.created ? "created" : "edited"}
+              {view.created ? "created" : view.overwrite ? "overwrote" : "edited"}
             </span>
             <span className="code-tool-path mono">{view.path}</span>
             {view.replacementsApplied > 1 ? (
@@ -53,25 +53,43 @@ export function CodeToolItem({ view }: { view: CodeToolView }) {
           </span>
           <span className="tool-item-action">diff</span>
         </summary>
-        <div className="code-output">
-          <CopyButton
-            className="code-output-copy"
-            getText={() => diffText(view.diff)}
-          />
-          <pre className="code-diff" data-testid="code-diff">
-            {view.diff.map((line, index) => (
-              <div
-                className={`code-diff-line code-diff-${line.kind}`}
-                key={`${line.kind}-${index}`}
-              >
-                <span aria-hidden="true" className="code-diff-gutter">
-                  {line.kind === "add" ? "+" : "-"}
-                </span>
-                <span className="code-diff-text">{line.text}</span>
-              </div>
-            ))}
-          </pre>
-        </div>
+        {view.overwrite ? (
+          <div className="tool-item-body">
+            <div className="muted small" data-testid="code-overwrite-note">
+              Replaced the file&apos;s previous contents — no diff basis exists. New
+              contents:
+            </div>
+            <div className="code-output">
+              <CopyButton
+                className="code-output-copy"
+                getText={() => view.diff.map((line) => line.text).join("\n")}
+              />
+              <pre className="code-terminal" data-testid="code-overwrite-content">
+                {view.diff.map((line) => line.text).join("\n")}
+              </pre>
+            </div>
+          </div>
+        ) : (
+          <div className="code-output">
+            <CopyButton
+              className="code-output-copy"
+              getText={() => diffText(view.diff)}
+            />
+            <pre className="code-diff" data-testid="code-diff">
+              {view.diff.map((line, index) => (
+                <div
+                  className={`code-diff-line code-diff-${line.kind}`}
+                  key={`${line.kind}-${index}`}
+                >
+                  <span aria-hidden="true" className="code-diff-gutter">
+                    {line.kind === "add" ? "+" : "-"}
+                  </span>
+                  <span className="code-diff-text">{line.text}</span>
+                </div>
+              ))}
+            </pre>
+          </div>
+        )}
       </details>
     );
   }

--- a/apps/desktop-tauri/src/components/codeTools/codeTools.ts
+++ b/apps/desktop-tauri/src/components/codeTools/codeTools.ts
@@ -20,6 +20,11 @@ export type FileEditView = {
   kind: "fileEdit";
   path: string;
   created: boolean;
+  /**
+   * write_file onto an existing file: the previous contents were replaced
+   * and are unknowable client-side, so an all-additions diff would lie.
+   */
+  overwrite: boolean;
   /** >1 when edit_file replace_all touched multiple sites. */
   replacementsApplied: number;
   diff: DiffLine[];
@@ -321,6 +326,7 @@ function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView 
   }
   // Only write_file's metadata carries `created`; edit_file edits by contract.
   const created = name === "write_file" && meta["created"] === true;
+  const overwrite = name === "write_file" && meta["created"] === false;
   const replacementsRaw = meta["replacements_applied"];
   const replacementsApplied =
     typeof replacementsRaw === "number" && replacementsRaw > 0 ? replacementsRaw : 1;
@@ -333,7 +339,7 @@ function toFileEditView(tool: RenderedToolCallView, name: string): FileEditView 
       ...toDiffLines(stringField(args, "new_text") ?? "", "add"),
     ];
   }
-  return { kind: "fileEdit", path, created, replacementsApplied, diff };
+  return { kind: "fileEdit", path, created, overwrite, replacementsApplied, diff };
 }
 
 function toCommandRunView(tool: RenderedToolCallView): CommandRunView | null {

--- a/apps/desktop-tauri/tests/code-tools.test.tsx
+++ b/apps/desktop-tauri/tests/code-tools.test.tsx
@@ -44,6 +44,7 @@ describe("toCodeToolView", () => {
       kind: "fileEdit",
       path: "src/main.rs",
       created: false,
+      overwrite: false,
       replacementsApplied: 1,
       diff: [
         { kind: "del", text: "let x = 1;" },
@@ -103,7 +104,11 @@ describe("toCodeToolView", () => {
         ),
       }),
     );
-    expect(overwrote).toMatchObject({ kind: "fileEdit", created: false });
+    expect(overwrote).toMatchObject({
+      kind: "fileEdit",
+      created: false,
+      overwrite: true,
+    });
   });
 
   it("parses the stdout/stderr framing and prefers the envelope's full command line", () => {
@@ -441,5 +446,30 @@ describe("CodeToolItem", () => {
       />,
     );
     expect(screen.getByTestId("code-exit")).toHaveTextContent("timed out");
+  });
+});
+
+describe("overwrite rendering honesty", () => {
+  it("renders an overwrite as replaced contents, not an all-additions diff", () => {
+    render(
+      <CodeToolItem
+        view={{
+          kind: "fileEdit",
+          path: "README.md",
+          created: false,
+          overwrite: true,
+          replacementsApplied: 1,
+          diff: [
+            { kind: "add", text: "brand" },
+            { kind: "add", text: "new" },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("overwrote")).toBeInTheDocument();
+    expect(screen.getByTestId("code-overwrite-note")).toBeInTheDocument();
+    expect(screen.getByTestId("code-overwrite-content")).toHaveTextContent("brand new");
+    expect(screen.queryByTestId("code-diff")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
WS3 Code-mode slice of #608. A `write_file` onto an existing file rendered as an all-additions diff labeled "edited" — implying pure addition when the previous contents were destroyed and are unknowable client-side.

Overwrites (envelope `created: false`) now label as **overwrote** and render the new contents as a plain copyable block with an explicit note ("Replaced the file's previous contents — no diff basis exists"), instead of a fabricated `+` gutter. Created files keep the honest all-add diff; `edit_file` keeps its real del/add diff. Legacy envelopes without the `created` field keep today's rendering.

Fences: projection flags + render assertions in `code-tools.test.tsx`. Unit 227, e2e 120, visual unchanged.

Stacked on #764. Part of #608 (WS3 code-mode).