### PR TITLE
feat(desktop): stuck-work attention badge + diagnostics strip

### DIFF
--- a/apps/desktop-tauri/src/components/ChatWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ChatWorkspace.tsx
@@ -13,7 +13,10 @@ import { McpHealthPanel } from "./mcpHealth";
 import { OperationsRail, OperationsRailProvider } from "./operations";
 import type { OperationsRailTabDescriptor } from "./operations";
 import { BackgroundedToolsPanel } from "./backgroundedTools";
+import { useOperationsSnapshot } from "./backgroundedTools/useOperationsSnapshot";
 import { SubagentLineageView } from "./subagentLineage";
+
+const OPS_SNAPSHOT_REQUEST = { rootRequestId: null };
 
 export type ChatWorkspaceProps = {
   selectedDeployment: DeploymentView | null;
@@ -143,6 +146,11 @@ export function ActiveChatWorkspace({
     [selectedDeployment.agentDid],
   );
 
+  // Workspace-level poll so the closed drawer can still raise attention —
+  // the panels only poll while mounted inside the open drawer.
+  const { snapshot: opsSnapshot } = useOperationsSnapshot(OPS_SNAPSHOT_REQUEST);
+  const stuckCount = opsSnapshot?.stuckDiagnostics.length ?? 0;
+
   const operationsRailTabs = useMemo<OperationsRailTabDescriptor[]>(() => {
     const rootRequestId = lineageRootOverride ?? session?.latestRequestId ?? null;
     const lineageAgentDid = selectedDeployment.agentDid;
@@ -150,6 +158,7 @@ export function ActiveChatWorkspace({
       {
         id: "background-tools",
         label: "Background",
+        badge: stuckCount > 0 ? String(stuckCount) : null,
         render: () => (
           <BackgroundedToolsPanel
             onOpenLineage={setLineageRootOverride}
@@ -185,6 +194,7 @@ export function ActiveChatWorkspace({
     selectedDeployment.agentDid,
     lineageRootOverride,
     beginInterrupt,
+    stuckCount,
   ]);
 
   function onInterruptClick() {
@@ -229,7 +239,11 @@ export function ActiveChatWorkspace({
             skills={selectedDeployment.skills ?? []}
           />
         </div>
-        <OperationsRail open={operationsOpen} onOpenChange={setOperationsOpen} />
+        <OperationsRail
+          open={operationsOpen}
+          onOpenChange={setOperationsOpen}
+          attentionCount={stuckCount}
+        />
         {interruptResultBanner ? (
           <div
             className={`chat-toast${

--- a/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
+++ b/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useContext, useMemo, useState } from "react";
 
-import type { DesktopOperationsSnapshotRequest } from "../../lib/types/operations";
+import type {
+  DesktopOperationsSnapshotRequest,
+  StuckWorkDiagnosticView,
+} from "../../lib/types/operations";
 import { OperationsRailContext } from "../operations/operationsRailContext";
 import {
   correlateProcess,
@@ -22,6 +25,27 @@ type SortDir = "ascending" | "descending";
 // 8-slot ceiling per the operator-surfaces spec §"Panel 1". Hardcoded
 // until the bridge exposes a per-agent backgrounded-tool capacity.
 const MAX_BACKGROUND_SLOTS = 8;
+
+function shortRequestId(requestId: string): string {
+  return requestId.length > 14 ? `${requestId.slice(0, 14)}…` : requestId;
+}
+
+/** The bridge's diagnosis, in operator language. */
+function diagnosticSentence(diag: StuckWorkDiagnosticView): string {
+  const tool = diag.toolName ?? "a tool";
+  switch (diag.reason) {
+    case "expiredProcessing":
+      return `Request ${shortRequestId(diag.requestId)} ran past its deadline`;
+    case "expiredTool":
+      return `${tool} on ${shortRequestId(diag.requestId)} ran past its deadline`;
+    case "stuckTool":
+      return `${tool} on ${shortRequestId(diag.requestId)} has stopped making progress`;
+    case "pendingRemoteCancelAck":
+      return `Waiting on a remote node to acknowledge cancelling ${shortRequestId(diag.requestId)}`;
+    default:
+      return `${shortRequestId(diag.requestId)} needs attention`;
+  }
+}
 
 export type BackgroundedToolsPanelProps = {
   rootRequestId?: string | null;
@@ -149,8 +173,23 @@ export function BackgroundedToolsPanel({
     );
   }
 
+  const diagnostics = snapshot?.stuckDiagnostics ?? [];
+
   return (
     <section className="background-tools-panel" aria-label="Background tools">
+      {diagnostics.length > 0 ? (
+        <div className="stuck-diagnostics" data-testid="stuck-diagnostics" role="alert">
+          {diagnostics.map((diag, index) => (
+            <div
+              className={`stuck-diagnostic is-${diag.severity}`}
+              key={`${diag.requestId}-${diag.toolCallId ?? index}`}
+            >
+              <span aria-hidden="true" className="stuck-diagnostic-dot" />
+              {diagnosticSentence(diag)}
+            </div>
+          ))}
+        </div>
+      ) : null}
       <div className="chip-row" role="group" aria-label="Filter by parent">
         <span className="chip-label">Parent</span>
         <button

--- a/apps/desktop-tauri/src/components/operations/OperationsRail.tsx
+++ b/apps/desktop-tauri/src/components/operations/OperationsRail.tsx
@@ -19,6 +19,8 @@ export type OperationsRailProviderProps = {
 export type OperationsRailProps = {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /** Count of stuck/at-risk operations; badges the collapsed handle. */
+  attentionCount?: number;
 };
 
 export function OperationsRailProvider({
@@ -56,6 +58,7 @@ export function OperationsRailProvider({
 export function OperationsRail({
   open = true,
   onOpenChange,
+  attentionCount = 0,
 }: OperationsRailProps = {}) {
   const value = useContext(OperationsRailContext);
   if (!value || value.tabs.length === 0) {
@@ -74,9 +77,20 @@ export function OperationsRail({
           type="button"
           className="operations-rail-collapsed-button"
           aria-expanded="false"
-          aria-label={`Open operations drawer, ${activeLabel} selected`}
+          aria-label={
+            attentionCount > 0
+              ? `Open operations drawer, ${attentionCount} ${
+                  attentionCount === 1 ? "item needs" : "items need"
+                } attention`
+              : `Open operations drawer, ${activeLabel} selected`
+          }
           onClick={() => onOpenChange?.(true)}
         >
+          {attentionCount > 0 ? (
+            <span className="operations-rail-attention" data-testid="ops-attention">
+              {attentionCount}
+            </span>
+          ) : null}
           <span aria-hidden="true">‹</span>
           <span>Operations</span>
         </button>

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -16,6 +16,39 @@
 
   /* ── Chip row / filter row ─────────────────────────────────────────────── */
 
+  .background-tools-panel .stuck-diagnostics {
+    display: grid;
+    gap: var(--space-2);
+    padding: var(--space-4) var(--space-5);
+    border: 1px solid var(--color-warning);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-deep);
+  }
+
+  .background-tools-panel .stuck-diagnostic {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    color: var(--color-text-soft);
+    font-size: var(--text-sm);
+  }
+
+  .background-tools-panel .stuck-diagnostic-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: var(--radius-pill);
+    background: var(--color-warning);
+    animation: thinking-pulse var(--motion-pulse) ease-in-out infinite;
+  }
+
+  .background-tools-panel .stuck-diagnostic.is-critical .stuck-diagnostic-dot {
+    background: var(--color-error-strong);
+  }
+
+  .background-tools-panel .stuck-diagnostic.is-critical {
+    color: var(--color-error);
+  }
+
   .background-tools-panel .chip-row {
     display: flex;
     flex-wrap: wrap;

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -73,6 +73,18 @@
     outline-offset: 2px;
   }
 
+  .operations-rail-attention {
+    min-width: var(--space-7);
+    padding: 0 var(--space-1);
+    border-radius: var(--radius-pill);
+    background: var(--color-warning);
+    color: var(--source-black);
+    font-size: var(--text-2xs);
+    font-weight: 700;
+    text-align: center;
+    writing-mode: horizontal-tb;
+  }
+
   .operations-rail-header {
     display: flex;
     align-items: flex-start;

--- a/apps/desktop-tauri/tests/ops-attention.test.tsx
+++ b/apps/desktop-tauri/tests/ops-attention.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/components/backgroundedTools/useOperationsSnapshot", () => ({
+  useOperationsSnapshot: vi.fn(),
+}));
+
+import { BackgroundedToolsPanel } from "../src/components/backgroundedTools";
+import { useOperationsSnapshot } from "../src/components/backgroundedTools/useOperationsSnapshot";
+import { OperationsRail, OperationsRailProvider } from "../src/components/operations";
+import type { DesktopOperationsSnapshot } from "../src/lib/types/operations";
+
+const mockedSnapshot = vi.mocked(useOperationsSnapshot);
+
+const snapshot: DesktopOperationsSnapshot = {
+  fetchedAt: new Date().toISOString(),
+  backgroundedTools: [],
+  stuckDiagnostics: [
+    {
+      requestId: "req_0123456789abcdef",
+      severity: "warning",
+      reason: "stuckTool",
+      toolName: "bash",
+      toolCallId: "tc1",
+    },
+    {
+      requestId: "req_critical",
+      severity: "critical",
+      reason: "expiredProcessing",
+    },
+  ],
+};
+
+describe("stuck-work attention", () => {
+  beforeEach(() => {
+    mockedSnapshot.mockReturnValue({
+      snapshot,
+      error: null,
+      isLoading: false,
+      refresh: vi.fn(),
+    });
+  });
+
+  it("renders diagnostics in operator language inside the panel", () => {
+    render(<BackgroundedToolsPanel />);
+    const strip = screen.getByTestId("stuck-diagnostics");
+    expect(strip).toHaveTextContent(
+      "bash on req_0123456789… has stopped making progress",
+    );
+    expect(strip).toHaveTextContent("Request req_critical ran past its deadline");
+  });
+
+  it("badges the collapsed rail handle with the attention count", () => {
+    render(
+      <OperationsRailProvider
+        tabs={[{ id: "background-tools", label: "Background", render: () => null }]}
+      >
+        <OperationsRail open={false} attentionCount={2} />
+      </OperationsRailProvider>,
+    );
+    expect(screen.getByTestId("ops-attention")).toHaveTextContent("2");
+    expect(
+      screen.getByRole("button", { name: /2 items need attention/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the quiet handle when nothing needs attention", () => {
+    render(
+      <OperationsRailProvider
+        tabs={[{ id: "background-tools", label: "Background", render: () => null }]}
+      >
+        <OperationsRail open={false} attentionCount={0} />
+      </OperationsRailProvider>,
+    );
+    expect(screen.queryByTestId("ops-attention")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-live-backend-contract.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-live-backend-contract.spec.ts
@@ -89,6 +89,14 @@ async function fulfillBridgeRoute(
     );
     return;
   }
+  if (method === "POST" && path === "/desktop/operations/snapshot") {
+    // The chat workspace polls this for the stuck-work attention badge.
+    await fulfillJson(
+      route,
+      await fixture.adapter.fetchOperationsSnapshot({ rootRequestId: null }),
+    );
+    return;
+  }
 
   await route.fulfill({
     status: 404,

--- a/apps/desktop-tauri/tests/playwright/desktop-operations-rich.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-operations-rich.spec.ts
@@ -15,12 +15,16 @@ test.describe("desktop operations drawer rich states", () => {
     await page.getByRole("button", { name: /open operations drawer/i }).click();
 
     await expect(page.getByRole("complementary", { name: "Operations" })).toBeVisible();
-    await expect(page.getByText("cargo test")).toBeVisible();
+    await expect(
+      page.getByRole("gridcell", { name: "cargo test", exact: true }),
+    ).toBeVisible();
     await expect(page.getByText("query_logs")).toBeVisible();
     await expect(page.getByText("2 live")).toBeVisible();
 
     await page.getByRole("button", { name: "Stuck" }).click();
-    await expect(page.getByText("cargo test")).toBeVisible();
+    await expect(
+      page.getByRole("gridcell", { name: "cargo test", exact: true }),
+    ).toBeVisible();
     await expect(page.getByText("query_logs")).toHaveCount(0);
     await expect(
       page.getByRole("button", { name: /Open lineage for cargo test/ }),


### PR DESCRIPTION
WS6 slice of #608. The bridge computes stuck-work diagnostics on every operations snapshot, but nothing rendered them — the drawer could not alert an operator to the very conditions it was built to surface.

- **Attention badge**: a workspace-level snapshot poll (the panels only poll while mounted in the open drawer) badges the collapsed rail handle and the Background tab with the count of stuck/at-risk items; the handle's aria-label says "N items need attention".
- **Diagnostics strip**: the Background panel leads with the bridge's diagnoses in operator language ("bash on req_0123456789… has stopped making progress", "Request … ran past its deadline", remote cancel-ack waits), warning/critical toned, with the pulsing-dot motion token.
- The live-backend contract mock gained the operations-snapshot route the new poll exercises, and the operations-rich spec's `getByText("cargo test")` locator became ambiguous **because the fixture's diagnostic now actually renders** — tightened to the exact gridcell.

Fences: `ops-attention.test.tsx` (operator sentences, badge + aria at count>0, quiet handle at 0). Unit 230, e2e 120, visual unchanged.

Stacked on #765. Part of #608 (WS6).