### PR TITLE
polish(desktop): visible fleet health + DID copy

### DIFF
--- a/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
@@ -1,5 +1,7 @@
 import { isTerminalTurnState } from "../../lib/chat-shell";
+import { formatPeerConnectionError } from "../../lib/peerConnectionErrors";
 import type { BootstrapSummary, DeploymentView } from "../../lib/types";
+import { CopyButton } from "../CopyButton";
 import {
   displayAgentIdentity,
   displayBehaviorLabel,
@@ -62,7 +64,15 @@ export function FleetRow({
     <tr data-testid={`fleet-row-${deployment.peerId}`}>
       <td>
         <div className="fleet-agent-cell">
-          <span className={`fleet-status-dot ${status.tone}`} title={status.title} />
+          <span className={`fleet-status ${status.tone}`} title={status.title}>
+            <span aria-hidden="true" className={`fleet-status-dot ${status.tone}`} />
+            <span
+              className="fleet-status-label"
+              data-testid={`fleet-status-${deployment.peerId}`}
+            >
+              {status.label}
+            </span>
+          </span>
           <div className="fleet-agent-copy">
             <button
               className="fleet-agent-name"
@@ -73,14 +83,27 @@ export function FleetRow({
             >
               {deployment.agentPrincipal.displayName ?? deployment.label}
             </button>
-            <span className="muted mono">
+            <span className="muted mono fleet-agent-identity">
               {[
                 agentIdentity,
                 defaultBehaviorLabel ? `default: ${defaultBehaviorLabel}` : null,
               ]
                 .filter(Boolean)
                 .join(" | ")}
+              <CopyButton
+                className="fleet-did-copy"
+                label="Copy DID"
+                getText={() => deployment.agentDid}
+              />
             </span>
+            {status.lastError ? (
+              <span
+                className="fleet-agent-error"
+                data-testid={`fleet-error-${deployment.peerId}`}
+              >
+                {formatPeerConnectionError(status.lastError, "repair-p2p")}
+              </span>
+            ) : null}
             {graphqlEndpoint ? (
               <span
                 className="fleet-agent-endpoint mono"

--- a/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
+++ b/apps/desktop-tauri/src/components/fleet/fleetMetrics.ts
@@ -13,6 +13,9 @@ export type ToolIcon = {
 export function deploymentStatus(deployment: DeploymentView): {
   title: string;
   tone: StatusTone;
+  /** Visible one-word status — health must not be a hover-only dot. */
+  label: string;
+  lastError: string | null;
 } {
   const p2p = deployment.dialSucceeded ? "connected" : "saved";
   const runtime = deployment.runtime?.processState ?? "unknown";
@@ -28,15 +31,19 @@ export function deploymentStatus(deployment: DeploymentView): {
     .filter(Boolean)
     .join(" | ");
 
-  if (!deployment.dialSucceeded || lastError) {
-    return { title, tone: "red" };
+  if (lastError) {
+    return { title, tone: "red", label: "Error", lastError };
+  }
+
+  if (!deployment.dialSucceeded) {
+    return { title, tone: "red", label: "Not connected", lastError };
   }
 
   if (reconcile !== "idle" && reconcile !== "unknown") {
-    return { title, tone: "yellow" };
+    return { title, tone: "yellow", label: "Syncing", lastError };
   }
 
-  return { title, tone: "green" };
+  return { title, tone: "green", label: "Online", lastError };
 }
 
 export function inferenceBackendTitle(deployment: DeploymentView) {

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -42,6 +42,47 @@
     min-width: 260px;
   }
 
+  .fleet-status {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    white-space: nowrap;
+  }
+
+  .fleet-status-label {
+    font-size: var(--text-xs);
+    color: var(--color-text-soft);
+  }
+
+  .fleet-status.red .fleet-status-label {
+    color: var(--color-error);
+  }
+
+  .fleet-status.yellow .fleet-status-label {
+    color: var(--color-warning-soft);
+  }
+
+  .fleet-agent-identity {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .fleet-did-copy {
+    opacity: 0;
+  }
+
+  .fleet-agent-cell:hover .fleet-did-copy,
+  .fleet-did-copy:focus-visible {
+    opacity: 1;
+  }
+
+  .fleet-agent-error {
+    color: var(--color-error);
+    font-size: var(--text-xs);
+    max-width: 52ch;
+  }
+
   .fleet-status-dot {
     width: 10px;
     height: 10px;

--- a/apps/desktop-tauri/tests/fleet-health-visibility.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-health-visibility.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { FleetRow, type FleetRowProps } from "../src/components/fleet/FleetRow";
+import { deploymentStatus } from "../src/components/fleet/fleetMetrics";
+import type { DeploymentView } from "../src/lib/types";
+import { deployment } from "./config-panel-wiring/fixtures";
+
+function renderRow(dep: DeploymentView) {
+  const props: FleetRowProps = {
+    bootstrap: null,
+    deployment: dep,
+    onOpenChat: vi.fn(),
+    onOpenConfig: vi.fn(),
+  };
+  render(
+    <table>
+      <tbody>
+        <FleetRow {...props} />
+      </tbody>
+    </table>,
+  );
+}
+
+describe("fleet health visibility", () => {
+  it("labels statuses instead of relying on a hover dot", () => {
+    expect(
+      deploymentStatus({ ...deployment, dialSucceeded: true, lastError: null }).label,
+    ).toBe("Online");
+    expect(deploymentStatus({ ...deployment, dialSucceeded: false }).label).toBe(
+      "Not connected",
+    );
+    expect(deploymentStatus({ ...deployment, lastError: "dial timeout" }).label).toBe(
+      "Error",
+    );
+  });
+
+  it("shows a visible error line with remediation-aware copy on failing rows", () => {
+    renderRow({ ...deployment, dialSucceeded: true, lastError: "dial timeout" });
+    expect(screen.getByTestId("fleet-status-peer-1")).toHaveTextContent("Error");
+    expect(screen.getByTestId("fleet-error-peer-1")).toHaveTextContent("dial timeout");
+  });
+
+  it("offers a DID copy affordance in the agent cell", () => {
+    renderRow({ ...deployment, dialSucceeded: true, lastError: null });
+    expect(screen.getByRole("button", { name: "Copy DID" })).toBeInTheDocument();
+    expect(screen.queryByTestId("fleet-error-peer-1")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
WS4 slice of #608. Agent health was a 10px hover-only dot with a raw pipe-joined tooltip, and failing rows showed no visible error.

- **Visible status labels**: every row shows Online / Syncing / Not connected / Error next to the dot (tones mapped; detailed states stay in the tooltip). Error takes precedence over connectivity.
- **Failing rows explain themselves**: a visible error line renders under the agent identity, run through the existing peer-connection formatter so operators get remediation-aware copy instead of raw transport errors.
- **DID copy affordance**: hover copy on the agent identity (the raw DID was prominent but uncopyable).

Fences: `fleet-health-visibility.test.tsx` (label mapping, error-line render + precedence, copy affordance). Unit 233, e2e 120, fleet visual baselines regenerated.

Stacked on #767. Part of #608 (WS4).