### PR TITLE
feat(desktop): config dirty-state tracking (slice 1)

### DIFF
--- a/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
@@ -6,6 +6,7 @@ import type {
   DeploymentView,
   InferenceBackendView,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
@@ -101,27 +102,38 @@ export function BackendConfigEditor({
   const [enabled, setEnabled] = useState(true);
 
   useEffect(() => {
-    setBackendId(backend?.backendId ?? "");
-    setName(backend?.name ?? backend?.backendId ?? "");
-    setProviderKind(
-      backend?.providerKind === "OpenRouter" || backend?.providerKind === "openrouter"
-        ? "openrouter"
-        : "openai",
-    );
-    setEndpoint(backend?.endpoint ?? "");
-    setApiKey("");
-    setApiKeyEnvVar(backend?.apiKeyEnvVar ?? "");
-    setClearApiKey(false);
-    setModels((backend?.models ?? []).join("\n"));
-    setMaxConcurrent(
-      backend?.maxConcurrent != null ? String(backend.maxConcurrent) : "",
-    );
-    setMaxQueueDepth(
-      backend?.maxQueueDepth != null ? String(backend.maxQueueDepth) : "",
-    );
-    setEnabled(backend?.enabled ?? true);
+    const base = backendFormValues(backend);
+    setBackendId(base.backendId);
+    setName(base.name);
+    setProviderKind(base.providerKind);
+    setEndpoint(base.endpoint);
+    setApiKey(base.apiKey);
+    setApiKeyEnvVar(base.apiKeyEnvVar);
+    setClearApiKey(base.clearApiKey);
+    setModels(base.models);
+    setMaxConcurrent(base.maxConcurrent);
+    setMaxQueueDepth(base.maxQueueDepth);
+    setEnabled(base.enabled);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend?.backendId]);
+
+  const dirty = isDirty(
+    {
+      backendId,
+      name,
+      providerKind,
+      endpoint,
+      apiKey,
+      apiKeyEnvVar,
+      clearApiKey,
+      models,
+      maxConcurrent,
+      maxQueueDepth,
+      enabled,
+    },
+    backendFormValues(backend),
+  );
 
   const maxConcurrentValid = isOptionalInt(maxConcurrent, { min: 1 });
   const maxQueueDepthValid = isOptionalInt(maxQueueDepth, { min: 1 });
@@ -155,6 +167,7 @@ export function BackendConfigEditor({
         eyebrow="Backend"
         saved={savedStatus === `backend:${backendId.trim()}`}
         title={name || backendId || "New Backend"}
+        dirty={dirty}
       />
       <div className="grid-2">
         <label className="field">
@@ -292,4 +305,24 @@ export function BackendConfigEditor({
       </div>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function backendFormValues(backend: InferenceBackendView | null) {
+  return {
+    backendId: backend?.backendId ?? "",
+    name: backend?.name ?? backend?.backendId ?? "",
+    providerKind:
+      backend?.providerKind === "OpenRouter" || backend?.providerKind === "openrouter"
+        ? "openrouter"
+        : "openai",
+    endpoint: backend?.endpoint ?? "",
+    apiKey: "",
+    apiKeyEnvVar: backend?.apiKeyEnvVar ?? "",
+    clearApiKey: false,
+    models: (backend?.models ?? []).join("\n"),
+    maxConcurrent: backend?.maxConcurrent != null ? String(backend.maxConcurrent) : "",
+    maxQueueDepth: backend?.maxQueueDepth != null ? String(backend.maxQueueDepth) : "",
+    enabled: backend?.enabled ?? true,
+  };
 }

--- a/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
+++ b/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
@@ -2,16 +2,28 @@ export type ConfigEditorHeaderProps = {
   eyebrow: string;
   saved: boolean;
   title: string;
+  dirty?: boolean;
 };
 
-export function ConfigEditorHeader({ eyebrow, saved, title }: ConfigEditorHeaderProps) {
+export function ConfigEditorHeader({
+  eyebrow,
+  saved,
+  title,
+  dirty = false,
+}: ConfigEditorHeaderProps) {
   return (
     <div className="panel-header">
       <div>
         <p className="eyebrow">{eyebrow}</p>
         <h3>{title}</h3>
       </div>
-      {saved ? <span className="chip chip-green">Saved</span> : null}
+      {dirty ? (
+        <span className="chip chip-amber" data-testid="unsaved-chip">
+          Unsaved changes
+        </span>
+      ) : saved ? (
+        <span className="chip chip-green">Saved</span>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
@@ -8,6 +8,7 @@ import type {
   SkillView,
 } from "../../lib/types";
 import { ConfirmDialog } from "../ConfirmDialog";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import { ignoreHandledActionError, linesToArray, optionalString } from "./formUtils";
 
@@ -112,16 +113,23 @@ export function SkillConfigEditor({
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
   useEffect(() => {
-    setSkillId(skill?.skillId ?? "");
-    setName(skill?.name ?? skill?.skillId ?? "");
-    setScope(skill?.scope ?? "behavior");
-    setDescription(skill?.description ?? "");
-    setInstructions(skill?.instructions ?? "");
-    setToolRefs((skill?.toolRefs ?? []).join("\n"));
-    setDisplayName(skill?.displayName ?? "");
-    setEnabled(skill?.enabled ?? true);
+    const base = skillFormValues(skill);
+    setSkillId(base.skillId);
+    setName(base.name);
+    setScope(base.scope);
+    setDescription(base.description);
+    setInstructions(base.instructions);
+    setToolRefs(base.toolRefs);
+    setDisplayName(base.displayName);
+    setEnabled(base.enabled);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skill?.skillId]);
+
+  const dirty = isDirty(
+    { skillId, name, scope, description, instructions, toolRefs, displayName, enabled },
+    skillFormValues(skill),
+  );
 
   async function submitSkill(event: FormEvent) {
     event.preventDefault();
@@ -172,6 +180,7 @@ export function SkillConfigEditor({
         eyebrow="Skill"
         saved={savedStatus === `skill:${skillId.trim()}`}
         title={name || skillId || "New Skill"}
+        dirty={dirty}
       />
       <div className="grid-2">
         <label className="field">
@@ -290,6 +299,20 @@ export function SkillConfigEditor({
       </div>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function skillFormValues(skill: SkillView | null) {
+  return {
+    skillId: skill?.skillId ?? "",
+    name: skill?.name ?? skill?.skillId ?? "",
+    scope: skill?.scope ?? "behavior",
+    description: skill?.description ?? "",
+    instructions: skill?.instructions ?? "",
+    toolRefs: (skill?.toolRefs ?? []).join("\n"),
+    displayName: skill?.displayName ?? "",
+    enabled: skill?.enabled ?? true,
+  };
 }
 
 function displaySkillListTitle(skill: SkillView) {

--- a/apps/desktop-tauri/src/components/config/configDirty.ts
+++ b/apps/desktop-tauri/src/components/config/configDirty.ts
@@ -1,0 +1,9 @@
+/// Dirty tracking for config editors, timing-free: each editor expresses its
+/// view→form hydration as a pure function, used both by the id-keyed reset
+/// effect and to compare current form values against the persisted document.
+/// After a save, the snapshot refresh updates the view and the comparison
+/// heals itself — and a backend that normalizes values keeps the editor
+/// honestly marked dirty until the form matches what is actually persisted.
+export function isDirty<T>(current: T, baseline: T): boolean {
+  return JSON.stringify(current) !== JSON.stringify(baseline);
+}

--- a/apps/desktop-tauri/src/styles/primitives/controls.css
+++ b/apps/desktop-tauri/src/styles/primitives/controls.css
@@ -145,6 +145,12 @@
     border-color: rgb(var(--source-green-rgb) / 0.24);
   }
 
+  .chip-amber {
+    background: transparent;
+    color: var(--color-warning-soft);
+    border-color: var(--color-warning);
+  }
+
   .chip-button {
     --button-border: rgb(var(--source-green-rgb) / 0.2);
     --button-rail-width: 2px;

--- a/apps/desktop-tauri/tests/config-dirty-state.test.tsx
+++ b/apps/desktop-tauri/tests/config-dirty-state.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackendConfigPanel, SkillConfigPanel } from "../src/components/config";
+import type { DeploymentView } from "../src/lib/types";
+
+function makeDeployment(): DeploymentView {
+  return {
+    deploymentId: "dep-1",
+    agentDid: "did:test:operator",
+    displayName: "test",
+    defaultBehaviorId: "default",
+    behaviors: [{ behaviorId: "default", displayName: "default" }],
+    conversations: [],
+    process: null,
+    runtime: null,
+    inbox: { hasUnread: false, count: 0 },
+    inferenceBackends: [
+      {
+        backendId: "backend-a",
+        name: "Backend A",
+        providerKind: "openai",
+        endpoint: "http://localhost:1234/v1",
+        models: ["m-1"],
+        enabled: true,
+      },
+    ],
+    skills: [
+      {
+        skillId: "review-skill",
+        name: "Review",
+        instructions: "review things",
+        toolRefs: [],
+        scope: "behavior",
+        enabled: true,
+      },
+    ],
+  };
+}
+
+const backendHandlers = {
+  saving: false,
+  savedStatus: null,
+  onSelectBackend: vi.fn(),
+  onCreateBackend: vi.fn(),
+  onSavedStatusChange: vi.fn(),
+  onSaveBackendConfig: vi.fn(),
+};
+
+describe("config dirty state", () => {
+  it("marks the backend editor dirty on edit and clean when the view catches up", () => {
+    const { rerender } = render(
+      <BackendConfigPanel
+        deployment={makeDeployment()}
+        selectedBackendId="backend-a"
+        {...backendHandlers}
+      />,
+    );
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("backend-endpoint"), {
+      target: { value: "http://edited:9999/v1" },
+    });
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+
+    // Post-save snapshot refresh: the view now carries the edited value.
+    const saved = makeDeployment();
+    saved.inferenceBackends[0].endpoint = "http://edited:9999/v1";
+    rerender(
+      <BackendConfigPanel
+        deployment={saved}
+        selectedBackendId="backend-a"
+        {...backendHandlers}
+      />,
+    );
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+  });
+
+  it("marks the skill editor dirty on edit", () => {
+    render(
+      <SkillConfigPanel
+        deployment={makeDeployment()}
+        selectedSkillId="review-skill"
+        saving={false}
+        savedStatus={null}
+        onSelectSkill={vi.fn()}
+        onCreateSkill={vi.fn()}
+        onDeletedSkill={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onDeleteSkillConfig={vi.fn()}
+        onSaveSkillConfig={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("skill-name"), {
+      target: { value: "Edited" },
+    });
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
WS5 slice of #608. Config editors gave no indication of unsaved changes.

**Design — timing-free by construction**: each editor expresses its view→form hydration as a pure function, used both by the id-keyed reset effect and to compare current form values against the persisted document (`isDirty` = deep compare). No baseline capture racing hydration effects; after a save the snapshot refresh updates the view and the comparison heals itself — and a backend that normalizes values keeps the editor honestly marked dirty until the form matches what's actually persisted.

- `ConfigEditorHeader` gains an amber **Unsaved changes** chip (takes precedence over Saved; token-only styling, no new raw literals).
- Wired for **Skill** and **Backend** in this slice; the remaining eight editors follow the identical mechanical pattern in slice 2.

Fences: `config-dirty-state.test.tsx` (clean → dirty on edit → clean when the view catches up, both editors). Unit 235, e2e 120, visual unchanged.

Stacked on #768. Part of #608 (WS5).