### PR TITLE
feat(desktop): config dirty-state tracking (slice 2)

### DIFF
--- a/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
@@ -7,6 +7,7 @@ import type {
   EventTriggerView,
   TaskView,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import { ignoreHandledActionError, optionalString } from "./formUtils";
 
@@ -105,13 +106,14 @@ export function EventTriggerConfigEditor({
   const [concurrency, setConcurrency] = useState("serial");
 
   useEffect(() => {
-    setTriggerId(eventTrigger?.triggerId ?? "");
-    setTaskId(eventTrigger?.taskId ?? selectedTask?.taskId ?? "");
-    setSourceCollection(eventTrigger?.sourceCollection ?? "AgentRequest");
-    setEventKind("created");
-    setFilter(eventTrigger?.filter ?? "");
-    setEnabled(eventTrigger?.enabled ?? true);
-    setConcurrency(eventTrigger?.concurrency ?? "serial");
+    const b = eventTriggerFormValues(eventTrigger, selectedTask?.taskId ?? null);
+    setTriggerId(b.triggerId);
+    setTaskId(b.taskId);
+    setSourceCollection(b.sourceCollection);
+    setEventKind(b.eventKind);
+    setFilter(b.filter);
+    setEnabled(b.enabled);
+    setConcurrency(b.concurrency);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [eventTrigger?.triggerId, selectedTask?.taskId]);
 
@@ -137,6 +139,18 @@ export function EventTriggerConfigEditor({
   return (
     <form className="panel config-editor" onSubmit={submitEventTrigger}>
       <ConfigEditorHeader
+        dirty={isDirty(
+          {
+            triggerId,
+            taskId,
+            sourceCollection,
+            eventKind,
+            filter,
+            enabled,
+            concurrency,
+          },
+          eventTriggerFormValues(eventTrigger, selectedTask?.taskId ?? null),
+        )}
         eyebrow="Event Trigger"
         saved={savedStatus === `event-trigger:${triggerId.trim()}`}
         title={triggerId || "New Event Trigger"}
@@ -266,4 +280,20 @@ export function EventTriggerConfigEditor({
       </div>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function eventTriggerFormValues(
+  eventTrigger: EventTriggerView | null,
+  fallbackTaskId: string | null,
+) {
+  return {
+    triggerId: eventTrigger?.triggerId ?? "",
+    taskId: eventTrigger?.taskId ?? fallbackTaskId ?? "",
+    sourceCollection: eventTrigger?.sourceCollection ?? "AgentRequest",
+    eventKind: "created",
+    filter: eventTrigger?.filter ?? "",
+    enabled: eventTrigger?.enabled ?? true,
+    concurrency: eventTrigger?.concurrency ?? "serial",
+  };
 }

--- a/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
@@ -6,6 +6,7 @@ import type {
   InferenceProfileSaveRequest,
   InferenceProfileView,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
@@ -107,27 +108,16 @@ export function InferenceProfileConfigEditor({
   const [deadlineSecs, setDeadlineSecs] = useState("");
 
   useEffect(() => {
-    setProfileId(profile?.profileId ?? "");
-    setDisplayName(profile?.displayName ?? profile?.profileId ?? "");
-    setContextWindow(
-      profile?.contextWindow != null ? String(profile.contextWindow) : "",
-    );
-    setMaxOutputTokens(
-      profile?.maxOutputTokens != null ? String(profile.maxOutputTokens) : "",
-    );
-    setMaxTurns(profile?.maxTurns != null ? String(profile.maxTurns) : "");
-    setTemperature(profile?.temperature != null ? String(profile.temperature) : "");
-    setStreamBatchMs(
-      profile?.streamBatchMs != null ? String(profile.streamBatchMs) : "",
-    );
-    setStreamLivenessSecs(
-      profile?.streamLivenessTimeoutSecs != null
-        ? String(profile.streamLivenessTimeoutSecs)
-        : "",
-    );
-    setDeadlineSecs(
-      profile?.deadlineDurationSecs != null ? String(profile.deadlineDurationSecs) : "",
-    );
+    const b = profileFormValues(profile);
+    setProfileId(b.profileId);
+    setDisplayName(b.displayName);
+    setContextWindow(b.contextWindow);
+    setMaxOutputTokens(b.maxOutputTokens);
+    setMaxTurns(b.maxTurns);
+    setTemperature(b.temperature);
+    setStreamBatchMs(b.streamBatchMs);
+    setStreamLivenessSecs(b.streamLivenessSecs);
+    setDeadlineSecs(b.deadlineSecs);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [profile?.profileId]);
 
@@ -163,6 +153,20 @@ export function InferenceProfileConfigEditor({
   return (
     <form className="panel config-editor" onSubmit={submitProfile}>
       <ConfigEditorHeader
+        dirty={isDirty(
+          {
+            profileId,
+            displayName,
+            contextWindow,
+            maxOutputTokens,
+            maxTurns,
+            temperature,
+            streamBatchMs,
+            streamLivenessSecs,
+            deadlineSecs,
+          },
+          profileFormValues(profile),
+        )}
         eyebrow="Profile"
         saved={savedStatus === `profile:${profileId.trim()}`}
         title={displayName || profileId || "New Profile"}
@@ -286,4 +290,24 @@ export function InferenceProfileConfigEditor({
       </div>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function profileFormValues(profile: InferenceProfileView | null) {
+  return {
+    profileId: profile?.profileId ?? "",
+    displayName: profile?.displayName ?? profile?.profileId ?? "",
+    contextWindow: profile?.contextWindow != null ? String(profile.contextWindow) : "",
+    maxOutputTokens:
+      profile?.maxOutputTokens != null ? String(profile.maxOutputTokens) : "",
+    maxTurns: profile?.maxTurns != null ? String(profile.maxTurns) : "",
+    temperature: profile?.temperature != null ? String(profile.temperature) : "",
+    streamBatchMs: profile?.streamBatchMs != null ? String(profile.streamBatchMs) : "",
+    streamLivenessSecs:
+      profile?.streamLivenessTimeoutSecs != null
+        ? String(profile.streamLivenessTimeoutSecs)
+        : "",
+    deadlineSecs:
+      profile?.deadlineDurationSecs != null ? String(profile.deadlineDurationSecs) : "",
+  };
 }

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -8,6 +8,7 @@ import type {
   TaskRunResult,
   TaskView,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import { ignoreHandledActionError, isOptionalInt, parseOptionalInt } from "./formUtils";
 
@@ -115,13 +116,12 @@ export function ScheduleConfigEditor({
   const [runStatus, setRunStatus] = useState<TaskRunResult | null>(null);
 
   useEffect(() => {
-    setScheduleId(schedule?.scheduleId ?? "");
-    setTaskId(schedule?.taskId ?? selectedTask?.taskId ?? "");
-    setIntervalSecs(
-      schedule?.intervalSecs != null ? String(schedule.intervalSecs) : "",
-    );
-    setEnabled(schedule?.enabled ?? true);
-    setConcurrency(schedule?.concurrency ?? "serial");
+    const b = scheduleFormValues(schedule, selectedTask?.taskId ?? null);
+    setScheduleId(b.scheduleId);
+    setTaskId(b.taskId);
+    setIntervalSecs(b.intervalSecs);
+    setEnabled(b.enabled);
+    setConcurrency(b.concurrency);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [schedule?.scheduleId, selectedTask?.taskId]);
 
@@ -160,6 +160,10 @@ export function ScheduleConfigEditor({
   return (
     <form className="panel config-editor" onSubmit={submitSchedule}>
       <ConfigEditorHeader
+        dirty={isDirty(
+          { scheduleId, taskId, intervalSecs, enabled, concurrency },
+          scheduleFormValues(schedule, selectedTask?.taskId ?? null),
+        )}
         eyebrow="Timer Trigger"
         saved={savedStatus === `schedule:${scheduleId.trim()}`}
         title={scheduleId || "New Timer Trigger"}
@@ -294,4 +298,18 @@ export function ScheduleConfigEditor({
       </section>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function scheduleFormValues(
+  schedule: ScheduleView | null,
+  fallbackTaskId: string | null,
+) {
+  return {
+    scheduleId: schedule?.scheduleId ?? "",
+    taskId: schedule?.taskId ?? fallbackTaskId ?? "",
+    intervalSecs: schedule?.intervalSecs != null ? String(schedule.intervalSecs) : "",
+    enabled: schedule?.enabled ?? true,
+    concurrency: schedule?.concurrency ?? "serial",
+  };
 }

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -8,6 +8,7 @@ import type {
   TaskSaveRequest,
   TaskView,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import { ignoreHandledActionError, optionalString } from "./formUtils";
 
@@ -114,13 +115,14 @@ export function TaskConfigEditor({
   const [runStatus, setRunStatus] = useState<TaskRunResult | null>(null);
 
   useEffect(() => {
-    setTaskId(task?.taskId ?? "");
-    setName(task?.name ?? task?.taskId ?? "");
-    setDescription(task?.description ?? "");
-    setBehaviorId(task?.behaviorId ?? selectedBehavior?.behaviorId ?? "");
-    setPromptTemplate(task?.promptTemplate ?? "");
-    setOutputSchemaRef(task?.outputSchemaRef ?? "");
-    setEnabled(task?.enabled ?? true);
+    const b = taskFormValues(task, selectedBehavior?.behaviorId ?? null);
+    setTaskId(b.taskId);
+    setName(b.name);
+    setDescription(b.description);
+    setBehaviorId(b.behaviorId);
+    setPromptTemplate(b.promptTemplate);
+    setOutputSchemaRef(b.outputSchemaRef);
+    setEnabled(b.enabled);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [selectedBehavior?.behaviorId, task?.taskId]);
 
@@ -164,6 +166,18 @@ export function TaskConfigEditor({
   return (
     <form className="panel config-editor" onSubmit={submitTask}>
       <ConfigEditorHeader
+        dirty={isDirty(
+          {
+            taskId,
+            name,
+            description,
+            behaviorId,
+            promptTemplate,
+            outputSchemaRef,
+            enabled,
+          },
+          taskFormValues(task, selectedBehavior?.behaviorId ?? null),
+        )}
         eyebrow="Task"
         saved={savedStatus === `task:${taskId.trim()}`}
         title={name || taskId || "New Task"}
@@ -363,4 +377,17 @@ function displayTaskListTitle(task: TaskView) {
   }
 
   return task.taskId;
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function taskFormValues(task: TaskView | null, fallbackBehaviorId: string | null) {
+  return {
+    taskId: task?.taskId ?? "",
+    name: task?.name ?? task?.taskId ?? "",
+    description: task?.description ?? "",
+    behaviorId: task?.behaviorId ?? fallbackBehaviorId ?? "",
+    promptTemplate: task?.promptTemplate ?? "",
+    outputSchemaRef: task?.outputSchemaRef ?? "",
+    enabled: task?.enabled ?? true,
+  };
 }

--- a/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
@@ -8,6 +8,7 @@ import type {
   ToolServiceTestRequest,
   ToolServiceTestResult,
 } from "../../lib/types";
+import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
@@ -118,15 +119,16 @@ export function ToolServiceConfigEditor({
   const [testError, setTestError] = useState<string | null>(null);
 
   useEffect(() => {
-    setServiceId(toolService?.serviceId ?? "");
-    setDisplayName(toolService?.displayName ?? toolService?.serviceId ?? "");
-    setDescription(toolService?.description ?? "");
-    setHostname(toolService?.hostname ?? "");
-    setTailscaleIp(toolService?.tailscaleIp ?? "");
-    setLanIp(toolService?.lanIp ?? "");
-    setMcpPort(toolService?.mcpPort != null ? String(toolService.mcpPort) : "");
-    setMcpPath(toolService?.mcpPath ?? "/mcp");
-    setStatus(toolService?.status ?? "online");
+    const b = toolServiceFormValues(toolService);
+    setServiceId(b.serviceId);
+    setDisplayName(b.displayName);
+    setDescription(b.description);
+    setHostname(b.hostname);
+    setTailscaleIp(b.tailscaleIp);
+    setLanIp(b.lanIp);
+    setMcpPort(b.mcpPort);
+    setMcpPath(b.mcpPath);
+    setStatus(b.status);
     setTestResult(null);
     setTestError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
@@ -186,6 +188,20 @@ export function ToolServiceConfigEditor({
   return (
     <form className="panel config-editor" onSubmit={submitToolService}>
       <ConfigEditorHeader
+        dirty={isDirty(
+          {
+            serviceId,
+            displayName,
+            description,
+            hostname,
+            tailscaleIp,
+            lanIp,
+            mcpPort,
+            mcpPath,
+            status,
+          },
+          toolServiceFormValues(toolService),
+        )}
         eyebrow="HTTP MCP Service"
         saved={savedStatus === `tool-service:${serviceId.trim()}`}
         title={displayName || serviceId || "New Service"}
@@ -350,4 +366,19 @@ export function ToolServiceConfigEditor({
       ) : null}
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function toolServiceFormValues(toolService: ToolServiceRegistryView | null) {
+  return {
+    serviceId: toolService?.serviceId ?? "",
+    displayName: toolService?.displayName ?? toolService?.serviceId ?? "",
+    description: toolService?.description ?? "",
+    hostname: toolService?.hostname ?? "",
+    tailscaleIp: toolService?.tailscaleIp ?? "",
+    lanIp: toolService?.lanIp ?? "",
+    mcpPort: toolService?.mcpPort != null ? String(toolService.mcpPort) : "",
+    mcpPath: toolService?.mcpPath ?? "/mcp",
+    status: toolService?.status ?? "online",
+  };
 }

--- a/apps/desktop-tauri/tests/config-dirty-state.test.tsx
+++ b/apps/desktop-tauri/tests/config-dirty-state.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { BackendConfigPanel, SkillConfigPanel } from "../src/components/config";
+import {
+  BackendConfigPanel,
+  ScheduleConfigPanel,
+  SkillConfigPanel,
+} from "../src/components/config";
 import type { DeploymentView } from "../src/lib/types";
 
 function makeDeployment(): DeploymentView {
@@ -94,6 +98,40 @@ describe("config dirty state", () => {
     expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
     fireEvent.change(screen.getByTestId("skill-name"), {
       target: { value: "Edited" },
+    });
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+  });
+
+  it("marks the schedule editor dirty on edit", () => {
+    const dep = makeDeployment();
+    dep.tasks = [];
+    dep.schedules = [
+      {
+        scheduleId: "sched-1",
+        taskId: null,
+        intervalSecs: 60,
+        enabled: true,
+        concurrency: "serial",
+      },
+    ];
+    render(
+      <ScheduleConfigPanel
+        deployment={dep}
+        selectedScheduleId="sched-1"
+        selectedTaskId={null}
+        saving={false}
+        runningTask={false}
+        savedStatus={null}
+        onSelectSchedule={vi.fn()}
+        onCreateSchedule={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSaveScheduleConfig={vi.fn()}
+        onRunSchedule={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("schedule-interval-secs"), {
+      target: { value: "120" },
     });
     expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
   });


### PR DESCRIPTION
WS5 continuation of #770 — the same timing-free pattern (pure view→form hydration function shared by the id-keyed reset effect and the `isDirty` comparison, amber Unsaved-changes chip) applied to five more editors:

- **InferenceProfile**, **ToolService**, **Task**, **Schedule**, **EventTrigger** — including the secondary hydration inputs (fallback task id for Schedule/EventTrigger, fallback behavior id for Task) threaded through the pure functions so the baselines are exact.
- Non-form state (test results, run status) stays outside the dirty comparison; the Agent panel is deferred to the one-editing-paradigm item since it has no ConfigEditorHeader.

Fence extended with the schedule editor case. Unit 235 (all suites), e2e 120, visual unchanged.

Remaining for slice 3: Behavior and ToolSelection (their hydration has derived inputs — profile-set fallback and known-service migration — needing careful extraction).

Stacked on #770. Part of #608 (WS5).