### PR TITLE
fix(desktop): keyboard-accessible config tabs

### DIFF
--- a/apps/desktop-tauri/src/components/ConfigWorkspace.tsx
+++ b/apps/desktop-tauri/src/components/ConfigWorkspace.tsx
@@ -165,7 +165,32 @@ export function ConfigWorkspace({
         </div>
       </header>
 
-      <nav className="config-screen-nav" role="tablist" aria-label="Configuration">
+      <nav
+        className="config-screen-nav"
+        role="tablist"
+        aria-label="Configuration"
+        // Roving tabindex needs the arrow keys to actually rove (WAI-ARIA
+        // tabs pattern): Left/Right cycle, Home/End jump, focus follows.
+        onKeyDown={(event) => {
+          const keys = ["ArrowLeft", "ArrowRight", "Home", "End"];
+          if (!keys.includes(event.key)) {
+            return;
+          }
+          event.preventDefault();
+          const currentIndex = TABS.findIndex((tab) => tab.id === activeTab);
+          const nextIndex =
+            event.key === "Home"
+              ? 0
+              : event.key === "End"
+                ? TABS.length - 1
+                : (currentIndex + (event.key === "ArrowRight" ? 1 : -1) + TABS.length) %
+                  TABS.length;
+          const next = TABS[nextIndex];
+          setActiveTab(next.id);
+          setSavedStatus(null);
+          document.getElementById(`config-tab-control-${next.id}`)?.focus();
+        }}
+      >
         {TABS.map((tab) => (
           <button
             aria-controls={`config-tab-panel-${tab.id}`}

--- a/apps/desktop-tauri/tests/config-tabs-a11y.test.tsx
+++ b/apps/desktop-tauri/tests/config-tabs-a11y.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ConfigWorkspace } from "../src/components/ConfigWorkspace";
+import { deployment } from "./config-panel-wiring/fixtures";
+
+function renderWorkspace() {
+  render(
+    <ConfigWorkspace
+      bootstrap={null}
+      selectedDeployment={deployment}
+      selectedBehaviorId={null}
+      saving={false}
+      runningTask={false}
+      onBack={vi.fn()}
+      onDeleteSkillConfig={vi.fn()}
+      onSaveAgentConfig={vi.fn()}
+      onRunTask={vi.fn()}
+      onSaveBackendConfig={vi.fn()}
+      onSaveBehaviorConfig={vi.fn()}
+      onSaveEventTriggerConfig={vi.fn()}
+      onSaveInferenceProfileConfig={vi.fn()}
+      onSaveScheduleConfig={vi.fn()}
+      onSaveSkillConfig={vi.fn()}
+      onSaveTaskConfig={vi.fn()}
+      onSaveToolSelectionConfig={vi.fn()}
+      onSaveToolServiceConfig={vi.fn()}
+      onTestToolService={vi.fn()}
+      onRunSchedule={vi.fn()}
+    />,
+  );
+}
+
+describe("config tabs keyboard navigation", () => {
+  it("ArrowRight moves selection and focus; Home/End jump; wraps around", () => {
+    renderWorkspace();
+    const tablist = screen.getByRole("tablist", { name: "Configuration" });
+    const tabs = screen.getAllByRole("tab");
+    fireEvent.click(tabs[0]);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[0]).toHaveAttribute("tabindex", "-1");
+
+    fireEvent.keyDown(tablist, { key: "End" });
+    expect(tabs[tabs.length - 1]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+    expect(tabs[tabs.length - 1]).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tablist, { key: "Home" });
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+  });
+});


### PR DESCRIPTION
WS5 slice of #608. The config tab strip used a roving tabindex with no arrow-key handling — the ARIA tabs contract without its keyboard half, leaving the ten tabs mouse-only.

The tablist now implements the WAI-ARIA tabs pattern: Left/Right cycle with wrap-around, Home/End jump to the edges, selection and focus move together, and the saved-status reset matches click behavior.

Fence: `config-tabs-a11y.test.tsx` (cycle, wrap, Home/End, roving tabindex flip). Unit 237, e2e 120, visual unchanged.

Stacked on #772. Part of #608 (WS5).