### PR TITLE
feat(desktop): visible validation reasons in config editors

### DIFF
--- a/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
@@ -7,7 +7,7 @@ import type {
   InferenceBackendView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
   isOptionalInt,
@@ -254,6 +254,7 @@ export function BackendConfigEditor({
             type="number"
             value={maxConcurrent}
           />
+          <FieldHint show={!maxConcurrentValid}>Whole number of 1 or more</FieldHint>
         </label>
         <label className="field">
           <span>Max queue depth</span>
@@ -263,6 +264,7 @@ export function BackendConfigEditor({
             type="number"
             value={maxQueueDepth}
           />
+          <FieldHint show={!maxQueueDepthValid}>Whole number of 1 or more</FieldHint>
         </label>
         <label className="checkbox">
           <input

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -11,7 +11,7 @@ import type {
   SkillView,
   ToolSelectionView,
 } from "../../lib/types";
-import { ConfigDocumentList, PlusIcon } from "./ConfigChrome";
+import { ConfigDocumentList, FieldHint, PlusIcon } from "./ConfigChrome";
 import {
   boolText,
   ignoreHandledActionError,
@@ -425,6 +425,9 @@ export function BehaviorConfigEditor({
               type="number"
               value={compactionThreshold}
             />
+            <FieldHint show={!compactionThresholdValid}>
+              Number between 0 and 1
+            </FieldHint>
           </label>
         </div>
       </section>

--- a/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
+++ b/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
@@ -1,3 +1,5 @@
+import type React from "react";
+
 export type ConfigEditorHeaderProps = {
   eyebrow: string;
   saved: boolean;
@@ -25,6 +27,25 @@ export function ConfigEditorHeader({
         <span className="chip chip-green">Saved</span>
       ) : null}
     </div>
+  );
+}
+
+/** Inline validation reason — invalid input must explain itself, not just
+ * disable Save. */
+export function FieldHint({
+  show,
+  children,
+}: {
+  show: boolean;
+  children: React.ReactNode;
+}) {
+  if (!show) {
+    return null;
+  }
+  return (
+    <span className="field-hint-error" role="alert">
+      {children}
+    </span>
   );
 }
 

--- a/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
@@ -7,7 +7,7 @@ import type {
   InferenceProfileView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
   isOptionalFloat,
@@ -206,6 +206,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={contextWindow}
           />
+          <FieldHint show={!contextWindowValid}>Whole number of 1 or more</FieldHint>
         </label>
         <label className="field">
           <span>Max output tokens</span>
@@ -215,6 +216,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={maxOutputTokens}
           />
+          <FieldHint show={!maxOutputTokensValid}>Whole number of 1 or more</FieldHint>
         </label>
         <label className="field">
           <span>Max turns</span>
@@ -224,6 +226,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={maxTurns}
           />
+          <FieldHint show={!maxTurnsValid}>Whole number of 1 or more</FieldHint>
         </label>
       </div>
       <div className="grid-3">
@@ -236,6 +239,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={temperature}
           />
+          <FieldHint show={!temperatureValid}>Number of 0 or more</FieldHint>
         </label>
         <label className="field">
           <span>Stream batch ms</span>
@@ -245,6 +249,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={streamBatchMs}
           />
+          <FieldHint show={!streamBatchValid}>Whole number of 0 or more</FieldHint>
         </label>
         <label className="field">
           <span>Stream liveness seconds</span>
@@ -254,6 +259,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={streamLivenessSecs}
           />
+          <FieldHint show={!streamLivenessValid}>Whole number of 1 or more</FieldHint>
         </label>
       </div>
       <div className="grid-3">
@@ -265,6 +271,7 @@ export function InferenceProfileConfigEditor({
             type="number"
             value={deadlineSecs}
           />
+          <FieldHint show={!deadlineValid}>Whole number of 1 or more</FieldHint>
         </label>
       </div>
       <div className="config-actions">

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -9,7 +9,7 @@ import type {
   TaskView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import { ignoreHandledActionError, isOptionalInt, parseOptionalInt } from "./formUtils";
 
 export type ScheduleConfigPanelProps = {
@@ -210,6 +210,7 @@ export function ScheduleConfigEditor({
             type="number"
             value={intervalSecs}
           />
+          <FieldHint show={!intervalValid}>Whole number of 1 or more</FieldHint>
         </label>
         <label className="field">
           <span>Concurrency</span>

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -9,7 +9,7 @@ import type {
   TaskView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import { ignoreHandledActionError, optionalString } from "./formUtils";
 
 export type TaskConfigPanelProps = {
@@ -344,6 +344,7 @@ export function TaskConfigEditor({
             onChange={(event) => setRunArgs(event.currentTarget.value)}
             value={runArgs}
           />
+          <FieldHint show={!runArgsValid}>Must be a JSON object</FieldHint>
         </label>
         <div className="config-actions">
           <button

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -8,7 +8,7 @@ import type {
   ToolServiceRegistryView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
   isOptionalInt,
@@ -553,6 +553,9 @@ export function ToolSelectionConfigEditor({
             }
             value={crossDeploymentSpawnTimeoutSeconds}
           />
+          <FieldHint show={!crossDeploymentSpawnTimeoutValid}>
+            Whole number of 1 or more
+          </FieldHint>
         </label>
       </div>
       <div className="grid-2">

--- a/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
@@ -9,7 +9,7 @@ import type {
   ToolServiceTestResult,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import {
   ignoreHandledActionError,
   isOptionalInt,
@@ -278,6 +278,7 @@ export function ToolServiceConfigEditor({
             type="number"
             value={mcpPort}
           />
+          <FieldHint show={!mcpPortValid}>Port between 1 and 65535</FieldHint>
         </label>
         <label className="field">
           <span>MCP path</span>

--- a/apps/desktop-tauri/src/styles/config/forms.css
+++ b/apps/desktop-tauri/src/styles/config/forms.css
@@ -1,4 +1,9 @@
 @layer config {
+  .field-hint-error {
+    color: var(--color-error);
+    font-size: var(--text-xs);
+  }
+
   .config-icon-button {
     width: 28px;
     height: 28px;

--- a/apps/desktop-tauri/tests/config-validation-hints.test.tsx
+++ b/apps/desktop-tauri/tests/config-validation-hints.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { BackendConfigPanel } from "../src/components/config";
+import type { DeploymentView } from "../src/lib/types";
+
+const deployment = {
+  deploymentId: "dep-1",
+  agentDid: "did:test:operator",
+  displayName: "test",
+  defaultBehaviorId: "default",
+  behaviors: [{ behaviorId: "default", displayName: "default" }],
+  conversations: [],
+  process: null,
+  runtime: null,
+  inbox: { hasUnread: false, count: 0 },
+  inferenceBackends: [
+    {
+      backendId: "backend-a",
+      name: "Backend A",
+      providerKind: "openai",
+      endpoint: "http://localhost:1234/v1",
+      models: ["m-1"],
+      enabled: true,
+    },
+  ],
+} as unknown as DeploymentView;
+
+describe("visible validation reasons", () => {
+  it("explains an invalid numeric field instead of silently disabling Save", () => {
+    render(
+      <BackendConfigPanel
+        deployment={deployment}
+        selectedBackendId="backend-a"
+        saving={false}
+        savedStatus={null}
+        onSelectBackend={vi.fn()}
+        onCreateBackend={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onSaveBackendConfig={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByTestId("backend-max-concurrent"), {
+      target: { value: "0" },
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("Whole number of 1 or more");
+
+    fireEvent.change(screen.getByTestId("backend-max-concurrent"), {
+      target: { value: "4" },
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
WS5 slice of #608. Invalid input silently disabled Save with zero explanation.

Every validity flag that gates a Save button now renders an inline reason under its field (`FieldHint`, `role="alert"`, error tone): 14 fields across seven editors — Backend (max concurrent/queue depth), InferenceProfile (context window, output tokens, turns, temperature, stream batch/liveness, deadline), Schedule (interval), ToolService (port range), ToolSelection (spawn timeout), Task (run-args JSON), Behavior (compaction threshold 0–1). Messages state the constraint ("Whole number of 1 or more", "Port between 1 and 65535"), appear on invalid input, and disappear when fixed.

Fence: `config-validation-hints.test.tsx` (absent → present with constraint text → absent again). Unit 238, e2e 120, visual unchanged.

Stacked on #773. Part of #608 (WS5).