### PR TITLE
fix(desktop): ops-panel liveness consistency

### DIFF
--- a/apps/desktop-tauri/src/components/backendHealth/useBackendHealth.ts
+++ b/apps/desktop-tauri/src/components/backendHealth/useBackendHealth.ts
@@ -15,8 +15,10 @@ export function useBackendHealth(): BackendHealthState {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const refresh = useCallback(async () => {
-    setLoading(true);
+  const refresh = useCallback(async (background = false) => {
+    if (!background) {
+      setLoading(true);
+    }
     setError(null);
     try {
       const rows = await listBackendsWithHealth();
@@ -24,12 +26,20 @@ export function useBackendHealth(): BackendHealthState {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
-      setLoading(false);
+      if (!background) {
+        setLoading(false);
+      }
     }
   }, []);
 
+  // Poll like the MCP panel (10 s) so statuses and relative ages stay live
+  // instead of freezing at mount; background refreshes skip the loading flip.
   useEffect(() => {
     void refresh();
+    const handle = window.setInterval(() => {
+      void refresh(true);
+    }, 10_000);
+    return () => window.clearInterval(handle);
   }, [refresh]);
 
   return { backends, loading, error, refresh };

--- a/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
+++ b/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
@@ -40,7 +40,10 @@ export function SubagentLineageView({
 
   const treeContainerRef = useRef<HTMLUListElement | null>(null);
 
-  // Fetch when root or agent changes.
+  // Fetch when root or agent changes, then keep polling while mounted —
+  // the lineage exists to observe a LIVE turn, so a one-shot snapshot
+  // going stale defeats it. Background refreshes preserve the operator's
+  // expand/collapse choices and only auto-expand genuinely new nodes.
   useEffect(() => {
     let cancelled = false;
     if (!rootRequestId) {
@@ -49,36 +52,63 @@ export function SubagentLineageView({
       setLoading(false);
       return;
     }
-    setLoading(true);
-    setError(null);
-    listSubagentTree({
-      rootRequestId,
-      agentDid: agentDid ?? null,
-      includeTerminal: true,
-    })
-      .then((value) => {
+
+    const treeKeys = (value: SubagentTreeView) => {
+      const keys = new Set<string>();
+      for (const node of value.nodes) keys.add(`req:${node.requestId}`);
+      for (const edge of value.edges) {
+        keys.add(
+          `tool:${edge.parentToolCallId ?? `${edge.parentRequestId}->${edge.childRequestId}`}`,
+        );
+      }
+      return keys;
+    };
+    let seenKeys: Set<string> | null = null;
+
+    const fetchTree = async (background: boolean) => {
+      if (!background) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const value = await listSubagentTree({
+          rootRequestId,
+          agentDid: agentDid ?? null,
+          includeTerminal: true,
+        });
         if (cancelled) return;
+        const keys = treeKeys(value);
         setTree(value);
-        // Expand everything by default so the panel shows useful data on load.
-        const next = new Set<string>();
-        for (const node of value.nodes) next.add(`req:${node.requestId}`);
-        for (const edge of value.edges) {
-          next.add(
-            `tool:${edge.parentToolCallId ?? `${edge.parentRequestId}->${edge.childRequestId}`}`,
-          );
+        if (seenKeys === null) {
+          // Expand everything by default so the panel shows useful data.
+          setExpanded(keys);
+        } else {
+          const previous = seenKeys;
+          setExpanded((current) => {
+            const next = new Set(current);
+            for (const key of keys) {
+              if (!previous.has(key)) next.add(key);
+            }
+            return next;
+          });
         }
-        setExpanded(next);
-      })
-      .catch((error: unknown) => {
-        if (cancelled) return;
+        seenKeys = keys;
+      } catch (error: unknown) {
+        if (cancelled || background) return;
         setTree(null);
         setError(error instanceof Error ? error.message : String(error));
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
+      } finally {
+        if (!cancelled && !background) setLoading(false);
+      }
+    };
+
+    void fetchTree(false);
+    const handle = window.setInterval(() => {
+      void fetchTree(true);
+    }, 5_000);
     return () => {
       cancelled = true;
+      window.clearInterval(handle);
     };
   }, [rootRequestId, agentDid]);
 

--- a/apps/desktop-tauri/tests/ops-liveness.test.tsx
+++ b/apps/desktop-tauri/tests/ops-liveness.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../src/lib/desktop-api", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../src/lib/desktop-api")>();
+  return {
+    ...original,
+    listBackendsWithHealth: vi.fn(),
+    listSubagentTree: vi.fn(),
+  };
+});
+
+import { listBackendsWithHealth, listSubagentTree } from "../src/lib/desktop-api";
+import { BackendHealthPanel } from "../src/components/backendHealth";
+import { SubagentLineageView } from "../src/components/subagentLineage";
+
+const mockedBackends = vi.mocked(listBackendsWithHealth);
+const mockedTree = vi.mocked(listSubagentTree);
+
+describe("ops panel liveness", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("backend health keeps polling instead of freezing at mount", async () => {
+    mockedBackends.mockResolvedValue([]);
+    render(<BackendHealthPanel />);
+    await waitFor(() => expect(mockedBackends).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mockedBackends.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("lineage keeps polling while mounted and preserves collapse choices", async () => {
+    mockedTree.mockResolvedValue({
+      rootRequestId: "req_root",
+      nodes: [{ requestId: "req_root" }],
+      edges: [],
+    } as never);
+
+    render(<SubagentLineageView rootRequestId="req_root" agentDid="did:test:op" />);
+    await waitFor(() => expect(mockedTree).toHaveBeenCalledTimes(1));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(mockedTree.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText(/req_root/).length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
WS6 slice of #608. The four ops tabs had wildly inconsistent liveness: Background polled at 2s, MCP at 10s, while **Backend health** was a one-shot whose relative ages froze at mount and **Lineage** was a one-shot snapshot — static during the very live turn it exists to observe.

- **Backend health** now polls at 10s (matching MCP); background refreshes skip the loading flip so the table doesn't flicker, and relative ages re-render live.
- **Lineage** polls at 5s while mounted. Background refreshes preserve the operator's expand/collapse choices and auto-expand only genuinely new nodes (a new subagent spawning appears expanded; nothing the operator collapsed reopens). Transient background poll failures keep the last-good tree instead of blanking the panel.

Fences: `ops-liveness.test.tsx` (both panels keep calling under fake timers; lineage tree persists across refreshes). Unit 240, e2e 120, visual unchanged.

Stacked on #774. Part of #608 (WS6).