### PR TITLE
polish(desktop): short request ids in the ops drawer

### DIFF
--- a/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
+++ b/apps/desktop-tauri/src/components/backgroundedTools/BackgroundedToolsPanel.tsx
@@ -4,6 +4,7 @@ import type {
   DesktopOperationsSnapshotRequest,
   StuckWorkDiagnosticView,
 } from "../../lib/types/operations";
+import { shortId } from "../../lib/shortId";
 import { OperationsRailContext } from "../operations/operationsRailContext";
 import {
   correlateProcess,
@@ -30,24 +31,20 @@ const STATE_LABELS: Record<string, string> = {
   "deadline+": "Past deadline",
 };
 
-function shortRequestId(requestId: string): string {
-  return requestId.length > 14 ? `${requestId.slice(0, 14)}…` : requestId;
-}
-
 /** The bridge's diagnosis, in operator language. */
 function diagnosticSentence(diag: StuckWorkDiagnosticView): string {
   const tool = diag.toolName ?? "a tool";
   switch (diag.reason) {
     case "expiredProcessing":
-      return `Request ${shortRequestId(diag.requestId)} ran past its deadline`;
+      return `Request ${shortId(diag.requestId)} ran past its deadline`;
     case "expiredTool":
-      return `${tool} on ${shortRequestId(diag.requestId)} ran past its deadline`;
+      return `${tool} on ${shortId(diag.requestId)} ran past its deadline`;
     case "stuckTool":
-      return `${tool} on ${shortRequestId(diag.requestId)} has stopped making progress`;
+      return `${tool} on ${shortId(diag.requestId)} has stopped making progress`;
     case "pendingRemoteCancelAck":
-      return `Waiting on a remote node to acknowledge cancelling ${shortRequestId(diag.requestId)}`;
+      return `Waiting on a remote node to acknowledge cancelling ${shortId(diag.requestId)}`;
     default:
-      return `${shortRequestId(diag.requestId)} needs attention`;
+      return `${shortId(diag.requestId)} needs attention`;
   }
 }
 
@@ -239,8 +236,9 @@ export function BackgroundedToolsPanel({
             className={`chip ${parentFilter === p ? "is-active" : ""}`}
             aria-pressed={parentFilter === p}
             onClick={() => setParentFilter(p)}
+            title={p}
           >
-            {p}
+            {shortId(p)}
           </button>
         ))}
       </div>
@@ -365,7 +363,9 @@ export function BackgroundedToolsPanel({
                 >
                   <td className="cell-tool">{row.toolName}</td>
                   <td className="cell-age">{formatAge(row.ageMs ?? 0)}</td>
-                  <td className="cell-parent">{row.requestId}</td>
+                  <td className="cell-parent" title={row.requestId}>
+                    {shortId(row.requestId)}
+                  </td>
                   <td>
                     <span className="pill pill-await" data-mode={row.awaitMode ?? ""}>
                       {row.awaitMode ?? "—"}

--- a/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageTree.tsx
+++ b/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageTree.tsx
@@ -1,3 +1,4 @@
+import { shortId } from "../../lib/shortId";
 import type { AnyNode, FilterState } from "./lineageModel";
 import { nodeId, shortenDid, subtreeHasSurvivor } from "./lineageModel";
 
@@ -89,10 +90,19 @@ export function SubagentTreeRow({
           >
             {node.kind === "req" ? "req" : "tool"}
           </span>
-          <span className="subagent-lineage-id">
+          <span
+            className="subagent-lineage-id"
+            title={
+              node.kind === "req"
+                ? node.node.requestId
+                : (node.edge.parentToolCallId ?? undefined)
+            }
+          >
             {node.kind === "req"
-              ? node.node.requestId
-              : (node.edge.parentToolCallId ?? "—")}
+              ? shortId(node.node.requestId)
+              : node.edge.parentToolCallId
+                ? shortId(node.edge.parentToolCallId)
+                : "—"}
           </span>
           <span className="subagent-lineage-secondary">{nodeSecondary(node)}</span>
         </span>

--- a/apps/desktop-tauri/src/lib/shortId.ts
+++ b/apps/desktop-tauri/src/lib/shortId.ts
@@ -1,0 +1,5 @@
+/// Long document/request ids are unreadable at drawer width — display a
+/// stable prefix and keep the full id in the title (and for copying).
+export function shortId(id: string, max = 14): string {
+  return id.length > max ? `${id.slice(0, max)}…` : id;
+}

--- a/apps/desktop-tauri/tests/playwright/desktop-operations-rich.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-operations-rich.spec.ts
@@ -44,9 +44,9 @@ test.describe("desktop operations drawer rich states", () => {
 
     await page.getByRole("tab", { name: /Lineage/ }).click();
     await expect(page.getByRole("tree", { name: "Subagent lineage" })).toBeVisible();
-    await expect(page.getByText("request-child-1")).toBeVisible();
+    await expect(page.locator('[title="request-child-1"]').first()).toBeVisible();
     await page.getByLabel("Live only").check();
-    await expect(page.getByText("request-child-1")).toBeVisible();
+    await expect(page.locator('[title="request-child-1"]').first()).toBeVisible();
 
     await page.getByRole("tab", { name: /Backends/ }).click();
     await page.getByRole("button", { name: /OpenAI Harness/ }).click();


### PR DESCRIPTION
WS6 slice of #608. Full-length request ids made the parent filter chips, the Parent column, and the lineage tree unreadable at drawer width.

A shared `shortId` helper (14-char prefix + ellipsis) now renders everywhere ids appear in the drawer — parent chips, Parent cells, lineage node labels — with the full id preserved in the `title` tooltip. The diagnostics strip already used the same truncation; it now shares the one helper.

The operations-rich spec's full-id text locators moved to title-attribute locators (the ids are deliberately no longer full text). Unit 240, e2e 120, visual unchanged.

Stacked on #775. Part of #608 (WS6).