### PR TITLE
feat(desktop): fleet-to-Code path

### DIFF
--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -70,6 +70,7 @@ function AppShell() {
           onFetchPeerStatus={shell.onFetchPeerStatus}
           onInitLocalRuntime={shell.onInitLocalRuntime}
           onOpenChat={openChat}
+          onOpenCode={openCode}
           onOpenConfig={openConfig}
           onRepairP2P={shell.onRepairP2P}
         />

--- a/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetDashboard.tsx
@@ -24,6 +24,7 @@ type FleetDashboardProps = {
   onFetchPeerStatus: (serverAddress: string) => Promise<unknown>;
   onInitLocalRuntime: (label?: string | null) => Promise<unknown>;
   onOpenChat: (agentDid: string) => void;
+  onOpenCode?: (agentDid: string) => void;
   onOpenConfig: (agentDid: string) => void;
   onRepairP2P: () => Promise<unknown>;
 };
@@ -47,6 +48,7 @@ export function FleetDashboard({
   onFetchPeerStatus,
   onInitLocalRuntime,
   onOpenChat,
+  onOpenCode,
   onOpenConfig,
   onRepairP2P,
 }: FleetDashboardProps) {
@@ -198,6 +200,7 @@ export function FleetDashboard({
                 deployment={deployment}
                 key={deployment.peerId}
                 onOpenChat={onOpenChat}
+                onOpenCode={onOpenCode}
                 onOpenConfig={onOpenConfig}
               />
             ))}

--- a/apps/desktop-tauri/src/components/fleet/FleetIcons.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetIcons.tsx
@@ -8,6 +8,16 @@ export function ChatIcon() {
   );
 }
 
+export function CodeIcon() {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true">
+      <path d="M8 6 3 12l5 6" />
+      <path d="m16 6 5 6-5 6" />
+      <path d="M13 4 11 20" />
+    </svg>
+  );
+}
+
 export function ConfigIcon() {
   return (
     <svg viewBox="0 0 24 24" aria-hidden="true">

--- a/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
+++ b/apps/desktop-tauri/src/components/fleet/FleetRow.tsx
@@ -7,7 +7,7 @@ import {
   displayBehaviorLabel,
   displayGraphqlEndpoint,
 } from "../../lib/types";
-import { ChatIcon, ConfigIcon, ToolIconGlyph } from "./FleetIcons";
+import { ChatIcon, CodeIcon, ConfigIcon, ToolIconGlyph } from "./FleetIcons";
 import {
   deploymentStatus,
   formatRelativeTime,
@@ -21,6 +21,7 @@ export type FleetRowProps = {
   bootstrap: BootstrapSummary | null;
   deployment: DeploymentView;
   onOpenChat: (agentDid: string) => void;
+  onOpenCode?: (agentDid: string) => void;
   onOpenConfig: (agentDid: string) => void;
 };
 
@@ -28,6 +29,7 @@ export function FleetRow({
   bootstrap,
   deployment,
   onOpenChat,
+  onOpenCode,
   onOpenConfig,
 }: FleetRowProps) {
   const status = deploymentStatus(deployment);
@@ -149,6 +151,18 @@ export function FleetRow({
           >
             <ChatIcon />
           </button>
+          {onOpenCode ? (
+            <button
+              aria-label={`Open ${deployment.label} in Code mode`}
+              className="ghost-button fleet-table-action"
+              data-testid={`fleet-code-${deployment.peerId}`}
+              onClick={() => onOpenCode(deployment.agentDid)}
+              title="Open Code mode"
+              type="button"
+            >
+              <CodeIcon />
+            </button>
+          ) : null}
           <button
             aria-label={`Configure ${deployment.label}`}
             className="ghost-button fleet-table-action"

--- a/apps/desktop-tauri/tests/fleet-health-visibility.test.tsx
+++ b/apps/desktop-tauri/tests/fleet-health-visibility.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { FleetRow, type FleetRowProps } from "../src/components/fleet/FleetRow";
@@ -45,5 +45,24 @@ describe("fleet health visibility", () => {
     renderRow({ ...deployment, dialSucceeded: true, lastError: null });
     expect(screen.getByRole("button", { name: "Copy DID" })).toBeInTheDocument();
     expect(screen.queryByTestId("fleet-error-peer-1")).not.toBeInTheDocument();
+  });
+
+  it("offers a Code-mode action when wired", () => {
+    const onOpenCode = vi.fn();
+    render(
+      <table>
+        <tbody>
+          <FleetRow
+            bootstrap={null}
+            deployment={{ ...deployment, dialSucceeded: true, lastError: null }}
+            onOpenChat={vi.fn()}
+            onOpenCode={onOpenCode}
+            onOpenConfig={vi.fn()}
+          />
+        </tbody>
+      </table>,
+    );
+    fireEvent.click(screen.getByTestId("fleet-code-peer-1"));
+    expect(onOpenCode).toHaveBeenCalledWith(deployment.agentDid);
   });
 });


### PR DESCRIPTION
WS4 slice of #608. Code mode existed but had no path from the fleet — operators had to open chat first, then find the buried entry.

Fleet rows gain a Code action (brackets glyph, between Chat and Configure) that selects the agent and opens Code mode directly, matching the existing action-button pattern with a proper aria-label and testid. The dashboard/App threading mirrors `onOpenChat`.

Fence: click-through test in `fleet-health-visibility.test.tsx`. Unit 241, e2e 120, fleet baselines regenerated (new action column width).

Stacked on #776. Part of #608 (WS4).