### PR TITLE
feat(desktop): save errors near the form

### DIFF
--- a/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BackendConfigPanel.tsx
@@ -8,12 +8,7 @@ import type {
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
-import {
-  ignoreHandledActionError,
-  isOptionalInt,
-  linesToArray,
-  parseOptionalInt,
-} from "./formUtils";
+import { isOptionalInt, linesToArray, parseOptionalInt } from "./formUtils";
 
 export type BackendConfigPanelProps = {
   deployment: DeploymentView;
@@ -101,6 +96,8 @@ export function BackendConfigEditor({
   const [maxQueueDepth, setMaxQueueDepth] = useState("");
   const [enabled, setEnabled] = useState(true);
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const base = backendFormValues(backend);
     setBackendId(base.backendId);
@@ -114,6 +111,7 @@ export function BackendConfigEditor({
     setMaxConcurrent(base.maxConcurrent);
     setMaxQueueDepth(base.maxQueueDepth);
     setEnabled(base.enabled);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend?.backendId]);
@@ -156,8 +154,9 @@ export function BackendConfigEditor({
         enabled,
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -169,6 +168,7 @@ export function BackendConfigEditor({
         title={name || backendId || "New Backend"}
         dirty={dirty}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Backend ID</span>

--- a/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/EventTriggerConfigPanel.tsx
@@ -8,8 +8,8 @@ import type {
   TaskView,
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
-import { ignoreHandledActionError, optionalString } from "./formUtils";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
+import { optionalString } from "./formUtils";
 
 export type EventTriggerConfigPanelProps = {
   deployment: DeploymentView;
@@ -105,6 +105,8 @@ export function EventTriggerConfigEditor({
   const [enabled, setEnabled] = useState(true);
   const [concurrency, setConcurrency] = useState("serial");
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = eventTriggerFormValues(eventTrigger, selectedTask?.taskId ?? null);
     setTriggerId(b.triggerId);
@@ -114,6 +116,7 @@ export function EventTriggerConfigEditor({
     setFilter(b.filter);
     setEnabled(b.enabled);
     setConcurrency(b.concurrency);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [eventTrigger?.triggerId, selectedTask?.taskId]);
 
@@ -131,8 +134,9 @@ export function EventTriggerConfigEditor({
         concurrency,
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -155,6 +159,7 @@ export function EventTriggerConfigEditor({
         saved={savedStatus === `event-trigger:${triggerId.trim()}`}
         title={triggerId || "New Event Trigger"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Trigger ID</span>

--- a/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/InferenceProfileConfigPanel.tsx
@@ -9,7 +9,6 @@ import type {
 import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import {
-  ignoreHandledActionError,
   isOptionalFloat,
   isOptionalInt,
   parseOptionalFloat,
@@ -107,6 +106,8 @@ export function InferenceProfileConfigEditor({
   const [streamLivenessSecs, setStreamLivenessSecs] = useState("");
   const [deadlineSecs, setDeadlineSecs] = useState("");
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = profileFormValues(profile);
     setProfileId(b.profileId);
@@ -118,6 +119,7 @@ export function InferenceProfileConfigEditor({
     setStreamBatchMs(b.streamBatchMs);
     setStreamLivenessSecs(b.streamLivenessSecs);
     setDeadlineSecs(b.deadlineSecs);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [profile?.profileId]);
 
@@ -145,8 +147,9 @@ export function InferenceProfileConfigEditor({
         deadlineDurationSecs: parseOptionalInt(deadlineSecs),
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -171,6 +174,7 @@ export function InferenceProfileConfigEditor({
         saved={savedStatus === `profile:${profileId.trim()}`}
         title={displayName || profileId || "New Profile"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Profile document ID</span>

--- a/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ScheduleConfigPanel.tsx
@@ -115,6 +115,8 @@ export function ScheduleConfigEditor({
   const [concurrency, setConcurrency] = useState("serial");
   const [runStatus, setRunStatus] = useState<TaskRunResult | null>(null);
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = scheduleFormValues(schedule, selectedTask?.taskId ?? null);
     setScheduleId(b.scheduleId);
@@ -122,6 +124,7 @@ export function ScheduleConfigEditor({
     setIntervalSecs(b.intervalSecs);
     setEnabled(b.enabled);
     setConcurrency(b.concurrency);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [schedule?.scheduleId, selectedTask?.taskId]);
 
@@ -143,8 +146,9 @@ export function ScheduleConfigEditor({
         concurrency,
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -168,6 +172,7 @@ export function ScheduleConfigEditor({
         saved={savedStatus === `schedule:${scheduleId.trim()}`}
         title={scheduleId || "New Timer Trigger"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Schedule ID</span>

--- a/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/SkillConfigPanel.tsx
@@ -9,7 +9,7 @@ import type {
 } from "../../lib/types";
 import { ConfirmDialog } from "../ConfirmDialog";
 import { isDirty } from "./configDirty";
-import { ConfigDocumentList, ConfigEditorHeader } from "./ConfigChrome";
+import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
 import { ignoreHandledActionError, linesToArray, optionalString } from "./formUtils";
 
 export type SkillConfigPanelProps = {
@@ -112,6 +112,8 @@ export function SkillConfigEditor({
   const [enabled, setEnabled] = useState(true);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const base = skillFormValues(skill);
     setSkillId(base.skillId);
@@ -122,6 +124,7 @@ export function SkillConfigEditor({
     setToolRefs(base.toolRefs);
     setDisplayName(base.displayName);
     setEnabled(base.enabled);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skill?.skillId]);
@@ -147,8 +150,9 @@ export function SkillConfigEditor({
         enabled,
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -182,6 +186,7 @@ export function SkillConfigEditor({
         title={name || skillId || "New Skill"}
         dirty={dirty}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Skill ID</span>

--- a/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/TaskConfigPanel.tsx
@@ -114,6 +114,8 @@ export function TaskConfigEditor({
   const [runArgs, setRunArgs] = useState("{}");
   const [runStatus, setRunStatus] = useState<TaskRunResult | null>(null);
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = taskFormValues(task, selectedBehavior?.behaviorId ?? null);
     setTaskId(b.taskId);
@@ -123,6 +125,7 @@ export function TaskConfigEditor({
     setPromptTemplate(b.promptTemplate);
     setOutputSchemaRef(b.outputSchemaRef);
     setEnabled(b.enabled);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [selectedBehavior?.behaviorId, task?.taskId]);
 
@@ -146,8 +149,9 @@ export function TaskConfigEditor({
         outputSchemaRef: optionalString(outputSchemaRef),
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -182,6 +186,7 @@ export function TaskConfigEditor({
         saved={savedStatus === `task:${taskId.trim()}`}
         title={name || taskId || "New Task"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Task ID</span>

--- a/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolSelectionConfigPanel.tsx
@@ -9,12 +9,7 @@ import type {
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
-import {
-  ignoreHandledActionError,
-  isOptionalInt,
-  linesToArray,
-  parseOptionalInt,
-} from "./formUtils";
+import { isOptionalInt, linesToArray, parseOptionalInt } from "./formUtils";
 
 const COMMAND_POLICY_OPTIONS = [
   { value: "", label: "Default for bash mode" },
@@ -166,6 +161,8 @@ export function ToolSelectionConfigEditor({
     [toolServiceRegistries],
   );
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = toolSelectionFormValues(toolSelection, toolServiceIdKey);
     setSelectionId(b.selectionId);
@@ -190,6 +187,7 @@ export function ToolSelectionConfigEditor({
     setSubagentBackgroundEnabled(b.subagentBackgroundEnabled);
     setCrossDeploymentSpawnTimeoutSeconds(b.crossDeploymentSpawnTimeoutSeconds);
     setDefraQueryCollections(b.defraQueryCollections);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [toolSelection?.selectionId, toolServiceIdKey]);
 
@@ -248,8 +246,9 @@ export function ToolSelectionConfigEditor({
         ),
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -287,6 +286,7 @@ export function ToolSelectionConfigEditor({
         saved={savedStatus === `tool:${selectionId.trim()}`}
         title={displayName || selectionId || "New Tool Selection"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="facts">
         <div>
           <dt>Server ceiling</dt>

--- a/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/ToolServiceConfigPanel.tsx
@@ -10,12 +10,7 @@ import type {
 } from "../../lib/types";
 import { isDirty } from "./configDirty";
 import { ConfigDocumentList, ConfigEditorHeader, FieldHint } from "./ConfigChrome";
-import {
-  ignoreHandledActionError,
-  isOptionalInt,
-  optionalString,
-  parseOptionalInt,
-} from "./formUtils";
+import { isOptionalInt, optionalString, parseOptionalInt } from "./formUtils";
 
 export type ToolServiceConfigPanelProps = {
   deployment: DeploymentView;
@@ -118,6 +113,8 @@ export function ToolServiceConfigEditor({
   const [testResult, setTestResult] = useState<ToolServiceTestResult | null>(null);
   const [testError, setTestError] = useState<string | null>(null);
 
+  const [saveError, setSaveError] = useState<string | null>(null);
+
   useEffect(() => {
     const b = toolServiceFormValues(toolService);
     setServiceId(b.serviceId);
@@ -131,6 +128,7 @@ export function ToolServiceConfigEditor({
     setStatus(b.status);
     setTestResult(null);
     setTestError(null);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [toolService?.serviceId]);
 
@@ -166,8 +164,9 @@ export function ToolServiceConfigEditor({
         status: optionalString(status) || "online",
       });
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -206,6 +205,7 @@ export function ToolServiceConfigEditor({
         saved={savedStatus === `tool-service:${serviceId.trim()}`}
         title={displayName || serviceId || "New Service"}
       />
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
       <div className="grid-2">
         <label className="field">
           <span>Service ID</span>

--- a/apps/desktop-tauri/tests/config-dirty-state.test.tsx
+++ b/apps/desktop-tauri/tests/config-dirty-state.test.tsx
@@ -135,4 +135,24 @@ describe("config dirty state", () => {
     });
     expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
   });
+
+  it("renders a save failure next to the form, not just the global banner", async () => {
+    const onSaveSkillConfig = vi.fn().mockRejectedValue(new Error("schema mismatch"));
+    render(
+      <SkillConfigPanel
+        deployment={makeDeployment()}
+        selectedSkillId="review-skill"
+        saving={false}
+        savedStatus={null}
+        onSelectSkill={vi.fn()}
+        onCreateSkill={vi.fn()}
+        onDeletedSkill={vi.fn()}
+        onSavedStatusChange={vi.fn()}
+        onDeleteSkillConfig={vi.fn()}
+        onSaveSkillConfig={onSaveSkillConfig}
+      />,
+    );
+    fireEvent.submit(screen.getByTestId("skill-save").closest("form")!);
+    expect(await screen.findByText(/Save failed: schema mismatch/)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
WS5 slice of #608 — the last of the config-editor UX items. Save failures surfaced only as a raw `String(err)` in the global banner at the top of the app, disconnected from the form the operator was editing.

All eight header-based editors now catch the (already-rethrown) save failure locally and render "Save failed: {message}" directly under the editor header — cleared on the next successful save and on document switch. The global banner behavior is unchanged (shell handlers still set it), so nothing regresses for surfaces that rely on it; the form just stops being silent. The now-unused `ignoreHandledActionError` imports came out of the five editors whose only catch was the save path.

Fence: skill-editor save-failure case in `config-dirty-state.test.tsx`. Unit 241, e2e 120, visual unchanged.

Stacked on #777. Part of #608 (WS5).