### PR TITLE
feat(desktop): one editing paradigm for Agent/Behavior editors

### DIFF
--- a/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/AgentConfigPanel.tsx
@@ -8,8 +8,7 @@ import type {
   BootstrapSummary,
   DeploymentView,
 } from "../../lib/types";
-import { PencilIcon } from "./ConfigChrome";
-import { ignoreHandledActionError } from "./formUtils";
+import { EditorStatusChip, FieldHint, PencilIcon } from "./ConfigChrome";
 
 export type AgentConfigPanelProps = {
   bootstrap: BootstrapSummary | null;
@@ -64,12 +63,16 @@ export function AgentConfigEditor({
 }: AgentConfigEditorProps) {
   const [displayName, setDisplayName] = useState("");
   const [editingDisplayName, setEditingDisplayName] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
     setDisplayName(agent.displayName ?? "");
     setEditingDisplayName(false);
+    setSaveError(null);
     // Id-keyed: background snapshot refreshes must not wipe in-progress edits.
   }, [agent.agentDid]);
+
+  const dirty = editingDisplayName && displayName !== (agent.displayName ?? "");
 
   const defaultBehaviorId =
     agent.defaultBehaviorId ??
@@ -90,8 +93,9 @@ export function AgentConfigEditor({
       });
       setEditingDisplayName(false);
       onSaved(agent.agentDid);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -130,10 +134,12 @@ export function AgentConfigEditor({
             ) : null}
           </div>
         </div>
-        {savedStatus === `agent:${agent.agentDid}` ? (
-          <span className="chip chip-green">Saved</span>
-        ) : null}
+        <EditorStatusChip
+          dirty={dirty}
+          saved={savedStatus === `agent:${agent.agentDid}`}
+        />
       </div>
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
 
       <div className="facts agent-install-facts">
         <div>
@@ -165,6 +171,8 @@ export function AgentConfigEditor({
             onClick={() => {
               setDisplayName(agent.displayName ?? "");
               setEditingDisplayName(false);
+              // An abandoned rename must not leave its failure on screen.
+              setSaveError(null);
             }}
             type="button"
           >

--- a/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
+++ b/apps/desktop-tauri/src/components/config/BehaviorConfigPanel.tsx
@@ -11,10 +11,15 @@ import type {
   SkillView,
   ToolSelectionView,
 } from "../../lib/types";
-import { ConfigDocumentList, FieldHint, PlusIcon } from "./ConfigChrome";
+import { isDirty } from "./configDirty";
+import {
+  ConfigDocumentList,
+  EditorStatusChip,
+  FieldHint,
+  PlusIcon,
+} from "./ConfigChrome";
 import {
   boolText,
-  ignoreHandledActionError,
   isOptionalFloat,
   optionalString,
   parseOptionalFloat,
@@ -154,48 +159,34 @@ export function BehaviorConfigEditor({
   const [defaultForAgent, setDefaultForAgent] = useState(false);
   const [skillRefs, setSkillRefs] = useState<string[]>([]);
   const [skillExcludes, setSkillExcludes] = useState<string[]>([]);
-
-  // Sorted like toolServiceIdKey: the joined key must not depend on row order.
-  const profileIdKey = inferenceProfiles
-    .map((p) => p.profileId)
-    .sort()
-    .join("|");
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   useEffect(() => {
-    setBehaviorId(behavior?.behaviorId ?? "");
-    setSystemPrompt(behavior?.systemPrompt ?? "");
-    setBackendId(behavior?.backendId ?? "");
-    setProfileId(behavior?.inferenceProfileId ?? "");
-    setToolSelectionId(behavior?.toolSelectionId ?? "");
-    setCompactionStrategy(behavior?.compactionStrategy ?? DEFAULT_COMPACTION_STRATEGY);
-    setCompactionThreshold(
-      behavior?.compactionThreshold != null
-        ? String(behavior.compactionThreshold)
-        : DEFAULT_COMPACTION_THRESHOLD,
-    );
-    setEnabled(behavior?.enabled ?? true);
-    setDefaultForAgent(behavior?.isDefault ?? false);
-    setSkillRefs(behavior?.skillRefs ?? []);
-    setSkillExcludes(behavior?.skillExcludes ?? []);
+    const base = behaviorFormValues(behavior);
+    setBehaviorId(base.behaviorId);
+    setSystemPrompt(base.systemPrompt);
+    setBackendId(base.backendId);
+    setProfileId(base.profileId);
+    setToolSelectionId(base.toolSelectionId);
+    setCompactionStrategy(base.compactionStrategy);
+    setCompactionThreshold(base.compactionThreshold);
+    setEnabled(base.enabled);
+    setDefaultForAgent(base.defaultForAgent);
+    setSkillRefs(base.skillRefs);
+    setSkillExcludes(base.skillExcludes);
+    setSaveError(null);
     // Id-keyed only: background snapshot refreshes (including profile-list
     // churn) must not wipe in-progress edits.
   }, [behavior?.behaviorId]);
 
-  // Default-profile fallback in its own effect so profile-set churn never
-  // resets the rest of the form: keep the current pick while it exists,
-  // otherwise fall back to the document's selection, then the first profile.
-  useEffect(() => {
-    setProfileId((current) => {
-      if (current && inferenceProfiles.some((p) => p.profileId === current)) {
-        return current;
-      }
-      const selected = behavior?.inferenceProfileId;
-      if (selected && inferenceProfiles.some((p) => p.profileId === selected)) {
-        return selected;
-      }
-      return inferenceProfiles[0]?.profileId ?? "";
-    });
-  }, [behavior?.behaviorId, profileIdKey]);
+  // The profile fallback is derived, not stored: profileId holds only what
+  // hydration or the user put there, so profile-list churn can never bake a
+  // fallback into state (a stored fallback both defeats dirty tracking and
+  // gets silently persisted over the document's own selection on Save).
+  const effectiveProfileId = pickValidProfile(
+    [profileId, behavior?.inferenceProfileId ?? ""],
+    inferenceProfiles,
+  );
 
   const behaviorScopedSkills = skills.filter((skill) => skill.scope === "behavior");
   const principalScopedSkills = skills.filter((skill) => skill.scope === "principal");
@@ -234,6 +225,31 @@ export function BehaviorConfigEditor({
     max: 1,
   });
 
+  // Baseline applies the same derived-profile fallback; skill arrays compare
+  // as sets — toggling off and back on must not read as an edit.
+  const base = behaviorFormValues(behavior);
+  const dirty = isDirty(
+    {
+      behaviorId,
+      systemPrompt,
+      backendId,
+      profileId: effectiveProfileId,
+      toolSelectionId,
+      compactionStrategy,
+      compactionThreshold,
+      enabled,
+      defaultForAgent,
+      skillRefs: [...skillRefs].sort(),
+      skillExcludes: [...skillExcludes].sort(),
+    },
+    {
+      ...base,
+      profileId: pickValidProfile([base.profileId], inferenceProfiles),
+      skillRefs: [...base.skillRefs].sort(),
+      skillExcludes: [...base.skillExcludes].sort(),
+    },
+  );
+
   async function submitBehavior(event: FormEvent) {
     event.preventDefault();
     const nextId = behaviorId.trim();
@@ -244,7 +260,7 @@ export function BehaviorConfigEditor({
         displayName: nextId,
         systemPrompt,
         backendId: optionalString(backendId),
-        inferenceProfileId: profileId.trim(),
+        inferenceProfileId: effectiveProfileId,
         toolSelectionId: optionalString(toolSelectionId),
         compactionStrategy: optionalString(compactionStrategy),
         compactionThreshold: parseOptionalFloat(compactionThreshold),
@@ -261,8 +277,9 @@ export function BehaviorConfigEditor({
         });
       }
       onSaved(nextId);
+      setSaveError(null);
     } catch (error) {
-      ignoreHandledActionError(error);
+      setSaveError(error instanceof Error ? error.message : String(error));
     }
   }
 
@@ -287,10 +304,12 @@ export function BehaviorConfigEditor({
             )}
           </div>
         </div>
-        {savedStatus === `behavior:${behaviorId.trim()}` ? (
-          <span className="chip chip-green">Saved</span>
-        ) : null}
+        <EditorStatusChip
+          dirty={dirty}
+          saved={savedStatus === `behavior:${behaviorId.trim()}`}
+        />
       </div>
+      {saveError ? <FieldHint show>Save failed: {saveError}</FieldHint> : null}
 
       <div className="behavior-link-grid">
         <label className="field behavior-link-field">
@@ -326,7 +345,7 @@ export function BehaviorConfigEditor({
             <select
               data-testid="behavior-profile-id"
               onChange={(event) => setProfileId(event.currentTarget.value)}
-              value={profileId}
+              value={effectiveProfileId}
             >
               {!inferenceProfiles.length ? (
                 <option value="">No profiles available</option>
@@ -503,7 +522,7 @@ export function BehaviorConfigEditor({
             saving ||
             !behaviorId.trim() ||
             !systemPrompt.trim() ||
-            !profileId.trim() ||
+            !effectiveProfileId ||
             !compactionThresholdValid
           }
           type="submit"
@@ -513,4 +532,34 @@ export function BehaviorConfigEditor({
       </div>
     </form>
   );
+}
+
+/** View→form hydration, shared by the reset effect and dirty comparison. */
+function behaviorFormValues(behavior: BehaviorView | null) {
+  return {
+    behaviorId: behavior?.behaviorId ?? "",
+    systemPrompt: behavior?.systemPrompt ?? "",
+    backendId: behavior?.backendId ?? "",
+    profileId: behavior?.inferenceProfileId ?? "",
+    toolSelectionId: behavior?.toolSelectionId ?? "",
+    compactionStrategy: behavior?.compactionStrategy ?? DEFAULT_COMPACTION_STRATEGY,
+    compactionThreshold:
+      behavior?.compactionThreshold != null
+        ? String(behavior.compactionThreshold)
+        : DEFAULT_COMPACTION_THRESHOLD,
+    enabled: behavior?.enabled ?? true,
+    defaultForAgent: behavior?.isDefault ?? false,
+    skillRefs: behavior?.skillRefs ?? [],
+    skillExcludes: behavior?.skillExcludes ?? [],
+  };
+}
+
+/** First candidate that names an available profile, else the first profile. */
+function pickValidProfile(candidates: string[], profiles: InferenceProfileView[]) {
+  for (const candidate of candidates) {
+    if (candidate && profiles.some((profile) => profile.profileId === candidate)) {
+      return candidate;
+    }
+  }
+  return profiles[0]?.profileId ?? "";
 }

--- a/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
+++ b/apps/desktop-tauri/src/components/config/ConfigChrome.tsx
@@ -19,15 +19,25 @@ export function ConfigEditorHeader({
         <p className="eyebrow">{eyebrow}</p>
         <h3>{title}</h3>
       </div>
-      {dirty ? (
-        <span className="chip chip-amber" data-testid="unsaved-chip">
-          Unsaved changes
-        </span>
-      ) : saved ? (
-        <span className="chip chip-green">Saved</span>
-      ) : null}
+      <EditorStatusChip dirty={dirty} saved={saved} />
     </div>
   );
+}
+
+/** One save-state vocabulary for every editor, including the custom-header
+ * Agent/Behavior panels: dirty outranks saved. */
+export function EditorStatusChip({ dirty, saved }: { dirty: boolean; saved: boolean }) {
+  if (dirty) {
+    return (
+      <span className="chip chip-amber" data-testid="unsaved-chip">
+        Unsaved changes
+      </span>
+    );
+  }
+  if (saved) {
+    return <span className="chip chip-green">Saved</span>;
+  }
+  return null;
 }
 
 /** Inline validation reason — invalid input must explain itself, not just

--- a/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
+++ b/apps/desktop-tauri/tests/behavior-config-panel.test.tsx
@@ -1,9 +1,12 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+import { AgentConfigEditor } from "../src/components/config/AgentConfigPanel";
 import { BehaviorConfigEditor } from "../src/components/config/BehaviorConfigPanel";
 import type {
   AgentConfigSaveRequest,
+  AgentPrincipalView,
+  SkillView,
   BehaviorSaveRequest,
   BehaviorView,
   InferenceBackendView,
@@ -155,5 +158,205 @@ describe("BehaviorConfigEditor", () => {
       defaultBehaviorId: "did:key:z6MkAgent:ops",
       enabled: true,
     });
+  });
+
+  it("tracks edits with the shared unsaved chip and heals on revert", () => {
+    render(
+      <BehaviorConfigEditor
+        agentDid="did:key:z6MkAgent"
+        agentDisplayName="Local Agent"
+        agentEnabled
+        behavior={behavior}
+        currentDefaultBehaviorId={behavior.behaviorId}
+        inferenceBackends={inferenceBackends}
+        inferenceProfiles={inferenceProfiles}
+        savedStatus={null}
+        saving={false}
+        toolSelections={toolSelections}
+        onCreateBackend={vi.fn()}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={vi.fn()}
+        onSaveBehaviorConfig={vi.fn()}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("behavior-system-prompt"), {
+      target: { value: "You are the default agent. Be brief." },
+    });
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("behavior-system-prompt"), {
+      target: { value: "You are the default agent." },
+    });
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+  });
+
+  it("renders save failures next to the form", async () => {
+    const onSaveBehaviorConfig = vi.fn(() => Promise.reject(new Error("acp denied")));
+
+    render(
+      <BehaviorConfigEditor
+        agentDid="did:key:z6MkAgent"
+        agentDisplayName="Local Agent"
+        agentEnabled
+        behavior={behavior}
+        currentDefaultBehaviorId={behavior.behaviorId}
+        inferenceBackends={inferenceBackends}
+        inferenceProfiles={inferenceProfiles}
+        savedStatus={null}
+        saving={false}
+        toolSelections={toolSelections}
+        onCreateBackend={vi.fn()}
+        onCreateProfile={vi.fn()}
+        onCreateToolSelection={vi.fn()}
+        onSaveAgentConfig={vi.fn()}
+        onSaveBehaviorConfig={onSaveBehaviorConfig}
+        onSaved={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("behavior-save"));
+    expect(await screen.findByText(/Save failed: acp denied/)).toBeInTheDocument();
+  });
+
+  function editorProps(overrides: Record<string, unknown> = {}) {
+    return {
+      agentDid: "did:key:z6MkAgent",
+      agentDisplayName: "Local Agent",
+      agentEnabled: true,
+      behavior,
+      currentDefaultBehaviorId: behavior.behaviorId,
+      inferenceBackends,
+      inferenceProfiles,
+      savedStatus: null,
+      saving: false,
+      toolSelections,
+      onCreateBackend: vi.fn(),
+      onCreateProfile: vi.fn(),
+      onCreateToolSelection: vi.fn(),
+      onSaveAgentConfig: vi.fn(),
+      onSaveBehaviorConfig: vi.fn(),
+      onSaved: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it("does not read a skill toggled off and back on as an edit", () => {
+    const skills: SkillView[] = [
+      { skillId: "writer", name: "Writer", scope: "behavior" },
+      { skillId: "ops", name: "Ops", scope: "behavior" },
+    ];
+    render(
+      <BehaviorConfigEditor
+        {...editorProps({
+          behavior: { ...behavior, skillRefs: ["writer"] },
+          skills,
+        })}
+      />,
+    );
+
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("behavior-skill-ref-writer"));
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("behavior-skill-ref-writer"));
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("behavior-skill-ref-ops"));
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+  });
+
+  it("selects the document profile over the first profile, without dirt", () => {
+    render(
+      <BehaviorConfigEditor
+        {...editorProps({
+          inferenceProfiles: [{ profileId: "other-profile" }, ...inferenceProfiles],
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("behavior-profile-id")).toHaveValue("default-profile");
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+  });
+
+  it("stays clean when the document profile drops out and reappears", () => {
+    const remote = { ...behavior, inferenceProfileId: "profile-remote" };
+    const { rerender } = render(
+      <BehaviorConfigEditor {...editorProps({ behavior: remote })} />,
+    );
+
+    // Document profile unavailable: the select falls back without dirt.
+    expect(screen.getByTestId("behavior-profile-id")).toHaveValue("default-profile");
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+
+    // The profile registers later: the document selection is truth again.
+    rerender(
+      <BehaviorConfigEditor
+        {...editorProps({
+          behavior: remote,
+          inferenceProfiles: [...inferenceProfiles, { profileId: "profile-remote" }],
+        })}
+      />,
+    );
+    expect(screen.getByTestId("behavior-profile-id")).toHaveValue("profile-remote");
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+  });
+});
+
+describe("AgentConfigEditor", () => {
+  const agent: AgentPrincipalView = {
+    agentDid: "did:key:z6MkAgent",
+    displayName: "Local Agent",
+    defaultBehaviorId: "did:key:z6MkAgent:default",
+    enabled: true,
+  };
+
+  function renderAgent(onSaveAgentConfig = vi.fn(() => Promise.resolve())) {
+    render(
+      <AgentConfigEditor
+        agent={agent}
+        behaviors={[behavior]}
+        bootstrap={null}
+        savedStatus={null}
+        saving={false}
+        onSaved={vi.fn()}
+        onSaveAgentConfig={onSaveAgentConfig}
+      />,
+    );
+  }
+
+  it("flags an in-progress rename with the shared unsaved chip", () => {
+    renderAgent();
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("agent-display-name"), {
+      target: { value: "Renamed Agent" },
+    });
+    expect(screen.getByTestId("unsaved-chip")).toBeInTheDocument();
+  });
+
+  it("renders save failures next to the form", async () => {
+    renderAgent(vi.fn(() => Promise.reject(new Error("store offline"))));
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.change(screen.getByTestId("agent-display-name"), {
+      target: { value: "Renamed Agent" },
+    });
+    fireEvent.click(screen.getByTestId("agent-save"));
+    expect(await screen.findByText(/Save failed: store offline/)).toBeInTheDocument();
+  });
+
+  it("clears the save failure when the rename is cancelled", async () => {
+    renderAgent(vi.fn(() => Promise.reject(new Error("store offline"))));
+    fireEvent.click(screen.getByTestId("agent-edit-display-name"));
+    fireEvent.change(screen.getByTestId("agent-display-name"), {
+      target: { value: "Renamed Agent" },
+    });
+    fireEvent.click(screen.getByTestId("agent-save"));
+    expect(await screen.findByText(/Save failed: store offline/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByText(/Save failed/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId("unsaved-chip")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
WS5 slice of #608. The Agent and Behavior editors were the last two outside the shared editor paradigm: no dirty tracking, and save failures vanished into the global banner.

- Shared `EditorStatusChip` extracted from `ConfigEditorHeader` — one save-state vocabulary (amber "Unsaved changes" outranks green "Saved") across all ten editors, including these two custom-header panels.
- Both editors get the pure view→form baseline dirty comparator and local "Save failed: …" routing; Cancel on an agent rename clears the abandoned edit's error.
- The Behavior profile fallback is now derived instead of stored. The old fallback effect baked its pick into state, which adversarial review showed both defeats dirty tracking after profile-list churn and — worse — silently persists the fallback over the document's own `inferenceProfileId` on Save. Deriving the effective profile (state → document → first) removes the divergence at the root and restores the document's selection when its profile registers late.

Fences: skill toggle round-trip is not an edit, document profile beats positional first, drop-out/reappear churn stays clean, cancelled rename clears the failure. Unit 250, e2e 120, visual unchanged.

Stacked on #778. Part of #608 (WS5).