### PR TITLE
refactor(desktop): token sweep — zero raw rgb() literals

### DIFF
--- a/apps/desktop-tauri/src/styles/backend-health/backend-health.css
+++ b/apps/desktop-tauri/src/styles/backend-health/backend-health.css
@@ -60,7 +60,7 @@
     border-color: rgb(var(--source-orange-rgb) / 0.36);
   }
   .backend-health__summary-chip[data-tone="error"] {
-    border-color: rgb(255 111 95 / 0.36);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.36);
   }
 
   .backend-health__summary-count {
@@ -81,7 +81,7 @@
 
   .backend-health__error {
     color: var(--color-error);
-    border-color: rgb(255 111 95 / 0.36);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.36);
   }
 
   /* ── list ──────────────────────────────────────────────── */
@@ -169,7 +169,7 @@
   }
   .backend-health__status-glyph[data-state="unhealthy"] {
     color: var(--color-error);
-    border-color: rgb(255 111 95 / 0.4);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.4);
   }
   .backend-health__status-glyph[data-state="stale"],
   .backend-health__status-glyph[data-state="rate-limited"],
@@ -280,7 +280,7 @@
     gap: var(--space-9);
     padding: var(--space-7) var(--space-7) var(--space-9);
     border-top: 1px solid var(--border-subtle);
-    background: rgb(0 0 0 / 0.2);
+    background: rgb(var(--source-black-rgb) / 0.2);
   }
 
   .backend-health__detail-section {
@@ -415,7 +415,7 @@
   }
   .backend-health__call-state[data-state="failed"] {
     color: var(--color-error);
-    background: rgb(255 111 95 / 0.1);
+    background: rgb(var(--color-error-strong-rgb) / 0.1);
   }
   .backend-health__call-state[data-state="cancelled"] {
     color: var(--color-warning);

--- a/apps/desktop-tauri/src/styles/backgrounded-tools.css
+++ b/apps/desktop-tauri/src/styles/backgrounded-tools.css
@@ -11,7 +11,7 @@
 
   .background-tools-panel {
     /* --border-warning is not present in tokens.css; declare it here only. */
-    --border-warning: rgb(255 160 17 / 0.55);
+    --border-warning: rgb(var(--source-orange-rgb) / 0.55);
   }
 
   /* ── Chip row / filter row ─────────────────────────────────────────────── */
@@ -99,7 +99,7 @@
 
   .background-tools-panel .chip[aria-pressed="true"],
   .background-tools-panel .chip.is-active {
-    background: rgb(6 178 80 / 0.22);
+    background: rgb(var(--source-green-rgb) / 0.22);
     border-color: var(--border-selected);
     color: var(--color-text-warm);
   }
@@ -210,23 +210,23 @@
   }
 
   .background-tools-panel table.tools tbody tr:hover {
-    background: rgb(6 178 80 / 0.06);
+    background: rgb(var(--source-green-rgb) / 0.06);
   }
 
   .background-tools-panel table.tools tbody tr:focus-within,
   .background-tools-panel table.tools tbody tr.is-selected {
-    background: rgb(6 178 80 / 0.1);
+    background: rgb(var(--source-green-rgb) / 0.1);
     box-shadow: inset 3px 0 0 0 var(--color-accent-strong);
   }
 
   .background-tools-panel table.tools tbody tr.row-stuck,
   .background-tools-panel table.tools tbody tr.row-warn {
     box-shadow: inset 3px 0 0 0 var(--color-warning);
-    background: rgb(255 160 17 / 0.06);
+    background: rgb(var(--source-orange-rgb) / 0.06);
   }
 
   .background-tools-panel table.tools tbody tr.row-stuck:focus-within {
-    background: rgb(255 160 17 / 0.1);
+    background: rgb(var(--source-orange-rgb) / 0.1);
   }
 
   .background-tools-panel table.tools td {
@@ -278,17 +278,17 @@
 
   .background-tools-panel .pill.pill-await {
     color: var(--color-info);
-    border-color: rgb(16 203 255 / 0.45);
+    border-color: rgb(var(--source-blue-rgb) / 0.45);
   }
 
   .background-tools-panel .pill.pill-await[data-mode="bridge"] {
     color: var(--color-accent-strong);
-    border-color: rgb(57 226 122 / 0.45);
+    border-color: rgb(var(--color-accent-strong-rgb) / 0.45);
   }
 
   .background-tools-panel .pill.pill-await[data-mode="detach"] {
     color: var(--color-text-muted);
-    border-color: rgb(149 164 157 / 0.45);
+    border-color: rgb(var(--color-text-muted-rgb) / 0.45);
   }
 
   .background-tools-panel .pill.pill-status {
@@ -297,25 +297,25 @@
 
   .background-tools-panel .pill.pill-status[data-state="running"] {
     color: var(--color-success);
-    border-color: rgb(141 242 180 / 0.45);
+    border-color: rgb(var(--color-success-rgb) / 0.45);
   }
 
   .background-tools-panel .pill.pill-status[data-state="background"] {
     color: var(--color-info);
-    border-color: rgb(16 203 255 / 0.45);
+    border-color: rgb(var(--source-blue-rgb) / 0.45);
   }
 
   .background-tools-panel .pill.pill-status[data-state="stuck"],
   .background-tools-panel .pill.pill-status[data-state="cancelPending"] {
     color: var(--color-warning);
     border-color: var(--border-warning);
-    background: rgb(255 160 17 / 0.08);
+    background: rgb(var(--source-orange-rgb) / 0.08);
   }
 
   .background-tools-panel .pill.pill-status[data-state="deadline+"] {
     color: var(--color-error);
-    border-color: rgb(255 111 95 / 0.5);
-    background: rgb(255 111 95 / 0.08);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.5);
+    background: rgb(var(--color-error-strong-rgb) / 0.08);
   }
 
   /* ── Row actions ─────────────────────────────────────────────────────────── */

--- a/apps/desktop-tauri/src/styles/cancel-ux.css
+++ b/apps/desktop-tauri/src/styles/cancel-ux.css
@@ -41,8 +41,8 @@
 
   .cause-unknown {
     color: var(--color-text-muted);
-    background: rgb(255 255 255 / 0.04);
-    border-color: rgb(255 255 255 / 0.1);
+    background: rgb(var(--source-white-rgb) / 0.04);
+    border-color: rgb(var(--source-white-rgb) / 0.1);
   }
 
   /* Wrapper for cause evidence details list (CancelCauseDetails component) */
@@ -90,7 +90,7 @@
   .dialog-backdrop {
     position: fixed;
     inset: 0;
-    background: rgb(0 0 0 / 0.62);
+    background: rgb(var(--source-black-rgb) / 0.62);
     display: none;
     align-items: flex-start;
     justify-content: center;
@@ -119,7 +119,7 @@
     width: min(560px, 100%);
     max-height: calc(100vh - 128px);
     overflow: auto;
-    box-shadow: 0 24px 60px rgb(0 0 0 / 0.5);
+    box-shadow: 0 24px 60px rgb(var(--source-black-rgb) / 0.5);
   }
 
   .dialog header {

--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -15,9 +15,9 @@
     min-width: 0;
     min-height: 0;
     border: 1px solid rgb(var(--source-green-rgb) / 0.16);
-    background: rgb(2 8 6 / 0.94);
+    background: rgb(var(--source-ink-2-rgb) / 0.94);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.025),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.025),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
   }
 
@@ -29,10 +29,10 @@
     grid-template-rows: auto auto minmax(0, 1fr);
     overflow: hidden;
     /* Fully opaque: the transcript must not ghost through the open drawer. */
-    background: rgb(2 8 6);
+    background: rgb(var(--source-ink-2-rgb));
     box-shadow:
-      0 20px 80px rgb(0 0 0 / 0.5),
-      inset 0 1px 0 rgb(255 255 255 / 0.025),
+      0 20px 80px rgb(var(--source-black-rgb) / 0.5),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.025),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
   }
 
@@ -110,7 +110,7 @@
     border: 1px solid var(--border-default);
     border-radius: 0;
     padding: 0 var(--space-4);
-    background: rgb(1 8 6 / 0.9);
+    background: rgb(var(--source-ink-rgb) / 0.9);
     color: var(--color-text-soft);
     font-size: var(--text-sm);
     font-weight: 600;
@@ -198,7 +198,7 @@
       linear-gradient(180deg, rgb(var(--source-green-rgb) / 0.035), transparent 42%),
       var(--color-surface-strong);
     border-color: rgb(var(--source-green-rgb) / 0.16);
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.025);
+    box-shadow: inset 0 1px 0 rgb(var(--source-white-rgb) / 0.025);
   }
 
   .composer-actions {
@@ -212,7 +212,7 @@
     padding-top: var(--space-6);
     background: var(--color-surface-strong);
     border-color: rgb(var(--source-green-rgb) / 0.16);
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.025);
+    box-shadow: inset 0 1px 0 rgb(var(--source-white-rgb) / 0.025);
   }
 
   .composer-input-wrap {

--- a/apps/desktop-tauri/src/styles/config/documents.css
+++ b/apps/desktop-tauri/src/styles/config/documents.css
@@ -21,15 +21,15 @@
   }
 
   .config-document-list-body .list-item:hover {
-    background: rgb(255 255 255 / 0.035);
+    background: rgb(var(--source-white-rgb) / 0.035);
   }
 
   .config-document-list-body .list-item.selected {
     border-color: var(--border-subtle);
-    background: rgb(0 0 0 / 0.32);
+    background: rgb(var(--source-black-rgb) / 0.32);
     box-shadow:
       inset 3px 0 0 rgb(var(--source-green-rgb) / 0.72),
-      inset 0 0 0 1px rgb(255 255 255 / 0.035);
+      inset 0 0 0 1px rgb(var(--source-white-rgb) / 0.035);
   }
 
   .config-document-list-body .list-item-meta {

--- a/apps/desktop-tauri/src/styles/config/forms.css
+++ b/apps/desktop-tauri/src/styles/config/forms.css
@@ -76,7 +76,7 @@
   }
 
   .config-result-error {
-    border-color: rgb(255 111 95 / 0.34);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.34);
     color: var(--color-error);
   }
 
@@ -123,7 +123,7 @@
 
   .config-workspace .field > input[readonly] {
     border-color: var(--border-subtle);
-    background: rgb(0 0 0 / 0.48);
+    background: rgb(var(--source-black-rgb) / 0.48);
     color: var(--color-text-muted);
     cursor: default;
   }

--- a/apps/desktop-tauri/src/styles/config/workspace.css
+++ b/apps/desktop-tauri/src/styles/config/workspace.css
@@ -42,7 +42,7 @@
     flex: 0 0 auto;
     border: 1px solid rgb(var(--source-green-rgb) / 0.2);
     border-radius: var(--radius-sm);
-    background: rgb(0 0 0 / 0.58);
+    background: rgb(var(--source-black-rgb) / 0.58);
     object-fit: contain;
     padding: var(--space-2);
   }
@@ -76,7 +76,7 @@
     width: 10px;
     height: 10px;
     border-radius: var(--radius-pill);
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 0.04);
+    box-shadow: 0 0 0 3px rgb(var(--source-white-rgb) / 0.04);
   }
 
   .config-status-dot.green {

--- a/apps/desktop-tauri/src/styles/fleet/layout.css
+++ b/apps/desktop-tauri/src/styles/fleet/layout.css
@@ -48,7 +48,7 @@
     flex: 0 0 auto;
     border: 1px solid rgb(var(--source-green-rgb) / 0.2);
     border-radius: var(--radius-sm);
-    background: rgb(0 0 0 / 0.58);
+    background: rgb(var(--source-black-rgb) / 0.58);
     object-fit: contain;
     padding: var(--space-2);
   }
@@ -66,7 +66,7 @@
     align-items: center;
     padding: var(--space-5);
     border: 1px solid rgb(var(--source-green-rgb) / 0.18);
-    background: rgb(1 8 6 / 0.72);
+    background: rgb(var(--source-ink-rgb) / 0.72);
   }
 
   .fleet-local-runtime-copy {

--- a/apps/desktop-tauri/src/styles/fleet/table.css
+++ b/apps/desktop-tauri/src/styles/fleet/table.css
@@ -4,7 +4,7 @@
     overflow: auto;
     border: 1px solid var(--border-default);
     background: var(--color-surface-row);
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.03);
+    box-shadow: inset 0 1px 0 rgb(var(--source-white-rgb) / 0.03);
   }
 
   .fleet-table {
@@ -23,7 +23,7 @@
 
   .fleet-table th {
     color: var(--color-text-muted);
-    background: rgb(0 0 0 / 0.88);
+    background: rgb(var(--source-black-rgb) / 0.88);
     font-size: var(--text-xs);
     letter-spacing: 0.05em;
     text-transform: uppercase;
@@ -87,7 +87,7 @@
     width: 10px;
     height: 10px;
     border-radius: var(--radius-pill);
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 0.04);
+    box-shadow: 0 0 0 3px rgb(var(--source-white-rgb) / 0.04);
     cursor: help;
   }
 
@@ -234,7 +234,7 @@
       var(--color-surface-row),
       var(--color-surface-row)
     );
-    box-shadow: -10px 0 10px -10px rgb(0 0 0 / 0.7);
+    box-shadow: -10px 0 10px -10px rgb(var(--source-black-rgb) / 0.7);
   }
 
   .fleet-table tbody tr:hover td.fleet-actions-cell {

--- a/apps/desktop-tauri/src/styles/mcp-health.css
+++ b/apps/desktop-tauri/src/styles/mcp-health.css
@@ -71,7 +71,7 @@
     gap: var(--space-3);
     padding: var(--space-2) var(--space-4) var(--space-2) var(--space-3);
     border: 1px solid var(--border-subtle);
-    background: rgb(0 0 0 / 0.45);
+    background: rgb(var(--source-black-rgb) / 0.45);
     border-radius: var(--radius-pill);
     font-size: var(--text-sm);
     color: var(--color-text-soft);
@@ -86,7 +86,7 @@
     width: 8px;
     height: 8px;
     border-radius: 999px;
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 0.04);
+    box-shadow: 0 0 0 3px rgb(var(--source-white-rgb) / 0.04);
   }
 
   .mcp-health-pill-green .mcp-health-pill-dot {
@@ -170,7 +170,7 @@
     border: 1px solid var(--border-default);
     background: var(--color-surface-row);
     border-radius: var(--radius-md);
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.03);
+    box-shadow: inset 0 1px 0 rgb(var(--source-white-rgb) / 0.03);
   }
 
   .mcp-health-table {
@@ -189,7 +189,7 @@
 
   .mcp-health-table thead th {
     color: var(--color-text-muted);
-    background: rgb(0 0 0 / 0.88);
+    background: rgb(var(--source-black-rgb) / 0.88);
     font-size: var(--text-xs);
     letter-spacing: 0.05em;
     text-transform: uppercase;
@@ -219,7 +219,7 @@
   }
 
   .mcp-health-detail-row > td {
-    background: rgb(0 0 0 / 0.55);
+    background: rgb(var(--source-black-rgb) / 0.55);
     padding: 0;
   }
 
@@ -287,7 +287,7 @@
     width: 10px;
     height: 10px;
     border-radius: 999px;
-    box-shadow: 0 0 0 3px rgb(255 255 255 / 0.04);
+    box-shadow: 0 0 0 3px rgb(var(--source-white-rgb) / 0.04);
   }
 
   .mcp-health-dot-green {
@@ -339,7 +339,7 @@
   }
 
   .mcp-health-k-badge-single {
-    background: rgb(0 0 0 / 0.55);
+    background: rgb(var(--source-black-rgb) / 0.55);
     color: var(--color-text-muted);
     border: 1px solid var(--border-subtle);
   }
@@ -351,9 +351,9 @@
   }
 
   .mcp-health-k-badge-alarm {
-    background: rgb(255 111 95 / 0.1);
+    background: rgb(var(--color-error-strong-rgb) / 0.1);
     color: var(--color-error-strong);
-    border-color: rgb(255 111 95 / 0.4);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.4);
   }
 
   .mcp-health-k-explainer {

--- a/apps/desktop-tauri/src/styles/primitives/controls.css
+++ b/apps/desktop-tauri/src/styles/primitives/controls.css
@@ -17,7 +17,7 @@
     letter-spacing: 0.01em;
     line-height: 1;
     box-shadow:
-      inset 0 1px 0 var(--button-top-line, rgb(255 255 255 / 0.05)),
+      inset 0 1px 0 var(--button-top-line, rgb(var(--source-white-rgb) / 0.05)),
       inset var(--button-rail-width, 0) 0 0 var(--button-rail, transparent);
     transition:
       background-color var(--motion-fast) ease,
@@ -31,7 +31,7 @@
     --button-rail-width: 2px;
     --button-rail: rgb(var(--source-green-rgb) / 0.18);
     color: var(--color-text-soft);
-    background: rgb(1 8 6 / 0.9);
+    background: rgb(var(--source-ink-rgb) / 0.9);
   }
 
   .ghost-button:not(:disabled):hover,
@@ -44,17 +44,17 @@
   }
 
   .danger-button {
-    --button-border: rgb(255 111 95 / 0.34);
-    --button-rail: rgb(255 111 95 / 0.28);
-    color: rgb(255 191 184);
+    --button-border: rgb(var(--color-error-strong-rgb) / 0.34);
+    --button-rail: rgb(var(--color-error-strong-rgb) / 0.28);
+    color: var(--color-error-tint);
   }
 
   .danger-button:not(:disabled):hover {
     --button-rail-width: 3px;
-    --button-rail: rgb(255 111 95 / 0.72);
-    border-color: rgb(255 111 95 / 0.58);
-    background: rgb(255 111 95 / 0.1);
-    color: rgb(255 226 222);
+    --button-rail: rgb(var(--color-error-strong-rgb) / 0.72);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.58);
+    background: rgb(var(--color-error-strong-rgb) / 0.1);
+    color: var(--color-error-soft);
   }
 
   .primary-button {
@@ -62,9 +62,9 @@
     --button-rail-width: 3px;
     --button-rail: var(--color-accent);
     color: var(--color-text);
-    background: rgb(1 8 6 / 0.94);
+    background: rgb(var(--source-ink-rgb) / 0.94);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.06),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.06),
       inset 3px 0 0 var(--color-accent);
   }
 
@@ -72,7 +72,7 @@
     border-color: rgb(var(--source-green-rgb) / 0.68);
     background: rgb(var(--source-green-rgb) / 0.1);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.07),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.07),
       inset 4px 0 0 var(--color-accent);
   }
 
@@ -101,7 +101,7 @@
     justify-content: center;
     min-height: 32px;
     border: 1px solid rgb(var(--source-green-rgb) / 0.24);
-    background: rgb(1 8 6 / 0.9);
+    background: rgb(var(--source-ink-rgb) / 0.9);
     color: var(--color-text-soft);
     border-radius: 0;
     padding: 0 var(--space-4);
@@ -110,7 +110,7 @@
     line-height: 1;
     flex-shrink: 0;
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.05),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.05),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
     transition:
       background-color var(--motion-fast) ease,
@@ -123,7 +123,7 @@
     border-color: rgb(var(--source-green-rgb) / 0.52);
     background: rgb(var(--source-green-rgb) / 0.1);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.06),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.06),
       inset 3px 0 0 var(--color-accent);
     color: var(--color-text);
   }
@@ -157,7 +157,7 @@
     --button-rail: rgb(var(--source-green-rgb) / 0.14);
     min-height: 30px;
     padding: 0 var(--space-5);
-    background: rgb(1 8 6 / 0.88);
+    background: rgb(var(--source-ink-rgb) / 0.88);
     color: var(--color-text-warm);
     font-size: var(--text-sm);
   }

--- a/apps/desktop-tauri/src/styles/primitives/layout.css
+++ b/apps/desktop-tauri/src/styles/primitives/layout.css
@@ -3,8 +3,8 @@
     border: 1px solid var(--border-default);
     background: var(--color-surface);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.04),
-      0 18px 60px rgb(0 0 0 / 0.22);
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.04),
+      0 18px 60px rgb(var(--source-black-rgb) / 0.22);
     padding: var(--space-7);
   }
 
@@ -42,7 +42,7 @@
     text-align: left;
     border-radius: var(--radius-lg);
     border: 1px solid var(--border-subtle);
-    background: rgb(0 0 0 / 0.58);
+    background: rgb(var(--source-black-rgb) / 0.58);
     padding: var(--space-5) var(--space-6);
     display: grid;
     gap: var(--space-1);
@@ -93,7 +93,7 @@
   .centered-panel {
     border-radius: var(--radius-lg);
     border: 1px solid var(--border-subtle);
-    background: rgb(0 0 0 / 0.58);
+    background: rgb(var(--source-black-rgb) / 0.58);
   }
 
   .callout,

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -8,7 +8,11 @@
     gap: var(--space-6);
     overflow: hidden;
     background:
-      linear-gradient(180deg, rgb(0 0 0 / 0.96) 0%, rgb(2 8 6 / 0.98) 100%),
+      linear-gradient(
+        180deg,
+        rgb(var(--source-black-rgb) / 0.96) 0%,
+        rgb(var(--source-ink-2-rgb) / 0.98) 100%
+      ),
       var(--color-bg);
   }
 
@@ -134,8 +138,8 @@
 
   .error-banner {
     color: var(--color-error);
-    border-color: rgb(255 111 95 / 0.28);
-    background: rgb(72 15 10 / 0.42);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.28);
+    background: rgb(var(--color-error-deep-rgb) / 0.42);
     display: flex;
     align-items: flex-start;
     gap: var(--space-4);

--- a/apps/desktop-tauri/src/styles/sidebar/conversations.css
+++ b/apps/desktop-tauri/src/styles/sidebar/conversations.css
@@ -79,7 +79,7 @@
 
   .conversation-status-dot-error {
     background: var(--color-error-strong);
-    box-shadow: 0 0 0 1px rgb(255 111 95 / 0.22);
+    box-shadow: 0 0 0 1px rgb(var(--color-error-strong-rgb) / 0.22);
   }
 
   .conversation-status-dot-running {
@@ -88,8 +88,8 @@
   }
 
   .conversation-status-dot-idle {
-    background: rgb(149 164 157 / 0.55);
-    box-shadow: 0 0 0 1px rgb(149 164 157 / 0.16);
+    background: rgb(var(--color-text-muted-rgb) / 0.55);
+    box-shadow: 0 0 0 1px rgb(var(--color-text-muted-rgb) / 0.16);
   }
 
   .untitled-title {

--- a/apps/desktop-tauri/src/styles/sidebar/lists.css
+++ b/apps/desktop-tauri/src/styles/sidebar/lists.css
@@ -22,15 +22,15 @@
   }
 
   .sidebar .list-item:hover {
-    background: rgb(255 255 255 / 0.035);
+    background: rgb(var(--source-white-rgb) / 0.035);
   }
 
   .sidebar .list-item.selected {
     border-color: var(--border-subtle);
-    background: rgb(0 0 0 / 0.32);
+    background: rgb(var(--source-black-rgb) / 0.32);
     box-shadow:
       inset 3px 0 0 rgb(var(--source-green-rgb) / 0.72),
-      inset 0 0 0 1px rgb(255 255 255 / 0.035);
+      inset 0 0 0 1px rgb(var(--source-white-rgb) / 0.035);
   }
 
   .sidebar .list-item-title {

--- a/apps/desktop-tauri/src/styles/sidebar/peer-card.css
+++ b/apps/desktop-tauri/src/styles/sidebar/peer-card.css
@@ -29,11 +29,11 @@
     place-items: center;
     border: 1px solid rgb(var(--source-green-rgb) / 0.24);
     border-radius: 0;
-    background: rgb(1 8 6 / 0.9);
+    background: rgb(var(--source-ink-rgb) / 0.9);
     color: var(--color-text-soft);
     padding: 0;
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.05),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.05),
       inset 2px 0 0 rgb(var(--source-green-rgb) / 0.16);
     transition:
       background-color var(--motion-fast) ease,
@@ -47,7 +47,7 @@
     border-color: rgb(var(--source-green-rgb) / 0.52);
     background: rgb(var(--source-green-rgb) / 0.1);
     box-shadow:
-      inset 0 1px 0 rgb(255 255 255 / 0.06),
+      inset 0 1px 0 rgb(var(--source-white-rgb) / 0.06),
       inset 3px 0 0 var(--color-accent);
   }
 

--- a/apps/desktop-tauri/src/styles/subagent-lineage.css
+++ b/apps/desktop-tauri/src/styles/subagent-lineage.css
@@ -224,7 +224,7 @@
   }
   .subagent-lineage-kind-tool {
     color: var(--color-info);
-    border-color: rgb(16 203 255 / 0.35);
+    border-color: rgb(var(--source-blue-rgb) / 0.35);
   }
   .subagent-lineage-id {
     color: var(--color-text);

--- a/apps/desktop-tauri/src/styles/tokens.css
+++ b/apps/desktop-tauri/src/styles/tokens.css
@@ -25,6 +25,8 @@
     --source-white: #ffffff;
     --source-blue: #10cbff;
     --source-orange: #ffa011;
+    --source-white-rgb: 255 255 255;
+    --source-black-rgb: 0 0 0;
     --source-green-rgb: 6 178 80;
     --source-dark-green-rgb: 28 39 36;
     --source-blue-rgb: 16 203 255;
@@ -34,7 +36,12 @@
     --color-surface-strong: #07110e;
     --color-surface-deep: #020504;
     --color-surface-muted: rgb(var(--source-dark-green-rgb) / 0.58);
-    --color-surface-row: rgb(9 17 14 / 0.86);
+    /* Near-black green inks used by dense surfaces; alpha applied at use
+       sites so a future light theme only overrides the triplets. */
+    --source-ink-rgb: 1 8 6;
+    --source-ink-2-rgb: 2 8 6;
+    --source-ink-3-rgb: 9 17 14;
+    --color-surface-row: rgb(var(--source-ink-3-rgb) / 0.86);
     --color-text: var(--source-white);
     --color-text-muted: #95a49d;
     --color-text-soft: #d6ddda;
@@ -49,6 +56,13 @@
     --color-info: var(--source-blue);
     --color-error: #ffad9d;
     --color-error-strong: #ff6f5f;
+    --color-error-strong-rgb: 255 111 95;
+    --color-error-deep-rgb: 72 15 10;
+    --color-error-soft: #ffe2de;
+    --color-error-tint: #ffbfb8;
+    --color-text-muted-rgb: 149 164 157;
+    --color-accent-strong-rgb: 57 226 122;
+    --color-success-rgb: 141 242 180;
     --border-subtle: rgb(var(--source-green-rgb) / 0.12);
     --border-default: rgb(var(--source-green-rgb) / 0.18);
     --border-strong: rgb(var(--source-green-rgb) / 0.28);

--- a/apps/desktop-tauri/src/styles/transcript/messages.css
+++ b/apps/desktop-tauri/src/styles/transcript/messages.css
@@ -29,7 +29,7 @@
   }
 
   .transcript-panel .response-error-card {
-    border-color: rgb(255 111 95 / 0.34);
+    border-color: rgb(var(--color-error-strong-rgb) / 0.34);
     box-shadow: inset 2px 0 0 var(--color-error-strong);
   }
 

--- a/apps/desktop-tauri/tests/design-system-conformance.test.ts
+++ b/apps/desktop-tauri/tests/design-system-conformance.test.ts
@@ -146,8 +146,8 @@ describe("token ratchets", () => {
     expect(count).toBeLessThanOrEqual(40);
   });
 
-  it("raw rgb() literals do not grow (ceiling 90)", () => {
-    expect(countMatches(/rgb\(\d+ \d+ \d+/g)).toBeLessThanOrEqual(90);
+  it("raw rgb() literals stay eliminated: colors live in tokens.css", () => {
+    expect(countMatches(/rgb\(\d+ \d+ \d+/g)).toBe(0);
   });
 
   it("bespoke box-shadows do not grow (ceiling 38)", () => {


### PR DESCRIPTION
Groundwork slice of #608 for the upcoming light theme: every color the desktop client paints must come from `tokens.css` before a second theme can override it.

All 89 literal `rgb()` sites across 18 stylesheets now reference token triplets (`rgb(var(--x-rgb) / α)` — alphas stay at use sites so a theme only overrides the triplets). New tokens cover the recurring families the sweep exposed: white/black overlay bases, the near-black green inks, and rgb forms of the existing error/muted/accent/success colors; two one-off error tints became hex tokens.

Zero visual change, proven two ways: the visual suite passes against **unchanged** baselines, and a whole-file check (forward-map HEAD's content, compare whitespace-normalized) shows every substitution is exactly value-preserving. The conformance ratchet drops from ≤90 to =0 so literals cannot return.

Stacked on #780. Part of #608 (WS2, theme groundwork).