### PR TITLE
feat(desktop): keyboard shortcuts

### DIFF
--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -7,6 +7,8 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FleetDashboard } from "./components/fleet/FleetDashboard";
 import { ErrorBanner } from "./components/ErrorBanner";
 import { applyTheme, loadTheme } from "./lib/theme";
+import { ShortcutsHelp } from "./components/ShortcutsHelp";
+import { useAppShortcuts } from "./hooks/useAppShortcuts";
 import { Sidebar } from "./components/Sidebar";
 import { useDesktopShell } from "./hooks/useDesktopShell";
 import { installExternalLinkGuard } from "./lib/externalLinks";
@@ -35,6 +37,28 @@ function AppShell() {
   const [workspaceView, setWorkspaceView] = useState<
     "fleet" | "chat" | "config" | "code"
   >("fleet");
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+
+  useAppShortcuts({
+    setView: setWorkspaceView,
+    newConversation: () => {
+      const behaviorId =
+        shell.selectedBehaviorId ?? shell.behaviorOptions[0]?.behaviorId ?? null;
+      if (behaviorId) {
+        setWorkspaceView("chat");
+        shell.onStartNewConversation(behaviorId);
+      }
+    },
+    focusComposer: () => {
+      setWorkspaceView("chat");
+      requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLTextAreaElement>('[data-testid="composer-input"]')
+          ?.focus();
+      });
+    },
+    toggleHelp: () => setShortcutsOpen((open) => !open),
+  });
 
   function openChat(agentDid?: string) {
     if (agentDid) {
@@ -62,6 +86,7 @@ function AppShell() {
       {shell.error ? (
         <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
       ) : null}
+      <ShortcutsHelp open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
 
       {workspaceView === "fleet" ? (
         <FleetDashboard

--- a/apps/desktop-tauri/src/components/ShortcutsHelp.tsx
+++ b/apps/desktop-tauri/src/components/ShortcutsHelp.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from "react";
+
+const IS_MAC = navigator.platform.toUpperCase().includes("MAC");
+const MOD = IS_MAC ? "⌘" : "Ctrl+";
+
+const SHORTCUTS: Array<[string, string]> = [
+  [`${MOD}1`, "Fleet dashboard"],
+  [`${MOD}2`, "Chat"],
+  [`${MOD}3`, "Code mode"],
+  [`${MOD}4`, "Configuration"],
+  [`${MOD}N`, "New conversation"],
+  [`${MOD}K`, "Focus the composer"],
+  [`${MOD}/`, "Show this reference"],
+];
+
+export function ShortcutsHelp({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open, onClose]);
+
+  if (!open) {
+    return null;
+  }
+  return (
+    <div className="dialog-backdrop open" role="presentation" onClick={onClose}>
+      <div
+        aria-label="Keyboard shortcuts"
+        className="dialog shortcuts-help"
+        data-testid="shortcuts-help"
+        role="dialog"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <p className="eyebrow">Keyboard shortcuts</p>
+        <dl className="shortcuts-list">
+          {SHORTCUTS.map(([keys, action]) => (
+            <div className="shortcuts-row" key={keys}>
+              <dt>
+                <kbd>{keys}</kbd>
+              </dt>
+              <dd>{action}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop-tauri/src/hooks/useAppShortcuts.ts
+++ b/apps/desktop-tauri/src/hooks/useAppShortcuts.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from "react";
+
+export type AppShortcutHandlers = {
+  setView: (view: "fleet" | "chat" | "code" | "config") => void;
+  newConversation: () => void;
+  focusComposer: () => void;
+  toggleHelp: () => void;
+};
+
+/// App-level keyboard shortcuts: Cmd/Ctrl+1..4 switch views, Cmd/Ctrl+N
+/// starts a conversation, Cmd/Ctrl+K focuses the composer, Cmd/Ctrl+/ shows
+/// the shortcut reference. Handlers ride a ref so the window listener is
+/// installed exactly once.
+export function useAppShortcuts(handlers: AppShortcutHandlers) {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (!(event.metaKey || event.ctrlKey) || event.altKey || event.shiftKey) {
+        return;
+      }
+      const current = handlersRef.current;
+      switch (event.key) {
+        case "1":
+          current.setView("fleet");
+          break;
+        case "2":
+          current.setView("chat");
+          break;
+        case "3":
+          current.setView("code");
+          break;
+        case "4":
+          current.setView("config");
+          break;
+        case "n":
+          current.newConversation();
+          break;
+        case "k":
+          current.focusComposer();
+          break;
+        case "/":
+          current.toggleHelp();
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+}

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -1,4 +1,40 @@
 @layer shell {
+  .shortcuts-help {
+    min-width: 320px;
+  }
+
+  .shortcuts-list {
+    margin: var(--space-5) 0 0;
+    display: grid;
+    gap: var(--space-3);
+  }
+
+  .shortcuts-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-6);
+  }
+
+  .shortcuts-row dt {
+    flex: none;
+    width: 64px;
+  }
+
+  .shortcuts-row kbd {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-sm);
+    padding: 0 var(--space-2);
+    background: var(--color-surface-strong);
+  }
+
+  .shortcuts-row dd {
+    margin: 0;
+    color: var(--color-text-soft);
+    font-size: var(--text-sm);
+  }
+
   .app-shell {
     position: relative;
     isolation: isolate;

--- a/apps/desktop-tauri/tests/app-shortcuts.test.tsx
+++ b/apps/desktop-tauri/tests/app-shortcuts.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { ShortcutsHelp } from "../src/components/ShortcutsHelp";
+import { useAppShortcuts } from "../src/hooks/useAppShortcuts";
+import type { AppShortcutHandlers } from "../src/hooks/useAppShortcuts";
+
+function Probe(handlers: AppShortcutHandlers) {
+  useAppShortcuts(handlers);
+  return null;
+}
+
+function makeHandlers(): AppShortcutHandlers {
+  return {
+    setView: vi.fn(),
+    newConversation: vi.fn(),
+    focusComposer: vi.fn(),
+    toggleHelp: vi.fn(),
+  };
+}
+
+describe("app shortcuts", () => {
+  it("maps modifier chords to actions and ignores bare keys", () => {
+    const handlers = makeHandlers();
+    render(<Probe {...handlers} />);
+
+    fireEvent.keyDown(window, { key: "2", metaKey: true });
+    expect(handlers.setView).toHaveBeenCalledWith("chat");
+    fireEvent.keyDown(window, { key: "4", ctrlKey: true });
+    expect(handlers.setView).toHaveBeenCalledWith("config");
+    fireEvent.keyDown(window, { key: "n", metaKey: true });
+    expect(handlers.newConversation).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(handlers.focusComposer).toHaveBeenCalledTimes(1);
+    fireEvent.keyDown(window, { key: "/", metaKey: true });
+    expect(handlers.toggleHelp).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(window, { key: "2" });
+    fireEvent.keyDown(window, { key: "n", metaKey: true, shiftKey: true });
+    expect(handlers.setView).toHaveBeenCalledTimes(2);
+    expect(handlers.newConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the reference dialog and closes on Escape and backdrop", () => {
+    const onClose = vi.fn();
+    render(<ShortcutsHelp open onClose={onClose} />);
+
+    expect(screen.getByTestId("shortcuts-help")).toBeInTheDocument();
+    expect(screen.getByText("New conversation")).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("presentation"));
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop-tauri/tests/playwright/desktop-shortcuts.spec.ts
+++ b/apps/desktop-tauri/tests/playwright/desktop-shortcuts.spec.ts
@@ -1,0 +1,21 @@
+import { expect, gotoHarness, test } from "./desktopTest";
+
+test.describe("keyboard shortcuts", () => {
+  test("switch views, open help, and focus the composer", async ({ page }) => {
+    await gotoHarness(page);
+
+    await page.keyboard.press("ControlOrMeta+2");
+    await expect(page.getByTestId("composer-input")).toBeVisible();
+
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(page.getByTestId("composer-input")).toBeFocused();
+
+    await page.keyboard.press("ControlOrMeta+1");
+    await expect(page.getByTestId("fleet-dashboard")).toBeVisible();
+
+    await page.keyboard.press("ControlOrMeta+/");
+    await expect(page.getByTestId("shortcuts-help")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("shortcuts-help")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
WS2 slice of #608 — the audit's "everything requires the mouse" item.

Cmd/Ctrl+1–4 switch views (fleet/chat/code/config), Cmd/Ctrl+N starts a conversation on the selected behavior, Cmd/Ctrl+K jumps to the composer (switching to chat first), and Cmd/Ctrl+/ opens a small shortcut-reference dialog (Escape/backdrop closes). One window listener installed once, handlers on a ref; chords with Shift/Alt pass through untouched so text editing is unaffected.

Fences: unit hook mapping + dialog behavior; a Playwright journey (via the shared desktop fixture — the fixture guard rejects bare `@playwright/test` imports) drives the real chords. Unit 264, e2e 123, visual 3/3 unchanged, prettier clean.

Stacked on #785. Part of #608 (WS2).