### PR TITLE
feat(desktop): macOS shell treatment

### DIFF
--- a/apps/desktop-tauri/src-tauri/tauri.conf.json
+++ b/apps/desktop-tauri/src-tauri/tauri.conf.json
@@ -16,7 +16,9 @@
         "width": 1480,
         "height": 920,
         "minWidth": 1180,
-        "minHeight": 720
+        "minHeight": 720,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true
       }
     ],
     "security": {

--- a/apps/desktop-tauri/src/App.tsx
+++ b/apps/desktop-tauri/src/App.tsx
@@ -7,6 +7,7 @@ import { ErrorBoundary } from "./components/ErrorBoundary";
 import { FleetDashboard } from "./components/fleet/FleetDashboard";
 import { ErrorBanner } from "./components/ErrorBanner";
 import { applyTheme, loadTheme } from "./lib/theme";
+import { applyShellPlatform } from "./lib/shellPlatform";
 import { ShortcutsHelp } from "./components/ShortcutsHelp";
 import { useAppShortcuts } from "./hooks/useAppShortcuts";
 import { Sidebar } from "./components/Sidebar";
@@ -29,6 +30,7 @@ function AppShell() {
   // plain hook-free function, and the e2e harness mounts App directly.
   useEffect(() => {
     applyTheme(loadTheme());
+    applyShellPlatform();
   }, []);
 
   // External links (e.g. markdown links in the transcript) must open in the
@@ -83,6 +85,7 @@ function AppShell() {
 
   return (
     <main className="app-shell">
+      <div aria-hidden="true" className="titlebar-drag-region" data-tauri-drag-region />
       {shell.error ? (
         <ErrorBanner message={shell.error} onDismiss={shell.onDismissError} />
       ) : null}

--- a/apps/desktop-tauri/src/lib/shellPlatform.ts
+++ b/apps/desktop-tauri/src/lib/shellPlatform.ts
@@ -1,0 +1,14 @@
+export function isMacTauriShell(): boolean {
+  return (
+    "__TAURI_INTERNALS__" in window && navigator.platform.toUpperCase().includes("MAC")
+  );
+}
+
+/// Overlay titlebar: the webview owns the top strip, so the shell needs to
+/// reserve drag + traffic-light space — but only in the real macOS app, never
+/// in the browser harness.
+export function applyShellPlatform(root: HTMLElement = document.documentElement) {
+  if (isMacTauriShell()) {
+    root.dataset.shell = "mac";
+  }
+}

--- a/apps/desktop-tauri/src/styles/shell.css
+++ b/apps/desktop-tauri/src/styles/shell.css
@@ -1,4 +1,24 @@
 @layer shell {
+  /* macOS overlay titlebar: reserved strip is drag surface + traffic-light
+     clearance. Inert outside the packaged app (no data-shell stamp). */
+  .titlebar-drag-region {
+    display: none;
+  }
+
+  :root[data-shell="mac"] .titlebar-drag-region {
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--titlebar-height);
+    z-index: 40;
+  }
+
+  :root[data-shell="mac"] .app-shell {
+    padding-top: var(--titlebar-clearance);
+  }
+
   .shortcuts-help {
     min-width: 320px;
   }

--- a/apps/desktop-tauri/src/styles/tokens.css
+++ b/apps/desktop-tauri/src/styles/tokens.css
@@ -100,6 +100,9 @@
     --motion-fast: 120ms;
     --motion-medium: 150ms;
     --motion-pulse: 1.4s;
+    /* macOS overlay titlebar geometry (traffic-light clearance). */
+    --titlebar-height: 34px;
+    --titlebar-clearance: 44px;
   }
 
   :root[data-theme="light"] {

--- a/apps/desktop-tauri/tests/shell-platform.test.tsx
+++ b/apps/desktop-tauri/tests/shell-platform.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { applyShellPlatform } from "../src/lib/shellPlatform";
+
+describe("macOS shell classifier", () => {
+  afterEach(() => {
+    delete (window as Record<string, unknown>).__TAURI_INTERNALS__;
+    delete document.documentElement.dataset.shell;
+  });
+
+  it("stamps the shell only inside the macOS Tauri app", () => {
+    applyShellPlatform();
+    expect(document.documentElement.dataset.shell).toBeUndefined();
+
+    (window as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    Object.defineProperty(navigator, "platform", {
+      configurable: true,
+      value: "MacIntel",
+    });
+    applyShellPlatform();
+    expect(document.documentElement.dataset.shell).toBe("mac");
+  });
+});


### PR DESCRIPTION
WS2 slice of #608 — the native-feel item. The app shipped with the stock opaque macOS titlebar over a dark shell.

- `titleBarStyle: Overlay` + `hiddenTitle` in tauri.conf.json: the shell surface extends to the window edge with inset traffic lights, Claude-desktop style.
- A `data-tauri-drag-region` strip (token-sized: `--titlebar-height`) keeps the window draggable, and the shell reserves `--titlebar-clearance` of top padding — both gated on a `data-shell="mac"` stamp applied only when running inside Tauri on macOS (`__TAURI_INTERNALS__` + platform check), so the browser harness, e2e, and visual captures are untouched by design.
- The spacing ratchet caught the first draft's raw px paddings; the geometry now lives in tokens.

**Verification honesty**: unit-fenced classifier (no stamp in the harness, stamp under a stubbed Tauri global) and all suites green, but the actual overlay rendering needs a real `tauri dev` launch on macOS — flagging that for your visual check when reviewing, since it can't be exercised headless.

Unit 274, e2e 123, visual 3/3 (unchanged — by design), prettier clean.

Stacked on #791. Part of #608 (WS2).