### PR TITLE
feat(desktop): cross-node subagent lineage

### DIFF
--- a/apps/desktop-tauri/src-tauri/src/bin/bridge_runner/http/routes.rs
+++ b/apps/desktop-tauri/src-tauri/src/bin/bridge_runner/http/routes.rs
@@ -550,7 +550,7 @@ async fn list_subagent_tree_response(
     };
     let Some(graphql) = core.graphql_for_agent(&agent_did).await else {
         return build_local_subagent_tree(
-            core.node(),
+            core.node_arc(),
             root_request_id,
             request.include_terminal.unwrap_or(false),
             effective_subagent_tree_max_depth(request.max_depth),

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/subagent_tree.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/subagent_tree.rs
@@ -1,8 +1,11 @@
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
+use defra_agent_protocol::graphql::{execute_graphql_async, GraphqlRequestOptions};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -90,8 +93,73 @@ pub(crate) fn effective_subagent_tree_max_depth(max_depth: Option<u32>) -> usize
         .unwrap_or(DEFAULT_SUBAGENT_TREE_MAX_DEPTH)
 }
 
+/// One queryable deployment for the lineage walk. `label: None` is the
+/// local node; remote peers carry their saved-peer label for attribution.
+pub(crate) struct SubagentTreeAccess {
+    pub label: Option<String>,
+    pub access: TreeQueryAccess,
+}
+
+/// Independent of the runtime's ConfigAccess so this ships without the
+/// (unmerged) Arc-based Local variant; same two transports.
+pub(crate) enum TreeQueryAccess {
+    Local(Arc<EmbeddedNode>),
+    Graphql(String),
+}
+
+impl TreeQueryAccess {
+    async fn execute(&self, query: &str) -> Result<Value> {
+        match self {
+            Self::Local(node) => {
+                let response = node.execute(query).await;
+                if response.has_errors() {
+                    let errors = response
+                        .errors
+                        .iter()
+                        .map(|error| error.message.as_str())
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    anyhow::bail!("graphql returned errors: {errors}");
+                }
+                Ok(serde_json::json!({
+                    "data": response.data.unwrap_or(Value::Null),
+                }))
+            }
+            Self::Graphql(endpoint) => {
+                execute_graphql_async(endpoint, query, GraphqlRequestOptions::default()).await
+            }
+        }
+    }
+}
+
+/// Local-only wrapper kept for the runner's HTTP endpoint, which serves this
+/// node's view to other desktops and knows nothing of our peer directory.
+/// (Only the runner bin calls it; the lib target sees it as dead.)
+#[allow(dead_code)]
 pub(crate) async fn build_local_subagent_tree(
-    node: &EmbeddedNode,
+    node: Arc<EmbeddedNode>,
+    root_request_id: &str,
+    include_terminal: bool,
+    max_depth: usize,
+) -> Result<SubagentTreeView> {
+    build_subagent_tree(
+        &[SubagentTreeAccess {
+            label: None,
+            access: TreeQueryAccess::Local(node),
+        }],
+        root_request_id,
+        include_terminal,
+        max_depth,
+    )
+    .await
+}
+
+/// Cross-node lineage: every level of the walk fans out to every known
+/// deployment and unions the rows, so a child spawned on another peer
+/// resolves instead of dangling. A dead peer degrades to a partial error,
+/// never a failed tree.
+pub(crate) async fn build_subagent_tree(
+    accesses: &[SubagentTreeAccess],
     root_request_id: &str,
     include_terminal: bool,
     max_depth: usize,
@@ -99,9 +167,27 @@ pub(crate) async fn build_local_subagent_tree(
     let mut nodes: BTreeMap<String, SubagentNodeView> = BTreeMap::new();
     let mut edges: Vec<SubagentEdgeView> = Vec::new();
     let mut seen_edges: BTreeSet<(String, String)> = BTreeSet::new();
+    let mut partial_errors: Vec<String> = Vec::new();
+    let mut dead_accesses: BTreeSet<usize> = BTreeSet::new();
 
-    if let Some(root) = fetch_root_request(node, root_request_id).await? {
-        nodes.insert(root.request_id.clone(), request_row_into_node(root));
+    for (index, entry) in accesses.iter().enumerate() {
+        match fetch_root_request(&entry.access, root_request_id).await {
+            Ok(Some(root)) => {
+                let mut node = request_row_into_node(root);
+                node.resolved_via = entry.label.clone();
+                nodes.entry(node.request_id.clone()).or_insert(node);
+            }
+            Ok(None) => {}
+            Err(error) => {
+                record_dead_access(
+                    &mut partial_errors,
+                    &mut dead_accesses,
+                    index,
+                    entry,
+                    &error,
+                );
+            }
+        }
     }
 
     let mut frontier: VecDeque<String> = VecDeque::from([root_request_id.to_string()]);
@@ -110,15 +196,44 @@ pub(crate) async fn build_local_subagent_tree(
 
     while !frontier.is_empty() && depth < max_depth {
         let level = frontier.drain(..).collect::<Vec<_>>();
-        let envelope = fetch_level(node, &level).await?;
+        let mut level_requests = Vec::new();
+        let mut level_bridges = Vec::new();
+        for (index, entry) in accesses.iter().enumerate() {
+            if dead_accesses.contains(&index) {
+                continue;
+            }
+            match fetch_level(&entry.access, &level).await {
+                Ok(envelope) => {
+                    for request in envelope.requests {
+                        level_requests.push((entry.label.clone(), request));
+                    }
+                    level_bridges.extend(envelope.bridges);
+                }
+                Err(error) => {
+                    record_dead_access(
+                        &mut partial_errors,
+                        &mut dead_accesses,
+                        index,
+                        entry,
+                        &error,
+                    );
+                }
+            }
+        }
 
-        for request in envelope.requests {
+        for (label, request) in level_requests {
             if request.request_id.trim().is_empty() {
                 continue;
             }
-            let node = request_row_into_node(request);
+            let mut node = request_row_into_node(request);
+            node.resolved_via = label;
             nodes.entry(node.request_id.clone()).or_insert(node);
         }
+
+        let envelope = LevelQueryEnvelope {
+            requests: Vec::new(),
+            bridges: level_bridges,
+        };
 
         let mut next_frontier: BTreeSet<String> = BTreeSet::new();
         for bridge in envelope.bridges {
@@ -177,12 +292,27 @@ pub(crate) async fn build_local_subagent_tree(
         nodes: nodes.into_values().collect(),
         edges,
         truncated,
+        partial_errors,
     })
+}
+
+fn record_dead_access(
+    partial_errors: &mut Vec<String>,
+    dead_accesses: &mut BTreeSet<usize>,
+    index: usize,
+    entry: &SubagentTreeAccess,
+    error: &anyhow::Error,
+) {
+    if dead_accesses.insert(index) {
+        let who = entry.label.as_deref().unwrap_or("local node");
+        partial_errors.push(format!("{who}: {error:#}"));
+    }
 }
 
 fn request_row_into_node(row: RequestRow) -> SubagentNodeView {
     SubagentNodeView {
         request_id: clean_string(&row.request_id),
+        resolved_via: None,
         session_id: clean_optional_string(row.session_id.as_deref()),
         agent_did: clean_optional_string(row.agent_did.as_deref()),
         behavior_id: clean_optional_string(row.behavior_id.as_deref()),
@@ -200,7 +330,7 @@ fn request_row_into_node(row: RequestRow) -> SubagentNodeView {
 }
 
 async fn fetch_root_request(
-    node: &EmbeddedNode,
+    access: &TreeQueryAccess,
     root_request_id: &str,
 ) -> Result<Option<RequestRow>> {
     let escaped = escape_graphql_string(root_request_id);
@@ -224,12 +354,12 @@ async fn fetch_root_request(
         }}"#
     );
     let envelope: RootRequestEnvelope =
-        execute_local_query(node, &query, "root request lookup").await?;
+        execute_access_query(access, &query, "root request lookup").await?;
     Ok(envelope.requests.into_iter().next())
 }
 
 async fn fetch_level(
-    node: &EmbeddedNode,
+    access: &TreeQueryAccess,
     parent_request_ids: &[String],
 ) -> Result<LevelQueryEnvelope> {
     let list = parent_request_ids
@@ -274,26 +404,21 @@ async fn fetch_level(
             }}
         }}"#
     );
-    execute_local_query(node, &query, "subagent tree level fetch").await
+    execute_access_query(access, &query, "subagent tree level fetch").await
 }
 
-async fn execute_local_query<T: serde::de::DeserializeOwned>(
-    node: &EmbeddedNode,
+async fn execute_access_query<T: serde::de::DeserializeOwned>(
+    access: &TreeQueryAccess,
     query: &str,
     context: &str,
 ) -> Result<T> {
-    let response = node.execute(query).await;
-    if response.has_errors() {
-        let errors = response
-            .errors
-            .iter()
-            .map(|error| error.message.as_str())
-            .collect::<Vec<_>>()
-            .join("; ");
-        anyhow::bail!("{context} query failed: {errors}");
-    }
-    let data: Value = response
-        .data
+    let response = access
+        .execute(query)
+        .await
+        .with_context(|| format!("{context} query failed"))?;
+    let data = response
+        .get("data")
+        .cloned()
         .with_context(|| format!("{context} response missing object data"))?;
     serde_json::from_value(data).with_context(|| format!("decoding {context}"))
 }

--- a/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/subagent_lineage.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/snapshot/tests/subagent_lineage.rs
@@ -13,9 +13,11 @@ use lean_vocab_test::{lean_r5_cross_deployment_cases, LeanR5CrossDeploymentCase}
 /// caused-by lineage) survives the trip into the operator surface.
 fn subagent_tree_view_from_lean_case(case: &LeanR5CrossDeploymentCase) -> SubagentTreeView {
     SubagentTreeView {
+        partial_errors: Vec::new(),
         root_request_id: case.parent_request_id.clone(),
         nodes: vec![
             SubagentNodeView {
+                resolved_via: None,
                 request_id: case.parent_request_id.clone(),
                 session_id: None,
                 agent_did: Some(case.parent_deployment.clone()),
@@ -28,6 +30,7 @@ fn subagent_tree_view_from_lean_case(case: &LeanR5CrossDeploymentCase) -> Subage
                 backend_id: None,
             },
             SubagentNodeView {
+                resolved_via: None,
                 request_id: case.child_request_id.clone(),
                 session_id: None,
                 agent_did: Some(case.child_deployment.clone()),

--- a/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/tauri_commands/operations.rs
@@ -4,6 +4,7 @@
 //! #276) and the MCP-health commands (panel #278) are live.
 
 use std::sync::Arc;
+#[cfg(test)]
 use std::time::Duration;
 
 use chrono::Utc;
@@ -11,6 +12,7 @@ use defra_agent::backend_registry::{derive_display_state, list_all_backends};
 use defra_agent::defra_node::EmbeddedNode;
 use defra_agent::graphql::escape_graphql_string;
 use defra_agent_desktop_core::client::ClientCore;
+#[cfg(test)]
 use reqwest::Url;
 use tauri::State;
 
@@ -19,7 +21,7 @@ use super::super::snapshot::operations_snapshot::{
     project_backgrounded_tools, stuck_diagnostics_from_tool_calls, ToolCallRow,
 };
 use super::super::snapshot::subagent_tree::{
-    build_local_subagent_tree, effective_subagent_tree_max_depth,
+    build_subagent_tree, effective_subagent_tree_max_depth, SubagentTreeAccess, TreeQueryAccess,
 };
 use super::super::state::{current_core, DesktopAppState};
 use super::super::types::{
@@ -30,6 +32,7 @@ use super::super::types::{
     RuntimeLivenessView, SubagentTreeView,
 };
 
+#[cfg(test)]
 const SUBAGENT_TREE_TIMEOUT: Duration = Duration::from_secs(10);
 const BACKGROUND_TOOL_CALL_LIMIT: usize = 256;
 
@@ -256,55 +259,43 @@ pub(crate) async fn desktop_list_subagent_tree(
     let core = current_core(&state)
         .ok_or_else(|| "desktop bridge has not finished bootstrapping".to_string())?;
 
-    let agent_did = match request.agent_did.as_deref().map(str::trim) {
-        Some(value) if !value.is_empty() => value.to_string(),
-        _ => core
-            .selected_agent_did()
-            .ok_or_else(|| "no agent selected; pass agentDid explicitly".to_string())?,
-    };
-
-    let Some(graphql) = core.graphql_for_agent(&agent_did).await else {
-        return build_local_subagent_tree(
-            core.node(),
-            root_request_id,
-            request.include_terminal.unwrap_or(false),
-            effective_subagent_tree_max_depth(request.max_depth),
-        )
-        .await
-        .map_err(|error| format!("local subagent tree query failed: {error:#}"));
-    };
-    let url = subagent_tree_url(&graphql, root_request_id, &request)?;
-
-    let client = reqwest::Client::builder()
-        .timeout(SUBAGENT_TREE_TIMEOUT)
-        .build()
-        .map_err(|error| format!("build subagent tree http client: {error}"))?;
-
-    let response = client
-        .get(url.clone())
-        .send()
-        .await
-        .map_err(|error| format!("subagent tree fetch failed: {error}"))?;
-
-    if !response.status().is_success() {
-        let status = response.status();
-        let body = response.text().await.unwrap_or_default();
-        return Err(format!(
-            "subagent tree fetch returned {status}: {}",
-            body.trim()
-        ));
+    // Cross-node lineage: the walk fans out to the local node plus every
+    // saved peer with a GraphQL endpoint, so children spawned on other
+    // deployments resolve regardless of which agent is selected.
+    let mut accesses = vec![SubagentTreeAccess {
+        label: None,
+        access: TreeQueryAccess::Local(core.node_arc()),
+    }];
+    for record in core.peer_records().await {
+        let Some(graphql) = record
+            .graphql
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        accesses.push(SubagentTreeAccess {
+            label: Some(record.label.clone()),
+            access: TreeQueryAccess::Graphql(graphql.to_string()),
+        });
     }
 
-    response
-        .json::<SubagentTreeView>()
-        .await
-        .map_err(|error| format!("decode subagent tree response: {error}"))
+    build_subagent_tree(
+        &accesses,
+        root_request_id,
+        request.include_terminal.unwrap_or(false),
+        effective_subagent_tree_max_depth(request.max_depth),
+    )
+    .await
+    .map_err(|error| format!("subagent tree query failed: {error:#}"))
 }
 
 /// Translate the agent's GraphQL URL into the runtime's `/subagents/tree`
 /// endpoint URL. Mirrors the path-stripping logic in
 /// `defra_agent_desktop_core::local_runtime::runtime_status_url` but targets
 /// the R5 subagent-lineage handler.
+#[cfg(test)]
 fn subagent_tree_url(
     graphql: &str,
     root_request_id: &str,

--- a/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
+++ b/apps/desktop-tauri/src-tauri/src/bridge/types/views/operations.rs
@@ -107,12 +107,19 @@ pub(crate) struct SubagentTreeView {
     pub nodes: Vec<SubagentNodeView>,
     pub edges: Vec<SubagentEdgeView>,
     pub truncated: bool,
+    /// Deployments that could not be queried this walk; the tree may be
+    /// missing their branches. Empty when every access answered.
+    #[serde(default)]
+    pub partial_errors: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct SubagentNodeView {
     pub request_id: String,
+    /// Peer label the row was resolved from; None = the local node.
+    #[serde(default)]
+    pub resolved_via: Option<String>,
     #[serde(default)]
     pub session_id: Option<String>,
     #[serde(default)]

--- a/apps/desktop-tauri/src/components/subagentLineage/SubagentDetailPanel.tsx
+++ b/apps/desktop-tauri/src/components/subagentLineage/SubagentDetailPanel.tsx
@@ -13,6 +13,7 @@ export function SubagentDetailPanel({ selected }: { selected: Selected }) {
     return (
       <dl className="subagent-lineage-detail-grid">
         <DetailRow label="request id" value={node.requestId} />
+        <DetailRow label="resolved via" value={node.resolvedVia ?? "local node"} />
         <DetailRow label="session" value={node.sessionId} />
         <DetailRow label="deployment" value={node.agentDid} mono />
         <DetailRow label="behavior" value={node.behaviorId} />

--- a/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
+++ b/apps/desktop-tauri/src/components/subagentLineage/SubagentLineageView.tsx
@@ -261,6 +261,16 @@ export function SubagentLineageView({
         </div>
       </header>
 
+      {tree?.partialErrors?.length ? (
+        <p
+          className="subagent-lineage-partial"
+          data-testid="lineage-partial-errors"
+          role="alert"
+        >
+          Some deployments could not be queried — branches may be missing:{" "}
+          {tree.partialErrors.join("; ")}
+        </p>
+      ) : null}
       <div
         className="subagent-lineage-filters"
         role="toolbar"

--- a/apps/desktop-tauri/src/lib/types/operations.ts
+++ b/apps/desktop-tauri/src/lib/types/operations.ts
@@ -86,10 +86,14 @@ export type SubagentTreeView = {
   nodes: SubagentNodeView[];
   edges: SubagentEdgeView[];
   truncated: boolean;
+  /** Deployments that could not be queried; their branches may be missing. */
+  partialErrors?: string[];
 };
 
 export type SubagentNodeView = {
   requestId: string;
+  /** Peer label the row was resolved from; absent = the local node. */
+  resolvedVia?: string | null;
   sessionId?: string | null;
   agentDid?: string | null;
   behaviorId?: string | null;

--- a/apps/desktop-tauri/src/styles/subagent-lineage.css
+++ b/apps/desktop-tauri/src/styles/subagent-lineage.css
@@ -1,4 +1,11 @@
 @layer components {
+  .subagent-lineage-partial {
+    color: var(--color-warning-soft);
+    font-size: var(--text-xs);
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
   .subagent-lineage {
     display: grid;
     grid-template-rows: auto auto minmax(0, 1fr);

--- a/apps/desktop-tauri/tests/lineage-crossnode.test.tsx
+++ b/apps/desktop-tauri/tests/lineage-crossnode.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listSubagentTree } from "../src/lib/desktop-api";
+import { SubagentLineageView } from "../src/components/subagentLineage";
+
+vi.mock("../src/lib/desktop-api", async (orig) => ({
+  ...(await orig()),
+  listSubagentTree: vi.fn(),
+}));
+const mockedTree = vi.mocked(listSubagentTree);
+
+describe("cross-node lineage", () => {
+  beforeEach(() => mockedTree.mockReset());
+
+  it("warns when a deployment could not be queried", async () => {
+    mockedTree.mockResolvedValue({
+      rootRequestId: "req_root",
+      nodes: [{ requestId: "req_root" }],
+      edges: [],
+      truncated: false,
+      partialErrors: ["Edge Rack: subagent tree level fetch query failed"],
+    } as never);
+    render(<SubagentLineageView rootRequestId="req_root" agentDid="did:test:op" />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("lineage-partial-errors")).toHaveTextContent(
+        "Edge Rack",
+      ),
+    );
+  });
+
+  it("stays silent when every deployment answered", async () => {
+    mockedTree.mockResolvedValue({
+      rootRequestId: "req_root",
+      nodes: [{ requestId: "req_root", resolvedVia: "Edge Rack" }],
+      edges: [],
+      truncated: false,
+      partialErrors: [],
+    } as never);
+    render(<SubagentLineageView rootRequestId="req_root" agentDid="did:test:op" />);
+
+    await waitFor(() => expect(mockedTree).toHaveBeenCalled());
+    expect(screen.queryByTestId("lineage-partial-errors")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
One batched PR closing the audit's "cross-node subagent links are unresolvable: the lineage tree only queries the local DefraDB" item (#608).

- **Multi-access walk**: every level of the subagent-tree BFS now fans out to the local node plus every saved peer with a registered GraphQL endpoint, unioning rows (dedup by request id / edge pair). A child spawned on another deployment resolves instead of dangling as an edge to nowhere.
- **Honest degradation**: a dead or unreachable peer is dropped from the walk after its first failure and reported in `partialErrors` on the tree view — the drawer shows a "branches may be missing" alert naming the peer, never a failed tree.
- **Attribution**: nodes carry `resolvedVia` (peer label; absent = local), surfaced in the detail panel.
- The transport enum is local to the bridge (`TreeQueryAccess`) rather than reusing `ConfigAccess`, keeping this PR independent of #795's Arc-based `Local` variant; whichever merges first, the other rebases trivially. The runner's HTTP endpoint keeps serving its local-only view (other desktops' walkers do their own fan-out); the tauri path no longer proxies whole trees to a single peer endpoint.
- Lean-fenced R5 cross-deployment case constructors updated for the new view fields.

Gates: bridge 113 cargo tests, workspace check (zero errors/warnings), fmt; unit 300, e2e 123, visual 3/3 unchanged (harness models a single node — fenced at unit level instead).