### PR TITLE
fix: preserve successful Bombadil runs during cleanup

### DIFF
--- a/apps/desktop-tauri/tests/bombadil/runner-control.mjs
+++ b/apps/desktop-tauri/tests/bombadil/runner-control.mjs
@@ -67,8 +67,17 @@ export async function stopProcess(
     return;
   }
 
+  const termSignalSent = sendSignal(
+    child,
+    "SIGTERM",
+    killProcessGroup,
+    killByPid,
+    alreadyExited,
+  );
+  if (!termSignalSent) {
+    return;
+  }
   const exitPromise = alreadyExited ? Promise.resolve() : waitForExit(child);
-  sendSignal(child, "SIGTERM", killProcessGroup, killByPid);
   await Promise.race([exitPromise, delay(graceMs)]);
 
   let sentFinalKill = false;
@@ -76,7 +85,10 @@ export async function stopProcess(
     // Bombadil launches Chrome descendants. The CLI may exit on SIGTERM while
     // a wedged browser remains in its process group, so always fence the group
     // with SIGKILL after the grace period (ESRCH simply means it is clean).
-    sendSignal(child, "SIGKILL", true, killByPid);
+    const killSignalSent = sendSignal(child, "SIGKILL", true, killByPid, alreadyExited);
+    if (!killSignalSent) {
+      return;
+    }
     sentFinalKill = true;
   } else if (child.exitCode === null && child.signalCode === null) {
     child.kill("SIGKILL");
@@ -122,17 +134,29 @@ async function waitForProcessGroupDrain(pid, timeoutMs, killByPid) {
   }
 }
 
-function sendSignal(child, signal, killProcessGroup, killByPid) {
+function sendSignal(
+  child,
+  signal,
+  killProcessGroup,
+  killByPid,
+  ignorePermissionDenied = false,
+) {
   if (killProcessGroup && Number.isInteger(child.pid) && child.pid > 0) {
     try {
       killByPid(-child.pid, signal);
-      return;
+      return true;
     } catch (error) {
       if (error?.code === "ESRCH") {
         if (child.exitCode === null && child.signalCode === null) {
           child.kill(signal);
         }
-        return;
+        return true;
+      }
+      if (error?.code === "EPERM" && ignorePermissionDenied) {
+        // A naturally exited Bombadil leader can leave a process-group ID that
+        // macOS reports as unsignalable. The successful child result remains
+        // authoritative; cleanup must not turn that run into a failure.
+        return false;
       }
       throw error;
     }
@@ -141,6 +165,7 @@ function sendSignal(child, signal, killProcessGroup, killByPid) {
   if (child.exitCode === null && child.signalCode === null) {
     child.kill(signal);
   }
+  return true;
 }
 
 function waitForExit(child) {

--- a/apps/desktop-tauri/tests/bombadil/runner-control.test.ts
+++ b/apps/desktop-tauri/tests/bombadil/runner-control.test.ts
@@ -119,6 +119,40 @@ describe("Bombadil watchdog recovery", () => {
     expect(child.killSignals).toEqual([]);
   });
 
+  it("preserves a successful run when macOS denies cleanup of its exited group", async () => {
+    const child = new FakeChild(432);
+    child.finish(0);
+    const signals: Array<[number, string]> = [];
+
+    await stopProcess(child, {
+      killProcessGroup: true,
+      killByPid: (pid: number, signal: string | number) => {
+        signals.push([pid, String(signal)]);
+        const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+        error.code = "EPERM";
+        throw error;
+      },
+    });
+
+    expect(signals).toEqual([[-432, "SIGTERM"]]);
+    expect(child.exitCode).toBe(0);
+  });
+
+  it("rejects permission errors while the Bombadil leader is still running", async () => {
+    const child = new FakeChild(543);
+
+    await expect(
+      stopProcess(child, {
+        killProcessGroup: true,
+        killByPid: () => {
+          const error = new Error("operation not permitted") as NodeJS.ErrnoException;
+          error.code = "EPERM";
+          throw error;
+        },
+      }),
+    ).rejects.toMatchObject({ code: "EPERM" });
+  });
+
   it("drains the killed Bombadil leader before allowing a retry", async () => {
     const child = new FakeChild(654);
     const signals: Array<[number, string]> = [];


### PR DESCRIPTION
## Summary

- tolerate macOS `EPERM` when cleaning an already-exited Bombadil process group
- keep permission failures fatal while the Bombadil leader is still running
- cover both paths with runner-control regression tests

## Release context

Main CI run 29696693365 completed the 30-second Bombadil smoke with zero UI violations, then failed in `finally` while signaling the already-exited process group. The cleanup exception replaced Bombadil’s successful exit status.

## Validation

- `npm run format:check`
- `npm test -- tests/bombadil/runner-control.test.ts` (8/8)
- `npm run test:ui:fuzz -- --time-limit 10s` (timed run exited 0 on macOS)
- full `npm test` completed all reported test files successfully; the local Vitest coordinator retained idle workers afterward and was interrupted