### PR TITLE
fix: retry goal mutations after DefraDB conflicts

### DIFF
--- a/crates/defra-agent/src/goal.rs
+++ b/crates/defra-agent/src/goal.rs
@@ -7,7 +7,7 @@
 
 use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
-use defra_node::EmbeddedNode;
+use defra_node::{EmbeddedNode, QueryResponse};
 use serde::{Deserialize, Serialize};
 
 use crate::graphql::escape_graphql_string;
@@ -704,10 +704,7 @@ pub async fn delete_goal(node: &EmbeddedNode, goal: &GoalDocument) -> Result<boo
             delete_Goal(filter: {{ _docID: {{ _eq: "{doc_id}" }}, agent_did: {{ _eq: "{agent_did}" }} }}) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    if response.has_errors() {
-        bail!("delete goal failed: {:?}", response.errors);
-    }
+    let response = execute_goal_mutation_response(node, &mutation, "delete goal").await?;
     Ok(response
         .data
         .as_ref()
@@ -734,10 +731,7 @@ pub async fn delete_goals_for_session(
             }}) {{ _docID }}
         }}"#
     );
-    let response = node.execute(&mutation).await;
-    if response.has_errors() {
-        bail!("delete session goals failed: {:?}", response.errors);
-    }
+    let response = execute_goal_mutation_response(node, &mutation, "delete session goals").await?;
     Ok(response
         .data
         .as_ref()
@@ -911,11 +905,21 @@ async fn load_goal_by_doc_id(node: &EmbeddedNode, doc_id: &str) -> Result<Option
 }
 
 async fn execute_goal_mutation(node: &EmbeddedNode, mutation: &str, label: &str) -> Result<()> {
-    let response = node.execute(mutation).await;
+    execute_goal_mutation_response(node, mutation, label)
+        .await
+        .map(|_| ())
+}
+
+async fn execute_goal_mutation_response(
+    node: &EmbeddedNode,
+    mutation: &str,
+    label: &str,
+) -> Result<QueryResponse> {
+    let response = crate::retry::execute_graphql_with_conflict_retry(node, mutation, label).await;
     if response.has_errors() {
         bail!("{label} failed: {:?}", response.errors);
     }
-    Ok(())
+    Ok(response)
 }
 
 fn mutation_returned_rows(value: &serde_json::Value) -> bool {


### PR DESCRIPTION
## Summary

- route goal create/update/delete mutations through the existing DefraDB conflict retry helper
- preserve delete response rows so single-goal and session-sweep return values remain unchanged
- keep non-conflict GraphQL errors fail-fast

## Release context

Main CI run 29696693365 failed `thread_goal_round_trip_survives_shim_restart` when `thread/goal/clear` received `transaction conflict. Please retry`. Goal writes were one of the remaining direct `node.execute` mutation paths and bypassed the repository-wide retry classifier.

## Validation

- `cargo fmt --all --check`
- `cargo test -p defra-agent goal::tests` (3/3)
- `cargo test -p defra-agent-cli --test cli_codex_shim thread_goal_round_trip_survives_shim_restart -- --nocapture --test-threads=1` (passes)