### PR TITLE
fix: close release-gate readiness and Bombadil flakes

### DIFF
--- a/apps/desktop-tauri/tests/bombadil/spec.ts
+++ b/apps/desktop-tauri/tests/bombadil/spec.ts
@@ -4,6 +4,7 @@ export * from "@antithesishq/bombadil/browser/defaults";
 
 const shellState = extract((state) => {
   const document = state.document;
+  const errorBanner = document.querySelector('[data-testid="error-banner"]');
   const surfaceSelectors = [
     '[data-testid="fleet-dashboard"]',
     '[data-testid="fleet-empty"]',
@@ -12,8 +13,17 @@ const shellState = extract((state) => {
   ];
   return {
     shellMounted: Boolean(document.querySelector(".app-shell")),
-    errorBanner:
-      document.querySelector('[data-testid="error-banner"]')?.textContent ?? "",
+    errorBanner: {
+      visible: Boolean(errorBanner),
+      message: normalizeText(
+        errorBanner?.querySelector(".error-banner-message")?.textContent ?? "",
+      ),
+      isAlert: errorBanner?.getAttribute("role") === "alert",
+      copyActionCount: errorBanner?.querySelectorAll("button.copy-button").length ?? 0,
+      dismissActionCount:
+        errorBanner?.querySelectorAll('[data-testid="error-banner-dismiss"]').length ??
+        0,
+    },
     documentWidth: Math.max(
       document.documentElement.scrollWidth,
       document.body?.scrollWidth ?? 0,
@@ -161,9 +171,16 @@ export const desktop_shell_has_one_primary_surface = always(
   () => shellState.current.primarySurfaceCount === 1,
 );
 
-export const desktop_shell_does_not_show_global_errors = always(
-  () => shellState.current.errorBanner.length === 0,
-);
+export const desktop_global_errors_are_actionable = always(() => {
+  const banner = shellState.current.errorBanner;
+  return (
+    !banner.visible ||
+    (banner.message.length > 0 &&
+      banner.isAlert &&
+      banner.copyActionCount === 1 &&
+      banner.dismissActionCount === 1)
+  );
+});
 
 export const desktop_shell_does_not_horizontally_overflow = always(
   () => shellState.current.documentWidth <= shellState.current.viewportWidth + 2,

--- a/crates/defra-agent/src/agent/runtime/control_watcher.rs
+++ b/crates/defra-agent/src/agent/runtime/control_watcher.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use defra_node::EventName;
 use tokio::sync::{mpsc, watch};
 
 use crate::runtime_snapshot::ResolvedRuntimeSnapshot;
@@ -20,6 +19,7 @@ const CONTROL_WATCHER_IDLE_SLEEP: Duration = Duration::from_secs(60 * 60 * 24 * 
 
 pub(super) async fn run_control_watcher(
     node: Arc<defra_node::EmbeddedNode>,
+    mut subscription: events::Subscription,
     agent_did: String,
     resolve_context: DocumentResolveContext,
     proposals_tx: mpsc::Sender<ResolvedRuntimeSnapshot>,
@@ -29,7 +29,6 @@ pub(super) async fn run_control_watcher(
 ) -> Result<()> {
     let mut document_view =
         document_view::load_document_runtime_view(node.as_ref(), &agent_did).await?;
-    let mut subscription = node.subscribe(&[EventName::Update]);
     let sleep = tokio::time::sleep(CONTROL_WATCHER_IDLE_SLEEP);
     tokio::pin!(sleep);
     let mut dirty = false;

--- a/crates/defra-agent/src/agent/runtime/startup.rs
+++ b/crates/defra-agent/src/agent/runtime/startup.rs
@@ -348,6 +348,15 @@ pub(in crate::agent) async fn run_agent(
         engine.run(sources, trigger_engine_cancel).await;
     });
 
+    // DefraDB's event bus is live-only: updates published before a subscriber
+    // exists cannot be replayed. Establish the control subscription before
+    // the readiness task can publish `Ready`, so callers that wait for Ready
+    // cannot race the watcher startup and lose their first config mutation.
+    let control_subscription = agent
+        .document_runtime_context()
+        .is_some()
+        .then(|| agent.node.subscribe(&[defra_node::EventName::Update]));
+
     let ready_cancel = cancel.child_token();
     let ready_startup_barrier = startup_barrier.clone();
     let ready_observer = agent.process_state_observer.clone();
@@ -591,6 +600,8 @@ pub(in crate::agent) async fn run_agent(
 
     if agent.document_runtime_context().is_some() {
         let control_node = agent.node.clone();
+        let control_subscription =
+            control_subscription.expect("document runtime context has control subscription");
         let control_agent_did = agent.agent_did().to_string();
         let control_context = agent
             .document_runtime_context()
@@ -603,6 +614,7 @@ pub(in crate::agent) async fn run_agent(
             BackgroundTaskResult::Control(
                 super::control_watcher::run_control_watcher(
                     control_node,
+                    control_subscription,
                     control_agent_did,
                     control_context,
                     control_tx,

--- a/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
+++ b/crates/defra-agent/src/agent/runtime/tests/control_watcher.rs
@@ -53,18 +53,11 @@ async fn control_watcher_publishes_reconciled_snapshot_after_relevant_update() {
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     let (proposal_tx, mut proposal_rx) = mpsc::channel(4);
 
-    let watcher_task = tokio::spawn(run_control_watcher(
-        node.clone(),
-        agent.agent_did().to_string(),
-        resolve_context,
-        proposal_tx,
-        runtime_status.clone(),
-        mpsc::channel::<()>(1).1,
-        shutdown_rx,
-    ));
-
-    tokio::task::yield_now().await;
-
+    // Subscribe first, then publish before the watcher future is ever polled.
+    // DefraDB subscriptions are live-only, so this deterministically guards
+    // the startup ordering that prevents a post-Ready config update from
+    // falling into the gap between readiness and watcher startup.
+    let subscription = node.subscribe(&[defra_node::EventName::Update]);
     let mut default_behavior =
         crate::load_agent_behavior(node.as_ref(), agent.default_behavior_id())
             .await
@@ -74,6 +67,17 @@ async fn control_watcher_publishes_reconciled_snapshot_after_relevant_update() {
     crate::upsert_agent_behavior(node.as_ref(), &default_behavior)
         .await
         .unwrap();
+
+    let watcher_task = tokio::spawn(run_control_watcher(
+        node.clone(),
+        subscription,
+        agent.agent_did().to_string(),
+        resolve_context,
+        proposal_tx,
+        runtime_status.clone(),
+        mpsc::channel::<()>(1).1,
+        shutdown_rx,
+    ));
 
     tokio::task::yield_now().await;
     let debouncing = fetch_runtime_status(node.as_ref(), agent.agent_did()).await;
@@ -136,6 +140,7 @@ async fn control_watcher_demotes_and_recovers_behavior_on_measured_health_flip()
 
     let watcher_task = tokio::spawn(run_control_watcher(
         node.clone(),
+        node.subscribe(&[defra_node::EventName::Update]),
         agent.agent_did().to_string(),
         resolve_context,
         proposal_tx,
@@ -244,6 +249,7 @@ async fn control_watcher_recovers_after_resolve_error() {
 
     let watcher_task = tokio::spawn(run_control_watcher(
         node.clone(),
+        node.subscribe(&[defra_node::EventName::Update]),
         agent.agent_did().to_string(),
         resolve_context,
         proposal_tx,
@@ -312,6 +318,7 @@ async fn control_watcher_resolves_tool_selection_into_reconciled_tool_surface() 
 
     let watcher_task = tokio::spawn(run_control_watcher(
         node.clone(),
+        node.subscribe(&[defra_node::EventName::Update]),
         agent.agent_did().to_string(),
         resolve_context,
         proposal_tx,


### PR DESCRIPTION
## Summary

- establish the live-only DefraDB control-update subscription before `AgentRuntime` can publish `ready`
- pass that subscription into the existing control watcher instead of creating it on first poll
- make the watcher regression test publish before the watcher future is polled, deterministically proving the buffered handoff
- replace Bombadil’s invalid “global errors can never appear” invariant with a product-aligned contract requiring visible errors to have a nonempty message, alert semantics, and Copy/Dismiss actions

The watcher fix addresses the release-fence failure where `scheduling::generation_bump_reconfigures_active_schedules` remained at generation 1 because its post-Ready Schedule insert raced watcher startup. No lifecycle transition or schema semantics change; this is startup ordering around the existing reconcile path.

The Bombadil correction addresses a healthy random path: deleting a task still referenced by a schedule must surface a validation error. The previous invariant incorrectly classified that handled error as a shell failure.

## Validation

- `cargo fmt --all --check`
- control-watcher unit tests: 4/4
- exact failed conformance case: 10/10 consecutive passes
- `cargo test -p defra-agent --test conformance`: 312/312
- `cargo test -p defra-agent`: green
- `cargo check --workspace --all-targets`: green
- desktop Prettier check and production build: green
- Bombadil randomized browser run, 60 seconds: green