### PR TITLE
chore(release): prepare v0.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-lock",
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-trait",
@@ -6601,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "anyhow",
  "document",
@@ -6700,7 +6700,7 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "defra-agent"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "acp",
  "agent-tool-call-lifecycle-v1-to-v2-lens",
@@ -6759,7 +6759,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "acp",
  "anyhow",
@@ -6813,7 +6813,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -6827,7 +6827,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6855,7 +6855,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-desktop-tauri"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -6883,7 +6883,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-lean-contract"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "serde",
@@ -6892,7 +6892,7 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-protocol"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -6911,12 +6911,12 @@ dependencies = [
 
 [[package]]
 name = "defra-agent-schemas"
-version = "0.7.1"
+version = "0.7.2"
 
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "cid",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-stream",
@@ -6971,7 +6971,7 @@ dependencies = [
 
 [[package]]
 name = "defra-native-fs-runner"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "globset",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "anyhow",
@@ -7018,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-trait",
@@ -7052,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "serde",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11048,7 +11048,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12281,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-lock",
@@ -12429,7 +12429,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15159,7 +15159,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "anyhow",
@@ -16584,7 +16584,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16620,7 +16620,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16637,7 +16637,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "async-lock",
@@ -16669,7 +16669,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17622,7 +17622,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "p2p",
  "query",
@@ -18421,7 +18421,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "cid",
  "defra-core",
@@ -19623,7 +19623,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20050,7 +20050,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24500,7 +24500,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1c38ab0c397437beb2664b212f85abb6ea6cd841#1c38ab0c397437beb2664b212f85abb6ea6cd841"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-lock",
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-trait",
@@ -6601,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "anyhow",
  "document",
@@ -6916,7 +6916,7 @@ version = "0.7.2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "cid",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-stream",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "anyhow",
@@ -7018,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-trait",
@@ -7052,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "serde",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11048,7 +11048,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12281,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-lock",
@@ -12429,7 +12429,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15159,7 +15159,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "anyhow",
@@ -16584,7 +16584,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16620,7 +16620,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16637,7 +16637,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "async-lock",
@@ -16669,7 +16669,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17622,7 +17622,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "p2p",
  "query",
@@ -18421,7 +18421,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "cid",
  "defra-core",
@@ -19623,7 +19623,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20050,7 +20050,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24500,7 +24500,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=1e4d0e48a209fb804c472f722c8f0376a4bd8904#1e4d0e48a209fb804c472f722c8f0376a4bd8904"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/sourcenetwork/defra-agent"
@@ -57,22 +57,23 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs v0.16.1: v0.15 store migration plus the v0.16.0 release fixes
+# defradb.rs v0.16.2: v0.15 store migration plus terminal pending-DAG
+# quarantine and per-root fetch single-flight for production upgrades.
 # default/action parity, ordered GraphQL mutation fragments, bulk ACP endpoints,
 # CID-indexed pending-DAG waiters, and the release conformance hardening batch.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -80,8 +81,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1c38ab0c397437beb2664b212f85abb6ea6cd841" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,22 +58,23 @@ codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 # defradb.rs v0.16.2: v0.15 store migration plus terminal pending-DAG
-# quarantine and per-root fetch single-flight for production upgrades.
+# quarantine, per-root fetch single-flight, and authorizer-scoped replay capabilities
+# for production upgrades.
 # default/action parity, ordered GraphQL mutation fragments, bulk ACP endpoints,
 # CID-indexed pending-DAG waiters, and the release conformance hardening batch.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -81,8 +82,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "1e4d0e48a209fb804c472f722c8f0376a4bd8904" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"


### PR DESCRIPTION
## Summary

- bump the workspace patch version from v0.7.1 to v0.7.2
- advance the DefraDB pin to `364db72bd009d5e126b6f4ccf45fa9fa1ad937b0` (the v0.16.2 release candidate)
- retain the existing v0.6.12 populated-store upgrade fixture and existing runtime migration pipeline

## Why

The v0.7.1 migration itself succeeded on the local production canary and on the studio-1 hub store. Restoring studio-1 historical pending-DAG state then exposed two independent upstream P2P blockers:

1. DefraDB [#1160](https://github.com/sourcenetwork/defradb.rs/pull/1160) closes [#1159](https://github.com/sourcenetwork/defradb.rs/issues/1159) by routing deterministic invalid-signature poison roots through the existing durable quarantine and making pending-DAG poll fetches single-flight per root.
2. DefraDB [#1163](https://github.com/sourcenetwork/defradb.rs/pull/1163) closes [#1161](https://github.com/sourcenetwork/defradb.rs/issues/1161) by retaining the verified replay-capability authorizer and attaching a cached capability only when the outgoing document creator matches that authorizer. Unrelated public pushes continue through ordinary admission.

No migration system or store transform is added here. The v0.15 to v0.16 physical migration remains in the existing DefraDB database migration and Lens pipeline; defra-agent retains its existing runtime migration module and consolidated populated-store e2e fixture.

## Local gates

- `cargo test -p defra-agent` (all library and integration suites green)
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- populated v0.6.12 RocksDB upgrade and reopen fixture explicitly green
- lockfile diff limited to the nine DefraDB source pins

## Rollout

After signed release assets are published, use the existing Amygdala release gate and stage workflow and resume from the stopped, cold-backed-up studio-1 canary. Amygdalabook already completed the v0.7.1 migration and ten-minute soak successfully.