### PR TITLE
fix(desktop): keep mobile operations drawer interactive

### DIFF
--- a/apps/desktop-tauri/src/styles/chat.css
+++ b/apps/desktop-tauri/src/styles/chat.css
@@ -346,4 +346,23 @@
   .compact-empty {
     min-height: 180px;
   }
+
+  @media (max-width: 760px) {
+    .operations-rail.is-open {
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100dvh;
+    }
+
+    .operations-rail-header {
+      padding-top: calc(var(--space-6) + env(safe-area-inset-top));
+      padding-right: calc(var(--space-6) + env(safe-area-inset-right));
+      padding-left: calc(var(--space-6) + env(safe-area-inset-left));
+    }
+
+    .operations-rail-tab-panel {
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- render the open operations rail as a viewport-level drawer on narrow screens
- preserve mobile safe-area padding around drawer controls
- keep drawer content scrollable and reachable instead of clipping it inside the auto-height chat workspace

## Verification

- `npm run format:check`
- `npm run build`
- `npx playwright test tests/playwright/desktop-operations-rich.spec.ts --project=chromium-narrow` (2 passed)
- `npm run test:ui:e2e` (124 passed, 2 skipped)