### PR TITLE
fix(approvals): close release compile gaps

### DIFF
--- a/crates/defra-agent/src/config_client/approval.rs
+++ b/crates/defra-agent/src/config_client/approval.rs
@@ -142,7 +142,7 @@ mod tests {
             .await
             .unwrap();
         crate::ensure_schemas(&node).await.unwrap();
-        let access = ConfigAccess::Local(node);
+        let access = ConfigAccess::Local(std::sync::Arc::new(node));
 
         // Persist a held row shaped like the runtime's hold_for_approval.
         let deadline = (chrono::Utc::now() + chrono::Duration::seconds(60)).to_rfc3339();

--- a/crates/defra-agent/src/mcp_pool/tests.rs
+++ b/crates/defra-agent/src/mcp_pool/tests.rs
@@ -66,15 +66,8 @@ fn rust_idempotency(value: &str) -> ToolIdempotencyEvidence {
 }
 
 fn rust_failure_class(value: &str) -> ToolFailureClass {
-    match value {
-        "argumentInvalid" => ToolFailureClass::ArgumentInvalid,
-        "serviceUnavailable" => ToolFailureClass::ServiceUnavailable,
-        "transport" => ToolFailureClass::Transport,
-        "toolReturnedError" => ToolFailureClass::ToolReturnedError,
-        "policyDenied" => ToolFailureClass::PolicyDenied,
-        "external" => ToolFailureClass::External,
-        other => panic!("unknown Lean tool failure class {other:?}"),
-    }
+    ToolFailureClass::from_persisted(value)
+        .unwrap_or_else(|| panic!("unknown Lean tool failure class {value:?}"))
 }
 
 #[test]

--- a/crates/defra-agent/src/trace_export.rs
+++ b/crates/defra-agent/src/trace_export.rs
@@ -559,15 +559,11 @@ fn string_array_field(object: &serde_json::Map<String, Value>, field: &str) -> O
 fn failure_class_from_str(raw: &str) -> Option<ToolFailureClass> {
     // Accept both new camelCase persisted vocab and legacy snake_case strings
     // emitted by older MCP tool envelopes.
+    if let Some(failure_class) = ToolFailureClass::from_persisted(raw) {
+        return Some(failure_class);
+    }
     match raw {
-        // New canonical camelCase vocab (from FailureClass::as_str / serde).
-        "argumentInvalid" => Some(ToolFailureClass::ArgumentInvalid),
-        "serviceUnavailable" => Some(ToolFailureClass::ServiceUnavailable),
-        "transport" => Some(ToolFailureClass::Transport),
-        "toolReturnedError" => Some(ToolFailureClass::ToolReturnedError),
-        "policyDenied" => Some(ToolFailureClass::PolicyDenied),
-        "external" => Some(ToolFailureClass::External),
-        // Legacy snake_case strings — rebucketed to 5-variant spec.
+        // Legacy snake_case strings rebucketed into the canonical vocabulary.
         "service_unavailable"
         | "tool_not_found"
         | "tool_not_allowed"

--- a/crates/defra-agent/src/trace_export/tests.rs
+++ b/crates/defra-agent/src/trace_export/tests.rs
@@ -2,6 +2,14 @@ use super::*;
 use crate::llm::message::{Text, ToolCall, ToolFunction};
 
 #[test]
+fn canonical_failure_class_parser_preserves_approval_denied() {
+    assert_eq!(
+        failure_class_from_str("approvalDenied"),
+        Some(ToolFailureClass::ApprovalDenied)
+    );
+}
+
+#[test]
 fn successful_completed_result_has_no_failure_class() {
     let analysis = analyze_tool_call("read", r#"{"path":"README.md"}"#, "contents", "completed");
 


### PR DESCRIPTION
## Summary

- wrap the approval config-client test node in the `Arc` required by `ConfigAccess::Local`
- route canonical tool failure parsing through `FailureClass::from_persisted`
- preserve `approvalDenied` in trace export and prevent future Lean/Rust parser drift

## Verification

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test -p defra-agent`
- focused approval retry-disposition and trace-export tests