### PR TITLE
fix: retry admission persistence conflicts

### DIFF
--- a/crates/defra-agent/src/admission/persistence.rs
+++ b/crates/defra-agent/src/admission/persistence.rs
@@ -7,6 +7,7 @@ use rig::completion::{CompletionError, Usage};
 
 use super::controller::InferenceCallRecord;
 use crate::graphql::escape_graphql_string;
+use crate::retry::execute_graphql_with_conflict_retry;
 
 pub(super) fn spawn_persistence<F>(future: F)
 where
@@ -45,7 +46,12 @@ pub(super) async fn persist_call_queued(
 ) -> Result<String> {
     let now = chrono::Utc::now().to_rfc3339();
     let mutation = add_call_mutation(call, "queued", None, Some(&now), None, None, None);
-    let resp = node.execute(&mutation).await;
+    let resp = execute_graphql_with_conflict_retry(
+        node.as_ref(),
+        &mutation,
+        "persist queued InferenceCall",
+    )
+    .await;
     if resp.has_errors() {
         anyhow::bail!("persisting queued InferenceCall failed: {:?}", resp.errors);
     }
@@ -58,7 +64,12 @@ pub(super) async fn persist_call_started(
 ) -> Result<String, CompletionError> {
     let now = chrono::Utc::now().to_rfc3339();
     let mutation = add_call_mutation(call, "running", None, Some(&now), Some(&now), None, None);
-    let resp = node.execute(&mutation).await;
+    let resp = execute_graphql_with_conflict_retry(
+        node.as_ref(),
+        &mutation,
+        "persist running InferenceCall",
+    )
+    .await;
     if resp.has_errors() {
         return Err(CompletionError::ProviderError(format!(
             "persisting running InferenceCall failed: {:?}",
@@ -74,7 +85,12 @@ pub(super) async fn persist_existing_call_running(
 ) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     let mutation = upsert_call_running_mutation(call, &now);
-    let resp = node.execute(&mutation).await;
+    let resp = execute_graphql_with_conflict_retry(
+        node.as_ref(),
+        &mutation,
+        "persist existing running InferenceCall",
+    )
+    .await;
     if resp.has_errors() {
         anyhow::bail!("persisting running InferenceCall failed: {:?}", resp.errors);
     }
@@ -98,7 +114,12 @@ pub(super) async fn persist_terminal_call(
         Some(&now),
         usage,
     );
-    let resp = node.execute(&mutation).await;
+    let resp = execute_graphql_with_conflict_retry(
+        node.as_ref(),
+        &mutation,
+        "persist terminal InferenceCall",
+    )
+    .await;
     if resp.has_errors() {
         anyhow::bail!(
             "persisting terminal InferenceCall failed: {:?}",
@@ -117,7 +138,12 @@ pub(super) async fn persist_existing_call_terminal(
 ) -> Result<()> {
     let now = chrono::Utc::now().to_rfc3339();
     let mutation = upsert_call_terminal_mutation(call, call_state, failure_reason, &now, usage);
-    let resp = node.execute(&mutation).await;
+    let resp = execute_graphql_with_conflict_retry(
+        node.as_ref(),
+        &mutation,
+        "persist existing terminal InferenceCall",
+    )
+    .await;
     if resp.has_errors() {
         anyhow::bail!(
             "persisting terminal InferenceCall failed: {:?}",

--- a/crates/defra-agent/tests/e2e_runtime/completion_retry_tape.rs
+++ b/crates/defra-agent/tests/e2e_runtime/completion_retry_tape.rs
@@ -61,7 +61,26 @@ async fn backend_restart_cluster_recovers() {
     }
 
     for (doc_id, request_id, marker) in &request_doc_ids {
-        wait_for_request_lifecycle_state(db.node.as_ref(), doc_id, "completed").await;
+        let terminal_state = wait_for_request_terminal_state(db.node.as_ref(), doc_id).await;
+        if terminal_state != "completed" {
+            let snapshot = fetch_request_snapshot(db.node.as_ref(), doc_id).await;
+            let calls = fetch_inference_calls(db.node.as_ref(), request_id).await;
+            let all_calls = fetch_call_diagnostics(db.node.as_ref(), request_id).await;
+            let response = fetch_response_diagnostic(db.node.as_ref(), request_id).await;
+            let request_counts = request_doc_ids
+                .iter()
+                .map(|(_, request_id, marker)| {
+                    (request_id.as_str(), backend.observed_requests(marker))
+                })
+                .collect::<Vec<_>>();
+            panic!(
+                "request {request_id} unexpectedly reached {terminal_state}; \
+                 failure_reason={:?}; inference_calls={calls:?}; \
+                 all_calls={all_calls:?}; response={response:?}; \
+                 backend_request_counts={request_counts:?}",
+                snapshot.failure_reason
+            );
+        }
 
         let calls = fetch_inference_calls(db.node.as_ref(), request_id).await;
         assert_retry_recovered(&calls, 1);
@@ -560,6 +579,31 @@ async fn fetch_response_error_message(
         .map(ToOwned::to_owned)
 }
 
+async fn fetch_response_diagnostic(node: &EmbeddedNode, request_id: &str) -> Option<Value> {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            AgentResponse(filter: {{ request_id: {{ _eq: "{request_id}" }} }}, limit: 1) {{
+                status
+                error_message
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "fetch response diagnostic failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("AgentResponse"))
+        .and_then(Value::as_array)
+        .and_then(|rows| rows.first())
+        .cloned()
+}
+
 async fn fetch_inference_calls(
     node: &EmbeddedNode,
     request_id: &str,
@@ -605,6 +649,43 @@ async fn fetch_inference_calls(
         .into_iter()
         .map(|value| serde_json::from_value(value).expect("decode TimelineInferenceCallRow"))
         .collect()
+}
+
+async fn fetch_call_diagnostics(node: &EmbeddedNode, request_id: &str) -> Vec<Value> {
+    let request_id = escape_graphql_string(request_id);
+    let query = format!(
+        r#"{{
+            InferenceCall(
+                filter: {{ request_id: {{ _eq: "{request_id}" }} }},
+                order: {{ call_seq: ASC }}
+            ) {{
+                call_id
+                call_seq
+                attempt
+                call_kind
+                call_state
+                failure_reason
+                queued_at
+                started_at
+                ended_at
+                backend_id
+                controller_generation
+            }}
+        }}"#
+    );
+    let response = node.execute(&query).await;
+    assert!(
+        !response.has_errors(),
+        "fetch call diagnostics failed: {:?}",
+        response.errors
+    );
+    response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("InferenceCall"))
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
 }
 
 async fn build_timeline(node: &EmbeddedNode, request_id: &str) -> RunTimeline {


### PR DESCRIPTION
## Summary

- retry all admission `InferenceCall` persistence mutations after recognized DefraDB transaction conflicts
- preserve the original mutation payload and lifecycle transition across bounded storage retries
- add actionable clustered backend-restart diagnostics for terminal request failures

## Root cause

The first immediate admission attempt could lose a concurrent DefraDB transaction conflict before making any provider request. That persistence error was classified as transient and consumed the request retry budget. The second attempt then reached the backend, received the test tape’s planned first 503, and exhausted the budget. This change treats the storage conflict as an implementation-level stutter instead of a provider attempt.

No Lean model change is required: the legal admission lifecycle and provider transitions are unchanged; only persistence of an already-selected transition is retried.

## Validation

- `cargo fmt --check`
- `cargo test -p defra-agent admission:: --lib` — 22 passed
- `cargo test -p defra-agent` — 1,811 non-ignored tests passed
- `cargo check --workspace --all-targets`
- full `e2e_runtime` suite repeated 20 times after the fix — 1,280 tests passed; the pre-fix build reproduced the failure on iteration 6

Closes #848