### PR TITLE
chore: add executable Gents rename audit and guard

### DIFF
--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -1,0 +1,499 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+cd "$REPO_ROOT"
+# =============================================================================
+# rename-to-gents.sh — Executable rename tool for the defra-agent → Gents
+# hard cutover (source-inc/defra-agent#822, epic #811).
+#
+# Modes:
+#   audit          — report paths and contents deterministically (read-only)
+#   apply-moves    — perform only the reviewable git-mv phase
+#   apply-content  — perform only scripted content substitutions
+#   apply          — perform both mechanical phases
+#   guard          — reject stale path/content tokens outside the allowlist
+#   self-test      — exercise the substitution edge cases in a temporary file
+#
+# Usage:
+#   scripts/rename-to-gents.sh audit
+#   scripts/rename-to-gents.sh apply-moves
+#   scripts/rename-to-gents.sh apply-content
+#   scripts/rename-to-gents.sh guard
+#
+# Design:
+#   - Audit mode is read-only and prints affected-file + occurrence summaries.
+#   - Apply mode performs git mv on paths and sed on file contents.
+#   - Re-running apply is safe (no-op on already-renamed files).
+#   - Scans both paths and contents.
+#   - Explicitly scans old product tokens, both GitHub org coordinates,
+#     SSH/HTTPS repository forms, and com.sourcenetwork / org.sourcenetwork.
+#   - Preserves DefraDB/defradb.rs and domain-level agent vocabulary.
+#
+# Three-part review commit structure (documented for reviewers):
+#   1. git mv only (directory/crate renames)
+#   2. Scripted content substitutions (this script's apply mode)
+#   3. Hand fixes, generated-file/lockfile regeneration, formatting
+#
+# Allowlist — old product names may remain only in:
+#   - docs/gents-cutover.md
+#   - scripts/rename-to-gents.sh (this file)
+#   - narrowly justified machine-required references recorded in the guard
+# =============================================================================
+# ---------------------------------------------------------------------------
+# Locked rename map (from #811 section "Locked naming contract")
+# ---------------------------------------------------------------------------
+
+# Crate directory renames (git mv)
+declare -a CRATE_MV=(
+  "crates/defra-agent:crates/gents"
+  "crates/defra-agent-cli:crates/gents-cli"
+  "crates/defra-agent-protocol:crates/gents-protocol"
+  "crates/defra-agent-schemas:crates/gents-schemas"
+  "crates/defra-agent-desktop:crates/gents-desktop"
+  "crates/defra-agent-desktop-core:crates/gents-desktop-core"
+  "crates/defra-agent-lean-contract:crates/gents-lean-contract"
+  "crates/defra-agent-lenses:crates/gents-lenses"
+  "crates/defra-native-fs-runner:crates/gents-fs-runner"
+)
+
+# Content substitutions — applied in order from most specific to most general.
+# Each entry is "old|new". Order matters: longer/more-specific patterns first.
+declare -a CONTENT_SUBS=(
+  # Reverse-domain identifiers (most specific first — must run before
+  # generic defra-agent rules to avoid partial matches)
+  "com.sourcenetwork.defra-agent-desktop|com.source-inc.gents"
+  "org.sourcenetwork.defra-agent|com.source-inc.gents.cli"
+  "com.sourcenetwork|com.source-inc.gents"
+  "org.sourcenetwork|com.source-inc.gents"
+  # Repository coordinates — both org forms
+  "git@github.com:sourcenetwork/defra-agent|git@github.com:source-inc/gents"
+  "git@github.com:source-inc/defra-agent|git@github.com:source-inc/gents"
+  "github.com/sourcenetwork/defra-agent|github.com/source-inc/gents"
+  "github.com/source-inc/defra-agent|github.com/source-inc/gents"
+  "sourcenetwork/defra-agent|source-inc/gents"
+  "source-inc/defra-agent|source-inc/gents"
+  # Product crate prefix (most specific first)
+  "defra-agent-desktop-core|gents-desktop-core"
+  "defra-agent-desktop|gents-desktop"
+  "defra-agent-lean-contract|gents-lean-contract"
+  "defra-agent-lenses|gents-lenses"
+  "defra-agent-protocol|gents-protocol"
+  "defra-agent-schemas|gents-schemas"
+  "defra-agent-cli|gents-cli"
+  "defra-native-fs-runner|gents-fs-runner"
+  "defra_native_fs_runner|gents_fs_runner"
+  "defra_agent_fs_runner|gents_fs_runner"
+  # Also handle the defra_agent::fs_runner path form if it exists
+  "defra_agent_fs|gents_fs"
+  # Runtime crate/path/import (Rust module form)
+  "defra_agent|gents"
+  # Environment variable prefix
+  "DEFRA_AGENT|GENTS"
+  # Default home directory (literal dot, not regex)
+  ".defra-agent|.gents"
+  # Display/product name (proper case)
+  "Defra Agent|Gents"
+  "DefraAgent|Gents"
+  # CLI executable / product name (kebab-case) — catch-all, run last
+  "defra-agent|gents"
+  # NOTE: did:defra-agent:* is NOT mechanically substituted.
+  # Per #811: string-only fixtures → did:test:*; real crypto → did:key.
+  # This is a hand-fix item for #823, not a scripted substitution.
+  # The guard still scans for did:defra-agent as a stale token.
+)
+
+# Stale tokens for the guard scan (from #811 section 1)
+declare -a STALE_TOKENS=(
+  "defra-agent"
+  "defra_agent"
+  "DEFRA_AGENT"
+  "Defra Agent"
+  "DefraAgent"
+  "defra-native-fs-runner"
+  "defra_native_fs_runner"
+  ".defra-agent"
+  "did:defra-agent"
+  "sourcenetwork/defra-agent"
+  "source-inc/defra-agent"
+  "github.com/sourcenetwork/defra-agent"
+  "github.com/source-inc/defra-agent"
+  "git@github.com:sourcenetwork/defra-agent"
+  "git@github.com:source-inc/defra-agent"
+  "com.sourcenetwork"
+  "org.sourcenetwork"
+  "com.sourcenetwork.defra-agent-desktop"
+  "org.sourcenetwork.defra-agent"
+)
+
+# Guard allowlist — files where old names are permitted to remain
+declare -a ALLOWLIST=(
+  "docs/gents-cutover.md"
+  "scripts/rename-to-gents.sh"
+)
+
+# Domain vocabulary to preserve (NOT substituted)
+# These are explicitly listed for clarity; the script does not touch them.
+# - defradb / defradb.rs
+# - defra-core, defra-node, defra-p2p-adapter (upstream DefraDB crates)
+# - agent_did, AgentRequest, AgentResponse, AgentToolCall (domain nouns)
+# - agent-tool-call-lifecycle-v1-to-v2-lens (lens name = domain vocabulary)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+DID_SENTINEL="__GENTS_PRESERVE_PRODUCT_DID__"
+
+is_allowlisted() {
+  local file="$1"
+  local allowed
+  for allowed in "${ALLOWLIST[@]}"; do
+    if [[ "$file" == "$allowed" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+literal_occurrences_in_string() {
+  local value="$1"
+  local token="$2"
+  local count=0
+  while [[ "$value" == *"$token"* ]]; do
+    value="${value#*"$token"}"
+    count=$((count + 1))
+  done
+  printf '%d\n' "$count"
+}
+
+content_occurrences() {
+  local token="$1"
+  local file="$2"
+  if [[ -L "$file" ]]; then
+    literal_occurrences_in_string "$(readlink "$file")" "$token"
+  elif [[ -f "$file" ]]; then
+    { grep -IFo -- "$token" "$file" 2>/dev/null || true; } | wc -l | tr -d ' '
+  else
+    printf '0\n'
+  fi
+}
+
+sed_inplace() {
+  local file="$1"
+  shift
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "$@" "$file"
+  else
+    sed -i "$@" "$file"
+  fi
+}
+
+replace_token() {
+  local file="$1"
+  local old="$2"
+  local new="$3"
+  local old_escaped
+  local new_escaped
+  old_escaped=$(printf '%s\n' "$old" | sed 's/[][\\.^$*+?{}|\/&]/\\&/g')
+  new_escaped=$(printf '%s\n' "$new" | sed 's/[\\\/&]/\\&/g')
+
+  if [[ "$old" == "defra-agent" ]]; then
+    sed_inplace "$file" \
+      -e "s/did:defra-agent/$DID_SENTINEL/g" \
+      -e "s/$old_escaped/$new_escaped/g" \
+      -e "s/$DID_SENTINEL/did:defra-agent/g"
+  else
+    sed_inplace "$file" -e "s/$old_escaped/$new_escaped/g"
+  fi
+}
+
+check_clean() {
+  if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "working tree and index must be clean before apply modes" >&2
+    return 1
+  fi
+}
+
+preflight_moves() {
+  local pair old new
+  local sources=0
+  local destinations=0
+  for pair in "${CRATE_MV[@]}"; do
+    old="${pair%%:*}"
+    new="${pair#*:}"
+    [[ -d "$old" ]] && sources=$((sources + 1))
+    [[ -d "$new" ]] && destinations=$((destinations + 1))
+    if [[ -e "$old" && -e "$new" ]]; then
+      echo "both rename source and destination exist: $old / $new" >&2
+      return 1
+    fi
+  done
+  if [[ "$sources" -ne "${#CRATE_MV[@]}" && "$destinations" -ne "${#CRATE_MV[@]}" ]]; then
+    echo "mixed or incomplete crate-rename state" >&2
+    return 1
+  fi
+}
+
+preflight_content() {
+  local file
+  while IFS= read -r -d '' file; do
+    is_allowlisted "$file" && continue
+    [[ -L "$file" ]] && continue
+    [[ -f "$file" ]] || continue
+    if grep -Fq -- "$DID_SENTINEL" "$file" 2>/dev/null; then
+      echo "DID sentinel collision in $file" >&2
+      return 1
+    fi
+    if [[ ! -w "$file" ]]; then
+      echo "tracked file is not writable: $file" >&2
+      return 1
+    fi
+  done < <(git ls-files -z)
+}
+
+apply_moves() {
+  preflight_moves
+  local pair old new
+  for pair in "${CRATE_MV[@]}"; do
+    old="${pair%%:*}"
+    new="${pair#*:}"
+    if [[ -d "$old" ]]; then
+      echo "git mv $old -> $new"
+      git mv "$old" "$new"
+    fi
+  done
+}
+
+apply_content() {
+  preflight_content
+  local file sub old new
+  local changed
+  local count=0
+  while IFS= read -r -d '' file; do
+    is_allowlisted "$file" && continue
+    [[ -L "$file" ]] && continue
+    [[ -f "$file" ]] || continue
+    grep -Iq . "$file" 2>/dev/null || continue
+    changed=0
+    for sub in "${CONTENT_SUBS[@]}"; do
+      old="${sub%%|*}"
+      new="${sub#*|}"
+      if grep -Fq -- "$old" "$file"; then
+        replace_token "$file" "$old" "$new"
+        changed=1
+      fi
+    done
+    if [[ "$changed" -eq 1 ]]; then
+      git add "$file"
+      count=$((count + 1))
+    fi
+  done < <(git ls-files -z)
+  echo "content substitutions applied to $count tracked files"
+}
+
+print_move_audit() {
+  local pair old new file
+  local count total=0
+  echo "--- Crate-directory moves ---"
+  for pair in "${CRATE_MV[@]}"; do
+    old="${pair%%:*}"
+    new="${pair#*:}"
+    count=0
+    while IFS= read -r -d '' file; do
+      count=$((count + 1))
+    done < <(git ls-files -z "$old/")
+    if [[ "$count" -gt 0 ]]; then
+      printf '  %s -> %s (%d files)\n' "$old" "$new" "$count"
+      total=$((total + count))
+    fi
+  done
+  echo "  Total files under crate-directory moves: $total"
+}
+
+scan_stale_tokens() {
+  local token file allowed link_target
+  local path_count link_count path_occurrences content_occurrences symlink_occurrences
+  local path_file_count content_file_count symlink_file_count
+  local total=0
+  local violations=0
+  local -a path_files content_files symlink_files pathspecs
+
+  pathspecs=(-- .)
+  for allowed in "${ALLOWLIST[@]}"; do
+    pathspecs+=(":(exclude)$allowed")
+  done
+
+  echo "--- Stale path and content tokens ---"
+  for token in "${STALE_TOKENS[@]}"; do
+    path_occurrences=0
+    symlink_occurrences=0
+    path_file_count=0
+    symlink_file_count=0
+    path_files=("")
+    symlink_files=("")
+    while IFS= read -r -d '' file; do
+      is_allowlisted "$file" && continue
+      path_count=$(literal_occurrences_in_string "$file" "$token")
+      if [[ "$path_count" -gt 0 ]]; then
+        path_files+=("$file")
+        path_file_count=$((path_file_count + 1))
+        path_occurrences=$((path_occurrences + path_count))
+      fi
+      if [[ -L "$file" ]]; then
+        link_target=$(readlink "$file")
+        link_count=$(literal_occurrences_in_string "$link_target" "$token")
+        if [[ "$link_count" -gt 0 ]]; then
+          symlink_files+=("$file")
+          symlink_file_count=$((symlink_file_count + 1))
+          symlink_occurrences=$((symlink_occurrences + link_count))
+        fi
+      fi
+    done < <(git ls-files -z)
+
+    content_file_count=0
+    content_files=("")
+    while IFS= read -r -d '' file; do
+      content_files+=("$file")
+      content_file_count=$((content_file_count + 1))
+    done < <(git grep -I -l -z -F -e "$token" "${pathspecs[@]}" 2>/dev/null || true)
+    content_occurrences=$(
+      { git grep -I -o -F -e "$token" "${pathspecs[@]}" 2>/dev/null || true; } |
+        wc -l | tr -d ' '
+    )
+
+    if [[ "$path_occurrences" -gt 0 || "$content_occurrences" -gt 0 || "$symlink_occurrences" -gt 0 ]]; then
+      printf '  %-45s %4d path files %4d content files %6d occurrences\n' \
+        "$token" "$path_file_count" "$((content_file_count + symlink_file_count))" \
+        "$((path_occurrences + content_occurrences + symlink_occurrences))"
+      for file in "${path_files[@]}"; do
+        [[ -n "$file" ]] || continue
+        printf '    path: %s\n' "$file"
+      done
+      for file in "${content_files[@]}"; do
+        [[ -n "$file" ]] || continue
+        printf '    content: %s\n' "$file"
+      done
+      for file in "${symlink_files[@]}"; do
+        [[ -n "$file" ]] || continue
+        printf '    symlink target: %s\n' "$file"
+      done
+      total=$((total + path_occurrences + content_occurrences + symlink_occurrences))
+      violations=$((violations + 1))
+    fi
+  done
+
+  SCAN_TOTAL="$total"
+  SCAN_VIOLATIONS="$violations"
+}
+
+run_audit() {
+  echo "=== Gents Rename Audit ==="
+  print_move_audit
+  scan_stale_tokens
+  echo "Audit: $SCAN_VIOLATIONS token classes, $SCAN_TOTAL occurrences"
+}
+
+run_guard() {
+  echo "=== Gents Rename Stale-Token Guard ==="
+  scan_stale_tokens
+  if [[ "$SCAN_VIOLATIONS" -eq 0 ]]; then
+    echo "PASS: no stale path or content tokens outside the allowlist"
+    return 0
+  fi
+  echo "FAIL: $SCAN_VIOLATIONS token classes, $SCAN_TOTAL occurrences"
+  return 1
+}
+
+apply_substitutions_to_file() {
+  local file="$1"
+  local sub old new
+  for sub in "${CONTENT_SUBS[@]}"; do
+    old="${sub%%|*}"
+    new="${sub#*|}"
+    if grep -Fq -- "$old" "$file"; then
+      replace_token "$file" "$old" "$new"
+    fi
+  done
+}
+
+self_test() {
+  local test_dir test_file fixture_repo fixture_path first_checksum second_checksum
+  test_dir=$(mktemp -d)
+  test_file="$test_dir/substitutions.txt"
+  trap 'rm -rf "$test_dir"' EXIT
+  printf '%s\n' \
+    'git@github.com:sourcenetwork/defra-agent' \
+    'git@github.com:source-inc/defra-agent' \
+    'did:defra-agent:test' \
+    'DefraAgent' \
+    'DEFRA_AGENT_HOME' >"$test_file"
+
+  apply_substitutions_to_file "$test_file"
+  grep -Fxq 'git@github.com:source-inc/gents' "$test_file"
+  grep -Fxq 'did:defra-agent:test' "$test_file"
+  grep -Fxq 'Gents' "$test_file"
+  grep -Fxq 'GENTS_HOME' "$test_file"
+  if grep -Fq -- "$DID_SENTINEL" "$test_file"; then
+    echo "self-test left a DID sentinel behind" >&2
+    return 1
+  fi
+
+  first_checksum=$(cksum "$test_file")
+  apply_substitutions_to_file "$test_file"
+  second_checksum=$(cksum "$test_file")
+  [[ "$first_checksum" == "$second_checksum" ]]
+
+  # Exercise the real tracked-path and symlink-target scanner. The embedded
+  # newline ensures this fails if tracked paths are ever read line-by-line.
+  fixture_repo="$test_dir/path-fixture"
+  fixture_path=$'nested/defra-native-fs-runner\nfixture'
+  mkdir -p "$fixture_repo/nested"
+  git -C "$fixture_repo" init -q
+  printf 'path fixture\n' >"$fixture_repo/$fixture_path"
+  ln -s 'defra-native-fs-runner-target' "$fixture_repo/nested/runner-link"
+  git -C "$fixture_repo" add -A
+  cd "$fixture_repo"
+  ALLOWLIST=("__no_fixture_allowlist__")
+  STALE_TOKENS=("defra-native-fs-runner")
+  scan_stale_tokens >/dev/null
+  [[ "$SCAN_VIOLATIONS" -eq 1 ]]
+  [[ "$SCAN_TOTAL" -eq 2 ]]
+  cd "$REPO_ROOT"
+
+  rm -rf "$test_dir"
+  trap - EXIT
+  echo "self-test PASS"
+}
+
+case "${1:-}" in
+  audit)
+    run_audit
+    ;;
+  guard)
+    run_guard
+    ;;
+  apply-moves)
+    check_clean
+    apply_moves
+    ;;
+  apply-content)
+    check_clean
+    apply_content
+    ;;
+  apply)
+    check_clean
+    preflight_moves
+    preflight_content
+    apply_moves
+    apply_content
+    ;;
+  self-test)
+    self_test
+    ;;
+  *)
+    echo "usage: $0 {audit|guard|apply-moves|apply-content|apply|self-test}" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -8,23 +8,27 @@ cd "$REPO_ROOT"
 # rename-to-gents.sh — Executable rename tool for the defra-agent → Gents
 # hard cutover (source-inc/defra-agent#822, epic #811).
 #
-# Modes:
-#   audit          — report paths and contents deterministically (read-only)
-#   apply-moves    — perform only the reviewable git-mv phase
-#   apply-content  — perform only scripted content substitutions
-#   apply          — perform both mechanical phases
-#   guard          — reject stale path/content tokens outside the allowlist
-#   self-test      — exercise the substitution edge cases in a temporary file
+# Modes (all repository modes require a slice):
+#   audit SLICE          — report paths and contents deterministically (read-only)
+#   apply-moves SLICE    — perform only the reviewable git-mv phase
+#   apply-content SLICE  — perform only scripted content substitutions
+#   apply SLICE          — perform both mechanical phases
+#   guard SLICE          — reject stale path/content tokens outside the allowlist
+#   self-test            — exercise slices and scanner edge cases in fixtures
+#
+# Slices are core, desktop, release, docs, and all. The all slice always runs
+# the four owned slices in that order. This lets #823–#826 use the same locked
+# map without a later issue mechanically rewriting an earlier issue's files.
 #
 # Usage:
-#   scripts/rename-to-gents.sh audit
-#   scripts/rename-to-gents.sh apply-moves
-#   scripts/rename-to-gents.sh apply-content
-#   scripts/rename-to-gents.sh guard
+#   scripts/rename-to-gents.sh audit core
+#   scripts/rename-to-gents.sh apply-moves desktop
+#   scripts/rename-to-gents.sh apply-content release
+#   scripts/rename-to-gents.sh guard all
 #
 # Design:
 #   - Audit mode is read-only and prints affected-file + occurrence summaries.
-#   - Apply mode performs git mv on paths and sed on file contents.
+#   - Apply mode performs only the selected slice's git mv and substitutions.
 #   - Re-running apply is safe (no-op on already-renamed files).
 #   - Scans both paths and contents.
 #   - Explicitly scans old product tokens, both GitHub org coordinates,
@@ -36,37 +40,59 @@ cd "$REPO_ROOT"
 #   2. Scripted content substitutions (this script's apply mode)
 #   3. Hand fixes, generated-file/lockfile regeneration, formatting
 #
-# Allowlist — old product names may remain only in:
+# Guard allowlist — old product names may remain only in:
 #   - docs/gents-cutover.md
 #   - scripts/rename-to-gents.sh (this file)
 #   - narrowly justified machine-required references recorded in the guard
+#
+# Protected apply paths are a separate concept. docs/gents.md and generated
+# Apple internals are never edited by this script. Cargo.lock is regenerated
+# from the slice-correct manifests instead of being text-substituted. All three
+# remain visible to their slice/final guards until their owners resolve them.
 # =============================================================================
 # ---------------------------------------------------------------------------
 # Locked rename map (from #811 section "Locked naming contract")
 # ---------------------------------------------------------------------------
 
-# Crate directory renames (git mv)
-declare -a CRATE_MV=(
+# Core path renames (#823). The product-branded Lean file is handled after the
+# runtime root moves so its source exists at the new root.
+declare -a CORE_MV=(
   "crates/defra-agent:crates/gents"
   "crates/defra-agent-cli:crates/gents-cli"
   "crates/defra-agent-protocol:crates/gents-protocol"
   "crates/defra-agent-schemas:crates/gents-schemas"
-  "crates/defra-agent-desktop:crates/gents-desktop"
-  "crates/defra-agent-desktop-core:crates/gents-desktop-core"
   "crates/defra-agent-lean-contract:crates/gents-lean-contract"
   "crates/defra-agent-lenses:crates/gents-lenses"
   "crates/defra-native-fs-runner:crates/gents-fs-runner"
 )
+CORE_LEAN_OLD_BEFORE="crates/defra-agent/proofs/Proofs/Conformance/DefraAgent.lean"
+CORE_LEAN_OLD_AFTER="crates/gents/proofs/Proofs/Conformance/DefraAgent.lean"
+CORE_LEAN_NEW="crates/gents/proofs/Proofs/Conformance/Gents.lean"
+
+# Desktop path renames (#824). Generated Apple internals beneath the app root
+# move with their parent but are deliberately excluded from content edits.
+declare -a DESKTOP_MV=(
+  "crates/defra-agent-desktop:crates/gents-desktop"
+  "crates/defra-agent-desktop-core:crates/gents-desktop-core"
+  "apps/desktop-tauri:apps/gents-desktop"
+)
+
+# Release path renames (#825).
+declare -a RELEASE_MV=(
+  "scripts/enable-defra-agent-runner-session.sh:scripts/enable-gents-runner-session.sh"
+)
+
+declare -a SLICE_ORDER=(core desktop release docs)
 
 # Content substitutions — applied in order from most specific to most general.
 # Each entry is "old|new". Order matters: longer/more-specific patterns first.
 declare -a CONTENT_SUBS=(
-  # Reverse-domain identifiers (most specific first — must run before
-  # generic defra-agent rules to avoid partial matches)
+  # Exact identity/platform identifiers. Do not add broad com.sourcenetwork or
+  # org.sourcenetwork substitutions: unknown identifiers require a hand fix.
+  "defra-agent.identity|com.source-inc.gents.identity"
   "com.sourcenetwork.defra-agent-desktop|com.source-inc.gents"
+  "__APPLE_TEAM_ID__.org.sourcenetwork.defra-agent|__APPLE_TEAM_ID__.com.source-inc.gents"
   "org.sourcenetwork.defra-agent|com.source-inc.gents.cli"
-  "com.sourcenetwork|com.source-inc.gents"
-  "org.sourcenetwork|com.source-inc.gents"
   # Repository coordinates — both org forms
   "git@github.com:sourcenetwork/defra-agent|git@github.com:source-inc/gents"
   "git@github.com:source-inc/defra-agent|git@github.com:source-inc/gents"
@@ -104,6 +130,80 @@ declare -a CONTENT_SUBS=(
   # The guard still scans for did:defra-agent as a stale token.
 )
 
+# #823 must update direct consumers of renamed core crates even where those
+# consumers are owned by desktop or release. Keep this list exact: it must not
+# rewrite desktop branding, release artifacts, or documentation ahead of their
+# slices. Remaining semantic/selector fixes belong in the hand-fix commit.
+declare -a CORE_CONSUMER_SUBS=(
+  'defra-agent = { path = "../defra-agent" }|gents = { path = "../gents" }'
+  'defra-agent = { path = "../../../crates/defra-agent" }|gents = { path = "../../../crates/gents" }'
+  "defra-agent-protocol|gents-protocol"
+  "defra_agent_protocol|gents_protocol"
+  "defra-agent-schemas|gents-schemas"
+  "defra_agent_schemas|gents_schemas"
+  "defra-agent-lean-contract|gents-lean-contract"
+  "defra_agent_lean_contract|gents_lean_contract"
+  "defra-agent-lenses|gents-lenses"
+  "defra_agent_lenses|gents_lenses"
+  "defra-native-fs-runner|gents-fs-runner"
+  "defra_native_fs_runner|gents_fs_runner"
+  "/defra-agent/src/|/gents/src/"
+  "crates/defra-agent/src/|crates/gents/src/"
+  "defra_agent::|gents::"
+  "crates/defra-agent/proofs|crates/gents/proofs"
+)
+
+# Root workspace files are shared across slices, so they cannot receive the
+# catch-all substitution map. These exact entries keep every intermediate
+# workspace valid: #823 rewrites only core members/dependencies, then #824
+# rewrites only desktop members/dependencies.
+declare -a CORE_WORKSPACE_SUBS=(
+  '"crates/defra-agent"|"crates/gents"'
+  '"crates/defra-agent-cli"|"crates/gents-cli"'
+  '"crates/defra-agent-lean-contract"|"crates/gents-lean-contract"'
+  '"crates/defra-agent-lenses/|"crates/gents-lenses/'
+  '"crates/defra-native-fs-runner"|"crates/gents-fs-runner"'
+  '"crates/defra-agent-protocol"|"crates/gents-protocol"'
+  '"crates/defra-agent-schemas"|"crates/gents-schemas"'
+  "defra-agent-protocol =|gents-protocol ="
+  "defra-agent-schemas =|gents-schemas ="
+  "defra-agent-lean-contract =|gents-lean-contract ="
+  "https://github.com/sourcenetwork/defra-agent|https://github.com/source-inc/gents"
+  "https://github.com/source-inc/defra-agent|https://github.com/source-inc/gents"
+  "defra-agent#|gents#"
+)
+
+declare -a DESKTOP_WORKSPACE_SUBS=(
+  '"apps/desktop-tauri/src-tauri"|"apps/gents-desktop/src-tauri"'
+  '"crates/defra-agent-desktop"|"crates/gents-desktop"'
+  '"crates/defra-agent-desktop-core"|"crates/gents-desktop-core"'
+  "defra-agent-desktop-core =|gents-desktop-core ="
+)
+
+# Cargo.lock is never rewritten mechanically. These exact old entries let a
+# slice guard verify that `cargo generate-lockfile`/Cargo regeneration happened
+# without mistaking still-deferred desktop packages for stale core packages.
+declare -a CORE_LOCK_SUBS=(
+  'name = "defra-agent"|name = "gents"'
+  'name = "defra-agent-cli"|name = "gents-cli"'
+  'name = "defra-agent-lean-contract"|name = "gents-lean-contract"'
+  'name = "defra-agent-protocol"|name = "gents-protocol"'
+  'name = "defra-agent-schemas"|name = "gents-schemas"'
+  'name = "defra-native-fs-runner"|name = "gents-fs-runner"'
+  '"defra-agent",|"gents",'
+  '"defra-agent-lean-contract",|"gents-lean-contract",'
+  '"defra-agent-protocol",|"gents-protocol",'
+  '"defra-agent-schemas",|"gents-schemas",'
+  '"defra-native-fs-runner",|"gents-fs-runner",'
+)
+
+declare -a DESKTOP_LOCK_SUBS=(
+  'name = "defra-agent-desktop"|name = "gents-desktop"'
+  'name = "defra-agent-desktop-core"|name = "gents-desktop-core"'
+  'name = "defra-agent-desktop-tauri"|name = "gents-desktop-tauri"'
+  '"defra-agent-desktop-core",|"gents-desktop-core",'
+)
+
 # Stale tokens for the guard scan (from #811 section 1)
 declare -a STALE_TOKENS=(
   "defra-agent"
@@ -127,7 +227,8 @@ declare -a STALE_TOKENS=(
   "org.sourcenetwork.defra-agent"
 )
 
-# Guard allowlist — files where old names are permitted to remain
+# Guard allowlist — files where old names are permitted to remain. In
+# particular, docs/gents.md and generated Apple files are NOT allowlisted.
 declare -a ALLOWLIST=(
   "docs/gents-cutover.md"
   "scripts/rename-to-gents.sh"
@@ -157,6 +258,74 @@ is_allowlisted() {
   return 1
 }
 
+is_generated_apple() {
+  local file="$1"
+  case "$file" in
+    apps/desktop-tauri/src-tauri/gen/apple/* | apps/gents-desktop/src-tauri/gen/apple/*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+is_apply_protected() {
+  local file="$1"
+  case "$file" in
+    Cargo.lock | docs/gents.md | docs/gents-cutover.md | scripts/rename-to-gents.sh)
+      return 0
+      ;;
+  esac
+  is_generated_apple "$file"
+}
+
+path_slice() {
+  local file="$1"
+  case "$file" in
+    crates/defra-agent-desktop | crates/defra-agent-desktop/* | \
+      crates/gents-desktop | crates/gents-desktop/* | \
+      crates/defra-agent-desktop-core | crates/defra-agent-desktop-core/* | \
+      crates/gents-desktop-core | crates/gents-desktop-core/* | \
+      apps/desktop-tauri | apps/desktop-tauri/* | \
+      apps/gents-desktop | apps/gents-desktop/*)
+      PATH_SLICE=desktop
+      ;;
+    .github/* | release | release/* | scripts | scripts/* | Makefile)
+      PATH_SLICE=release
+      ;;
+    crates | crates/*)
+      PATH_SLICE=core
+      ;;
+    docs | docs/* | demo | demo/* | examples | examples/* | \
+      AGENTS.md | CLAUDE.md | DEVELOPMENT.md | README.md | *.md)
+      PATH_SLICE=docs
+      ;;
+    *)
+      PATH_SLICE=core
+      ;;
+  esac
+}
+
+in_slice() {
+  local requested="$1"
+  local file="$2"
+  [[ "$requested" == "all" ]] && return 0
+  path_slice "$file"
+  [[ "$PATH_SLICE" == "$requested" ]]
+}
+
+require_slice() {
+  local slice="${1:-}"
+  case "$slice" in
+    core | desktop | release | docs | all)
+      printf '%s\n' "$slice"
+      ;;
+    *)
+      echo "slice is required and must be one of: core, desktop, release, docs, all" >&2
+      return 2
+      ;;
+  esac
+}
+
 literal_occurrences_in_string() {
   local value="$1"
   local token="$2"
@@ -165,19 +334,7 @@ literal_occurrences_in_string() {
     value="${value#*"$token"}"
     count=$((count + 1))
   done
-  printf '%d\n' "$count"
-}
-
-content_occurrences() {
-  local token="$1"
-  local file="$2"
-  if [[ -L "$file" ]]; then
-    literal_occurrences_in_string "$(readlink "$file")" "$token"
-  elif [[ -f "$file" ]]; then
-    { grep -IFo -- "$token" "$file" 2>/dev/null || true; } | wc -l | tr -d ' '
-  else
-    printf '0\n'
-  fi
+  LITERAL_COUNT="$count"
 }
 
 sed_inplace() {
@@ -196,7 +353,11 @@ replace_token() {
   local new="$3"
   local old_escaped
   local new_escaped
-  old_escaped=$(printf '%s\n' "$old" | sed 's/[][\\.^$*+?{}|\/&]/\\&/g')
+  # sed uses basic regular expressions here. In BRE, + ? { } and | are
+  # literals unless escaped; escaping them would turn a literal Cargo table
+  # fragment such as `{ path = ... }` into an invalid repetition operator on
+  # BSD sed. Escape only BRE-active characters plus our delimiter.
+  old_escaped=$(printf '%s\n' "$old" | sed 's/[][\\.^$*\/&]/\\&/g')
   new_escaped=$(printf '%s\n' "$new" | sed 's/[\\\/&]/\\&/g')
 
   if [[ "$old" == "defra-agent" ]]; then
@@ -216,30 +377,70 @@ check_clean() {
   fi
 }
 
-preflight_moves() {
+path_exists() {
+  [[ -e "$1" || -L "$1" ]]
+}
+
+preflight_move_array() {
+  local array_name="$1"
   local pair old new
-  local sources=0
-  local destinations=0
-  for pair in "${CRATE_MV[@]}"; do
+  local -a moves
+  eval "moves=(\"\${${array_name}[@]}\")"
+  for pair in "${moves[@]}"; do
     old="${pair%%:*}"
     new="${pair#*:}"
-    [[ -d "$old" ]] && sources=$((sources + 1))
-    [[ -d "$new" ]] && destinations=$((destinations + 1))
-    if [[ -e "$old" && -e "$new" ]]; then
+    if path_exists "$old" && path_exists "$new"; then
       echo "both rename source and destination exist: $old / $new" >&2
       return 1
     fi
+    if ! path_exists "$old" && ! path_exists "$new"; then
+      echo "neither rename source nor destination exists: $old / $new" >&2
+      return 1
+    fi
   done
-  if [[ "$sources" -ne "${#CRATE_MV[@]}" && "$destinations" -ne "${#CRATE_MV[@]}" ]]; then
-    echo "mixed or incomplete crate-rename state" >&2
+}
+
+preflight_core_lean_move() {
+  local count=0
+  path_exists "$CORE_LEAN_OLD_BEFORE" && count=$((count + 1))
+  path_exists "$CORE_LEAN_OLD_AFTER" && count=$((count + 1))
+  path_exists "$CORE_LEAN_NEW" && count=$((count + 1))
+  if [[ "$count" -ne 1 ]]; then
+    echo "ambiguous Lean rename state: expected exactly one of $CORE_LEAN_OLD_BEFORE, $CORE_LEAN_OLD_AFTER, or $CORE_LEAN_NEW" >&2
     return 1
   fi
 }
 
-preflight_content() {
+preflight_moves_for_slice() {
+  local slice="$1"
+  case "$slice" in
+    core)
+      preflight_move_array CORE_MV
+      preflight_core_lean_move
+      ;;
+    desktop)
+      preflight_move_array DESKTOP_MV
+      ;;
+    release)
+      preflight_move_array RELEASE_MV
+      ;;
+    docs)
+      ;;
+    all)
+      local owned_slice
+      for owned_slice in "${SLICE_ORDER[@]}"; do
+        preflight_moves_for_slice "$owned_slice"
+      done
+      ;;
+  esac
+}
+
+preflight_content_for_slice() {
+  local slice="$1"
   local file
   while IFS= read -r -d '' file; do
-    is_allowlisted "$file" && continue
+    in_slice "$slice" "$file" || continue
+    is_apply_protected "$file" && continue
     [[ -L "$file" ]] && continue
     [[ -f "$file" ]] || continue
     if grep -Fq -- "$DID_SENTINEL" "$file" 2>/dev/null; then
@@ -253,97 +454,350 @@ preflight_content() {
   done < <(git ls-files -z)
 }
 
-apply_moves() {
-  preflight_moves
+apply_move_array() {
+  local array_name="$1"
   local pair old new
-  for pair in "${CRATE_MV[@]}"; do
+  local -a moves
+  eval "moves=(\"\${${array_name}[@]}\")"
+  for pair in "${moves[@]}"; do
     old="${pair%%:*}"
     new="${pair#*:}"
-    if [[ -d "$old" ]]; then
+    if path_exists "$old"; then
       echo "git mv $old -> $new"
       git mv "$old" "$new"
     fi
   done
 }
 
-apply_content() {
-  preflight_content
-  local file sub old new
+apply_moves_for_slice() {
+  local slice="$1"
+  preflight_moves_for_slice "$slice"
+  case "$slice" in
+    core)
+      apply_move_array CORE_MV
+      if path_exists "$CORE_LEAN_OLD_AFTER"; then
+        echo "git mv $CORE_LEAN_OLD_AFTER -> $CORE_LEAN_NEW"
+        git mv "$CORE_LEAN_OLD_AFTER" "$CORE_LEAN_NEW"
+      fi
+      ;;
+    desktop)
+      apply_move_array DESKTOP_MV
+      ;;
+    release)
+      apply_move_array RELEASE_MV
+      ;;
+    docs)
+      echo "no path moves for docs slice"
+      ;;
+    all)
+      local owned_slice
+      for owned_slice in "${SLICE_ORDER[@]}"; do
+        apply_moves_for_slice "$owned_slice"
+      done
+      ;;
+  esac
+}
+
+apply_substitution_array_to_file() {
+  local file="$1"
+  local array_name="$2"
+  local sub old new
+  local -a substitutions
+  eval "substitutions=(\"\${${array_name}[@]}\")"
+  for sub in "${substitutions[@]}"; do
+    old="${sub%%|*}"
+    new="${sub#*|}"
+    if grep -Fq -- "$old" "$file"; then
+      replace_token "$file" "$old" "$new"
+    fi
+  done
+}
+
+apply_content_for_slice() {
+  local slice="$1"
+  if [[ "$slice" == "all" ]]; then
+    local owned_slice
+    preflight_content_for_slice all
+    for owned_slice in "${SLICE_ORDER[@]}"; do
+      apply_content_for_slice "$owned_slice"
+    done
+    return
+  fi
+  preflight_content_for_slice "$slice"
+  local file first_checksum second_checksum
   local changed
   local count=0
   while IFS= read -r -d '' file; do
-    is_allowlisted "$file" && continue
+    in_slice "$slice" "$file" || continue
+    is_apply_protected "$file" && continue
     [[ -L "$file" ]] && continue
     [[ -f "$file" ]] || continue
     grep -Iq . "$file" 2>/dev/null || continue
-    changed=0
-    for sub in "${CONTENT_SUBS[@]}"; do
-      old="${sub%%|*}"
-      new="${sub#*|}"
-      if grep -Fq -- "$old" "$file"; then
-        replace_token "$file" "$old" "$new"
-        changed=1
-      fi
-    done
-    if [[ "$changed" -eq 1 ]]; then
+    first_checksum=$(cksum "$file")
+    if [[ "$slice" == "core" && "$file" == "Cargo.toml" ]]; then
+      apply_substitution_array_to_file "$file" CORE_WORKSPACE_SUBS
+    else
+      apply_substitution_array_to_file "$file" CONTENT_SUBS
+    fi
+    second_checksum=$(cksum "$file")
+    if [[ "$first_checksum" != "$second_checksum" ]]; then
       git add "$file"
       count=$((count + 1))
     fi
   done < <(git ls-files -z)
-  echo "content substitutions applied to $count tracked files"
+  echo "$slice content substitutions applied to $count tracked files"
+
+  # Core's exact consumer seam is deliberately narrower than CONTENT_SUBS.
+  if [[ "$slice" == "core" ]]; then
+    local consumer_count=0
+    while IFS= read -r -d '' file; do
+      path_slice "$file"
+      case "$PATH_SLICE" in
+        desktop | release) ;;
+        *) continue ;;
+      esac
+      is_apply_protected "$file" && continue
+      [[ -L "$file" ]] && continue
+      [[ -f "$file" ]] || continue
+      grep -Iq . "$file" 2>/dev/null || continue
+      first_checksum=$(cksum "$file")
+      apply_substitution_array_to_file "$file" CORE_CONSUMER_SUBS
+      second_checksum=$(cksum "$file")
+      if [[ "$first_checksum" != "$second_checksum" ]]; then
+        git add "$file"
+        consumer_count=$((consumer_count + 1))
+      fi
+    done < <(git ls-files -z)
+    echo "core consumer substitutions applied to $consumer_count desktop/release files"
+  fi
+
+  if [[ "$slice" == "desktop" && -f Cargo.toml ]]; then
+    first_checksum=$(cksum Cargo.toml)
+    apply_substitution_array_to_file Cargo.toml DESKTOP_WORKSPACE_SUBS
+    second_checksum=$(cksum Cargo.toml)
+    if [[ "$first_checksum" != "$second_checksum" ]]; then
+      git add Cargo.toml
+      echo "desktop workspace substitutions applied to Cargo.toml"
+    fi
+  fi
+}
+
+apply_for_slice() {
+  local slice="$1"
+  local owned_slice
+  preflight_moves_for_slice "$slice"
+  preflight_content_for_slice "$slice"
+  if [[ "$slice" == "all" ]]; then
+    for owned_slice in "${SLICE_ORDER[@]}"; do
+      apply_moves_for_slice "$owned_slice"
+      apply_content_for_slice "$owned_slice"
+    done
+  else
+    apply_moves_for_slice "$slice"
+    apply_content_for_slice "$slice"
+  fi
+}
+
+tracked_path_count() {
+  local path="$1"
+  local file count=0
+  while IFS= read -r -d '' file; do
+    if [[ "$file" == "$path" || "$file" == "$path/"* ]]; then
+      count=$((count + 1))
+    fi
+  done < <(git ls-files -z)
+  printf '%d\n' "$count"
+}
+
+print_move_array_audit() {
+  local array_name="$1"
+  local pair old new count
+  local -a moves
+  eval "moves=(\"\${${array_name}[@]}\")"
+  for pair in "${moves[@]}"; do
+    old="${pair%%:*}"
+    new="${pair#*:}"
+    count=$(tracked_path_count "$old")
+    printf '  %s -> %s (%d tracked paths)\n' "$old" "$new" "$count"
+    MOVE_AUDIT_TOTAL=$((MOVE_AUDIT_TOTAL + count))
+  done
 }
 
 print_move_audit() {
-  local pair old new file
-  local count total=0
-  echo "--- Crate-directory moves ---"
-  for pair in "${CRATE_MV[@]}"; do
-    old="${pair%%:*}"
-    new="${pair#*:}"
-    count=0
-    while IFS= read -r -d '' file; do
-      count=$((count + 1))
-    done < <(git ls-files -z "$old/")
+  local slice="$1"
+  local owned_slice lean_count
+  MOVE_AUDIT_TOTAL=0
+  echo "--- $slice path moves ---"
+  case "$slice" in
+    core)
+      print_move_array_audit CORE_MV
+      lean_count=$(tracked_path_count "$CORE_LEAN_OLD_BEFORE")
+      printf '  %s -> %s (%d tracked paths)\n' \
+        "$CORE_LEAN_OLD_BEFORE" "$CORE_LEAN_NEW" \
+        "$lean_count"
+      MOVE_AUDIT_TOTAL=$((MOVE_AUDIT_TOTAL + lean_count))
+      ;;
+    desktop)
+      print_move_array_audit DESKTOP_MV
+      ;;
+    release)
+      print_move_array_audit RELEASE_MV
+      ;;
+    docs)
+      ;;
+    all)
+      for owned_slice in "${SLICE_ORDER[@]}"; do
+        case "$owned_slice" in
+          core)
+            print_move_array_audit CORE_MV
+            lean_count=$(tracked_path_count "$CORE_LEAN_OLD_BEFORE")
+            printf '  %s -> %s (%d tracked paths)\n' \
+              "$CORE_LEAN_OLD_BEFORE" "$CORE_LEAN_NEW" \
+              "$lean_count"
+            MOVE_AUDIT_TOTAL=$((MOVE_AUDIT_TOTAL + lean_count))
+            ;;
+          desktop) print_move_array_audit DESKTOP_MV ;;
+          release) print_move_array_audit RELEASE_MV ;;
+          docs) ;;
+        esac
+      done
+      ;;
+  esac
+  echo "  Total move-source entries (nested moves may overlap): $MOVE_AUDIT_TOTAL"
+}
+
+is_regular_guard_excluded() {
+  local slice="$1"
+  local file="$2"
+  [[ "$slice" == "core" && ( "$file" == "Cargo.toml" || "$file" == "Cargo.lock" ) ]]
+}
+
+count_literal_in_file() {
+  local file="$1"
+  local token="$2"
+  local count
+  count=$({ grep -F -o -- "$token" "$file" 2>/dev/null || true; } | wc -l | tr -d ' ')
+  FILE_LITERAL_COUNT="$count"
+}
+
+scan_contract_array_in_file() {
+  local file="$1"
+  local array_name="$2"
+  local label="$3"
+  local sub old count
+  local -a substitutions
+  [[ -f "$file" ]] || return 0
+  eval "substitutions=(\"\${${array_name}[@]}\")"
+  for sub in "${substitutions[@]}"; do
+    old="${sub%%|*}"
+    count_literal_in_file "$file" "$old"
+    count="$FILE_LITERAL_COUNT"
     if [[ "$count" -gt 0 ]]; then
-      printf '  %s -> %s (%d files)\n' "$old" "$new" "$count"
-      total=$((total + count))
+      printf '  contract %-34s %6d occurrences\n' "$label: $old" "$count"
+      printf '    content: %s\n' "$file"
+      SCAN_TOTAL=$((SCAN_TOTAL + count))
+      SCAN_VIOLATIONS=$((SCAN_VIOLATIONS + 1))
     fi
   done
-  echo "  Total files under crate-directory moves: $total"
+}
+
+scan_core_consumer_contracts() {
+  local sub old file count token_total
+  local -a substitutions files
+  eval "substitutions=(\"\${CORE_CONSUMER_SUBS[@]}\")"
+  for sub in "${substitutions[@]}"; do
+    old="${sub%%|*}"
+    token_total=0
+    files=("")
+    while IFS= read -r -d '' file; do
+      path_slice "$file"
+      case "$PATH_SLICE" in
+        desktop | release) ;;
+        *) continue ;;
+      esac
+      case "$file" in
+        *.md) continue ;;
+      esac
+      is_allowlisted "$file" && continue
+      is_apply_protected "$file" && continue
+      [[ -L "$file" || ! -f "$file" ]] && continue
+      count_literal_in_file "$file" "$old"
+      count="$FILE_LITERAL_COUNT"
+      if [[ "$count" -gt 0 ]]; then
+        files+=("$file")
+        token_total=$((token_total + count))
+      fi
+    done < <(git grep -I -l -z -F -e "$old" -- . 2>/dev/null || true)
+    if [[ "$token_total" -gt 0 ]]; then
+      printf '  contract %-34s %6d occurrences\n' "core consumers: $old" "$token_total"
+      for file in "${files[@]}"; do
+        [[ -n "$file" ]] || continue
+        printf '    content: %s\n' "$file"
+      done
+      SCAN_TOTAL=$((SCAN_TOTAL + token_total))
+      SCAN_VIOLATIONS=$((SCAN_VIOLATIONS + 1))
+    fi
+  done
+}
+
+scan_slice_contracts() {
+  local slice="$1"
+  case "$slice" in
+    core)
+      echo "--- Shared-file and consumer contracts (core) ---"
+      scan_contract_array_in_file Cargo.toml CORE_WORKSPACE_SUBS "core workspace"
+      scan_contract_array_in_file Cargo.lock CORE_LOCK_SUBS "core lockfile"
+      scan_core_consumer_contracts
+      ;;
+    desktop)
+      echo "--- Shared-file contracts (desktop) ---"
+      scan_contract_array_in_file Cargo.toml DESKTOP_WORKSPACE_SUBS "desktop workspace"
+      scan_contract_array_in_file Cargo.lock DESKTOP_LOCK_SUBS "desktop lockfile"
+      ;;
+  esac
 }
 
 scan_stale_tokens() {
-  local token file allowed link_target
-  local path_count link_count path_occurrences content_occurrences symlink_occurrences
+  local slice="$1"
+  local token file link_target match last_content_file
+  local path_count link_count
+  local path_occurrences content_occurrences_total symlink_occurrences
   local path_file_count content_file_count symlink_file_count
   local total=0
   local violations=0
-  local -a path_files content_files symlink_files pathspecs
+  local -a path_files content_files symlink_files
 
-  pathspecs=(-- .)
-  for allowed in "${ALLOWLIST[@]}"; do
-    pathspecs+=(":(exclude)$allowed")
-  done
-
-  echo "--- Stale path and content tokens ---"
+  echo "--- Stale path and content tokens ($slice) ---"
   for token in "${STALE_TOKENS[@]}"; do
     path_occurrences=0
+    content_occurrences_total=0
     symlink_occurrences=0
     path_file_count=0
+    content_file_count=0
     symlink_file_count=0
+    # Bash 3.2 with nounset treats expansion of an empty array as unbound.
     path_files=("")
+    content_files=("")
     symlink_files=("")
+    last_content_file=""
+
     while IFS= read -r -d '' file; do
+      in_slice "$slice" "$file" || continue
       is_allowlisted "$file" && continue
-      path_count=$(literal_occurrences_in_string "$file" "$token")
+      is_regular_guard_excluded "$slice" "$file" && continue
+
+      literal_occurrences_in_string "$file" "$token"
+      path_count="$LITERAL_COUNT"
       if [[ "$path_count" -gt 0 ]]; then
         path_files+=("$file")
         path_file_count=$((path_file_count + 1))
         path_occurrences=$((path_occurrences + path_count))
       fi
+
       if [[ -L "$file" ]]; then
         link_target=$(readlink "$file")
-        link_count=$(literal_occurrences_in_string "$link_target" "$token")
+        literal_occurrences_in_string "$link_target" "$token"
+        link_count="$LITERAL_COUNT"
         if [[ "$link_count" -gt 0 ]]; then
           symlink_files+=("$file")
           symlink_file_count=$((symlink_file_count + 1))
@@ -352,21 +806,26 @@ scan_stale_tokens() {
       fi
     done < <(git ls-files -z)
 
-    content_file_count=0
-    content_files=("")
-    while IFS= read -r -d '' file; do
-      content_files+=("$file")
-      content_file_count=$((content_file_count + 1))
-    done < <(git grep -I -l -z -F -e "$token" "${pathspecs[@]}" 2>/dev/null || true)
-    content_occurrences=$(
-      { git grep -I -o -F -e "$token" "${pathspecs[@]}" 2>/dev/null || true; } |
-        wc -l | tr -d ' '
-    )
+    # `git grep -o -z` emits one NUL-terminated path plus one newline-terminated
+    # literal match per occurrence, preserving newline-bearing paths while
+    # avoiding a process per file.
+    while IFS= read -r -d '' file && IFS= read -r match; do
+      in_slice "$slice" "$file" || continue
+      is_allowlisted "$file" && continue
+      is_regular_guard_excluded "$slice" "$file" && continue
+      [[ -L "$file" ]] && continue
+      content_occurrences_total=$((content_occurrences_total + 1))
+      if [[ "$file" != "$last_content_file" ]]; then
+        content_files+=("$file")
+        content_file_count=$((content_file_count + 1))
+        last_content_file="$file"
+      fi
+    done < <(git grep -I -o -z -F -e "$token" -- . 2>/dev/null || true)
 
-    if [[ "$path_occurrences" -gt 0 || "$content_occurrences" -gt 0 || "$symlink_occurrences" -gt 0 ]]; then
+    if [[ "$path_occurrences" -gt 0 || "$content_occurrences_total" -gt 0 || "$symlink_occurrences" -gt 0 ]]; then
       printf '  %-45s %4d path files %4d content files %6d occurrences\n' \
         "$token" "$path_file_count" "$((content_file_count + symlink_file_count))" \
-        "$((path_occurrences + content_occurrences + symlink_occurrences))"
+        "$((path_occurrences + content_occurrences_total + symlink_occurrences))"
       for file in "${path_files[@]}"; do
         [[ -n "$file" ]] || continue
         printf '    path: %s\n' "$file"
@@ -379,25 +838,28 @@ scan_stale_tokens() {
         [[ -n "$file" ]] || continue
         printf '    symlink target: %s\n' "$file"
       done
-      total=$((total + path_occurrences + content_occurrences + symlink_occurrences))
+      total=$((total + path_occurrences + content_occurrences_total + symlink_occurrences))
       violations=$((violations + 1))
     fi
   done
 
   SCAN_TOTAL="$total"
   SCAN_VIOLATIONS="$violations"
+  scan_slice_contracts "$slice"
 }
 
 run_audit() {
-  echo "=== Gents Rename Audit ==="
-  print_move_audit
-  scan_stale_tokens
+  local slice="$1"
+  echo "=== Gents Rename Audit ($slice) ==="
+  print_move_audit "$slice"
+  scan_stale_tokens "$slice"
   echo "Audit: $SCAN_VIOLATIONS token classes, $SCAN_TOTAL occurrences"
 }
 
 run_guard() {
-  echo "=== Gents Rename Stale-Token Guard ==="
-  scan_stale_tokens
+  local slice="$1"
+  echo "=== Gents Rename Stale-Token Guard ($slice) ==="
+  scan_stale_tokens "$slice"
   if [[ "$SCAN_VIOLATIONS" -eq 0 ]]; then
     echo "PASS: no stale path or content tokens outside the allowlist"
     return 0
@@ -408,22 +870,128 @@ run_guard() {
 
 apply_substitutions_to_file() {
   local file="$1"
-  local sub old new
-  for sub in "${CONTENT_SUBS[@]}"; do
-    old="${sub%%|*}"
-    new="${sub#*|}"
-    if grep -Fq -- "$old" "$file"; then
-      replace_token "$file" "$old" "$new"
-    fi
-  done
+  apply_substitution_array_to_file "$file" CONTENT_SUBS
 }
 
-self_test() {
-  local test_dir test_file fixture_repo fixture_path first_checksum second_checksum
+self_test_fixture() {
+  local fixture_repo="$1"
+  local core_path
+
+  mkdir -p \
+    "$fixture_repo/crates/defra-agent/proofs/Proofs/Conformance" \
+    "$fixture_repo/crates/defra-agent-cli" \
+    "$fixture_repo/crates/defra-agent-protocol" \
+    "$fixture_repo/crates/defra-agent-schemas" \
+    "$fixture_repo/crates/defra-agent-lean-contract" \
+    "$fixture_repo/crates/defra-agent-lenses" \
+    "$fixture_repo/crates/defra-native-fs-runner" \
+    "$fixture_repo/crates/defra-agent-desktop" \
+    "$fixture_repo/crates/defra-agent-desktop-core" \
+    "$fixture_repo/apps/desktop-tauri/src-tauri/gen/apple" \
+    "$fixture_repo/.github/workflows" \
+    "$fixture_repo/release" \
+    "$fixture_repo/scripts" \
+    "$fixture_repo/docs"
+
+  printf '%s\n' \
+    'service=defra-agent.identity' \
+    'product=DefraAgent' \
+    'home=.defra-agent' \
+    'test_did=did:defra-agent:test' \
+    'repo=git@github.com:sourcenetwork/defra-agent' \
+    >"$fixture_repo/crates/defra-agent/runtime.txt"
+  printf 'namespace Proofs.Conformance.DefraAgent\n' \
+    >"$fixture_repo/$CORE_LEAN_OLD_BEFORE"
+  for core_path in \
+    crates/defra-agent-cli \
+    crates/defra-agent-protocol \
+    crates/defra-agent-schemas \
+    crates/defra-agent-lean-contract \
+    crates/defra-agent-lenses \
+    crates/defra-native-fs-runner; do
+    printf 'package=defra-agent-protocol\n' >"$fixture_repo/$core_path/fixture.txt"
+  done
+
+  printf '%s\n' \
+    'defra-agent-protocol.workspace = true' \
+    'defra-agent = { path = "../defra-agent" }' \
+    >"$fixture_repo/crates/defra-agent-desktop-core/Cargo.toml"
+  printf 'desktop brand: defra-agent-desktop\n' \
+    >"$fixture_repo/crates/defra-agent-desktop/branding.txt"
+  printf 'identifier=com.sourcenetwork.defra-agent-desktop\n' \
+    >"$fixture_repo/apps/desktop-tauri/src-tauri/tauri.conf.json"
+  printf 'generated=com.sourcenetwork.defra-agent-desktop\n' \
+    >"$fixture_repo/apps/desktop-tauri/src-tauri/gen/apple/project.yml"
+
+  printf 'cargo test -p defra-agent-protocol -p defra-agent\n' \
+    >"$fixture_repo/.github/workflows/ci.yml"
+  printf '__APPLE_TEAM_ID__.org.sourcenetwork.defra-agent\n' \
+    >"$fixture_repo/release/entitlements.plist"
+  printf 'launch defra-agent\n' \
+    >"$fixture_repo/scripts/enable-defra-agent-runner-session.sh"
+  printf 'tool source-inc/defra-agent\n' \
+    >"$fixture_repo/scripts/rename-to-gents.sh"
+
+  printf 'owner draft keeps defra-agent until its author resolves it\n' \
+    >"$fixture_repo/docs/gents.md"
+  printf 'cutover mapping: defra-agent to Gents\n' \
+    >"$fixture_repo/docs/gents-cutover.md"
+  printf 'Run defra-agent from ~/.defra-agent.\n' >"$fixture_repo/README.md"
+
+  cat >"$fixture_repo/Cargo.toml" <<'EOF'
+[workspace]
+members = [
+  "apps/desktop-tauri/src-tauri",
+  "crates/defra-agent",
+  "crates/defra-agent-cli",
+  "crates/defra-agent-desktop",
+  "crates/defra-agent-desktop-core",
+  "crates/defra-agent-protocol",
+]
+default-members = [
+  "crates/defra-agent",
+  "crates/defra-agent-desktop",
+]
+
+[workspace.package]
+repository = "https://github.com/sourcenetwork/defra-agent"
+
+[workspace.dependencies]
+defra-agent-protocol = { path = "crates/defra-agent-protocol" }
+defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
+EOF
+  cat >"$fixture_repo/Cargo.lock" <<'EOF'
+[[package]]
+name = "defra-agent"
+dependencies = [
+ "defra-agent-protocol",
+ "defra-agent-desktop-core",
+]
+
+[[package]]
+name = "defra-agent-desktop"
+dependencies = [
+ "defra-agent",
+]
+EOF
+
+  git -C "$fixture_repo" init -q
+  git -C "$fixture_repo" add -A
+  git -C "$fixture_repo" \
+    -c user.name='Gents Rename Self-Test' \
+    -c user.email='self-test@example.invalid' \
+    commit -qm fixture
+}
+
+self_test() (
+  local test_dir test_file fixture_base fixture_slice fixture_sequential fixture_all
+  local fixture_path first_checksum second_checksum owner_checksum apple_checksum
+  local lock_checksum sequential_tree all_tree idempotent_tree guard_output
   test_dir=$(mktemp -d)
   test_file="$test_dir/substitutions.txt"
   trap 'rm -rf "$test_dir"' EXIT
   printf '%s\n' \
+    'defra-agent.identity' \
     'git@github.com:sourcenetwork/defra-agent' \
     'git@github.com:source-inc/defra-agent' \
     'did:defra-agent:test' \
@@ -431,6 +999,7 @@ self_test() {
     'DEFRA_AGENT_HOME' >"$test_file"
 
   apply_substitutions_to_file "$test_file"
+  grep -Fxq 'com.source-inc.gents.identity' "$test_file"
   grep -Fxq 'git@github.com:source-inc/gents' "$test_file"
   grep -Fxq 'did:defra-agent:test' "$test_file"
   grep -Fxq 'Gents' "$test_file"
@@ -445,6 +1014,93 @@ self_test() {
   second_checksum=$(cksum "$test_file")
   [[ "$first_checksum" == "$second_checksum" ]]
 
+  fixture_base="$test_dir/base"
+  fixture_slice="$test_dir/slice"
+  fixture_sequential="$test_dir/sequential"
+  fixture_all="$test_dir/all"
+  self_test_fixture "$fixture_base"
+  cp -R "$fixture_base" "$fixture_slice"
+  cp -R "$fixture_base" "$fixture_sequential"
+  cp -R "$fixture_base" "$fixture_all"
+
+  # A core run moves only core paths and applies only exact dependency/import
+  # substitutions to desktop/release consumers. Branding remains untouched.
+  cd "$fixture_slice"
+  owner_checksum=$(cksum docs/gents.md)
+  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  lock_checksum=$(cksum Cargo.lock)
+  first_checksum=$(cksum crates/defra-agent-desktop/branding.txt)
+  apply_for_slice core >/dev/null
+  [[ -d crates/gents && ! -e crates/defra-agent ]]
+  [[ -f crates/gents/proofs/Proofs/Conformance/Gents.lean ]]
+  [[ -d apps/desktop-tauri && ! -e apps/gents-desktop ]]
+  [[ -f scripts/enable-defra-agent-runner-session.sh ]]
+  grep -Fq 'gents-protocol.workspace' crates/defra-agent-desktop-core/Cargo.toml
+  grep -Fq 'gents = { path = "../gents" }' crates/defra-agent-desktop-core/Cargo.toml
+  grep -Fq '"crates/gents"' Cargo.toml
+  grep -Fq '"crates/gents-cli"' Cargo.toml
+  grep -Fq 'gents-protocol = { path = "crates/gents-protocol" }' Cargo.toml
+  grep -Fq '"crates/defra-agent-desktop"' Cargo.toml
+  grep -Fq 'defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }' Cargo.toml
+  if grep -Fq '"crates/gents-desktop"' Cargo.toml; then
+    echo "core slice rewrote a deferred desktop workspace member" >&2
+    return 1
+  fi
+  [[ "$lock_checksum" == "$(cksum Cargo.lock)" ]]
+  # Package selectors are an explicit #823 hand fix, not an unsafe catch-all
+  # rewrite in shared release-owned files.
+  grep -Fq 'cargo test -p gents-protocol -p defra-agent' .github/workflows/ci.yml
+  second_checksum=$(cksum crates/defra-agent-desktop/branding.txt)
+  [[ "$first_checksum" == "$second_checksum" ]]
+  [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
+  [[ "$apple_checksum" == "$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)" ]]
+  grep -Fq 'service=com.source-inc.gents.identity' crates/gents/runtime.txt
+  grep -Fq 'test_did=did:defra-agent:test' crates/gents/runtime.txt
+  if guard_output=$(run_guard core 2>&1); then
+    echo "core guard unexpectedly accepted preserved did:defra-agent" >&2
+    return 1
+  fi
+  grep -Fq 'did:defra-agent' <<<"$guard_output"
+
+  # Explicit slice execution and `apply all` must materialize the same tree.
+  cd "$fixture_sequential"
+  owner_checksum=$(cksum docs/gents.md)
+  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  for owned_slice in "${SLICE_ORDER[@]}"; do
+    apply_for_slice "$owned_slice" >/dev/null
+  done
+  sequential_tree=$(git write-tree)
+  [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
+  [[ "$apple_checksum" == "$(cksum apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
+
+  cd "$fixture_all"
+  owner_checksum=$(cksum docs/gents.md)
+  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  apply_for_slice all >/dev/null
+  all_tree=$(git write-tree)
+  [[ "$sequential_tree" == "$all_tree" ]]
+  [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
+  [[ "$apple_checksum" == "$(cksum apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
+  grep -Fq 'service=com.source-inc.gents.identity' crates/gents/runtime.txt
+  grep -Fxq '__APPLE_TEAM_ID__.com.source-inc.gents' release/entitlements.plist
+  grep -Fq '"apps/gents-desktop/src-tauri"' Cargo.toml
+  grep -Fq '"crates/gents-desktop"' Cargo.toml
+  grep -Fq 'gents-desktop-core = { path = "crates/gents-desktop-core" }' Cargo.toml
+
+  # A second all run is a byte-for-byte no-op.
+  idempotent_tree=$(git write-tree)
+  apply_for_slice all >/dev/null
+  [[ "$idempotent_tree" == "$(git write-tree)" ]]
+
+  # Protected owner/generated files are still final-guard violations: apply
+  # protection is intentionally not a stale-token allowlist.
+  if guard_output=$(run_guard all 2>&1); then
+    echo "global guard unexpectedly accepted protected stale files" >&2
+    return 1
+  fi
+  grep -Fq 'docs/gents.md' <<<"$guard_output"
+  grep -Fq 'apps/gents-desktop/src-tauri/gen/apple/project.yml' <<<"$guard_output"
+
   # Exercise the real tracked-path and symlink-target scanner. The embedded
   # newline ensures this fails if tracked paths are ever read line-by-line.
   fixture_repo="$test_dir/path-fixture"
@@ -457,43 +1113,48 @@ self_test() {
   cd "$fixture_repo"
   ALLOWLIST=("__no_fixture_allowlist__")
   STALE_TOKENS=("defra-native-fs-runner")
-  scan_stale_tokens >/dev/null
+  scan_stale_tokens all >/dev/null
   [[ "$SCAN_VIOLATIONS" -eq 1 ]]
   [[ "$SCAN_TOTAL" -eq 2 ]]
-  cd "$REPO_ROOT"
 
-  rm -rf "$test_dir"
   trap - EXIT
+  rm -rf "$test_dir"
   echo "self-test PASS"
+)
+
+usage() {
+  echo "usage: $0 {audit|guard|apply-moves|apply-content|apply} {core|desktop|release|docs|all}" >&2
+  echo "       $0 self-test" >&2
 }
 
-case "${1:-}" in
-  audit)
-    run_audit
-    ;;
-  guard)
-    run_guard
-    ;;
-  apply-moves)
-    check_clean
-    apply_moves
-    ;;
-  apply-content)
-    check_clean
-    apply_content
-    ;;
-  apply)
-    check_clean
-    preflight_moves
-    preflight_content
-    apply_moves
-    apply_content
-    ;;
+mode="${1:-}"
+case "$mode" in
   self-test)
+    [[ "$#" -eq 1 ]] || { usage; exit 2; }
     self_test
     ;;
+  audit | guard | apply-moves | apply-content | apply)
+    [[ "$#" -eq 2 ]] || { usage; exit 2; }
+    slice=$(require_slice "$2")
+    case "$mode" in
+      audit) run_audit "$slice" ;;
+      guard) run_guard "$slice" ;;
+      apply-moves)
+        check_clean
+        apply_moves_for_slice "$slice"
+        ;;
+      apply-content)
+        check_clean
+        apply_content_for_slice "$slice"
+        ;;
+      apply)
+        check_clean
+        apply_for_slice "$slice"
+        ;;
+    esac
+    ;;
   *)
-    echo "usage: $0 {audit|guard|apply-moves|apply-content|apply|self-test}" >&2
+    usage
     exit 2
     ;;
 esac


### PR DESCRIPTION
## Summary

- add a checked-in executable rename tool with slice-aware `audit`, `apply-moves`, `apply-content`, `apply`, `guard`, and `self-test` modes
- encode the reviewed hard-cutover rename contract for `core`, `desktop`, `release`, `docs`, and ordered `all` execution
- keep each intermediate workspace buildable by applying exact core/desktop substitutions to shared `Cargo.toml` entries and requiring `Cargo.lock` regeneration instead of sed-editing it
- protect `docs/gents.md`, cutover documentation, and generated Apple internals from mechanical edits while keeping their stale tokens visible to the appropriate/final guards
- preserve `did:defra-agent:*` during mechanical application so #823 handles the discovered identity semantics deliberately; the core/final guards still reject it

## Review shape

This is stacked on #851 / #821. Later rename PRs can be reviewed as path moves, scoped generated substitutions, then hand fixes. Apply modes require an explicit slice; there is no implicit whole-repository rewrite.

The tool includes the seven core roots plus the nested Lean module, both desktop crate roots plus the Tauri app root, and the runner-session release path. Exact keychain replacement maps to `com.source-inc.gents.identity`; broad reverse-domain rewrites are intentionally rejected.

## Validation

- `bash -n scripts/rename-to-gents.sh`
- `scripts/rename-to-gents.sh self-test` — slice isolation, sequential-vs-all equivalence, idempotence, mixed root workspace, lockfile protection, owner/generated byte preservation, keychain/DID behavior, newline paths, and symlink targets
- `git diff --check`
- deterministic repeated core audits
- disposable real-tree `apply core`: 380 core files + 67 exact consumers; preserved desktop workspace entries and `docs/gents.md`; `cargo metadata --no-deps --format-version 1` passed
- global audit reports both owner-doc and generated-Apple stale tokens
- pre-amendment stacked branch passed `cargo test -p defra-agent` and `cargo check --workspace --all-targets`

Closes #822