### PR TITLE
fix: stabilize CLI chat persistence across concurrent writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-lock",
@@ -6586,7 +6586,7 @@ dependencies = [
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-trait",
@@ -6601,7 +6601,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "anyhow",
  "document",
@@ -6916,7 +6916,7 @@ version = "0.7.2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "cid",
@@ -6940,7 +6940,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-stream",
@@ -6984,7 +6984,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "anyhow",
@@ -7018,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-trait",
@@ -7052,7 +7052,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "serde",
 ]
@@ -7470,7 +7470,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7928,7 +7928,7 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -11048,7 +11048,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -12281,7 +12281,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-lock",
@@ -12429,7 +12429,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -15159,7 +15159,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "anyhow",
@@ -16584,7 +16584,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16620,7 +16620,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16637,7 +16637,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "async-lock",
@@ -16669,7 +16669,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17622,7 +17622,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "p2p",
  "query",
@@ -18421,7 +18421,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "cid",
  "defra-core",
@@ -19623,7 +19623,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20050,7 +20050,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24500,7 +24500,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=364db72bd009d5e126b6f4ccf45fa9fa1ad937b0#364db72bd009d5e126b6f4ccf45fa9fa1ad937b0"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=ef772a439ec84d3fb1a7c0ef740085666ea008b4#ef772a439ec84d3fb1a7c0ef740085666ea008b4"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,24 +57,21 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs v0.16.2: v0.15 store migration plus terminal pending-DAG
-# quarantine, per-root fetch single-flight, and authorizer-scoped replay capabilities
-# for production upgrades.
-# default/action parity, ordered GraphQL mutation fragments, bulk ACP endpoints,
-# CID-indexed pending-DAG waiters, and the release conformance hardening batch.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+# defradb.rs v0.16.2 plus active-snapshot conflict retention and atomic
+# RocksDB conflict-version/physical-snapshot pairing (#1162, #1167).
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
 defra-agent-protocol = { path = "crates/defra-agent-protocol" }
 defra-agent-schemas = { path = "crates/defra-agent-schemas" }
 defra-agent-desktop-core = { path = "crates/defra-agent-desktop-core" }
 defra-agent-lean-contract = { path = "crates/defra-agent-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -82,8 +79,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "364db72bd009d5e126b6f4ccf45fa9fa1ad937b0" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "ef772a439ec84d3fb1a7c0ef740085666ea008b4" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/crates/defra-agent/src/hook.rs
+++ b/crates/defra-agent/src/hook.rs
@@ -882,17 +882,6 @@ impl DefraSessionHook {
     }
 }
 
-impl Drop for DefraSessionHook {
-    fn drop(&mut self) {
-        // Drain the in-flight map. Lifecycles dropped without completing a
-        // transition leave their AgentToolCall row in state Running on disk —
-        // startup recovery sweeps these on daemon restart.
-        if let Ok(mut map) = self.in_flight_lifecycles.try_lock() {
-            map.clear();
-        }
-    }
-}
-
 fn decide_persistence_outcome(
     failure_policy: FailurePolicy,
     counters: &HookCounters,

--- a/crates/defra-agent/src/hook/tests.rs
+++ b/crates/defra-agent/src/hook/tests.rs
@@ -77,6 +77,64 @@ async fn legacy_request_id_setter_clears_requester_lineage() {
     node.shutdown().await;
 }
 
+#[tokio::test]
+async fn dropping_hook_clone_preserves_in_flight_tool_lifecycle() {
+    let data_path =
+        std::env::temp_dir().join(format!("agent-hook-clone-drop-{}", uuid::Uuid::new_v4()));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:defra-agent:general",
+        FailurePolicy::default(),
+    );
+    assert!(matches!(
+        hook.on_completion_call(&user_text_message("Read notes.txt"), &[])
+            .await,
+        HookAction::Continue
+    ));
+    hook.set_active_request_id(Some("request-clone-drop".to_string()))
+        .await;
+    hook.set_request_deadline_at(Some(chrono::Utc::now() + chrono::Duration::minutes(5)))
+        .await;
+
+    assert!(matches!(
+        hook.on_tool_call("read_file", None, "call-clone-drop", "{}")
+            .await,
+        ToolCallHookAction::Continue
+    ));
+    assert!(hook
+        .in_flight_lifecycles
+        .lock()
+        .await
+        .contains_key("call-clone-drop"));
+
+    drop(hook.clone());
+
+    assert!(hook
+        .in_flight_lifecycles
+        .lock()
+        .await
+        .contains_key("call-clone-drop"));
+    assert!(matches!(
+        hook.on_tool_result("read_file", None, "call-clone-drop", "{}", "done")
+            .await,
+        HookAction::Continue
+    ));
+
+    drop(hook);
+    node.shutdown().await;
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
 fn failure_policy_from_contract(policy: &str) -> FailurePolicy {
     match policy {
         "failOpen" => FailurePolicy::FailOpen,

--- a/crates/defra-agent/tests/conformance/transcript.rs
+++ b/crates/defra-agent/tests/conformance/transcript.rs
@@ -676,8 +676,16 @@ pub(super) async fn generated_transcript_cases_drive_agent_message_ordering_cont
         abandon.pre_tool_call_count,
     )
     .await;
-    let observer = hook.clone();
     drop(hook);
+    let observer = DefraSessionHook::resume_or_create_with_identity_policy(
+        db.node.clone(),
+        &session_id,
+        AGENT_NAME,
+        AGENT_DID,
+        FailurePolicy::default(),
+    )
+    .await
+    .expect("resume transcript observer after ownership abandonment");
     assert_eq!(
         observer.cancel_in_flight_tool_calls().await.unwrap(),
         abandon.post_in_flight_count,


### PR DESCRIPTION
Closes #853.

## Summary

- pin DefraDB to the RocksDB snapshot/commit synchronization fix
- stop `DefraSessionHook` clones from clearing their shared in-flight lifecycle map on drop
- correct the conformance driver so ownership abandonment means dropping the last hook owner
- add a regression test covering tool completion after a temporary hook clone is dropped

## Root causes

The failing CLI chat test exposed two independent persistence faults:

1. RocksDB transactions could observe an advanced logical conflict version while pairing it with the preceding physical snapshot. Concurrent creates could therefore miss their conflict and reuse the same short document ID, corrupting document/index correspondence.
2. `DefraSessionHook` derives `Clone` and shares its lifecycle map through an `Arc`, but its custom `Drop` implementation cleared that map whenever any clone was dropped.

The upstream storage fix makes logical conflict state and physical snapshots/commits advance atomically. Removing the custom hook destructor preserves shared state until the last owner disappears, at which point normal `Arc` destruction already releases it.

This does not change legal lifecycle transitions. The Lean ownership-abandonment contract was already correct; the Rust conformance driver incorrectly modeled abandonment by dropping one clone while retaining another, so no Lean model change is required.

## Validation

- [x] upstream RocksDB synchronization regression tests
- [x] `cargo check -p storage`
- [x] hook clone-drop regression test from the exact remote dependency pin
- [x] formerly failing CLI chat test from the exact remote dependency pin
- [x] repeated CLI chat stress run: 50/50 passes (the prior fix failed by runs 13 and 18)
- [x] `cargo metadata --locked --no-deps --format-version 1`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --locked -p defra-agent-cli`
- [x] `cargo test --locked -p defra-agent`
- [x] `cargo check --locked --workspace --all-targets`

A first fresh-cache CLI suite run passed 506/507 tests but exposed an unrelated race between concurrent Lean contract loaders initializing mathlib. The targeted retry and a second full CLI suite passed; the flake is tracked as #855.

## Dependency

The pinned DefraDB commit is published in sourcenetwork/defradb.rs#1167, stacked on sourcenetwork/defradb.rs#1162. The lockfile changes only the 32 DefraDB package source SHAs; it contains no unrelated resolver movement.