### PR TITLE
[Gents 7] Enforce and freeze the final cutover candidate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,17 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      full_candidate:
+        description: Run the full non-PR candidate suites.
+        required: true
+        type: boolean
+        default: true
+      candidate_sha:
+        description: Exact 40-character commit SHA expected at the dispatched ref.
+        required: true
+        type: string
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -22,12 +33,55 @@ env:
   SCCACHE_DIR: ${{ vars.SCCACHE_DIR || '/Users/admin/.cache/sccache' }}
 
 jobs:
+  rename-guard:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify immutable full-candidate dispatch
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+          FULL_CANDIDATE: ${{ inputs.full_candidate }}
+        run: |
+          set -euo pipefail
+          if [[ "${FULL_CANDIDATE}" != "true" ]]; then
+            echo "::error::Manual CI dispatches must select full_candidate."
+            exit 1
+          fi
+          if [[ ! "${CANDIDATE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::candidate_sha must be a full lowercase 40-character commit SHA."
+            exit 1
+          fi
+          if [[ "${CANDIDATE_SHA}" != "${GITHUB_SHA}" ]]; then
+            echo "::error::candidate_sha ${CANDIDATE_SHA} does not match checked-out GITHUB_SHA ${GITHUB_SHA}."
+            exit 1
+          fi
+
+      - name: Check rename tool syntax
+        run: bash -n scripts/rename-to-gents.sh
+
+      - name: Run rename tool self-test
+        run: scripts/rename-to-gents.sh self-test
+
+      - name: Reject stale product identifiers
+        run: scripts/rename-to-gents.sh guard all
+
   rust-and-cli:
-    needs: lean-proofs
+    needs: [rename-guard, lean-proofs]
     if: ${{ always() }}
     runs-on: [self-hosted, macOS, ARM64, studio]
     timeout-minutes: 90
     steps:
+      - name: Require rename guard
+        if: ${{ needs.rename-guard.result != 'success' }}
+        run: |
+          echo "::error::rename-guard must pass before the Rust and CLI suites run (got '${{ needs.rename-guard.result }}')."
+          exit 1
+
       - name: Require Lean/Rust contract gate
         if: ${{ needs.lean-proofs.result != 'success' }}
         run: |
@@ -106,6 +160,9 @@ jobs:
       # (#646). It also warms the build cache for the test steps that follow.
       - name: Compile all targets
         run: cargo check --workspace --all-targets
+
+      - name: Build the WASM lens target
+        run: cargo build -p agent-tool-call-lifecycle-v1-to-v2-lens --target wasm32-unknown-unknown
 
       # Guards the noq 1.0.1 active_connections underflow fix (gents#634 /
       # n0-computer/noq#743). Vendored under third_party/; not a workspace member.
@@ -212,6 +269,14 @@ jobs:
 
       - name: Prepare disk-backed Rust build cache
         run: .github/scripts/setup-rust-build-cache.sh
+
+      - name: Reject Lean sorry placeholders
+        working-directory: crates/gents/proofs
+        run: |
+          if find . -type f -name '*.lean' -exec grep -n -E '(^|[^[:alnum:]_])sorry([^[:alnum:]_]|$)' {} +; then
+            echo "::error::Lean proof sources must not contain sorry placeholders."
+            exit 1
+          fi
 
       - name: Build proofs
         working-directory: crates/gents/proofs

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -24,12 +24,11 @@ env:
   SCCACHE_DIR: ${{ vars.SCCACHE_DIR || '/Users/admin/.cache/sccache' }}
   GENTS_CLI_E2E_MODEL_ENDPOINT: ${{ github.event.inputs.inference_endpoint }}
   GENTS_CLI_E2E_MODEL_NAME: ${{ github.event.inputs.model_name }}
-  GENTS_CLI_E2E_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
+  GENTS_CLI_E2E_API_KEY: ${{ secrets.GENTS_API_KEY }}
   GENTS_TAURI_LIVE_INFERENCE_URL: ${{ github.event.inputs.inference_endpoint }}
   GENTS_TAURI_LIVE_MODEL_NAME: ${{ github.event.inputs.model_name }}
-  GENTS_TAURI_LIVE_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
+  GENTS_TAURI_LIVE_API_KEY: ${{ secrets.GENTS_API_KEY }}
   GENTS_TAURI_LIVE_REQUIRE_REAL_INFERENCE: "1"
-  AGENT_DAEMON_API_KEY: ${{ secrets.AGENT_DAEMON_API_KEY }}
 
 jobs:
   live-cli-smoke:

--- a/crates/gents-cli/Cargo.toml
+++ b/crates/gents-cli/Cargo.toml
@@ -3,7 +3,8 @@ name = "gents-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Consumer CLI for the gents library"
+repository.workspace = true
+description = "Command-line interface for the Gents runtime"
 autobins = false
 
 [features]

--- a/crates/gents-cli/src/http/version.rs
+++ b/crates/gents-cli/src/http/version.rs
@@ -77,3 +77,16 @@ pub(crate) fn version_text() -> String {
         option_env!("GENTS_BUILD_RUSTC").unwrap_or("rustc unknown")
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_response_reports_canonical_repository() {
+        assert_eq!(
+            version_response().repository,
+            "https://github.com/source-inc/gents"
+        );
+    }
+}

--- a/crates/gents-cli/tests/cli_server.rs
+++ b/crates/gents-cli/tests/cli_server.rs
@@ -282,17 +282,9 @@ async fn server_exposes_prometheus_metrics_endpoint() -> Result<()> {
         r#"mutation { create_AgentMessage(input: { message_key: "self-budget-session:1", session_id: "self-budget-session", sequence: 1, role: "user", content: "hello", timestamp: "2026-06-02T10:01:00Z" }) { _docID } }"#.to_string(),
         r#"mutation { create_CompactionEntry(input: { compaction_key: "self-budget-ce", session_id: "self-budget-session", sequence: 1, original_tokens: 1234, compacted_tokens: 567, created_at: "2026-06-02T10:00:00Z" }) { _docID } }"#.to_string(),
     ] {
-        let seed = client
-            .post(graphql.as_str())
-            .json(&serde_json::json!({ "query": mutation }))
-            .send()
+        graphql_query(&graphql, &mutation)
             .await
             .context("seeding self-view fixtures")?;
-        let seed_body: Value = seed.json().await.context("reading seed mutation response")?;
-        assert!(
-            seed_body.get("errors").is_none(),
-            "seed mutation returned errors: {seed_body}"
-        );
     }
 
     // /status carries the behavior join plus context budget/indicator.
@@ -1328,7 +1320,6 @@ async fn query_command_reconstructs_a_trace() -> Result<()> {
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
     // Seed a linked trace (same request_id + session_id across collections).
-    let client = reqwest::Client::new();
     let mutations = [
         format!(
             r#"mutation {{ create_AgentRequest(input: {{ request_id: "trace-req", agent_did: "{agent_did}", session_id: "trace-session", status: "completed", content: "hi", created_at: "2026-06-03T10:00:00Z" }}) {{ _docID }} }}"#
@@ -1338,17 +1329,9 @@ async fn query_command_reconstructs_a_trace() -> Result<()> {
         r#"mutation { create_AgentToolCall(input: { tool_call_key: "trace-tc", request_id: "trace-req", session_id: "trace-session", tool_name: "defra_query", args: "{\"collection\":\"AgentRequest\"}", result: "{\"ok\":true}", status: "completed" }) { _docID } }"#.to_string(),
     ];
     for mutation in mutations {
-        let resp = client
-            .post(graphql.as_str())
-            .json(&serde_json::json!({ "query": mutation }))
-            .send()
+        graphql_query(&graphql, &mutation)
             .await
             .context("seeding trace")?;
-        let body: Value = resp.json().await?;
-        assert!(
-            body.get("errors").is_none(),
-            "seed mutation errored: {body}"
-        );
     }
 
     // Reconstruct each collection via `gents query`.
@@ -1570,21 +1553,15 @@ async fn mcp_endpoint_serves_defra_query() -> Result<()> {
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
 
     // Seed a linked request + tool call.
-    let http = reqwest::Client::new();
     for mutation in [
         format!(
             r#"mutation {{ create_AgentRequest(input: {{ request_id: "mcp-req", agent_did: "{agent_did}", session_id: "mcp-session", status: "completed", created_at: "2026-06-03T10:00:00Z" }}) {{ _docID }} }}"#
         ),
         r#"mutation { create_AgentToolCall(input: { tool_call_key: "mcp-tc", request_id: "mcp-req", session_id: "mcp-session", tool_name: "defra_query", args: "{\"collection\":\"AgentRequest\"}", result: "{\"ok\":true}", status: "completed" }) { _docID } }"#.to_string(),
     ] {
-        let resp = http
-            .post(graphql.as_str())
-            .json(&serde_json::json!({ "query": mutation }))
-            .send()
+        graphql_query(&graphql, &mutation)
             .await
             .context("seeding mcp trace")?;
-        let body: Value = resp.json().await?;
-        assert!(body.get("errors").is_none(), "seed mutation errored: {body}");
     }
 
     // Connect an MCP client to the mounted /mcp endpoint.

--- a/crates/gents-desktop-core/Cargo.toml
+++ b/crates/gents-desktop-core/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Reusable desktop client runtime for gents"
+description = "Reusable desktop client runtime for Gents"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/gents-fs-runner/Cargo.toml
+++ b/crates/gents-fs-runner/Cargo.toml
@@ -3,7 +3,8 @@ name = "gents-fs-runner"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Out-of-process native filesystem runner for gents"
+repository.workspace = true
+description = "Out-of-process native filesystem runner for Gents"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/gents-lean-contract/Cargo.toml
+++ b/crates/gents-lean-contract/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Test helper for loading gents Lean conformance contracts"
+description = "Test helper for loading Gents Lean conformance contracts"
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/gents-lenses/agent_subagent_v2_to_v3/Cargo.toml
+++ b/crates/gents-lenses/agent_subagent_v2_to_v3/Cargo.toml
@@ -3,6 +3,7 @@ name = "agent-subagent-v2-to-v3-lens"
 version = "0.1.0"
 edition = "2021"
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/gents-lenses/agent_tool_call_lifecycle_v1_to_v2/Cargo.toml
+++ b/crates/gents-lenses/agent_tool_call_lifecycle_v1_to_v2/Cargo.toml
@@ -3,6 +3,7 @@ name = "agent-tool-call-lifecycle-v1-to-v2-lens"
 version = "0.1.0"
 edition = "2021"
 license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/gents-protocol/Cargo.toml
+++ b/crates/gents-protocol/Cargo.toml
@@ -3,7 +3,8 @@ name = "gents-protocol"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Shared schemas, client turn-observation protocol, and collection row mirrors for gents"
+repository.workspace = true
+description = "Shared schemas, client turn-observation protocol, and collection row mirrors for Gents"
 
 [dependencies]
 anyhow = { workspace = true }

--- a/crates/gents-schemas/Cargo.toml
+++ b/crates/gents-schemas/Cargo.toml
@@ -4,6 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Dependency-free GraphQL schema bundle for gents agent collections"
+description = "Dependency-free GraphQL schema bundle for Gents agent collections"
 
 [dependencies]

--- a/crates/gents/Cargo.toml
+++ b/crates/gents/Cargo.toml
@@ -3,7 +3,8 @@ name = "gents"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
-description = "Reusable DefraDB-backed agent framework extracted from agent-daemon"
+repository.workspace = true
+description = "Core DefraDB-backed agent runtime for Gents"
 
 [features]
 default = ["defra-node/http", "defra-node/p2p", "rocksdb"]

--- a/crates/gents/src/compaction/tests.rs
+++ b/crates/gents/src/compaction/tests.rs
@@ -676,8 +676,7 @@ fn estimate_tokens_rough() {
 
 #[tokio::test]
 async fn integration_compaction_persists_entry_and_prompt_builder_uses_it() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-daemon-compactor-{}", uuid::Uuid::new_v4()));
+    let data_path = std::env::temp_dir().join(format!("gents-compactor-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()

--- a/crates/gents/src/error.rs
+++ b/crates/gents/src/error.rs
@@ -1,4 +1,4 @@
-//! Domain-specific error types for the agent daemon.
+//! Domain-specific error types for the Gents runtime.
 //!
 //! Replaces bare `anyhow::Result` on public boundaries with typed errors
 //! so callers can distinguish retryable failures from permanent ones.

--- a/crates/gents/src/graphql.rs
+++ b/crates/gents/src/graphql.rs
@@ -1,4 +1,4 @@
-//! Shared GraphQL utility functions used across agent-daemon modules.
+//! Shared GraphQL utility functions used across Gents runtime modules.
 
 pub fn escape_graphql_string(s: &str) -> String {
     s.replace('\\', "\\\\")

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -1222,8 +1222,7 @@ async fn hook_can_fail_live_tool_call_without_conflating_timeout_or_cancel() {
 
 #[tokio::test]
 async fn streaming_turn_persists_full_assistant_history_in_sequence() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-daemon-hook-{}", uuid::Uuid::new_v4()));
+    let data_path = std::env::temp_dir().join(format!("gents-hook-{}", uuid::Uuid::new_v4()));
     let node = Arc::new(
         defra_node::EmbeddedNode::builder()
             .data_path(&data_path)

--- a/crates/gents/src/lib.rs
+++ b/crates/gents/src/lib.rs
@@ -1,7 +1,7 @@
-//! DefraDB-backed agent framework extracted from `agent-daemon`.
+//! Core DefraDB-backed agent runtime for Gents.
 //!
-//! This crate preserves the current agent runtime pieces while
-//! `agent-daemon` remains the first consumer during the extraction phase.
+//! This crate owns request execution, lifecycle enforcement, persistence,
+//! identity, tools, networking, and provider-input assembly.
 
 pub mod adapter_projection;
 pub(crate) mod admission;

--- a/crates/gents/src/session/tests.rs
+++ b/crates/gents/src/session/tests.rs
@@ -43,8 +43,7 @@ fn test_load_history_deserializes_legacy_assistant_content() {
 
 #[tokio::test]
 async fn compaction_entries_track_files_cumulatively() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-daemon-compaction-{}", uuid::Uuid::new_v4()));
+    let data_path = std::env::temp_dir().join(format!("gents-compaction-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -90,8 +89,7 @@ async fn compaction_entries_track_files_cumulatively() {
 
 #[tokio::test]
 async fn close_session_preserves_started_datetime() {
-    let data_path =
-        std::env::temp_dir().join(format!("agent-daemon-session-{}", uuid::Uuid::new_v4()));
+    let data_path = std::env::temp_dir().join(format!("gents-session-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -156,10 +154,8 @@ async fn close_session_preserves_started_datetime() {
 
 #[tokio::test]
 async fn create_session_with_id_is_idempotent() {
-    let data_path = std::env::temp_dir().join(format!(
-        "agent-daemon-session-upsert-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let data_path =
+        std::env::temp_dir().join(format!("gents-session-upsert-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -216,10 +212,8 @@ async fn create_session_with_id_is_idempotent() {
 
 #[tokio::test]
 async fn upsert_conversation_from_request_keeps_title_empty_until_generated() {
-    let data_path = std::env::temp_dir().join(format!(
-        "agent-daemon-conversation-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let data_path =
+        std::env::temp_dir().join(format!("gents-conversation-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -331,10 +325,8 @@ async fn upsert_conversation_from_request_keeps_title_empty_until_generated() {
 
 #[tokio::test]
 async fn update_conversation_title_with_source_persists_generated_title() {
-    let data_path = std::env::temp_dir().join(format!(
-        "agent-daemon-conversation-title-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let data_path =
+        std::env::temp_dir().join(format!("gents-conversation-title-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -401,10 +393,8 @@ async fn update_conversation_title_with_source_persists_generated_title() {
 
 #[tokio::test]
 async fn create_session_with_behavior_id_rejects_mismatched_existing_binding() {
-    let data_path = std::env::temp_dir().join(format!(
-        "agent-daemon-session-binding-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let data_path =
+        std::env::temp_dir().join(format!("gents-session-binding-{}", uuid::Uuid::new_v4()));
     let node = defra_node::EmbeddedNode::builder()
         .data_path(&data_path)
         .build()
@@ -428,7 +418,7 @@ async fn create_session_with_behavior_id_rejects_mismatched_existing_binding() {
 #[tokio::test]
 async fn upsert_conversation_rejects_mismatched_existing_behavior() {
     let data_path = std::env::temp_dir().join(format!(
-        "agent-daemon-conversation-binding-{}",
+        "gents-conversation-binding-{}",
         uuid::Uuid::new_v4()
     ));
     let node = defra_node::EmbeddedNode::builder()

--- a/crates/gents/src/toolset/orchestration.rs
+++ b/crates/gents/src/toolset/orchestration.rs
@@ -268,7 +268,7 @@ fn not_yet_executable_error(tool_name: &str) -> ToolError {
         "ok": false,
         "failure_class": "service_unavailable",
         "path": "/",
-        "message": format!("{tool_name} is hook-managed and cannot be executed outside the Defra session hook"),
+        "message": format!("{tool_name} is hook-managed and cannot be executed outside the Gents session hook"),
         "retryable": true,
         "service_id": ORCHESTRATION_SERVICE_ID,
         "tool_name": tool_name

--- a/crates/gents/src/toolset/tests.rs
+++ b/crates/gents/src/toolset/tests.rs
@@ -330,6 +330,15 @@ async fn fan_out_and_synthesize_validate_rejects_bad_args() {
         ok_err.contains("service_unavailable"),
         "valid args must pass validation and hit the hook-managed guard, got: {ok_err}"
     );
+    assert!(
+        ok_err.contains("outside the Gents session hook"),
+        "hook-managed guard must use the final product name, got: {ok_err}"
+    );
+    let legacy_hook_name = ["Defra", " session hook"].concat();
+    assert!(
+        !ok_err.contains(&legacy_hook_name),
+        "hook-managed guard retained the legacy product name: {ok_err}"
+    );
 }
 
 #[test]

--- a/crates/gents/tests/backend_auth_config.rs
+++ b/crates/gents/tests/backend_auth_config.rs
@@ -65,15 +65,3 @@ fn behavior_config_prefers_backend_specific_api_key_env_var() {
 
     assert_eq!(resolved.as_deref(), Some("backend-key"));
 }
-
-#[test]
-fn behavior_config_does_not_fall_back_to_legacy_global_api_key_env_var() {
-    let _env_guard = ENV_VAR_LOCK.blocking_lock();
-    let mut env = TestEnvGuard::new(&["AGENT_DAEMON_API_KEY"]);
-    let behavior = test_behavior("behavior-b", "backend-b", None);
-
-    env.set("AGENT_DAEMON_API_KEY", "legacy-key");
-    let resolved = behavior.resolve_backend_api_key().expect("resolve api key");
-
-    assert_eq!(resolved.as_deref(), None);
-}

--- a/docs/gents-cutover.md
+++ b/docs/gents-cutover.md
@@ -73,6 +73,8 @@ Complete these once for the fleet:
   `source-inc/gents` and that `gents version` succeeds.
 - [ ] Prepare a portable manifest root for each host. Keep secrets out of the
   manifest and record how each host receives them.
+- [ ] Provision the GitHub Actions secret `GENTS_API_KEY` for live smoke. Do
+  not retain `AGENT_DAEMON_API_KEY` as an alias.
 - [ ] Decide the new fleet topology and which DIDs require network membership,
   conversation data-plane edges, or cross-deployment subagent permission.
 - [ ] Schedule a quiet repository rename window and update local remotes only

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -1229,7 +1229,7 @@ self_test() (
   # substitutions to desktop/release consumers. Branding remains untouched.
   cd "$fixture_slice"
   owner_checksum=$(cksum docs/gents.md)
-  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  apple_checksum=$(cksum <apps/desktop-tauri/src-tauri/gen/apple/project.yml)
   lock_checksum=$(cksum Cargo.lock)
   first_checksum=$(cksum crates/defra-agent-desktop/branding.txt)
   apply_for_slice core >/dev/null
@@ -1255,7 +1255,7 @@ self_test() (
   second_checksum=$(cksum crates/defra-agent-desktop/branding.txt)
   [[ "$first_checksum" == "$second_checksum" ]]
   [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
-  [[ "$apple_checksum" == "$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)" ]]
+  [[ "$apple_checksum" == "$(cksum <apps/desktop-tauri/src-tauri/gen/apple/project.yml)" ]]
   grep -Fq 'service=com.source-inc.gents.identity' crates/gents/runtime.txt
   grep -Fq 'test_did=did:defra-agent:test' crates/gents/runtime.txt
   if guard_output=$(run_guard core 2>&1); then
@@ -1291,22 +1291,22 @@ self_test() (
   # Explicit slice execution and `apply all` must materialize the same tree.
   cd "$fixture_sequential"
   owner_checksum=$(cksum docs/gents.md)
-  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  apple_checksum=$(cksum <apps/desktop-tauri/src-tauri/gen/apple/project.yml)
   for owned_slice in "${SLICE_ORDER[@]}"; do
     apply_for_slice "$owned_slice" >/dev/null
   done
   sequential_tree=$(git write-tree)
   [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
-  [[ "$apple_checksum" == "$(cksum apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
+  [[ "$apple_checksum" == "$(cksum <apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
 
   cd "$fixture_all"
   owner_checksum=$(cksum docs/gents.md)
-  apple_checksum=$(cksum apps/desktop-tauri/src-tauri/gen/apple/project.yml)
+  apple_checksum=$(cksum <apps/desktop-tauri/src-tauri/gen/apple/project.yml)
   apply_for_slice all >/dev/null
   all_tree=$(git write-tree)
   [[ "$sequential_tree" == "$all_tree" ]]
   [[ "$owner_checksum" == "$(cksum docs/gents.md)" ]]
-  [[ "$apple_checksum" == "$(cksum apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
+  [[ "$apple_checksum" == "$(cksum <apps/gents-desktop/src-tauri/gen/apple/project.yml)" ]]
   grep -Fq 'service=com.source-inc.gents.identity' crates/gents/runtime.txt
   grep -Fxq '__APPLE_TEAM_ID__.com.source-inc.gents' release/entitlements.plist
   grep -Fq 'adapter docs retain gents until the docs slice' \

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -232,6 +232,11 @@ declare -a DESKTOP_LOCK_SUBS=(
 
 # Stale tokens for the guard scan (from #811 section 1)
 declare -a STALE_TOKENS=(
+  "agent-daemon"
+  "agent_daemon"
+  "AGENT_DAEMON"
+  "Agent Daemon"
+  "agent daemon"
   "defra-agent"
   "apps/desktop-tauri"
   "defra_agent"

--- a/scripts/rename-to-gents.sh
+++ b/scripts/rename-to-gents.sh
@@ -312,6 +312,7 @@ declare -a STALE_TOKENS=(
   "Defra-owned"
   "Defra remote runtime"
   "Defra runtime"
+  "Defra session hook"
   "Defra tools"
   "Defra import"
   "Defra Test"
@@ -883,6 +884,14 @@ scan_slice_contracts() {
       scan_contract_array_in_file Cargo.lock DESKTOP_LOCK_SUBS "desktop lockfile"
       scan_desktop_consumer_contracts
       ;;
+    all)
+      # The final guard must retain the stricter shared-file and consumer
+      # contracts owned by the incremental core and desktop slices. A plain
+      # all-tree token scan is not equivalent: some exact legacy selectors,
+      # such as `app: "desktop-tauri"`, do not contain a broad stale token.
+      scan_slice_contracts core
+      scan_slice_contracts desktop
+      ;;
   esac
 }
 
@@ -1179,6 +1188,7 @@ self_test() (
   local test_dir test_file fixture_base fixture_slice fixture_sequential fixture_all
   local fixture_path first_checksum second_checksum owner_checksum apple_checksum
   local lock_checksum sequential_tree all_tree idempotent_tree guard_output
+  local -a original_stale_tokens
   test_dir=$(mktemp -d)
   test_file="$test_dir/substitutions.txt"
   trap 'rm -rf "$test_dir"' EXIT
@@ -1310,6 +1320,22 @@ self_test() (
   apply_for_slice all >/dev/null
   [[ "$idempotent_tree" == "$(git write-tree)" ]]
 
+  # The final all-tree guard must run the exact core and desktop contracts,
+  # not just the broad stale-token list. Temporarily use an unrelated token so
+  # these assertions fail if `scan_slice_contracts all` stops delegating.
+  printf '\n"crates/defra-agent"\n' >>Cargo.toml
+  printf '\napp: "desktop-tauri"\n' \
+    >>crates/gents/tests/support/conformance_consumers.rs
+  original_stale_tokens=("${STALE_TOKENS[@]}")
+  STALE_TOKENS=("__no_fixture_stale_token__")
+  if guard_output=$(run_guard all 2>&1); then
+    echo "global guard unexpectedly skipped slice-specific contracts" >&2
+    return 1
+  fi
+  grep -Fq 'core workspace' <<<"$guard_output"
+  grep -Fq 'desktop consumer' <<<"$guard_output"
+  STALE_TOKENS=("${original_stale_tokens[@]}")
+
   # Protected owner/generated files are still final-guard violations: apply
   # protection is intentionally not a stale-token allowlist.
   if guard_output=$(run_guard all 2>&1); then
@@ -1334,6 +1360,28 @@ self_test() (
   scan_stale_tokens all >/dev/null
   [[ "$SCAN_VIOLATIONS" -eq 1 ]]
   [[ "$SCAN_TOTAL" -eq 2 ]]
+
+  # A narrow product-message token catches legacy Gents branding without
+  # treating legitimate DefraDB/upstream crate vocabulary as stale.
+  fixture_repo="$test_dir/product-message-fixture"
+  mkdir -p "$fixture_repo"
+  git -C "$fixture_repo" init -q
+  printf '%s\n' \
+    'outside the Defra session hook' \
+    'DefraDB uses defra-core and defra-node' \
+    >"$fixture_repo/messages.txt"
+  git -C "$fixture_repo" add messages.txt
+  cd "$fixture_repo"
+  ALLOWLIST=("__no_fixture_allowlist__")
+  STALE_TOKENS=("Defra session hook")
+  scan_stale_tokens all >"$test_dir/product-message-guard.txt"
+  [[ "$SCAN_VIOLATIONS" -eq 1 ]]
+  [[ "$SCAN_TOTAL" -eq 1 ]]
+  grep -Fq 'Defra session hook' "$test_dir/product-message-guard.txt"
+  if grep -Eq 'DefraDB|defra-core|defra-node' "$test_dir/product-message-guard.txt"; then
+    echo "product-message guard flagged legitimate DefraDB vocabulary" >&2
+    return 1
+  fi
 
   trap - EXIT
   rm -rf "$test_dir"

--- a/scripts/verify-macos.sh
+++ b/scripts/verify-macos.sh
@@ -7,6 +7,9 @@ cd "$repo_root"
 export CARGO_INCREMENTAL=0
 
 cargo check -p gents -p gents-cli
-cargo test -p gents --test backend_auth -- --nocapture --test-threads=1
-cargo test -p gents-cli --test cli_e2e -- --nocapture --test-threads=1
+cargo test -p gents \
+  --test backend_auth_config \
+  --test backend_auth_startup \
+  -- --nocapture --test-threads=1
+cargo test -p gents-cli --tests -- --nocapture --test-threads=1
 (cd crates/gents/proofs && lake build)


### PR DESCRIPTION
Closes #827

Depends on #826, merged as #859 at `1a154101501e325b870034838623745a951efef2`.

## What changed

- Makes `guard all` execute the strict core and desktop consumer contracts, with a self-test that proves both fire independently of broad token matching.
- Catches the remaining product message `Defra session hook`, updates it to Gents, and adds focused regression coverage without flagging DefraDB/domain vocabulary.
- Adds a dependency-light Ubuntu rename-guard CI job: Bash syntax, executable self-test, and strict global guard.
- Requires Rust CI to receive successful rename-guard and Lean results while preserving explicit failure propagation and the measured 90-minute Rust timeout.
- Adds a zero-`sorry` Lean fence and the standalone WASM lens build required outside default workspace coverage.
- Adds exact-SHA `workflow_dispatch` candidate mode so the full non-PR suites can run against an immutable 40-character candidate SHA.

## Validation

- Bash syntax and rename self-test
- focused runtime regression test
- `cargo fmt --all --check`
- zero-`sorry` scan
- standalone WASM lens build
- `actionlint`
- core, desktop, release, and global guards
- independent enforcement review: GO
- full `guard all` passes after the owner-authorized `docs/gents.md` finalization

## Candidate status

The owner gates are resolved: #829 records `v0.8.0`, `docs/gents.md` uses final Gents naming, and `guard all` passes. #858 and #859 are merged; Linux and signed macOS dry runs succeeded with Apache-2.0-bearing artifacts. The integrated candidate remains NO-GO until:

- fresh PR CI passes at the exact final head;
- the full candidate workflow passes on that frozen SHA;
- three independent reviewers return GO on the same frozen SHA.
