### PR TITLE
Fix startup shim and heartbeat races

### DIFF
--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -244,7 +244,7 @@ async fn server_keeps_running_when_codex_shim_port_is_taken() -> Result<()> {
     let occupied = std::net::TcpListener::bind("127.0.0.1:0").context("occupying a port")?;
     let shim_port = occupied.local_addr()?.port();
     let shim_port_string = shim_port.to_string();
-    let mut serve = spawn_server_with_env(
+    let (mut serve, readiness) = spawn_server_with_ready_json(
         &home_dir,
         server_port,
         &["--codex-shim", "--codex-shim-port", &shim_port_string],
@@ -252,6 +252,14 @@ async fn server_keeps_running_when_codex_shim_port_is_taken() -> Result<()> {
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    assert_eq!(
+        readiness
+            .pointer("/codex_shim/disabled")
+            .and_then(Value::as_bool),
+        Some(true),
+        "server readiness must report the shim as disabled: {readiness}"
+    );
 
     let (_stdout, stderr) = serve.captured_output()?;
     assert!(

--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -6116,7 +6116,7 @@ async fn codex_shim_waits_for_a_missing_bound_behavior_instead_of_disabling() ->
     // rather than disable itself for the life of the process (#699). The port
     // stays closed — there is nothing to serve yet — and the server keeps
     // serving everything else.
-    let mut serve = spawn_server_with_env(
+    let (mut serve, readiness) = spawn_server_with_ready_json(
         &home_dir,
         server_port,
         &[
@@ -6130,6 +6130,21 @@ async fn codex_shim_waits_for_a_missing_bound_behavior_instead_of_disabling() ->
     )?;
     wait_for_port(server_port, &mut serve)?;
     wait_for_runtime_ready(&graphql, &agent_did, Duration::from_secs(30)).await?;
+
+    assert_eq!(
+        readiness
+            .pointer("/codex_shim/pending")
+            .and_then(Value::as_bool),
+        Some(true),
+        "server readiness must report the shim as pending: {readiness}"
+    );
+    assert_eq!(
+        readiness
+            .pointer("/codex_shim/bound_behavior_id")
+            .and_then(Value::as_str),
+        Some("behavior-that-does-not-exist"),
+        "server readiness must name the missing bound behavior: {readiness}"
+    );
 
     let (_stdout, stderr) = serve.captured_output()?;
     assert!(

--- a/crates/gents/src/agent/p2p_reconcile/endpoint.rs
+++ b/crates/gents/src/agent/p2p_reconcile/endpoint.rs
@@ -37,6 +37,11 @@ pub async fn run_endpoint_heartbeat(
         );
     }
 
+    // `tokio::time::interval` makes its first tick immediately ready. Consume
+    // that scheduling tick after the explicit startup write so entering the
+    // loop does not issue a redundant second upsert during startup contention.
+    interval.tick().await;
+
     loop {
         tokio::select! {
             _ = cancel.cancelled() => return Ok(()),
@@ -89,7 +94,12 @@ async fn tick_endpoint(
         .await
         .context("signing PeerEndpoint binding")?;
     let mutation = peer_endpoint_upsert_mutation(&record);
-    let response = node.execute(&mutation).await;
+    let response = crate::retry::execute_graphql_with_conflict_retry(
+        node,
+        &mutation,
+        "upsert_peer_endpoint_heartbeat",
+    )
+    .await;
     if response.has_errors() {
         bail!("upsert_PeerEndpoint failed: {:?}", response.errors);
     }

--- a/crates/gents/src/agent/p2p_reconcile/registry.rs
+++ b/crates/gents/src/agent/p2p_reconcile/registry.rs
@@ -221,6 +221,11 @@ pub async fn run_registry_heartbeat(
         );
     }
 
+    // `tokio::time::interval` makes its first tick immediately ready. Consume
+    // that scheduling tick after the explicit startup write so entering the
+    // loop does not issue a redundant second upsert during startup contention.
+    interval.tick().await;
+
     loop {
         tokio::select! {
             _ = cancel.cancelled() => {
@@ -299,7 +304,12 @@ async fn tick_registry(
     // which is empty here — the operator path sets it). The heartbeat still
     // re-advertises the offered templates so the registry offer stays fresh.
     let mutation = registry_upsert_mutation(&entry, &now, UpsertKind::Heartbeat);
-    let response = node.execute(&mutation).await;
+    let response = crate::retry::execute_graphql_with_conflict_retry(
+        node,
+        &mutation,
+        "upsert_peer_registry_heartbeat",
+    )
+    .await;
 
     if response.has_errors() {
         bail!("upsert_PeerRegistry failed: {:?}", response.errors);


### PR DESCRIPTION
## What changed

- order both Codex-shim startup regressions on the existing post-classification server readiness JSON
- assert readiness reports the expected pending or disabled state before checking operator logs and the shim port
- route both PeerRegistry and signed PeerEndpoint heartbeat upserts through the existing bounded DefraDB transaction-conflict retry
- consume each Tokio interval's immediately-ready scheduling tick so startup performs one immediate heartbeat write per collection, not two

## Root cause

Both exact-main CI attempts sampled stderr after `AgentRuntime` became ready but before Codex-shim classification completed. The tests therefore raced a legal startup gap. Concurrent PeerRegistry and PeerEndpoint transaction conflicts exposed a symmetric resilience hole: both heartbeat paths bypassed the conflict-retry helper used elsewhere and performed a redundant second immediate upsert.

The #699 pending-shim behavior itself was correct.

## Impact

Startup tests observe the lifecycle boundary they actually assert, and transient heartbeat MVCC conflicts receive the repository's existing bounded retry policy. Logical registry and endpoint transitions and cadence remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- independent focused review: GO
- both focused Codex-shim regressions pass individually on workstation-1 at exact head `458036e1`
- 50/50 paired repeated runs pass at exact head (100 startup scenarios, binary SHA-256 `706a0f6658ba48b01982097b634f7281148d3bd07583dcf9d17d8f6697fe2c29`)
- draft PR CI pending

No Lean model change is required because this changes test observation ordering and physical write retries, not legal transitions.

Closes #862.
Blocks #860 until merged and rebased.
