### PR TITLE
feat(cli): interactive first-run backend picker for `gents init`

### DIFF
--- a/crates/gents-cli/src/commands/codex_login.rs
+++ b/crates/gents-cli/src/commands/codex_login.rs
@@ -3,41 +3,86 @@ use codex_login::{
     run_device_code_login, run_login_server, AuthCredentialsStoreMode, AuthManager, ServerOptions,
     CLIENT_ID,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use uuid::Uuid;
 
 use crate::cli::args::CodexLoginArgs;
+use crate::config_writes::ConfigAccess;
 use crate::{print_json, resolve_agent_did, resolve_config_access};
+
+/// Inputs to a single ChatGPT/Codex OAuth login, independent of how the caller
+/// obtained the target node. Shared by the `codex-login` command and `init`'s
+/// inline first-login.
+pub(crate) struct CodexLoginOptions {
+    pub(crate) provider: String,
+    pub(crate) client_id: Option<String>,
+    pub(crate) issuer: Option<String>,
+    pub(crate) device_auth: bool,
+}
+
+/// The persisted result of a successful login.
+pub(crate) struct CodexLoginOutcome {
+    pub(crate) doc_id: String,
+    pub(crate) credential: gents::chatgpt_codex::OAuthCredential,
+}
 
 pub(crate) async fn codex_login(args: CodexLoginArgs) -> Result<()> {
     let (access, home_dir) =
         resolve_config_access(args.home.as_deref(), args.graphql.as_deref(), true).await?;
     let agent_did = resolve_agent_did(Some(&home_dir), args.agent_did.as_deref())?;
-    let provider = gents::chatgpt_codex::normalize_provider(&args.provider);
+    let outcome = run_codex_login(
+        &access,
+        &agent_did,
+        &CodexLoginOptions {
+            provider: args.provider,
+            client_id: args.client_id,
+            issuer: args.issuer,
+            device_auth: args.device_auth,
+        },
+    )
+    .await?;
+    print_json(&codex_login_result_json(&outcome))?;
+    Ok(())
+}
+
+/// Drive the ChatGPT OAuth flow and upsert the resulting `OAuthCredential`
+/// through `access`. Emits the sign-in prompt to stderr but never prints the
+/// result — the caller owns output so `init` can fold it into its single JSON
+/// object.
+pub(crate) async fn run_codex_login(
+    access: &ConfigAccess,
+    agent_did: &str,
+    opts: &CodexLoginOptions,
+) -> Result<CodexLoginOutcome> {
+    let provider = gents::chatgpt_codex::normalize_provider(&opts.provider);
     let synthetic_home = std::env::temp_dir().join(format!("gents-codex-login-{}", Uuid::new_v4()));
-    let mut opts = ServerOptions::new(
+    let mut server_opts = ServerOptions::new(
         synthetic_home.clone(),
-        args.client_id.unwrap_or_else(|| CLIENT_ID.to_string()),
+        opts.client_id
+            .clone()
+            .unwrap_or_else(|| CLIENT_ID.to_string()),
         None,
         AuthCredentialsStoreMode::Ephemeral,
     );
-    if let Some(issuer) = args.issuer.filter(|value| !value.trim().is_empty()) {
-        opts.issuer = issuer;
+    if let Some(issuer) = opts
+        .issuer
+        .as_ref()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        server_opts.issuer = issuer.to_string();
     }
 
-    if args.device_auth {
-        opts.open_browser = false;
-        run_device_code_login(opts)
+    if opts.device_auth {
+        server_opts.open_browser = false;
+        run_device_code_login(server_opts)
             .await
             .context("ChatGPT device-code login failed")?;
     } else {
-        let server = run_login_server(opts).context("starting ChatGPT login server")?;
-        // Human prompt goes to stderr so stdout stays pure JSON (the command emits a single JSON
-        // object via print_json on success) for automation.
-        eprintln!(
-            "Open this URL to sign in with ChatGPT:\n{}",
-            server.auth_url
-        );
+        let server = run_login_server(server_opts).context("starting ChatGPT login server")?;
+        // Human prompt goes to stderr so stdout stays reserved for the caller's
+        // machine-readable JSON.
+        eprintln!("Open this URL to sign in with ChatGPT:\n{}", server.auth_url);
         server
             .block_until_done()
             .await
@@ -65,7 +110,7 @@ pub(crate) async fn codex_login(args: CodexLoginArgs) -> Result<()> {
         .get_token_data()
         .context("ChatGPT login did not expose token data")?;
     let credential = gents::chatgpt_codex::OAuthCredential::from_login_token_data(
-        &agent_did,
+        agent_did,
         &provider,
         &token_data,
         chrono::Utc::now(),
@@ -74,8 +119,15 @@ pub(crate) async fn codex_login(args: CodexLoginArgs) -> Result<()> {
     let response = access.execute(&mutation).await?;
     let doc_id = gents_protocol::graphql::extract_mutation_doc_id(&response, "OAuthCredential")?;
 
-    print_json(&json!({
-        "doc_id": doc_id,
+    Ok(CodexLoginOutcome { doc_id, credential })
+}
+
+/// The redacted JSON view of a login result, shared by the standalone command
+/// and `init`'s folded output.
+pub(crate) fn codex_login_result_json(outcome: &CodexLoginOutcome) -> Value {
+    let credential = &outcome.credential;
+    json!({
+        "doc_id": outcome.doc_id,
         "credential_id": credential.credential_id,
         "agent_did": credential.agent_did,
         "provider": credential.provider,
@@ -88,6 +140,5 @@ pub(crate) async fn codex_login(args: CodexLoginArgs) -> Result<()> {
         "access_token": "<redacted>",
         "refresh_token": "<redacted>",
         "id_token": credential.id_token.as_ref().map(|_| "<redacted>"),
-    }))?;
-    Ok(())
+    })
 }

--- a/crates/gents-cli/src/commands/codex_login.rs
+++ b/crates/gents-cli/src/commands/codex_login.rs
@@ -82,7 +82,10 @@ pub(crate) async fn run_codex_login(
         let server = run_login_server(server_opts).context("starting ChatGPT login server")?;
         // Human prompt goes to stderr so stdout stays reserved for the caller's
         // machine-readable JSON.
-        eprintln!("Open this URL to sign in with ChatGPT:\n{}", server.auth_url);
+        eprintln!(
+            "Open this URL to sign in with ChatGPT:\n{}",
+            server.auth_url
+        );
         server
             .block_until_done()
             .await

--- a/crates/gents-cli/src/commands/init.rs
+++ b/crates/gents-cli/src/commands/init.rs
@@ -230,9 +230,9 @@ pub(crate) async fn init(mut args: InitArgs) -> Result<()> {
             "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
         },
         "codex_login": codex_login
-            .as_ref()
+            .outcome()
             .map(crate::commands::codex_login::codex_login_result_json),
-        "next_steps": init_next_steps(&summary, codex_login.is_some()),
+        "next_steps": init_next_steps(&summary, codex_login.is_authenticated()),
         "init": summary,
     });
     print_json(&output)?;
@@ -242,32 +242,51 @@ pub(crate) async fn init(mut args: InitArgs) -> Result<()> {
 
 /// Offer to complete ChatGPT sign-in inline when `init` just seeded a
 /// chatgpt-codex backend interactively and no credential exists yet. Returns
-/// `None` (and keeps the `gents codex-login` next step) for non-codex backends,
-/// non-terminal sessions, an already-authenticated agent, a declined prompt, or
-/// a failed login — none of which are init failures.
+/// Existing credentials count as authenticated without producing a fresh login
+/// result. Non-codex backends, non-terminal sessions, declined prompts, and
+/// failed logins remain unauthenticated here; none of those are init failures.
+enum InlineCodexLoginState {
+    Unauthenticated,
+    ExistingCredential,
+    Completed(crate::commands::codex_login::CodexLoginOutcome),
+}
+
+impl InlineCodexLoginState {
+    fn is_authenticated(&self) -> bool {
+        matches!(self, Self::ExistingCredential | Self::Completed(_))
+    }
+
+    fn outcome(&self) -> Option<&crate::commands::codex_login::CodexLoginOutcome> {
+        match self {
+            Self::Completed(outcome) => Some(outcome),
+            Self::Unauthenticated | Self::ExistingCredential => None,
+        }
+    }
+}
+
 async fn maybe_inline_codex_login(
     access: &ConfigAccess,
     agent_did: &str,
     summary: &InitSummary,
-) -> Option<crate::commands::codex_login::CodexLoginOutcome> {
+) -> InlineCodexLoginState {
     if summary.provider_kind != gents::BackendProviderKind::ChatGptCodex {
-        return None;
+        return InlineCodexLoginState::Unauthenticated;
     }
     if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
-        return None;
+        return InlineCodexLoginState::Unauthenticated;
     }
     let provider = gents::chatgpt_codex::normalize_provider("chatgpt-codex");
     match crate::commands::codex_auth_probe::load_oauth_credential(access, agent_did, &provider)
         .await
     {
-        Ok(Some(_)) => return None, // already signed in — don't re-prompt on a re-run
+        Ok(Some(_)) => return InlineCodexLoginState::ExistingCredential,
         Ok(None) => {}
         Err(error) => {
             eprintln!("Could not check for an existing ChatGPT credential: {error:#}");
         }
     }
     if !crate::interactive_backend::confirm("Log in to ChatGPT now to finish setup?", true).await {
-        return None;
+        return InlineCodexLoginState::Unauthenticated;
     }
     match crate::commands::codex_login::run_codex_login(
         access,
@@ -281,14 +300,14 @@ async fn maybe_inline_codex_login(
     )
     .await
     {
-        Ok(outcome) => Some(outcome),
+        Ok(outcome) => InlineCodexLoginState::Completed(outcome),
         Err(error) => {
             eprintln!(
                 "ChatGPT login did not complete: {error:#}\n\
                  The backend is configured; finish later with `gents codex-login` \
                  (add --device-auth on a headless machine)."
             );
-            None
+            InlineCodexLoginState::Unauthenticated
         }
     }
 }
@@ -1005,6 +1024,22 @@ mod tests {
                 "https://chatgpt.com/backend-api/codex",
             ),
             true,
+        );
+        assert!(!steps.iter().any(|step| step == "gents codex-login"));
+    }
+
+    #[test]
+    fn existing_codex_credential_drops_login_step_without_new_outcome() {
+        let state = InlineCodexLoginState::ExistingCredential;
+        assert!(state.is_authenticated());
+        assert!(state.outcome().is_none());
+
+        let steps = init_next_steps(
+            &init_summary(
+                BackendProviderKind::ChatGptCodex,
+                "https://chatgpt.com/backend-api/codex",
+            ),
+            state.is_authenticated(),
         );
         assert!(!steps.iter().any(|step| step == "gents codex-login"));
     }

--- a/crates/gents-cli/src/commands/init.rs
+++ b/crates/gents-cli/src/commands/init.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -61,13 +62,17 @@ WARNING: --yolo bootstraps UNRESTRICTED tools. The agent can run any command\n\
 and write any file your user account can reach — no sandbox, no containment.\n\
 Use --write for sandboxed writes scoped to the tool root.";
 
-pub(crate) async fn init(args: InitArgs) -> Result<()> {
+pub(crate) async fn init(mut args: InitArgs) -> Result<()> {
     let home_dir = resolve_home_dir(args.home.as_deref());
     let tool_package = resolve_init_tool_package(args.write_tools, args.yolo, args.tool_package)?;
     validate_init_tool_flags(&args, tool_package)?;
     if matches!(tool_package, ToolPackageArg::Yolo) {
         eprintln!("{YOLO_WARNING}");
     }
+    // First-run ergonomics: when nothing names a backend and we have a
+    // terminal, ask instead of silently defaulting to a local llama-server
+    // that may not be running. No-op under pipes/CI/--identity-only.
+    crate::interactive_backend::resolve_backend_interactively(&mut args).await?;
     if args.dangerously_overwrite {
         dangerously_overwrite_home(&home_dir)?;
     }
@@ -190,6 +195,12 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
         false
     };
 
+    // Config is fully persisted; the inline ChatGPT login is best-effort and
+    // never fails init (a declined or failed login just leaves the next_steps
+    // guidance in place).
+    let codex_login =
+        maybe_inline_codex_login(&access, initialized_identity.identity.did(), &summary).await;
+
     let output = json!({
         "status": "initialized",
         "home": home_dir,
@@ -218,12 +229,68 @@ pub(crate) async fn init(args: InitArgs) -> Result<()> {
             "secure_enclave_label": stored.secure_enclave_label,
             "permission_boundary": "This DID and key identify the permission boundary for every action the agent runtime performs."
         },
-        "next_steps": init_next_steps(&summary),
+        "codex_login": codex_login
+            .as_ref()
+            .map(crate::commands::codex_login::codex_login_result_json),
+        "next_steps": init_next_steps(&summary, codex_login.is_some()),
         "init": summary,
     });
     print_json(&output)?;
 
     Ok(())
+}
+
+/// Offer to complete ChatGPT sign-in inline when `init` just seeded a
+/// chatgpt-codex backend interactively and no credential exists yet. Returns
+/// `None` (and keeps the `gents codex-login` next step) for non-codex backends,
+/// non-terminal sessions, an already-authenticated agent, a declined prompt, or
+/// a failed login — none of which are init failures.
+async fn maybe_inline_codex_login(
+    access: &ConfigAccess,
+    agent_did: &str,
+    summary: &InitSummary,
+) -> Option<crate::commands::codex_login::CodexLoginOutcome> {
+    if summary.provider_kind != gents::BackendProviderKind::ChatGptCodex {
+        return None;
+    }
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return None;
+    }
+    let provider = gents::chatgpt_codex::normalize_provider("chatgpt-codex");
+    match crate::commands::codex_auth_probe::load_oauth_credential(access, agent_did, &provider)
+        .await
+    {
+        Ok(Some(_)) => return None, // already signed in — don't re-prompt on a re-run
+        Ok(None) => {}
+        Err(error) => {
+            eprintln!("Could not check for an existing ChatGPT credential: {error:#}");
+        }
+    }
+    if !crate::interactive_backend::confirm("Log in to ChatGPT now to finish setup?", true).await {
+        return None;
+    }
+    match crate::commands::codex_login::run_codex_login(
+        access,
+        agent_did,
+        &crate::commands::codex_login::CodexLoginOptions {
+            provider,
+            client_id: None,
+            issuer: None,
+            device_auth: false,
+        },
+    )
+    .await
+    {
+        Ok(outcome) => Some(outcome),
+        Err(error) => {
+            eprintln!(
+                "ChatGPT login did not complete: {error:#}\n\
+                 The backend is configured; finish later with `gents codex-login` \
+                 (add --device-auth on a headless machine)."
+            );
+            None
+        }
+    }
 }
 
 pub(crate) struct IdentityOnlyHomeOptions<'a> {
@@ -811,8 +878,14 @@ fn standard_system_prompt(tool_package: ToolPackageArg) -> &'static str {
     }
 }
 
-fn init_next_steps(summary: &InitSummary) -> Vec<String> {
+fn init_next_steps(summary: &InitSummary, codex_logged_in: bool) -> Vec<String> {
     let mut steps = Vec::new();
+    // The chatgpt-codex backend authenticates with an OAuthCredential, not an
+    // API key: sign in first or the first chat turn has no token. When the
+    // inline login already ran, this step is done.
+    if summary.provider_kind == gents::BackendProviderKind::ChatGptCodex && !codex_logged_in {
+        steps.push("gents codex-login".to_string());
+    }
     if is_probably_ollama_endpoint(&summary.endpoint) {
         steps.push(format!("ollama pull {}", summary.model_name));
     } else if is_probably_llama_server_endpoint(&summary.endpoint) {
@@ -884,6 +957,66 @@ fn resolve_default_tool_root(explicit: Option<&Path>) -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gents::BackendProviderKind;
+
+    fn init_summary(provider_kind: BackendProviderKind, endpoint: &str) -> InitSummary {
+        InitSummary {
+            backend_id: "did:key:z-init:backend".to_string(),
+            backend_name: "test-agent backend".to_string(),
+            provider_kind,
+            endpoint: endpoint.to_string(),
+            api_key: None,
+            api_key_env_var: None,
+            model_name: "test-model".to_string(),
+            max_concurrent: 2,
+            max_queue_depth: 16,
+            default_behavior_id: "default".to_string(),
+            tool_selection_id: "default-tools".to_string(),
+            wide_open_preset_id: "wide-open".to_string(),
+            inference_profile_id: "default-profile".to_string(),
+            tool_package: ToolPackageArg::Readonly,
+            tool_ceiling: ToolCeilingArg::Readonly,
+            tool_root: None,
+            enable_memory: false,
+            enable_defra_query: false,
+            defra_query_collections: Vec::new(),
+            created_principal: true,
+            created_default_behavior: true,
+        }
+    }
+
+    #[test]
+    fn chatgpt_codex_next_steps_lead_with_login() {
+        let steps = init_next_steps(
+            &init_summary(
+                BackendProviderKind::ChatGptCodex,
+                "https://chatgpt.com/backend-api/codex",
+            ),
+            false,
+        );
+        assert_eq!(steps.first().map(String::as_str), Some("gents codex-login"));
+    }
+
+    #[test]
+    fn chatgpt_codex_next_steps_drop_login_after_inline_login() {
+        let steps = init_next_steps(
+            &init_summary(
+                BackendProviderKind::ChatGptCodex,
+                "https://chatgpt.com/backend-api/codex",
+            ),
+            true,
+        );
+        assert!(!steps.iter().any(|step| step == "gents codex-login"));
+    }
+
+    #[test]
+    fn non_codex_next_steps_omit_login() {
+        let steps = init_next_steps(
+            &init_summary(BackendProviderKind::OpenAiCompatible, "http://127.0.0.1:8080/v1"),
+            false,
+        );
+        assert!(!steps.iter().any(|step| step == "gents codex-login"));
+    }
 
     fn init_args() -> InitArgs {
         InitArgs {

--- a/crates/gents-cli/src/commands/init.rs
+++ b/crates/gents-cli/src/commands/init.rs
@@ -1012,7 +1012,10 @@ mod tests {
     #[test]
     fn non_codex_next_steps_omit_login() {
         let steps = init_next_steps(
-            &init_summary(BackendProviderKind::OpenAiCompatible, "http://127.0.0.1:8080/v1"),
+            &init_summary(
+                BackendProviderKind::OpenAiCompatible,
+                "http://127.0.0.1:8080/v1",
+            ),
             false,
         );
         assert!(!steps.iter().any(|step| step == "gents codex-login"));

--- a/crates/gents-cli/src/interactive_backend.rs
+++ b/crates/gents-cli/src/interactive_backend.rs
@@ -1,0 +1,385 @@
+//! Interactive first-run backend picker for `gents init`.
+//!
+//! When `init` runs in a terminal with no backend selection at all — no
+//! `--inference-url`/`--backend-preset`/`--api-key`/`--model-name` and no
+//! `INFERENCE_ENDPOINT` — it falls through to this picker instead of silently
+//! defaulting to a local llama-server that may not be running. Non-interactive
+//! runs (pipes, CI, `--identity-only`) skip it entirely and keep the historical
+//! default, so every existing script and test is unaffected.
+//!
+//! Prompts are written to stderr so `init`'s machine-readable JSON on stdout
+//! stays clean. The probe/echo logic mirrors the `demo` first-run picker
+//! (`commands/demo/backend.rs`); a future change should collapse the two onto
+//! this shared module (see docs/onboarding-improvements.md #1).
+
+use std::io::{IsTerminal, Write as _};
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use serde_json::Value;
+
+use crate::cli::args::{BackendPresetArg, InitArgs};
+
+const OPENAI_DEFAULT_MODEL: &str = "gpt-5.4-mini";
+const OLLAMA_DEFAULT_URL: &str = "http://127.0.0.1:11434/v1";
+const LOCAL_PROBE_URLS: [&str; 2] = ["http://127.0.0.1:8080/v1", "http://127.0.0.1:11434/v1"];
+
+/// The backend fields an interactive pick resolves onto `InitArgs`.
+struct BackendSelection {
+    inference_url: Option<String>,
+    backend_preset: Option<BackendPresetArg>,
+    model_name: Option<String>,
+    api_key: Option<String>,
+    label: String,
+}
+
+impl BackendSelection {
+    fn apply_to(self, args: &mut InitArgs) {
+        args.inference_endpoint = self.inference_url;
+        args.backend_preset = self.backend_preset;
+        args.model_name = self.model_name;
+        args.api_key = self.api_key;
+    }
+}
+
+/// Interactively resolve a backend for `init` when nothing was specified.
+///
+/// A no-op that returns `Ok(())` when a backend signal was already given, when
+/// stdin/stderr is not a terminal, or under `--identity-only`. Otherwise it
+/// prompts and writes the chosen backend onto `args` before normal resolution.
+pub(crate) async fn resolve_backend_interactively(args: &mut InitArgs) -> Result<()> {
+    if !should_prompt(args) {
+        return Ok(());
+    }
+    let selection = pick_backend().await?;
+    eprintln!("Using {}.\n", selection.label);
+    selection.apply_to(args);
+    Ok(())
+}
+
+fn should_prompt(args: &InitArgs) -> bool {
+    !args.identity_only
+        && std::io::stdin().is_terminal()
+        && std::io::stderr().is_terminal()
+        && !has_backend_arg(args)
+        && !inference_endpoint_env_set()
+}
+
+/// True when the invocation already names a backend, so prompting would only
+/// override an explicit choice.
+fn has_backend_arg(args: &InitArgs) -> bool {
+    args.resolved_inference_endpoint().is_some()
+        || args.backend_preset.is_some()
+        || args.api_key.is_some()
+        || args.api_key_env_var.is_some()
+        || args.model_name.is_some()
+}
+
+fn inference_endpoint_env_set() -> bool {
+    std::env::var("INFERENCE_ENDPOINT")
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+}
+
+async fn pick_backend() -> Result<BackendSelection> {
+    let local = detect_local_server().await;
+    eprintln!("How do you want to run inference?");
+    eprintln!("  1) OpenAI API key   (paste it; stored in the backend document)");
+    match &local {
+        Some((url, _)) => eprintln!("  2) local server     (detected at {url})"),
+        None => eprintln!("  2) local server     (e.g. ollama / llama-server)"),
+    }
+    eprintln!("  3) custom URL");
+    eprintln!("  4) ChatGPT / Codex subscription   (uses your ChatGPT plan; log in after init)");
+    let choice = prompt_line("> ").await?;
+    match choice.trim() {
+        "1" | "" => {
+            let key = prompt_secret("Paste your OpenAI API key (hidden): ").await?;
+            let key = key.trim();
+            if key.is_empty() {
+                bail!("no API key entered");
+            }
+            let model = prompt_line_default("Model", OPENAI_DEFAULT_MODEL).await?;
+            Ok(BackendSelection {
+                inference_url: None,
+                backend_preset: Some(BackendPresetArg::OpenAi),
+                model_name: Some(model.clone()),
+                api_key: Some(key.to_string()),
+                label: format!("openai · {model}"),
+            })
+        }
+        "2" => {
+            let (url, detected_model) = match local {
+                Some(found) => found,
+                None => {
+                    let url = prompt_line_default("Local server base URL", OLLAMA_DEFAULT_URL).await?;
+                    let detected = probe_models(&url).await.unwrap_or_default();
+                    (url, detected)
+                }
+            };
+            let model = if detected_model.trim().is_empty() {
+                prompt_line("Model name: ").await?.trim().to_string()
+            } else {
+                detected_model
+            };
+            if model.is_empty() {
+                bail!("no model name entered");
+            }
+            Ok(BackendSelection {
+                label: format!("{url} · {model}"),
+                inference_url: Some(url),
+                backend_preset: None,
+                model_name: Some(model),
+                api_key: None,
+            })
+        }
+        "3" => {
+            let url = prompt_line("Backend base URL (incl. /v1): ").await?;
+            let url = url.trim().to_string();
+            if url.is_empty() {
+                bail!("no URL entered");
+            }
+            let model = prompt_line("Model name: ").await?.trim().to_string();
+            if model.is_empty() {
+                bail!("no model name entered");
+            }
+            Ok(BackendSelection {
+                label: format!("{url} · {model}"),
+                inference_url: Some(url),
+                backend_preset: None,
+                model_name: Some(model),
+                api_key: None,
+            })
+        }
+        "4" => {
+            // The credential is stored against the agent DID and node that only
+            // exist after `init` completes, so we seed the backend here and hand
+            // off to `codex-login` (also surfaced in the init next_steps).
+            eprintln!(
+                "\nAfter init, run `gents codex-login` to store the subscription\n\
+                 credential for this agent. `gents init` only seeds the backend."
+            );
+            Ok(BackendSelection {
+                inference_url: None,
+                backend_preset: Some(BackendPresetArg::ChatGptCodex),
+                model_name: None,
+                api_key: None,
+                label: "ChatGPT / Codex subscription".to_string(),
+            })
+        }
+        other => bail!("unrecognized choice: {other}"),
+    }
+}
+
+/// GET `{base}/models` on the well-known local ports; return the first that
+/// answers together with its first advertised model id.
+async fn detect_local_server() -> Option<(String, String)> {
+    for url in LOCAL_PROBE_URLS {
+        if let Some(model) = probe_models(url).await {
+            return Some((url.to_string(), model));
+        }
+    }
+    None
+}
+
+/// GET `{base}/models`; return the first advertised model id if reachable.
+async fn probe_models(base: &str) -> Option<String> {
+    let response = reqwest::Client::new()
+        .get(format!("{base}/models"))
+        .timeout(Duration::from_millis(700))
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let body: Value = response.json().await.ok()?;
+    body.pointer("/data/0/id")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+}
+
+/// Ask a yes/no question on the terminal. An empty answer takes `default_yes`;
+/// a read error also falls back to it so a closed stdin never wedges a caller.
+pub(crate) async fn confirm(question: &str, default_yes: bool) -> bool {
+    let hint = if default_yes { "[Y/n]" } else { "[y/N]" };
+    eprint!("{question} {hint} ");
+    let _ = std::io::stderr().flush();
+    match read_line().await {
+        Ok(line) => match line.trim().to_ascii_lowercase().as_str() {
+            "y" | "yes" => true,
+            "n" | "no" => false,
+            _ => default_yes,
+        },
+        Err(_) => default_yes,
+    }
+}
+
+async fn prompt_line(text: &str) -> Result<String> {
+    eprint!("{text}");
+    let _ = std::io::stderr().flush();
+    read_line().await
+}
+
+/// Prompt showing a default in brackets; an empty answer takes the default.
+async fn prompt_line_default(label: &str, default: &str) -> Result<String> {
+    eprint!("{label} [{default}]: ");
+    let _ = std::io::stderr().flush();
+    let line = read_line().await?;
+    let trimmed = line.trim();
+    Ok(if trimmed.is_empty() {
+        default.to_string()
+    } else {
+        trimmed.to_string()
+    })
+}
+
+/// Read one line without echoing it (best-effort via `stty`).
+async fn prompt_secret(text: &str) -> Result<String> {
+    eprint!("{text}");
+    let _ = std::io::stderr().flush();
+    let hidden = set_terminal_echo(false);
+    let line = read_line().await;
+    if hidden {
+        set_terminal_echo(true);
+        eprintln!();
+    }
+    line
+}
+
+fn set_terminal_echo(on: bool) -> bool {
+    std::process::Command::new("stty")
+        .arg(if on { "echo" } else { "-echo" })
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+/// Read one line from stdin off the async runtime's worker threads.
+async fn read_line() -> Result<String> {
+    tokio::task::spawn_blocking(|| -> Result<String> {
+        let mut buf = String::new();
+        std::io::stdin()
+            .read_line(&mut buf)
+            .context("reading from stdin")?;
+        Ok(buf)
+    })
+    .await
+    .context("stdin reader task panicked")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::args::IdentityBackendArg;
+
+    fn bare_init_args() -> InitArgs {
+        InitArgs {
+            home: None,
+            data_dir: None,
+            dangerously_overwrite: false,
+            reset: false,
+            identity_only: false,
+            agent_name: "test-agent".to_string(),
+            key_path: None,
+            identity_backend: IdentityBackendArg::File,
+            keychain_label: None,
+            secure_enclave_label: None,
+            inference_endpoint: None,
+            inference_endpoint_legacy: None,
+            backend_id: None,
+            backend_name: None,
+            backend_preset: None,
+            provider_kind: None,
+            openai_wire_api: None,
+            api_key: None,
+            api_key_env_var: None,
+            model_name: None,
+            max_concurrent: 2,
+            max_queue_depth: 16,
+            write_tools: false,
+            yolo: false,
+            tool_package: None,
+            tool_root: None,
+            enable_memory: false,
+            disable_defra_query: false,
+            enable_defra_query: false,
+            defra_query_collections: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn bare_invocation_has_no_backend_arg() {
+        assert!(!has_backend_arg(&bare_init_args()));
+    }
+
+    #[test]
+    fn each_backend_signal_is_detected() {
+        let mut endpoint = bare_init_args();
+        endpoint.inference_endpoint = Some("http://127.0.0.1:8080/v1".to_string());
+        assert!(has_backend_arg(&endpoint));
+
+        let mut legacy = bare_init_args();
+        legacy.inference_endpoint_legacy = Some("http://127.0.0.1:8080/v1".to_string());
+        assert!(has_backend_arg(&legacy));
+
+        let mut preset = bare_init_args();
+        preset.backend_preset = Some(BackendPresetArg::OpenAi);
+        assert!(has_backend_arg(&preset));
+
+        let mut api_key = bare_init_args();
+        api_key.api_key = Some("sk-test".to_string());
+        assert!(has_backend_arg(&api_key));
+
+        let mut api_key_env = bare_init_args();
+        api_key_env.api_key_env_var = Some("OPENAI_API_KEY".to_string());
+        assert!(has_backend_arg(&api_key_env));
+
+        let mut model = bare_init_args();
+        model.model_name = Some("gpt-5.4-mini".to_string());
+        assert!(has_backend_arg(&model));
+    }
+
+    #[test]
+    fn selection_overwrites_backend_fields_only() {
+        let mut args = bare_init_args();
+        args.agent_name = "keep-me".to_string();
+        args.enable_memory = true;
+        BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::OpenAi),
+            model_name: Some("gpt-5.4-mini".to_string()),
+            api_key: Some("sk-test".to_string()),
+            label: "openai · gpt-5.4-mini".to_string(),
+        }
+        .apply_to(&mut args);
+
+        assert_eq!(args.backend_preset, Some(BackendPresetArg::OpenAi));
+        assert_eq!(args.model_name.as_deref(), Some("gpt-5.4-mini"));
+        assert_eq!(args.api_key.as_deref(), Some("sk-test"));
+        assert_eq!(args.inference_endpoint, None);
+        // Non-backend fields are untouched.
+        assert_eq!(args.agent_name, "keep-me");
+        assert!(args.enable_memory);
+    }
+
+    #[test]
+    fn codex_subscription_selection_seeds_keyless_preset() {
+        let mut args = bare_init_args();
+        BackendSelection {
+            inference_url: None,
+            backend_preset: Some(BackendPresetArg::ChatGptCodex),
+            model_name: None,
+            api_key: None,
+            label: "ChatGPT / Codex subscription".to_string(),
+        }
+        .apply_to(&mut args);
+
+        assert_eq!(args.backend_preset, Some(BackendPresetArg::ChatGptCodex));
+        // No key and no explicit model: the preset default model and the
+        // OAuthCredential carry those at resolve time.
+        assert_eq!(args.api_key, None);
+        assert_eq!(args.model_name, None);
+        assert_eq!(args.inference_endpoint, None);
+    }
+}

--- a/crates/gents-cli/src/interactive_backend.rs
+++ b/crates/gents-cli/src/interactive_backend.rs
@@ -112,7 +112,8 @@ async fn pick_backend() -> Result<BackendSelection> {
             let (url, detected_model) = match local {
                 Some(found) => found,
                 None => {
-                    let url = prompt_line_default("Local server base URL", OLLAMA_DEFAULT_URL).await?;
+                    let url =
+                        prompt_line_default("Local server base URL", OLLAMA_DEFAULT_URL).await?;
                     let detected = probe_models(&url).await.unwrap_or_default();
                     (url, detected)
                 }

--- a/crates/gents-cli/src/interactive_backend.rs
+++ b/crates/gents-cli/src/interactive_backend.rs
@@ -70,6 +70,8 @@ fn should_prompt(args: &InitArgs) -> bool {
 fn has_backend_arg(args: &InitArgs) -> bool {
     args.resolved_inference_endpoint().is_some()
         || args.backend_preset.is_some()
+        || args.provider_kind.is_some()
+        || args.openai_wire_api.is_some()
         || args.api_key.is_some()
         || args.api_key_env_var.is_some()
         || args.model_name.is_some()
@@ -327,6 +329,14 @@ mod tests {
         let mut preset = bare_init_args();
         preset.backend_preset = Some(BackendPresetArg::OpenAi);
         assert!(has_backend_arg(&preset));
+
+        let mut provider_kind = bare_init_args();
+        provider_kind.provider_kind = Some("Anthropic".to_string());
+        assert!(has_backend_arg(&provider_kind));
+
+        let mut wire_api = bare_init_args();
+        wire_api.openai_wire_api = Some(crate::cli::args::OpenAiWireApiArg::Responses);
+        assert!(has_backend_arg(&wire_api));
 
         let mut api_key = bare_init_args();
         api_key.api_key = Some("sk-test".to_string());

--- a/crates/gents-cli/src/main.rs
+++ b/crates/gents-cli/src/main.rs
@@ -19,6 +19,7 @@ mod desired_state;
 mod graphql_access;
 mod home_state;
 mod http;
+mod interactive_backend;
 mod p2p_relay;
 mod request_helpers;
 mod resolve_helpers;


### PR DESCRIPTION
When `gents init` runs in a terminal with no backend selection, fall through to an interactive picker instead of silently defaulting to a local llama-server that may not be running. Non-interactive runs (pipes, CI, --identity-only) skip it and keep the historical default, so every existing script and test is unaffected.

The picker (crates/gents-cli/src/interactive_backend.rs) probes for a local server on :8080/:11434 and offers OpenAI key / local server / custom URL / ChatGPT-Codex subscription. Prompts go to stderr so init's stdout JSON stays clean.

Selecting the Codex subscription seeds the keyless chatgpt-codex preset and, interactively after config is persisted, offers an inline ChatGPT login. The login core is extracted from the `codex-login` command (run_codex_login) and reused against init's live node, so no second DB is opened; the standalone command is unchanged and remains the re-auth path. The inline login is best-effort: a declined/failed login or a non-terminal session leaves the `gents codex-login` next-step in place and init still exits 0. On success the redacted credential folds into init's single output JSON and the next-step drops.