### PR TITLE
Extend CI timeout for cold Rust builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,9 @@ jobs:
     needs: [rename-guard, lean-proofs]
     if: ${{ always() }}
     runs-on: [self-hosted, macOS, ARM64, studio]
-    timeout-minutes: 90
+    # A cold self-hosted checkout must compile and link every Rust test target;
+    # repository/path changes invalidate the disk-backed build cache.
+    timeout-minutes: 180
     steps:
       - name: Require rename guard
         if: ${{ needs.rename-guard.result != 'success' }}


### PR DESCRIPTION
## What changed

Increase the `rust-and-cli` job timeout from 90 to 180 minutes and document why cold self-hosted checkouts need the extra headroom.

## Root cause

The first post-repository-rename full CI run (29888079632) used a new `_work/gents/gents` path, invalidating the path-sensitive Rust build cache. Every completed gate passed, but GitHub cancelled `rust-and-cli` exactly at 90 minutes while the final desktop package was still actively linking; the CLI suite never ran.

## Impact

Warm builds are unaffected. Fresh runners, renamed checkout paths, and evicted caches can now complete the full workspace, runtime, desktop Rust, and CLI gates without a false timeout cancellation.

## Validation

- `git diff --check`
- `scripts/rename-to-gents.sh guard all`
- protected `docs/gents.md` SHA-256 unchanged: `96a0b2cd9863ee22c9878b80d336bc6a0560e29c33b4904d290bac4bb91da7e9`
- exact cancellation evidence: run 29888079632, `rust-and-cli` from 03:49:07Z to 05:19:26Z

Local `actionlint` is unavailable; GitHub workflow parsing and PR CI are the authoritative validation.
