### PR TITLE
perf(p2p): narrow subagent return replication

### DIFF
--- a/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/Derivation.lean
@@ -159,20 +159,15 @@ theorem subagentCoordinator_filter_eq (peerDid localDid : Did) :
       = [ { collection := "AgentToolCall", field := "spawn_target_did", value := peerDid } ] := by
   simp [scopeFilter, subagentCoordinatorRules]
 
-/-- The host subagent leg returns every child-lineage artifact only to the peer
-that requested it. Host-owned artifacts outside that requester lineage carry a
-different or null route key and therefore do not match this filter. -/
+/-- The host subagent leg returns the child completion/readable-transcript
+projection only to the peer that requested it. -/
 theorem subagentHost_filter_eq (peerDid localDid : Did) :
     scopeFilter (.perCollection subagentHostRules) [] peerDid localDid
       = [ { collection := "AgentRequest",      field := "requester_did", value := peerDid }
         , { collection := "AgentResponse",     field := "requester_did", value := peerDid }
         , { collection := "AgentMessage",      field := "requester_did", value := peerDid }
-        , { collection := "AgentToolCall",     field := "requester_did", value := peerDid }
-        , { collection := "AgentToolResult",   field := "requester_did", value := peerDid }
-        , { collection := "AgentSession",      field := "requester_did", value := peerDid }
-        , { collection := "AgentConversation", field := "requester_did", value := peerDid }
-        , { collection := "CompactionEntry",   field := "requester_did", value := peerDid } ] := by
-  simp [scopeFilter, subagentHostRules, subagentHostCollections, conversationCollections]
+        , { collection := "AgentToolCall",     field := "requester_did", value := peerDid } ] := by
+  simp [scopeFilter, subagentHostRules, subagentHostCollections]
 
 /-- Every host-return predicate is keyed to the requesting peer, so local DID
 ownership alone is insufficient for an unrelated host artifact to cross. -/
@@ -208,7 +203,17 @@ theorem subagentHost_filters_declared_collections (peerDid localDid : Did) :
         (fun k => k.collection)).toFinset
       = subagentHostTemplate.collections := by
   simp [scopeFilter, subagentHostTemplate, subagentHostRules,
-    subagentHostCollections, conversationCollections]
+    subagentHostCollections]
+
+/-- The host return leg carries only the coordinator's completion and readable
+transcript projection. Host-local session ownership, conversation metadata,
+standalone tool-result rows, and compaction history never cross this leg. -/
+theorem subagentHost_excludes_host_local_artifacts :
+    "AgentToolResult" ∉ subagentHostTemplate.collections ∧
+    "AgentSession" ∉ subagentHostTemplate.collections ∧
+    "AgentConversation" ∉ subagentHostTemplate.collections ∧
+    "CompactionEntry" ∉ subagentHostTemplate.collections := by
+  decide
 
 /-- Concrete catalog membership: the coordinator template resolves from the
 built-in catalog. -/

--- a/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
+++ b/crates/gents/proofs/Proofs/ScopeTemplates/State.lean
@@ -102,7 +102,7 @@ def networkControlCollections : List String :=
   ["AgentNetwork", "NetworkMembership", "PeerEndpoint", "NetworkJoinRequest"]
 
 def subagentHostCollections : List String :=
-  conversationCollections
+  ["AgentRequest", "AgentResponse", "AgentMessage", "AgentToolCall"]
 
 def subagentCoordinatorRules : List CollectionRule :=
   [ { collection := "AgentToolCall", field := "spawn_target_did", source := .peerDid } ]
@@ -111,11 +111,7 @@ def subagentHostRules : List CollectionRule :=
   [ { collection := "AgentRequest",      field := "requester_did", source := .peerDid }
   , { collection := "AgentResponse",     field := "requester_did", source := .peerDid }
   , { collection := "AgentMessage",      field := "requester_did", source := .peerDid }
-  , { collection := "AgentToolCall",     field := "requester_did", source := .peerDid }
-  , { collection := "AgentToolResult",   field := "requester_did", source := .peerDid }
-  , { collection := "AgentSession",      field := "requester_did", source := .peerDid }
-  , { collection := "AgentConversation", field := "requester_did", source := .peerDid }
-  , { collection := "CompactionEntry",   field := "requester_did", source := .peerDid } ]
+  , { collection := "AgentToolCall",     field := "requester_did", source := .peerDid } ]
 
 def conversationTemplate : Template :=
   { id := "conversation"

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -708,7 +708,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn embedded_subagent_host_replays_only_requester_lineage() {
+    async fn embedded_subagent_host_replays_only_return_projection() {
         let sender_test = runtime_test_node().await;
         let receiver_test = runtime_test_node().await;
         let sender = Arc::clone(&sender_test.node);
@@ -721,18 +721,20 @@ mod tests {
         seed_subagent_return_artifacts(&sender, "match", Some("did:key:coord")).await;
         seed_subagent_return_artifacts(&sender, "unrelated", None).await;
 
-        let collections = vec![
+        let available_collections = vec![
+            "AgentRequest".to_string(),
             "AgentResponse".to_string(),
             "AgentMessage".to_string(),
+            "AgentToolCall".to_string(),
             "AgentSession".to_string(),
             "AgentConversation".to_string(),
         ];
         sender_admin
-            .add_p2p_collections(&collections)
+            .add_p2p_collections(&available_collections)
             .await
             .expect("add sender p2p collections");
         receiver_admin
-            .add_p2p_collections(&collections)
+            .add_p2p_collections(&available_collections)
             .await
             .expect("add receiver p2p collections");
 
@@ -743,18 +745,26 @@ mod tests {
         wait_for_active_peer(&sender_admin).await;
         wait_for_active_peer(&receiver_admin).await;
         receiver_admin
-            .add_replicator(&sender_addresses, &collections, &PairingFilters::default())
+            .add_replicator(
+                &sender_addresses,
+                &available_collections,
+                &PairingFilters::default(),
+            )
             .await
             .expect("authorize sender as receiver-side replicator");
 
         let template = resolve_template(SUBAGENT_HOST_TEMPLATE).expect("subagent-host template");
-        let mut filters = scope_filter(
+        let collections = template
+            .collections
+            .iter()
+            .map(|collection| (*collection).to_string())
+            .collect::<Vec<_>>();
+        let filters = scope_filter(
             &template.scope,
             template.collections,
             "did:key:coord",
             "did:key:host",
         );
-        filters.retain(|collection, _| collections.contains(collection));
         sender_admin
             .add_replicator(&receiver_addresses, &collections, &filters)
             .await
@@ -774,21 +784,6 @@ mod tests {
             "return-match-session:1",
         )
         .await;
-        wait_for_value(
-            &receiver,
-            "AgentSession",
-            "session_id",
-            "return-match-session",
-        )
-        .await;
-        wait_for_value(
-            &receiver,
-            "AgentConversation",
-            "session_id",
-            "return-match-session",
-        )
-        .await;
-
         assert_eq!(
             collection_values(&receiver, "AgentResponse", "response_key").await,
             BTreeSet::from(["return-match-response".to_string()])
@@ -799,12 +794,13 @@ mod tests {
         );
         assert_eq!(
             collection_values(&receiver, "AgentSession", "session_id").await,
-            BTreeSet::from(["return-match-session".to_string()])
+            BTreeSet::new(),
+            "host-local session ownership must not cross the return leg"
         );
         assert_eq!(
             collection_values(&receiver, "AgentConversation", "session_id").await,
-            BTreeSet::from(["return-match-session".to_string()]),
-            "unrelated host conversation history must not cross the return leg"
+            BTreeSet::new(),
+            "host-local conversation metadata must not cross the return leg"
         );
 
         sender.shutdown().await;

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -1456,7 +1456,7 @@ mod tests {
     }
 
     #[test]
-    fn data_plane_subagent_host_scopes_all_artifacts_to_signed_requester() {
+    fn data_plane_subagent_host_scopes_return_projection_to_signed_requester() {
         let signed_endpoint = NetworkEndpointEntry {
             peer_id: "peer-a".to_string(),
             agent_did: "did:key:coord".to_string(),
@@ -1476,7 +1476,16 @@ mod tests {
         .expect("data-plane host desired")
         .expect("some data-plane layer");
 
-        assert_eq!(desired.replicator_filter.len(), 8);
+        assert_eq!(
+            desired.replicator_collections,
+            set(&[
+                "AgentRequest",
+                "AgentResponse",
+                "AgentMessage",
+                "AgentToolCall"
+            ])
+        );
+        assert_eq!(desired.replicator_filter.len(), 4);
         for predicate in desired.replicator_filter.values() {
             assert_eq!(predicate.field, "requester_did");
             assert_eq!(predicate.value, "did:key:coord");
@@ -2549,7 +2558,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_host_template_filters_all_artifacts_to_requester() {
+    fn subagent_host_template_filters_return_projection_to_requester() {
         let desired = desired_from_pairing_row(
             desired_row(Some("subagent-host"), Some("did:key:coord")),
             "did:key:host",
@@ -2558,8 +2567,16 @@ mod tests {
         .expect("some desired layer");
 
         assert!(desired.collections.is_empty());
-        assert!(desired.replicator_collections.contains("AgentToolCall"));
-        assert_eq!(desired.replicator_filter.len(), 8);
+        assert_eq!(
+            desired.replicator_collections,
+            set(&[
+                "AgentRequest",
+                "AgentResponse",
+                "AgentMessage",
+                "AgentToolCall"
+            ])
+        );
+        assert_eq!(desired.replicator_filter.len(), 4);
         for predicate in desired.replicator_filter.values() {
             assert_eq!(predicate.field, "requester_did");
             assert_eq!(predicate.value, "did:key:coord");

--- a/crates/gents/src/agent/p2p_reconcile/templates.rs
+++ b/crates/gents/src/agent/p2p_reconcile/templates.rs
@@ -169,6 +169,13 @@ const SUBAGENT_COORDINATOR_RULES: &[CollectionRule] = &[CollectionRule {
 /// Host → coordinator leg for subagent completion: carry only artifacts whose
 /// immutable requester route names this coordinator. This preserves child
 /// returns without replaying unrelated host-owned conversation history.
+const SUBAGENT_HOST_COLLECTIONS: &[&str] = &[
+    "AgentRequest",
+    "AgentResponse",
+    "AgentMessage",
+    "AgentToolCall",
+];
+
 const SUBAGENT_HOST_RULES: &[CollectionRule] = &[
     CollectionRule {
         collection: "AgentRequest",
@@ -187,26 +194,6 @@ const SUBAGENT_HOST_RULES: &[CollectionRule] = &[
     },
     CollectionRule {
         collection: "AgentToolCall",
-        field: "requester_did",
-        source: DidSource::PeerDid,
-    },
-    CollectionRule {
-        collection: "AgentToolResult",
-        field: "requester_did",
-        source: DidSource::PeerDid,
-    },
-    CollectionRule {
-        collection: "AgentSession",
-        field: "requester_did",
-        source: DidSource::PeerDid,
-    },
-    CollectionRule {
-        collection: "AgentConversation",
-        field: "requester_did",
-        source: DidSource::PeerDid,
-    },
-    CollectionRule {
-        collection: "CompactionEntry",
         field: "requester_did",
         source: DidSource::PeerDid,
     },
@@ -256,7 +243,7 @@ static BUILTIN_TEMPLATES: &[ScopeTemplate] = &[
     },
     ScopeTemplate {
         id: SUBAGENT_HOST_TEMPLATE,
-        collections: CONVERSATION_COLLECTIONS,
+        collections: SUBAGENT_HOST_COLLECTIONS,
         scope: Scope::PerCollection(SUBAGENT_HOST_RULES),
         delivery: Delivery::Push,
     },
@@ -473,12 +460,12 @@ mod tests {
     }
 
     #[test]
-    fn subagent_host_filters_every_artifact_on_requester() {
+    fn subagent_host_filters_only_return_projection_on_requester() {
         let t = resolve_template(SUBAGENT_HOST_TEMPLATE).unwrap();
         assert_eq!(t.delivery, Delivery::Push);
-        assert_eq!(t.collections, CONVERSATION_COLLECTIONS);
+        assert_eq!(t.collections, SUBAGENT_HOST_COLLECTIONS);
         let f = scope_filter(&t.scope, t.collections, "did:key:coord", "did:key:host");
-        assert_eq!(f.len(), CONVERSATION_COLLECTIONS.len());
+        assert_eq!(f.len(), SUBAGENT_HOST_COLLECTIONS.len());
         assert_eq!(
             f.get("AgentRequest"),
             Some(&FilterPredicate {
@@ -486,7 +473,7 @@ mod tests {
                 value: "did:key:coord".to_string(),
             })
         );
-        for col in CONVERSATION_COLLECTIONS {
+        for col in SUBAGENT_HOST_COLLECTIONS {
             assert_eq!(
                 f.get(*col),
                 Some(&FilterPredicate {
@@ -495,6 +482,15 @@ mod tests {
                 }),
                 "unexpected subagent-host filter for {col}"
             );
+        }
+        for local_collection in [
+            "AgentToolResult",
+            "AgentSession",
+            "AgentConversation",
+            "CompactionEntry",
+        ] {
+            assert!(!t.collections.contains(&local_collection));
+            assert!(!f.contains_key(local_collection));
         }
     }
 }

--- a/crates/gents/tests/conformance/scope_templates.rs
+++ b/crates/gents/tests/conformance/scope_templates.rs
@@ -61,18 +61,15 @@ fn unscoped_scope_resolves_to_no_filter() {
 /// Mirrors Lean `subagentCoordinator_filter_eq` / `subagentHost_filter_eq` /
 /// `subagentHost_filters_requester_lineage`: coordinator parent requests do
 /// not fan out to hosts, and every host artifact returns only to the paired
-/// requester DID.
+/// requester DID. The return leg contains only the completion/readable-
+/// transcript projection consumed by the coordinator.
 #[test]
 fn subagent_templates_resolve_to_exact_directional_filters() {
-    const CONVERSATION: &[&str] = &[
+    const RETURN_PROJECTION: &[&str] = &[
         "AgentRequest",
         "AgentResponse",
         "AgentMessage",
         "AgentToolCall",
-        "AgentToolResult",
-        "AgentSession",
-        "AgentConversation",
-        "CompactionEntry",
     ];
 
     let coord = resolve_template("subagent-coordinator").expect("coordinator template");
@@ -96,14 +93,14 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
 
     let host = resolve_template("subagent-host").expect("host template");
     assert_eq!(host.delivery, Delivery::Push);
-    assert_eq!(host.collections, CONVERSATION);
+    assert_eq!(host.collections, RETURN_PROJECTION);
     let host_filter = scope_filter(
         &host.scope,
         host.collections,
         "did:key:coord",
         "did:key:host",
     );
-    assert_eq!(host_filter.len(), CONVERSATION.len());
+    assert_eq!(host_filter.len(), RETURN_PROJECTION.len());
     assert_eq!(
         host_filter.get("AgentRequest"),
         Some(&FilterPredicate {
@@ -111,7 +108,7 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
             value: "did:key:coord".to_string(),
         })
     );
-    for collection in CONVERSATION {
+    for collection in RETURN_PROJECTION {
         assert_eq!(
             host_filter.get(*collection),
             Some(&FilterPredicate {
@@ -120,6 +117,15 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
             }),
             "unexpected host filter for {collection}"
         );
+    }
+    for local_collection in [
+        "AgentToolResult",
+        "AgentSession",
+        "AgentConversation",
+        "CompactionEntry",
+    ] {
+        assert!(!host.collections.contains(&local_collection));
+        assert!(!host_filter.contains_key(local_collection));
     }
 
     for predicate in coord_filter.values().chain(host_filter.values()) {
@@ -130,12 +136,12 @@ fn subagent_templates_resolve_to_exact_directional_filters() {
     }
 }
 
-/// Regression for #713: owner scoping made an unrelated host conversation
-/// match the return leg. The requester route key keeps the coordinator-spawned
-/// child conversation and excludes unrelated host history, even though both
-/// rows share the same host `agent_did`.
+/// Regression for #713: owner scoping made unrelated host history match the
+/// return leg. The requester route key keeps the coordinator-spawned child
+/// messages and excludes unrelated host history, even though both rows share
+/// the same host `agent_did`.
 #[test]
-fn subagent_host_conversation_filter_excludes_unrelated_host_history() {
+fn subagent_host_message_filter_excludes_unrelated_host_history() {
     let host = resolve_template("subagent-host").expect("host template");
     let filter = scope_filter(
         &host.scope,
@@ -143,9 +149,7 @@ fn subagent_host_conversation_filter_excludes_unrelated_host_history() {
         "did:key:coord",
         "did:key:host",
     );
-    let predicate = filter
-        .get("AgentConversation")
-        .expect("conversation filter");
+    let predicate = filter.get("AgentMessage").expect("message filter");
 
     let child_requester_did = Some("did:key:coord");
     let unrelated_requester_did: Option<&str> = None;


### PR DESCRIPTION
## Summary

- reduce the `subagent-host` return leg from the full conversation collection set to the projection consumed by coordinators
- retain `AgentRequest`, `AgentResponse`, `AgentMessage`, and `AgentToolCall` while keeping host-local session, conversation, standalone tool-result, and compaction rows local
- update the Lean model, conformance coverage, reconciliation tests, and embedded two-node replication test

## Why

Each host previously pushed eight conversation-related collections toward a coordinator even though coordinator-side completion and transcript reads consume only four. The narrower projection removes unnecessary replicated state while preserving durable child lifecycle, final response, readable transcript, and tool-call identity.

This is a targeted mitigation for #630, not a claim that the fleet saturation issue is closed. The 16-to-1 hardware acceptance run remains required.

## Validation

- `lake build Proofs.ScopeTemplates`
- `cargo test -p gents`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`