### PR TITLE
Authenticate remote app-server clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8665,6 +8665,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "subtle",
  "tempfile",
  "tokio",
  "tokio-tungstenite 0.26.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 sha2 = "0.10"
+subtle = "2.6"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 tokio-util = "0.7"

--- a/crates/gents-cli/Cargo.toml
+++ b/crates/gents-cli/Cargo.toml
@@ -58,6 +58,7 @@ schemars = "1"
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
+subtle.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 tracing-opentelemetry.workspace = true

--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -20,6 +20,19 @@ use crate::{
 
 use crate::default_backend_max_queue_depth;
 
+fn parse_env_var_name(value: &str) -> Result<String, String> {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return Err("environment variable name cannot be empty".to_string());
+    };
+    if !(first == '_' || first.is_ascii_alphabetic())
+        || !chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        return Err(format!("invalid environment variable name {value:?}"));
+    }
+    Ok(value.to_string())
+}
+
 #[derive(Parser)]
 #[command(
     name = "gents",
@@ -529,11 +542,27 @@ pub(crate) struct ServeArgs {
     #[arg(
         long,
         default_value = "127.0.0.1",
-        help = "Address for the Codex shim to listen on. Use a specific trusted private/Tailscale IP for remote Codex clients; default is loopback only"
+        help = "Address for the app-server shim to listen on; non-loopback addresses require --codex-shim-auth-token-env"
     )]
     pub(crate) codex_shim_bind_addr: IpAddr,
     #[arg(long, default_value_t = crate::DEFAULT_CODEX_SHIM_PORT)]
     pub(crate) codex_shim_port: u16,
+    #[arg(
+        long,
+        value_name = "ENV_VAR",
+        value_parser = parse_env_var_name,
+        conflicts_with = "no_codex_shim",
+        help = "Environment variable containing the bearer token required by the app-server WebSocket"
+    )]
+    pub(crate) codex_shim_auth_token_env: Option<String>,
+    #[arg(
+        long,
+        value_name = "WSS_URL",
+        requires = "codex_shim_auth_token_env",
+        conflicts_with = "no_codex_shim",
+        help = "Public wss:// app-server URL advertised when TLS terminates in a reverse proxy"
+    )]
+    pub(crate) codex_shim_public_url: Option<String>,
     #[arg(long, help = "Optional GENTS behavior override for Codex turns")]
     pub(crate) codex_shim_behavior_id: Option<String>,
     #[arg(long, default_value_t = crate::DEFAULT_CODEX_SHIM_TIMEOUT_SECS)]
@@ -597,6 +626,13 @@ pub(crate) struct CodexArgs {
         help = "Codex shim endpoint (ws://HOST:PORT, wss://HOST:PORT, or unix://PATH)"
     )]
     pub(crate) remote: String,
+    #[arg(
+        long,
+        value_name = "ENV_VAR",
+        value_parser = parse_env_var_name,
+        help = "Environment variable containing the bearer token for the remote app server; requires wss:// or loopback ws://"
+    )]
+    pub(crate) remote_auth_token_env: Option<String>,
     #[arg(
         long,
         default_value_t = false,

--- a/crates/gents-cli/src/commands/codex.rs
+++ b/crates/gents-cli/src/commands/codex.rs
@@ -34,7 +34,10 @@ pub(crate) async fn codex(args: CodexArgs) -> Result<()> {
         bail!("`gents codex` is interactive and needs a terminal; use `gents chat` for scripted turns");
     }
 
-    let endpoint = resolve_endpoint(&args.remote)?;
+    let endpoint = with_remote_auth_token(
+        resolve_endpoint(&args.remote)?,
+        read_remote_auth_token(args.remote_auth_token_env.as_deref())?,
+    )?;
     probe_shim(&endpoint).await?;
 
     let cli = build_tui_cli(&args);
@@ -69,6 +72,48 @@ pub(crate) async fn codex(_args: CodexArgs) -> Result<()> {
 fn resolve_endpoint(remote: &str) -> Result<RemoteAppServerEndpoint> {
     codex_tui::resolve_remote_addr(remote)
         .map_err(|error| anyhow!("invalid --remote address {remote:?}: {error}"))
+}
+
+#[cfg(feature = "codex-tui")]
+fn read_remote_auth_token(env_name: Option<&str>) -> Result<Option<String>> {
+    env_name
+        .map(|name| read_remote_auth_token_with(name, |name| std::env::var(name)))
+        .transpose()
+}
+
+#[cfg(feature = "codex-tui")]
+fn read_remote_auth_token_with<F>(env_name: &str, read: F) -> Result<String>
+where
+    F: FnOnce(&str) -> std::result::Result<String, std::env::VarError>,
+{
+    let token = read(env_name)
+        .with_context(|| format!("reading remote app-server token from {env_name}"))?;
+    let token = token.trim();
+    if token.is_empty() {
+        bail!("remote app-server token in {env_name} is empty");
+    }
+    Ok(token.to_string())
+}
+
+#[cfg(feature = "codex-tui")]
+fn with_remote_auth_token(
+    mut endpoint: RemoteAppServerEndpoint,
+    auth_token: Option<String>,
+) -> Result<RemoteAppServerEndpoint> {
+    let Some(auth_token) = auth_token else {
+        return Ok(endpoint);
+    };
+    if !codex_tui::remote_addr_supports_auth_token(&endpoint) {
+        bail!("remote app-server tokens require a wss:// or loopback ws:// endpoint");
+    }
+    let RemoteAppServerEndpoint::WebSocket {
+        auth_token: slot, ..
+    } = &mut endpoint
+    else {
+        bail!("remote app-server tokens are only supported for WebSocket endpoints");
+    };
+    *slot = Some(auth_token);
+    Ok(endpoint)
 }
 
 #[cfg(feature = "codex-tui")]
@@ -126,10 +171,13 @@ fn probe_authority(endpoint: &RemoteAppServerEndpoint) -> Option<String> {
 #[cfg(all(test, feature = "codex-tui"))]
 mod tests {
     use super::*;
+    use crate::cli::{Cli, Command};
+    use clap::Parser;
 
     fn args(remote: &str) -> CodexArgs {
         CodexArgs {
             remote: remote.to_string(),
+            remote_auth_token_env: None,
             no_alt_screen: false,
             prompt: None,
         }
@@ -155,6 +203,61 @@ mod tests {
     #[test]
     fn invalid_remote_is_rejected() {
         assert!(resolve_endpoint("not-a-url").is_err());
+    }
+
+    #[test]
+    fn remote_auth_token_is_attached_to_loopback_websocket() {
+        let endpoint = with_remote_auth_token(
+            resolve_endpoint(crate::DEFAULT_CODEX_REMOTE).expect("resolves"),
+            Some("secret".to_string()),
+        )
+        .expect("token accepted");
+        let RemoteAppServerEndpoint::WebSocket { auth_token, .. } = endpoint else {
+            panic!("expected websocket endpoint");
+        };
+        assert_eq!(auth_token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn remote_auth_token_rejects_plaintext_remote_websocket() {
+        let endpoint = resolve_endpoint("ws://192.0.2.10:9292/").expect("resolves");
+        assert!(with_remote_auth_token(endpoint, Some("secret".to_string())).is_err());
+    }
+
+    #[test]
+    fn remote_auth_token_env_is_trimmed_and_required() {
+        assert_eq!(
+            read_remote_auth_token_with("GENTS_TOKEN", |_| Ok("  secret  ".to_string()))
+                .expect("token"),
+            "secret"
+        );
+        assert!(read_remote_auth_token_with("GENTS_TOKEN", |_| Ok("  ".to_string())).is_err());
+        assert!(read_remote_auth_token_with("GENTS_TOKEN", |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn remote_auth_token_env_flag_parses() {
+        let cli = Cli::try_parse_from([
+            "gents",
+            "codex",
+            "--remote-auth-token-env",
+            "GENTS_REMOTE_TOKEN",
+        ])
+        .expect("parse");
+        let Command::Codex(args) = cli.command else {
+            panic!("expected codex command");
+        };
+        assert_eq!(
+            args.remote_auth_token_env.as_deref(),
+            Some("GENTS_REMOTE_TOKEN")
+        );
+        assert!(
+            Cli::try_parse_from(["gents", "codex", "--remote-auth-token-env", "unsafe;name",])
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/codex_shim.rs
+++ b/crates/gents-cli/src/commands/codex_shim.rs
@@ -9,12 +9,15 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::State;
-use axum::response::IntoResponse;
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Router;
 use codex_app_server_protocol as codex;
 use futures_util::{SinkExt, StreamExt};
 use gents::defra_node::EmbeddedNode;
+use subtle::ConstantTimeEq;
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::JoinHandle;
@@ -58,6 +61,7 @@ struct ShimState {
     timeout: Duration,
     poll_interval: Duration,
     sidecar: Arc<Mutex<CodexSidecar>>,
+    auth_token: Option<Arc<str>>,
 }
 
 type Outbound = mpsc::UnboundedSender<String>;
@@ -120,6 +124,7 @@ pub(crate) struct CodexShimBindArgs {
     pub(crate) graphql: String,
     pub(crate) agent_did: String,
     pub(crate) behavior_id: Option<String>,
+    pub(crate) auth_token: Option<String>,
     pub(crate) bind_addr: std::net::IpAddr,
     pub(crate) port: u16,
     pub(crate) timeout_secs: u64,
@@ -132,6 +137,9 @@ pub(crate) struct BoundCodexShim {
     trace_path: PathBuf,
     listener: TcpListener,
     app: Router,
+    agent_did: String,
+    behavior_id: String,
+    auth_required: bool,
 }
 
 impl BoundCodexShim {
@@ -145,6 +153,18 @@ impl BoundCodexShim {
 
     pub(crate) fn trace_path(&self) -> &Path {
         &self.trace_path
+    }
+
+    pub(crate) fn agent_did(&self) -> &str {
+        &self.agent_did
+    }
+
+    pub(crate) fn behavior_id(&self) -> &str {
+        &self.behavior_id
+    }
+
+    pub(crate) fn auth_required(&self) -> bool {
+        self.auth_required
     }
 
     pub(crate) fn spawn(self) -> JoinHandle<Result<()>> {
@@ -202,12 +222,8 @@ impl CodexShimBindError {
 pub(crate) async fn bind_codex_shim(
     args: CodexShimBindArgs,
 ) -> std::result::Result<BoundCodexShim, CodexShimBindError> {
-    if args.bind_addr.is_unspecified() {
-        return Err(CodexShimBindError::HostResource(anyhow::anyhow!(
-            "refusing to bind unauthenticated Codex shim on {}; bind loopback or a specific trusted private/Tailscale IP instead",
-            args.bind_addr
-        )));
-    }
+    validate_bind_security(args.bind_addr, args.auth_token.as_deref())
+        .map_err(CodexShimBindError::HostResource)?;
 
     let codex_home = args.home.join("codex-ui");
     let codex_log_dir = codex_home.join("log");
@@ -215,6 +231,8 @@ pub(crate) async fn bind_codex_shim(
         .with_context(|| format!("creating Codex UI log dir {}", codex_log_dir.display()))
         .map_err(CodexShimBindError::HostResource)?;
     let trace_path = codex_log_dir.join("codex-shim-events.jsonl");
+    let agent_did = args.agent_did.clone();
+    let auth_required = args.auth_token.is_some();
 
     let bound_behavior_id = bound_behavior::resolve_bound_behavior_id(
         args.node.as_ref(),
@@ -238,11 +256,12 @@ pub(crate) async fn bind_codex_shim(
         background_execution_registry: args.background_execution_registry,
         graphql: Arc::from(args.graphql.clone()),
         agent_did: Arc::from(args.agent_did.clone()),
-        behavior_id: Arc::from(bound_behavior_id),
+        behavior_id: Arc::from(bound_behavior_id.clone()),
         id_counter: Arc::new(AtomicU64::new(1)),
         timeout: Duration::from_secs(args.timeout_secs),
         poll_interval: Duration::from_millis(args.poll_ms.max(1)),
         sidecar: Arc::new(Mutex::new(CodexSidecar::default())),
+        auth_token: args.auth_token.map(Arc::from),
     };
 
     let app = Router::new()
@@ -260,11 +279,48 @@ pub(crate) async fn bind_codex_shim(
         trace_path,
         listener,
         app,
+        agent_did,
+        behavior_id: bound_behavior_id,
+        auth_required,
     })
 }
 
-async fn ws_upgrade(ws: WebSocketUpgrade, State(state): State<ShimState>) -> impl IntoResponse {
+fn validate_bind_security(bind_addr: std::net::IpAddr, auth_token: Option<&str>) -> Result<()> {
+    if bind_addr.is_unspecified() {
+        anyhow::bail!(
+            "refusing to bind app-server shim on unspecified address {bind_addr}; bind loopback or a specific interface instead"
+        );
+    }
+    if !bind_addr.is_loopback() && auth_token.is_none() {
+        anyhow::bail!(
+            "refusing to bind unauthenticated app-server shim on {bind_addr}; set --codex-shim-auth-token-env or bind loopback"
+        );
+    }
+    Ok(())
+}
+
+async fn ws_upgrade(
+    ws: WebSocketUpgrade,
+    State(state): State<ShimState>,
+    headers: HeaderMap,
+) -> Response {
+    if !request_is_authorized(&headers, state.auth_token.as_deref()) {
+        tracing::warn!("rejected unauthorized app-server WebSocket handshake");
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
     ws.on_upgrade(move |socket| handle_socket(socket, state))
+        .into_response()
+}
+
+fn request_is_authorized(headers: &HeaderMap, expected: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return true;
+    };
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.strip_prefix("Bearer "))
+        .is_some_and(|provided| bool::from(expected.as_bytes().ct_eq(provided.as_bytes())))
 }
 
 async fn handle_socket(socket: WebSocket, state: ShimState) {
@@ -498,7 +554,9 @@ impl ConnectionState {
 
 #[cfg(test)]
 mod tests {
-    use super::{CodexSidecar, DEFAULT_MEMORY_MODE};
+    use super::{request_is_authorized, validate_bind_security, CodexSidecar, DEFAULT_MEMORY_MODE};
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{HeaderMap, HeaderValue};
 
     #[test]
     fn memory_mode_defaults_to_disabled_for_unknown_thread() {
@@ -515,5 +573,26 @@ mod tests {
             .insert("t1".to_string(), "enabled".to_string());
         assert_eq!(sidecar.memory_mode_or_default("t1"), "enabled");
         assert_eq!(sidecar.memory_mode_or_default("t2"), "disabled");
+    }
+
+    #[test]
+    fn websocket_auth_requires_exact_bearer_token_when_configured() {
+        let mut headers = HeaderMap::new();
+        assert!(request_is_authorized(&headers, None));
+        assert!(!request_is_authorized(&headers, Some("secret")));
+
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer wrong"));
+        assert!(!request_is_authorized(&headers, Some("secret")));
+
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer secret"));
+        assert!(request_is_authorized(&headers, Some("secret")));
+    }
+
+    #[test]
+    fn non_loopback_bind_requires_authentication() {
+        assert!(validate_bind_security("127.0.0.1".parse().unwrap(), None).is_ok());
+        assert!(validate_bind_security("192.0.2.10".parse().unwrap(), None).is_err());
+        assert!(validate_bind_security("192.0.2.10".parse().unwrap(), Some("secret")).is_ok());
+        assert!(validate_bind_security("0.0.0.0".parse().unwrap(), Some("secret")).is_err());
     }
 }

--- a/crates/gents-cli/src/commands/codex_shim/background.rs
+++ b/crates/gents-cli/src/commands/codex_shim/background.rs
@@ -360,6 +360,7 @@ mod tests {
             timeout: Duration::from_secs(5),
             poll_interval: Duration::from_secs(60),
             sidecar: Arc::new(Mutex::new(CodexSidecar::default())),
+            auth_token: None,
         };
 
         let mut running = BTreeMap::new();

--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use axum::http::Uri;
 use gents::defra_node::EmbeddedNode;
 use gents::{
     ensure_runtime_schemas, load_macos_keychain_identity, load_macos_secure_enclave_identity,
@@ -56,40 +57,46 @@ fn announce_codex_shim(
     bound: &crate::commands::codex_shim::BoundCodexShim,
     args: &ServeArgs,
 ) -> Value {
-    let codex_shim_url = format!(
+    let bound_url = format!(
         "ws://{}:{}/",
         display_shim_host(bound.addr().ip()),
         bound.addr().port()
     );
+    let codex_shim_url = args.codex_shim_public_url.as_deref().unwrap_or(&bound_url);
+    let launch_command =
+        codex_shim_launch_command(codex_shim_url, args.codex_shim_auth_token_env.as_deref());
     eprintln!(
-        "Codex shim is running on {codex_shim_url} with state dir {}",
+        "Codex shim is listening on {bound_url} with state dir {}",
         bound.codex_home().display(),
     );
+    if codex_shim_url != bound_url {
+        eprintln!("Codex shim public endpoint: {codex_shim_url}");
+    }
     eprintln!("Codex shim event log: {}", bound.trace_path().display());
-    eprintln!("Chat from another terminal with: gents codex");
-    if codex_shim_url != crate::DEFAULT_CODEX_REMOTE {
-        eprintln!("  (this shim is not on the default address; pass --remote {codex_shim_url})");
-    }
-    if args.codex_shim_bind_addr.is_loopback() {
-        eprintln!(
-            "For another device, restart with --codex-shim-bind-addr <trusted-private-or-tailscale-ip> and use that host in --remote."
-        );
-    } else {
-        eprintln!(
-            "Codex shim has no transport authentication; only expose this address on a trusted private network."
-        );
-    }
+    eprintln!("Chat from another terminal with: {launch_command}");
     json!({
         "websocket": codex_shim_url,
-        "launch_command": if codex_shim_url == crate::DEFAULT_CODEX_REMOTE {
-            "gents codex".to_string()
-        } else {
-            format!("gents codex --remote {codex_shim_url}")
-        },
+        "launch_command": launch_command,
+        "auth_required": bound.auth_required(),
+        "bound_agent_did": bound.agent_did(),
+        "bound_behavior_id": bound.behavior_id(),
         "shim_home": bound.codex_home().to_path_buf(),
         "codex_home": bound.codex_home().to_path_buf(),
         "event_log": bound.trace_path().to_path_buf(),
     })
+}
+
+fn codex_shim_launch_command(websocket: &str, auth_token_env: Option<&str>) -> String {
+    let mut command = if websocket == crate::DEFAULT_CODEX_REMOTE {
+        "gents codex".to_string()
+    } else {
+        format!("gents codex --remote {websocket}")
+    };
+    if let Some(env_name) = auth_token_env {
+        command.push_str(" --remote-auth-token-env ");
+        command.push_str(env_name);
+    }
+    command
 }
 
 /// Watch published generations and bind the shim on the one that makes its bound
@@ -111,7 +118,8 @@ fn spawn_codex_shim_supervisor(
     bind_args: CodexShimBindArgs,
     bound_behavior_id: String,
     mut runnable_rx: watch::Receiver<Vec<String>>,
-    bind_addr: IpAddr,
+    public_url: Option<String>,
+    auth_token_env: Option<String>,
     health: CodexShimHealthHandle,
 ) {
     tokio::spawn(async move {
@@ -127,24 +135,29 @@ fn spawn_codex_shim_supervisor(
                 match bind_codex_shim(bind_args.clone()).await {
                     Ok(bound) => {
                         binding.settle_listen(true);
-                        let url = format!(
+                        let bound_url = format!(
                             "ws://{}:{}/",
                             display_shim_host(bound.addr().ip()),
                             bound.addr().port()
                         );
+                        let url = public_url.as_deref().unwrap_or(&bound_url).to_string();
                         set_codex_shim_health(
                             &health,
                             CodexShimHealth::Listening {
                                 websocket: url.clone(),
+                                auth_required: bound.auth_required(),
+                                bound_agent_did: bound.agent_did().to_string(),
+                                bound_behavior_id: bound.behavior_id().to_string(),
                             },
                         );
                         eprintln!(
                             "Codex endpoint bound: behavior {bound_behavior_id:?} became runnable; \
                              the shim is now running on {url} (no restart was needed)."
                         );
-                        if bind_addr.is_loopback() {
-                            eprintln!("Chat from another terminal with: gents codex");
-                        }
+                        eprintln!(
+                            "Chat from another terminal with: {}",
+                            codex_shim_launch_command(&url, auth_token_env.as_deref())
+                        );
                         bound.spawn();
                         return;
                     }
@@ -188,7 +201,61 @@ fn spawn_codex_shim_supervisor(
     });
 }
 
-pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
+fn read_codex_shim_auth_token(env_name: Option<&str>) -> Result<Option<String>> {
+    env_name
+        .map(|name| read_codex_shim_auth_token_with(name, |name| std::env::var(name)))
+        .transpose()
+}
+
+fn read_codex_shim_auth_token_with<F>(env_name: &str, read: F) -> Result<String>
+where
+    F: FnOnce(&str) -> std::result::Result<String, std::env::VarError>,
+{
+    let token =
+        read(env_name).with_context(|| format!("reading app-server token from {env_name}"))?;
+    let token = token.trim();
+    if token.is_empty() {
+        anyhow::bail!("app-server token in {env_name} is empty");
+    }
+    Ok(token.to_string())
+}
+
+fn normalize_codex_shim_public_url(raw: &str) -> Result<String> {
+    let uri = raw
+        .parse::<Uri>()
+        .with_context(|| format!("invalid --codex-shim-public-url {raw:?}"))?;
+    if uri.scheme_str() != Some("wss") {
+        anyhow::bail!("--codex-shim-public-url must use wss://");
+    }
+    let authority = uri
+        .authority()
+        .ok_or_else(|| anyhow::anyhow!("--codex-shim-public-url must include a host"))?;
+    if authority.as_str().contains('@') {
+        anyhow::bail!("--codex-shim-public-url must not contain credentials");
+    }
+    if authority.port_u16().is_none() {
+        anyhow::bail!("--codex-shim-public-url must include an explicit port");
+    }
+    if uri.path() != "/" || uri.query().is_some() {
+        anyhow::bail!("--codex-shim-public-url must point to the root path without a query");
+    }
+    Ok(format!("wss://{authority}/"))
+}
+
+pub(crate) async fn serve(mut args: ServeArgs) -> Result<()> {
+    args.codex_shim_public_url = args
+        .codex_shim_public_url
+        .as_deref()
+        .map(normalize_codex_shim_public_url)
+        .transpose()?;
+    let codex_shim_auth_token = if args.no_codex_shim {
+        None
+    } else {
+        read_codex_shim_auth_token(args.codex_shim_auth_token_env.as_deref())?
+    };
+    if args.codex_shim_public_url.is_some() && codex_shim_auth_token.is_none() {
+        anyhow::bail!("--codex-shim-public-url requires --codex-shim-auth-token-env");
+    }
     let home_dir = resolve_home_dir(args.home.as_deref());
     let data_dir = args
         .data_dir
@@ -452,6 +519,7 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
         graphql: graphql_url.clone(),
         agent_did: identity.did().to_string(),
         behavior_id: args.codex_shim_behavior_id.clone(),
+        auth_token: codex_shim_auth_token,
         bind_addr: args.codex_shim_bind_addr,
         port: args.codex_shim_port,
         timeout_secs: args.codex_shim_timeout_secs,
@@ -471,6 +539,9 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
                             .and_then(Value::as_str)
                             .unwrap_or_default()
                             .to_string(),
+                        auth_required: bound.auth_required(),
+                        bound_agent_did: bound.agent_did().to_string(),
+                        bound_behavior_id: bound.behavior_id().to_string(),
                     },
                 );
                 codex_shim_output = Some(announced);
@@ -505,7 +576,8 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
                     codex_shim_bind_args.clone(),
                     bound_behavior_id,
                     runnable_rx,
-                    args.codex_shim_bind_addr,
+                    args.codex_shim_public_url.clone(),
+                    args.codex_shim_auth_token_env.clone(),
                     codex_shim_health.clone(),
                 );
                 None
@@ -1015,6 +1087,59 @@ mod shim_host_tests {
     fn ipv6_shim_hosts_are_bracketed() {
         assert_eq!(display_shim_host("::1".parse().unwrap()), "[::1]");
         assert_eq!(display_shim_host("127.0.0.1".parse().unwrap()), "127.0.0.1");
+    }
+
+    #[test]
+    fn public_shim_url_requires_a_root_wss_endpoint_with_explicit_port() {
+        assert_eq!(
+            normalize_codex_shim_public_url("wss://agent.example:443/").unwrap(),
+            "wss://agent.example:443/"
+        );
+        assert!(normalize_codex_shim_public_url("ws://agent.example:9292/").is_err());
+        assert!(normalize_codex_shim_public_url("wss://agent.example/").is_err());
+        assert!(normalize_codex_shim_public_url("wss://agent.example:443/rpc").is_err());
+    }
+
+    #[test]
+    fn shim_auth_token_env_is_trimmed_and_required() {
+        assert_eq!(
+            read_codex_shim_auth_token_with("GENTS_TOKEN", |_| Ok(" secret ".to_string())).unwrap(),
+            "secret"
+        );
+        assert!(read_codex_shim_auth_token_with("GENTS_TOKEN", |_| Ok(" ".to_string())).is_err());
+        assert!(read_codex_shim_auth_token_with("GENTS_TOKEN", |_| {
+            Err(std::env::VarError::NotPresent)
+        })
+        .is_err());
+    }
+
+    #[test]
+    fn shim_launch_command_references_the_token_environment_variable() {
+        assert_eq!(
+            codex_shim_launch_command(
+                "wss://agent.example:443/",
+                Some("GENTS_REMOTE_TOKEN")
+            ),
+            "gents codex --remote wss://agent.example:443/ --remote-auth-token-env GENTS_REMOTE_TOKEN"
+        );
+    }
+
+    #[test]
+    fn server_parses_remote_shim_security_flags() {
+        let args = parse_server(&[
+            "--codex-shim-auth-token-env",
+            "GENTS_REMOTE_TOKEN",
+            "--codex-shim-public-url",
+            "wss://agent.example:443/",
+        ]);
+        assert_eq!(
+            args.codex_shim_auth_token_env.as_deref(),
+            Some("GENTS_REMOTE_TOKEN")
+        );
+        assert_eq!(
+            args.codex_shim_public_url.as_deref(),
+            Some("wss://agent.example:443/")
+        );
     }
 
     #[test]

--- a/crates/gents-cli/src/http/healthz.rs
+++ b/crates/gents-cli/src/http/healthz.rs
@@ -313,6 +313,9 @@ mod tests {
     fn healthz_reports_a_listening_shim_as_ok() {
         let state = state_with_shim(crate::shared::CodexShimHealth::Listening {
             websocket: "ws://127.0.0.1:9292/".to_string(),
+            auth_required: true,
+            bound_agent_did: "did:key:agent".to_string(),
+            bound_behavior_id: "did:key:agent:default".to_string(),
         });
         let payload = render_healthz_payload(&state, Some(&healthy_data()), None);
 
@@ -321,6 +324,18 @@ mod tests {
                 .pointer("/checks/codex_shim/status")
                 .and_then(Value::as_str),
             Some("ok")
+        );
+        assert_eq!(
+            payload
+                .pointer("/checks/codex_shim/auth_required")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            payload
+                .pointer("/checks/codex_shim/bound_agent_did")
+                .and_then(Value::as_str),
+            Some("did:key:agent")
         );
         assert_eq!(payload.get("status").and_then(Value::as_str), Some("ok"));
     }

--- a/crates/gents-cli/src/main.rs
+++ b/crates/gents-cli/src/main.rs
@@ -147,9 +147,10 @@ Common flow:
 The server runs the Codex TUI endpoint by default (loopback only); disable it
 with --no-codex-shim. `gents codex` in another terminal connects to it.
 
-For laptop-to-fleet use, bind the shim on a reachable interface:
-  gents server --codex-shim-bind-addr <trusted-private-or-tailscale-ip>
-  gents codex --remote ws://<tailscale-host>:9292/
+For authenticated remote use, terminate TLS in a reverse proxy to the loopback
+listener and advertise that endpoint:
+  gents server --codex-shim-auth-token-env GENTS_REMOTE_TOKEN --codex-shim-public-url wss://<host>:443/
+  gents codex --remote wss://<host>:443/ --remote-auth-token-env GENTS_REMOTE_TOKEN
 
 Identity note:
   Standalone server startup supports file keys, macOS keychain software-key homes initialized with identity_backend=macos-keychain, and macOS Secure Enclave homes initialized with identity_backend=macos-secure-enclave.

--- a/crates/gents-cli/src/shared.rs
+++ b/crates/gents-cli/src/shared.rs
@@ -87,7 +87,12 @@ pub(crate) enum CodexShimHealth {
     /// `--no-codex-shim`: not an error, and not a thing to report as degraded.
     Off,
     /// Listening on its port.
-    Listening { websocket: String },
+    Listening {
+        websocket: String,
+        auth_required: bool,
+        bound_agent_did: String,
+        bound_behavior_id: String,
+    },
     /// Waiting for the control plane to supply the bound behavior. Transient by
     /// construction — the supervisor binds on the generation that carries it.
     Pending {
@@ -109,9 +114,17 @@ impl CodexShimHealth {
     pub(crate) fn to_json(&self) -> serde_json::Value {
         match self {
             Self::Off => serde_json::json!({ "status": "off" }),
-            Self::Listening { websocket } => serde_json::json!({
+            Self::Listening {
+                websocket,
+                auth_required,
+                bound_agent_did,
+                bound_behavior_id,
+            } => serde_json::json!({
                 "status": "ok",
                 "websocket": websocket,
+                "auth_required": auth_required,
+                "bound_agent_did": bound_agent_did,
+                "bound_behavior_id": bound_behavior_id,
             }),
             Self::Pending {
                 bound_behavior_id,

--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -12,6 +12,9 @@ use gents::subagent_target_entry;
 use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::AUTHORIZATION;
+use tokio_tungstenite::tungstenite::http::{HeaderValue, StatusCode};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use uuid::Uuid;
@@ -25,6 +28,97 @@ fn gents_model_selection_id(backend_id: &str, model_name: &str) -> String {
 
 fn default_backend_id(agent_did: &str) -> String {
     format!("{agent_did}:backend")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_handshake_requires_configured_bearer_token() -> Result<()> {
+    let tempdir = tempfile::tempdir().context("creating tempdir")?;
+    let home_dir = tempdir.path().join("home");
+    fs::create_dir_all(&home_dir)?;
+    let model_name = format!("mock-auth-{}", Uuid::new_v4().simple());
+    let mock_endpoint = MockChatEndpoint::start(&model_name, "unused")?;
+    let init = run_init_json(
+        &home_dir,
+        &[
+            "--agent-name",
+            "authenticated-shim",
+            "--model-name",
+            &model_name,
+            mock_endpoint.endpoint(),
+        ],
+    )?;
+    let agent_did = agent_did_from_init(&init)?;
+    let server_port = allocate_port()?;
+    let shim_port = allocate_port()?;
+    let shim_port_string = shim_port.to_string();
+    let mut serve = spawn_server_with_env(
+        &home_dir,
+        server_port,
+        &[
+            "--codex-shim-port",
+            &shim_port_string,
+            "--codex-shim-auth-token-env",
+            "GENTS_SHIM_TEST_TOKEN",
+        ],
+        &[("GENTS_SHIM_TEST_TOKEN", "correct-secret")],
+    )?;
+    wait_for_port(server_port, &mut serve)?;
+    wait_for_port(shim_port, &mut serve)?;
+    let url = format!("ws://127.0.0.1:{shim_port}/");
+    let health = reqwest::get(format!("http://127.0.0.1:{server_port}/healthz"))
+        .await?
+        .json::<Value>()
+        .await?;
+    assert_eq!(
+        health
+            .pointer("/checks/codex_shim/auth_required")
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        health
+            .pointer("/checks/codex_shim/bound_agent_did")
+            .and_then(Value::as_str),
+        Some(agent_did.as_str())
+    );
+    assert!(!health.to_string().contains("correct-secret"));
+
+    let unauthenticated = connect_async(&url)
+        .await
+        .expect_err("missing token rejected");
+    assert_http_status(unauthenticated, StatusCode::UNAUTHORIZED)?;
+
+    let mut wrong_request = url.clone().into_client_request()?;
+    wrong_request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Bearer wrong-secret"),
+    );
+    let wrong = connect_async(wrong_request)
+        .await
+        .expect_err("wrong token rejected");
+    assert_http_status(wrong, StatusCode::UNAUTHORIZED)?;
+
+    let mut request = url.into_client_request()?;
+    request.headers_mut().insert(
+        AUTHORIZATION,
+        HeaderValue::from_static("Bearer correct-secret"),
+    );
+    let (mut websocket, _) = connect_async(request).await?;
+    websocket.close(None).await?;
+    Ok(())
+}
+
+fn assert_http_status(
+    error: tokio_tungstenite::tungstenite::Error,
+    expected: StatusCode,
+) -> Result<()> {
+    let tokio_tungstenite::tungstenite::Error::Http(response) = error else {
+        bail!("expected HTTP {expected}, got {error}");
+    };
+    if response.status() != expected {
+        bail!("expected HTTP {expected}, got {}", response.status());
+    }
+    Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/gents-cli/tests/cli_help.rs
+++ b/crates/gents-cli/tests/cli_help.rs
@@ -57,15 +57,15 @@ fn status_without_runtime_suggests_init_and_server() -> Result<()> {
 }
 
 #[test]
-fn server_help_does_not_suggest_unspecified_codex_shim_bind() -> Result<()> {
+fn server_help_requires_authentication_for_remote_app_server_bind() -> Result<()> {
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");
     fs::create_dir_all(&home_dir)?;
 
     let output = run_cli_text(&home_dir, &["server", "--help"])?;
     assert!(
-        output.contains("<trusted-private-or-tailscale-ip>"),
-        "expected trusted private bind guidance in server help, got:\n{output}"
+        output.contains("--codex-shim-auth-token-env"),
+        "expected authenticated remote-bind guidance in server help, got:\n{output}"
     );
     assert!(
         !output.contains("0.0.0.0"),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -245,16 +245,27 @@ walkthrough](demo.md#part-3--grow-the-link-into-a-fleet).
 
 ## Remote Codex clients
 
-The Codex endpoint binds loopback by default and has no transport
-authentication. To drive a runtime from another machine, bind it to a trusted
-private or Tailscale IP and point the client at it:
+The app-server endpoint binds loopback by default. For remote access, keep the
+listener on loopback, terminate TLS in a reverse proxy, and require a bearer
+token sourced from an environment variable:
 
 ```bash
-gents server --codex-shim-bind-addr <trusted-private-or-tailscale-ip>
-gents codex --remote ws://<that-host>:9292/
+export GENTS_REMOTE_TOKEN="$(openssl rand -hex 32)"
+gents server \
+  --codex-shim-auth-token-env GENTS_REMOTE_TOKEN \
+  --codex-shim-public-url wss://agent.example:443/
+
+# On the client, set the same token without placing it in shell history.
+gents codex \
+  --remote wss://agent.example:443/ \
+  --remote-auth-token-env GENTS_REMOTE_TOKEN
 ```
 
-Never bind it to an unspecified address; the server refuses `0.0.0.0`.
+The reverse proxy must forward the `Authorization` header to
+`ws://127.0.0.1:9292/`. The server refuses unspecified listeners and refuses
+unauthenticated non-loopback listeners. Startup readiness JSON and `/healthz`
+advertise the public WebSocket URL, whether authentication is required, and the
+bound agent and behavior; they never contain the token.
 
 ## Operations API
 


### PR DESCRIPTION
## Summary

- add environment-sourced bearer authentication to the app-server WebSocket listener and embedded terminal client
- refuse unspecified listeners and unauthenticated non-loopback binds
- advertise the dialable WSS URL, authentication requirement, and bound agent/behavior through startup readiness and `/healthz`
- document TLS reverse-proxy operation and cover missing, incorrect, and valid credentials with a real process-level handshake test

## Security model

- tokens are read from named environment variables and are never placed in command arguments, readiness output, health payloads, or logs
- advertised public endpoints must be root `wss://` URLs with an explicit port
- loopback use remains backward compatible without authentication

## Validation

- `cargo test -p gents-cli`
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

Related to #705. The wider thin-client and desktop transport migration remains separate.