### PR TITLE
Publish multi-platform release container

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -1,0 +1,244 @@
+name: Release container image
+
+on:
+  workflow_run:
+    workflows:
+      - Release Linux gents
+    types:
+      - completed
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing published release tag to package.
+        required: true
+        type: string
+
+concurrency:
+  group: release-container-${{ github.event.workflow_run.head_branch || inputs.release_tag || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish multi-platform image
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        (github.event.workflow_run.conclusion == 'success' &&
+         startsWith(github.event.workflow_run.head_branch, 'v'))
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Resolve published release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+          WORKFLOW_RUN_TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" ]]; then
+            release_tag="${WORKFLOW_RUN_TAG}"
+          else
+            release_tag="${REQUESTED_TAG}"
+          fi
+
+          if [[ ! "${release_tag}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "::error::Release tag '${release_tag}' is not a supported semantic version (expected vMAJOR.MINOR.PATCH[-PRERELEASE])."
+            exit 1
+          fi
+          release_major="${BASH_REMATCH[1]}"
+          release_minor="${BASH_REMATCH[2]}"
+          release_suffix="${BASH_REMATCH[4]:-}"
+
+          release_json="$(gh release view "${release_tag}" --json isDraft,isPrerelease,tagName,url)"
+          if [[ "$(jq -r '.tagName' <<<"${release_json}")" != "${release_tag}" ]]; then
+            echo "::error::GitHub returned a different release than ${release_tag}."
+            exit 1
+          fi
+          if [[ "$(jq -r '.isDraft' <<<"${release_json}")" != "false" ]]; then
+            echo "::error::Release ${release_tag} is still a draft."
+            exit 1
+          fi
+
+          release_version="${release_tag#v}"
+          release_commit="$(gh api "repos/${GH_REPO}/commits/${release_tag}" --jq '.sha')"
+          is_prerelease="$(jq -r '.isPrerelease' <<<"${release_json}")"
+          image="ghcr.io/${GITHUB_REPOSITORY,,}"
+
+          image_tags=(
+            "${image}:${release_tag}"
+            "${image}:${release_version}"
+          )
+          if [[ "${is_prerelease}" == "false" && -z "${release_suffix}" ]]; then
+            image_tags+=(
+              "${image}:${release_major}.${release_minor}"
+              "${image}:${release_major}"
+              "${image}:latest"
+            )
+          fi
+
+          {
+            echo "release_tag=${release_tag}"
+            echo "release_version=${release_version}"
+            echo "release_commit=${release_commit}"
+            echo "image=${image}"
+            echo "canonical_ref=${image}:${release_tag}"
+            echo "tags<<EOF"
+            printf '%s\n' "${image_tags[@]}"
+            echo "EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+          echo "Packaging $(jq -r '.url' <<<"${release_json}") as ${image}:${release_tag}."
+
+      - name: Download and verify Linux release artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.release.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p release-assets release/container/bin
+          gh release download "${RELEASE_TAG}" \
+            --pattern 'gents-*-unknown-linux-gnu.tar.gz' \
+            --pattern 'gents-*-unknown-linux-gnu.tar.gz.sha256' \
+            --dir release-assets
+
+          targets=(
+            x86_64-unknown-linux-gnu
+            aarch64-unknown-linux-gnu
+          )
+          for target in "${targets[@]}"; do
+            tarball="release-assets/gents-${target}.tar.gz"
+            checksum="${tarball}.sha256"
+            if [[ ! -f "${tarball}" || ! -f "${checksum}" ]]; then
+              echo "::error::Release ${RELEASE_TAG} is missing ${target} assets."
+              exit 1
+            fi
+            (
+              cd release-assets
+              sha256sum -c "$(basename "${checksum}")"
+            )
+
+            archive_root="gents-${target}"
+            archive_files="$(tar -tzf "${tarball}" | sed '/\/$/d' | LC_ALL=C sort)"
+            expected_files="$(printf '%s\n' "${archive_root}/LICENSE" "${archive_root}/gents")"
+            if [[ "${archive_files}" != "${expected_files}" ]]; then
+              echo "::error::Unexpected files in ${tarball}:"
+              printf '%s\n' "${archive_files}"
+              exit 1
+            fi
+
+            packaged_license="$(mktemp)"
+            tar -xOf "${tarball}" "${archive_root}/LICENSE" > "${packaged_license}"
+            if [[ -f release/container/LICENSE ]] && ! cmp -s release/container/LICENSE "${packaged_license}"; then
+              echo "::error::The Linux release artifacts contain different licenses."
+              exit 1
+            fi
+            install -m 0644 "${packaged_license}" release/container/LICENSE
+            rm -f "${packaged_license}"
+
+            case "${target}" in
+              x86_64-unknown-linux-gnu) platform_arch=amd64 ;;
+              aarch64-unknown-linux-gnu) platform_arch=arm64 ;;
+              *) echo "::error::Unsupported target ${target}."; exit 1 ;;
+            esac
+            tar -xOf "${tarball}" "${archive_root}/gents" > "release/container/bin/gents-${platform_arch}"
+            chmod 0755 "release/container/bin/gents-${platform_arch}"
+          done
+
+          if ! grep -q 'Apache License' release/container/LICENSE ||
+             ! grep -q 'Version 2.0' release/container/LICENSE; then
+            echo "::error::Release ${RELEASE_TAG} does not contain the Apache-2.0 license."
+            exit 1
+          fi
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and publish image
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: release/container/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          pull: true
+          tags: ${{ steps.release.outputs.tags }}
+          labels: |
+            org.opencontainers.image.title=Gents
+            org.opencontainers.image.description=Database-native agent runtime built on DefraDB
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.release.outputs.release_version }}
+            org.opencontainers.image.revision=${{ steps.release.outputs.release_commit }}
+            org.opencontainers.image.licenses=Apache-2.0
+          build-args: |
+            GENTS_VERSION=${{ steps.release.outputs.release_version }}
+          provenance: mode=max
+          sbom: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify published image
+        env:
+          IMAGE_REF: ${{ steps.release.outputs.canonical_ref }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
+        run: |
+          set -euo pipefail
+
+          manifest="$(docker buildx imagetools inspect "${IMAGE_REF}")"
+          printf '%s\n' "${manifest}"
+          grep -qE 'Platform:[[:space:]]+linux/amd64' <<<"${manifest}"
+          grep -qE 'Platform:[[:space:]]+linux/arm64' <<<"${manifest}"
+
+          for platform in linux/amd64 linux/arm64; do
+            version_output="$(docker run --rm --platform "${platform}" "${IMAGE_REF}" version)"
+            printf '%s: %s\n' "${platform}" "${version_output}"
+            expected_prefix="gents ${RELEASE_VERSION} ("
+            if [[ "${version_output}" != "${expected_prefix}"* ]]; then
+              echo "::error::${platform} image version does not start with '${expected_prefix}'."
+              exit 1
+            fi
+          done
+
+      - name: Publish summary
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE_REF: ${{ steps.release.outputs.canonical_ref }}
+          TAGS: ${{ steps.release.outputs.tags }}
+        run: |
+          {
+            echo "## Container image published"
+            echo
+            echo "- Image: \`${IMAGE_REF}\`"
+            echo "- Digest: \`${DIGEST}\`"
+            echo "- Platforms: \`linux/amd64\`, \`linux/arm64\`"
+            echo "- Tags:"
+            while IFS= read -r tag; do
+              echo "  - \`${tag}\`"
+            done <<<"${TAGS}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,6 +3,41 @@
 Operational reference beyond the [getting-started walkthrough](demo.md):
 desktop pairing, multi-runtime bring-up, and the operations API.
 
+## Container image
+
+Each published release includes a multi-platform image for Linux amd64 and
+arm64 at `ghcr.io/source-inc/gents`. Stable releases also update the major,
+major/minor, and `latest` tags. Pin the published digest instead of a tag when
+the deployment must be byte-for-byte immutable.
+
+```bash
+docker pull ghcr.io/source-inc/gents:v0.8.0
+docker run --rm ghcr.io/source-inc/gents:v0.8.0 version
+```
+
+The image runs as the non-root `gents` user. Persist its default home across
+container replacements with a named volume:
+
+```bash
+docker volume create gents-home
+docker run --rm -it \
+  -v gents-home:/home/gents/.gents \
+  ghcr.io/source-inc/gents:v0.8.0 \
+  init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
+
+docker run --rm -it \
+  -v gents-home:/home/gents/.gents \
+  -p 9191:9191 \
+  ghcr.io/source-inc/gents:v0.8.0 \
+  server --http-addr 0.0.0.0 --no-codex-shim
+```
+
+The GraphQL API defaults to port 9191. Bind it to `0.0.0.0` inside the
+container before publishing that port. The Codex shim defaults to loopback on
+port 9292 and should remain disabled unless it is explicitly authenticated and
+exposed. On Linux, add `--add-host host.docker.internal:host-gateway` when the
+runtime needs to reach a provider on the Docker host.
+
 ## Desktop app
 
 Build and install the desktop binaries:

--- a/release/container/.gitignore
+++ b/release/container/.gitignore
@@ -1,0 +1,2 @@
+/LICENSE
+/bin/

--- a/release/container/Dockerfile
+++ b/release/container/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7
+
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+ARG GENTS_VERSION
+
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libgcc-s1 \
+        liblzma5 \
+        libssl3t64 \
+        libstdc++6 \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd --gid 10001 gents \
+    && useradd \
+        --uid 10001 \
+        --gid 10001 \
+        --create-home \
+        --home-dir /home/gents \
+        --shell /usr/sbin/nologin \
+        gents \
+    && install -d -o gents -g gents /home/gents/.gents /workspace
+
+COPY --chmod=0755 release/container/bin/gents-${TARGETARCH} /usr/local/bin/gents
+COPY release/container/LICENSE /usr/share/licenses/gents/LICENSE
+
+RUN version_output="$(/usr/local/bin/gents version)" \
+    && printf '%s\n' "${version_output}" \
+    && case "${version_output}" in \
+        "gents ${GENTS_VERSION} ("*) ;; \
+        *) echo "unexpected gents version: ${version_output}" >&2; exit 1 ;; \
+    esac
+
+USER gents
+WORKDIR /workspace
+
+VOLUME ["/home/gents/.gents"]
+EXPOSE 9191 9292
+STOPSIGNAL SIGTERM
+
+ENTRYPOINT ["/usr/local/bin/gents"]

--- a/release/container/Dockerfile.dockerignore
+++ b/release/container/Dockerfile.dockerignore
@@ -1,0 +1,3 @@
+**
+!release/container/LICENSE
+!release/container/bin/gents-*


### PR DESCRIPTION
## What changed

- add a release-followup workflow that publishes `ghcr.io/source-inc/gents`
- consume and checksum the existing verified Linux release archives instead of rebuilding the CLI
- publish one OCI index for `linux/amd64` and `linux/arm64`, with semantic aliases for stable releases
- attach Apache-2.0 metadata, an SBOM, and build provenance
- run the CLI as a non-root user with `/home/gents/.gents` as its persistent home
- document container initialization, server exposure, and host-provider networking

## Why

The native `v0.8.0` artifacts are published, but the release has no container distribution. Keeping container packaging downstream of `Release Linux gents` preserves the verified binaries as the single build output and also lets us backfill an already-published release without moving or rebuilding its tag.

## Validation

- `actionlint` v1.7.12 passes for the new workflow
- Dockerfile static checks pass for both target platforms
- built the actual `v0.8.0` amd64 and arm64 release binaries into their respective images
- ran `gents version` successfully in both images
- verified UID 10001, writable Gents home, and packaged Apache-2.0 license in both images
- verified release checksums, archive layouts, matching licenses, and tag-to-commit resolution
- `scripts/rename-to-gents.sh guard all`
- `git diff --check`

## After merge

Manually dispatch **Release container image** with `release_tag=v0.8.0` to backfill the current release, then verify the GHCR package visibility before treating it as a public OSS download.
