### PR TITLE
Isolate container version checks from OTLP environment

### DIFF
--- a/.github/workflows/release-container.yml
+++ b/.github/workflows/release-container.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 45
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -216,7 +216,11 @@ jobs:
           grep -qE 'Platform:[[:space:]]+linux/arm64' <<<"${manifest}"
 
           for platform in linux/amd64 linux/arm64; do
-            version_output="$(docker run --rm --platform "${platform}" "${IMAGE_REF}" version)"
+            version_output="$(docker run --rm \
+              --platform "${platform}" \
+              --env OTEL_EXPORTER_OTLP_ENDPOINT= \
+              --env OTEL_EXPORTER_OTLP_TRACES_ENDPOINT= \
+              "${IMAGE_REF}" version)"
             printf '%s: %s\n' "${platform}" "${version_output}"
             expected_prefix="gents ${RELEASE_VERSION} ("
             if [[ "${version_output}" != "${expected_prefix}"* ]]; then

--- a/release/container/Dockerfile
+++ b/release/container/Dockerfile
@@ -26,7 +26,8 @@ RUN apt-get update \
 COPY --chmod=0755 release/container/bin/gents-${TARGETARCH} /usr/local/bin/gents
 COPY release/container/LICENSE /usr/share/licenses/gents/LICENSE
 
-RUN version_output="$(/usr/local/bin/gents version)" \
+RUN unset OTEL_EXPORTER_OTLP_ENDPOINT OTEL_EXPORTER_OTLP_TRACES_ENDPOINT \
+    && version_output="$(/usr/local/bin/gents version)" \
     && printf '%s\n' "${version_output}" \
     && case "${version_output}" in \
         "gents ${GENTS_VERSION} ("*) ;; \


### PR DESCRIPTION
## Root cause

GitHub's BuildKit environment exposes `OTEL_EXPORTER_OTLP_ENDPOINT` to the Dockerfile verification process. The `v0.8.0` CLI interprets that as a request to initialize OTLP even for `gents version`, then fails because this build has no OTLP HTTP client configured.

## Fix

- clear only the two OTLP endpoint variables around build-time and post-push version checks
- keep the image's normal runtime environment untouched, so operators can still configure telemetry deliberately
- update this new workflow to `actions/checkout@v6` to remove the Node 20 deprecation warning observed in the publish run

## Validation

- reproduced the exact `building OTLP span exporter: no http client specified` failure locally
- verified clearing the endpoint variables makes the same shipped binary succeed
- rebuilt and ran the real `v0.8.0` amd64 and arm64 images
- `actionlint` v1.7.12
- Dockerfile static checks for amd64 and arm64
- `git diff --check`

Failed backfill run: https://github.com/source-inc/gents/actions/runs/29946856704
