### PR TITLE
Serialize Lean contract loading across concurrent test consumers

### DIFF
--- a/crates/gents-lean-contract/src/lib.rs
+++ b/crates/gents-lean-contract/src/lib.rs
@@ -46,31 +46,45 @@ pub fn load_contract_json() -> Result<String> {
 }
 
 pub fn load_contract_stdout() -> Result<String> {
-    if let Some(cached) = PROCESS_STDOUT_CACHE.get() {
+    load_contract_stdout_for(
+        &proofs_dir()?,
+        &PROCESS_STDOUT_CACHE,
+        &PROCESS_LOAD_MUTEX,
+        &run_lake_build_unlocked,
+        &run_contract_generator_unlocked,
+    )
+}
+
+/// Single-flight + cross-process-locked load core.
+///
+/// Production `load_contract_stdout` and concurrency tests share this path so
+/// regressions cannot pass against a parallel reimplementation that omits the
+/// lock. Callers inject build/generate (real Lake, or fixtures).
+fn load_contract_stdout_for(
+    proofs_dir: &Path,
+    cache: &OnceLock<String>,
+    flight: &Mutex<()>,
+    build: &dyn Fn(&Path) -> Result<()>,
+    generate: &dyn Fn(&Path) -> Result<String>,
+) -> Result<String> {
+    if let Some(cached) = cache.get() {
         return Ok(cached.clone());
     }
 
-    let _in_process = PROCESS_LOAD_MUTEX
+    let _in_process = flight
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
 
-    if let Some(cached) = PROCESS_STDOUT_CACHE.get() {
+    if let Some(cached) = cache.get() {
         return Ok(cached.clone());
     }
 
-    let proofs_dir = proofs_dir()?;
-    let stdout = load_contract_stdout_uncached(&proofs_dir)?;
-    let _ = PROCESS_STDOUT_CACHE.set(stdout.clone());
+    let stdout = with_proofs_dir_lock(proofs_dir, || {
+        build(proofs_dir)?;
+        generate(proofs_dir)
+    })?;
+    let _ = cache.set(stdout.clone());
     Ok(stdout)
-}
-
-/// Build + generate under the cross-process proofs lock, without the process
-/// cache. Used by the public loader after the single-flight gate, and by tests.
-fn load_contract_stdout_uncached(proofs_dir: &Path) -> Result<String> {
-    with_proofs_dir_lock(proofs_dir, || {
-        run_lake_build_unlocked(proofs_dir)?;
-        run_contract_generator_unlocked(proofs_dir)
-    })
 }
 
 /// Run `lake build` for the contract target under the proofs-dir lock.
@@ -213,6 +227,7 @@ fn acquire_exclusive_lock(lock_path: &Path) -> Result<File> {
 
     let file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(lock_path)
@@ -367,32 +382,12 @@ mod tests {
         dir
     }
 
-    /// In-process single-flight + cross-process lock with injectable build/generate.
-    fn load_with_injectable_ops(
-        cache: &Mutex<Option<String>>,
-        proofs_dir: &Path,
-        build: &dyn Fn(&Path) -> Result<()>,
-        generate: &dyn Fn(&Path) -> Result<String>,
-    ) -> Result<String> {
-        let mut guard = cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        if let Some(cached) = guard.as_ref() {
-            return Ok(cached.clone());
-        }
-
-        let stdout = with_proofs_dir_lock(proofs_dir, || {
-            build(proofs_dir)?;
-            generate(proofs_dir)
-        })?;
-        *guard = Some(stdout.clone());
-        Ok(stdout)
-    }
-
     #[test]
     fn concurrent_threads_single_flight_same_payload() {
         let proofs_dir = unique_temp_dir("single-flight");
-        let cache = Mutex::new(None);
+        // Shared cache/flight: same production wiring as load_contract_stdout.
+        let cache = OnceLock::new();
+        let flight = Mutex::new(());
         let build_count = AtomicUsize::new(0);
         let generate_count = AtomicUsize::new(0);
         let payload =
@@ -413,7 +408,8 @@ mod tests {
             let mut handles = Vec::new();
             for _ in 0..8 {
                 handles.push(scope.spawn(|| {
-                    load_with_injectable_ops(&cache, &proofs_dir, &build, &generate).unwrap()
+                    load_contract_stdout_for(&proofs_dir, &cache, &flight, &build, &generate)
+                        .unwrap()
                 }));
             }
             let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
@@ -440,10 +436,16 @@ mod tests {
     fn failed_protected_operation_releases_lock_for_next_caller() {
         let proofs_dir = unique_temp_dir("fail-release");
         let lock_path = lock_path_for(&proofs_dir).unwrap();
+        let flight = Mutex::new(());
 
-        let err = with_proofs_dir_lock(&proofs_dir, || -> Result<()> {
-            anyhow::bail!("intentional protected failure")
-        })
+        // Failures must not be cached, so each attempt uses a fresh OnceLock.
+        let err = load_contract_stdout_for(
+            &proofs_dir,
+            &OnceLock::new(),
+            &flight,
+            &|_| anyhow::bail!("intentional protected failure"),
+            &|_| unreachable!("generate must not run after build fails"),
+        )
         .unwrap_err();
         let err = format!("{err:#}");
         assert!(
@@ -456,8 +458,11 @@ mod tests {
             "failure should retain lock diagnostics, got: {err}"
         );
 
-        // Lock must be free immediately for the next caller.
-        with_proofs_dir_lock(&proofs_dir, || Ok(())).unwrap();
+        // Lock must be free immediately for the next production-core caller.
+        load_contract_stdout_for(&proofs_dir, &OnceLock::new(), &flight, &|_| Ok(()), &|_| {
+            Ok(String::from("ok"))
+        })
+        .unwrap();
 
         let _ = std::fs::remove_dir_all(&proofs_dir);
     }
@@ -473,13 +478,40 @@ mod tests {
             "distinct proof checkouts need distinct locks"
         );
 
-        let guard_a = acquire_exclusive_lock(&lock_a).unwrap();
-        // Holding A must not block acquisition of B.
-        let guard_b = acquire_exclusive_lock(&lock_b).unwrap();
+        // Hold A's lock via the production load path (build blocks until released).
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (held_tx, held_rx) = std::sync::mpsc::channel::<()>();
+        let dir_a_thread = dir_a.clone();
+        let holder = thread::spawn(move || {
+            load_contract_stdout_for(
+                &dir_a_thread,
+                &OnceLock::new(),
+                &Mutex::new(()),
+                &|_| {
+                    held_tx.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    Ok(())
+                },
+                &|_| Ok(String::from("a")),
+            )
+            .unwrap()
+        });
+        held_rx.recv().unwrap();
+
+        // B must still load while A is held.
+        load_contract_stdout_for(
+            &dir_b,
+            &OnceLock::new(),
+            &Mutex::new(()),
+            &|_| Ok(()),
+            &|_| Ok(String::from("b")),
+        )
+        .unwrap();
 
         // Same directory must contend while A is held.
         let contended = OpenOptions::new()
             .create(true)
+            .truncate(false)
             .read(true)
             .write(true)
             .open(&lock_a)
@@ -489,10 +521,8 @@ mod tests {
             other => panic!("expected WouldBlock on same proofs lock, got {other:?}"),
         }
 
-        drop(guard_a);
-        drop(guard_b);
-        // After release, same path is acquirable again.
-        let _reacquired = acquire_exclusive_lock(&lock_a).unwrap();
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
 
         let _ = std::fs::remove_dir_all(&dir_a);
         let _ = std::fs::remove_dir_all(&dir_b);
@@ -519,9 +549,15 @@ mod tests {
         let lake_as_file = base.join(".lake");
         std::fs::write(&lake_as_file, b"not a directory").unwrap();
 
-        let err = with_proofs_dir_lock(&base, || Ok(()))
-            .unwrap_err()
-            .to_string();
+        let err = load_contract_stdout_for(
+            &base,
+            &OnceLock::new(),
+            &Mutex::new(()),
+            &|_| Ok(()),
+            &|_| Ok(String::from("unused")),
+        )
+        .unwrap_err()
+        .to_string();
         assert!(
             err.contains("lock") || err.contains(".lake"),
             "expected lock-path diagnostics, got: {err}"
@@ -534,12 +570,18 @@ mod tests {
     fn protected_op_failure_includes_lock_and_proofs_context() {
         let proofs_dir = unique_temp_dir("diag");
         let lock_path = lock_path_for(&proofs_dir).unwrap();
-        let err = with_proofs_dir_lock(&proofs_dir, || -> Result<String> {
-            anyhow::bail!(
-                "Lean conformance contract build failed\n  cwd: {}\n  status: exit 1\n  stderr:\nbogus",
-                proofs_dir.display()
-            )
-        })
+        let err = load_contract_stdout_for(
+            &proofs_dir,
+            &OnceLock::new(),
+            &Mutex::new(()),
+            &|dir| {
+                anyhow::bail!(
+                    "Lean conformance contract build failed\n  cwd: {}\n  status: exit 1\n  stderr:\nbogus",
+                    dir.display()
+                )
+            },
+            &|_| unreachable!("generate must not run after build fails"),
+        )
         .unwrap_err();
         let err = format!("{err:#}");
 
@@ -573,8 +615,8 @@ mod tests {
             let overlap_path = fixture.join("overlap");
             let done_dir = fixture.join("done");
 
-            with_proofs_dir_lock(&proofs_dir, || {
-                // If another process is inside the critical section, holder exists.
+            // Drive the production load core so a disconnect from the lock fails.
+            let build = |_: &Path| -> Result<()> {
                 if holder_path.exists() {
                     std::fs::write(&overlap_path, b"overlap detected").ok();
                     anyhow::bail!("overlapping critical section: holder already present");
@@ -589,7 +631,14 @@ mod tests {
                 std::fs::remove_file(&holder_path)?;
                 std::fs::write(done_dir.join(std::process::id().to_string()), b"ok")?;
                 Ok(())
-            })
+            };
+            load_contract_stdout_for(
+                &proofs_dir,
+                &OnceLock::new(),
+                &Mutex::new(()),
+                &build,
+                &|_| Ok(String::from("child-payload")),
+            )
             .expect("child critical section");
             return;
         }
@@ -657,6 +706,8 @@ mod tests {
         let active = Arc::new(AtomicUsize::new(0));
         let max_active = Arc::new(AtomicUsize::new(0));
 
+        // Independent caches so each thread enters the production locked path
+        // rather than collapsing into single-flight.
         thread::scope(|scope| {
             let mut handles = Vec::new();
             for i in 0..6 {
@@ -664,13 +715,20 @@ mod tests {
                 let active = Arc::clone(&active);
                 let max_active = Arc::clone(&max_active);
                 handles.push(scope.spawn(move || {
-                    with_proofs_dir_lock(proofs_dir, || {
+                    let build = |_: &Path| -> Result<()> {
                         let now = active.fetch_add(1, Ordering::SeqCst) + 1;
                         max_active.fetch_max(now, Ordering::SeqCst);
                         thread::sleep(Duration::from_millis(50));
                         active.fetch_sub(1, Ordering::SeqCst);
-                        Ok(i)
-                    })
+                        Ok(())
+                    };
+                    load_contract_stdout_for(
+                        proofs_dir,
+                        &OnceLock::new(),
+                        &Mutex::new(()),
+                        &build,
+                        &|_| Ok(i.to_string()),
+                    )
                     .unwrap()
                 }));
             }

--- a/crates/gents-lean-contract/src/lib.rs
+++ b/crates/gents-lean-contract/src/lib.rs
@@ -1,5 +1,7 @@
+use std::fs::{File, OpenOptions, TryLockError};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
@@ -13,6 +15,19 @@ pub const CONTRACT_JSON_END: &str = "---END GENTS LEAN CONTRACT JSON---";
 const CONTRACT_TARGET: &str = "Proofs.Conformance.Contracts:olean";
 const CONTRACT_RUN_FILE: &str = "Proofs/Conformance/Contracts.lean";
 const LAKE_BUILD_ATTEMPTS: usize = 3;
+
+/// Advisory lock file under the proofs `.lake` tree. Scoped per proofs checkout
+/// so independent worktrees do not serialize on each other, while every
+/// consumer of the same checkout shares one exclusive mutation guard.
+const LOCK_FILE_NAME: &str = "gents-lean-contract.lock";
+
+/// Process-wide successful stdout payload. Failures are not cached so the next
+/// caller can retry after a transient or prior error.
+static PROCESS_STDOUT_CACHE: OnceLock<String> = OnceLock::new();
+
+/// In-process single-flight gate. Only one thread runs Lake / generation; the
+/// rest wait and then observe the cache (or retry after a failed attempt).
+static PROCESS_LOAD_MUTEX: Mutex<()> = Mutex::new(());
 
 pub fn load_contract_snapshot<T>() -> Result<T>
 where
@@ -31,12 +46,39 @@ pub fn load_contract_json() -> Result<String> {
 }
 
 pub fn load_contract_stdout() -> Result<String> {
+    if let Some(cached) = PROCESS_STDOUT_CACHE.get() {
+        return Ok(cached.clone());
+    }
+
+    let _in_process = PROCESS_LOAD_MUTEX
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    if let Some(cached) = PROCESS_STDOUT_CACHE.get() {
+        return Ok(cached.clone());
+    }
+
     let proofs_dir = proofs_dir()?;
-    run_lake_build(&proofs_dir)?;
-    run_contract_generator(&proofs_dir)
+    let stdout = load_contract_stdout_uncached(&proofs_dir)?;
+    let _ = PROCESS_STDOUT_CACHE.set(stdout.clone());
+    Ok(stdout)
 }
 
+/// Build + generate under the cross-process proofs lock, without the process
+/// cache. Used by the public loader after the single-flight gate, and by tests.
+fn load_contract_stdout_uncached(proofs_dir: &Path) -> Result<String> {
+    with_proofs_dir_lock(proofs_dir, || {
+        run_lake_build_unlocked(proofs_dir)?;
+        run_contract_generator_unlocked(proofs_dir)
+    })
+}
+
+/// Run `lake build` for the contract target under the proofs-dir lock.
 pub fn run_lake_build(proofs_dir: &Path) -> Result<()> {
+    with_proofs_dir_lock(proofs_dir, || run_lake_build_unlocked(proofs_dir))
+}
+
+fn run_lake_build_unlocked(proofs_dir: &Path) -> Result<()> {
     let mut failures = Vec::new();
 
     for attempt in 1..=LAKE_BUILD_ATTEMPTS {
@@ -84,7 +126,12 @@ fn is_retryable_lake_build_failure(stdout: &str, stderr: &str) -> bool {
         || combined.contains("ProofWidgets not up-to-date")
 }
 
+/// Run the contract generator under the proofs-dir lock.
 pub fn run_contract_generator(proofs_dir: &Path) -> Result<String> {
+    with_proofs_dir_lock(proofs_dir, || run_contract_generator_unlocked(proofs_dir))
+}
+
+fn run_contract_generator_unlocked(proofs_dir: &Path) -> Result<String> {
     let output = Command::new("lake")
         .args(["env", "lean", "--run", CONTRACT_RUN_FILE])
         .current_dir(proofs_dir)
@@ -107,6 +154,93 @@ pub fn run_contract_generator(proofs_dir: &Path) -> Result<String> {
     }
 
     String::from_utf8(output.stdout).context("Lean conformance contract stdout was not UTF-8")
+}
+
+/// Hold an exclusive advisory lock for `proofs_dir` for the duration of `op`.
+///
+/// The lock file lives under the canonical proofs checkout's `.lake` directory,
+/// is released when the guard is dropped (including on panic/process exit), and
+/// is independent across distinct proof checkouts (e.g. separate worktrees).
+fn with_proofs_dir_lock<T>(proofs_dir: &Path, op: impl FnOnce() -> Result<T>) -> Result<T> {
+    let lock_path = lock_path_for(proofs_dir)?;
+    let _guard = acquire_exclusive_lock(&lock_path)?;
+    op().with_context(|| {
+        format!(
+            "while holding exclusive Lean contract load lock\n  lock: {}\n  proofs: {}",
+            lock_path.display(),
+            proofs_dir.display()
+        )
+    })
+}
+
+fn lock_path_for(proofs_dir: &Path) -> Result<PathBuf> {
+    let canonical = canonicalize_proofs_dir(proofs_dir)?;
+    Ok(canonical.join(".lake").join(LOCK_FILE_NAME))
+}
+
+fn canonicalize_proofs_dir(proofs_dir: &Path) -> Result<PathBuf> {
+    match std::fs::canonicalize(proofs_dir) {
+        Ok(path) => Ok(path),
+        Err(err) => {
+            // Fixtures may not exist yet; fall back to an absolute path so the
+            // lock is still scoped to this checkout rather than the process cwd.
+            let absolute = if proofs_dir.is_absolute() {
+                proofs_dir.to_path_buf()
+            } else {
+                std::env::current_dir()
+                    .with_context(|| {
+                        format!(
+                            "failed to resolve proofs dir {} (canonicalize: {err})",
+                            proofs_dir.display()
+                        )
+                    })?
+                    .join(proofs_dir)
+            };
+            Ok(absolute)
+        }
+    }
+}
+
+fn acquire_exclusive_lock(lock_path: &Path) -> Result<File> {
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create Lean contract load lock directory {}",
+                parent.display()
+            )
+        })?;
+    }
+
+    let file = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(lock_path)
+        .with_context(|| {
+            format!(
+                "failed to open Lean contract load lock at {}",
+                lock_path.display()
+            )
+        })?;
+
+    match file.try_lock() {
+        Ok(()) => Ok(file),
+        Err(TryLockError::WouldBlock) => {
+            file.lock().with_context(|| {
+                format!(
+                    "failed waiting for exclusive Lean contract load lock\n  lock: {}\n  hint: another process is running lake build / contract generation for this proofs directory",
+                    lock_path.display()
+                )
+            })?;
+            Ok(file)
+        }
+        Err(TryLockError::Error(err)) => Err(err).with_context(|| {
+            format!(
+                "failed to acquire exclusive Lean contract load lock at {}",
+                lock_path.display()
+            )
+        }),
+    }
 }
 
 pub fn proofs_dir() -> Result<PathBuf> {
@@ -176,6 +310,10 @@ fn unique_marker_position(stdout: &str, marker: &str) -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     #[test]
     fn extracts_contract_json_between_unique_sentinels() {
@@ -214,5 +352,338 @@ mod tests {
             "",
             "error: Proofs/Foo.lean:12:4: unknown identifier 'bar'"
         ));
+    }
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "gents-lean-contract-{label}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        dir
+    }
+
+    /// In-process single-flight + cross-process lock with injectable build/generate.
+    fn load_with_injectable_ops(
+        cache: &Mutex<Option<String>>,
+        proofs_dir: &Path,
+        build: &dyn Fn(&Path) -> Result<()>,
+        generate: &dyn Fn(&Path) -> Result<String>,
+    ) -> Result<String> {
+        let mut guard = cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(cached) = guard.as_ref() {
+            return Ok(cached.clone());
+        }
+
+        let stdout = with_proofs_dir_lock(proofs_dir, || {
+            build(proofs_dir)?;
+            generate(proofs_dir)
+        })?;
+        *guard = Some(stdout.clone());
+        Ok(stdout)
+    }
+
+    #[test]
+    fn concurrent_threads_single_flight_same_payload() {
+        let proofs_dir = unique_temp_dir("single-flight");
+        let cache = Mutex::new(None);
+        let build_count = AtomicUsize::new(0);
+        let generate_count = AtomicUsize::new(0);
+        let payload =
+            format!("{CONTRACT_JSON_BEGIN}\n{{\"thread_test\":true}}\n{CONTRACT_JSON_END}\n");
+
+        let build = |_: &Path| -> Result<()> {
+            build_count.fetch_add(1, Ordering::SeqCst);
+            // Hold the critical section long enough for other threads to pile up.
+            thread::sleep(Duration::from_millis(100));
+            Ok(())
+        };
+        let generate = |_: &Path| -> Result<String> {
+            generate_count.fetch_add(1, Ordering::SeqCst);
+            Ok(payload.clone())
+        };
+
+        thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for _ in 0..8 {
+                handles.push(scope.spawn(|| {
+                    load_with_injectable_ops(&cache, &proofs_dir, &build, &generate).unwrap()
+                }));
+            }
+            let results: Vec<String> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+            for result in &results {
+                assert_eq!(result, &payload);
+            }
+        });
+
+        assert_eq!(
+            build_count.load(Ordering::SeqCst),
+            1,
+            "build should run once under single-flight"
+        );
+        assert_eq!(
+            generate_count.load(Ordering::SeqCst),
+            1,
+            "generator should run once under single-flight"
+        );
+
+        let _ = std::fs::remove_dir_all(&proofs_dir);
+    }
+
+    #[test]
+    fn failed_protected_operation_releases_lock_for_next_caller() {
+        let proofs_dir = unique_temp_dir("fail-release");
+        let lock_path = lock_path_for(&proofs_dir).unwrap();
+
+        let err = with_proofs_dir_lock(&proofs_dir, || -> Result<()> {
+            anyhow::bail!("intentional protected failure")
+        })
+        .unwrap_err();
+        let err = format!("{err:#}");
+        assert!(
+            err.contains("intentional protected failure"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains(lock_path.to_string_lossy().as_ref())
+                || err.contains("while holding exclusive Lean contract load lock"),
+            "failure should retain lock diagnostics, got: {err}"
+        );
+
+        // Lock must be free immediately for the next caller.
+        with_proofs_dir_lock(&proofs_dir, || Ok(())).unwrap();
+
+        let _ = std::fs::remove_dir_all(&proofs_dir);
+    }
+
+    #[test]
+    fn different_proof_directories_do_not_share_a_lock() {
+        let dir_a = unique_temp_dir("lock-a");
+        let dir_b = unique_temp_dir("lock-b");
+        let lock_a = lock_path_for(&dir_a).unwrap();
+        let lock_b = lock_path_for(&dir_b).unwrap();
+        assert_ne!(
+            lock_a, lock_b,
+            "distinct proof checkouts need distinct locks"
+        );
+
+        let guard_a = acquire_exclusive_lock(&lock_a).unwrap();
+        // Holding A must not block acquisition of B.
+        let guard_b = acquire_exclusive_lock(&lock_b).unwrap();
+
+        // Same directory must contend while A is held.
+        let contended = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(&lock_a)
+            .unwrap();
+        match contended.try_lock() {
+            Err(TryLockError::WouldBlock) => {}
+            other => panic!("expected WouldBlock on same proofs lock, got {other:?}"),
+        }
+
+        drop(guard_a);
+        drop(guard_b);
+        // After release, same path is acquirable again.
+        let _reacquired = acquire_exclusive_lock(&lock_a).unwrap();
+
+        let _ = std::fs::remove_dir_all(&dir_a);
+        let _ = std::fs::remove_dir_all(&dir_b);
+    }
+
+    #[test]
+    fn same_canonical_proofs_dir_shares_lock_path() {
+        let dir = unique_temp_dir("canonical");
+        // Create a real directory so canonicalize succeeds.
+        let via_dot = dir.join(".");
+        let path_a = lock_path_for(&dir).unwrap();
+        let path_b = lock_path_for(&via_dot).unwrap();
+        assert_eq!(
+            path_a, path_b,
+            "paths that resolve to the same checkout must share a lock"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn lock_open_failure_includes_lock_path() {
+        let base = unique_temp_dir("lock-open-fail");
+        // Make `.lake` a file so create_dir_all / open of the lock path fails.
+        let lake_as_file = base.join(".lake");
+        std::fs::write(&lake_as_file, b"not a directory").unwrap();
+
+        let err = with_proofs_dir_lock(&base, || Ok(()))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("lock") || err.contains(".lake"),
+            "expected lock-path diagnostics, got: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn protected_op_failure_includes_lock_and_proofs_context() {
+        let proofs_dir = unique_temp_dir("diag");
+        let lock_path = lock_path_for(&proofs_dir).unwrap();
+        let err = with_proofs_dir_lock(&proofs_dir, || -> Result<String> {
+            anyhow::bail!(
+                "Lean conformance contract build failed\n  cwd: {}\n  status: exit 1\n  stderr:\nbogus",
+                proofs_dir.display()
+            )
+        })
+        .unwrap_err();
+        let err = format!("{err:#}");
+
+        assert!(
+            err.contains("Lean conformance contract build failed"),
+            "original lake diagnostics must be preserved: {err}"
+        );
+        assert!(
+            err.contains("while holding exclusive Lean contract load lock"),
+            "lock context missing: {err}"
+        );
+        assert!(
+            err.contains(&lock_path.display().to_string())
+                || err.contains(&proofs_dir.display().to_string()),
+            "lock/proofs paths missing: {err}"
+        );
+
+        let _ = std::fs::remove_dir_all(&proofs_dir);
+    }
+
+    #[test]
+    fn cross_process_mutations_do_not_overlap() {
+        const ENV_FIXTURE: &str = "GENTS_LEAN_CONTRACT_CROSS_PROCESS_FIXTURE";
+        const CHILDREN: usize = 4;
+        const HOLD_MS: u64 = 150;
+
+        if let Ok(fixture) = std::env::var(ENV_FIXTURE) {
+            let fixture = PathBuf::from(fixture);
+            let proofs_dir = fixture.join("proofs");
+            let holder_path = fixture.join("holder");
+            let overlap_path = fixture.join("overlap");
+            let done_dir = fixture.join("done");
+
+            with_proofs_dir_lock(&proofs_dir, || {
+                // If another process is inside the critical section, holder exists.
+                if holder_path.exists() {
+                    std::fs::write(&overlap_path, b"overlap detected").ok();
+                    anyhow::bail!("overlapping critical section: holder already present");
+                }
+                std::fs::write(&holder_path, std::process::id().to_string())?;
+                thread::sleep(Duration::from_millis(HOLD_MS));
+                let held_by = std::fs::read_to_string(&holder_path)?;
+                if held_by.trim() != std::process::id().to_string() {
+                    std::fs::write(&overlap_path, b"holder stolen").ok();
+                    anyhow::bail!("holder rewritten by another process: {held_by}");
+                }
+                std::fs::remove_file(&holder_path)?;
+                std::fs::write(done_dir.join(std::process::id().to_string()), b"ok")?;
+                Ok(())
+            })
+            .expect("child critical section");
+            return;
+        }
+
+        let fixture = unique_temp_dir("cross-process");
+        let proofs_dir = fixture.join("proofs");
+        let done_dir = fixture.join("done");
+        std::fs::create_dir_all(&proofs_dir).unwrap();
+        std::fs::create_dir_all(&done_dir).unwrap();
+
+        let exe = std::env::current_exe().expect("current test binary");
+        let mut children = Vec::new();
+        for _ in 0..CHILDREN {
+            let child = std::process::Command::new(&exe)
+                // Full libtest path so the child actually executes this test body.
+                .arg("tests::cross_process_mutations_do_not_overlap")
+                .arg("--exact")
+                .arg("--nocapture")
+                .env(ENV_FIXTURE, &fixture)
+                .env("RUST_BACKTRACE", "0")
+                .spawn()
+                .expect("spawn lock child");
+            children.push(child);
+        }
+
+        let mut failures = Vec::new();
+        for (idx, child) in children.into_iter().enumerate() {
+            let output = child.wait_with_output().expect("wait child");
+            if !output.status.success() {
+                failures.push(format!(
+                    "child {idx} failed: {}\nstdout:\n{}\nstderr:\n{}",
+                    output.status,
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+        }
+
+        let completed = std::fs::read_dir(&done_dir)
+            .unwrap()
+            .filter_map(|entry| entry.ok())
+            .count();
+        assert_eq!(
+            completed, CHILDREN,
+            "expected {CHILDREN} child critical-section completions, got {completed}"
+        );
+
+        let overlap = fixture.join("overlap");
+        assert!(
+            !overlap.exists(),
+            "processes overlapped inside the protected mutation"
+        );
+        assert!(
+            failures.is_empty(),
+            "cross-process lock children failed:\n{}",
+            failures.join("\n\n")
+        );
+
+        let _ = std::fs::remove_dir_all(&fixture);
+    }
+
+    #[test]
+    fn concurrent_threads_under_lock_never_overlap_mutation() {
+        let proofs_dir = unique_temp_dir("thread-overlap");
+        let active = Arc::new(AtomicUsize::new(0));
+        let max_active = Arc::new(AtomicUsize::new(0));
+
+        thread::scope(|scope| {
+            let mut handles = Vec::new();
+            for i in 0..6 {
+                let proofs_dir = &proofs_dir;
+                let active = Arc::clone(&active);
+                let max_active = Arc::clone(&max_active);
+                handles.push(scope.spawn(move || {
+                    with_proofs_dir_lock(proofs_dir, || {
+                        let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+                        max_active.fetch_max(now, Ordering::SeqCst);
+                        thread::sleep(Duration::from_millis(50));
+                        active.fetch_sub(1, Ordering::SeqCst);
+                        Ok(i)
+                    })
+                    .unwrap()
+                }));
+            }
+            for handle in handles {
+                handle.join().unwrap();
+            }
+        });
+
+        assert_eq!(
+            max_active.load(Ordering::SeqCst),
+            1,
+            "exclusive proofs lock must serialize the protected mutation"
+        );
+        let _ = std::fs::remove_dir_all(&proofs_dir);
     }
 }


### PR DESCRIPTION
## Summary
- Fix #855 by serializing Lean conformance contract loading in `gents-lean-contract`, the shared mutation boundary for all contract consumers.
- Add process-wide single-flight caching so one binary runs Lake/generation once and reuses a successful payload.
- Add a proofs-dir-scoped OS advisory file lock (`{canonical_proofs}/.lake/gents-lean-contract.lock`) so independent Cargo test binaries cannot concurrently mutate the same `.lake` checkout, while distinct worktrees remain independent.
- Preserve public loader APIs and detailed Lake diagnostics; extend errors with lock/wait context. Lock is held across build+generate and released on drop/exit/panic.

## Test plan
- [x] `cargo test -p gents-lean-contract` (including concurrent/cross-process regressions, repeated)
- [x] `cargo test -p gents`
- [x] `cargo test -p gents-cli` (lean consumers green; package suite exercised)
- [x] `cargo test -p gents-desktop-core`
- [x] `cargo test -p gents-desktop-tauri --lib`
- [x] `cd crates/gents/proofs && lake build`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`