### PR TITLE
fix(runtime): terminalize interrupted fan_out composites promptly (#837)

### DIFF
--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Snapshot.lean
@@ -168,6 +168,8 @@ def snapshotJson : String :=
         (cancelPropagationCases.map cancelPropagationCaseJson) ++ ","
     ++ "\"workflow_cases\":"
       ++ workflowCasesJson ++ ","
+    ++ "\"workflow_composite_interrupt_cases\":"
+      ++ compositeInterruptCasesJson ++ ","
     ++ "\"r6_background_theorem_witnesses\":"
       ++ jsonArray
         (r6BackgroundTheoremWitnesses.map backgroundTheoremWitnessJson) ++ ","

--- a/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Workflow.lean
+++ b/crates/gents/proofs/Proofs/Conformance/Contracts/Json/Workflow.lean
@@ -9,6 +9,7 @@ import Proofs.Workflow.Conformance
 namespace Conformance.Contracts
 
 open Conformance.ContractCases
+open ToolExecution
 
 def workflowBarrierCaseJson
     (witness : Workflow.Conformance.BarrierCase) : String :=
@@ -16,12 +17,46 @@ def workflowBarrierCaseJson
     ++ "\"name\":" ++ jsonString witness.name ++ ","
     ++ "\"group_terminal_states\":"
       ++ jsonStringArray
-        (witness.groupTerminalStates.map ToolExecution.ToolCallState.toDefraDB) ++ ","
+        (witness.groupTerminalStates.map ToolCallState.toDefraDB) ++ ","
     ++ "\"synthesis_present\":" ++ boolString witness.synthesisPresent ++ ","
     ++ "\"legal\":" ++ boolString witness.legal
     ++ "}"
 
 def workflowCasesJson : String :=
   jsonArray (Workflow.Conformance.workflowCases.map workflowBarrierCaseJson)
+
+def cancelCauseJson : Option CancelCause → String
+  | none => "null"
+  | some c => jsonString c.toDefraDB
+
+def toolCallStateJson : ToolCallState → String :=
+  fun s => jsonString s.toDefraDB
+
+def toolCallStateOptionJson : Option ToolCallState → String
+  | none => "null"
+  | some s => toolCallStateJson s
+
+def compositeInterruptCaseJson
+    (witness : Workflow.Conformance.CompositeInterruptCase) : String :=
+  "{"
+    ++ "\"name\":" ++ jsonString witness.name ++ ","
+    ++ "\"phase\":" ++ jsonString witness.phase.toContract ++ ","
+    ++ "\"parent_state\":" ++ jsonString witness.parentState.toDefraDB ++ ","
+    ++ "\"outer_state\":" ++ toolCallStateJson witness.outerState ++ ","
+    ++ "\"outer_cancel_cause\":" ++ cancelCauseJson witness.outerCancelCause ++ ","
+    ++ "\"fan_out_bridges\":"
+      ++ jsonStringArray (witness.fanOutBridges.map ToolCallState.toDefraDB) ++ ","
+    ++ "\"synthesis_bridge\":" ++ toolCallStateOptionJson witness.synthesisBridge ++ ","
+    ++ "\"continuation_owned\":" ++ boolString witness.continuationOwned ++ ","
+    ++ "\"pending_child_cleanup\":" ++ boolString witness.pendingChildCleanup ++ ","
+    ++ "\"post_outer_eligible_active\":" ++ boolString witness.postOuterEligibleActive ++ ","
+    ++ "\"post_outer_state\":" ++ toolCallStateJson witness.postOuterState ++ ","
+    ++ "\"post_outer_cancel_cause\":" ++ cancelCauseJson witness.postOuterCancelCause ++ ","
+    ++ "\"post_continuation_owned\":" ++ boolString witness.postContinuationOwned
+    ++ "}"
+
+def compositeInterruptCasesJson : String :=
+  jsonArray
+    (Workflow.Conformance.compositeInterruptCases.map compositeInterruptCaseJson)
 
 end Conformance.Contracts

--- a/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
+++ b/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
@@ -91,11 +91,11 @@ def recoverySweepCases : List RecoverySweepCase :=
       "running"
       "failed"
       "gents-837-terminalize-interrupted-composites"
-  , -- Detached under non-interrupt terminal parent is still stale for this
-    -- sweep (product: only interrupted parents leave detached bridges running).
+  , -- Detached under a *failed* parent is still stale (clean completion would
+    -- exempt linked children; fail is cancel-worthy).
     recoveryCase
       terminalParentOwnedToolSweep
-      "live_detached_bridge_parent_completed_to_failed"
+      "live_detached_bridge_parent_failed_to_failed"
       "running"
       "failed"
       "gents-837-terminalize-interrupted-composites"

--- a/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
+++ b/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
@@ -91,6 +91,14 @@ def recoverySweepCases : List RecoverySweepCase :=
       "running"
       "failed"
       "gents-837-terminalize-interrupted-composites"
+  , -- Detached under non-interrupt terminal parent is still stale for this
+    -- sweep (product: only interrupted parents leave detached bridges running).
+    recoveryCase
+      terminalParentOwnedToolSweep
+      "live_detached_bridge_parent_completed_to_failed"
+      "running"
+      "failed"
+      "gents-837-terminalize-interrupted-composites"
   , recoveryCase
       toolCallRecoverySweep
       "tool_backgrounded_running_live_parent_to_cancelled"

--- a/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
+++ b/crates/gents/proofs/Proofs/Recovery/ContractCases.lean
@@ -80,6 +80,18 @@ def recoverySweepCases : List RecoverySweepCase :=
       "failed"
       "deadline-plumbing-audit-2026-05-12-tool-call-persisted-deadline"
   , recoveryCase
+      terminalParentOwnedToolSweep
+      "live_running_composite_parent_interrupted_to_cancelled"
+      "running"
+      "cancelled"
+      "gents-837-terminalize-interrupted-composites"
+  , recoveryCase
+      terminalParentOwnedToolSweep
+      "live_running_tool_parent_terminal_to_failed"
+      "running"
+      "failed"
+      "gents-837-terminalize-interrupted-composites"
+  , recoveryCase
       toolCallRecoverySweep
       "tool_backgrounded_running_live_parent_to_cancelled"
       "running"
@@ -280,6 +292,8 @@ def recoveryEquivalenceTheorem (sweepId : String) : String :=
     "Recovery.responseRecover_matches_uninterrupted"
   else if sweepId = toolCallRecoverySweep.sweepId then
     "Recovery.toolCallRecover_matches_uninterrupted"
+  else if sweepId = terminalParentOwnedToolSweep.sweepId then
+    "Recovery.terminalParentToolRecover_matches_uninterrupted"
   else if sweepId = detachedBridgeRecoverySweep.sweepId then
     "Recovery.detachedBridgeRecover_matches_uninterrupted"
   else if sweepId = inferenceCallRecoverySweep.sweepId then

--- a/crates/gents/proofs/Proofs/Recovery/Sweeps/Registry.lean
+++ b/crates/gents/proofs/Proofs/Recovery/Sweeps/Registry.lean
@@ -13,6 +13,7 @@ def registeredRecoverySweeps : List RecoverySweep :=
   [ requestRecoverySweep
   , responseRecoverySweep
   , toolCallRecoverySweep
+  , terminalParentOwnedToolSweep
   , detachedBridgeRecoverySweep
   , inferenceCallRecoverySweep
   , expiredSubagentChildSweep

--- a/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
+++ b/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
@@ -159,10 +159,17 @@ structure TerminalParentToolRow where
   parentInterrupted : Bool
   deriving Repr
 
+/-- Matches Rust live + startup product rule for this sweep:
+
+    * running, and
+    * parent is interrupted **or** otherwise terminal, and
+    * **not** (detached bridge ∧ parent interrupted) — detached may outlive an
+      interrupted parent; under a completed/failed parent the row is still stale.
+-/
 def terminalParentToolStale (row : TerminalParentToolRow) : Prop :=
   row.call.state = .running ∧
-  ¬ isDetachedBridgeCall row.call ∧
-  (row.parentInterrupted = true ∨ row.parentTerminal = true)
+  (row.parentInterrupted = true ∨ row.parentTerminal = true) ∧
+  ¬ (isDetachedBridgeCall row.call ∧ row.parentInterrupted = true)
 
 instance (row : TerminalParentToolRow) : Decidable (terminalParentToolStale row) := by
   unfold terminalParentToolStale
@@ -199,8 +206,9 @@ theorem terminalParentToolRecover_terminal :
   by_cases h_int : row.parentInterrupted
   · simp [h_int, ToolRecoveryCause.terminalState,
       HasTerminal.isTerminal, ToolCallState.instHasTerminal]
-  · have h_term : row.parentTerminal = true := by
-      rcases h_stale with ⟨_, _, h_parent⟩
+  · -- not interrupted: parentTerminal must hold for staleness
+    have h_term : row.parentTerminal = true := by
+      rcases h_stale with ⟨_, h_parent, _⟩
       cases h_parent with
       | inl h => exact absurd h (by simpa using h_int)
       | inr h => exact h

--- a/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
+++ b/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
@@ -157,19 +157,33 @@ structure TerminalParentToolRow where
   call : ToolCallContext
   parentTerminal : Bool
   parentInterrupted : Bool
+  /-- Parent reached a successful completed terminal (not interrupt/fail/dead).
+      Clean completion is **not** a cancel signal for linked children. -/
+  parentCleanCompleted : Bool
   deriving Repr
+
+/-- Linked subagent bridge (has a child request id). -/
+def isChildLinkedBridge (call : ToolCallContext) : Prop :=
+  call.childRequestId.isSome
+
+instance (call : ToolCallContext) : Decidable (isChildLinkedBridge call) := by
+  unfold isChildLinkedBridge
+  infer_instance
 
 /-- Matches Rust live + startup product rule for this sweep:
 
     * running, and
     * parent is interrupted **or** otherwise terminal, and
     * **not** (detached bridge ∧ parent interrupted) — detached may outlive an
-      interrupted parent; under a completed/failed parent the row is still stale.
+      interrupted parent, and
+    * **not** (child-linked bridge ∧ parent cleanly completed) — clean completion
+      does not cancel background cascade children.
 -/
 def terminalParentToolStale (row : TerminalParentToolRow) : Prop :=
   row.call.state = .running ∧
   (row.parentInterrupted = true ∨ row.parentTerminal = true) ∧
-  ¬ (isDetachedBridgeCall row.call ∧ row.parentInterrupted = true)
+  ¬ (isDetachedBridgeCall row.call ∧ row.parentInterrupted = true) ∧
+  ¬ (isChildLinkedBridge row.call ∧ row.parentCleanCompleted = true)
 
 instance (row : TerminalParentToolRow) : Decidable (terminalParentToolStale row) := by
   unfold terminalParentToolStale
@@ -208,7 +222,7 @@ theorem terminalParentToolRecover_terminal :
       HasTerminal.isTerminal, ToolCallState.instHasTerminal]
   · -- not interrupted: parentTerminal must hold for staleness
     have h_term : row.parentTerminal = true := by
-      rcases h_stale with ⟨_, h_parent, _⟩
+      rcases h_stale with ⟨_, h_parent, _, _⟩
       cases h_parent with
       | inl h => exact absurd h (by simpa using h_int)
       | inr h => exact h
@@ -221,7 +235,7 @@ theorem terminalParentToolRecover_zero :
   intro row h_stale
   have h_not : ¬ terminalParentToolStale (terminalParentToolRecover row) := by
     intro h
-    rcases h with ⟨h_running, _, _⟩
+    rcases h with ⟨h_running, _, _, _⟩
     unfold terminalParentToolRecover at h_running
     by_cases h_int : row.parentInterrupted
     · simp [h_int, ToolRecoveryCause.terminalState] at h_running

--- a/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
+++ b/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
@@ -157,8 +157,10 @@ structure TerminalParentToolRow where
   call : ToolCallContext
   parentTerminal : Bool
   parentInterrupted : Bool
-  /-- Parent reached a successful completed terminal (not interrupt/fail/dead).
-      Clean completion is **not** a cancel signal for linked children. -/
+  /-- Exclusive clean completion: parent shows completed evidence and **no**
+      cancel-worthy field. Must be false whenever `parentInterrupted` (or any
+      other cancel-worthy terminal) is true — mirrors Rust where cancel-worthy
+      evidence takes precedence over a divergent `completed` sibling field. -/
   parentCleanCompleted : Bool
   deriving Repr
 
@@ -170,20 +172,29 @@ instance (call : ToolCallContext) : Decidable (isChildLinkedBridge call) := by
   unfold isChildLinkedBridge
   infer_instance
 
+/-- Exclusive clean completion: completed without interrupt evidence. -/
+def exclusiveCleanCompleted (row : TerminalParentToolRow) : Prop :=
+  row.parentCleanCompleted = true ∧ row.parentInterrupted = false
+
+instance (row : TerminalParentToolRow) : Decidable (exclusiveCleanCompleted row) := by
+  unfold exclusiveCleanCompleted
+  infer_instance
+
 /-- Matches Rust live + startup product rule for this sweep:
 
     * running, and
     * parent is interrupted **or** otherwise terminal, and
     * **not** (detached bridge ∧ parent interrupted) — detached may outlive an
       interrupted parent, and
-    * **not** (child-linked bridge ∧ parent cleanly completed) — clean completion
-      does not cancel background cascade children.
+    * **not** (child-linked bridge ∧ *exclusive* clean completion) — clean
+      completion does not cancel background cascade children, but any interrupt
+      evidence cancels the exemption (cancel-worthy takes precedence).
 -/
 def terminalParentToolStale (row : TerminalParentToolRow) : Prop :=
   row.call.state = .running ∧
   (row.parentInterrupted = true ∨ row.parentTerminal = true) ∧
   ¬ (isDetachedBridgeCall row.call ∧ row.parentInterrupted = true) ∧
-  ¬ (isChildLinkedBridge row.call ∧ row.parentCleanCompleted = true)
+  ¬ (isChildLinkedBridge row.call ∧ exclusiveCleanCompleted row)
 
 instance (row : TerminalParentToolRow) : Decidable (terminalParentToolStale row) := by
   unfold terminalParentToolStale

--- a/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
+++ b/crates/gents/proofs/Proofs/Recovery/Sweeps/ToolCalls.lean
@@ -146,4 +146,100 @@ def toolCallRecoveryEquivalence : RecoveryEquivalence toolCallRecoverySweep :=
   , h_recover_eq_uninterrupted := toolCallRecover_matches_uninterrupted
   }
 
+/-! ## Live terminal-parent owned tool cleanup (#837)
+
+Periodic (not restart-only) counterpart of the parent-interrupted /
+parent-terminal arms of `toolCallRecoverySweep`. Does **not** apply the
+restart-only `terminalizeBackgroundedAsInterrupted` path.
+-/
+
+structure TerminalParentToolRow where
+  call : ToolCallContext
+  parentTerminal : Bool
+  parentInterrupted : Bool
+  deriving Repr
+
+def terminalParentToolStale (row : TerminalParentToolRow) : Prop :=
+  row.call.state = .running ∧
+  ¬ isDetachedBridgeCall row.call ∧
+  (row.parentInterrupted = true ∨ row.parentTerminal = true)
+
+instance (row : TerminalParentToolRow) : Decidable (terminalParentToolStale row) := by
+  unfold terminalParentToolStale
+  infer_instance
+
+def terminalParentToolRecover (row : TerminalParentToolRow) : TerminalParentToolRow :=
+  let cause : ToolRecoveryCause :=
+    if row.parentInterrupted then .parentInterrupted else .parentTerminal
+  { row with call := { row.call with state := cause.terminalState } }
+
+def terminalParentToolUninterruptedTerminalize
+    (row : TerminalParentToolRow) : TerminalParentToolRow :=
+  terminalParentToolRecover row
+
+def terminalParentToolMeasure (row : TerminalParentToolRow) : Nat :=
+  if terminalParentToolStale row then 1 else 0
+
+theorem terminalParentToolRecover_matches_uninterrupted :
+    ∀ row, terminalParentToolStale row →
+      terminalParentToolRecover row = terminalParentToolUninterruptedTerminalize row := by
+  intro row _h_stale
+  rfl
+
+theorem terminalParentTool_stale_positive :
+    ∀ row, terminalParentToolStale row → terminalParentToolMeasure row > 0 := by
+  intro row h_stale
+  simp [terminalParentToolMeasure, h_stale]
+
+theorem terminalParentToolRecover_terminal :
+    ∀ row, terminalParentToolStale row →
+      isTerminal (terminalParentToolRecover row).call.state := by
+  intro row h_stale
+  unfold terminalParentToolRecover
+  by_cases h_int : row.parentInterrupted
+  · simp [h_int, ToolRecoveryCause.terminalState,
+      HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+  · have h_term : row.parentTerminal = true := by
+      rcases h_stale with ⟨_, _, h_parent⟩
+      cases h_parent with
+      | inl h => exact absurd h (by simpa using h_int)
+      | inr h => exact h
+    simp [h_int, h_term, ToolRecoveryCause.terminalState,
+      HasTerminal.isTerminal, ToolCallState.instHasTerminal]
+
+theorem terminalParentToolRecover_zero :
+    ∀ row, terminalParentToolStale row →
+      terminalParentToolMeasure (terminalParentToolRecover row) = 0 := by
+  intro row h_stale
+  have h_not : ¬ terminalParentToolStale (terminalParentToolRecover row) := by
+    intro h
+    rcases h with ⟨h_running, _, _⟩
+    unfold terminalParentToolRecover at h_running
+    by_cases h_int : row.parentInterrupted
+    · simp [h_int, ToolRecoveryCause.terminalState] at h_running
+    · simp [h_int, ToolRecoveryCause.terminalState] at h_running
+  simp [terminalParentToolMeasure, h_not]
+
+def terminalParentOwnedToolSweep : RecoverySweep :=
+  { Row := TerminalParentToolRow
+  , collection := .agentToolCall
+  , sweepId := "tool_call_lifecycle_reconcile_terminal_parent_owned_tools"
+  , rustFunction := "ToolCallLifecycle::reconcile_terminal_parent_owned_tools"
+  , cadence := .periodic
+  , implementationStatus := .implemented
+  , stale := terminalParentToolStale
+  , recover := terminalParentToolRecover
+  , terminal := fun row => isTerminal row.call.state
+  , measure := terminalParentToolMeasure
+  , h_stale_positive := terminalParentTool_stale_positive
+  , h_recover_terminal := terminalParentToolRecover_terminal
+  , h_recover_zero := terminalParentToolRecover_zero
+  }
+
+def terminalParentOwnedToolEquivalence :
+    RecoveryEquivalence terminalParentOwnedToolSweep :=
+  { uninterrupted := terminalParentToolUninterruptedTerminalize
+  , h_recover_eq_uninterrupted := terminalParentToolRecover_matches_uninterrupted
+  }
+
 end Recovery

--- a/crates/gents/proofs/Proofs/Workflow.lean
+++ b/crates/gents/proofs/Proofs/Workflow.lean
@@ -1,4 +1,6 @@
 import Proofs.Workflow.FanOut
+import Proofs.Workflow.CompositeInterrupt
+import Proofs.Workflow.Conformance
 
 /-!
 # Workflow

--- a/crates/gents/proofs/Proofs/Workflow/CompositeInterrupt.lean
+++ b/crates/gents/proofs/Proofs/Workflow/CompositeInterrupt.lean
@@ -24,8 +24,8 @@ pending child cleanup. The bad state — parent terminal while outer is eligible
 as active — is *representable*. Bounded interrupt cleanup excludes it, and
 late normal terminalization cannot overwrite an interrupt terminal.
 
-Meaningfulness comes from induction over `Step` / `Trace`, not from baking
-"outer is cancelled" into a constructor premise.
+Meaningfulness comes from step preservation (and its trace lift), not from
+baking "outer is cancelled" into a constructor premise.
 -/
 
 namespace Workflow
@@ -419,6 +419,17 @@ theorem Step.preserves_interrupt_terminal
       exact ⟨h_canc, h_cause, h_owned⟩
   | recoverTerminalParent h_parent h_outer h_post =>
       rw [h_canc] at h_outer; cases h_outer
+
+/-- Trace lift of `Step.preserves_interrupt_terminal`. -/
+theorem Trace.preserves_interrupt_terminal
+    {pre post : State}
+    (h_term : interruptTerminal pre)
+    (h_trace : Trace pre post) :
+    interruptTerminal post := by
+  induction h_trace with
+  | refl => exact h_term
+  | step h_step _ ih =>
+      exact ih (h_step.preserves_interrupt_terminal h_term)
 
 /-- Explicit cleanup invariant after interrupt post-state construction. -/
 theorem interrupt_post_satisfies_cleanup_invariant (pre : State) :

--- a/crates/gents/proofs/Proofs/Workflow/CompositeInterrupt.lean
+++ b/crates/gents/proofs/Proofs/Workflow/CompositeInterrupt.lean
@@ -1,0 +1,479 @@
+import Proofs.Request.State
+import Proofs.ToolExecution.CancelCause
+import Proofs.ToolExecution.State
+import Proofs.Workflow.FanOut
+
+/-!
+# Workflow.CompositeInterrupt
+
+Model for the outer `fan_out_and_synthesize` composite tool call under parent
+interrupt (#837).
+
+## Broken invariant (pre-fix)
+
+The outer composite `AgentToolCall` is owned as a *local* lifecycle while its
+fan-out/synthesis workflow runs. Child bridges live in the cancel-visible map.
+On parent interrupt the map drains and children terminalize, but the outer row
+can remain `running` until deadline or daemon restart.
+
+## What this model proves
+
+A composite workflow is an evolving record: parent request state, outer tool
+state, phase, child/synthesis projected states, continuation ownership, and
+pending child cleanup. The bad state — parent terminal while outer is eligible
+as active — is *representable*. Bounded interrupt cleanup excludes it, and
+late normal terminalization cannot overwrite an interrupt terminal.
+
+Meaningfulness comes from induction over `Step` / `Trace`, not from baking
+"outer is cancelled" into a constructor premise.
+-/
+
+namespace Workflow
+namespace CompositeInterrupt
+
+open ToolExecution
+open RequestState
+
+/-- Phases of the composite workflow where interrupt may land. -/
+inductive Phase where
+  | fanOutSpawn
+  | fanOutBarrier
+  | synthesisSpawn
+  | synthesisRun
+  | resultPersist
+  deriving DecidableEq, Repr
+
+namespace Phase
+
+def toContract : Phase → String
+  | .fanOutSpawn => "fanOutSpawn"
+  | .fanOutBarrier => "fanOutBarrier"
+  | .synthesisSpawn => "synthesisSpawn"
+  | .synthesisRun => "synthesisRun"
+  | .resultPersist => "resultPersist"
+
+def all : List Phase :=
+  [ .fanOutSpawn, .fanOutBarrier, .synthesisSpawn, .synthesisRun, .resultPersist ]
+
+theorem all_complete (p : Phase) : p ∈ all := by
+  cases p <;> simp [all]
+
+end Phase
+
+/-- Evolving composite-orchestration state owned by one parent request. -/
+structure State where
+  parentState : RequestState
+  outerState : ToolCallState
+  outerCancelCause : Option CancelCause
+  phase : Phase
+  fanOutBridges : List ToolCallState
+  synthesisBridge : Option ToolCallState
+  /-- In-memory barrier/continuation ownership still held by the workflow. -/
+  continuationOwned : Bool
+  /-- Best-effort child/bridge cleanup still pending (retryable). -/
+  pendingChildCleanup : Bool
+  deriving Repr
+
+namespace State
+
+/-- Outer composite is eligible as active for liveness / status. -/
+def outerEligibleActive (s : State) : Prop :=
+  s.outerState = .running ∨ s.outerState = .pending ∨ s.outerState = .awaitingApproval
+
+instance (s : State) : Decidable s.outerEligibleActive := by
+  unfold outerEligibleActive; infer_instance
+
+/-- Computable mirror of `outerEligibleActive`. -/
+def outerEligibleActiveB (s : State) : Bool :=
+  decide (s.outerEligibleActive)
+
+/-- Parent has reached a terminal request state. -/
+def parentTerminal (s : State) : Prop :=
+  isTerminal s.parentState
+
+instance (s : State) : Decidable s.parentTerminal := by
+  unfold parentTerminal; infer_instance
+
+/-- The post-interrupt cleanup invariant:
+    if the parent is terminal, the outer composite is not eligible as active. -/
+def cleanupInvariant (s : State) : Prop :=
+  s.parentTerminal → ¬ s.outerEligibleActive
+
+instance (s : State) : Decidable s.cleanupInvariant := by
+  unfold cleanupInvariant; infer_instance
+
+def cleanupInvariantB (s : State) : Bool :=
+  decide (s.cleanupInvariant)
+
+/-- Cancel-cause projection is consistent when the outer is cancelled. -/
+def cancelCauseConsistent (s : State) : Prop :=
+  s.outerState = .cancelled → s.outerCancelCause = some .interrupted
+
+instance (s : State) : Decidable s.cancelCauseConsistent := by
+  unfold cancelCauseConsistent; infer_instance
+
+/-- Outer has a single interrupt terminal with released continuation. -/
+def interruptTerminal (s : State) : Prop :=
+  s.outerState = .cancelled ∧
+  s.outerCancelCause = some .interrupted ∧
+  s.continuationOwned = false
+
+instance (s : State) : Decidable s.interruptTerminal := by
+  unfold interruptTerminal; infer_instance
+
+/-- Pure post-state constructor for bounded interrupt cleanup. -/
+def interruptCleanupPost (pre : State) : State :=
+  { pre with
+    parentState := .interrupted
+  , outerState :=
+      if pre.outerEligibleActive then .cancelled else pre.outerState
+  , outerCancelCause :=
+      if pre.outerEligibleActive then some .interrupted
+      else pre.outerCancelCause
+  , continuationOwned := false
+  , pendingChildCleanup :=
+      pre.pendingChildCleanup ||
+        (pre.fanOutBridges.any (fun b => !decide (isTerminal b)) ||
+          match pre.synthesisBridge with
+          | some b => !decide (isTerminal b)
+          | none => false) }
+
+/-- Pure post-state constructor for terminal-parent recovery.
+
+    Mirrors Rust `recover_stuck_running_tool_calls` / live reconcile:
+    interrupted parent → cancelled+interrupted; other terminal parent → failed. -/
+def recoverTerminalParentPost (pre : State) : State :=
+  let interrupted := pre.parentState = .interrupted
+  { pre with
+    outerState := if interrupted then .cancelled else .failed
+  , outerCancelCause := if interrupted then some .interrupted else none
+  , continuationOwned := false
+  , pendingChildCleanup :=
+      pre.pendingChildCleanup ||
+        (pre.fanOutBridges.any (fun b => !decide (isTerminal b)) ||
+          match pre.synthesisBridge with
+          | some b => !decide (isTerminal b)
+          | none => false) }
+
+/-- Pure post-state for best-effort child cleanup after outer interrupt. -/
+def finishChildCleanupPost (pre : State) : State :=
+  { pre with
+    pendingChildCleanup := false
+  , fanOutBridges := pre.fanOutBridges.map (fun b =>
+      if isTerminal b then b else .cancelled)
+  , synthesisBridge :=
+      match pre.synthesisBridge with
+      | some b => some (if isTerminal b then b else .cancelled)
+      | none => none }
+
+end State
+
+open State
+
+/-- Initial post-`start_running` composite: parent processing, outer running,
+    ownership held, no synthesis yet, cleanup not pending. -/
+def Initial (s : State) : Prop :=
+  s.parentState = .processing ∧
+  s.outerState = .running ∧
+  s.outerCancelCause = none ∧
+  s.phase = .fanOutSpawn ∧
+  (∀ b ∈ s.fanOutBridges, b = .running) ∧
+  s.synthesisBridge = none ∧
+  s.continuationOwned = true ∧
+  s.pendingChildCleanup = false
+
+/-- Small-step relation. `interruptCleanup` is the bounded parent-interrupt
+    transition: parent becomes interrupted, outer terminalizes exactly once if
+    still eligible, continuation ownership is released, and child cleanup may
+    remain pending without keeping the outer active. -/
+inductive Step : State → State → Prop where
+  | advancePhase
+      (pre : State)
+      (next : Phase)
+      (h_parent_live : ¬ isTerminal pre.parentState)
+      (h_outer_running : pre.outerState = .running)
+      (h_owned : pre.continuationOwned = true)
+      {post : State}
+      (h_post : post = { pre with phase := next }) :
+      Step pre post
+
+  | terminalizeFanOut
+      (pre : State)
+      (idx : Nat)
+      (t : ToolCallState)
+      (h_parent_live : ¬ isTerminal pre.parentState)
+      (h_running : pre.fanOutBridges[idx]? = some .running)
+      (h_terminal : isTerminal t)
+      {post : State}
+      (h_post : post =
+        { pre with fanOutBridges := pre.fanOutBridges.set idx t }) :
+      Step pre post
+
+  | spawnSynthesis
+      (pre : State)
+      (h_parent_live : ¬ isTerminal pre.parentState)
+      (h_outer_running : pre.outerState = .running)
+      (h_phase : pre.phase = .synthesisSpawn)
+      (h_absent : pre.synthesisBridge = none)
+      (h_all_terminal : ∀ b ∈ pre.fanOutBridges, isTerminal b)
+      {post : State}
+      (h_post : post =
+        { pre with
+          synthesisBridge := some .running
+        , phase := .synthesisRun }) :
+      Step pre post
+
+  | terminalizeSynthesis
+      (pre : State)
+      (t : ToolCallState)
+      (h_parent_live : ¬ isTerminal pre.parentState)
+      (h_running : pre.synthesisBridge = some .running)
+      (h_terminal : isTerminal t)
+      {post : State}
+      (h_post : post = { pre with synthesisBridge := some t }) :
+      Step pre post
+
+  /-- Normal successful completion of the outer composite. Guarded on outer
+      still running so an interrupt terminal cannot be overwritten. -/
+  | completeOuter
+      (pre : State)
+      (h_parent_live : ¬ isTerminal pre.parentState)
+      (h_outer_running : pre.outerState = .running)
+      (h_owned : pre.continuationOwned = true)
+      {post : State}
+      (h_post : post =
+        { pre with
+          outerState := .completed
+        , continuationOwned := false
+        , phase := .resultPersist }) :
+      Step pre post
+
+  /-- Bounded interrupt cleanup. Representable from any phase while outer is
+      still eligible; duplicate delivery is a no-op via already-terminal outer. -/
+  | interruptCleanup
+      (pre : State)
+      (h_parent_live_or_interrupted :
+        pre.parentState = .processing ∨ pre.parentState = .interrupted)
+      {post : State}
+      (h_post : post = interruptCleanupPost pre) :
+      Step pre post
+
+  /-- Best-effort child cleanup after outer is already interrupt-terminal.
+      Must not re-activate the outer composite. -/
+  | finishChildCleanup
+      (pre : State)
+      (h_interrupt : interruptTerminal pre)
+      (h_pending : pre.pendingChildCleanup = true)
+      {post : State}
+      (h_post : post = finishChildCleanupPost pre) :
+      Step pre post
+
+  /-- Late normal completion after interrupt: refused. State unchanged.
+      Models CAS-lost complete/fail against an already-cancelled outer. -/
+  | lateCompleteRefused
+      (pre : State)
+      (h_cancelled : pre.outerState = .cancelled)
+      {post : State}
+      (h_post : post = pre) :
+      Step pre post
+
+  /-- Startup / live recovery from the representable bad durable state:
+      parent already terminal, outer still running. -/
+  | recoverTerminalParent
+      (pre : State)
+      (h_parent_terminal : isTerminal pre.parentState)
+      (h_outer_running : pre.outerState = .running)
+      {post : State}
+      (h_post : post = recoverTerminalParentPost pre) :
+      Step pre post
+
+inductive Trace : State → State → Prop where
+  | refl {s : State} : Trace s s
+  | step {s₁ s₂ s₃ : State} : Step s₁ s₂ → Trace s₂ s₃ → Trace s₁ s₃
+
+def Reachable (s : State) : Prop :=
+  ∃ init : State, Initial init ∧ Trace init s
+
+/-! ## Properties -/
+
+/-- The post-state of `interruptCleanup` never leaves the outer eligible as
+    active, always marks the parent interrupted, and releases ownership. -/
+theorem interrupt_cleanup_terminalizes_outer (pre : State) :
+    let post := interruptCleanupPost pre
+    ¬ post.outerEligibleActive ∧
+    post.parentState = .interrupted ∧
+    post.continuationOwned = false ∧
+    (pre.outerEligibleActive → interruptTerminal post) := by
+  intro post
+  refine ⟨?_, rfl, rfl, ?_⟩
+  · intro h_elig
+    unfold outerEligibleActive at h_elig
+    by_cases h_pre : pre.outerEligibleActive
+    · -- interrupt forces outer to cancelled, which is never eligible.
+      have h_out : post.outerState = .cancelled := by
+        simp only [post, interruptCleanupPost, h_pre, ite_true]
+      rw [h_out] at h_elig
+      rcases h_elig with h | h | h <;> exact absurd h (by decide)
+    · -- outer state unchanged and was not eligible pre.
+      have h_out : post.outerState = pre.outerState := by
+        simp only [post, interruptCleanupPost, h_pre, ite_false]
+      rw [h_out] at h_elig
+      exact h_pre (by simpa [outerEligibleActive] using h_elig)
+  · intro h_pre
+    simp [post, interruptCleanupPost, interruptTerminal, h_pre]
+
+/-- Duplicate interrupt is idempotent on an already interrupt-terminal state. -/
+theorem interrupt_cleanup_idempotent
+    (pre : State)
+    (h_term : interruptTerminal pre) :
+    let post := interruptCleanupPost pre
+    post.outerState = pre.outerState ∧
+    post.outerCancelCause = pre.outerCancelCause ∧
+    post.continuationOwned = false := by
+  have h_not_elig : ¬ pre.outerEligibleActive := by
+    intro h
+    rcases h_term with ⟨h_canc, _, _⟩
+    simp [outerEligibleActive, h_canc] at h
+  intro post
+  simp [post, interruptCleanupPost, h_not_elig]
+
+/-- Child cleanup after interrupt does not re-activate the outer. -/
+theorem finish_child_cleanup_preserves_outer_terminal
+    (pre : State)
+    (h_term : interruptTerminal pre) :
+    let post := finishChildCleanupPost pre
+    interruptTerminal post ∧ post.pendingChildCleanup = false := by
+  intro post
+  refine ⟨?_, rfl⟩
+  rcases h_term with ⟨h1, h2, h3⟩
+  simp [post, finishChildCleanupPost, interruptTerminal, h1, h2, h3]
+
+/-- Late complete against a cancelled outer is a no-op. -/
+theorem late_complete_refused_preserves
+    (pre : State)
+    (h_canc : pre.outerState = .cancelled)
+    (post : State)
+    (h_post : post = pre) :
+    post = pre ∧ post.outerState = .cancelled := by
+  subst h_post
+  exact ⟨rfl, h_canc⟩
+
+/-- Recovery from terminal-parent / running-outer converges to a non-active
+    outer terminal (cancelled if parent interrupted, else failed). -/
+theorem recover_terminal_parent_cancels_outer
+    (pre : State)
+    (_h_parent : isTerminal pre.parentState)
+    (_h_outer : pre.outerState = .running) :
+    let post := recoverTerminalParentPost pre
+    ¬ post.outerEligibleActive ∧
+    isTerminal post.outerState ∧
+    post.continuationOwned = false ∧
+    (pre.parentState = .interrupted →
+      post.outerState = .cancelled ∧ post.outerCancelCause = some .interrupted) := by
+  intro post
+  refine ⟨?_, ?_, rfl, ?_⟩
+  · intro h
+    by_cases h_int : pre.parentState = .interrupted
+    · simp [post, recoverTerminalParentPost, h_int, outerEligibleActive] at h
+    · simp [post, recoverTerminalParentPost, h_int, outerEligibleActive] at h
+  · by_cases h_int : pre.parentState = .interrupted
+    · simp [post, recoverTerminalParentPost, h_int, HasTerminal.isTerminal,
+        ToolCallState.instHasTerminal]
+    · simp [post, recoverTerminalParentPost, h_int, HasTerminal.isTerminal,
+        ToolCallState.instHasTerminal]
+  · intro h_int
+    simp [post, recoverTerminalParentPost, h_int]
+
+/-- `Step` preserves: once outer is cancelled with interrupted cause, it stays
+    that way and never becomes eligible again. -/
+theorem Step.preserves_interrupt_terminal
+    {pre post : State}
+    (h_term : interruptTerminal pre)
+    (h_step : Step pre post) :
+    interruptTerminal post := by
+  rcases h_term with ⟨h_canc, h_cause, h_owned⟩
+  cases h_step with
+  | advancePhase next h_parent h_outer h_owned' h_post =>
+      rw [h_canc] at h_outer; cases h_outer
+  | terminalizeFanOut idx t h_parent h_running h_t h_post =>
+      subst h_post
+      exact ⟨h_canc, h_cause, h_owned⟩
+  | spawnSynthesis h_parent h_outer h_phase h_absent h_all h_post =>
+      rw [h_canc] at h_outer; cases h_outer
+  | terminalizeSynthesis t h_parent h_running h_t h_post =>
+      subst h_post
+      exact ⟨h_canc, h_cause, h_owned⟩
+  | completeOuter h_parent h_outer h_owned' h_post =>
+      rw [h_canc] at h_outer; cases h_outer
+  | interruptCleanup h_parent h_post =>
+      have h_not_elig : ¬ pre.outerEligibleActive := by
+        intro h
+        simp [outerEligibleActive, h_canc] at h
+      subst h_post
+      simp [interruptCleanupPost, interruptTerminal, h_not_elig, h_canc, h_cause]
+  | finishChildCleanup h_term' h_pending h_post =>
+      subst h_post
+      exact ⟨h_canc, h_cause, h_owned⟩
+  | lateCompleteRefused h_canc' h_post =>
+      subst h_post
+      exact ⟨h_canc, h_cause, h_owned⟩
+  | recoverTerminalParent h_parent h_outer h_post =>
+      rw [h_canc] at h_outer; cases h_outer
+
+/-- Explicit cleanup invariant after interrupt post-state construction. -/
+theorem interrupt_post_satisfies_cleanup_invariant (pre : State) :
+    cleanupInvariant (interruptCleanupPost pre) := by
+  intro _
+  exact (interrupt_cleanup_terminalizes_outer pre).1
+
+/-- Initial state is well-formed for non-vacuity: outer is eligible while
+    parent is live. -/
+theorem Initial.outer_eligible {s : State} (h : Initial s) :
+    s.outerEligibleActive ∧ ¬ s.parentTerminal := by
+  rcases h with ⟨h_parent, h_outer, _, _, _, _, _, _⟩
+  refine ⟨?_, ?_⟩
+  · simp [outerEligibleActive, h_outer]
+  · simp [parentTerminal, h_parent, HasTerminal.isTerminal]
+
+/-- **Main safety:** a single interrupt cleanup from a live-or-already-
+    interrupted parent yields a state where no owned outer remains eligible. -/
+theorem terminal_parent_no_active_outer_after_cleanup
+    (pre : State)
+    (h_parent : pre.parentState = .processing ∨ pre.parentState = .interrupted) :
+    ∃ post : State,
+      Step pre post ∧
+      post.parentState = .interrupted ∧
+      ¬ post.outerEligibleActive ∧
+      post.continuationOwned = false ∧
+      (pre.outerEligibleActive →
+        post.outerState = .cancelled ∧
+        post.outerCancelCause = some .interrupted) := by
+  let post := interruptCleanupPost pre
+  have h_step : Step pre post :=
+    Step.interruptCleanup pre h_parent (post := post) rfl
+  have h_facts := interrupt_cleanup_terminalizes_outer pre
+  refine ⟨post, h_step, rfl, h_facts.1, rfl, ?_⟩
+  intro h_elig
+  have h_term := h_facts.2.2.2 h_elig
+  exact ⟨h_term.1, h_term.2.1⟩
+
+/-- Recovery establishes the cleanup invariant when the parent is already
+    terminal and the outer is still running. -/
+theorem recover_establishes_cleanup_invariant
+    (pre : State)
+    (h_parent : isTerminal pre.parentState)
+    (h_outer : pre.outerState = .running) :
+    ∃ post : State,
+      Step pre post ∧
+      cleanupInvariant post ∧
+      isTerminal post.outerState := by
+  let post := recoverTerminalParentPost pre
+  have h_step : Step pre post :=
+    Step.recoverTerminalParent pre h_parent h_outer (post := post) rfl
+  have h_facts := recover_terminal_parent_cancels_outer pre h_parent h_outer
+  refine ⟨post, h_step, ?_, h_facts.2.1⟩
+  intro _
+  exact h_facts.1
+
+end CompositeInterrupt
+end Workflow

--- a/crates/gents/proofs/Proofs/Workflow/Conformance.lean
+++ b/crates/gents/proofs/Proofs/Workflow/Conformance.lean
@@ -1,9 +1,11 @@
 import Proofs.Workflow.FanOut
+import Proofs.Workflow.CompositeInterrupt
 
 /-!
 # Workflow conformance witnesses
 
-Finite witness rows for the Rust barrier-projection fence.
+Finite witness rows for the Rust barrier-projection fence and composite
+interrupt cleanup fence (#837).
 
 Every `legal` annotation below is *entailed by the model*, not hand-asserted:
 `workflowCasesLegalCorrect` decides that each row's `legal` equals the computable
@@ -13,12 +15,20 @@ fails to build.
 `barrierLegal` is the computable mirror of the Rust
 `workflow_barrier_projection_legal`: a group is legal iff it is non-empty AND
 (synthesis is absent OR every fan-out bridge is terminal).
+
+Composite interrupt cases pin the post-cleanup invariant: after bounded
+interrupt cleanup (or terminal-parent recovery), the outer composite is not
+eligible as active and carries a consistent interrupted cancel cause when it
+was still running.
 -/
 
 namespace Workflow
 namespace Conformance
 
 open ToolExecution
+open CompositeInterrupt
+open CompositeInterrupt.State
+open RequestState
 
 structure BarrierCase where
   name : String
@@ -87,6 +97,140 @@ def workflowCases : List BarrierCase :=
     `native_decide`, so a wrong `legal` annotation fails to build. -/
 theorem workflowCasesLegalCorrect :
     workflowCases.all caseLegalCorrect = true := by
+  native_decide
+
+/-! ## Composite interrupt cleanup cases (#837) -/
+
+structure CompositeInterruptCase where
+  name : String
+  phase : Phase
+  parentState : RequestState
+  outerState : ToolCallState
+  outerCancelCause : Option CancelCause
+  fanOutBridges : List ToolCallState
+  synthesisBridge : Option ToolCallState
+  continuationOwned : Bool
+  pendingChildCleanup : Bool
+  /-- Expected post-cleanup outer eligible-active flag. -/
+  postOuterEligibleActive : Bool
+  /-- Expected post-cleanup outer state. -/
+  postOuterState : ToolCallState
+  /-- Expected post-cleanup cancel cause (None when outer was already terminal
+      non-cancel). -/
+  postOuterCancelCause : Option CancelCause
+  /-- Expected post-cleanup continuation ownership. -/
+  postContinuationOwned : Bool
+  deriving Repr
+
+/-- Build a pre-state from a case row. -/
+def caseToState (c : CompositeInterruptCase) : State :=
+  { parentState := c.parentState
+  , outerState := c.outerState
+  , outerCancelCause := c.outerCancelCause
+  , phase := c.phase
+  , fanOutBridges := c.fanOutBridges
+  , synthesisBridge := c.synthesisBridge
+  , continuationOwned := c.continuationOwned
+  , pendingChildCleanup := c.pendingChildCleanup }
+
+/-- Apply the cleanup transition appropriate to the pre-state:
+    - parent processing/interrupted → interruptCleanupPost
+    - parent otherwise terminal with running outer → recoverTerminalParentPost
+    - else identity (should not appear in witnesses). -/
+def applyCleanup (s : State) : State :=
+  if s.parentState = .processing || s.parentState = .interrupted then
+    interruptCleanupPost s
+  else if isTerminal s.parentState && s.outerState = .running then
+    recoverTerminalParentPost s
+  else
+    s
+
+def casePostCorrect (c : CompositeInterruptCase) : Bool :=
+  let post := applyCleanup (caseToState c)
+  decide (post.outerEligibleActive) == c.postOuterEligibleActive &&
+  post.outerState == c.postOuterState &&
+  post.outerCancelCause == c.postOuterCancelCause &&
+  post.continuationOwned == c.postContinuationOwned &&
+  decide (cleanupInvariant post)
+
+def mkInterruptCase
+    (name : String)
+    (phase : Phase)
+    (fanOut : List ToolCallState)
+    (synthesis : Option ToolCallState)
+    : CompositeInterruptCase :=
+  { name := name
+  , phase := phase
+  , parentState := .processing
+  , outerState := .running
+  , outerCancelCause := none
+  , fanOutBridges := fanOut
+  , synthesisBridge := synthesis
+  , continuationOwned := true
+  , pendingChildCleanup := false
+  , postOuterEligibleActive := false
+  , postOuterState := .cancelled
+  , postOuterCancelCause := some .interrupted
+  , postContinuationOwned := false }
+
+def compositeInterruptCases : List CompositeInterruptCase :=
+  [ mkInterruptCase "interrupt_during_fan_out_spawn" .fanOutSpawn
+      [.running, .running] none
+  , mkInterruptCase "interrupt_during_fan_out_barrier" .fanOutBarrier
+      [.completed, .running] none
+  , mkInterruptCase "interrupt_between_barrier_and_synthesis" .synthesisSpawn
+      [.completed, .completed, .cancelled] none
+  , mkInterruptCase "interrupt_during_synthesis_run" .synthesisRun
+      [.completed, .completed] (some .running)
+  , mkInterruptCase "interrupt_during_result_persist" .resultPersist
+      [.completed, .completed] (some .completed)
+  , -- Duplicate interrupt: parent already interrupted, outer already cancelled.
+    { name := "duplicate_interrupt_delivery"
+    , phase := .fanOutBarrier
+    , parentState := .interrupted
+    , outerState := .cancelled
+    , outerCancelCause := some .interrupted
+    , fanOutBridges := [.cancelled, .cancelled]
+    , synthesisBridge := none
+    , continuationOwned := false
+    , pendingChildCleanup := true
+    , postOuterEligibleActive := false
+    , postOuterState := .cancelled
+    , postOuterCancelCause := some .interrupted
+    , postContinuationOwned := false }
+  , -- Restart/live recovery: terminal parent, running outer composite.
+    { name := "recover_terminal_parent_running_outer"
+    , phase := .fanOutBarrier
+    , parentState := .interrupted
+    , outerState := .running
+    , outerCancelCause := none
+    , fanOutBridges := [.cancelled, .running]
+    , synthesisBridge := none
+    , continuationOwned := false
+    , pendingChildCleanup := false
+    , postOuterEligibleActive := false
+    , postOuterState := .cancelled
+    , postOuterCancelCause := some .interrupted
+    , postContinuationOwned := false }
+  , -- Recovery when children already terminal but outer still running and the
+    -- parent is non-interrupt terminal (failed) → outer fails (not cancelled).
+    { name := "recover_terminal_children_running_outer"
+    , phase := .resultPersist
+    , parentState := .failed
+    , outerState := .running
+    , outerCancelCause := none
+    , fanOutBridges := [.completed, .completed]
+    , synthesisBridge := some .completed
+    , continuationOwned := false
+    , pendingChildCleanup := false
+    , postOuterEligibleActive := false
+    , postOuterState := .failed
+    , postOuterCancelCause := none
+    , postContinuationOwned := false }
+  ]
+
+theorem compositeInterruptCasesCorrect :
+    compositeInterruptCases.all casePostCorrect = true := by
   native_decide
 
 end Conformance

--- a/crates/gents/src/hook/persistence/orchestration.rs
+++ b/crates/gents/src/hook/persistence/orchestration.rs
@@ -137,23 +137,90 @@ impl DefraSessionHook {
         }
 
         lifecycle.start_running().await?;
-
-        let result = match self
-            .run_fan_out_and_synthesize(internal_call_id, seq, &parent_context, &parsed)
+        // Register the outer composite in the cancel-visible map so parent
+        // interrupt can terminalize it promptly (#837). The workflow future
+        // must not hold exclusive ownership across await points; completion
+        // re-takes (or reloads) the lifecycle and uses CAS terminalization so
+        // a concurrent interrupt wins cleanly.
+        self.in_flight_lifecycles
+            .lock()
             .await
+            .insert(internal_call_id.to_string(), lifecycle);
+
+        let run_result = self
+            .run_fan_out_and_synthesize(internal_call_id, seq, &parent_context, &parsed)
+            .await;
+
+        let result = self
+            .terminalize_fan_out_composite(&parent_context.session_id, internal_call_id, run_result)
+            .await?;
+
+        Ok(self.skip_tool_result(FAN_OUT_AND_SYNTHESIZE_TOOL_NAME, result))
+    }
+
+    /// Terminalize the outer `fan_out_and_synthesize` composite after the
+    /// workflow future returns (or after interrupt cancelled it mid-flight).
+    ///
+    /// Uses take-or-load + lifecycle CAS so:
+    /// - interrupt that already cancelled the durable row wins;
+    /// - late complete/fail cannot overwrite a cancel terminal;
+    /// - in-memory map ownership is released either way.
+    async fn terminalize_fan_out_composite(
+        &self,
+        session_id: &str,
+        internal_call_id: &str,
+        run_result: anyhow::Result<String>,
+    ) -> anyhow::Result<String> {
+        let mut lifecycle = match self
+            .take_or_load_in_flight_lifecycle(session_id, internal_call_id)
+            .await?
         {
+            Some(lifecycle) => lifecycle,
+            None => {
+                // Lifecycle disappeared without a durable row — treat as cancelled
+                // so the model still gets a tool result.
+                return Ok(crate::tool_call_lifecycle::runtime::cancelled_result());
+            }
+        };
+
+        if lifecycle.is_cancelled() || lifecycle.is_terminal() {
+            // Interrupt (or recovery) already won the durable race.
+            self.discard_in_flight_lifecycle(internal_call_id).await;
+            return Ok(match lifecycle.state() {
+                crate::tool_call_lifecycle::ToolCallState::Cancelled => {
+                    crate::tool_call_lifecycle::runtime::cancelled_result()
+                }
+                crate::tool_call_lifecycle::ToolCallState::TimedOut => {
+                    "tool call deadline exceeded".to_string()
+                }
+                crate::tool_call_lifecycle::ToolCallState::Failed => "tool call failed".to_string(),
+                crate::tool_call_lifecycle::ToolCallState::Completed => {
+                    // Extremely narrow race: another path completed it.
+                    "tool call completed".to_string()
+                }
+                _ => crate::tool_call_lifecycle::runtime::cancelled_result(),
+            });
+        }
+
+        match run_result {
             Ok(result) => {
                 lifecycle.complete(&result).await?;
-                result
+                if lifecycle.is_cancelled() {
+                    Ok(crate::tool_call_lifecycle::runtime::cancelled_result())
+                } else {
+                    Ok(result)
+                }
             }
             Err(error) => {
                 let (failure_class, payload) = classify_workflow_run_error(&error);
                 lifecycle.fail(&payload, failure_class).await?;
-                payload
+                if lifecycle.is_cancelled() {
+                    Ok(crate::tool_call_lifecycle::runtime::cancelled_result())
+                } else {
+                    Ok(payload)
+                }
             }
-        };
-
-        Ok(self.skip_tool_result(FAN_OUT_AND_SYNTHESIZE_TOOL_NAME, result))
+        }
     }
 
     /// Fail-fast guard for LOCAL workflow targets (mirrors the spawn path's #377

--- a/crates/gents/src/hook/persistence/orchestration.rs
+++ b/crates/gents/src/hook/persistence/orchestration.rs
@@ -183,43 +183,67 @@ impl DefraSessionHook {
             }
         };
 
-        if lifecycle.is_cancelled() || lifecycle.is_terminal() {
-            // Interrupt (or recovery) already won the durable race.
+        if lifecycle.is_terminal() {
+            // Interrupt, deadline sweep, or recovery already won the durable race.
             self.discard_in_flight_lifecycle(internal_call_id).await;
-            return Ok(match lifecycle.state() {
-                crate::tool_call_lifecycle::ToolCallState::Cancelled => {
-                    crate::tool_call_lifecycle::runtime::cancelled_result()
-                }
-                crate::tool_call_lifecycle::ToolCallState::TimedOut => {
-                    "tool call deadline exceeded".to_string()
-                }
-                crate::tool_call_lifecycle::ToolCallState::Failed => "tool call failed".to_string(),
-                crate::tool_call_lifecycle::ToolCallState::Completed => {
-                    // Extremely narrow race: another path completed it.
-                    "tool call completed".to_string()
-                }
-                _ => crate::tool_call_lifecycle::runtime::cancelled_result(),
-            });
+            return Ok(self
+                .composite_terminal_payload(session_id, &lifecycle)
+                .await);
         }
 
         match run_result {
             Ok(result) => {
                 lifecycle.complete(&result).await?;
-                if lifecycle.is_cancelled() {
-                    Ok(crate::tool_call_lifecycle::runtime::cancelled_result())
-                } else {
-                    Ok(result)
+                if !lifecycle.is_running() {
+                    // Lost CAS to cancel/timeout/fail: return the durable terminal
+                    // payload, not the would-be success string (#837 review #2).
+                    return Ok(self
+                        .composite_terminal_payload(session_id, &lifecycle)
+                        .await);
                 }
+                Ok(result)
             }
             Err(error) => {
                 let (failure_class, payload) = classify_workflow_run_error(&error);
                 lifecycle.fail(&payload, failure_class).await?;
-                if lifecycle.is_cancelled() {
-                    Ok(crate::tool_call_lifecycle::runtime::cancelled_result())
-                } else {
-                    Ok(payload)
+                if !lifecycle.is_running()
+                    && lifecycle.state() != crate::tool_call_lifecycle::ToolCallState::Failed
+                {
+                    // Lost CAS to cancel/timeout: do not report our failure payload.
+                    return Ok(self
+                        .composite_terminal_payload(session_id, &lifecycle)
+                        .await);
                 }
+                Ok(payload)
             }
+        }
+    }
+
+    /// Model-facing tool result for a durable terminal composite row.
+    async fn composite_terminal_payload(
+        &self,
+        session_id: &str,
+        lifecycle: &ToolCallLifecycle,
+    ) -> String {
+        match lifecycle.state() {
+            crate::tool_call_lifecycle::ToolCallState::Cancelled => {
+                crate::tool_call_lifecycle::runtime::cancelled_result()
+            }
+            crate::tool_call_lifecycle::ToolCallState::TimedOut => {
+                "tool call deadline exceeded".to_string()
+            }
+            crate::tool_call_lifecycle::ToolCallState::Failed => "tool call failed".to_string(),
+            crate::tool_call_lifecycle::ToolCallState::Completed => {
+                // Prefer the durable result when another path completed first.
+                crate::tool_call_lifecycle::query::load_tool_call_result(
+                    &self.node,
+                    session_id,
+                    lifecycle.tool_call_id(),
+                )
+                .await
+                .unwrap_or_else(|_| "tool call completed".to_string())
+            }
+            _ => crate::tool_call_lifecycle::runtime::cancelled_result(),
         }
     }
 

--- a/crates/gents/src/hook/persistence/orchestration.rs
+++ b/crates/gents/src/hook/persistence/orchestration.rs
@@ -194,27 +194,28 @@ impl DefraSessionHook {
         match run_result {
             Ok(result) => {
                 lifecycle.complete(&result).await?;
-                if !lifecycle.is_running() {
-                    // Lost CAS to cancel/timeout/fail: return the durable terminal
-                    // payload, not the would-be success string (#837 review #2).
-                    return Ok(self
+                if lifecycle.state() == crate::tool_call_lifecycle::ToolCallState::Completed {
+                    // Happy path: our CAS won — return the real result without a
+                    // redundant durable re-read.
+                    Ok(result)
+                } else {
+                    // Lost CAS to cancel/timeout/fail: durable terminal wins.
+                    Ok(self
                         .composite_terminal_payload(session_id, &lifecycle)
-                        .await);
+                        .await)
                 }
-                Ok(result)
             }
             Err(error) => {
                 let (failure_class, payload) = classify_workflow_run_error(&error);
                 lifecycle.fail(&payload, failure_class).await?;
-                if !lifecycle.is_running()
-                    && lifecycle.state() != crate::tool_call_lifecycle::ToolCallState::Failed
-                {
+                if lifecycle.state() == crate::tool_call_lifecycle::ToolCallState::Failed {
+                    Ok(payload)
+                } else {
                     // Lost CAS to cancel/timeout: do not report our failure payload.
-                    return Ok(self
+                    Ok(self
                         .composite_terminal_payload(session_id, &lifecycle)
-                        .await);
+                        .await)
                 }
-                Ok(payload)
             }
         }
     }

--- a/crates/gents/src/hook/tests.rs
+++ b/crates/gents/src/hook/tests.rs
@@ -476,6 +476,9 @@ async fn fetch_tool_call_row(
                     result
                     status
                     tool_failure_class
+                    cancel_cause
+                    await_mode
+                    cancel_policy
                 }}
             }}"#
         ))
@@ -1159,6 +1162,160 @@ async fn cancelling_detached_subagent_tool_does_not_interrupt_child() {
     assert!(
         child_interrupt.is_none(),
         "detached cancel must leave child request interrupt unset"
+    );
+
+    let _ = std::fs::remove_dir_all(&data_path);
+}
+
+/// #837: outer `fan_out_and_synthesize` composite must terminalize when the
+/// parent interrupt path drains in-flight lifecycles — not wait for deadline.
+#[tokio::test]
+async fn cancelling_in_flight_terminalizes_fan_out_composite_and_children() {
+    let data_path = std::env::temp_dir().join(format!(
+        "agent-hook-composite-cancel-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let node = Arc::new(
+        defra_node::EmbeddedNode::builder()
+            .data_path(&data_path)
+            .build()
+            .await
+            .unwrap(),
+    );
+    ensure_schemas(&node).await.unwrap();
+
+    let session_id = "session-composite";
+    let child_request_id = "child-composite-fan";
+    create_interruptible_request(&node, child_request_id, session_id).await;
+
+    let hook = DefraSessionHook::with_identity(
+        node.clone(),
+        "general",
+        "did:test:general",
+        FailurePolicy::default(),
+    );
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
+
+    // Outer composite (no child_request_id) — the row that used to survive interrupt.
+    let mut outer = crate::tool_call_lifecycle::ToolCallLifecycle::new(
+        node.clone(),
+        "parent-composite".to_string(),
+        session_id.to_string(),
+        "did:test:general".to_string(),
+        "composite-outer".to_string(),
+        1,
+        crate::workflow::FAN_OUT_AND_SYNTHESIZE_TOOL_NAME.to_string(),
+        r#"{"tasks":[]}"#.to_string(),
+        deadline,
+    );
+    outer.start_running().await.unwrap();
+    hook.in_flight_lifecycles
+        .lock()
+        .await
+        .insert("composite-outer".to_string(), outer);
+
+    // One fan-out child bridge under the same parent cancel map.
+    let mut bridge = crate::tool_call_lifecycle::ToolCallLifecycle::new_subagent(
+        node.clone(),
+        "parent-composite".to_string(),
+        session_id.to_string(),
+        "did:test:general".to_string(),
+        "composite-fan-0".to_string(),
+        2,
+        "spawn_subagent".to_string(),
+        "{}".to_string(),
+        deadline,
+        crate::tool_call_lifecycle::AwaitMode::Background,
+        crate::tool_call_lifecycle::CancelPolicy::Cascade,
+        child_request_id.to_string(),
+        "did:test:target".to_string(),
+    );
+    bridge.set_workflow_group("composite-outer", "fan_out_child");
+    bridge.start_running().await.unwrap();
+    hook.in_flight_lifecycles
+        .lock()
+        .await
+        .insert("composite-fan-0".to_string(), bridge);
+
+    assert_eq!(hook.cancel_in_flight_tool_calls().await.unwrap(), 2);
+    // Duplicate interrupt delivery is a no-op once the map is empty.
+    assert_eq!(hook.cancel_in_flight_tool_calls().await.unwrap(), 0);
+
+    let outer_row = fetch_tool_call_row(&node, session_id, "composite-outer").await;
+    assert_eq!(
+        outer_row
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        outer_row
+            .get("cancel_cause")
+            .and_then(|value| value.as_str()),
+        Some("interrupted")
+    );
+    assert_eq!(
+        outer_row.get("await_mode").and_then(|value| value.as_str()),
+        Some("foreground")
+    );
+    assert_eq!(
+        outer_row
+            .get("cancel_policy")
+            .and_then(|value| value.as_str()),
+        Some("cascade")
+    );
+
+    let bridge_row = fetch_tool_call_row(&node, session_id, "composite-fan-0").await;
+    assert_eq!(
+        bridge_row
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        bridge_row
+            .get("cancel_cause")
+            .and_then(|value| value.as_str()),
+        Some("interrupted")
+    );
+
+    let child_interrupt = crate::interrupt::fetch_interrupt_requested_at(&node, child_request_id)
+        .await
+        .unwrap();
+    assert!(
+        child_interrupt.is_some(),
+        "cascade cancel should latch child interrupt_requested_at"
+    );
+
+    // Late complete must not overwrite the interrupt terminal (CAS).
+    let mut reloaded = crate::tool_call_lifecycle::ToolCallLifecycle::load(
+        node.clone(),
+        session_id,
+        "composite-outer",
+    )
+    .await
+    .unwrap()
+    .expect("outer row");
+    // Force in-memory running so complete() is attempted; durable CAS must lose.
+    reloaded.set_state(crate::tool_call_lifecycle::ToolCallState::Running);
+    reloaded.set_started_at(Some(chrono::Utc::now() - chrono::Duration::seconds(1)));
+    reloaded.complete("late success").await.unwrap();
+    assert!(
+        reloaded.is_cancelled(),
+        "late complete must adopt durable cancelled state"
+    );
+    let outer_after = fetch_tool_call_row(&node, session_id, "composite-outer").await;
+    assert_eq!(
+        outer_after
+            .get("lifecycle_state")
+            .and_then(|value| value.as_str()),
+        Some("cancelled")
+    );
+    assert_eq!(
+        outer_after
+            .get("cancel_cause")
+            .and_then(|value| value.as_str()),
+        Some("interrupted")
     );
 
     let _ = std::fs::remove_dir_all(&data_path);

--- a/crates/gents/src/lean_vocab_test.rs
+++ b/crates/gents/src/lean_vocab_test.rs
@@ -134,6 +134,8 @@ pub(crate) struct LeanContractSnapshot {
     #[serde(default)]
     pub(crate) workflow_cases: Vec<LeanWorkflowCase>,
     #[serde(default)]
+    pub(crate) workflow_composite_interrupt_cases: Vec<LeanWorkflowCompositeInterruptCase>,
+    #[serde(default)]
     pub(crate) event_delivery_transition_case_count: usize,
     #[serde(default)]
     pub(crate) event_delivery_transition_cases: Vec<LeanEventDeliveryTransitionCase>,
@@ -172,6 +174,23 @@ pub(crate) struct LeanWorkflowCase {
     pub(crate) group_terminal_states: Vec<String>,
     pub(crate) synthesis_present: bool,
     pub(crate) legal: bool,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeanWorkflowCompositeInterruptCase {
+    pub(crate) name: String,
+    pub(crate) phase: String,
+    pub(crate) parent_state: String,
+    pub(crate) outer_state: String,
+    pub(crate) outer_cancel_cause: Option<String>,
+    pub(crate) fan_out_bridges: Vec<String>,
+    pub(crate) synthesis_bridge: Option<String>,
+    pub(crate) continuation_owned: bool,
+    pub(crate) pending_child_cleanup: bool,
+    pub(crate) post_outer_eligible_active: bool,
+    pub(crate) post_outer_state: String,
+    pub(crate) post_outer_cancel_cause: Option<String>,
+    pub(crate) post_continuation_owned: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -361,6 +380,11 @@ pub(crate) fn lean_contract_snapshot() -> &'static LeanContractSnapshot {
 
 pub(crate) fn lean_workflow_cases() -> &'static [LeanWorkflowCase] {
     &lean_contract_snapshot().workflow_cases
+}
+
+pub(crate) fn lean_workflow_composite_interrupt_cases(
+) -> &'static [LeanWorkflowCompositeInterruptCase] {
+    &lean_contract_snapshot().workflow_composite_interrupt_cases
 }
 
 pub(crate) fn lean_vocabulary_contract(domain: &str) -> &'static LeanVocabularyContract {

--- a/crates/gents/src/periodic_recovery.rs
+++ b/crates/gents/src/periodic_recovery.rs
@@ -10,13 +10,17 @@ use defra_node::EmbeddedNode;
 
 use crate::lifecycle::{RequestLifecycle, TerminalRepairReport};
 use crate::llm::tool::BoxFuture;
-use crate::tool_call_lifecycle::{SubagentLivenessReport, ToolCallLifecycle};
+use crate::tool_call_lifecycle::{
+    SubagentLivenessReport, TerminalParentToolReport, ToolCallLifecycle,
+};
 
 const SUBAGENT_LIVENESS_SWEEP_IDS: &[&str] = &[
     "subagent_liveness_terminalize_expired_children",
     "subagent_liveness_interrupt_queued_descendants",
 ];
 const REQUEST_TERMINAL_REPAIR_SWEEP_IDS: &[&str] = &["request_lifecycle_recover_all_requests"];
+const TERMINAL_PARENT_TOOL_SWEEP_IDS: &[&str] =
+    &["tool_call_lifecycle_reconcile_terminal_parent_owned_tools"];
 
 /// Lean-facing metadata for one Rust periodic recovery executor.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -34,6 +38,7 @@ pub struct PeriodicRecoverySweepMetadata {
 pub enum PeriodicRecoverySweepOutcome {
     RequestTerminalRepair(TerminalRepairReport),
     SubagentLiveness(SubagentLivenessReport),
+    TerminalParentTools(TerminalParentToolReport),
 }
 
 impl PeriodicRecoverySweepOutcome {
@@ -41,6 +46,7 @@ impl PeriodicRecoverySweepOutcome {
         match self {
             Self::RequestTerminalRepair(report) => report.is_noop(),
             Self::SubagentLiveness(report) => report.is_noop(),
+            Self::TerminalParentTools(report) => report.is_noop(),
         }
     }
 }
@@ -75,6 +81,10 @@ const PERIODIC_RECOVERY_SWEEP_METADATA: &[PeriodicRecoverySweepMetadata] = &[
         sweep_ids: SUBAGENT_LIVENESS_SWEEP_IDS,
         rust_function: "ToolCallLifecycle::reconcile_subagent_liveness",
     },
+    PeriodicRecoverySweepMetadata {
+        sweep_ids: TERMINAL_PARENT_TOOL_SWEEP_IDS,
+        rust_function: "ToolCallLifecycle::reconcile_terminal_parent_owned_tools",
+    },
 ];
 
 const PERIODIC_RECOVERY_SWEEP_EXECUTORS: &[PeriodicRecoverySweepExecutor] = &[
@@ -85,6 +95,10 @@ const PERIODIC_RECOVERY_SWEEP_EXECUTORS: &[PeriodicRecoverySweepExecutor] = &[
     PeriodicRecoverySweepExecutor {
         metadata_index: 1,
         run: reconcile_subagent_liveness,
+    },
+    PeriodicRecoverySweepExecutor {
+        metadata_index: 2,
+        run: reconcile_terminal_parent_owned_tools,
     },
 ];
 
@@ -115,6 +129,17 @@ fn reconcile_subagent_liveness<'a>(
         ToolCallLifecycle::reconcile_subagent_liveness(node, agent_did)
             .await
             .map(PeriodicRecoverySweepOutcome::SubagentLiveness)
+    })
+}
+
+fn reconcile_terminal_parent_owned_tools<'a>(
+    node: &'a EmbeddedNode,
+    agent_did: &'a str,
+) -> BoxFuture<'a, Result<PeriodicRecoverySweepOutcome>> {
+    Box::pin(async move {
+        ToolCallLifecycle::reconcile_terminal_parent_owned_tools(node, agent_did)
+            .await
+            .map(PeriodicRecoverySweepOutcome::TerminalParentTools)
     })
 }
 

--- a/crates/gents/src/tool_call_lifecycle.rs
+++ b/crates/gents/src/tool_call_lifecycle.rs
@@ -270,7 +270,7 @@ pub(crate) mod runtime;
 pub mod subagent_request;
 mod transition;
 
-pub use recovery::{SubagentLivenessReport, ToolCallRecoveryReport};
+pub use recovery::{SubagentLivenessReport, TerminalParentToolReport, ToolCallRecoveryReport};
 pub use subagent_request::{
     create_subagent_request, create_subagent_request_with_request_id,
     create_subagent_request_with_trusted_parent_request_id, MAX_SUBAGENT_DEPTH,

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -1,7 +1,9 @@
 //! Recovery for persisted running tool calls: the startup sweep over rows
-//! orphaned by a daemon restart, plus the periodic subagent-liveness sweep
+//! orphaned by a daemon restart, the periodic subagent-liveness sweep
 //! (#465) that terminalizes expired children and orphaned queued descendants
-//! on the live reconciler tick.
+//! on the live reconciler tick, and the live terminal-parent owned-tool
+//! cleanup (#837) that cancels running composites/tools whose parent is
+//! already terminal without waiting for deadline or daemon restart.
 
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
@@ -35,6 +37,18 @@ pub struct SubagentLivenessReport {
 }
 
 impl SubagentLivenessReport {
+    pub fn is_noop(&self) -> bool {
+        *self == Self::default()
+    }
+}
+
+/// Live reconcile of running tool rows owned by a terminal parent (#837).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct TerminalParentToolReport {
+    pub tool_calls_terminalized: usize,
+}
+
+impl TerminalParentToolReport {
     pub fn is_noop(&self) -> bool {
         *self == Self::default()
     }
@@ -214,6 +228,101 @@ impl super::ToolCallLifecycle {
                 bridges_projected = report.bridges_projected,
                 queued_descendants_interrupted = report.queued_descendants_interrupted,
                 "reconciled subagent liveness"
+            );
+        }
+        Ok(report)
+    }
+
+    /// Live reconcile: terminalize running tool calls whose parent request is
+    /// already terminal (#837). Unlike full startup `recover_all`, this does
+    /// **not** interrupt live-parent background tools (restart-only path).
+    ///
+    /// Covers the durable bad state observed for `fan_out_and_synthesize`:
+    /// parent interrupted, outer composite still `running`, no executor active.
+    pub async fn reconcile_terminal_parent_owned_tools(
+        node: &EmbeddedNode,
+        agent_did: &str,
+    ) -> Result<TerminalParentToolReport> {
+        let rows = load_running_tool_call_rows(node).await?;
+        let mut report = TerminalParentToolReport::default();
+
+        for row in rows {
+            let parent = match row
+                .request_id
+                .as_deref()
+                .filter(|request_id| !request_id.is_empty())
+            {
+                Some(request_id) => lookup_parent_request(node, agent_did, request_id).await?,
+                None => None,
+            };
+            let Some(parent) = parent else {
+                continue;
+            };
+
+            // Detached bridges may outlive an interrupted parent by design.
+            if is_detached_subagent_tool(&row) && request_is_interrupted(&parent) {
+                continue;
+            }
+
+            let outcome = if request_is_interrupted(&parent) {
+                Some(RecoveryOutcome::Cancelled)
+            } else if request_is_terminal(&parent) {
+                Some(RecoveryOutcome::Failed)
+            } else {
+                None
+            };
+            let Some(outcome) = outcome else {
+                continue;
+            };
+
+            // Cascade to linked children before terminalizing the tool row.
+            let mut remote_cancel_intent_at = None;
+            if let Some(child_request_id) = cascade_child_request_id(&row) {
+                if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
+                    if let Err(error) = interrupt_request(node, child_request_id).await {
+                        tracing::warn!(
+                            doc_id = %row.doc_id,
+                            request_id = row.request_id.as_deref().unwrap_or(""),
+                            tool_call_id = %row.tool_call_id,
+                            child_request_id,
+                            error = %error,
+                            "failed to cascade live terminal-parent cancel to child request"
+                        );
+                    }
+                } else {
+                    remote_cancel_intent_at = Some(Utc::now());
+                }
+            }
+
+            let deadline_at = parse_datetime(row.deadline_at.as_deref());
+            if let Err(error) =
+                recover_tool_call_row(node, &row, deadline_at, outcome, remote_cancel_intent_at)
+                    .await
+            {
+                tracing::warn!(
+                    doc_id = %row.doc_id,
+                    request_id = row.request_id.as_deref().unwrap_or(""),
+                    tool_call_id = %row.tool_call_id,
+                    error = %error,
+                    "failed to terminalize running tool owned by terminal parent"
+                );
+                continue;
+            }
+
+            report.tool_calls_terminalized += 1;
+            tracing::info!(
+                doc_id = %row.doc_id,
+                request_id = row.request_id.as_deref().unwrap_or(""),
+                tool_call_id = %row.tool_call_id,
+                lifecycle_state = %outcome.lifecycle_state().as_str(),
+                "reconciled running tool owned by terminal parent"
+            );
+        }
+
+        if !report.is_noop() {
+            tracing::info!(
+                tool_calls_terminalized = report.tool_calls_terminalized,
+                "reconciled terminal-parent owned tools"
             );
         }
         Ok(report)

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -84,7 +84,7 @@ struct RunningToolCallRow {
     unclaimed_deadline_at: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct ParentRequestRow {
     agent_did: String,
     status: String,
@@ -237,6 +237,11 @@ impl super::ToolCallLifecycle {
     /// already terminal (#837). Unlike full startup `recover_all`, this does
     /// **not** interrupt live-parent background tools (restart-only path).
     ///
+    /// Ordering matches startup `recover_stuck_running_tool_calls` for bridges:
+    /// project an already-terminal child onto the bridge first, so a completed
+    /// child under a just-interrupted parent converges to the same terminal as
+    /// restart recovery rather than being overwritten as cancelled/failed.
+    ///
     /// Covers the durable bad state observed for `fan_out_and_synthesize`:
     /// parent interrupted, outer composite still `running`, no executor active.
     pub async fn reconcile_terminal_parent_owned_tools(
@@ -245,14 +250,37 @@ impl super::ToolCallLifecycle {
     ) -> Result<TerminalParentToolReport> {
         let rows = load_running_tool_call_rows(node).await?;
         let mut report = TerminalParentToolReport::default();
+        let mut parent_cache: std::collections::HashMap<String, Option<ParentRequestRow>> =
+            std::collections::HashMap::new();
 
         for row in rows {
+            // Same precedence as startup recovery: a terminal child owns the
+            // bridge projection even when the parent is already terminal.
+            if recover_bridge_terminal_child(node, agent_did, &row).await? {
+                report.tool_calls_terminalized += 1;
+                tracing::info!(
+                    doc_id = %row.doc_id,
+                    request_id = row.request_id.as_deref().unwrap_or(""),
+                    tool_call_id = %row.tool_call_id,
+                    "reconciled running bridge from already-terminal child"
+                );
+                continue;
+            }
+
             let parent = match row
                 .request_id
                 .as_deref()
                 .filter(|request_id| !request_id.is_empty())
             {
-                Some(request_id) => lookup_parent_request(node, agent_did, request_id).await?,
+                Some(request_id) => {
+                    if let Some(cached) = parent_cache.get(request_id) {
+                        cached.clone()
+                    } else {
+                        let loaded = lookup_parent_request(node, agent_did, request_id).await?;
+                        parent_cache.insert(request_id.to_string(), loaded.clone());
+                        loaded
+                    }
+                }
                 None => None,
             };
             let Some(parent) = parent else {

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -407,6 +407,36 @@ mod tests {
         );
         assert_eq!(RecoveryOutcome::Cancelled.failure_class(), None);
     }
+
+    #[test]
+    fn cancel_worthy_field_takes_precedence_over_divergent_completed_status() {
+        let divergent = ParentRequestRow {
+            agent_did: "did:test:x".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: Some("interrupted".to_string()),
+            subagent_depth: None,
+        };
+        assert!(request_has_cancel_worthy_field(&divergent));
+        assert!(request_is_cancel_worthy_terminal(&divergent));
+        assert!(request_is_interrupted(&divergent));
+        assert!(
+            !request_is_cleanly_completed(&divergent),
+            "status=completed must not suppress lifecycle_state=interrupted"
+        );
+    }
+
+    #[test]
+    fn clean_completion_requires_no_cancel_worthy_fields() {
+        let clean = ParentRequestRow {
+            agent_did: "did:test:x".to_string(),
+            status: "completed".to_string(),
+            lifecycle_state: Some("completed".to_string()),
+            subagent_depth: None,
+        };
+        assert!(!request_has_cancel_worthy_field(&clean));
+        assert!(request_is_cleanly_completed(&clean));
+        assert!(!request_is_cancel_worthy_terminal(&clean));
+    }
 }
 
 async fn recover_orphan_subagent_children(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
@@ -1699,9 +1729,29 @@ fn request_is_interrupted(parent: &ParentRequestRow) -> bool {
     parent.status == "interrupted" || parent.lifecycle_state.as_deref() == Some("interrupted")
 }
 
-/// Parent reached a successful terminal without interrupt — not a cancel signal
-/// for linked background/cascade children.
+/// Cancel-worthy evidence on either field takes precedence over a divergent
+/// `completed` sibling field. Mirrors
+/// `subagent_source::parent_reached_cancel_worthy_terminal` (plus `failed` on
+/// status for rows that stamp that vocabulary).
+fn request_has_cancel_worthy_field(parent: &ParentRequestRow) -> bool {
+    matches!(
+        parent.status.as_str(),
+        "error" | "failed" | "superseded" | "dead" | "interrupted"
+    ) || matches!(
+        parent.lifecycle_state.as_deref(),
+        Some("failed" | "error" | "superseded" | "dead" | "interrupted")
+    )
+}
+
+/// Parent reached a successful terminal **without** any cancel-worthy field
+/// evidence — not a cancel signal for linked background/cascade children.
+///
+/// Divergent replications such as `status=completed` + `lifecycle_state=interrupted`
+/// are **not** clean: cancel-worthy evidence wins.
 fn request_is_cleanly_completed(parent: &ParentRequestRow) -> bool {
+    if request_has_cancel_worthy_field(parent) {
+        return false;
+    }
     matches!(parent.status.as_str(), "completed" | "complete")
         || matches!(
             parent.lifecycle_state.as_deref(),
@@ -1710,9 +1760,10 @@ fn request_is_cleanly_completed(parent: &ParentRequestRow) -> bool {
 }
 
 /// Terminal parent whose terminal is cancel-worthy (interrupt, failure, dead,
-/// supersede, …) — clean completion is excluded.
+/// supersede, …). Cancel-worthy field evidence is checked first so a stale
+/// `completed` on the other column cannot suppress cascade.
 fn request_is_cancel_worthy_terminal(parent: &ParentRequestRow) -> bool {
-    request_is_terminal(parent) && !request_is_cleanly_completed(parent)
+    request_has_cancel_worthy_field(parent)
 }
 
 fn request_is_terminal(parent: &ParentRequestRow) -> bool {

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -237,10 +237,14 @@ impl super::ToolCallLifecycle {
     /// already terminal (#837). Unlike full startup `recover_all`, this does
     /// **not** interrupt live-parent background tools (restart-only path).
     ///
-    /// Ordering matches startup `recover_stuck_running_tool_calls` for bridges:
-    /// project an already-terminal child onto the bridge first, so a completed
-    /// child under a just-interrupted parent converges to the same terminal as
-    /// restart recovery rather than being overwritten as cancelled/failed.
+    /// Scope and ordering:
+    /// 1. Resolve the parent under `agent_did` first — rows whose parent is
+    ///    missing or foreign are skipped (no cross-principal mutation).
+    /// 2. Require a terminal parent before any write.
+    /// 3. Detached bridges under an *interrupted* parent are left running
+    ///    (same product rule as startup recovery).
+    /// 4. Then project already-terminal children onto bridges (matches startup
+    ///    child-precedence so restart and live ticks converge).
     ///
     /// Covers the durable bad state observed for `fan_out_and_synthesize`:
     /// parent interrupted, outer composite still `running`, no executor active.
@@ -254,19 +258,6 @@ impl super::ToolCallLifecycle {
             std::collections::HashMap::new();
 
         for row in rows {
-            // Same precedence as startup recovery: a terminal child owns the
-            // bridge projection even when the parent is already terminal.
-            if recover_bridge_terminal_child(node, agent_did, &row).await? {
-                report.tool_calls_terminalized += 1;
-                tracing::info!(
-                    doc_id = %row.doc_id,
-                    request_id = row.request_id.as_deref().unwrap_or(""),
-                    tool_call_id = %row.tool_call_id,
-                    "reconciled running bridge from already-terminal child"
-                );
-                continue;
-            }
-
             let parent = match row
                 .request_id
                 .as_deref()
@@ -283,24 +274,38 @@ impl super::ToolCallLifecycle {
                 }
                 None => None,
             };
+            // Ownership gate: parent must resolve under this agent's DID.
             let Some(parent) = parent else {
                 continue;
             };
+            // Live parents are out of scope for this sweep.
+            if !request_is_terminal(&parent) {
+                continue;
+            }
 
-            // Detached bridges may outlive an interrupted parent by design.
+            // Detached bridges may outlive an interrupted parent by design
+            // (startup recovery leaves them running too). Other terminal
+            // parents still force recovery so detached work cannot strand.
             if is_detached_subagent_tool(&row) && request_is_interrupted(&parent) {
                 continue;
             }
 
-            let outcome = if request_is_interrupted(&parent) {
-                Some(RecoveryOutcome::Cancelled)
-            } else if request_is_terminal(&parent) {
-                Some(RecoveryOutcome::Failed)
-            } else {
-                None
-            };
-            let Some(outcome) = outcome else {
+            // Child-terminal precedence only after owner + terminal-parent gates.
+            if recover_bridge_terminal_child(node, agent_did, &row).await? {
+                report.tool_calls_terminalized += 1;
+                tracing::info!(
+                    doc_id = %row.doc_id,
+                    request_id = row.request_id.as_deref().unwrap_or(""),
+                    tool_call_id = %row.tool_call_id,
+                    "reconciled running bridge from already-terminal child"
+                );
                 continue;
+            }
+
+            let outcome = if request_is_interrupted(&parent) {
+                RecoveryOutcome::Cancelled
+            } else {
+                RecoveryOutcome::Failed
             };
 
             // Cascade to linked children before terminalizing the tool row.
@@ -323,17 +328,29 @@ impl super::ToolCallLifecycle {
             }
 
             let deadline_at = parse_datetime(row.deadline_at.as_deref());
-            if let Err(error) =
-                recover_tool_call_row(node, &row, deadline_at, outcome, remote_cancel_intent_at)
-                    .await
+            let updated = match recover_tool_call_row(
+                node,
+                &row,
+                deadline_at,
+                outcome,
+                remote_cancel_intent_at,
+            )
+            .await
             {
-                tracing::warn!(
-                    doc_id = %row.doc_id,
-                    request_id = row.request_id.as_deref().unwrap_or(""),
-                    tool_call_id = %row.tool_call_id,
-                    error = %error,
-                    "failed to terminalize running tool owned by terminal parent"
-                );
+                Ok(updated) => updated,
+                Err(error) => {
+                    tracing::warn!(
+                        doc_id = %row.doc_id,
+                        request_id = row.request_id.as_deref().unwrap_or(""),
+                        tool_call_id = %row.tool_call_id,
+                        error = %error,
+                        "failed to terminalize running tool owned by terminal parent"
+                    );
+                    continue;
+                }
+            };
+            if !updated {
+                // Lost CAS: concurrent complete/fail/cancel already terminalized.
                 continue;
             }
 
@@ -681,17 +698,26 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
             }
         }
 
-        if let Err(error) =
-            recover_tool_call_row(node, &row, deadline_at, outcome, remote_cancel_intent_at).await
-        {
-            tracing::warn!(
-                doc_id = %row.doc_id,
-                request_id = row.request_id.as_deref().unwrap_or(""),
-                session_id = %row.session_id,
-                tool_call_id = %row.tool_call_id,
-                error = %error,
-                "failed to recover running tool call"
-            );
+        let updated =
+            match recover_tool_call_row(node, &row, deadline_at, outcome, remote_cancel_intent_at)
+                .await
+            {
+                Ok(updated) => updated,
+                Err(error) => {
+                    tracing::warn!(
+                        doc_id = %row.doc_id,
+                        request_id = row.request_id.as_deref().unwrap_or(""),
+                        session_id = %row.session_id,
+                        tool_call_id = %row.tool_call_id,
+                        error = %error,
+                        "failed to recover running tool call"
+                    );
+                    continue;
+                }
+            };
+        if !updated {
+            // Lost CAS against a concurrent terminal writer — leave the durable
+            // terminal untouched (first-writer-wins).
             continue;
         }
 
@@ -1528,13 +1554,16 @@ async fn recover_bridge_failed_row(
     Ok(())
 }
 
+/// Terminalize a running tool-call row. Returns `Ok(true)` when the
+/// compare-and-set updated the row, `Ok(false)` when a concurrent writer
+/// already left `running` (first terminal wins — do not overwrite).
 async fn recover_tool_call_row(
     node: &EmbeddedNode,
     row: &RunningToolCallRow,
     deadline_at: Option<DateTime<Utc>>,
     outcome: RecoveryOutcome,
     remote_cancel_intent_at: Option<DateTime<Utc>>,
-) -> Result<()> {
+) -> Result<bool> {
     let now = Utc::now();
     let started_at = parse_datetime(row.started_at.as_deref()).unwrap_or(now);
     let latency_ms = (now - started_at).num_milliseconds().max(0);
@@ -1565,7 +1594,10 @@ async fn recover_tool_call_row(
     let mutation = format!(
         r#"mutation {{
             update_AgentToolCall(
-                filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                filter: {{
+                    _docID: {{ _eq: "{escaped_doc_id}" }},
+                    lifecycle_state: {{ _eq: "running" }}
+                }},
                 input: {{
                     result: "{escaped_result}",
                     status: "completed",
@@ -1580,10 +1612,14 @@ async fn recover_tool_call_row(
         lifecycle_state = outcome.lifecycle_state().as_str(),
     );
 
-    execute_mutation_with_retry(node, &mutation, "recover_running_tool_call")
+    let response = execute_mutation_with_retry(node, &mutation, "recover_running_tool_call")
         .await
         .context("recover running tool call mutation")?;
-    Ok(())
+    Ok(response
+        .data
+        .as_ref()
+        .and_then(|data| data.get("update_AgentToolCall"))
+        .is_some_and(response_has_documents))
 }
 
 fn parse_datetime(value: Option<&str>) -> Option<DateTime<Utc>> {

--- a/crates/gents/src/tool_call_lifecycle/recovery.rs
+++ b/crates/gents/src/tool_call_lifecycle/recovery.rs
@@ -60,6 +60,10 @@ struct RunningToolCallRow {
     doc_id: String,
     #[serde(default)]
     request_id: Option<String>,
+    /// Immutable owner principal stamped at create. Recovery scopes by this
+    /// field — `request_id` alone is not unique across agents.
+    #[serde(default)]
+    agent_did: Option<String>,
     session_id: String,
     tool_call_id: String,
     #[serde(default)]
@@ -238,12 +242,15 @@ impl super::ToolCallLifecycle {
     /// **not** interrupt live-parent background tools (restart-only path).
     ///
     /// Scope and ordering:
-    /// 1. Resolve the parent under `agent_did` first — rows whose parent is
-    ///    missing or foreign are skipped (no cross-principal mutation).
-    /// 2. Require a terminal parent before any write.
-    /// 3. Detached bridges under an *interrupted* parent are left running
-    ///    (same product rule as startup recovery).
-    /// 4. Then project already-terminal children onto bridges (matches startup
+    /// 1. Load only tool rows stamped with this agent's immutable `agent_did`
+    ///    (not global `request_id` matches — that field is not unique).
+    /// 2. Resolve the parent under the same DID; skip missing/foreign parents.
+    /// 3. Require a terminal parent before any write.
+    /// 4. Detached bridges under an *interrupted* parent are left running.
+    /// 5. Child-linked bridges under a *cleanly completed* parent are left
+    ///    running — clean completion is not a cancel signal (live cascade and
+    ///    recovery only cancel on cancel-worthy terminals).
+    /// 6. Then project already-terminal children onto bridges (matches startup
     ///    child-precedence so restart and live ticks converge).
     ///
     /// Covers the durable bad state observed for `fan_out_and_synthesize`:
@@ -252,12 +259,17 @@ impl super::ToolCallLifecycle {
         node: &EmbeddedNode,
         agent_did: &str,
     ) -> Result<TerminalParentToolReport> {
-        let rows = load_running_tool_call_rows(node).await?;
+        let rows = load_running_tool_call_rows_for_agent(node, agent_did).await?;
         let mut report = TerminalParentToolReport::default();
         let mut parent_cache: std::collections::HashMap<String, Option<ParentRequestRow>> =
             std::collections::HashMap::new();
 
         for row in rows {
+            // Defense in depth: never mutate a row whose stamped owner differs.
+            if row.agent_did.as_deref() != Some(agent_did) {
+                continue;
+            }
+
             let parent = match row
                 .request_id
                 .as_deref()
@@ -284,8 +296,7 @@ impl super::ToolCallLifecycle {
             }
 
             // Detached bridges may outlive an interrupted parent by design
-            // (startup recovery leaves them running too). Other terminal
-            // parents still force recovery so detached work cannot strand.
+            // (startup recovery leaves them running too).
             if is_detached_subagent_tool(&row) && request_is_interrupted(&parent) {
                 continue;
             }
@@ -302,28 +313,38 @@ impl super::ToolCallLifecycle {
                 continue;
             }
 
+            // Clean parent completion is not a cancel signal for linked
+            // background/cascade children — leave the bridge running.
+            if request_is_cleanly_completed(&parent) && child_request_id(&row).is_some() {
+                continue;
+            }
+
             let outcome = if request_is_interrupted(&parent) {
                 RecoveryOutcome::Cancelled
             } else {
+                // Cancel-worthy non-interrupt terminals, or a native composite
+                // stranded under a cleanly-completed parent.
                 RecoveryOutcome::Failed
             };
 
-            // Cascade to linked children before terminalizing the tool row.
+            // Cascade only for cancel-worthy terminals — never on clean complete.
             let mut remote_cancel_intent_at = None;
-            if let Some(child_request_id) = cascade_child_request_id(&row) {
-                if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
-                    if let Err(error) = interrupt_request(node, child_request_id).await {
-                        tracing::warn!(
-                            doc_id = %row.doc_id,
-                            request_id = row.request_id.as_deref().unwrap_or(""),
-                            tool_call_id = %row.tool_call_id,
-                            child_request_id,
-                            error = %error,
-                            "failed to cascade live terminal-parent cancel to child request"
-                        );
+            if request_is_cancel_worthy_terminal(&parent) {
+                if let Some(child_request_id) = cascade_child_request_id(&row) {
+                    if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
+                        if let Err(error) = interrupt_request(node, child_request_id).await {
+                            tracing::warn!(
+                                doc_id = %row.doc_id,
+                                request_id = row.request_id.as_deref().unwrap_or(""),
+                                tool_call_id = %row.tool_call_id,
+                                child_request_id,
+                                error = %error,
+                                "failed to cascade live terminal-parent cancel to child request"
+                            );
+                        }
+                    } else {
+                        remote_cancel_intent_at = Some(Utc::now());
                     }
-                } else {
-                    remote_cancel_intent_at = Some(Utc::now());
                 }
             }
 
@@ -389,10 +410,13 @@ mod tests {
 }
 
 async fn recover_orphan_subagent_children(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
-    let rows = load_running_tool_call_rows(node).await?;
+    let rows = load_running_tool_call_rows_for_agent(node, agent_did).await?;
     let mut materialized = 0;
 
     for row in rows {
+        if row.agent_did.as_deref() != Some(agent_did) {
+            continue;
+        }
         let Some(child_request_id) = child_request_id(&row).map(str::to_string) else {
             continue;
         };
@@ -612,10 +636,14 @@ async fn fail_unauthorized_orphan_subagent_tool_call(
 }
 
 async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) -> Result<usize> {
-    let rows = load_running_tool_call_rows(node).await?;
+    let rows = load_running_tool_call_rows_for_agent(node, agent_did).await?;
 
     let mut recovered = 0;
     for row in rows {
+        if row.agent_did.as_deref() != Some(agent_did) {
+            continue;
+        }
+
         let deadline_at = parse_datetime(row.deadline_at.as_deref());
         let unclaimed_deadline_at = parse_datetime(row.unclaimed_deadline_at.as_deref());
         let parent = match row
@@ -652,6 +680,11 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
                 .is_some_and(|parent| request_is_interrupted(parent))
         {
             None
+        } else if parent.as_ref().is_some_and(request_is_cleanly_completed)
+            && child_request_id(&row).is_some()
+        {
+            // Clean parent completion is not a cancel signal for linked children.
+            None
         } else if parent
             .as_ref()
             .is_some_and(|parent| request_is_interrupted(parent))
@@ -677,8 +710,13 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
             continue;
         };
 
+        // Cascade only on cancel-worthy parent terminals (not clean completion).
         let mut remote_cancel_intent_at = None;
-        if outcome != RecoveryOutcome::UnclaimedCrossDeploymentSpawn {
+        let should_cascade = outcome != RecoveryOutcome::UnclaimedCrossDeploymentSpawn
+            && parent
+                .as_ref()
+                .is_none_or(|p| !request_is_cleanly_completed(p));
+        if should_cascade {
             if let Some(child_request_id) = cascade_child_request_id(&row) {
                 if child_request_is_locally_owned(node, agent_did, child_request_id).await? {
                     if let Err(error) = interrupt_request(node, child_request_id).await {
@@ -761,8 +799,17 @@ async fn recover_stuck_running_tool_calls(node: &EmbeddedNode, agent_did: &str) 
     Ok(recovered)
 }
 
-async fn load_running_tool_call_rows(node: &EmbeddedNode) -> Result<Vec<RunningToolCallRow>> {
-    load_running_tool_call_rows_with_filter(node, "").await
+/// Running tool rows owned by `agent_did` (immutable scope key on create).
+async fn load_running_tool_call_rows_for_agent(
+    node: &EmbeddedNode,
+    agent_did: &str,
+) -> Result<Vec<RunningToolCallRow>> {
+    let escaped = escape_graphql_string(agent_did);
+    load_running_tool_call_rows_with_filter(
+        node,
+        &format!(r#", agent_did: {{ _eq: "{escaped}" }}"#),
+    )
+    .await
 }
 
 /// Running bridge rows only (`child_request_id` set) — the periodic liveness
@@ -783,6 +830,7 @@ async fn load_running_tool_call_rows_with_filter(
         ) {{
             _docID
             request_id
+            agent_did
             session_id
             tool_call_id
             tool_name
@@ -1649,6 +1697,22 @@ fn effective_deadline(
 
 fn request_is_interrupted(parent: &ParentRequestRow) -> bool {
     parent.status == "interrupted" || parent.lifecycle_state.as_deref() == Some("interrupted")
+}
+
+/// Parent reached a successful terminal without interrupt — not a cancel signal
+/// for linked background/cascade children.
+fn request_is_cleanly_completed(parent: &ParentRequestRow) -> bool {
+    matches!(parent.status.as_str(), "completed" | "complete")
+        || matches!(
+            parent.lifecycle_state.as_deref(),
+            Some("completed" | "complete")
+        )
+}
+
+/// Terminal parent whose terminal is cancel-worthy (interrupt, failure, dead,
+/// supersede, …) — clean completion is excluded.
+fn request_is_cancel_worthy_terminal(parent: &ParentRequestRow) -> bool {
+    request_is_terminal(parent) && !request_is_cleanly_completed(parent)
 }
 
 fn request_is_terminal(parent: &ParentRequestRow) -> bool {

--- a/crates/gents/src/tool_call_lifecycle/transition/native.rs
+++ b/crates/gents/src/tool_call_lifecycle/transition/native.rs
@@ -47,47 +47,43 @@ impl ToolCallLifecycle {
         let tool_call_key = format!("{escaped_session_id}:{escaped_tool_call_id}");
         let message_sequence = self.message_sequence;
 
-        // Persist bridge fields for both R4 subagent bridges and R6 ordinary
-        // backgrounded tool rows. Native foreground calls omit them for
-        // back-compat with older rows.
-        let bridge_fields = if self.is_bridge() {
-            let await_mode_str = self.await_mode.as_str();
-            let cancel_policy_str = self.cancel_policy.as_str();
-            let child_field = self
-                .child_request_id
-                .as_ref()
-                .map(|crid| {
-                    let escaped_crid = escape_graphql_string(crid);
-                    format!(r#"child_request_id: "{escaped_crid}","#)
-                })
-                .unwrap_or_default();
-            let spawn_target_field = self
-                .spawn_target_did
-                .as_ref()
-                .map(|did| {
-                    let escaped_did = escape_graphql_string(did);
-                    format!(r#"spawn_target_did: "{escaped_did}","#)
-                })
-                .unwrap_or_default();
-            let unclaimed_deadline_field = self
-                .unclaimed_deadline_at
-                .map(|deadline| {
-                    let escaped_deadline = escape_graphql_string(
-                        &deadline.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
-                    );
-                    format!(r#"unclaimed_deadline_at: "{escaped_deadline}","#)
-                })
-                .unwrap_or_default();
-            format!(
-                r#"{child_field}
+        // Persist await_mode / cancel_policy for every tool call so composites
+        // and native calls are not projected as `unknown` (#837). Child link,
+        // spawn target, and unclaimed deadline remain bridge-only fields.
+        let await_mode_str = self.await_mode.as_str();
+        let cancel_policy_str = self.cancel_policy.as_str();
+        let child_field = self
+            .child_request_id
+            .as_ref()
+            .map(|crid| {
+                let escaped_crid = escape_graphql_string(crid);
+                format!(r#"child_request_id: "{escaped_crid}","#)
+            })
+            .unwrap_or_default();
+        let spawn_target_field = self
+            .spawn_target_did
+            .as_ref()
+            .map(|did| {
+                let escaped_did = escape_graphql_string(did);
+                format!(r#"spawn_target_did: "{escaped_did}","#)
+            })
+            .unwrap_or_default();
+        let unclaimed_deadline_field = self
+            .unclaimed_deadline_at
+            .map(|deadline| {
+                let escaped_deadline = escape_graphql_string(
+                    &deadline.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+                );
+                format!(r#"unclaimed_deadline_at: "{escaped_deadline}","#)
+            })
+            .unwrap_or_default();
+        let bridge_fields = format!(
+            r#"{child_field}
                     {spawn_target_field}
                     {unclaimed_deadline_field}
                     await_mode: "{await_mode_str}",
                     cancel_policy: "{cancel_policy_str}","#
-            )
-        } else {
-            String::new()
-        };
+        );
         let requester_did_field = self.requester_did_fragment();
         let workflow_fields = self.workflow_fields_fragment();
 
@@ -161,7 +157,10 @@ impl ToolCallLifecycle {
         let mutation = format!(
             r#"mutation {{
                 update_AgentToolCall(
-                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    filter: {{
+                        _docID: {{ _eq: "{escaped_doc_id}" }},
+                        lifecycle_state: {{ _eq: "running" }}
+                    }},
                     input: {{
                         result: "{escaped_result}",
                         status: "completed",
@@ -176,9 +175,19 @@ impl ToolCallLifecycle {
             }}"#
         );
 
-        execute_mutation_with_retry(&self.node, &mutation, "complete")
+        let response = execute_mutation_with_retry(&self.node, &mutation, "complete")
             .await
             .context("complete mutation")?;
+        if !response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentToolCall"))
+            .is_some_and(response_has_documents)
+        {
+            // Interrupt/timeout won the race — adopt the durable terminal.
+            self.sync_after_lost_running_compare("complete").await?;
+            return Ok(());
+        }
 
         self.state = ToolCallState::Completed;
         Ok(())
@@ -232,7 +241,10 @@ impl ToolCallLifecycle {
         let mutation = format!(
             r#"mutation {{
                 update_AgentToolCall(
-                    filter: {{ _docID: {{ _eq: "{escaped_doc_id}" }} }},
+                    filter: {{
+                        _docID: {{ _eq: "{escaped_doc_id}" }},
+                        lifecycle_state: {{ _eq: "running" }}
+                    }},
                     input: {{
                         result: "{escaped_result}",
                         status: "completed",
@@ -249,9 +261,19 @@ impl ToolCallLifecycle {
             }}"#
         );
 
-        execute_mutation_with_retry(&self.node, &mutation, "fail")
+        let response = execute_mutation_with_retry(&self.node, &mutation, "fail")
             .await
             .context("fail mutation")?;
+        if !response
+            .data
+            .as_ref()
+            .and_then(|data| data.get("update_AgentToolCall"))
+            .is_some_and(response_has_documents)
+        {
+            // Interrupt/timeout won the race — adopt the durable terminal.
+            self.sync_after_lost_running_compare("fail").await?;
+            return Ok(());
+        }
 
         self.state = ToolCallState::Failed;
         self.failure_class = Some(failure);

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -172,8 +172,8 @@ pub(super) fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);
-    assert_eq!(lean_recovery_sweep_cases().len(), 28);
-    assert_eq!(lean_recovery_equivalence_cases().len(), 28);
+    assert_eq!(lean_recovery_sweep_cases().len(), 30);
+    assert_eq!(lean_recovery_equivalence_cases().len(), 30);
     assert_eq!(lean_recovery_outcome_cases().len(), 4);
     assert_eq!(lean_transcript_cases().len(), 7);
     assert_eq!(lean_response_interrupt_flow_cases().len(), 1);

--- a/crates/gents/tests/conformance/coverage.rs
+++ b/crates/gents/tests/conformance/coverage.rs
@@ -172,8 +172,8 @@ pub(super) fn lean_executable_contracts_cover_initial_domains() {
     assert_eq!(lean_contract_snapshot().command_sandbox_cases.len(), 4);
     assert_eq!(lean_contract_snapshot().command_env_cases.len(), 14);
     assert_eq!(lean_queue_deadline_cases().len(), 5);
-    assert_eq!(lean_recovery_sweep_cases().len(), 30);
-    assert_eq!(lean_recovery_equivalence_cases().len(), 30);
+    assert_eq!(lean_recovery_sweep_cases().len(), 31);
+    assert_eq!(lean_recovery_equivalence_cases().len(), 31);
     assert_eq!(lean_recovery_outcome_cases().len(), 4);
     assert_eq!(lean_transcript_cases().len(), 7);
     assert_eq!(lean_response_interrupt_flow_cases().len(), 1);

--- a/crates/gents/tests/conformance/recovery_sweeps.rs
+++ b/crates/gents/tests/conformance/recovery_sweeps.rs
@@ -8,7 +8,7 @@ pub(super) async fn generated_recovery_sweep_cases_drive_startup_recovery_contra
     let cases = lean_recovery_sweep_cases();
     assert_eq!(
         cases.len(),
-        30,
+        31,
         "Lean should emit one row per registered recovery predicate witness"
     );
 
@@ -51,7 +51,7 @@ pub(super) fn generated_recovery_equivalence_cases_pin_uninterrupted_convergence
     );
     assert_eq!(
         equivalence_cases.len(),
-        30,
+        31,
         "Lean recovery equivalence witness count drifted"
     );
 
@@ -1121,6 +1121,26 @@ async fn seed_tool_parent_and_row(
                 "slow_tool".to_string(),
                 "{}".to_string(),
                 future_deadline,
+            )
+        }
+        "live_detached_bridge_parent_completed_to_failed" => {
+            set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed").await;
+            let child_request_id = format!("{tool_call_id}-detached-child");
+            seed_child_request(&node, &child_request_id, "processing").await;
+            ToolCallLifecycle::new_subagent(
+                node.clone(),
+                parent_request_id.to_string(),
+                parent_session_id.to_string(),
+                "did:test:test".to_string(),
+                tool_call_id.to_string(),
+                1,
+                "spawn_subagent".to_string(),
+                "{}".to_string(),
+                future_deadline,
+                AwaitMode::Background,
+                CancelPolicy::Detach,
+                child_request_id,
+                "did:test:target".to_string(),
             )
         }
         "tool_running_unclaimed_cross_deployment_spawn_to_failed" => {

--- a/crates/gents/tests/conformance/recovery_sweeps.rs
+++ b/crates/gents/tests/conformance/recovery_sweeps.rs
@@ -1053,8 +1053,9 @@ async fn seed_tool_parent_and_row(
             };
             seed_child_request(&node, &child_request_id, child_state).await;
             if case.name == "detached_bridge_terminal_parent_to_failed" {
-                set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed")
-                    .await;
+                // Cancel-worthy terminal (not clean completion): clean complete
+                // must leave linked children running (#880 / #377 policy).
+                set_request_status_and_lifecycle(&node, &parent_doc_id, "error", "failed").await;
             }
             ToolCallLifecycle::new_subagent(
                 node.clone(),
@@ -1123,8 +1124,8 @@ async fn seed_tool_parent_and_row(
                 future_deadline,
             )
         }
-        "live_detached_bridge_parent_completed_to_failed" => {
-            set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed").await;
+        "live_detached_bridge_parent_failed_to_failed" => {
+            set_request_status_and_lifecycle(&node, &parent_doc_id, "error", "failed").await;
             let child_request_id = format!("{tool_call_id}-detached-child");
             seed_child_request(&node, &child_request_id, "processing").await;
             ToolCallLifecycle::new_subagent(

--- a/crates/gents/tests/conformance/recovery_sweeps.rs
+++ b/crates/gents/tests/conformance/recovery_sweeps.rs
@@ -8,7 +8,7 @@ pub(super) async fn generated_recovery_sweep_cases_drive_startup_recovery_contra
     let cases = lean_recovery_sweep_cases();
     assert_eq!(
         cases.len(),
-        28,
+        30,
         "Lean should emit one row per registered recovery predicate witness"
     );
 
@@ -16,6 +16,7 @@ pub(super) async fn generated_recovery_sweep_cases_drive_startup_recovery_contra
         "request_lifecycle_recover_all_requests",
         "request_lifecycle_recover_all_streaming_responses",
         "tool_call_lifecycle_recover_all_running_calls",
+        "tool_call_lifecycle_reconcile_terminal_parent_owned_tools",
         "tool_call_lifecycle_recover_detached_bridge_rows",
         "inference_call_recover_all_stale_calls",
         "subagent_liveness_terminalize_expired_children",
@@ -50,7 +51,7 @@ pub(super) fn generated_recovery_equivalence_cases_pin_uninterrupted_convergence
     );
     assert_eq!(
         equivalence_cases.len(),
-        28,
+        30,
         "Lean recovery equivalence witness count drifted"
     );
 
@@ -129,6 +130,9 @@ fn expected_recovery_equivalence_theorem(sweep_id: &str) -> &'static str {
         }
         "tool_call_lifecycle_recover_all_running_calls" => {
             "Recovery.toolCallRecover_matches_uninterrupted"
+        }
+        "tool_call_lifecycle_reconcile_terminal_parent_owned_tools" => {
+            "Recovery.terminalParentToolRecover_matches_uninterrupted"
         }
         "tool_call_lifecycle_recover_detached_bridge_rows" => {
             "Recovery.detachedBridgeRecover_matches_uninterrupted"
@@ -856,14 +860,34 @@ async fn drive_tool_call_recovery_case(case: &lean_vocab_test::LeanRecoverySweep
     )
     .await;
 
-    let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
-        .await
-        .unwrap();
-    assert_eq!(
-        report.tool_calls_recovered, 1,
-        "tool recovery case {} should recover one tool call",
-        case.name
-    );
+    if case.sweep_id == "tool_call_lifecycle_reconcile_terminal_parent_owned_tools" {
+        let report = ToolCallLifecycle::reconcile_terminal_parent_owned_tools(&db.node, AGENT_DID)
+            .await
+            .unwrap();
+        assert_eq!(
+            report.tool_calls_terminalized, 1,
+            "live terminal-parent tool case {} should terminalize one tool call",
+            case.name
+        );
+        // Idempotent under a second live tick.
+        let second = ToolCallLifecycle::reconcile_terminal_parent_owned_tools(&db.node, AGENT_DID)
+            .await
+            .unwrap();
+        assert_eq!(
+            second.tool_calls_terminalized, 0,
+            "live terminal-parent tool case {} must be idempotent",
+            case.name
+        );
+    } else {
+        let report = ToolCallLifecycle::recover_all(&db.node, AGENT_DID)
+            .await
+            .unwrap();
+        assert_eq!(
+            report.tool_calls_recovered, 1,
+            "tool recovery case {} should recover one tool call",
+            case.name
+        );
+    }
 
     let row = fetch_tool_recovery_row(&db.node, &tool_call_id).await;
     assert_eq!(
@@ -1063,7 +1087,8 @@ async fn seed_tool_parent_and_row(
             "{}".to_string(),
             past_deadline,
         ),
-        "tool_running_parent_interrupted_to_cancelled" => {
+        "tool_running_parent_interrupted_to_cancelled"
+        | "live_running_composite_parent_interrupted_to_cancelled" => {
             set_request_status_and_lifecycle(&node, &parent_doc_id, "interrupted", "interrupted")
                 .await;
             ToolCallLifecycle::new(
@@ -1073,12 +1098,18 @@ async fn seed_tool_parent_and_row(
                 "did:test:test".to_string(),
                 tool_call_id.to_string(),
                 1,
-                "slow_tool".to_string(),
+                if case.name == "live_running_composite_parent_interrupted_to_cancelled" {
+                    "fan_out_and_synthesize"
+                } else {
+                    "slow_tool"
+                }
+                .to_string(),
                 "{}".to_string(),
                 future_deadline,
             )
         }
-        "tool_running_terminal_parent_to_failed" => {
+        "tool_running_terminal_parent_to_failed"
+        | "live_running_tool_parent_terminal_to_failed" => {
             set_request_status_and_lifecycle(&node, &parent_doc_id, "completed", "completed").await;
             ToolCallLifecycle::new(
                 node.clone(),

--- a/crates/gents/tests/workflow_conformance.rs
+++ b/crates/gents/tests/workflow_conformance.rs
@@ -21,3 +21,89 @@ fn barrier_cases_match_projection() {
         );
     }
 }
+
+/// #837: Lean composite-interrupt cleanup cases pin that after bounded
+/// interrupt cleanup (or terminal-parent recovery) the outer composite is
+/// not eligible as active and carries a consistent interrupt cancel cause.
+#[test]
+fn composite_interrupt_cases_pin_cleanup_invariant() {
+    let cases = lean_vocab_test::lean_workflow_composite_interrupt_cases();
+    assert!(
+        !cases.is_empty(),
+        "Lean workflow_composite_interrupt_cases must include interrupt witnesses"
+    );
+
+    let required_phases = [
+        "fanOutSpawn",
+        "fanOutBarrier",
+        "synthesisSpawn",
+        "synthesisRun",
+        "resultPersist",
+    ];
+    for phase in required_phases {
+        assert!(
+            cases.iter().any(|case| case.phase == phase),
+            "missing composite interrupt phase witness {phase}"
+        );
+    }
+    assert!(
+        cases
+            .iter()
+            .any(|case| case.name == "duplicate_interrupt_delivery"),
+        "missing duplicate interrupt witness"
+    );
+    assert!(
+        cases
+            .iter()
+            .any(|case| case.name.contains("recover_terminal_parent")),
+        "missing terminal-parent recovery witness"
+    );
+
+    for case in cases {
+        assert!(
+            !case.post_outer_eligible_active,
+            "case {} must leave outer not eligible as active",
+            case.name
+        );
+        assert!(
+            !case.post_continuation_owned,
+            "case {} must release continuation ownership",
+            case.name
+        );
+        if case.outer_state == "running" || case.outer_state == "pending" {
+            if case.parent_state == "interrupted" || case.parent_state == "processing" {
+                assert_eq!(
+                    case.post_outer_state, "cancelled",
+                    "case {} should cancel a still-eligible outer under interrupt",
+                    case.name
+                );
+                assert_eq!(
+                    case.post_outer_cancel_cause.as_deref(),
+                    Some("interrupted"),
+                    "case {} should project cancel_cause=interrupted",
+                    case.name
+                );
+            } else {
+                assert!(
+                    case.post_outer_state == "cancelled" || case.post_outer_state == "failed",
+                    "case {} must terminalize eligible outer, got {}",
+                    case.name,
+                    case.post_outer_state
+                );
+            }
+        }
+        if case.outer_state == "cancelled" {
+            assert_eq!(
+                case.post_outer_state, "cancelled",
+                "duplicate interrupt must keep cancelled outer for {}",
+                case.name
+            );
+            assert_eq!(
+                case.post_outer_cancel_cause.as_deref(),
+                Some("interrupted"),
+                "duplicate interrupt must keep cause for {}",
+                case.name
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fix #837: when a parent is interrupted during `fan_out_and_synthesize`, the outer composite `AgentToolCall` no longer stays `running` until deadline/restart.
- Register the outer composite lifecycle in the cancel-visible map; terminalize with compare-and-set so interrupt wins over late complete/fail.
- Live-reconcile terminal-parent / running-tool rows on the periodic recovery tick without applying the restart-only background-interrupt path.
- Lean: `Workflow.CompositeInterrupt` proves cleanup invariants; conformance cases cover interrupt phases, duplicate delivery, and recovery; new periodic sweep `tool_call_lifecycle_reconcile_terminal_parent_owned_tools`.

## Test plan

- [x] `cd crates/gents/proofs && lake build`
- [x] `cargo test -p gents --test conformance`
- [x] `cargo test -p gents --test workflow_conformance`
- [x] `cargo test -p gents --lib` (two pre-existing flakes pass alone; fail under concurrent suite load: P2P return projection, backend health recovery)
- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [ ] CI green on this PR