### PR TITLE
fix(tests): align recovery fixtures with owner-scoped recovery

### DIFF
--- a/crates/gents/tests/conformance/subagent_source.rs
+++ b/crates/gents/tests/conformance/subagent_source.rs
@@ -909,7 +909,7 @@ async fn cascade_after_source_spawn_reaches_child_request() {
         db.node.clone(),
         parent_request_id.to_string(),
         "r3-session-cascade".to_string(),
-        "did:test:test".to_string(),
+        running.booted.agent_did.clone(),
         parent_tool_call_id.to_string(),
         1,
         "spawn_subagent".to_string(),
@@ -2347,6 +2347,7 @@ async fn create_orphan_cross_deployment_tool_call(
             create_AgentToolCall(input: {{
                 tool_call_key: "{tool_call_key}",
                 request_id: "{escaped_parent_request_id}",
+                agent_did: "{agent_did}",
                 session_id: "{escaped_parent_session_id}",
                 message_sequence: 1,
                 tool_name: "spawn_subagent",
@@ -2366,7 +2367,8 @@ async fn create_orphan_cross_deployment_tool_call(
                 tool_failure_class: null,
                 latency_ms: null
             }}) {{ _docID }}
-        }}"#
+        }}"#,
+        agent_did = escape_graphql_string(crate::support::AGENT_DID),
     );
     let response = node.execute(&mutation).await;
     assert!(
@@ -2443,6 +2445,7 @@ async fn create_orphan_subagent_tool_call_with_await_mode(
             create_AgentToolCall(input: {{
                 tool_call_key: "{tool_call_key}",
                 request_id: "{escaped_parent_request_id}",
+                agent_did: "{agent_did}",
                 session_id: "{escaped_parent_session_id}",
                 message_sequence: 1,
                 tool_name: "spawn_subagent",
@@ -2462,7 +2465,8 @@ async fn create_orphan_subagent_tool_call_with_await_mode(
                 tool_failure_class: null,
                 latency_ms: null
             }}) {{ _docID }}
-        }}"#
+        }}"#,
+        agent_did = escape_graphql_string(crate::support::AGENT_DID),
     );
     let response = node.execute(&mutation).await;
     assert!(

--- a/crates/gents/tests/e2e_subagent/r4_subagent_completion.rs
+++ b/crates/gents/tests/e2e_subagent/r4_subagent_completion.rs
@@ -218,7 +218,7 @@ async fn create_child_and_bridge(
         node.clone(),
         parent_request_id.to_string(),
         parent_session_id.to_string(),
-        "did:test:test".to_string(),
+        AGENT_DID.to_string(),
         tool_call_id.to_string(),
         message_sequence,
         "spawn_subagent".to_string(),
@@ -996,7 +996,7 @@ async fn background_completion_wakeup_waits_behind_active_foreground_parent_then
 }
 
 #[tokio::test]
-async fn recovery_fails_running_background_bridge_after_parent_completes() {
+async fn recovery_leaves_running_background_bridge_after_clean_parent_completion() {
     let (db, session_id, parent_request_id) =
         setup_fixture("background_completion_recovery_skip").await;
     let (child_request_id, _) = create_child_and_bridge(
@@ -1014,23 +1014,17 @@ async fn recovery_fails_running_background_bridge_after_parent_completes() {
     let report = ToolCallLifecycle::recover_all(db.node.as_ref(), AGENT_DID)
         .await
         .unwrap();
-    assert_eq!(report.tool_calls_recovered, 1);
+    assert_eq!(report.tool_calls_recovered, 0);
 
     let tool = fetch_tool_call(db.node.as_ref(), &session_id, "spawn-bg-recovery-skip").await;
-    assert_eq!(tool.lifecycle_state.as_deref(), Some("failed"));
+    assert_eq!(tool.lifecycle_state.as_deref(), Some("running"));
     assert_eq!(tool.await_mode.as_deref(), Some("background"));
-    assert!(
-        tool.result
-            .as_deref()
-            .is_some_and(|result| result.contains("parent request was already terminal")),
-        "background bridge failure should explain the terminal parent"
-    );
     let interrupt = fetch_interrupt_requested_at(db.node.as_ref(), &child_request_id)
         .await
         .unwrap();
     assert!(
-        interrupt.is_some(),
-        "cascade background child should be interrupted once recovery fails the parent bridge"
+        interrupt.is_none(),
+        "clean parent completion must not interrupt its linked background child"
     );
 }
 


### PR DESCRIPTION
## Summary

- stamp recovery fixtures with the immutable owning `agent_did` introduced by #880
- use the booted principal when constructing the cascade-recovery lifecycle fixture
- align the background-bridge recovery test with the proven clean-parent-completion contract from #880

## Root cause

Recovery now scopes running tool calls by immutable `agent_did`. Several test fixtures either omitted that field or used a mismatched placeholder DID, so the recovery scan correctly ignored them. One e2e expectation also still asserted the pre-#880 behavior that clean parent completion fails the bridge and interrupts the child.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p gents --test conformance subagent_source:: -- --test-threads=1` (28 passed)
- `cargo test -p gents --test e2e_subagent r4_subagent_completion::recovery_ -- --test-threads=1` (2 passed)
- `cargo test -p gents`
- `cargo check --workspace --all-targets`