### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.8.0"
+        default: "0.9.0"
 
 concurrency:
   group: release-linux-${{ github.ref }}

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -10,7 +10,7 @@ on:
         description: Release version without the v prefix; must match workspace.package.version.
         required: true
         type: string
-        default: "0.8.0"
+        default: "0.9.0"
       codesign_timestamp:
         description: Timestamp mode for codesign. Signed releases notarize, so timestamping must succeed unless dry_run_unsigned is true.
         required: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,7 +15,7 @@ dependencies = [
 [[package]]
 name = "acp"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.11.0",
  "log",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2482,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "blockstore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "crdt"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "defra-core",
@@ -5998,7 +5998,7 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 [[package]]
 name = "crypto"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "aes-gcm",
  "blst",
@@ -6196,7 +6196,7 @@ dependencies = [
 [[package]]
 name = "cursor"
 version = "0.1.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "base64 0.22.1",
  "serde",
@@ -6443,7 +6443,7 @@ dependencies = [
 [[package]]
 name = "datastore"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -6458,7 +6458,7 @@ dependencies = [
 [[package]]
 name = "db"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "anyhow",
@@ -6508,7 +6508,7 @@ dependencies = [
 [[package]]
 name = "db-blocks"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "blockstore",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "db-index"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "datastore",
@@ -6547,7 +6547,7 @@ dependencies = [
 [[package]]
 name = "db-merge"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-lock",
@@ -6565,6 +6565,7 @@ dependencies = [
  "document",
  "events",
  "futures",
+ "hex",
  "identity",
  "kms",
  "libp2p",
@@ -6580,13 +6581,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "wasm-bindgen-futures",
  "zeroize",
 ]
 
 [[package]]
 name = "db-nac"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-trait",
@@ -6601,7 +6603,7 @@ dependencies = [
 [[package]]
 name = "db-search"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "anyhow",
  "document",
@@ -6701,9 +6703,10 @@ checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 [[package]]
 name = "defra-core"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
+ "bytes",
  "cid",
  "ipld-core",
  "multibase",
@@ -6725,7 +6728,7 @@ dependencies = [
 [[package]]
 name = "defra-http"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-stream",
@@ -6757,7 +6760,7 @@ dependencies = [
 [[package]]
 name = "defra-node"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "anyhow",
@@ -6791,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "defra-p2p-adapter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-trait",
@@ -6825,7 +6828,7 @@ dependencies = [
 [[package]]
 name = "defra-version"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "serde",
 ]
@@ -7243,7 +7246,7 @@ dependencies = [
 [[package]]
 name = "document"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7701,16 +7704,15 @@ dependencies = [
 [[package]]
 name = "events"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
+ "async-channel 2.5.0",
  "async-trait",
  "bytes",
  "cid",
  "defra-core",
  "parking_lot 0.12.5",
  "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
  "tracing",
 ]
 
@@ -8563,7 +8565,7 @@ dependencies = [
 
 [[package]]
 name = "gents"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "acp",
  "agent-tool-call-lifecycle-v1-to-v2-lens",
@@ -8622,7 +8624,7 @@ dependencies = [
 
 [[package]]
 name = "gents-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "acp",
  "anyhow",
@@ -8678,7 +8680,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -8692,7 +8694,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8721,7 +8723,7 @@ dependencies = [
 
 [[package]]
 name = "gents-desktop-tauri"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -8750,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "gents-fs-runner"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "globset",
@@ -8762,7 +8764,7 @@ dependencies = [
 
 [[package]]
 name = "gents-lean-contract"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -8771,7 +8773,7 @@ dependencies = [
 
 [[package]]
 name = "gents-protocol"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -8790,7 +8792,7 @@ dependencies = [
 
 [[package]]
 name = "gents-schemas"
-version = "0.8.0"
+version = "0.9.0"
 
 [[package]]
 name = "gethostname"
@@ -10826,7 +10828,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -11052,7 +11054,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 [[package]]
 name = "identity"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "base64 0.22.1",
  "crypto",
@@ -11610,7 +11612,7 @@ dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
  "chrono",
- "constant_time_eq 0.3.1",
+ "constant_time_eq 0.1.5",
  "data-encoding",
  "derive_more 2.1.1",
  "genawaiter",
@@ -12285,7 +12287,7 @@ dependencies = [
 [[package]]
 name = "kms"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-lock",
@@ -12402,7 +12404,7 @@ checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 [[package]]
 name = "lark-kv"
 version = "0.1.0"
-source = "git+https://github.com/sourcenetwork/lark.git?rev=ab924471c2e376591c1e3b3cd419655f9c7c6dc4#ab924471c2e376591c1e3b3cd419655f9c7c6dc4"
+source = "git+https://github.com/sourcenetwork/lark.git?rev=d1ec2e727bad6c160e6c1d71e2cbb163892b3a02#d1ec2e727bad6c160e6c1d71e2cbb163892b3a02"
 dependencies = [
  "crossbeam-skiplist",
  "lru 0.16.4",
@@ -12433,7 +12435,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lens"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -14491,7 +14493,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 3.5.0",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -15163,7 +15165,7 @@ dependencies = [
 [[package]]
 name = "p2p"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "anyhow",
@@ -16454,7 +16456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16467,7 +16469,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -16588,7 +16590,7 @@ dependencies = [
 [[package]]
 name = "query"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-graphql",
@@ -16624,7 +16626,7 @@ dependencies = [
 [[package]]
 name = "query-parse"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "chrono",
@@ -16641,7 +16643,7 @@ dependencies = [
 [[package]]
 name = "query-plan"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "async-lock",
@@ -16673,7 +16675,7 @@ dependencies = [
 [[package]]
 name = "query-types"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "chrono",
@@ -17626,7 +17628,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "replication-filter"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "p2p",
  "query",
@@ -18425,7 +18427,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "cid",
  "defra-core",
@@ -19627,7 +19629,7 @@ dependencies = [
 [[package]]
 name = "sourcehub"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "acp",
  "acp-light-client",
@@ -20054,7 +20056,7 @@ dependencies = [
 [[package]]
 name = "storage"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-trait",
  "bm25",
@@ -24504,7 +24506,7 @@ dependencies = [
 [[package]]
 name = "zanzibar"
 version = "0.5.0"
-source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=a9370b3b554393158c06ca94e93a30f70194a084#a9370b3b554393158c06ca94e93a30f70194a084"
+source = "git+ssh://git@github.com/sourcenetwork/defradb.rs.git?rev=8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195#8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195"
 dependencies = [
  "async-lock",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/source-inc/gents"
@@ -57,23 +57,21 @@ codex-model-provider-info = { git = "https://github.com/openai/codex", rev = "c4
 codex-protocol = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-tui = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
 codex-utils-absolute-path = { git = "https://github.com/openai/codex", rev = "c4e53d103c102f8d5201247adbc60bbddd47c88d" }
-# defradb.rs v0.16.2 plus active-snapshot conflict retention, atomic
-# RocksDB conflict-version/physical-snapshot pairing, and iterative parent-DAG
-# replay (#1162, #1167, #1176). Iterative replay is required on iOS: a deep
-# collection history otherwise exhausts even a 32 MiB Tokio worker stack.
-acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
-crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
-defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
+# defradb.rs v0.17.1. Its iterative parent-DAG replay remains required on iOS:
+# a deep collection history otherwise exhausts even a 32 MiB Tokio worker stack.
+acp = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
+crypto = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
+defra-core = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
 gents-protocol = { path = "crates/gents-protocol" }
 gents-schemas = { path = "crates/gents-schemas" }
 gents-desktop-core = { path = "crates/gents-desktop-core" }
 gents-lean-contract = { path = "crates/gents-lean-contract" }
-defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
-defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
+defra-node = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
+defra-p2p-adapter = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
 dirs = "5"
-events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
+events = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
 hostname = "0.4"
-identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
+identity = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
 # Must stay version-aligned with the iroh used by the defradb.rs `p2p` crate;
 # the CLI uses it to inspect the default relay set at startup (#588).
 iroh = "1"
@@ -81,8 +79,8 @@ minijinja = { version = "2", default-features = false, features = ["builtins", "
 opentelemetry = { version = "0.31", default-features = false, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31.1", default-features = false, features = ["trace", "http-proto", "reqwest-client"] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["trace"] }
-p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
-query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "a9370b3b554393158c06ca94e93a30f70194a084" }
+p2p = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
+query = { git = "ssh://git@github.com/sourcenetwork/defradb.rs.git", rev = "8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195" }
 rand = "0.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rig-core = "0.35.0"

--- a/apps/gents-desktop/package-lock.json
+++ b/apps/gents-desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gents-desktop-tauri",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gents-desktop-tauri",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/funnel-display": "^5.2.8",

--- a/apps/gents-desktop/package.json
+++ b/apps/gents-desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gents-desktop-tauri",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
+++ b/apps/gents-desktop/src-tauri/gen/apple/gents-desktop-tauri_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.8.0</string>
+	<string>0.9.0</string>
 	<key>CFBundleVersion</key>
-	<string>0.8.0</string>
+	<string>0.9.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/apps/gents-desktop/src-tauri/gen/apple/project.yml
+++ b/apps/gents-desktop/src-tauri/gen/apple/project.yml
@@ -54,8 +54,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 0.8.0
-        CFBundleVersion: "0.8.0"
+        CFBundleShortVersionString: 0.9.0
+        CFBundleVersion: "0.9.0"
     entitlements:
       path: gents-desktop-tauri_iOS/gents-desktop-tauri_iOS.entitlements
     scheme:

--- a/apps/gents-desktop/src-tauri/tauri.conf.json
+++ b/apps/gents-desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Gents",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "identifier": "com.source-inc.gents",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -903,6 +903,7 @@ fn resolve_server_p2p_config(
             P2pDiscoveryArg::N0 => p2p::iroh::IrohDiscoveryConfig::N0,
             P2pDiscoveryArg::Disabled => p2p::iroh::IrohDiscoveryConfig::Disabled,
         },
+        max_concurrent_multipath_paths: None,
         secret_key_path: Some(secret_key_path),
         load_persisted_collections: true,
         max_concurrent_dag_fetches,

--- a/crates/gents-desktop-core/src/client/core/bootstrap.rs
+++ b/crates/gents-desktop-core/src/client/core/bootstrap.rs
@@ -158,6 +158,7 @@ fn desktop_p2p_config(paths: &DesktopPaths, options: &ClientCoreOptions) -> P2PC
         bind_addr: options.bind_addr,
         relay_mode: options.relay_mode.clone(),
         discovery: options.discovery.clone(),
+        max_concurrent_multipath_paths: None,
         secret_key_path: Some(paths.iroh_secret_key_path().to_path_buf()),
         load_persisted_collections: options.load_persisted_collections,
         max_concurrent_dag_fetches: options.max_concurrent_dag_fetches,

--- a/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
+++ b/crates/gents/src/agent/p2p_reconcile/embedded_impl.rs
@@ -329,6 +329,7 @@ mod tests {
                     bind_addr: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
                     relay_mode: IrohRelayModeConfig::Disabled,
                     discovery: IrohDiscoveryConfig::Disabled,
+                    max_concurrent_multipath_paths: None,
                     secret_key_path: None,
                     load_persisted_collections: false,
                     max_concurrent_dag_fetches: p2p::sync::DEFAULT_MAX_CONCURRENT_DAG_FETCHES,

--- a/crates/gents/src/backend_health.rs
+++ b/crates/gents/src/backend_health.rs
@@ -488,7 +488,9 @@ mod tests {
             let port = listener.local_addr().expect("local addr").port();
             let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let stop_for_thread = stop.clone();
+            let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
             let handle = std::thread::spawn(move || {
+                ready_tx.send(()).expect("signal models listener ready");
                 while !stop_for_thread.load(std::sync::atomic::Ordering::Relaxed) {
                     match listener.accept() {
                         Ok((mut stream, _)) => {
@@ -509,6 +511,7 @@ mod tests {
                     }
                 }
             });
+            ready_rx.recv().expect("models listener thread started");
             Self {
                 port,
                 stop,

--- a/crates/gents/tests/conformance/streaming_compaction.rs
+++ b/crates/gents/tests/conformance/streaming_compaction.rs
@@ -30,6 +30,7 @@ struct StreamingResponseRow {
     status: String,
     error_message: Option<String>,
     token_count: i64,
+    progress_seq: i64,
     materialized_message_sequence: Option<i64>,
     interrupted_at: Option<String>,
     completed_at: Option<String>,
@@ -170,7 +171,7 @@ async fn drive_streaming_response_idle_timeout_case(
     )
     .await;
 
-    wait_for_backend_chunks_with_time_advance(&backend, IDLE_TIMEOUT_MARKER, 1).await;
+    wait_for_backend_chunks_realtime(&backend, IDLE_TIMEOUT_MARKER, 1).await;
     let response_doc_id = wait_for_response_doc_id_realtime(db.node.as_ref(), &request_id).await;
     let pre_response = wait_for_response_content_contains_realtime(
         db.node.as_ref(),
@@ -191,17 +192,16 @@ async fn drive_streaming_response_idle_timeout_case(
             .await;
     assert!(!inference_call_state_is_terminal(&pre_call.call_state));
 
-    for _ in 0..2 {
-        tokio::time::advance(Duration::from_secs(IDLE_TIMEOUT_CONFIGURED_SECS + 1)).await;
+    // The progress write above is the final operation for the first stream
+    // item. Give the processor a turn to install its next-poll idle deadline,
+    // then cross that deadline exactly once. Repeated virtual-time advances
+    // while terminal persistence is running can incorrectly exhaust DefraDB's
+    // own query timeout under host load.
+    for _ in 0..10 {
         tokio::task::yield_now().await;
-        if load_streaming_response_row(&db.node, &response_doc_id)
-            .await
-            .status
-            == case.post_status
-        {
-            break;
-        }
     }
+    tokio::time::advance(Duration::from_secs(IDLE_TIMEOUT_CONFIGURED_SECS + 1)).await;
+    tokio::task::yield_now().await;
 
     let post_response =
         wait_for_response_status_realtime(db.node.as_ref(), &response_doc_id, &case.post_status)
@@ -289,7 +289,7 @@ async fn wait_for_response_doc_id_realtime(node: &EmbeddedNode, request_id: &str
     }
 }
 
-async fn wait_for_backend_chunks_with_time_advance(
+async fn wait_for_backend_chunks_realtime(
     backend: &MockStreamingBackend,
     marker: &str,
     expected: usize,
@@ -304,7 +304,10 @@ async fn wait_for_backend_chunks_with_time_advance(
             started.elapsed() < Duration::from_secs(10),
             "timed out waiting for {expected} chunk(s) for marker {marker}, observed {observed}"
         );
-        tokio::time::advance(Duration::from_millis(50)).await;
+        // This test pauses Tokio time so it can trigger the five-second idle
+        // deadline deterministically below. Do not advance that clock before
+        // the mock's first real network chunk arrives: doing so can fire the
+        // idle timer while the request is still traversing the I/O reactor.
         tokio::task::yield_now().await;
     }
 }
@@ -317,7 +320,11 @@ async fn wait_for_response_content_contains_realtime(
     let started = std::time::Instant::now();
     loop {
         let row = load_streaming_response_row(node, response_doc_id).await;
-        if row.content.contains(expected) {
+        // The content flush becomes query-visible before StreamProcessor
+        // performs the lifecycle progress write and returns to the poll that
+        // installs the idle deadline. Waiting for both keeps paused-time
+        // advancement from racing that first item boundary under load.
+        if row.content.contains(expected) && row.progress_seq >= 2 {
             return row;
         }
         assert_ne!(
@@ -916,6 +923,7 @@ async fn load_streaming_response_row(node: &EmbeddedNode, doc_id: &str) -> Strea
                 status
                 error_message
                 token_count
+                progress_seq
                 materialized_message_sequence
                 interrupted_at
                 completed_at

--- a/crates/gents/tests/e2e_subagent/r6_background_tools.rs
+++ b/crates/gents/tests/e2e_subagent/r6_background_tools.rs
@@ -206,6 +206,21 @@ async fn fetch_background_wakes(node: &EmbeddedNode, session_id: &str) -> Vec<Wa
         .unwrap_or_default()
 }
 
+async fn wait_for_background_wakes(
+    node: &EmbeddedNode,
+    session_id: &str,
+    expected_count: usize,
+) -> Vec<WakeRequestRow> {
+    for _ in 0..20 {
+        let wakes = fetch_background_wakes(node, session_id).await;
+        if wakes.len() >= expected_count {
+            return wakes;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("expected at least {expected_count} background wake rows for session {session_id}");
+}
+
 fn registry(tools: Vec<Box<dyn ToolDyn>>, allowlist: &[&str]) -> BackgroundToolRegistry {
     BackgroundToolRegistry::from_tools(
         tools,
@@ -331,7 +346,7 @@ async fn background_tool_success_returns_handle_and_wait_tool_returns_terminal_e
     assert!(message.content.contains(r#"status="completed""#));
     assert!(message.content.contains("<result>done</result>"));
 
-    let wakes = fetch_background_wakes(db.node.as_ref(), &session_id).await;
+    let wakes = wait_for_background_wakes(db.node.as_ref(), &session_id, 1).await;
     assert_eq!(wakes.len(), 1);
     let metadata: serde_json::Value =
         serde_json::from_str(wakes[0].metadata.as_deref().unwrap()).unwrap();
@@ -563,7 +578,7 @@ async fn cancel_tool_cancels_running_background_row_without_persisting_cancel_to
     assert!(message.content.contains(r#"status="cancelled""#));
     assert!(message.content.contains("<reason>explicit_cancel</reason>"));
 
-    let wakes = fetch_background_wakes(db.node.as_ref(), &session_id).await;
+    let wakes = wait_for_background_wakes(db.node.as_ref(), &session_id, 1).await;
     assert_eq!(wakes.len(), 1);
 }
 

--- a/crates/gents/tests/support/mod.rs
+++ b/crates/gents/tests/support/mod.rs
@@ -251,6 +251,7 @@ pub async fn test_p2p_db_with_admission(name: &str, admission: TestP2pAdmission)
                 bind_addr: Some(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)),
                 relay_mode: p2p::iroh::IrohRelayModeConfig::Disabled,
                 discovery: p2p::iroh::IrohDiscoveryConfig::Disabled,
+                max_concurrent_multipath_paths: None,
                 secret_key_path: None,
                 load_persisted_collections: false,
                 max_concurrent_dag_fetches: admission.max_concurrent_dag_fetches,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,8 +11,8 @@ major/minor, and `latest` tags. Pin the published digest instead of a tag when
 the deployment must be byte-for-byte immutable.
 
 ```bash
-docker pull ghcr.io/source-inc/gents:v0.8.0
-docker run --rm ghcr.io/source-inc/gents:v0.8.0 version
+docker pull ghcr.io/source-inc/gents:v0.9.0
+docker run --rm ghcr.io/source-inc/gents:v0.9.0 version
 ```
 
 The image runs as the non-root `gents` user. Persist its default home across
@@ -22,13 +22,13 @@ container replacements with a named volume:
 docker volume create gents-home
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
-  ghcr.io/source-inc/gents:v0.8.0 \
+  ghcr.io/source-inc/gents:v0.9.0 \
   init --inference-url http://host.docker.internal:8000/v1 --model-name MODEL
 
 docker run --rm -it \
   -v gents-home:/home/gents/.gents \
   -p 9191:9191 \
-  ghcr.io/source-inc/gents:v0.8.0 \
+  ghcr.io/source-inc/gents:v0.9.0 \
   server --http-addr 0.0.0.0 --no-codex-shim
 ```
 


### PR DESCRIPTION
## Summary

- upgrade the pinned DefraDB revision to the released v0.17.1 commit
- adapt Gents P2P configuration to the new multipath setting
- bump workspace, desktop, workflows, and operator docs to v0.9.0
- harden asynchronous test readiness exposed by the database upgrade

## Validation

- cargo test -p gents
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- git diff --check
- JSON and Apple plist validation

DefraDB v0.17.1 commit: 8eba3d5eea0d1d4c08cc1f464038bb3fd0b2f195