### PR TITLE
test(p2p): align CLI catalog with conversation scope

### DIFF
--- a/crates/gents-cli/src/commands/p2p/templates.rs
+++ b/crates/gents-cli/src/commands/p2p/templates.rs
@@ -192,13 +192,13 @@ mod tests {
     }
 
     #[test]
-    fn conversation_row_is_push_agent_did() {
+    fn conversation_row_is_push_per_collection() {
         let rows = template_rows();
         let row = rows.iter().find(|r| r.id == "conversation").unwrap();
         assert_eq!(row.delivery, "push");
-        assert_eq!(row.scope, "agent_did");
-        // 8 collections comma-separated
-        assert_eq!(row.collections.split(',').count(), 8);
+        assert_eq!(row.scope, "per-collection");
+        // Transcript collections plus BearerPairingReady.
+        assert_eq!(row.collections.split(',').count(), 9);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- update the CLI template catalog test for the per-collection conversation scope introduced by #875
- account for the BearerPairingReady collection added to the conversation template

## Cause

Main CI correctly reported that the stale test still expected the former single-field agent_did scope and eight collections. Runtime behavior and the canonical template tests already expect per-collection requester/claimant filtering across nine collections.

## Validation

- cargo test -p gents-cli --bin gents commands::p2p::templates::tests::
- cargo test -p gents-cli --bin gents (534 passed)
- cargo fmt --all -- --check
- git diff --check