### PR TITLE
test(desktop): fail when package tests disappear

### DIFF
--- a/packages/gents-desktop-chat/package.json
+++ b/packages/gents-desktop-chat/package.json
@@ -24,7 +24,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/clean-desktop-package-dist.mjs && tsc -p tsconfig.json",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "peerDependencies": {
     "react-markdown": "^10.0.0",

--- a/packages/gents-desktop-client/package.json
+++ b/packages/gents-desktop-client/package.json
@@ -27,7 +27,7 @@
   ],
   "scripts": {
     "build": "node ../../scripts/clean-desktop-package-dist.mjs && tsc -p tsconfig.json",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "dependencies": {
     "@tauri-apps/api": "^2"


### PR DESCRIPTION
## Summary

- remove `--passWithNoTests` from the reusable desktop chat and client package test scripts
- make missing or broken Vitest discovery fail instead of producing a false-green workspace run
- leave runtime code, exports, package dependencies, and lockfiles unchanged

## Evidence

Both packages have non-empty, actively discovered suites:

- `@source-inc/gents-desktop-client`: 3 files, 8 tests
- `@source-inc/gents-desktop-chat`: 2 files, 19 tests

The chat suite's first collection performs a cold Lean `Proofs.Conformance.Contracts` build; that completed successfully, and the warm rerun finished normally. `--passWithNoTests` therefore serves no current positive purpose and would only mask future test disappearance or discovery drift.

An independent audit reviewed the exact two-line diff, confirmed that npm's lockfile does not record package scripts, and found no runtime or public-library API impact.

## Validation

- `npm run test -w @source-inc/gents-desktop-client`
- `npm run test -w @source-inc/gents-desktop-chat`
- `npm run test:packages` (58 tests passed across five tested packages)
- `npm run build:packages`
- `npm run check:package-boundaries`
- `git diff --check`
