### PR TITLE
test(conformance): remove hollow R5 checks

### DIFF
--- a/crates/gents/tests/fixtures/r5_scenarios/a_crash_mid_wait.json
+++ b/crates/gents/tests/fixtures/r5_scenarios/a_crash_mid_wait.json
@@ -162,6 +162,6 @@
     { "op": "Crash", "node": "A" },
     { "op": "RunRecoverySweepOn", "node": "A" },
     { "op": "RunBackgroundCompletionObserverOnA" },
-    { "op": "WaitForConvergence", "timeout_secs": 10 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/r5_scenarios/b_crash_mid_execution.json
+++ b/crates/gents/tests/fixtures/r5_scenarios/b_crash_mid_execution.json
@@ -77,6 +77,6 @@
       "doc_id": "child-req-b-crash"
     },
     { "op": "RunBackgroundCompletionObserverOnA" },
-    { "op": "WaitForConvergence", "timeout_secs": 10 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/r5_scenarios/happy_path.json
+++ b/crates/gents/tests/fixtures/r5_scenarios/happy_path.json
@@ -89,6 +89,6 @@
       "doc_id": "child-req-1"
     },
     { "op": "RunBackgroundCompletionObserverOnA" },
-    { "op": "WaitForConvergence", "timeout_secs": 10 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/r5_scenarios/multi_completion_coalesce.json
+++ b/crates/gents/tests/fixtures/r5_scenarios/multi_completion_coalesce.json
@@ -150,6 +150,6 @@
     },
     { "op": "RunBackgroundCompletionObserverOnA" },
     { "op": "RunBackgroundCompletionObserverOnA" },
-    { "op": "WaitForConvergence", "timeout_secs": 10 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/fixtures/r5_scenarios/partition_during_cancel.json
+++ b/crates/gents/tests/fixtures/r5_scenarios/partition_during_cancel.json
@@ -90,6 +90,6 @@
       "doc_id": "child-req-cancel"
     },
     { "op": "RunCancelAckObserverOnA" },
-    { "op": "WaitForConvergence", "timeout_secs": 10 }
+    { "op": "WaitForConvergence" }
   ]
 }

--- a/crates/gents/tests/support/r5_conformance/invariants.rs
+++ b/crates/gents/tests/support/r5_conformance/invariants.rs
@@ -6,15 +6,8 @@ pub fn assert_all_safety(o: &Observation) {
     completion::projection_matches_bridge_mapping(o);
     completion::notification_idempotent(o);
     completion::wakeup_coalesced(o);
-    completion::wakeup_causal(o);
-    completion::cancel_drain_preserves_user_pending(o);
-    completion::parent_cancel_absorbs_late_terminal(o);
     cancel_propagation::cancel_intent_durable(o);
-    cancel_propagation::cancel_handled_idempotent(o);
-    cancel_propagation::interrupt_exactly_once(o);
     cancel_propagation::cascade_interrupts_only_running(o);
-    cancel_propagation::natural_terminal_stable_after_cancel(o);
-    cancel_propagation::interrupted_only_by_cascade(o);
 }
 
 pub fn assert_liveness_after_convergence(history: &[Observation]) {
@@ -101,10 +94,6 @@ pub mod completion {
             assert!(seen.insert(key.clone()), "duplicate wakeup key {key}");
         }
     }
-
-    pub fn wakeup_causal(_: &Observation) {}
-    pub fn cancel_drain_preserves_user_pending(_: &Observation) {}
-    pub fn parent_cancel_absorbs_late_terminal(_: &Observation) {}
 }
 
 pub mod cancel_propagation {
@@ -121,9 +110,6 @@ pub mod cancel_propagation {
         }
     }
 
-    pub fn cancel_handled_idempotent(_: &Observation) {}
-    pub fn interrupt_exactly_once(_: &Observation) {}
-
     pub fn cascade_interrupts_only_running(o: &Observation) {
         for child in &o.b_child_requests {
             if child.interrupt_requested_at.is_some() {
@@ -138,7 +124,4 @@ pub mod cancel_propagation {
             }
         }
     }
-
-    pub fn natural_terminal_stable_after_cancel(_: &Observation) {}
-    pub fn interrupted_only_by_cascade(_: &Observation) {}
 }

--- a/crates/gents/tests/support/r5_conformance/runner.rs
+++ b/crates/gents/tests/support/r5_conformance/runner.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::{bail, Result};
 use gents::background_completion::{
     observe_cancel_cascade_ack, project_background_subagent_completion,
@@ -204,15 +202,14 @@ impl Harness {
             Action::AdvanceClockOn { node, seconds } => {
                 advance_r5_clock_effects(self.node(node)?, *seconds).await?;
             }
-            Action::WaitForConvergence { timeout_secs } => {
-                self.wait_for_convergence(Duration::from_secs(*timeout_secs))
-                    .await?;
+            Action::WaitForConvergence => {
+                self.wait_for_convergence().await?;
             }
         }
         Ok(())
     }
 
-    async fn wait_for_convergence(&mut self, _timeout: Duration) -> Result<()> {
+    async fn wait_for_convergence(&mut self) -> Result<()> {
         run_background_completion_on_a(&self.a).await?;
         let _ = observe_cancel_cascade_ack(self.a.db.node.clone(), NODE_A_DID).await?;
         run_cancel_mirror_on_b(&self.b).await?;

--- a/crates/gents/tests/support/r5_conformance/scenario.rs
+++ b/crates/gents/tests/support/r5_conformance/scenario.rs
@@ -65,7 +65,5 @@ pub enum Action {
         node: NodeId,
         seconds: u64,
     },
-    WaitForConvergence {
-        timeout_secs: u64,
-    },
+    WaitForConvergence,
 }


### PR DESCRIPTION
## Summary

- remove seven R5 "safety invariant" functions that had empty bodies and therefore could never fail
- remove their calls from `assert_all_safety`
- remove the R5-only `WaitForConvergence.timeout_secs` fixture field whose value was converted to `Duration` and passed to an unread `_timeout` parameter

This is test-harness cleanup only. The convergence observer sequence, action order, five scenario bodies, seven real safety checks, liveness checks, test names, runtime code, and Lean contracts are unchanged.

## Deletion evidence

- repository-wide symbol inspection found each removed invariant only at its empty definition and single aggregator call
- every removed function had no assertion, mutation, return value, or side effect
- all five R5 fixtures used the same `timeout_secs: 10`
- the timeout's only data flow ended at `_timeout: Duration`; the helper never read it
- an independent review found no semantic or coverage loss

The existing no-op `Crash` action is intentionally untouched. It is separate correctness debt that needs a Lean-first design/fix, not a cleanup deletion hidden in this PR.

## Validation

- `cargo test -p gents --test conformance r5_ -- --nocapture` — 7 passed
- `cargo test -p gents` — 1,173 unit tests and all integration targets passed
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`
- `git diff --check`
