### PR TITLE
refactor(graphql): reuse canonical string escaping

### DIFF
--- a/crates/gents/src/graphql/tests.rs
+++ b/crates/gents/src/graphql/tests.rs
@@ -5,6 +5,7 @@ fn test_escape_graphql_string() {
     assert_eq!(escape_graphql_string("hello"), "hello");
     assert_eq!(escape_graphql_string("he\"llo"), "he\\\"llo");
     assert_eq!(escape_graphql_string("line1\nline2"), "line1\\nline2");
+    assert_eq!(escape_graphql_string("cr\r"), "cr\\r");
     assert_eq!(escape_graphql_string("tab\there"), "tab\\there");
     assert_eq!(escape_graphql_string("back\\slash"), "back\\\\slash");
     assert_eq!(escape_graphql_string("mixed\"\n\\"), "mixed\\\"\\n\\\\");

--- a/crates/gents/src/meta_tools/shared.rs
+++ b/crates/gents/src/meta_tools/shared.rs
@@ -4,6 +4,7 @@ use anyhow::{anyhow, Context as _};
 use defra_node::EmbeddedNode;
 use serde::{Deserialize, Serialize};
 
+use crate::graphql::escape_graphql_string;
 use crate::health_checker::{HealthStatus, ServiceHealth, ServiceHealthMap};
 use crate::mcp_pool::resolve_mcp_url;
 use crate::mcp_pool::McpPool;
@@ -208,15 +209,6 @@ impl StructuredToolError {
     }
 }
 
-pub(super) fn escape_graphql(value: &str) -> String {
-    value
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
-}
-
 #[derive(Debug, Clone, Deserialize)]
 struct RegistryServiceEntry {
     #[serde(default, deserialize_with = "crate::registry::null_as_empty_string")]
@@ -246,7 +238,7 @@ impl ResolvedMcpService {
 }
 
 pub(super) fn lookup_service_query(service_id: &str) -> String {
-    let sid = escape_graphql(service_id);
+    let sid = escape_graphql_string(service_id);
     format!(
         r#"{{
   ToolServiceRegistry(

--- a/crates/gents/src/meta_tools/tests.rs
+++ b/crates/gents/src/meta_tools/tests.rs
@@ -1,6 +1,5 @@
 use super::shared::{
-    escape_graphql, extract_text, lookup_service_query, mcp_service_allowed, MetaToolError,
-    StructuredToolError,
+    extract_text, lookup_service_query, mcp_service_allowed, MetaToolError, StructuredToolError,
 };
 
 fn make_call_result(texts: &[&str]) -> rmcp::model::CallToolResult {
@@ -12,31 +11,6 @@ fn make_call_result(texts: &[&str]) -> rmcp::model::CallToolResult {
         .collect();
 
     CallToolResult::success(content)
-}
-
-#[test]
-fn escape_graphql_handles_quotes() {
-    assert_eq!(escape_graphql(r#"say "hello""#), r#"say \"hello\""#);
-}
-
-#[test]
-fn escape_graphql_handles_backslashes() {
-    assert_eq!(escape_graphql(r"path\to\file"), r"path\\to\\file");
-}
-
-#[test]
-fn escape_graphql_handles_newlines_and_tabs() {
-    assert_eq!(escape_graphql("line1\nline2\ttab"), r"line1\nline2\ttab");
-}
-
-#[test]
-fn escape_graphql_handles_carriage_return() {
-    assert_eq!(escape_graphql("cr\r"), r"cr\r");
-}
-
-#[test]
-fn escape_graphql_combined() {
-    assert_eq!(escape_graphql("a\\b\"c\nd"), r#"a\\b\"c\nd"#);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- replace the private `meta_tools::shared::escape_graphql` duplicate with the canonical `graphql::escape_graphql_string`
- remove five tests tied to the duplicate implementation
- preserve the only unique assertion (carriage-return escaping) in the canonical helper suite
- preserve both query-construction integration tests

No public path, visibility, query shape, escaping order, runtime behavior, or error text changes.

## Deletion evidence

The removed and canonical implementations used the identical ordered replacement chain and byte literals:

1. backslash
2. double quote
3. line feed
4. carriage return
5. tab

Four deleted tests exactly overlapped the canonical suite. The fifth supplied the only unique CR assertion, which is moved rather than deleted. Repository-wide inspection finds no remaining references to the local helper.

An independent Grok review approved the change, confirming semantic equivalence, coverage preservation, visibility, and safe GraphQL interpolation.

## Validation

- `cargo test -p gents escape_graphql` (1 passed)
- `cargo test -p gents lookup_service_query_` (2 passed)
- `cargo test -p gents` (full package suite passed)
- `cargo fmt --all -- --check`
- `git diff --check`
