### PR TITLE
test(cli): remove duplicate pairing token coverage

### DIFF
--- a/crates/gents-cli/src/commands/p2p/invite.rs
+++ b/crates/gents-cli/src/commands/p2p/invite.rs
@@ -549,7 +549,6 @@ mod tests {
     use flate2::read::GzDecoder;
     use gents_protocol::bearer_token::{encode_bearer, BearerInviteToken, BEARER_TOKEN_VERSION};
     use gents_protocol::network_token::{MembershipRecord, NetworkRecord};
-    use gents_protocol::pairing_token::{decode, encode, TOKEN_PREFIX};
 
     use super::*;
 
@@ -620,65 +619,6 @@ mod tests {
         let decoded: BearerInviteToken =
             ciborium::de::from_reader(cbor.as_slice()).expect("decode compact QR CBOR");
         assert_eq!(decoded, token);
-    }
-
-    fn v5_token() -> InviteToken {
-        InviteToken {
-            v: 5,
-            issuer_did: "did:key:agent-a".to_string(),
-            peer_id: "peer-a".to_string(),
-            ticket: "/ip4/127.0.0.1/tcp/4001/p2p/peer-a".to_string(),
-            nonce: "nonce-a".to_string(),
-            network_id: "default".to_string(),
-            issued_at: "2026-06-13T00:00:00Z".to_string(),
-            template: "conversation".to_string(),
-            grant: grant_record(),
-            network: network_record(),
-            sig: vec![0xAB, 0xCD],
-        }
-    }
-
-    #[test]
-    fn invite_token_v5_round_trips_with_template_nonce_and_grant() {
-        let original = v5_token();
-        let encoded = encode(&original).expect("encode");
-        assert!(encoded.starts_with(TOKEN_PREFIX));
-        let decoded = decode(&encoded).expect("decode");
-        assert_eq!(decoded, original);
-        assert_eq!(decoded.template, "conversation");
-        assert_eq!(decoded.nonce, "nonce-a");
-        assert_eq!(decoded.grant.member_did, "did:key:agent-b");
-        assert_eq!(decoded.network.admin_did, "did:key:agent-a");
-    }
-
-    #[test]
-    fn invite_token_rejects_wrong_prefix() {
-        let err = decode("wrong-prefix").unwrap_err().to_string();
-        assert!(err.contains("invalid pairing invite token prefix"));
-    }
-
-    #[test]
-    fn invite_token_rejects_v4_token() {
-        let mut old = v5_token();
-        old.v = 4;
-        let encoded = encode(&old).expect("encode v4");
-        let err = decode(&encoded).unwrap_err().to_string();
-        assert!(
-            err.contains("re-issue") || err.contains("newer"),
-            "unexpected error: {err}"
-        );
-    }
-
-    #[test]
-    fn invite_token_rejects_truncated_base58() {
-        let encoded = encode(&v5_token()).expect("encode");
-        let truncated = &encoded[..encoded.len() - 4];
-        let err = decode(truncated).unwrap_err().to_string();
-        assert!(
-            err.contains("decoding pairing invite token")
-                || err.contains("parsing pairing invite token"),
-            "unexpected error: {err}"
-        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Remove four CLI-local tests that directly called `gents-protocol` pairing-token functions without exercising CLI parsing, command dispatch, rendering, GraphQL, or I/O.

The protocol implementation and its stronger canonical tests are unchanged. All CLI-specific P2P invite coverage remains.

## Redundancy evidence

| Removed CLI test | Canonical protocol coverage |
| --- | --- |
| `invite_token_v5_round_trips_with_template_nonce_and_grant` | `token_v5_round_trips_and_signing_payload_ignores_sig` encodes a complete v5 token, checks the prefix, decodes, compares the full struct, and additionally verifies signing behavior |
| `invite_token_rejects_wrong_prefix` | `decode_rejects_wrong_prefix` uses the same `"wrong-prefix"` input and exact error assertion |
| `invite_token_rejects_v4_token` | `decode_rejects_v4` exercises the same version gate and `re-issue || newer` assertions |
| `invite_token_rejects_truncated_base58` | `decode_rejects_truncated_base58` uses the same four-character truncation and identical decoding/parsing error alternatives |

The now-unused `v5_token` fixture and test-only `{decode, encode, TOKEN_PREFIX}` import are removed with them.

Preserved CLI-specific coverage includes compact bearer QR encoding/decompression and size, GraphQL mutation escaping/no-empty-list behavior, invite grant validation, CLI argument parsing, command integration, and end-to-end P2P tests.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`

Focused protocol/CLI validation and CI are pending; the PR remains draft until green.
