### PR TITLE
Make Bash command timeout configurable

### DIFF
--- a/crates/gents-cli/src/cli/args.rs
+++ b/crates/gents-cli/src/cli/args.rs
@@ -507,6 +507,12 @@ pub(crate) struct ServeArgs {
         help = "Operator safety cap that clamps document tool selection at runtime"
     )]
     pub(crate) tool_ceiling: Option<ToolCeilingArg>,
+    #[arg(
+        long,
+        default_value_t = 10,
+        help = "Maximum foreground Bash command duration in seconds"
+    )]
+    pub(crate) command_timeout_secs: u64,
     #[arg(long = "cli-tool")]
     pub(crate) cli_tools: Vec<String>,
     #[arg(
@@ -3146,6 +3152,15 @@ mod tests {
         assert_eq!(args.p2p_max_concurrent_dag_fetches, Some(12));
         assert_eq!(args.p2p_rate_limit_burst, Some(654));
         assert_eq!(args.p2p_rate_limit_rate, Some(98.5));
+    }
+
+    #[test]
+    fn server_command_timeout_defaults_and_parses() {
+        assert_eq!(parse_server(&[]).command_timeout_secs, 10);
+        assert_eq!(
+            parse_server(&["--command-timeout-secs", "120"]).command_timeout_secs,
+            120
+        );
     }
 
     #[test]

--- a/crates/gents-cli/src/commands/serve.rs
+++ b/crates/gents-cli/src/commands/serve.rs
@@ -323,6 +323,11 @@ pub(crate) async fn serve(mut args: ServeArgs) -> Result<()> {
                 .expect("readwrite root resolved"),
         ),
     };
+    tool_ceiling = tool_ceiling.with_command_timeout_secs(args.command_timeout_secs);
+    tracing::info!(
+        command_timeout_secs = args.command_timeout_secs.max(1),
+        "configured foreground command timeout ceiling"
+    );
     for cli_tool_arg in &args.cli_tools {
         tool_ceiling = tool_ceiling.with_cli_tool(parse_cli_tool_arg(cli_tool_arg)?);
     }

--- a/crates/gents/src/tool_surface/build.rs
+++ b/crates/gents/src/tool_surface/build.rs
@@ -88,8 +88,9 @@ pub(super) fn build_host_tools(
         BashMode::Off => {}
         BashMode::ReadOnly => {
             builder = match command_policy.clone() {
-                Some(policy) => builder.bash_read_only_with_policy(policy),
-                None => builder.bash_read_only(),
+                Some(policy) => builder
+                    .bash_read_only_with_policy_and_timeout(policy, ceiling.command_timeout()),
+                None => builder.bash_read_only_with_timeout(ceiling.command_timeout()),
             };
         }
         BashMode::Unrestricted => {
@@ -97,8 +98,12 @@ pub(super) fn build_host_tools(
                 .clone()
                 .ok_or_else(|| anyhow!("unrestricted bash requires a configured tool root"))?;
             builder = match command_policy.clone() {
-                Some(policy) => builder.bash_unrestricted_with_policy(root, policy),
-                None => builder.bash_unrestricted(root),
+                Some(policy) => builder.bash_unrestricted_with_policy_and_timeout(
+                    root,
+                    policy,
+                    ceiling.command_timeout(),
+                ),
+                None => builder.bash_unrestricted_with_timeout(root, ceiling.command_timeout()),
             };
         }
     }

--- a/crates/gents/src/tool_surface/modes.rs
+++ b/crates/gents/src/tool_surface/modes.rs
@@ -65,6 +65,7 @@ pub struct ToolCeiling {
     file_tools: FileToolMode,
     bash: BashMode,
     cli_tools: Vec<CliToolConfig>,
+    command_timeout: std::time::Duration,
     root: Option<PathBuf>,
     policy: ToolPolicySurface,
 }
@@ -75,6 +76,7 @@ impl ToolCeiling {
             file_tools: FileToolMode::Off,
             bash: BashMode::Off,
             cli_tools: Vec::new(),
+            command_timeout: std::time::Duration::from_secs(10),
             root: None,
             policy: ToolPolicySurface::legacy_non_host_wide(FileToolMode::Off, BashMode::Off),
         }
@@ -85,6 +87,7 @@ impl ToolCeiling {
             file_tools: FileToolMode::ReadOnly,
             bash: BashMode::ReadOnly,
             cli_tools: Vec::new(),
+            command_timeout: std::time::Duration::from_secs(10),
             root: None,
             policy: ToolPolicySurface::legacy_non_host_wide(
                 FileToolMode::ReadOnly,
@@ -98,6 +101,7 @@ impl ToolCeiling {
             file_tools: FileToolMode::ReadOnly,
             bash: BashMode::ReadOnly,
             cli_tools: Vec::new(),
+            command_timeout: std::time::Duration::from_secs(10),
             root: Some(root.into()),
             policy: ToolPolicySurface::legacy_non_host_wide(
                 FileToolMode::ReadOnly,
@@ -111,6 +115,7 @@ impl ToolCeiling {
             file_tools: FileToolMode::ReadWrite,
             bash: BashMode::Unrestricted,
             cli_tools: Vec::new(),
+            command_timeout: std::time::Duration::from_secs(10),
             root: Some(root.into()),
             policy: ToolPolicySurface::legacy_non_host_wide(
                 FileToolMode::ReadWrite,
@@ -134,6 +139,11 @@ impl ToolCeiling {
         self
     }
 
+    pub fn with_command_timeout_secs(mut self, timeout_secs: u64) -> Self {
+        self.command_timeout = std::time::Duration::from_secs(timeout_secs.max(1));
+        self
+    }
+
     pub fn with_policy(mut self, policy: ToolPolicySurface) -> Self {
         self.file_tools = policy.file;
         self.bash = policy.bash.tool;
@@ -152,6 +162,10 @@ impl ToolCeiling {
 
     pub fn cli_tools(&self) -> &[CliToolConfig] {
         &self.cli_tools
+    }
+
+    pub(crate) fn command_timeout(&self) -> std::time::Duration {
+        self.command_timeout
     }
 
     pub fn root(&self) -> Option<&Path> {

--- a/crates/gents/src/tool_surface/tests.rs
+++ b/crates/gents/src/tool_surface/tests.rs
@@ -74,6 +74,46 @@ fn selection_file_tool_root_clamps_within_operator_root() {
 }
 
 #[test]
+fn command_timeout_ceiling_reaches_selected_bash_tool() {
+    let operator_root = temp_root("gents-command-timeout-root");
+    let ceiling = ToolCeiling::readonly_at(&operator_root).with_command_timeout_secs(120);
+    let config = BehaviorToolConfig::from_selection(
+        "classifier",
+        ToolSelection {
+            file_tools: FileToolMode::Off,
+            file_tool_root: None,
+            bash: BashMode::ReadOnly,
+            command_policy: None,
+            cli_tool_names: Vec::new(),
+            enable_meta_tools: false,
+            allowed_mcp_service_ids: Vec::new(),
+            backgroundable_tool_names: Vec::new(),
+            approval_required_tools: Vec::new(),
+            orchestration_enabled: false,
+            enable_memory: false,
+            enable_session_history_tool: false,
+            enable_context_budget: false,
+            enable_defra_query: false,
+            defra_query_collections: Vec::new(),
+            write_tools: Vec::new(),
+            enable_self_config: false,
+            self_config_categories: None,
+            self_config_no_lockout: false,
+            self_config_dry_run: false,
+        },
+        &ceiling,
+        Vec::new(),
+    )
+    .unwrap();
+
+    assert!(matches!(
+        config.host_tools().native_tools(),
+        [crate::toolset::NativeTool::BashReadOnly { timeout, .. }]
+            if timeout.as_secs() == 120
+    ));
+}
+
+#[test]
 fn selection_file_tool_root_rejects_escape_outside_operator_root() {
     let operator_root = temp_root("gents-operator-root");
     let outside_root = temp_root("gents-outside-root");

--- a/crates/gents/src/toolset.rs
+++ b/crates/gents/src/toolset.rs
@@ -353,27 +353,50 @@ impl ToolSetBuilder {
         self
     }
 
-    pub fn bash_read_only(mut self) -> Self {
+    pub fn bash_read_only(self) -> Self {
+        self.bash_read_only_with_timeout(Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS))
+    }
+
+    pub fn bash_read_only_with_timeout(mut self, timeout: Duration) -> Self {
         self.tools.push(NativeTool::BashReadOnly {
-            timeout: Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+            timeout,
             allowlist: default_read_only_commands(),
             policy: CommandExecutionPolicy::read_only(default_read_only_commands()),
         });
         self
     }
 
-    pub fn bash_read_only_with_policy(mut self, policy: CommandExecutionPolicy) -> Self {
+    pub fn bash_read_only_with_policy(self, policy: CommandExecutionPolicy) -> Self {
+        self.bash_read_only_with_policy_and_timeout(
+            policy,
+            Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+        )
+    }
+
+    pub fn bash_read_only_with_policy_and_timeout(
+        mut self,
+        policy: CommandExecutionPolicy,
+        timeout: Duration,
+    ) -> Self {
         self.tools.push(NativeTool::BashReadOnly {
-            timeout: Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+            timeout,
             allowlist: default_read_only_commands(),
             policy,
         });
         self
     }
 
-    pub fn bash_unrestricted(mut self, root: impl Into<PathBuf>) -> Self {
+    pub fn bash_unrestricted(self, root: impl Into<PathBuf>) -> Self {
+        self.bash_unrestricted_with_timeout(root, Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS))
+    }
+
+    pub fn bash_unrestricted_with_timeout(
+        mut self,
+        root: impl Into<PathBuf>,
+        timeout: Duration,
+    ) -> Self {
         self.tools.push(NativeTool::BashUnrestricted {
-            timeout: Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+            timeout,
             root: root.into(),
             policy: CommandExecutionPolicy::write_capable(),
         });
@@ -381,12 +404,25 @@ impl ToolSetBuilder {
     }
 
     pub fn bash_unrestricted_with_policy(
-        mut self,
+        self,
         root: impl Into<PathBuf>,
         policy: CommandExecutionPolicy,
     ) -> Self {
+        self.bash_unrestricted_with_policy_and_timeout(
+            root,
+            policy,
+            Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+        )
+    }
+
+    pub fn bash_unrestricted_with_policy_and_timeout(
+        mut self,
+        root: impl Into<PathBuf>,
+        policy: CommandExecutionPolicy,
+        timeout: Duration,
+    ) -> Self {
         self.tools.push(NativeTool::BashUnrestricted {
-            timeout: Duration::from_secs(DEFAULT_COMMAND_TIMEOUT_SECS),
+            timeout,
             root: root.into(),
             policy,
         });


### PR DESCRIPTION
## Summary

- make the foreground Bash timeout ceiling configurable on `gents server`
- preserve the existing 10-second default
- propagate the operator ceiling into selected read-only and unrestricted Bash tools
- cover CLI parsing and effective tool construction

This is the narrow production unblocker described in source-inc/gents#899. It
does not attempt to define the higher-level timeout hierarchy proposed there.

## Validation

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p gents`
- `CARGO_INCREMENTAL=0 cargo check --workspace --all-targets`
