### PR TITLE
test(toolset): assert concurrent edit success

### DIFF
--- a/crates/gents/src/toolset/tests.rs
+++ b/crates/gents/src/toolset/tests.rs
@@ -2138,7 +2138,7 @@ async fn write_file_and_edit_file_serialize_on_the_same_lock() {
         );
         let (re, rw) = tokio::join!(edit, write);
         rw.unwrap();
-        let _ = re; // edit may legitimately fail if it reads mid-transition
+        re.unwrap();
         let text = std::fs::read_to_string(&file).unwrap();
         let legal = text == "alpha: 1\nbeta: 1\n" // write then edit
             || text == "alpha: 0\nbeta: 1\n"; // edit then write (write wins)


### PR DESCRIPTION
## Summary

Make the concurrent `EditFile`/`WriteFile` serialization test assert that both operations succeed instead of discarding the edit result.

## False-green evidence

Both operations acquire the same mutation guard before reading or writing the file. The test already accepts the two valid serialized final states:

- write, then edit
- edit, then write (the write wins)

There is therefore no valid serialized schedule in which the edit result should be ignored. The previous `let _ = re` could hide an `EditFile` regression while the final-content assertion still passed through the write-only state.

No runtime code, public API, error string, retry behavior, or test coverage is removed.

## Validation

- `cargo test -p gents write_file_and_edit_file_serialize_on_the_same_lock`
  - 1 passed, 0 failed
  - all package integration targets compiled
- `cargo fmt --all -- --check`
- `git diff --check`
