### PR TITLE
Make live test prerequisites explicit

### DIFF
--- a/crates/gents-cli/tests/cli_codex_shim.rs
+++ b/crates/gents-cli/tests/cli_codex_shim.rs
@@ -8015,17 +8015,18 @@ async fn config_skill_cli_disable_enable_and_rm_round_trip() -> Result<()> {
 
 /// Real-world round-trip (#340 slice 5): import the NousResearch/hermes-agent
 /// skill tree (~177 SKILL.md files), export it back to SKILL.md, and re-import
-/// the export. Gated on the hermes skills directory existing (override with
-/// HERMES_SKILLS_DIR); skipped otherwise so CI stays green without that checkout.
+/// the export. Ignored by default; set HERMES_SKILLS_DIR to the external skill
+/// tree and pass `--ignored` to run it.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "external fixture: set HERMES_SKILLS_DIR and pass --ignored"]
 async fn config_skill_import_export_roundtrip_hermes() -> Result<()> {
-    let hermes_dir = std::env::var("HERMES_SKILLS_DIR").unwrap_or_else(|_| {
-        "/Users/johnzampolin/go/src/github.com/NousResearch/hermes-agent/skills".to_string()
-    });
-    if !std::path::Path::new(&hermes_dir).is_dir() {
-        eprintln!("skipping config_skill_import_export_roundtrip_hermes: {hermes_dir} not found");
-        return Ok(());
-    }
+    let hermes_dir = std::env::var("HERMES_SKILLS_DIR").context(
+        "set HERMES_SKILLS_DIR to the NousResearch/hermes-agent skills directory and pass --ignored",
+    )?;
+    anyhow::ensure!(
+        std::path::Path::new(&hermes_dir).is_dir(),
+        "HERMES_SKILLS_DIR must point to an existing Hermes skills directory: {hermes_dir}"
+    );
 
     let tempdir = tempfile::tempdir().context("creating tempdir")?;
     let home_dir = tempdir.path().join("home");

--- a/crates/gents/tests/e2e_live/edit_file_live.rs
+++ b/crates/gents/tests/e2e_live/edit_file_live.rs
@@ -16,7 +16,8 @@
 //!
 //! ```bash
 //! GENTS_D4F_LIVE=1 cargo test --test e2e_live \
-//!   -- --test-threads=1 edit_file_live --nocapture
+//!   edit_file_live_model_lands_drifted_edit_without_write_file \
+//!   -- --ignored --test-threads=1 --nocapture
 //! ```
 
 use std::sync::Arc;
@@ -84,11 +85,12 @@ async fn fetch_tool_calls(node: &EmbeddedNode, request_id: &str) -> Vec<ToolCall
 }
 
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "live: set GENTS_D4F_LIVE=1 and pass --ignored"]
 async fn edit_file_live_model_lands_drifted_edit_without_write_file() {
-    if !d4f_enabled() {
-        eprintln!("GENTS_D4F_LIVE is not 1; skipping edit_file live qualification");
-        return;
-    }
+    assert!(
+        d4f_enabled(),
+        "set GENTS_D4F_LIVE=1 and pass --ignored to run the edit_file live qualification"
+    );
 
     let db = test_db("edit-file-live").await;
     let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity("edit-file-live"));

--- a/crates/gents/tests/e2e_live/goal_continuation_live.rs
+++ b/crates/gents/tests/e2e_live/goal_continuation_live.rs
@@ -58,10 +58,12 @@ async fn wait_for_goal_child(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live: set GENTS_D4F_LIVE=1 and pass --ignored"]
 async fn durable_goal_continues_with_real_inference_until_model_completes() {
-    if std::env::var("GENTS_D4F_LIVE").as_deref() != Ok("1") {
-        return;
-    }
+    assert!(
+        std::env::var("GENTS_D4F_LIVE").as_deref() == Ok("1"),
+        "set GENTS_D4F_LIVE=1 and pass --ignored to run the durable-goal live qualification"
+    );
 
     let db = test_db("durable-goal-real-inference").await;
     let identity: Arc<dyn AgentIdentity> = Arc::new(test_identity("durable-goal-real-inference"));

--- a/crates/gents/tests/e2e_live/steward_loop_live.rs
+++ b/crates/gents/tests/e2e_live/steward_loop_live.rs
@@ -31,13 +31,14 @@
 //!
 //! ## Running
 //!
-//! Gated on `GENTS_D4F_LIVE=1`. Without it every test early-returns and
-//! passes as a no-op, so offline/CI runs skip cleanly.
+//! Ignored by default and gated on `GENTS_D4F_LIVE=1`, so offline/CI runs
+//! skip cleanly. Explicit runs fail if the live gate is missing.
 //!
 //! ```bash
-//! GENTS_D4F_LIVE=1 cargo test --test steward_loop_live \
+//! GENTS_D4F_LIVE=1 cargo test --test e2e_live \
 //!   --features defra-node/http,defra-node/p2p,rocksdb \
-//!   -- --test-threads=1 d4f_backend_probes_healthy_and_completes --nocapture
+//!   d4f_backend_probes_healthy_and_completes \
+//!   -- --ignored --test-threads=1 --nocapture
 //! ```
 
 use std::sync::Arc;
@@ -61,8 +62,8 @@ use crate::support::{first_optional_row, test_db, TestDb};
 // Gate + d4f connection constants
 // ---------------------------------------------------------------------------
 
-/// Every test in this file early-returns unless this is set, so offline/CI runs
-/// skip cleanly.
+/// Returns whether the explicit live prerequisite is enabled. Ignored tests
+/// assert this before starting local or remote setup.
 fn d4f_enabled() -> bool {
     std::env::var("GENTS_D4F_LIVE").as_deref() == Ok("1")
 }
@@ -328,11 +329,12 @@ pub async fn wait_for_assistant_answer(
 /// non-empty assistant answer lands. This is the foundation 2a-2 / 2a-3 build on
 /// (it exercises bind + boot + full-run-and-wait against d4f end to end).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "live: set GENTS_D4F_LIVE=1 and pass --ignored"]
 async fn d4f_backend_probes_healthy_and_completes() {
-    if !d4f_enabled() {
-        eprintln!("GENTS_D4F_LIVE is not 1; skipping d4f live smoke test");
-        return;
-    }
+    assert!(
+        d4f_enabled(),
+        "set GENTS_D4F_LIVE=1 and pass --ignored to run the d4f live smoke test"
+    );
 
     assert_d4f_reachable().await;
 


### PR DESCRIPTION
## What changed

- Mark the three D4F live qualifications as ignored by default with descriptive prerequisite text.
- Replace their missing-`GENTS_D4F_LIVE=1` early returns with immediate actionable assertion failures when explicitly run with `--ignored`.
- Mark the Hermes import/export round-trip as an ignored external-fixture test.
- Remove the developer-local absolute Hermes path fallback and fail immediately when `HERMES_SKILLS_DIR` is missing or is not a directory.
- Update the existing D4F run recipes to include `--ignored`.

The substantive live test bodies and assertions after each prerequisite gate are unchanged.

## Why

These tests were false-green: the D4F qualifications returned successfully when their environment gate was absent, while the Hermes test silently fell back to one developer's absolute checkout and returned successfully when it was unavailable. Default package runs should remain offline-safe, but an explicit request to run these qualifications must either exercise them or fail with setup instructions.

## Impact

Normal test runs continue to skip external/live qualifications explicitly. Maintainers can opt in with `--ignored`; missing prerequisites now fail before database, server, tempdir, or remote setup instead of reporting success.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p gents --test e2e_live -- --list` (21 tests listed)
- Default targeted runs for all three D4F tests: each reported `ignored` in 0.00s.
- Explicit `--ignored` runs for all three D4F tests with `GENTS_D4F_LIVE` unset: each exited 101 in 0.01s with its actionable prerequisite message.
- `cargo test -p gents-cli --test cli_codex_shim config_skill_import_export_roundtrip_hermes -- --list`
- Default targeted Hermes run: reported `ignored` in 0.00s.
- Explicit Hermes run with `HERMES_SKILLS_DIR` unset: exited 101 in 0.00s with setup instructions.
- Explicit Hermes run with a verified nonexistent directory: exited 101 in 0.00s with the invalid-directory message.

The commit was rebased onto `main` after #907. Stable patch IDs before and after rebase are identical (`2e8100e8bec832c3a8e329f98e11eadc166958a4`), and post-rebase formatting/diff checks are clean.
