### PR TITLE
Deduplicate private P2P GraphQL helpers

### DIFF
--- a/crates/gents/src/agent/p2p_reconcile/bearer_claim.rs
+++ b/crates/gents/src/agent/p2p_reconcile/bearer_claim.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use defra_node::{EmbeddedNode, EventName};
 use gents_protocol::bearer_token::{
     bearer_signing_payload, check_bearer_freshness, decode_bearer, BearerClaimRecord,
 };
@@ -39,6 +39,8 @@ use tokio_util::sync::CancellationToken;
 
 use crate::graphql::escape_graphql_string;
 use crate::identity::AgentIdentity;
+
+use super::graphql_helpers::{ensure_no_errors, first_row, rows};
 
 pub const BEARER_CONVERSATION_TEMPLATE: &str = "conversation";
 
@@ -578,30 +580,6 @@ async fn verify_sig(identity: &dyn AgentIdentity, did: &str, payload: &[u8], sig
             false
         }
     }
-}
-
-fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
-    if response.has_errors() {
-        bail!("{label} failed: {:?}", response.errors);
-    }
-    Ok(())
-}
-
-fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
-        return Ok(Vec::new());
-    };
-    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
-}
-
-fn first_row<T>(response: &QueryResponse, field: &str) -> Result<Option<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    Ok(rows::<T>(response, field)?.into_iter().next())
 }
 
 #[derive(Deserialize)]

--- a/crates/gents/src/agent/p2p_reconcile/discovery.rs
+++ b/crates/gents/src/agent/p2p_reconcile/discovery.rs
@@ -30,16 +30,19 @@ use std::collections::BTreeSet;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use defra_node::{EmbeddedNode, EventName};
 use tokio_util::sync::CancellationToken;
 
 use serde::Deserialize;
 
 use crate::graphql::escape_graphql_string;
 
+use super::graphql_helpers::{
+    ensure_no_errors, graphql_nullable_string_literal, graphql_string_list_literal, rows,
+};
 use super::registry::REGISTRY_HEARTBEAT_INTERVAL;
 use super::templates::{resolve_template, ScopeTemplate};
 
@@ -736,29 +739,6 @@ pub fn upsert_registry_desired_mutation(
     )
 }
 
-/// Render a GraphQL string-list literal, emitting `null` for an empty list
-/// (never `[]`, which types as `JsonArray` and corrupts nillable array columns).
-fn graphql_string_list_literal<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
-    let items: Vec<String> = values
-        .into_iter()
-        .map(|v| format!(r#""{}""#, escape_graphql_string(v)))
-        .collect();
-    if items.is_empty() {
-        "null".to_string()
-    } else {
-        format!("[{}]", items.join(", "))
-    }
-}
-
-/// Render a nullable GraphQL string literal, emitting `null` for absent/blank.
-fn graphql_nullable_string_literal(value: Option<&str>) -> String {
-    value
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-        .map(|v| format!(r#""{}""#, escape_graphql_string(v)))
-        .unwrap_or_else(|| "null".to_string())
-}
-
 /// Delete the registry-owned `PeerPairingDesired` row for `peer_id`. The
 /// `source = "registry"` predicate guarantees an operator-owned row for the same
 /// peer is never deleted (mirrors Lean `retraction_sound`).
@@ -772,23 +752,6 @@ pub fn delete_registry_desired_mutation(peer_id: &str) -> String {
             ) {{ _docID }}
         }}"#
     )
-}
-
-fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
-    if response.has_errors() {
-        bail!("{label} failed: {:?}", response.errors);
-    }
-    Ok(())
-}
-
-fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
-        return Ok(Vec::new());
-    };
-    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
 }
 
 #[derive(Deserialize)]

--- a/crates/gents/src/agent/p2p_reconcile/engine.rs
+++ b/crates/gents/src/agent/p2p_reconcile/engine.rs
@@ -4,10 +4,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use defra_node::{EmbeddedNode, EventName};
 use futures::{stream, StreamExt};
 use gents_protocol::bearer_token::{derive_bearer_readiness_key, BearerPairingReadyRecord};
 use p2p::iroh::parse_public_peer_addr;
@@ -17,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use crate::graphql::escape_graphql_string;
 use crate::identity::AgentIdentity;
 
+use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_literal, rows};
 use super::network::{GraphqlNetworkStore, NetworkEndpointEntry, NetworkStore};
 use super::reciprocal::GraphqlReciprocalStore;
 use super::templates::{
@@ -1643,30 +1644,6 @@ pub fn bearer_pairing_ready_upsert_mutation(
     )
 }
 
-fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
-    if response.has_errors() {
-        bail!("{label} failed: {:?}", response.errors);
-    }
-    Ok(())
-}
-
-fn first_row<T>(response: &QueryResponse, field: &str) -> Result<Option<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    Ok(rows::<T>(response, field)?.into_iter().next())
-}
-
-fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
-        return Ok(Vec::new());
-    };
-    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
-}
-
 /// Serialize the per-pairing scope filter to a GraphQL String literal (JSON),
 /// emitting `null` for the unfiltered (empty) case so the column is never an
 /// empty-list literal. The JSON round-trips through `decode_replicator_filter`.
@@ -1694,17 +1671,7 @@ fn decode_replicator_filter(value: Option<&str>) -> PairingFilters {
 }
 
 fn graphql_nullable_string_array(values: &BTreeSet<String>) -> String {
-    if values.is_empty() {
-        return "null".to_string();
-    }
-    format!(
-        "[{}]",
-        values
-            .iter()
-            .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
+    graphql_string_list_literal(values.iter().map(String::as_str))
 }
 
 #[cfg(test)]

--- a/crates/gents/src/agent/p2p_reconcile/graphql_helpers.rs
+++ b/crates/gents/src/agent/p2p_reconcile/graphql_helpers.rs
@@ -1,0 +1,52 @@
+use anyhow::{bail, Context, Result};
+use defra_node::QueryResponse;
+use serde::Deserialize;
+
+use crate::graphql::escape_graphql_string;
+
+pub(super) fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
+    if response.has_errors() {
+        bail!("{label} failed: {:?}", response.errors);
+    }
+    Ok(())
+}
+
+pub(super) fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
+        return Ok(Vec::new());
+    };
+    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
+}
+
+pub(super) fn first_row<T>(response: &QueryResponse, field: &str) -> Result<Option<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    Ok(rows::<T>(response, field)?.into_iter().next())
+}
+
+/// Render a GraphQL string-list literal, emitting `null` for an empty list
+/// (never `[]`, which types as `JsonArray` and corrupts nillable array columns).
+pub(super) fn graphql_string_list_literal<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
+    let items = values
+        .into_iter()
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .collect::<Vec<_>>();
+    if items.is_empty() {
+        "null".to_string()
+    } else {
+        format!("[{}]", items.join(", "))
+    }
+}
+
+/// Render a nullable GraphQL string literal, emitting `null` for absent/blank.
+pub(super) fn graphql_nullable_string_literal(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
+        .unwrap_or_else(|| "null".to_string())
+}

--- a/crates/gents/src/agent/p2p_reconcile/mod.rs
+++ b/crates/gents/src/agent/p2p_reconcile/mod.rs
@@ -7,6 +7,7 @@ pub mod embedded_impl;
 pub mod endpoint;
 pub mod engine;
 pub mod error_class;
+mod graphql_helpers;
 pub mod intervals;
 pub mod network;
 pub mod profiles;

--- a/crates/gents/src/agent/p2p_reconcile/network.rs
+++ b/crates/gents/src/agent/p2p_reconcile/network.rs
@@ -10,10 +10,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use defra_node::{EmbeddedNode, EventName};
 use gents_protocol::network_token::{EndpointRecord, MembershipRecord, NetworkRecord};
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
@@ -21,6 +21,7 @@ use tokio_util::sync::CancellationToken;
 use crate::graphql::escape_graphql_string;
 use crate::identity::AgentIdentity;
 
+use super::graphql_helpers::{ensure_no_errors, graphql_string_list_literal, rows};
 use super::templates::{resolve_template, NETWORK_CONTROL_TEMPLATE};
 
 pub const SOURCE_NETWORK: &str = "network";
@@ -789,35 +790,6 @@ fn decode_sig(sig: String) -> Result<Vec<u8>> {
     bs58::decode(sig)
         .into_vec()
         .context("decoding base58 signature")
-}
-
-fn graphql_string_list_literal<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
-    let items = values
-        .into_iter()
-        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
-        .collect::<Vec<_>>();
-    if items.is_empty() {
-        "null".to_string()
-    } else {
-        format!("[{}]", items.join(", "))
-    }
-}
-
-fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
-    if response.has_errors() {
-        bail!("{label} failed: {:?}", response.errors);
-    }
-    Ok(())
-}
-
-fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
-        return Ok(Vec::new());
-    };
-    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
 }
 
 #[derive(Deserialize)]

--- a/crates/gents/src/agent/p2p_reconcile/reciprocal.rs
+++ b/crates/gents/src/agent/p2p_reconcile/reciprocal.rs
@@ -1,10 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use chrono::{SecondsFormat, Utc};
-use defra_node::{EmbeddedNode, EventName, QueryResponse};
+use defra_node::{EmbeddedNode, EventName};
 use gents_protocol::network_token::EndpointRecord;
 use serde::Deserialize;
 use tokio_util::sync::CancellationToken;
@@ -12,6 +12,7 @@ use tokio_util::sync::CancellationToken;
 use crate::graphql::escape_graphql_string;
 use crate::identity::AgentIdentity;
 
+use super::graphql_helpers::{ensure_no_errors, first_row, graphql_string_list_literal, rows};
 use super::network::{endpoint_is_fresh, NetworkEndpointEntry};
 use super::templates::resolve_template;
 
@@ -507,18 +508,6 @@ fn decode_sig(sig: String) -> Result<Vec<u8>> {
         .context("decoding base58 signature")
 }
 
-fn graphql_string_list_literal<'a>(values: impl IntoIterator<Item = &'a str>) -> String {
-    let items = values
-        .into_iter()
-        .map(|value| format!(r#""{}""#, escape_graphql_string(value)))
-        .collect::<Vec<_>>();
-    if items.is_empty() {
-        "null".to_string()
-    } else {
-        format!("[{}]", items.join(", "))
-    }
-}
-
 fn data_plane_source_is_reciprocal(source: Option<&str>) -> bool {
     source.map(str::trim) == Some(SOURCE_RECIPROCAL)
 }
@@ -540,30 +529,6 @@ enum DataPlaneOwnership {
     Absent,
     Reciprocal,
     NonReciprocal,
-}
-
-fn ensure_no_errors(response: &QueryResponse, label: &str) -> Result<()> {
-    if response.has_errors() {
-        bail!("{label} failed: {:?}", response.errors);
-    }
-    Ok(())
-}
-
-fn rows<T>(response: &QueryResponse, field: &str) -> Result<Vec<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    let Some(value) = response.data.as_ref().and_then(|data| data.get(field)) else {
-        return Ok(Vec::new());
-    };
-    serde_json::from_value(value.clone()).with_context(|| format!("decode {field} rows"))
-}
-
-fn first_row<T>(response: &QueryResponse, field: &str) -> Result<Option<T>>
-where
-    T: for<'de> Deserialize<'de>,
-{
-    Ok(rows::<T>(response, field)?.into_iter().next())
 }
 
 #[derive(Deserialize)]

--- a/crates/gents/src/agent/p2p_reconcile/registry.rs
+++ b/crates/gents/src/agent/p2p_reconcile/registry.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::graphql::escape_graphql_string;
 
+use super::graphql_helpers::{graphql_nullable_string_literal, graphql_string_list_literal};
 use super::templates::resolve_template;
 
 /// How often the node refreshes its `updated_at` heartbeat in `PeerRegistry`.
@@ -133,8 +134,8 @@ pub enum UpsertKind {
 pub fn registry_upsert_mutation(entry: &RegistryEntry, now: &str, kind: UpsertKind) -> String {
     let peer_id = escape_graphql_string(&entry.peer_id);
     let agent_did = escape_graphql_string(&entry.agent_did);
-    let addresses = graphql_nullable_string_list_literal(&entry.addresses);
-    let templates = graphql_nullable_string_list_literal(&entry.templates);
+    let addresses = graphql_string_list_literal(entry.addresses.iter().map(String::as_str));
+    let templates = graphql_string_list_literal(entry.templates.iter().map(String::as_str));
     let display_name = graphql_nullable_string_literal(entry.display_name.as_deref());
     let status = escape_graphql_string(&entry.status);
     let network_id = escape_graphql_string(&entry.network_id);
@@ -323,28 +324,6 @@ async fn tick_registry(
     );
 
     Ok(())
-}
-
-fn graphql_nullable_string_list_literal(values: &[String]) -> String {
-    if values.is_empty() {
-        return "null".to_string();
-    }
-    format!(
-        "[{}]",
-        values
-            .iter()
-            .map(|v| format!(r#""{}""#, escape_graphql_string(v)))
-            .collect::<Vec<_>>()
-            .join(", ")
-    )
-}
-
-fn graphql_nullable_string_literal(value: Option<&str>) -> String {
-    value
-        .map(str::trim)
-        .filter(|v| !v.is_empty())
-        .map(|v| format!(r#""{}""#, escape_graphql_string(v)))
-        .unwrap_or_else(|| "null".to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add one private `p2p_reconcile::graphql_helpers` module for shared GraphQL response decoding and literal rendering
- remove the duplicate implementations from `engine`, `network`, `reciprocal`, `discovery`, `bearer_claim`, and `registry`
- retain `graphql_nullable_filter_literal` in `engine` and retain the tested `graphql_nullable_string_array` name as a thin adapter

This is a mechanical private refactor: 74 additions, 197 deletions (123 net lines removed). It does not change public APIs, module paths, visibility outside `p2p_reconcile`, lifecycle rules, runtime algorithms, error strings, logging, retries, feature gates, or formal invariants.

## Deletion and parity evidence

The removed helpers were compared before extraction:

- five `ensure_no_errors` implementations were byte-equivalent; the shared body preserves `"{label} failed: {:?}"` exactly
- five `rows<T>` implementations were byte-equivalent; the shared body preserves absent-field `Ok(Vec::new())` and `"decode {field} rows"` context exactly
- three `first_row<T>` implementations were byte-equivalent and still select the first decoded row
- the list renderers preserve iteration order, canonical `escape_graphql_string` application before quoting, `", "` delimiters, and `null` rather than `[]` for empty inputs
- the two nullable scalar renderers were byte-equivalent and preserve trim-before-blank-filter behavior
- the engine's JSON filter literal remains local because it is a distinct serializer; its tested array helper remains as a thin shared-renderer adapter

No tests or assertions were deleted. Existing boundary coverage for escaping and empty-list `null` behavior remains in the discovery, engine, and registry suites.

## Independent semantic review

- **Grok:** approved with no findings. Its read-only parity review confirmed the five helper families preserve the error text, row decode context, absent-field behavior, nullable-scalar normalization, list ordering/delimiter, canonical escaping, and empty-list `null` behavior.
- **Claude Opus:** approved with no findings. Its independent read-only review checked helper visibility and all call sites, confirming bearer/discovery/network/reciprocal/registry query parsing and error behavior are unchanged and the engine adapter remains available to its existing test path.

## Validation

Before rebasing the commit onto current `main`:

- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed
- `cargo test -p gents p2p_reconcile` — 128 passed, 0 failed, 0 ignored; every package integration-test target compiled
- `cargo test -p gents` — passed: 1,169 unit tests; all enabled integration suites green; seven explicitly opt-in tests remained ignored (six live/interop tests and one adapter fixture test)
- `cargo check --workspace --all-targets` — passed in 31m07s, including runtime, CLI, desktop, Tauri, examples/test targets, DefraDB/P2P, and feature-resolved workspace consumers

The validated commit was then rebased cleanly onto `origin/main` at `0a4f2876` (#907 touched unrelated files). Post-rebase `cargo fmt --all -- --check`, whitespace checks, and eight-file diff-scope checks all passed.
