### PR TITLE
refactor(agent): remove unreachable behavior build path

### DIFF
--- a/crates/gents/src/agent/builder.rs
+++ b/crates/gents/src/agent/builder.rs
@@ -540,50 +540,6 @@ impl PendingAgentBehavior {
         }))
     }
 
-    #[allow(dead_code)]
-    async fn build(
-        self,
-        node: &EmbeddedNode,
-        principal: Arc<AgentPrincipal>,
-        tool_ceiling: &ToolCeiling,
-    ) -> Result<AgentBehavior> {
-        let backend_id = self
-            .backend_id
-            .clone()
-            .ok_or_else(|| anyhow!("behavior '{}' is missing backend_id", self.name))?;
-        let backend = lookup_backend(node, &backend_id).await?.ok_or_else(|| {
-            anyhow!(
-                "behavior '{}' references missing backend {}",
-                self.name,
-                backend_id
-            )
-        })?;
-        if !backend.is_available() {
-            anyhow::bail!(
-                "behavior '{}' backend {} is unavailable (enabled={} probe_status={})",
-                self.name,
-                backend_id,
-                backend.enabled,
-                backend.probe_status
-            );
-        }
-        BackendAdmissionConfig::from_backend(&backend)?;
-        self.build_with_resolved_backend(
-            principal,
-            Some(backend.backend_id),
-            backend.provider_kind,
-            crate::OpenAiWireApi::effective_for_provider(
-                backend.provider_kind,
-                backend.openai_wire_api,
-                &backend_id,
-            ),
-            backend.endpoint,
-            backend.api_key,
-            backend.api_key_env_var,
-            tool_ceiling,
-        )
-    }
-
     #[allow(clippy::too_many_arguments)]
     fn build_with_resolved_backend(
         self,


### PR DESCRIPTION
## Summary

Remove the private, dead-code-allowed `PendingAgentBehavior::build` implementation.

## Reachability evidence

- repository-wide symbol and call-site searches find no consumer of `PendingAgentBehavior::build`
- the active resolved behavior path remains `into_factory`
- no public type, method, visibility, error string, logging, retry behavior, feature gate, or module path changes
- the removed method was already annotated `#[allow(dead_code)]`

## Validation

- combined authoritative `cargo test -p gents`: 1,169 unit tests, 316 conformance tests, all package integration binaries, and doc tests passed
- all combined package integration targets compiled
- `cargo fmt --all -- --check`
- `git diff --check`

## Combined workspace and lint gate

- `cargo check --workspace --all-targets` passed in 12m55s on the integrated cleanup batch.
- strict workspace/all-target/all-feature clippy stops on untouched baseline warnings in the lifecycle lens and `gents-protocol`; neither file is in this PR.
- the non-strict full clippy pass completed. No newly added adapter, pairing, or P2P support file emitted a warning; the one warning in the changed builder file blames to pre-existing commit `3d76af9e7`.